### PR TITLE
fix(app): stop a custom-STT hiccup from tearing down the transcription socket

### DIFF
--- a/app/lib/pages/conversations/widgets/processing_capture.dart
+++ b/app/lib/pages/conversations/widgets/processing_capture.dart
@@ -44,7 +44,7 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     _offlineTicker = Timer.periodic(const Duration(seconds: 1), (_) async {
       if (!mounted) return;
       final provider = context.read<CaptureProvider>();
-      if (provider.offlineRecordingStartedAt != null) {
+      if (provider.offlineRecordingStartedAt != null || provider.customSttBufferingDuration != null) {
         setState(() {});
       }
       _offlineTick++;
@@ -280,10 +280,17 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     } else if (!isHavingRecordingDevice && !isUsingPhoneMic) {
       stateText = "";
     } else if (isUsingPhoneMic || isHavingRecordingDevice) {
+      final bufferingFor = captureProvider.customSttBufferingDuration;
       if (captureProvider.terminalTranscriptionFailure != null) {
         // Audio remains in the WAL while reconnecting, but the server has
         // explicitly said live STT is unavailable. Do not claim "Listening".
         stateText = context.l10n.transcriptionUnavailable;
+        statusIndicator = const PausedStatusIndicator();
+      } else if (bufferingFor != null) {
+        // Custom STT endpoint unreachable. Audio keeps recording
+        // and buffering locally (see PurePollingSocket) — say so instead of
+        // silently claiming "Listening" while nothing is being transcribed.
+        stateText = _customSttBufferingText(bufferingFor);
         statusIndicator = const PausedStatusIndicator();
       } else {
         // Show "Listening" for all active recording states — WAL ensures audio is
@@ -333,6 +340,13 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     );
   }
 
+  // Short status text for how long the custom STT endpoint has
+  // been unreachable while audio keeps recording and buffering locally.
+  String _customSttBufferingText(Duration bufferingFor) {
+    if (bufferingFor.inMinutes < 1) return 'Offline, buffering';
+    return 'Offline, buffering ${bufferingFor.inMinutes}m';
+  }
+
   Widget _buildUnifiedRecordingUI(CaptureProvider provider, Widget? header) {
     bool isDeviceRecording = provider.havingRecordingDevice &&
         (provider.recordingState == RecordingState.deviceRecord || provider.recordingState == RecordingState.pause);
@@ -364,6 +378,7 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
       isPaused = _isPhoneMicPaused || provider.isPaused || isAudioInterrupted;
     }
     final hasTerminalTranscriptionFailure = provider.terminalTranscriptionFailure != null;
+    final bufferingFor = provider.customSttBufferingDuration;
 
     // Determine if this is an OmiGlass-type device (captures photos)
     bool hasPhotos = provider.photos.isNotEmpty;
@@ -375,9 +390,13 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
             ? (isDeviceRecording ? context.l10n.muted : context.l10n.paused)
             : hasTerminalTranscriptionFailure
                 ? context.l10n.transcriptionUnavailable
-                : hasPhotos
-                    ? 'Capturing'
-                    : context.l10n.listening;
+                // Custom STT endpoint unreachable, audio still buffering
+                // locally (see customSttBufferingDuration / PurePollingSocket).
+                : bufferingFor != null
+                    ? _customSttBufferingText(bufferingFor)
+                    : hasPhotos
+                        ? 'Capturing'
+                        : context.l10n.listening;
 
     // When recording is active, show the unified UI design
     if (isDeviceRecording || isPhoneRecording) {

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -119,6 +119,27 @@ class CaptureController extends ChangeNotifier
   MessageServiceStatusEvent? _terminalTranscriptionFailure;
   MessageServiceStatusEvent? get terminalTranscriptionFailure => _terminalTranscriptionFailure;
 
+  // When custom STT is configured, its polling socket keeps
+  // buffering audio locally and retrying instead of tearing the transcription
+  // socket down on every failure (see PurePollingSocket). Surface that local
+  // state here so the recording UI can show "offline, buffering" instead of
+  // silently showing "Listening" while nothing is actually being transcribed.
+  PurePollingSocket? get _activeCustomSttPollingSocket {
+    final socket = _socket?.socket;
+    if (socket is CompositeTranscriptionSocket) {
+      final primary = socket.primarySocket;
+      return primary is PurePollingSocket ? primary : null;
+    }
+    return socket is PurePollingSocket ? socket : null;
+  }
+
+  /// How long the custom STT endpoint has been unreachable, or null if it is
+  /// not in use or is currently healthy.
+  Duration? get customSttBufferingDuration {
+    final since = _activeCustomSttPollingSocket?.bufferingSince;
+    return since == null ? null : DateTime.now().difference(since);
+  }
+
   // Phone mic WAL: buffer for splitting variable-sized PCM chunks into fixed-size frames
   bool _phoneMicWalActive = false;
 
@@ -859,9 +880,8 @@ class CaptureController extends ChangeNotifier
       onButtonReceived: (List<int> value) {
         final snapshot = List<int>.from(value);
         if (snapshot.isEmpty || snapshot.length < 4) return;
-        var buttonState = ByteData.view(
-          Uint8List.fromList(snapshot.sublist(0, 4).reversed.toList()).buffer,
-        ).getUint32(0);
+        var buttonState =
+            ByteData.view(Uint8List.fromList(snapshot.sublist(0, 4).reversed.toList()).buffer).getUint32(0);
         Logger.debug("device button $buttonState");
 
         // Intercept for interactive device onboarding

--- a/app/lib/services/sockets/pure_polling.dart
+++ b/app/lib/services/sockets/pure_polling.dart
@@ -16,12 +16,18 @@ class AudioPollingConfig {
   final int minBufferSizeBytes;
   final String? serviceId;
   final IAudioTranscoder? transcoder;
+  // Ceiling on how much unflushed audio we hold in memory
+  // while the custom STT endpoint is unreachable. ~10 minutes of 16kHz/16-bit
+  // mono PCM (32000 B/s); oldest frames are dropped past this to keep memory
+  // bounded during a long outage instead of buffering forever.
+  final int maxBufferBytes;
 
   const AudioPollingConfig({
     this.bufferDuration = const Duration(seconds: 3),
     this.minBufferSizeBytes = 8000,
     this.serviceId,
     this.transcoder,
+    this.maxBufferBytes = 19200000,
   });
 }
 
@@ -64,6 +70,18 @@ class PurePollingSocket implements IPureSocket {
   final List<Uint8List> _audioFrames = [];
   bool _isProcessing = false;
   double _audioOffsetSeconds = 0;
+
+  // Local buffering state, exposed so the recording UI can
+  // show "offline, buffering" instead of silently sitting on "Listening"
+  // while transcribe() keeps failing. Set on the first failed flush after a
+  // success, cleared on the next successful one.
+  DateTime? _bufferingSince;
+  int _consecutiveFailures = 0;
+
+  DateTime? get bufferingSince => _bufferingSince;
+  int get consecutiveFailures => _consecutiveFailures;
+  bool get isBuffering => _bufferingSince != null;
+  int get bufferedBytes => _totalBufferBytes;
 
   PurePollingSocket({required this.config, required this.sttProvider});
 
@@ -150,6 +168,8 @@ class PurePollingSocket implements IPureSocket {
     final serviceId = config.serviceId ?? 'Polling';
     try {
       final result = await sttProvider.transcribe(audioData, audioOffsetSeconds: _audioOffsetSeconds);
+      _bufferingSince = null;
+      _consecutiveFailures = 0;
       if (result != null && result.isNotEmpty) {
         if (result.segments.isNotEmpty) {
           _audioOffsetSeconds = result.segments.last.end;
@@ -163,9 +183,45 @@ class PurePollingSocket implements IPureSocket {
     } catch (e, trace) {
       CustomSttLogService.instance.error(serviceId, 'Transcription error: $e');
       DebugLogManager.logError(e, trace, 'polling_socket_transcription_error', {'service_id': serviceId});
-      onError(e, trace);
+      _consecutiveFailures++;
+      _bufferingSince ??= DateTime.now();
+      _requeueFrames(frames);
+      // Do NOT call onError()/propagate this as a fatal
+      // socket error here. sttProvider.transcribe() already retries
+      // transient failures internally; a failure this far up means the STT
+      // endpoint is genuinely unreachable right now. The old behavior
+      // reported this as a fatal error, which CompositeTranscriptionSocket
+      // treated as "tear down both sockets" — killing the healthy
+      // raw-audio/secondary channel too and forcing a full reconnect every
+      // time custom STT hiccuped. Instead: keep the frames buffered above
+      // (capped by maxBufferBytes) and let the next timer tick retry, so a
+      // transient outage is invisible and a real one just keeps buffering
+      // until the endpoint comes back.
     } finally {
       _isProcessing = false;
+    }
+  }
+
+  /// Puts frames that failed to transcribe back at the front of the buffer
+  /// (ahead of anything captured since the attempt started), trimming the
+  /// oldest audio if the combined buffer now exceeds [AudioPollingConfig.maxBufferBytes].
+  void _requeueFrames(List<Uint8List> frames) {
+    _audioFrames.insertAll(0, frames);
+
+    var droppedBytes = 0;
+    while (_totalBufferBytes > config.maxBufferBytes && _audioFrames.isNotEmpty) {
+      droppedBytes += _audioFrames.removeAt(0).length;
+    }
+    if (droppedBytes > 0) {
+      final serviceId = config.serviceId ?? 'Polling';
+      CustomSttLogService.instance.warning(
+        serviceId,
+        'Buffer cap exceeded while offline, dropped $droppedBytes bytes of oldest audio',
+      );
+      DebugLogManager.logWarning('polling_socket_buffer_overflow', {
+        'service_id': serviceId,
+        'dropped_bytes': droppedBytes,
+      });
     }
   }
 

--- a/app/lib/services/sockets/transcription_polling_service.dart
+++ b/app/lib/services/sockets/transcription_polling_service.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
 import 'package:omi/models/stt_response_schema.dart';
@@ -93,6 +93,16 @@ class SchemaBasedSttProvider implements ISttProvider {
   final SttFileUploadConfig? fileUploadConfig;
   final http.Client _client;
 
+  // A single custom-STT request used to hang for a full 60s
+  // before failing, which made every buffered chunk feel like a freeze
+  // during an outage. Fail fast and retry a couple of times with backoff
+  // instead — most transient blips (a dropped LAN packet, a slow cold
+  // start) resolve within a retry or two, and a real outage now surfaces in
+  // well under 60s per chunk instead of after it.
+  static const _requestTimeout = Duration(seconds: 10);
+  static const _maxAttempts = 3;
+  static const _retryBackoff = [Duration(seconds: 1), Duration(seconds: 2)];
+
   SchemaBasedSttProvider({
     required this.apiUrl,
     required this.schema,
@@ -103,8 +113,9 @@ class SchemaBasedSttProvider implements ISttProvider {
     String? requestType, // String version for unified config
     this.jsonBodyBuilder,
     this.fileUploadConfig,
+    @visibleForTesting http.Client? client,
   })  : requestBodyType = requestBodyType ?? SttRequestBodyType.fromString(requestType),
-        _client = http.Client();
+        _client = client ?? http.Client();
 
   factory SchemaBasedSttProvider.openAI({required String apiKey, String model = 'whisper-1', String language = 'en'}) {
     return SchemaBasedSttProvider(
@@ -277,6 +288,31 @@ class SchemaBasedSttProvider implements ISttProvider {
     }
   }
 
+  /// Retries [attempt] on network exceptions (including the 10s timeout
+  /// above) and 5xx responses, with a short backoff between tries. 4xx
+  /// responses are returned immediately — retrying a bad request/auth error
+  /// would not help. Rethrows/returns the last outcome once attempts run out.
+  Future<http.Response> _sendWithRetry(Future<http.Response> Function() attempt) async {
+    for (var i = 0; i < _maxAttempts; i++) {
+      final isLastAttempt = i == _maxAttempts - 1;
+      try {
+        final response = await attempt();
+        if (response.statusCode < 500 || isLastAttempt) {
+          return response;
+        }
+        CustomSttLogService.instance.warning(
+          'SchemaSTT',
+          'HTTP ${response.statusCode}, retrying (${i + 1}/$_maxAttempts)',
+        );
+      } catch (e) {
+        if (isLastAttempt) rethrow;
+        CustomSttLogService.instance.warning('SchemaSTT', 'Request failed ($e), retrying (${i + 1}/$_maxAttempts)');
+      }
+      await Future.delayed(_retryBackoff[i]);
+    }
+    throw StateError('unreachable');
+  }
+
   @override
   Future<SttTranscriptionResult?> transcribe(dynamic audioData, {double audioOffsetSeconds = 0}) async {
     final Uint8List audioBytes = audioData is Uint8List ? audioData : Uint8List.fromList(audioData);
@@ -292,8 +328,9 @@ class SchemaBasedSttProvider implements ISttProvider {
 
       switch (requestBodyType) {
         case SttRequestBodyType.rawBinary:
-          response =
-              await _client.post(uri, headers: defaultHeaders, body: audioBytes).timeout(const Duration(seconds: 60));
+          response = await _sendWithRetry(
+            () => _client.post(uri, headers: defaultHeaders, body: audioBytes).timeout(_requestTimeout),
+          );
           break;
 
         case SttRequestBodyType.jsonBase64:
@@ -301,19 +338,28 @@ class SchemaBasedSttProvider implements ISttProvider {
             throw Exception('jsonBodyBuilder required for jsonBase64 request type');
           }
           final audioInput = audioUrlFromUpload ?? base64Encode(audioBytes);
-          response = await _client
-              .post(uri, headers: defaultHeaders, body: jsonEncode(jsonBodyBuilder!(audioInput)))
-              .timeout(const Duration(seconds: 60));
+          response = await _sendWithRetry(
+            () => _client
+                .post(uri, headers: defaultHeaders, body: jsonEncode(jsonBodyBuilder!(audioInput)))
+                .timeout(_requestTimeout),
+          );
           break;
 
         case SttRequestBodyType.multipartForm:
-          final request = http.MultipartRequest('POST', uri)
-            ..headers.addAll(defaultHeaders)
-            ..fields.addAll(defaultFields)
-            ..files.add(http.MultipartFile.fromBytes(audioFieldName, audioBytes, filename: 'audio.wav'));
+          response = await _sendWithRetry(() async {
+            final request = http.MultipartRequest('POST', uri)
+              ..headers.addAll(defaultHeaders)
+              ..fields.addAll(defaultFields)
+              ..files.add(http.MultipartFile.fromBytes(audioFieldName, audioBytes, filename: 'audio.wav'));
 
-          final streamedResponse = await request.send().timeout(const Duration(seconds: 60));
-          response = await http.Response.fromStream(streamedResponse);
+            // BaseRequest.send() (no receiver) spins up its own
+            // throwaway http.Client() instead of using this provider's
+            // _client, bypassing both the injected test client and (in
+            // practice) any client-level config. Route it through _client
+            // like every other request path here.
+            final streamedResponse = await _client.send(request).timeout(_requestTimeout);
+            return http.Response.fromStream(streamedResponse);
+          });
           break;
       }
 

--- a/app/test/unit/pure_polling_test.dart
+++ b/app/test/unit/pure_polling_test.dart
@@ -1,0 +1,131 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/models/stt_result.dart';
+import 'package:omi/services/sockets/pure_polling.dart';
+import 'package:omi/services/sockets/pure_socket.dart';
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  test('a failed transcribe keeps the audio buffered and does not tear the socket down', () async {
+    final provider = _FakeSttProvider();
+    provider.enqueueError(Exception('connection refused'));
+    provider.enqueueSuccess(SttTranscriptionResult(segments: [SttSegment(text: 'hi', start: 0, end: 1)]));
+
+    final socket = PurePollingSocket(config: const AudioPollingConfig(minBufferSizeBytes: 1), sttProvider: provider);
+    final listener = _FakeListener();
+    socket.setListener(listener);
+
+    expect(await socket.connect(), isTrue);
+
+    socket.send(Uint8List.fromList([1, 2, 3]));
+    await socket.flushNow();
+
+    // The failed attempt must not be reported as a fatal socket error/close —
+    // that used to tear down the whole composite (including the healthy
+    // secondary/raw-audio socket) on every transient STT hiccup.
+    expect(listener.errors, isEmpty);
+    expect(listener.closes, isEmpty);
+    expect(socket.status, PureSocketStatus.connected);
+    expect(socket.isBuffering, isTrue);
+    expect(socket.bufferingSince, isNotNull);
+
+    // More audio arrives while still "offline".
+    socket.send(Uint8List.fromList([4, 5, 6]));
+    await socket.flushNow();
+
+    // The retry call must have seen both the requeued and the newly
+    // captured audio — nothing was dropped while offline.
+    expect(provider.receivedCalls.last, [1, 2, 3, 4, 5, 6]);
+    expect(listener.messages, hasLength(1));
+    expect(socket.isBuffering, isFalse);
+    expect(socket.bufferingSince, isNull);
+  });
+
+  test('keeps retrying on every subsequent flush while the endpoint stays down', () async {
+    final provider = _FakeSttProvider()..alwaysThrow(Exception('still down'));
+
+    final socket = PurePollingSocket(config: const AudioPollingConfig(minBufferSizeBytes: 1), sttProvider: provider);
+    socket.setListener(_FakeListener());
+    await socket.connect();
+
+    socket.send(Uint8List.fromList([1]));
+    await socket.flushNow();
+    socket.send(Uint8List.fromList([2]));
+    await socket.flushNow();
+    socket.send(Uint8List.fromList([3]));
+    await socket.flushNow();
+
+    expect(provider.receivedCalls, [
+      [1],
+      [1, 2],
+      [1, 2, 3],
+    ]);
+    expect(socket.bufferedBytes, 3);
+  });
+
+  test('trims the oldest buffered audio once past the configured cap', () async {
+    final provider = _FakeSttProvider()..alwaysThrow(Exception('still down'));
+
+    final socket = PurePollingSocket(
+      config: const AudioPollingConfig(minBufferSizeBytes: 1, maxBufferBytes: 5),
+      sttProvider: provider,
+    );
+    socket.setListener(_FakeListener());
+    await socket.connect();
+
+    for (final byte in [1, 2, 3, 4, 5, 6, 7]) {
+      socket.send(Uint8List.fromList([byte]));
+      await socket.flushNow();
+    }
+
+    expect(socket.bufferedBytes, lessThanOrEqualTo(5));
+    // Newest audio survives; oldest was dropped.
+    expect(provider.receivedCalls.last.last, 7);
+  });
+}
+
+class _FakeSttProvider implements ISttProvider {
+  final List<List<int>> receivedCalls = [];
+  final _behaviors = <Future<SttTranscriptionResult?> Function()>[];
+  Future<SttTranscriptionResult?> Function()? _default;
+
+  void enqueueError(Object error) => _behaviors.add(() => Future<SttTranscriptionResult?>.error(error));
+  void enqueueSuccess(SttTranscriptionResult result) => _behaviors.add(() async => result);
+  void alwaysThrow(Object error) => _default = () => Future<SttTranscriptionResult?>.error(error);
+
+  @override
+  Future<SttTranscriptionResult?> transcribe(Uint8List audioData, {double audioOffsetSeconds = 0}) {
+    receivedCalls.add(audioData.toList());
+    final behavior = _behaviors.isNotEmpty ? _behaviors.removeAt(0) : (_default ?? () async => null);
+    return behavior();
+  }
+
+  @override
+  void dispose() {}
+}
+
+class _FakeListener implements IPureSocketListener {
+  final List<Object> errors = [];
+  final List<int?> closes = [];
+  final List<dynamic> messages = [];
+  int connects = 0;
+
+  @override
+  void onConnected() => connects++;
+
+  @override
+  void onMessage(dynamic message) => messages.add(message);
+
+  @override
+  void onClosed([int? closeCode]) => closes.add(closeCode);
+
+  @override
+  void onError(Object err, StackTrace trace) => errors.add(err);
+}

--- a/app/test/unit/transcription_polling_service_retry_test.dart
+++ b/app/test/unit/transcription_polling_service_retry_test.dart
@@ -1,0 +1,109 @@
+import 'dart:typed_data';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:omi/models/stt_response_schema.dart';
+import 'package:omi/services/sockets/transcription_polling_service.dart';
+
+void main() {
+  final audio = Uint8List.fromList([1, 2, 3]);
+
+  SchemaBasedSttProvider providerWith(http.Client client) {
+    // Mirrors how the custom STT provider is actually configured
+    // (multipart_form is "the real path used for custom STT" per its
+    // provider config in stt_provider.dart).
+    return SchemaBasedSttProvider(
+      apiUrl: 'http://127.0.0.1:8080/inference',
+      schema: SttResponseSchema.openAI,
+      audioFieldName: 'file',
+      requestBodyType: SttRequestBodyType.multipartForm,
+      client: client,
+    );
+  }
+
+  test('retries a multipart request on 5xx and succeeds once the endpoint recovers', () {
+    fakeAsync((async) {
+      var calls = 0;
+      final client = MockClient((request) async {
+        calls++;
+        if (calls < 3) return http.Response('server error', 503);
+        return http.Response('{"segments": [{"text": "hi", "start": 0, "end": 1}]}', 200);
+      });
+
+      int? segmentCount;
+      providerWith(client).transcribe(audio).then((r) => segmentCount = r?.segments.length);
+
+      async.elapse(const Duration(seconds: 10));
+
+      expect(calls, 3);
+      expect(segmentCount, 1);
+    });
+  });
+
+  test('does not retry a 4xx response', () {
+    fakeAsync((async) {
+      var calls = 0;
+      final client = MockClient((request) async {
+        calls++;
+        return http.Response('bad request', 400);
+      });
+
+      var completed = false;
+      providerWith(client).transcribe(audio).then((_) => completed = true);
+
+      async.elapse(const Duration(seconds: 10));
+
+      expect(calls, 1);
+      expect(completed, isTrue);
+    });
+  });
+
+  test('gives up after the max attempts and rethrows', () {
+    fakeAsync((async) {
+      var calls = 0;
+      final client = MockClient((request) async {
+        calls++;
+        throw Exception('connection refused');
+      });
+
+      Object? error;
+      providerWith(client).transcribe(audio).catchError((e) {
+        error = e;
+        return null;
+      });
+
+      async.elapse(const Duration(seconds: 10));
+
+      expect(calls, 3);
+      expect(error, isNotNull);
+    });
+  });
+
+  test('a hanging endpoint fails well under the old 60s-per-chunk hang', () {
+    fakeAsync((async) {
+      var calls = 0;
+      final client = MockClient((request) async {
+        calls++;
+        // Never responds — exercises the per-attempt timeout instead of
+        // hanging for a real 60s like before this patch.
+        await Future.delayed(const Duration(minutes: 5));
+        return http.Response('{"segments": []}', 200);
+      });
+
+      Object? error;
+      providerWith(client).transcribe(audio).catchError((e) {
+        error = e;
+        return null;
+      });
+
+      // Old behavior needed 60s+ to fail a *single* attempt; 3 attempts at a
+      // 10s timeout plus backoff should all resolve well before 40s.
+      async.elapse(const Duration(seconds: 40));
+
+      expect(calls, 3);
+      expect(error, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## What changed and why

A single failed request to a custom STT endpoint used to be treated as fatal all the way
up the stack: `SchemaBasedSttProvider.transcribe()` had no retry and a 60s timeout, and
once it threw, `PurePollingSocket` discarded the buffered audio and reported it as a
fatal socket error. `CompositeTranscriptionSocket` reacts to *any* child socket error by
tearing down both sockets — so one slow/dropped custom-STT request also killed the
healthy raw-audio socket and forced a full transcription-socket reconnect. In practice
this meant every transient hiccup produced a small transcript gap, and a real outage
turned into a reconnect storm roughly every 60 seconds instead of a quiet local buffer.

- `SchemaBasedSttProvider` now retries a request up to 3 times with backoff on network
  errors/5xx (not 4xx, which won't be fixed by retrying) at a 10s per-attempt timeout
  instead of a single 60s attempt.
- The multipart request path called bare `MultipartRequest.send()`, which per
  `package:http` silently creates and discards a throwaway `http.Client()` instead of
  reusing the provider's own `_client` — routed it through `_client.send(request)`
  instead, which also makes the retry logic (and injecting a test client) actually work
  for the multipart path used by the custom STT provider.
- `PurePollingSocket` now requeues audio from a failed flush (capped by
  `maxBufferBytes`, oldest dropped first) instead of discarding it, and no longer reports
  a failed `transcribe()` call as a fatal socket error. It keeps buffering and retrying
  locally on the next timer tick, so a transient hiccup no longer cascades into tearing
  down the whole composite socket.
- `CaptureController`/the recording UI can now show how long custom STT has been
  unreachable ("Offline, buffering Nm") instead of silently claiming "Listening" while
  nothing is actually being transcribed.

## Product invariants affected

none

## How it was verified

- `flutter test test/unit/pure_polling_test.dart test/unit/transcription_polling_service_retry_test.dart`
  — 7/7 passed (3 new tests covering requeue-on-failure/no-teardown, continued retrying
  while an endpoint stays down, and the buffer cap; 4 new tests covering retry-on-5xx,
  no-retry-on-4xx, giving up after max attempts, and the per-attempt timeout).
- `flutter test test/unit/composite_transcription_socket_test.dart` — 8/8 passed
  (unchanged; confirms the composite's other behavior — raw-audio forwarding, secondary
  socket handling — is untouched).
- `dart format --line-length 120 --set-exit-if-changed` on the 4 changed files — clean.
- `flutter analyze` on the 4 changed files — no issues found.

## Tests

Bug fix — regression tests added in `test/unit/pure_polling_test.dart` (buffer
requeue/no-teardown/cap behavior, using a fake `ISttProvider`) and
`test/unit/transcription_polling_service_retry_test.dart` (retry/timeout behavior of the
real HTTP request path, using `package:http/testing.dart`'s `MockClient` inside
`fake_async` so no test relies on wall-clock delays).

## Failure class (fixes)

Failure-Class: none

## Scoped cleanups (optional)

none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

