### PR TITLE
fix(deploy): keep Cloud Run jobs in the rendered runtime-env state

### DIFF
--- a/backend/scripts/render_backend_runtime_env.py
+++ b/backend/scripts/render_backend_runtime_env.py
@@ -200,13 +200,29 @@ def _render_cloud_run_state(env_config: ConfigDict) -> ConfigDict:
         service_config = _as_config_dict(raw_service_config)
         if service_config is None:
             raise ValueError(f'Cloud Run service {service_name} must be a mapping')
-        env_entries = _render_env_entries(_as_config_dict(service_config.get('env')) or {})
-        secret_entries = _render_secret_entries(_as_config_dict(service_config.get('secrets')) or {})
         services[str(service_name)] = {
-            'env': [*env_entries, *secret_entries],
+            'env': _render_state_env(service_config),
             'flags': dict(network_flags),
         }
-    return {'services': services}
+    # Jobs ship from their own workflows, but their env, secret and forbidden_env contract is
+    # declared in this manifest and validated against this state; omitting them retires that check.
+    jobs: ConfigDict = {}
+    for job_name, raw_job_config in (_as_config_dict(cloud_run.get('jobs')) or {}).items():
+        job_config = _as_config_dict(raw_job_config)
+        if job_config is None:
+            raise ValueError(f'Cloud Run job {job_name} must be a mapping')
+        jobs[str(job_name)] = {
+            'env': _render_state_env(job_config),
+            'flags': _render_flag_values(_as_config_dict(job_config.get('flags')) or {}),
+        }
+    return {'services': services, 'jobs': jobs}
+
+
+def _render_state_env(config: ConfigDict) -> list[ConfigDict]:
+    return [
+        *_render_env_entries(_as_config_dict(config.get('env')) or {}),
+        *_render_secret_entries(_as_config_dict(config.get('secrets')) or {}),
+    ]
 
 
 def _runtime_value(name: str, entry: ConfigDict, *, allow_missing: bool = False) -> str | None:

--- a/backend/tests/unit/test_render_backend_runtime_env.py
+++ b/backend/tests/unit/test_render_backend_runtime_env.py
@@ -428,3 +428,55 @@ def test_desktop_backend_compose_pins_vertex_pt(env, project):
     assert _MODULE['_render_secrets'](desktop['secrets']) == 'METRICS_SECRET=METRICS_SECRET:latest'
     docs = Path(__file__).resolve().parents[2] / 'docs' / 'vertex-pt-flash.md'
     assert VERTEX_PT_CONTRACT.split(',')[0] in docs.read_text(encoding='utf-8')
+
+
+def test_state_output_carries_cloud_run_jobs(tmp_path, monkeypatch):
+    env_config = {
+        'cloud_run': {
+            'network': {'flags': {'--vpc-egress': 'private-ranges-only'}},
+            'services': {'backend': {'env': {'OMI_ENV_STAGE': {'value': 'dev'}}, 'secrets': {}}},
+            'jobs': {
+                'notifications-job': {
+                    'flags': {'--task-timeout': '3600s'},
+                    'env': {'OMI_ENV_STAGE': {'value': 'dev'}},
+                    'secrets': {'OPENAI_API_KEY': {'secret': 'OPENAI_API_KEY', 'version': 'latest'}},
+                }
+            },
+        }
+    }
+    state_path = tmp_path / 'runtime-env-state.json'
+    monkeypatch.setitem(_MODULE['main'].__globals__, '_load_yaml', lambda _path: {'environments': {'dev': env_config}})
+    monkeypatch.setattr(
+        'sys.argv',
+        ['render_backend_runtime_env.py', '--env', 'dev', '--state-output', str(state_path)],
+    )
+
+    assert _MODULE['main']() == 0
+
+    state = json.loads(state_path.read_text(encoding='utf-8'))
+
+    assert state['jobs'] == {
+        'notifications-job': {
+            'env': [
+                {'name': 'OMI_ENV_STAGE', 'value': 'dev'},
+                {
+                    'name': 'OPENAI_API_KEY',
+                    'valueFrom': {'secretKeyRef': {'name': 'OPENAI_API_KEY', 'key': 'latest'}},
+                },
+            ],
+            'flags': {'--task-timeout': '3600s'},
+        }
+    }
+
+
+@pytest.mark.parametrize('env', ['dev', 'prod'])
+def test_state_output_covers_every_declared_job(env, monkeypatch):
+    monkeypatch.setenv('CLOUD_RUN_VPC_NETWORK', 'omi-vpc-1')
+    monkeypatch.setenv('CLOUD_RUN_VPC_SUBNET', 'omi-subnet-1')
+    env_config = _MANIFEST['environments'][env]
+    cloud_run = env_config['cloud_run']
+
+    # Services need the deploy workflow's environment; the job contract does not.
+    state = _MODULE['_render_cloud_run_state']({'cloud_run': {**cloud_run, 'services': {}}})
+
+    assert set(state['jobs']) == set(cloud_run['jobs'])


### PR DESCRIPTION
## What changed and why

#12098 moved the pre-deploy runtime-env gate onto the artifact the renderer produces, which is the right shape — but `_render_cloud_run_state` emits `services` only. `_validate_cloud_run` skips its entire job branch when the state has no `jobs` key (`backend/scripts/runtime_env_validation/cloud_run.py:140-141`), so the env, secret and `forbidden_env` contract the manifest declares for `notifications-job` and `memory-maintenance-job` is now validated nowhere:

- the pre-deploy gate gets a state without jobs;
- the job workflows (`gcp_notifications_job.yml:115`, `gcp_memory_maintenance_job.yml:156`, `gcp_memory_maintenance_job_auto_dev.yml:130`) call the validator with `--check-workflows` only, so no Cloud Run state is loaded there either;
- the post-deploy pass is `--check-live-cloud-run`, which is services-only on purpose.

`_fetch_live_cloud_run_state` still documents the guarantee that has gone: *"The job contract is still validated statically against the rendered state."*

`_render_cloud_run_state` now renders jobs too, through the same helpers that already render those jobs' env, secrets and flags for `deploy-cloudrun` in the same invocation — a full render (no `--job`) always renders every job, so this adds no new failure mode. The shared "env entries plus secret refs" step is factored into `_render_state_env` so a service and a job cannot drift apart in how they are rendered.

Fixing it in the validator instead (treating a missing `jobs` key as an error) would break the post-deploy live check, which deliberately reports services only because jobs are deployed by their own workflows. The renderer is the layer that lost the data; the second test below is the ratchet against narrowing it again.

## Product invariants affected

none

## How it was verified

Against the repo's real `backend/deploy/runtime_env.yaml`, with `HOSTED_PUSHER_API_URL` injected into `notifications-job.env` — a name that job's own `forbidden_env` list rejects:

- at `48d9625908^` (the commit before #12098), `validate_runtime_env(env='dev', check_rendered_cloud_run=True)` reports `cloud_run/notifications-job: forbidden env HOSTED_PUSHER_API_URL is present`;
- at `02c48d7da6` (current main), rendering with `--state-output` and validating with `--cloud-run-state` reports `[]` — the deploy gate passes the violation;
- with this change, the same run reports `cloud_run/notifications-job: forbidden env HOSTED_PUSHER_API_URL is present` again.

Not a red-vs-green claim only: on the unmodified manifest the rendered state now carries `{'memory-maintenance-job', 'notifications-job'}` for both `dev` and `prod`, and `validate_runtime_env` returns **no errors** for either environment, so the restored check does not turn the deploy red.

- `python -m pytest tests/unit/test_render_backend_runtime_env.py tests/unit/test_backend_runtime_env_validator.py tests/unit/test_attach_cloud_run_gmp_sidecar.py tests/unit/test_verify_backend_release_vector.py` — 173 passed.
- The sidecar reads `state['services'][service]['env']` only (`attach_cloud_run_gmp_sidecar.py:205-223`), so the added `jobs` key does not affect `--expected-env-state`; its suite is in the run above.
- `black --check backend/scripts/render_backend_runtime_env.py backend/tests/unit/test_render_backend_runtime_env.py` — clean.

Not verified against a live GCP project: the change is to the rendered artifact and to offline validation of it.

## Tests

`backend/tests/unit/test_render_backend_runtime_env.py`:

- `test_state_output_carries_cloud_run_jobs` — the regression test; before the change it fails with `KeyError: 'jobs'`. It pins the whole job entry, including that a secret binding is rendered as a `secretKeyRef` and that the job's own flags (not the shared network flags) are carried.
- `test_state_output_covers_every_declared_job[dev|prod]` — the ratchet against a future "services only" narrowing: every job the real manifest declares must appear in the rendered state. Also red before the change.

## Failure class (fixes)

The rendered state is a hand-written mirror of the manifest's Cloud Run inventory: it restates which units exist rather than deriving them, so the units it omits are dropped in silence — no decode error, no unhandled case, no failing test, because the mirror stays internally consistent. `_render_state_env` and the per-job loop derive the state from the manifest's own inventory, and `test_state_output_covers_every_declared_job` makes an omission fail instead of disappear.

Failure-Class: FC-mirrored-model-omits-new-member


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

