### PR TITLE
test(backend): stub with_rate_limit so test_task_sharing can be colle…

### DIFF
--- a/backend/tests/unit/test_task_sharing.py
+++ b/backend/tests/unit/test_task_sharing.py
@@ -123,6 +123,11 @@ utils_users_mod.get_user_display_name = MagicMock(return_value="TestUser")
 _stub_module("utils.other")
 _stub_module("utils.other.endpoints")
 sys.modules["utils.other.endpoints"].get_current_user_uid = MagicMock()
+# The list route wraps its auth dependency in the rate-limit decorator at MODULE level
+# (routers/action_items.py), so the stub has to carry it or importing the router raises before a
+# single test runs. Identity rather than a MagicMock: the return value IS the FastAPI dependency,
+# and a MagicMock there fails signature inspection further in.
+sys.modules["utils.other.endpoints"].with_rate_limit = lambda dependency, _policy: dependency
 
 # The action-items router imports the list-read budget seam at module level
 # (#11831). Delegate the stubbed submodule to the real (stdlib-only) module so


### PR DESCRIPTION
…cted

tests/unit/test_task_sharing.py fails at COLLECTION on main:

    tests/unit/test_task_sharing.py:144: in <module>
        import routers.action_items as action_items_router
    routers/action_items.py:362: in <module>
        uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "action_items:list")),
    AttributeError: module 'utils.other.endpoints' has no attribute 'with_rate_limit'

The list route started wrapping its auth dependency in the rate-limit decorator at module level, and this file stubs utils.other.endpoints with only get_current_user_uid. Nothing in the file runs -- all 30 tests are lost, and the failure is a collection error rather than a test failure, so it does not look like a broken assertion.

It is invisible to a changed-file selector: the PR that added the decorator touched routers/action_items.py and utils/other/endpoints.py, not this test, so the selection never included it. Found by running the whole backend suite file-by-file.

The stub returns the dependency itself rather than a MagicMock: the decorator's return value IS the FastAPI dependency, and a MagicMock there fails signature inspection further in.

Verification: tests/unit/test_task_sharing.py -> 30 passed (was: 1 collection error).

<!-- Keep this short and honest. Reviewers read the Verification section first. -->

## What changed and why

<!-- One or two sentences. Link the issue if there is one. -->

## Product invariants affected

<!-- Name locked invariant IDs this PR touches (e.g. INV-CHAT-1), or "none".
     Registry: docs/product/invariants/ — required when changing paths listed
     on a locked invariant. -->

## How it was verified

<!-- The commands you ran and what they showed. Exercising the real user-facing
     path counts as verification; compiling or lint passing does not.
     If something could not be verified, say so explicitly. -->

## Tests

<!-- Bug fix: point to the regression test that would have caught the bug.
     Feature: point to the tests for the core path and main error path.
     No test change: explain why none was needed. -->

## Failure class (fixes)

<!-- Every `fix:` commit needs this exact, machine-validated declaration.
     Use `scripts/failure-class prepare` or `explain` to choose a class.
     `harden:` commits may cite a class but do not need a declaration. -->

Failure-Class: none

## Failure-class transition narrative (only when needed)

<!-- Required only when declaring `new`, changing a class's canonical prevention
     primitive/owner, or making a registry-only lifecycle transition. A dormant
     transition sets `status: dormant` and an ISO-8601 `dormant_since`; a reopen
     sets `status: open` and removes `dormant_since`. Make that transition in a
     separate PR, never in the instance-fix PR. State the violated contract, the
     canonical guard, and the supporting evidence. Delete this section for an
     ordinary instance fix. -->

## New guards (only when adding a check or ratchet)

<!-- Cite the real merged PR or incident this guard would have caught, then answer
     in one sentence: why is this not a shared primitive instead? Delete this
     section when no check or ratchet is added. -->

## Scoped cleanups (optional)

<!-- Related fixes you made along the way (see AGENTS.md → "Leave It Better
     Than You Found It"). Each should be its own commit and verifiable. -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

