### PR TITLE
fix(ci): count a landed change once in the failure-class guard ratchet

### DIFF
--- a/.github/failure-classes/FC-same-subject-counted-once-per-evidence-source.json
+++ b/.github/failure-classes/FC-same-subject-counted-once-per-evidence-source.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-same-subject-counted-once-per-evidence-source",
+  "violated_contract": "A threshold computed over subjects must count each subject once, however many sources describe it. When a counter sums a landed-history source with a pending-change source that can carry the same subject, the total moves with the vantage point: the subject counts once before it lands and twice afterwards. The threshold then fires on a total no single moment ever held, and a gate that was answerable while the change was in review turns red where the author can no longer answer it.",
+  "canonical_prevention": "Keep one authority per subject and let the second source contribute only what the first cannot see: before adding the pending-change evidence, drop the subjects the historical source already counted -- for a git-history counter, the ones HEAD's own message carries. Pin the three vantage points such a check runs from -- the pull request, that pull request's landed push, and the local pre-push run -- with a test each, so a counting change that makes them disagree fails in review.",
+  "canonical_prevention_artifact": [
+    ".github/scripts/check_failure_class_guard_ratchet.py",
+    ".github/scripts/test_check_failure_class_guard_ratchet.py"
+  ],
+  "evidence_prs": [10518],
+  "scope_hints": [
+    ".github/scripts/check_failure_class_guard_ratchet.py",
+    ".github/scripts/check_product_file_line_count_ratchet.py",
+    ".github/scripts/pr_metadata.py"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/check_failure_class_guard_ratchet.py
+++ b/.github/scripts/check_failure_class_guard_ratchet.py
@@ -14,6 +14,9 @@ Determinism and hermeticity:
 - Counts come from `git log --first-parent` in the checkout. No network.
 - Integration changes are counted, not raw commits: one merged PR routinely
   carries a dozen `fix:` commits, so a raw-commit threshold would be noise.
+- The change under review is counted once wherever the window is measured: its
+  `--pr-body-file` declaration is added only when HEAD did not already carry it,
+  so a PR run, that PR's main push, and a local pre-push run agree on the count.
 - History-dependent checks must degrade safely. On a shallow clone, or when
   first-parent history does not reach back to the window start, this prints a
   loud SKIP and exits 0 rather than passing silently or failing spuriously.
@@ -178,6 +181,20 @@ def read_pr_body(path: Path | None) -> str:
         return ""
 
 
+def head_declarations(root: Path) -> set[str]:
+    """Classes HEAD's own message already contributed to `declaration_counts`.
+
+    `--pr-body-file` stands in for the change under review, which is why its
+    declaration is added to the window. On a main push, and on a local run over
+    a feature branch, that change is HEAD: `declaration_counts` walks from HEAD
+    and counted it already, so adding the body on top counts one integration
+    change twice. On a `pull_request` run the checkout is the merge ref, whose
+    message declares nothing, and the body stays the only evidence of the
+    pending change.
+    """
+    return declarations_in(run_git(root, "log", "--max-count=1", "--format=%B", "HEAD"))
+
+
 def evaluate(
     definitions: dict[str, dict[str, Any]],
     allowlist: dict[str, GrandfatherEntry],
@@ -240,7 +257,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--pr-body-file",
         type=Path,
         default=None,
-        help="PR body under review; its declaration counts toward the window so the declaring PR fails first.",
+        help=(
+            "PR body under review; its declaration counts toward the window so the declaring PR fails first, "
+            "unless HEAD already declared it and was counted from history."
+        ),
     )
     parser.add_argument("--now", default=None, help="UTC ISO-8601 timestamp; makes the window deterministic in tests.")
     return parser.parse_args(argv)
@@ -274,7 +294,10 @@ def main(argv: list[str] | None = None) -> int:
         definitions = load_definitions(root)
         allowlist = load_allowlist(root)
         counts = declaration_counts(root, cutoff)
+        already_counted = head_declarations(root)
         for class_id in declarations_in(read_pr_body(args.pr_body_file)):
+            if class_id in already_counted:
+                continue
             counts[class_id] = counts.get(class_id, 0) + 1
     except (CheckError, ValueError) as exc:
         print(f"FAIL: failure-class guard ratchet could not run: {exc}", file=sys.stderr)

--- a/.github/scripts/test_check_failure_class_guard_ratchet.py
+++ b/.github/scripts/test_check_failure_class_guard_ratchet.py
@@ -128,6 +128,11 @@ class GuardRatchetTests(unittest.TestCase):
             json.dumps({"schema_version": 1, "grandfathered": entries}, indent=2) + "\n", encoding="utf-8"
         )
 
+    def pr_body(self, class_id: str) -> Path:
+        path = self.root / "pr-body.md"
+        path.write_text(f"## Summary\n\nFailure-Class: {class_id}\n", encoding="utf-8")
+        return path
+
     def check(self, *extra: str) -> subprocess.CompletedProcess[str]:
         return run_checker(self.root, *extra)
 
@@ -200,8 +205,33 @@ class GuardRatchetTests(unittest.TestCase):
     def test_pr_body_declaration_counts_toward_the_window(self) -> None:
         self.define("FC-recurring-thing")
         self.declare("FC-recurring-thing", count=2)
-        body = self.root / "pr-body.md"
-        body.write_text("## Summary\n\nFailure-Class: FC-recurring-thing\n", encoding="utf-8")
+        # A `pull_request` run checks out the merge ref, whose message declares
+        # nothing: the pending change exists only in the body.
+        self.commit("Merge 1111111 into 2222222", date="2026-07-02T00:00:00Z")
+        body = self.pr_body("FC-recurring-thing")
+        result = self.check("--pr-body-file", str(body))
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("FC-recurring-thing", result.stderr)
+
+    def test_a_landed_declaration_is_not_counted_twice_from_its_own_pr_body(self) -> None:
+        """A main push re-reads the merged PR body while HEAD already carries the
+        same declaration; counting both turns a green PR red right after merge."""
+        self.define("FC-recurring-thing")
+        self.declare("FC-recurring-thing", count=1)
+        self.commit(
+            "fix(scope): the change being pushed (#4242)\n\nFailure-Class: FC-recurring-thing\n",
+            date="2026-07-02T00:00:00Z",
+        )
+        body = self.pr_body("FC-recurring-thing")
+        result = self.check("--pr-body-file", str(body))
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_a_pr_body_still_counts_when_the_squash_message_omits_the_trailer(self) -> None:
+        """Subtracting HEAD must not swallow a declaration history never saw."""
+        self.define("FC-recurring-thing")
+        self.declare("FC-recurring-thing", count=2)
+        self.commit("fix(scope): declared in the body only (#4243)", date="2026-07-02T00:00:00Z")
+        body = self.pr_body("FC-recurring-thing")
         result = self.check("--pr-body-file", str(body))
         self.assertEqual(result.returncode, 1, result.stdout)
         self.assertIn("FC-recurring-thing", result.stderr)


### PR DESCRIPTION
## What changed and why

The guard ratchet counts, over a 90-day window, the first-parent integration changes that declare each failure class, and requires a class at or above the threshold to name a `canonical_prevention_artifact`. It builds that count from two sources: `git log --first-parent` for what has landed, and `--pr-body-file` for the change under review, whose declaration is added so that "the declaring PR fails first".

Both sources can describe the same change. On a main push HEAD *is* that integration change — its squash message carries the class trailer, so `declaration_counts` already counted it — and `pr_metadata.py` hands the same PR's body to the same check. The class is counted twice.

The count therefore depends on the vantage point rather than on the history:

| where the check runs | what it computes for a class with `k` landed declarations |
| --- | --- |
| `pull_request` (merge ref: declares nothing) | `k + 1` |
| the main push of that same PR | `k + 2` |
| local `pr-preflight` over a feature branch | `k + 2` |

With the default threshold of 3, `k = 1` is green in review and red on the push that follows it — an after-merge red on a gate the author can no longer answer, which is the failure mode the main-push metadata path (#11835, #12003, #12085) exists to prevent. It also means the local pre-push lane does not predict its own PR: it reports a class one declaration closer to the threshold than CI will.

The fix subtracts what HEAD already contributed: a class the body declares is added only when HEAD's own message did not declare it. On a `pull_request` run the checkout is the merge ref, whose message declares nothing, so the pending change still counts exactly as before.

## Product invariants affected

none

## How it was verified

Verified by running the shipped checker against real history in this repository, at the merge commit of #11904 (`59af86646e`), whose live PR body declares `FC-assumed-credential-lifetime` — a class with no `canonical_prevention_artifact` and, in the 90 days to that date, exactly two first-parent declarations including this one.

```
# the PR's own vantage point: main before the merge, plus the live PR body
$ check_failure_class_guard_ratchet.py --root <main@59af86646e^> \
    --now 2026-08-22T14:41:39+00:00 --pr-body-file <live #11904 body>
OK: every class at or above the threshold names a guard artifact or is explicitly grandfathered.

# the main push of that same change: HEAD is the squash commit, same body
$ check_failure_class_guard_ratchet.py --root <main@59af86646e> ... --pr-body-file <same body>
FAIL: a recurring failure class has no reusable guard surface.
- FC-assumed-credential-lifetime: 3 declarations in the window (threshold 3) with no
  'canonical_prevention_artifact'. ...

# same commit, no body: the true number
OK: ...
```

With this change, the third invocation's verdict is what the main push produces (`OK`, exit 0), so the PR and its push agree.

One honest qualification: that particular push's `Repo Checks` run was cancelled by the workflow's concurrency group before it reached a conclusion, as main-push runs on a busy main frequently are. The claim verified here is that the shipped script computes a different number for the same history depending on where it runs, not that this specific run turned red.

- `python3 .github/scripts/test_check_failure_class_guard_ratchet.py` — 16 passed (14 before). The suite builds real disposable git repositories and runs the checker end to end, so the counting executes for real.
- The regression test fails on `main` with `AssertionError: 1 != 0` and, on stderr, `FC-recurring-thing: 3 declarations in the window (threshold 3)` where the window holds two.
- Not verified: a live GitHub Actions main-push run — that requires this change to be on `main` first. The `--root`/`--now` invocations above reproduce that job's inputs deterministically.

## Tests

- `test_a_landed_declaration_is_not_counted_twice_from_its_own_pr_body` — the regression test: one prior declaration, HEAD carrying the second as a squash subject with `(#NNNN)` and the trailer, and that PR's body passed in. Red before the change, green after.
- `test_a_pr_body_still_counts_when_the_squash_message_omits_the_trailer` — the paired guard: when the squash message carries no trailer, history never counted the change, and the body must still add it. Without this, "subtract HEAD" could quietly become "ignore the body".
- `test_pr_body_declaration_counts_toward_the_window` — kept, with one fixture correction: its HEAD used to be a commit declaring the class, which stands for a landed change and a pending one at the same time. A `pull_request` checkout is the merge ref, so the test now puts a `Merge <sha> into <sha>` commit at HEAD and still asserts that the body's declaration crosses the threshold.

## Failure class (fixes)

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

