### PR TITLE
fix(dev-harness): reject non-executable Typesense overrides

### DIFF
--- a/scripts/dev-harness/dev_harness/cli.py
+++ b/scripts/dev-harness/dev_harness/cli.py
@@ -99,8 +99,14 @@ def _service_record(cfg: config.HarnessConfig, service: str) -> dict[str, object
 def _native_typesense_binary() -> str | None:
     override = os.environ.get("OMI_TYPESENSE_SERVER_BIN", "").strip()
     if override:
-        if not Path(override).is_file():
+        binary = Path(override)
+        if not binary.is_file():
             raise SystemExit(f"OMI_TYPESENSE_SERVER_BIN points to a missing binary: {override}")
+        if not os.access(binary, os.X_OK):
+            raise SystemExit(
+                f"OMI_TYPESENSE_SERVER_BIN points to a file that is not executable: {override}; "
+                "make it executable (for example, chmod +x on macOS/Linux) or choose another binary"
+            )
         return override
     return shutil.which("typesense-server")
 

--- a/scripts/dev-harness/tests/test_typesense_runtime.py
+++ b/scripts/dev-harness/tests/test_typesense_runtime.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -94,6 +96,7 @@ def test_preflight_docker_runtime_reports_dead_daemon(monkeypatch: pytest.Monkey
 def test_native_command_uses_binary_and_pinned_loopback_port(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     binary = tmp_path / "typesense-server"
     binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    binary.chmod(binary.stat().st_mode | stat.S_IXUSR)
     monkeypatch.setenv("OMI_TYPESENSE_RUNTIME", "native")
     monkeypatch.setenv("OMI_TYPESENSE_SERVER_BIN", str(binary))
     cfg = _cfg(tmp_path, monkeypatch)
@@ -105,6 +108,24 @@ def test_native_command_uses_binary_and_pinned_loopback_port(monkeypatch: pytest
     assert "--api-port" in command and str(config.TYPESENSE_PORT) in command
     assert config.LOCAL_TYPESENSE_API_KEY in command
     assert "docker" not in command
+
+
+def test_native_override_non_executable_fails_before_command_startup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    binary = tmp_path / "typesense-server"
+    binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    binary.chmod(0o600)
+    if os.access(binary, os.X_OK):
+        # Windows does not model POSIX execute bits. Keep the contract portable
+        # while still proving that production consults executable access.
+        monkeypatch.setattr(cli.os, "access", lambda _path, _mode: False)
+    monkeypatch.setenv("OMI_TYPESENSE_RUNTIME", "native")
+    monkeypatch.setenv("OMI_TYPESENSE_SERVER_BIN", str(binary))
+    cfg = _cfg(tmp_path, monkeypatch)
+
+    with pytest.raises(SystemExit, match=r"OMI_TYPESENSE_SERVER_BIN.*not executable.*chmod \+x"):
+        cli._typesense_command(cfg)
 
 
 def test_native_override_missing_binary_fails_loud(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`OMI_TYPESENSE_SERVER_BIN` currently validates only that the override is a file. A readable but non-executable file is consequently selected as the native Typesense runtime and fails later at process startup with a low-level permission error.

Validate executable access at runtime selection and fail immediately with an actionable message. Missing-file behavior and valid executable overrides are unchanged, including portable coverage for platforms without POSIX execute bits.

## Verification

- Red on the test-only commit: a mode `0600` override reached command construction instead of failing.
- Green focused suite: 12 passed.
- Green full dev-harness suite: 95 passed, 6 skipped.
- Mutation proof removing the executable guard reproduced the focused failure.
- Black, `git diff --check`, `make preflight`, and PR-body preflight pass.

## Product invariants affected

none

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

