### PR TITLE
fix(app): report why a phone call was refused instead of always blaming verification

### DIFF
--- a/app/lib/backend/http/api/phone_calls.dart
+++ b/app/lib/backend/http/api/phone_calls.dart
@@ -8,6 +8,40 @@ import 'package:omi/env/env.dart';
 import 'package:omi/utils/logger.dart';
 
 // ************************************************
+// ************** ERROR REPORTING *****************
+// ************************************************
+
+/// Human-readable reason out of a FastAPI error body, or null when the body
+/// carries none.
+///
+/// ``detail`` is deliberately untyped on the wire: most phone-call endpoints
+/// answer with a plain string, but the quota error answers with a map (see
+/// ``check_call_access`` in ``backend/utils/phone_calls.py``). Reading it as a
+/// string crashes on that map, so both shapes are handled here once.
+String? errorDetailMessage(String body) {
+  try {
+    final parsed = misc_wire.GeneratedErrorResponse.fromJson(jsonDecode(body) as Map<String, dynamic>);
+    final detail = parsed.detail;
+    if (detail is String) {
+      return detail.trim().isEmpty ? null : detail;
+    }
+    if (detail is Map) {
+      final code = detail['error'];
+      if (code == 'phone_call_quota_exceeded') {
+        final limit = detail['monthly_limit'];
+        return limit is int
+            ? 'Monthly call limit reached ($limit calls). It resets at the start of next month.'
+            : 'Monthly call limit reached. It resets at the start of next month.';
+      }
+      if (code is String && code.trim().isNotEmpty) {
+        return code;
+      }
+    }
+  } catch (_) {}
+  return null;
+}
+
+// ************************************************
 // *********** PHONE NUMBER MANAGEMENT ************
 // ************************************************
 
@@ -26,12 +60,10 @@ Future<Map<String, dynamic>?> verifyPhoneNumber(String phoneNumber) async {
     );
     return generated.toJson();
   }
-  try {
-    final body = misc_wire.GeneratedErrorResponse.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
-    if (body.detail != null) {
-      return {'error': body.detail};
-    }
-  } catch (_) {}
+  final detail = errorDetailMessage(response.body);
+  if (detail != null) {
+    return {'error': detail};
+  }
   return null;
 }
 
@@ -77,15 +109,23 @@ Future<bool> deleteVerifiedPhoneNumber(String phoneNumberId) async {
 // ************** TOKEN MANAGEMENT ****************
 // ************************************************
 
-Future<PhoneCallToken?> getPhoneCallToken() async {
+/// A call token, or the reason the backend refused to mint one.
+class PhoneCallTokenResult {
+  final PhoneCallToken? token;
+  final String? error;
+
+  const PhoneCallTokenResult({this.token, this.error});
+}
+
+Future<PhoneCallTokenResult> getPhoneCallToken() async {
   var response = await makeApiCall(url: '${Env.apiBaseUrl}v1/phone/token', headers: {}, method: 'POST', body: '');
-  if (response == null) return null;
+  if (response == null) return const PhoneCallTokenResult();
   Logger.debug('getPhoneCallToken: ${response.body}');
   if (response.statusCode == 200) {
     final generated = wire.GeneratedTokenResponse.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
-    return PhoneCallToken.fromGenerated(generated);
+    return PhoneCallTokenResult(token: PhoneCallToken.fromGenerated(generated));
   }
-  return null;
+  return PhoneCallTokenResult(error: errorDetailMessage(response.body));
 }
 
 // ************************************************

--- a/app/lib/providers/phone_call_provider.dart
+++ b/app/lib/providers/phone_call_provider.dart
@@ -235,11 +235,14 @@ class PhoneCallProvider extends ChangeNotifier {
     if (generation != _sessionGeneration) return false;
 
     // Get Twilio token
-    var token = await api.getPhoneCallToken();
+    var tokenResult = await api.getPhoneCallToken();
     if (generation != _sessionGeneration) return false;
+    var token = tokenResult.token;
     if (token == null) {
       _callState = PhoneCallState.idle;
-      _error = 'Failed to get call token. Verify your phone number first.';
+      // The backend refuses for several different reasons (no verified number, quota
+      // exhausted, plan without calling). Reporting its own reason beats guessing one.
+      _error = tokenResult.error ?? 'Failed to get call token. Please try again.';
       notifyListeners();
       return false;
     }
@@ -437,7 +440,7 @@ class PhoneCallProvider extends ChangeNotifier {
       if (generation != _sessionGeneration || !_sessionEnabled) return;
       if (_callState != PhoneCallState.active && _callState != PhoneCallState.ringing) return;
       Logger.info('PhoneCallProvider: refreshing call token');
-      var token = await api.getPhoneCallToken();
+      var token = (await api.getPhoneCallToken()).token;
       if (generation != _sessionGeneration || !_sessionEnabled) return;
       if (token != null) {
         await _nativeService.initialize(token.accessToken);

--- a/app/test/unit/phone_call_error_detail_test.dart
+++ b/app/test/unit/phone_call_error_detail_test.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/http/api/phone_calls.dart';
+
+void main() {
+  group('errorDetailMessage', () {
+    test('returns a string detail as-is', () {
+      final body = jsonEncode({'detail': 'No verified phone number found. Verify a number first.'});
+      expect(errorDetailMessage(body), 'No verified phone number found. Verify a number first.');
+    });
+
+    test('returns null for a blank string detail', () {
+      expect(errorDetailMessage(jsonEncode({'detail': '   '})), isNull);
+    });
+
+    test('renders the quota map instead of throwing on it', () {
+      final body = jsonEncode({
+        'detail': {
+          'error': 'phone_call_quota_exceeded',
+          'monthly_limit': 5,
+          'monthly_used': 5,
+          'reset_at': 1767225600,
+        },
+      });
+      expect(errorDetailMessage(body), contains('5 calls'));
+    });
+
+    test('falls back to the raw code for an unknown map detail', () {
+      final body = jsonEncode({
+        'detail': {'error': 'something_else'},
+      });
+      expect(errorDetailMessage(body), 'something_else');
+    });
+
+    test('returns null for a body without a detail', () {
+      expect(errorDetailMessage(jsonEncode({'message': 'nope'})), isNull);
+      expect(errorDetailMessage('not json at all'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
# What changed and why

**What's wrong**

Starting a call surfaces `Failed to get call token. Verify your phone number first.` for
*every* non-200 answer from `POST /v1/phone/token`. `getPhoneCallToken()` throws the response
body away and returns `null`, so the provider has nothing but a fixed guess to show.

That guess is wrong in every case except one. A user whose number *is* verified sees it when:

- the monthly free-tier quota is exhausted — `402` with
  `{'error': 'phone_call_quota_exceeded', ...}` (`check_call_access`, `backend/utils/phone_calls.py`);
- their plan doesn't include calling — `403 "Phone calls require a paid subscription"`;
- Twilio is misconfigured server-side — `500 "Failed to generate token: ..."`.

In all three, the app tells them to re-verify a number that is already verified.

There's a second, sharper edge on the same data. `startVerification` does
`result['error'] as String?`, but `detail` is untyped on the wire and the quota error answers
with a **map**. The cast throws a `TypeError` inside an un-awaited async path, so the
number-entry screen fails instead of explaining the quota.

**What this changes**

- `getPhoneCallToken()` returns a small `PhoneCallTokenResult` (token *or* the backend's own
  reason) instead of a bare nullable token; the provider shows that reason and keeps a neutral
  fallback (`Failed to get call token. Please try again.`) for the no-body case.
- One shared `errorDetailMessage(body)` reader handles both `detail` shapes — plain string and
  the quota map (rendered as `Monthly call limit reached (N calls). ...`) — so neither call
  site can trip over the map again.

No API surface, no string that a user could previously rely on, no behavior change on the
happy path.

## Product invariants affected

none

## How it was verified

- `flutter test test/unit/phone_call_error_detail_test.dart` — 5/5 green.
- Adjacent suites touching the same surfaces (`phone_number_input_test.dart`,
  `batch_recording_phone_test.dart`, `phone_mic_wal_test.dart`) — 81/81 green.
- `flutter analyze` on the changed files — clean apart from a pre-existing `avoid_print`
  not introduced by this change; `dart format --line-length 120` — clean.
- Not verified live: an end-to-end refused call against a backend answering 402/403/500
  (no funded Twilio account on the dev setup). The error-body shapes the tests encode are
  taken directly from `check_call_access` / the token route in `backend/utils/phone_calls.py`
  and `backend/routers/phone_calls.py`.

## Tests

`app/test/unit/phone_call_error_detail_test.dart` covers both `detail` shapes (plain string
and the quota map), a blank detail, an unknown map code, and a body with no detail — the
map-shaped `402` case is the regression test that would have caught the original
`TypeError`.

## Failure class (fixes)

Failure-Class: none
