### PR TITLE
fix(macOS): repair onboarding permission and profile setup

### DIFF
--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -515,6 +515,8 @@ async def create_memory_import_batch(
         logger.exception("Memory import ingest failed uid=%s source_type=%s", uid, request.source_type)
         raise HTTPException(status_code=503, detail="Service temporarily unavailable")
     parity_capture.observe("inbound", {"type": "memory_import_result", **result.response.model_dump(mode="json")})
+    parity_capture.persist()
+    return result.response
 
 
 @router.get('/v3/memories', tags=['memories'], response_model=List[MemoryDB])

--- a/backend/tests/unit/test_memory_import_route.py
+++ b/backend/tests/unit/test_memory_import_route.py
@@ -1,0 +1,71 @@
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+import pytest  # noqa: E402
+
+from database.memory_imports import MemoryImportIngestResult  # noqa: E402
+from models.memory_imports import (  # noqa: E402
+    MemoryImportBatchItem,
+    MemoryImportBatchRequest,
+    MemoryImportBatchResponse,
+)
+from routers import memories as mem_mod  # noqa: E402
+
+
+class _Capture:
+    def __init__(self):
+        self.observations = []
+        self.persisted = False
+
+    def observe(self, lane, payload):
+        self.observations.append((lane, payload))
+
+    def persist(self):
+        self.persisted = True
+
+
+class _CaptureFactory:
+    capture = _Capture()
+
+    @classmethod
+    def from_environ(cls, **_kwargs):
+        cls.capture = _Capture()
+        return cls.capture
+
+
+@pytest.mark.asyncio
+async def test_memory_import_route_returns_the_ingest_response(monkeypatch):
+    request = MemoryImportBatchRequest(
+        source_type='local_files',
+        import_run_id='run-local-files-1',
+        items=[MemoryImportBatchItem(title='Local profile', snippet='267 files indexed')],
+    )
+    expected = MemoryImportBatchResponse(
+        run_id='run-local-files-1',
+        artifacts_received=1,
+        artifacts_created=1,
+        artifacts_deduped=0,
+    )
+
+    async def fake_run_blocking(_executor, function, uid, received_request, *, db_client):
+        assert function is mem_mod.ingest_memory_import_batch
+        assert uid == 'uid-1'
+        assert received_request is request
+        assert db_client is fake_db
+        return MemoryImportIngestResult(response=expected)
+
+    fake_db = object()
+    monkeypatch.setattr(mem_mod.db_client_module, 'db', fake_db)
+    monkeypatch.setattr(mem_mod, 'run_blocking', fake_run_blocking)
+    monkeypatch.setattr(mem_mod, 'SurfaceParityCapture', _CaptureFactory)
+
+    response = await mem_mod.create_memory_import_batch(request=request, uid='uid-1')
+
+    assert response == expected
+    assert _CaptureFactory.capture.persisted
+    assert _CaptureFactory.capture.observations[-1] == (
+        'inbound',
+        {'type': 'memory_import_result', **expected.model_dump(mode='json')},
+    )

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
@@ -825,11 +825,7 @@ extension AppState {
 
   /// Open Accessibility preferences in System Settings
   func openAccessibilityPreferences() {
-    if let url = URL(
-      string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
-    {
-      NSWorkspace.shared.open(url)
-    }
+    PermissionDragGuidance.openAccessibilitySettings()
   }
 
   /// Reset accessibility permission (requires terminal command)

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
@@ -506,15 +506,16 @@ struct OnboardingChatView: View {
   }
 
   private func openSettingsForPermission(_ type: String) {
+    if type == "notifications" {
+      appState.openNotificationPreferences()
+      return
+    }
     switch type {
     case "screen_recording":
       ScreenCaptureService.openScreenRecordingPreferences()
       return
     case "accessibility":
       appState.openAccessibilityPreferences()
-      return
-    case "notifications":
-      appState.openNotificationPreferences()
       return
     default: break
     }

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
@@ -505,22 +505,23 @@ struct OnboardingChatView: View {
     }
   }
 
-  /// Open System Settings to the correct pane for a permission type
   private func openSettingsForPermission(_ type: String) {
-    if type == "screen_recording" {
+    switch type {
+    case "screen_recording":
       ScreenCaptureService.openScreenRecordingPreferences()
       return
-    }
-    if type == "notifications" {
+    case "accessibility":
+      appState.openAccessibilityPreferences()
+      return
+    case "notifications":
       appState.openNotificationPreferences()
       return
+    default: break
     }
     let urlString: String? = {
       switch type {
       case "microphone":
         return "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
-      case "accessibility":
-        return "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
       case "automation":
         return "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation"
       case "full_disk_access":
@@ -529,12 +530,10 @@ struct OnboardingChatView: View {
         return nil
       }
     }()
-    if let urlString, let url = URL(string: urlString) {
-      NSWorkspace.shared.open(url)
-      // Full Disk Access uses the same drag-to-grant mechanic as Screen Recording.
-      if type == "full_disk_access" {
-        Task { await PermissionDragGuidance.presentDragToGrantHelper() }
-      }
+    guard let urlString, let url = URL(string: urlString) else { return }
+    NSWorkspace.shared.open(url)
+    if type == "full_disk_access" {
+      Task { await PermissionDragGuidance.presentDragToGrantHelper() }
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/PermissionDragGuidance.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/PermissionDragGuidance.swift
@@ -4,6 +4,34 @@ import AppKit
 enum PermissionDragGuidance {
   private static var lastPresentedAt: Date?
 
+  /// Open the Accessibility privacy pane and show the same draggable app card
+  /// used by Screen Recording and Full Disk Access. On current macOS releases,
+  /// asking AX to prompt can register the request without showing usable UI, so
+  /// opening Settings alone leaves a fresh named bundle with no obvious row to
+  /// enable.
+  @discardableResult
+  static func openAccessibilitySettings(
+    isAuthorized: () -> Bool = { true },
+    open: (URL) -> Bool = { NSWorkspace.shared.open($0) },
+    suspendForPermissionPrompt: () -> Void = {
+      ShellSummon.suspendForPermissionPrompt()
+    },
+    presentDragGuidance: () -> Void = {
+      Task { await PermissionDragGuidance.presentDragToGrantHelper() }
+    }
+  ) -> Bool {
+    guard
+      let url = URL(
+        string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
+    else { return false }
+
+    guard isAuthorized() else { return false }
+    suspendForPermissionPrompt()
+    guard open(url) else { return false }
+    presentDragGuidance()
+    return true
+  }
+
   /// Remove the drag card immediately — the permission was granted or the user
   /// skipped, so the floating icon should not linger.
   static func dismiss() {

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -330,7 +330,7 @@ final class SBOnboardingModel: ObservableObject {
       return
         "You're all set, \(name). Should I listen all the time, or only during your meetings?"
     case .referral:
-      return "Want to invite a friend? They'll get one free month of Operator."
+      return "Want to invite a friend? They'll get one free month."
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -2403,10 +2403,10 @@ class ChatToolExecutor {
     let options = ["AXTrustedCheckOptionPrompt": true] as CFDictionary
     let granted = AXIsProcessTrustedWithOptions(options)
     if !granted {
-      _ = openPermissionPrivacySettings(
-        pane: "Privacy_Accessibility",
-        expectedOwnerID: expectedOwnerID,
-        authorizationSnapshot: authorizationSnapshot)
+      _ = PermissionDragGuidance.openAccessibilitySettings(
+        isAuthorized: {
+          isPermissionAuthorizationCurrent(expectedOwnerID, authorizationSnapshot: authorizationSnapshot)
+        })
     }
   }
 

--- a/desktop/macos/Desktop/Tests/SBOnboardingPermissionFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingPermissionFlowTests.swift
@@ -353,6 +353,37 @@ final class SBOnboardingPermissionFlowTests: XCTestCase {
 /// The permission probes `AppState` owns, exercised through their injected seams.
 @MainActor
 final class AppStatePermissionProbeTests: XCTestCase {
+  func testAccessibilitySettingsOpenPresentsDragGuidance() {
+    var openedURL: URL?
+    var presentedDragGuidance = false
+
+    let opened = PermissionDragGuidance.openAccessibilitySettings(
+      open: {
+        openedURL = $0
+        return true
+      },
+      suspendForPermissionPrompt: {},
+      presentDragGuidance: { presentedDragGuidance = true })
+
+    XCTAssertTrue(opened)
+    XCTAssertEqual(
+      openedURL?.absoluteString,
+      "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
+    XCTAssertTrue(presentedDragGuidance)
+  }
+
+  func testAccessibilityDragGuidanceIsNotPresentedWhenSettingsFailsToOpen() {
+    var presentedDragGuidance = false
+
+    let opened = PermissionDragGuidance.openAccessibilitySettings(
+      open: { _ in false },
+      suspendForPermissionPrompt: {},
+      presentDragGuidance: { presentedDragGuidance = true })
+
+    XCTAssertFalse(opened)
+    XCTAssertFalse(presentedDragGuidance)
+  }
+
   // MARK: - Defect 5: automation status is readable by the caller that acts on it
 
   func testAutomationRefreshReturnsTheFreshStatusToItsCaller() async {

--- a/desktop/macos/Desktop/Tests/SBPostOnboardingGuidanceWiringTests.swift
+++ b/desktop/macos/Desktop/Tests/SBPostOnboardingGuidanceWiringTests.swift
@@ -171,6 +171,14 @@ final class SBPostOnboardingGuidanceWiringTests: XCTestCase {
     XCTAssertFalse(try XCTUnwrap(appState).hasCompletedOnboarding)
   }
 
+  func testReferralRewardCopyStaysPlanAgnostic() {
+    let model = makeModel()
+
+    XCTAssertEqual(
+      model.message(for: .referral),
+      "Want to invite a friend? They'll get one free month.")
+  }
+
   func testSkippedSetupStillProducesAnswerableGuidance() {
     let model = makeModel()
 

--- a/desktop/macos/changelog/unreleased/20260823-macos-onboarding-qa-fixes.json
+++ b/desktop/macos/changelog/unreleased/20260823-macos-onboarding-qa-fixes.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed local-profile saves and Accessibility setup, and clarified the one-month referral reward"
+}


### PR DESCRIPTION
## What changed and why

Fixes the three issues found in the named macOS QA build: local-file imports now return their persisted response instead of producing a FastAPI 500, Accessibility opens the same draggable app guidance used by the other permissions, and the referral reward copy no longer names a plan.

## Product invariants affected

- INV-CHAT-1
- INV-MEM-3
- INV-MEM-4
- INV-MEM-1

## How it was verified

- Reproduced the original local-file flow from the QA bundle logs: Full Disk Access was granted and 267 files indexed, then `/v3/memory-imports/batch` returned 500.
- Rebuilt and launched `/Applications/omi-qa-20260823.app` from the rebased branch; its signature verifies and the running executable contains the generic one-month copy.
- `make runtime-image-source-closure`
- `cd backend && ./.venv/bin/python scripts/scan_async_blockers.py --dirs routers utils`
- `cd desktop/macos && ./scripts/agent-logic-harness.sh --cross-surface-smoke`

## Tests

- `cd backend && ./.venv/bin/pytest -q tests/unit/test_memory_import_route.py tests/unit/test_memory_imports.py tests/unit/test_memory_import_static_guards.py tests/unit/test_desktop_rest_inventory.py` (21 passed)
- `cd desktop/macos && xcrun swift test --package-path Desktop --filter 'SBOnboardingPermissionFlowTests|AppStatePermissionProbeTests|SBPostOnboardingGuidanceWiringTests'` (45 passed)
- Regression coverage asserts that the import route returns and persists its response, Accessibility guidance appears only after Settings opens successfully, and referral copy remains plan-agnostic.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

