### PR TITLE
fix(dev-harness): reject loopback-lookalike hostnames

### DIFF
--- a/scripts/dev-harness/dev_harness/safety.py
+++ b/scripts/dev-harness/dev_harness/safety.py
@@ -13,7 +13,6 @@ import json
 import os
 import re
 import signal
-import socket
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -123,8 +122,6 @@ _PROVIDER_SECRET_RE = re.compile(
     r"(API_KEY|ACCESS_TOKEN|AUTH_TOKEN|SECRET|DEEPGRAM|OPENAI|ANTHROPIC|GROQ|ELEVENLABS)", re.IGNORECASE
 )
 _LOOPBACK_NAMES = {"localhost"}
-_LOOPBACK_V4_PREFIX = "127."
-_LOOPBACK_V6 = {"::1", "0:0:0:0:0:0:0:1"}
 _DANGEROUS_NAMES = {"", ".", ".."}
 
 
@@ -181,15 +178,12 @@ def _host_from_emulator_value(value: str) -> str:
 
 def is_loopback_host(value: str) -> bool:
     host = _host_from_emulator_value(value)
-    if host in _LOOPBACK_NAMES or host in _LOOPBACK_V6:
-        return True
-    if host.startswith(_LOOPBACK_V4_PREFIX):
+    if host in _LOOPBACK_NAMES:
         return True
     try:
-        ip = socket.inet_pton(socket.AF_INET6, host)
-    except OSError:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
         return False
-    return ip == socket.inet_pton(socket.AF_INET6, "::1")
 
 
 def validate_loopback_emulator_host(value: str, *, name: str = "emulator") -> str:

--- a/scripts/dev-harness/tests/test_safety.py
+++ b/scripts/dev-harness/tests/test_safety.py
@@ -64,6 +64,20 @@ def test_project_database_and_loopback_validation() -> None:
         safety.validate_loopback_emulator_host("firestore.googleapis.com:443")
 
 
+@pytest.mark.parametrize(
+    "host",
+    (
+        "127.attacker.example:8085",
+        "127.0.0.1.example:8085",
+        "127.0.0.256:8085",
+    ),
+)
+def test_loopback_validation_rejects_ipv4_hostname_lookalikes(host: str) -> None:
+    assert safety.is_loopback_host(host) is False
+    with pytest.raises(safety.SafetyError, match="loopback"):
+        safety.validate_loopback_emulator_host(host)
+
+
 def test_private_dev_host_accepts_loopback_lan_and_tailnet_rejects_public() -> None:
     # #11774: a physical device reaches the harness over a LAN or Tailscale
     # (CGNAT, 100.64.0.0/10) address. This guard is deliberately separate from
@@ -194,9 +208,7 @@ def test_windows_process_probe_reports_close_failure(monkeypatch: pytest.MonkeyP
         safety.process_exists(456)
 
 
-def test_windows_command_line_probe_ignores_path_shadowing(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_windows_command_line_probe_ignores_path_shadowing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     if os.name != "nt":
         pytest.skip("Windows PowerShell lookup is not used on this platform")
 


### PR DESCRIPTION
## Summary

The dev harness accepted any hostname beginning with `127.` as loopback. Values such as `127.attacker.example:8085`, `127.0.0.1.example:8085`, and the invalid address `127.0.0.256:8085` therefore crossed a safety boundary intended to admit literal loopback endpoints only.

Parse literal IP addresses with `ipaddress.ip_address()` and accept them only when Python classifies them as loopback. `localhost`, IPv4 loopback addresses, IPv6 loopback addresses, and bracketed/ported forms keep working; hostname lookalikes now fail closed.

## Verification

- Red on the test-only commit: all three hostname lookalikes were accepted.
- Green focused suite: 11 passed, 3 skipped.
- Green full dev-harness suite: 96 passed, 7 skipped on macOS.
- Mutation proof restoring the prefix check reproduced the same three failures.
- Black, Ruff, `py_compile`, `git diff --check`, `make preflight`, and PR-body preflight pass.

## Product invariants affected

none

Failure-Class: FC-implicit-resource-selection


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

