### PR TITLE
feat(memory): govern ledger slots and prompt winners

### DIFF
--- a/backend/models/knowledge_ledger_policy.py
+++ b/backend/models/knowledge_ledger_policy.py
@@ -1,0 +1,194 @@
+"""Stable slot and rendering policy for ``knowledge_ledger.v1`` facts.
+
+This module is intentionally pure so models, prompt projections, and tests can
+share one contract without importing database or runtime code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import re
+from typing import Any, Iterable, Optional
+
+PROFILE_CHARACTER_BUDGET = 2_400
+PLAYBOOK_INDEX_CHARACTER_BUDGET = 800
+PLAYBOOK_HANDLE_CHARACTER_LIMIT = 360
+PROFILE_LINE_CHARACTER_LIMIT = 360
+
+
+@dataclass(frozen=True)
+class LedgerSlotDefinition:
+    name: str
+    renderer_order: int
+    aliases: tuple[str, ...] = ()
+
+
+# Canonical names remain snake_case because that is the released wire shape.
+# New names are append-only: renaming a canonical entry would split history.
+LEDGER_SLOT_DEFINITIONS: tuple[LedgerSlotDefinition, ...] = (
+    LedgerSlotDefinition("preferred_name", 10, ("name", "display_name", "called_name")),
+    LedgerSlotDefinition("pronouns", 20, ("preferred_pronouns",)),
+    LedgerSlotDefinition("primary_language", 30, ("language", "preferred_language")),
+    LedgerSlotDefinition("age_years", 35, ("age",)),
+    LedgerSlotDefinition("timezone", 40, ("time_zone", "user_timezone")),
+    LedgerSlotDefinition("home_city", 50, ("city", "home_location", "residence_city")),
+    LedgerSlotDefinition("work_city", 60, ("office_city", "work_location")),
+    LedgerSlotDefinition("occupation", 70, ("job", "job_title", "role")),
+    LedgerSlotDefinition("employer", 80, ("company", "workplace")),
+    LedgerSlotDefinition("communication_style", 90, ("preferred_communication_style",)),
+    LedgerSlotDefinition("dietary_preferences", 100, ("diet", "dietary_restrictions")),
+    LedgerSlotDefinition("current_focus", 110, ("current_priority", "primary_focus")),
+)
+
+# Released legacy predicates that may become current profile slots during
+# migration. Keep this beside the registry so producer growth gets the same
+# append-only policy review.
+LEDGER_SLOT_BY_LEGACY_PREDICATE = {
+    "resides_in": "home_city",
+    "works_at": "employer",
+    "age_years": "age_years",
+}
+
+
+_SLOT_TOKEN_PATTERN = re.compile(r"[^a-z0-9]+")
+_SLOT_BY_NAME = {definition.name: definition for definition in LEDGER_SLOT_DEFINITIONS}
+_SLOT_ALIASES = {
+    alias: definition.name for definition in LEDGER_SLOT_DEFINITIONS for alias in (definition.name, *definition.aliases)
+}
+
+
+# Higher rank always wins before recency or curation. This is the durable
+# product authority order; curation cannot make an inference outrank a user.
+LEDGER_AUTHORITY_RANK = {
+    "direct_user_statement": 600,
+    "explicit_remember": 600,
+    "onboarding": 500,
+    "agent_reusable_conclusion": 400,
+    "daily_reconciliation": 300,
+    "legacy_migration": 200,
+    "recurring_workflow": 100,
+    "standing_trigger": 100,
+}
+
+
+def normalize_slot_token(value: str) -> str:
+    """Normalize spelling only; this does not admit an unknown slot."""
+
+    return _SLOT_TOKEN_PATTERN.sub("_", (value or "").strip().lower()).strip("_")
+
+
+def normalize_playbook_handle(value: Any) -> str:
+    """Collapse a playbook description to one compact, single-line handle."""
+
+    return " ".join(str(value or "").split())
+
+
+def canonicalize_ledger_slot(value: Optional[str], *, strict: bool = True) -> Optional[str]:
+    """Return one released canonical slot name.
+
+    Unknown slots fail new writes in strict mode. Read projections use
+    ``strict=False`` so historic/future names remain stored but do not enter a
+    prompt under an invented ordering contract.
+    """
+
+    if value is None:
+        return None
+    normalized = normalize_slot_token(value)
+    if not normalized:
+        return None
+    canonical = _SLOT_ALIASES.get(normalized)
+    if canonical is None and strict:
+        raise ValueError(f"unsupported knowledge ledger slot: {normalized}")
+    return canonical
+
+
+def ledger_authority_rank(reason: Any) -> int:
+    value = getattr(reason, "value", reason)
+    return LEDGER_AUTHORITY_RANK.get(str(value or ""), 0)
+
+
+def _row_timestamp(row: Any) -> float:
+    value = (
+        getattr(row, "valid_from", None)
+        or getattr(row, "valid_at", None)
+        or getattr(row, "captured_at", None)
+        or getattr(row, "created_at", None)
+    )
+    if not isinstance(value, datetime):
+        return 0.0
+    try:
+        return value.timestamp()
+    except (OSError, OverflowError, ValueError):
+        return 0.0
+
+
+def _row_identity(row: Any) -> str:
+    return str(getattr(row, "memory_id", None) or getattr(row, "id", ""))
+
+
+def _winner_key(row: Any) -> tuple[int, float, int, str]:
+    return (
+        ledger_authority_rank(getattr(row, "write_reason", None)),
+        _row_timestamp(row),
+        int(getattr(row, "curation_weight", 0) or 0),
+        _row_identity(row),
+    )
+
+
+def select_profile_slot_winners(rows: Iterable[Any]) -> list[tuple[str, Any]]:
+    """Choose exactly one current fact per canonical slot.
+
+    Authority wins first, then newest fact at the same authority, then explicit
+    curation weight and stable row identity. Renderer order is independent of
+    curation, keeping prompt diffs deterministic.
+    """
+
+    winners: dict[str, Any] = {}
+    for row in rows:
+        slot = canonicalize_ledger_slot(getattr(row, "slot", None), strict=False)
+        if slot is None:
+            continue
+        current = winners.get(slot)
+        if current is None or _winner_key(row) > _winner_key(current):
+            winners[slot] = row
+    return sorted(
+        winners.items(),
+        key=lambda pair: (_SLOT_BY_NAME[pair[0]].renderer_order, pair[0], _row_identity(pair[1])),
+    )
+
+
+def render_bounded_profile(rows: Iterable[Any], *, character_budget: int = PROFILE_CHARACTER_BUDGET) -> str:
+    if character_budget < 0:
+        raise ValueError("character_budget must be nonnegative")
+    lines: list[str] = []
+    used = 0
+    for slot, row in select_profile_slot_winners(rows):
+        content = " ".join(str(getattr(row, "content", "") or "").split())[:PROFILE_LINE_CHARACTER_LIMIT]
+        if not content:
+            continue
+        line = f"{slot}: {content}"
+        separator = 1 if lines else 0
+        if used + separator + len(line) > character_budget:
+            continue
+        lines.append(line)
+        used += separator + len(line)
+    return "\n".join(lines)
+
+
+__all__ = [
+    "LEDGER_AUTHORITY_RANK",
+    "LEDGER_SLOT_BY_LEGACY_PREDICATE",
+    "LEDGER_SLOT_DEFINITIONS",
+    "PLAYBOOK_HANDLE_CHARACTER_LIMIT",
+    "PLAYBOOK_INDEX_CHARACTER_BUDGET",
+    "PROFILE_CHARACTER_BUDGET",
+    "PROFILE_LINE_CHARACTER_LIMIT",
+    "LedgerSlotDefinition",
+    "canonicalize_ledger_slot",
+    "ledger_authority_rank",
+    "normalize_playbook_handle",
+    "normalize_slot_token",
+    "render_bounded_profile",
+    "select_profile_slot_winners",
+]

--- a/backend/tests/unit/test_knowledge_ledger.py
+++ b/backend/tests/unit/test_knowledge_ledger.py
@@ -388,6 +388,175 @@ def test_profile_renderer_is_current_user_only_deterministic_and_bounded():
     assert render_profile([current], character_budget=10) == ""
 
 
+def test_ledger_slot_aliases_are_canonical_and_unknown_new_slots_fail_closed():
+    provenance = LedgerProvenance(
+        source_id="turn-slot",
+        source_type="chat_turn",
+        action_id="action-slot",
+    )
+    aliased = LedgerWrite(
+        kind=MemoryKind.fact,
+        content="Brooklyn",
+        provenance=provenance,
+        write_reason=LedgerWriteReason.direct_user_statement,
+        slot=" Home-Location ",
+    )
+
+    assert aliased.slot == "home_city"
+
+    with pytest.raises(ValueError, match="unsupported knowledge ledger slot"):
+        LedgerWrite(
+            kind=MemoryKind.fact,
+            content="Unknown",
+            provenance=provenance,
+            write_reason=LedgerWriteReason.agent_reusable_conclusion,
+            slot="invented_slot",
+        )
+
+    migrated = LedgerWrite(
+        kind=MemoryKind.fact,
+        content="Retained legacy knowledge",
+        provenance=provenance,
+        write_reason=LedgerWriteReason.legacy_migration,
+        slot="historic_custom_label",
+    )
+    assert migrated.slot is None
+
+
+def test_playbook_and_trigger_writes_require_their_own_authority():
+    provenance = LedgerProvenance(
+        source_id="turn-authority",
+        source_type="chat_turn",
+        action_id="action-authority",
+    )
+
+    with pytest.raises(ValueError, match="recurring_workflow authority"):
+        LedgerWrite(
+            kind=MemoryKind.document,
+            content="Release workflow",
+            body="Do the safe release steps.",
+            provenance=provenance,
+            write_reason=LedgerWriteReason.agent_reusable_conclusion,
+        )
+
+    with pytest.raises(ValueError, match="standing_trigger authority"):
+        LedgerWrite(
+            kind=MemoryKind.trigger,
+            content="Notify on release readiness",
+            trigger_condition={"keyword": "ready"},
+            provenance=provenance,
+            write_reason=LedgerWriteReason.agent_reusable_conclusion,
+        )
+
+    with pytest.raises(ValueError, match="primary_user scope"):
+        LedgerWrite(
+            kind=MemoryKind.document,
+            content="Third-party workflow",
+            body="Private third-party steps",
+            provenance=provenance,
+            write_reason=LedgerWriteReason.recurring_workflow,
+            subject_scope=MemorySubjectScope.third_party,
+            subject_entity_id="person-sarah",
+        )
+
+    for invalid_reason in (LedgerWriteReason.recurring_workflow, LedgerWriteReason.standing_trigger):
+        with pytest.raises(ValueError, match="facts cannot use document or trigger authority"):
+            LedgerWrite(
+                kind=MemoryKind.fact,
+                content="Wrong authority",
+                provenance=provenance,
+                write_reason=invalid_reason,
+                slot="home_city",
+            )
+
+
+def test_playbook_description_is_one_bounded_handle_in_write_and_projection():
+    provenance = LedgerProvenance(
+        source_id="turn-playbook",
+        source_type="chat_turn",
+        action_id="action-playbook",
+    )
+    write = LedgerWrite(
+        kind=MemoryKind.document,
+        content="Deploy safely\n1. Export artifacts\n2. Verify release",
+        body="Full private workflow",
+        provenance=provenance,
+        write_reason=LedgerWriteReason.recurring_workflow,
+    )
+    historical = _item(
+        "playbook-multiline",
+        kind=MemoryKind.document,
+        slot=None,
+        content="Deploy safely\n1. Export artifacts\n2. Verify release",
+        body="Full private workflow",
+        write_reason=LedgerWriteReason.recurring_workflow,
+    )
+    third_party = historical.model_copy(
+        update={
+            "memory_id": "third-party-playbook",
+            "subject_scope": MemorySubjectScope.third_party,
+            "subject_entity_id": "person-sarah",
+        }
+    )
+
+    assert write.content == "Deploy safely 1. Export artifacts 2. Verify release"
+    assert render_playbook_index([historical]) == (
+        "playbook-multiline: Deploy safely 1. Export artifacts 2. Verify release"
+    )
+    assert render_playbook_index([third_party, historical]) == (
+        "playbook-multiline: Deploy safely 1. Export artifacts 2. Verify release"
+    )
+
+    with pytest.raises(ValueError, match="compact handle limit"):
+        LedgerWrite(
+            kind=MemoryKind.document,
+            content="x" * 361,
+            body="Full private workflow",
+            provenance=provenance,
+            write_reason=LedgerWriteReason.recurring_workflow,
+        )
+
+
+def test_profile_renderer_selects_one_slot_winner_by_authority_then_recency():
+    direct = _item(
+        "direct",
+        content="Brooklyn",
+        valid_from=NOW,
+        curation_weight=-100,
+        write_reason=LedgerWriteReason.direct_user_statement,
+    )
+    newer_daily = _item(
+        "newer-daily",
+        content="Boston",
+        valid_from=NOW + timedelta(days=2),
+        curation_weight=100,
+        write_reason=LedgerWriteReason.daily_reconciliation,
+        user_asserted=False,
+    )
+    newer_direct = _item(
+        "newer-direct",
+        content="Queens",
+        valid_from=NOW + timedelta(days=1),
+        write_reason=LedgerWriteReason.direct_user_statement,
+    )
+    preferred_name = _item(
+        "preferred-name",
+        content="David",
+        slot="preferred_name",
+    )
+    unknown_historic = _item(
+        "unknown",
+        content="Must stay out of the prompt",
+        slot="future_slot",
+        write_reason=LedgerWriteReason.legacy_migration,
+    )
+
+    assert render_profile([newer_daily, unknown_historic, direct, preferred_name]) == (
+        "preferred_name: David\nhome_city: Brooklyn"
+    )
+    assert render_profile([direct, newer_direct]) == "home_city: Queens"
+
+
 def test_profile_renderer_rejects_promotion_without_changing_order_or_budget():
     """A rejected high-priority row must not consume the profile projection budget."""
     accepted_without_review = _item(

--- a/backend/tests/unit/test_knowledge_ledger_migration.py
+++ b/backend/tests/unit/test_knowledge_ledger_migration.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from models.memory_evidence import ArtifactPreservationState, MemoryEvidence, SourceState
+from models.knowledge_ledger_policy import LEDGER_SLOT_BY_LEGACY_PREDICATE, canonicalize_ledger_slot
 from models.product_memory import MemoryItem, MemoryItemStatus, MemoryLayer, ProcessingState
 from utils.memory import knowledge_ledger_migration
 from utils.memory.knowledge_ledger_migration import LedgerMigrationAction, migration_marker, plan_ledger_migration
@@ -68,6 +69,14 @@ def test_user_asserted_long_term_row_retains_direct_authority():
 
     assert plan.updates["intent_backed"] is True
     assert plan.updates["write_reason"] == "direct_user_statement"
+
+
+@pytest.mark.parametrize(("predicate", "expected_slot"), LEDGER_SLOT_BY_LEGACY_PREDICATE.items())
+def test_every_migration_producer_slot_is_in_the_released_registry(predicate, expected_slot):
+    plan = plan_ledger_migration(_item(predicate=predicate, user_asserted=True))
+
+    assert plan.updates["slot"] == expected_slot
+    assert canonicalize_ledger_slot(expected_slot) == expected_slot
 
 
 def test_short_term_rows_fail_closed_to_separate_adjudication():
@@ -267,7 +276,9 @@ def test_hermetic_fixture_proves_counts_provenance_profile_and_resume_without_co
     assert first.report.resumed_count == 1
     assert first.report.blocking_row_count == 2
     assert first.report.provenance_complete_count == 2
-    assert first.report.profile_slot_count == 2
+    # Both migrated rows claim home_city. The released slot-governance
+    # contract renders one authority/recency winner per canonical slot.
+    assert first.report.profile_slot_count == 1
     assert first.report.profile_character_count > 0
     assert len(first.report.profile_sha256) == 64
     assert first.report.planner_admissible is False

--- a/backend/tests/unit/test_knowledge_ledger_prompt.py
+++ b/backend/tests/unit/test_knowledge_ledger_prompt.py
@@ -70,6 +70,80 @@ def test_prompt_progressively_discloses_playbook_body():
     assert "read_playbook" in rendered
 
 
+def test_prompt_compacts_historical_multiline_playbook_description():
+    playbook = _row(
+        "playbook-multiline",
+        kind=MemoryKind.document,
+        slot=None,
+        content="Deploy safely\n1. Export artifacts\n2. Verify release",
+        body="private full workflow",
+        write_reason=LedgerWriteReason.recurring_workflow,
+    )
+
+    rendered = _render_ledger_prompt_context("David", [playbook])
+
+    assert "playbook-multiline: Deploy safely 1. Export artifacts 2. Verify release" in rendered
+    assert rendered.count("\n1. Export artifacts") == 0
+
+
+def test_prompt_excludes_unhydratable_third_party_playbook():
+    primary = _row(
+        "primary-playbook",
+        kind=MemoryKind.document,
+        slot=None,
+        content="Release safely",
+        body="private workflow",
+        write_reason=LedgerWriteReason.recurring_workflow,
+    )
+    third_party = _row(
+        "third-party-playbook",
+        kind=MemoryKind.document,
+        slot=None,
+        content="How Sarah releases",
+        body="third-party workflow",
+        write_reason=LedgerWriteReason.recurring_workflow,
+        subject_scope=MemorySubjectScope.third_party,
+        subject_entity_id="person-sarah",
+    )
+
+    rendered = _render_ledger_prompt_context("David", [third_party, primary])
+
+    assert "primary-playbook: Release safely" in rendered
+    assert "third-party-playbook" not in rendered
+    assert "How Sarah releases" not in rendered
+
+
+def test_prompt_uses_the_same_authority_first_slot_winner_policy():
+    direct = _row(
+        "direct",
+        content="Brooklyn",
+        valid_at=NOW,
+        curation_weight=-100,
+        write_reason=LedgerWriteReason.direct_user_statement,
+    )
+    newer_daily = _row(
+        "daily",
+        content="Boston",
+        valid_at=NOW.replace(day=24),
+        curation_weight=100,
+        write_reason=LedgerWriteReason.daily_reconciliation,
+    )
+    alias = _row(
+        "alias",
+        content="Queens",
+        slot="home_location",
+        valid_at=NOW.replace(day=22),
+        write_reason=LedgerWriteReason.direct_user_statement,
+    )
+
+    rendered = _render_ledger_prompt_context("David", [newer_daily, alias, direct])
+
+    assert rendered.count("home_city:") == 1
+    assert "home_city: Brooklyn" in rendered
+    assert "Boston" not in rendered
+    assert "Queens" not in rendered
+
+
 def test_prompt_projection_rejects_promotion_without_changing_order_or_bounds():
     """Rejected canonical rows must not displace visible facts or playbook handles."""
     accepted_fact_without_review = _row_from_promotion(

--- a/backend/tests/unit/test_knowledge_ledger_tools.py
+++ b/backend/tests/unit/test_knowledge_ledger_tools.py
@@ -74,6 +74,12 @@ def test_search_current_knowledge_returns_only_requested_current_ledger_kinds(mo
         _memory("mem_rejected", kind=MemoryKind.document, user_review=False),
         _memory("mem_closed", kind=MemoryKind.document, invalid_at=NOW),
         _memory("mem_passive", kind=MemoryKind.document, intent_backed=False),
+        _memory(
+            "mem_third_party_doc",
+            kind=MemoryKind.document,
+            subject_scope=MemorySubjectScope.third_party,
+            body="private third-party body",
+        ),
         _memory("mem_wrong_owner", kind=MemoryKind.document, uid="u2"),
     ]
 
@@ -85,6 +91,10 @@ def test_search_current_knowledge_returns_only_requested_current_ledger_kinds(mo
             assert (uid, query, limit) == ("u1", "release", 8)
             assert canonical_item_filter(_playbook()) is True
             assert canonical_item_filter(_playbook().model_copy(update={"kind": MemoryKind.fact})) is False
+            assert (
+                canonical_item_filter(_playbook().model_copy(update={"subject_scope": MemorySubjectScope.third_party}))
+                is False
+            )
             return [SimpleNamespace(memory=row) for row in rows if result_filter(row)]
 
     monkeypatch.setattr(tools, "MemoryService", FakeService)
@@ -102,6 +112,23 @@ def test_search_current_knowledge_returns_only_requested_current_ledger_kinds(mo
     assert "[trigger] mem_trigger" in rendered
     assert "private body" not in rendered
     assert "keywords" not in rendered
+    assert "mem_third_party_doc" not in rendered
+
+
+def test_search_compacts_and_caps_legacy_playbook_handles():
+    row = _memory(
+        "legacy-long-playbook",
+        kind=MemoryKind.document,
+        content="Deploy safely\n" + ("x" * 4_000),
+        body="private full workflow",
+    )
+
+    rendered = tools._format_search_results([row], query="deploy")
+    handle = rendered.splitlines()[1].split(": ", 1)[1]
+
+    assert "\n" not in handle
+    assert len(handle) == tools.MAX_PLAYBOOK_DESCRIPTION_CHARACTERS
+    assert "private full workflow" not in rendered
 
 
 def test_read_current_playbook_applies_chat_visibility_and_ledger_semantics(monkeypatch):

--- a/backend/utils/llms/memory.py
+++ b/backend/utils/llms/memory.py
@@ -5,9 +5,16 @@ from cachetools import TTLCache
 
 from database._client import db as firestore_db
 from database.auth import get_user_name
+from models.knowledge_ledger_policy import (
+    PLAYBOOK_HANDLE_CHARACTER_LIMIT,
+    PLAYBOOK_INDEX_CHARACTER_BUDGET,
+    PROFILE_CHARACTER_BUDGET,
+    normalize_playbook_handle,
+    render_bounded_profile,
+)
 from models.memories import Memory, MemoryDB
 from models.product_memory import MemoryKind, MemorySubjectScope
-from utils.memory.knowledge_ledger import DEFAULT_PROFILE_CHARACTER_BUDGET, LEDGER_SCHEMA_VERSION
+from utils.memory.knowledge_ledger import LEDGER_SCHEMA_VERSION
 from utils.memory.knowledge_ledger_migration import read_ledger_migration_completion
 from utils.memory.memory_service import MemoryService
 import logging
@@ -113,21 +120,25 @@ def _render_ledger_prompt_context(user_name: Optional[str], rows: List[MemoryDB]
         and row.slot
         and row.content.strip()
     ]
-    facts.sort(key=lambda row: (-row.curation_weight, row.slot or '', row.valid_at or row.created_at, row.id))
-    profile = _bounded_lines(
-        [f"{row.slot}: {row.content.strip()}" for row in facts],
-        DEFAULT_PROFILE_CHARACTER_BUDGET,
-    )
+    profile = render_bounded_profile(facts, character_budget=PROFILE_CHARACTER_BUDGET)
     playbooks = [
         row
         for row in rows
         if row.kind == MemoryKind.document
+        and row.subject_scope == MemorySubjectScope.primary_user
         and row.user_review is not False
         and row.invalid_at is None
         and row.content.strip()
     ]
     playbooks.sort(key=lambda row: (-row.curation_weight, row.content, row.id))
-    playbook_index = _bounded_lines([f"{row.id}: {row.content.strip()}" for row in playbooks], 800)
+    playbook_index = _bounded_lines(
+        [
+            f"{row.id}: {normalize_playbook_handle(row.content)[:PLAYBOOK_HANDLE_CHARACTER_LIMIT]}"
+            for row in playbooks
+            if normalize_playbook_handle(row.content)
+        ],
+        PLAYBOOK_INDEX_CHARACTER_BUDGET,
+    )
     sections = [f"Current profile for {user_name or 'the user'}:\n{profile or '(no current slotted facts)'}"]
     if playbook_index:
         sections.append(

--- a/backend/utils/memory/knowledge_ledger.py
+++ b/backend/utils/memory/knowledge_ledger.py
@@ -13,6 +13,14 @@ from typing import Any, Dict, Iterable, List, Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from models.knowledge_ledger_policy import (
+    PLAYBOOK_HANDLE_CHARACTER_LIMIT,
+    PLAYBOOK_INDEX_CHARACTER_BUDGET,
+    PROFILE_CHARACTER_BUDGET,
+    canonicalize_ledger_slot,
+    normalize_playbook_handle,
+    render_bounded_profile,
+)
 from models.memory_contracts import deterministic_contract_id
 from models.product_memory import (
     MAX_LEDGER_PLAYBOOK_BODY_CHARACTERS,
@@ -33,7 +41,7 @@ from utils.memory.canonical_memory_adapter import (
 )
 
 LEDGER_SCHEMA_VERSION = "knowledge_ledger.v1"
-DEFAULT_PROFILE_CHARACTER_BUDGET = 2_400
+DEFAULT_PROFILE_CHARACTER_BUDGET = PROFILE_CHARACTER_BUDGET
 MAX_PLAYBOOK_BODY_CHARACTERS = MAX_LEDGER_PLAYBOOK_BODY_CHARACTERS
 MAX_TRIGGER_CONDITION_KEYS = MAX_LEDGER_TRIGGER_CONDITION_KEYS
 
@@ -106,8 +114,33 @@ class LedgerWrite(BaseModel):
             raise ValueError("playbook body exceeds the ledger limit")
         if self.kind == MemoryKind.document and not (self.body or "").strip():
             raise ValueError("playbooks require a non-empty body")
+        if self.kind == MemoryKind.document and self.write_reason != LedgerWriteReason.recurring_workflow:
+            raise ValueError("playbooks require recurring_workflow authority")
+        if self.kind == MemoryKind.document and self.subject_scope != MemorySubjectScope.primary_user:
+            raise ValueError("playbooks require primary_user scope")
+        if self.kind == MemoryKind.document:
+            description = normalize_playbook_handle(self.content)
+            if len(description) > PLAYBOOK_HANDLE_CHARACTER_LIMIT:
+                raise ValueError("playbook description exceeds the compact handle limit")
+            self.content = description
         if self.kind != MemoryKind.document and self.body is not None:
             raise ValueError("only playbooks may define a body")
+        if self.kind != MemoryKind.fact and self.slot is not None:
+            raise ValueError("only facts may define a slot")
+        if self.kind == MemoryKind.fact and self.slot is not None:
+            # Preserve unknown historical migration labels as unslotted facts;
+            # every new semantic write must use the stable registry.
+            self.slot = canonicalize_ledger_slot(
+                self.slot,
+                strict=self.write_reason != LedgerWriteReason.legacy_migration,
+            )
+        if self.kind == MemoryKind.fact and self.write_reason in {
+            LedgerWriteReason.recurring_workflow,
+            LedgerWriteReason.standing_trigger,
+        }:
+            raise ValueError("facts cannot use document or trigger authority")
+        if self.kind == MemoryKind.trigger and self.write_reason != LedgerWriteReason.standing_trigger:
+            raise ValueError("triggers require standing_trigger authority")
         if self.kind == MemoryKind.trigger and len(self.trigger_condition) > MAX_TRIGGER_CONDITION_KEYS:
             raise ValueError("trigger condition exceeds the ledger key limit")
         try:
@@ -366,30 +399,13 @@ def render_profile(
         and item.slot
         and (item.content or "").strip()
     ]
-    eligible.sort(
-        key=lambda item: (
-            -item.curation_weight,
-            item.slot or "",
-            item.valid_from or item.captured_at,
-            item.memory_id,
-        )
-    )
-    lines: List[str] = []
-    used = 0
-    for item in eligible:
-        line = f"{item.slot}: {(item.content or '').strip()}"
-        separator = 1 if lines else 0
-        if used + separator + len(line) > character_budget:
-            continue
-        lines.append(line)
-        used += separator + len(line)
-    return "\n".join(lines)
+    return render_bounded_profile(eligible, character_budget=character_budget)
 
 
 def render_playbook_index(
     items: Iterable[MemoryItem],
     *,
-    character_budget: int = 800,
+    character_budget: int = PLAYBOOK_INDEX_CHARACTER_BUDGET,
 ) -> str:
     """Render one-line progressive-disclosure handles, never playbook bodies."""
     active = [
@@ -397,6 +413,7 @@ def render_playbook_index(
         for item in items
         if item.ledger_schema_version == LEDGER_SCHEMA_VERSION
         and item.kind == MemoryKind.document
+        and item.subject_scope == MemorySubjectScope.primary_user
         and item.status == MemoryItemStatus.active
         and _is_review_visible(item)
         and item.valid_to is None
@@ -405,7 +422,10 @@ def render_playbook_index(
     lines: List[str] = []
     used = 0
     for item in active:
-        line = f"{item.memory_id}: {(item.content or '').strip()}"
+        description = normalize_playbook_handle(item.content)[:PLAYBOOK_HANDLE_CHARACTER_LIMIT]
+        if not description:
+            continue
+        line = f"{item.memory_id}: {description}"
         separator = 1 if lines else 0
         if used + separator + len(line) > character_budget:
             continue

--- a/backend/utils/memory/knowledge_ledger_migration.py
+++ b/backend/utils/memory/knowledge_ledger_migration.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Literal, Optional
 from pydantic import BaseModel, Field
 
 from database.memory_collections import MemoryCollections
+from models.knowledge_ledger_policy import LEDGER_SLOT_BY_LEGACY_PREDICATE
 from models.product_memory import (
     LedgerWriteReason,
     MemoryItem,
@@ -80,13 +81,6 @@ def read_ledger_migration_completion(uid: str, *, db_client: Any) -> Optional[Le
     return completion
 
 
-_STABLE_SLOT_BY_PREDICATE = {
-    "resides_in": "home_city",
-    "works_at": "employer",
-    "age_years": "age_years",
-}
-
-
 def _subject_scope(item: MemoryItem) -> MemorySubjectScope:
     attribution = str(((item.promotion or {}).get("source_attribution") or {}).get("subject_attribution") or "")
     if attribution == "third_party":
@@ -142,7 +136,7 @@ def plan_ledger_migration(item: MemoryItem) -> LedgerMigrationPlan:
             "ledger_schema_version": LEDGER_SCHEMA_VERSION,
             "kind": MemoryKind.fact.value,
             "subject_scope": scope.value,
-            "slot": _STABLE_SLOT_BY_PREDICATE.get(item.predicate or ""),
+            "slot": LEDGER_SLOT_BY_LEGACY_PREDICATE.get(item.predicate or ""),
             "valid_from": item.captured_at,
             # Preserve historical/expiry semantics. Clearing this boundary
             # would make a closed legacy row look current in the ledger view.

--- a/backend/utils/retrieval/tools/knowledge_ledger_tools.py
+++ b/backend/utils/retrieval/tools/knowledge_ledger_tools.py
@@ -18,6 +18,10 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool  # type: ignore[reportUnknownVariableType]
 
 from models.memories import MemoryDB
+from models.knowledge_ledger_policy import (
+    PLAYBOOK_HANDLE_CHARACTER_LIMIT,
+    normalize_playbook_handle,
+)
 from models.product_memory import (
     MAX_LEDGER_PLAYBOOK_BODY_CHARACTERS,
     MemoryAccessPolicy,
@@ -42,7 +46,7 @@ HISTORICAL_PROVIDER_PARTIAL_NOTICE = (
     "this is not exhaustive.]"
 )
 MAX_PLAYBOOK_ID_CHARACTERS = 256
-MAX_PLAYBOOK_DESCRIPTION_CHARACTERS = 600
+MAX_PLAYBOOK_DESCRIPTION_CHARACTERS = PLAYBOOK_HANDLE_CHARACTER_LIMIT
 _PLAYBOOK_ID_PATTERN = re.compile(r"[A-Za-z0-9._:-]+")
 _LEDGER_KINDS = frozenset({kind.value for kind in MemoryKind})
 
@@ -76,6 +80,11 @@ def _parse_kinds(kinds: Optional[str]) -> frozenset[str]:
 
 def _is_current_ledger_memory(memory: MemoryDB, *, kinds: frozenset[str]) -> bool:
     kind = memory.kind.value if isinstance(memory.kind, MemoryKind) else str(memory.kind or "")
+    subject_scope = (
+        memory.subject_scope.value
+        if isinstance(memory.subject_scope, MemorySubjectScope)
+        else str(memory.subject_scope or "")
+    )
     return (
         memory.ledger_schema_version == LEDGER_SCHEMA_VERSION
         and kind in kinds
@@ -83,6 +92,7 @@ def _is_current_ledger_memory(memory: MemoryDB, *, kinds: frozenset[str]) -> boo
         and memory.invalid_at is None
         and memory.user_review is not False
         and not memory.is_locked
+        and (kind != MemoryKind.document.value or subject_scope == MemorySubjectScope.primary_user.value)
     )
 
 
@@ -95,6 +105,7 @@ def _is_current_ledger_item(item: MemoryItem, *, kinds: frozenset[str]) -> bool:
         and item.valid_to is None
         and promotion.get("is_locked") is not True
         and promotion.get("user_review") is not False
+        and (item.kind != MemoryKind.document or item.subject_scope == MemorySubjectScope.primary_user)
     )
 
 
@@ -104,7 +115,10 @@ def _format_search_results(rows: Iterable[MemoryDB], *, query: str) -> str:
     truncated = False
     for row in rows:
         kind = row.kind.value if isinstance(row.kind, MemoryKind) else str(row.kind or "unknown")
-        content = " ".join((row.content or "").split())
+        if kind == MemoryKind.document.value:
+            content = normalize_playbook_handle(row.content)[:PLAYBOOK_HANDLE_CHARACTER_LIMIT]
+        else:
+            content = " ".join((row.content or "").split())
         suffix = f" slot={row.slot}" if row.slot else ""
         candidate = f"- [{kind}] {row.id}{suffix}: {content}"
         if len("\n".join(lines + [candidate])) > MAX_KNOWLEDGE_RESULT_CHARACTERS:

--- a/docs/doc/developer/jit-ledger-governance.md
+++ b/docs/doc/developer/jit-ledger-governance.md
@@ -1,0 +1,52 @@
+---
+title: JIT ledger slot and playbook governance
+description: Stable knowledge-ledger slots, profile ordering, and progressive-disclosure limits.
+---
+
+`knowledge_ledger.v1` uses an append-only slot registry implemented in
+`backend/models/knowledge_ledger_policy.py`. Canonical slot names are released
+wire values. A canonical name may gain spelling aliases, but it must not be
+renamed or reused for a different meaning.
+
+| Render order | Canonical slot | Accepted aliases |
+| ---: | --- | --- |
+| 10 | `preferred_name` | `name`, `display_name`, `called_name` |
+| 20 | `pronouns` | `preferred_pronouns` |
+| 30 | `primary_language` | `language`, `preferred_language` |
+| 35 | `age_years` | `age` |
+| 40 | `timezone` | `time_zone`, `user_timezone` |
+| 50 | `home_city` | `city`, `home_location`, `residence_city` |
+| 60 | `work_city` | `office_city`, `work_location` |
+| 70 | `occupation` | `job`, `job_title`, `role` |
+| 80 | `employer` | `company`, `workplace` |
+| 90 | `communication_style` | `preferred_communication_style` |
+| 100 | `dietary_preferences` | `diet`, `dietary_restrictions` |
+| 110 | `current_focus` | `current_priority`, `primary_focus` |
+
+New semantic writes fail closed on an unknown slotted name. Historical
+migration preserves the fact as unslotted history instead of inventing a new
+prompt field. Unslotted facts remain searchable but never enter the always-on
+profile.
+
+The renderer selects one row per canonical slot. Authority wins first:
+
+1. direct user statement or explicit remember;
+2. onboarding;
+3. reusable in-agent conclusion;
+4. daily reconciliation inference;
+5. legacy migration.
+
+Within the same authority, the newest valid fact wins, then curation weight,
+then stable row identity. Curation is bounded to `-100...100` and cannot make
+an inference outrank a direct user statement. Final lines use the registry
+order, not discovery order or curation score. The full profile is capped at
+2,400 characters and each normalized fact value at 360 characters.
+
+Playbook descriptions and bodies are separate. Descriptions are normalized to
+one line and capped at 360 characters; the prompt receives only an 800-character
+index of current, review-visible handles. `read_playbook` is the
+owner-scoped body hydration boundary. Bodies are capped at 24,000 characters,
+new versions supersede prior rows transactionally, and normal projection and
+vector outboxes synchronize searchable descriptions. Search never indexes or
+returns the body through the compact handle endpoint. Only the recurring-
+workflow write authority may create a playbook through the ledger helper.


### PR DESCRIPTION
## Summary

- define an append-only registry for released profile slots and spelling aliases
- fail closed on unknown new slotted writes while keeping unknown migrated facts as unslotted history
- select exactly one current fact per slot using user-authority first, then recency, bounded curation, and stable identity
- share the same deterministic renderer between canonical fixtures and the production prompt projection
- freeze profile, line, playbook-index, playbook-handle, and playbook-body budgets and require kind-specific write authority
- cover every released migration-produced slot and normalize playbook descriptions to a single compact handle
- apply the same playbook-handle cap and primary-user hydration contract to agent knowledge search

## Stack

This is an additive follow-up on `codex/jit-processing-end-state@2fcc05f2037d45999d046131bfd6f88770eb9efe` (PR #12084). It does not activate a rollout, deploy a backend, mutate PostHog, migrate production data, disable a legacy reader/writer, or delete data.

## Product invariants affected

- INV-MEM-4
- INV-MEM-1

Failure-Class: none

The expected migration-fixture slot count changes from two duplicate `home_city` lines to one authoritative winner. External product source: David's 2026-08-24 ratification that direct user statements outrank in-agent conclusions, which outrank daily-sweep inference, and that the durable profile is a bounded deterministic slot projection rather than a wholesale fact dump.

## Verification

- 53 focused ledger/prompt/migration/tool tests
- 111 broader ledger, tool, migration, mutation, and canonical-apply tests
- focused production Pyright: 0 errors
- exact Black contract and `git diff --check`
- repository preflight against the exact stacked base

## Compatibility boundary

Canonical wire names stay snake_case and append-only. Existing aliases are normalized only at new semantic writes and projection time; stored unknown historical or future slots are not destroyed, but they do not enter the always-on prompt without an explicit registry contract. Unslotted facts remain available through bounded search/history surfaces.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

