### PR TITLE
fix(deploy): read gcloud's export in the dialect gcloud writes

### DIFF
--- a/.github/failure-classes/FC-serialiser-dialect-mismatch-retypes-values.json
+++ b/.github/failure-classes/FC-serialiser-dialect-mismatch-retypes-values.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-serialiser-dialect-mismatch-retypes-values",
+  "violated_contract": "A tool that reads another tool's serialized output, edits it, and writes it back must parse under the same dialect the producer emitted. When the reader's dialect types a plain scalar differently from the writer's, the round trip silently rewrites values the edit never touched, and the corruption is attributed to whoever reads the record next rather than to the tool that rewrote it.",
+  "canonical_prevention": "Pin the reader to the producer's dialect rather than the library default, and prove the round trip is value-preserving with a fixture copied verbatim from the producer's real output -- not a hand-written approximation, which will be written in the dialect the author already assumes.",
+  "canonical_prevention_artifact": [
+    "backend/scripts/attach_cloud_run_gmp_sidecar.py",
+    "backend/tests/unit/test_attach_cloud_run_gmp_sidecar.py"
+  ],
+  "evidence_prs": [11998],
+  "scope_hints": [
+    "backend/scripts/attach_cloud_run_gmp_sidecar.py",
+    "backend/deploy/runtime_env.yaml",
+    ".github/actions/deploy-backend-stack/action.yml"
+  ],
+  "status": "open"
+}

--- a/backend/scripts/attach_cloud_run_gmp_sidecar.py
+++ b/backend/scripts/attach_cloud_run_gmp_sidecar.py
@@ -14,7 +14,39 @@ import subprocess
 import tempfile
 from typing import Any, Mapping, Sequence, cast
 
+import re
 import yaml
+
+
+class GcloudExportLoader(yaml.SafeLoader):
+    """Read gcloud's YAML export under YAML 1.2 core semantics.
+
+    gcloud emits plain `on` / `off` for *string* env values -- production's
+    export literally contains `value: on` for MEMORY_ENABLED. PyYAML implements
+    YAML 1.1, where `on`/`off`/`yes`/`no` are booleans, so `yaml.safe_load`
+    turns those into True/False and dumping back through `services replace`
+    rewrites the live value to 'true'/'false'.
+
+    Nothing fails at attach time: Cloud Run stores the rewritten string happily
+    and every consumer of these three flags accepts the coerced spelling. It
+    surfaces one step later, when the post-deploy runtime-env validator compares
+    the live value against the manifest's 'on' and finds 'true' -- on a service
+    nobody edited. Restricting the bool resolver to the YAML 1.2 core set makes
+    the round trip preserve exactly what gcloud wrote. Genuine unquoted numbers
+    (containerPort, periodSeconds) and real booleans still load as themselves.
+    """
+
+
+GcloudExportLoader.yaml_implicit_resolvers = {
+    key: [(tag, regexp) for tag, regexp in resolvers if tag != 'tag:yaml.org,2002:bool']
+    for key, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
+GcloudExportLoader.add_implicit_resolver(
+    'tag:yaml.org,2002:bool',
+    re.compile(r'^(?:true|True|TRUE|false|False|FALSE)$'),
+    list('tTfF'),
+)
+
 
 SIDECAR_IMAGE = (
     'us-docker.pkg.dev/cloud-ops-agents-artifacts/cloud-run-gmp-sidecar/'
@@ -310,7 +342,7 @@ def attach_sidecar(args: argparse.Namespace) -> None:
         ],
         capture_output=True,
     )
-    service = yaml.safe_load(_check(export, action=f'exporting {args.service}'))
+    service = yaml.load(_check(export, action=f'exporting {args.service}'), Loader=GcloudExportLoader)
     if not isinstance(service, dict):
         raise RuntimeError('Cloud Run service export was not a mapping')
     latest_created = _run(

--- a/backend/tests/unit/test_attach_cloud_run_gmp_sidecar.py
+++ b/backend/tests/unit/test_attach_cloud_run_gmp_sidecar.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import yaml
 
 SCRIPT = Path(__file__).resolve().parents[2] / 'scripts' / 'attach_cloud_run_gmp_sidecar.py'
 
@@ -243,3 +244,62 @@ def test_patch_service_refuses_a_different_latest_created_revision():
             config_secret='cloud-run-gmp-config',
             config_secret_version='7',
         )
+
+
+def test_gcloud_export_loader_preserves_on_off_env_values_as_strings() -> None:
+    """gcloud writes `value: on` unquoted; YAML 1.1 would make that a boolean.
+
+    These bytes are copied from a real `gcloud run services describe
+    --format=export` of the production backend service. Under yaml.safe_load
+    the three flags come back as booleans and the dump back through
+    `services replace` rewrites them to 'true'/'false', which is what broke
+    development deploys at the post-deploy runtime-env validator.
+    """
+    module = _load_module()
+    export = """\
+spec:
+  template:
+    spec:
+      containerConcurrency: 80
+      containers:
+      - name: backend-1
+        env:
+        - name: MEMORY_ENABLED
+          value: on
+        - name: ACCOUNT_CUTOVER_ENFORCEMENT
+          value: off
+        - name: PUBLIC_SHARED_CONVERSATION_CHAT_MODE
+          value: off
+        - name: MEMORY_V3_CURSOR_SECRET_VERSION
+          value: prod-v1
+        - name: REDIS_DB_PORT
+          value: '13151'
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          periodSeconds: 240
+"""
+    loaded = yaml.load(export, Loader=module.GcloudExportLoader)
+    container = loaded['spec']['template']['spec']['containers'][0]
+    env = {entry['name']: entry['value'] for entry in container['env']}
+
+    assert env['MEMORY_ENABLED'] == 'on'
+    assert env['ACCOUNT_CUTOVER_ENFORCEMENT'] == 'off'
+    assert env['PUBLIC_SHARED_CONVERSATION_CHAT_MODE'] == 'off'
+    assert all(isinstance(value, str) for value in env.values())
+
+    # structural numbers must still load as numbers, not strings
+    assert container['ports'][0]['containerPort'] == 8080
+    assert container['readinessProbe']['periodSeconds'] == 240
+    assert loaded['spec']['template']['spec']['containerConcurrency'] == 80
+
+    # and the round trip back out must reproduce what gcloud gave us
+    round_tripped = yaml.load(yaml.safe_dump(loaded), Loader=module.GcloudExportLoader)
+    assert round_tripped == loaded
+
+
+def test_gcloud_export_loader_still_reads_real_booleans() -> None:
+    """Only the YAML 1.1 extras are dropped; the 1.2 core set is intact."""
+    module = _load_module()
+    loaded = yaml.load('a: true\nb: false\nc: on\nd: off\ne: yes\nf: no\n', Loader=module.GcloudExportLoader)
+    assert loaded == {'a': True, 'b': False, 'c': 'on', 'd': 'off', 'e': 'yes', 'f': 'no'}


### PR DESCRIPTION
## What breaks

Development backend deploys fail at the post-deploy runtime-env validator:

```
ERROR [cloud_run/backend]: env PUBLIC_SHARED_CONVERSATION_CHAT_MODE value mismatch: expected 'off'
ERROR [cloud_run/backend]: env ACCOUNT_CUTOVER_ENFORCEMENT value mismatch: expected 'off'
ERROR [cloud_run/backend]: env MEMORY_ENABLED value mismatch: expected 'on'
```

The deploy sets these correctly — the gcloud command in the run log contains `MEMORY_ENABLED=on`, `ACCOUNT_CUTOVER_ENFORCEMENT=off`, `PUBLIC_SHARED_CONVERSATION_CHAT_MODE=off`. The live revision then holds `'true'`, `'false'`, `'false'`.

`attach_cloud_run_gmp_sidecar.py` rewrites them in between.

## The chain

gcloud emits YAML 1.2, where `on` is a string. Production's untouched export literally contains:

```yaml
- name: MEMORY_ENABLED
  value: on
```

PyYAML implements YAML 1.1, where `on`/`off`/`yes`/`no` are booleans. The attach script does `yaml.safe_load` of that export, patches it, and `yaml.safe_dump`s it back through `gcloud run services replace`:

1. deploy writes `MEMORY_ENABLED=on`
2. export emits `value: on` unquoted
3. `yaml.safe_load` → Python `True`
4. `yaml.safe_dump` → `value: true`
5. `services replace` stores the string `"true"`
6. the validator compares against the manifest's `'on'` and fails

Every one of the three `on`/`off` keys the manifest declares is affected — 3 of 3, none survive.

## Why it read as unrelated

Nothing fails at attach time. Cloud Run accepts the rewritten string, and all three consumers accept the coerced spelling (`_ENABLED_ON = {"on", "true", "1"}`; the other two only enable on `on`/`gateway`, so `false` disables exactly as `off` did). **No behaviour changes.** It surfaces one step later, in a validator, on a service nobody edited — the same shape as #12080 and #12081.

## Production

Production has never attached the sidecar, so its export still says `value: on`. Its first attach would rewrite all three flags and then fail its own deploy gate. This lands before that.

## The fix

Pin the loader to the dialect gcloud actually emits: restrict the bool resolver to the YAML 1.2 core set (`true`/`false`), so `on`/`off`/`yes`/`no` stay strings. `yaml.safe_dump` already quotes ambiguous strings correctly, so only the read side needed changing.

Structural values are untouched — `containerPort: 8080`, `periodSeconds: 240` and `containerConcurrency: 80` still load as integers, and real booleans still load as booleans.

## Verification

The fixture in the new test is copied verbatim from a real `gcloud run services describe --format=export` of the production service, including the unquoted `value: on`. A hand-written fixture would have been written in the dialect the author already assumes and would not have reproduced this.

Both new tests fail against the current script and pass with the fix. 113 passed across `test_attach_cloud_run_gmp_sidecar.py`, `test_preflight_cloud_run_deploy.py`, and `test_backend_runtime_env_validator.py`.

The live dev service still carries the coerced values; the next deploy re-sets them to `on`/`off` and, with this fix, they survive the attach.

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

