### PR TITLE
fix(backend): usage counters written with set(merge=True) never nest,…

### DIFF
--- a/backend/database/llm_usage.py
+++ b/backend/database/llm_usage.py
@@ -82,6 +82,37 @@ def _plan_key(uid: str, firestore_client: Any | None) -> str:
     return resolve_usage_plan_id(uid, firestore_client=firestore_client) or _UNATTRIBUTED_PLAN
 
 
+def _nested(update: Dict[str, Any]) -> Dict[str, Any]:
+    """Expand dotted field paths into nested maps, for writes that use ``set(..., merge=True)``.
+
+    Firestore treats a dot as a field PATH in ``update()`` but as a literal character in ``set()``. These
+    usage documents are written with ``set(merge=True)`` because they must be created on first use, so a
+    key like ``chat.gpt-4o.input_tokens`` lands as ONE top-level field whose name contains dots — the
+    counter still increments correctly, but nothing is nested, and every reader that walks
+    ``feature -> model -> counter`` (``get_usage_summary``, ``_aggregate_summary``,
+    ``get_plan_usage_report``) skips it and reports empty usage.
+
+    Every dot in these keys is a separator by construction: the model name, the cost-exclusion label and
+    the plan id are each sanitised of ``.`` before being interpolated, and the remaining segments are
+    literals in this module.
+    """
+    nested: Dict[str, Any] = {}
+    for path, value in update.items():
+        if '.' not in path:
+            nested[path] = value
+            continue
+        cursor = nested
+        *parents, leaf = path.split('.')
+        for segment in parents:
+            branch = cursor.get(segment)
+            if not isinstance(branch, dict):
+                branch = {}
+                cursor[segment] = branch
+            cursor = branch
+        cursor[leaf] = value
+    return nested
+
+
 def _record_plan_metadata(
     update: Dict[str, Any],
     plan_key: str,
@@ -214,7 +245,7 @@ def record_llm_usage(
         cost_exclusion=cost_exclusion,
     )
 
-    usage_ref.set(update_data, merge=True)
+    usage_ref.set(_nested(update_data), merge=True)
 
 
 @transactional  # pyright: ignore[reportUntypedFunctionDecorator]
@@ -239,7 +270,7 @@ def _record_chat_quota_question_transaction(
     }
     _record_plan_bucket(update, plan_key, 'backend_chat', quota_questions=1)
     _record_plan_metadata(update, plan_key, cost_status='missing', cost_exclusion='chat_token_cost_not_recorded')
-    transaction.set(usage_ref, update, merge=True)
+    transaction.set(usage_ref, _nested(update), merge=True)
     return True
 
 
@@ -516,7 +547,7 @@ def record_llm_usage_bucket(
         count_call=count_call,
     )
     _record_plan_metadata(update, plan_key, cost_status=cost_status, cost_exclusion=cost_exclusion)
-    ref.set(update, merge=True)
+    ref.set(_nested(update), merge=True)
 
 
 def record_llm_cost_exclusion(
@@ -535,7 +566,7 @@ def record_llm_cost_exclusion(
     plan_key = _plan_key(uid, firestore_client)
     update: Dict[str, Any] = {'date': today, 'last_updated': datetime.now(timezone.utc)}
     _record_plan_metadata(update, plan_key, cost_status='excluded', cost_exclusion=cost_exclusion)
-    ref.set(update, merge=True)
+    ref.set(_nested(update), merge=True)
 
 
 def _merge_cost_status(existing: str | None, observed: str) -> str:

--- a/backend/tests/unit/test_desktop_migration.py
+++ b/backend/tests/unit/test_desktop_migration.py
@@ -1536,13 +1536,15 @@ class TestLlmUsageBucketParam:
 
         set_call = mock_ref.set.call_args
         update_data = set_call[0][0]
-        # Primary bucket
-        assert 'custom_feature.input_tokens' in update_data
-        assert 'custom_feature.output_tokens' in update_data
-        assert 'custom_feature.call_count' in update_data
+        # Primary bucket. `set(merge=True)` reads a dot as a literal character, not as a
+        # field path, so the counters must arrive already nested for a reader that walks
+        # bucket -> counter to find them.
+        assert 'input_tokens' in update_data['custom_feature']
+        assert 'output_tokens' in update_data['custom_feature']
+        assert 'call_count' in update_data['custom_feature']
         # Per-account bucket
-        assert 'custom_feature_openai.input_tokens' in update_data
-        assert 'custom_feature_openai.output_tokens' in update_data
+        assert 'input_tokens' in update_data['custom_feature_openai']
+        assert 'output_tokens' in update_data['custom_feature_openai']
 
     def test_get_total_llm_cost_custom_bucket(self):
         """get_total_llm_cost with custom bucket reads from the specified bucket only."""
@@ -1836,15 +1838,13 @@ class TestLlmUsage:
         update_data = mock_ref.set.call_args[0][0]
         assert mock_ref.set.call_args[1] == {'merge': True}
 
-        # Must have both desktop_chat and desktop_chat_anthropic keys
-        desktop_chat_keys = [k for k in update_data if k.startswith('desktop_chat.')]
-        desktop_chat_acct_keys = [k for k in update_data if k.startswith('desktop_chat_anthropic.')]
-        assert len(desktop_chat_keys) > 0, "Missing desktop_chat.* keys"
-        assert len(desktop_chat_acct_keys) > 0, "Missing desktop_chat_anthropic.* keys"
+        # Must have both desktop_chat and desktop_chat_anthropic buckets
+        assert update_data.get('desktop_chat'), "Missing desktop_chat bucket"
+        assert update_data.get('desktop_chat_anthropic'), "Missing desktop_chat_anthropic bucket"
 
         # Verify input_tokens increment is present for both buckets
-        assert 'desktop_chat.input_tokens' in update_data
-        assert 'desktop_chat_anthropic.input_tokens' in update_data
+        assert 'input_tokens' in update_data['desktop_chat']
+        assert 'input_tokens' in update_data['desktop_chat_anthropic']
 
     def test_record_default_account_omi(self):
         """Default account produces desktop_chat_omi keys."""
@@ -1856,7 +1856,7 @@ class TestLlmUsage:
             llm_usage_db.record_llm_usage_bucket('test-uid', input_tokens=10, output_tokens=5)
 
         update_data = mock_ref.set.call_args[0][0]
-        assert 'desktop_chat_omi.input_tokens' in update_data
+        assert 'input_tokens' in update_data['desktop_chat_omi']
 
     def test_get_total_cost_only_sums_desktop_chat_bucket(self):
         """get_total_llm_cost only sums the desktop_chat bucket, not desktop_chat_{account}."""
@@ -2611,8 +2611,8 @@ class TestLlmDualWritePayloadParity:
             'call_count',
         ]
         for field in expected_fields:
-            assert f'desktop_chat.{field}' in data, f"Missing desktop_chat.{field}"
-            assert f'desktop_chat_omi.{field}' in data, f"Missing desktop_chat_omi.{field}"
+            assert field in data['desktop_chat'], f"Missing desktop_chat.{field}"
+            assert field in data['desktop_chat_omi'], f"Missing desktop_chat_omi.{field}"
 
         # Verify shared metadata fields
         assert 'date' in data

--- a/backend/tests/unit/test_llm_usage_db.py
+++ b/backend/tests/unit/test_llm_usage_db.py
@@ -109,8 +109,11 @@ def test_record_llm_usage_sanitizes_model_with_dots():
     call = doc_ref.set_calls[0]
     assert call["merge"] is True
     # Check that '.' is replaced with '_'
-    assert "chat.gpt-4_1-mini.input_tokens" in call["data"]
-    assert "chat.gpt-4_1-mini.output_tokens" in call["data"]
+    # Asserted on the STORED SHAPE, not on a dotted key in the payload. These assertions used to read
+    # `"chat.gpt-4_1-mini.input_tokens" in call["data"]`, which is why the nesting defect was invisible:
+    # the payload was exactly right and Firestore stored it as one field whose NAME contained dots,
+    # because a dot is a field path in update() and a literal character in set().
+    assert set(call["data"]["chat"]["gpt-4_1-mini"]) >= {"input_tokens", "output_tokens"}
 
 
 def test_bucket_attribution_maps_legacy_pro_and_omits_unmeasured_cost():
@@ -123,11 +126,12 @@ def test_bucket_attribution_maps_legacy_pro_and_omits_unmeasured_cost():
         llm_usage.record_llm_usage_bucket('user', input_tokens=10, output_tokens=5)
 
     data = doc_ref.set_calls[0]['data']
-    assert 'desktop_chat.cost_usd' not in data
-    assert 'desktop_chat_omi.cost_usd' not in data
-    assert data['plan_usage.architect.desktop_chat.input_tokens'] == 10
-    assert data['plan_usage.architect.desktop_chat.output_tokens'] == 5
-    assert data['plan_usage.architect._metadata.cost_status_counts.missing'] == 1
+    assert 'cost_usd' not in data.get('desktop_chat', {})
+    assert 'cost_usd' not in data.get('desktop_chat_omi', {})
+    architect = data['plan_usage']['architect']
+    assert architect['desktop_chat']['input_tokens'] == 10
+    assert architect['desktop_chat']['output_tokens'] == 5
+    assert architect['_metadata']['cost_status_counts']['missing'] == 1
 
 
 def test_bucket_complete_cost_is_joinable_to_catalog_plan():
@@ -146,9 +150,10 @@ def test_bucket_complete_cost_is_joinable_to_catalog_plan():
         )
 
     data = doc_ref.set_calls[0]['data']
-    assert data['desktop_chat.cost_usd'] == 0.25
-    assert data['plan_usage.operator.desktop_chat.cost_usd'] == 0.25
-    assert data['plan_usage.operator._metadata.cost_status_counts.complete'] == 1
+    assert data['desktop_chat']['cost_usd'] == 0.25
+    operator = data['plan_usage']['operator']
+    assert operator['desktop_chat']['cost_usd'] == 0.25
+    assert operator['_metadata']['cost_status_counts']['complete'] == 1
 
 
 def test_record_llm_usage_sanitizes_model_with_slash():
@@ -172,8 +177,7 @@ def test_record_llm_usage_sanitizes_model_with_slash():
     call = doc_ref.set_calls[0]
     assert call["merge"] is True
     # Check that both '/' and '.' are replaced with '_'
-    assert "chat.google_gemini-flash-1_5-8b.input_tokens" in call["data"]
-    assert "chat.google_gemini-flash-1_5-8b.output_tokens" in call["data"]
+    assert set(call["data"]["chat"]["google_gemini-flash-1_5-8b"]) >= {"input_tokens", "output_tokens"}
 
 
 def test_record_llm_usage_skips_zero_tokens():
@@ -272,7 +276,7 @@ def test_record_llm_usage_sanitizes_all_special_chars():
     assert len(doc_ref.set_calls) == 1
     call = doc_ref.set_calls[0]
     # All special chars should be replaced with '_'
-    assert "chat.foo_bar_baz_qux_quux_corge_grault_garply.input_tokens" in call["data"]
+    assert "input_tokens" in call["data"]["chat"]["foo_bar_baz_qux_quux_corge_grault_garply"]
 
 
 def test_record_llm_usage_nonzero_input_only():

--- a/backend/tests/unit/test_llm_usage_nested_field_paths.py
+++ b/backend/tests/unit/test_llm_usage_nested_field_paths.py
@@ -1,0 +1,123 @@
+"""Usage counters written with `set(merge=True)` must land NESTED, not under a dotted field name.
+
+`record_llm_usage` and its siblings build keys like `chat.gpt-4o.input_tokens` — the module's own comment
+says "Use nested field paths" and sanitises `.` out of the model name precisely so the remaining dots are
+separators. But those dicts are written with `set(..., merge=True)`, and Firestore treats a dot as a
+field PATH only in `update()`; in `set()` it is a literal character.
+
+Measured against the Firestore emulator before this fix, after two calls of 5 and 7 input tokens:
+
+    {'date': '2026-01-01', 'chat.model-x.input_tokens': 12, ...}
+
+The counter is right and the shape is not. Every reader walks `feature -> model -> counter`
+(`_aggregate_summary`, `get_usage_summary`, `get_plan_usage_report`) and skips a value that is not a
+dict, so usage summaries read empty on Firestore.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from google.cloud import firestore
+
+from database.llm_usage import _nested
+
+
+def test_a_dotted_path_becomes_a_nested_map():
+    assert _nested({'chat.gpt-4o.input_tokens': 3}) == {'chat': {'gpt-4o': {'input_tokens': 3}}}
+
+
+def test_a_key_without_dots_is_left_alone():
+    assert _nested({'date': '2026-01-01'}) == {'date': '2026-01-01'}
+
+
+def test_paths_that_share_a_prefix_merge_into_one_branch():
+    """The whole point: three counters for one model must be three keys of one map, not three maps."""
+    nested = _nested(
+        {
+            'chat.gpt-4o.input_tokens': 1,
+            'chat.gpt-4o.output_tokens': 2,
+            'chat.gpt-4o.call_count': 3,
+            'chat.claude.call_count': 4,
+        }
+    )
+
+    assert nested == {
+        'chat': {
+            'gpt-4o': {'input_tokens': 1, 'output_tokens': 2, 'call_count': 3},
+            'claude': {'call_count': 4},
+        }
+    }
+
+
+def test_sentinels_are_carried_through_untouched():
+    """The values are `firestore.Increment`, and they must reach the leaf as themselves — nesting must
+    not stringify or copy them, or the write stops being an atomic increment."""
+    increment = firestore.Increment(2)
+
+    nested = _nested({'chat.gpt-4o.input_tokens': increment})
+
+    assert nested['chat']['gpt-4o']['input_tokens'] is increment
+
+
+def test_a_leaf_and_a_branch_at_the_same_path_do_not_lose_the_branch():
+    """`plan_usage.<plan>._metadata.last_cost_status` is a leaf while
+    `plan_usage.<plan>._metadata.cost_status_counts.missing` is a branch under the same parent."""
+    nested = _nested(
+        {
+            'plan_usage.free._metadata.last_cost_status': 'missing',
+            'plan_usage.free._metadata.cost_status_counts.missing': 1,
+        }
+    )
+
+    metadata = nested['plan_usage']['free']['_metadata']
+    assert metadata['last_cost_status'] == 'missing'
+    assert metadata['cost_status_counts'] == {'missing': 1}
+
+
+# --- the real writer -------------------------------------------------------------------------------
+
+
+class _Ref:
+    """A document reference that records the last write and can be walked like Firestore's."""
+
+    def __init__(self) -> None:
+        self.written: Dict[str, Any] = {}
+        self.merge: Any = None
+
+    def set(self, data: Dict[str, Any], merge: bool = False) -> None:
+        self.written = data
+        self.merge = merge
+
+    def get(self, *_args: Any, **_kwargs: Any) -> Any:
+        return type('S', (), {'exists': False, 'to_dict': staticmethod(lambda: {})})()
+
+    def collection(self, *_args: Any) -> "_Collection":
+        return _Collection(self)
+
+
+class _Collection:
+    def __init__(self, ref: "_Ref") -> None:
+        self._ref = ref
+
+    def document(self, *_args: Any) -> "_Ref":
+        return self._ref
+
+
+class _Client:
+    def __init__(self, ref: "_Ref") -> None:
+        self._ref = ref
+
+    def collection(self, *_args: Any) -> _Collection:
+        return _Collection(self._ref)
+
+
+def test_record_llm_usage_writes_a_nested_document():
+    from database.llm_usage import record_llm_usage
+
+    ref = _Ref()
+    record_llm_usage('user-1', 'chat', 'gpt-4o', 5, 7, firestore_client=_Client(ref))
+
+    assert ref.merge is True
+    assert [k for k in ref.written if '.' in k] == [], 'no field name may contain a literal dot'
+    assert set(ref.written['chat']['gpt-4o']) == {'input_tokens', 'output_tokens', 'call_count'}


### PR DESCRIPTION
… so every summary reads empty

`record_llm_usage` and its siblings build keys like `chat.gpt-4o.input_tokens` — the module's own comment says "Use nested field paths" and it sanitises `.` out of the model name precisely so the remaining dots are separators. But those dicts are written with `set(..., merge=True)`, and Firestore treats a dot as a field PATH only in `update()`; in `set()` it is a literal character in the field NAME.

Measured against the Firestore emulator, after two calls of 5 and 7 input tokens:

    {'date': '2026-01-01', 'chat.model-x.input_tokens': 12, ...}

The counter is correct. The shape is not: nothing is nested under `chat`. Every reader walks feature -> model -> counter and skips a value that is not a dict — `_aggregate_summary`, `get_usage_summary`, `get_plan_usage_report` — so usage summaries come back EMPTY while the data is sitting in the document.

All four `set(..., merge=True)` writes in the module are affected, including the keys added by `_record_plan_bucket` and `_record_plan_metadata`, so plan attribution reads empty the same way.

The fix expands dotted paths into nested maps at the write. Every dot in these keys is a separator by construction: the model name, the cost-exclusion label and the plan id are each sanitised of '.' before interpolation, and the remaining segments are literals in this module.

Why it was invisible: the existing tests assert the PAYLOAD, e.g. `"chat.gpt-4_1-mini.input_tokens" in call["data"]` — which was exactly right, and says nothing about what Firestore then stores. Those five assertions are re-expressed on the stored shape rather than deleted; they still hold the property they were written for (a model name's dots are sanitised so they cannot be mistaken for separators).

Verification
  emulator, before: `keys with a literal dot: ['chat.model-x.call_count', 'plan_usage._unattributed...']`
                    and `nested under 'chat'? False`
  emulator, after:  `keys with a literal dot: []`, `chat -> {'model-x': {'input_tokens': 12, ...}}`
  tests/unit/test_llm_usage_db.py 19 passed, test_llm_usage_tracker.py 18, test_llm_usage_endpoints.py 2
  new tests/unit/test_llm_usage_nested_field_paths.py 6 passed
  tests/unit/test_desktop_migration.py 114 passed after the second commit updates four assertions that
    pinned the pre-fix shape (they looked for a top-level key literally named `desktop_chat.input_tokens`)
  reverting database/llm_usage.py to upstream turns 9 tests red across test_desktop_migration.py and
    test_llm_usage_db.py, the four rewritten ones among them — they exercise the writer, not themselves

<!-- Keep this short and honest. Reviewers read the Verification section first. -->

## What changed and why

<!-- One or two sentences. Link the issue if there is one. -->

## Product invariants affected

<!-- Name locked invariant IDs this PR touches (e.g. INV-CHAT-1), or "none".
     Registry: docs/product/invariants/ — required when changing paths listed
     on a locked invariant. -->

## How it was verified

<!-- The commands you ran and what they showed. Exercising the real user-facing
     path counts as verification; compiling or lint passing does not.
     If something could not be verified, say so explicitly. -->

## Tests

<!-- Bug fix: point to the regression test that would have caught the bug.
     Feature: point to the tests for the core path and main error path.
     No test change: explain why none was needed. -->

## Failure class (fixes)

<!-- Every `fix:` commit needs this exact, machine-validated declaration.
     Use `scripts/failure-class prepare` or `explain` to choose a class.
     `harden:` commits may cite a class but do not need a declaration. -->

Failure-Class: none

## Failure-class transition narrative (only when needed)

<!-- Required only when declaring `new`, changing a class's canonical prevention
     primitive/owner, or making a registry-only lifecycle transition. A dormant
     transition sets `status: dormant` and an ISO-8601 `dormant_since`; a reopen
     sets `status: open` and removes `dormant_since`. Make that transition in a
     separate PR, never in the instance-fix PR. State the violated contract, the
     canonical guard, and the supporting evidence. Delete this section for an
     ordinary instance fix. -->

## New guards (only when adding a check or ratchet)

<!-- Cite the real merged PR or incident this guard would have caught, then answer
     in one sentence: why is this not a shared primitive instead? Delete this
     section when no check or ratchet is added. -->

## Scoped cleanups (optional)

<!-- Related fixes you made along the way (see AGENTS.md → "Leave It Better
     Than You Found It"). Each should be its own commit and verifiable. -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


