### PR TITLE
fix(backend): stop a lapsed suggestion from swallowing the next one

### DIFF
--- a/backend/database/candidates.py
+++ b/backend/database/candidates.py
@@ -37,7 +37,6 @@ TASK_INTELLIGENCE_CONTROL_DOCUMENT = 'state'
 PENDING_CANDIDATE_SEMANTIC_VERSION = 'task-create.v1'
 WORKSTREAM_CANDIDATE_SEMANTIC_VERSION = 'workstream-create.v1'
 MAX_CANDIDATE_EVIDENCE_REFS = 20
-PENDING_CANDIDATE_REUSE_WINDOW = timedelta(days=14)
 # A suggestion the user does not act on expires and is gone. This is a real
 # stored deadline, not a display filter: every read treats a lapsed pending
 # Candidate as expired.
@@ -559,7 +558,10 @@ def create_candidate(
             claimed_candidate is not None
             and claimed_candidate.status == CandidateStatus.pending
             and claimed_candidate.created_at.tzinfo is not None
-            and claimed_candidate.created_at >= now_value - PENDING_CANDIDATE_REUSE_WINDOW
+            # Reuse is bounded by the suggestion's own life, not by a separate
+            # window: a lapsed pending Candidate is unreadable, so merging a new
+            # capture into it would store a proposal the user can never see.
+            and not candidate_has_lapsed(claimed_candidate, now=now_value)
         )
         if (
             claimed_candidate is not None

--- a/backend/tests/unit/test_candidate_lifecycle.py
+++ b/backend/tests/unit/test_candidate_lifecycle.py
@@ -407,7 +407,7 @@ def test_fresh_high_confidence_capture_replaces_stale_low_confidence_pending_cla
         account_generation=3,
         now=captured_at,
     )
-    refreshed_at = captured_at + candidates_db.PENDING_CANDIDATE_REUSE_WINDOW + timedelta(days=1)
+    refreshed_at = captured_at + candidates_db.SUGGESTION_TTL + timedelta(days=1)
     fresh = candidates_db.create_candidate(
         'user-1',
         task_create_proposal(
@@ -436,6 +436,63 @@ def test_fresh_high_confidence_capture_replaces_stale_low_confidence_pending_cla
     assert len(alias_paths(fake_db)) == 2
     claim = fake_db.rows[pending_claim_paths(fake_db)[0]]
     assert claim['candidate_id'] == fresh.candidate_id
+
+
+def test_a_lapsed_pending_claim_is_not_reused_for_a_later_capture(fake_db):
+    """A suggestion the user never saw must not swallow the next one.
+
+    A pending Candidate stops being readable once its two-day window closes, so
+    merging a fresh capture into a lapsed one stores a proposal the Suggested
+    surface will never show — the shape INV-TASK-2 forbids.
+    """
+    captured_at = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    lapsed = candidates_db.create_candidate(
+        'user-1',
+        task_create_proposal(evidence_refs=evidence_refs(0, 1)),
+        idempotency_key='capture:first-mention',
+        account_generation=3,
+        now=captured_at,
+    )
+    heard_again_at = captured_at + candidates_db.SUGGESTION_TTL + timedelta(hours=1)
+    reproposed = candidates_db.create_candidate(
+        'user-1',
+        task_create_proposal(evidence_refs=evidence_refs(1, 2), source_surface='screen'),
+        idempotency_key='capture:second-mention',
+        account_generation=3,
+        now=heard_again_at,
+    )
+
+    assert candidates_db.candidate_has_lapsed(lapsed, now=heard_again_at)
+    assert reproposed.candidate_id != lapsed.candidate_id
+    assert not candidates_db.candidate_has_lapsed(reproposed, now=heard_again_at)
+    assert reproposed.created_at == heard_again_at
+    assert reproposed.expires_at == heard_again_at + candidates_db.SUGGESTION_TTL
+    assert len(candidate_paths(fake_db)) == 2
+    claim = fake_db.rows[pending_claim_paths(fake_db)[0]]
+    assert claim['candidate_id'] == reproposed.candidate_id
+
+
+def test_a_live_pending_claim_is_still_reused_within_its_window(fake_db):
+    captured_at = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    first = candidates_db.create_candidate(
+        'user-1',
+        task_create_proposal(evidence_refs=evidence_refs(0, 1)),
+        idempotency_key='capture:first-mention',
+        account_generation=3,
+        now=captured_at,
+    )
+    heard_again_at = captured_at + candidates_db.SUGGESTION_TTL - timedelta(hours=1)
+    merged = candidates_db.create_candidate(
+        'user-1',
+        task_create_proposal(evidence_refs=evidence_refs(1, 2), source_surface='screen'),
+        idempotency_key='capture:second-mention',
+        account_generation=3,
+        now=heard_again_at,
+    )
+
+    assert merged.candidate_id == first.candidate_id
+    assert [evidence.id for evidence in merged.evidence_refs] == ['conversation-0', 'conversation-1']
+    assert len(candidate_paths(fake_db)) == 1
 
 
 def test_pending_candidate_evidence_union_is_stable_deduplicated_and_capped(fake_db):


### PR DESCRIPTION
## What changed and why

A pending Candidate stops being readable two days after it is created: every suggested-surface read runs `candidate_has_lapsed` and drops it. Candidate *creation* did not ask the same question — a semantic claim was reusable for 14 days on `created_at` alone (`PENDING_CANDIDATE_REUSE_WINDOW`), so from day 2 to day 14 a fresh capture of the same task merged into a Candidate the Suggested surface will never show. The merge refreshes neither `created_at` nor `expires_at`, so the proposal stays invisible for the remaining twelve days however often the user mentions the task again; only after day 14 does a new Candidate get created.

That is the shape INV-TASK-2 forbids: *"Admit a proposal the Suggested surface will not show. A stored, invisible Candidate is a dropped one that also costs storage."* It was recorded as a known gap when the two-day TTL landed in #11974 — "the 14-day candidate reuse window now outlives the 2-day suggestion TTL".

That note called the gap "dedup-vs-expiry semantics — a product call, not a defect", and closed it with "self-heals once TTL reaps the doc". Two things argue for treating it as a defect after all. First, nothing reaps the doc: the comment on `SUGGESTION_TTL` in this same file states that a Firestore TTL policy cannot be declared through the repo's manifest, so "Expired Candidates therefore remain stored but unreadable". The row is never collected, and the only thing that ends the window is the 14-day reuse clock itself — so the self-healing arrives on day 15, not on day 3. Second, whatever the intended dedup semantics, the observable outcome is the one INV-TASK-2 names: from day 2 the user keeps mentioning a task and keeps being offered nothing, while a row that will never be shown absorbs each new capture. If the product call is that a semantic claim should survive its suggestion, the honest form of that is refreshing `expires_at` on merge; what happens today is neither.

This does not grow storage. The invisible row was already being written and kept — bounding reuse changes which row a later capture lands on, not how many rows exist; the "1,014 Candidates … growing by ~100/day" the invariant complains about is the population this fix makes visible again rather than one it adds to.

Reuse is now bounded by the suggestion's own life: a lapsed pending claim is not reused, so the next capture creates a fresh Candidate, repoints the semantic claim at it, and the user is offered the task again. A live claim still merges exactly as before, so repeated mentions inside the window do not multiply rows. `PENDING_CANDIDATE_REUSE_WINDOW` had no other reader and is removed rather than left to disagree with the TTL.

A lapsed twin does not suppress the new Candidate on the read side: `_suggested_candidates` suppresses a semantic identity only via user dismissals (`suppressed_dedupe_keys`) or terminal accepted/rejected resolutions, and a lapsed pending row is neither.

## Product invariants affected

INV-TASK-2 — this is the "admit only proposals the user will actually see" clause, applied to Candidate reuse rather than to the confidence floor.

## How it was verified

- Reproduced against `upstream/main` at `02c48d7da6` with a new store-level test through the strict Firestore transaction fake: a capture at T, then the same task captured again at T + 2d 1h. Before the change the second capture returns the *same* `candidate_id`, and `candidate_has_lapsed` is true for it — the user is offered nothing:

  ```
  E       AssertionError: assert 'cand_df5463cfac2fba1f4e429aeed51f2ac4' != 'cand_df5463cfac2fba1f4e429aeed51f2ac4'
  ```

  After the change the second capture is a new Candidate with a fresh `expires_at`, and the pending claim points at it.
- `python -m pytest tests/unit/test_candidate_lifecycle.py` — 51 passed (49 before, +2 new).
- Candidate and task-intelligence suites: `test_candidate_lifecycle.py`, `test_conversation_suggestion_visibility.py`, `test_backend_candidate_capture.py`, `test_task_intelligence_contract_freeze.py`, `test_process_conversation_usage_context.py` — 165 passed; `test_candidates_router.py`, `test_candidates_skip_malformed.py`, `test_get_candidate_skip_malformed.py`, `test_staged_candidate_migration.py`, `test_staged_tasks_dedup.py`, `test_task_intelligence_rollout.py`, `test_task_intelligence_attribution.py` — 123 passed.
- `.github/scripts/check_task_capture_authority.py` — `INV-TASK-2 holds (automatic capture proposes only)`.
- `black --check backend/database/candidates.py backend/tests/unit/test_candidate_lifecycle.py` — clean.
- `scripts/pr-preflight --base upstream/main --pr-body-file <this body>` — **26 checks passed** in 200s, including `product-invariants`, `failure-class-protocol`, `firestore-query-coverage`, `backend-async-blockers`, `backend-import-purity` and `backend-module-isolation`.

Not verified against a live Firestore project: the reuse path is exercised through the repo's strict transaction fake, the same harness the surrounding lifecycle tests use.

## Tests

`backend/tests/unit/test_candidate_lifecycle.py`:

- `test_a_lapsed_pending_claim_is_not_reused_for_a_later_capture` — the regression test; red before the change with the assertion quoted above.
- `test_a_live_pending_claim_is_still_reused_within_its_window` — pins the other side, so the fix cannot turn into "stop deduplicating".

`test_fresh_high_confidence_capture_replaces_stale_low_confidence_pending_claim` referenced the removed constant; it now advances past `SUGGESTION_TTL` instead of past the 14-day window, which is the same thing it was proving.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

