### PR TITLE
fix(app): stop a socket reconnect from restarting the in-progress poll cycle

### DIFF
--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -1830,6 +1830,12 @@ class CaptureController extends ChangeNotifier
 
   void _startInProgressConversationRefresh() {
     if (!_canRefreshInProgressConversation || segments.isNotEmpty || photos.isNotEmpty) return;
+    // The socket calls this on every connect. If a cycle is already running, leave it
+    // alone: restarting it resets the attempt counter, so a connection that reconnects
+    // more often than the give-up window keeps this polling
+    // GET /v1/conversations?...&statuses=in_progress forever instead of ever
+    // reaching the cap.
+    if (_inProgressConversationRefreshTimer?.isActive ?? false) return;
 
     _stopInProgressConversationRefresh();
     _inProgressConversationRefreshAttempts = 0;
@@ -1837,6 +1843,15 @@ class CaptureController extends ChangeNotifier
       _refreshInProgressConversationTick();
     });
   }
+
+  @visibleForTesting
+  void startInProgressConversationRefreshForTesting() => _startInProgressConversationRefresh();
+
+  @visibleForTesting
+  bool get inProgressConversationRefreshActiveForTesting => _inProgressConversationRefreshTimer?.isActive ?? false;
+
+  @visibleForTesting
+  int get inProgressConversationRefreshAttemptsForTesting => _inProgressConversationRefreshAttempts;
 
   void _stopInProgressConversationRefresh() {
     _inProgressConversationRefreshTimer?.cancel();

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -1480,4 +1480,57 @@ void main() {
       provider.dispose();
     });
   });
+
+  group('in-progress conversation poll cycle', () {
+    // The socket starts this cycle on every connect. Restarting an already
+    // running cycle put its attempt counter back to zero, so a connection that
+    // reconnects more often than the give-up window kept the app polling
+    // GET /v1/conversations?...&statuses=in_progress indefinitely instead of
+    // ever reaching the cap.
+    test('a reconnect mid-cycle does not reset the attempt counter', () {
+      fakeAsync((async) {
+        final provider = CaptureProvider(inProgressConversationLoader: () async {});
+        provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.omi));
+        provider.updateRecordingState(RecordingState.deviceRecord);
+
+        provider.startInProgressConversationRefreshForTesting();
+        async.elapse(const Duration(seconds: 10));
+        async.flushMicrotasks();
+
+        final attemptsBeforeReconnect = provider.inProgressConversationRefreshAttemptsForTesting;
+        expect(attemptsBeforeReconnect, greaterThan(0));
+
+        // Simulate a socket reconnect landing while the cycle is still running.
+        provider.startInProgressConversationRefreshForTesting();
+
+        expect(
+          provider.inProgressConversationRefreshAttemptsForTesting,
+          attemptsBeforeReconnect,
+          reason: 'a reconnect must not restart an already-running poll cycle',
+        );
+
+        provider.dispose();
+      });
+    });
+
+    test('the cycle self-terminates at its cap when nothing interrupts it', () {
+      fakeAsync((async) {
+        var loadCalls = 0;
+        final provider = CaptureProvider(
+          inProgressConversationLoader: () async => loadCalls++,
+        );
+        provider.updateRecordingDevice(_device(id: 'AA:BB:CC:DD:EE:FF', type: DeviceType.omi));
+        provider.updateRecordingState(RecordingState.deviceRecord);
+
+        provider.startInProgressConversationRefreshForTesting();
+        async.elapse(const Duration(seconds: 90));
+        async.flushMicrotasks();
+
+        expect(provider.inProgressConversationRefreshActiveForTesting, isFalse);
+        expect(loadCalls, 30);
+
+        provider.dispose();
+      });
+    });
+  });
 }


### PR DESCRIPTION
## What changed and why

`_connectTranscriptionSocket` ends every successful connect — including every reconnect after a
network drop — with `_startInProgressConversationRefresh()`. That method unconditionally cancelled
the running timer, reset `_inProgressConversationRefreshAttempts` to zero and started a fresh
`Timer.periodic`.

The cycle is designed to stop itself once it reaches
`_maxInProgressConversationRefreshAttempts`, but a connection that reconnects more often than that
window never reaches it: every reconnect wipes the counter, so the app keeps issuing
`GET /v1/conversations?...&statuses=in_progress` on the poll interval for as long as the capture
session lasts. This is not backend-specific — any backend serving a client on a flaky link takes
the same unbounded stream of reads, and the client keeps paying for them in battery and data.

The fix returns early when the timer is still active, so a reconnect joins the cycle already in
flight instead of restarting it. A cycle that has already stopped — because it hit the cap, or
because segments/photos arrived — still starts fresh on the next connect, which is the intended
behaviour. Poll interval and attempt cap are unchanged, so nothing about how quickly an
in-progress conversation appears on screen changes.

## Product invariants affected

none

## How it was verified

- `flutter test test/providers/capture_provider_test.dart` from `app/` → 81 passed (79 pre-existing
  plus the 2 added here).
- Removed only the added guard line and re-ran the new tests: the regression case fails with
  `Expected: <5> / Actual: <0>` and the reason `a reconnect must not restart an already-running poll
  cycle`, so it fails for the counter reset and not for an unrelated reason. Restored the line, green
  again.
- `dart format --line-length 120 --set-exit-if-changed` on both touched files → 0 changed.
- `flutter analyze` on both touched files reports only the three infos that already exist on
  `main` for this test file; the change adds none.

## Tests

`app/test/providers/capture_provider_test.dart`, group `in-progress conversation poll cycle`, driven
with `fake_async` so the timer is exercised without real waiting:

- *a reconnect mid-cycle does not reset the attempt counter* — the regression test. It starts the
  cycle, lets it tick, then calls the start path again the way a socket reconnect does, and asserts
  the attempt counter is unchanged. Without the guard it reads 0 instead of 5.
- *the cycle self-terminates at its cap when nothing interrupts it* — pins the property the guard
  must not break: left alone, the cycle still calls the loader exactly
  `_maxInProgressConversationRefreshAttempts` times and then cancels its own timer.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

