### PR TITLE
fix(desktop-windows): authorize the bar as a PTT command sender

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-08-ptt-bar-authorization.json
+++ b/desktop/windows/changelog/unreleased/2026-08-ptt-bar-authorization.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Fixed push-to-talk never actually starting from the top-edge bar: the bar's PTT commands (warm/start/release/drain/dispose/rebuild) were silently rejected by an authorization check written before PTT moved into the bar."
+  ]
+}

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -853,7 +853,11 @@ app.whenReady().then(async () => {
   registerCaptureBridge(
     getCaptureWc,
     () => (mainWindow && !mainWindow.isDestroyed() ? mainWindow.webContents : null),
-    isListenSessionOwnedBy
+    isListenSessionOwnedBy,
+    () => {
+      const bar = getBarWindow()
+      return bar && !bar.isDestroyed() ? bar.webContents : null
+    }
   )
   // Soak telemetry (inert unless OMI_SOAK=1): samples process metrics + listen
   // byte counters to userData/soak.jsonl for the 8h idle-soak verification.

--- a/desktop/windows/src/main/ipc/captureBridge.test.ts
+++ b/desktop/windows/src/main/ipc/captureBridge.test.ts
@@ -139,9 +139,26 @@ describe('canForwardRendererCaptureCommand', () => {
     ).toBe(false)
   })
 
-  it('allows UI controls only from the main window', () => {
-    expect(canForwardRendererCaptureCommand({ type: 'ptt-warm' }, 7, owns, 7)).toBe(true)
-    expect(canForwardRendererCaptureCommand({ type: 'ptt-warm' }, 8, owns, 7)).toBe(false)
+  it('allows main-only UI controls (live-view etc.) only from the main window', () => {
+    expect(canForwardRendererCaptureCommand({ type: 'live-view', active: true }, 7, owns, 7)).toBe(
+      true
+    )
+    expect(canForwardRendererCaptureCommand({ type: 'live-view', active: true }, 8, owns, 7)).toBe(
+      false
+    )
+  })
+
+  it('allows PTT controls from either the main window or the bar (usePushToTalk is bar-only)', () => {
+    expect(canForwardRendererCaptureCommand({ type: 'ptt-warm' }, 7, owns, 7, 42)).toBe(true) // main
+    expect(canForwardRendererCaptureCommand({ type: 'ptt-warm' }, 42, owns, 7, 42)).toBe(true) // bar
+    expect(canForwardRendererCaptureCommand({ type: 'ptt-warm' }, 8, owns, 7, 42)).toBe(false) // neither
+  })
+
+  it('does NOT extend the bar-window allowance to the main-only controls', () => {
+    // The bar is the sole PTT sender, but must not gain live-view/screen-view/etc.
+    expect(
+      canForwardRendererCaptureCommand({ type: 'live-view', active: true }, 42, owns, 7, 42)
+    ).toBe(false)
   })
 
   it('rejects unknown runtime commands instead of forwarding them', () => {

--- a/desktop/windows/src/main/ipc/captureBridge.ts
+++ b/desktop/windows/src/main/ipc/captureBridge.ts
@@ -79,7 +79,8 @@ export function canForwardRendererCaptureCommand(
   command: CaptureCommand,
   senderId: number,
   ownsListenSession: (sessionId: string, ownerId: number) => boolean,
-  mainWindowId?: number
+  mainWindowId?: number,
+  barWindowId?: number
 ): boolean {
   // Meeting capture is main-process policy. No renderer may bypass the detector
   // and consent flow by issuing these commands through the public preload API.
@@ -92,16 +93,23 @@ export function canForwardRendererCaptureCommand(
     case 'audio-start':
     case 'audio-stop':
       return ownsListenSession(command.sessionId, senderId)
-    // All remaining controls originate in the main UI. Keeping them off auxiliary
-    // renderers prevents a compromised toast/glow window from controlling capture.
-    case 'live-finalize':
-    case 'live-view':
+    // Push-to-talk UI lives in the top-edge bar, not the main window (it replaced
+    // the old acrylic overlay window — see bar/window.ts) — usePushToTalk.ts is
+    // called ONLY from bar components. The bar must be allowed to issue these, or
+    // every warm/release/start/drain/dispose/rebuild silently no-ops (a dropped
+    // console.warn, no UI error) and PTT capture never actually starts.
     case 'ptt-warm':
     case 'ptt-release':
     case 'ptt-start':
     case 'ptt-drain':
     case 'ptt-dispose':
     case 'ptt-rebuild':
+      return senderId === mainWindowId || senderId === barWindowId
+    // All remaining controls originate in the main UI only. Keeping them off
+    // auxiliary renderers prevents a compromised toast/glow/bar window from
+    // controlling capture.
+    case 'live-finalize':
+    case 'live-view':
     case 'screen-view':
     case 'assistant-speaking':
     case 'assistant-utterance':
@@ -129,11 +137,15 @@ export function emitCaptureEventFromMain(event: CaptureEvent, captureWcId: numbe
  * Wire the capture bridge. `getCaptureWc` returns the capture window's
  * webContents (or null before it exists / after teardown) — it's read live on
  * every message so a recreated capture window is picked up automatically.
+ * `getBarWc` authorizes the bar as a PTT command sender (see
+ * canForwardRendererCaptureCommand) — optional so callers/tests that don't
+ * care about PTT-from-the-bar can omit it.
  */
 export function registerCaptureBridge(
   getCaptureWc: () => WebContents | null,
   getMainWc: () => WebContents | null,
-  ownsListenSession: (sessionId: string, ownerId: number) => boolean
+  ownsListenSession: (sessionId: string, ownerId: number) => boolean,
+  getBarWc?: () => WebContents | null
 ): void {
   ipcMain.on('omi-capture:cmd', (e, cmd: CaptureCommand) => {
     const wc = getCaptureWc()
@@ -141,7 +153,17 @@ export function registerCaptureBridge(
     if (!cmd || typeof cmd !== 'object' || typeof cmd.type !== 'string') return
     const mainWc = getMainWc()
     const mainWindowId = mainWc && !mainWc.isDestroyed() ? mainWc.id : undefined
-    if (!canForwardRendererCaptureCommand(cmd, e.sender.id, ownsListenSession, mainWindowId)) {
+    const barWc = getBarWc?.()
+    const barWindowId = barWc && !barWc.isDestroyed() ? barWc.id : undefined
+    if (
+      !canForwardRendererCaptureCommand(
+        cmd,
+        e.sender.id,
+        ownsListenSession,
+        mainWindowId,
+        barWindowId
+      )
+    ) {
       console.warn('[capture] rejected unauthorized command:', cmd.type)
       return
     }


### PR DESCRIPTION
## Summary
- `canForwardRendererCaptureCommand` restricted `ptt-warm`/`release`/`start`/`drain`/`dispose`/`rebuild` to `senderId === mainWindowId` only. `usePushToTalk.ts` — the only caller of these commands — is used exclusively by bar components (`BarApp.tsx`, `BarChatSurface.tsx`, `BarHintStrip.tsx`); there is no main-window caller. The check predates the bar (comment: "all remaining controls originate in the main UI"), left over from when PTT lived in the old overlay window it replaced.
- Every PTT command the bar issued was therefore silently dropped (`console.warn('[capture] rejected unauthorized command: ptt-release')`, no renderer-visible error), so holding to talk from the bar never actually started the mic graph.
- Fix: the bar window is now an authorized sender for the PTT command group specifically. The other main-only commands (`live-view`, `live-finalize`, `screen-view`, `assistant-speaking`, `assistant-utterance`, `auth-changed`) are unaffected — grep confirms no bar component calls them.

## Test plan
- [x] Unit tests added/updated in `captureBridge.test.ts`
- [ ] Manual verification that hold-to-talk from the bar starts the mic graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

Failure-Class: none
