### PR TITLE
fix(deploy): write the GMP secret annotation with a project number

### DIFF
--- a/.github/failure-classes/FC-metadata-format-validated-only-on-next-read.json
+++ b/.github/failure-classes/FC-metadata-format-validated-only-on-next-read.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-metadata-format-validated-only-on-next-read",
+  "violated_contract": "A value written into shared platform metadata must satisfy the parser of every tool that later reads that metadata, not merely the API that accepts the write. When the writing API is permissive and a different consumer is strict, the write succeeds and the failure surfaces on the next unrelated operation against the same resource, pointing away from the change that caused it.",
+  "canonical_prevention": "Write the strictest form every known consumer accepts, and assert that form in the writer's own test against the consumer's actual validation rule rather than a hand-copied expectation. Where the consumer is a vendored tool, copy its rule verbatim into the test so a vendor upgrade that tightens it fails locally instead of on the next deploy.",
+  "canonical_prevention_artifact": [
+    "backend/scripts/attach_cloud_run_gmp_sidecar.py",
+    "backend/tests/unit/test_attach_cloud_run_gmp_sidecar.py"
+  ],
+  "evidence_prs": [11998],
+  "scope_hints": [
+    "backend/scripts/attach_cloud_run_gmp_sidecar.py",
+    "backend/deploy/cloud_run_gmp_sidecar.yaml",
+    ".github/actions/deploy-backend-stack/action.yml"
+  ],
+  "status": "open"
+}

--- a/backend/scripts/attach_cloud_run_gmp_sidecar.py
+++ b/backend/scripts/attach_cloud_run_gmp_sidecar.py
@@ -42,6 +42,32 @@ def _check(result: subprocess.CompletedProcess[str], *, action: str) -> str:
     return result.stdout or ''
 
 
+def _project_number(project: str) -> str:
+    """Resolve a project to its number for the run.googleapis.com/secrets annotation.
+
+    gcloud parses that annotation with `^projects/[0-9]{1,19}/secrets/...`, so a
+    project ID in the path makes every later `gcloud run deploy` on the service
+    crash with "Invalid secret path". Cloud Run itself accepts either form, so
+    the breakage only surfaces on the next deploy, not on the attach.
+    """
+    if project.isdigit():
+        return project
+    result = _run(
+        [
+            'gcloud',
+            'projects',
+            'describe',
+            project,
+            '--format=value(projectNumber)',
+        ],
+        capture_output=True,
+    )
+    number = _check(result, action=f'resolving the {project} project number').strip()
+    if not number.isdigit():
+        raise RuntimeError(f'project number for {project} was not numeric')
+    return number
+
+
 def _latest_secret_version(*, project: str, secret: str) -> str:
     result = _run(
         [
@@ -144,14 +170,14 @@ def _normalize_string_mapping(raw: object) -> None:
         raw[key] = _cloud_run_string(value)
 
 
-def _merge_secret_annotation(existing: object, *, project: str, secret: str) -> str:
+def _merge_secret_annotation(existing: object, *, project_number: str, secret: str) -> str:
     entries: dict[str, str] = {}
     if isinstance(existing, str):
         for raw_entry in existing.split(','):
             name, separator, resource = raw_entry.strip().partition(':')
             if name and separator and resource:
                 entries[name] = resource
-    entries[secret] = f'projects/{project}/secrets/{secret}'
+    entries[secret] = f'projects/{project_number}/secrets/{secret}'
     return ','.join(f'{name}:{resource}' for name, resource in sorted(entries.items()))
 
 
@@ -175,7 +201,7 @@ def _merge_container_dependencies(existing: object, *, ingress_container_name: s
 def patch_service(
     service: Mapping[str, Any],
     *,
-    project: str,
+    project_number: str,
     base_revision: str,
     latest_created_revision: str,
     final_revision: str,
@@ -214,7 +240,7 @@ def patch_service(
     )
     template_annotations['run.googleapis.com/secrets'] = _merge_secret_annotation(
         template_annotations.get('run.googleapis.com/secrets'),
-        project=project,
+        project_number=project_number,
         secret=config_secret,
     )
 
@@ -308,7 +334,7 @@ def attach_sidecar(args: argparse.Namespace) -> None:
     ).strip()
     patched = patch_service(
         service,
-        project=args.project,
+        project_number=_project_number(args.project),
         base_revision=args.base_revision,
         latest_created_revision=latest_created_revision,
         final_revision=args.final_revision,

--- a/backend/tests/unit/test_attach_cloud_run_gmp_sidecar.py
+++ b/backend/tests/unit/test_attach_cloud_run_gmp_sidecar.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -85,7 +87,7 @@ def test_patch_service_adds_pinned_sidecar_without_losing_ingress_contract():
 
     patched = module.patch_service(
         source,
-        project='example-project',
+        project_number='1031333818730',
         base_revision='desktop-backend-base',
         latest_created_revision='desktop-backend-base',
         final_revision='desktop-backend-final',
@@ -122,6 +124,73 @@ def test_patch_service_adds_pinned_sidecar_without_losing_ingress_contract():
     assert 'name' not in source['spec']['template']['metadata']
 
 
+def test_secret_annotation_uses_a_project_number_gcloud_can_parse():
+    """gcloud rejects a project ID in the run.googleapis.com/secrets annotation.
+
+    Its parser is `^projects/[0-9]{1,19}/secrets/<name>(:v|/versions/v)?$`, so an
+    ID there makes every later `gcloud run deploy` on the service crash with
+    "Invalid secret path". Cloud Run accepts the attach either way, so the break
+    only appears on the next deploy -- long after the change that caused it.
+    """
+    module = _load_module()
+
+    patched = module.patch_service(
+        _service(),
+        project_number='1031333818730',
+        base_revision='desktop-backend-base',
+        latest_created_revision='desktop-backend-base',
+        final_revision='desktop-backend-final',
+        ingress_container_name='desktop-backend-1',
+        config_secret='cloud-run-gmp-config',
+        config_secret_version='7',
+    )
+
+    annotation = patched['spec']['template']['metadata']['annotations']['run.googleapis.com/secrets']
+    assert annotation == 'cloud-run-gmp-config:projects/1031333818730/secrets/cloud-run-gmp-config'
+
+    # verbatim from googlecloudsdk/command_lib/run/secrets_mapping.py
+    gcloud_remote_secret_path = re.compile(
+        r'^projects/(?P<project>[0-9]{1,19})'
+        r'/secrets/(?P<secret>[a-zA-Z0-9-_]{1,255})'
+        r'(?::(?P<version_short>.+)|/versions/(?P<version_long>.+))?$'
+    )
+    for entry in annotation.split(','):
+        _alias, _sep, remote_path = entry.partition(':')
+        assert gcloud_remote_secret_path.search(remote_path), remote_path
+
+
+def test_project_number_passes_through_a_number_without_calling_gcloud(monkeypatch):
+    module = _load_module()
+
+    def fail(*_args, **_kwargs):
+        raise AssertionError('a numeric project must not be resolved through gcloud')
+
+    monkeypatch.setattr(module, '_run', fail)
+
+    assert module._project_number('1031333818730') == '1031333818730'
+
+
+def test_project_number_resolves_an_id_and_rejects_a_non_numeric_answer(monkeypatch):
+    module = _load_module()
+    calls: list[list[str]] = []
+
+    def fake_run(args, *, capture_output=False):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout='1031333818730\n', stderr='')
+
+    monkeypatch.setattr(module, '_run', fake_run)
+    assert module._project_number('based-hardware-dev') == '1031333818730'
+    assert calls == [['gcloud', 'projects', 'describe', 'based-hardware-dev', '--format=value(projectNumber)']]
+
+    monkeypatch.setattr(
+        module,
+        '_run',
+        lambda args, *, capture_output=False: SimpleNamespace(returncode=0, stdout='not-a-number\n', stderr=''),
+    )
+    with pytest.raises(RuntimeError, match='project number'):
+        module._project_number('based-hardware-dev')
+
+
 def test_patch_service_names_an_initial_unnamed_singleton_ingress():
     module = _load_module()
     source = _service()
@@ -132,7 +201,7 @@ def test_patch_service_names_an_initial_unnamed_singleton_ingress():
 
     patched = module.patch_service(
         source,
-        project='example-project',
+        project_number='1031333818730',
         base_revision='desktop-backend-base',
         latest_created_revision='desktop-backend-base',
         final_revision='desktop-backend-final',
@@ -150,7 +219,7 @@ def test_patch_service_refuses_latest_revision_traffic():
     with pytest.raises(ValueError, match='traffic follows latestRevision'):
         module.patch_service(
             _service(latest_traffic=True),
-            project='example-project',
+            project_number='1031333818730',
             base_revision='desktop-backend-base',
             latest_created_revision='desktop-backend-base',
             final_revision='desktop-backend-final',
@@ -166,7 +235,7 @@ def test_patch_service_refuses_a_different_latest_created_revision():
     with pytest.raises(ValueError, match="expected base revision 'desktop-backend-base', found 'another-revision'"):
         module.patch_service(
             _service(),
-            project='example-project',
+            project_number='1031333818730',
             base_revision='desktop-backend-base',
             latest_created_revision='another-revision',
             final_revision='desktop-backend-final',


### PR DESCRIPTION
## What still breaks dev

After #12080 got past the container-count check, `gcloud` itself crashes:

```
ERROR: gcloud crashed (ValueError): Invalid secret path
'projects/based-hardware-dev/secrets/cloud-run-gmp-config' in annotation
```

`_merge_secret_annotation` wrote the config secret into `run.googleapis.com/secrets` using the project **ID**. gcloud parses that annotation with a regex whose project segment is numeric (`googlecloudsdk/command_lib/run/secrets_mapping.py`):

```python
_PROJECT_NUMBER_PARTIAL = r'(?P<project>[0-9]{1,19})'
_REMOTE_SECRET_FLAG_VALUE = r'^projects/' + _PROJECT_NUMBER_PARTIAL + r'/secrets/' + _SECRET_NAME_PARTIAL + _REMOTE_SECRET_VERSION + r'$'
```

`based-hardware-dev` is not numeric, so the path is rejected. The fix resolves the project number and writes that.

## Why this was expensive to find

Cloud Run accepts the attach with either form. The annotation is only re-parsed by the **next** `gcloud run deploy` against that service. So the deploy that introduces the bad annotation succeeds, and a later deploy — touching nothing related — crashes inside a vendored tool. Nothing in the failing run points at #11998.

That is the shape of the new failure class this declares: `FC-metadata-format-validated-only-on-next-read`. The guard artifact is a test that asserts the annotation against gcloud's *actual* regex copied verbatim, so a vendor upgrade that tightens the rule fails locally instead of on the next deploy.

## Production

Production has no sidecar attached, so it has never written this annotation and does not carry the defect today. On its current code it would have written the bad form on its first deploy and crashed on its second — the same delayed trap as #12080, one layer down.

## Note on the live dev service

The dev `backend` service still carries the bad annotation from the earlier attach. This PR stops it being rewritten, but the existing value needs a one-time repair before dev deploys succeed; that is an operational fix, not a code one.

## Verification

`patch_service` stays pure — `attach_sidecar` resolves the number and passes it in, so no test needs a subprocess, and a numeric project is passed through without calling gcloud at all.

All 8 tests in `tests/unit/test_attach_cloud_run_gmp_sidecar.py` pass; the new ones fail against the current script.

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

