### PR TITLE
fix(web): Enter mid-IME-composition must not send the chat message

### DIFF
--- a/web/app/src/components/chat/ChatComposer.tsx
+++ b/web/app/src/components/chat/ChatComposer.tsx
@@ -8,6 +8,7 @@ import { OmiPulseMark } from '@/components/ui/OmiPulseMark';
 import { uploadChatFiles } from '@/lib/api';
 import type { MessageFile } from '@/types/conversation';
 import { cn } from '@/lib/utils';
+import { shouldSubmitComposerKey } from '@/lib/chatComposerKey';
 
 /**
  * The ask bar: one pill that carries the text and every control that acts on
@@ -186,7 +187,7 @@ export function ChatComposer({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (shouldSubmitComposerKey(e)) {
       e.preventDefault();
       void handleSend();
     }

--- a/web/app/src/components/chat/ChatPanel.tsx
+++ b/web/app/src/components/chat/ChatPanel.tsx
@@ -11,6 +11,7 @@ import { uploadChatFiles, getChatApps } from '@/lib/api';
 import type { App } from '@/lib/api';
 import { cn } from '@/lib/utils';
 import { MixpanelManager } from '@/lib/analytics/mixpanel';
+import { shouldSubmitComposerKey } from '@/lib/chatComposerKey';
 import { ChatMarkdown } from './ChatMarkdown';
 
 interface FilePreviewItem {
@@ -201,7 +202,7 @@ export function ChatPanel() {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (shouldSubmitComposerKey(e)) {
       e.preventDefault();
       handleSend();
     }

--- a/web/app/src/components/chat/__tests__/ChatComposer.test.tsx
+++ b/web/app/src/components/chat/__tests__/ChatComposer.test.tsx
@@ -249,3 +249,45 @@ describe('ChatComposer attachments', () => {
     );
   });
 });
+
+/**
+ * Enter means two different things while an IME is open.
+ *
+ * Typing Japanese, Chinese or Korean, the first Enter confirms the conversion
+ * candidate the IME is offering; only a later Enter is meant for the composer.
+ * The composer read `e.key === 'Enter' && !e.shiftKey` and sent on both, so
+ * confirming a kanji conversion sent the half-written message. macOS already
+ * draws the distinction — `ComposerKeyAction.resolve` reads `hasMarkedText`.
+ */
+describe('ChatComposer IME composition', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const typed = () => {
+    const onSend = vi.fn(async () => {});
+    render(<ChatComposer onSend={onSend} isStreaming={false} />);
+    const textarea = screen.getByPlaceholderText('Ask anything...');
+    fireEvent.change(textarea, { target: { value: '漢字' } });
+    return { onSend, textarea };
+  };
+
+  it('does not send while the IME is composing', () => {
+    const { onSend, textarea } = typed();
+    fireEvent.keyDown(textarea, { key: 'Enter', isComposing: true });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('does not send on the legacy keyCode 229 composition keydown', () => {
+    // Engines without `isComposing` report every composition keydown as 229.
+    const { onSend, textarea } = typed();
+    fireEvent.keyDown(textarea, { key: 'Enter', keyCode: 229 });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('sends on the Enter that follows a finished composition', async () => {
+    const { onSend, textarea } = typed();
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith('漢字', []));
+  });
+});

--- a/web/app/src/lib/chatComposerKey.ts
+++ b/web/app/src/lib/chatComposerKey.ts
@@ -1,0 +1,19 @@
+/** The parts of a React keydown event the composer needs to read. */
+export interface ComposerKeyEvent {
+  key: string;
+  shiftKey: boolean;
+  nativeEvent: { isComposing: boolean; keyCode?: number };
+}
+
+/**
+ * Whether an Enter keypress should send the message.
+ *
+ * Enter pressed while an IME is composing commits the candidate text; it is
+ * never the composer's send key. `KeyboardEvent.isComposing` reports that
+ * state, and engines that predate it surface the composition keydown as
+ * `keyCode` 229 instead, so both are checked.
+ */
+export function shouldSubmitComposerKey(event: ComposerKeyEvent): boolean {
+  if (event.key !== 'Enter' || event.shiftKey) return false;
+  return !event.nativeEvent.isComposing && event.nativeEvent.keyCode !== 229;
+}


### PR DESCRIPTION
Closes #4936.

Typing Japanese, Chinese or Korean, the first Enter confirms the conversion candidate the IME is offering; only a later Enter is meant for the composer. Both web chat composers read `e.key === 'Enter' && !e.shiftKey` and sent on both, so confirming a kanji conversion sent the half-written message.

macOS already draws this distinction — `ComposerKeyAction.resolve` reads `hasMarkedText` and returns `.newline` mid-composition (`desktop/macos/Desktop/Sources/Theme/OmiTextEditor.swift:49`). The web composer had no equivalent: `isComposing` appeared nowhere under `web/`. This ports the same rule to `ChatComposer` and `ChatPanel` through one shared predicate instead of a third copy of the condition.

The issue reports the platform as iOS/Android, but Flutter does not bind send to Enter and macOS already handles marked text; the web app is the surface that is actually broken.

## Source for the expected value

`KeyboardEvent.isComposing` is the standard signal for an in-flight IME composition (UI Events). Engines that predate it surface every composition keydown as `keyCode` 229 instead, so the predicate checks both.

## Verification

- `bash web/app/test.sh` — typecheck clean, 58 files / 329 tests (3 new) passing
- Reverting only the two component call sites on this branch turns the two composing cases red and leaves the other six green, so the test exercises the composer rather than asserting the predicate in isolation

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

