### PR TITLE
fix(deploy): repair project-ID secret paths that crash the next deploy

### DIFF
--- a/backend/scripts/attach_cloud_run_gmp_sidecar.py
+++ b/backend/scripts/attach_cloud_run_gmp_sidecar.py
@@ -268,6 +268,65 @@ def _validate_expected_literal_env(
             )
 
 
+SECRET_ANNOTATION = 'run.googleapis.com/secrets'
+
+_SECRET_RESOURCE_RE = re.compile(r'^projects/(?P<project>[^/]+)/secrets/(?P<secret>.+)$')
+
+
+def _normalize_secret_resource(resource: str, *, project_number: str) -> str:
+    """Rewrite a secret path that names the project by ID into one naming it by number.
+
+    gcloud validates this annotation against ``^projects/[0-9]{1,19}/secrets/...``.
+    Cloud Run itself accepts a project ID, so an ID written here is stored happily
+    and then crashes the *next* ``gcloud run deploy`` with "Invalid secret path".
+    """
+    match = _SECRET_RESOURCE_RE.match(resource)
+    if not match or match.group('project').isdigit():
+        return resource
+    return f"projects/{project_number}/secrets/{match.group('secret')}"
+
+
+def _parse_secret_annotation(existing: object) -> dict[str, str] | None:
+    """Parse the annotation into {name: resource}, or None when it is absent or malformed.
+
+    Returning None for a malformed value is deliberate: a repair pass must refuse to
+    guess at a shape it does not recognise rather than rewrite it into something new.
+    """
+    if not isinstance(existing, str) or not existing.strip():
+        return None
+    entries: dict[str, str] = {}
+    for raw_entry in existing.split(','):
+        candidate = raw_entry.strip()
+        if not candidate:
+            continue
+        name, separator, resource = candidate.partition(':')
+        if not (name and separator and resource):
+            return None
+        entries[name] = resource
+    return entries or None
+
+
+def _render_secret_annotation(entries: Mapping[str, str]) -> str:
+    return ','.join(f'{name}:{resource}' for name, resource in sorted(entries.items()))
+
+
+def _normalize_secret_annotation(existing: object, *, project_number: str) -> str | None:
+    """Return a repaired annotation, or None when nothing needs to change.
+
+    Normalizes *every* entry, not just the sidecar's own: a bad path under any
+    secret name breaks the same deploy.
+    """
+    entries = _parse_secret_annotation(existing)
+    if entries is None:
+        return None
+    repaired = {
+        name: _normalize_secret_resource(resource, project_number=project_number) for name, resource in entries.items()
+    }
+    if repaired == entries:
+        return None
+    return _render_secret_annotation(repaired)
+
+
 def _merge_secret_annotation(existing: object, *, project_number: str, secret: str) -> str:
     entries: dict[str, str] = {}
     if isinstance(existing, str):
@@ -275,8 +334,11 @@ def _merge_secret_annotation(existing: object, *, project_number: str, secret: s
             name, separator, resource = raw_entry.strip().partition(':')
             if name and separator and resource:
                 entries[name] = resource
+    entries = {
+        name: _normalize_secret_resource(resource, project_number=project_number) for name, resource in entries.items()
+    }
     entries[secret] = f'projects/{project_number}/secrets/{secret}'
-    return ','.join(f'{name}:{resource}' for name, resource in sorted(entries.items()))
+    return _render_secret_annotation(entries)
 
 
 def _merge_container_dependencies(existing: object, *, ingress_container_name: str) -> str:
@@ -336,8 +398,8 @@ def patch_service(
         template_annotations.get('run.googleapis.com/container-dependencies'),
         ingress_container_name=ingress_container_name,
     )
-    template_annotations['run.googleapis.com/secrets'] = _merge_secret_annotation(
-        template_annotations.get('run.googleapis.com/secrets'),
+    template_annotations[SECRET_ANNOTATION] = _merge_secret_annotation(
+        template_annotations.get(SECRET_ANNOTATION),
         project_number=project_number,
         secret=config_secret,
     )
@@ -527,23 +589,174 @@ def attach_sidecar(args: argparse.Namespace) -> None:
     print(f'Attached pinned GMP sidecar to zero-traffic revision {args.final_revision}')
 
 
+def repair_secret_annotations(args: argparse.Namespace) -> int:
+    """Rewrite project-ID secret paths on a live service into project-number paths.
+
+    A previous sidecar attach persisted `projects/<id>/secrets/...` into the
+    template annotation. Cloud Run stored it, but every subsequent
+    `gcloud run deploy` on that service crashes with "Invalid secret path", so no
+    code change can unblock a deploy - the damage is in the live service and has
+    to be repaired there.
+
+    Idempotent: when nothing needs repair it reports so and writes nothing.
+    """
+    project_number = _project_number(args.project)
+    export = _run(
+        [
+            'gcloud',
+            'run',
+            'services',
+            'describe',
+            args.service,
+            '--project',
+            args.project,
+            '--region',
+            args.region,
+            '--format=export',
+        ],
+        capture_output=True,
+    )
+    service = yaml.load(_check(export, action=f'exporting {args.service}'), Loader=GcloudExportLoader)
+    if not isinstance(service, dict):
+        raise RuntimeError('Cloud Run service export was not a mapping')
+
+    scopes: list[tuple[str, dict[str, Any]]] = []
+    service_meta = service.get('metadata')
+    if isinstance(service_meta, dict) and isinstance(service_meta.get('annotations'), dict):
+        scopes.append(('service', cast(dict[str, Any], service_meta['annotations'])))
+    template = service.get('spec', {}).get('template') if isinstance(service.get('spec'), dict) else None
+    if isinstance(template, dict):
+        template_meta = template.get('metadata')
+        if isinstance(template_meta, dict) and isinstance(template_meta.get('annotations'), dict):
+            scopes.append(('template', cast(dict[str, Any], template_meta['annotations'])))
+
+    changes: list[str] = []
+    for scope, annotations in scopes:
+        current = annotations.get(SECRET_ANNOTATION)
+        if current is None:
+            continue
+        repaired = _normalize_secret_annotation(current, project_number=project_number)
+        if repaired is None:
+            if _parse_secret_annotation(current) is None:
+                print(f'[{scope}] {SECRET_ANNOTATION} is absent or unrecognised; leaving it untouched')
+            else:
+                print(f'[{scope}] {SECRET_ANNOTATION} already uses project numbers; no change')
+            continue
+        changes.append(f'[{scope}] {current}  ->  {repaired}')
+        annotations[SECRET_ANNOTATION] = repaired
+
+    if not changes:
+        print(f'{args.service} needs no secret-annotation repair')
+        return 0
+
+    for change in changes:
+        print(change)
+    if args.dry_run:
+        print('--dry-run: no changes applied')
+        return 0
+
+    path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile('w', prefix='cloud-run-repair-', suffix='.yaml', delete=False) as handle:
+            path = Path(handle.name)
+            os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+            yaml.safe_dump(service, handle, sort_keys=False)
+        replace = _run(
+            [
+                'gcloud',
+                'run',
+                'services',
+                'replace',
+                str(path),
+                '--project',
+                args.project,
+                '--region',
+                args.region,
+                '--format=json',
+            ],
+            capture_output=True,
+        )
+        _check(replace, action=f'repairing secret annotations on {args.service}')
+    finally:
+        if path is not None:
+            path.unlink(missing_ok=True)
+
+    verify = _run(
+        [
+            'gcloud',
+            'run',
+            'services',
+            'describe',
+            args.service,
+            '--project',
+            args.project,
+            '--region',
+            args.region,
+            '--format=export',
+        ],
+        capture_output=True,
+    )
+    after = yaml.load(_check(verify, action=f're-reading {args.service}'), Loader=GcloudExportLoader)
+    if not isinstance(after, dict):
+        raise RuntimeError('Cloud Run service re-read was not a mapping')
+    for scope, annotations in (
+        ('service', after.get('metadata', {}).get('annotations', {})),
+        ('template', after.get('spec', {}).get('template', {}).get('metadata', {}).get('annotations', {})),
+    ):
+        current = annotations.get(SECRET_ANNOTATION) if isinstance(annotations, dict) else None
+        if current is None:
+            continue
+        if _normalize_secret_annotation(current, project_number=project_number) is not None:
+            raise RuntimeError(f'[{scope}] {SECRET_ANNOTATION} still needs repair after replace: {current}')
+    print(f'Repaired secret annotations on {args.service}')
+    return 0
+
+
+_ATTACH_REQUIRED = (
+    'base_revision',
+    'final_revision',
+    'ingress_container',
+    'config',
+    'expected_env_state',
+)
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument('--project', required=True)
     parser.add_argument('--region', default='us-central1')
     parser.add_argument('--service', required=True)
-    parser.add_argument('--base-revision', required=True)
-    parser.add_argument('--final-revision', required=True)
-    parser.add_argument('--ingress-container', required=True)
-    parser.add_argument('--config', type=Path, required=True)
+    # Attach-only. Not argparse-required so --repair-secret-annotations can run
+    # standalone; main() enforces them for the attach path instead.
+    parser.add_argument('--base-revision')
+    parser.add_argument('--final-revision')
+    parser.add_argument('--ingress-container')
+    parser.add_argument('--config', type=Path)
     parser.add_argument('--config-secret', default='cloud-run-gmp-config')
-    parser.add_argument('--expected-env-state', type=Path, required=True)
+    parser.add_argument('--expected-env-state', type=Path)
     parser.add_argument('--tag', default='')
+    parser.add_argument(
+        '--repair-secret-annotations',
+        action='store_true',
+        help='Repair project-ID secret paths on the live service and exit. Does not attach a sidecar.',
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='With --repair-secret-annotations, report the change without applying it.',
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
+    if args.repair_secret_annotations:
+        return repair_secret_annotations(args)
+    if args.dry_run:
+        raise SystemExit('--dry-run is only supported with --repair-secret-annotations')
+    missing = [f"--{name.replace('_', '-')}" for name in _ATTACH_REQUIRED if getattr(args, name) is None]
+    if missing:
+        raise SystemExit(f"attach mode requires: {', '.join(missing)}")
     if not args.config.is_file():
         raise SystemExit(f'RunMonitoring config not found: {args.config}')
     attach_sidecar(args)

--- a/backend/tests/unit/test_attach_cloud_run_gmp_sidecar.py
+++ b/backend/tests/unit/test_attach_cloud_run_gmp_sidecar.py
@@ -389,3 +389,105 @@ spec:
 
     assert not any(args[1:4] == ['run', 'services', 'replace'] for args in calls)
     assert secret_calls == []
+
+
+# A project ID in run.googleapis.com/secrets crashes the NEXT gcloud run deploy.
+# Cloud Run accepts the ID and stores it, so nothing fails at attach time and the
+# breakage lands on whoever deploys next. Production carried
+# `cloud-run-gmp-config:projects/based-hardware/secrets/cloud-run-gmp-config` and
+# every deploy died with "Invalid secret path" until the live service was repaired.
+PROJECT_NUMBER = '208440318997'
+
+
+def test_project_id_path_is_rewritten_to_project_number():
+    module = _load_module()
+    repaired = module._normalize_secret_annotation(
+        'cloud-run-gmp-config:projects/based-hardware/secrets/cloud-run-gmp-config',
+        project_number=PROJECT_NUMBER,
+    )
+    assert repaired == f'cloud-run-gmp-config:projects/{PROJECT_NUMBER}/secrets/cloud-run-gmp-config'
+
+
+def test_already_numeric_path_needs_no_change():
+    module = _load_module()
+    annotation = f'cloud-run-gmp-config:projects/{PROJECT_NUMBER}/secrets/cloud-run-gmp-config'
+    assert module._normalize_secret_annotation(annotation, project_number=PROJECT_NUMBER) is None
+
+
+def test_every_entry_is_repaired_not_just_the_sidecar_secret():
+    module = _load_module()
+    repaired = module._normalize_secret_annotation(
+        'other-secret:projects/based-hardware/secrets/other-secret,'
+        f'cloud-run-gmp-config:projects/{PROJECT_NUMBER}/secrets/cloud-run-gmp-config',
+        project_number=PROJECT_NUMBER,
+    )
+    assert repaired == (
+        f'cloud-run-gmp-config:projects/{PROJECT_NUMBER}/secrets/cloud-run-gmp-config,'
+        f'other-secret:projects/{PROJECT_NUMBER}/secrets/other-secret'
+    )
+
+
+@pytest.mark.parametrize('value', ['not-an-entry', '', None])
+def test_unrecognised_annotation_is_left_alone_rather_than_guessed_at(value):
+    module = _load_module()
+    assert module._normalize_secret_annotation(value, project_number=PROJECT_NUMBER) is None
+
+
+def test_attach_merge_heals_a_stale_entry_for_another_secret():
+    module = _load_module()
+    merged = module._merge_secret_annotation(
+        'other-secret:projects/based-hardware/secrets/other-secret',
+        project_number=PROJECT_NUMBER,
+        secret='cloud-run-gmp-config',
+    )
+    assert 'projects/based-hardware/' not in merged
+    assert f'other-secret:projects/{PROJECT_NUMBER}/secrets/other-secret' in merged
+
+
+def test_repair_is_a_no_op_when_the_annotation_is_already_correct(monkeypatch):
+    """Idempotence: a second repair run must not issue a services replace."""
+    module = _load_module()
+    good = f'cloud-run-gmp-config:projects/{PROJECT_NUMBER}/secrets/cloud-run-gmp-config'
+    service = {
+        'metadata': {'name': 'backend'},
+        'spec': {'template': {'metadata': {'annotations': {module.SECRET_ANNOTATION: good}}}},
+    }
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        if 'describe' in argv:
+            return SimpleNamespace(returncode=0, stdout=yaml.safe_dump(service), stderr='')
+        raise AssertionError(f'unexpected gcloud call: {argv}')
+
+    monkeypatch.setattr(module, '_run', fake_run)
+    monkeypatch.setattr(module, '_project_number', lambda project: PROJECT_NUMBER)
+    args = SimpleNamespace(project='based-hardware', region='us-central1', service='backend', dry_run=False)
+    assert module.repair_secret_annotations(args) == 0
+    assert not any('replace' in argv for argv in calls)
+
+
+# gcloud's own validation rule, copied verbatim from googlecloudsdk's secret-path
+# parser so a vendor upgrade that tightens it fails here rather than on the next
+# production deploy. This is the strict consumer that FC-metadata-format-validated-
+# only-on-next-read exists for: Cloud Run's API accepts a project ID here, gcloud
+# does not, and the mismatch surfaces on an unrelated later deploy.
+GCLOUD_SECRET_PATH_RULE = re.compile(r'^projects/[0-9]{1,19}/secrets/[^/:]+$')
+
+
+@pytest.mark.parametrize(
+    'existing',
+    [
+        None,
+        '',
+        'cloud-run-gmp-config:projects/based-hardware/secrets/cloud-run-gmp-config',
+        'other-secret:projects/based-hardware/secrets/other-secret',
+        f'cloud-run-gmp-config:projects/{PROJECT_NUMBER}/secrets/cloud-run-gmp-config',
+    ],
+)
+def test_every_written_entry_satisfies_gclouds_actual_rule(existing):
+    module = _load_module()
+    merged = module._merge_secret_annotation(existing, project_number=PROJECT_NUMBER, secret='cloud-run-gmp-config')
+    for entry in merged.split(','):
+        _, _, resource = entry.partition(':')
+        assert GCLOUD_SECRET_PATH_RULE.match(resource), f'gcloud would reject {resource!r}'


### PR DESCRIPTION
## What changed and why

Production backend deploys crash before they can promote traffic:

```
ERROR: gcloud crashed (ValueError): Invalid secret path
  'projects/based-hardware/secrets/cloud-run-gmp-config' in annotation
```

An earlier GMP sidecar attach wrote the `run.googleapis.com/secrets` annotation naming the project by **ID**. gcloud validates that annotation against `^projects/[0-9]{1,19}/secrets/...`, so an ID never matches. Cloud Run's own API accepts either form and stored it happily, which is why nothing failed at attach time — the failure lands on whoever deploys next, pointing away from the change that caused it.

`_project_number()` (added by #12083's sibling work) stops *new* corruption, but the bad value is already persisted on the live service. No code change can unblock a deploy while it sits there: the damage is in production state, not in the repo. That is what this adds a path to fix.

- **`--repair-secret-annotations`** rewrites every project-ID secret path on a live service into its project-number form, then re-reads the service and fails if any path still needs repair. Idempotent: when nothing needs changing it writes nothing and says so. `--dry-run` reports the change without applying it.
- **`_merge_secret_annotation` now normalizes every entry**, not just the secret it manages. A stale path under any other secret name breaks the same deploy, and the old code preserved those untouched.
- **Malformed annotations are left alone** rather than rewritten into a guess.
- The attach-only arguments are no longer `argparse`-required so repair can run standalone; `main()` enforces them for the attach path instead, so the existing workflow invocation is unchanged.

## Product invariants affected

None. Deploy tooling only; no product code path.

## How it was verified

Dry-run against production, which reported exactly one change and applied nothing:

```
[template] cloud-run-gmp-config:projects/based-hardware/secrets/cloud-run-gmp-config
        -> cloud-run-gmp-config:projects/208440318997/secrets/cloud-run-gmp-config
```

Confirmed independently that `208440318997` is the project number for `based-hardware`, and that `gcloud secrets describe cloud-run-gmp-config` resolves to `projects/208440318997/secrets/cloud-run-gmp-config` — the numeric form gcloud itself emits.

Red-first: with the script reverted and only the new tests applied, 8 of them fail, including `test_attach_merge_heals_a_stale_entry_for_another_secret`, which fails on a real assertion rather than a missing attribute. All 24 pass with the change.

Not verified here: that a full production deploy now succeeds. The live annotation still has to be repaired before that can be tested, and this PR only ships the ability to do it.

## Tests

`backend/tests/unit/test_attach_cloud_run_gmp_sidecar.py`:
- project-ID path is rewritten to the project-number form
- an already-numeric path reports no change (idempotence)
- every entry is repaired, not just the sidecar's own secret
- unrecognised and absent annotations are left untouched
- `repair_secret_annotations` issues no `services replace` when the annotation is already correct
- `test_every_written_entry_satisfies_gclouds_actual_rule` asserts every written path against `^projects/[0-9]{1,19}/secrets/[^/:]+$`, gcloud's rule copied verbatim, so a vendor upgrade that tightens it fails locally instead of on the next deploy

## Failure class (fixes)

Failure-Class: FC-metadata-format-validated-only-on-next-read

This is an instance fix for that class, whose evidence PR is #11998 and whose canonical prevention artifacts are the two files this PR changes. The verbatim-rule test above is the prevention primitive that class asks for; no registry change is needed, so none is made here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

