### PR TITLE
fix(backend): declare the missing composite index for the default conversation list read

### DIFF
--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -618,6 +618,21 @@ STALE_IN_PROGRESS_CONVERSATIONS_QUERY = FirestoreQuerySpec(
     ),
 )
 
+CONVERSATIONS_ACTIVE_ORDERED_QUERY = FirestoreQuerySpec(
+    identifier='conversations_discarded_created',
+    collection_group='conversations',
+    query_scope='COLLECTION',
+    # `get_conversations`/`get_conversations_without_photos` called with their
+    # defaults (`include_discarded=False`, no `statuses`/`categories`/`folder_id`/
+    # `starred` filter) build exactly this shape — it's the default `GET
+    # /v1/conversations` list call, i.e. the app's main screen. Production has
+    # this index only because it was created by hand at some point; a fresh
+    # self-host deploy 400s with FailedPrecondition the first time anyone loads
+    # their conversation list.
+    filters=(FirestoreQueryFilter('discarded', '==', 'discarded'),),
+    index_fields=(_asc('discarded'), _desc('created_at'), _desc('__name__')),
+)
+
 ACTION_ITEMS_COMPLETION_ID_SCAN_QUERY = FirestoreQuerySpec(
     identifier='action_items_completion_id_scan',
     collection_group='action_items',
@@ -795,6 +810,7 @@ QUERY_SPECS = (
     MEETING_RECEIPTS_DUE_QUERY,
     HOURLY_USAGE_PLAN_ATTRIBUTION_QUERY,
     MESSAGES_BY_APP_ORDERED_QUERY,
+    CONVERSATIONS_ACTIVE_ORDERED_QUERY,
 )
 
 _INDEX_ONLY_REQUIREMENT_SIGNATURES = frozenset(requirement.signature for requirement in INDEX_ONLY_REQUIREMENTS)

--- a/backend/tests/unit/test_firestore_query_contract.py
+++ b/backend/tests/unit/test_firestore_query_contract.py
@@ -9,6 +9,7 @@ from google.cloud.firestore_v1 import FieldFilter
 
 import database.action_items as action_items_db
 import database.chat as chat_db
+import database.conversations as conversations_db
 import database.task_recommendations as task_recommendations_db
 import routers.task_recommendations as task_recommendations_router
 from database.firestore_index_registry import (
@@ -16,6 +17,7 @@ from database.firestore_index_registry import (
     CANONICAL_CONSOLIDATION_QUERY,
     CANONICAL_MEMORY_ATLAS_READ_QUERY,
     CONVERSATION_SOURCE_MEMORY_QUERY,
+    CONVERSATIONS_ACTIVE_ORDERED_QUERY,
     DUE_MEMORY_OUTBOX_QUERY,
     EXPIRED_SHORT_TERM_LIFECYCLE_QUERY,
     EXPIRED_MEMORY_OUTBOX_LEASE_QUERY,
@@ -622,6 +624,41 @@ def test_app_scoped_message_reads_have_a_declared_composite_index(monkeypatch, s
 def test_messages_by_app_ordered_query_is_registered_for_the_messages_collection():
     assert MESSAGES_BY_APP_ORDERED_QUERY.collection_group == 'messages'
     assert MESSAGES_BY_APP_ORDERED_QUERY.index_requirement.to_manifest() in firebase_index_manifest()['indexes']
+
+
+@pytest.mark.parametrize(
+    ('symbol', 'call'),
+    [
+        ('get_conversations', lambda: conversations_db.get_conversations('index-contract-user', limit=20)),
+        (
+            'get_conversations_without_photos',
+            lambda: conversations_db.get_conversations_without_photos('index-contract-user', limit=20),
+        ),
+    ],
+)
+def test_default_conversation_list_reads_have_a_declared_composite_index(monkeypatch, symbol, call):
+    """The bare `discarded == False` + `created_at` descending list read needs a declared composite.
+
+    Regression for a self-host FailedPrecondition 400 on GET /v1/conversations: this is the
+    app's default conversation list call (no status/category/folder/starred filter), prod has
+    the index only because it was created by hand at some point, but firestore_index_registry.py
+    never declared it, so a fresh self-host deploy 400s the first time anyone loads their list.
+    """
+    recorder = []
+    monkeypatch.setattr(conversations_db, 'db', _StreamRecordingFirestore(recorder, collection_name='conversations'))
+
+    call()
+
+    compound = [(filters, orders) for filters, orders in recorder if orders and any(op == '==' for _, op in filters)]
+    assert compound, f'{symbol} no longer builds a discarded equality + created_at ordering chain'
+    declared = _declared_index_signatures()
+    for filters, orders in compound:
+        assert _equality_plus_order_signature('conversations', filters, orders) in declared
+
+
+def test_conversations_active_ordered_query_is_registered_for_the_conversations_collection():
+    assert CONVERSATIONS_ACTIVE_ORDERED_QUERY.collection_group == 'conversations'
+    assert CONVERSATIONS_ACTIVE_ORDERED_QUERY.index_requirement.to_manifest() in firebase_index_manifest()['indexes']
 
 
 def test_query_source_paths_are_posix_canonical_on_every_host_platform():

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -911,6 +911,24 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "conversations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "discarded",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": [


### PR DESCRIPTION
## What changed and why

`get_conversations` and `get_conversations_without_photos` (both in
`backend/database/conversations.py`), called with their defaults (`include_discarded=False`,
no `statuses`/`categories`/`folder_id`/`starred` filter — i.e. the app's default
`GET /v1/conversations` list call, the main screen), filter the `conversations` collection by
`discarded` and order by `created_at` descending, but `firestore_index_registry.py` never
declared the composite Firestore needs for that shape. Production has it only because it was
created by hand at some point; a fresh self-host deploy gets `FailedPrecondition` 400 on
`GET /v1/conversations` the first time anyone loads their conversation list.

Adds `CONVERSATIONS_ACTIVE_ORDERED_QUERY` to the registry (mirrors the already-registered
`chat_sessions_current_by_app_created_at` / `messages_by_app_ordered` shape) and regenerates
`firestore.indexes.json`.

## Product invariants affected

none

## How it was verified

- `python3 backend/scripts/generate_firestore_indexes.py --write` — regenerated
  `firestore.indexes.json` from the updated registry; diff is exactly the new
  `conversations(discarded ASC, created_at DESC, __name__ DESC)` composite.
- `.venv/bin/python -m pytest backend/tests/unit/test_firestore_query_contract.py -m ""` —
  34/34 passed (31 baseline, now including the already-merged `messages_by_app_ordered`
  case from #12069, + 3 new: two parametrized regression cases plus the spec-is-registered
  sanity check for conversations).
- `.venv/bin/python -m pytest backend/tests/unit/test_firestore_query_contract.py
  backend/tests/unit/test_reconcile_firestore_indexes.py
  backend/tests/unit/test_reconcile_firestore_field_exemptions.py
  backend/tests/unit/test_universal_memory_list_cursor.py
  backend/tests/unit/test_action_items_due_range_index_contract.py
  backend/tests/unit/test_chat_message_count.py
  backend/tests/unit/test_chat_messages_pagination.py -m ""` — 109/109 passed
  (34 + 75), no regression in the surrounding index-reconcile/contract suite.
- `black --check backend/database/firestore_index_registry.py
  backend/tests/unit/test_firestore_query_contract.py` — clean.

## Tests

Bug fix — regression test added:
`test_default_conversation_list_reads_have_a_declared_composite_index` (parametrized over
`get_conversations` and `get_conversations_without_photos`) in
`backend/tests/unit/test_firestore_query_contract.py` calls each against a recording
Firestore fake, extracts the real filter+order chain it builds, and asserts
`firebase_index_manifest()` declares a matching composite — so either function regressing to
an undeclared shape fails this test, not just self-host in production. Also added
`test_conversations_active_ordered_query_is_registered_for_the_conversations_collection` as a
direct sanity check on the new spec.

## Failure class (fixes)

Failure-Class: FC-undeclared-serving-query-index


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

