### PR TITLE
fix(rn): sort macos rewind timeline in one time unit

### DIFF
--- a/react-native/App.tsx
+++ b/react-native/App.tsx
@@ -1857,13 +1857,12 @@ function App({initialRoute}: AppProps): React.JSX.Element {
         ? readOutcomes.memories.value.items
         : []),
     ].sort((left, right) => {
-      const timestamp = (item: DesktopReadProjection) =>
-        item.kind === 'conversation'
-          ? Date.parse(item.startedAt ?? item.createdAt)
-          : item.kind === 'memory'
-            ? (item.timestamp ?? 0)
-            : 0;
-      return timestamp(right) - timestamp(left);
+      const leftTs = projectionTimestamp(left);
+      const rightTs = projectionTimestamp(right);
+      return (
+        (rightTs ?? Number.NEGATIVE_INFINITY) -
+        (leftTs ?? Number.NEGATIVE_INFINITY)
+      );
     });
   }, [readOutcomes]);
 

--- a/react-native/__tests__/App.test.tsx
+++ b/react-native/__tests__/App.test.tsx
@@ -790,6 +790,103 @@ test('shows the desktop chronological spine at rest and filters that same loaded
   ).toBe('');
 });
 
+test('orders macos Home timeline by normalized conversation and memory time', async () => {
+  mockPlatformOS = 'macos';
+  mockBackend.request.mockImplementation(async request => {
+    if (request.path === '/v1/chat-messages?limit=50') {
+      return {
+        id: request.id,
+        status: 200,
+        body: '{"messages":[],"page":{"olderCursor":null,"hasOlder":false}}',
+      };
+    }
+    if (request.path.startsWith('/v1/conversations')) {
+      return {
+        id: request.id,
+        status: 200,
+        body: JSON.stringify([
+          {
+            id: 'older-conversation',
+            structured: {title: 'Older conversation', overview: 'Earlier'},
+            created_at: '2026-08-07T09:00:00.000Z',
+            updated_at: '2026-08-07T09:00:00.000Z',
+            started_at: '2026-08-07T09:00:00.000Z',
+            finished_at: '2026-08-07T09:10:00.000Z',
+            source: 'omi',
+            status: 'completed',
+            discarded: false,
+            starred: false,
+            visibility: 'private',
+            is_locked: false,
+            folder_id: null,
+          },
+        ]),
+      };
+    }
+    if (request.path === '/v1/tasks') {
+      return {
+        id: request.id,
+        status: 200,
+        body: JSON.stringify({
+          contractVersion: '1.0.0',
+          items: [],
+          window: {
+            status: 'complete',
+            complete: true,
+            hasMore: false,
+            nextCursor: null,
+          },
+          completeness: {
+            version: 'tasks-completeness-v1',
+            status: 'complete',
+            reasons: [],
+          },
+          absence: null,
+        }),
+      };
+    }
+    return {
+      id: request.id,
+      status: 200,
+      body: JSON.stringify({
+        contractVersion: '1.0.0',
+        items: [
+          {
+            id: 'newer-memory',
+            text: 'Newer memory',
+            citations: [],
+            provenance: {
+              synthesisVersion: 'v1',
+              inputDigest: 'input',
+              outputDigest: 'output',
+            },
+            updatedAt: 1786251600,
+          },
+        ],
+        window: {
+          status: 'complete',
+          complete: true,
+          hasMore: false,
+          nextCursor: null,
+        },
+        completeness: {
+          version: 'recall-completeness-v1',
+          status: 'complete',
+          reasons: [],
+        },
+        absence: null,
+      }),
+    };
+  });
+  const renderer = await renderApp();
+  const output = JSON.stringify(renderer.toJSON());
+  expect(output).toContain('Home chronological timeline');
+  expect(output.indexOf('Newer memory')).toBeGreaterThan(-1);
+  expect(output.indexOf('Newer memory')).toBeLessThan(
+    output.indexOf('Older conversation'),
+  );
+});
+
 test('keeps chat inside the Home destination', async () => {
   const renderer = await renderApp();
   await ReactTestRenderer.act(async () => {


### PR DESCRIPTION
## Summary
- macOS Home rewind timeline was sorting conversations (Date.parse ms) against memories (epoch seconds), so every conversation stacked above every memory.
- Sort now uses `projectionTimestamp` so both kinds share milliseconds; memories without a time sort last.
- Adds a regression test with a seconds-based newer memory vs an older conversation.

## Test plan
- [x] `bun run --cwd react-native test -- --runInBand App.test.tsx` (59 passing)
- [ ] Visual check on macOS Home: mixed conversation + memory rows newest-first

Do not merge until CI is green and Max explicitly approves.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

