### PR TITLE
fix(desktop-windows): classify a permanent mic/loopback failure as terminal

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-08-mic-permanent-failure-classification.json
+++ b/desktop/windows/changelog/unreleased/2026-08-mic-permanent-failure-classification.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "A permanently missing/blocked microphone (no device, permission denied) no longer retries silently for minutes with no error shown — it's now classified as terminal, matching how quota/sign-in failures are already handled."
+  ]
+}

--- a/desktop/windows/src/renderer/src/capture/liveMicSession.ts
+++ b/desktop/windows/src/renderer/src/capture/liveMicSession.ts
@@ -277,7 +277,7 @@ export function startLiveMicSession(): LiveMicController {
             /* ignore */
           }
           handle = null
-          if (!isRetryableDropError((e as Error).message)) {
+          if (!isRetryableDropError((e as Error).message, (e as Error).name)) {
             // Quota/entitlement/sign-in error — reconnecting can't help. Surface it
             // now (no rescue: a quota-blocked account can't create conversations).
             // On a quota exhaustion this mirrored 'error' status drives the main

--- a/desktop/windows/src/renderer/src/capture/liveRescue.test.ts
+++ b/desktop/windows/src/renderer/src/capture/liveRescue.test.ts
@@ -75,6 +75,22 @@ describe('isRetryableDropError', () => {
     expect(isRetryableDropError('Omi transcription unavailable (not signed in)')).toBe(false)
     expect(isRetryableDropError('Omi v4/listen requires sign-in.')).toBe(false)
   })
+
+  it('does NOT retry a permanent mic/loopback source failure (no device, denied, unreadable)', () => {
+    // Live bug: enumerateDevices() found zero audio inputs on a real machine, so
+    // getUserMedia threw NotFoundError — the message alone ("Requested device not
+    // found") doesn't match any existing pattern, so only checking `name` catches
+    // it. Without this, a dead mic retried silently for the whole backoff budget.
+    expect(isRetryableDropError('Requested device not found', 'NotFoundError')).toBe(false)
+    expect(isRetryableDropError('Permission denied', 'NotAllowedError')).toBe(false)
+    expect(isRetryableDropError('Could not start source', 'NotReadableError')).toBe(false)
+    expect(isRetryableDropError('Overconstrained', 'OverconstrainedError')).toBe(false)
+  })
+
+  it('still retries an ordinary drop when a name is present but not a permanent one', () => {
+    expect(isRetryableDropError('socket dropped', 'AbortError')).toBe(true)
+    expect(isRetryableDropError('socket dropped', undefined)).toBe(true)
+  })
 })
 
 describe('toSyncSegments', () => {

--- a/desktop/windows/src/renderer/src/capture/liveRescue.ts
+++ b/desktop/windows/src/renderer/src/capture/liveRescue.ts
@@ -39,12 +39,32 @@ export function reconnectDelayJitteredMs(
   return Math.round(base + rand() * RECONNECT_JITTER_MS)
 }
 
+// getUserMedia/getDisplayMedia DOMException names for a PERMANENT source
+// failure (no device, permission denied, device unusable, constraints
+// impossible to satisfy) — see AudioSessionHost.ts's audio-source-error and
+// omiListenClient.ts, which relays the DOMException's `name` onto the Error it
+// hands to onError. Reconnecting the /v4/listen socket can never fix these:
+// the mic/loopback SOURCE is the problem, not the transport. Before this, only
+// the message text was checked, so a dead mic (e.g. no PipeWire source
+// enumerable — confirmed live via CDP: enumerateDevices() returned zero
+// audioinputs, getUserMedia threw NotFoundError) retried silently for the full
+// ~4.5min backoff budget with no error ever reaching the UI.
+const PERMANENT_SOURCE_ERROR_NAMES = new Set([
+  'NotFoundError',
+  'NotAllowedError',
+  'NotReadableError',
+  'OverconstrainedError'
+])
+
 /** Whether a transcription error is worth reconnecting for. Quota/entitlement
- *  exhaustion (1008 / trial_expired) and a missing sign-in are terminal —
- *  reconnecting just re-hits the same wall, so surface them at once instead of
- *  burning the whole backoff budget (~55s) first. Everything else (network drops,
- *  timeouts, transient server closes) is retryable. */
-export function isRetryableDropError(message: string): boolean {
+ *  exhaustion (1008 / trial_expired), a missing sign-in, and a permanent
+ *  mic/loopback source failure are terminal — reconnecting just re-hits the
+ *  same wall, so surface them at once instead of burning the whole backoff
+ *  budget (~55s) first. Everything else (network drops, timeouts, transient
+ *  server closes) is retryable. `name` is the source error's DOMException name
+ *  when available (omitted for backend/network drops, which have none). */
+export function isRetryableDropError(message: string, name?: string): boolean {
+  if (name && PERMANENT_SOURCE_ERROR_NAMES.has(name)) return false
   return !isQuotaExhaustedMessage(message) && !/not signed in|requires sign-in/i.test(message)
 }
 


### PR DESCRIPTION
## Summary
- `isRetryableDropError` only inspected the error message, never the source error's `DOMException` `name` — so a permanent `getUserMedia` failure (no device, permission denied, device unreadable) fell through the same path as an ordinary transient network drop and retried silently through the whole ~4.5min backoff budget (`MAX_RECONNECT_ATTEMPTS=10`), with no error ever reaching `captureLiveStore` / the UI.
- Fix: pass the error's `name` through (`AudioSessionHost.ts`'s `audio-source-error` already relays it) and treat `NotFoundError`/`NotAllowedError`/`NotReadableError`/`OverconstrainedError` as terminal, alongside the existing quota/sign-in cases.

## Verification
Reproduced live on real hardware via CDP against the running dev instance's capture window: `navigator.mediaDevices.enumerateDevices()` returned zero audioinputs and `getUserMedia({audio:true})` threw `NotFoundError` ("Requested device not found") — a genuinely permanent source failure (separately confirmed as a PipeWire/asahi-audio config gap on that machine, not an Omi bug). The message text alone never matched `isRetryableDropError`'s quota/sign-in patterns, so this exact case retried forever before the fix.

**Known follow-up (not bundled here):** even with this fix, a non-quota terminal error still has no UI surface — `maybeTriggerTranscriptionQuotaPopup` (`usageLimit.ts`) only reacts to quota messages, so `captureLiveStore`'s `'error'` status is otherwise silently dropped. That's a broader product decision (what should a generic recording-failure toast say, where does it render), filed separately.

## Test plan
- [x] Unit tests added in `liveRescue.test.ts`
- [x] Reproduced and verified fixed on real hardware with a permanently unavailable mic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

Failure-Class: none
