### PR TITLE
fix(desktop-windows): stop the bar auto-retracting on native Wayland

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-08-bar-wayland-auto-retract.json
+++ b/desktop/windows/changelog/unreleased/2026-08-bar-wayland-auto-retract.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Fixed the companion bar auto-retracting to fully invisible ~3 seconds after every summon on native Wayland (Linux), regardless of an ongoing hover."
+  ]
+}

--- a/desktop/windows/src/main/bar/watchdog.test.ts
+++ b/desktop/windows/src/main/bar/watchdog.test.ts
@@ -5,6 +5,7 @@ import {
   barWatchPlan,
   barGestureSeesOpen,
   clickEdge,
+  corroboratedCursorInFootprint,
   type WatchdogInput
 } from './watchdog'
 
@@ -90,6 +91,22 @@ describe('evaluatePeekWatchdog — retract grace', () => {
       expect(s.retract).toBe(false)
       expect(s.outsideSince).toBe(null)
     }
+  })
+})
+
+describe('corroboratedCursorInFootprint — native-Wayland cursor-query fallback', () => {
+  it('trusts the renderer-reported hover even when the OS reading says outside', () => {
+    // screen.getCursorScreenPoint() is unreliable on native Wayland — a live
+    // renderer mouseenter must still keep the pill from starving hasBeenHovered.
+    expect(corroboratedCursorInFootprint(false, true)).toBe(true)
+  })
+
+  it('trusts the OS reading even when the renderer has not reported hover', () => {
+    expect(corroboratedCursorInFootprint(true, false)).toBe(true)
+  })
+
+  it('is false only when BOTH signals agree nothing is hovering', () => {
+    expect(corroboratedCursorInFootprint(false, false)).toBe(false)
   })
 })
 

--- a/desktop/windows/src/main/bar/watchdog.ts
+++ b/desktop/windows/src/main/bar/watchdog.ts
@@ -90,6 +90,28 @@ export function barGestureSeesOpen(s: {
   return s.visible && s.mode !== null && !s.hiding
 }
 
+/** Corroborate the OS cursor-in-footprint reading with the renderer's own
+ *  mouseenter-confirmed interactive state (`barInteractive` in window.ts, kept
+ *  live by the real `bar:setInteractive` IPC the renderer already sends on
+ *  genuine DOM mouseenter/leave). `screen.getCursorScreenPoint()` is unreliable
+ *  on native Wayland — the protocol doesn't let an app query the global pointer
+ *  position outside its own focused surface, unlike XWayland (see AGENTS.md's
+ *  Linux dev environment section) — which silently starved `hasBeenHovered` and
+ *  made every peek pill auto-retract after the fixed lingerMs regardless of a
+ *  real, ongoing hover (the window went fully invisible — opacity 0 — while
+ *  still mapped, which read as "the bar never shows anything"). OR-ing in the
+ *  renderer's own report can only make the watchdog LESS eager to retract: once
+ *  the cursor genuinely leaves, the renderer's real mouseleave flips
+ *  `barInteractive` back to false on its own, so this never wedges the pill
+ *  open past a real leave — it only rescues the case where the OS poll alone
+ *  never saw the hover at all. */
+export function corroboratedCursorInFootprint(
+  osReading: boolean,
+  rendererInteractive: boolean
+): boolean {
+  return osReading || rendererInteractive
+}
+
 /** Edge-detect a primary-button CLICK on the pill from a polled physical-button
  *  sample (main-side; the transparent overlay never receives real hardware
  *  mouse-downs for EITHER an external mouse or a touchpad — see clickTick in

--- a/desktop/windows/src/main/bar/window.ts
+++ b/desktop/windows/src/main/bar/window.ts
@@ -57,7 +57,8 @@ import {
   nextInteractivity,
   barWatchPlan,
   barGestureSeesOpen,
-  clickEdge
+  clickEdge,
+  corroboratedCursorInFootprint
 } from './watchdog'
 import { makeKeySampler, makePrimaryMouseButtonSampler } from './keyState'
 import { installBarContextMenu } from './barContextMenu'
@@ -627,7 +628,10 @@ function peekTick(): void {
     peekOutsideSince = null
     return
   }
-  const cursorInFootprint = isCursorInPeekFootprint(cursor, dl)
+  const cursorInFootprint = corroboratedCursorInFootprint(
+    isCursorInPeekFootprint(cursor, dl),
+    barInteractive
+  )
   if (cursorInFootprint) peekHasBeenHovered = true
   const { outsideSince, retract } = evaluatePeekWatchdog({
     suspended: peekWatchSuspended,


### PR DESCRIPTION
## Summary
- The peek-pill retract watchdog trusted `screen.getCursorScreenPoint()` as the sole signal for "has the cursor visited the pill" (`src/main/bar/watchdog.ts`). That API is unreliable on native Wayland (the protocol doesn't let an app query the global pointer position outside its own focused surface), so `hasBeenHovered` never armed and every peek pill retracted to opacity 0 after the fixed ~3s linger, regardless of a real ongoing hover — the window stayed mapped (visible to the compositor) but its content was permanently invisible.
- Fix corroborates the OS reading with the renderer's own `mouseenter`-confirmed interactivity signal (already relayed via the existing `bar:setInteractive` IPC), which only ever makes the watchdog less eager to retract.

## Verification
- Reproduced live via CDP against the running dev instance: the bar's DOM was captured mounted correctly ("Listening" label + orb) but stuck in the `.bar-slide-out` class (`opacity: 0`).
- Confirmed fixed by the reporter on real hardware (Asahi Fedora Remix aarch64 + niri): the pill now stays open and expands to the chat surface on click.

## Test plan
- [x] Unit tests added in `watchdog.test.ts`
- [x] Manually verified on native Wayland (Asahi Fedora Remix + niri)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

Failure-Class: none
