### PR TITLE
chore(backend): keep the query-coverage baseline honest about itself

### DIFF
--- a/backend/scripts/firestore_query_coverage.py
+++ b/backend/scripts/firestore_query_coverage.py
@@ -474,6 +474,38 @@ def check_ratchet(report: Mapping[str, Any], baseline: Mapping[str, Any]) -> lis
     return errors
 
 
+REGENERATE_HINT = (
+    'regenerate with: python3 backend/scripts/firestore_query_coverage.py --format baseline '
+    '> backend/scripts/firestore_query_coverage_baseline.json'
+)
+
+
+def check_baseline_freshness(report: Mapping[str, Any], baseline: Mapping[str, Any]) -> list[str]:
+    """Report ways the committed baseline no longer describes the current inventory.
+
+    The ratchet only asks whether today's debt is a subset of the baselined debt, so a
+    baseline drifts silently in the safe direction: shapes that were registered or
+    rewritten stay listed as permitted debt, and the summary counts keep reporting an
+    older, lower coverage floor.  Both are enforcement surface, not just reporting
+    surface -- a stale entry re-permits the exact shape it was recorded for, and stale
+    counts hold the percentage ratchet below the coverage already achieved.
+    """
+    errors: list[str] = []
+    if baseline.get('schema_version') != 1:
+        return ['Firestore query coverage baseline has an unsupported schema version']
+    current = baseline_for(report)
+    for key in ('raw_unregistered', 'unsupported'):
+        stale = sorted(set(baseline.get(key, [])) - set(current[key]))
+        if stale:
+            errors.append(f'baselined {key} shape(s) no longer present: {", ".join(stale)}')
+    for key in ('registered_serving', 'eligible_serving'):
+        if int(baseline.get(key, 0)) != current[key]:
+            errors.append(f'baseline {key} is {baseline.get(key)}, current inventory reports {current[key]}')
+    if errors:
+        errors.append(REGENERATE_HINT)
+    return errors
+
+
 def _render_human(report: Mapping[str, Any]) -> str:
     serving = report['counts']['serving']
     non_serving = report['counts']['non_serving']
@@ -504,7 +536,7 @@ def main() -> int:
         report = report_for(inventory(waiver_ids=_load_waivers(args.waivers.resolve())))
         if args.check_ratchet:
             baseline = json.loads(args.baseline.resolve().read_text(encoding='utf-8'))
-            errors = check_ratchet(report, baseline)
+            errors = check_ratchet(report, baseline) + check_baseline_freshness(report, baseline)
             if errors:
                 for error in errors:
                     print(f'ERROR: {error}', file=sys.stderr)

--- a/backend/scripts/firestore_query_coverage_baseline.json
+++ b/backend/scripts/firestore_query_coverage_baseline.json
@@ -1,5 +1,5 @@
 {
-  "eligible_serving": 70,
+  "eligible_serving": 102,
   "raw_unregistered": [
     "05fdb282df637274",
     "0c75b579eb9f7f04",
@@ -8,17 +8,13 @@
     "22ddf94e28ce6efc",
     "24a4e24a308881dc",
     "2a846099f82aa044",
-    "2e3df6553113f693",
     "3897bd4019721e0e",
     "4697c32b6eda9c89",
     "4c64bf8ddb021ead",
     "5483ca63032ff8e5",
     "5e1801d8a93d95b2",
-    "6349dbe884bdc903",
     "67648c7513966177",
     "766f4615b8337172",
-    "7974cb3672cd19e7",
-    "7ed4cc825ad9f782",
     "8b14d56f55926b7c",
     "92c65999902cd6f2",
     "92ddcc8ed8cf0e94",
@@ -35,8 +31,6 @@
     "d2bd1198af3f25a1",
     "d3f5a567b8a2363d",
     "d4cf7676519c097c",
-    "dac5e11c45953ac1",
-    "db0f0af923c67e1a",
     "db91448693d164b7",
     "dba3e56194d22a9f",
     "e056656ec5fc547a",
@@ -45,7 +39,7 @@
     "fbf6a1e1fdc6920e",
     "fcb4a9e8a36ebd5e"
   ],
-  "registered_serving": 24,
+  "registered_serving": 62,
   "schema_version": 1,
   "unsupported": [
     "4a1b611f6580fc78",

--- a/backend/tests/unit/test_firestore_query_contract.py
+++ b/backend/tests/unit/test_firestore_query_contract.py
@@ -531,6 +531,81 @@ def test_query_coverage_baseline_tracks_current_raw_and_unsupported_debt():
     assert firestore_query_coverage.check_ratchet(report, committed) == []
 
 
+def test_query_coverage_freshness_rejects_a_baselined_shape_that_is_gone():
+    baseline = {
+        'schema_version': 1,
+        'eligible_serving': 2,
+        'registered_serving': 1,
+        'raw_unregistered': ['retired-raw', 'still-raw'],
+        'unsupported': ['retired-unsupported'],
+    }
+    report = {
+        'counts': {
+            'serving': {
+                'eligible': 2,
+                'registered': 1,
+                'raw_unregistered': 1,
+                'waived': 0,
+                'unsupported': 0,
+            }
+        },
+        'queries': [
+            {'id': 'registered', 'classification': 'registered'},
+            {'id': 'still-raw', 'classification': 'raw_unregistered'},
+        ],
+    }
+
+    # The ratchet stays silent: today's debt is still a subset of the baselined debt.
+    assert firestore_query_coverage.check_ratchet(report, baseline) == []
+    assert firestore_query_coverage.check_baseline_freshness(report, baseline) == [
+        'baselined raw_unregistered shape(s) no longer present: retired-raw',
+        'baselined unsupported shape(s) no longer present: retired-unsupported',
+        firestore_query_coverage.REGENERATE_HINT,
+    ]
+
+
+def test_query_coverage_freshness_rejects_stale_summary_counts():
+    baseline = {
+        'schema_version': 1,
+        'eligible_serving': 1,
+        'registered_serving': 0,
+        'raw_unregistered': ['still-raw'],
+        'unsupported': [],
+    }
+    report = {
+        'counts': {
+            'serving': {
+                'eligible': 2,
+                'registered': 1,
+                'raw_unregistered': 1,
+                'waived': 0,
+                'unsupported': 0,
+            }
+        },
+        'queries': [
+            {'id': 'registered', 'classification': 'registered'},
+            {'id': 'still-raw', 'classification': 'raw_unregistered'},
+        ],
+    }
+
+    assert firestore_query_coverage.check_ratchet(report, baseline) == []
+    assert firestore_query_coverage.check_baseline_freshness(report, baseline) == [
+        'baseline registered_serving is 0, current inventory reports 1',
+        'baseline eligible_serving is 1, current inventory reports 2',
+        firestore_query_coverage.REGENERATE_HINT,
+    ]
+
+
+@pytest.mark.slow
+def test_committed_query_coverage_baseline_is_regenerated_from_the_current_inventory():
+    baseline_path = Path(__file__).resolve().parents[2] / 'scripts' / 'firestore_query_coverage_baseline.json'
+    committed = json.loads(baseline_path.read_text(encoding='utf-8'))
+    report = firestore_query_coverage.report_for(firestore_query_coverage.inventory(waiver_ids=set()))
+
+    assert firestore_query_coverage.check_baseline_freshness(report, committed) == []
+    assert committed == firestore_query_coverage.baseline_for(report)
+
+
 class _StreamRecordingQuery:
     """One Firestore query chain that records itself when production code streams it."""
 


### PR DESCRIPTION
## What changed

- Refresh `firestore_query_coverage_baseline.json` against the current `main` after #12125.
- Keep the baseline-freshness guard in `firestore_query_coverage.py`.
- Keep the regression coverage for retired fingerprints and stale summary counts.

The regenerated inventory now records 62 registered and 102 eligible serving query shapes. It also removes the retired raw-unregistered fingerprints `6349dbe884bdc903` and `7974cb3672cd19e7`.

## Why

The ratchet previously accepted a baseline that contained query shapes no longer present in the tree and summary counts lower than the current inventory. That could silently re-permit retired debt and hold the coverage floor below reality. The freshness check makes the committed baseline match the generated inventory exactly.

No serving query, index, or registry entry changes in this PR.

## Product invariants affected

none

## Verification after rebasing onto current main

- `python3 backend/scripts/firestore_query_coverage.py --check-ratchet` — exit 0; 62 registered / 102 eligible.
- `backend/.venv-pr12126/bin/python -m pytest backend/tests/unit/test_firestore_query_contract.py -m ""` — 44 passed.
- `black --check --line-length 120 --skip-string-normalization backend/scripts/firestore_query_coverage.py backend/tests/unit/test_firestore_query_contract.py` — clean.
- `git diff --check upstream/main...HEAD` — clean.

The full local manifest preflight was not runnable in the intentionally sparse checkout because unrelated trigger paths were absent; GitHub CI runs it against the complete repository.

## Failure class

Failure-Class: none