### PR TITLE
fix(app): give a client-synthesized cutover fence a way out

### DIFF
--- a/app/lib/services/account_cutover/account_cutover_blocking_gate.dart
+++ b/app/lib/services/account_cutover/account_cutover_blocking_gate.dart
@@ -4,6 +4,7 @@
 /// LIFECYCLE: permanent
 library;
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -13,7 +14,7 @@ import 'package:omi/services/account_cutover/account_cutover_gate.dart';
 import 'package:omi/services/account_cutover/account_cutover_runtime.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
-class AccountCutoverBlockingGate extends StatelessWidget {
+class AccountCutoverBlockingGate extends StatefulWidget {
   const AccountCutoverBlockingGate({
     super.key,
     this.productBuilder,
@@ -30,21 +31,67 @@ class AccountCutoverBlockingGate extends StatelessWidget {
   static final Uri _playStoreUrl = Uri.parse('https://play.google.com/store/apps/details?id=com.friend.ios');
 
   @override
+  State<AccountCutoverBlockingGate> createState() => _AccountCutoverBlockingGateState();
+}
+
+class _AccountCutoverBlockingGateState extends State<AccountCutoverBlockingGate> {
+  // While a fence is on screen, nothing else in the app re-fetches the cutover
+  // control (product traffic is blocked), so without this timer the fence
+  // could only ever clear on an app lifecycle event. Poll so a fence caused by
+  // a transient control-plane outage lifts on its own — and a real migration
+  // fence lifts as soon as the migration completes.
+  Timer? _fenceRefreshTimer;
+  bool _refreshInFlight = false;
+
+  static const _fenceRefreshInterval = Duration(seconds: 30);
+
+  void _syncFenceRefreshTimer(bool fenceVisible) {
+    if (fenceVisible && _fenceRefreshTimer == null) {
+      _fenceRefreshTimer = Timer.periodic(_fenceRefreshInterval, (_) async {
+        if (_refreshInFlight) return;
+        _refreshInFlight = true;
+        try {
+          await AccountCutoverRuntime.instance.refresh();
+        } finally {
+          _refreshInFlight = false;
+        }
+      });
+    } else if (!fenceVisible && _fenceRefreshTimer != null) {
+      _fenceRefreshTimer!.cancel();
+      _fenceRefreshTimer = null;
+    }
+  }
+
+  @override
+  void dispose() {
+    _fenceRefreshTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return ListenableBuilder(
       listenable: AccountCutoverRuntime.instance,
       builder: (context, _) {
         final runtime = AccountCutoverRuntime.instance;
         final decision = runtime.decision;
-        if (decision == AccountCutoverGateDecision.allowProductTraffic) {
-          return productBuilder?.call(context) ?? child!;
+        final fenceVisible = decision != AccountCutoverGateDecision.allowProductTraffic;
+        _syncFenceRefreshTimer(fenceVisible);
+        if (!fenceVisible) {
+          return widget.productBuilder?.call(context) ?? widget.child!;
         }
 
         return AccountCutoverBlockingView(
           decision: decision,
           strandedNewData: runtime.control.strandedNewData,
-          appStoreUrl: _appStoreUrl,
-          playStoreUrl: _playStoreUrl,
+          appStoreUrl: AccountCutoverBlockingGate._appStoreUrl,
+          playStoreUrl: AccountCutoverBlockingGate._playStoreUrl,
+          // A fence this client synthesized after the server had allowed the
+          // owner (unreachable control plane, a blown refresh) keeps a manual
+          // way back to that last authoritative projection. A fence the server
+          // itself decided — or one with no server allow to return to — does
+          // not.
+          onSkipUnresolvedFence: runtime.canSkipUnresolvedFence ? runtime.skipUnresolvedFence : null,
         );
       },
     );
@@ -58,12 +105,18 @@ class AccountCutoverBlockingView extends StatelessWidget {
     required this.strandedNewData,
     required this.appStoreUrl,
     required this.playStoreUrl,
+    this.onSkipUnresolvedFence,
   });
 
   final AccountCutoverGateDecision decision;
   final bool strandedNewData;
   final Uri appStoreUrl;
   final Uri playStoreUrl;
+
+  /// Non-null only while this client synthesized the fence and the server had
+  /// authoritatively allowed the owner. Pressing it returns to that last
+  /// authoritative projection for this session.
+  final VoidCallback? onSkipUnresolvedFence;
 
   @override
   Widget build(BuildContext context) {
@@ -120,6 +173,12 @@ class AccountCutoverBlockingView extends StatelessWidget {
                           await launchUrl(url, mode: LaunchMode.externalApplication);
                         },
                         child: Text(l10n.accountCutoverOpenStore),
+                      ),
+                    ] else if (onSkipUnresolvedFence != null) ...[
+                      const SizedBox(height: 20),
+                      TextButton(
+                        onPressed: onSkipUnresolvedFence,
+                        child: Text(l10n.skip, style: const TextStyle(color: Colors.white70)),
                       ),
                     ],
                   ],

--- a/app/lib/services/account_cutover/account_cutover_runtime.dart
+++ b/app/lib/services/account_cutover/account_cutover_runtime.dart
@@ -13,9 +13,15 @@ class AccountCutoverRuntime extends ChangeNotifier {
   AccountCutoverRuntime._();
   static final AccountCutoverRuntime instance = AccountCutoverRuntime._();
 
+  /// Test seam for the blocking screen's own retry loop, which calls the
+  /// parameterless [refresh]. Production code never assigns this.
+  @visibleForTesting
+  static AccountCutoverControlClient? controlClientOverrideForTesting;
+
   final AccountCutoverGate _gate = const AccountCutoverGate();
   AccountCutoverControl _control = AccountCutoverControl.legacyDefault();
   bool _hasAuthoritative = false;
+  AccountCutoverControl? _lastAuthoritativeControl;
   String? _ownerUid;
   int _refreshEpoch = 0;
   bool _resolvedForOwner = true;
@@ -24,6 +30,32 @@ class AccountCutoverRuntime extends ChangeNotifier {
   bool get hasAuthoritativeControl => _hasAuthoritative;
   String? get ownerUid => _ownerUid;
   bool get isResolvedForOwner => _resolvedForOwner;
+
+  /// The only projection [skipUnresolvedFence] may return to: the last
+  /// AUTHORITATIVE projection for this owner, and only while that projection
+  /// allowed product traffic.
+  ///
+  /// Null when the server has never allowed this owner — nothing authoritative
+  /// has arrived yet, or the last authoritative word was itself a fence. Then
+  /// the fence holds and only a fresh server answer can lift it, so a fence is
+  /// never traded for a legacy projection the server never sent.
+  AccountCutoverControl? get _lastAuthoritativeAllow {
+    final last = _lastAuthoritativeControl;
+    if (last == null) return null;
+    if (_gate.decide(last) != AccountCutoverGateDecision.allowProductTraffic) return null;
+    return last;
+  }
+
+  /// True while the fence currently on screen was synthesized by this client
+  /// (503, timeouts, an in-flight owner refresh) after the server had
+  /// authoritatively allowed this owner. Only such a fence is skippable.
+  ///
+  /// This is the distinction the `hasAuthoritativeControl` gate got wrong:
+  /// after one successful "legacy/allow" fetch, a single blown refresh
+  /// produced a maintenance fence with no exit at all — the server never
+  /// actually said "migrating", but the skip affordance was hidden because
+  /// SOME authoritative projection had been seen.
+  bool get canSkipUnresolvedFence => _lastAuthoritativeAllow != null;
 
   AccountCutoverGateDecision get decision {
     // Owner transitions fail closed until the matching refresh settles so a
@@ -38,6 +70,9 @@ class AccountCutoverRuntime extends ChangeNotifier {
   void apply(AccountCutoverControl control, {bool authoritative = true}) {
     _control = control;
     _hasAuthoritative = authoritative;
+    if (authoritative) {
+      _lastAuthoritativeControl = control;
+    }
     _resolvedForOwner = true;
     notifyListeners();
   }
@@ -45,9 +80,11 @@ class AccountCutoverRuntime extends ChangeNotifier {
   void resetForTesting() {
     _control = AccountCutoverControl.legacyDefault();
     _hasAuthoritative = false;
+    _lastAuthoritativeControl = null;
     _ownerUid = null;
     _refreshEpoch = 0;
     _resolvedForOwner = true;
+    controlClientOverrideForTesting = null;
   }
 
   /// Bind runtime state to the authenticated owner and refresh control.
@@ -66,20 +103,35 @@ class AccountCutoverRuntime extends ChangeNotifier {
       _ownerUid = null;
       _control = AccountCutoverControl.legacyDefault();
       _hasAuthoritative = false;
+      _lastAuthoritativeControl = null;
       _resolvedForOwner = true;
       notifyListeners();
       return;
     }
 
     if (normalized != _ownerUid) {
+      // Only a genuine switch between two real accounts on this device needs
+      // the synchronous fence: it stops account A's stale allow decision
+      // from leaking into account B's session while B's fetch is in flight.
+      // The very first bind of a fresh runtime (no prior owner in memory,
+      // e.g. cold app start) has no prior decision to leak, so leave
+      // `_control` at its legacy-compatible default — a transport failure on
+      // this bind can then fall back to it in `applyFetchResult` instead of
+      // being permanently stuck behind a fence it never needed.
+      final isGenuineOwnerSwitch = _ownerUid != null;
       _ownerUid = normalized;
-      _control = AccountCutoverControl.unavailable();
       _hasAuthoritative = false;
+      // The prior owner's projection must not survive an owner change in any
+      // form — including as the "last known good" a skip could restore.
+      _lastAuthoritativeControl = null;
       _resolvedForOwner = false;
+      if (isGenuineOwnerSwitch) {
+        _control = AccountCutoverControl.unavailable();
+      }
       notifyListeners();
     }
 
-    final fetchClient = client ?? AccountCutoverControlClient();
+    final fetchClient = client ?? controlClientOverrideForTesting ?? AccountCutoverControlClient();
     final result = await fetchClient.fetchControl();
     if (epoch != _refreshEpoch || _ownerUid != normalized) {
       return;
@@ -99,18 +151,34 @@ class AccountCutoverRuntime extends ChangeNotifier {
 
   @visibleForTesting
   void applyFetchResult(AccountCutoverFetchResult result) {
+    final lastAuthAllow = _lastAuthoritativeAllow;
     switch (result.kind) {
       case AccountCutoverFetchKind.success:
         _control = result.control!;
         _hasAuthoritative = true;
+        _lastAuthoritativeControl = result.control;
         break;
       case AccountCutoverFetchKind.unavailable:
+        // The server explicitly failed closed — respect it and fence. When the
+        // last authoritative word was "allow", this fence is the client's own:
+        // the blocking screen offers skip and keeps retrying (see
+        // canSkipUnresolvedFence).
         _control = AccountCutoverControl.unavailable(
           retaining: _hasAuthoritative ? _control : null,
         );
         break;
       case AccountCutoverFetchKind.transportFailure:
-        if (_hasAuthoritative) {
+        if (lastAuthAllow != null) {
+          // The control plane is unreachable, but its last authoritative word
+          // for this owner was "allow". A transport blip is not evidence of a
+          // migration — stay on the last-known-good projection instead of
+          // synthesizing a maintenance fence with no exit. Without this, a
+          // single timed-out refresh on a flaky connection could block the
+          // whole app while the server kept answering legacy/none.
+          _control = lastAuthAllow;
+        } else if (_hasAuthoritative) {
+          // Last authoritative state was itself a fence (migrating/new/...):
+          // keep failing closed across the outage.
           _control = AccountCutoverControl.unavailable(retaining: _control);
         } else if (_gate.decide(_control) == AccountCutoverGateDecision.allowProductTraffic) {
           // No authoritative projection yet (bridge rollout): stay legacy-compatible.
@@ -119,6 +187,23 @@ class AccountCutoverRuntime extends ChangeNotifier {
         // If already blocked (e.g. owner-change unavailable), keep that fence.
         break;
     }
+  }
+
+  /// Escape hatch for a fence this client synthesized after the server had
+  /// allowed the owner: returns to that last authoritative projection.
+  ///
+  /// A no-op — the fence holds — whenever there is nothing the server itself
+  /// allowed to go back to: a confirmed migrating/new/rolled_back_stranded
+  /// state, an unavailable or malformed document before any allow, or an owner
+  /// whose first fetch has not landed yet. It can never synthesize a legacy
+  /// projection of its own.
+  bool skipUnresolvedFence() {
+    final lastGood = _lastAuthoritativeAllow;
+    if (lastGood == null) return false;
+    _control = lastGood;
+    _resolvedForOwner = true;
+    notifyListeners();
+    return true;
   }
 
   bool get allowsOfflineQueueUpload {

--- a/app/test/unit/account_cutover_gate_test.dart
+++ b/app/test/unit/account_cutover_gate_test.dart
@@ -218,6 +218,148 @@ void main() {
     expect(runtime.allowsOfflineQueueUpload, isFalse);
   });
 
+  test('first bind of a fresh runtime recovers to legacy-compatible after a transport failure', () async {
+    final runtime = AccountCutoverRuntime.instance;
+    final client = AccountCutoverControlClient(fetch: () async => const AccountCutoverFetchResult.transportFailure());
+
+    await runtime.bindAuthenticatedOwner('owner-a', client: client);
+
+    expect(runtime.isResolvedForOwner, isTrue);
+    expect(runtime.hasAuthoritativeControl, isFalse);
+    expect(runtime.decision, AccountCutoverGateDecision.allowProductTraffic);
+  });
+
+  test('a genuine owner switch stays fenced across a transport failure (no leaked prior allow)', () async {
+    final runtime = AccountCutoverRuntime.instance;
+    final ownerAControl = AccountCutoverControl.fromJson(_validControlJson(accountGeneration: 7));
+    await runtime.bindAuthenticatedOwner(
+      'owner-a',
+      client: AccountCutoverControlClient(fetch: () async => AccountCutoverFetchResult.success(ownerAControl)),
+    );
+    expect(runtime.decision, AccountCutoverGateDecision.allowProductTraffic);
+
+    final failingClient = AccountCutoverControlClient(
+      fetch: () async => const AccountCutoverFetchResult.transportFailure(),
+    );
+    await runtime.bindAuthenticatedOwner('owner-b', client: failingClient);
+
+    expect(runtime.isResolvedForOwner, isTrue);
+    expect(runtime.hasAuthoritativeControl, isFalse);
+    expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+
+    // The owner change discarded owner-a's projection, so there is nothing the
+    // server ever allowed for owner-b to fall back to: no escape hatch, and
+    // owner-a's allow can never be reached through one.
+    expect(runtime.canSkipUnresolvedFence, isFalse);
+    expect(runtime.skipUnresolvedFence(), isFalse);
+    expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+  });
+
+  test('the escape hatch never invents an allow the server has not given', () async {
+    final runtime = AccountCutoverRuntime.instance;
+    final pending = Completer<AccountCutoverFetchResult>();
+    unawaited(
+      runtime.bindAuthenticatedOwner('owner-a', client: AccountCutoverControlClient(fetch: () => pending.future)),
+    );
+
+    // The owner's first fetch has not landed, so the fence has no
+    // server-allowed projection to fall back to: it must hold.
+    expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+    expect(runtime.canSkipUnresolvedFence, isFalse);
+    expect(runtime.skipUnresolvedFence(), isFalse);
+    expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+
+    // Same once the server answers with a fence of its own.
+    final fenced = AccountCutoverControl.fromJson(
+      _validControlJson(state: 'migrating', clientAction: 'migration_maintenance', productTrafficAllowed: false),
+    );
+    pending.complete(AccountCutoverFetchResult.success(fenced));
+    await Future<void>.delayed(Duration.zero);
+    expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+    expect(runtime.canSkipUnresolvedFence, isFalse);
+    expect(runtime.skipUnresolvedFence(), isFalse);
+    expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+  });
+
+  test('a transport blip after an authoritative allow does NOT fence (stays on last-known-good)', () async {
+    final runtime = AccountCutoverRuntime.instance;
+    final legacy = AccountCutoverControl.fromJson(_validControlJson(accountGeneration: 5));
+    var fetches = 0;
+    final client = AccountCutoverControlClient(
+      fetch: () async {
+        fetches++;
+        if (fetches == 1) return AccountCutoverFetchResult.success(legacy);
+        return const AccountCutoverFetchResult.transportFailure();
+      },
+    );
+
+    await runtime.bindAuthenticatedOwner('owner-a', client: client);
+    expect(runtime.decision, AccountCutoverGateDecision.allowProductTraffic);
+
+    // Regression: one timed-out control refresh used to synthesize a
+    // maintenance fence with no exit, while the server kept answering
+    // legacy/none the whole time.
+    await runtime.refresh(client: client);
+    expect(runtime.decision, AccountCutoverGateDecision.allowProductTraffic);
+    expect(runtime.control.accountGeneration, 5);
+    expect(runtime.canSkipUnresolvedFence, isTrue);
+  });
+
+  test('an explicit 503 after an authoritative allow fences but keeps the escape hatch', () async {
+    final runtime = AccountCutoverRuntime.instance;
+    final legacy = AccountCutoverControl.fromJson(_validControlJson(accountGeneration: 5));
+    var fetches = 0;
+    final client = AccountCutoverControlClient(
+      fetch: () async {
+        fetches++;
+        if (fetches == 1) return AccountCutoverFetchResult.success(legacy);
+        return const AccountCutoverFetchResult.unavailable();
+      },
+    );
+
+    await runtime.bindAuthenticatedOwner('owner-a', client: client);
+    await runtime.refresh(client: client);
+
+    // The server explicitly failed closed — respect the fence...
+    expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+    // ...but it never authoritatively said "migrating", so the fence is
+    // unconfirmed and the user can skip back to the last-known-good state.
+    expect(runtime.canSkipUnresolvedFence, isTrue);
+    expect(runtime.skipUnresolvedFence(), isTrue);
+    expect(runtime.decision, AccountCutoverGateDecision.allowProductTraffic);
+    expect(runtime.control.accountGeneration, 5);
+  });
+
+  test('a server-confirmed fence refuses the escape hatch across outages', () async {
+    final runtime = AccountCutoverRuntime.instance;
+    final migrating = AccountCutoverControl.fromJson(
+      _validControlJson(
+        state: 'migrating',
+        accountGeneration: 9,
+        clientAction: 'migration_maintenance',
+        offlineQueueInstruction: 'quarantine',
+        productTrafficAllowed: false,
+        legacyWritesAllowed: false,
+      ),
+    );
+    var fetches = 0;
+    final client = AccountCutoverControlClient(
+      fetch: () async {
+        fetches++;
+        if (fetches == 1) return AccountCutoverFetchResult.success(migrating);
+        return const AccountCutoverFetchResult.transportFailure();
+      },
+    );
+
+    await runtime.bindAuthenticatedOwner('owner-a', client: client);
+    await runtime.refresh(client: client);
+
+    expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+    expect(runtime.canSkipUnresolvedFence, isFalse);
+    expect(runtime.skipUnresolvedFence(), isFalse);
+    expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+  });
+
   test('owner transition clears prior account state and ignores stale in-flight results', () async {
     final runtime = AccountCutoverRuntime.instance;
     final pendingFirst = Completer<AccountCutoverFetchResult>();

--- a/app/test/widgets/account_cutover_fence_test.dart
+++ b/app/test/widgets/account_cutover_fence_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/services/account_cutover/account_cutover_blocking_gate.dart';
+import 'package:omi/services/account_cutover/account_cutover_control.dart';
+import 'package:omi/services/account_cutover/account_cutover_control_client.dart';
+import 'package:omi/services/account_cutover/account_cutover_gate.dart';
+import 'package:omi/services/account_cutover/account_cutover_runtime.dart';
+
+AccountCutoverControl _control({
+  String state = 'legacy',
+  int accountGeneration = 0,
+  String clientAction = 'none',
+  bool productTrafficAllowed = true,
+  bool legacyWritesAllowed = true,
+}) {
+  return AccountCutoverControl.fromJson({
+    'state': state,
+    'account_generation': accountGeneration,
+    'ui_generation': accountGeneration,
+    'api_generation': accountGeneration,
+    'client_action': clientAction,
+    'offline_queue_instruction': productTrafficAllowed ? 'none' : 'quarantine',
+    'product_traffic_allowed': productTrafficAllowed,
+    'legacy_writes_allowed': legacyWritesAllowed,
+    'auth_bootstrap_reachable': true,
+    'stranded_new_data': false,
+  });
+}
+
+Future<void> _pumpGate(WidgetTester tester) async {
+  await tester.pumpWidget(
+    const MaterialApp(
+      localizationsDelegates: [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: AccountCutoverBlockingGate(child: Text('product')),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  setUp(() {
+    AccountCutoverRuntime.instance.resetForTesting();
+  });
+
+  tearDown(() {
+    AccountCutoverRuntime.instance.resetForTesting();
+  });
+
+  testWidgets('a fence the server never confirmed keeps a working escape hatch', (tester) async {
+    final runtime = AccountCutoverRuntime.instance;
+    // The server authoritatively allowed product traffic, then a single
+    // refresh failed closed (control-plane 503 / unparseable body).
+    runtime.apply(_control(accountGeneration: 5));
+    runtime.applyFetchResult(const AccountCutoverFetchResult.unavailable());
+
+    await _pumpGate(tester);
+
+    // The fence is correct — it fails closed — but the server never asked for
+    // a migration, so this screen must not be a dead end.
+    expect(find.text('product'), findsNothing);
+    expect(find.byType(TextButton), findsOneWidget);
+
+    await tester.tap(find.byType(TextButton));
+    await tester.pump();
+
+    expect(find.text('product'), findsOneWidget);
+    // Skip restores the last projection the server actually sent, not a blank
+    // legacy default that would forget the account generation.
+    expect(runtime.control.accountGeneration, 5);
+
+    // Unmount so the gate cancels its fence-refresh timer.
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('the escape hatch is hidden only while the server itself confirms the fence', (tester) async {
+    final runtime = AccountCutoverRuntime.instance;
+    // A migration the server authoritatively declared: no way around it.
+    runtime.apply(
+      _control(
+        state: 'migrating',
+        accountGeneration: 9,
+        clientAction: 'migration_maintenance',
+        productTrafficAllowed: false,
+        legacyWritesAllowed: false,
+      ),
+    );
+
+    await _pumpGate(tester);
+
+    expect(find.text('product'), findsNothing);
+    expect(find.byType(TextButton), findsNothing);
+
+    // Same widget, same screen, different cause: the server answers "allow"
+    // for this owner and a later refresh then fails closed. That fence was
+    // synthesized by the client, so the escape hatch must come back.
+    var fetches = 0;
+    final client = AccountCutoverControlClient(
+      fetch: () async {
+        fetches++;
+        if (fetches == 1) return AccountCutoverFetchResult.success(_control(accountGeneration: 5));
+        return const AccountCutoverFetchResult.unavailable();
+      },
+    );
+
+    await runtime.bindAuthenticatedOwner('owner-a', client: client);
+    await tester.pump();
+    expect(find.text('product'), findsOneWidget);
+
+    await runtime.refresh(client: client);
+    await tester.pump();
+
+    expect(find.text('product'), findsNothing);
+    expect(find.byType(TextButton), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('the fence re-fetches control every 30s and lifts itself when the server recovers', (tester) async {
+    final runtime = AccountCutoverRuntime.instance;
+    var fetches = 0;
+    final client = AccountCutoverControlClient(
+      fetch: () async {
+        fetches++;
+        // Two failed control fetches, then the control plane comes back.
+        if (fetches <= 2) return const AccountCutoverFetchResult.unavailable();
+        return AccountCutoverFetchResult.success(_control());
+      },
+    );
+    // The gate's retry loop calls the parameterless refresh(); point that at
+    // the scripted client instead of the network.
+    AccountCutoverRuntime.controlClientOverrideForTesting = client;
+
+    await runtime.bindAuthenticatedOwner('owner-a');
+    expect(fetches, 1);
+    expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+
+    await _pumpGate(tester);
+    expect(find.text('product'), findsNothing);
+    // The server has never allowed this owner, so there is no escape hatch to
+    // fall back on: retrying is the only way this screen can ever clear.
+    expect(find.byType(TextButton), findsNothing);
+
+    // Nothing else in the app re-fetches control while product traffic is
+    // blocked, so the fence can only lift if the gate retries by itself.
+    await tester.pump(const Duration(seconds: 29));
+    expect(fetches, 1);
+    expect(find.text('product'), findsNothing);
+
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump();
+    expect(fetches, 2);
+    expect(find.text('product'), findsNothing);
+
+    await tester.pump(const Duration(seconds: 30));
+    await tester.pump();
+    expect(fetches, 3);
+    expect(find.text('product'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+}


### PR DESCRIPTION
## What changed and why

Losing the network on a cold start can strand the app behind the account-migration screen with no
exit and no retry, while the server is not asking for a migration at all — it keeps answering
`state: legacy` / `client_action: none`. Force-stopping the app is the only way out, and the next
cold start can land in the same place.

Two independent paths produce that dead end.

`bindAuthenticatedOwner()` synchronously poisoned `_control` to `unavailable()` (client action
`migration_maintenance`) on ANY owner change. That synchronous fence exists to stop account A's
stale "allow" from leaking into account B's session while B's fetch is in flight — but the very
first bind of a fresh runtime is also an "owner change" (`null` → uid), and there is no prior
decision to leak there. `applyFetchResult` has a fallback for exactly that case ("no authoritative
projection yet: stay legacy-compatible"), but it re-derives its decision from `_control`, which the
bind has already poisoned, so on a cold start it could never fire.

Separately, the blocking screen offered no way out once ANY authoritative projection had been seen
— even when the projection that had been seen said ALLOW. After one successful `legacy`/`none`
fetch that flag is true forever, so a single blown refresh synthesized a "Migration in progress"
screen the server had never asked for. Nothing lifted it either: product traffic is blocked while
the fence is up, so no other code path re-fetches the control document and the app cannot notice
the server answering again.

The contract this restores: a fence only stands on the server's own word, and no fence is permanent
while the server disagrees.

- `AccountCutoverRuntime` tracks the last authoritative projection and exposes
  `canSkipUnresolvedFence` — true only while this client synthesized the fence AND the server had
  authoritatively allowed the owner. It is cleared on owner change and on sign-out, so nothing leaks
  across accounts, including as the last-known-good a skip could return to.
- `bindAuthenticatedOwner` fences synchronously only on a genuine owner switch. A real
  owner-to-owner switch still fences immediately and stays fenced on failure, preserving the
  documented anti-leak property.
- `applyFetchResult`: a transport failure after an authoritative ALLOW stays on the last-known-good
  projection instead of synthesizing a maintenance fence — a blip is not evidence of a migration.
  An explicit 503 still fences (the server said so), and a fence-state prior (`migrating`, `new`,
  `rolled_back_stranded`) still fails closed across an outage. Both unchanged.
- `skipUnresolvedFence()` returns to that last authoritative projection and nothing else. It is a
  no-op whenever there is no server-sent allow to go back to — a server-decided fence, an
  unavailable or malformed document before any allow, or an owner whose first fetch has not landed
  — so it can never synthesize a legacy projection of its own.
- `AccountCutoverBlockingGate` becomes stateful and re-fetches the control document every 30s while
  any fence is on screen. That is what lets a transient-outage fence lift on its own, a fence with
  no escape hatch clear at all, and a real migration fence lift as soon as the migration finishes.

## Product invariants affected

INV-CUTOVER-1

The locked contract is unchanged, and the escape hatch is deliberately scoped so it stays that way.
State is still discovered only through the authenticated cutover control projection; a malformed or
unavailable document still fences; a `migrating` / `new` / `rolled_back_stranded` projection still
fails closed across an outage; and because the skip can only restore a projection the server itself
sent, nothing here can present a legacy projection as an answer the server never gave. The one
behaviour that changes is which fences are permanent: a fence this client synthesized on top of a
server "allow" is no longer one of them.

## How it was verified

`app/test/unit/account_cutover_gate_test.dart` and `app/test/widgets/account_cutover_fence_test.dart`
pass (22 tests), and so does the rest of `bash app/test.sh` (1463 passed, 5 skipped).
`bash app/scripts/analyze_ratchet.sh` passes. `dart format --line-length 120
--set-exit-if-changed` is clean on all four files, and `flutter analyze` reports no issues for
`lib/services/account_cutover` and both test files.

The three widget tests were run against the unmodified `lib/` to confirm they describe behaviour
that does not exist yet: all three fail there — two because the blocking screen renders no
`TextButton` at all, and the retry test because the fetch counter is still 1 after 30 simulated
seconds.

The unit tests assert on API this PR introduces, so they cannot run against the old code. They were
checked by mutation instead — each mutation reverts exactly one behaviour and leaves the rest
intact:

- fencing unconditionally on any owner change → the cold-start recovery test goes red;
- dropping the "transport failure after an authoritative allow" branch → the transport-blip test
  goes red;
- keying the skip affordance to `hasAuthoritativeControl` again → all three widget tests go red;
- removing the gate's 30s retry → the retry test goes red;
- restoring the old skip semantics (`_hasAuthoritative` guard, blank legacy default) → the
  owner-switch, escape-hatch and 503 tests and the first widget test go red;
- letting the skip fall back to a legacy default when there is nothing to return to → the
  owner-switch, escape-hatch and server-confirmed-fence tests go red;
- letting the previous owner's projection survive an owner change → the owner-switch test goes red.

Not exercised on a device; the incident path is reproduced in the widget tests.

## Tests

`app/test/widgets/account_cutover_fence_test.dart` — new, 3 tests over the real
`AccountCutoverBlockingGate`:

- a fence the server never confirmed (authoritative allow, then a 503 on refresh) renders the skip
  affordance, and pressing it returns to product traffic on the last projection the server actually
  sent — `account_generation` is preserved, not reset. This is the regression: that screen used to
  render with no way out at all.
- the escape hatch is hidden only while the server itself confirms the fence — a server-declared
  `migrating` projection renders without it, and on the same mounted widget an
  allow-then-failed-refresh fence brings it back.
- the fence re-fetches the control document every 30s and lifts itself when the server recovers:
  no fetch at 29s, one at 30s (server still down, fence holds), a third at 60s that succeeds and
  clears the screen. That fence has no escape hatch at all — the server never allowed this owner —
  so the retry is the only thing that can clear it.

`app/test/unit/account_cutover_gate_test.dart` — 6 added tests:

- the first bind of a fresh runtime recovers to legacy-compatible after a transport failure (the
  cold-start half of the bug);
- a genuine owner switch still stays fenced across a transport failure, and gets no escape hatch,
  because the previous owner's projection was discarded and there is nothing this owner was ever
  allowed to fall back to;
- the escape hatch never invents an allow the server has not given — refused while the owner's
  first fetch is still in flight, and refused once the server answers `migrating`;
- a transport blip after an authoritative allow does not fence and keeps the last-known-good
  generation;
- an explicit 503 after an authoritative allow does fence, but that fence stays skippable back to
  the last-known-good projection;
- a server-confirmed fence refuses the escape hatch across an outage.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

