### PR TITLE
fix(backend): back a failed deletion wipe off instead of re-selecting it every tick

### DIFF
--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -33,6 +33,12 @@ import logging
 
 logger = logging.getLogger(__name__)
 DELETION_WIPE_RUNNING_STALE_AFTER = timedelta(hours=6)
+# A wipe that fails for a persistent reason (a missing queue, a dependency that is down) is
+# re-selected by every reconciler tick on every pod. Without a delay that is one claim
+# transaction per pod per tick, forever, against a record that cannot make progress. The
+# delay backs off per attempt and stops there: it never gives up on an accepted deletion.
+DELETION_WIPE_RETRY_BASE_DELAY = timedelta(minutes=5)
+DELETION_WIPE_RETRY_MAX_DELAY = timedelta(hours=1)
 _DELETION_WIPE_TERMINAL_STATUSES = frozenset({'completed', 'cancelled'})
 _DELETION_WIPE_LEGACY_ACTIONABLE_STATUSES = frozenset({'pending', 'retrying', 'running', 'failed'})
 LOCATION_CONTEXT_CONSENT_TTL = timedelta(days=30)
@@ -438,7 +444,11 @@ def mark_user_deletion_wipe_completed(uid: str) -> bool:
 def mark_user_deletion_wipe_failed(uid: str):
     """Mark the background data wipe as failed so a reconciliation worker can retry."""
     db.collection('account_deletions').document(uid).set(
-        {'wipe_status': 'failed', 'wipe_failed_at': datetime.now(timezone.utc)},
+        {
+            'wipe_status': 'failed',
+            'wipe_failed_at': datetime.now(timezone.utc),
+            'wipe_attempts': firestore.Increment(1),
+        },
         merge=True,
     )
 
@@ -604,6 +614,20 @@ def cancel_user_deletion_wipe(uid: str):
     )
 
 
+def deletion_wipe_retry_delay(attempts: int) -> timedelta:
+    """How long a ``failed`` wipe waits before it is selected again.
+
+    Doubles per recorded attempt and saturates at ``DELETION_WIPE_RETRY_MAX_DELAY``. The first
+    failure still retries on the next tick, so a transient error costs nothing.
+    """
+    if attempts <= 1:
+        return timedelta(0)
+    # Clamp the exponent before applying it: ``timedelta * 2 ** large`` overflows, and any
+    # exponent past the cap is the same answer anyway.
+    doublings = min(attempts - 2, 20)
+    return min(DELETION_WIPE_RETRY_BASE_DELAY * (2**doublings), DELETION_WIPE_RETRY_MAX_DELAY)
+
+
 def get_pending_deletion_wipes(
     limit: int = 100,
     stale_after: timedelta = timedelta(minutes=10),
@@ -611,7 +635,7 @@ def get_pending_deletion_wipes(
 ) -> list[dict]:
     """Return account_deletions documents whose wipe needs retry.
 
-    Queries ``failed`` records (always actionable), stale ``pending`` records
+    Queries ``failed`` records whose per-attempt backoff has elapsed, stale ``pending`` records
     (queued more than ``stale_after`` ago), stale ``deleting_auth`` records
     (intent written but never transitioned to ``pending`` — usually a crash
     after ``auth.delete_account()`` succeeded), stale ``running`` records (worker
@@ -632,8 +656,22 @@ def get_pending_deletion_wipes(
     running_cutoff = datetime.now(timezone.utc) - running_stale_after
     budget = limit
 
-    failed_docs = db.collection('account_deletions').where('wipe_status', '==', 'failed').limit(budget).stream()
-    result = [doc.to_dict() | {'uid': doc.id} for doc in failed_docs]
+    # Over-fetch *all* failed docs and back-off-filter in Python, for the same reason the
+    # ``pending`` branch below does: a tight ``.limit(budget)`` could return a page made
+    # entirely of records still inside their backoff window and starve one that is ready.
+    now = datetime.now(timezone.utc)
+    result: list[dict] = []
+    failed_docs = db.collection('account_deletions').where('wipe_status', '==', 'failed').stream()
+    for doc in failed_docs:
+        if len(result) >= limit:
+            break
+        data = doc.to_dict()
+        failed_at = data.get('wipe_failed_at')
+        # A record with no ``wipe_failed_at`` predates the backoff and stays immediately
+        # actionable: a missing timestamp must never be a reason to stop retrying a wipe.
+        if failed_at and failed_at + deletion_wipe_retry_delay(data.get('wipe_attempts') or 1) > now:
+            continue
+        result.append(data | {'uid': doc.id})
 
     if len(result) < limit:
         # Over-fetch *all* pending docs and age-filter in Python. A tight

--- a/backend/tests/unit/test_deletion_wipe_retry_backoff.py
+++ b/backend/tests/unit/test_deletion_wipe_retry_backoff.py
@@ -1,0 +1,144 @@
+"""A ``failed`` account-deletion wipe backs off instead of being re-selected every tick.
+
+``get_pending_deletion_wipes`` age-filters every status it returns except ``failed``, which its
+docstring called "always actionable". A wipe that fails for a persistent reason — the missing
+Cloud Tasks queue in #11680, or any dependency that is down — is therefore re-selected by every
+reconciler tick on every pod, forever: one claim transaction and one error log per pod per 300s
+against a record that cannot make progress, while the user who asked for deletion was told
+``{"status": "ok"}``.
+
+The delay backs off per recorded attempt and saturates. It never gives up: an accepted deletion
+stays actionable, and a record that predates the counter or the timestamp stays immediately
+actionable rather than becoming permanently stuck.
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+import database.users as users
+
+
+def _doc(doc_id, data):
+    d = MagicMock()
+    d.exists = True
+    d.id = doc_id
+    d.to_dict.return_value = data
+    return d
+
+
+class _Query:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def limit(self, n):
+        return _Query(self._docs[:n])
+
+    def stream(self):
+        return iter(self._docs)
+
+
+class _Collection:
+    def __init__(self, by_status, doc_ref):
+        self._by_status = by_status
+        self._doc_ref = doc_ref
+
+    def where(self, field, op, value):
+        assert (field, op) == ('wipe_status', '==')
+        return _Query(self._by_status.get(value, []))
+
+    def document(self, _uid):
+        return self._doc_ref
+
+
+def _patch_db(monkeypatch, by_status=None, doc_ref=None):
+    collection = _Collection(by_status or {}, doc_ref or MagicMock())
+    fake = MagicMock()
+    fake.collection.return_value = collection
+    monkeypatch.setattr(users, 'db', fake)
+
+
+def _failed(uid, *, minutes_ago, attempts=None):
+    data = {
+        'wipe_status': 'failed',
+        'wipe_failed_at': datetime.now(timezone.utc) - timedelta(minutes=minutes_ago),
+    }
+    if attempts is not None:
+        data['wipe_attempts'] = attempts
+    return _doc(uid, data)
+
+
+def _uids(rows):
+    return [row['uid'] for row in rows]
+
+
+def test_backoff_doubles_per_attempt_and_saturates():
+    assert users.deletion_wipe_retry_delay(1) == timedelta(0)
+    assert users.deletion_wipe_retry_delay(2) == timedelta(minutes=5)
+    assert users.deletion_wipe_retry_delay(3) == timedelta(minutes=10)
+    assert users.deletion_wipe_retry_delay(4) == timedelta(minutes=20)
+    assert users.deletion_wipe_retry_delay(50) == users.DELETION_WIPE_RETRY_MAX_DELAY
+
+
+def test_first_failure_is_retried_on_the_next_tick(monkeypatch):
+    # A transient error must cost nothing: one failure, no wait.
+    _patch_db(monkeypatch, {'failed': [_failed('uid1', minutes_ago=0, attempts=1)]})
+    assert _uids(users.get_pending_deletion_wipes()) == ['uid1']
+
+
+def test_repeatedly_failing_wipe_is_not_reselected_inside_its_window(monkeypatch):
+    # Three attempts -> 10 minutes; it failed one minute ago.
+    _patch_db(monkeypatch, {'failed': [_failed('uid1', minutes_ago=1, attempts=3)]})
+    assert users.get_pending_deletion_wipes() == []
+
+
+def test_repeatedly_failing_wipe_returns_once_the_window_elapses(monkeypatch):
+    _patch_db(monkeypatch, {'failed': [_failed('uid1', minutes_ago=30, attempts=3)]})
+    assert _uids(users.get_pending_deletion_wipes()) == ['uid1']
+
+
+def test_a_poisoned_record_never_shadows_a_ready_one(monkeypatch):
+    # The old code took the first page of failed docs; a page full of backed-off
+    # records must not starve one whose window has elapsed.
+    _patch_db(
+        monkeypatch,
+        {
+            'failed': [
+                _failed('poisoned', minutes_ago=1, attempts=40),
+                _failed('ready', minutes_ago=1, attempts=1),
+            ]
+        },
+    )
+    assert _uids(users.get_pending_deletion_wipes()) == ['ready']
+
+
+def test_record_written_before_the_counter_existed_stays_actionable(monkeypatch):
+    # Legacy principal: no wipe_attempts field. Counted as a first attempt, not as
+    # an unknown that gets skipped.
+    _patch_db(monkeypatch, {'failed': [_failed('legacy', minutes_ago=0)]})
+    assert _uids(users.get_pending_deletion_wipes()) == ['legacy']
+
+
+def test_record_without_a_failure_timestamp_stays_actionable(monkeypatch):
+    # A missing timestamp must never be a reason to stop retrying a wipe the user
+    # has already been told was accepted.
+    _patch_db(monkeypatch, {'failed': [_doc('no_ts', {'wipe_status': 'failed', 'wipe_attempts': 9})]})
+    assert _uids(users.get_pending_deletion_wipes()) == ['no_ts']
+
+
+def test_marking_a_wipe_failed_counts_the_attempt(monkeypatch):
+    doc_ref = MagicMock()
+    _patch_db(monkeypatch, doc_ref=doc_ref)
+
+    users.mark_user_deletion_wipe_failed('uid1')
+
+    payload, kwargs = doc_ref.set.call_args[0][0], doc_ref.set.call_args[1]
+    assert kwargs == {'merge': True}
+    assert payload['wipe_status'] == 'failed'
+    # An Increment, not a read-modify-write: two pods failing the same wipe both count.
+    assert isinstance(payload['wipe_attempts'], users.firestore.Increment)


### PR DESCRIPTION
Follow-up 5 of #11680 — *"an attempt cap / backoff in `reconcile_pending_deletion_wipes` so one poisoned record can't loop forever"*. Only the backoff half; see below for what is deliberately left out.

`get_pending_deletion_wipes` age-filters every status it returns except `failed`, whose docstring called it "always actionable". So a wipe that fails for a persistent reason is re-selected by every reconciler tick on every pod, forever — `_periodic_deletion_wipe_reconcile` runs every 300s per pod, and the issue measured **30+ claim transactions per minute against a single uid, 24/7, for at least a month**, while the user who asked for deletion had been told `{"status": "ok"}`.

## What changed

- `mark_user_deletion_wipe_failed` counts the attempt with an `Increment`, so two pods failing the same wipe both count.
- `deletion_wipe_retry_delay` doubles per attempt from 5 minutes and saturates at 1 hour. The first failure still retries on the next tick, so a transient error costs nothing.
- The `failed` branch over-fetches and filters in Python, matching what the `pending` branch already does and for the reason its own comment gives: a tight `.limit()` could return a page made entirely of backed-off records and starve one that is ready.

No new Firestore index: the selection stays a single-field equality filter on `wipe_status`, with age filtering in Python, as the function's docstring requires.

## What this deliberately does not do

**No attempt cap.** Giving up on an accepted deletion is a data-retention decision, not a scheduling one — it belongs to whoever owns that policy, not to this PR. Backoff alone takes the worst case from every 300s to hourly without changing what eventually happens.

It also does not address follow-ups 1–4 of the issue (creating the queue, IaC, the startup probe that asserts the queue resolves, the backlog audit).

## Legacy principals

Two records must never become stuck, and both are covered by tests: one written before the counter existed has no `wipe_attempts` and counts as a first attempt; one with no `wipe_failed_at` stays immediately actionable. A missing field is not a reason to stop retrying a deletion.

## Verification

- new `tests/unit/test_deletion_wipe_retry_backoff.py` — 8 passed
- `tests/services/users/test_account_deletion.py` + `test_claim_deletion_wipe_txn.py` + `tests/routers/test_users.py` — 108 passed, unchanged
- reverting `database/users.py` to this branch's merge-base turns **4 of the 8 red**: the backoff table, the inside-window case, the starvation case and the attempt counter. The other 4 assert that a record *stays* actionable, which holds on both sides by design.
- the backoff table caught a real overflow while it was being written: `timedelta * 2 ** 48` raises `OverflowError`, so the exponent is clamped before it is applied.

## Line-count ratchet

The change lands in the module that already owns both the selector and the failure marker, so it grows an oversized file rather than splitting it; splitting `database/users.py` is a refactor of its own and does not belong in a fix.

Line-Count-Exception: backend/database/users.py | 2140 -> 2178 | backoff constants, one pure helper and the age filter belong beside get_pending_deletion_wipes and mark_user_deletion_wipe_failed; splitting this module is out of scope for a fix

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

