### PR TITLE
fix(backend): keep mentor past context when one source fails

### DIFF
--- a/backend/tests/unit/test_mentor_notifications.py
+++ b/backend/tests/unit/test_mentor_notifications.py
@@ -688,6 +688,99 @@ def test_process_mentor_proactive_notification_sends():
     mock_send.assert_called()
 
 
+def _pass_all_three_steps():
+    """Configure mock_llm_mini so gate, generate and critic all approve."""
+    results = [
+        RelevanceResult(
+            is_relevant=True,
+            relevance_score=0.85,
+            reasoning="User is skipping gym despite their 3x/week goal.",
+            context_summary="User discussing skipping exercise.",
+        ),
+        NotificationDraft(
+            notification_text="You've been skipping gym — remember your 3x/week goal!",
+            reasoning="User's goal is 'Exercise 3x per week' and they mentioned skipping today.",
+            confidence=0.82,
+            category="goal_connection",
+        ),
+        ValidationResult(approved=True, reasoning="Concrete, tied to a goal and the current action."),
+    ]
+    call_count = [0]
+
+    def side_effect_structured_output(model_class):
+        parser = MagicMock()
+        parser.invoke = MagicMock(return_value=results[min(call_count[0], len(results) - 1)])
+        call_count[0] += 1
+        return parser
+
+    mock_llm_mini.with_structured_output = MagicMock(side_effect=side_effect_structured_output)
+
+
+def test_mentor_past_context_survives_embedding_failure():
+    """A failing embedding provider must not also drop the recent-conversations context.
+
+    Semantic search and recent-by-time are separate sources: the first needs an embedding
+    provider and a vector store, the second needs neither. When they shared one try/except,
+    one embedding error (missing key, quota, outage) silently stripped both.
+    """
+    _setup_app_integrations_stubs()
+    _pass_all_three_steps()
+
+    mock_generate_embedding.side_effect = RuntimeError("no embedding provider configured")
+    mock_get_convos.reset_mock()
+    mock_get_convos.return_value = [{'id': 'conv-1', 'is_locked': False}]
+    mock_convos_to_string.reset_mock()
+    mock_convos_to_string.return_value = 'yesterday: user talked about the gym'
+
+    try:
+        result = app_int._process_mentor_proactive_notification(
+            "uid_embed_fail", [{"text": "I'll skip the gym today", "is_user": True}]
+        )
+    finally:
+        mock_generate_embedding.side_effect = None
+        mock_get_convos.return_value = []
+        mock_convos_to_string.return_value = ''
+
+    assert result is not None
+    # The recent-conversations fetch ran and its result was rendered for the prompt.
+    mock_get_convos.assert_called()
+    mock_convos_to_string.assert_called()
+
+
+def test_mentor_vector_context_survives_recent_conversations_failure():
+    """The mirror case: a failing recent-by-time fetch must not discard the vector hits.
+
+    The rendering step runs after both sources, so under the shared try/except a
+    conversations-store error thrown by the second source also threw away the
+    semantically relevant conversations the first source had already collected.
+    """
+    _setup_app_integrations_stubs()
+    _pass_all_three_steps()
+
+    mock_query_vectors.return_value = ['conv-vector-1']
+    mock_get_convos_by_id.return_value = [{'id': 'conv-vector-1', 'is_locked': False}]
+    mock_get_convos.reset_mock()
+    mock_get_convos.side_effect = RuntimeError("conversations store unavailable")
+    mock_convos_to_string.reset_mock()
+    mock_convos_to_string.return_value = 'last week: user set a 3x/week gym goal'
+
+    try:
+        result = app_int._process_mentor_proactive_notification(
+            "uid_convos_fail", [{"text": "I'll skip the gym today", "is_user": True}]
+        )
+    finally:
+        mock_query_vectors.return_value = []
+        mock_get_convos_by_id.return_value = []
+        mock_get_convos.side_effect = None
+        mock_convos_to_string.return_value = ''
+
+    assert result is not None
+    # The vector-search hit was still rendered into the prompt context.
+    mock_deserialize_convos.assert_called()
+    assert mock_deserialize_convos.call_args[0][0] == [{'id': 'conv-vector-1', 'is_locked': False}]
+    mock_convos_to_string.assert_called()
+
+
 def test_process_mentor_proactive_notification_gate_rejects():
     """_process_mentor_proactive_notification should return None when gate rejects."""
     _setup_app_integrations_stubs()

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -579,12 +579,18 @@ def _process_mentor_proactive_notification(uid: str, conversation_messages: list
     )
 
     # ── Gather full context (expensive: vector search + recent convos) ───
+    #
+    # The two sources are guarded separately on purpose: semantic search needs an embedding
+    # provider and a vector store, recent-by-time needs neither. Under one shared try/except a
+    # single embedding failure (missing key, quota, provider outage) also took down the
+    # recent-conversations fetch that follows it, leaving the mentor with no past context at
+    # all — silently, because the draft is still written from the live transcript alone.
     past_conversations_str = ''
+    all_past: list[dict] = []
+
+    # Vector search for semantically relevant conversations
     try:
         conversation_text = ' '.join(msg.get('text', '') for msg in conversation_messages)
-        all_past = []
-
-        # Vector search for semantically relevant conversations
         if conversation_text.strip():
             vector = generate_embedding(conversation_text[:2000])
             memory_ids = query_vectors_by_metadata(
@@ -594,19 +600,25 @@ def _process_mentor_proactive_notification(uid: str, conversation_messages: list
                 vector_convos = conversations_db.get_conversations_by_id(uid, memory_ids)
                 if vector_convos:
                     all_past.extend([c for c in vector_convos if not c.get('is_locked')])
+    except Exception as e:
+        logger.error(f"mentor_proactive vector_search_failed uid={uid} error={e}")
 
-        # Also fetch recent conversations by time for additional context
+    # Also fetch recent conversations by time for additional context
+    try:
         recent_convos = conversations_db.get_conversations(uid, limit=5, offset=0)
         if recent_convos:
             existing_ids = {c.get('id') for c in all_past}
             for rc in recent_convos:
                 if rc.get('id') not in existing_ids and not rc.get('is_locked'):
                     all_past.append(rc)
+    except Exception as e:
+        logger.error(f"mentor_proactive recent_conversations_failed uid={uid} error={e}")
 
+    try:
         if all_past:
             past_conversations_str = conversations_to_string(deserialize_conversations(all_past[:5]))
     except Exception as e:
-        logger.error(f"mentor_proactive past_conversations_failed uid={uid} error={e}")
+        logger.error(f"mentor_proactive past_conversations_render_failed uid={uid} error={e}")
 
     # Resolve the user's output language once so the notification is generated in it, not English
     # (the daily summary already respects this setting) (#5214).


### PR DESCRIPTION
## What changed and why

The mentor's proactive pipeline gathers past conversations from two independent sources —
semantic search (needs an embedding provider and a vector store) and the most recent
conversations by time (needs neither) — and then renders whatever it collected into the
generate prompt. All three steps shared a single `try/except`, so a failure in any one of them
discarded the work of the others:

- an embedding error (missing key, quota, provider outage) jumped over the recent-conversations
  fetch that follows it, and
- a conversations-store error in that fetch threw away the vector hits already collected.

Either way `past_conversations_str` stays empty and the notification is drafted from the live
transcript alone, silently: the pipeline keeps going, and nothing downstream can tell "no past
context exists" apart from "past context was lost". A missing embedding provider is enough to
put the mentor permanently in that state, which is how we hit it.

This guards the two sources and the rendering separately, each with its own log line. That is
already the convention everywhere else in this function — `get_prompt_memories`,
`get_user_goals`, `get_app_messages` and the language preference lookup each sit in their own
`try/except` with their own fallback; the past-conversations block was the one exception.

No behaviour changes on the happy path: same sources, same order, same rendering.

## Product invariants affected

none

## How it was verified

- `.venv/bin/python -m pytest backend/tests/unit/test_mentor_notifications.py -m ""` —
  49 passed (47 before this change; +2 new).
- Both new tests were confirmed to fail on unmodified `main` (`AssertionError: Expected 'mock'
  to have been called` — the rendering never runs) and to pass with the fix, so they are
  regression proofs rather than restatements of current behaviour.
- `.venv/bin/python -m pytest backend/tests/unit/test_app_integrations_async.py
  backend/tests/unit/test_app_integrations_safe_messages.py
  backend/tests/unit/test_async_app_integrations.py
  backend/tests/unit/test_proactive_notification_language.py
  backend/tests/unit/test_mem_db_proactive_noti_cap.py
  backend/tests/unit/test_chat_first_proactive_engine.py -m ""` — identical results before and
  after the change (39 passed, 14 pre-existing failures on unmodified `main` in
  `test_async_app_integrations.py`, unrelated to this file).
- `black --check` on both changed files — clean.

## Tests

Two tests in `backend/tests/unit/test_mentor_notifications.py`, one per direction of the loss:

- `test_mentor_past_context_survives_embedding_failure` — `generate_embedding` raises; asserts
  the recent-conversations fetch still runs and its result still reaches the prompt renderer.
- `test_mentor_vector_context_survives_recent_conversations_failure` — the mirror case: the
  vector search returns a hit, the recent-by-time fetch raises; asserts the vector hit is still
  the payload handed to the renderer.

Both use the file's existing fixtures (`_setup_app_integrations_stubs`, the shared runtime
mocks) and add a small `_pass_all_three_steps()` helper that makes the gate, generate and critic
LLM calls approve, so the pipeline reaches the send path.

## Failure class (fixes)

Failure-Class: none
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

