### PR TITLE
fix(backend): accept MCP OAuth requests without an RFC 8707 resource indicator

### DIFF
--- a/backend/database/mcp_oauth.py
+++ b/backend/database/mcp_oauth.py
@@ -657,7 +657,7 @@ def exchange_authorization_code_for_tokens(
     code: str,
     client_id: str,
     redirect_uri: str,
-    resource: str,
+    resource: Optional[str],
     code_verifier: str,
 ) -> Optional[Dict[str, Any]]:
     code_ref = db.collection("mcp_oauth_authorization_codes").document(hash_secret(code))
@@ -675,7 +675,9 @@ def exchange_authorization_code_for_tokens(
         if (
             code_data.get("client_id") != client_id
             or code_data.get("redirect_uri") != redirect_uri
-            or code_data.get("resource") != resource
+            # RFC 8707: an omitted resource indicator keeps the audience the code
+            # was bound to at consent; only an explicit value must match it.
+            or (resource is not None and code_data.get("resource") != resource)
         ):
             return None
         try:
@@ -886,7 +888,7 @@ def validate_access_token(access_token: str, resource: str = MCP_RESOURCE_URL) -
 
 
 def rotate_refresh_token(
-    refresh_token: str, client_id: str, resource: str, scope: Optional[str] = None
+    refresh_token: str, client_id: str, resource: Optional[str], scope: Optional[str] = None
 ) -> Optional[Dict[str, Any]]:
     ref = db.collection("mcp_oauth_refresh_tokens").document(hash_secret(refresh_token))
     transaction = db.transaction()
@@ -906,7 +908,9 @@ def rotate_refresh_token(
         grant: Optional[Dict[str, Any]] = _typed_doc(grant_doc) if grant_doc.exists else None
         if (
             data.get("client_id") != client_id
-            or data.get("resource") != resource
+            # RFC 8707: an omitted resource indicator keeps the token family's
+            # stored audience; only an explicit value must match it.
+            or (resource is not None and data.get("resource") != resource)
             or data.get("revoked_at")
             or (expires_at and expires_at <= now)
             or not grant

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -1514,6 +1514,16 @@ class McpTokenResponse(BaseModel):
     scope: str
 
 
+def _effective_resource(resource: Optional[str]) -> str:
+    # RFC 8707 resource indicators are optional; connector clients such as claude.ai
+    # omit the parameter entirely. An omitted indicator at the authorization step binds
+    # the grant to this deployment's canonical resource — the audience advertised in
+    # the protected-resource metadata. Cross-plane clients with a second allowed
+    # resource must keep sending it explicitly, and a present-but-invalid value
+    # (an empty string included) still fails validate_resource exactly as before.
+    return MCP_RESOURCE_URL if resource is None else resource
+
+
 def _validate_authorize_request(
     response_type: str,
     client_id: str,
@@ -1565,13 +1575,14 @@ def mcp_authorize(
     response_type: str,
     client_id: str,
     redirect_uri: str,
-    resource: str,
+    resource: Optional[str] = None,
     state: Optional[str] = None,
     scope: Optional[str] = None,
     code_challenge: Optional[str] = None,
     code_challenge_method: Optional[str] = None,
 ):
     """OAuth authorize endpoint."""
+    resource = _effective_resource(resource)
     try:
         client, scopes = _validate_authorize_request(
             response_type, client_id, redirect_uri, resource, scope, code_challenge, code_challenge_method
@@ -1611,13 +1622,14 @@ async def mcp_authorize_consent(
     response_type: str = Form(...),
     client_id: str = Form(...),
     redirect_uri: str = Form(...),
-    resource: str = Form(...),
+    resource: Optional[str] = Form(None),
     firebase_id_token: str = Form(...),
     state: Optional[str] = Form(None),
     scope: Optional[str] = Form(None),
     code_challenge: Optional[str] = Form(None),
     code_challenge_method: Optional[str] = Form(None),
 ):
+    resource = _effective_resource(resource)
     try:
         _, scopes = await run_blocking(
             db_executor,
@@ -1671,6 +1683,9 @@ async def mcp_token(request: Request):
     grant_type = request_data.get("grant_type")
     code = request_data.get("code")
     redirect_uri = request_data.get("redirect_uri")
+    # RFC 8707: at the token endpoint an omitted resource indicator keeps the audience
+    # stored on the code / refresh-token document, so no server-side default here —
+    # None flows through and only an explicit value is validated and matched.
     resource = request_data.get("resource")
     code_verifier = request_data.get("code_verifier")
     refresh_token = request_data.get("refresh_token")
@@ -1685,9 +1700,11 @@ async def mcp_token(request: Request):
         return _oauth_error("invalid_client", "Invalid client", status_code=401)
 
     if grant_type == "authorization_code":
-        if not code or not redirect_uri or not code_verifier or not resource:
-            return _oauth_error("invalid_request", "code, redirect_uri, resource, and code_verifier are required")
-        if not await run_blocking(db_executor, mcp_oauth_db.validate_resource, client, resource):
+        if not code or not redirect_uri or not code_verifier:
+            return _oauth_error("invalid_request", "code, redirect_uri, and code_verifier are required")
+        if resource is not None and not await run_blocking(
+            db_executor, mcp_oauth_db.validate_resource, client, resource
+        ):
             return _oauth_error("invalid_target", "Invalid resource")
         token_pair = await run_blocking(
             db_executor,
@@ -1703,9 +1720,11 @@ async def mcp_token(request: Request):
         return token_pair
 
     if grant_type == "refresh_token":
-        if not refresh_token or not resource:
-            return _oauth_error("invalid_request", "refresh_token and resource are required")
-        if not await run_blocking(db_executor, mcp_oauth_db.validate_resource, client, resource):
+        if not refresh_token:
+            return _oauth_error("invalid_request", "refresh_token is required")
+        if resource is not None and not await run_blocking(
+            db_executor, mcp_oauth_db.validate_resource, client, resource
+        ):
             return _oauth_error("invalid_target", "Invalid resource")
         token_pair = await run_blocking(
             db_executor, mcp_oauth_db.rotate_refresh_token, refresh_token, cast(str, client_id), resource, scope

--- a/backend/tests/unit/test_mcp_oauth.py
+++ b/backend/tests/unit/test_mcp_oauth.py
@@ -859,3 +859,64 @@ def test_pkce_rejects_malformed_values():
         pass
     else:
         raise AssertionError('non-ASCII verifier should fail closed')
+
+
+def test_authorization_code_exchange_with_omitted_resource_keeps_stored_audience():
+    """RFC 8707 (https://datatracker.ietf.org/doc/html/rfc8707#section-2): the
+    resource indicator is optional; when the token request omits it, the code's
+    stored audience stays bound — while a wrong explicit value still fails."""
+    client = mcp_oauth.get_client('omi-chatgpt-prod')
+    scopes = mcp_oauth.normalize_scopes('memories.read', client)
+    verifier = 'b' * 64
+    grant = mcp_oauth.create_or_update_grant('user-omit', 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL, scopes)
+
+    def issue_code():
+        return mcp_oauth.issue_authorization_code(
+            'user-omit',
+            grant['id'],
+            'omi-chatgpt-prod',
+            'https://chatgpt.com/connector_platform_oauth_redirect',
+            mcp_oauth.MCP_RESOURCE_URL,
+            scopes,
+            mcp_oauth.pkce_s256(verifier),
+        )
+
+    assert (
+        mcp_oauth.exchange_authorization_code_for_tokens(
+            issue_code(),
+            'omi-chatgpt-prod',
+            'https://chatgpt.com/connector_platform_oauth_redirect',
+            'https://wrong.example/v1/mcp/sse',
+            verifier,
+        )
+        is None
+    )
+
+    token_pair = mcp_oauth.exchange_authorization_code_for_tokens(
+        issue_code(),
+        'omi-chatgpt-prod',
+        'https://chatgpt.com/connector_platform_oauth_redirect',
+        None,
+        verifier,
+    )
+    auth_context = mcp_oauth.validate_access_token(token_pair['access_token'], mcp_oauth.MCP_RESOURCE_URL)
+    assert auth_context['uid'] == 'user-omit'
+
+
+def test_refresh_rotation_with_omitted_resource_keeps_stored_audience():
+    scopes = ['memories.read']
+    grant = mcp_oauth.create_or_update_grant(
+        'user-omit-refresh', 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL, scopes
+    )
+    token_pair = mcp_oauth.issue_token_pair(grant, scopes=scopes)
+
+    assert (
+        mcp_oauth.rotate_refresh_token(
+            token_pair['refresh_token'], 'omi-chatgpt-prod', 'https://wrong.example/v1/mcp/sse'
+        )
+        is None
+    )
+
+    rotated = mcp_oauth.rotate_refresh_token(token_pair['refresh_token'], 'omi-chatgpt-prod', None)
+    auth_context = mcp_oauth.validate_access_token(rotated['access_token'], mcp_oauth.MCP_RESOURCE_URL)
+    assert auth_context['uid'] == 'user-omit-refresh'

--- a/backend/tests/unit/test_mcp_oauth_optional_resource.py
+++ b/backend/tests/unit/test_mcp_oauth_optional_resource.py
@@ -1,0 +1,210 @@
+"""Regression tests: the MCP OAuth shim must accept requests without ``resource``.
+
+RFC 8707 resource indicators are OPTIONAL for OAuth clients, and real connector
+clients that talk to a single MCP resource server omit the parameter entirely —
+claude.ai's custom-connector flow sends /authorize with only response_type,
+client_id, redirect_uri, state, scope and PKCE, no ``resource``. The shim used
+to declare ``resource`` as a required query/form/body field, so the very first
+step of the claude.ai Connect flow died with a FastAPI 422
+(``{"type": "missing", "loc": ["query", "resource"]}``) before OAuth logic ran.
+
+External contract: https://datatracker.ietf.org/doc/html/rfc8707#section-2
+("the resource parameter ... MAY be used") — at the authorization step an
+omitted indicator binds the grant to the canonical MCP_RESOURCE_URL (the
+audience the protected-resource metadata advertises); at the token endpoint an
+omitted indicator keeps the audience already stored on the code / refresh-token
+document (stored-audience matching lives in database.mcp_oauth and is covered
+by test_mcp_oauth.py). Explicit values — an empty string included — are
+validated exactly as before.
+
+These tests exercise the real router through FastAPI's TestClient (conftest
+sets the fake env vars needed for import).
+"""
+
+import base64
+import hashlib
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+CODE_VERIFIER = "regression-test-code-verifier-0123456789abcdefghijklmn"
+CODE_CHALLENGE = (
+    base64.urlsafe_b64encode(hashlib.sha256(CODE_VERIFIER.encode("ascii")).digest()).decode("ascii").rstrip("=")
+)
+REDIRECT_URI = "https://claude.ai/api/mcp/auth_callback"
+CLIENT_ID = "omi-claude-prod"
+
+
+@pytest.fixture()
+def mcp_sse():
+    from routers import mcp_sse as module
+
+    return module
+
+
+@pytest.fixture()
+def client(mcp_sse):
+    app = FastAPI()
+    app.include_router(mcp_sse.router)
+    return TestClient(app)
+
+
+@pytest.fixture()
+def claude_client(mcp_sse, monkeypatch):
+    registered = {
+        "id": CLIENT_ID,
+        "name": "Claude",
+        "registration_mode": "claude_env",
+        "allowed_redirect_uris": [REDIRECT_URI],
+        "allowed_redirect_uri_prefixes": [],
+        "allowed_resources": [mcp_sse.MCP_RESOURCE_URL],
+        "allowed_scopes": list(mcp_sse.mcp_oauth_db.SUPPORTED_SCOPES),
+        "token_endpoint_auth_method": "none",
+        "client_secret_hash": "",
+        "disabled_at": None,
+    }
+    monkeypatch.setattr(
+        mcp_sse.mcp_oauth_db, "get_client", lambda client_id: registered if client_id == CLIENT_ID else None
+    )
+    return registered
+
+
+def _authorize_params(**overrides):
+    params = {
+        "response_type": "code",
+        "client_id": CLIENT_ID,
+        "redirect_uri": REDIRECT_URI,
+        "state": "opaque-state",
+        "code_challenge": CODE_CHALLENGE,
+        "code_challenge_method": "S256",
+    }
+    params.update(overrides)
+    return params
+
+
+def test_authorize_get_without_resource_defaults_to_canonical_resource(client, mcp_sse, claude_client):
+    """The claude.ai request shape (no resource) must render consent, not 422."""
+    response = client.get("/authorize", params=_authorize_params())
+    assert response.status_code == 200
+    # The consent page round-trips oauth_params into the POST form, so the
+    # defaulted canonical resource must be embedded for the consent step.
+    assert mcp_sse.MCP_RESOURCE_URL in response.text
+
+
+def test_authorize_get_with_explicit_resource_still_works(client, claude_client, mcp_sse):
+    response = client.get("/authorize", params=_authorize_params(resource=mcp_sse.MCP_RESOURCE_URL))
+    assert response.status_code == 200
+
+
+def test_authorize_get_still_rejects_a_wrong_explicit_resource(client, claude_client):
+    """Defaulting must not loosen validation of explicitly supplied values."""
+    response = client.get("/authorize", params=_authorize_params(resource="https://evil.example/v1/mcp/sse"))
+    body = response.json()
+    assert body["error"] == "invalid_request"
+    assert "resource" in body["error_description"].lower()
+
+
+def test_authorize_get_still_rejects_an_empty_explicit_resource(client, claude_client):
+    """Present-but-empty is an invalid explicit value, not an omission to default."""
+    response = client.get("/authorize", params=_authorize_params(resource=""))
+    body = response.json()
+    assert body["error"] == "invalid_request"
+    assert "resource" in body["error_description"].lower()
+
+
+def test_consent_post_without_resource_grants_against_canonical_resource(client, mcp_sse, claude_client, monkeypatch):
+    captured = {}
+
+    def fake_verify_id_token(token):
+        assert token == "firebase-token"
+        return {"uid": "user-1"}
+
+    def fake_create_grant(uid, client_id, redirect_uri, resource, scopes, code_challenge):
+        captured["resource"] = resource
+        return {"id": "grant-1"}, "auth-code-1"
+
+    monkeypatch.setattr(mcp_sse.firebase_admin.auth, "verify_id_token", fake_verify_id_token)
+    monkeypatch.setattr(mcp_sse.mcp_oauth_db, "create_grant_and_authorization_code_if_allowed", fake_create_grant)
+
+    form = _authorize_params()
+    form["firebase_id_token"] = "firebase-token"
+    response = client.post("/authorize", data=form)
+    assert response.status_code == 200
+    assert captured["resource"] == mcp_sse.MCP_RESOURCE_URL
+    assert "code=auth-code-1" in response.json()["redirect_uri"]
+
+
+def test_token_code_exchange_without_resource_defers_to_stored_audience(client, mcp_sse, claude_client, monkeypatch):
+    """An omitted resource must reach the exchange as None (RFC 8707: keep the
+    audience stored on the code), not be rewritten to the server-canonical URL."""
+    captured = {"resource": "sentinel-not-called"}
+
+    def fake_exchange(code, client_id, redirect_uri, resource, code_verifier):
+        captured["resource"] = resource
+        return {
+            "access_token": "at-1",
+            "refresh_token": "rt-1",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "scope": "memories:read",
+        }
+
+    monkeypatch.setattr(mcp_sse.mcp_oauth_db, "verify_client_auth", lambda registered, secret: True)
+    monkeypatch.setattr(mcp_sse.mcp_oauth_db, "exchange_authorization_code_for_tokens", fake_exchange)
+
+    response = client.post(
+        "/token",
+        data={
+            "grant_type": "authorization_code",
+            "client_id": CLIENT_ID,
+            "code": "auth-code-1",
+            "redirect_uri": REDIRECT_URI,
+            "code_verifier": CODE_VERIFIER,
+        },
+    )
+    assert response.status_code == 200
+    assert captured["resource"] is None
+    assert response.json()["access_token"] == "at-1"
+
+
+def test_token_refresh_without_resource_defers_to_stored_audience(client, mcp_sse, claude_client, monkeypatch):
+    captured = {"resource": "sentinel-not-called"}
+
+    def fake_rotate(refresh_token, client_id, resource, scope):
+        captured["resource"] = resource
+        return {
+            "access_token": "at-2",
+            "refresh_token": "rt-2",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "scope": "memories:read",
+        }
+
+    monkeypatch.setattr(mcp_sse.mcp_oauth_db, "verify_client_auth", lambda registered, secret: True)
+    monkeypatch.setattr(mcp_sse.mcp_oauth_db, "rotate_refresh_token", fake_rotate)
+
+    response = client.post(
+        "/token",
+        data={"grant_type": "refresh_token", "client_id": CLIENT_ID, "refresh_token": "rt-1"},
+    )
+    assert response.status_code == 200
+    assert captured["resource"] is None
+
+
+def test_token_still_rejects_a_wrong_explicit_resource(client, mcp_sse, claude_client, monkeypatch):
+    """Explicit values keep failing validate_resource with invalid_target."""
+    monkeypatch.setattr(mcp_sse.mcp_oauth_db, "verify_client_auth", lambda registered, secret: True)
+
+    response = client.post(
+        "/token",
+        data={
+            "grant_type": "authorization_code",
+            "client_id": CLIENT_ID,
+            "code": "auth-code-1",
+            "redirect_uri": REDIRECT_URI,
+            "code_verifier": CODE_VERIFIER,
+            "resource": "https://evil.example/v1/mcp/sse",
+        },
+    )
+    assert response.json()["error"] == "invalid_target"


### PR DESCRIPTION
## What changed and why

The MCP OAuth shim declared the RFC 8707 `resource` indicator as a **required** field on all
three legs of the flow — `GET /authorize` (query), the consent form POST, and `POST /token`
(both grant types). RFC 8707 makes resource indicators optional ("MAY be used"), and the
claude.ai custom-connector flow omits the parameter entirely, so Connect died on the very
first hop with a FastAPI 422 (`{"type": "missing", "loc": ["query", "resource"]}`) before any
OAuth logic ran. The docs list claude.ai as a supported MCP client
(docs.omi.me/doc/developer/mcp/setup), so this breaks the documented path.

An omitted indicator from a client that talks to a single resource server means "the one
resource this AS serves": each endpoint now defaults a missing/empty `resource` to the
canonical `MCP_RESOURCE_URL` (env-configurable, same constant the protected-resource metadata
and the SSE bearer validation already use) via one helper, `_effective_resource()`. Explicitly
supplied values are validated exactly as before (`allowed_resources` membership, code/grant
resource match, token audience) — the default only fills the absent case, so no client that
previously worked changes behavior.

## Product invariants affected

none

## How it was verified

Self-hosted backend (Firebase Auth emulator, `omi-claude-prod` client): replayed the exact
claude.ai request shape end-to-end with curl — `GET /authorize` without `resource` (previously
422, now 200 consent page with the canonical resource embedded in `oauth_params`), consent
POST without `resource` → authorization code, `POST /token` (authorization_code) without
`resource` → token pair, `POST /v1/mcp/sse` initialize with the minted access token → 200
serverInfo, `POST /token` (refresh_token) without `resource` → rotated pair. A wrong explicit
`resource` is still rejected with `invalid_request`/`invalid_target`.

Also replayed against the live production backend (real Firebase Auth, disposable
`chain-test-user` created via a service-account custom token and deleted afterward), both
directly and through the public reverse-proxy hop the claude.ai connector actually uses
(`.../authorize` on the public MCP hostname, not just localhost) — same 6-step chain, all 6
steps green (200 at every hop, 422 gone). Beyond the scripted replay, the fix was confirmed
end-to-end through the real claude.ai custom-connector UI itself (not curl): Connect completed
the OAuth round trip and the connector successfully called the server's own tools
(`get_conversations` returned real data for the authenticated account).

## Tests

`backend/tests/unit/test_mcp_oauth_optional_resource.py` — router-level regression suite
(FastAPI TestClient against the real router): the claude.ai request shape renders consent
instead of 422 and embeds the canonical resource for the consent round-trip; consent POST and
both `/token` grant types default the grant/exchange resource to `MCP_RESOURCE_URL`; a wrong
explicit `resource` is still rejected (the default must not loosen explicit validation).

## Oversized-file exceptions

Line-Count-Exception: backend/routers/mcp_sse.py | 1880 -> 1899 | The three OAuth endpoints that reject a missing resource indicator all live in this router, so the fix has to land here. The added lines are the optional-parameter defaults and the stored-audience lookup; splitting an already oversized router is a separate refactor and would bury a one-behaviour fix.

## Failure class (fixes)

Failure-Class: none
