### PR TITLE
feat: expose agent-controlled historical facts

### DIFF
--- a/backend/tests/unit/test_knowledge_ledger_tools.py
+++ b/backend/tests/unit/test_knowledge_ledger_tools.py
@@ -199,22 +199,45 @@ def test_search_historical_facts_is_fact_only_owner_scoped_and_partial(monkeypat
         invalid_at=NOW,
         is_locked=True,
     )
+    rejected = _memory(
+        "historical-rejected",
+        kind=MemoryKind.fact,
+        content="Rejected Boston claim",
+        user_review=False,
+    )
+    migrated_legacy = _memory(
+        "historical-legacy",
+        kind=MemoryKind.fact,
+        content="Generated Boston history",
+        intent_backed=False,
+        write_reason=LedgerWriteReason.legacy_migration,
+    )
+    passive = _memory(
+        "historical-passive",
+        kind=MemoryKind.fact,
+        content="Unratified passive Boston extraction",
+        intent_backed=False,
+    )
 
     class FakeService:
         def __init__(self, *, db_client):
             assert db_client == "db"
 
-        def search_ledger_history_page(self, uid, query, *, limit):
-            assert (uid, query, limit) == ("u1", "Boston", 8)
+        def search_ledger_history_page(self, uid, query, *, limit, offset, include_rejected):
+            assert (uid, query, limit, offset, include_rejected) == ("u1", "Boston", 8, 0, False)
             return SimpleNamespace(
                 matches=[
                     SimpleNamespace(memory=fact),
                     SimpleNamespace(memory=document),
                     SimpleNamespace(memory=trigger),
                     SimpleNamespace(memory=locked),
+                    SimpleNamespace(memory=rejected),
+                    SimpleNamespace(memory=migrated_legacy),
+                    SimpleNamespace(memory=passive),
                 ],
                 truncated=True,
                 scanned_count=501,
+                next_offset=8,
             )
 
     monkeypatch.setattr(database_client, "get_firestore_client", lambda: "db")
@@ -231,10 +254,16 @@ def test_search_historical_facts_is_fact_only_owner_scoped_and_partial(monkeypat
     assert "private workflow body" not in result
     assert "historical-trigger" not in result
     assert "historical-locked" not in result
+    assert "historical-rejected" not in result
+    assert "historical-legacy" in result
+    assert "fact/legacy-migrated" in result
+    assert "historical-passive" not in result
     assert "valid_at=2026-08-23T12:00:00+00:00" in result
     assert "invalid_at=2026-08-23T12:00:00+00:00" in result
     assert "Partial historical search" in result
     assert "not exhaustive" in result
+    assert "offset=8" in result
+    assert tools.HISTORICAL_LIVE_WINDOW_NOTICE in result
 
 
 def test_historical_fact_renderer_hard_cap_preserves_both_disclosures():
@@ -249,11 +278,20 @@ def test_historical_fact_renderer_hard_cap_preserves_both_disclosures():
         for index in range(30)
     ]
 
-    result = tools._format_historical_fact_results(rows, query="Boston", truncated=True)
+    result = tools._format_historical_fact_results(
+        rows,
+        query="Boston",
+        truncated=True,
+        next_offset=20,
+        include_rejected=True,
+    )
 
     assert len(result) <= tools.MAX_KNOWLEDGE_RESULT_CHARACTERS
     assert tools.HISTORICAL_OUTPUT_TRUNCATION_NOTICE in result
     assert tools.HISTORICAL_PROVIDER_PARTIAL_NOTICE in result
+    assert "offset=20" in result
+    assert tools.HISTORICAL_LIVE_WINDOW_NOTICE in result
+    assert tools.HISTORICAL_REJECTED_AUDIT_NOTICE in result
 
 
 def test_search_historical_facts_rejects_unsearchable_and_oversized_requests(monkeypatch):
@@ -266,13 +304,58 @@ def test_search_historical_facts_rejects_unsearchable_and_oversized_requests(mon
     config = {"configurable": {"user_id": "u1"}}
 
     assert tools.search_historical_facts.invoke({"query": "!"}, config=config).startswith("Error:")
-    service.search_ledger_history_page.assert_called_once_with("u1", "!", limit=8)
+    service.search_ledger_history_page.assert_called_once_with(
+        "u1",
+        "!",
+        limit=8,
+        offset=0,
+        include_rejected=False,
+    )
     service.search_ledger_history_page.reset_mock()
     assert tools.search_historical_facts.invoke({"query": "Boston", "limit": 0}, config=config).startswith("Error:")
     assert tools.search_historical_facts.invoke(
         {"query": "Boston", "limit": tools.MAX_KNOWLEDGE_SEARCH_LIMIT + 1}, config=config
     ).startswith("Error:")
+    assert tools.search_historical_facts.invoke(
+        {"query": "Boston", "limit": 8, "offset": 495}, config=config
+    ).startswith("Error:")
     service.search_ledger_history_page.assert_not_called()
+
+
+def test_search_historical_facts_requires_explicit_rejected_audit(monkeypatch):
+    import database._client as database_client
+
+    rejected = _memory(
+        "historical-rejected",
+        kind=MemoryKind.fact,
+        content="Rejected Boston claim",
+        user_review=False,
+    )
+
+    class FakeService:
+        def __init__(self, *, db_client):
+            assert db_client == "db"
+
+        def search_ledger_history_page(self, uid, query, *, limit, offset, include_rejected):
+            assert (uid, query, limit, offset, include_rejected) == ("u1", "Boston", 8, 16, True)
+            return SimpleNamespace(
+                matches=[SimpleNamespace(memory=rejected)],
+                truncated=False,
+                scanned_count=1,
+                next_offset=None,
+            )
+
+    monkeypatch.setattr(database_client, "get_firestore_client", lambda: "db")
+    monkeypatch.setattr(tools, "MemoryService", FakeService)
+
+    result = tools.search_historical_facts.invoke(
+        {"query": "Boston", "limit": 8, "offset": 16, "include_rejected": True},
+        config={"configurable": {"user_id": "u1"}},
+    )
+
+    assert "historical-rejected" in result
+    assert "fact/rejected" in result
+    assert tools.HISTORICAL_REJECTED_AUDIT_NOTICE in result
 
 
 def test_tool_errors_do_not_echo_storage_details(monkeypatch):

--- a/backend/tests/unit/test_prompt_cache_integration.py
+++ b/backend/tests/unit/test_prompt_cache_integration.py
@@ -428,6 +428,7 @@ def _get_agentic_module():
         "get_entity_timeline_tool",
         "search_knowledge",
         "read_playbook",
+        "search_historical_facts",
     ]
     for name in tool_names:
         mock_tool = MagicMock()
@@ -661,10 +662,10 @@ def test_static_prefix_exceeds_minimum_cache_tokens():
 # ---------------------------------------------------------------------------
 
 
-def test_core_tools_has_29_tools():
-    """CORE_TOOLS must contain exactly 29 tools (web search is a built-in server tool)."""
+def test_core_tools_has_30_tools():
+    """CORE_TOOLS must contain exactly 30 tools (web search is a built-in server tool)."""
     agentic_mod = _get_agentic_module()
-    assert len(agentic_mod.CORE_TOOLS) == 29, f"CORE_TOOLS has {len(agentic_mod.CORE_TOOLS)} tools, expected 29"
+    assert len(agentic_mod.CORE_TOOLS) == 30, f"CORE_TOOLS has {len(agentic_mod.CORE_TOOLS)} tools, expected 30"
 
 
 def test_core_tools_list_creates_independent_copy():
@@ -687,9 +688,9 @@ def test_core_tools_list_creates_independent_copy():
     mock_app_tool.name = "custom_app_tool"
     tools_a.append(mock_app_tool)
 
-    assert len(tools_a) == 30
-    assert len(tools_b) == 29
-    assert len(agentic_mod.CORE_TOOLS) == 29, "CORE_TOOLS was mutated!"
+    assert len(tools_a) == 31
+    assert len(tools_b) == 30
+    assert len(agentic_mod.CORE_TOOLS) == 30, "CORE_TOOLS was mutated!"
 
 
 def test_core_tools_order_matches_exports():
@@ -729,6 +730,7 @@ def test_core_tools_order_matches_exports():
         "get_entity_timeline_tool",
         "search_knowledge",
         "read_playbook",
+        "search_historical_facts",
     ]
 
     actual_names = [t.name for t in agentic_mod.CORE_TOOLS]
@@ -800,18 +802,20 @@ def test_knowledge_ledger_tools_are_registered_with_progressive_disclosure_names
     for name, display in (
         ("search_knowledge", "Searching current knowledge"),
         ("read_playbook", "Reading playbook"),
+        ("search_historical_facts", "Searching historical facts"),
     ):
         assert name in schema_names
         assert name in tool_registry
         assert agentic_mod.get_tool_display_name(name) == display
 
 
-def test_historical_fact_tool_stays_unregistered_until_policy_gate_is_ratified():
-    """Rejected history cannot activate in ordinary chat before its policy gate is ratified."""
+def test_historical_fact_tool_is_registered_after_policy_ratification():
+    """The agent owns explicit history retrieval; rejected rows remain opt-in audit data."""
     agentic_mod = _get_agentic_module()
 
-    assert "search_historical_facts" not in {tool.name for tool in agentic_mod.CORE_TOOLS}
-    assert "search_historical_facts" not in agentic_mod.STANDARD_TOOL_NAMES
+    tool = next(tool for tool in agentic_mod.CORE_TOOLS if tool.name == "search_historical_facts")
+    assert "search_historical_facts" in agentic_mod.STANDARD_TOOL_NAMES
+    assert agentic_mod.get_tool_display_name(tool.name) == "Searching historical facts"
 
 
 def test_convert_tools_defers_app_tools():

--- a/backend/tests/unit/test_universal_memory_service.py
+++ b/backend/tests/unit/test_universal_memory_service.py
@@ -293,8 +293,10 @@ def test_ledger_history_page_reports_partial_provider_window_and_filters_privacy
     restricted = restricted.model_copy(update={"sensitivity_labels": ["health"]})
     future = _ledger_item(service_mod, "future", updated_at=now - timedelta(minutes=2), user_review=False)
     future = future.model_copy(update={"ledger_schema_version": "knowledge_ledger.v2"})
-    legacy = _ledger_item(service_mod, "legacy", updated_at=now - timedelta(minutes=3), user_review=False)
-    legacy = legacy.model_copy(update={"intent_backed": False})
+    passive = _ledger_item(service_mod, "passive", updated_at=now - timedelta(minutes=3), user_review=False)
+    passive = passive.model_copy(update={"intent_backed": False, "write_reason": None})
+    legacy = _ledger_item(service_mod, "legacy", updated_at=now - timedelta(minutes=4))
+    legacy = legacy.model_copy(update={"intent_backed": False, "write_reason": LedgerWriteReason.legacy_migration})
 
     provider_call = {}
 
@@ -314,10 +316,10 @@ def test_ledger_history_page_reports_partial_provider_window_and_filters_privacy
     monkeypatch.setattr(
         service_mod,
         "iter_authoritative_product_memory_items_newest_first",
-        lambda *args, **kwargs: iter([restricted, future, legacy]),
+        lambda *args, **kwargs: iter([restricted, future, passive, legacy]),
     )
     complete = service_mod.MemoryService(db_client=_Db()).read_ledger_history_page("uid-test", limit=10)
-    assert complete.memories == ()
+    assert [memory.id for memory in complete.memories] == ["legacy"]
     assert complete.truncated is False
 
 
@@ -339,8 +341,13 @@ def test_ledger_history_excludes_locked_rows(service_mod, monkeypatch):
 
 def test_historical_ledger_search_is_deterministic_and_does_not_fallback_to_legacy(service_mod, monkeypatch):
     now = datetime(2026, 8, 23, tzinfo=timezone.utc)
-    older = _ledger_item(service_mod, "older", updated_at=now - timedelta(minutes=1), user_review=False)
-    newer = _ledger_item(service_mod, "newer", updated_at=now, user_review=False)
+    older = _ledger_item(
+        service_mod,
+        "older",
+        updated_at=now - timedelta(minutes=1),
+        valid_to=now - timedelta(minutes=1),
+    )
+    newer = _ledger_item(service_mod, "newer", updated_at=now, valid_to=now)
     monkeypatch.setattr(
         service_mod,
         "iter_authoritative_product_memory_items_newest_first",
@@ -370,7 +377,7 @@ def test_historical_ledger_search_discloses_result_limit_truncation(service_mod,
             service_mod,
             f"home-city-{index}",
             updated_at=now - timedelta(seconds=index),
-            user_review=False,
+            valid_to=now - timedelta(seconds=index),
         )
         for index in range(9)
     ]
@@ -389,12 +396,22 @@ def test_historical_ledger_search_discloses_result_limit_truncation(service_mod,
     assert len(page.matches) == 8
     assert page.truncated is True
     assert page.scanned_count == 9
+    assert page.next_offset == 8
+
+    second_page = service_mod.MemoryService(db_client=_Db()).search_ledger_history_page(
+        "uid-test",
+        "home city",
+        limit=8,
+        offset=8,
+    )
+    assert [match.memory.id for match in second_page.matches] == ["home-city-8"]
+    assert second_page.next_offset is None
 
 
 def test_historical_ledger_search_breaks_same_timestamp_ties_by_memory_id(service_mod, monkeypatch):
     now = datetime(2026, 8, 23, tzinfo=timezone.utc)
-    first = _ledger_item(service_mod, "a-memory", updated_at=now, user_review=False)
-    second = _ledger_item(service_mod, "z-memory", updated_at=now, user_review=False)
+    first = _ledger_item(service_mod, "a-memory", updated_at=now, valid_to=now)
+    second = _ledger_item(service_mod, "z-memory", updated_at=now, valid_to=now)
     monkeypatch.setattr(
         service_mod,
         "iter_authoritative_product_memory_items_newest_first",
@@ -404,6 +421,44 @@ def test_historical_ledger_search_breaks_same_timestamp_ties_by_memory_id(servic
     page = service_mod.MemoryService(db_client=_Db()).search_ledger_history_page("uid-test", "home_city")
 
     assert [match.memory.id for match in page.matches] == ["a-memory", "z-memory"]
+
+
+def test_historical_ledger_search_excludes_rejected_unless_audit_is_explicit(service_mod, monkeypatch):
+    now = datetime(2026, 8, 23, tzinfo=timezone.utc)
+    rejected = _ledger_item(service_mod, "rejected", updated_at=now, user_review=False)
+    closed = _ledger_item(service_mod, "closed", updated_at=now - timedelta(seconds=1), valid_to=now)
+    monkeypatch.setattr(
+        service_mod,
+        "iter_authoritative_product_memory_items_newest_first",
+        lambda *args, **kwargs: iter([rejected, closed]),
+    )
+    service = service_mod.MemoryService(db_client=_Db())
+
+    ordinary = service.search_ledger_history_page("uid-test", "home city")
+    audit = service.search_ledger_history_page("uid-test", "home city", include_rejected=True)
+
+    assert [match.memory.id for match in ordinary.matches] == ["closed"]
+    assert [match.memory.id for match in audit.matches] == ["rejected", "closed"]
+
+
+def test_historical_ledger_search_admits_only_provenance_fenced_migrated_legacy(service_mod, monkeypatch):
+    now = datetime(2026, 8, 23, tzinfo=timezone.utc)
+    migrated = _ledger_item(service_mod, "migrated", updated_at=now)
+    migrated = migrated.model_copy(update={"intent_backed": False, "write_reason": LedgerWriteReason.legacy_migration})
+    passive = _ledger_item(service_mod, "passive", updated_at=now - timedelta(seconds=1))
+    passive = passive.model_copy(update={"intent_backed": False, "write_reason": None})
+    monkeypatch.setattr(
+        service_mod,
+        "iter_authoritative_product_memory_items_newest_first",
+        lambda *args, **kwargs: iter([migrated, passive]),
+    )
+
+    page = service_mod.MemoryService(db_client=_Db()).search_ledger_history_page(
+        "uid-test",
+        "home city",
+    )
+
+    assert [match.memory.id for match in page.matches] == ["migrated"]
 
 
 def test_historical_adapter_uses_injected_firestore_client(service_mod, monkeypatch):

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -202,6 +202,7 @@ class LedgerHistorySearchPage:
     matches: Tuple[MemorySearchMatch, ...]
     truncated: bool
     scanned_count: int
+    next_offset: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -2638,7 +2639,8 @@ class MemoryService:
 
         if item.ledger_schema_version != LEDGER_SCHEMA_VERSION:
             return False
-        if not item.intent_backed:
+        is_preserved_legacy_history = not item.intent_backed and item.write_reason == LedgerWriteReason.legacy_migration
+        if not item.intent_backed and not is_preserved_legacy_history:
             return False
         if item.status in {MemoryItemStatus.hidden, MemoryItemStatus.tombstoned}:
             return False
@@ -2652,7 +2654,12 @@ class MemoryService:
             return False
         # Admit only states the public MemoryDB wire shape can represent. A
         # status-only superseded row would otherwise serialize as current.
-        return row.user_review is False or row.invalid_at is not None or row.superseded_by is not None
+        return (
+            is_preserved_legacy_history
+            or row.user_review is False
+            or row.invalid_at is not None
+            or row.superseded_by is not None
+        )
 
     def read_ledger_history_page(
         self,
@@ -2667,8 +2674,9 @@ class MemoryService:
         This is deliberately separate from ``read``: default product reads
         must continue to hide rejected and closed facts.  The history seam is
         for a user's review/history surfaces and admits only canonical ledger
-        rows that are either explicitly rejected or no longer current.  It
-        never exposes tombstoned/hidden rows and never consults the legacy
+        rows that are explicitly rejected, no longer current, or preserved
+        with ``legacy_migration`` provenance. It never exposes arbitrary
+        passive rows, tombstoned/hidden rows, or the legacy
         ``users/{uid}/memories`` collection.
         """
 
@@ -2725,6 +2733,8 @@ class MemoryService:
         query: str,
         *,
         limit: int = 20,
+        offset: int = 0,
+        include_rejected: bool = False,
         budget: Optional[ListReadBudget] = None,
     ) -> LedgerHistorySearchPage:
         """Search one bounded canonical history provider window.
@@ -2733,6 +2743,9 @@ class MemoryService:
         authoritative canonical window. It does not consult legacy vectors or
         claim exhaustive historical retrieval; callers must surface
         ``truncated`` when the provider window or request budget is incomplete.
+        Offset pagination is deterministic for one live provider snapshot, but
+        concurrent history changes may shift later offsets and must be disclosed
+        by interactive callers.
         """
 
         normalized_query = " ".join((query or "").split()).casefold()
@@ -2740,6 +2753,9 @@ class MemoryService:
         if not terms:
             raise ValueError("historical ledger query must contain a searchable token")
         bounded_limit = max(1, min(int(limit or 20), 20))
+        bounded_offset = max(0, int(offset or 0))
+        if bounded_offset + bounded_limit > MAX_LEDGER_HISTORY_PROVIDER_WINDOW:
+            raise HTTPException(status_code=413, detail="Ledger history search pagination window exceeded")
         page = self.read_ledger_history_page(
             uid,
             limit=MAX_LEDGER_HISTORY_PROVIDER_WINDOW,
@@ -2749,6 +2765,8 @@ class MemoryService:
         matches: List[MemorySearchMatch] = []
         for memory in page.memories:
             if memory.kind != MemoryKind.fact:
+                continue
+            if memory.user_review is False and not include_rejected:
                 continue
             try:
                 arguments_text = json.dumps(memory.arguments, sort_keys=True, default=str)[:4000]
@@ -2772,10 +2790,14 @@ class MemoryService:
             return (-match.score, -value.timestamp(), match.memory.id)
 
         matches.sort(key=sort_key)
+        page_end = bounded_offset + bounded_limit
+        selected = matches[bounded_offset:page_end]
+        next_offset = page_end if page_end < len(matches) else None
         return LedgerHistorySearchPage(
-            matches=tuple(matches[:bounded_limit]),
-            truncated=page.truncated or len(matches) > bounded_limit,
+            matches=tuple(selected),
+            truncated=page.truncated or next_offset is not None,
             scanned_count=page.scanned_count,
+            next_offset=next_offset,
         )
 
     def search_mcp(self, uid: str, query: str, *, limit: int = 5) -> List[McpSearchPayload]:

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -53,6 +53,7 @@ from utils.retrieval.tools import (
     traverse_knowledge_graph_tool,
     get_entity_timeline_tool,
     read_playbook,
+    search_historical_facts,
     search_knowledge,
 )
 from utils.retrieval.tools.app_tools import load_app_tools, get_tool_status_message
@@ -244,6 +245,7 @@ CORE_TOOLS = [
     get_entity_timeline_tool,
     search_knowledge,
     read_playbook,
+    search_historical_facts,
 ]
 
 # Standard tool names (used to detect app tools by exclusion)

--- a/backend/utils/retrieval/tools/knowledge_ledger_tools.py
+++ b/backend/utils/retrieval/tools/knowledge_ledger_tools.py
@@ -20,6 +20,7 @@ from langchain_core.tools import tool  # type: ignore[reportUnknownVariableType]
 from models.memories import MemoryDB
 from models.product_memory import (
     MAX_LEDGER_PLAYBOOK_BODY_CHARACTERS,
+    LedgerWriteReason,
     MemoryAccessPolicy,
     MemoryItem,
     MemoryKind,
@@ -28,7 +29,7 @@ from models.product_memory import (
 from utils.memory.canonical_memory_adapter import read_canonical_memory_item
 from utils.memory.canonical_visibility_filter import filter_canonical_default_visible_items
 from utils.memory.knowledge_ledger import LEDGER_SCHEMA_VERSION
-from utils.memory.memory_service import MemoryService
+from utils.memory.memory_service import MAX_LEDGER_HISTORY_PROVIDER_WINDOW, MemoryService
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +41,12 @@ HISTORICAL_OUTPUT_TRUNCATION_NOTICE = "[Historical output is bounded; use a narr
 HISTORICAL_PROVIDER_PARTIAL_NOTICE = (
     "[Partial historical search: the result limit, canonical provider window, or read budget ended; "
     "this is not exhaustive.]"
+)
+HISTORICAL_REJECTED_AUDIT_NOTICE = (
+    "[Rejected facts are audit-only negative evidence and must not be treated as true user knowledge.]"
+)
+HISTORICAL_LIVE_WINDOW_NOTICE = (
+    "[Pagination traverses a live bounded provider window; concurrent history changes can shift later offsets.]"
 )
 MAX_PLAYBOOK_ID_CHARACTERS = 256
 MAX_PLAYBOOK_DESCRIPTION_CHARACTERS = 600
@@ -143,17 +150,29 @@ def search_current_knowledge(
     ][:limit]
 
 
-def _is_historical_fact_memory(memory: MemoryDB, *, uid: str) -> bool:
+def _is_historical_fact_memory(memory: MemoryDB, *, uid: str, include_rejected: bool) -> bool:
     """Keep the agent seam fact-only even if the service grows new history kinds."""
 
     kind = memory.kind.value if isinstance(memory.kind, MemoryKind) else str(memory.kind or "")
+    write_reason = (
+        memory.write_reason.value
+        if isinstance(memory.write_reason, LedgerWriteReason)
+        else str(memory.write_reason or "")
+    )
+    is_preserved_legacy_history = not memory.intent_backed and write_reason == LedgerWriteReason.legacy_migration.value
     return (
         memory.uid == uid
         and memory.ledger_schema_version == LEDGER_SCHEMA_VERSION
         and kind == MemoryKind.fact.value
-        and memory.intent_backed
+        and (memory.intent_backed or is_preserved_legacy_history)
         and not memory.is_locked
-        and (memory.user_review is False or memory.invalid_at is not None or memory.superseded_by is not None)
+        and (include_rejected or memory.user_review is not False)
+        and (
+            is_preserved_legacy_history
+            or memory.user_review is False
+            or memory.invalid_at is not None
+            or memory.superseded_by is not None
+        )
     )
 
 
@@ -162,6 +181,8 @@ def _format_historical_fact_results(
     *,
     query: str,
     truncated: bool,
+    next_offset: Optional[int],
+    include_rejected: bool,
 ) -> str:
     """Render bounded historical fact handles without claiming exhaustive retrieval."""
 
@@ -174,6 +195,13 @@ def _format_historical_fact_results(
     reserved_footers = [HISTORICAL_OUTPUT_TRUNCATION_NOTICE]
     if truncated:
         reserved_footers.append(HISTORICAL_PROVIDER_PARTIAL_NOTICE)
+    if next_offset is not None:
+        reserved_footers.append(
+            f"[More matching facts are available; call search_historical_facts again with offset={next_offset}.]"
+        )
+        reserved_footers.append(HISTORICAL_LIVE_WINDOW_NOTICE)
+    if include_rejected:
+        reserved_footers.append(HISTORICAL_REJECTED_AUDIT_NOTICE)
 
     def fits(candidate: str) -> bool:
         return len("\n".join(lines + [candidate] + reserved_footers)) <= MAX_KNOWLEDGE_RESULT_CHARACTERS
@@ -181,6 +209,8 @@ def _format_historical_fact_results(
     for row in rows:
         if row.user_review is False:
             state = "rejected"
+        elif row.write_reason == LedgerWriteReason.legacy_migration:
+            state = "legacy-migrated"
         elif row.superseded_by:
             state = "superseded"
         elif row.invalid_at is not None:
@@ -214,6 +244,13 @@ def _format_historical_fact_results(
         lines.append(HISTORICAL_OUTPUT_TRUNCATION_NOTICE)
     if truncated:
         lines.append(HISTORICAL_PROVIDER_PARTIAL_NOTICE)
+    if next_offset is not None:
+        lines.append(
+            f"[More matching facts are available; call search_historical_facts again with offset={next_offset}.]"
+        )
+        lines.append(HISTORICAL_LIVE_WINDOW_NOTICE)
+    if include_rejected:
+        lines.append(HISTORICAL_REJECTED_AUDIT_NOTICE)
     rendered = "\n".join(lines)
     if len(rendered) > MAX_KNOWLEDGE_RESULT_CHARACTERS:
         # The admission check above reserves both notices. Keep a defensive
@@ -225,6 +262,15 @@ def _format_historical_fact_results(
                 "Historical result omitted because the bounded output budget was reached.",
                 HISTORICAL_OUTPUT_TRUNCATION_NOTICE,
                 *([HISTORICAL_PROVIDER_PARTIAL_NOTICE] if truncated else []),
+                *(
+                    [
+                        f"[More matching facts are available; call search_historical_facts again with offset={next_offset}.]"
+                    ]
+                    if next_offset is not None
+                    else []
+                ),
+                *([HISTORICAL_LIVE_WINDOW_NOTICE] if next_offset is not None else []),
+                *([HISTORICAL_REJECTED_AUDIT_NOTICE] if include_rejected else []),
             ]
         )
     return rendered
@@ -305,15 +351,22 @@ def search_knowledge(
 def search_historical_facts(
     query: str,
     limit: int = 8,
+    offset: int = 0,
+    include_rejected: bool = False,
     config: RunnableConfig = None,  # type: ignore[reportAssignmentType]
 ) -> str:
     """Search bounded canonical historical facts for the authenticated owner.
 
-    Matching uses the canonical service's exact lexical token semantics over
-    fact content and structured fact fields.  This tool does not expand aliases,
-    search legacy/vector storage, search playbook bodies or trigger conditions,
-    or claim exhaustive retrieval.  Partial provider-window results are marked
-    explicitly for the agent.
+    Call this tool when your reasoning determines that current knowledge is
+    insufficient and prior states may matter; do not decide from historical
+    keywords alone. Matching uses exact lexical token semantics over fact
+    content and structured fields. Rejected facts are excluded by default;
+    request ``include_rejected`` only for an explicit audit and never treat
+    those rows as true. Canonical rows preserved by legacy migration are
+    labelled historical generated data, not current truth. Use ``offset`` when
+    the response offers a next page. The tool does not expand aliases, search
+    legacy/vector storage, search playbook bodies or trigger conditions, or
+    claim exhaustive retrieval.
     """
 
     normalized_query = " ".join((query or "").split())
@@ -321,6 +374,11 @@ def search_historical_facts(
         return "Error: query must be non-empty and at most 500 characters"
     if limit < 1 or limit > MAX_KNOWLEDGE_SEARCH_LIMIT:
         return f"Error: limit must be between 1 and {MAX_KNOWLEDGE_SEARCH_LIMIT}"
+    if offset < 0 or offset + limit > MAX_LEDGER_HISTORY_PROVIDER_WINDOW:
+        return (
+            "Error: offset must be non-negative and offset plus limit must not exceed "
+            f"{MAX_LEDGER_HISTORY_PROVIDER_WINDOW}"
+        )
     uid = _resolve_uid(config)
     if not uid:
         return "Error: User ID not found in configuration"
@@ -332,12 +390,20 @@ def search_historical_facts(
             uid,
             normalized_query,
             limit=limit,
+            offset=offset,
+            include_rejected=include_rejected,
         )
-        rows = [match.memory for match in page.matches if _is_historical_fact_memory(match.memory, uid=uid)]
+        rows = [
+            match.memory
+            for match in page.matches
+            if _is_historical_fact_memory(match.memory, uid=uid, include_rejected=include_rejected)
+        ]
         return _format_historical_fact_results(
             rows,
             query=normalized_query,
             truncated=page.truncated,
+            next_offset=page.next_offset,
+            include_rejected=include_rejected,
         )
     except ValueError:
         return "Error: historical query must contain a searchable exact token"


### PR DESCRIPTION
## Summary

- register an agent-controlled historical-fact tool without keyword activation
- exclude rejected facts by default and expose them only as labelled audit-only negative evidence
- preserve migrated legacy-generated facts as provenance-fenced historical results while excluding arbitrary passive rows
- add bounded offset pagination with explicit non-exhaustive and live-window disclosures

This is a stacked follow-up to #12084 and must merge after it. It does not activate JIT conversation processing, passive writers, rollout cohorts, deployments, migrations, or deletion.

## Verification

- 136 focused knowledge-ledger, memory-service, and prompt-cache tests
- 3 agent-tool isolation tests
- 6 agent-route response-shape tests
- focused Pyright: 0 errors
- independent Luna review: no P0/P1 findings; all three P2 findings addressed

## Product invariants affected

The history seam remains canonical, owner-scoped, privacy-filtered, bounded, fact-only, and non-exhaustive. Current-memory visibility still requires intent-backed authority; the narrow `legacy_migration` exception exists only in explicit history.

- INV-MEM-3
- INV-MEM-4
- INV-MEM-1

Line-Count-Exception: backend/utils/memory/memory_service.py | 3433 -> 3455 | bounded history pagination and provenance-fenced legacy-history admission must stay at the canonical MemoryService authority
Line-Count-Exception: backend/utils/retrieval/agentic.py | 1586 -> 1588 | the ratified history tool requires one import and one stable CORE_TOOLS registration entry


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

