### PR TITLE
fix(monitoring): keep alert UIDs within Grafana's 40-character limit

### DIFF
--- a/backend/charts/monitoring/README.md
+++ b/backend/charts/monitoring/README.md
@@ -617,7 +617,7 @@ specifically for failures that stay green on every other signal, and are documen
 
 | Rule | Catches |
 |---|---|
-| `omi-llm-gateway-invalid-request-rejections` | Requests rejected during validation, **before** a route is selected. These are counted by `llm_gateway_request_rejections_total` and never reach `llm_gateway_requests_total`, so the affected lane keeps reporting 100% success. |
+| `omi-llm-gateway-invalid-requests` | Requests rejected during validation, **before** a route is selected. These are counted by `llm_gateway_request_rejections_total` and never reach `llm_gateway_requests_total`, so the affected lane keeps reporting 100% success. |
 | `omi-llm-gateway-lane-failure-ratio` | A lane failing more than a quarter of its real requests over an hour. |
 | `omi-llm-gateway-lane-zero-success` | A lane with attempts but no successful request in six hours. The `or ... * 0` zero-fill is required: a lane that has never succeeded has no `outcome="success"` series, so a plain ratio produces no series and no alert. |
 | `omi-journey-signal-dead` | A journey counter that stopped reporting while the platform is demonstrably serving traffic. Every real-traffic journey rule assumes its counter is scraped; when that breaks, the rule goes quiet rather than failing loudly. |

--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -9559,7 +9559,7 @@
     "record": null
   },
   {
-    "uid": "omi-cloud-run-metrics-egress-query-rejected",
+    "uid": "omi-cloud-run-egress-query-rejected",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
     "ruleGroup": "Cloud Run Ingestion",
@@ -9689,7 +9689,7 @@
     "labels": {
       "severity": "critical",
       "instatus_component": "observability",
-      "alert_identity": "omi-cloud-run-metrics-egress-query-rejected",
+      "alert_identity": "omi-cloud-run-egress-query-rejected",
       "component": "observability",
       "impact": "infrastructure"
     },
@@ -9700,7 +9700,7 @@
     "record": null
   },
   {
-    "uid": "omi-llm-gateway-invalid-request-rejections",
+    "uid": "omi-llm-gateway-invalid-requests",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
     "ruleGroup": "LLM Gateway",
@@ -9830,7 +9830,7 @@
       "runbook": "backend/docs/runbooks/silent-failure-detection.md"
     },
     "labels": {
-      "alert_identity": "omi-llm-gateway-invalid-request-rejections",
+      "alert_identity": "omi-llm-gateway-invalid-requests",
       "severity": "critical",
       "instatus_component": "ai-chat",
       "component": "llm-gateway",

--- a/backend/charts/monitoring/alerts/cloud-run-ingestion.json
+++ b/backend/charts/monitoring/alerts/cloud-run-ingestion.json
@@ -141,7 +141,7 @@
     "record": null
   },
   {
-    "uid": "omi-cloud-run-metrics-egress-query-rejected",
+    "uid": "omi-cloud-run-egress-query-rejected",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
     "ruleGroup": "Cloud Run Ingestion",
@@ -271,7 +271,7 @@
     "labels": {
       "severity": "critical",
       "instatus_component": "observability",
-      "alert_identity": "omi-cloud-run-metrics-egress-query-rejected",
+      "alert_identity": "omi-cloud-run-egress-query-rejected",
       "component": "observability",
       "impact": "infrastructure"
     },

--- a/backend/charts/monitoring/alerts/resilience.json
+++ b/backend/charts/monitoring/alerts/resilience.json
@@ -1071,7 +1071,7 @@
     "record": null
   },
   {
-    "uid": "omi-llm-gateway-invalid-request-rejections",
+    "uid": "omi-llm-gateway-invalid-requests",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",
     "ruleGroup": "LLM Gateway",
@@ -1201,7 +1201,7 @@
       "runbook": "backend/docs/runbooks/silent-failure-detection.md"
     },
     "labels": {
-      "alert_identity": "omi-llm-gateway-invalid-request-rejections",
+      "alert_identity": "omi-llm-gateway-invalid-requests",
       "severity": "critical",
       "instatus_component": "ai-chat",
       "component": "llm-gateway",

--- a/backend/docs/runbooks/silent-failure-detection.md
+++ b/backend/docs/runbooks/silent-failure-detection.md
@@ -43,7 +43,7 @@ All five rules link to **Grafana → Resilience / Fallbacks**:
 
 ### LLM Gateway — clients rejected before routing
 
-`omi-llm-gateway-invalid-request-rejections`
+`omi-llm-gateway-invalid-requests`
 
 ```promql
 sum(increase(llm_gateway_request_rejections_total{error_class="invalid_request"}[30m])) or vector(0)
@@ -160,7 +160,7 @@ to page anyone.
 
 | Rule | Breaching evaluations | What it caught |
 |---|---|---|
-| `omi-llm-gateway-invalid-request-rejections` | 58 / 673 (8.6%) | The desktop chat outage window, and nothing after the fix deployed. |
+| `omi-llm-gateway-invalid-requests` | 58 / 673 (8.6%) | The desktop chat outage window, and nothing after the fix deployed. |
 | `omi-llm-gateway-lane-failure-ratio` | 100 / 21,314 (0.47%) | `omi:auto:translation` only. |
 | `omi-llm-gateway-lane-zero-success` | 350 / 21,472 (1.6%) | `omi:auto:translation` and `omi:auto:web-search`. |
 | `omi-journey-signal-dead` | 0 / 1,346 | No false positives on the two journeys that do report. |

--- a/backend/tests/unit/test_monitoring_alert_rule_contract.py
+++ b/backend/tests/unit/test_monitoring_alert_rule_contract.py
@@ -56,6 +56,14 @@ PARAKEET_FATAL_CUDA_EXPR = (
 )
 
 
+# Grafana rejects a rule whose UID exceeds 40 characters with
+# "UID is longer than 40 symbols", at create time. A repo export is a mirror, so
+# an over-long UID costs nothing until someone tries to provision it -- and then
+# the rule that was written, reviewed, and merged simply cannot be made live.
+# Two rules were already past the limit before this was pinned.
+GRAFANA_MAX_UID_LENGTH = 40
+
+
 def _rules(path: Path) -> dict[str, dict]:
     rules = json.loads(path.read_text(encoding="utf-8"))
     by_uid = {rule["uid"]: rule for rule in rules}
@@ -100,6 +108,13 @@ def test_split_alert_exports_preserve_error_count_no_data_contract():
     assert ERROR_COUNT_RULES <= split.keys()
     for uid in ERROR_COUNT_RULES:
         assert combined[uid]["noDataState"] == split[uid]["noDataState"] == "OK"
+
+
+def test_alert_uids_are_short_enough_for_grafana_to_accept():
+    """Every exported rule must be creatable; Grafana caps UIDs at 40 characters."""
+    for export_name, rules in _all_rule_exports().items():
+        over = {uid: len(uid) for uid in rules if len(uid) > GRAFANA_MAX_UID_LENGTH}
+        assert not over, f"{export_name}: Grafana will reject these UIDs at create time: {over}"
 
 
 def test_managed_gke_disables_unavailable_control_plane_scrapes_and_alerts():
@@ -275,7 +290,7 @@ def test_live_transcription_alert_is_traffic_gated_and_ignores_idle_no_data():
 
 
 SILENT_FAILURE_RUNBOOK = "backend/docs/runbooks/silent-failure-detection.md"
-PRE_ROUTE_REJECTION_RULE = "omi-llm-gateway-invalid-request-rejections"
+PRE_ROUTE_REJECTION_RULE = "omi-llm-gateway-invalid-requests"
 PRE_ROUTE_REJECTION_EXPR = (
     'sum(increase(llm_gateway_request_rejections_total{error_class="invalid_request"}[30m])) or vector(0)'
 )


### PR DESCRIPTION
## Summary

Grafana rejects an alert rule whose UID is longer than 40 characters, at create time:

```
POST /api/v1/provisioning/alert-rules -> 400
{"message":"invalid alert rule\ncannot create rule with UID
 'omi-cloud-run-metrics-egress-query-rejected': UID is longer than 40 symbols"}
```

Two exported rules are over the limit and therefore cannot be made live at all:

| UID | Length |
| --- | --- |
| `omi-cloud-run-metrics-egress-query-rejected` | 43 |
| `omi-llm-gateway-invalid-request-rejections` | 42 |

The first is mine, from #12099, and I hit this trying to provision it an hour after merging. The second predates it. Both are renamed here, and the limit is pinned so the next one fails in CI instead of at the console.

- `omi-cloud-run-metrics-egress-query-rejected` → `omi-cloud-run-egress-query-rejected` (35)
- `omi-llm-gateway-invalid-request-rejections` → `omi-llm-gateway-invalid-requests` (32)

Neither rule was ever live — both returned 404 from prod Grafana's provisioning API before this change — so no live rule identity is being broken and no alert history is lost. `alert_identity` labels, the README inventory, `silent-failure-detection.md`, and `PRE_ROUTE_REJECTION_RULE` in the contract test are updated with them.

## Why this survived review

`alert-rules.json` is a repo mirror; prod Grafana is the live source. An unprovisionable rule costs nothing until someone tries to provision it, so a rule can be written, reviewed, merged, and inventoried while being permanently incapable of firing. That is the same shape as the defect #12099 just fixed, one layer up: the artifact looked complete everywhere except where it had to work.

`test_alert_uids_are_short_enough_for_grafana_to_accept` now asserts the 40-character cap across both the combined export and the split sources.

## Verification

- `test_monitoring_alert_rule_contract.py`, `test_monitoring_telemetry_contract.py`, `test_journey_observability.py`: `51 passed`
- Negative proof: restoring either long UID fails the new test, naming the UID and its length.
- `omi-cloud-run-metric-names-unnormalized` (39 chars, from #11998, also never live) was provisioned to prod Grafana successfully during this work, which is how the sibling's length was found to be the only thing blocking it.
- No rule content changed: the diff is UID and `alert_identity` string replacement plus the new test.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

