### PR TITLE
fix(backend): bound the Firestore deadline on the MCP auth gate

### DIFF
--- a/backend/database/mcp_api_key.py
+++ b/backend/database/mcp_api_key.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional, Tuple, cast
 from google.cloud import firestore
 
 import database.redis_db as redis_db
+from database.mcp_auth_read import mcp_auth_stream
 from database._client import get_firestore_client
 from database.api_key_metadata import (
     MCP_API_KEY_AUTH_CONTEXT_VERSION,
@@ -316,7 +317,10 @@ def get_api_key_auth_result(api_key: str) -> ApiKeyAuthLookupResult:
 
     firestore_client = _db()
     keys_ref = firestore_client.collection("mcp_api_keys").where("hashed_key", "==", hashed_key).limit(1)
-    docs = list(keys_ref.stream())
+    # Bounded deadline: this lookup gates the request and runs on a shared thread
+    # pool, so a Firestore outage must not park a worker for the client's default
+    # 300-second retry deadline (rationale in database/mcp_auth_read.py).
+    docs = list(mcp_auth_stream(keys_ref))
 
     if not docs:
         return ApiKeyAuthLookupResult(context=None)

--- a/backend/database/mcp_auth_read.py
+++ b/backend/database/mcp_auth_read.py
@@ -1,0 +1,63 @@
+"""Bounded Firestore reads for the MCP request-gating authentication path.
+
+Bearer-token lookups gate every MCP request and run synchronously on a shared
+thread pool, so they must fail fast rather than wait out a Firestore outage: the
+client's default retry deadline for a document read is 300 seconds, and an MCP
+client that keeps retrying (connectors do) would pin one pool worker per
+in-flight request for five minutes each until the pool is exhausted and every
+other Firestore caller in the process stalls behind it.
+
+A few seconds is far beyond a healthy auth read (tens of milliseconds) and far
+below that failure mode. Exhausting the bounded retry raises a
+``google.api_core`` error, which the MCP router turns into a 503 with
+``Retry-After`` — a retryable "come back shortly", never a 401 that would make a
+connector discard a perfectly good token over a transient backend problem.
+"""
+
+import os
+from typing import Any
+
+MCP_AUTH_DB_TIMEOUT_SECONDS = float(os.getenv("MCP_AUTH_DB_TIMEOUT_SECONDS", "5"))
+
+_retry_policy: Any = None
+
+
+def mcp_auth_db_retry() -> Any:
+    """Return the bounded retry policy, built once on first use.
+
+    Built lazily rather than at import time: ``google.api_core.retry`` drags in
+    ``google.auth`` and its credential machinery, and this module sits on the
+    import path of every MCP router. Keeping production imports cheap is the
+    Tier-1 rule in ``docs/test_isolation.md``.
+    """
+    global _retry_policy
+    if _retry_policy is None:
+        from google.api_core import exceptions as google_api_exceptions
+        from google.api_core import retry as google_api_retry
+
+        _retry_policy = google_api_retry.Retry(
+            # Bounding the deadline must not stop transient failures from being
+            # retried at all — only cap how long that retrying may take.
+            predicate=google_api_retry.if_exception_type(
+                google_api_exceptions.ServiceUnavailable,
+                google_api_exceptions.InternalServerError,
+                google_api_exceptions.DeadlineExceeded,
+                google_api_exceptions.ResourceExhausted,
+                google_api_exceptions.Aborted,
+            ),
+            initial=0.2,
+            maximum=1.0,
+            multiplier=2.0,
+            timeout=MCP_AUTH_DB_TIMEOUT_SECONDS,
+        )
+    return _retry_policy
+
+
+def mcp_auth_read(reference: Any) -> Any:
+    """Read a document on the auth path with the bounded deadline."""
+    return reference.get(retry=mcp_auth_db_retry(), timeout=MCP_AUTH_DB_TIMEOUT_SECONDS)
+
+
+def mcp_auth_stream(query: Any) -> Any:
+    """Stream a query on the auth path with the bounded deadline."""
+    return query.stream(retry=mcp_auth_db_retry(), timeout=MCP_AUTH_DB_TIMEOUT_SECONDS)

--- a/backend/database/mcp_oauth.py
+++ b/backend/database/mcp_oauth.py
@@ -13,6 +13,7 @@ from urllib.parse import unquote, urlsplit
 from google.cloud import firestore
 
 from database._client import db
+from database.mcp_auth_read import mcp_auth_read
 from database.account_deletion_policy import account_deletion_blocks_access, normalize_account_deletion_status
 from database.memory_app_key_grants import (
     APP_KEY_MEMORY_GRANT_DOC_ID,
@@ -26,6 +27,7 @@ PRODUCTION_MCP_RESOURCE_URL = "https://api.omi.me/v1/mcp/sse"
 # OAuth authority and its production Firestore grants.
 BETA_MCP_RESOURCE_URL = "https://api.omiapi.com/v1/mcp/sse"
 MCP_RESOURCE_URL = os.getenv("MCP_RESOURCE_URL", PRODUCTION_MCP_RESOURCE_URL)
+
 DEFAULT_CLIENT_ID = os.getenv("MCP_OAUTH_CHATGPT_CLIENT_ID", "omi-chatgpt-prod")
 DEFAULT_CLIENT_NAME = os.getenv("MCP_OAUTH_CHATGPT_CLIENT_NAME", "ChatGPT")
 DEFAULT_CLAUDE_CLIENT_ID = os.getenv("MCP_OAUTH_CLAUDE_CLIENT_ID", "omi-claude-prod")
@@ -782,7 +784,7 @@ def _token_pair_response(access_token: str, refresh_token: str, scopes: List[str
 def get_active_grant(grant_id: str) -> Optional[Dict[str, Any]]:
     if not grant_id.strip():
         return None
-    doc = db.collection("mcp_oauth_grants").document(grant_id).get()
+    doc = mcp_auth_read(db.collection("mcp_oauth_grants").document(grant_id))
     if not doc.exists:
         return None
     data: Dict[str, Any] = _typed_doc(doc)
@@ -867,7 +869,7 @@ def _validated_access_token_identity(
 
 
 def validate_access_token(access_token: str, resource: str = MCP_RESOURCE_URL) -> Optional[Dict[str, Any]]:
-    doc = db.collection("mcp_oauth_access_tokens").document(hash_secret(access_token)).get()
+    doc = mcp_auth_read(db.collection("mcp_oauth_access_tokens").document(hash_secret(access_token)))
     if not doc.exists:
         return None
     data: Dict[str, Any] = _typed_doc(doc)

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -19,6 +19,7 @@ from urllib.parse import urlencode, urlsplit, urlunsplit, parse_qsl
 from pydantic import BaseModel
 
 import firebase_admin.auth
+from google.api_core import exceptions as google_api_exceptions
 from google.api_core.exceptions import FailedPrecondition
 from fastapi import APIRouter, HTTPException, Header, Request, Response, Form
 from fastapi.responses import StreamingResponse, JSONResponse, HTMLResponse
@@ -100,6 +101,10 @@ MCP_AUTHORIZATION_SERVER_URL = os.getenv("MCP_AUTHORIZATION_SERVER_URL", "https:
 MCP_AUTHORIZATION_ENDPOINT = f"{MCP_AUTHORIZATION_SERVER_URL}/authorize"
 MCP_TOKEN_ENDPOINT = f"{MCP_AUTHORIZATION_SERVER_URL}/token"
 MCP_PROTECTED_RESOURCE_METADATA_URL = f"{MCP_AUTHORIZATION_SERVER_URL}/.well-known/oauth-protected-resource/v1/mcp/sse"
+# How long a client should wait before retrying once the token store is down.
+# Kept short: the outages this covers (quota, transient Firestore unavailability)
+# clear on their own, and MCP clients hold no session state to rebuild.
+MCP_AUTH_UNAVAILABLE_RETRY_AFTER_SECONDS = int(os.getenv("MCP_AUTH_UNAVAILABLE_RETRY_AFTER_SECONDS", "30"))
 OPENAI_APPS_CHALLENGE_TOKEN = "ZsVB_wpc4R35_tHloCZCokY6H2fBkKyBJrz-4MtXjYE"
 
 MCP_SCOPES_SUPPORTED = list(MCP_FULL_ACCESS_SCOPES)
@@ -196,7 +201,12 @@ def authenticate_api_key_auth_context(authorization: Optional[str]) -> Optional[
 
 
 def authenticate_mcp_request(authorization: Optional[str]) -> Optional[MCPAuthContext]:
-    """Validate Authorization and return an MCP auth context."""
+    """Validate Authorization and return an MCP auth context.
+
+    Raises 503 (never 401) when the token store itself is unreachable: a client
+    told "unauthorized" discards its token and restarts the whole OAuth dance,
+    which is the wrong answer to a transient backend outage.
+    """
     if not authorization:
         return None
 
@@ -204,6 +214,23 @@ def authenticate_mcp_request(authorization: Optional[str]) -> Optional[MCPAuthCo
     if authorization.startswith("Bearer "):
         token = authorization[7:]
 
+    try:
+        return _authenticate_mcp_token(token)
+    except google_api_exceptions.GoogleAPIError as exc:
+        logger.warning("MCP auth lookup failed against the token store: %s", exc)
+        raise mcp_auth_store_unavailable_exception() from exc
+
+
+def mcp_auth_store_unavailable_exception() -> HTTPException:
+    """Return a retryable failure for an unreachable MCP token store."""
+    return HTTPException(
+        status_code=503,
+        detail="MCP authentication is temporarily unavailable. Please retry shortly.",
+        headers={"Retry-After": str(MCP_AUTH_UNAVAILABLE_RETRY_AFTER_SECONDS)},
+    )
+
+
+def _authenticate_mcp_token(token: str) -> Optional[MCPAuthContext]:
     if token.startswith("omi_mcp_"):
         auth_result = mcp_api_key_db.get_api_key_auth_result(token)
         record_api_key_repairs(key_kind="mcp", operation="auth", repairs=auth_result.repairs, log=logger)

--- a/backend/tests/unit/test_api_key_listability_contract.py
+++ b/backend/tests/unit/test_api_key_listability_contract.py
@@ -53,7 +53,9 @@ class _DocumentReference:
     def collection(self, name: str) -> "_Collection":
         return self._collection._db.collection(f"{self._collection.name}/{self.id}/{name}")
 
-    def get(self) -> _DocumentSnapshot:
+    # ``**_read_options`` mirrors the real Firestore signature: reads on the MCP
+    # auth path pass retry/timeout to bound their deadline (database/mcp_auth_read.py).
+    def get(self, **_read_options: object) -> _DocumentSnapshot:
         record = self._collection._records.get(self.id)
         return _DocumentSnapshot(
             self,
@@ -98,7 +100,7 @@ class _Query:
     def limit(self, limit: int) -> "_Query":
         return _Query(self._collection, self._conditions, limit)
 
-    def stream(self) -> list[_DocumentSnapshot]:
+    def stream(self, **_read_options: object) -> list[_DocumentSnapshot]:
         docs = []
         for doc_id, record in self._collection._records.items():
             data = record["data"]

--- a/backend/tests/unit/test_mcp_api_key_auth_context.py
+++ b/backend/tests/unit/test_mcp_api_key_auth_context.py
@@ -68,7 +68,9 @@ class _FakeQuery:
     def limit(self, _limit):
         return self
 
-    def stream(self):
+    # ``**_read_options`` mirrors the real Firestore signature: reads on the MCP
+    # auth path pass retry/timeout to bound their deadline (database/mcp_auth_read.py).
+    def stream(self, **_read_options):
         return list(self._docs)
 
 
@@ -121,7 +123,7 @@ class _FakeGrantDoc:
     def set(self, payload, merge=False):
         self.parent.grant_sets.append((self.user_id, self.collection_name, self.doc_id, payload, merge))
 
-    def get(self):
+    def get(self, **_read_options):
         return SimpleNamespace(exists=False, to_dict=lambda: {})
 
 

--- a/backend/tests/unit/test_mcp_api_key_full_access.py
+++ b/backend/tests/unit/test_mcp_api_key_full_access.py
@@ -35,7 +35,9 @@ class _DocReference:
     def collection(self, name):
         return self._collection._db.collection(f"{self._collection.name}/{self.id}/{name}")
 
-    def get(self):
+    # ``**_read_options`` mirrors the real Firestore signature: reads on the MCP
+    # auth path pass retry/timeout to bound their deadline (database/mcp_auth_read.py).
+    def get(self, **_read_options):
         return _DocSnapshot(self, self._collection._docs.get(self.id))
 
     def set(self, data, merge=False):
@@ -79,7 +81,7 @@ class _Query:
         self._limit = limit
         return self
 
-    def stream(self):
+    def stream(self, **_read_options):
         matches = [
             _DocSnapshot(_DocReference(self._collection, doc_id), data)
             for doc_id, data in self._collection._docs.items()

--- a/backend/tests/unit/test_mcp_auth_db_failfast.py
+++ b/backend/tests/unit/test_mcp_auth_db_failfast.py
@@ -1,0 +1,166 @@
+"""Regression tests: MCP bearer-token auth must fail fast, and fail honestly.
+
+Both halves matter, and both were live failures on 2026-08-23.
+
+*Fail fast.* ``authenticate_mcp_request`` runs synchronously on the shared
+``db_executor`` pool and gates every MCP request. The Firestore client retries a
+document read for 300 seconds by default, so while the project's daily read
+quota was exhausted each request parked one of the pool's 24 workers for five
+minutes. An MCP connector retrying its handshake (claude.ai sent ~100 requests)
+is therefore enough to exhaust the pool that the rest of the backend shares for
+all of its Firestore work. The bounded retry in ``database.mcp_auth_read`` caps
+that hold at a few seconds.
+
+*Fail honestly.* Once the read gives up, the request must not be reported as
+401: a connector told "unauthorized" throws its token away and restarts the
+OAuth flow, which is a permanent, user-visible response to a transient backend
+problem. 503 with ``Retry-After`` says the true thing.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from google.api_core import exceptions as google_api_exceptions
+from google.api_core.exceptions import RetryError
+
+from database import mcp_auth_read
+
+_BACKEND = Path(__file__).resolve().parents[2]
+
+# The default the bound exists to escape (google-cloud-firestore's retry
+# deadline for batch_get_documents), asserted against rather than assumed.
+FIRESTORE_DEFAULT_RETRY_DEADLINE_SECONDS = 300.0
+
+
+class _SpyReference:
+    """Records the read kwargs the auth path asks Firestore for."""
+
+    def __init__(self):
+        self.get_kwargs = None
+        self.stream_kwargs = None
+
+    def get(self, **kwargs):
+        self.get_kwargs = kwargs
+        return "snapshot"
+
+    def stream(self, **kwargs):
+        self.stream_kwargs = kwargs
+        return iter(())
+
+
+def test_auth_read_is_bounded():
+    ref = _SpyReference()
+    assert mcp_auth_read.mcp_auth_read(ref) == "snapshot"
+    assert ref.get_kwargs == {
+        "retry": mcp_auth_read.mcp_auth_db_retry(),
+        "timeout": mcp_auth_read.MCP_AUTH_DB_TIMEOUT_SECONDS,
+    }
+
+
+def test_auth_stream_is_bounded():
+    ref = _SpyReference()
+    list(mcp_auth_read.mcp_auth_stream(ref))
+    assert ref.stream_kwargs == {
+        "retry": mcp_auth_read.mcp_auth_db_retry(),
+        "timeout": mcp_auth_read.MCP_AUTH_DB_TIMEOUT_SECONDS,
+    }
+
+
+def test_auth_deadline_stays_far_below_the_firestore_default():
+    """A worker must be released in seconds, not in the default five minutes."""
+    assert 0 < mcp_auth_read.MCP_AUTH_DB_TIMEOUT_SECONDS <= 15
+    assert mcp_auth_read.mcp_auth_db_retry()._timeout == mcp_auth_read.MCP_AUTH_DB_TIMEOUT_SECONDS
+    assert mcp_auth_read.mcp_auth_db_retry()._timeout < FIRESTORE_DEFAULT_RETRY_DEADLINE_SECONDS / 10
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        # The one that actually happened: Firestore daily quota exhausted.
+        google_api_exceptions.ResourceExhausted("429 Quota exceeded."),
+        google_api_exceptions.ServiceUnavailable("503"),
+        google_api_exceptions.InternalServerError("500"),
+    ],
+)
+def test_auth_retry_still_retries_transient_errors(error):
+    """Bounding the deadline must not turn off retrying — only cap how long."""
+    assert mcp_auth_read.mcp_auth_db_retry()._predicate(error) is True
+
+
+def test_auth_retry_does_not_retry_permanent_errors():
+    assert mcp_auth_read.mcp_auth_db_retry()._predicate(google_api_exceptions.NotFound("404")) is False
+
+
+@pytest.fixture()
+def mcp_sse():
+    from routers import mcp_sse as module
+
+    return module
+
+
+def _quota_retry_error():
+    return RetryError(
+        "Timeout of 300.0s exceeded, last exception: 429 Quota exceeded.",
+        cause=google_api_exceptions.ResourceExhausted("429 Quota exceeded."),
+    )
+
+
+def test_oauth_token_store_outage_is_503_not_401(mcp_sse, monkeypatch):
+    def boom(*_args, **_kwargs):
+        raise _quota_retry_error()
+
+    monkeypatch.setattr(mcp_sse.mcp_oauth_db, "validate_access_token", boom)
+
+    with pytest.raises(HTTPException) as excinfo:
+        mcp_sse.authenticate_mcp_request("Bearer some-oauth-access-token")
+
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.headers["Retry-After"] == str(mcp_sse.MCP_AUTH_UNAVAILABLE_RETRY_AFTER_SECONDS)
+
+
+def test_legacy_key_store_outage_is_503_not_401(mcp_sse, monkeypatch):
+    def boom(*_args, **_kwargs):
+        raise google_api_exceptions.ResourceExhausted("429 Quota exceeded.")
+
+    monkeypatch.setattr(mcp_sse.mcp_api_key_db, "get_api_key_auth_result", boom)
+
+    with pytest.raises(HTTPException) as excinfo:
+        mcp_sse.authenticate_mcp_request("Bearer omi_mcp_deadbeef")
+
+    assert excinfo.value.status_code == 503
+
+
+def test_reachable_store_still_rejects_an_unknown_token(mcp_sse, monkeypatch):
+    """The 401 path is unchanged: only an unreachable store becomes a 503."""
+    monkeypatch.setattr(mcp_sse.mcp_oauth_db, "validate_access_token", lambda *a, **k: None)
+
+    assert mcp_sse.authenticate_mcp_request("Bearer unknown-token") is None
+
+
+def test_missing_authorization_header_still_returns_none(mcp_sse):
+    assert mcp_sse.authenticate_mcp_request(None) is None
+
+
+def test_importing_the_helper_stays_cheap():
+    """The retry policy is built on first use, not at import.
+
+    ``google.api_core.retry`` pulls in ``google.auth`` and its credential
+    machinery. This module sits on the import path of every MCP router, and
+    tests exercise those routers against a stubbed ``google`` namespace, so an
+    import-time dependency here would be paid — and would break — everywhere.
+    """
+    probe = (
+        "import sys, database.mcp_auth_read;"
+        "print('google.api_core.retry' in sys.modules, 'google.auth' in sys.modules)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=_BACKEND,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "False False", result.stdout

--- a/backend/tests/unit/test_mcp_oauth.py
+++ b/backend/tests/unit/test_mcp_oauth.py
@@ -34,7 +34,9 @@ class _DocReference:
         self._collection = collection
         self.id = doc_id
 
-    def get(self, transaction=None):
+    # ``**_read_options`` mirrors the real Firestore signature: reads on the MCP
+    # auth path pass retry/timeout to bound their deadline (database/mcp_auth_read.py).
+    def get(self, transaction=None, **_read_options):
         return _DocSnapshot(self, self._collection._docs.get(self.id))
 
     def set(self, data, merge=False):
@@ -56,7 +58,7 @@ class _Query:
         self._field = field
         self._expected = expected
 
-    def stream(self):
+    def stream(self, **_read_options):
         for doc_id, data in self._collection._docs.items():
             if data.get(self._field) == self._expected:
                 yield _DocSnapshot(_DocReference(self._collection, doc_id), data)


### PR DESCRIPTION
## What changed and why

`authenticate_mcp_request` gates every MCP request and runs synchronously on the shared
`db_executor` pool (`utils/executors.py`, 24 workers). Its token lookups —
`mcp_oauth.validate_access_token` for OAuth bearers and `mcp_api_key.get_api_key_auth_result`
for legacy `omi_mcp_` keys — go straight to Firestore, and the client's default retry deadline
for a document read is 300 seconds. While Firestore was degraded, each in-flight MCP request
therefore parked one pool worker for five minutes.

That is not contained to MCP. `db_executor` is the pool the rest of the backend uses for all of
its Firestore work, so an MCP client retrying its handshake is enough to starve it: measured on
a self-hosted instance, a `POST /v1/mcp/sse` **without** an `Authorization` header — a request
that never touches the database and returns 401 from the router — took over 30 seconds because
it was queued behind stuck auth reads. Once those threads were released the same request took
14 ms.

Two independent changes:

1. **Bound the deadline.** A new `database/mcp_auth_read.py` gives both auth lookups a retry
   policy with a 5-second deadline (env-overridable via `MCP_AUTH_DB_TIMEOUT_SECONDS`) instead
   of the default 300. Five seconds is orders of magnitude above a healthy auth read (tens of
   milliseconds) and two orders below the failure mode. Transient errors are still retried —
   only the total time is capped. The policy is built lazily because `google.api_core.retry`
   pulls in `google.auth`, and this module sits on the import path of every MCP router.

2. **Report it honestly.** An exhausted retry previously escaped as a 500. The router now
   answers **503 with `Retry-After`**. 401 would be actively harmful here: a client told
   "unauthorized" discards its token and restarts the OAuth flow, turning a transient backend
   problem into a permanently broken connection. The 401 path is unchanged for tokens that are
   genuinely unknown to a reachable store.

## Product invariants affected

none

## How it was verified

Self-hosted backend, against a live Firestore whose daily read quota was exhausted — the exact
failure this fixes, not a simulated one.

Before: `POST /v1/mcp/sse` with a bearer token hung past a 40-second client timeout (backend
traceback: `RetryError: Timeout of 300.0s exceeded, last exception: 429 Quota exceeded.`), and
the reverse proxy in front of it returned 504.

After deploying the change and restarting the backend: the same request returns **503 in 5.03 s
with `Retry-After: 30`**, both directly and through the public hostname; a request with no
`Authorization` header still returns **401 in 5 ms**. The real claude.ai connector polling the
server received the new 503s and kept its existing grant instead of dropping it.

## Tests

`backend/tests/unit/test_mcp_auth_db_failfast.py` — 12 tests: the auth read/stream helpers pass
the bounded retry and timeout; the deadline stays far below the Firestore default; the retry
predicate still covers transient errors (`ResourceExhausted`, `ServiceUnavailable`,
`InternalServerError`) and still does not retry `NotFound`; an unreachable token store yields
503 with `Retry-After` on both the OAuth and the legacy-key path; a reachable store still
returns None (401) for an unknown token; and importing the helper module does not pull
`google.auth` into `sys.modules`.

Four existing test doubles (`test_mcp_oauth.py`, `test_mcp_api_key_auth_context.py`,
`test_mcp_api_key_full_access.py`, `test_api_key_listability_contract.py`) were taught to accept
the `retry`/`timeout` keywords the real Firestore API accepts.

## Oversized-file exceptions

Line-Count-Exception: backend/routers/mcp_sse.py | 1880 -> 1907 | The auth gate this PR bounds is called from this router, and the 503 + Retry-After response has to be raised where the request is handled. The read itself moved out into the new database/mcp_auth_read.py rather than growing this file further; splitting the router is a separate refactor.

## Failure class (fixes)

Failure-Class: none
