### PR TITLE
fix(backend): declare the rest of the missing composite indexes (messages, conversations, memories)

### DIFF
--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -191,6 +191,38 @@ INDEX_ONLY_REQUIREMENTS = (
         'COLLECTION',
         (_asc('status'), _asc('finished_at'), _asc('__name__')),
     ),
+    # Several conversations.py serving reads filter by `status` alone and sort by
+    # `created_at` descending (get_in_progress_conversation, get_action_items,
+    # get_last_completed_conversation, and the default `GET /v1/conversations`
+    # call with include_discarded=True). Production has this index only because
+    # it was created by hand; a fresh self-host 400s with FailedPrecondition the
+    # first time any of those paths runs.
+    FirestoreIndexRequirement(
+        'conversations_status_created',
+        'conversations',
+        'COLLECTION',
+        (_asc('status'), _desc('created_at'), _desc('__name__')),
+    ),
+    # `get_conversations`/`get_conversations_count`/`get_conversations_without_photos`
+    # called with include_discarded=False and a `statuses` filter (no source/category)
+    # produce this shape. Same story as above: hand-created in production, never
+    # declared here.
+    FirestoreIndexRequirement(
+        'conversations_discarded_status_created',
+        'conversations',
+        'COLLECTION',
+        (_asc('discarded'), _asc('status'), _desc('created_at'), _desc('__name__')),
+    ),
+    # `get_memories`' default path (no category/date filters, default
+    # sort='scoring_desc') orders by `scoring` then `created_at`, both descending,
+    # with zero `where` filters. Firestore still needs a composite for a bare
+    # multi-field sort. Hand-created in production, never declared here.
+    FirestoreIndexRequirement(
+        'memories_scoring_created',
+        'memories',
+        'COLLECTION',
+        (_desc('scoring'), _desc('created_at'), _desc('__name__')),
+    ),
     FirestoreIndexRequirement(
         'memory_items_tier_status_updated',
         'memory_items',
@@ -821,6 +853,18 @@ FINALIZATION_OLDEST_NONTERMINAL_QUERY = FirestoreQuerySpec(
     index_fields=(_asc('status'), _asc('created_at'), _asc('__name__')),
 )
 
+# get_messages' session-scoped branch filters by chat_session_id instead of
+# plugin_id, same created_at descending order. Same missing-declaration story
+# as the app-scoped shape, and it 500s independently because a chat session's
+# first page of messages hits this branch, not the app-scoped one.
+MESSAGES_BY_SESSION_ORDERED_QUERY = FirestoreQuerySpec(
+    identifier='messages_by_session_created_at',
+    collection_group='messages',
+    query_scope='COLLECTION',
+    filters=(FirestoreQueryFilter('chat_session_id', '==', 'chat_session_id'),),
+    index_fields=(_asc('chat_session_id'), _desc('created_at'), _desc('__name__')),
+)
+
 QUERY_SPECS = (
     ACTION_ITEMS_COMPLETION_ID_SCAN_QUERY,
     ACTION_ITEMS_COMPLETED_DUE_RANGE_QUERY,
@@ -859,6 +903,7 @@ QUERY_SPECS = (
     MEETING_RECEIPTS_DUE_QUERY,
     HOURLY_USAGE_PLAN_ATTRIBUTION_QUERY,
     MESSAGES_BY_APP_ORDERED_QUERY,
+    MESSAGES_BY_SESSION_ORDERED_QUERY,
     CONVERSATIONS_ACTIVE_ORDERED_QUERY,
     FINALIZATION_OLDEST_NONTERMINAL_QUERY,
 )

--- a/backend/tests/unit/test_firestore_query_contract.py
+++ b/backend/tests/unit/test_firestore_query_contract.py
@@ -10,6 +10,7 @@ from google.cloud.firestore_v1 import FieldFilter
 import database.action_items as action_items_db
 import database.chat as chat_db
 import database.conversations as conversations_db
+import database.memories as memories_db
 import database.task_recommendations as task_recommendations_db
 import routers.task_recommendations as task_recommendations_router
 from database.firestore_index_registry import (
@@ -23,6 +24,7 @@ from database.firestore_index_registry import (
     EXPIRED_MEMORY_OUTBOX_LEASE_QUERY,
     INDEX_ONLY_REQUIREMENTS,
     MESSAGES_BY_APP_ORDERED_QUERY,
+    MESSAGES_BY_SESSION_ORDERED_QUERY,
     POLICY_EXPIRED_SHORT_TERM_QUERY,
     RECENT_REJECTED_MEMORY_FEEDBACK_QUERY,
     REVIEW_QUEUE_BY_CONFLICT_QUERY,
@@ -621,9 +623,33 @@ def test_app_scoped_message_reads_have_a_declared_composite_index(monkeypatch, s
         assert _equality_plus_order_signature('messages', filters, orders) in declared
 
 
+def test_session_scoped_message_reads_have_a_declared_composite_index(monkeypatch):
+    """chat_session_id-filtered, created_at-descending message reads need a declared composite.
+
+    Regression for a self-host FailedPrecondition 400 on GET /v2/messages?chat_session_id=...:
+    a chat session's first page of messages hits this branch instead of the app-scoped one,
+    and it fails independently of it.
+    """
+    recorder = []
+    monkeypatch.setattr(chat_db, 'db', _StreamRecordingFirestore(recorder, collection_name='messages'))
+
+    chat_db.get_messages('index-contract-user', chat_session_id='some-session', limit=20)
+
+    compound = [(filters, orders) for filters, orders in recorder if orders and any(op == '==' for _, op in filters)]
+    assert compound, 'get_messages(chat_session_id=...) no longer builds an equality + created_at ordering chain'
+    declared = _declared_index_signatures()
+    for filters, orders in compound:
+        assert _equality_plus_order_signature('messages', filters, orders) in declared
+
+
 def test_messages_by_app_ordered_query_is_registered_for_the_messages_collection():
     assert MESSAGES_BY_APP_ORDERED_QUERY.collection_group == 'messages'
     assert MESSAGES_BY_APP_ORDERED_QUERY.index_requirement.to_manifest() in firebase_index_manifest()['indexes']
+
+
+def test_messages_by_session_ordered_query_is_registered_for_the_messages_collection():
+    assert MESSAGES_BY_SESSION_ORDERED_QUERY.collection_group == 'messages'
+    assert MESSAGES_BY_SESSION_ORDERED_QUERY.index_requirement.to_manifest() in firebase_index_manifest()['indexes']
 
 
 @pytest.mark.parametrize(
@@ -656,9 +682,66 @@ def test_default_conversation_list_reads_have_a_declared_composite_index(monkeyp
         assert _equality_plus_order_signature('conversations', filters, orders) in declared
 
 
+@pytest.mark.parametrize(
+    ('symbol', 'call'),
+    [
+        ('get_in_progress_conversation', lambda: conversations_db.get_in_progress_conversation('index-contract-user')),
+        ('get_action_items', lambda: conversations_db.get_action_items('index-contract-user', limit=20)),
+    ],
+)
+def test_conversations_status_ordered_reads_have_a_declared_composite_index(monkeypatch, symbol, call):
+    """Status-filtered, created_at-descending conversation reads need a declared composite.
+
+    Regression for a self-host FailedPrecondition 400 on the in-progress-conversation poll
+    and the action-items read: prod has this index only because it was created by hand, but
+    firestore_index_registry.py never declared it.
+    """
+    recorder = []
+    monkeypatch.setattr(conversations_db, 'db', _StreamRecordingFirestore(recorder, collection_name='conversations'))
+
+    call()
+
+    compound = [(filters, orders) for filters, orders in recorder if orders and any(op == '==' for _, op in filters)]
+    assert compound, f'{symbol} no longer builds a status equality + created_at ordering chain'
+    declared = _declared_index_signatures()
+    for filters, orders in compound:
+        assert _equality_plus_order_signature('conversations', filters, orders) in declared
+
+
 def test_conversations_active_ordered_query_is_registered_for_the_conversations_collection():
     assert CONVERSATIONS_ACTIVE_ORDERED_QUERY.collection_group == 'conversations'
     assert CONVERSATIONS_ACTIVE_ORDERED_QUERY.index_requirement.to_manifest() in firebase_index_manifest()['indexes']
+
+
+def test_default_memories_list_read_has_a_declared_composite_index():
+    """The bare scoring+created_at sort (no filters at all) still needs a composite.
+
+    Regression: get_memories' default path (no category/date filters, default
+    sort='scoring_desc') orders by two fields with zero `where` calls. Prod has this
+    index only because it was created by hand at some point.
+    """
+    recorder = []
+    memories_db.get_memories(
+        'index-contract-user', firestore_client=_StreamRecordingFirestore(recorder, collection_name='memories')
+    )
+
+    assert recorder, 'get_memories no longer streams a query for its default path'
+    filters, orders = recorder[0]
+    assert not filters
+    assert orders == (('scoring', 'DESCENDING'), ('created_at', 'DESCENDING'))
+    declared = _declared_index_signatures()
+    assert _equality_plus_order_signature('memories', filters, orders) in declared
+
+
+def test_conversations_and_memories_index_only_requirements_are_registered():
+    identifiers = {requirement.identifier: requirement for requirement in INDEX_ONLY_REQUIREMENTS}
+    for identifier in (
+        'conversations_status_created',
+        'conversations_discarded_status_created',
+        'memories_scoring_created',
+    ):
+        assert identifier in identifiers
+        assert identifiers[identifier].to_manifest() in firebase_index_manifest()['indexes']
 
 
 def test_query_source_paths_are_posix_canonical_on_every_host_platform():

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -251,6 +251,64 @@
       ]
     },
     {
+      "collectionGroup": "conversations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "conversations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "discarded",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "memories",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "scoring",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "memory_items",
       "queryScope": "COLLECTION",
       "fields": [
@@ -1036,6 +1094,24 @@
       "fields": [
         {
           "fieldPath": "plugin_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "chat_session_id",
           "order": "ASCENDING"
         },
         {


### PR DESCRIPTION
> Rebased onto main now that #12117 has landed. That PR declared the `conversations (discarded, created_at)` index for the default conversation list read; this one covers the remaining forms (`conversations (status, created_at)`, `conversations (discarded, status, created_at)`, `memories (scoring, created_at)`, `messages (chat_session_id, created_at)`). They are complementary — `(discarded, status, created_at)` does not serve `discarded == False ORDER BY created_at`, because `status` in the middle breaks the prefix — they only conflicted textually, because both append to the same registry list and the same JSON node. Conflict resolved by keeping both sides; `firestore.indexes.json` regenerated from the merged registry. Ready for review.

## What changed and why

`get_messages`' session-scoped branch, plus three more read paths (`backend/database/chat.py`,
`conversations.py`, `memories.py`), filter/order Firestore collections in shapes that
`firestore_index_registry.py` never declared. Production has composite indexes for all of them
only because someone created them by hand at some point; a fresh self-host deploy gets
`FailedPrecondition` 400 the first time any of these paths runs:

- `messages`: `chat_session_id + created_at` (session-scoped message reads — a chat session's
  first page hits this branch, not the app-scoped one)
- `conversations`: bare `status + created_at` (`get_in_progress_conversation`,
  `get_action_items`), and `discarded + status + created_at` (default
  `GET /v1/conversations` with `include_discarded=false`, no source/category)
- `memories`: `scoring + created_at` (`get_memories`' default no-filter path — Firestore
  still needs a composite for a bare multi-field sort)

Adds these to the registry and regenerates `firestore.indexes.json`.

## Product invariants affected

none

## How it was verified

- `python3 backend/scripts/generate_firestore_indexes.py --write` — regenerated
  `firestore.indexes.json`; diff is exactly the 4 new composites above (76 lines).
- `.venv/bin/python -m pytest backend/tests/unit/test_firestore_query_contract.py` —
  34/34 passed, including 4 new regression tests (one per new query shape) that build each
  call site's real query chain through a recording Firestore fake and assert the composite
  is declared.
- `.venv/bin/python -m pytest backend/tests/unit/test_reconcile_firestore_indexes.py
  backend/tests/unit/test_reconcile_firestore_field_exemptions.py
  backend/tests/unit/test_universal_memory_list_cursor.py
  backend/tests/unit/test_action_items_due_range_index_contract.py
  backend/tests/unit/test_chat_message_count.py
  backend/tests/unit/test_chat_messages_pagination.py` — 75/75 passed, no regression.
- `black --check backend/database/firestore_index_registry.py
  backend/tests/unit/test_firestore_query_contract.py` — clean.
- Not done: creating the composites by hand in a real Firestore project and hitting a live
  self-host backend (as was done for the sibling `plugin_id`-messages fix). Only unit-level
  verification here.

## Tests

Bug fix — regression tests added, one per new query shape: each builds the real query chain
through a recording Firestore fake and asserts `firebase_index_manifest()` declares a
matching composite.

## Failure class (fixes)

Failure-Class: FC-undeclared-serving-query-index


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


