### PR TITLE
fix(deploy): let Cloud Run preflight see past the metrics sidecar

### DIFF
--- a/.github/failure-classes/FC-config-target-identified-by-count-not-identity.json
+++ b/.github/failure-classes/FC-config-target-identified-by-count-not-identity.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-config-target-identified-by-count-not-identity",
+  "violated_contract": "A check that reads or rewrites one component's configuration must select that component by identity, never by asserting it is the only one present. Counting is a proxy for identity that holds only until something legitimately adds a second component, and when it breaks it rejects a correctly configured service rather than reporting real drift.",
+  "canonical_prevention": "Select the target by name or role and exclude known companions explicitly, sharing one definition of those companions with whatever attaches them. Reserve a cardinality assertion for the set that remains after companions are excluded, so the check still fails a genuinely ambiguous shape.",
+  "canonical_prevention_artifact": [
+    "backend/scripts/preflight-cloud-run-deploy.py",
+    "backend/tests/unit/test_preflight_cloud_run_deploy.py"
+  ],
+  "evidence_prs": [11998],
+  "scope_hints": [
+    "backend/scripts/preflight-cloud-run-deploy.py",
+    "backend/scripts/attach_cloud_run_gmp_sidecar.py",
+    ".github/actions/deploy-backend-stack/action.yml"
+  ],
+  "status": "open"
+}

--- a/backend/scripts/preflight-cloud-run-deploy.py
+++ b/backend/scripts/preflight-cloud-run-deploy.py
@@ -17,6 +17,7 @@ if str(BACKEND_ROOT) not in sys.path:
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import render_backend_runtime_env  # noqa: E402
 import repair_cloud_run_traffic  # noqa: E402
+from attach_cloud_run_gmp_sidecar import SIDECAR_NAME  # noqa: E402
 from runtime_env_validation.common import compute_project  # noqa: E402
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -167,7 +168,7 @@ def migrate_legacy_public_bindings(
             raise ValueError(f'Missing public environment config for {service}')
         public_binding_names = set(public_env)
         document = _describe_cloud_run_service(service=service, project=project, region=region, runner=runner)
-        containers = _single_container(document, operation='Legacy public-binding migration')
+        containers = _application_container(document, operation='Legacy public-binding migration')
         legacy_binding_names = sorted(
             entry['name']
             for entry in _container_env_entries(containers, operation='Legacy public-binding migration')
@@ -226,7 +227,7 @@ def check_runtime_bindings(
         expected = _expected_runtime_bindings(service=service, service_config=service_config)
         declared_names = expected.public_names | set(expected.secret_references)
         document = _describe_cloud_run_service(service=service, project=project, region=region, runner=runner)
-        container = _single_container(document, operation='Runtime binding check')
+        container = _application_container(document, operation='Runtime binding check')
         actual = _actual_runtime_bindings(
             service=service,
             env_entries=_container_env_entries(container, operation='Runtime binding check'),
@@ -339,14 +340,28 @@ def _describe_cloud_run_service(*, service: str, project: str, region: str, runn
     return cast(dict[str, Any], document)
 
 
-def _single_container(document: dict[str, Any], *, operation: str) -> dict[str, Any]:
+def _application_container(document: dict[str, Any], *, operation: str) -> dict[str, Any]:
+    """Return the one application container, ignoring the GMP metrics sidecar.
+
+    These checks read and rewrite the application's own runtime bindings, so
+    they need exactly one application container. The Managed Prometheus
+    collector attached after deploy is observability-only and carries none of
+    those bindings, so it is excluded by name rather than counted -- otherwise
+    every deploy after the first sidecar attach fails on a service that is
+    correctly configured.
+    """
     spec = document.get('spec')
     template = spec.get('template') if isinstance(spec, dict) else None
     template_spec = template.get('spec') if isinstance(template, dict) else None
     containers = template_spec.get('containers') if isinstance(template_spec, dict) else None
-    if not isinstance(containers, list) or len(containers) != 1 or not isinstance(containers[0], dict):
-        raise ValueError(f'{operation} requires exactly one container per Cloud Run service')
-    return cast(dict[str, Any], containers[0])
+    if not isinstance(containers, list):
+        raise ValueError(f'{operation} requires exactly one application container per Cloud Run service')
+    application = [
+        container for container in containers if isinstance(container, dict) and container.get('name') != SIDECAR_NAME
+    ]
+    if len(application) != 1:
+        raise ValueError(f'{operation} requires exactly one application container per Cloud Run service')
+    return cast(dict[str, Any], application[0])
 
 
 def _container_env_entries(container: dict[str, Any], *, operation: str) -> list[Any]:

--- a/backend/tests/unit/test_preflight_cloud_run_deploy.py
+++ b/backend/tests/unit/test_preflight_cloud_run_deploy.py
@@ -210,7 +210,7 @@ environments:
         }
     }
 
-    with pytest.raises(ValueError, match='exactly one container'):
+    with pytest.raises(ValueError, match='exactly one application container'):
         preflight.check_runtime_bindings(
             services=('backend',),
             env='dev',
@@ -219,6 +219,115 @@ environments:
             manifest_path=manifest,
             runner=lambda _command, **_kwargs: SimpleNamespace(stdout=json.dumps(document)),
         )
+
+
+def test_runtime_binding_check_ignores_the_attached_gmp_metrics_sidecar(tmp_path: Path) -> None:
+    """A service carrying the observability sidecar is still a single-application service.
+
+    Every deploy after the first sidecar attach describes two containers. The
+    sidecar holds none of the runtime bindings these checks read, so counting it
+    would fail a correctly configured service on its second deploy onward.
+    """
+    preflight = load_preflight()
+    manifest = tmp_path / 'runtime_env.yaml'
+    manifest.write_text(
+        """\
+environments:
+  dev:
+    gcp_project: based-hardware-dev
+    cloud_run:
+      services:
+        backend:
+          env:
+            PUBLIC_SETTING:
+              value: public
+""",
+        encoding='utf-8',
+    )
+    document = {
+        'spec': {
+            'template': {
+                'spec': {
+                    'containers': [
+                        {'name': 'backend-1', 'env': [{'name': 'PUBLIC_SETTING', 'value': 'public'}]},
+                        {'name': 'collector', 'env': []},
+                    ]
+                }
+            }
+        }
+    }
+
+    drift = preflight.check_runtime_bindings(
+        services=('backend',),
+        env='dev',
+        project='based-hardware-dev',
+        region='us-central1',
+        manifest_path=manifest,
+        runner=lambda _command, **_kwargs: SimpleNamespace(stdout=json.dumps(document)),
+    )
+
+    assert drift == []
+
+
+def test_legacy_public_binding_migration_ignores_the_attached_gmp_metrics_sidecar(tmp_path: Path) -> None:
+    """The migration reads the application container's legacy secret bindings.
+
+    This runs on production as well as development, so the sidecar must not
+    turn a production deploy into an argument error.
+    """
+    preflight = load_preflight()
+    manifest = tmp_path / 'runtime_env.yaml'
+    manifest.write_text(
+        """\
+environments:
+  dev:
+    gcp_project: based-hardware-dev
+    cloud_run:
+      services:
+        backend:
+          env:
+            PUBLIC_SETTING:
+              value: public
+""",
+        encoding='utf-8',
+    )
+    document = {
+        'spec': {
+            'template': {
+                'spec': {
+                    'containers': [
+                        {
+                            'name': 'backend-1',
+                            'env': [
+                                {
+                                    'name': 'PUBLIC_SETTING',
+                                    'valueFrom': {'secretKeyRef': {'name': 'PUBLIC_SETTING', 'key': 'latest'}},
+                                }
+                            ],
+                        },
+                        {'name': 'collector', 'env': []},
+                    ]
+                }
+            }
+        }
+    }
+    commands: list[list[str]] = []
+
+    def runner(command: list[str], **_kwargs: object) -> SimpleNamespace:
+        commands.append(command)
+        return SimpleNamespace(stdout=json.dumps(document))
+
+    migrated = preflight.migrate_legacy_public_bindings(
+        services=('backend',),
+        env='dev',
+        project='based-hardware-dev',
+        region='us-central1',
+        manifest_path=manifest,
+        runner=runner,
+    )
+
+    assert migrated == ['backend']
+    assert any('--remove-secrets=PUBLIC_SETTING' in argument for command in commands for argument in command)
 
 
 def test_runtime_binding_check_propagates_gcloud_describe_failure(tmp_path: Path) -> None:

--- a/backend/tests/unit/test_verify_backend_release_vector.py
+++ b/backend/tests/unit/test_verify_backend_release_vector.py
@@ -287,7 +287,7 @@ def test_legacy_binding_migration_rejects_multi_container_services_without_mutat
         commands.append(command)
         return SimpleNamespace(stdout=json.dumps(multi_container_service))
 
-    with pytest.raises(ValueError, match='exactly one container'):
+    with pytest.raises(ValueError, match='exactly one application container'):
         preflight.migrate_legacy_public_bindings(
             services=('backend',), env='dev', project='based-hardware-dev', region='us-central1', runner=runner
         )


### PR DESCRIPTION
## What broke

Automatic development backend deploys have failed on every run since the Managed Prometheus sidecar landed in #11998:

```
preflight-cloud-run-deploy.py: error: Legacy public-binding migration
requires exactly one container per Cloud Run service
```

`deploy-backend-stack` attaches the GMP collector to the candidate revision *after* the deploy, so from the first attach onward the service describes two containers. `_single_container` counted containers to prove there was one unambiguous set of runtime bindings to read, and the collector — which carries none of those bindings — broke the count. A correctly configured service now fails an argument check.

Live confirmation:

```
backend   dev=[backend-1;collector]   prod=[backend-1]
```

## The fix

Select the application container by excluding the sidecar by name, instead of counting containers. This is the same rule `attach_cloud_run_gmp_sidecar.py` already applies when it resolves the ingress container, so the two scripts now agree on what the sidecar is.

## This is not development-only

`check_runtime_bindings` is gated to the `auto-dev` profile, but **`migrate_legacy_public_bindings` runs unconditionally** in `deploy-backend-stack`, and the sidecar attach step is likewise ungated. Production has one container today, so the sequence there would be:

1. First production deploy attaches the sidecar and succeeds.
2. Every production deploy after it fails this check.

This lands before that trap arms rather than after.

## A second occurrence, deliberately not fixed here

`backend/scripts/sync_ledger_fence_cutover.py:307` has the same defect:

```python
if len(images) != 1:
    raise CutoverError("Cloud Run candidate must have exactly one container image")
```

It collects images across every container and requires exactly one, and its `SERVICES` tuple includes `backend` — the service that now carries the collector. It is `workflow_dispatch`-only, so it blocks nothing today, but the next manual sync-ledger fence cutover would fail on it.

It is left out of this PR on purpose: that script sets up no sibling imports, so sharing the sidecar name with it means either duplicating a magic string (the drift that caused this class) or adding import machinery to a deploy-critical script under `backend-import-purity`. That deserves its own change rather than riding along with an urgent unblock.

## Verification

Both new tests fail against the current script with the exact error string seen in CI, and pass with the fix. Coverage runs in both directions: a service carrying the collector is accepted, and a service with two genuine application containers is still rejected.

- `tests/unit/test_preflight_cloud_run_deploy.py` — 18 passed
- plus `test_attach_cloud_run_gmp_sidecar.py`, `test_backend_runtime_env_validator.py`, `test_render_backend_runtime_env.py` — 114 passed

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

