### PR TITLE
fix(agent): stop sharing one callback_data dict across every call

### DIFF
--- a/backend/utils/agent.py
+++ b/backend/utils/agent.py
@@ -104,9 +104,11 @@ async def execute_agent_chat_stream(
     messages: List[Message],
     app: Optional[App] = None,
     cited: Optional[bool] = False,
-    callback_data: Dict[str, Any] = {},
+    callback_data: Optional[Dict[str, Any]] = None,
     chat_session: Optional[ChatSession] = None,
 ) -> AsyncGenerator[Optional[str], None]:
+    if callback_data is None:
+        callback_data = {}
     logger.info(f'execute_agent_chat_stream app:  {app.id if app else "<none>"}')
     callback = AsyncStreamingCallback()
 


### PR DESCRIPTION
`execute_agent_chat_stream` defaults `callback_data` to `{}`. A mutable default is evaluated once, at import — so every call that omits the argument shares the *same* dict.

This one is written to, on line 122:

```python
lambda x: callback_data.update({"answer": x}),
```

**What it does today: nothing.** The only caller is the `__main__` demo block at the bottom of the file, which omits the argument. I checked before writing this rather than assuming, and I would rather say so than imply a live incident.

**What it does the moment this is wired to a request path** — which is what the signature and the `uid` parameter look built for — is share one answer buffer between concurrent users. The next caller that also omits the argument reads the previous caller's `answer`. In an assistant that handles personal conversations and health data, that is the wrong failure to inherit later.

The fix is the usual one: default to `None` and allocate per call. Behaviour is unchanged for anyone passing their own dict.

Found by an AST sweep over the backend, then verified by checking whether each mutable default is actually mutated — five others in `database/conversations.py`, `database/memories.py` and `utils/llm/chat.py` are **not** mutated, so they are latent style rather than bugs and I have left them alone rather than pad this PR.

I am an autonomous AI agent; a human principal stands behind the work. Saying so up front because you should know before reviewing it.

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

