### PR TITLE
fix(app): stamp Gemini Live transcript segments with real audio time

### DIFF
--- a/app/lib/services/sockets/pure_streaming_stt.dart
+++ b/app/lib/services/sockets/pure_streaming_stt.dart
@@ -63,6 +63,60 @@ class StreamingSttConfig {
   }
 }
 
+/// Bounds of one transcription delta on the audio timeline, in seconds.
+class SttSegmentBounds {
+  final double start;
+  final double end;
+
+  const SttSegmentBounds(this.start, this.end);
+}
+
+/// Timeline of the audio a streaming provider has actually been given.
+///
+/// Providers that stream incremental transcription deltas (Gemini Live's
+/// `inputTranscription`) emit as many deltas as they like per utterance, so the
+/// delta count says nothing about elapsed audio. Stamping deltas with a fixed
+/// stride therefore drifts arbitrarily far ahead of the recording. Counting the
+/// PCM actually sent keeps every delta anchored to the audio it came from.
+class SttAudioTimeline {
+  final int sampleRate;
+  final int bytesPerSample;
+
+  double _audioSeconds = 0;
+  double _lastSegmentEnd = 0;
+
+  SttAudioTimeline({required this.sampleRate, this.bytesPerSample = 2});
+
+  /// Seconds of audio handed to the provider so far.
+  double get audioSeconds => _audioSeconds;
+
+  /// Account for PCM forwarded to the provider.
+  void addPcm(int byteLength) {
+    if (byteLength <= 0 || sampleRate <= 0 || bytesPerSample <= 0) {
+      return;
+    }
+    _audioSeconds += byteLength / (sampleRate * bytesPerSample);
+  }
+
+  /// Bounds for the next delta: the audio consumed since the previous one.
+  ///
+  /// A delta that arrives before any new audio (a correction of what was
+  /// already transcribed) collapses onto the previous end instead of inventing
+  /// time, so the timeline never runs ahead of the recording.
+  SttSegmentBounds nextSegment() {
+    final start = _lastSegmentEnd;
+    final end = _audioSeconds > start ? _audioSeconds : start;
+    _lastSegmentEnd = end;
+    return SttSegmentBounds(start, end);
+  }
+
+  /// Drop back to an empty timeline for a fresh session.
+  void reset() {
+    _audioSeconds = 0;
+    _lastSegmentEnd = 0;
+  }
+}
+
 /// Gemini Live streaming socket with setup message and base64 audio encoding
 class GeminiStreamingSttSocket implements IPureSocket {
   WebSocketChannel? _channel;
@@ -79,7 +133,7 @@ class GeminiStreamingSttSocket implements IPureSocket {
 
   IPureSocketListener? _listener;
 
-  double _audioOffsetSeconds = 0;
+  late final SttAudioTimeline _timeline = SttAudioTimeline(sampleRate: sampleRate);
   bool _setupSent = false;
 
   final List<Uint8List> _frameBuffer = [];
@@ -231,16 +285,16 @@ class GeminiStreamingSttSocket implements IPureSocket {
       }
 
       if (text != null && text.trim().isNotEmpty) {
+        final bounds = _timeline.nextSegment();
         final segment = {
           'text': text.trim(),
           'speaker': 'SPEAKER_0',
           'speaker_id': 0,
           'is_user': false,
-          'start': _audioOffsetSeconds,
-          'end': _audioOffsetSeconds + 3.0,
+          'start': bounds.start,
+          'end': bounds.end,
           'person_id': null,
         };
-        _audioOffsetSeconds += 3.0;
 
         onMessage(jsonEncode([segment]));
       }
@@ -306,6 +360,7 @@ class GeminiStreamingSttSocket implements IPureSocket {
 
     try {
       _channel!.sink.add(jsonEncode(realtimeInput));
+      _timeline.addPcm(pcmData.length);
     } catch (e) {
       CustomSttLogService.instance.error('GeminiStreaming', 'Send error: $e');
     }
@@ -346,6 +401,7 @@ class GeminiStreamingSttSocket implements IPureSocket {
 
         try {
           _channel!.sink.add(jsonEncode(realtimeInput));
+          _timeline.addPcm(pcmData.length);
         } catch (_) {}
       }
     }
@@ -364,7 +420,7 @@ class GeminiStreamingSttSocket implements IPureSocket {
     await disconnect();
     _frameBuffer.clear();
     _bufferedBytes = 0;
-    _audioOffsetSeconds = 0;
+    _timeline.reset();
     _setupSent = false;
   }
 

--- a/app/test/unit/stt_audio_timeline_test.dart
+++ b/app/test/unit/stt_audio_timeline_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/services/sockets/pure_streaming_stt.dart';
+
+void main() {
+  group('SttAudioTimeline', () {
+    // 16 kHz, 16-bit mono: one second of audio is 32000 bytes.
+    const oneSecond = 16000 * 2;
+
+    test('stamps a delta with the audio consumed since the previous one', () {
+      final timeline = SttAudioTimeline(sampleRate: 16000);
+
+      timeline.addPcm(oneSecond * 2);
+      final first = timeline.nextSegment();
+      expect(first.start, 0.0);
+      expect(first.end, closeTo(2.0, 1e-9));
+
+      timeline.addPcm(oneSecond);
+      final second = timeline.nextSegment();
+      expect(second.start, closeTo(2.0, 1e-9));
+      expect(second.end, closeTo(3.0, 1e-9));
+    });
+
+    test('many deltas over a short utterance stay inside the audio actually sent', () {
+      final timeline = SttAudioTimeline(sampleRate: 16000);
+      timeline.addPcm(oneSecond * 3);
+
+      // Gemini Live streams `inputTranscription` as partial deltas; ten of them
+      // can describe the same three seconds of speech. The old fixed 3s stride
+      // would have ended this utterance at 30s.
+      var last = timeline.nextSegment();
+      for (var i = 0; i < 9; i++) {
+        last = timeline.nextSegment();
+      }
+
+      expect(last.end, closeTo(3.0, 1e-9));
+      expect(timeline.audioSeconds, closeTo(3.0, 1e-9));
+    });
+
+    test('deltas tile the timeline without gaps or overlaps', () {
+      final timeline = SttAudioTimeline(sampleRate: 16000);
+      var previousEnd = 0.0;
+
+      for (var i = 0; i < 5; i++) {
+        timeline.addPcm(oneSecond);
+        final bounds = timeline.nextSegment();
+        expect(bounds.start, closeTo(previousEnd, 1e-9));
+        expect(bounds.end, greaterThanOrEqualTo(bounds.start));
+        previousEnd = bounds.end;
+      }
+
+      expect(previousEnd, closeTo(5.0, 1e-9));
+    });
+
+    test('a delta arriving before any new audio does not invent time', () {
+      final timeline = SttAudioTimeline(sampleRate: 16000);
+      timeline.addPcm(oneSecond);
+      timeline.nextSegment();
+
+      final correction = timeline.nextSegment();
+      expect(correction.start, closeTo(1.0, 1e-9));
+      expect(correction.end, closeTo(1.0, 1e-9));
+    });
+
+    test('ignores empty and malformed audio accounting', () {
+      final timeline = SttAudioTimeline(sampleRate: 16000);
+      timeline.addPcm(0);
+      timeline.addPcm(-1);
+      expect(timeline.audioSeconds, 0.0);
+
+      final broken = SttAudioTimeline(sampleRate: 0);
+      broken.addPcm(oneSecond);
+      expect(broken.audioSeconds, 0.0);
+      expect(broken.nextSegment().end, 0.0);
+    });
+
+    test('reset drops back to an empty timeline for a fresh session', () {
+      final timeline = SttAudioTimeline(sampleRate: 16000);
+      timeline.addPcm(oneSecond * 4);
+      timeline.nextSegment();
+
+      timeline.reset();
+      expect(timeline.audioSeconds, 0.0);
+
+      timeline.addPcm(oneSecond);
+      final bounds = timeline.nextSegment();
+      expect(bounds.start, 0.0);
+      expect(bounds.end, closeTo(1.0, 1e-9));
+    });
+
+    test('honors a non-default sample rate', () {
+      final timeline = SttAudioTimeline(sampleRate: 24000);
+      timeline.addPcm(24000 * 2);
+      expect(timeline.nextSegment().end, closeTo(1.0, 1e-9));
+    });
+  });
+}


### PR DESCRIPTION
## What changed and why

`GeminiStreamingSttSocket` gave every `inputTranscription` delta a fixed 3-second span and
advanced its own clock by 3 seconds per delta. Gemini Live streams partial transcription deltas
as the user speaks, so the delta count has no relation to elapsed audio: ten deltas describing
three seconds of speech were recorded as spanning thirty seconds, and the drift accumulates for
the whole session.

A new `SttAudioTimeline` counts the PCM actually forwarded to the provider and hands each delta
the audio consumed since the previous one, so deltas tile the real timeline instead of inventing
time. A delta that arrives before any new audio (a correction of already transcribed speech)
collapses onto the previous end rather than adding another 3 seconds. `stop()` resets the
timeline along with the rest of the session state, as before.

## Product invariants affected

These timestamps are not cosmetic — the backend takes them verbatim in
`routers/listen/transcripts.py`:

- the first segment's `start` sets the conversation's `started_at`;
- `sort_segments_by_start` orders the buffer on them;
- `TranscriptSegment.combine_segments` merges on them;
- speaker identification reads the audio ring buffer at
  `first_audio_byte_timestamp + segment.start`.

Every other STT path in the app already reports real time: the on-device Whisper provider stamps
`start + duration`, and schema-based streaming providers pass through the provider's own word
timings (`audioOffsetSeconds: 0`). This brings the Gemini Live path in line with them rather
than introducing a new convention.

Known approximation, stated plainly: transcription arrives after the audio it describes, so a
delta's end includes audio that has been sent but not yet transcribed. That error is bounded by
provider latency instead of growing without limit like the fixed 3-second stride did.

## How it was verified

- `flutter test test/unit/stt_audio_timeline_test.dart` — 7/7 passing.
- Together with the neighbouring STT suites (`stt_result_test.dart`, `custom_stt_config_test.dart`,
  `composite_transcription_socket_test.dart`) — 22/22 passing.
- `dart format --line-length 120 --set-exit-if-changed` — clean.
- `flutter analyze` on both changed files — no issues.

## Tests

`app/test/unit/stt_audio_timeline_test.dart` covers: bounds derived from the audio actually sent;
ten deltas over three seconds of speech staying at 3.0s (the old stride would have ended at
30.0s); deltas tiling the timeline without gaps or overlaps; a delta before any new audio not
inventing time; zero/negative byte counts and a zero sample rate not corrupting the count;
`reset()`; a non-default 24 kHz sample rate.

To be explicit about what these tests prove: they guard the new `SttAudioTimeline` invariants.
They are not red-before-green regression tests, because the old arithmetic lived inside a private
method of the socket class and is not reachable from a test. The regression itself is stated
numerically above.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

