### PR TITLE
fix(app): survive [core/duplicate-app] instead of failing to start

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -38,6 +38,7 @@ import 'package:omi/firebase_options_prod.dart' as prod;
 import 'package:omi/flavors.dart';
 import 'package:omi/startup_auth.dart';
 import 'package:omi/startup_failure_app.dart';
+import 'package:omi/startup_firebase.dart';
 import 'package:omi/startup_routing.dart';
 import 'package:omi/l10n/app_localizations.dart';
 import 'package:omi/pages/apps/providers/add_app_provider.dart';
@@ -87,10 +88,34 @@ import 'package:omi/utils/platform/platform_service.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:omi/utils/notification_channel_strings.dart';
 
+/// Firebase parameters for the current flavor, resolved identically in every engine.
+FirebaseOptions _firebaseOptionsForFlavor() => Env.profile == AppEnvironmentProfile.localDev
+    ? local.DefaultFirebaseOptions.currentPlatform
+    : prod.DefaultFirebaseOptions.currentPlatform;
+
+/// The single Firebase entry point for every Flutter engine in the app.
+///
+/// See [ensureFirebaseApp] for why `Firebase.apps.isEmpty` was never a valid
+/// guard and why `[core/duplicate-app]` must not kill startup.
+Future<FirebaseApp> _ensureFirebaseApp() {
+  final options = _firebaseOptionsForFlavor();
+  return ensureFirebaseApp<FirebaseApp>(
+    existingApp: () => Firebase.apps.isEmpty ? null : Firebase.app(),
+    configuredProjectId: options.projectId,
+    initializeApp: () => Firebase.initializeApp(options: options),
+    projectIdOf: (app) => app.options.projectId,
+    validateProject: (projectId) => Env.validateFirebaseProject(projectId: projectId),
+  );
+}
+
 /// Background message handler for FCM data messages
 @pragma('vm:entry-point')
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  await Firebase.initializeApp();
+  // Same path as _init(). This runs in a SEPARATE Flutter engine and used to call
+  // Firebase.initializeApp() with no arguments, so it could bring [DEFAULT] up
+  // from the platform resources with parameters that differ from the ones the UI
+  // engine uses. Now both engines resolve the parameters the same way.
+  await _ensureFirebaseApp();
   await NotificationChannelStrings.loadAppLocale();
 
   await AwesomeNotifications().initialize(null, [
@@ -142,18 +167,7 @@ Future _init() async {
   LimitlessDeviceConnection.realtimeSuppressionPolicy = () => SharedPreferencesUtil().batchModeEnabled;
 
   // Firebase
-  if (Firebase.apps.isEmpty) {
-    final profile = Env.profile;
-    final options = profile == AppEnvironmentProfile.localDev
-        ? local.DefaultFirebaseOptions.currentPlatform
-        : prod.DefaultFirebaseOptions.currentPlatform;
-    Env.validateFirebaseProject(projectId: options.projectId);
-    await Firebase.initializeApp(options: options);
-  } else {
-    // Firebase may already be initialized by native SDK (macOS)
-    debugPrint('Firebase already initialized.');
-    Env.validateFirebaseProject(projectId: Firebase.app().options.projectId);
-  }
+  await _ensureFirebaseApp();
 
   if (Env.profile.usesFirebaseAuthEmulator) {
     await FirebaseAuth.instance.useAuthEmulator(Env.firebaseAuthEmulatorHost, Env.firebaseAuthEmulatorPort);

--- a/app/lib/startup_firebase.dart
+++ b/app/lib/startup_firebase.dart
@@ -1,0 +1,77 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
+
+/// The `firebase_core` error code raised when `initializeApp` is asked to create
+/// an app that the native SDK has already created with different parameters.
+const String _duplicateAppCode = 'duplicate-app';
+
+/// Bring up the Firebase app for the current engine without letting a
+/// configuration mismatch take the whole app down.
+///
+/// The check this replaces was `if (Firebase.apps.isEmpty) initializeApp()`, and
+/// it guaranteed nothing: `Firebase.apps` is empty until the *Dart* side calls
+/// `initializeApp`, even when a native `[DEFAULT]` app is already running — on
+/// Android `FirebaseInitProvider` creates it from `google-services.json` before
+/// any Dart code runs, and on macOS the native SDK does the same. The real check
+/// lives *inside* `initializeApp`: `firebase_core` pulls in the native apps and
+/// throws `[core/duplicate-app]` when our `apiKey` / `databaseURL` /
+/// `storageBucket` disagree with the native ones
+/// (`firebase_core_platform_interface/method_channel_firebase.dart`).
+///
+/// That throw only reproduces on a device, and it is fatal: it escapes startup
+/// before the first frame, so `runApp` is never reached for the real UI and the
+/// user gets `StartupFailureApp` ("Omi could not start") — while a perfectly
+/// usable native Firebase app sits right next to it. A configuration mismatch is
+/// worth complaining loudly about; it is not worth refusing to start over.
+///
+/// So `duplicate-app` is no longer fatal: the app that already exists is adopted
+/// and run through the same [validateProject] check, which means a genuinely
+/// foreign Firebase project is still caught and still fails startup.
+///
+/// [existingApp] must return the already-initialized app, or `null` when there
+/// is none — callers pass `() => Firebase.apps.isEmpty ? null : Firebase.app()`,
+/// because `Firebase.app()` throws instead of returning `null`.
+///
+/// Generic over the app type so it can be unit-tested: `FirebaseApp` has no
+/// public constructor, and obtaining a real one needs a live platform channel.
+/// Kept in its own library, free of the generated `firebase_options_*` imports,
+/// for the same reason `startup_auth.dart` is separate — it stays testable
+/// without codegen.
+///
+/// Not test-only: called from `main.dart` by both `_init()` and the FCM
+/// background handler, and directly by `startup_firebase_duplicate_app_test.dart`.
+Future<T> ensureFirebaseApp<T extends Object>({
+  required T? Function() existingApp,
+  required String configuredProjectId,
+  required Future<T> Function() initializeApp,
+  required String Function(T app) projectIdOf,
+  required void Function(String projectId) validateProject,
+}) async {
+  final alreadyRunning = existingApp();
+  if (alreadyRunning != null) {
+    debugPrint('Firebase already initialized.');
+    validateProject(projectIdOf(alreadyRunning));
+    return alreadyRunning;
+  }
+
+  validateProject(configuredProjectId);
+  try {
+    return await initializeApp();
+  } on FirebaseException catch (error) {
+    if (error.code != _duplicateAppCode) rethrow;
+
+    // `duplicate-app` is only thrown when a native app already exists, so this
+    // is expected to be non-null. If it somehow is not, the original failure is
+    // the more useful one to report.
+    final native = existingApp();
+    if (native == null) rethrow;
+
+    final nativeProjectId = projectIdOf(native);
+    debugPrint(
+      'Firebase was already initialized natively (project $nativeProjectId) with parameters that '
+      'differ from ours (project $configuredProjectId); continuing with the existing app.',
+    );
+    validateProject(nativeProjectId);
+    return native;
+  }
+}

--- a/app/test/unit/env_test.dart
+++ b/app/test/unit/env_test.dart
@@ -261,6 +261,22 @@ void main() {
       mainSource.indexOf('validateApplicationStartupRouting();'),
       lessThan(mainSource.indexOf('ServiceManager.init()')),
     );
-    expect(mainSource, contains('Env.validateFirebaseProject(projectId: Firebase.app().options.projectId);'));
+    // Same guarantee as before — the project id of the Firebase app main.dart ends
+    // up with is fed to Env.validateFirebaseProject — but the statement it used to
+    // name verbatim now lives in ensureFirebaseApp() (lib/startup_firebase.dart),
+    // which applies it to the freshly initialized app, the already-running native
+    // app, and the app adopted after [core/duplicate-app] alike. So this pins the
+    // wiring instead of one branch's text; that ensureFirebaseApp actually calls it
+    // on every one of those paths is asserted behaviorally in
+    // test/unit/startup_firebase_duplicate_app_test.dart.
+    expect(
+      mainSource,
+      matches(
+        RegExp(
+          r'projectIdOf:\s*\(app\)\s*=>\s*app\.options\.projectId,\s*'
+          r'validateProject:\s*\(projectId\)\s*=>\s*Env\.validateFirebaseProject\(projectId:\s*projectId\),',
+        ),
+      ),
+    );
   });
 }

--- a/app/test/unit/startup_firebase_duplicate_app_test.dart
+++ b/app/test/unit/startup_firebase_duplicate_app_test.dart
@@ -1,0 +1,166 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/startup_firebase.dart';
+
+/// Stands in for `FirebaseApp`, which has no public constructor and cannot be
+/// obtained without a live platform channel. Only the project id matters here.
+class _App {
+  const _App(this.projectId);
+  final String projectId;
+}
+
+/// The exact exception `firebase_core` raises when the Dart-side parameters
+/// disagree with the natively-created `[DEFAULT]` app — see `duplicateApp()` in
+/// `firebase_core_platform_interface/src/firebase_core_exceptions.dart`.
+FirebaseException _duplicateApp() => FirebaseException(
+      plugin: 'core',
+      code: 'duplicate-app',
+      message: 'A Firebase App named "[DEFAULT]" already exists',
+    );
+
+/// Mirrors `Env.validateFirebaseProject`: the profile pins one project id.
+void Function(String) _validatorFor(String expectedProjectId) => (projectId) {
+      if (projectId != expectedProjectId) {
+        throw StateError(
+          'Mobile profile requires Firebase project $expectedProjectId, '
+          'but the app was initialized with $projectId.',
+        );
+      }
+    };
+
+void main() {
+  group('ensureFirebaseApp', () {
+    test('a duplicate-app from the native [DEFAULT] app does not kill startup', () async {
+      // The regression this guards. `Firebase.apps` is empty until the Dart side
+      // calls initializeApp, even when Android's FirebaseInitProvider has already
+      // created [DEFAULT] from google-services.json. So `if (Firebase.apps.isEmpty)`
+      // waved the call through, initializeApp compared our apiKey/databaseURL/
+      // storageBucket against the native ones, disagreed, and threw
+      // `[core/duplicate-app]`. That throw escaped _init() before the first frame,
+      // so runApp() was never reached and the user got StartupFailureApp with
+      // "Omi could not start" — with a working native Firebase app right there.
+      const native = _App('omi-project');
+      var apps = <_App>[];
+      var initializeCalls = 0;
+
+      final app = await ensureFirebaseApp<_App>(
+        existingApp: () => apps.isEmpty ? null : apps.first,
+        configuredProjectId: 'omi-project',
+        initializeApp: () async {
+          initializeCalls++;
+          // Exactly what firebase_core does: the native app becomes visible and
+          // the call fails because the parameters did not match.
+          apps = [native];
+          throw _duplicateApp();
+        },
+        projectIdOf: (app) => app.projectId,
+        validateProject: _validatorFor('omi-project'),
+      );
+
+      expect(app, same(native), reason: 'startup must adopt the app that already exists');
+      expect(initializeCalls, 1);
+    });
+
+    test('a genuinely foreign native project still fails validation', () async {
+      // Tolerating duplicate-app must not turn into ignoring it: if the native
+      // app really belongs to another Firebase project, startup must still stop.
+      const native = _App('someone-elses-project');
+      var apps = <_App>[];
+
+      await expectLater(
+        ensureFirebaseApp<_App>(
+          existingApp: () => apps.isEmpty ? null : apps.first,
+          configuredProjectId: 'omi-project',
+          initializeApp: () async {
+            apps = [native];
+            throw _duplicateApp();
+          },
+          projectIdOf: (app) => app.projectId,
+          validateProject: _validatorFor('omi-project'),
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('someone-elses-project'),
+          ),
+        ),
+      );
+    });
+
+    test('an already-initialized app is adopted without a second initializeApp', () async {
+      // The macOS path the old `else` branch handled, kept intact.
+      const native = _App('omi-project');
+      var initializeCalls = 0;
+
+      final app = await ensureFirebaseApp<_App>(
+        existingApp: () => native,
+        configuredProjectId: 'omi-project',
+        initializeApp: () async {
+          initializeCalls++;
+          return const _App('unused');
+        },
+        projectIdOf: (app) => app.projectId,
+        validateProject: _validatorFor('omi-project'),
+      );
+
+      expect(app, same(native));
+      expect(initializeCalls, 0);
+    });
+
+    test('the normal path initializes with our own options', () async {
+      const created = _App('omi-project');
+      var initializeCalls = 0;
+
+      final app = await ensureFirebaseApp<_App>(
+        existingApp: () => null,
+        configuredProjectId: 'omi-project',
+        initializeApp: () async {
+          initializeCalls++;
+          return created;
+        },
+        projectIdOf: (app) => app.projectId,
+        validateProject: _validatorFor('omi-project'),
+      );
+
+      expect(app, same(created));
+      expect(initializeCalls, 1);
+    });
+
+    test('a misconfigured flavor still fails before initializeApp runs', () async {
+      // Validating our own options up front is the pre-existing behaviour and is
+      // deliberately still fatal — this is a build wired to the wrong project.
+      var initializeCalls = 0;
+
+      await expectLater(
+        ensureFirebaseApp<_App>(
+          existingApp: () => null,
+          configuredProjectId: 'wrong-project',
+          initializeApp: () async {
+            initializeCalls++;
+            return const _App('wrong-project');
+          },
+          projectIdOf: (app) => app.projectId,
+          validateProject: _validatorFor('omi-project'),
+        ),
+        throwsStateError,
+      );
+      expect(initializeCalls, 0, reason: 'a bad flavor must not reach initializeApp');
+    });
+
+    test('any other FirebaseException still fails startup', () async {
+      // Only duplicate-app is survivable; everything else is a real failure.
+      await expectLater(
+        ensureFirebaseApp<_App>(
+          existingApp: () => null,
+          configuredProjectId: 'omi-project',
+          initializeApp: () async => throw FirebaseException(plugin: 'core', code: 'no-app'),
+          projectIdOf: (app) => app.projectId,
+          validateProject: _validatorFor('omi-project'),
+        ),
+        throwsA(isA<FirebaseException>().having((e) => e.code, 'code', 'no-app')),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What changed and why

The app does not start at all: instead of the first frame the user gets
`StartupFailureApp` with `[core/duplicate-app] A Firebase App named "[DEFAULT]" already
exists`, thrown out of `_init()`.

`if (Firebase.apps.isEmpty)` guaranteed nothing. `Firebase.apps` is empty until the Dart
side calls `initializeApp`, even when a native `[DEFAULT]` app is already running — on
Android `FirebaseInitProvider` creates it from `google-services.json` before any Dart code
runs, and on macOS the native SDK does the same. The real check lives *inside*
`initializeApp`: `firebase_core` pulls in the native apps and throws `duplicate-app` when
our `apiKey` / `databaseURL` / `storageBucket` disagree with the native ones
(`firebase_core_platform_interface`, `method_channel_firebase.dart`). That throw escaped
`_init()` before `runApp()`, so the whole app died — while a perfectly usable native
Firebase app sat right next to it. A configuration mismatch is worth complaining loudly
about; it is not a reason to refuse to start.

`ensureFirebaseApp()` (new `app/lib/startup_firebase.dart`) is now the single
initialization point: adopt the app that already exists, otherwise `initializeApp`, and
`duplicate-app` is no longer fatal — the existing app is adopted and run through the same
`Env.validateFirebaseProject`, so a genuinely foreign Firebase project is still caught and
still fails startup. Every other `FirebaseException` is still rethrown, and validating our
own flavor's options before `initializeApp` is unchanged and still fatal.

The FCM background handler goes through the same path. It runs in a separate Flutter
engine and called `Firebase.initializeApp()` with no arguments, so it could bring
`[DEFAULT]` up from the platform resources with parameters that differ from the ones the UI
engine uses; both engines now resolve the parameters identically.

The logic lives in its own library, generic over the app type, because it has to be
testable: `FirebaseApp` has no public constructor, and a test cannot import `main.dart`
since that pulls in the generated, gitignored `firebase_options_prod.dart`. Same reason
`startup_auth.dart` and `startup_routing.dart` are separate libraries.

`env_test.dart`'s static wiring tripwire named the removed `else` branch verbatim
(`Env.validateFirebaseProject(projectId: Firebase.app().options.projectId);`). It now pins
the same guarantee where the guarantee moved to — `main.dart` feeding the resolved app's
`options.projectId` into `Env.validateFirebaseProject` — instead of one branch's text. See
Tests for why this is a stronger check, not a weaker one.

## Product invariants affected

INV-DATA-1 (production-family customer data-plane continuity) — touched, not relaxed.
`app/lib/main.dart` is on the invariant's locked paths, and the invariant's requirement here
is that a production-family artifact cannot end up on a different Firebase project or
account universe. That requirement is enforced by `Env.validateFirebaseProject`, and it
still runs on whichever app startup ends up with: the freshly initialized one, an
already-running native one, and — new in this PR — the one adopted after `duplicate-app`.
What changes is only the failure mode of a *matching* project whose non-identity parameters
(`apiKey` / `databaseURL` / `storageBucket`) differ: that used to kill the app and now
continues on the native app. A different `projectId` still throws `StateError` and still
fails startup, which is asserted directly by the new test.

## How it was verified

- `bash app/test.sh` (full suite, the same entry point CI uses) — `+1460 ~5`, all tests
  passed, exit 0.
- `flutter test test/unit/env_test.dart` — 23/23 passed, including the static wiring
  tripwire this PR updates.
- `flutter test test/unit/startup_firebase_duplicate_app_test.dart` — 6/6 passed.
- Red-before-green confirmed: with `ensureFirebaseApp` temporarily reverted to the old
  `if (apps.isEmpty) { validate; initializeApp } else { validate }` body, the run is
  `+4 -2` — the two duplicate-app cases fail with
  `[core/duplicate-app] A Firebase App named "[DEFAULT]" already exists`, and the four
  preserved-behaviour cases stay green.
- The updated tripwire was checked to still trip: replacing `main.dart`'s
  `validateProject: (projectId) => Env.validateFirebaseProject(projectId: projectId)` with
  an empty lambda turns `env_test.dart` red.
- `dart format --line-length 120 --set-exit-if-changed` on the four changed files — clean.
- `flutter analyze` on the changed files — the only finding is the pre-existing
  `library_private_types_in_public_api` info on `MyApp.of` in `main.dart`, untouched by this
  change; no new issues.
- Not verified: no on-device run was made for this revision. The original failure was
  observed on a self-hosted build with its own Firebase project (Android, where
  `FirebaseInitProvider` creates `[DEFAULT]` before Dart runs); the fix as reworked here has
  only been exercised through the test suite, which cannot reach a real native
  `[DEFAULT]` app.

## Tests

Bug fix — regression test added in `app/test/unit/startup_firebase_duplicate_app_test.dart`.
The case that would have caught this: a native `[DEFAULT]` that becomes visible only when
`initializeApp` throws `duplicate-app` must be adopted rather than kill startup. It also
pins the guardrails: a native app from a genuinely different Firebase project still fails
validation, a non-`duplicate-app` `FirebaseException` still fails startup, a flavor
configured for the wrong project still fails before `initializeApp` is reached, and the
pre-existing "already initialized natively" path (macOS) still skips `initializeApp`.

`app/test/unit/env_test.dart`'s "main invokes the production startup routing seam" case is a
static tripwire (`AGENTS.md`: "Asserting that source strings occur in a certain order is a
static tripwire, not behavioral coverage"). Its third assertion quoted a statement this PR
deletes, so it was adapted rather than dropped, and it is still a single assertion. The
adaptation strengthens it: the old string only proved that one `if`/`else` branch contained
that text, while the new one pins the wiring — the resolved app's `options.projectId` going
into `Env.validateFirebaseProject` — that now covers every path, including the newly added
adopt-after-`duplicate-app` one. That the wiring is actually exercised on each of those
paths is no longer left to a string at all: it is asserted behaviorally in the new test,
which the "already initialized" branch previously had no coverage for. The two ordering
assertions in that test (routing seam present, and before `ServiceManager.init()`) are
untouched and still pass.

## Failure class (fixes)

Failure-Class: none
