### PR TITLE
fix(desktop): cap onboarding demo audio at 10s and stop it repeating

### DIFF
--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
@@ -797,6 +797,15 @@ struct OnboardingVideoView: NSViewRepresentable {
       playerView.showsSharingServiceButton = false
       player.play()
 
+      // Onboarding sound must not play longer than 10s or repeat. Mute the audio
+      // once playback reaches 10s; the video keeps looping silently afterwards.
+      let muteAt = NSValue(time: CMTime(seconds: 10, preferredTimescale: 600))
+      context.coordinator.muteObserver = player.addBoundaryTimeObserver(
+        forTimes: [muteAt], queue: .main
+      ) { [weak player] in
+        player?.isMuted = true
+      }
+
       NotificationCenter.default.addObserver(
         context.coordinator,
         selector: #selector(Coordinator.playerDidFinishPlaying(_:)),
@@ -814,6 +823,13 @@ struct OnboardingVideoView: NSViewRepresentable {
 
   class Coordinator: NSObject {
     var player: AVPlayer?
+    var muteObserver: Any?
+
+    deinit {
+      if let muteObserver {
+        player?.removeTimeObserver(muteObserver)
+      }
+    }
 
     @objc func playerDidFinishPlaying(_ notification: Notification) {
       player?.seek(to: .zero)


### PR DESCRIPTION
The onboarding `omi-demo.mp4` (26s) loops forever, so its audio played the whole clip and repeated on every loop. Mute the player once playback reaches 10s so the sound never plays longer than 10s or repeats; the video keeps looping silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

