### PR TITLE
fix(app): warn when setup.sh ios targets a physical device with OMI_DEV_HOST unset

### DIFF
--- a/app/setup.sh
+++ b/app/setup.sh
@@ -355,6 +355,17 @@ function select_ios_device() {
   return 1
 }
 
+# True if $1 is the id of a physical iOS device rather than a simulator, per
+# `flutter devices --machine`'s own "emulator" field.
+function _ios_device_is_physical() {
+  local device_id="$1"
+  local devices_json
+  devices_json=$(flutter devices --machine 2>/dev/null) || return 1
+  local emulator
+  emulator=$(echo "$devices_json" | jq -r --arg id "$device_id" '.[] | select(.id == $id) | .emulator')
+  [[ "$emulator" == "false" ]]
+}
+
 # #########
 # Build iOS
 # #########
@@ -364,6 +375,13 @@ function run_build_ios() {
   check_ios_prerequisites || return 1
   local device_id
   device_id=$(select_ios_device) || return 1
+  if [[ "$flavor" == "dev" && -z "${OMI_DEV_HOST:-}" ]] && _ios_device_is_physical "$device_id"; then
+    echo "⚠️  Building for a physical device with OMI_DEV_HOST unset — the dev backend" >&2
+    echo "   will default to 127.0.0.1, which on the device is itself, not this Mac." >&2
+    echo "   Set OMI_DEV_HOST to this Mac's LAN or Tailscale address before running" >&2
+    echo "   both setup.sh and make dev-up, or the app will hang waiting for the" >&2
+    echo "   backend. See the physical-device tip in docs/doc/developer/AppSetup.mdx." >&2
+  fi
   flutter pub get \
     && pushd ios && pod install --repo-update && popd \
     && dart run build_runner build \

--- a/app/test/shell/ios_device_selection_test.sh
+++ b/app/test/shell/ios_device_selection_test.sh
@@ -43,6 +43,18 @@ extract_function() {
   extract_function select_ios_device
 } > "$HARNESS"
 
+PHYSICAL_DEVICE_HARNESS="$(mktemp -t omi_ios_physical_XXXXXX)"
+trap 'rm -f "$HARNESS" "$PHYSICAL_DEVICE_HARNESS"' EXIT
+{
+  echo "set -uo pipefail"
+  extract_function _ios_device_is_physical
+} > "$PHYSICAL_DEVICE_HARNESS"
+
+if ! bash -n "$PHYSICAL_DEVICE_HARNESS"; then
+  echo "FAIL: extracted _ios_device_is_physical harness is not valid bash" >&2
+  exit 1
+fi
+
 if ! bash -n "$HARNESS"; then
   echo "FAIL: extracted harness is not valid bash" >&2
   exit 1
@@ -130,6 +142,35 @@ if [[ "$rc" -ne 0 ]] && [[ "$out" == *"No iOS device or simulator found"* ]]; th
 else
   fail "expected a named no-iOS-device failure, got (rc=$rc): $out"
 fi
+
+echo "_ios_device_is_physical:"
+
+run_physical_check() {
+  local root="$1" device_id="$2"
+  PATH="$root/bin" bash -c "source '$PHYSICAL_DEVICE_HARNESS'; _ios_device_is_physical '$device_id'"
+}
+
+# 5. A physical device's id reports true (regression: setup.sh ios silently
+#    defaulted the dev backend host to 127.0.0.1 on physical devices, which is
+#    the device's own loopback, not the Mac's — see issue #11534).
+root=$(mktemp -d -t omi_ios_dev_physical_XXXXXX)
+stub_devices "$root" '[
+  {"name":"Revtim'"'"'s iPhone","id":"PHYS-1","isSupported":true,"targetPlatform":"ios","emulator":false},
+  {"name":"iPhone 17 Pro","id":"SIM-2","isSupported":true,"targetPlatform":"ios","emulator":true}
+]'
+if run_physical_check "$root" "PHYS-1"; then
+  pass "reports true for a physical device id"
+else
+  fail "expected true for physical device id PHYS-1"
+fi
+
+# 6. A simulator's id reports false.
+if run_physical_check "$root" "SIM-2"; then
+  fail "expected false for simulator id SIM-2"
+else
+  pass "reports false for a simulator id"
+fi
+rm -rf "$root"
 
 echo
 if [[ "$failures" -gt 0 ]]; then


### PR DESCRIPTION
## What

`setup.sh ios` builds a `dev` flavor app pointing at `http://127.0.0.1:8000/` by
default. On a physical iOS device, `127.0.0.1` resolves to the device itself,
not the Mac running the harness — so the app hangs waiting for a backend it
can never reach, with no indication why.

Two other setup blockers reported in #11534 (the `npx firebase-tools` install
prompt blocking headless, and the macOS Java stub passing the preflight check)
were already fixed on `main`. The harness also already supports a bind-host
override (`OMI_DEV_HOST` / `OMI_DEV_BIND_HOST`, documented in
`docs/doc/developer/AppSetup.mdx`). What was still missing is the third
remedy the reporter suggested: detect a physical-device target and warn
before the build starts, since the env var is easy to miss.

This adds that warning: `run_build_ios` in `app/setup.sh` now checks, for
`dev` builds, whether the selected device is physical (`flutter devices
--machine`'s own `emulator` field) and `OMI_DEV_HOST` is unset, and prints a
warning pointing at the fix instead of silently building a build that will
hang.

## Testing

Extended `app/test/shell/ios_device_selection_test.sh` (the existing
behavioral-test harness for this file's device-selection logic) with cases
for the new `_ios_device_is_physical` helper — asserts `true` for a physical
device id and `false` for a simulator id, using the same `flutter devices
--machine` stub the file already uses.

```
$ bash app/test/shell/ios_device_selection_test.sh
select_ios_device:
  ok   - returns the single iOS device's id, ignoring the non-iOS macOS entry
  ok   - fails with a named error instead of silently picking macOS (the regression)
  ok   - fails fast (rc=1) instead of blocking on read without a TTY
  ok   - fails with a named error when no devices are connected at all
_ios_device_is_physical:
  ok   - reports true for a physical device id
  ok   - reports false for a simulator id

all iOS device selection shell tests passed
```

Also verified `bash -n app/setup.sh` and `shellcheck app/setup.sh` produce no
new warnings.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

<!-- This is a diagnostics/DX addition (a warning), not a repair of a
violated invariant from a past incident — no existing FC-* class describes
this shape and it does not warrant minting a new recurring class for a
single-site warning. -->

fixes #11534

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

