### PR TITLE
fix(backend): stop the async scanner flagging coroutines handed to asyncio

### DIFF
--- a/backend/scripts/scan_async_blockers.py
+++ b/backend/scripts/scan_async_blockers.py
@@ -76,6 +76,16 @@ SYNC_NETWORK_UTILITY_IMPORTS = {
     "utils.notifications": frozenset({"send_notification"}),
 }
 
+# asyncio entry points whose arguments must already be awaitables. Handing a call to one of
+# them is the same handoff as `await call()`: the coroutine is driven by the event loop, not
+# by the calling frame. Keep this list exact — a name outside it is not assumed to await.
+COROUTINE_HANDOFF_ASYNCIO_FUNCTIONS = frozenset(
+    {"as_completed", "ensure_future", "gather", "shield", "wait", "wait_for"}
+)
+# `create_task` is matched on the attribute alone because the receiver is either the asyncio
+# module or a TaskGroup/loop instance, and all three drive the argument on the event loop.
+COROUTINE_HANDOFF_METHODS = frozenset({"create_task"})
+
 
 def _node_lineno(node: ast.AST) -> int:
     """Best-effort line number for an arbitrary AST node."""
@@ -281,6 +291,54 @@ def _awaited_call_ids(node: FunctionNode) -> Set[int]:
     return awaited
 
 
+def _coroutine_handoff_call_ids(node: FunctionNode) -> Set[int]:
+    """Identities of the Call nodes handed to asyncio to be awaited on the event loop.
+
+    `await asyncio.gather(load_a(), load_b())`, `asyncio.create_task(load())` and
+    `await asyncio.wait_for(load(), timeout=5)` are the ordinary ways to await more than one
+    coroutine, or to await one with a deadline. The inner call is not the direct operand of an
+    `await`, so `_awaited_call_ids` cannot see it, yet it blocks the calling frame no more than
+    a directly awaited call does: calling an `async def` only builds a coroutine object.
+
+    Only arguments written at the call site are covered — directly, unpacked with `*`, or as
+    elements of a literal list/tuple/set, which is how `asyncio.wait` and `as_completed` take
+    their awaitables. A name passed in from elsewhere stays outside this analysis, in keeping
+    with the rest of this scanner.
+    """
+    handed_off: Set[int] = set()
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call) or not _is_coroutine_handoff(child.func):
+            continue
+        for argument in [*child.args, *(keyword.value for keyword in child.keywords)]:
+            for candidate in _handed_off_operands(argument):
+                handed_off.add(id(candidate))
+    return handed_off
+
+
+def _is_coroutine_handoff(func: ast.expr) -> bool:
+    """True for `asyncio.<awaiting entry point>` and for any `<receiver>.create_task`."""
+    if not isinstance(func, ast.Attribute):
+        return False
+    if func.attr in COROUTINE_HANDOFF_METHODS:
+        return True
+    return (
+        isinstance(func.value, ast.Name)
+        and func.value.id == "asyncio"
+        and func.attr in COROUTINE_HANDOFF_ASYNCIO_FUNCTIONS
+    )
+
+
+def _handed_off_operands(argument: ast.expr) -> Iterator[ast.Call]:
+    """Yield the calls an argument hands over: itself, `*unpacked`, or literal collection items."""
+    if isinstance(argument, ast.Starred):
+        yield from _handed_off_operands(argument.value)
+    elif isinstance(argument, (ast.List, ast.Tuple, ast.Set)):
+        for element in argument.elts:
+            yield from _handed_off_operands(element)
+    elif isinstance(argument, ast.Call):
+        yield argument
+
+
 def _scan_function_body(
     node: FunctionNode,
     db_names: Set[str],
@@ -298,7 +356,7 @@ def _scan_function_body(
 
     offloaded = _get_offloaded_lines(node)
     nested = _collect_nested_func_lines(node)
-    awaited = _awaited_call_ids(node)
+    awaited = _awaited_call_ids(node) | _coroutine_handoff_call_ids(node)
 
     for child in _walk_body(node):
         if not isinstance(child, ast.Call):
@@ -309,7 +367,8 @@ def _scan_function_body(
         # `await f()` yields to the event loop; it is the correct way to call an async
         # helper, including the async accessors in `database.*`. Counting it as blocking
         # made a correct fix unpushable and offered no way to say so — there is no
-        # allowlist or inline waiver in this scanner.
+        # allowlist or inline waiver in this scanner. The same holds when the coroutine
+        # reaches the loop through asyncio instead of a direct `await`.
         if id(child) in awaited:
             continue
         body_call_lines.add(line)

--- a/backend/tests/unit/test_scan_async_blockers.py
+++ b/backend/tests/unit/test_scan_async_blockers.py
@@ -590,3 +590,93 @@ def test_unawaited_sync_db_call_is_still_blocking(scanner, tmp_path):
     )
 
     assert len(results["async_helpers_with_blocking"]) == 1
+
+
+def test_coroutines_handed_to_asyncio_are_not_blocking(scanner, tmp_path):
+    """Awaiting through asyncio is the same handoff as `await`, so it is not blocking either.
+
+    `_awaited_call_ids` only sees a call that is the direct operand of an `await`. Awaiting two
+    accessors at once, or one with a deadline, means writing `asyncio.gather(...)`,
+    `asyncio.create_task(...)` or `asyncio.wait_for(...)`, and the inner call stops being that
+    operand — so the same async accessor the previous fix cleared was reported again the moment
+    a second one was awaited beside it.
+    """
+    for form in (
+        "await asyncio.gather(get_async_redis_client(), get_async_cache_client())",
+        "await asyncio.wait_for(get_async_redis_client(), timeout=5)",
+        "await asyncio.wait([get_async_redis_client(), get_async_cache_client()])",
+        "await asyncio.create_task(get_async_redis_client())",
+        "await asyncio.shield(get_async_redis_client())",
+    ):
+        _source_path, results = _scan_source(
+            scanner,
+            tmp_path,
+            f"""
+            import asyncio
+
+            from database.redis_db import get_async_cache_client, get_async_redis_client
+
+            async def dispatcher():
+                return {form}
+            """,
+        )
+
+        assert results["async_helpers_with_blocking"] == [], form
+
+
+def test_task_group_create_task_is_not_blocking(scanner, tmp_path):
+    """A TaskGroup drives its argument on the event loop exactly as `asyncio.create_task` does."""
+    _source_path, results = _scan_source(
+        scanner,
+        tmp_path,
+        """
+        import asyncio
+
+        from database.redis_db import get_async_redis_client
+
+        async def dispatcher():
+            async with asyncio.TaskGroup() as group:
+                group.create_task(get_async_redis_client())
+        """,
+    )
+
+    assert results["async_helpers_with_blocking"] == []
+
+
+def test_a_sync_db_call_beside_a_handoff_on_one_line_is_still_blocking(scanner, tmp_path):
+    """The skip stays keyed on the call node: only the handed-off half of a line is cleared."""
+    _source_path, results = _scan_source(
+        scanner,
+        tmp_path,
+        """
+        import asyncio
+
+        from database.redis_db import get_async_redis_client, get_redis_client
+
+        async def dispatcher():
+            return await asyncio.gather(get_async_redis_client()), get_redis_client()
+        """,
+    )
+
+    assert [call["call"] for finding in results["async_helpers_with_blocking"] for call in finding["db_calls"]] == [
+        "get_redis_client"
+    ]
+
+
+def test_a_call_asyncio_never_receives_is_still_blocking(scanner, tmp_path):
+    """The guard must not widen: importing asyncio near a sync DB call does not clear it."""
+    _source_path, results = _scan_source(
+        scanner,
+        tmp_path,
+        """
+        import asyncio
+
+        from database.redis_db import get_redis_client
+
+        async def dispatcher():
+            await asyncio.sleep(1)
+            return get_redis_client()
+        """,
+    )
+
+    assert len(results["async_helpers_with_blocking"]) == 1


### PR DESCRIPTION
## What changed and why

#12060 taught the async blocker scanner that `await get_async_redis_client()` is not a
synchronous DB call. That skip is keyed on the `Call` node being the direct operand of an
`await`, so it only covers the single-coroutine form.

Awaiting two accessors at once, or one with a deadline, is spelled `asyncio.gather(...)`,
`asyncio.create_task(...)` or `asyncio.wait_for(...)`. The inner call then stops being the
operand of the `await`, and the same accessor #12060 cleared is reported again the moment a
second one is awaited beside it. Calling an `async def` only builds a coroutine object;
whether the event loop receives it directly or through asyncio, the calling frame does not
block.

`backend-async-blockers` is a blocking pre-push gate with no allowlist and no inline waiver,
so a false positive leaves only two routes: restructure working code around the linter, or
bypass the gate.

Coverage is deliberately narrow, matching the rest of this scanner: only arguments written at
the call site count — directly, unpacked with `*`, or as elements of a literal list/tuple/set,
which is how `asyncio.wait` and `as_completed` take their awaitables. A list built elsewhere
and passed in by name stays outside the analysis and is still reported.

The rule does not widen. An unawaited `database.*` call is still reported, including on a line
that also carries a handoff, because the skip stays keyed on node identity rather than line.

Out of scope, named honestly: `async with cm()` and `async for x in gen()` still report the
operand call. Unlike an awaitable argument, a class-based async context manager or a sync
function returning an async iterable does run code in the calling frame, so clearing those
needs its own argument.

## Product invariants affected

none

## How it was verified

Ran the scanner against the forms in question rather than reading it, loading
`backend/scripts/scan_async_blockers.py` and calling `scan_dirs` on a one-file tree:

Before this change (upstream/main, 02c48d7da6):

| source in an `async def` | `async_helpers_with_blocking` |
|---|---|
| `await get_async_redis_client()` | clean (#12060) |
| `await asyncio.gather(get_async_redis_client(), get_async_cache_client())` | `get_async_redis_client`, `get_async_cache_client` |
| `await asyncio.create_task(get_async_redis_client())` | `get_async_redis_client` |
| `await asyncio.wait_for(get_async_redis_client(), timeout=5)` | `get_async_redis_client` |
| `await asyncio.wait([get_async_redis_client(), get_async_cache_client()])` | both |
| `client = get_async_redis_client()` (no await) | `get_async_redis_client` |

After: every awaited form is clean, and the unawaited call is still reported.

Full-tree effect, the honest number: on the scanned dirs
(`backend/routers backend/utils backend/dependencies.py`, 400 files, 141 async endpoints) the
summary is byte-identical before and after — all categories zero. No current finding is
silently dropped by this change; what it removes is the next false positive, not an existing
one.

## Tests

`backend/tests/unit/test_scan_async_blockers.py` — 31 passed, up from 27.

Regression tests, red on `upstream/main` before the fix:
- `test_coroutines_handed_to_asyncio_are_not_blocking` — the five handoff spellings; first
  failure is `AssertionError: await asyncio.gather(get_async_redis_client(),
  get_async_cache_client())` / `Left contains one more item: {...'function': 'dispatcher'...}`.
- `test_task_group_create_task_is_not_blocking` — `group.create_task(...)` inside a
  `TaskGroup`.
- `test_a_sync_db_call_beside_a_handoff_on_one_line_is_still_blocking` — before the fix the
  assertion collects two calls where one is correct, which is what pins the skip to node
  identity rather than to the line.

Pinning that the rule does not widen: `test_a_call_asyncio_never_receives_is_still_blocking`
(an `await asyncio.sleep(1)` in the same function does not clear a later sync call). It passes
both before and after, by design — it exists so a broader future skip cannot pass silently.

`scripts/pr-preflight --base upstream/main` and `black --check` were run on the branch.

## Failure class (fixes)

Failure-Class: none

Same declaration as #12060, which fixed the previous instance in this scanner.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

