### PR TITLE
fix(stt): scope and bound speaker identity

### DIFF
--- a/backend/models/transcript_segment.py
+++ b/backend/models/transcript_segment.py
@@ -1,8 +1,10 @@
 from datetime import timedelta
+from enum import Enum
 from typing import Any, Optional, List, Tuple, cast
 import uuid
 import re
 from pydantic import BaseModel, Field
+from pydantic.json_schema import SkipJsonSchema
 
 from models.other import Person
 
@@ -23,6 +25,15 @@ class Translation(BaseModel):
     text: str
 
 
+class SpeakerIdentityStatus(str, Enum):
+    """Evidence state behind the legacy boolean ``is_user`` projection."""
+
+    unknown = 'unknown'
+    user = 'user'
+    not_user = 'not_user'
+    no_match = 'no_match'
+
+
 class TranscriptSegment(BaseModel):
     id: Optional[str] = None
     text: str
@@ -35,12 +46,21 @@ class TranscriptSegment(BaseModel):
     translations: Optional[List[Translation]] = Field(default_factory=list)
     speech_profile_processed: bool = True
     stt_provider: Optional[str] = None
+    # These fields are persisted for backend identity consumers, but are not part
+    # of the first-party app wire contract. SkipJsonSchema leaves validation and
+    # model_dump intact while avoiding generated-client fan-out for internal state.
+    speaker_id_scope: SkipJsonSchema[Optional[str]] = None
+    speaker_identity_status: SkipJsonSchema[str] = SpeakerIdentityStatus.unknown
 
     def __init__(self, **data: Any):
+        if 'speaker_identity_status' not in data and data.get('is_user') is True:
+            data['speaker_identity_status'] = SpeakerIdentityStatus.user
         super().__init__(**data)
         if not self.id:
             self.id = str(uuid.uuid4())
 
+        if self.speaker_id is not None:
+            return
         if self.speaker:
             try:
                 self.speaker_id = int(self.speaker.split('_', 1)[1])
@@ -167,6 +187,8 @@ class TranscriptSegment(BaseModel):
             if not a or not b:
                 return a, b
             if b.stt_provider != a.stt_provider:
+                return a, b
+            if b.speaker_id_scope != a.speaker_id_scope:
                 return a, b
 
             if a.speaker != b.speaker and not (a.is_user and b.is_user) and a.text and b.text:

--- a/backend/models/transcript_segment.py
+++ b/backend/models/transcript_segment.py
@@ -46,9 +46,10 @@ class TranscriptSegment(BaseModel):
     translations: Optional[List[Translation]] = Field(default_factory=list)
     speech_profile_processed: bool = True
     stt_provider: Optional[str] = None
-    # These fields are persisted for backend identity consumers, but are not part
-    # of the first-party app wire contract. SkipJsonSchema leaves validation and
-    # model_dump intact while avoiding generated-client fan-out for internal state.
+    # Persisted for backend identity consumers. SkipJsonSchema keeps these out of
+    # the generated OpenAPI/Dart/Swift client schema while validation and
+    # model_dump (Firestore persistence, and the pusher transcript frames that
+    # document them) stay intact.
     speaker_id_scope: SkipJsonSchema[Optional[str]] = None
     speaker_identity_status: SkipJsonSchema[str] = SpeakerIdentityStatus.unknown
 

--- a/backend/parakeet/speaker_math.py
+++ b/backend/parakeet/speaker_math.py
@@ -1,4 +1,12 @@
+import os
+from typing import Callable, Sequence
+
 import numpy as np
+
+# Enrollment verification is a separate backend operation fixed at 0.45. These
+# defaults are for short, noisy in-session/batch centroid clustering only.
+SPEAKER_CLUSTERING_THRESHOLD = float(os.getenv("PARAKEET_SPEAKER_CLUSTERING_THRESHOLD", "0.60"))
+SPEAKER_CLUSTERING_MAX_SPEAKERS = max(1, int(os.getenv("PARAKEET_SPEAKER_CLUSTERING_MAX_SPEAKERS", "8")))
 
 
 def cosine_distance(a: object, b: object) -> float:
@@ -9,3 +17,30 @@ def cosine_distance(a: object, b: object) -> float:
         return 1.0
     distance = 1.0 - float(np.dot(a_vec, b_vec) / denom)
     return max(0.0, min(2.0, distance))
+
+
+def select_speaker_cluster(
+    embedding: object,
+    centroids: Sequence[object],
+    distance: Callable[[object, object], float] = cosine_distance,
+    *,
+    threshold: float = SPEAKER_CLUSTERING_THRESHOLD,
+    max_speakers: int = SPEAKER_CLUSTERING_MAX_SPEAKERS,
+) -> tuple[int, bool, float]:
+    """Choose a cluster, merging to the nearest once the configured cap is full."""
+    if not centroids:
+        return 0, True, float("inf")
+
+    best_index = 0
+    best_distance = float("inf")
+    for index, centroid in enumerate(centroids):
+        candidate_distance = distance(embedding, centroid)
+        if candidate_distance < best_distance:
+            best_index = index
+            best_distance = candidate_distance
+
+    if best_distance < threshold:
+        return best_index, False, best_distance
+    if len(centroids) < max(1, max_speakers):
+        return len(centroids), True, best_distance
+    return best_index, False, best_distance

--- a/backend/parakeet/speaker_math.py
+++ b/backend/parakeet/speaker_math.py
@@ -26,10 +26,16 @@ def select_speaker_cluster(
     *,
     threshold: float = SPEAKER_CLUSTERING_THRESHOLD,
     max_speakers: int = SPEAKER_CLUSTERING_MAX_SPEAKERS,
-) -> tuple[int, bool, float]:
-    """Choose a cluster, merging to the nearest once the configured cap is full."""
+) -> tuple[int, bool, float, bool]:
+    """Choose a cluster, merging to the nearest once the configured cap is full.
+
+    Mirrors utils/stt/speaker_clustering.py (this image cannot import it); the
+    tests pin the two copies to the same behavior. The fourth value is True when
+    the merge was forced by the cap rather than earned by the threshold, so
+    callers can log it and keep the miss out of the centroid running mean.
+    """
     if not centroids:
-        return 0, True, float("inf")
+        return 0, True, float("inf"), False
 
     best_index = 0
     best_distance = float("inf")
@@ -40,7 +46,7 @@ def select_speaker_cluster(
             best_distance = candidate_distance
 
     if best_distance < threshold:
-        return best_index, False, best_distance
+        return best_index, False, best_distance, False
     if len(centroids) < max(1, max_speakers):
-        return len(centroids), True, best_distance
-    return best_index, False, best_distance
+        return len(centroids), True, best_distance, False
+    return best_index, False, best_distance, True

--- a/backend/parakeet/stream_handler.py
+++ b/backend/parakeet/stream_handler.py
@@ -24,7 +24,7 @@ import numpy as np
 import torch  # type: ignore[reportMissingImports]
 from langdetect import detect as langdetect_detect  # type: ignore[reportUnknownVariableType]  # langdetect ships no py.typed marker
 from langdetect.lang_detect_exception import LangDetectException
-from speaker_math import cosine_distance
+from speaker_math import cosine_distance as cosine_distance, select_speaker_cluster
 import transcribe as _transcribe_mod
 
 try:
@@ -71,7 +71,6 @@ HANGOVER_S = float(os.getenv("PARAKEET_HANGOVER_S", "0.8"))
 CHUNK_SECONDS = float(os.getenv("PARAKEET_CHUNK_S", "2.0"))
 LEFT_CONTEXT_SECONDS = float(os.getenv("PARAKEET_LEFT_CONTEXT_S", "10.0"))
 RIGHT_CONTEXT_SECONDS = float(os.getenv("PARAKEET_RIGHT_CONTEXT_S", "2.0"))
-SPEAKER_MATCH_THRESHOLD = float(os.getenv("PARAKEET_SPEAKER_THRESHOLD", "0.45"))
 SPEAKER_EMBEDDING_URL = os.getenv("HOSTED_SPEAKER_EMBEDDING_API_URL", "")
 MIN_EMBEDDING_AUDIO_S = 0.5
 
@@ -717,13 +716,8 @@ class StreamSession:
             if emb is None:
                 return f"SPEAKER_{self._last_speaker}"
 
-            best_i, best_dist = -1, 1e9
-            for i, c in enumerate(self._spk_centroids):
-                d = cosine_distance(emb, c)
-                if d < best_dist:
-                    best_i, best_dist = i, d
-
-            if best_i >= 0 and best_dist < SPEAKER_MATCH_THRESHOLD:
+            best_i, create_new, _ = select_speaker_cluster(emb, self._spk_centroids)
+            if not create_new:
                 n = self._spk_counts[best_i]
                 self._spk_centroids[best_i] = (self._spk_centroids[best_i] * n + emb) / (n + 1)
                 self._spk_counts[best_i] = n + 1
@@ -732,7 +726,7 @@ class StreamSession:
 
             self._spk_centroids.append(emb)
             self._spk_counts.append(1)
-            self._last_speaker = len(self._spk_centroids) - 1
+            self._last_speaker = best_i
             return f"SPEAKER_{self._last_speaker}"
 
         except Exception as e:

--- a/backend/parakeet/stream_handler.py
+++ b/backend/parakeet/stream_handler.py
@@ -716,8 +716,17 @@ class StreamSession:
             if emb is None:
                 return f"SPEAKER_{self._last_speaker}"
 
-            best_i, create_new, _ = select_speaker_cluster(emb, self._spk_centroids)
+            best_i, create_new, _, capped = select_speaker_cluster(emb, self._spk_centroids)
             if not create_new:
+                if capped:
+                    # This image cannot import the shared fallback helper, so a
+                    # log line is the cap telemetry. The miss stays out of the
+                    # running mean to avoid dragging the centroid off its speaker.
+                    logger.warning(
+                        f"Speaker cap ({len(self._spk_centroids)}) reached; merging miss into SPEAKER_{best_i}"
+                    )
+                    self._last_speaker = best_i
+                    return f"SPEAKER_{best_i}"
                 n = self._spk_counts[best_i]
                 self._spk_centroids[best_i] = (self._spk_centroids[best_i] * n + emb) / (n + 1)
                 self._spk_counts[best_i] = n + 1

--- a/backend/parakeet/transcribe.py
+++ b/backend/parakeet/transcribe.py
@@ -279,11 +279,17 @@ def _diarize_segments(file_path: str, base: Dict[str, Any]) -> Dict[str, Any]:
                 seg["speaker"] = f"SPEAKER_{len(centroids) - 1}" if centroids else "SPEAKER_0"
                 continue
 
-            best_i, create_new, _ = select_speaker_cluster(emb, centroids)
+            best_i, create_new, _, capped = select_speaker_cluster(emb, centroids)
             if not create_new:
-                n = counts[best_i]
-                centroids[best_i] = (centroids[best_i] * n + emb) / (n + 1)
-                counts[best_i] = n + 1
+                if capped:
+                    # Standalone image: log is the cap telemetry (no shared
+                    # fallback helper here). Keep the miss out of the running
+                    # mean so the centroid keeps representing its own speaker.
+                    logger.warning(f"Speaker cap ({len(centroids)}) reached; merging miss into SPEAKER_{best_i}")
+                else:
+                    n = counts[best_i]
+                    centroids[best_i] = (centroids[best_i] * n + emb) / (n + 1)
+                    counts[best_i] = n + 1
                 seg["speaker"] = f"SPEAKER_{best_i}"
             else:
                 centroids.append(emb)

--- a/backend/parakeet/transcribe.py
+++ b/backend/parakeet/transcribe.py
@@ -8,7 +8,7 @@ import httpx
 import numpy as np
 from langdetect import detect as _langdetect_detect_raw  # type: ignore[reportUnknownVariableType]  # langdetect ships partial type info
 from langdetect.lang_detect_exception import LangDetectException
-from speaker_math import cosine_distance
+from speaker_math import cosine_distance as cosine_distance, select_speaker_cluster
 
 logger = logging.getLogger(__name__)
 
@@ -201,7 +201,6 @@ def transcribe_file_v2(
 
 
 SPEAKER_EMBEDDING_URL: str = os.getenv("HOSTED_SPEAKER_EMBEDDING_API_URL", "")
-SPEAKER_MATCH_THRESHOLD: float = float(os.getenv("PARAKEET_SPEAKER_THRESHOLD", "0.45"))
 MIN_SEGMENT_DURATION = 0.6
 
 
@@ -280,13 +279,8 @@ def _diarize_segments(file_path: str, base: Dict[str, Any]) -> Dict[str, Any]:
                 seg["speaker"] = f"SPEAKER_{len(centroids) - 1}" if centroids else "SPEAKER_0"
                 continue
 
-            best_i, best_dist = -1, 1e9
-            for i, c in enumerate(centroids):
-                d = cosine_distance(emb, c)
-                if d < best_dist:
-                    best_i, best_dist = i, d
-
-            if best_i >= 0 and best_dist < SPEAKER_MATCH_THRESHOLD:
+            best_i, create_new, _ = select_speaker_cluster(emb, centroids)
+            if not create_new:
                 n = counts[best_i]
                 centroids[best_i] = (centroids[best_i] * n + emb) / (n + 1)
                 counts[best_i] = n + 1
@@ -294,7 +288,7 @@ def _diarize_segments(file_path: str, base: Dict[str, Any]) -> Dict[str, Any]:
             else:
                 centroids.append(emb)
                 counts.append(1)
-                seg["speaker"] = f"SPEAKER_{len(centroids) - 1}"
+                seg["speaker"] = f"SPEAKER_{best_i}"
 
         except Exception as e:
             logger.warning(f"Diarization failed for segment {seg['start']:.1f}-{seg['end']:.1f}: {e}")

--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -34,6 +34,7 @@ from fastapi.websockets import WebSocketDisconnect
 import database.users as users_db
 from models.conversation_photo import ConversationPhoto
 from models.message_event import PhotoDescribedEvent, PhotoProcessingEvent
+from models.transcript_segment import SpeakerIdentityStatus
 from utils.aac import AACDecoder
 from utils.llm.openglass import describe_image
 from utils.request_validation import ImageChunkEnvelope
@@ -60,6 +61,7 @@ from utils.stt.streaming import (
     process_audio_modulate,
     process_audio_parakeet,
 )
+from utils.stt.speaker_identity import SpeakerProviderEpoch
 from utils.stt.vad_gate import GatedSTTSocket, VADStreamingGate, VAD_GATE_MODE, is_gate_enabled
 from utils.transcribe_decisions import (
     TARGET_SAMPLE_RATE,
@@ -131,6 +133,7 @@ class ListenReceiver:
         self.last_image_chunk_cleanup = 0.0
         self.decode_failure_streak = 0
         self.decode_stream_reported = False
+        self.speaker_provider_epoch = SpeakerProviderEpoch()
 
     def _capture(self, method: str, *args: Any) -> None:
         """Keep optional dev capture out of the production audio failure domain."""
@@ -183,6 +186,12 @@ class ListenReceiver:
         failure to Parakeet (#11306).
         """
         return getattr(self.host.stt_service, 'value', self.host.stt_service)
+
+    def _enqueue_stt_segments(self, segments: List[Dict[str, Any]], provider: Optional[str] = None) -> None:
+        """Persist the provider epoch before local speaker numbers enter the conversation."""
+        self._capture('capture_inbound_stt', segments)
+        self.speaker_provider_epoch.stamp(segments, provider or self._serving_provider())
+        self.host.transcripts.enqueue(segments)
 
     def initialize_decoders(self) -> None:
         request = self.host.request
@@ -350,11 +359,15 @@ class ListenReceiver:
                 for index, config in enumerate(self.channel_configs):
 
                     def callback(segments: List[Dict[str, Any]], channel: ChannelConfig = config) -> None:
-                        self._capture('capture_inbound_stt', segments)
                         for segment in segments:
                             segment['is_user'] = channel.is_user
+                            segment['speaker_identity_status'] = (
+                                SpeakerIdentityStatus.user.value
+                                if channel.is_user
+                                else SpeakerIdentityStatus.not_user.value
+                            )
                             segment['speaker'] = channel.speaker_label
-                        self.host.transcripts.enqueue(segments)
+                        self._enqueue_stt_segments(segments)
 
                     socket = await self._create_stt_socket(callback, TARGET_SAMPLE_RATE)
                     if socket is None:
@@ -382,8 +395,7 @@ class ListenReceiver:
                     logger.exception('VAD gate initialization failed; continuing without it')
 
             def capture_and_enqueue(segments: List[Dict[str, Any]]) -> None:
-                self._capture('capture_inbound_stt', segments)
-                self.host.transcripts.enqueue(segments)
+                self._enqueue_stt_segments(segments)
 
             parakeet_callback = make_stream_callback(capture_and_enqueue, self.vad_gate, False)
             modulate_callback = make_stream_callback(capture_and_enqueue, self.vad_gate, True)
@@ -627,10 +639,7 @@ class ListenReceiver:
         elif kind == 'suggested_transcript' and self.host.use_custom_stt:
             segments = payload.get('segments', [])
             provider = payload.get('stt_provider')
-            if provider:
-                for segment in segments:
-                    segment['stt_provider'] = provider
-            self.host.transcripts.enqueue(segments)
+            self._enqueue_stt_segments(segments, provider=provider or 'custom')
         elif kind == 'speaker_assigned':
             await self._handle_speaker_assigned(payload)
         elif kind == 'finalization_reason':

--- a/backend/routers/listen/speakers.py
+++ b/backend/routers/listen/speakers.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional, cast
 import av
 import numpy as np
 
+from models.transcript_segment import SpeakerIdentityStatus
 from utils.audio import AudioRingBuffer
 from utils.executors import storage_executor, sync_executor, run_blocking
 from utils.other.storage import get_profile_audio_if_exists
@@ -36,6 +37,7 @@ class SpeakerMatcher:
         self.person_embeddings: Dict[str, Dict[str, Any]] = {}
         self.speaker_to_person: Dict[int, tuple[str, str]] = {}
         self.segment_assignments: Dict[str, str] = {}
+        self.segment_identity_status: Dict[str, SpeakerIdentityStatus] = {}
         self.tasks: set[asyncio.Task[Any]] = set()
 
     async def load_and_run(self) -> None:
@@ -187,9 +189,14 @@ class SpeakerMatcher:
             if best_id and best_name and best_distance < SPEAKER_MATCH_THRESHOLD:
                 self.speaker_to_person[speaker_id] = (best_id, best_name)
                 self.segment_assignments[segment['id']] = best_id
+                self.segment_identity_status[segment['id']] = (
+                    SpeakerIdentityStatus.user if best_id == USER_SELF_PERSON_ID else SpeakerIdentityStatus.not_user
+                )
                 self.host.state.speaker_map_dirty = True
                 self.host.emit_speaker_suggestion(speaker_id, best_id, best_name, segment['id'])
             else:
+                self.segment_identity_status[segment['id']] = SpeakerIdentityStatus.no_match
+                self.host.state.speaker_map_dirty = True
                 logger.info('Speaker ID no match speaker=%s best_distance=%.3f', speaker_id, best_distance)
         except Exception as error:
             logger.error('Speaker ID match failed speaker=%s type=%s', speaker_id, type(error).__name__)
@@ -202,3 +209,4 @@ class SpeakerMatcher:
         self.person_embeddings.clear()
         self.speaker_to_person.clear()
         self.segment_assignments.clear()
+        self.segment_identity_status.clear()

--- a/backend/routers/listen/transcripts.py
+++ b/backend/routers/listen/transcripts.py
@@ -20,13 +20,14 @@ from models.message_event import (
     SpeakerLabelSuggestionEvent,
     TranslationEvent,
 )
-from models.transcript_segment import TranscriptSegment, Translation
+from models.transcript_segment import SpeakerIdentityStatus, TranscriptSegment, Translation
 from utils.app_integrations import trigger_realtime_integrations
 from utils.conversations.factory import deserialize_conversation
 from utils.observability.fallback import record_fallback
 from utils.speaker_assignment import process_speaker_assigned_segments, should_update_speaker_to_person_map
 from utils.speaker_identification import detect_speaker_from_text
 from utils.stt.streaming import sort_segments_by_start, sort_transcript_segments_in_place
+from utils.stt.speaker_identity import ConversationSpeakerIdAllocator
 from utils.transcribe_decisions import (
     is_user_self_match,
     person_id_for_client,
@@ -86,6 +87,7 @@ class TranscriptProcessor:
         self.cache = ConversationCache(self._load_conversation)
         self.current_session_segments: Dict[str, bool] = {}
         self.suggested_segments: set[str] = set()
+        self.speaker_id_allocator = ConversationSpeakerIdAllocator()
         self.language_cache = TranscriptSegmentLanguageCache()
         self.translation_service = TranslationService()
         self.translation_lock = asyncio.Lock()
@@ -187,6 +189,7 @@ class TranscriptProcessor:
             speaker = self.host.speakers
             targets = conversation.transcript_segments if self.host.state.speaker_map_dirty else updated
             process_speaker_assigned_segments(targets, speaker.segment_assignments, speaker.speaker_to_person)
+            self._apply_speaker_identity_statuses(targets)
             self.host.state.speaker_map_dirty = False
             serialised = [segment.model_dump() for segment in conversation.transcript_segments]
             written = await self.host.persistence.call(
@@ -222,7 +225,9 @@ class TranscriptProcessor:
 
     async def flush_speaker_assignments(self, conversation_id: Optional[str]) -> None:
         speaker = self.host.speakers
-        if not conversation_id or not (speaker.speaker_to_person or speaker.segment_assignments):
+        if not conversation_id or not (
+            speaker.speaker_to_person or speaker.segment_assignments or speaker.segment_identity_status
+        ):
             return
         data = await self.cache.get(conversation_id, force_refresh=True)
         if not data:
@@ -231,6 +236,7 @@ class TranscriptProcessor:
         process_speaker_assigned_segments(
             conversation.transcript_segments, speaker.segment_assignments, speaker.speaker_to_person
         )
+        self._apply_speaker_identity_statuses(conversation.transcript_segments)
         serialised = [segment.model_dump() for segment in conversation.transcript_segments]
         await self.host.persistence.call(
             conversations_db.update_conversation_segments,
@@ -241,6 +247,21 @@ class TranscriptProcessor:
         )
         self.cache.update_segments(serialised)
         self.host.state.speaker_map_dirty = False
+
+    def _apply_speaker_identity_statuses(self, segments: List[TranscriptSegment]) -> None:
+        speaker = self.host.speakers
+        for segment in segments:
+            person_id = speaker.segment_assignments.get(cast(str, segment.id))
+            if person_id is None and segment.speaker_id in speaker.speaker_to_person:
+                person_id = speaker.speaker_to_person[cast(int, segment.speaker_id)][0]
+            if person_id is not None:
+                segment.speaker_identity_status = (
+                    SpeakerIdentityStatus.user if is_user_self_match(person_id) else SpeakerIdentityStatus.not_user
+                )
+                continue
+            status = speaker.segment_identity_status.get(cast(str, segment.id))
+            if status is not None:
+                segment.speaker_identity_status = status
 
     async def _translate(self, segments: List[TranscriptSegment], conversation_id: str, removed: List[str]) -> None:
         if self.translation_coordinator:
@@ -272,10 +293,6 @@ class TranscriptProcessor:
                 continue
             raw_segments = sort_segments_by_start(list(self.segment_buffer))
             conversation_id = self.host.state.current_conversation_id
-            if conversation_id:
-                diarized_speaker_ids_by_conversation.setdefault(conversation_id, set()).update(
-                    int(segment['speaker_id']) for segment in raw_segments if isinstance(segment.get('speaker_id'), int)
-                )
             self.segment_buffer.clear()
             photos = list(self.photo_buffer)
             self.photo_buffer.clear()
@@ -299,7 +316,9 @@ class TranscriptProcessor:
                 if isinstance(conversation_started, str):
                     conversation_started = datetime.fromisoformat(conversation_started)
                 offset = self.host.state.first_audio_byte_timestamp - conversation_started.timestamp()
+                self.speaker_id_allocator.hydrate(data.get('transcript_segments', []))
                 for raw in raw_segments:
+                    self.speaker_id_allocator.assign(raw)
                     raw['start'] += offset
                     raw['end'] += offset
                     segment = TranscriptSegment(**raw, speech_profile_processed=True)
@@ -308,8 +327,13 @@ class TranscriptProcessor:
                         and raw.get('speaker_id') != self.host.onboarding_omi_speaker_id
                     ):
                         segment.is_user = True
+                        segment.speaker_identity_status = SpeakerIdentityStatus.user
                     new_segments.append(segment)
                     self.current_session_segments[cast(str, segment.id)] = segment.speech_profile_processed
+                if conversation_id:
+                    diarized_speaker_ids_by_conversation.setdefault(conversation_id, set()).update(
+                        segment.speaker_id for segment in new_segments if isinstance(segment.speaker_id, int)
+                    )
                 self.host.state.words_transcribed_since_last_record += len(
                     ' '.join(segment.text for segment in new_segments).split()
                 )
@@ -411,7 +435,9 @@ class TranscriptProcessor:
                 person_id, person_name = speaker.speaker_to_person[segment.speaker_id]
                 if is_user_self_match(person_id):
                     segment.is_user = True
+                    segment.speaker_identity_status = SpeakerIdentityStatus.user
                 else:
+                    segment.speaker_identity_status = SpeakerIdentityStatus.not_user
                     self.host.emit_speaker_suggestion(segment.speaker_id, person_id, person_name, segment_id)
                 self.suggested_segments.add(segment_id)
                 continue

--- a/backend/tests/unit/test_listen_parity_runtime.py
+++ b/backend/tests/unit/test_listen_parity_runtime.py
@@ -243,7 +243,13 @@ async def test_listen_runtime_persists_and_exports_capture_exactly_once_after_cl
     assert runtime.parity_capture.enabled is True
     assert len(stt_sockets) == 1
     assert stt_sockets[0].sent == [_AUDIO]
-    assert runtime.transcripts.inbound == [{'text': _TRANSCRIPT, 'start': 0.0, 'end': 0.03}]
+    assert len(runtime.transcripts.inbound) == 1
+    inbound = runtime.transcripts.inbound[0]
+    assert inbound['text'] == _TRANSCRIPT
+    assert inbound['start'] == 0.0
+    assert inbound['end'] == 0.03
+    assert inbound['stt_provider'] == 'parakeet'
+    assert inbound['speaker_id_scope'].endswith(':0')
     assert len(persist_calls) == 1
     persist_offloads = [
         (executor, function)

--- a/backend/tests/unit/test_listen_receiver_frame_recovery.py
+++ b/backend/tests/unit/test_listen_receiver_frame_recovery.py
@@ -100,7 +100,11 @@ async def test_receiver_drops_malformed_codec_frame_and_continues_to_custom_tran
 
     await receiver.receive_data()
 
-    assert received_segments == [{'id': 'recovered', 'text': 'Recovered transcript', 'stt_provider': 'test-provider'}]
+    assert len(received_segments) == 1
+    assert received_segments[0]['id'] == 'recovered'
+    assert received_segments[0]['text'] == 'Recovered transcript'
+    assert received_segments[0]['stt_provider'] == 'test-provider'
+    assert received_segments[0]['speaker_id_scope'].endswith(':0')
     assert live_transcription_starts == [True]
     assert host.state.close_code == 1000
 

--- a/backend/tests/unit/test_listen_runtime_regressions.py
+++ b/backend/tests/unit/test_listen_runtime_regressions.py
@@ -296,6 +296,17 @@ async def test_bootstrap_sends_first_onboarding_question_before_any_audio(monkey
     assert enqueued_segments and enqueued_segments[0]['speaker_id'] == OnboardingHandler.OMI_SPEAKER_ID
 
 
+def test_allocator_sentinel_matches_the_onboarding_handler_reservation():
+    # The allocator reserves OMI_SPEAKER_ID_SENTINEL so a long session with
+    # many provider transitions can never allocate 99 to a real speaker. That
+    # reservation is only meaningful while it equals the value onboarding
+    # actually stamps its question segments with, so pin the two together.
+    # (This file already owns the heavy utils.onboarding import chain.)
+    from utils.stt.speaker_identity import OMI_SPEAKER_ID_SENTINEL
+
+    assert OMI_SPEAKER_ID_SENTINEL == OnboardingHandler.OMI_SPEAKER_ID
+
+
 @pytest.mark.anyio
 async def test_bootstrap_passes_explicit_parakeet_through_capability_aware_selection(monkeypatch):
     import routers.listen.runtime as runtime_module

--- a/backend/tests/unit/test_listen_runtime_regressions.py
+++ b/backend/tests/unit/test_listen_runtime_regressions.py
@@ -543,6 +543,7 @@ def _transcript_processor_for_delivery(monkeypatch, websocket):
             self.end = data['end']
             self.speech_profile_processed = data['speech_profile_processed']
             self.is_user = False
+            self.speaker_id = data.get('speaker_id')
 
         def model_dump(self):
             return {'id': self.id, 'text': self.text}
@@ -597,6 +598,7 @@ def _transcript_processor_for_delivery(monkeypatch, websocket):
     processor.photo_buffer = deque()
     processor.cache = SimpleNamespace(get=cache_get)
     processor.current_session_segments = {}
+    processor.speaker_id_allocator = SimpleNamespace(hydrate=lambda _segments: None, assign=lambda _segment: None)
     processor._update_live_conversation = update
     processor._translate = no_op
     processor._speaker_detection = no_op

--- a/backend/tests/unit/test_parakeet_diarization.py
+++ b/backend/tests/unit/test_parakeet_diarization.py
@@ -15,6 +15,8 @@ os.environ.setdefault('HOSTED_SPEAKER_EMBEDDING_API_URL', 'http://fake')  # enab
 os.environ.setdefault('DEEPGRAM_API_KEY', 'x')
 
 import utils.stt.streaming as st  # noqa: E402
+from utils.stt.speaker_clustering import SPEAKER_CLUSTERING_THRESHOLD  # noqa: E402
+from utils.stt.speaker_embedding import SPEAKER_MATCH_THRESHOLD  # noqa: E402
 
 
 def _cosine_distance(a, b):
@@ -67,6 +69,11 @@ def test_clusters_two_speakers_stably(monkeypatch):
     assert got == [0, 0, 1, 0, 1]
 
 
+def test_clustering_threshold_is_separate_from_enrollment_verification():
+    assert SPEAKER_MATCH_THRESHOLD == 0.45
+    assert SPEAKER_CLUSTERING_THRESHOLD == 0.60
+
+
 def test_short_clip_inherits_last_speaker_without_embedding(monkeypatch):
     rng = np.random.default_rng(1)
     calls = _patch_embeddings(monkeypatch, [_dir_vec(1, rng)])
@@ -93,6 +100,19 @@ def test_embedding_failure_falls_back_to_last_speaker(monkeypatch):
     sock = _make_socket()
     sock._last_speaker = 2
     assert asyncio.run(sock._assign_speaker(b'\x01\x00' * 16000)) == 2  # never drops the segment
+
+
+def test_online_clustering_merges_to_nearest_after_eight_speakers(monkeypatch):
+    embeddings = [np.eye(9, dtype=np.float32)[index].reshape(1, -1) for index in range(9)]
+    _patch_embeddings(monkeypatch, embeddings)
+    sock = _make_socket()
+    long_pcm = b'\x01\x00' * 16000
+
+    assigned = [asyncio.run(sock._assign_speaker(long_pcm)) for _ in embeddings]
+
+    assert assigned[:8] == list(range(8))
+    assert assigned[8] == 0
+    assert len(sock._spk_centroids) == 8
 
 
 def test_slice_pcm_bounds():

--- a/backend/tests/unit/test_parakeet_diarization.py
+++ b/backend/tests/unit/test_parakeet_diarization.py
@@ -115,6 +115,78 @@ def test_online_clustering_merges_to_nearest_after_eight_speakers(monkeypatch):
     assert len(sock._spk_centroids) == 8
 
 
+def test_clustering_boundary_at_exactly_the_threshold_creates_a_new_speaker():
+    # The clustering boundary is strict: a clip at exactly 0.60 cosine distance
+    # is NOT the same speaker and must open a new centroid (while capacity
+    # remains). Pinning the exact boundary keeps future refactors from quietly
+    # turning < into <= and re-merging borderline speakers.
+    decision = st.select_speaker_cluster('emb', ['centroid'], lambda _a, _b: SPEAKER_CLUSTERING_THRESHOLD)
+    just_inside = st.select_speaker_cluster('emb', ['centroid'], lambda _a, _b: SPEAKER_CLUSTERING_THRESHOLD - 1e-9)
+
+    index, create_new, _distance, capped = decision
+    assert (index, create_new, capped) == (1, True, False)
+    assert just_inside[1] is False  # strictly below the threshold merges
+
+
+def test_enrollment_boundary_at_exactly_the_threshold_is_not_a_match(monkeypatch):
+    # Voiceprint verification is equally strict at its own 0.45 operating
+    # point: exactly at the threshold the answer is "not the same speaker".
+    from utils.stt import speaker_embedding
+
+    monkeypatch.setattr(speaker_embedding, 'compare_embeddings', lambda _a, _b: SPEAKER_MATCH_THRESHOLD)
+    same, distance = speaker_embedding.is_same_speaker('a', 'b')
+    assert same is False
+    assert distance == SPEAKER_MATCH_THRESHOLD
+
+
+def test_cap_merge_is_reported_and_does_not_drift_the_centroid(monkeypatch):
+    # When the eighth centroid is full, a ninth distinct voice is force-merged
+    # into the nearest centroid. That merge misattributes the segment, so it
+    # must be observable (shared fallback telemetry) and must not update the
+    # winning centroid's running mean — folding a >0.60 embedding into a mean
+    # would drag that centroid toward the wrong speaker and chain further
+    # misattributions.
+    embeddings = [np.eye(9, dtype=np.float32)[index].reshape(1, -1) for index in range(9)]
+    _patch_embeddings(monkeypatch, embeddings + [embeddings[0]])
+    fallbacks = []
+    monkeypatch.setattr(st, 'record_fallback', lambda **kwargs: fallbacks.append(kwargs))
+    sock = _make_socket()
+    long_pcm = b'\x01\x00' * 16000
+
+    assigned = [asyncio.run(sock._assign_speaker(long_pcm)) for _ in embeddings]
+    again = asyncio.run(sock._assign_speaker(long_pcm))  # speaker 0 keeps its own identity
+
+    assert assigned[8] == 0
+    assert len(fallbacks) == 1
+    assert fallbacks[0]['reason'] == 'capacity_full'
+    assert fallbacks[0]['outcome'] == 'degraded'
+    # The forced merge left centroid 0 exactly on its own first embedding...
+    np.testing.assert_array_equal(sock._spk_centroids[0], embeddings[0])
+    # ...so speaker 0's next clip still lands on speaker 0 deterministically.
+    assert again == 0
+
+
+def test_rare_owner_is_not_fragmented_among_many_speakers(monkeypatch):
+    # The conference-call shape: several distinct voices, clean audio, and the
+    # owner only speaking occasionally. If each rare owner turn opened a new
+    # centroid, the owner's transcript would fragment across several speaker
+    # labels — the mislabelling failure users actually notice. Within-speaker
+    # distance must stay comfortably under the 0.60 clustering threshold.
+    rng = np.random.default_rng(7)
+    order = [0, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6, 1, 2, 0]
+    _patch_embeddings(monkeypatch, [_dir_vec(index, rng) for index in order])
+    sock = _make_socket()
+    long_pcm = b'\x01\x00' * 16000
+
+    assigned = [asyncio.run(sock._assign_speaker(long_pcm)) for _ in order]
+
+    owner_turns = [index for index, speaker in enumerate(order) if speaker == 0]
+    owner_ids = {assigned[index] for index in owner_turns}
+    assert len(owner_ids) == 1  # first and last owner turn share one identity
+    # Nobody else was relabeled into the owner's identity.
+    assert assigned[owner_turns[0]] not in {assigned[i] for i, s in enumerate(order) if s != 0}
+
+
 def test_slice_pcm_bounds():
     sock = _make_socket()
     pcm = b'\x00\x00' * 16000  # 1s @ 16kHz int16

--- a/backend/tests/unit/test_parakeet_stream_session.py
+++ b/backend/tests/unit/test_parakeet_stream_session.py
@@ -342,6 +342,17 @@ class TestStreamSessionSpeaker:
             result = session._assign_speaker(_make_pcm(1.0), 0.0, 1.0)
         assert result == "SPEAKER_0"
 
+    def test_clustering_merges_to_nearest_after_eight_speakers(self):
+        session = sh.StreamSession(sample_rate=16000)
+        embeddings = iter(np.eye(9, dtype=np.float32))
+
+        with patch.object(session, '_get_embedding', side_effect=lambda _wav: next(embeddings)):
+            assigned = [session._assign_speaker(_make_pcm(1.0), 0.0, 1.0) for _ in range(9)]
+
+        assert assigned[:8] == [f"SPEAKER_{index}" for index in range(8)]
+        assert assigned[8] == "SPEAKER_0"
+        assert len(session._spk_centroids) == 8
+
 
 class TestStreamSessionVADParams:
 

--- a/backend/tests/unit/test_parakeet_stream_session.py
+++ b/backend/tests/unit/test_parakeet_stream_session.py
@@ -353,6 +353,24 @@ class TestStreamSessionSpeaker:
         assert assigned[8] == "SPEAKER_0"
         assert len(session._spk_centroids) == 8
 
+    def test_cap_merge_keeps_the_winning_centroid_undrifted(self):
+        # The standalone Parakeet image mirrors the backend clustering policy;
+        # its tests pin the mirror. A cap-forced merge must not feed the missed
+        # embedding into the winning centroid's running mean, or the ninth
+        # speaker drags the first speaker's centroid toward itself and chains
+        # further misattributions.
+        session = sh.StreamSession(sample_rate=16000)
+        embeddings = [np.eye(9, dtype=np.float32)[index] for index in range(9)]
+        stream = iter(embeddings + [embeddings[0]])
+
+        with patch.object(session, '_get_embedding', side_effect=lambda _wav: next(stream)):
+            assigned = [session._assign_speaker(_make_pcm(1.0), 0.0, 1.0) for _ in range(9)]
+            again = session._assign_speaker(_make_pcm(1.0), 0.0, 1.0)
+
+        assert assigned[8] == "SPEAKER_0"
+        np.testing.assert_array_equal(np.asarray(session._spk_centroids[0]).reshape(-1), embeddings[0])
+        assert again == "SPEAKER_0"
+
 
 class TestStreamSessionVADParams:
 

--- a/backend/tests/unit/test_stt_speaker_identity.py
+++ b/backend/tests/unit/test_stt_speaker_identity.py
@@ -1,4 +1,8 @@
-from utils.stt.speaker_identity import ConversationSpeakerIdAllocator, SpeakerProviderEpoch
+from utils.stt.speaker_identity import (
+    OMI_SPEAKER_ID_SENTINEL,
+    ConversationSpeakerIdAllocator,
+    SpeakerProviderEpoch,
+)
 
 
 def test_provider_change_scopes_padded_and_unpadded_speaker_numbers():
@@ -78,3 +82,130 @@ def test_segments_without_a_provider_fall_back_to_the_host_selection():
 
     assert unstamped['stt_provider'] == 'parakeet'
     assert unstamped['speaker_id_scope'] == 'connection-a:0'
+
+
+def test_provider_fallback_mid_conversation_keeps_peer_identities_separate():
+    # A live conversation can fall back between serving peers mid-stream, and
+    # each peer restarts its own SPEAKER_00 numbering. If the two numbering
+    # spaces were shared, the first speaker after the transition would inherit
+    # the other peer's identity (and its person assignment).
+    epoch = SpeakerProviderEpoch('connection-a')
+    allocator = ConversationSpeakerIdAllocator()
+
+    peer_one_alice = {'speaker': 'SPEAKER_00', 'stt_provider': 'deepgram'}
+    peer_one_bob = {'speaker': 'SPEAKER_01', 'stt_provider': 'deepgram'}
+    epoch.stamp([peer_one_alice, peer_one_bob], 'deepgram')
+    allocator.assign(peer_one_alice)
+    allocator.assign(peer_one_bob)
+
+    peer_two_first = {'speaker': 'SPEAKER_00', 'stt_provider': 'modulate'}
+    peer_two_second = {'speaker': 'SPEAKER_01', 'stt_provider': 'modulate'}
+    epoch.stamp([peer_two_first, peer_two_second], 'deepgram')
+    allocator.assign(peer_two_first)
+    allocator.assign(peer_two_second)
+
+    # Same provider-local label, different peer: must never share an ID.
+    assert peer_one_alice['speaker_id'] != peer_two_first['speaker_id']
+    assert peer_one_bob['speaker_id'] != peer_two_second['speaker_id']
+    # Within one peer the labels stay stable and distinct.
+    assert peer_one_alice['speaker_id'] != peer_one_bob['speaker_id']
+    assert peer_two_first['speaker_id'] != peer_two_second['speaker_id']
+    # The epoch only moves forward: a peer whose name returns after an
+    # interlude gets a NEW scope rather than rejoining its old numbering space.
+    # Rejoining would be wrong whenever the peer actually restarted (its
+    # SPEAKER_00 may be a different human), and merging numbering spaces is the
+    # one mistake this design refuses to make — the cost is at most a split
+    # identity, never a stolen one.
+    peer_one_alice_again = {'speaker': 'SPEAKER_00', 'stt_provider': 'deepgram'}
+    epoch.stamp([peer_one_alice_again], 'deepgram')
+    allocator.assign(peer_one_alice_again)
+    assert peer_one_alice_again['speaker_id'] not in {
+        peer_one_alice['speaker_id'],
+        peer_two_first['speaker_id'],
+    }
+    assert peer_one_alice_again['speaker_id_scope'] != peer_one_alice['speaker_id_scope']
+
+
+def test_reconnect_rehydrates_without_reuse_or_renumbering():
+    # A websocket reconnect builds a fresh epoch (new connection scope) but the
+    # conversation keeps its persisted segments. Rehydration must guarantee two
+    # things: no previously issued ID is handed to a new speaker, and no
+    # persisted assignment is recomputed to a different value.
+    allocator = ConversationSpeakerIdAllocator()
+    persisted = [
+        {'speaker': 'SPEAKER_00', 'speaker_id': 0, 'speaker_id_scope': 'connection-a:0'},
+        {'speaker': 'SPEAKER_01', 'speaker_id': 1, 'speaker_id_scope': 'connection-a:0'},
+    ]
+    allocator.hydrate(persisted)
+
+    reconnect_epoch = SpeakerProviderEpoch('connection-b')
+    resumed_speaker = {'speaker': 'SPEAKER_00'}
+    reconnect_epoch.stamp([resumed_speaker], 'deepgram')
+    allocator.assign(resumed_speaker)
+    assert resumed_speaker['speaker_id'] == 2  # not 0 and not 1: no reuse
+
+    # The old numbering space keeps resolving to its persisted IDs, so nothing
+    # already shown to the user gets renumbered after the reconnect.
+    replayed = {'speaker': 'SPEAKER_01', 'speaker_id_scope': 'connection-a:0'}
+    allocator.assign(replayed)
+    assert replayed['speaker_id'] == 1
+
+
+def test_allocator_never_allocates_the_onboarding_sentinel():
+    # Omi's onboarding questions ride the same transcript pipeline with
+    # speaker_id=99 (OnboardingHandler.OMI_SPEAKER_ID), and transcripts.py
+    # distinguishes them by exact value. Provider transitions multiply scopes,
+    # so a long flapping session can push the allocation counter past 98 — the
+    # allocator must skip 99 rather than hand a real speaker the sentinel.
+    # (The sentinel's equality with OnboardingHandler.OMI_SPEAKER_ID is pinned
+    # in test_listen_runtime_regressions.py, which already owns that import.)
+    allocator = ConversationSpeakerIdAllocator()
+    assigned = []
+    for index in range(120):
+        segment = {'speaker_id_scope': f'connection-a:{index}', 'speaker': 'SPEAKER_00'}
+        allocator.assign(segment)
+        assigned.append(segment['speaker_id'])
+
+    assert OMI_SPEAKER_ID_SENTINEL not in assigned
+    # The skip is a single hole: every other ID is allocated in order.
+    assert assigned == [value for value in range(121) if value != OMI_SPEAKER_ID_SENTINEL]
+
+
+def test_padded_and_unpadded_labels_share_one_identity():
+    # Providers disagree on zero padding (Deepgram/Modulate emit SPEAKER_02,
+    # Parakeet paths emit SPEAKER_2), and a custom-STT client may send a bare
+    # speaker_id with no label at all. If the allocator keyed on the raw
+    # spelling, one human inside one provider scope could split into two
+    # speakers depending on which segment arrived first.
+    allocator = ConversationSpeakerIdAllocator()
+    allocator.hydrate([{'speaker': 'SPEAKER_02', 'speaker_id': 2, 'speaker_id_scope': 'connection-a:0'}])
+
+    unpadded = {'speaker': 'SPEAKER_2', 'speaker_id_scope': 'connection-a:0'}
+    unlabeled = {'speaker_id': 2, 'speaker_id_scope': 'connection-a:0'}
+    allocator.assign(unpadded)
+    allocator.assign(unlabeled)
+
+    assert unpadded['speaker_id'] == 2
+    assert unlabeled['speaker_id'] == 2
+
+    # Distinct speakers still stay distinct: SPEAKER_10 is not SPEAKER_1.
+    ten = {'speaker': 'SPEAKER_10', 'speaker_id_scope': 'connection-a:0'}
+    allocator.assign(ten)
+    assert ten['speaker_id'] not in {2}
+
+
+def test_legacy_segments_without_a_scope_pass_through_unharmed():
+    # Conversations recorded before scoping exists (and Omi's onboarding
+    # segments today) carry no speaker_id_scope. They must leave the allocator
+    # untouched: no new key registered, no speaker_id rewritten, so legacy
+    # provider-local numbering and the 99 sentinel survive verbatim.
+    allocator = ConversationSpeakerIdAllocator()
+    legacy = {'speaker': 'SPEAKER_07', 'speaker_id': 7}
+    sentinel = {'speaker': 'SPEAKER_99', 'speaker_id': 99}
+
+    allocator.assign(legacy)
+    allocator.assign(sentinel)
+
+    assert legacy['speaker_id'] == 7
+    assert sentinel['speaker_id'] == 99
+    assert allocator._speaker_ids == {}

--- a/backend/tests/unit/test_stt_speaker_identity.py
+++ b/backend/tests/unit/test_stt_speaker_identity.py
@@ -1,0 +1,41 @@
+from utils.stt.speaker_identity import ConversationSpeakerIdAllocator, SpeakerProviderEpoch
+
+
+def test_provider_change_scopes_padded_and_unpadded_speaker_numbers():
+    epoch = SpeakerProviderEpoch('connection-a')
+    allocator = ConversationSpeakerIdAllocator()
+    deepgram = {'speaker': 'SPEAKER_0'}
+    modulate = {'speaker': 'SPEAKER_00'}
+
+    epoch.stamp([deepgram], 'deepgram')
+    allocator.assign(deepgram)
+    epoch.stamp([modulate], 'modulate')
+    allocator.assign(modulate)
+
+    assert deepgram['stt_provider'] == 'deepgram'
+    assert modulate['stt_provider'] == 'modulate'
+    assert deepgram['speaker_id_scope'] != modulate['speaker_id_scope']
+    assert deepgram['speaker_id'] == 0
+    assert modulate['speaker_id'] == 1
+
+
+def test_reconnect_resumes_after_persisted_conversation_speaker_ids():
+    allocator = ConversationSpeakerIdAllocator()
+    allocator.hydrate(
+        [
+            {
+                'speaker': 'SPEAKER_0',
+                'speaker_id': 0,
+                'speaker_id_scope': 'connection-a:0',
+                'stt_provider': 'deepgram',
+            }
+        ]
+    )
+    reconnect_epoch = SpeakerProviderEpoch('connection-b')
+    resumed = {'speaker': 'SPEAKER_0'}
+
+    reconnect_epoch.stamp([resumed], 'deepgram')
+    allocator.assign(resumed)
+
+    assert resumed['speaker_id_scope'] == 'connection-b:0'
+    assert resumed['speaker_id'] == 1

--- a/backend/tests/unit/test_stt_speaker_identity.py
+++ b/backend/tests/unit/test_stt_speaker_identity.py
@@ -39,3 +39,42 @@ def test_reconnect_resumes_after_persisted_conversation_speaker_ids():
 
     assert resumed['speaker_id_scope'] == 'connection-b:0'
     assert resumed['speaker_id'] == 1
+
+
+def test_segment_provider_survives_the_epoch_stamp():
+    # The socket knows the peer that actually served the segment; the caller only
+    # knows the host's configured selection. Overwriting the former with the latter
+    # erased a real provider name in the hermetic e2e wire contract.
+    epoch = SpeakerProviderEpoch('connection-a')
+    served = {'speaker': 'SPEAKER_00', 'stt_provider': 'parakeet-wire-peer'}
+
+    epoch.stamp([served], 'parakeet')
+
+    assert served['stt_provider'] == 'parakeet-wire-peer'
+    assert served['speaker_id_scope'] == 'connection-a:0'
+
+
+def test_a_provider_change_inside_one_batch_opens_a_new_scope():
+    epoch = SpeakerProviderEpoch('connection-a')
+    first = {'speaker': 'SPEAKER_00', 'stt_provider': 'deepgram'}
+    second = {'speaker': 'SPEAKER_00', 'stt_provider': 'modulate'}
+
+    epoch.stamp([first, second], 'deepgram')
+
+    # Same provider label, different provider: they must not share an identity space.
+    assert first['speaker_id_scope'] != second['speaker_id_scope']
+
+    allocator = ConversationSpeakerIdAllocator()
+    allocator.assign(first)
+    allocator.assign(second)
+    assert first['speaker_id'] != second['speaker_id']
+
+
+def test_segments_without_a_provider_fall_back_to_the_host_selection():
+    epoch = SpeakerProviderEpoch('connection-a')
+    unstamped = {'speaker': 'SPEAKER_00'}
+
+    epoch.stamp([unstamped], 'parakeet')
+
+    assert unstamped['stt_provider'] == 'parakeet'
+    assert unstamped['speaker_id_scope'] == 'connection-a:0'

--- a/backend/tests/unit/test_transcribe_speaker_id_queue_pii.py
+++ b/backend/tests/unit/test_transcribe_speaker_id_queue_pii.py
@@ -1,8 +1,11 @@
 from pathlib import Path
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
+from models.transcript_segment import SpeakerIdentityStatus, TranscriptSegment
+from routers.listen.transcripts import TranscriptProcessor
 from routers.listen.speakers import MAX_SPEAKER_EMBEDDING_AUDIO_SECONDS, SpeakerMatcher
 
 
@@ -31,6 +34,14 @@ class _RecordingRingBuffer:
         return b''
 
 
+class _AudioRingBuffer:
+    def get_time_range(self):
+        return 0.0, 60.0
+
+    def extract(self, _start, _end):
+        return b'\x00\x00' * 32000
+
+
 @pytest.mark.anyio
 async def test_speaker_match_extracts_a_centered_ten_second_window_for_long_segments():
     ring_buffer = _RecordingRingBuffer()
@@ -54,3 +65,52 @@ async def test_speaker_match_extracts_a_centered_ten_second_window_for_long_segm
 
     assert ring_buffer.extractions == [(5.0, 15.0)]
     assert ring_buffer.extractions[0][1] - ring_buffer.extractions[0][0] == MAX_SPEAKER_EMBEDDING_AUDIO_SECONDS
+
+
+@pytest.mark.anyio
+async def test_speaker_no_match_records_unknown_identity_instead_of_confident_negative(monkeypatch):
+    host = SimpleNamespace(
+        state=SimpleNamespace(audio_ring_buffer=_AudioRingBuffer(), speaker_map_dirty=False),
+        limits=SimpleNamespace(speaker_id_min_audio=1.0),
+        request=SimpleNamespace(sample_rate=16000),
+    )
+    matcher = SpeakerMatcher(host)
+    matcher.person_embeddings = {'user': {'embedding': np.array([[1.0, 0.0]], dtype=np.float32), 'name': 'User'}}
+    monkeypatch.setattr(
+        'routers.listen.speakers.extract_embedding_from_bytes',
+        lambda _audio, _name: np.array([[0.0, 1.0]], dtype=np.float32),
+    )
+
+    await matcher.match(
+        0,
+        {'id': 'unmatched-segment', 'duration': 2.0, 'abs_start': 0.0, 'abs_end': 2.0},
+    )
+
+    assert matcher.segment_identity_status['unmatched-segment'] == SpeakerIdentityStatus.no_match
+    assert host.state.speaker_map_dirty is True
+
+
+def test_no_match_status_reaches_the_persisted_segment_payload():
+    segment = TranscriptSegment(
+        id='unmatched-segment',
+        text='owner statement',
+        speaker='SPEAKER_0',
+        speaker_id=0,
+        is_user=False,
+        start=0.0,
+        end=2.0,
+    )
+    processor = object.__new__(TranscriptProcessor)
+    processor.host = SimpleNamespace(
+        speakers=SimpleNamespace(
+            segment_assignments={},
+            speaker_to_person={},
+            segment_identity_status={'unmatched-segment': SpeakerIdentityStatus.no_match},
+        )
+    )
+
+    processor._apply_speaker_identity_statuses([segment])
+    payload = segment.model_dump()
+
+    assert segment.is_user is False
+    assert payload['speaker_identity_status'] == SpeakerIdentityStatus.no_match

--- a/backend/tests/unit/test_transcript_segment.py
+++ b/backend/tests/unit/test_transcript_segment.py
@@ -374,6 +374,82 @@ def test_no_merge_when_stt_provider_differs():
     assert _concat_segments(segments) == input_concat
 
 
+def test_explicit_scoped_speaker_ids_keep_padded_provider_labels_distinct():
+    deepgram = TranscriptSegment(
+        text="Deepgram speaker",
+        speaker="SPEAKER_0",
+        speaker_id=0,
+        speaker_id_scope="connection-a:0",
+        stt_provider="deepgram",
+        is_user=False,
+        start=0.0,
+        end=1.0,
+    )
+    modulate = TranscriptSegment(
+        text="Modulate speaker",
+        speaker="SPEAKER_00",
+        speaker_id=1,
+        speaker_id_scope="connection-a:1",
+        stt_provider="modulate",
+        is_user=False,
+        start=1.0,
+        end=2.0,
+    )
+
+    assert deepgram.speaker_id == 0
+    assert modulate.speaker_id == 1
+    assert deepgram.speaker_id != modulate.speaker_id
+
+
+def test_internal_speaker_identity_fields_persist_without_widening_client_schema():
+    segment = TranscriptSegment(
+        text="Owner statement",
+        speaker="SPEAKER_00",
+        speaker_id=3,
+        speaker_id_scope="connection-a:0",
+        speaker_identity_status="no_match",
+        is_user=False,
+        start=0.0,
+        end=1.0,
+    )
+
+    payload = segment.model_dump()
+    properties = TranscriptSegment.model_json_schema()['properties']
+
+    assert payload['speaker_id_scope'] == "connection-a:0"
+    assert payload['speaker_identity_status'] == "no_match"
+    assert 'speaker_id_scope' not in properties
+    assert 'speaker_identity_status' not in properties
+
+
+def test_no_merge_across_provider_epochs_when_provider_name_is_unchanged():
+    before_reconnect = TranscriptSegment(
+        text="Before reconnect",
+        speaker="SPEAKER_0",
+        speaker_id=0,
+        speaker_id_scope="connection-a:0",
+        stt_provider="deepgram",
+        is_user=False,
+        start=0.0,
+        end=1.0,
+    )
+    after_reconnect = TranscriptSegment(
+        text="after reconnect.",
+        speaker="SPEAKER_0",
+        speaker_id=1,
+        speaker_id_scope="connection-b:0",
+        stt_provider="deepgram",
+        is_user=False,
+        start=1.1,
+        end=2.0,
+    )
+
+    segments, _, _ = TranscriptSegment.combine_segments([], [before_reconnect, after_reconnect])
+
+    assert len(segments) == 2
+    assert [segment.speaker_id for segment in segments] == [0, 1]
+
+
 def test_punctuation_cleanup_normalizes_spacing():
     a = _segment("Hello , world .", speaker="SPEAKER_00", start=0.0, end=1.0)
     input_concat = _concat_texts([a.text])

--- a/backend/utils/stt/ARCHITECTURE.md
+++ b/backend/utils/stt/ARCHITECTURE.md
@@ -26,7 +26,10 @@ its provider-local labels enter the resumed conversation.
 threshold is not a clustering control. `speaker_clustering.py` owns the more
 permissive short-clip clustering threshold and the eight-centroid cap used by
 backend Parakeet paths. Once full, clustering merges a miss into the nearest
-centroid and keeps the transcript.
+centroid and keeps the transcript: the forced merge is reported through the
+shared fallback telemetry (`reason=capacity_full`) in backend paths — the
+Parakeet image logs it — and the miss is kept out of the centroid's running
+mean so a capped speaker cannot drag another speaker's centroid away.
 
 `speaker_identity.py` scopes provider labels before persistence. It maps
 `(speaker_id_scope, speaker)` to a small conversation-local integer after

--- a/backend/utils/stt/ARCHITECTURE.md
+++ b/backend/utils/stt/ARCHITECTURE.md
@@ -1,0 +1,49 @@
+# STT utility architecture
+
+This package owns backend-side speech-provider selection, socket resilience,
+transcript normalization, VAD gating, and speaker-embedding policy. HTTP and
+WebSocket orchestration lives in `backend/routers/`; the independently deployed
+Parakeet runtime lives in `backend/parakeet/`.
+
+## Live path
+
+```text
+routers/listen/receiver.py
+  -> streaming.py                 provider sockets and fallback selection
+  -> vad_gate.py                  optional audio admission/remapping
+  -> speaker_identity.py          provider epoch and conversation-local IDs
+  -> routers/listen/transcripts.py
+  -> routers/listen/speakers.py   enrolled voiceprint matching
+```
+
+Provider fallback is a connection-time decision. A dead live socket terminates
+the client connection; reconnect creates a new speaker-provider epoch before
+its provider-local labels enter the resumed conversation.
+
+## Speaker boundaries
+
+`speaker_embedding.py` owns enrolled voiceprint verification. Its `0.45`
+threshold is not a clustering control. `speaker_clustering.py` owns the more
+permissive short-clip clustering threshold and the eight-centroid cap used by
+backend Parakeet paths. Once full, clustering merges a miss into the nearest
+centroid and keeps the transcript.
+
+`speaker_identity.py` scopes provider labels before persistence. It maps
+`(speaker_id_scope, speaker)` to a small conversation-local integer after
+hydrating IDs already stored on the conversation, so reconnects and provider
+changes cannot reuse another numbering space.
+
+## Other modules
+
+- `pre_recorded.py` normalizes batch-provider output and uses the shared
+  clustering policy when Parakeet has no server-side labels.
+- `provider_resilience.py`, `safe_socket.py`, `socket.py`, and
+  `live_failure.py` own provider health and terminal socket contracts.
+- `speech_profile.py` and `speaker_embedding.py` own voiceprint extraction and
+  verification; they do not assign in-session cluster identities.
+- `vad.py` and `vad_gate.py` own speech admission; `outcomes.py` owns bounded
+  transcription failure values.
+
+The Parakeet image cannot import this package through an undeclared deployment
+boundary, so `backend/parakeet/speaker_math.py` mirrors the two clustering
+defaults and bounded-nearest policy for that image. Tests pin both copies.

--- a/backend/utils/stt/pre_recorded.py
+++ b/backend/utils/stt/pre_recorded.py
@@ -34,7 +34,8 @@ from models.transcript_segment import TranscriptSegment
 from utils.byok import get_byok_key
 from utils.other.endpoints import timeit
 from utils.stt.outcomes import TranscriptionFailure
-from utils.stt.speaker_embedding import SPEAKER_MATCH_THRESHOLD, compare_embeddings, extract_embedding_from_bytes
+from utils.stt.speaker_clustering import select_speaker_cluster
+from utils.stt.speaker_embedding import compare_embeddings, extract_embedding_from_bytes
 
 _DG_TIMEOUT = httpx.Timeout(connect=10.0, read=120.0, write=30.0, pool=10.0)
 _MODULATE_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=30.0, pool=10.0)
@@ -971,13 +972,8 @@ def _parakeet_assign_speaker_sync(
         seg_wav = _wrap_pcm_as_wav(seg_pcm, sample_rate, 1)
         emb = extract_embedding_from_bytes(seg_wav)
 
-        best_i, best_dist = -1, 1e9
-        for i, centroid in enumerate(centroids):
-            d = compare_embeddings(emb, centroid)
-            if d < best_dist:
-                best_i, best_dist = i, d
-
-        if best_i >= 0 and best_dist < SPEAKER_MATCH_THRESHOLD:
+        best_i, create_new, _ = select_speaker_cluster(emb, centroids, compare_embeddings)
+        if not create_new:
             n = counts[best_i]
             centroids[best_i] = (centroids[best_i] * n + emb) / (n + 1)
             counts[best_i] = n + 1
@@ -985,7 +981,7 @@ def _parakeet_assign_speaker_sync(
 
         centroids.append(emb)
         counts.append(1)
-        return f'SPEAKER_{len(centroids) - 1:02d}'
+        return f'SPEAKER_{best_i:02d}'
     except Exception as e:
         logger.warning(f'Parakeet batch diarization failed, defaulting to SPEAKER_00: {e}')
         return 'SPEAKER_00'

--- a/backend/utils/stt/pre_recorded.py
+++ b/backend/utils/stt/pre_recorded.py
@@ -32,6 +32,7 @@ from config.stt_provider_policy import (
 )
 from models.transcript_segment import TranscriptSegment
 from utils.byok import get_byok_key
+from utils.observability.fallback import record_fallback
 from utils.other.endpoints import timeit
 from utils.stt.outcomes import TranscriptionFailure
 from utils.stt.speaker_clustering import select_speaker_cluster
@@ -972,8 +973,20 @@ def _parakeet_assign_speaker_sync(
         seg_wav = _wrap_pcm_as_wav(seg_pcm, sample_rate, 1)
         emb = extract_embedding_from_bytes(seg_wav)
 
-        best_i, create_new, _ = select_speaker_cluster(emb, centroids, compare_embeddings)
+        best_i, create_new, _, capped = select_speaker_cluster(emb, centroids, compare_embeddings)
         if not create_new:
+            if capped:
+                # Forced by the cap: the embedding missed every centroid, so keep
+                # it out of the running mean and report the degraded merge.
+                record_fallback(
+                    component='other',
+                    from_mode='new_speaker_centroid',
+                    to_mode='nearest_centroid',
+                    reason='capacity_full',
+                    outcome='degraded',
+                    log=logger,
+                )
+                return f'SPEAKER_{best_i:02d}'
             n = counts[best_i]
             centroids[best_i] = (centroids[best_i] * n + emb) / (n + 1)
             counts[best_i] = n + 1

--- a/backend/utils/stt/speaker_clustering.py
+++ b/backend/utils/stt/speaker_clustering.py
@@ -1,0 +1,49 @@
+"""Policy shared by backend-side speaker-embedding clustering paths."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Callable, Sequence
+
+# Enrollment verification compares a clip to a long-lived, taught voiceprint at
+# SPEAKER_MATCH_THRESHOLD=0.45. Online clustering compares short capture clips to
+# noisy in-session centroids, so it deliberately has a separate, more permissive
+# operating point. This changes clustering only; enrollment verification stays at 0.45.
+SPEAKER_CLUSTERING_THRESHOLD = float(os.getenv('SPEAKER_CLUSTERING_THRESHOLD', '0.60'))
+
+# Eight active speakers preserves ordinary group conversations while making a
+# pathological run of noisy embeddings finite. Once full, the nearest centroid
+# absorbs the clip even when it misses the threshold; audio/text is never dropped.
+SPEAKER_CLUSTERING_MAX_SPEAKERS = max(1, int(os.getenv('SPEAKER_CLUSTERING_MAX_SPEAKERS', '8')))
+
+
+def select_speaker_cluster(
+    embedding: Any,
+    centroids: Sequence[Any],
+    distance: Callable[[Any, Any], float],
+    *,
+    threshold: float = SPEAKER_CLUSTERING_THRESHOLD,
+    max_speakers: int = SPEAKER_CLUSTERING_MAX_SPEAKERS,
+) -> tuple[int, bool, float]:
+    """Return ``(index, create_new, distance)`` for bounded greedy clustering.
+
+    A miss creates a centroid only while capacity remains. At capacity, the
+    nearest existing centroid wins regardless of the threshold, which bounds
+    identity growth without dropping the segment or inventing an overflow ID.
+    """
+    if not centroids:
+        return 0, True, float('inf')
+
+    best_index = 0
+    best_distance = float('inf')
+    for index, centroid in enumerate(centroids):
+        candidate_distance = distance(embedding, centroid)
+        if candidate_distance < best_distance:
+            best_index = index
+            best_distance = candidate_distance
+
+    if best_distance < threshold:
+        return best_index, False, best_distance
+    if len(centroids) < max(1, max_speakers):
+        return len(centroids), True, best_distance
+    return best_index, False, best_distance

--- a/backend/utils/stt/speaker_clustering.py
+++ b/backend/utils/stt/speaker_clustering.py
@@ -24,15 +24,18 @@ def select_speaker_cluster(
     *,
     threshold: float = SPEAKER_CLUSTERING_THRESHOLD,
     max_speakers: int = SPEAKER_CLUSTERING_MAX_SPEAKERS,
-) -> tuple[int, bool, float]:
-    """Return ``(index, create_new, distance)`` for bounded greedy clustering.
+) -> tuple[int, bool, float, bool]:
+    """Return ``(index, create_new, distance, capped)`` for bounded greedy clustering.
 
     A miss creates a centroid only while capacity remains. At capacity, the
-    nearest existing centroid wins regardless of the threshold, which bounds
-    identity growth without dropping the segment or inventing an overflow ID.
+    nearest existing centroid wins regardless of the threshold — ``capped`` is
+    then True so callers can report the forced merge (it is a degraded,
+    misattribution-prone outcome, not a match) and keep the miss out of the
+    centroid's running mean. Audio/text is never dropped and no overflow ID is
+    invented.
     """
     if not centroids:
-        return 0, True, float('inf')
+        return 0, True, float('inf'), False
 
     best_index = 0
     best_distance = float('inf')
@@ -43,7 +46,7 @@ def select_speaker_cluster(
             best_distance = candidate_distance
 
     if best_distance < threshold:
-        return best_index, False, best_distance
+        return best_index, False, best_distance, False
     if len(centroids) < max(1, max_speakers):
-        return len(centroids), True, best_distance
-    return best_index, False, best_distance
+        return len(centroids), True, best_distance, False
+    return best_index, False, best_distance, True

--- a/backend/utils/stt/speaker_embedding.py
+++ b/backend/utils/stt/speaker_embedding.py
@@ -14,8 +14,9 @@ from utils.http_client import get_stt_client
 
 logger = logging.getLogger(__name__)
 
-# Cosine distance threshold for speaker matching
-# Based on VoxCeleb 1 test set EER of 2.8%
+# Cosine distance threshold for enrolled-voiceprint verification only.
+# Based on VoxCeleb 1 test set EER of 2.8%. In-session clustering has its own
+# policy in speaker_clustering.py and must not silently retune this boundary.
 SPEAKER_MATCH_THRESHOLD = 0.45
 
 # Minimum audio duration (seconds) for speaker embedding extraction.

--- a/backend/utils/stt/speaker_identity.py
+++ b/backend/utils/stt/speaker_identity.py
@@ -2,14 +2,37 @@
 
 from __future__ import annotations
 
+import re
 import uuid
 from typing import Any, Iterable, Mapping, MutableMapping, Optional
+
+# Onboarding reserves this ID for Omi's own question segments (canonical value:
+# OnboardingHandler.OMI_SPEAKER_ID in utils/onboarding.py; a unit test pins the
+# two together). The allocator never hands it to a real speaker, so a long
+# session with many provider transitions cannot collide with it.
+OMI_SPEAKER_ID_SENTINEL = 99
+
+_SPEAKER_NUMBER = re.compile(r'^SPEAKER_(\d+)$')
 
 
 def _read(record: Any, field: str) -> Any:
     if isinstance(record, Mapping):
         return record.get(field)
     return getattr(record, field, None)
+
+
+def _canonical_speaker_label(label: str) -> str:
+    """Fold ``SPEAKER_02`` and ``SPEAKER_2`` into one allocator key.
+
+    Providers disagree on zero padding (Deepgram/Modulate emit ``SPEAKER_02``,
+    Parakeet paths emit ``SPEAKER_2``), and a custom-STT client may send a bare
+    ``speaker_id`` with no label at all. hydrate() and assign() must agree on
+    one spelling or the same (scope, speaker) pair splits into two identities.
+    """
+    match = _SPEAKER_NUMBER.match(label)
+    if match:
+        return f'SPEAKER_{int(match.group(1))}'
+    return label
 
 
 class SpeakerProviderEpoch:
@@ -56,7 +79,14 @@ class ConversationSpeakerIdAllocator:
             scope = _read(segment, 'speaker_id_scope')
             speaker = _read(segment, 'speaker')
             if scope and speaker and isinstance(speaker_id, int):
-                self._speaker_ids.setdefault((str(scope), str(speaker)), speaker_id)
+                self._speaker_ids.setdefault((str(scope), _canonical_speaker_label(str(speaker))), speaker_id)
+
+    def _allocate(self) -> int:
+        speaker_id = self._next_id
+        if speaker_id == OMI_SPEAKER_ID_SENTINEL:
+            speaker_id += 1
+        self._next_id = speaker_id + 1
+        return speaker_id
 
     def assign(self, segment: MutableMapping[str, Any]) -> None:
         """Replace a provider-local number with its conversation-local integer."""
@@ -66,11 +96,10 @@ class ConversationSpeakerIdAllocator:
         speaker = segment.get('speaker')
         if not speaker and isinstance(segment.get('speaker_id'), int):
             speaker = f'SPEAKER_{segment["speaker_id"]}'
-        speaker = str(speaker or 'SPEAKER_00')
+        speaker = _canonical_speaker_label(str(speaker or 'SPEAKER_00'))
         key = (str(scope), speaker)
         speaker_id = self._speaker_ids.get(key)
         if speaker_id is None:
-            speaker_id = self._next_id
-            self._next_id += 1
+            speaker_id = self._allocate()
             self._speaker_ids[key] = speaker_id
         segment['speaker_id'] = speaker_id

--- a/backend/utils/stt/speaker_identity.py
+++ b/backend/utils/stt/speaker_identity.py
@@ -21,14 +21,23 @@ class SpeakerProviderEpoch:
         self._epoch = -1
 
     def stamp(self, segments: Iterable[MutableMapping[str, Any]], provider: Optional[str]) -> None:
-        provider_name = provider or 'unknown'
-        if provider_name != self._provider:
-            self._provider = provider_name
-            self._epoch += 1
-        scope = f'{self._connection_scope}:{self._epoch}'
+        """Scope each segment by the provider that actually served it.
+
+        A socket that knows its serving peer stamps ``stt_provider`` on the segment
+        itself, and that value is authoritative: the caller-supplied name is the
+        host's configured selection, which stays the same across a fallback to a
+        different peer. Overwriting it would erase the very transition the epoch
+        exists to separate. The epoch therefore advances per segment, so a provider
+        change inside one batch opens a new scope rather than being flattened.
+        """
+        fallback = provider or 'unknown'
         for segment in segments:
+            provider_name = segment.get('stt_provider') or fallback
+            if provider_name != self._provider:
+                self._provider = provider_name
+                self._epoch += 1
             segment['stt_provider'] = provider_name
-            segment['speaker_id_scope'] = scope
+            segment['speaker_id_scope'] = f'{self._connection_scope}:{self._epoch}'
 
 
 class ConversationSpeakerIdAllocator:

--- a/backend/utils/stt/speaker_identity.py
+++ b/backend/utils/stt/speaker_identity.py
@@ -1,0 +1,67 @@
+"""Connection/provider-scoped speaker identity for live transcript segments."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Iterable, Mapping, MutableMapping, Optional
+
+
+def _read(record: Any, field: str) -> Any:
+    if isinstance(record, Mapping):
+        return record.get(field)
+    return getattr(record, field, None)
+
+
+class SpeakerProviderEpoch:
+    """Stamp provider numbering with a new epoch on every provider transition."""
+
+    def __init__(self, connection_scope: Optional[str] = None) -> None:
+        self._connection_scope = connection_scope or uuid.uuid4().hex
+        self._provider: Optional[str] = None
+        self._epoch = -1
+
+    def stamp(self, segments: Iterable[MutableMapping[str, Any]], provider: Optional[str]) -> None:
+        provider_name = provider or 'unknown'
+        if provider_name != self._provider:
+            self._provider = provider_name
+            self._epoch += 1
+        scope = f'{self._connection_scope}:{self._epoch}'
+        for segment in segments:
+            segment['stt_provider'] = provider_name
+            segment['speaker_id_scope'] = scope
+
+
+class ConversationSpeakerIdAllocator:
+    """Allocate small conversation-local integer IDs for scoped provider labels."""
+
+    def __init__(self) -> None:
+        self._speaker_ids: dict[tuple[str, str], int] = {}
+        self._next_id = 0
+
+    def hydrate(self, segments: Iterable[Any]) -> None:
+        """Learn persisted assignments before allocating IDs after a reconnect."""
+        for segment in segments:
+            speaker_id = _read(segment, 'speaker_id')
+            if isinstance(speaker_id, int):
+                self._next_id = max(self._next_id, speaker_id + 1)
+            scope = _read(segment, 'speaker_id_scope')
+            speaker = _read(segment, 'speaker')
+            if scope and speaker and isinstance(speaker_id, int):
+                self._speaker_ids.setdefault((str(scope), str(speaker)), speaker_id)
+
+    def assign(self, segment: MutableMapping[str, Any]) -> None:
+        """Replace a provider-local number with its conversation-local integer."""
+        scope = segment.get('speaker_id_scope')
+        if not scope:
+            return
+        speaker = segment.get('speaker')
+        if not speaker and isinstance(segment.get('speaker_id'), int):
+            speaker = f'SPEAKER_{segment["speaker_id"]}'
+        speaker = str(speaker or 'SPEAKER_00')
+        key = (str(scope), speaker)
+        speaker_id = self._speaker_ids.get(key)
+        if speaker_id is None:
+            speaker_id = self._next_id
+            self._next_id += 1
+            self._speaker_ids[key] = speaker_id
+        segment['speaker_id'] = speaker_id

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -40,10 +40,10 @@ from utils.stt.provider_resilience import (
     fallback_socket_is_serving,
 )
 from utils.stt.speaker_embedding import (
-    SPEAKER_MATCH_THRESHOLD,
     async_extract_embedding_from_bytes,
     compare_embeddings,
 )
+from utils.stt.speaker_clustering import select_speaker_cluster
 from utils.observability.fallback import record_fallback
 from utils.other.backoff import calculate_backoff_with_jitter
 import logging
@@ -1355,10 +1355,10 @@ class ParakeetStreamingSocket(STTSocket):
     async def _assign_speaker(self, seg_pcm: bytes) -> int:
         """Cluster a segment's voice embedding into a session-stable speaker index.
 
-        Online greedy clustering: embed the clip, match it to the nearest known speaker
-        centroid (cosine < SPEAKER_MATCH_THRESHOLD) or start a new one. Falls back to the
-        previous speaker when diarization is off, the clip is too short to embed, or the
-        embedding service errs — so a transient failure never drops or mislabels the segment.
+        Online greedy clustering uses the short-clip threshold and cluster cap from
+        speaker_clustering. Once the cap is full, the nearest centroid absorbs misses.
+        Falls back to the previous speaker when diarization is off, the clip is too short
+        to embed, or the embedding service errs, so a transient failure never drops text.
         """
         if not self._diarize:
             return 0
@@ -1373,13 +1373,8 @@ class ParakeetStreamingSocket(STTSocket):
             logger.warning(f"Parakeet diarization embed failed; reusing speaker {self._last_speaker}: {e}")
             return self._last_speaker
 
-        best_i, best_dist = -1, 1e9
-        for i, centroid in enumerate(self._spk_centroids):
-            d = compare_embeddings(emb, centroid)
-            if d < best_dist:
-                best_i, best_dist = i, d
-
-        if best_i >= 0 and best_dist < SPEAKER_MATCH_THRESHOLD:
+        best_i, create_new, _ = select_speaker_cluster(emb, self._spk_centroids, compare_embeddings)
+        if not create_new:
             # Running-mean keeps the centroid stable as the speaker keeps talking.
             n = self._spk_counts[best_i]
             self._spk_centroids[best_i] = (self._spk_centroids[best_i] * n + emb) / (n + 1)
@@ -1389,7 +1384,7 @@ class ParakeetStreamingSocket(STTSocket):
 
         self._spk_centroids.append(emb)
         self._spk_counts.append(1)
-        self._last_speaker = len(self._spk_centroids) - 1
+        self._last_speaker = best_i
         return self._last_speaker
 
     def _slice_pcm(self, pcm: bytes, rel_start: float, rel_end: float) -> bytes:

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -1373,8 +1373,22 @@ class ParakeetStreamingSocket(STTSocket):
             logger.warning(f"Parakeet diarization embed failed; reusing speaker {self._last_speaker}: {e}")
             return self._last_speaker
 
-        best_i, create_new, _ = select_speaker_cluster(emb, self._spk_centroids, compare_embeddings)
+        best_i, create_new, _, capped = select_speaker_cluster(emb, self._spk_centroids, compare_embeddings)
         if not create_new:
+            if capped:
+                # The cap forced this merge; the embedding missed every centroid,
+                # so folding it into a running mean would drag that centroid
+                # toward a different speaker. Report the degraded outcome.
+                record_fallback(
+                    component='other',
+                    from_mode='new_speaker_centroid',
+                    to_mode='nearest_centroid',
+                    reason='capacity_full',
+                    outcome='degraded',
+                    log=logger,
+                )
+                self._last_speaker = best_i
+                return best_i
             # Running-mean keeps the centroid stable as the speaker keeps talking.
             n = self._spk_counts[best_i]
             self._spk_centroids[best_i] = (self._spk_centroids[best_i] * n + emb) / (n + 1)

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -505,9 +505,12 @@ states distinct.
 Parakeet embedding diarization does not use the enrollment threshold. Short
 in-session clips use a clustering cosine-distance threshold of `0.60`, while
 voiceprint verification remains `0.45`. Clustering creates at most eight
-centroids per stream. After the cap, a miss is merged into its nearest centroid
-and updates that running mean; the segment is never dropped and no overflow
-speaker ID is invented. Backend-side defaults use
+centroids per stream. After the cap, a miss is merged into its nearest
+centroid; the merge is reported as a degraded fallback (`omi_fallback_total`,
+`reason=capacity_full`, or a log line in the standalone Parakeet image) and
+the miss does not update that centroid's running mean, so a capped speaker
+cannot drag another speaker's centroid away. The segment is never dropped and
+no overflow speaker ID is invented. Backend-side defaults use
 `SPEAKER_CLUSTERING_THRESHOLD` / `SPEAKER_CLUSTERING_MAX_SPEAKERS`; the
 Parakeet service uses the `PARAKEET_`-prefixed equivalents.
 

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -6,7 +6,7 @@ description: "Sequence diagrams and finalization policy for the /v4/listen WebSo
 
 # Listen + Pusher Pipeline — Sequence Diagrams
 
-> Last updated: 2026-08-20 (durable meeting receipt; bounded client-kind propagation; end-of-conversation wake-word command adjudication)
+> Last updated: 2026-08-23 (provider-scoped speaker identity and bounded clustering; durable meeting receipt; bounded client-kind propagation; end-of-conversation wake-word command adjudication)
 >
 > These diagrams document the real behavior observed during E2E testing with
 > live services (backend, pusher, STT providers, embedding API). Update when the
@@ -47,6 +47,14 @@ Segments buffered in `realtime_segment_buffers` are sorted by `start` time
 before processing — this corrects non-deterministic WebSocket arrival order
 from providers like Modulate whose internal parallelism can deliver shorter
 utterances before longer ones.
+
+Provider speaker labels are connection-local. Before a live segment enters a
+conversation, listen stamps the actual `stt_provider` and an opaque
+`speaker_id_scope`. The scope advances whenever the provider changes and is
+new for every client reconnect. A conversation-local allocator hydrates the
+persisted IDs, then maps `(speaker_id_scope, speaker label)` to the next small
+integer `speaker_id`. Therefore Deepgram `SPEAKER_0`, Modulate `SPEAKER_00`, and
+a reconnect that restarts either provider's numbering cannot share an identity.
 
 Pre-recorded STT results from providers such as Modulate and Parakeet are
 normalized before they are written as transcript segments. Consecutive entries
@@ -483,8 +491,25 @@ sequenceDiagram
         Backend->>Backend: Set is_user=True on segments via speaker_to_person_map
     else Match is known person
         Backend-->>Client: {type: "speaker_label_suggestion", person_id, distance}
+    else No enrolled voiceprint matches
+        Backend->>Firestore: Persist speaker_identity_status=no_match
     end
 ```
+
+`is_user` remains the compatibility projection, while
+`speaker_identity_status` preserves its evidence state: `user`, `not_user`,
+`no_match`, or `unknown`. A failed enrollment match is `no_match`, not a
+confident `not_user`; downstream identity-sensitive consumers must keep those
+states distinct.
+
+Parakeet embedding diarization does not use the enrollment threshold. Short
+in-session clips use a clustering cosine-distance threshold of `0.60`, while
+voiceprint verification remains `0.45`. Clustering creates at most eight
+centroids per stream. After the cap, a miss is merged into its nearest centroid
+and updates that running mean; the segment is never dropped and no overflow
+speaker ID is invented. Backend-side defaults use
+`SPEAKER_CLUSTERING_THRESHOLD` / `SPEAKER_CLUSTERING_MAX_SPEAKERS`; the
+Parakeet service uses the `PARAKEET_`-prefixed equivalents.
 
 ## 5. Private Cloud Sync (Audio Upload)
 
@@ -522,7 +547,7 @@ Staleness is fingerprint-driven: when late chunks change `audio_files` (pusher b
 
 | Type | Format | Example |
 |------|--------|---------|
-| Transcripts | JSON array | `[{id, text, speaker, speaker_id, is_user, start, end}, ...]` |
+| Transcripts | JSON array | `[{id, text, speaker, speaker_id, speaker_id_scope, stt_provider, is_user, speaker_identity_status, start, end}, ...]` |
 | Events | JSON object | `{type: "...", ...}` |
 | Keepalive | Plain text | `"ping"` (not JSON — filter before parsing) |
 
@@ -555,7 +580,9 @@ Staleness is fingerprint-driven: when late chunks change `audio_files` (pusher b
 | `BG_DRAIN_TIMEOUT` | 30s | `pusher.py`, `routers/listen/contracts.py` | Grace period for background tasks to drain after disconnect before force-cancel |
 | `lifecycle_manager` poll | 5s | `routers/listen/conversations.py` | Check `finished_at` interval |
 | Pusher audio batch | 60s | pusher | GCS upload batch size |
-| Speaker match threshold | 0.45 | `routers/listen/speakers.py` | Cosine distance cutoff |
+| Speaker verification threshold | 0.45 | `utils/stt/speaker_embedding.py` | Enrolled voiceprint cosine-distance cutoff |
+| Speaker clustering threshold | 0.60 | `utils/stt/speaker_clustering.py`, `parakeet/speaker_math.py` | Short-clip in-session centroid cutoff |
+| Speaker clustering cap | 8 | `utils/stt/speaker_clustering.py`, `parakeet/speaker_math.py` | Merge misses to nearest centroid after capacity |
 | `PENDING_REQUEST_TIMEOUT` | 120s | `routers/listen/conversations.py` | Timeout before retrying a pending request |
 | `MAX_RETRIES_PER_REQUEST` | 3 | `routers/listen/conversations.py` | Max retries before keeping buffered |
 | `PUSHER_MAX_RECONNECT_ATTEMPTS` | 6 | `utils/listen_pusher_session.py` | Reconnect attempts before DEGRADED |


### PR DESCRIPTION
## Summary

- give short, noisy in-session speaker clustering its own `0.60` threshold while leaving enrolled-voiceprint verification at `0.45`
- cap each clustering session at eight centroids and merge later misses into the nearest running centroid without dropping transcript text
- stamp provider/connection epochs before persistence and allocate conversation-local speaker IDs from `(speaker_id_scope, speaker)`, so padded labels, provider changes, and reconnects cannot collide
- persist `speaker_identity_status` as `user`, `not_user`, `no_match`, or `unknown`; a failed enrollment match is no longer represented only by the legacy `is_user=false` projection

## Failure boundary

The authoritative boundaries are now explicit: clustering policy owns in-session centroid identity, provider epochs own provider-local numbering, the conversation allocator owns persisted integer IDs, and enrollment matching owns the evidence state behind `is_user`. The Parakeet runtime image cannot import backend utility modules through its deployment source closure, so its existing `speaker_math.py` boundary mirrors the clustering defaults and bounded-nearest policy; tests pin both implementations.

The memory consumer is intentionally outside this branch. It still reads a bare `is_user` boolean today; the parallel memory change must treat `speaker_identity_status` values `no_match` and `unknown` as uncertain rather than confidently third-party.

## Verified diagnosis and corrections

- The epoch stamp initially overwrote each segment's `stt_provider` with the host's configured STT selection. A socket that knows which peer actually served the segment stamps that name itself, and the configured selection does not change across a fallback, so the overwrite erased exactly the transition the epoch exists to separate. Five hermetic e2e tests caught it (`parakeet` observed where the peer was `parakeet-wire-peer`; `parakeet` where the fake socket had stamped `e2e-streaming-stt`). A segment's own provider is now authoritative, the caller's name is a fallback, and the epoch advances per segment so a provider change inside one batch opens a new scope. This is also the correction to the bullet below: normal backend STT segments *do* reach `enqueue` carrying a provider on the paths the hermetic harness exercises.
- The `0.45` enrollment threshold was also reused by `backend/utils/stt/pre_recorded.py` and `backend/parakeet/transcribe.py`, not only the two streaming paths named in the report.
- `connect_stt_socket_with_fallback` changes provider only while establishing a socket. A live provider failure terminates that connection; a resumed conversation can still acquire a colliding namespace on its next WebSocket connection, so the epoch is connection-scoped as well as provider-scoped.
- Normal backend STT segments previously did not persist `stt_provider`; only the custom-STT payload path stamped it.
- Ordinary processed short-term memories expire after 48 hours, but pending-required-processing rows have an explicit eligibility exception. This does not remove the identity-loss path for ordinary rows.

## External evidence for changed expectations

The account measurement supplied with this task covered 57 conversations, 4,047 segments, and 200 memories. It also identified conversation `30e9e5d6-e7fd-4f9c-91ad-f219e5b1952f`, where unpadded and padded provider labels coexist and one integer speaker identity carries contradictory `is_user` values. Those observed persisted shapes are the external basis for the new collision and reconnect regression expectations.

## Verification

- red-before runs: the new model test initially failed at collection because `SpeakerIdentityStatus` did not exist; the remaining regression files reported `4 failed, 63 passed` (explicit scoped ID overwritten, reconnect segments merged, and both backend and deployed-Parakeet clustering created a ninth speaker)
- affected and adjacent test files, each named directly and run in isolation: `436 passed`
- final persistence-only schema rerun: `39 passed` across `test_transcript_segment.py` and `test_transcribe_speaker_id_queue_pii.py`
- proper backend typecheck: `0 errors, 3752 warnings, 0 informations`
- `python -m compileall` for the changed backend modules: passed
- `speaker_id_scope` and `speaker_identity_status` remain persistence-only backend fields: `model_dump` includes them, while `SkipJsonSchema` keeps the app-client OpenAPI and all generated client contracts unchanged
- final pre-push gate: 24 PR checks passed, runtime-image closure passed for 10 images, eight selected backend files passed `105/105`, app-client OpenAPI and generated-client snapshots were current, and Black reported 20 files unchanged
- broad `backend/test.sh`: 890 of 892 isolated test files wrote successful status and none wrote a failure; the run was stopped after the two unrelated action-item files did not return. `test_action_item_canonical_contract.py` had already printed `13 passed`; `test_action_item_vector_best_effort.py` had reached 75%. This is not claimed as a completed full-suite pass.
- combined direct pytest runs exposed known cross-file pollution: the Parakeet builtin-embedding file raised a missing-NeMo collection error only in combination and passed `16/16` alone; four Modulate retired-config failures passed `94/94` alone. Two real parity fixture mismatches were fixed and then passed `2/2` alone.
- full hermetic e2e suite (`bash backend/testing/e2e/run.sh`): `116 passed, 3 skipped` after the provider-preservation fix; before it, 5 failed
- eight affected unit files run together in one process (not file-isolated): `105 passed`
- live provider/embedding services were not exercised because this worktree has no hermetic owner-account or provider-credential path; the production assignment and persistence seams were exercised with controllable embeddings and transcript payloads.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none


Line-Count-Exception: backend/utils/stt/streaming.py | 1683 -> 1692 | Cap-forced merge fallback telemetry and centroid-drift guard required by docs/agents/fallback-telemetry.md; the +9 lines are the record_fallback branch that makes the eight-speaker cap observable.
