### PR TITLE
fix(backend): a __name__ filter needs a Key, so both usage readers ra…

### DIFF
--- a/backend/database/llm_usage.py
+++ b/backend/database/llm_usage.py
@@ -351,7 +351,9 @@ def get_usage_summary(uid: str, days: int = 30) -> Dict[str, Dict[str, int]]:
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
     cutoff_id = f"{cutoff.year}-{cutoff.month:02d}-{cutoff.day:02d}"
 
-    docs = usage_collection.where("__name__", ">=", cutoff_id).stream()
+    # The value of a `__name__` filter must be a Key, not a string: Firestore answers
+    # `400 __key__ filter value must be a Key` otherwise, so this raised on every call.
+    docs = usage_collection.where("__name__", ">=", usage_collection.document(cutoff_id)).stream()
 
     # Aggregate by feature
     summary: Dict[str, Dict[str, int]] = {}
@@ -583,7 +585,8 @@ def get_plan_usage_report(uid: str, days: int = 30) -> Dict[str, Dict[str, Any]]
     usage_collection = db.collection('users').document(uid).collection('llm_usage')
     report: Dict[str, Dict[str, Any]] = {}
 
-    for doc in usage_collection.where('__name__', '>=', cutoff_id).stream():
+    # A `__name__` filter takes a Key, not a string (see get_usage_summary above).
+    for doc in usage_collection.where('__name__', '>=', usage_collection.document(cutoff_id)).stream():
         data = _typed_doc(doc)
         plan_usage = data.get('plan_usage')
         if isinstance(plan_usage, dict):

--- a/backend/tests/unit/test_llm_usage_name_filter_takes_a_key.py
+++ b/backend/tests/unit/test_llm_usage_name_filter_takes_a_key.py
@@ -1,0 +1,119 @@
+"""A `__name__` filter takes a Key, not a string — otherwise the query raises on every call.
+
+`get_usage_summary` and `get_plan_usage_report` bound their scan with
+`where("__name__", ">=", cutoff_id)` where `cutoff_id` is a date string like `2026-01-01`. Firestore
+requires a Key (a DocumentReference) there and rejects anything else:
+
+    google.api_core.exceptions.InvalidArgument: 400 __key__ filter value must be a Key
+
+Measured against the Firestore emulator: both functions raised on every call, for every user.
+
+The document ids ARE the dates, so the reference is simply `usage_collection.document(cutoff_id)` — the
+intent and the bound are unchanged, only the type is.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Tuple
+
+import database.llm_usage as llm_usage
+
+
+class _Doc:
+    def __init__(self, doc_id: str, data: dict) -> None:
+        self.id = doc_id
+        self._data = data
+
+    def to_dict(self) -> dict:
+        return self._data
+
+
+class _Query:
+    def __init__(self, collection: "_Collection") -> None:
+        self._collection = collection
+
+    def stream(self) -> List[_Doc]:
+        return self._collection.docs
+
+
+class _Collection:
+    """Records what `where` was called with, and hands back the documents regardless."""
+
+    def __init__(self, docs: List[_Doc]) -> None:
+        self.docs = docs
+        self.filters: List[Tuple[str, str, Any]] = []
+        self.requested_documents: List[str] = []
+        self.references: dict = {}
+
+    def where(self, field: str, op: str, value: Any) -> _Query:
+        self.filters.append((field, op, value))
+        return _Query(self)
+
+    def document(self, doc_id: str) -> Any:
+        # A stand-in for the DocumentReference the real collection returns. Constructing a real one here
+        # would reach for ambient credentials; what this pins is that the caller RESOLVES the cutoff
+        # through the collection instead of handing the query a bare string. That the resolved value must
+        # be a Key is Firestore's rule, measured against the emulator and quoted in the module docstring.
+        self.requested_documents.append(doc_id)
+        reference = object()
+        self.references[doc_id] = reference
+        return reference
+
+
+class _UserRef:
+    def __init__(self, collection: _Collection) -> None:
+        self._collection = collection
+
+    def collection(self, _name: str) -> _Collection:
+        return self._collection
+
+
+class _Db:
+    def __init__(self, collection: _Collection) -> None:
+        self._collection = collection
+
+    def collection(self, _name: str) -> Any:
+        return type('C', (), {'document': lambda _self, _uid: _UserRef(self._collection)})()
+
+
+def _run(monkeypatch, function, collection: _Collection):
+    # setattr rather than mock.patch: patching the module's `db` INTROSPECTS the lazy client proxy
+    # (`_is_async_obj`), which resolves a real Firestore client and reaches for ambient credentials.
+    monkeypatch.setattr(llm_usage, 'db', _Db(collection))
+    return function('test-user')
+
+
+def test_the_usage_summary_bounds_its_scan_with_a_key(monkeypatch):
+    collection = _Collection([_Doc('2026-01-02', {'chat': {'m': {'input_tokens': 1}}})])
+
+    _run(monkeypatch, llm_usage.get_usage_summary, collection)
+
+    field, op, value = collection.filters[0]
+    assert (field, op) == ('__name__', '>=')
+    assert not isinstance(
+        value, str
+    ), 'a string here is rejected by Firestore with 400 __key__ filter value must be a Key'
+    assert collection.requested_documents, 'the cutoff must be resolved to a reference on this collection'
+    assert value is collection.references[collection.requested_documents[0]]
+
+
+def test_the_plan_usage_report_bounds_its_scan_with_a_key(monkeypatch):
+    collection = _Collection([_Doc('2026-01-02', {'plan_usage': {}})])
+
+    _run(monkeypatch, llm_usage.get_plan_usage_report, collection)
+
+    field, op, value = collection.filters[0]
+    assert (field, op) == ('__name__', '>=')
+    assert not isinstance(value, str)
+    assert value is collection.references[collection.requested_documents[0]]
+
+
+def test_the_cutoff_reference_still_names_a_date(monkeypatch):
+    """The bound is unchanged — only its type is. A reference to some other id would silently widen or
+    narrow the window."""
+    import re
+
+    collection = _Collection([])
+    _run(monkeypatch, llm_usage.get_usage_summary, collection)
+
+    assert re.fullmatch(r'\d{4}-\d{2}-\d{2}', collection.requested_documents[0])


### PR DESCRIPTION
…ised on every call

`get_usage_summary` and `get_plan_usage_report` bound their scan with `where("__name__", ">=", cutoff_id)`, where `cutoff_id` is a date string like `2026-01-01`. Firestore requires a Key there:

    google.api_core.exceptions.InvalidArgument: 400 __key__ filter value must be a Key

Measured against the Firestore emulator: both functions raise, for every user, every time. The `__name__` field is fine — the value's TYPE is not.

The document ids ARE the dates, so the cutoff is simply `usage_collection.document(cutoff_id)`. The window is unchanged; only the type is.

Worth knowing for whoever reviews this: fixing it alone makes `get_usage_summary` return `{}` rather than raise, because a second, independent defect keeps the counters from ever nesting (a sibling PR: these documents are written with `set(merge=True)` and dotted keys, which Firestore stores as literal field names). With both applied, the same call against the emulator returns `{'chat': {'input_tokens': 5, 'output_tokens': 3, 'call_count': 1}}`. Either PR stands alone; neither restores the feature by itself.

One observation not addressed here, to keep this change to one thing: once the counters do nest, `_aggregate_summary` also reports `plan_usage` as if it were a feature (`{'input_tokens': 0, ...}`), because it walks every top-level map. That is a separate line and a separate decision.

Verification
  emulator, before: InvalidArgument 400 __key__ filter value must be a Key
  emulator, after:  the query runs and streams the in-window documents
  new tests/unit/test_llm_usage_name_filter_takes_a_key.py 3 passed; passing the bare string again
    fails all 3
  tests/unit/test_llm_usage_db.py 19 - test_llm_usage_tracker.py 18 - test_llm_usage_endpoints.py 2

<!-- Keep this short and honest. Reviewers read the Verification section first. -->

## What changed and why

<!-- One or two sentences. Link the issue if there is one. -->

## Product invariants affected

<!-- Name locked invariant IDs this PR touches (e.g. INV-CHAT-1), or "none".
     Registry: docs/product/invariants/ — required when changing paths listed
     on a locked invariant. -->

## How it was verified

<!-- The commands you ran and what they showed. Exercising the real user-facing
     path counts as verification; compiling or lint passing does not.
     If something could not be verified, say so explicitly. -->

## Tests

<!-- Bug fix: point to the regression test that would have caught the bug.
     Feature: point to the tests for the core path and main error path.
     No test change: explain why none was needed. -->

## Failure class (fixes)

<!-- Every `fix:` commit needs this exact, machine-validated declaration.
     Use `scripts/failure-class prepare` or `explain` to choose a class.
     `harden:` commits may cite a class but do not need a declaration. -->

Failure-Class: none

## Failure-class transition narrative (only when needed)

<!-- Required only when declaring `new`, changing a class's canonical prevention
     primitive/owner, or making a registry-only lifecycle transition. A dormant
     transition sets `status: dormant` and an ISO-8601 `dormant_since`; a reopen
     sets `status: open` and removes `dormant_since`. Make that transition in a
     separate PR, never in the instance-fix PR. State the violated contract, the
     canonical guard, and the supporting evidence. Delete this section for an
     ordinary instance fix. -->

## New guards (only when adding a check or ratchet)

<!-- Cite the real merged PR or incident this guard would have caught, then answer
     in one sentence: why is this not a shared primitive instead? Delete this
     section when no check or ratchet is added. -->

## Scoped cleanups (optional)

<!-- Related fixes you made along the way (see AGENTS.md → "Leave It Better
     Than You Found It"). Each should be its own commit and verifiable. -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


