### PR TITLE
fix(firmware): log and count offline-audio drops while RTC is unsynced

### DIFF
--- a/omi/firmware/omi/src/sd_card.c
+++ b/omi/firmware/omi/src/sd_card.c
@@ -1227,8 +1227,11 @@ void sd_notify_time_synced(uint32_t utc_time)
         return;
     }
 
+    /* Callers run on the BLE RX thread (transport.c) and the system workqueue
+     * (rtc.c); never block them for a best-effort log summary. Matches the
+     * K_NO_WAIT pattern of sd_notify_ble_state below. */
     req.type = REQ_TIME_SYNCED;
-    ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
+    ret = k_msgq_put(&sd_prio_msgq, &req, K_NO_WAIT);
     if (ret != 0) {
         LOG_WRN("failed to queue RTC sync drop summary: %d", ret);
     }

--- a/omi/firmware/omi/src/sd_card.c
+++ b/omi/firmware/omi/src/sd_card.c
@@ -30,6 +30,7 @@ LOG_MODULE_REGISTER(sd_card, CONFIG_LOG_DEFAULT_LEVEL);
 #define RAW_BATCH_HEADER_BYTES 32U
 #define RAW_PACKETS_PER_BATCH ((RAW_BATCH_BYTES - RAW_BATCH_HEADER_BYTES) / RAW_AUDIO_PACKET_BYTES)
 #define RAW_FLUSH_INTERVAL_MS 1000
+#define RAW_MIN_VALID_UTC_TIME 1700000000U
 
 #define RAW_META_MAGIC 0x4F4D4952U
 #define RAW_BATCH_MAGIC 0x4F4D4942U
@@ -108,6 +109,7 @@ static int wait_for_sd_worker_response(struct k_sem *sem, int timeout_ms, const 
 
 typedef enum {
     REQ_WRITE_DATA,
+    REQ_TIME_SYNCED,
     REQ_GET_RING_INFO,
     REQ_READ_PACKETS,
     REQ_ADVANCE_READ,
@@ -189,6 +191,7 @@ static uint8_t writing_error_counter;
 
 static uint32_t write_drop_packets;
 static uint32_t write_drop_bytes;
+static uint32_t rtc_unsynced_drop_packets;
 static int64_t last_write_blocked_log_ms;
 
 static char compat_current_name[MAX_FILENAME_LEN];
@@ -666,6 +669,17 @@ static int advance_read_seq_internal(uint64_t new_read_seq, bool sync_requested)
     return 0;
 }
 
+static void record_rtc_unsynced_drop(void)
+{
+    if (rtc_unsynced_drop_packets < UINT32_MAX) {
+        rtc_unsynced_drop_packets++;
+    }
+
+    if ((rtc_unsynced_drop_packets & (rtc_unsynced_drop_packets - 1U)) == 0U) {
+        LOG_WRN("offline audio discarded: clock has never been synced (dropped=%u packets)", rtc_unsynced_drop_packets);
+    }
+}
+
 static void process_write_data_req(const sd_req_t *req)
 {
     if (sd_write_blocked || sd_write_paused || !req) {
@@ -678,11 +692,13 @@ static void process_write_data_req(const sd_req_t *req)
     }
 
     if (!rtc_is_valid()) {
+        record_rtc_unsynced_drop();
         return;
     }
 
     uint32_t timestamp = get_utc_time();
-    if (timestamp == 0U || timestamp < 1700000000U) {
+    if (timestamp == 0U || timestamp < RAW_MIN_VALID_UTC_TIME) {
+        record_rtc_unsynced_drop();
         return;
     }
 
@@ -979,6 +995,13 @@ void sd_worker_thread(void)
             }
             break;
 
+        case REQ_TIME_SYNCED:
+            if (rtc_unsynced_drop_packets > 0U) {
+                LOG_WRN("clock synced after %u offline audio packets were discarded", rtc_unsynced_drop_packets);
+                rtc_unsynced_drop_packets = 0U;
+            }
+            break;
+
         case REQ_GET_RING_INFO:
             if (current_batch_dirty) {
                 (void) flush_current_batch(false);
@@ -1197,7 +1220,18 @@ void sd_request_power(bool on)
 
 void sd_notify_time_synced(uint32_t utc_time)
 {
-    ARG_UNUSED(utc_time);
+    sd_req_t req = {0};
+    int ret;
+
+    if (utc_time < RAW_MIN_VALID_UTC_TIME) {
+        return;
+    }
+
+    req.type = REQ_TIME_SYNCED;
+    ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
+    if (ret != 0) {
+        LOG_WRN("failed to queue RTC sync drop summary: %d", ret);
+    }
 }
 
 void sd_notify_ble_state(bool connected)


### PR DESCRIPTION
## What

A pendant whose clock has never been synced by the app (out-of-box before first pairing, or after a settings wipe) silently discards all offline SD audio: `process_write_data_req()` returns early on `!rtc_is_valid()` with zero trace. This PR makes that loss visible:

- Counts dropped packets and emits a rate-limited `LOG_WRN` (at 1, 2, 4, 8, … drops) naming the cause.
- Implements the previously no-op `sd_notify_time_synced()` hook: on time sync it enqueues a `REQ_TIME_SYNCED` message to the SD worker, which logs a one-line summary of how many packets were discarded pre-sync and resets the counter.
- Hoists the magic `1700000000U` timestamp floor into `RAW_MIN_VALID_UTC_TIME`.

Deliberately out of scope: recording with synthetic timestamps (would propagate bogus conversation dates through phone-side sync) and any BLE protocol change. Observability only.

All counter reads/writes stay on the SD worker thread (drops inside `process_write_data_req`, reset via the priority msgq), so no locking is needed.

Implementation by codex (gpt-5.6-sol), reviewed and verified by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Failure class (fixes)

Failure-Class: none

No existing failure-class covers firmware-side silent data discard (registry has no firmware/RTC/SD-surface classes); this is a single-instance observability fix, and minting a new class here would expand the PR beyond its stated firmware-only scope.
