### PR TITLE
fix(deploy): drop the stale pinned revision name when repairing annotations

### DIFF
--- a/backend/scripts/attach_cloud_run_gmp_sidecar.py
+++ b/backend/scripts/attach_cloud_run_gmp_sidecar.py
@@ -589,6 +589,23 @@ def attach_sidecar(args: argparse.Namespace) -> None:
     print(f'Attached pinned GMP sidecar to zero-traffic revision {args.final_revision}')
 
 
+def _drop_pinned_revision_name(service: dict[str, Any]) -> str | None:
+    """Remove spec.template.metadata.name, returning what was removed.
+
+    Cloud Run refuses `services replace` when the spec pins a revision name that
+    already exists with different configuration, which is exactly the state a
+    failed deploy leaves behind.
+    """
+    template = service.get('spec', {}).get('template') if isinstance(service.get('spec'), dict) else None
+    if not isinstance(template, dict):
+        return None
+    metadata = template.get('metadata')
+    if not isinstance(metadata, dict):
+        return None
+    name = metadata.pop('name', None)
+    return name if isinstance(name, str) and name else None
+
+
 def repair_secret_annotations(args: argparse.Namespace) -> int:
     """Rewrite project-ID secret paths on a live service into project-number paths.
 
@@ -654,6 +671,18 @@ def repair_secret_annotations(args: argparse.Namespace) -> int:
     if args.dry_run:
         print('--dry-run: no changes applied')
         return 0
+
+    # A failed deploy leaves its pinned revision name in the exported spec.
+    # `services replace` then tries to recreate that exact name with different
+    # config and Cloud Run rejects it:
+    #   ALREADY_EXISTS: Revision named '<name>' with different configuration
+    #   already exists.
+    # Repair is not creating a named release, so drop the pin and let Cloud Run
+    # assign a fresh name. Traffic is unaffected: the traffic block in the export
+    # still pins whatever revision is currently serving.
+    pinned = _drop_pinned_revision_name(service)
+    if pinned:
+        print(f'dropping stale pinned revision name {pinned} so Cloud Run can assign a fresh one')
 
     path: Path | None = None
     try:

--- a/backend/tests/unit/test_attach_cloud_run_gmp_sidecar.py
+++ b/backend/tests/unit/test_attach_cloud_run_gmp_sidecar.py
@@ -491,3 +491,34 @@ def test_every_written_entry_satisfies_gclouds_actual_rule(existing):
     for entry in merged.split(','):
         _, _, resource = entry.partition(':')
         assert GCLOUD_SECRET_PATH_RULE.match(resource), f'gcloud would reject {resource!r}'
+
+
+def test_repair_drops_a_stale_pinned_revision_name_before_replace():
+    """A failed deploy leaves its revision name pinned in the export.
+
+    `services replace` then fails with ALREADY_EXISTS because it would recreate
+    that exact name with different configuration. Repair must drop the pin.
+    """
+    module = _load_module()
+    service = {
+        'spec': {
+            'template': {
+                'metadata': {
+                    'name': 'backend-465cd0f-32620507075-1',
+                    'annotations': {module.SECRET_ANNOTATION: 'x:projects/p/secrets/x'},
+                }
+            }
+        }
+    }
+    removed = module._drop_pinned_revision_name(service)
+    assert removed == 'backend-465cd0f-32620507075-1'
+    assert 'name' not in service['spec']['template']['metadata']
+    # Annotations must survive untouched.
+    assert service['spec']['template']['metadata']['annotations'][module.SECRET_ANNOTATION]
+
+
+def test_dropping_a_pin_that_is_absent_is_not_an_error():
+    module = _load_module()
+    service = {'spec': {'template': {'metadata': {'annotations': {}}}}}
+    assert module._drop_pinned_revision_name(service) is None
+    assert module._drop_pinned_revision_name({}) is None


### PR DESCRIPTION
## What changed and why

Follow-up to #12132. Running that repair against production failed:

```
ERROR: (gcloud.run.services.replace) ALREADY_EXISTS: Revision named
  'backend-465cd0f-32620507075-1' with different configuration already exists.
```

A failed deploy leaves its pinned revision name in `spec.template.metadata.name`. `gcloud run services replace` then tries to recreate that exact name with different configuration, and Cloud Run rejects it. Since a failed deploy is precisely the state that leaves a corrupted annotation needing repair, the two conditions always co-occur — the repair path could never have worked on the state it exists to fix.

Repair is not creating a named release, so it now drops the pin and lets Cloud Run assign a fresh revision name. Traffic is unaffected: the traffic block in the export still pins whatever revision is currently serving, so the new revision lands at 0%.

`--dry-run` could not have caught this, because it returns before ever calling `replace`.

## Product invariants affected

None. Deploy tooling only.

## How it was verified

Reproduced against production: the export carried `spec.template.metadata.name = backend-465cd0f-32620507075-1` alongside the uncorrected annotation, and `replace` failed with ALREADY_EXISTS. The failure was atomic — traffic stayed at 100% on `backend-a55b0f6-32515107465-1` throughout, confirmed before and after.

Also confirmed the corruption is limited to one service: dry-run across `backend`, `backend-sync`, `backend-sync-backfill`, and `backend-integration` reported a change only for `backend`.

Not verified here: a completed repair. That is the next step and depends on this change.

## Tests

`backend/tests/unit/test_attach_cloud_run_gmp_sidecar.py`:
- a stale pinned revision name is removed, and annotations under the same metadata survive untouched
- dropping an absent pin is a no-op rather than an error, including on an empty service mapping

## Failure class (fixes)

Failure-Class: none

The underlying production defect is an instance of `FC-metadata-format-validated-only-on-next-read`, already declared on #12132. This PR fixes a defect in that fix's own tooling, not a new production failure class.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

