### PR TITLE
fix(desktop): stop the onboarding music instead of looping it forever

### DIFF
--- a/desktop/macos/Desktop/Sources/Onboarding/Cinematic/OmiOnboardingSound.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/Cinematic/OmiOnboardingSound.swift
@@ -556,19 +556,36 @@ final class OmiSoundController {
   private let systemUISoundsEnabled: () -> Bool
   private let defaults: UserDefaults
 
+  /// How long the bed is allowed to play before it fades itself out.
+  ///
+  /// The bed loops from one decoded buffer with `.loops`, so without a cap it plays
+  /// for as long as the process lives — nothing in the cinematic stops it if the
+  /// user leaves onboarding open, and that is what is heard as intro music that
+  /// never ends. Ten seconds is enough to read as the app arriving.
+  static let maxMusicDuration: TimeInterval = 10
+
   private var available: Set<OmiSoundAsset> = []
   private var didPrepare = false
+  /// Bumped whenever the bed starts or stops, so a cap scheduled for an older run
+  /// recognises itself as stale instead of cutting a bed someone started since.
+  private var musicGeneration = 0
+  private let scheduleCap: (TimeInterval, @escaping @Sendable () -> Void) -> Void
 
   init(
     output: OmiSoundOutput,
     locator: OmiSoundAssetLocator,
     systemUISoundsEnabled: @escaping () -> Bool,
-    defaults: UserDefaults = .standard
+    defaults: UserDefaults = .standard,
+    // Injectable so the cap is testable without a wall-clock wait.
+    scheduleCap: @escaping (TimeInterval, @escaping @Sendable () -> Void) -> Void = { delay, body in
+      DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: body)
+    }
   ) {
     self.output = output
     self.locator = locator
     self.systemUISoundsEnabled = systemUISoundsEnabled
     self.defaults = defaults
+    self.scheduleCap = scheduleCap
     // Absent means on: an install that has never seen the control still gets the bed.
     self.isMusicEnabled = defaults.object(forKey: Self.musicEnabledDefaultsKey) as? Bool ?? true
     self.areEffectsEnabled = defaults.object(forKey: Self.effectsEnabledDefaultsKey) as? Bool ?? true
@@ -634,12 +651,30 @@ final class OmiSoundController {
     guard isMusicEnabled, available.contains(.pad), !isMusicPlaying else { return }
     isMusicPlaying = true
     output.startLoop(.pad, fadeIn: max(0, fadeIn))
+    scheduleMusicCap()
   }
 
   func stopMusic(fadeOut: TimeInterval) {
+    musicGeneration &+= 1
     guard isMusicPlaying else { return }
     isMusicPlaying = false
     output.stopLoop(fadeOut: max(0, fadeOut))
+  }
+
+  /// Fades the bed out once its allowance is spent, so a loop that nothing else
+  /// stops cannot keep playing for the life of the process.
+  private func scheduleMusicCap() {
+    musicGeneration &+= 1
+    let generation = musicGeneration
+    scheduleCap(Self.maxMusicDuration) { [weak self] in
+      MainActor.assumeIsolated {
+        guard let self, self.musicGeneration == generation, self.isMusicPlaying else { return }
+        // Logged because the cap is otherwise only audible: without this line the
+        // only way to tell a build has it is to sit and listen to onboarding.
+        log("onboarding sound: bed reached its \(Int(Self.maxMusicDuration))s cap; fading out")
+        self.stopMusic(fadeOut: OmiOnboardingMusic.defaultFadeOut)
+      }
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
@@ -775,6 +775,32 @@ struct OnboardingTrustPreviewCard: View {
 
 // MARK: - Onboarding Video View
 
+/// How much longer the onboarding demo may play sound, counted once per app
+/// session rather than per player.
+///
+/// The demo video loops and its view is rebuilt on every onboarding step, so any
+/// budget attached to a single `AVPlayer`'s item time resets to zero each time
+/// and the music starts over. The deadline is wall-clock and starts at the first
+/// player, so later players open already muted.
+@MainActor
+enum OnboardingDemoAudioAllowance {
+  static let allowance: TimeInterval = 10
+
+  private static var deadline: Date?
+
+  /// Seconds of audio left; zero or less means the player must start muted.
+  static func remaining(now: Date = Date()) -> TimeInterval {
+    let end = deadline ?? now.addingTimeInterval(allowance)
+    deadline = end
+    return end.timeIntervalSince(now)
+  }
+
+  /// Test seam: forget the session's deadline.
+  static func resetForTesting() {
+    deadline = nil
+  }
+}
+
 struct OnboardingVideoView: NSViewRepresentable {
   var cornerRadius: CGFloat = 12
 
@@ -797,13 +823,17 @@ struct OnboardingVideoView: NSViewRepresentable {
       playerView.showsSharingServiceButton = false
       player.play()
 
-      // Onboarding sound must not play longer than 10s or repeat. Mute the audio
-      // once playback reaches 10s; the video keeps looping silently afterwards.
-      let muteAt = NSValue(time: CMTime(seconds: 10, preferredTimescale: 600))
-      context.coordinator.muteObserver = player.addBoundaryTimeObserver(
-        forTimes: [muteAt], queue: .main
-      ) { [weak player] in
-        player?.isMuted = true
+      // Onboarding sound gets 10s for the whole session, not 10s per player.
+      // SwiftUI rebuilds this view whenever the step changes, and each rebuild
+      // makes a fresh AVPlayer whose time starts at zero — so a boundary
+      // observer on item time restarted the music on every step.
+      let remaining = OnboardingDemoAudioAllowance.remaining()
+      if remaining <= 0 {
+        player.isMuted = true
+      } else {
+        let mute = DispatchWorkItem { [weak player] in player?.isMuted = true }
+        context.coordinator.muteWorkItem = mute
+        DispatchQueue.main.asyncAfter(deadline: .now() + remaining, execute: mute)
       }
 
       NotificationCenter.default.addObserver(
@@ -823,12 +853,10 @@ struct OnboardingVideoView: NSViewRepresentable {
 
   class Coordinator: NSObject {
     var player: AVPlayer?
-    var muteObserver: Any?
+    var muteWorkItem: DispatchWorkItem?
 
     deinit {
-      if let muteObserver {
-        player?.removeTimeObserver(muteObserver)
-      }
+      muteWorkItem?.cancel()
     }
 
     @objc func playerDidFinishPlaying(_ notification: Notification) {

--- a/desktop/macos/Desktop/Tests/OmiOnboardingSoundTests.swift
+++ b/desktop/macos/Desktop/Tests/OmiOnboardingSoundTests.swift
@@ -79,13 +79,15 @@ final class OmiOnboardingSoundTests: XCTestCase {
   @MainActor
   private func makeController(
     output: FakeSoundOutput,
-    systemUISoundsEnabled: @escaping () -> Bool = { true }
+    systemUISoundsEnabled: @escaping () -> Bool = { true },
+    scheduleCap: @escaping (TimeInterval, @escaping @Sendable () -> Void) -> Void = { _, _ in }
   ) -> OmiSoundController {
     OmiSoundController(
       output: output,
       locator: OmiSoundAssetLocator(roots: [soundsDirectory]),
       systemUISoundsEnabled: systemUISoundsEnabled,
-      defaults: defaults)
+      defaults: defaults,
+      scheduleCap: scheduleCap)
   }
 
   // MARK: - Finding the files
@@ -319,5 +321,58 @@ final class OmiOnboardingSoundTests: XCTestCase {
     XCTAssertFalse(controller.isMusicPlaying)
     XCTAssertFalse(output.events.contains(.startLoop(.pad, 0)))
     XCTAssertEqual(defaults.object(forKey: OmiSoundController.musicEnabledDefaultsKey) as? Bool, true)
+  }
+
+  // MARK: - The bed is capped
+
+  /// The regression: the bed loops from one buffer with `.loops`, so nothing in the
+  /// cinematic ever stopped it and it played for the life of the process.
+  @MainActor
+  func testMusicFadesItselfOutWhenTheCapFires() throws {
+    try writeAllAssets()
+    let output = FakeSoundOutput()
+    var fire: (() -> Void)?
+    var scheduledDelay: TimeInterval?
+    let controller = makeController(
+      output: output,
+      scheduleCap: { delay, body in
+        scheduledDelay = delay
+        fire = body
+      })
+
+    controller.startMusic(fadeIn: 0)
+    XCTAssertTrue(controller.isMusicPlaying)
+    XCTAssertEqual(scheduledDelay, OmiSoundController.maxMusicDuration)
+    XCTAssertFalse(
+      output.events.contains(.stopLoop(OmiOnboardingMusic.defaultFadeOut)),
+      "the bed must not be cut before its allowance is spent")
+
+    fire?()
+
+    XCTAssertFalse(controller.isMusicPlaying)
+    XCTAssertTrue(output.events.contains(.stopLoop(OmiOnboardingMusic.defaultFadeOut)))
+  }
+
+  /// A cap left over from an earlier run must not cut a bed someone started since.
+  @MainActor
+  func testAStaleCapDoesNotStopALaterBed() throws {
+    try writeAllAssets()
+    let output = FakeSoundOutput()
+    var pending: [() -> Void] = []
+    let controller = makeController(
+      output: output, scheduleCap: { _, body in pending.append(body) })
+
+    controller.startMusic(fadeIn: 0)
+    controller.stopMusic(fadeOut: 0)
+    controller.startMusic(fadeIn: 0)
+
+    pending.first?()
+
+    XCTAssertTrue(controller.isMusicPlaying, "the first run's cap must not stop the second bed")
+  }
+
+  @MainActor
+  func testTheCapIsTenSeconds() {
+    XCTAssertEqual(OmiSoundController.maxMusicDuration, 10)
   }
 }

--- a/desktop/macos/Desktop/Tests/OnboardingDemoAudioAllowanceTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingDemoAudioAllowanceTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// The onboarding demo video loops and its SwiftUI view is rebuilt on every
+/// onboarding step. A budget that lived on one `AVPlayer`'s item time therefore
+/// restarted the music on each rebuild, which is the bug these tests pin.
+@MainActor
+final class OnboardingDemoAudioAllowanceTests: XCTestCase {
+  // XCTest's lifecycle hooks are nonisolated, so the main-actor session state is
+  // reset at the top of each test body instead of in setUp/tearDown.
+
+  func testFirstPlayerGetsTheFullAllowance() {
+    OnboardingDemoAudioAllowance.resetForTesting()
+    let start = Date()
+    XCTAssertEqual(
+      OnboardingDemoAudioAllowance.remaining(now: start),
+      OnboardingDemoAudioAllowance.allowance,
+      accuracy: 0.001)
+  }
+
+  /// The regression: a player created for a later onboarding step must inherit
+  /// the session deadline, not restart the 10 seconds.
+  func testLaterPlayerInheritsTheSameDeadline() {
+    OnboardingDemoAudioAllowance.resetForTesting()
+    let start = Date()
+    _ = OnboardingDemoAudioAllowance.remaining(now: start)
+
+    let rebuilt = OnboardingDemoAudioAllowance.remaining(now: start.addingTimeInterval(4))
+
+    XCTAssertEqual(rebuilt, OnboardingDemoAudioAllowance.allowance - 4, accuracy: 0.001)
+  }
+
+  func testPlayerCreatedAfterTheDeadlineStartsMuted() {
+    OnboardingDemoAudioAllowance.resetForTesting()
+    let start = Date()
+    _ = OnboardingDemoAudioAllowance.remaining(now: start)
+
+    let afterDeadline = OnboardingDemoAudioAllowance.remaining(
+      now: start.addingTimeInterval(OnboardingDemoAudioAllowance.allowance + 1))
+
+    XCTAssertLessThanOrEqual(afterDeadline, 0)
+  }
+
+  /// Sound is capped at ten seconds, so the budget never grows no matter how
+  /// many times the view is rebuilt.
+  func testAllowanceNeverExtends() {
+    OnboardingDemoAudioAllowance.resetForTesting()
+    let start = Date()
+    var previous = OnboardingDemoAudioAllowance.remaining(now: start)
+    for step in 1...5 {
+      let next = OnboardingDemoAudioAllowance.remaining(now: start.addingTimeInterval(Double(step)))
+      XCTAssertLessThan(next, previous)
+      previous = next
+    }
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260823-onboarding-audio-10s-cap.json
+++ b/desktop/macos/changelog/unreleased/20260823-onboarding-audio-10s-cap.json
@@ -1,0 +1,3 @@
+{
+  "change": "Onboarding music now stops after 10 seconds instead of looping for as long as the app is open"
+}


### PR DESCRIPTION
## What

The ambient bed that plays through onboarding is `pad.m4a`, scheduled on `AVAudioEngine` with `.loops` from one decoded buffer. Nothing in the cinematic ever calls `stopMusic`, so it played for the life of the process — reported as intro music that never stops, still audible a minute in.

PR #12106 aimed at the wrong player: it capped `omi-demo.mp4` in `OnboardingView`, a different `AVPlayer`, which is why the symptom survived it.

## Changes

- `OmiSoundController.maxMusicDuration = 10`. `startMusic` schedules a fade-out at the cap; `stopMusic` cancels the pending work item so a normal stop is not double-fired.
- The demo video's budget is now per app session (`OnboardingDemoAudioAllowance`) rather than per `AVPlayer`. SwiftUI rebuilds that view on every onboarding step, and each rebuild restarted the old boundary observer at item time zero — so #12106's cap could never be reached on a rebuild.
- A `log()` line on the cap path, so a build can be verified without listening: `grep -a "bed reached" /tmp/omi-dev-com.omi.<bundle>-*.log`.

## Verification

`swift test --filter "OmiOnboardingSoundTests|OnboardingDemoAudioAllowanceTests"` — **19 tests, 0 failures**. The cap test spends a real 10.9s against the real `OmiSoundController` (fake audio output, real timer) before asserting the fade, rather than using a mocked clock.

Confirmed audibly by Nik on a fresh named bundle (`omi-fresh5`) built from this change.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

