### PR TITLE
feat(desktop-windows): add tray "Open Bar" fallback for the summon hotkey

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-08-tray-open-bar.json
+++ b/desktop/windows/changelog/unreleased/2026-08-tray-open-bar.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Added an \"Open Bar\" tray menu item to manually summon the companion bar — a fallback for when the global hotkey can't register (e.g. native Wayland on Linux)."
+  ]
+}

--- a/desktop/windows/changelog/unreleased/2026-08-tray-open-bar.json
+++ b/desktop/windows/changelog/unreleased/2026-08-tray-open-bar.json
@@ -1,5 +1,5 @@
 {
   "changes": [
-    "Added an \"Open Bar\" tray menu item to manually summon the companion bar — a fallback for when the global hotkey can't register (e.g. native Wayland on Linux)."
+    "Added a \"Toggle OMI Bar\" tray menu item to manually summon the companion bar — a fallback for when the global hotkey can't register (e.g. native Wayland on Linux)."
   ]
 }

--- a/desktop/windows/src/main/bar/window.test.ts
+++ b/desktop/windows/src/main/bar/window.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ----------- Module mocks (hoisted before all imports) -----------
+
+// vi.mock factories run before module imports, so refs that must be accessible
+// in both the factory and the test body need vi.hoisted().
+const { mockSend, mockFire } = vi.hoisted(() => ({
+  mockSend: vi.fn(),
+  mockFire: vi.fn()
+}))
+
+// Override the electron alias (set in vitest.config.ts) with a stub that
+// covers all the BrowserWindow methods createBarWindow() calls. The shared
+// stub only stubs the subset needed by pure-logic tests.
+vi.mock('electron', () => {
+  const win = {
+    setAlwaysOnTop: vi.fn(),
+    setIgnoreMouseEvents: vi.fn(),
+    setContentProtection: vi.fn(),
+    setOpacity: vi.fn(),
+    setBounds: vi.fn(),
+    getBounds: vi.fn(() => ({ x: -9999, y: -9999, width: 560, height: 400 })),
+    on: vi.fn(),
+    showInactive: vi.fn(),
+    loadURL: vi.fn(),
+    loadFile: vi.fn(),
+    isFocused: vi.fn(() => false),
+    isDestroyed: vi.fn(() => false),
+    webContents: { send: mockSend, on: vi.fn(), executeJavaScript: vi.fn() }
+  }
+  const BrowserWindow = vi.fn(() => win)
+  ;(BrowserWindow as unknown as Record<string, unknown>).getAllWindows = vi.fn(() => [])
+  return {
+    BrowserWindow,
+    ipcMain: { on: vi.fn(), handle: vi.fn(), removeAllListeners: vi.fn(), removeHandler: vi.fn() },
+    screen: {
+      getCursorScreenPoint: vi.fn(() => ({ x: 0, y: 0 })),
+      getDisplayNearestPoint: vi.fn(() => ({
+        id: 1,
+        bounds: { x: 0, y: 0, width: 1920, height: 1080 },
+        workArea: { x: 0, y: 0, width: 1920, height: 1040 },
+        scaleFactor: 1
+      }))
+    },
+    powerMonitor: { on: vi.fn() },
+    nativeImage: { createEmpty: () => ({}), createFromPath: () => ({}) },
+    app: { quit: vi.fn(), getPath: vi.fn(() => '/'), on: vi.fn(), getVersion: vi.fn(() => '0.0.0') },
+    globalShortcut: { register: vi.fn(), unregister: vi.fn(), isRegistered: vi.fn(() => false) },
+    shell: { openExternal: vi.fn() },
+    Menu: { buildFromTemplate: vi.fn(() => ({ popup: vi.fn() })) },
+    clipboard: { writeText: vi.fn() },
+    Notification: vi.fn()
+  }
+})
+
+vi.mock('@electron-toolkit/utils', () => ({ is: { dev: false } }))
+
+// Spy on the gesture machine so we can assert it is never entered by summonFromTray.
+vi.mock('./gesture', () => ({
+  SummonGesture: vi.fn().mockImplementation(() => ({
+    fire: mockFire,
+    dispose: vi.fn(),
+    endIfActive: vi.fn(),
+    get isActive() {
+      return false
+    }
+  }))
+}))
+
+// installBarContextMenu has a deep import chain (notify, voicePlaneIpc, insight,
+// notifications, Firebase, …). Stub the whole module so window.ts stays importable
+// without pulling in live network/auth dependencies.
+vi.mock('./barContextMenu', () => ({ installBarContextMenu: vi.fn() }))
+
+// ----------- Module under test -----------
+
+import { summonFromTray, setBarEnabled } from './window'
+
+describe('summonFromTray — PTT regression (PR #12074)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('never enters the gesture machine or emits bar:ptt when invoked as the tray callback', () => {
+    // Arm the bar — the tray item is only reachable when barEnabled is true.
+    setBarEnabled(true)
+
+    summonFromTray()
+
+    // Regression guard: the old code wired the tray item to handleSummonPress(),
+    // which routes through gesture.fire() → onGestureStart() → sendPtt('down').
+    // With no Space key physically held, the 1200ms gap timer fires onGestureEnd()
+    // with kind='hold' → sendPtt('up'), producing ~1s of unintended microphone
+    // capture. summonFromTray() bypasses the gesture machine entirely — it calls
+    // showBar()/hideBar() directly — so neither fire() nor bar:ptt must be touched.
+    expect(mockFire).not.toHaveBeenCalled()
+    expect(mockSend).not.toHaveBeenCalledWith('bar:ptt', expect.anything())
+  })
+})

--- a/desktop/windows/src/main/bar/window.ts
+++ b/desktop/windows/src/main/bar/window.ts
@@ -883,6 +883,19 @@ export function handleSummonPress(): void {
   gesture?.fire()
 }
 
+/** Toggle the bar from a non-keyboard source (e.g. tray menu item).
+ *  Applies tap UI behavior directly — peek when hidden, hide when cleanly
+ *  presented — without routing through the gesture machine or emitting PTT
+ *  phases. A tray click has no physical key to sample, so entering the
+ *  gesture state machine would start ~1 s of unintended microphone capture
+ *  via the GetAsyncKeyState sampler before the repeat-gap timer ends it. */
+export function summonFromTray(): void {
+  if (!barEnabled) return
+  broadcast('overlay:summoned')
+  if (isBarCleanlyPresented()) hideBar()
+  else showBar('peek', 'summon')
+}
+
 /** (Re)build the gesture machine for an accelerator — call at startup and
  *  after every rebind so hold detection tracks the current chord. */
 export function setSummonGestureAccelerator(accelerator: string): void {

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -44,6 +44,7 @@ import {
   registerBarIpc,
   destroyBar,
   handleSummonPress,
+  summonFromTray,
   setSummonGestureAccelerator,
   setBarEnabled,
   setPeekWatchSuspended,
@@ -1073,8 +1074,10 @@ app.whenReady().then(async () => {
     // Manual bar fallback: the bar is otherwise summon-only via the global
     // hotkey (see bar/window.ts), which can't register on native Wayland
     // (no XWayland grab semantics) — see AGENTS.md's Linux dev environment
-    // section. Fires the same gesture a hotkey tap would (toggles open/closed).
-    openBar: () => handleSummonPress(),
+    // section. Uses summonFromTray() rather than handleSummonPress() so the
+    // click does not enter the gesture machine or emit PTT phases — a tray
+    // click has no physical key to sample.
+    openBar: () => summonFromTray(),
     // Manual update check (mirrors Settings → About and Mac's "Check for Updates").
     // checkForUpdatesNow never throws; log the outcome for a manual tester.
     checkForUpdates: () => {

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -1070,6 +1070,11 @@ app.whenReady().then(async () => {
       surfaceMainWindow()
       withMainWindow((win) => win.webContents.send('tray:open-settings'))
     },
+    // Manual bar fallback: the bar is otherwise summon-only via the global
+    // hotkey (see bar/window.ts), which can't register on native Wayland
+    // (no XWayland grab semantics) — see AGENTS.md's Linux dev environment
+    // section. Fires the same gesture a hotkey tap would (toggles open/closed).
+    openBar: () => handleSummonPress(),
     // Manual update check (mirrors Settings → About and Mac's "Check for Updates").
     // checkForUpdatesNow never throws; log the outcome for a manual tester.
     checkForUpdates: () => {

--- a/desktop/windows/src/main/tray.ts
+++ b/desktop/windows/src/main/tray.ts
@@ -20,6 +20,9 @@ export interface TrayDeps {
   toggleListening: () => void
   /** Settings menu item — show the window and route to Settings. */
   openSettings: () => void
+  /** "Open Bar" menu item — manually summon the companion bar (fallback for
+   *  when the global hotkey can't register, e.g. native Wayland). */
+  openBar: () => void
   /** "Check for Updates" — run a manual update check (see updater.ts). */
   checkForUpdates: () => void
   /** "Screen Analysis" checkbox — flip the screenAnalysisEnabled master. The tray

--- a/desktop/windows/src/main/tray.ts
+++ b/desktop/windows/src/main/tray.ts
@@ -20,7 +20,7 @@ export interface TrayDeps {
   toggleListening: () => void
   /** Settings menu item — show the window and route to Settings. */
   openSettings: () => void
-  /** "Open Bar" menu item — manually summon the companion bar (fallback for
+  /** "Toggle OMI Bar" menu item — toggle the companion bar (fallback for
    *  when the global hotkey can't register, e.g. native Wayland). */
   openBar: () => void
   /** "Check for Updates" — run a manual update check (see updater.ts). */

--- a/desktop/windows/src/main/trayState.test.ts
+++ b/desktop/windows/src/main/trayState.test.ts
@@ -62,6 +62,7 @@ describe('buildTrayMenuTemplate', () => {
     openSettings: vi.fn(),
     checkForUpdates: vi.fn(),
     toggleScreenCapture: vi.fn(),
+    openBar: vi.fn(),
     quit: vi.fn()
   })
 
@@ -80,6 +81,7 @@ describe('buildTrayMenuTemplate', () => {
     expect(labels(items)).toEqual([
       'Screen Analysis',
       'Open Omi',
+      'Open Bar',
       'Pause listening',
       'Settings',
       'Check for Updates',
@@ -126,12 +128,14 @@ describe('buildTrayMenuTemplate', () => {
     ) as Item[]
     byLabel(items, 'Screen Analysis').click?.()
     byLabel(items, 'Open Omi').click?.()
+    byLabel(items, 'Open Bar').click?.()
     byLabel(items, 'Pause listening').click?.()
     byLabel(items, 'Settings').click?.()
     byLabel(items, 'Check for Updates').click?.()
     byLabel(items, 'Quit Omi').click?.()
     expect(actions.toggleScreenCapture).toHaveBeenCalledOnce()
     expect(actions.showMainWindow).toHaveBeenCalledOnce()
+    expect(actions.openBar).toHaveBeenCalledOnce()
     expect(actions.toggleListening).toHaveBeenCalledOnce()
     expect(actions.openSettings).toHaveBeenCalledOnce()
     expect(actions.checkForUpdates).toHaveBeenCalledOnce()

--- a/desktop/windows/src/main/trayState.test.ts
+++ b/desktop/windows/src/main/trayState.test.ts
@@ -81,7 +81,7 @@ describe('buildTrayMenuTemplate', () => {
     expect(labels(items)).toEqual([
       'Screen Analysis',
       'Open Omi',
-      'Open Bar',
+      'Toggle OMI Bar',
       'Pause listening',
       'Settings',
       'Check for Updates',
@@ -128,7 +128,7 @@ describe('buildTrayMenuTemplate', () => {
     ) as Item[]
     byLabel(items, 'Screen Analysis').click?.()
     byLabel(items, 'Open Omi').click?.()
-    byLabel(items, 'Open Bar').click?.()
+    byLabel(items, 'Toggle OMI Bar').click?.()
     byLabel(items, 'Pause listening').click?.()
     byLabel(items, 'Settings').click?.()
     byLabel(items, 'Check for Updates').click?.()

--- a/desktop/windows/src/main/trayState.ts
+++ b/desktop/windows/src/main/trayState.ts
@@ -53,6 +53,11 @@ export interface TrayMenuActions {
   toggleListening: () => void
   /** Show the window and route to Settings. */
   openSettings: () => void
+  /** Manually summon the top-edge companion bar — the only fallback on
+   *  platforms where the global hotkey can't register (e.g. native Wayland;
+   *  see desktop/windows/AGENTS.md's Linux dev environment section). Fires
+   *  the same gesture as a hotkey tap (toggles open/closed). */
+  openBar: () => void
   /** Run a manual update check (Mac's "Check for Updates…"). */
   checkForUpdates: () => void
   /** Flip the screen-analysis master. Labeled "Screen Analysis" on Windows: Mac's
@@ -69,7 +74,9 @@ export interface TrayMenuActions {
  * Menu.buildFromTemplate. Layout mirrors Mac's menu bar (OmiApp.swift): the
  * Screen Analysis toggle sits at the top and Check for Updates sits just before
  * Quit. `screenCaptureEnabled` drives the checkbox; `toggleLabel` is the
- * pause/resume label from describeTray.
+ * pause/resume label from describeTray. "Open Bar" has no Mac equivalent (the
+ * bar is Windows/Linux-only) — it's the manual fallback for platforms where
+ * the global summon hotkey can't register.
  */
 export function buildTrayMenuTemplate(
   opts: { toggleLabel: string; screenCaptureEnabled: boolean },
@@ -84,6 +91,7 @@ export function buildTrayMenuTemplate(
     },
     { type: 'separator' },
     { label: 'Open Omi', click: () => actions.showMainWindow() },
+    { label: 'Open Bar', click: () => actions.openBar() },
     { label: opts.toggleLabel, click: () => actions.toggleListening() },
     { type: 'separator' },
     { label: 'Settings', click: () => actions.openSettings() },

--- a/desktop/windows/src/main/trayState.ts
+++ b/desktop/windows/src/main/trayState.ts
@@ -74,7 +74,7 @@ export interface TrayMenuActions {
  * Menu.buildFromTemplate. Layout mirrors Mac's menu bar (OmiApp.swift): the
  * Screen Analysis toggle sits at the top and Check for Updates sits just before
  * Quit. `screenCaptureEnabled` drives the checkbox; `toggleLabel` is the
- * pause/resume label from describeTray. "Open Bar" has no Mac equivalent (the
+ * pause/resume label from describeTray. "Toggle OMI Bar" has no Mac equivalent (the
  * bar is Windows/Linux-only) — it's the manual fallback for platforms where
  * the global summon hotkey can't register.
  */
@@ -91,7 +91,7 @@ export function buildTrayMenuTemplate(
     },
     { type: 'separator' },
     { label: 'Open Omi', click: () => actions.showMainWindow() },
-    { label: 'Open Bar', click: () => actions.openBar() },
+    { label: 'Toggle OMI Bar', click: () => actions.openBar() },
     { label: opts.toggleLabel, click: () => actions.toggleListening() },
     { type: 'separator' },
     { label: 'Settings', click: () => actions.openSettings() },


### PR DESCRIPTION
## Summary
- The companion bar is summon-only via the global hotkey, which can't register on native Wayland (no XWayland grab semantics) — leaving no way to trigger it at all in that environment.
- Adds a tray menu item ("Toggle OMI Bar") as a fallback. Uses a new `summonFromTray()` function that applies the tap toggle directly (peek when hidden, hide when cleanly presented) without routing through the gesture machine or emitting `bar:ptt` phases.
- **Why not `handleSummonPress()`?** That routes through `gesture.fire()` → `onGestureStart()` → `sendPtt('down')` when a Windows key sampler is present. A tray click has no physical key to hold, so the 1200ms repeat-gap timer fires `onGestureEnd(kind='hold')` → `sendPtt('up')`, producing ~1s of unintended microphone capture on every tray click.

## Test plan
- [x] Unit tests in `trayState.test.ts`: menu structure, label, click routing
- [x] Regression test in `bar/window.test.ts`: enables bar, calls `summonFromTray()`, asserts `gesture.fire()` and `bar:ptt` are never touched
- [ ] Manual verification on native Wayland (no working global hotkey) that the tray item summons the bar

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)