### PR TITLE
feat(backend): export VAD gate audio-seconds and session counters to Prometheus

### DIFF
--- a/backend/tests/unit/test_vad_gate.py
+++ b/backend/tests/unit/test_vad_gate.py
@@ -26,6 +26,8 @@ _mock_vad_prob = None  # When set, overrides _mock_is_speech for exact probabili
 
 import numpy as np
 
+from utils.metrics import OMI_VAD_GATE_AUDIO_SECONDS_TOTAL, OMI_VAD_GATE_SESSIONS_TOTAL
+
 
 def _mock_run_vad_window(window, state, context):
     """Mock run_vad_window that returns controlled probability.
@@ -1201,6 +1203,41 @@ class TestCostMetrics:
         metrics = gate.get_metrics()
         assert metrics['bytes_sent'] == len(chunk)
         assert metrics['bytes_skipped'] == 0
+
+    @pytest.mark.parametrize('mode', ['active', 'shadow'])
+    def test_prometheus_audio_and_session_counters_match_byte_accounting(self, mode):
+        """Prometheus seconds should match the gate's sent/skipped byte semantics."""
+        sent_counter = OMI_VAD_GATE_AUDIO_SECONDS_TOTAL.labels(outcome='sent', mode=mode)
+        skipped_counter = OMI_VAD_GATE_AUDIO_SECONDS_TOTAL.labels(outcome='skipped', mode=mode)
+        session_counter = OMI_VAD_GATE_SESSIONS_TOTAL.labels(mode=mode)
+        sent_before = sent_counter._value.get()
+        skipped_before = skipped_counter._value.get()
+        sessions_before = session_counter._value.get()
+
+        gate = self._make_gate(mode=mode)
+        assert session_counter._value.get() == sessions_before + 1
+
+        chunk = _make_pcm(30)
+        t = 1000.0
+        _set_vad_speech(False)
+        for i in range(20):
+            gate.process_audio(chunk, t + i * 0.03)
+        if mode == 'active':
+            assert skipped_counter._value.get() > skipped_before
+        else:
+            assert sent_counter._value.get() > sent_before
+        _set_vad_speech(True)
+        for i in range(5):
+            gate.process_audio(chunk, t + 0.60 + i * 0.03)
+
+        metrics = gate.get_metrics()
+        bytes_per_second = gate.sample_rate * gate.channels * 2
+        sent_seconds = sent_counter._value.get() - sent_before
+        skipped_seconds = skipped_counter._value.get() - skipped_before
+
+        assert sent_seconds == pytest.approx(metrics['bytes_sent'] / bytes_per_second)
+        assert skipped_seconds == pytest.approx(metrics['bytes_skipped'] / bytes_per_second)
+        assert sent_seconds + skipped_seconds == pytest.approx(metrics['bytes_received'] / bytes_per_second)
 
 
 class TestStructuredMetricsLog:

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -329,6 +329,18 @@ OMI_LIVE_STT_MISALIGNED_FRAMES_TOTAL = Counter(
     ['provider', 'stage'],
 )
 
+OMI_VAD_GATE_AUDIO_SECONDS_TOTAL = Counter(
+    'omi_vad_gate_audio_seconds_total',
+    'Live VAD gate audio seconds by gate outcome and mode',
+    ['outcome', 'mode'],
+)
+
+OMI_VAD_GATE_SESSIONS_TOTAL = Counter(
+    'omi_vad_gate_sessions_total',
+    'Live VAD gate sessions by mode',
+    ['mode'],
+)
+
 OMI_LIVE_STT_TERMINAL_TOTAL = Counter(
     'omi_live_stt_terminal_total',
     'Terminal live-STT outcomes for accepted attempts by bounded labels',

--- a/backend/utils/stt/vad_gate.py
+++ b/backend/utils/stt/vad_gate.py
@@ -24,7 +24,11 @@ from typing import Any, Deque, Dict, List, Optional, Tuple
 
 import numpy as np
 
-from utils.metrics import OMI_LIVE_STT_MISALIGNED_FRAMES_TOTAL
+from utils.metrics import (
+    OMI_LIVE_STT_MISALIGNED_FRAMES_TOTAL,
+    OMI_VAD_GATE_AUDIO_SECONDS_TOTAL,
+    OMI_VAD_GATE_SESSIONS_TOTAL,
+)
 from utils.observability.fallback import record_fallback
 from utils.stt.socket import STTSocket
 from utils.stt.vad import (
@@ -214,6 +218,13 @@ class VADStreamingGate:
         self._speech_ms_total: float = 0.0
         self._speech_ms_delta: float = 0.0
 
+        # Prometheus accounting only advances once pre-roll audio has a final
+        # outcome, so buffered silence cannot be counted as skipped and later sent.
+        self._prometheus_bytes_sent = 0
+        self._prometheus_bytes_skipped = 0
+        if self.mode in ('active', 'shadow'):
+            OMI_VAD_GATE_SESSIONS_TOTAL.labels(mode=self.mode).inc()
+
     def activate(self) -> None:
         """Switch from shadow to active mode (used after speech profile completes).
 
@@ -356,12 +367,14 @@ class VADStreamingGate:
         if self.mode == 'shadow':
             self._bytes_sent += len(pcm_data)
             self._last_send_wall_time = wall_time
-            return GateOutput(
+            output = GateOutput(
                 audio_to_send=pcm_data,
                 should_finalize=False,
                 state=self._state,
                 is_speech=is_speech,
             )
+            self._record_prometheus_audio()
+            return output
 
         # Active mode: state machine
         prev_state = self._state
@@ -378,7 +391,28 @@ class VADStreamingGate:
                 self._audio_cursor_ms,
             )
 
+        self._record_prometheus_audio()
         return output
+
+    def _record_prometheus_audio(self) -> None:
+        """Record newly finalized sent/skipped audio without double-counting pre-roll."""
+        if self.mode not in ('active', 'shadow'):
+            return
+        bytes_per_second = self._sample_width * self.channels * self.sample_rate
+
+        sent_delta = self._bytes_sent - self._prometheus_bytes_sent
+        if sent_delta:
+            OMI_VAD_GATE_AUDIO_SECONDS_TOTAL.labels(outcome='sent', mode=self.mode).inc(sent_delta / bytes_per_second)
+            self._prometheus_bytes_sent = self._bytes_sent
+
+        pending_bytes = sum(len(chunk) for chunk in self._pre_roll)
+        skipped_bytes = max(0, self._bytes_received - self._bytes_sent - pending_bytes)
+        skipped_delta = skipped_bytes - self._prometheus_bytes_skipped
+        if skipped_delta:
+            OMI_VAD_GATE_AUDIO_SECONDS_TOTAL.labels(outcome='skipped', mode=self.mode).inc(
+                skipped_delta / bytes_per_second
+            )
+            self._prometheus_bytes_skipped = skipped_bytes
 
     def _update_state(self, pcm_data: bytes, is_speech: bool, wall_time: float) -> GateOutput:
         """State machine transition logic."""


### PR DESCRIPTION
## What

Adds two Prometheus counters so the live VAD streaming gate's effect is observable from Grafana instead of only per-session JSON log lines:

- `omi_vad_gate_audio_seconds_total{outcome=sent|skipped, mode=active|shadow}` — audio seconds forwarded to vs withheld from the STT provider
- `omi_vad_gate_sessions_total{mode}` — gated sessions

Increments are per-chunk (crash-safe, no teardown-only lag). Pre-roll audio is only counted once its final outcome is known, so buffered silence is never double-counted as skipped-then-sent. Gate behavior, thresholds, and the existing JSON log are unchanged. Gate failures already record via `OMI_FALLBACK_TOTAL{component=vad}`, so no new fallback counter.

## Why

Prod runs `VAD_GATE_MODE=active`, but the gate's actual rejection rate ("what fraction of audio never reaches Deepgram") currently requires log spelunking. These counters answer that directly and cheaply.

## Tests

`tests/unit/test_vad_gate.py`: new parametrized test asserting counter deltas match the gate's byte accounting in both modes. Full file: 121 passed.

Implementation by codex (gpt-5.6-sol), reviewed and verified by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

