### PR TITLE
fix(monitoring): accept the Cloud Run metrics egress filter at Cloud Monitoring

### DIFF
--- a/.github/failure-classes/FC-bridge-liveness-without-data-path-proof.json
+++ b/.github/failure-classes/FC-bridge-liveness-without-data-path-proof.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-bridge-liveness-without-data-path-proof",
+  "violated_contract": "A component whose only purpose is to move data between two systems is healthy only when a datum has recently crossed the whole path. Process availability, HTTP readiness, and a downstream scrape's `up` describe the relay's own endpoint, not its cargo, so they must never be allowed to classify it as healthy while every upstream query is rejected or every selector matches nothing. A relay that answers its own liveness probe while importing zero rows is indistinguishable, at the destination, from a source that is simply idle -- and idle is the reading an operator will take.",
+  "canonical_prevention": "Alert on the relay's own upstream outcome and on arrival, never on its liveness: the count of failed upstream queries, and the presence of at least one imported series under the name the destination actually queries. Execute the composed upstream expression against the real vendor endpoint before shipping the config that produces it -- a filter or query assembled in values is a program whose only compiler is the vendor API, and it is never exercised by rendering, unit tests, or deployment success.",
+  "canonical_prevention_artifact": [
+    "backend/charts/monitoring/alert-rules.json",
+    "backend/docs/runbooks/cloud-run-metrics-ingestion.md"
+  ],
+  "evidence_prs": [11998],
+  "scope_hints": [
+    "backend/charts/monitoring/prometheus-stackdriver-exporter/**",
+    "backend/charts/monitoring/kube-prometheus-stack/**",
+    ".github/workflows/gcp_cloud_run_metrics_egress.yml"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/check-mobile-production-routing.py
+++ b/.github/scripts/check-mobile-production-routing.py
@@ -28,9 +28,16 @@ RETIRED_GKE_DESKTOP_BACKEND_MANIFEST_SUFFIXES = {".tpl", ".yaml", ".yml"}
 RETIRED_GKE_DESKTOP_BACKEND_MARKERS = ("desktop-api.omi.me", "desktop-backend")
 GKE_WORKFLOW_MARKERS = ("gcloud container clusters", "helm ", "kubectl ")
 CLOUD_RUN_OBSERVER_ROOT = Path("backend/charts/monitoring/prometheus-stackdriver-exporter")
+# What makes one of these files an observer of Cloud Run is the monitored
+# resource it selects, not how it spells the namespace set. `__run__` is Cloud
+# Run's reserved pseudo-cluster, so these two markers together are proof; keying
+# the exemption on an exact namespace comparison instead made it collapse the
+# moment that disjunction was rewritten as one_of(...) to satisfy Cloud
+# Monitoring's filter grammar, and flagged a read-only metrics reader as retired
+# GKE ownership.
 CLOUD_RUN_OBSERVER_MARKERS = (
     "prometheus.googleapis.com/",
-    'resource.labels.namespace="desktop-backend"',
+    'resource.labels.cluster="__run__"',
 )
 LEGACY_BETA_ROUTING_PATHS = (
     "codemagic.yaml",

--- a/.github/scripts/test_check_mobile_production_routing.py
+++ b/.github/scripts/test_check_mobile_production_routing.py
@@ -50,7 +50,9 @@ class MobileProductionRoutingContractTests(unittest.TestCase):
             observer = root / "backend/charts/monitoring/prometheus-stackdriver-exporter/prod_cloud_run.yaml"
             observer.parent.mkdir(parents=True)
             observer.write_text(
-                "prefix: prometheus.googleapis.com/omi_\n" 'filter: resource.labels.namespace="desktop-backend"\n',
+                "prefix: prometheus.googleapis.com/omi_\n"
+                'filter: resource.labels.cluster="__run__" AND '
+                'resource.labels.namespace=one_of("backend","desktop-backend")\n',
                 encoding="utf-8",
             )
 

--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -9559,6 +9559,147 @@
     "record": null
   },
   {
+    "uid": "omi-cloud-run-metrics-egress-query-rejected",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Cloud Run Ingestion",
+    "title": "Cloud Run metrics - egress query rejected by Cloud Monitoring",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(stackdriver_monitoring_last_scrape_error{job=\"cloud-run-application-metrics\"}) or vector(0)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-08-21T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "15m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "summary": "The Cloud Run metrics exporter is failing its Cloud Monitoring queries, so no omi_ series are being imported",
+      "threshold": "stackdriver_monitoring_last_scrape_error > 0 on the cloud-run-application-metrics job for 15m",
+      "user_impact": "No direct user impact, but every Cloud Run journey metric stops arriving while the exporter Deployment stays Available and its Prometheus target stays up. Panels render empty and read as no traffic rather than no ingestion, so a real user-facing failure on a Cloud Run path can run unnoticed for as long as this is firing.",
+      "scope": "The dedicated Cloud Run metrics Stackdriver exporter and the Cloud Monitoring filter it is deployed with.",
+      "verification": "kubectl logs the <env>-omi-cloud-run-metrics-exporter Deployment. A rejected filter logs an HTTP 400 per descriptor naming the offending expression; a missing or expired Monitoring Viewer grant on its GSA logs 403.",
+      "safe_next_action": "Read the 400 back to the filter in backend/charts/monitoring/prometheus-stackdriver-exporter/<env>_omi_cloud_run_metrics_exporter.yaml, correct it, and re-run the Deploy Cloud Run Metrics Egress workflow for that environment. Cloud Monitoring rejects AND mixed with OR across resource.labels restrictions; express a disjunction as one_of(...). This egress is read-only, so nothing has to be rolled back to stop it.",
+      "runbook": "backend/docs/runbooks/cloud-run-metrics-ingestion.md"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "observability",
+      "alert_identity": "omi-cloud-run-metrics-egress-query-rejected",
+      "component": "observability",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
     "uid": "omi-llm-gateway-invalid-request-rejections",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",

--- a/backend/charts/monitoring/alerts/cloud-run-ingestion.json
+++ b/backend/charts/monitoring/alerts/cloud-run-ingestion.json
@@ -139,5 +139,146 @@
       "receiver": "Omi - Services Alerting (Telegram)"
     },
     "record": null
+  },
+  {
+    "uid": "omi-cloud-run-metrics-egress-query-rejected",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Cloud Run Ingestion",
+    "title": "Cloud Run metrics - egress query rejected by Cloud Monitoring",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(stackdriver_monitoring_last_scrape_error{job=\"cloud-run-application-metrics\"}) or vector(0)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-08-21T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "15m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "summary": "The Cloud Run metrics exporter is failing its Cloud Monitoring queries, so no omi_ series are being imported",
+      "threshold": "stackdriver_monitoring_last_scrape_error > 0 on the cloud-run-application-metrics job for 15m",
+      "user_impact": "No direct user impact, but every Cloud Run journey metric stops arriving while the exporter Deployment stays Available and its Prometheus target stays up. Panels render empty and read as no traffic rather than no ingestion, so a real user-facing failure on a Cloud Run path can run unnoticed for as long as this is firing.",
+      "scope": "The dedicated Cloud Run metrics Stackdriver exporter and the Cloud Monitoring filter it is deployed with.",
+      "verification": "kubectl logs the <env>-omi-cloud-run-metrics-exporter Deployment. A rejected filter logs an HTTP 400 per descriptor naming the offending expression; a missing or expired Monitoring Viewer grant on its GSA logs 403.",
+      "safe_next_action": "Read the 400 back to the filter in backend/charts/monitoring/prometheus-stackdriver-exporter/<env>_omi_cloud_run_metrics_exporter.yaml, correct it, and re-run the Deploy Cloud Run Metrics Egress workflow for that environment. Cloud Monitoring rejects AND mixed with OR across resource.labels restrictions; express a disjunction as one_of(...). This egress is read-only, so nothing has to be rolled back to stop it.",
+      "runbook": "backend/docs/runbooks/cloud-run-metrics-ingestion.md"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "observability",
+      "alert_identity": "omi-cloud-run-metrics-egress-query-rejected",
+      "component": "observability",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
   }
 ]

--- a/backend/charts/monitoring/prometheus-stackdriver-exporter/dev_omi_cloud_run_metrics_exporter.yaml
+++ b/backend/charts/monitoring/prometheus-stackdriver-exporter/dev_omi_cloud_run_metrics_exporter.yaml
@@ -7,7 +7,7 @@ stackdriver:
     prefixes:
       - 'prometheus.googleapis.com/omi_'
     filters:
-      - 'prometheus.googleapis.com/omi_:resource.labels.cluster="__run__" AND (resource.labels.namespace="backend" OR resource.labels.namespace="desktop-backend")'
+      - 'prometheus.googleapis.com/omi_:resource.labels.cluster="__run__" AND resource.labels.namespace=one_of("backend","desktop-backend")'
     interval: '2m'
     offset: '1m'
 

--- a/backend/charts/monitoring/prometheus-stackdriver-exporter/prod_omi_cloud_run_metrics_exporter.yaml
+++ b/backend/charts/monitoring/prometheus-stackdriver-exporter/prod_omi_cloud_run_metrics_exporter.yaml
@@ -7,7 +7,7 @@ stackdriver:
     prefixes:
       - 'prometheus.googleapis.com/omi_'
     filters:
-      - 'prometheus.googleapis.com/omi_:resource.labels.cluster="__run__" AND (resource.labels.namespace="backend" OR resource.labels.namespace="desktop-backend")'
+      - 'prometheus.googleapis.com/omi_:resource.labels.cluster="__run__" AND resource.labels.namespace=one_of("backend","desktop-backend")'
     interval: '2m'
     offset: '1m'
 

--- a/backend/docs/runbooks/cloud-run-metrics-ingestion.md
+++ b/backend/docs/runbooks/cloud-run-metrics-ingestion.md
@@ -77,7 +77,7 @@ The exporter accepts `prometheus.googleapis.com/` prefixes and converts Cloud Mo
 
 ### Dedicated isolated Stackdriver exporter — selected
 
-The new release imports only `prometheus.googleapis.com/omi_*` and filters monitored resources to `cluster=__run__` with namespace `backend` or `desktop-backend`. It reuses the existing exporter Kubernetes service account, so no new Workload Identity binding is required. Prometheus scrapes it every 30 seconds. The original load-balancer exporter and its HPA-sensitive cadence are unchanged.
+The new release imports only `prometheus.googleapis.com/omi_*` and filters monitored resources to `cluster=__run__` with namespace `backend` or `desktop-backend`. The namespace disjunction must be written as `resource.labels.namespace=one_of("backend","desktop-backend")`: Cloud Monitoring rejects a filter that mixes `AND` with `OR` across `resource.labels` restrictions (`AND and OR cannot be mixed for 'resource.labels' restrictions`, HTTP 400), and the exporter absorbs that rejection per descriptor without ever going unready. It reuses the existing exporter Kubernetes service account, so no new Workload Identity binding is required. Prometheus scrapes it every 30 seconds. The original load-balancer exporter and its HPA-sensitive cadence are unchanged.
 
 ## Metric names are rewritten back at scrape time
 
@@ -195,11 +195,17 @@ gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.serv
 ```
 
 5. In Cloud Monitoring Metrics Explorer, use PromQL and query an idle, zero-initialized metric such as `omi_journey_accepted_total`. Confirm both `service_name="backend"` and `service_name="desktop-backend"` exist and instances are distinct.
-6. Confirm the Prometheus target `cloud-run-application-metrics` is up. This proves only the GKE exporter scrape, not Cloud Run ingestion, so the target remains `coverage_status: declared` until a post-deploy normalized metric name can support a per-service freshness alert. In Grafana Explore, query:
+6. Confirm data actually crossed the bridge. `up` is not that proof: it reports only that Prometheus reached the exporter's own `/metrics`, and it stayed 1 for 21 hours while every Cloud Monitoring query returned HTTP 400 and not one series was imported. Require all three, in this order:
 
 ```promql
-{job="cloud-run-application-metrics", __name__=~"stackdriver_prometheus_target_prometheus_googleapis_com_omi_.*"}
+up{job="cloud-run-application-metrics"}                                  # exporter reachable  — necessary, not sufficient
+stackdriver_monitoring_last_scrape_error{job="cloud-run-application-metrics"}   # MUST be 0: the upstream query was accepted
+count({job="cloud-run-application-metrics", __name__=~"omi_.*"})         # MUST be > 0: series arrived, under their plain names
 ```
+
+Query the plain `omi_*` names, not the `stackdriver_prometheus_target_...` form. The scrape job rewrites `__name__` back to the plain name, so on a healthy deployment the mangled form returns zero — reading it as a health check inverts the signal. The mangled form is what `omi-cloud-run-metric-names-unnormalized` watches for, and it should be empty.
+
+The target stays `coverage_status: declared` until both prod services serve the sidecar and a per-service freshness alert can be written against a real series.
 
 7. Generate one known dev client journey, then confirm the corresponding counter increases in Cloud Monitoring and in kube-prometheus-stack after the one-minute exporter offset. Compare `sum(rate(...[5m]))` by service between both stores.
 8. Dispatch the production metrics egress workflow from `main`, then deploy the prod Cloud Run revisions and repeat the checks before enabling any new Grafana alert:

--- a/backend/tests/unit/test_monitoring_telemetry_contract.py
+++ b/backend/tests/unit/test_monitoring_telemetry_contract.py
@@ -24,6 +24,7 @@ ALERT_RULES = MONITORING / 'alert-rules.json'
 PARAKEET_SERVICEMONITOR = REPO / 'backend/charts/parakeet' / 'templates' / 'servicemonitor.yaml'
 STACKDRIVER_EXPORTER = MONITORING / 'prometheus-stackdriver-exporter' / 'prod_omi_stackdriver_exporter.yaml'
 CLOUD_RUN_EXPORTER = MONITORING / 'prometheus-stackdriver-exporter' / 'prod_omi_cloud_run_metrics_exporter.yaml'
+CLOUD_RUN_EXPORTER_DEV = MONITORING / 'prometheus-stackdriver-exporter' / 'dev_omi_cloud_run_metrics_exporter.yaml'
 
 
 def _load_inventory() -> dict[str, Any]:
@@ -113,20 +114,59 @@ def test_stackdriver_exporter_values_present():
     assert any(job['name'] == 'prometheus-stackdriver-metrics' for job in inventory['scrape_jobs'])
 
 
-def test_cloud_run_metrics_exporter_is_scoped_and_rate_limited():
-    values = yaml.safe_load(CLOUD_RUN_EXPORTER.read_text(encoding='utf-8'))
+# Cloud Monitoring rejects a filter that mixes AND with OR across resource.labels
+# restrictions ("AND and OR cannot be mixed for 'resource.labels' restrictions",
+# HTTP 400). The exporter answers that rejection per descriptor, so the pod stays
+# Available and `up` stays 1 while every import fails and Grafana shows an empty
+# panel that reads as no traffic. Use one_of() and pin the exact string.
+CLOUD_RUN_EXPORTER_FILTER = (
+    'prometheus.googleapis.com/omi_:resource.labels.cluster="__run__" AND '
+    'resource.labels.namespace=one_of("backend","desktop-backend")'
+)
+
+
+@pytest.mark.parametrize(
+    ('path', 'project_id', 'service_account'),
+    (
+        (CLOUD_RUN_EXPORTER, 'based-hardware', 'prod-omi-prometheus-stackdriver-exporter'),
+        (CLOUD_RUN_EXPORTER_DEV, 'based-hardware-dev', 'dev-omi-prometheus-stackdriver-exporter'),
+    ),
+    ids=('prod', 'dev'),
+)
+def test_cloud_run_metrics_exporter_is_scoped_and_rate_limited(path, project_id, service_account):
+    # Both environments are asserted: the dev values file is what the automatic
+    # post-merge rollout installs, so leaving it unpinned lets dev drift away
+    # from the contract prod is held to.
+    values = yaml.safe_load(path.read_text(encoding='utf-8'))
     metrics = values['stackdriver']['metrics']
+    assert values['stackdriver']['projectIds'] == [project_id]
     assert metrics['prefixes'] == ['prometheus.googleapis.com/omi_']
     assert metrics['interval'] == '2m'
     assert metrics['offset'] == '1m'
-    assert metrics['filters'] == [
-        'prometheus.googleapis.com/omi_:resource.labels.cluster="__run__" AND '
-        '(resource.labels.namespace="backend" OR resource.labels.namespace="desktop-backend")'
-    ]
+    assert metrics['filters'] == [CLOUD_RUN_EXPORTER_FILTER]
     assert values['serviceAccount'] == {
         'create': False,
-        'name': 'prod-omi-prometheus-stackdriver-exporter',
+        'name': service_account,
     }
+
+
+@pytest.mark.parametrize('path', (CLOUD_RUN_EXPORTER, CLOUD_RUN_EXPORTER_DEV), ids=('prod', 'dev'))
+def test_cloud_run_metrics_exporter_filter_has_no_mixed_and_or(path):
+    # A narrow static tripwire for the one shape that took the bridge down, not a
+    # grammar check: it does not parse the filter language and does not call Cloud
+    # Monitoring, so a malformed filter can still pass. Its only job is to make a
+    # reintroduced resource.labels disjunction fail with the reason attached
+    # instead of as a bare equality mismatch above. Acceptance is only ever proved
+    # against the live API, post-deploy, by stackdriver_monitoring_last_scrape_error.
+    values = yaml.safe_load(path.read_text(encoding='utf-8'))
+    for entry in values['stackdriver']['metrics']['filters']:
+        _, _, expression = entry.partition(':')
+        restrictions = re.findall(r'resource\.labels\.[A-Za-z0-9_]+', expression)
+        mixes_and_or = ' AND ' in expression and ' OR ' in expression
+        assert not (len(restrictions) > 1 and mixes_and_or), (
+            f'{path.name}: Cloud Monitoring rejects AND/OR mixed across resource.labels '
+            f'restrictions with HTTP 400; express the disjunction as one_of(...): {expression}'
+        )
 
 
 def test_enforced_coverage_alert_includes_declared_jobs():


### PR DESCRIPTION
## Summary

The Cloud Run metrics egress bridge added in #11998 has never imported a single series. The dedicated Stackdriver exporter is deployed and healthy in dev, its Prometheus target is up, and every one of its Cloud Monitoring queries returns HTTP 400. This makes the filter acceptable to Cloud Monitoring, and adds the alert that would have caught it on day one.

Cloud Monitoring rejects a filter that mixes `AND` with `OR` across `resource.labels` restrictions:

```
googleapi: Error 400: Field filter had an invalid value of
"metric.type="prometheus.googleapis.com/omi_client_journey_terminal_total/counter" AND
 (resource.labels.cluster="__run__" AND (resource.labels.namespace="backend" OR
  resource.labels.namespace="desktop-backend"))":
AND and OR cannot be mixed for 'resource.labels' restrictions., badRequest
```

The disjunction is now expressed as `one_of("backend","desktop-backend")`, which the filter grammar defines for exactly this case. The namespace scope is kept: dropping it would import every `omi_*` series from every Cloud Run service and job in the project, not just `backend` and `desktop-backend`.

## Why nothing caught this

The exporter answers the 400 per descriptor and stays Available. Its Prometheus target stays `up`. The deploy workflow verifies Helm status, Deployment rollout, and Service existence. The one ingestion alert counts Stackdriver-mangled names, and a bridge that imports nothing produces no mangled names, so it sits green. The runbook's own verification step queried the mangled form, which returns zero on a *healthy* deployment — the check was inverted.

Every signal in the path was scoped to the relay process rather than to its cargo, so 100% query failure rendered as an empty Grafana panel, which reads as no traffic.

## Changes

- `dev_omi_cloud_run_metrics_exporter.yaml`, `prod_omi_cloud_run_metrics_exporter.yaml`: `one_of(...)` filter.
- New alert `omi-cloud-run-metrics-egress-query-rejected` — fires on `stackdriver_monitoring_last_scrape_error > 0` for the egress job for 15m. This is the signal that was missing; it would have fired 15 minutes after #11998 rolled out.
- `test_monitoring_telemetry_contract.py`: the exporter contract now covers **both** environments (the dev file was entirely unasserted, and dev is what the automatic post-merge rollout installs), pins the corrected filter, and adds a narrow static tripwire for the mixed `AND`/`OR` shape. The tripwire is deliberately not called a grammar check: it does not parse the filter language and does not call Cloud Monitoring.
- Runbook: verification step 6 now requires `stackdriver_monitoring_last_scrape_error == 0` and a non-zero count of **plain** `omi_*` names, and states why `up` is not proof.

## Live evidence

Gathered against `based-hardware-dev` and `based-hardware` before this change:

| Signal | Value |
| --- | --- |
| `dev-omi-cloud-run-metrics-exporter` Deployment | 1/1 Available, 21h |
| `up{job="cloud-run-application-metrics"}` | 1 |
| `stackdriver_monitoring_api_calls_total` on that job | 54112 |
| `stackdriver_monitoring_last_scrape_error` on that job | **1** |
| `omi_*` series on that job | **0** |

Candidate filters tested directly against the Cloud Monitoring v3 `timeSeries` API, 20m window, `view=HEADERS`:

| Filter | Result |
| --- | --- |
| current, `AND` + `OR` mixed | **HTTP 400** |
| `... AND resource.labels.namespace=one_of("backend","desktop-backend")` | **200, 450 timeSeries** |
| `... AND resource.labels.cluster="__run__"` only | 200, 450 timeSeries |
| `metric.type` only, no resource restriction | 200, 450 timeSeries |

Returned series carry `resource.type=prometheus_target`, `resource.labels{cluster="__run__", namespace="backend", job="omi-cloud-run-application-metrics"}` and `metric.labels{journey, outcome, service_name, client_kind}` — confirming the `stackdriver_prometheus_target_prometheus_googleapis_com_` prefix the scrape job's rewrite regex expects.

## Product invariants affected

- INV-DATA-1

The routing guard change touches no serving authority. It widens nothing about where any client is routed: it replaces one over-specific literal in an *exemption* marker (`resource.labels.namespace="desktop-backend"`) with the monitored-resource literal that actually identifies Cloud Run (`resource.labels.cluster="__run__"`), so a read-only metrics reader stops being classified as retired GKE desktop-backend ownership. Every production-family routing pin, and the retired-GKE rule itself, is unchanged; `test_current_config_is_pinned` still validates the live tree, and all 12 guard tests pass.

## Verification

- `test_monitoring_telemetry_contract.py`, `test_monitoring_alert_rule_contract.py`, `test_journey_observability.py`, `test_cloud_run_metrics_egress_workflow.py`: `53 passed`
- Negative proof: restoring the original filter fails both the exact-string assertion and the tripwire, the latter naming the cause.
- `black --line-length=120 --skip-string-normalization`: unchanged. `ruff --target-version py39`: clean.
- `alert-rules.json` verified structurally, not by reading the diff: 72 → 73 rules, exactly one uid added, zero pre-existing rules altered, order preserved, and the split source in `alerts/cloud-run-ingestion.json` byte-identical to the combined entry.

## Not in this PR

- The new alert rule is added to the repo mirror. Per `backend/charts/monitoring/README.md`, prod is the live source, so merging this does not make the rule fire; it is provisioned separately.
- Prod has never served a sidecar revision (`backend-465cd0f-32620507075-1` went Ready then retired at 0% traffic), so prod Cloud Monitoring has no `omi_*` descriptors at all yet. That is a rollout state, not a defect, and it is unblocked by the normal deploy workflows.

## Review

Diagnosis, the `one_of()` repair, the rewrite regex, the rollout sequence, and the failure-class choice were independently reviewed by GPT-5.6 (codex) against this checkout. Its corrections are folded in: the tripwire test was renamed to stop overclaiming, the runbook query was inverted back, the egress-error alert was added, and the plan to hand-promote the retired prod revision was dropped in favour of the deploy workflows, which already do candidate → validate → promote → verify → roll back.

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

