### PR TITLE
fix(backend): stop recommending a suggestion that already expired

### DIFF
--- a/.github/failure-classes/FC-record-lifetime-enforced-by-one-reader.json
+++ b/.github/failure-classes/FC-record-lifetime-enforced-by-one-reader.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-record-lifetime-enforced-by-one-reader",
+  "violated_contract": "A stored lifetime that decides whether a record may still be put in front of the user must be evaluated by every reader that can surface it. A deadline honoured at one read path and left as prose for the rest is not a deadline: the record vanishes from the surface that asks and stays live on every surface that does not, so the expiry reads as working while the user keeps being shown the expired thing. Nothing fails -- the unchecked reader returns a well-formed, confident answer -- and the blast radius grows with the very backlog the deadline was introduced to shed, because records written before it carry no expiry field at all and are therefore permanently eligible wherever it is not derived.",
+  "canonical_prevention": "Express the deadline once, as a predicate that answers for every shape a reader actually holds -- the parsed record and the raw stored document alike -- and migrate every known reader in the same change instead of leaving the rule in a docstring for the next one to find. Pin it with a parity test asserting the shapes agree, including the derived deadline for records that predate the field, so a reader cannot silently opt out later.",
+  "canonical_prevention_artifact": [
+    "backend/database/candidates.py",
+    "backend/tests/unit/test_candidate_lifecycle.py"
+  ],
+  "evidence_prs": [11974],
+  "scope_hints": [
+    "backend/database/candidates.py",
+    "backend/routers/candidates.py",
+    "backend/utils/task_intelligence/**"
+  ],
+  "status": "open"
+}

--- a/backend/database/candidates.py
+++ b/backend/database/candidates.py
@@ -431,6 +431,30 @@ def _stored_task_priority(value: Any) -> Optional[TaskPriority]:
         return None
 
 
+def _as_utc(value: Any) -> Optional[datetime]:
+    if not isinstance(value, datetime):
+        return None
+    return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+
+
+def _suggestion_window_has_closed(
+    *,
+    status: str,
+    created_at: Optional[datetime],
+    expires_at: Optional[datetime],
+    now: datetime,
+) -> bool:
+    if status != CandidateStatus.pending.value:
+        return False
+    # Candidates written before suggestions had a deadline carry no `expires_at`.
+    # Derive one from creation so the pre-existing backlog ages out too, with no
+    # backfill.
+    deadline = expires_at or (created_at + SUGGESTION_TTL if created_at is not None else None)
+    if deadline is None:
+        return False
+    return deadline <= now
+
+
 def candidate_has_lapsed(candidate: CandidateRecord, *, now: datetime) -> bool:
     """Whether a pending Candidate's suggestion window has closed.
 
@@ -438,13 +462,30 @@ def candidate_has_lapsed(candidate: CandidateRecord, *, now: datetime) -> bool:
     readable. Every read path must ask this rather than trusting `status`.
     """
 
-    if candidate.status != CandidateStatus.pending:
-        return False
-    # Candidates written before suggestions had a deadline carry no `expires_at`.
-    # Derive one from creation so the pre-existing backlog ages out too, with no
-    # backfill.
-    deadline = candidate.expires_at or (candidate.created_at + SUGGESTION_TTL)
-    return deadline <= now
+    return _suggestion_window_has_closed(
+        status=candidate.status.value,
+        created_at=candidate.created_at,
+        expires_at=candidate.expires_at,
+        now=now,
+    )
+
+
+def stored_candidate_has_lapsed(candidate: dict[str, Any], *, now: datetime) -> bool:
+    """`candidate_has_lapsed` for a stored document that was never parsed into a record.
+
+    The recommendation reader loads canonical state as raw documents, so it cannot
+    ask the record-shaped question. It must still ask the same one: a deadline that
+    only one reader enforces is a deadline the other readers repeal.
+    """
+
+    stored_status = candidate.get('status')
+    status = getattr(stored_status, 'value', stored_status)
+    return _suggestion_window_has_closed(
+        status=str(status) if status else CandidateStatus.pending.value,
+        created_at=_as_utc(candidate.get('created_at')),
+        expires_at=_as_utc(candidate.get('expires_at')),
+        now=now,
+    )
 
 
 def create_candidate(
@@ -1361,6 +1402,7 @@ __all__ = [
     'pending_candidate_semantic_identity',
     'reconcile_migrated_candidate',
     'candidate_has_lapsed',
+    'stored_candidate_has_lapsed',
     'resolve_candidate_without_mutation',
     'resolve_task_candidate',
     'task_id_for_candidate',

--- a/backend/tests/unit/test_candidate_lifecycle.py
+++ b/backend/tests/unit/test_candidate_lifecycle.py
@@ -1236,6 +1236,36 @@ def test_integration_outbox_rejects_completion_from_an_expired_lease(fake_db):
     assert fake_db.rows[outbox_path]['status'] == 'completed'
 
 
+@pytest.mark.parametrize('stored_expires_at', [True, False])
+def test_the_stored_document_answers_the_deadline_exactly_like_the_record(fake_db, stored_expires_at):
+    """The raw-document twin exists so readers that never parse a record can still
+    ask the deadline question. It has to answer identically, or a Candidate is live
+    on one surface and gone on another."""
+
+    record = create_record(fake_db)
+    path = candidate_paths(fake_db)[0]
+    stored = deepcopy(fake_db.rows[path])
+    if not stored_expires_at:
+        # The backlog that predates the deadline carries no `expires_at`; both
+        # readers must derive the same one from creation.
+        stored.pop('expires_at')
+        record = record.model_copy(update={'expires_at': None})
+
+    deadline = record.created_at + candidates_db.SUGGESTION_TTL
+    for now in (deadline - timedelta(seconds=1), deadline, deadline + timedelta(days=30)):
+        assert candidates_db.stored_candidate_has_lapsed(stored, now=now) == candidates_db.candidate_has_lapsed(
+            record, now=now
+        ), now
+
+    candidates_db.resolve_task_candidate('user-1', record.candidate_id, account_generation=3)
+    resolved = candidates_db.get_candidate('user-1', record.candidate_id)
+    resolved_stored = deepcopy(fake_db.rows[path])
+    far_future = deadline + timedelta(days=365)
+    assert resolved is not None and resolved.status != CandidateStatus.pending
+    assert candidates_db.stored_candidate_has_lapsed(resolved_stored, now=far_future) is False
+    assert candidates_db.candidate_has_lapsed(resolved, now=far_future) is False
+
+
 def test_candidate_queries_have_required_firestore_composite_indexes():
     config = json.loads((Path(__file__).resolve().parents[3] / 'firestore.indexes.json').read_text())
     signatures = {

--- a/backend/tests/unit/test_task_recommendations.py
+++ b/backend/tests/unit/test_task_recommendations.py
@@ -1083,6 +1083,66 @@ def test_malformed_candidate_confidence_does_not_break_the_evaluation():
     assert not by_id['candidate-null'].eligibility.passes_recommendation_gates
 
 
+def _pending_candidate_row(candidate_id, *, created_at, expires_at=None):
+    row = {
+        'candidate_id': candidate_id,
+        'status': 'pending',
+        'subject_kind': 'task',
+        'proposed_action': 'create',
+        'task_change': {'description': 'Send the budget to Dana', 'due_at': NOW + timedelta(days=1)},
+        'capture_confidence': 0.9,
+        'ownership_confidence': 0.9,
+        'created_at': created_at,
+        'updated_at': created_at,
+        'evidence_refs': [{'kind': 'conversation', 'id': 'conversation-1', 'scope': 'canonical'}],
+    }
+    if expires_at is not None:
+        row['expires_at'] = expires_at
+    return row
+
+
+def test_a_lapsed_suggestion_is_not_recommended_after_the_suggested_surface_drops_it():
+    """A suggestion expires once, not per surface.
+
+    The Suggested surface stops showing a pending Candidate whose window closed.
+    Recommending it here would put it back in front of the user on a second
+    surface, days after it was supposed to be gone -- and, because the pre-existing
+    backlog carries no `expires_at`, it would keep months-old proposals eligible.
+    """
+
+    lapsed_created_at = NOW - timedelta(days=3)
+    state = {
+        'tasks': [],
+        'candidates': [
+            _pending_candidate_row(
+                'candidate-lapsed',
+                created_at=lapsed_created_at,
+                expires_at=lapsed_created_at + recommendations.candidates_db.SUGGESTION_TTL,
+            ),
+            _pending_candidate_row('candidate-backlog', created_at=NOW - timedelta(days=90)),
+            _pending_candidate_row(
+                'candidate-live',
+                created_at=NOW - timedelta(hours=1),
+                expires_at=NOW + timedelta(days=1),
+            ),
+        ],
+        'goals': [],
+        'workstreams': [],
+        'artifacts': [],
+    }
+
+    subjects = recommendations._build_subjects(state, context=None, open_loop_snapshots=[], now=NOW)
+    by_id = {subject.subject_id: subject for subject in subjects}
+
+    for lapsed in ('candidate-lapsed', 'candidate-backlog'):
+        assert by_id[lapsed].eligibility.open, lapsed
+        assert not by_id[lapsed].eligibility.unexpired, lapsed
+        assert not by_id[lapsed].eligibility.passes_recommendation_gates, lapsed
+
+    assert by_id['candidate-live'].eligibility.unexpired
+    assert [subject.subject_id for subject in recommendations.filter_shortlist(subjects, set())] == ['candidate-live']
+
+
 def test_recently_created_manual_task_qualifies_without_reanimating_old_edits_or_generated_rows():
     state = {
         'tasks': [

--- a/backend/utils/task_intelligence/recommendations.py
+++ b/backend/utils/task_intelligence/recommendations.py
@@ -416,6 +416,10 @@ def _build_subjects(
         )
         evidence = _valid_evidence(candidate.get('evidence_refs'), device_id=context.device_id if context else None)
         candidate_status = str(candidate.get('status') or CandidateStatus.pending.value)
+        # A suggestion the user did not act on expires; the Suggested surface stops
+        # showing it. Recommending it here would resurrect it on a second surface --
+        # the same dead end the task-mutation skip above avoids.
+        unexpired = not candidates_db.stored_candidate_has_lapsed(candidate, now=now)
         subjects.append(
             _subject(
                 kind=kind,
@@ -427,7 +431,7 @@ def _build_subjects(
                 evidence=evidence,
                 facts=facts,
                 is_open=candidate_status == CandidateStatus.pending.value,
-                unexpired=True,
+                unexpired=unexpired,
                 recent_material_activity=_recent(candidate.get('created_at'), now),
                 material_token=':'.join((candidate_status, _iso_token(candidate.get('created_at')))),
                 quality_eligible=ownership_confidence >= MINIMUM_CAPTURE_CONFIDENCE,


### PR DESCRIPTION
## What changed and why

#11974 gave a pending Candidate a real deadline — two days, stored as `expires_at` — and `candidate_has_lapsed` states the rule in its own docstring: *"Every read path must ask this rather than trusting `status`."* One read path asks. `routers/candidates.py` drops a lapsed Candidate from the Suggested surface; What Matters Now does not.

`_build_subjects` reads canonical state as raw documents and passes `unexpired=True` for every candidate subject. `unexpired` is one of the six recommendation gates, so hardcoding it repeals the deadline on that surface: a proposal the user was never shown, because it aged out unseen, is still shortlisted, judged, ranked and rendered as a live recommendation — and accepting it writes the task the Suggested surface had already retired. The two surfaces disagree about the same row on the same day.

A lapsed candidate's eligibility is also part of the projection's material version, and before this change the lapse itself was never what moved it. Its `material_token` is `status:created_at`, and `unexpired` was the constant `True`, so expiry could not register as a change. Other fields in the same hash do move on their own — `facts.days_to_due` and the due-window gates advance daily for a candidate that has a due date — so the projection is not necessarily frozen; it is simply never re-judged *because the suggestion expired*. For a candidate with no due date and no other account activity, that does mean the cached projection matches on refresh and is re-published unchanged, carrying the expired suggestion's card past its own deadline. Computing `unexpired` honestly makes the lapse a material change in its own right, so the projection is re-judged without it in every case rather than incidentally.

The backlog makes this the common case rather than a rare one. Candidates written before the deadline existed carry no `expires_at` at all — 1,014 of them in the measurement recorded on INV-TASK-2, with no backfill — and `candidate_has_lapsed` is what derives their deadline from `created_at`. A reader that never calls it treats that entire graveyard as permanently eligible, and `load_canonical_product_state` reads candidates with a flat `limit(200)`, so old rows also compete for the budget the live ones need.

- `unexpired` for a candidate subject now answers the question the field exists to ask. The snapshot subject three blocks down already computes it this way (`unexpired=snapshot.expires_at > now`).
- The deadline moves behind one predicate with two entry points: `candidate_has_lapsed` for a parsed record, `stored_candidate_has_lapsed` for a reader that holds the stored document and never parses it. A rule that lives in a docstring is a rule the next reader ships without.

Out of scope, stated rather than silently left: the `limit(200)` read is still unordered and unfiltered, so a large enough lapsed backlog can still crowd live suggestions out of the page before any gate runs. That needs a query change plus an index, not a gate fix.

## Product invariants affected

INV-TASK-2 — *"a Candidate nobody acts on expires rather than accumulating"*, and the MUST NOT clause *"Admit a proposal the Suggested surface will not show."* This is that clause applied to a second surface: the suggestion had already been retired, and the recommender put it back in front of the user.

## How it was verified

Verified by executing the reader against `upstream/main` at `02c48d7da6`, not by reading it. Three pending Candidates — one a day past its stored `expires_at`, one from the pre-deadline backlog (no `expires_at`, created 90 days ago), one created an hour ago — driven through `_build_subjects` and `filter_shortlist`:

```
# before
cand-lapsed            open=True unexpired=True gates=True
cand-legacy-lapsed     open=True unexpired=True gates=True
cand-live              open=True unexpired=True gates=True
SHORTLIST: ['cand-lapsed', 'cand-legacy-lapsed', 'cand-live']

# after
cand-lapsed            open=True unexpired=False gates=False
cand-legacy-lapsed     open=True unexpired=False gates=False
cand-live              open=True unexpired=True  gates=True
SHORTLIST: ['cand-live']
```

The committed regression test fails on `main` with:

```
>           assert not by_id[lapsed].eligibility.unexpired, lapsed
E           AssertionError: candidate-lapsed
E           assert not True
E            +  where True = ShortlistEligibility(open=True, unexpired=True, passes_recommendation_gates=True, ...).unexpired
```

- `python -m pytest tests/unit/test_task_recommendations.py` — 43 passed (42 before, +1 new).
- `python -m pytest tests/unit/test_candidate_lifecycle.py` — 51 passed (49 before, +2 parametrized cases).
- Candidate, staged-task, rollout and What-Matters-Now suites together — `test_backend_candidate_capture.py`, `test_candidate_lifecycle.py`, `test_candidates_router.py`, `test_candidates_skip_malformed.py`, `test_conversation_suggestion_visibility.py`, `test_get_candidate_skip_malformed.py`, `test_run_dev_candidate_acceptance.py`, `test_smoke_what_matters_now.py`, `test_staged_candidate_migration.py`, `test_staged_tasks_batch_scores.py`, `test_staged_tasks_dedup.py`, `test_staged_tasks_review_controls.py`, `test_task_intelligence_attribution.py`, `test_task_intelligence_contract_freeze.py`, `test_task_intelligence_known_gaps.py`, `test_task_intelligence_rollout.py`, `test_task_recommendations.py`, `test_what_matters_now_smoke_fixture.py`, `test_working_memory_candidate_schema.py` — 329 passed.
- `.github/scripts/check_task_capture_authority.py` — `INV-TASK-2 holds (automatic capture proposes only)`.
- `black --check` on the four changed Python files — clean.

Not verified against a live Firestore project or a live LLM judge: the reader is exercised through the state dict `load_canonical_product_state` returns, and the parity test through the repo's strict Firestore transaction fake.

## Tests

- `backend/tests/unit/test_task_recommendations.py::test_a_lapsed_suggestion_is_not_recommended_after_the_suggested_surface_drops_it` — the regression test, red before the change with the assertion quoted above. It covers both the stored-`expires_at` case and the pre-deadline backlog case, and pins that a live suggestion is still shortlisted, so the fix cannot turn into "stop recommending candidates".
- `backend/tests/unit/test_candidate_lifecycle.py::test_the_stored_document_answers_the_deadline_exactly_like_the_record` — the guard surface for the class below: the record-shaped and document-shaped entry points must agree at the second before the deadline, at the deadline, and long after it, with and without a stored `expires_at`, and neither may call a resolved Candidate lapsed. It caught a real defect while being written — the stored document can carry an enum where Firestore returns a string, and the twin answered `False` where the record answered `True`.

## Failure class (fixes)

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

