### PR TITLE
fix(macos): add cloud connector disconnect state

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AgentConnectPickerSheet.swift
@@ -121,6 +121,7 @@ private struct ConnectOptionCard: View {
   @State private var mcpKey: String?
   @State private var showManual = false
   @State private var permissionRefreshID = 0
+  @State private var isDisconnecting = false
 
   private let permissionRefreshTimer = Timer.publish(every: 1.0, on: .main, in: .common)
     .autoconnect()
@@ -302,23 +303,34 @@ private struct ConnectOptionCard: View {
   }
 
   private func setupCompleteBlock(_ completion: MCPSetupCompletionSummary) -> some View {
-    HStack(alignment: .top, spacing: OmiSpacing.sm) {
-      Image(systemName: "checkmark.seal.fill")
-        .scaledFont(size: OmiType.subheading, weight: .semibold)
-        .foregroundColor(Ink.listeningGreen)
-        .padding(.top, 1)
-      VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-        Text(completion.title)
-          .scaledFont(size: OmiType.body, weight: .semibold)
-          .foregroundColor(Ink.primary)
-        if destination == .claudeCode {
-          ClaudeCodeRestartSubtitle()
-        } else {
-          Text(completion.subtitle)
-            .scaledFont(size: OmiType.caption)
-            .foregroundColor(Ink.secondary)
-            .fixedSize(horizontal: false, vertical: true)
+    VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+      HStack(alignment: .top, spacing: OmiSpacing.sm) {
+        Image(systemName: "checkmark.seal.fill")
+          .scaledFont(size: OmiType.subheading, weight: .semibold)
+          .foregroundColor(Ink.listeningGreen)
+          .padding(.top, 1)
+        VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+          Text(completion.title)
+            .scaledFont(size: OmiType.body, weight: .semibold)
+            .foregroundColor(Ink.primary)
+          if destination == .claudeCode {
+            ClaudeCodeRestartSubtitle()
+          } else {
+            Text(completion.subtitle)
+              .scaledFont(size: OmiType.caption)
+              .foregroundColor(Ink.secondary)
+              .fixedSize(horizontal: false, vertical: true)
+          }
         }
+      }
+      if destination.cloudOAuthClientID != nil {
+        Button(isDisconnecting ? "Disconnecting…" : "Disconnect") {
+          disconnectCloudConnection()
+        }
+        .buttonStyle(.plain)
+        .foregroundColor(Ink.secondary)
+        .scaledFont(size: OmiType.caption, weight: .medium)
+        .disabled(isDisconnecting)
       }
     }
     .padding(OmiSpacing.sm)
@@ -330,6 +342,22 @@ private struct ConnectOptionCard: View {
           RoundedRectangle(cornerRadius: SettingsGlassMetrics.cardRadius, style: .continuous)
             .stroke(Ink.listeningGreen.opacity(0.22), lineWidth: 1))
     )
+  }
+
+  private func disconnectCloudConnection() {
+    guard !isDisconnecting else { return }
+    isDisconnecting = true
+    resultMessage = nil
+    Task { @MainActor in
+      do {
+        statuses[destination] = try await MemoryExportService.shared
+          .disconnectCloudOAuthConnection(for: destination)
+        resultMessage = .success("Disconnected from \(destination.title).")
+      } catch {
+        resultMessage = .failure("Couldn't disconnect \(destination.title). Try again.")
+      }
+      isDisconnecting = false
+    }
   }
 
   private func setupFailureMessage(for error: Error) -> String {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
@@ -494,6 +494,7 @@ struct MemoryExportDestinationSheet: View {
   @StateObject private var model = MemoryExportDestinationSheetModel()
   @State private var showManualSetup = false
   @State private var permissionRefreshID = 0
+  @State private var isDisconnecting = false
 
   private let permissionRefreshTimer = Timer.publish(every: 1.0, on: .main, in: .common)
     .autoconnect()
@@ -819,23 +820,34 @@ struct MemoryExportDestinationSheet: View {
   }
 
   private func setupCompleteBlock(_ completion: MCPSetupCompletionSummary) -> some View {
-    HStack(alignment: .top, spacing: OmiSpacing.sm) {
-      Image(systemName: "checkmark.seal.fill")
-        .scaledFont(size: OmiType.subheading, weight: .semibold)
-        .foregroundColor(Ink.listeningGreen)
-        .padding(.top, 1)
-      VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-        Text(completion.title)
+    VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+      HStack(alignment: .top, spacing: OmiSpacing.sm) {
+        Image(systemName: "checkmark.seal.fill")
           .scaledFont(size: OmiType.subheading, weight: .semibold)
-          .foregroundColor(Ink.primary)
-        if destination == .claudeCode {
-          ClaudeCodeRestartSubtitle()
-        } else {
-          Text(completion.subtitle)
-            .scaledFont(size: OmiType.caption)
-            .foregroundColor(Ink.secondary)
-            .fixedSize(horizontal: false, vertical: true)
+          .foregroundColor(Ink.listeningGreen)
+          .padding(.top, 1)
+        VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+          Text(completion.title)
+            .scaledFont(size: OmiType.subheading, weight: .semibold)
+            .foregroundColor(Ink.primary)
+          if destination == .claudeCode {
+            ClaudeCodeRestartSubtitle()
+          } else {
+            Text(completion.subtitle)
+              .scaledFont(size: OmiType.caption)
+              .foregroundColor(Ink.secondary)
+              .fixedSize(horizontal: false, vertical: true)
+          }
         }
+      }
+      if destination.cloudOAuthClientID != nil {
+        Button(isDisconnecting ? "Disconnecting…" : "Disconnect") {
+          disconnectCloudConnection()
+        }
+        .buttonStyle(.plain)
+        .foregroundColor(Ink.secondary)
+        .scaledFont(size: OmiType.caption, weight: .medium)
+        .disabled(isDisconnecting)
       }
     }
     .padding(OmiSpacing.md)
@@ -847,6 +859,23 @@ struct MemoryExportDestinationSheet: View {
           RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius, style: .continuous)
             .stroke(Ink.listeningGreen.opacity(0.22), lineWidth: 1))
     )
+  }
+
+  private func disconnectCloudConnection() {
+    guard !isDisconnecting else { return }
+    isDisconnecting = true
+    model.errorMessage = nil
+    model.statusMessage = nil
+    Task { @MainActor in
+      do {
+        statuses[destination] = try await MemoryExportService.shared
+          .disconnectCloudOAuthConnection(for: destination)
+        model.statusMessage = "Disconnected from \(destination.title)."
+      } catch {
+        model.errorMessage = "Couldn't disconnect \(destination.title). Try again."
+      }
+      isDisconnecting = false
+    }
   }
 
   private var isConnected: Bool {

--- a/desktop/macos/Desktop/Sources/MemoryExportService.swift
+++ b/desktop/macos/Desktop/Sources/MemoryExportService.swift
@@ -741,17 +741,25 @@ actor MemoryExportService {
   private static let mcpKeyOwnerDefaultsKey = "memoryExportMCPApiKeyOwnerUserId"
   private static let mcpKeyCreatedAtDefaultsKey = "memoryExportMCPApiKeyCreatedAt"
 
-  private let defaults = UserDefaults.standard
+  private let defaults: UserDefaults
+  private let apiClient: APIClient
   private let notionVersion = "2026-03-11"
   private let notionBaseURL = URL(string: "https://api.notion.com/v1")!
   private var mcpKeyWarmTask: (ownerUserId: String, id: UUID, task: Task<String, Error>)?
 
+  init(apiClient: APIClient = .shared, defaults: UserDefaults = .standard) {
+    self.apiClient = apiClient
+    self.defaults = defaults
+  }
+
   private struct OAuthGrant: Decodable {
+    let id: String?
     let clientID: String
     let status: String?
     let revokedAt: String?
 
     enum CodingKeys: String, CodingKey {
+      case id
       case clientID = "client_id"
       case status
       case revokedAt = "revoked_at"
@@ -865,7 +873,7 @@ actor MemoryExportService {
     guard !clientIDs.isEmpty else { return status(for: destination) }
     var observation = "authoritative_grant_check"
     do {
-      let response: OAuthGrantsResponse = try await APIClient.shared.get(
+      let response: OAuthGrantsResponse = try await apiClient.get(
         "v1/mcp/oauth/grants", customBaseURL: MemoryExportDestination.mcpOAuthBaseURL, includeBYOK: false)
       let isAuthorized = response.grants.contains { clientIDs.contains($0.clientID) && $0.isActive }
 
@@ -892,6 +900,42 @@ actor MemoryExportService {
       for: destination,
       localMCPConnections: localConnections,
       cloudGrantObservation: observation == "authoritative_grant_check" ? nil : observation)
+  }
+
+  /// Revokes every active OAuth grant for a cloud connector, then clears the
+  /// local cached projection. The local state is only cleared after the server
+  /// confirms each revoke so a transient failure cannot falsely report a
+  /// disconnect.
+  func disconnectCloudOAuthConnection(for destination: MemoryExportDestination) async throws
+    -> MemoryExportStatus
+  {
+    let clientIDs = destination.cloudOAuthGrantClientIDs
+    guard !clientIDs.isEmpty else { return status(for: destination) }
+
+    let response: OAuthGrantsResponse = try await apiClient.get(
+      "v1/mcp/oauth/grants", customBaseURL: MemoryExportDestination.mcpOAuthBaseURL, includeBYOK: false)
+    let activeGrants = response.grants.filter { clientIDs.contains($0.clientID) && $0.isActive }
+
+    for grant in activeGrants {
+      guard let grantID = grant.id, !grantID.isEmpty else {
+        throw MemoryExportError.requestFailed("Omi could not identify the (destination.title) authorization.")
+      }
+      let escapedGrantID = grantID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? grantID
+      try await apiClient.delete(
+        "v1/mcp/oauth/grants/\(escapedGrantID)",
+        customBaseURL: MemoryExportDestination.mcpOAuthBaseURL,
+        includeBYOK: false)
+    }
+
+    defaults.removeObject(forKey: destination.connectedAtKey)
+    defaults.removeObject(forKey: destination.detailKey)
+    let localConnections = MemoryExportConnectionDetector.scanLocalMCPConnections(
+      for: destination,
+      matchingKey: storedMCPKey())
+    return status(
+      for: destination,
+      localMCPConnections: localConnections,
+      cloudGrantObservation: "authoritative_grant_check")
   }
 
   func notionConfiguration() -> (token: String, parentPageID: String) {

--- a/desktop/macos/Desktop/Tests/MemoryExportStatusTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryExportStatusTests.swift
@@ -34,8 +34,13 @@ private final class CloudOAuthDisconnectURLProtocol: URLProtocol, @unchecked Sen
       ? Data("{\"grants\":[{\"id\":\"grant-123\",\"client_id\":\"omi-chatgpt-prod\",\"status\":\"active\"}]}".utf8)
       : Data()
     let statusCode = method == "DELETE" ? 204 : 200
-    let response = HTTPURLResponse(
-      url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+    guard let requestURL = request.url,
+      let response = HTTPURLResponse(
+        url: requestURL, statusCode: statusCode, httpVersion: nil, headerFields: nil)
+    else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+      return
+    }
     client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
     if !body.isEmpty {
       client?.urlProtocol(self, didLoad: body)
@@ -146,16 +151,18 @@ final class MemoryExportStatusTests: XCTestCase {
     let apiClient = APIClient(session: URLSession(configuration: configuration))
     await apiClient.setTestAuthHeaderForMemoryExportTests("Bearer test-token")
     let service = MemoryExportService(apiClient: apiClient)
+    let connectedAtKey = memoryExportDefaultsKey("memoryExportConnectedAt", destination: .chatgpt)
+    let detailKey = memoryExportDefaultsKey("memoryExportDetail", destination: .chatgpt)
 
-    UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "memoryExportConnectedAt.chatgpt")
-    UserDefaults.standard.set("Authorized through ChatGPT (cloud)", forKey: "memoryExportDetail.chatgpt")
+    UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: connectedAtKey)
+    UserDefaults.standard.set("Authorized through ChatGPT (cloud)", forKey: detailKey)
 
     let status = try await service.disconnectCloudOAuthConnection(for: .chatgpt)
 
     XCTAssertFalse(status.hasConnection)
     XCTAssertFalse(status.isConfigured)
-    XCTAssertNil(UserDefaults.standard.object(forKey: "memoryExportConnectedAt.chatgpt"))
-    XCTAssertNil(UserDefaults.standard.object(forKey: "memoryExportDetail.chatgpt"))
+    XCTAssertNil(UserDefaults.standard.object(forKey: connectedAtKey))
+    XCTAssertNil(UserDefaults.standard.object(forKey: detailKey))
     let requests = CloudOAuthDisconnectURLProtocol.capturedRequests
     XCTAssertEqual(requests.count, 2)
     XCTAssertEqual(requests[0].method, "GET")
@@ -562,6 +569,10 @@ final class MemoryExportStatusTests: XCTestCase {
       defaults.removeObject(forKey: "memoryExportLastExportPath.\(destination.rawValue)")
       defaults.removeObject(forKey: "memoryExportConnectedAt.\(destination.rawValue)")
     }
+  }
+
+  private func memoryExportDefaultsKey(_ prefix: String, destination: MemoryExportDestination) -> String {
+    "\(prefix).\(destination.rawValue)"
   }
 
   private func storeOwnedMCPKey(userId: String = "test-user", key: String = "test-key") {

--- a/desktop/macos/Desktop/Tests/MemoryExportStatusTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryExportStatusTests.swift
@@ -2,6 +2,56 @@ import XCTest
 
 @testable import Omi_Computer
 
+private final class CloudOAuthDisconnectURLProtocol: URLProtocol, @unchecked Sendable {
+  private static let lock = NSLock()
+  private nonisolated(unsafe) static var requests: [(method: String, path: String)] = []
+
+  static func reset() {
+    lock.lock()
+    requests.removeAll()
+    lock.unlock()
+  }
+
+  static var capturedRequests: [(method: String, path: String)] {
+    lock.lock()
+    defer { lock.unlock() }
+    return requests
+  }
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    let method = request.httpMethod ?? "GET"
+    let path = request.url?.path ?? ""
+    Self.lock.lock()
+    Self.requests.append((method: method, path: path))
+    Self.lock.unlock()
+
+    let body =
+      method == "GET"
+      ? Data("{\"grants\":[{\"id\":\"grant-123\",\"client_id\":\"omi-chatgpt-prod\",\"status\":\"active\"}]}".utf8)
+      : Data()
+    let statusCode = method == "DELETE" ? 204 : 200
+    let response = HTTPURLResponse(
+      url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    if !body.isEmpty {
+      client?.urlProtocol(self, didLoad: body)
+    }
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+}
+
+extension APIClient {
+  fileprivate func setTestAuthHeaderForMemoryExportTests(_ value: String) {
+    testAuthHeader = value
+  }
+}
+
 final class MemoryExportStatusTests: XCTestCase {
   private var tempHome: URL!
 
@@ -87,6 +137,31 @@ final class MemoryExportStatusTests: XCTestCase {
     XCTAssertFalse(status.isConfigured)
     XCTAssertFalse(status.hasConnection)
     XCTAssertEqual(presentation.primaryActionTitle, "Add Omi to ChatGPT")
+  }
+
+  func testDisconnectCloudAuthorizationRevokesGrantAndClearsProjection() async throws {
+    CloudOAuthDisconnectURLProtocol.reset()
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [CloudOAuthDisconnectURLProtocol.self]
+    let apiClient = APIClient(session: URLSession(configuration: configuration))
+    await apiClient.setTestAuthHeaderForMemoryExportTests("Bearer test-token")
+    let service = MemoryExportService(apiClient: apiClient)
+
+    UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "memoryExportConnectedAt.chatgpt")
+    UserDefaults.standard.set("Authorized through ChatGPT (cloud)", forKey: "memoryExportDetail.chatgpt")
+
+    let status = try await service.disconnectCloudOAuthConnection(for: .chatgpt)
+
+    XCTAssertFalse(status.hasConnection)
+    XCTAssertFalse(status.isConfigured)
+    XCTAssertNil(UserDefaults.standard.object(forKey: "memoryExportConnectedAt.chatgpt"))
+    XCTAssertNil(UserDefaults.standard.object(forKey: "memoryExportDetail.chatgpt"))
+    let requests = CloudOAuthDisconnectURLProtocol.capturedRequests
+    XCTAssertEqual(requests.count, 2)
+    XCTAssertEqual(requests[0].method, "GET")
+    XCTAssertEqual(requests[0].path, "/v1/mcp/oauth/grants")
+    XCTAssertEqual(requests[1].method, "DELETE")
+    XCTAssertEqual(requests[1].path, "/v1/mcp/oauth/grants/grant-123")
   }
 
   func testCachedCloudGrantStatusReadSignalsInferredConnectorAuthority() async {

--- a/desktop/macos/changelog/unreleased/20260822-chatgpt-disconnect-status.json
+++ b/desktop/macos/changelog/unreleased/20260822-chatgpt-disconnect-status.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added a Disconnect action for ChatGPT and Claude cloud connections so Omi shows them as disconnected after authorization is revoked"
+}


### PR DESCRIPTION
## What changed and why

Cloud ChatGPT and Claude setup had a one-way local connected projection backed by a cached timestamp, but no Disconnect action. Refresh could not revoke the server-side MCP OAuth grant and could retain stale connected UI when grant verification failed. This adds an explicit Disconnect action that revokes matching grants through the authoritative API, clears the local projection only after successful revocation, and reports failures without falsely showing disconnected.

## Product invariants affected

- INV-INT-1
- INV-MEM-1

## How it was verified

- `cd desktop/macos && ./scripts/dev-feedback.py --once swift 'MemoryExportStatusTests'` — 24 tests passed, 0 failures after rebasing onto current `origin/main`.
- Built the isolated QA bundle with `OMI_APP_NAME=omi-chatgpt-disconnect-status ./run.sh --full --yolo --no-wait` and refreshed it with `OMI_APP_NAME=omi-chatgpt-disconnect-status ./run.sh --yolo --fast-only --no-wait`.
- `codesign --verify --deep --strict --verbose=2 /Applications/omi-chatgpt-disconnect-status.app` — passed; bundle identifier `com.omi.omi-chatgpt-disconnect-status`.
- Runtime check in the isolated bundle: the Apps card showed `Not connected`, and the ChatGPT setup showed `Add Omi to ChatGPT` after the Disconnect action and authoritative refresh.
- Beta was not edited or rebuilt; after the shared server-side grant was revoked by the isolated-bundle test, Beta's refresh also projected ChatGPT as disconnected.

## Tests

Added `testDisconnectCloudAuthorizationRevokesGrantAndClearsProjection`, covering grant discovery, DELETE revocation, false disconnected projection, and local cache clearing. The existing status suite also covers stale cached state, grant/client matching, local config changes, commented or disabled configs, and Claude/ChatGPT memory-pack-vs-directory authorization distinctions.

## Failure class (fixes)

Failure-Class: FC-split-mutation-authority

Line-Count-Exception: desktop/macos/Desktop/Sources/MemoryExportService.swift | 1610 -> 1654 | Adds authoritative cloud OAuth revoke flow and status projection while preserving the existing service boundary.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

