### PR TITLE
fix(backend): name the exception behind a dead-lettered finalization

### DIFF
--- a/backend/tests/unit/test_conversation_finalizer_failure_logging.py
+++ b/backend/tests/unit/test_conversation_finalizer_failure_logging.py
@@ -1,0 +1,78 @@
+"""A dead-lettered finalization has to name the exception class behind it.
+
+The handler in ``utils/conversations/finalizer.py`` deliberately keeps provider and validation
+messages out of the log because they can quote the transcript. The class name is the one part
+that carries no transcript and is what makes ``processing_failed`` actionable.
+"""
+
+import logging
+
+import pytest
+
+from models.conversation_enums import ConversationStatus
+from utils.conversations import finalizer
+from utils.conversations.finalizer import ConversationFinalizationError
+
+
+class _Conversation:
+    """The minimum the finalizer touches before the failing step."""
+
+    def __init__(self):
+        self.id = "conversation-1"
+        self.status = ConversationStatus.processing
+        self.source = "omi"
+        self.discarded = False
+        self.structured = None
+        self.geolocation = None
+
+
+TRANSCRIPT_EXCERPT = "he said the quiet part out loud"
+
+
+@pytest.fixture
+def finalizer_that_fails_on_geolocation(monkeypatch):
+    """Let the finalizer reach its try block, then fail inside it with a telltale message."""
+
+    async def fake_run_blocking(_executor, function, *args, **kwargs):
+        if function is finalizer.conversations_db.get_conversation:
+            return {"id": "conversation-1"}
+        if function is finalizer.get_cached_user_geolocation:
+            raise LookupError(TRANSCRIPT_EXCERPT)
+        raise AssertionError(f"unexpected blocking call: {function!r}")
+
+    monkeypatch.setattr(finalizer, "run_blocking", fake_run_blocking)
+    monkeypatch.setattr(finalizer, "deserialize_conversation", lambda _data: _Conversation())
+
+
+@pytest.mark.asyncio
+async def test_dead_letter_log_names_the_exception_class(finalizer_that_fails_on_geolocation, caplog):
+    with caplog.at_level(logging.ERROR, logger=finalizer.logger.name):
+        with pytest.raises(ConversationFinalizationError) as raised:
+            await finalizer.finalize_persisted_conversation(
+                "user-1",
+                "conversation-1",
+                finalization_job_id="job-1",
+                dispatch_generation=1,
+                lease_epoch=1,
+            )
+
+    assert str(raised.value) == "processing_failed"
+    failures = [record.getMessage() for record in caplog.records if "failure=processing_failed" in record.getMessage()]
+    assert len(failures) == 1
+    assert "error=LookupError" in failures[0]
+
+
+@pytest.mark.asyncio
+async def test_dead_letter_log_still_withholds_the_exception_message(finalizer_that_fails_on_geolocation, caplog):
+    """The class name is safe to log; the message can quote the transcript and must not appear."""
+    with caplog.at_level(logging.ERROR, logger=finalizer.logger.name):
+        with pytest.raises(ConversationFinalizationError):
+            await finalizer.finalize_persisted_conversation(
+                "user-1",
+                "conversation-1",
+                finalization_job_id="job-1",
+                dispatch_generation=1,
+                lease_epoch=1,
+            )
+
+    assert TRANSCRIPT_EXCERPT not in "\n".join(record.getMessage() for record in caplog.records)

--- a/backend/utils/conversations/finalizer.py
+++ b/backend/utils/conversations/finalizer.py
@@ -205,11 +205,16 @@ async def finalize_persisted_conversation(
             raise ConversationFinalizationError('fanout_completion_conflict')
         return ConversationFinalizationDisposition.completed
     except Exception as error:
-        # Provider and validation exceptions can contain transcript excerpts.
-        # The job stores and logs only a bounded failure code.
+        # Provider and validation exceptions can contain transcript excerpts, so the job stores
+        # and logs a bounded failure code instead of the message. The exception TYPE carries no
+        # transcript and is the one thing that tells an operator where to look — provider,
+        # schema or datastore. Without it `processing_failed` is unactionable: a dead-lettered
+        # conversation reports the same nine characters whatever went wrong. The warning fifteen
+        # lines up already logs `type(error).__name__` under the same constraint.
         logger.error(
-            'persisted conversation finalization failed uid=%s conversation=%s failure=processing_failed',
+            'persisted conversation finalization failed uid=%s conversation=%s failure=processing_failed error=%s',
             uid,
             conversation_id,
+            type(error).__name__,
         )
         raise ConversationFinalizationError('processing_failed') from error


### PR DESCRIPTION
## What changed and why

`finalize_persisted_conversation` catches everything and logs the bounded code
`processing_failed`, deliberately keeping provider and validation messages out of the log
because they can quote the transcript. It also drops the exception type, and that is what
leaves an operator with nothing: a conversation dead-letters after three retries and the only
evidence is nine characters that read the same whether the provider timed out, the structured
output failed to validate, or the datastore rejected the write.

This logs `type(error).__name__` alongside the code. A class name quotes no transcript, and the
warning fifteen lines above in this same handler already logs exactly that under the same
constraint.

## Product invariants affected

none

## How it was verified

- `pytest tests/unit/test_conversation_finalizer_failure_logging.py` → 2 passed.
- Restored only the handler from `upstream/main` and re-ran: the first case fails with
  `assert 'error=LookupError' in 'persisted conversation finalization failed uid=... conversation=... failure=processing_failed'`,
  so it fails for the missing type and not for an unrelated reason.
- The change is running on a self-hosted backend whose conversations dead-letter, which is where
  the gap was found: 24 `failure=processing_failed` lines in a day, none of them attributable.

## Tests

`backend/tests/unit/test_conversation_finalizer_failure_logging.py` drives the real handler with
a blocking-call double that fails inside the try block, and asserts both halves of the contract:
the log names the exception class, and it still does not contain the exception message (the part
that can quote a transcript).

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

