### PR TITLE
fix(app): stop retrying a dead speech-profile socket, offer skip instead

### DIFF
--- a/app/lib/pages/onboarding/speech_profile_widget.dart
+++ b/app/lib/pages/onboarding/speech_profile_widget.dart
@@ -252,6 +252,27 @@ class _SpeechProfileWidgetState extends State<SpeechProfileWidget> with TickerPr
                   ),
                   barrierDismissible: false,
                 );
+              } else if (error == 'STT_UNAVAILABLE') {
+                // The provider already gave up reconnecting after repeated
+                // 1011 closes with no captured speech, so offer the same
+                // way out as the "Skip for now" link instead of a "Try
+                // again" that would only restart the same failing loop.
+                showDialog(
+                  context: context,
+                  builder: (c) => getDialog(
+                    context,
+                    () {
+                      provider.close();
+                      widget.onSkip();
+                    },
+                    () {},
+                    context.l10n.connectionLost,
+                    context.l10n.connectionLostDesc,
+                    okButtonText: context.l10n.skipForNow,
+                    singleButton: true,
+                  ),
+                  barrierDismissible: false,
+                );
               }
             },
             child: Column(

--- a/app/lib/pages/speech_profile/page.dart
+++ b/app/lib/pages/speech_profile/page.dart
@@ -192,7 +192,7 @@ class _SpeechProfilePageState extends State<SpeechProfilePage> with TickerProvid
                   ),
                   barrierDismissible: false,
                 );
-              } else if (error == 'SOCKET_DISCONNECTED' || error == 'SOCKET_ERROR') {
+              } else if (error == 'SOCKET_DISCONNECTED' || error == 'SOCKET_ERROR' || error == 'STT_UNAVAILABLE') {
                 showDialog(
                   context: context,
                   builder: (c) => getDialog(

--- a/app/lib/providers/speech_profile_provider.dart
+++ b/app/lib/providers/speech_profile_provider.dart
@@ -55,6 +55,13 @@ class SpeechProfileProvider extends ChangeNotifier
   Timer? _reconnectTimer;
   bool _reconnecting = false;
 
+  /// Consecutive closes with code 1011 (server-side STT failure) while no
+  /// user speech has been captured yet. This combination means the STT
+  /// backend is down, not that the socket hiccuped, so retrying it forever
+  /// only spins in place — see _maxSttUnavailableCloses below.
+  int _sttUnavailableCloseCount = 0;
+  static const int _maxSttUnavailableCloses = 3;
+
   bool isInitialising = false;
   bool isInitialised = false;
 
@@ -516,6 +523,14 @@ class SpeechProfileProvider extends ChangeNotifier
     Logger.debug('Speech profile socket closed with code: $closeCode');
     // Only notify error if we're still recording and not completed
     if (startedRecording && !profileCompleted && !uploadingProfile) {
+      final sttUnavailable = closeCode == 1011 && segments.isEmpty;
+      _sttUnavailableCloseCount = sttUnavailable ? _sttUnavailableCloseCount + 1 : 0;
+      if (sttUnavailable && _sttUnavailableCloseCount >= _maxSttUnavailableCloses) {
+        _reconnectTimer?.cancel();
+        _reconnectTimer = null;
+        notifyError('STT_UNAVAILABLE');
+        return;
+      }
       notifyError('SOCKET_DISCONNECTED');
       _scheduleReconnect();
     }

--- a/app/test/providers/speech_profile_provider_test.dart
+++ b/app/test/providers/speech_profile_provider_test.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/backend/schema/transcript_segment.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/providers/speech_profile_provider.dart';
 import 'package:omi/services/services.dart';
@@ -168,6 +169,95 @@ void main() {
         async.elapse(const Duration(seconds: 30));
 
         expect(provider.openCalls, 0, reason: 'onboarding already finished; nothing to reconnect');
+
+        provider.dispose();
+      });
+    });
+  });
+
+  // Regression coverage: closeCode 1011 (server-side STT failure) with no
+  // user speech captured yet means the STT backend is down, not that the
+  // socket hiccuped. Before this fix, every such close scheduled another 5s
+  // reconnect forever, spamming the "connection lost" dialog (see
+  // speech_profile_widget.dart/page.dart) with no way out except force-
+  // quitting, even though "Skip for now" sits right next to it.
+  group('speech-profile socket gives up when STT is unavailable', () {
+    test('stops reconnecting and surfaces STT_UNAVAILABLE after repeated 1011 closes', () {
+      fakeAsync((async) {
+        final provider = _CountingSpeechProfileProvider();
+        provider.usePhoneMic = true;
+        provider.updateStartedRecording(true);
+
+        provider.onClosed(1011);
+        expect(provider.error, 'SOCKET_DISCONNECTED');
+
+        provider.onClosed(1011);
+        expect(provider.error, 'SOCKET_DISCONNECTED');
+
+        provider.onClosed(1011);
+        expect(
+          provider.error,
+          'STT_UNAVAILABLE',
+          reason: 'third consecutive 1011 with no captured speech means STT is down; keep retrying cannot fix that',
+        );
+
+        async.elapse(const Duration(seconds: 30));
+        expect(provider.openCalls, 0, reason: 'must not keep scheduling reconnects once STT is deemed unavailable');
+
+        provider.dispose();
+      });
+    });
+
+    test('does not give up on an ordinary disconnect that is not a 1011 STT failure', () {
+      fakeAsync((async) {
+        final provider = _CountingSpeechProfileProvider();
+        provider.usePhoneMic = true;
+        provider.updateStartedRecording(true);
+
+        provider.onClosed(1006);
+        provider.onClosed(1006);
+        provider.onClosed(1006);
+
+        expect(provider.error, 'SOCKET_DISCONNECTED', reason: 'code 1006 is a generic drop, not the STT-down signal');
+
+        async.elapse(const Duration(seconds: 5));
+        expect(provider.openCalls, 1, reason: 'an ordinary disconnect must still keep retrying');
+
+        provider.dispose();
+      });
+    });
+
+    test('does not give up once real speech has been captured', () {
+      fakeAsync((async) {
+        final provider = _CountingSpeechProfileProvider();
+        provider.usePhoneMic = true;
+        provider.updateStartedRecording(true);
+
+        provider.onClosed(1011);
+        provider.onClosed(1011);
+
+        // Simulate captured speech directly rather than going through
+        // onSegmentReceived, which also touches the WavBytesUtil that
+        // initialise() (not exercised by this test) normally sets up.
+        provider.segments.add(
+          TranscriptSegment(
+            id: '1',
+            text: 'hello',
+            speaker: 'SPEAKER_1',
+            isUser: true,
+            personId: null,
+            start: 0,
+            end: 1,
+            translations: [],
+          ),
+        );
+
+        provider.onClosed(1011);
+        expect(
+          provider.error,
+          'SOCKET_DISCONNECTED',
+          reason: 'speech was captured, so STT is actually working; a later 1011 must not short-circuit to skip',
+        );
 
         provider.dispose();
       });


### PR DESCRIPTION
## What changed and why

`closeCode` 1011 with zero captured user segments means the onboarding speech-profile
socket's STT backend is down server-side, not that the socket merely hiccuped. The reconnect
loop added in #11704 retried this every 5s forever: each failed reconnect re-triggers
`onClosed`, which re-shows the "Connection Lost" dialog (`speech_profile_widget.dart` /
`page.dart`) and reschedules another attempt, even though the same screen already has a
working "Skip for now" link (`speech_profile_widget.dart:487-496`) right next to it.

After 3 consecutive 1011 closes with no captured speech, `SpeechProfileProvider` now stops
scheduling reconnects and surfaces a distinct `STT_UNAVAILABLE` error instead of
`SOCKET_DISCONNECTED`. The onboarding widget routes that to the existing skip path
(`provider.close()` + `widget.onSkip()`) instead of a dialog whose only button just popped
the screen without marking the step skipped.

## Product invariants affected

none

## How it was verified

- `flutter test test/providers/speech_profile_provider_test.dart` — 7/7 passed, including
  3 new regression tests (gives up and surfaces `STT_UNAVAILABLE` after 3×1011-with-no-speech;
  keeps retrying on an ordinary 1006 disconnect; does not give up once real speech was already
  captured).
- `dart format --line-length 120 --set-exit-if-changed` on the 4 changed files — clean.
- `flutter analyze` on the 4 changed files — no issues found.

## Tests

Bug fix — regression tests added in `test/providers/speech_profile_provider_test.dart`
covering the new give-up threshold, that an ordinary disconnect is unaffected, and that
already-captured speech prevents a false give-up.

## Failure class (fixes)

Failure-Class: none

## Scoped cleanups (optional)

none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

