### PR TITLE
fix(ci): use authoritative live PR body on main pushes

### DIFF
--- a/.github/scripts/pr_metadata.py
+++ b/.github/scripts/pr_metadata.py
@@ -165,15 +165,17 @@ def resolve_main_push_body(
     token: str,
     loader: Callable[..., PullRequestMetadata] = load_from_api,
 ) -> str:
-    """Commit message plus the merged PR body when HEAD is a squash/merge.
+    """Use the merged PR body when HEAD identifies a squash/merge.
 
     #10965 passed only `git log -1` through --pr-body-file, assuming GitHub
     folds the PR description into the squash message. This repo's squash
     default is the commit list, so INV-* citations that made PR Hygiene
-    green (see #11835) vanish on the main push. Append the live PR body
-    when the subject carries (#NNNN). API failures keep the commit
-    message — fail-closed for direct pushes, no new flake on API outage
-    when the commit already cites the IDs.
+    green (see #11835) vanish on the main push. When the subject carries
+    (#NNNN), the live PR body is the authoritative metadata: retaining the
+    merge message can reintroduce Git's wrapped, line-sensitive declarations
+    (#12003). API failures and empty PR bodies keep the commit message —
+    fail-closed for direct pushes without adding an API-outage flake when the
+    commit already cites the IDs.
     """
     number = extract_merged_pr_number(commit_body)
     if number is None or not repository or not token:
@@ -183,10 +185,9 @@ def resolve_main_push_body(
     except RuntimeError as exc:
         print(f"WARN: could not load merged PR #{number} body: {exc}", file=sys.stderr)
         return commit_body
-    pr_body = (metadata.body or "").strip()
-    if not pr_body or pr_body in commit_body:
+    if not (metadata.body or "").strip():
         return commit_body
-    return commit_body.rstrip() + "\n\n" + metadata.body
+    return metadata.body
 
 
 def parse_args() -> argparse.Namespace:
@@ -196,7 +197,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--from-commit-body-file",
         type=Path,
-        help="Main-push commit message; resolve (#NNNN) and append that PR body",
+        help="Main-push commit message; resolve (#NNNN) and prefer that live PR body",
     )
     parser.add_argument("--output", required=True, type=Path, help="File to receive the current PR body")
     return parser.parse_args()
@@ -218,7 +219,7 @@ def main() -> int:
         args.output.write_text(body, encoding="utf-8")
         number = extract_merged_pr_number(commit_body)
         if number is not None and body != commit_body:
-            print(f"Loaded merged PR #{number} body and appended it to the commit message.")
+            print(f"Loaded merged PR #{number} body as the authoritative main-push metadata.")
         else:
             print("Using commit message as the main-push PR body.")
         return 0

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -124,21 +124,42 @@ class MetadataTests(unittest.TestCase):
         self.assertIsNone(extract_merged_pr_number("security(backend): gate Anthropic web search"))
         self.assertIsNone(extract_merged_pr_number(""))
 
-    def test_main_push_body_appends_live_pr_body_for_squash_head(self) -> None:
-        """#11835: squash commit list omitted INV-CHAT-1; the PR body had it."""
+    def test_main_push_body_uses_live_pr_body_for_squash_head(self) -> None:
+        """#12003: wrapped merge text must not remain beside line-sensitive metadata."""
         commit = (
             "Cut the Windows app's idle and focus-driven backend request volume (#11835)\n\n"
-            "* Stop rebuilding the about-user card on every voice hub warm\n"
+            "Line-Count-Exception: backend/utils/conversations/process_conversation.py | 2403 ->\n"
+            "  2424 | extracted helper keeps the production owner readable\n"
         )
-        metadata = type("M", (), {"body": "## Product invariants affected\n\n- INV-CHAT-1\n", "number": 11835})()
-        combined = resolve_main_push_body(
+        live_body = (
+            "## Product invariants affected\n\n"
+            "- INV-CHAT-1\n\n"
+            "Line-Count-Exception: backend/utils/conversations/process_conversation.py | "
+            "2403 -> 2424 | extracted helper keeps the production owner readable\n"
+        )
+        metadata = type("M", (), {"body": live_body, "number": 11835})()
+        resolved = resolve_main_push_body(
             commit,
             repository="BasedHardware/omi",
             token="test-token",
             loader=lambda *args, **kwargs: metadata,
         )
-        self.assertIn("INV-CHAT-1", combined)
-        self.assertTrue(combined.startswith(commit.rstrip()))
+        self.assertEqual(resolved, live_body)
+        self.assertNotIn("2403 ->\n", resolved)
+
+    def test_main_push_body_keeps_commit_message_when_live_pr_body_is_empty(self) -> None:
+        commit = "Cut the Windows app's idle volume (#11835)\n\nFailure-Class: FC-example\n"
+        metadata = type("M", (), {"body": "  \n", "number": 11835})()
+
+        self.assertEqual(
+            resolve_main_push_body(
+                commit,
+                repository="BasedHardware/omi",
+                token="test-token",
+                loader=lambda *args, **kwargs: metadata,
+            ),
+            commit,
+        )
 
     def test_main_push_body_keeps_commit_message_without_pr_number_or_token(self) -> None:
         commit = "direct push that forgot INV-CHAT-1\n"


### PR DESCRIPTION
## Summary

Main-push Repo Checks currently append a recovered live PR body to the merge commit message. GitHub hard-wraps that embedded body, so line-oriented declarations such as `Line-Count-Exception` remain malformed even though the authoritative live PR body is valid.

Use the recovered live PR body as the authoritative metadata whenever it is non-empty. Direct pushes, missing tokens, API failures, and empty live bodies retain the commit-message fallback.

Fixes #12003.

## Verification

- Red on the test-only commit: the squash-head fixture retained the wrapped commit fragment instead of resolving to the live body.
- Green: `python3 -m unittest test_pr_preflight.py` — 42 tests passed, 2 skipped.
- Focused fallback coverage verifies direct pushes, missing tokens, API failures, and empty live bodies.
- `make preflight` and `scripts/pr-preflight --pr-body-file ...` pass from a complete checkout.

## Product invariants affected

none

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

