### PR TITLE
fix(web): point the app-store page's store buttons at the real listings

### DIFF
--- a/web/frontend/src/app/apps/components/app-header/index.tsx
+++ b/web/frontend/src/app/apps/components/app-header/index.tsx
@@ -81,7 +81,7 @@ export function AppHeader({ plugin }: AppHeaderProps) {
           {/* Store Buttons */}
           <div className="mt-6 flex items-center gap-4">
             <a
-              href="https://apps.apple.com/app/id123456789"
+              href="https://apps.apple.com/us/app/friend-ai-wearable/id6502156163"
               target="_blank"
               rel="noopener noreferrer"
               className="flex h-10 items-center gap-2 rounded-lg bg-[#1A1F2E] px-4 py-2 text-sm font-medium text-white transition-all hover:bg-[#242938]"
@@ -96,7 +96,7 @@ export function AppHeader({ plugin }: AppHeaderProps) {
               <span>App Store</span>
             </a>
             <a
-              href="https://play.google.com/store/apps/details?id=com.omi.app"
+              href="https://play.google.com/store/apps/details?id=com.friend.ios"
               target="_blank"
               rel="noopener noreferrer"
               className="flex h-10 items-center gap-2 rounded-lg bg-[#1A1F2E] px-4 py-2 text-sm font-medium text-white transition-all hover:bg-[#242938]"


### PR DESCRIPTION
Part of #4801 — the two store buttons on the public app detail page.

Both hrefs are dead. The App Store one is the literal placeholder `id123456789`; the Play Store one names `com.omi.app`, which is not the package the app ships under. Both have been there since the frontend landed on 2025-03-24, and both 404 today:

| URL | status |
|---|---|
| `https://apps.apple.com/app/id123456789` | **404** |
| `https://play.google.com/store/apps/details?id=com.omi.app` | **404** |
| `https://apps.apple.com/us/app/friend-ai-wearable/id6502156163` | 301 |
| `https://play.google.com/store/apps/details?id=com.friend.ios` | 200 |

## Source for the expected values

Not guesses — the repo's own canonical values. The App Store URL appears 25 times elsewhere under `web/`, and `com.friend.ios` is both the Play URL used in 29 other places and the `applicationId` of the prod flavor in `app/android/app/build.gradle:63`.

## What this does not cover

The issue also reports a broken mobile menu and outdated product references. The product/pricing half is already fixed on `main` (`web/frontend/src/app/components/product-banner/types.ts` now reads `Omi` / `$89`), and the omi.me storefront pages are outside this repo. Only the store links are addressed here, so this does not close the issue.

## Verification

- Every store URL in the repo enumerated; after this change no `apps.apple.com` or `play.google.com` link under `web/` points anywhere but the canonical listings, with one deliberate exception: `apps.apple.com/us/app/lightblue-explorer/id557428110`, a third-party BLE tool referenced from the firmware docs.
- Status codes above measured directly.

No test accompanies this: `web/frontend` has no test lane, and two URL constants carry no behaviour to exercise. A repo-wide store-link guard is possible but wants a declared source of truth for the App Store numeric id, which the repo does not have today — the Play half is derivable from `applicationId`, the App Store half is not. Happy to add one if you want it.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

