### PR TITLE
fix(dev-harness): honor explicit desktop profile environment

### DIFF
--- a/scripts/dev-harness/dev_harness/desktop_profile.py
+++ b/scripts/dev-harness/dev_harness/desktop_profile.py
@@ -161,6 +161,7 @@ def resolve_profile(
     seeded_users: Iterable[str],
     env: Mapping[str, str] | None = None,
 ) -> DesktopLocalProfile:
+    source_env = os.environ if env is None else env
     users = tuple(sorted(set(str(item) for item in seeded_users)))
     payload = _user_payload_from_seed_manifest(cfg, user)
     email = payload.get("email", f"{user}@local.omi.invalid")
@@ -168,11 +169,11 @@ def resolve_profile(
     password = payload.get("password", f"{user}-local-password-030")
     python_api_url = cfg.backend_url
     desktop_api_url = cfg.desktop_backend_url
-    app_name = _resolve_local_app_name(env)
+    app_name = _resolve_local_app_name(source_env)
     bundle_id = _local_bundle_id(app_name)
     url_scheme = _local_url_scheme(app_name)
     storage_name = _local_storage_name(app_name)
-    env = {
+    profile_env = {
         "OMI_DESKTOP_LOCAL_PROFILE": "1",
         "OMI_HARNESS_INSTANCE": cfg.instance,
         "OMI_SKIP_AUTH_SEED": "1",
@@ -192,10 +193,10 @@ def resolve_profile(
         "FIREBASE_API_KEY": LOCAL_FIREBASE_API_KEY,
     }
     if app_name != LOCAL_APP_NAME:
-        env["OMI_APP_NAME"] = app_name
-        env["OMI_ENABLE_LOCAL_AUTOMATION"] = os.environ.get("OMI_ENABLE_LOCAL_AUTOMATION", "1")
-        if os.environ.get("OMI_AUTOMATION_PORT"):
-            env["OMI_AUTOMATION_PORT"] = os.environ["OMI_AUTOMATION_PORT"]
+        profile_env["OMI_APP_NAME"] = app_name
+        profile_env["OMI_ENABLE_LOCAL_AUTOMATION"] = source_env.get("OMI_ENABLE_LOCAL_AUTOMATION", "1")
+        if source_env.get("OMI_AUTOMATION_PORT"):
+            profile_env["OMI_AUTOMATION_PORT"] = source_env["OMI_AUTOMATION_PORT"]
     return DesktopLocalProfile(
         app_name=app_name,
         display_name=app_name if app_name != LOCAL_APP_NAME else LOCAL_DISPLAY_NAME,
@@ -223,7 +224,7 @@ def resolve_profile(
         seeded_users=users,
         state_root=str(cfg.layout.state_root),
         session_summary_path=str(cfg.layout.reports_dir / "local-emulator-memory-session-summary.json"),
-        env=env,
+        env=profile_env,
     )
 
 

--- a/scripts/dev-harness/tests/test_desktop_profile.py
+++ b/scripts/dev-harness/tests/test_desktop_profile.py
@@ -37,3 +37,29 @@ def test_validate_profile_allows_omi_memory_named_bundle() -> None:
 
     errors = desktop_profile.validate_profile(profile)
     assert not errors
+
+
+def test_named_bundle_automation_uses_supplied_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OMI_ENABLE_LOCAL_AUTOMATION", "ambient-disabled")
+    monkeypatch.setenv("OMI_AUTOMATION_PORT", "9999")
+
+    profile = _resolve(
+        {
+            "OMI_APP_NAME": "omi-memory",
+            "OMI_ENABLE_LOCAL_AUTOMATION": "explicit-enabled",
+            "OMI_AUTOMATION_PORT": "8765",
+        }
+    )
+
+    assert profile.env["OMI_ENABLE_LOCAL_AUTOMATION"] == "explicit-enabled"
+    assert profile.env["OMI_AUTOMATION_PORT"] == "8765"
+
+
+def test_named_bundle_automation_defaults_ignore_ambient_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OMI_ENABLE_LOCAL_AUTOMATION", "ambient-disabled")
+    monkeypatch.setenv("OMI_AUTOMATION_PORT", "9999")
+
+    profile = _resolve({"OMI_APP_NAME": "omi-memory"})
+
+    assert profile.env["OMI_ENABLE_LOCAL_AUTOMATION"] == "1"
+    assert "OMI_AUTOMATION_PORT" not in profile.env


### PR DESCRIPTION
## Summary

`resolve_profile(..., env=...)` uses the supplied mapping for the app name but reads automation settings from ambient `os.environ`. The same explicit profile input can therefore produce different output—or silently pick up a developer shell's automation port—depending on unrelated process state.

Resolve every profile setting from one environment source. An explicitly supplied mapping is now authoritative, while callers that omit `env` retain the existing ambient-environment behavior.

## Verification

- Red on the test-only commit: explicit automation values lost to ambient values, and omitted values leaked ambient state.
- Green focused suite: 4 passed.
- Green full dev-harness suite: 96 passed, 6 skipped.
- Mutation proof restoring ambient reads reproduced both failures.
- Black, `py_compile`, `git diff --check`, `make preflight`, and PR-body preflight pass.

## Product invariants affected

none

Failure-Class: FC-settings-mirror-retains-stale-override


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

