### PR TITLE
feat: add explicit multi-source entity timeline

### DIFF
--- a/backend/database/entity_timeline_sources.py
+++ b/backend/database/entity_timeline_sources.py
@@ -1,0 +1,204 @@
+"""Bounded Firestore readers used only by the entity timeline tool."""
+
+import json
+import zlib
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any, Dict, List, Optional, cast
+
+from google.cloud import firestore
+from google.cloud.firestore_v1 import FieldFilter
+
+from models.conversation_enums import ConversationStatus
+from utils import encryption
+
+from .conversations import conversations_collection
+from .conversations import (
+    _document_data_with_revision as document_data_with_revision,  # pyright: ignore[reportPrivateUsage]
+)
+from .firestore_index_registry import (
+    ENTITY_TIMELINE_CONVERSATIONS_QUERY,
+    ENTITY_TIMELINE_MEETINGS_QUERY,
+    ENTITY_TIMELINE_SCREEN_ACTIVITY_QUERY,
+)
+from .screen_activity import SCREEN_ACTIVITY_COLLECTION, USERS_COLLECTION, normalize_screen_activity_timestamp
+
+_MAX_TRANSCRIPT_STORED_BYTES = 256 * 1024
+_MAX_TRANSCRIPT_DECODED_BYTES = 512 * 1024
+_MAX_TRANSCRIPT_SEGMENTS = 4096
+
+
+def _bounded_identity_segments(uid: str, data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Decode only bounded speaker identity fields, never transcript text."""
+
+    raw = data.get('transcript_segments')
+    if isinstance(raw, list):
+        if len(raw) > _MAX_TRANSCRIPT_SEGMENTS:
+            return []
+        parsed: object = raw
+    elif data.get('transcript_segments_compressed') is True:
+        try:
+            if isinstance(raw, str):
+                max_encrypted_chars = (((_MAX_TRANSCRIPT_STORED_BYTES * 2) + 28 + 2) // 3) * 4
+                if not raw.isascii() or len(raw) > max_encrypted_chars:
+                    return []
+                decrypted_hex = encryption.decrypt(raw, uid)
+                if len(decrypted_hex) > _MAX_TRANSCRIPT_STORED_BYTES * 2 or len(decrypted_hex) % 2:
+                    return []
+                compressed = bytes.fromhex(decrypted_hex)
+            elif isinstance(raw, (bytes, bytearray, memoryview)):
+                compressed = bytes(raw)
+            else:
+                return []
+            if len(compressed) > _MAX_TRANSCRIPT_STORED_BYTES:
+                return []
+            decompressor = zlib.decompressobj()
+            decoded = decompressor.decompress(compressed, _MAX_TRANSCRIPT_DECODED_BYTES + 1)
+            if (
+                len(decoded) > _MAX_TRANSCRIPT_DECODED_BYTES
+                or decompressor.unconsumed_tail
+                or not decompressor.eof
+                or decompressor.unused_data
+            ):
+                return []
+            parsed = json.loads(decoded.decode('utf-8'))
+        except (json.JSONDecodeError, RecursionError, TypeError, UnicodeDecodeError, ValueError, zlib.error):
+            return []
+        if not isinstance(parsed, list) or len(parsed) > _MAX_TRANSCRIPT_SEGMENTS:
+            return []
+    else:
+        # Legacy encrypted, uncompressed transcript strings have no bounded
+        # decode contract. Fail the identity join closed rather than inflate.
+        return []
+
+    identities: List[Dict[str, Any]] = []
+    for segment in parsed:
+        if not isinstance(segment, Mapping):
+            continue
+        identity: Dict[str, Any] = {}
+        if isinstance(segment.get('is_user'), bool):
+            identity['is_user'] = segment['is_user']
+        if isinstance(segment.get('person_id'), str):
+            identity['person_id'] = segment['person_id'][:160]
+        identities.append(identity)
+    return identities
+
+
+def list_entity_timeline_conversations(
+    uid: str,
+    *,
+    db_client: Any,
+    limit: int,
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+) -> List[Dict[str, Any]]:
+    """Read one deterministic, completed-conversation window for a timeline.
+
+    Speaker IDs are required to join a stable person. This boundary decodes at
+    most a fixed compressed/expanded byte budget and retains identity fields
+    only; transcript text and photos never leave the database boundary.
+    """
+
+    if limit < 1 or limit > 501:
+        raise ValueError('entity timeline conversation limit must be between 1 and 501')
+    collection = db_client.collection('users').document(uid).collection(conversations_collection)
+    query = ENTITY_TIMELINE_CONVERSATIONS_QUERY.build(
+        collection,
+        {
+            'discarded': False,
+            'status': ConversationStatus.completed.value,
+        },
+        field_filter_factory=FieldFilter,
+    )
+    if start_date is not None:
+        query = query.where(filter=FieldFilter('created_at', '>=', start_date))
+    if end_date is not None:
+        query = query.where(filter=FieldFilter('created_at', '<=', end_date))
+    query = (
+        query.order_by('created_at', direction=firestore.Query.DESCENDING)
+        .order_by('__name__', direction=firestore.Query.DESCENDING)
+        .limit(limit)
+    )
+    conversations: List[Dict[str, Any]] = []
+    for snapshot in query.stream():
+        data = document_data_with_revision(snapshot)
+        if data is None:
+            continue
+        data['id'] = snapshot.id
+        data['transcript_segments'] = _bounded_identity_segments(uid, data)
+        conversations.append(data)
+    return conversations
+
+
+def list_entity_timeline_meetings(
+    uid: str,
+    *,
+    db_client: Any,
+    limit: int,
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+) -> List[Dict[str, Any]]:
+    """Read a stable, bounded calendar window through an injected authority."""
+
+    if limit < 1 or limit > 501:
+        raise ValueError('entity timeline meeting limit must be between 1 and 501')
+    collection = db_client.collection('users').document(uid).collection('meetings')
+    query = ENTITY_TIMELINE_MEETINGS_QUERY.build(collection, {}, field_filter_factory=FieldFilter)
+    if start_date is not None:
+        query = query.where('start_time', '>=', start_date)
+    if end_date is not None:
+        query = query.where('start_time', '<=', end_date)
+    query = (
+        query.order_by('start_time', direction=firestore.Query.DESCENDING)
+        .order_by('__name__', direction=firestore.Query.DESCENDING)
+        .limit(limit)
+    )
+    meetings: List[Dict[str, Any]] = []
+    for snapshot in query.stream():
+        raw: object = snapshot.to_dict()
+        if not isinstance(raw, dict):
+            continue
+        data = dict(cast(Dict[str, Any], raw))
+        data['id'] = snapshot.id
+        meetings.append(data)
+    return meetings
+
+
+def list_entity_timeline_screen_activity(
+    uid: str,
+    *,
+    db_client: Any,
+    limit: int,
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+) -> List[Dict[str, Any]]:
+    """Read a deterministic screen-metadata window for exact alias matching."""
+
+    if limit < 1 or limit > 501:
+        raise ValueError('entity timeline screen limit must be between 1 and 501')
+    collection = db_client.collection(USERS_COLLECTION).document(uid).collection(SCREEN_ACTIVITY_COLLECTION)
+    query = ENTITY_TIMELINE_SCREEN_ACTIVITY_QUERY.build(collection, {}, field_filter_factory=FieldFilter)
+    if start_date is not None:
+        query = query.where(
+            filter=firestore.FieldFilter('timestamp', '>=', normalize_screen_activity_timestamp(start_date))
+        )
+    if end_date is not None:
+        query = query.where(
+            filter=firestore.FieldFilter(
+                'timestamp', '<=', normalize_screen_activity_timestamp(end_date, end_of_second=True)
+            )
+        )
+    query = (
+        query.order_by('timestamp', direction=firestore.Query.DESCENDING)
+        .order_by('__name__', direction=firestore.Query.DESCENDING)
+        .limit(limit)
+    )
+    rows: List[Dict[str, Any]] = []
+    for snapshot in query.stream():
+        raw: object = snapshot.to_dict()
+        if not isinstance(raw, dict):
+            continue
+        data = dict(cast(Dict[str, Any], raw))
+        data['id'] = snapshot.id
+        rows.append(data)
+    return rows

--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -618,6 +618,44 @@ STALE_IN_PROGRESS_CONVERSATIONS_QUERY = FirestoreQuerySpec(
     ),
 )
 
+ENTITY_TIMELINE_CONVERSATIONS_QUERY = FirestoreQuerySpec(
+    identifier='conversations_entity_timeline_completed',
+    collection_group='conversations',
+    query_scope='COLLECTION',
+    filters=(
+        FirestoreQueryFilter('discarded', '==', 'discarded'),
+        FirestoreQueryFilter('status', '==', 'status'),
+    ),
+    index_fields=(
+        _asc('discarded'),
+        _asc('status'),
+        _desc('created_at'),
+        _desc('__name__'),
+    ),
+)
+
+ENTITY_TIMELINE_MEETINGS_QUERY = FirestoreQuerySpec(
+    identifier='meetings_entity_timeline',
+    collection_group='meetings',
+    query_scope='COLLECTION',
+    filters=(),
+    index_fields=(
+        _desc('start_time'),
+        _desc('__name__'),
+    ),
+)
+
+ENTITY_TIMELINE_SCREEN_ACTIVITY_QUERY = FirestoreQuerySpec(
+    identifier='screen_activity_entity_timeline',
+    collection_group='screen_activity',
+    query_scope='COLLECTION',
+    filters=(),
+    index_fields=(
+        _desc('timestamp'),
+        _desc('__name__'),
+    ),
+)
+
 ACTION_ITEMS_COMPLETION_ID_SCAN_QUERY = FirestoreQuerySpec(
     identifier='action_items_completion_id_scan',
     collection_group='action_items',
@@ -788,6 +826,9 @@ QUERY_SPECS = (
     ACTIVE_ATTENTION_OVERRIDE_QUERY,
     LEGACY_CONVERSATION_RECOVERY_QUERY,
     STALE_IN_PROGRESS_CONVERSATIONS_QUERY,
+    ENTITY_TIMELINE_CONVERSATIONS_QUERY,
+    ENTITY_TIMELINE_MEETINGS_QUERY,
+    ENTITY_TIMELINE_SCREEN_ACTIVITY_QUERY,
     CHAT_FIRST_DEFERRALS_DUE_QUERY,
     CHAT_FIRST_DEFERRALS_SUBJECT_QUERY,
     CURRENT_CHAT_SESSION_QUERY,

--- a/backend/database/person_aliases.py
+++ b/backend/database/person_aliases.py
@@ -1,0 +1,63 @@
+"""Stable person rename and bounded exact-alias retention."""
+
+from datetime import datetime, timezone
+from typing import Any
+
+from google.api_core.exceptions import NotFound
+from google.cloud.firestore_v1 import transactional
+
+
+def normalized_person_alias(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = ' '.join(value.split()).strip()
+    if not normalized or len(normalized) > 128:
+        return None
+    return normalized
+
+
+@transactional
+def update_person_name_transaction(transaction: Any, person_ref: Any, name: str) -> bool:
+    """Rename one stable person while retaining bounded exact aliases."""
+
+    snapshot = person_ref.get(transaction=transaction)
+    if not snapshot.exists:
+        return False
+    raw = snapshot.to_dict()
+    data = raw if isinstance(raw, dict) else {}
+    normalized_name = normalized_person_alias(name)
+    if normalized_name is None:
+        return False
+
+    aliases: list[str] = []
+    seen: set[str] = {normalized_name.casefold()}
+    stored_aliases = data.get('aliases')
+    if isinstance(stored_aliases, list):
+        for value in stored_aliases:
+            alias = normalized_person_alias(value)
+            if alias is None or alias.casefold() in seen:
+                continue
+            seen.add(alias.casefold())
+            aliases.append(alias)
+    prior_name = normalized_person_alias(data.get('name'))
+    if prior_name is not None and prior_name.casefold() not in seen:
+        aliases.append(prior_name)
+    transaction.update(
+        person_ref,
+        {
+            'name': normalized_name,
+            'aliases': aliases[-24:],
+            'updated_at': datetime.now(timezone.utc),
+        },
+    )
+    return True
+
+
+def rename_person_retaining_aliases(db_client: Any, uid: str, person_id: str, name: str) -> bool:
+    """Rename an owner-scoped person and map concurrent deletion to missing."""
+
+    person_ref = db_client.collection('users').document(uid).collection('people').document(person_id)
+    try:
+        return update_person_name_transaction(db_client.transaction(), person_ref, name)
+    except NotFound:
+        return False

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -2,7 +2,6 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, Literal, Optional, TypedDict
 
-from google.api_core.exceptions import NotFound
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter, transactional
 from ._client import db, delete_collection_recursive, document_id_from_seed, get_firestore_client
@@ -13,6 +12,7 @@ from database.account_deletion_transitions import (
     record_late_agent_vm_cleanup as _record_late_agent_vm_cleanup_txn,
 )
 from database.firestore_cache import CachePolicy, get_or_fetch, invalidate
+from database.person_aliases import rename_person_retaining_aliases
 from database.read_boundary import parse_snapshot_or_none, parse_snapshot_strict
 from database.redis_db import (
     delete_cached_user_geolocation,
@@ -885,18 +885,9 @@ def get_people_by_ids(uid: str, person_ids: list[str]):
 
 
 def update_person(uid: str, person_id: str, name: str) -> bool:
-    """Rename a person. Returns False when the person does not exist so callers can 404,
-    instead of letting Firestore .update() raise NotFound and surface as an HTTP 500."""
-    person_ref = db.collection('users').document(uid).collection('people').document(person_id)
-    if not person_ref.get().exists:
-        return False
-    try:
-        person_ref.update({'name': name})
-    except NotFound:
-        # The person was deleted between the existence check and the update; treat as missing so
-        # the caller 404s instead of 500ing on the Firestore NotFound race.
-        return False
-    return True
+    """Rename a stable person and retain old names as owner-scoped aliases."""
+
+    return rename_person_retaining_aliases(db, uid, person_id, name)
 
 
 def delete_person(uid: str, person_id: str):

--- a/backend/tests/unit/test_entity_timeline_source_readers.py
+++ b/backend/tests/unit/test_entity_timeline_source_readers.py
@@ -1,0 +1,200 @@
+from datetime import datetime, timezone
+
+from database import entity_timeline_sources
+
+NOW = datetime(2026, 8, 24, 12, 0, tzinfo=timezone.utc)
+
+
+class _Snapshot:
+    def __init__(self, document_id, payload):
+        self.id = document_id
+        self._payload = payload
+        self.update_time = None
+
+    def to_dict(self):
+        return dict(self._payload)
+
+
+class _Query:
+    def __init__(self, store, path):
+        self._store = store
+        self._path = path
+
+    def document(self, document_id):
+        return _Document(self._store, (*self._path, document_id))
+
+    def where(self, *args, filter=None):
+        self._store.filters.append(filter if filter is not None else args)
+        return self
+
+    def order_by(self, field_path, direction=None):
+        self._store.orderings.append((field_path, direction))
+        return self
+
+    def limit(self, value):
+        self._store.limit_value = value
+        return self
+
+    def stream(self):
+        self._store.streamed_path = self._path
+        return iter(self._store.rows[: self._store.limit_value])
+
+
+class _Document:
+    def __init__(self, store, path):
+        self._store = store
+        self._path = path
+
+    def collection(self, name):
+        return _Query(self._store, (*self._path, name))
+
+
+class _Store:
+    def __init__(self, rows):
+        self.rows = rows
+        self.filters = []
+        self.orderings = []
+        self.limit_value = None
+        self.streamed_path = None
+
+    def collection(self, name):
+        return _Query(self, (name,))
+
+
+def _filter_triples(filters):
+    triples = []
+    for value in filters:
+        if isinstance(value, tuple):
+            triples.append(value)
+        else:
+            triples.append((value.field_path, value.op_string, value.value))
+    return triples
+
+
+def test_conversation_reader_is_owner_scoped_completed_and_deterministically_bounded():
+    store = _Store(
+        [
+            _Snapshot(
+                "conversation-1",
+                {
+                    "created_at": NOW,
+                    "status": "completed",
+                    "discarded": False,
+                    "transcript_segments": [{"person_id": "person-1", "text": "private"}],
+                },
+            )
+        ]
+    )
+
+    rows = entity_timeline_sources.list_entity_timeline_conversations(
+        "u1",
+        db_client=store,
+        limit=2,
+        start_date=NOW,
+        end_date=NOW,
+    )
+
+    assert rows[0]["id"] == "conversation-1"
+    assert rows[0]["transcript_segments"][0]["person_id"] == "person-1"
+    assert "text" not in rows[0]["transcript_segments"][0]
+    assert store.streamed_path == ("users", "u1", "conversations")
+    assert ("discarded", "==", False) in _filter_triples(store.filters)
+    assert ("status", "==", "completed") in _filter_triples(store.filters)
+    assert ("created_at", ">=", NOW) in _filter_triples(store.filters)
+    assert ("created_at", "<=", NOW) in _filter_triples(store.filters)
+    assert [field for field, _ in store.orderings] == ["created_at", "__name__"]
+    assert store.limit_value == 2
+
+
+def test_conversation_reader_bounds_compressed_decode_and_projects_identity_only():
+    from database.conversations import encode_conversation_for_write
+
+    encoded = encode_conversation_for_write(
+        "u1",
+        {"transcript_segments": [{"person_id": "person-1", "is_user": False, "text": "PRIVATE TRANSCRIPT"}]},
+    )
+    store = _Store(
+        [
+            _Snapshot(
+                "conversation-1",
+                {
+                    "created_at": NOW,
+                    "status": "completed",
+                    "discarded": False,
+                    **encoded,
+                },
+            )
+        ]
+    )
+
+    rows = entity_timeline_sources.list_entity_timeline_conversations("u1", db_client=store, limit=1)
+
+    assert rows[0]["transcript_segments"] == [{"is_user": False, "person_id": "person-1"}]
+    assert "PRIVATE TRANSCRIPT" not in repr(rows[0])
+
+
+def test_conversation_reader_fails_oversized_decoded_transcript_closed():
+    from database.conversations import encode_conversation_for_write
+
+    encoded = encode_conversation_for_write(
+        "u1",
+        {"transcript_segments": [{"person_id": "person-1", "text": "x" * (513 * 1024)}]},
+    )
+    store = _Store(
+        [
+            _Snapshot(
+                "conversation-1",
+                {
+                    "created_at": NOW,
+                    "status": "completed",
+                    "discarded": False,
+                    **encoded,
+                },
+            )
+        ]
+    )
+
+    rows = entity_timeline_sources.list_entity_timeline_conversations("u1", db_client=store, limit=1)
+
+    assert rows[0]["transcript_segments"] == []
+
+
+def test_calendar_and_screen_readers_use_owner_path_range_tiebreaker_and_limit():
+    meeting_store = _Store([_Snapshot("meeting-1", {"start_time": NOW, "title": "Review"})])
+    screen_store = _Store(
+        [
+            _Snapshot(
+                "screen-1",
+                {
+                    "timestamp": "2026-08-24 12:00:00.000",
+                    "appName": "Slack",
+                    "windowTitle": "Review",
+                    "ocrText": "Alice",
+                },
+            )
+        ]
+    )
+
+    meetings = entity_timeline_sources.list_entity_timeline_meetings(
+        "u1",
+        db_client=meeting_store,
+        limit=3,
+        start_date=NOW,
+        end_date=NOW,
+    )
+    screens = entity_timeline_sources.list_entity_timeline_screen_activity(
+        "u1",
+        db_client=screen_store,
+        limit=4,
+        start_date=NOW,
+        end_date=NOW,
+    )
+
+    assert meetings[0]["id"] == "meeting-1"
+    assert screens[0]["id"] == "screen-1"
+    assert meeting_store.streamed_path == ("users", "u1", "meetings")
+    assert screen_store.streamed_path == ("users", "u1", "screen_activity")
+    assert [field for field, _ in meeting_store.orderings] == ["start_time", "__name__"]
+    assert [field for field, _ in screen_store.orderings] == ["timestamp", "__name__"]
+    assert meeting_store.limit_value == 3
+    assert screen_store.limit_value == 4

--- a/backend/tests/unit/test_entity_timeline_tools.py
+++ b/backend/tests/unit/test_entity_timeline_tools.py
@@ -281,6 +281,34 @@ def test_timeline_limit_date_range_and_scan_count_are_explicit():
         timeline_tools.build_entity_timeline(items, "person:alice", start=NOW, end=NOW - timedelta(seconds=1))
 
 
+def test_character_budget_truncation_is_always_disclosed():
+    items = [
+        _item(
+            f"mem-{index:02d}",
+            occurred_at=NOW + timedelta(seconds=index),
+            content=f"entry-{index} " + ("x" * 700),
+        )
+        for index in range(40)
+    ]
+
+    timeline = timeline_tools.build_entity_timeline(items, "person:alice", limit=40)
+    timeline = timeline.model_copy(
+        update={
+            "truncated_sources": (timeline_tools.TimelineSource.conversations, timeline_tools.TimelineSource.calendar),
+            "unavailable_sources": (timeline_tools.TimelineSource.screen,),
+            "aliases_resolved": False,
+        }
+    )
+    rendered = timeline_tools.format_entity_timeline(timeline)
+
+    assert len(rendered) <= timeline_tools.MAX_TIMELINE_RESULT_CHARS
+    assert "Timeline output is bounded" in rendered
+    assert "Source windows were partial" in rendered
+    assert "Sources unavailable" in rendered
+    assert "No owner-scoped alias record" in rendered
+    assert sum(1 for line in rendered.splitlines() if line.startswith("- ")) < len(items)
+
+
 def test_tool_is_read_only_bounded_and_double_run_stable(monkeypatch):
     import database._client as database_client
 
@@ -399,3 +427,389 @@ def test_tool_scan_is_hard_bounded(monkeypatch):
 
     assert len(consumed) == timeline_tools.MAX_TIMELINE_SCAN + 1
     assert "Timeline output is bounded" in result
+
+
+class _AliasSnapshot:
+    def __init__(self, document_id, payload, *, exists=True):
+        self.id = document_id
+        self.exists = exists
+        self._payload = payload
+
+    def to_dict(self):
+        return dict(self._payload)
+
+
+class _AliasDocument:
+    def __init__(self, path, seen):
+        self._path = path
+        self._seen = seen
+
+    def collection(self, name):
+        return _AliasCollection((*self._path, name), self._seen)
+
+    def get(self):
+        self._seen.append(self._path)
+        payload = self._seen.payloads.get(self._path)
+        return _AliasSnapshot(self._path[-1], payload or {}, exists=payload is not None)
+
+
+class _AliasCollection:
+    def __init__(self, path, seen):
+        self._path = path
+        self._seen = seen
+        self._limit = timeline_tools.MAX_ALIAS_PEOPLE_SCAN + 1
+
+    def document(self, document_id):
+        return _AliasDocument((*self._path, document_id), self._seen)
+
+    def limit(self, value):
+        self._limit = value
+        return self
+
+    def stream(self):
+        rows = []
+        for path, payload in sorted(self._seen.payloads.items()):
+            if path[:-1] == self._path:
+                rows.append(_AliasSnapshot(path[-1], payload))
+        return iter(rows[: self._limit])
+
+
+class _AliasReads(list):
+    def __init__(self, payloads):
+        super().__init__()
+        self.payloads = payloads
+
+
+class _AliasFirestore:
+    def __init__(self, payloads):
+        self.seen = _AliasReads(payloads)
+
+    def collection(self, name):
+        return _AliasCollection((name,), self.seen)
+
+
+def test_alias_resolution_is_owner_scoped_by_stable_person_id_and_values_stay_match_only():
+    store = _AliasFirestore(
+        {
+            ("users", "u1"): {"name": "Owner"},
+            ("users", "u1", "people", "person-123"): {
+                "name": "Alice Smith",
+                "aliases": ["Alice", "A. Smith"],
+                "emails": ["alice@example.com"],
+            },
+            ("users", "u1", "people", "person-456"): {"name": "Bob"},
+        }
+    )
+    entity = timeline_tools.parse_entity_reference("person:person-123")
+
+    aliases = timeline_tools._resolve_entity_aliases("u1", entity, db_client=store)
+
+    assert aliases.resolved is True
+    assert aliases.values == ("a. smith", "alice", "alice smith", "alice@example.com")
+    assert store.seen == [("users", "u1", "people", "person-123"), ("users", "u1")]
+
+
+def test_alias_resolution_suppresses_owner_and_sibling_collisions_without_losing_stable_id():
+    store = _AliasFirestore(
+        {
+            ("users", "u1"): {"name": "Alice"},
+            ("users", "u1", "people", "person-123"): {
+                "name": "Alice Smith",
+                "aliases": ["Alice"],
+                "emails": ["alice@example.com"],
+            },
+            ("users", "u1", "people", "person-456"): {
+                "name": "Alice Smith",
+                "emails": ["other@example.com"],
+            },
+        }
+    )
+    entity = timeline_tools.parse_entity_reference("person:person-123")
+
+    aliases = timeline_tools._resolve_entity_aliases("u1", entity, db_client=store)
+
+    assert aliases.resolved is True
+    assert aliases.ambiguous is True
+    assert aliases.values == ("alice@example.com",)
+
+
+def test_alias_resolution_fails_alias_joins_closed_when_people_scan_is_not_exhaustive():
+    payloads = {
+        ("users", "u1", "people", "person-123"): {"name": "Alice", "email": "alice@example.com"},
+        **{
+            ("users", "u1", "people", f"sibling-{index:03d}"): {"name": f"Person {index}"}
+            for index in range(timeline_tools.MAX_ALIAS_PEOPLE_SCAN + 1)
+        },
+    }
+    aliases = timeline_tools._resolve_entity_aliases(
+        "u1",
+        timeline_tools.parse_entity_reference("person:person-123"),
+        db_client=_AliasFirestore(payloads),
+    )
+
+    assert aliases.resolved is True
+    assert aliases.ambiguous is True
+    assert aliases.values == ()
+
+
+def test_explicit_history_flag_controls_superseded_and_rejected_rows(monkeypatch):
+    import database._client as database_client
+
+    monkeypatch.setattr(database_client, "get_firestore_client", lambda: object())
+    monkeypatch.setattr(
+        timeline_tools,
+        "_resolve_entity_aliases",
+        lambda uid, entity, *, db_client: timeline_tools.EntityAliases(entity=entity, resolved=True),
+    )
+    current = _item("mem-current", content="Alice currently owns release review")
+    superseded = _item(
+        "mem-history",
+        status=MemoryItemStatus.superseded,
+        valid_to=NOW + timedelta(hours=1),
+        superseded_by="mem-current",
+        content="Alice previously owned release review",
+    )
+    rejected = _item("mem-rejected-audit", promotion={"user_review": False}, content="Rejected claim about Alice")
+    monkeypatch.setattr(
+        timeline_tools,
+        "_iter_authoritative_items",
+        lambda uid, *, db_client, limit: iter([current, superseded, rejected]),
+    )
+
+    current_only = timeline_tools.get_entity_timeline_tool.invoke(
+        {"entity": "person:alice", "sources": ["ledger"]},
+        config={"configurable": {"user_id": "u1"}},
+    )
+    with_history = timeline_tools.get_entity_timeline_tool.invoke(
+        {"entity": "person:alice", "sources": ["ledger"], "include_history": True},
+        config={"configurable": {"user_id": "u1"}},
+    )
+    audit = timeline_tools.get_entity_timeline_tool.invoke(
+        {
+            "entity": "person:alice",
+            "sources": ["ledger"],
+            "include_history": True,
+            "include_rejected": True,
+        },
+        config={"configurable": {"user_id": "u1"}},
+    )
+
+    assert "mem-current" in current_only
+    assert "mem-history" not in current_only
+    assert "mem-rejected-audit" not in current_only
+    assert "mem-history" in with_history
+    assert "mem-rejected-audit" not in with_history
+    assert "mem-rejected-audit" in audit
+
+
+def test_multi_source_alias_merge_is_deterministic_and_never_returns_transcript_ocr_or_email(monkeypatch):
+    import database._client as database_client
+
+    monkeypatch.setattr(database_client, "get_firestore_client", lambda: object())
+    monkeypatch.setattr(
+        timeline_tools,
+        "_resolve_entity_aliases",
+        lambda uid, entity, *, db_client: timeline_tools.EntityAliases(
+            entity=entity,
+            values=("alice smith", "alice@example.com"),
+            resolved=True,
+        ),
+    )
+    ledger = _item("mem-ledger", occurred_at=NOW, content="Alice owns the release review")
+    monkeypatch.setattr(
+        timeline_tools,
+        "_iter_authoritative_items",
+        lambda uid, *, db_client, limit: iter([ledger]),
+    )
+    monkeypatch.setattr(
+        timeline_tools,
+        "list_entity_timeline_conversations",
+        lambda *args, **kwargs: [
+            {
+                "id": "conversation-1",
+                "status": "completed",
+                "discarded": False,
+                "created_at": NOW,
+                "structured": {"title": "Release review", "overview": "Reviewed the ship checklist"},
+                "transcript_segments": [{"person_id": "alice", "text": "TRANSCRIPT_SECRET_SHOULD_NOT_RENDER"}],
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        timeline_tools,
+        "list_entity_timeline_meetings",
+        lambda *args, **kwargs: [
+            {
+                "id": "meeting-1",
+                "start_time": NOW,
+                "title": "Calendar release review",
+                "participants": [{"email": "alice@example.com"}],
+                "notes": "CALENDAR_NOTES_SECRET_SHOULD_NOT_RENDER",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        timeline_tools,
+        "list_entity_timeline_screen_activity",
+        lambda *args, **kwargs: [
+            {
+                "id": "screen-1",
+                "timestamp": NOW,
+                "appName": "Slack",
+                "windowTitle": "Release thread with Alice Smith alice@example.com",
+                "ocrText": "OCR_SECRET_SHOULD_NOT_RENDER alice@example.com",
+            }
+        ],
+    )
+
+    first = timeline_tools.get_entity_timeline_tool.invoke(
+        {
+            "entity": "person:alice",
+            "sources": ["screen", "calendar", "conversations", "ledger"],
+            "limit": 10,
+        },
+        config={"configurable": {"user_id": "u1"}},
+    )
+    second = timeline_tools.get_entity_timeline_tool.invoke(
+        {
+            "entity": "person:alice",
+            "sources": ["ledger", "conversations", "calendar", "screen"],
+            "limit": 10,
+        },
+        config={"configurable": {"user_id": "u1"}},
+    )
+
+    for record_id in ("mem-ledger", "conversation-1", "meeting-1", "screen-1"):
+        assert record_id in first
+        assert record_id in second
+    for secret in (
+        "TRANSCRIPT_SECRET_SHOULD_NOT_RENDER",
+        "CALENDAR_NOTES_SECRET_SHOULD_NOT_RENDER",
+        "OCR_SECRET_SHOULD_NOT_RENDER",
+        "alice@example.com",
+    ):
+        assert secret not in first
+        assert secret not in second
+    # Source argument order cannot affect the deterministic time/source/id merge.
+    assert [line for line in first.splitlines() if line.startswith("- ")] == [
+        line for line in second.splitlines() if line.startswith("- ")
+    ]
+
+
+def test_malformed_metadata_and_unicode_emails_never_cross_projection_boundary():
+    aliases = timeline_tools.EntityAliases(
+        entity=timeline_tools.parse_entity_reference("person:alice"),
+        values=("alice", "alice@example.com"),
+        resolved=True,
+    )
+    conversation = timeline_tools._conversation_entry(
+        {
+            "id": "conversation-1",
+            "created_at": NOW,
+            "structured": {
+                "title": {"transcript": "TRANSCRIPT_SECRET"},
+                "overview": ["CALENDAR_NOTE_SECRET"],
+            },
+            "transcript_segments": [{"person_id": "alice"}],
+        },
+        aliases,
+    )
+    calendar = timeline_tools._calendar_entry(
+        {
+            "id": "meeting-1",
+            "start_time": NOW,
+            "title": "Review with alice@例子.公司",
+            "participants": [{"email": "alice@example.com"}],
+        },
+        aliases,
+    )
+    screen = timeline_tools._screen_entry(
+        {
+            "id": "screen-1",
+            "timestamp": NOW,
+            "appName": {"frame": "FRAME_SECRET"},
+            "windowTitle": "Alice alice@例子.公司",
+            "ocrText": "Alice OCR_SECRET",
+        },
+        aliases,
+    )
+
+    assert conversation is not None and conversation.content == "Conversation"
+    assert calendar is not None and calendar.content == "Review with [redacted email]"
+    assert screen is not None and screen.content == "Screen activity — Alice [redacted email]"
+    combined = " ".join(entry.content for entry in (conversation, calendar, screen) if entry is not None)
+    for secret in ("TRANSCRIPT_SECRET", "CALENDAR_NOTE_SECRET", "FRAME_SECRET", "alice@例子.公司"):
+        assert secret not in combined
+
+
+def test_non_ledger_source_consumer_stays_bounded_when_reader_violates_its_limit(monkeypatch):
+    monkeypatch.setattr(timeline_tools.database_client, "get_firestore_client", lambda: object())
+    monkeypatch.setattr(
+        timeline_tools,
+        "_resolve_entity_aliases",
+        lambda uid, entity, *, db_client: timeline_tools.EntityAliases(
+            entity=entity,
+            values=("alice",),
+            resolved=True,
+        ),
+    )
+    rows = [
+        {
+            "id": f"meeting-{index}",
+            "start_time": NOW + timedelta(seconds=index),
+            "title": "Review",
+            "participants": [{"name": "Alice"}],
+        }
+        for index in range(timeline_tools.MAX_TIMELINE_SOURCE_SCAN + 50)
+    ]
+    monkeypatch.setattr(timeline_tools, "list_entity_timeline_meetings", lambda *args, **kwargs: rows)
+
+    result = timeline_tools.get_entity_timeline_tool.invoke(
+        {"entity": "person:alice", "sources": ["calendar"], "limit": 1},
+        config={"configurable": {"user_id": "u1"}},
+    )
+
+    assert "Source windows were partial: calendar" in result
+    assert f"meeting-{timeline_tools.MAX_TIMELINE_SOURCE_SCAN}" not in result
+
+
+def test_source_failure_is_partial_and_disclosed_without_falling_back(monkeypatch):
+    import database._client as database_client
+
+    monkeypatch.setattr(database_client, "get_firestore_client", lambda: object())
+    monkeypatch.setattr(
+        timeline_tools,
+        "_resolve_entity_aliases",
+        lambda uid, entity, *, db_client: timeline_tools.EntityAliases(entity=entity, resolved=True),
+    )
+
+    def unavailable(*args, **kwargs):
+        raise RuntimeError("private upstream detail")
+
+    monkeypatch.setattr(timeline_tools, "list_entity_timeline_conversations", unavailable)
+    result = timeline_tools.get_entity_timeline_tool.invoke(
+        {"entity": "person:alice", "sources": ["conversations"]},
+        config={"configurable": {"user_id": "u1"}},
+    )
+
+    assert "No entity timeline entries" in result
+    assert "Sources unavailable: conversations" in result
+    assert "private upstream detail" not in result
+
+
+def test_sources_and_history_audit_mode_are_explicitly_validated_before_storage(monkeypatch):
+    calls = []
+    monkeypatch.setattr(timeline_tools.database_client, "get_firestore_client", lambda: calls.append(True))
+
+    unknown = timeline_tools.get_entity_timeline_tool.invoke(
+        {"entity": "person:alice", "sources": ["semantic_guess"]},
+        config={"configurable": {"user_id": "u1"}},
+    )
+    invalid_audit = timeline_tools.get_entity_timeline_tool.invoke(
+        {"entity": "person:alice", "include_rejected": True},
+        config={"configurable": {"user_id": "u1"}},
+    )
+
+    assert "unsupported timeline source" in unknown
+    assert "include_rejected requires include_history" in invalid_audit
+    assert calls == []

--- a/backend/tests/unit/test_update_person_missing.py
+++ b/backend/tests/unit/test_update_person_missing.py
@@ -1,10 +1,4 @@
-"""Regression test for renaming a missing person.
-
-PATCH /v1/users/people/{person_id}/name -> update_person did a bare Firestore .update(), which
-raises NotFound on a missing/stale person id (e.g. after the idempotent DELETE removed it),
-surfacing as HTTP 500. update_person now checks existence and returns False so the router can 404.
-Pinned against a fake Firestore via patch.object on the db proxy, no live services.
-"""
+"""Regression tests for stable person rename and alias retention."""
 
 import os
 from unittest.mock import MagicMock, patch
@@ -15,6 +9,7 @@ os.environ.setdefault(
 )
 
 import database.users as users_db  # noqa: E402
+from database import person_aliases  # noqa: E402
 
 
 def _person_ref(fake_db, exists):
@@ -26,27 +21,67 @@ def _person_ref(fake_db, exists):
 
 def test_update_person_missing_returns_false_without_updating():
     fake_db = MagicMock()
-    ref = _person_ref(fake_db, exists=False)
-    with patch.object(users_db, "db", fake_db):
+    _person_ref(fake_db, exists=False)
+    with patch.object(users_db, "db", fake_db), patch.object(
+        users_db, "rename_person_retaining_aliases", return_value=False
+    ) as rename:
         assert users_db.update_person("u1", "missing", "Alice") is False
-    ref.update.assert_not_called()  # no .update() -> no NotFound -> no 500
+    rename.assert_called_once_with(fake_db, "u1", "missing", "Alice")
 
 
 def test_update_person_existing_updates_and_returns_true():
     fake_db = MagicMock()
-    ref = _person_ref(fake_db, exists=True)
-    with patch.object(users_db, "db", fake_db):
+    _person_ref(fake_db, exists=True)
+    with patch.object(users_db, "db", fake_db), patch.object(
+        users_db, "rename_person_retaining_aliases", return_value=True
+    ) as rename:
         assert users_db.update_person("u1", "p1", "Alice") is True
-    ref.update.assert_called_once_with({"name": "Alice"})
+    rename.assert_called_once_with(fake_db, "u1", "p1", "Alice")
 
 
 def test_update_person_deleted_between_check_and_update_returns_false():
-    # The person passes the existence check but is deleted before .update() lands, so Firestore
-    # raises NotFound. That race must still 404, not surface as a 500. Use users_db.NotFound (the exact
-    # class update_person catches) rather than importing google.api_core here, so this test is not
-    # broken by another test in the full suite that stubs the google namespace in sys.modules.
     fake_db = MagicMock()
-    ref = _person_ref(fake_db, exists=True)
-    ref.update.side_effect = users_db.NotFound("person deleted mid-rename")
-    with patch.object(users_db, "db", fake_db):
+    _person_ref(fake_db, exists=True)
+    with patch.object(users_db, "db", fake_db), patch.object(users_db, "rename_person_retaining_aliases") as rename:
+        rename.return_value = False
         assert users_db.update_person("u1", "racing", "Alice") is False
+
+
+def test_person_alias_boundary_maps_transactional_not_found_to_missing():
+    fake_db = MagicMock()
+    with patch.object(
+        person_aliases,
+        "update_person_name_transaction",
+        side_effect=person_aliases.NotFound("person deleted mid-rename"),
+    ):
+        assert person_aliases.rename_person_retaining_aliases(fake_db, "u1", "racing", "Alice") is False
+
+
+def test_person_rename_transaction_retains_old_names_as_bounded_exact_aliases():
+    transaction = MagicMock()
+    person_ref = MagicMock()
+    snapshot = person_ref.get.return_value
+    snapshot.exists = True
+    snapshot.to_dict.return_value = {
+        "name": "Alice Smith",
+        "aliases": ["Ally", " ALICE SMITH ", "A. Smith", None],
+    }
+
+    result = person_aliases.update_person_name_transaction.to_wrap(transaction, person_ref, " Alicia Smith ")
+
+    assert result is True
+    payload = transaction.update.call_args.args[1]
+    assert payload["name"] == "Alicia Smith"
+    assert payload["aliases"] == ["Ally", "ALICE SMITH", "A. Smith"]
+    assert payload["updated_at"].tzinfo is not None
+
+
+def test_person_rename_transaction_rejects_blank_without_mutation():
+    transaction = MagicMock()
+    person_ref = MagicMock()
+    snapshot = person_ref.get.return_value
+    snapshot.exists = True
+    snapshot.to_dict.return_value = {"name": "Alice"}
+
+    assert person_aliases.update_person_name_transaction.to_wrap(transaction, person_ref, "   ") is False
+    transaction.update.assert_not_called()

--- a/backend/utils/memory/ledger_history_policy.py
+++ b/backend/utils/memory/ledger_history_policy.py
@@ -1,0 +1,40 @@
+"""Shared admission policy for explicit canonical-ledger history reads."""
+
+from models.memories import MemoryDB
+from models.product_memory import (
+    LedgerWriteReason,
+    MemoryItem,
+    MemoryItemStatus,
+    ProcessingState,
+    RESTRICTED_SENSITIVITY_LABELS,
+    SourceState,
+)
+from utils.memory.knowledge_ledger import LEDGER_SCHEMA_VERSION
+
+
+def is_ledger_history_item(item: MemoryItem, row: MemoryDB) -> bool:
+    """Return whether one canonical row belongs to the explicit history view."""
+
+    if item.ledger_schema_version != LEDGER_SCHEMA_VERSION:
+        return False
+    is_preserved_legacy_history = not item.intent_backed and item.write_reason == LedgerWriteReason.legacy_migration
+    if not item.intent_backed and not is_preserved_legacy_history:
+        return False
+    if item.status in {MemoryItemStatus.hidden, MemoryItemStatus.tombstoned}:
+        return False
+    if item.processing_state != ProcessingState.processed:
+        return False
+    if item.source_state in {SourceState.tombstoned, SourceState.purged}:
+        return False
+    if set(item.sensitivity_labels).intersection(RESTRICTED_SENSITIVITY_LABELS):
+        return False
+    if row.is_locked:
+        return False
+    # Admit only states the public MemoryDB wire shape can represent. A
+    # status-only superseded row would otherwise serialize as current.
+    return (
+        is_preserved_legacy_history
+        or row.user_review is False
+        or row.invalid_at is not None
+        or row.superseded_by is not None
+    )

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -67,6 +67,7 @@ from utils.memory.knowledge_ledger import (
     amend_fact,
     evidence_id_for_ledger_provenance,
 )
+from utils.memory.ledger_history_policy import is_ledger_history_item
 from utils.memory.rejected_memory_feedback import clear_rejected_memory_feedback_cache
 from utils.memory.required_promotion import required_processing_payload
 from config.memory_rollout import MemoryRolloutMode, rollout_mode_env_value
@@ -2635,31 +2636,9 @@ class MemoryService:
 
     @staticmethod
     def _is_ledger_history_item(item: MemoryItem, row: MemoryDB) -> bool:
-        """Keep history reads canonical, privacy-filtered, and wire-representable."""
+        """Compatibility wrapper for callers that patch the legacy seam."""
 
-        if item.ledger_schema_version != LEDGER_SCHEMA_VERSION:
-            return False
-        is_preserved_legacy_history = not item.intent_backed and item.write_reason == LedgerWriteReason.legacy_migration
-        if not item.intent_backed and not is_preserved_legacy_history:
-            return False
-        if item.status in {MemoryItemStatus.hidden, MemoryItemStatus.tombstoned}:
-            return False
-        if item.processing_state != ProcessingState.processed:
-            return False
-        if item.source_state in {SourceState.tombstoned, SourceState.purged}:
-            return False
-        if set(item.sensitivity_labels).intersection(RESTRICTED_SENSITIVITY_LABELS):
-            return False
-        if row.is_locked:
-            return False
-        # Admit only states the public MemoryDB wire shape can represent. A
-        # status-only superseded row would otherwise serialize as current.
-        return (
-            is_preserved_legacy_history
-            or row.user_review is False
-            or row.invalid_at is not None
-            or row.superseded_by is not None
-        )
+        return is_ledger_history_item(item, row)
 
     def read_ledger_history_page(
         self,

--- a/backend/utils/retrieval/tools/entity_timeline_tools.py
+++ b/backend/utils/retrieval/tools/entity_timeline_tools.py
@@ -12,27 +12,49 @@ become a broad profile search.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from enum import Enum
 from itertools import islice
 import logging
 import re
-from typing import Any, Dict, Iterable, Iterator, List, Literal, Optional, Tuple, cast
+import unicodedata
+from typing import Any, Dict, Iterable, Iterator, List, Literal, Optional, Sequence, Tuple, cast
 
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool  # type: ignore[reportUnknownVariableType]
 from pydantic import BaseModel, ConfigDict, field_validator
 
+from database import _client as database_client
+from database.entity_timeline_sources import (
+    list_entity_timeline_conversations,
+    list_entity_timeline_meetings,
+    list_entity_timeline_screen_activity,
+)
 from models.product_memory import MemoryAccessPolicy, MemoryItem, MemoryItemStatus, MemoryKind, MemorySubjectScope
 from utils.memory.canonical_visibility_filter import filter_canonical_default_visible_items
+from utils.memory.canonical_memory_adapter import memory_item_to_memorydb
+from utils.memory.ledger_history_policy import is_ledger_history_item
 
 logger = logging.getLogger(__name__)
 
 MAX_TIMELINE_LIMIT = 40
 MAX_TIMELINE_SCAN = 500
+MAX_TIMELINE_SOURCE_SCAN = 200
 MAX_TIMELINE_RESULT_CHARS = 12_000
 MAX_TIMELINE_CONTENT_CHARS = 600
 MAX_ENTITY_REFERENCE_CHARS = 128
+MAX_ALIAS_PEOPLE_SCAN = 200
 SUPPORTED_ENTITY_KINDS = frozenset({"user", "person", "project", "organization", "place", "entity"})
 EntityKind = Literal["user", "person", "project", "organization", "place", "entity"]
+
+
+class TimelineSource(str, Enum):
+    ledger = "ledger"
+    conversations = "conversations"
+    calendar = "calendar"
+    screen = "screen"
+
+
+DEFAULT_TIMELINE_SOURCES = (TimelineSource.ledger,)
 
 
 class EntityReference(BaseModel):
@@ -56,13 +78,30 @@ class EntityReference(BaseModel):
         return "user" if self.kind == "user" else f"{self.kind}:{self.identifier}"
 
 
+class EntityAliases(BaseModel):
+    """Exact owner-scoped aliases for one canonical entity.
+
+    Alias values are match inputs only and are never rendered.  This lets an
+    email join a calendar record without disclosing it in the tool response.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    entity: EntityReference
+    values: Tuple[str, ...] = ()
+    resolved: bool = False
+    ambiguous: bool = False
+
+
 class TimelineEntry(BaseModel):
     """A compact fact projection; no transcript or arbitrary MemoryItem fields."""
 
     model_config = ConfigDict(frozen=True)
 
-    memory_id: str
-    status: MemoryItemStatus
+    source: TimelineSource = TimelineSource.ledger
+    record_id: str
+    memory_id: Optional[str] = None
+    status: Optional[MemoryItemStatus] = None
     content: str
     occurred_at: datetime
     valid_to: Optional[datetime] = None
@@ -84,6 +123,11 @@ class EntityTimeline(BaseModel):
     entries: Tuple[TimelineEntry, ...] = ()
     truncated: bool = False
     scanned_count: int = 0
+    aliases_resolved: bool = False
+    aliases_ambiguous: bool = False
+    requested_sources: Tuple[TimelineSource, ...] = ()
+    truncated_sources: Tuple[TimelineSource, ...] = ()
+    unavailable_sources: Tuple[TimelineSource, ...] = ()
 
 
 def _agent_config() -> Optional[Dict[str, Any]]:
@@ -126,6 +170,148 @@ def parse_entity_reference(raw: str) -> EntityReference:
     return EntityReference(kind=cast(EntityKind, kind), identifier=identifier)
 
 
+def _normalize_alias(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    normalized = " ".join(unicodedata.normalize("NFKC", value).split()).strip().casefold()
+    if not normalized or len(normalized) > MAX_ENTITY_REFERENCE_CHARS:
+        return None
+    return normalized
+
+
+def _parse_sources(values: Optional[Sequence[str]]) -> Tuple[TimelineSource, ...]:
+    if values is None:
+        return DEFAULT_TIMELINE_SOURCES
+    resolved: List[TimelineSource] = []
+    for value in values:
+        try:
+            source = TimelineSource(str(value).strip().casefold())
+        except ValueError as exc:
+            raise ValueError(f"unsupported timeline source: {value}") from exc
+        if source not in resolved:
+            resolved.append(source)
+    if not resolved:
+        raise ValueError("at least one timeline source is required")
+    return tuple(resolved)
+
+
+def _resolve_entity_aliases(uid: str, entity: EntityReference, *, db_client: Any) -> EntityAliases:
+    """Resolve exact aliases from the owner's canonical people document.
+
+    The people document ID remains authority.  Display-name equality is never
+    used to choose a person document, so duplicate names cannot cross-link two
+    stable people.  Existing optional ``aliases``/``emails`` fields are read
+    when present without making them mutation authority.
+    """
+
+    if entity.kind == "user":
+        return EntityAliases(entity=entity, resolved=True)
+    if entity.kind != "person":
+        return EntityAliases(entity=entity)
+    user_ref = db_client.collection("users").document(uid)
+    people = user_ref.collection("people")
+    snapshot = people.document(entity.identifier).get()
+    if not getattr(snapshot, "exists", False):
+        return EntityAliases(entity=entity)
+    raw = snapshot.to_dict()
+    if not isinstance(raw, dict):
+        return EntityAliases(entity=entity)
+    candidates = _person_alias_values(raw)
+
+    # Alias equality is not identity when two owner-scoped entities share the
+    # same name or address. Suppress every collision rather than cross-linking
+    # an unkeyed calendar/screen record to the selected stable person.
+    collisions: set[str] = set()
+    owner_snapshot = user_ref.get()
+    owner_raw = owner_snapshot.to_dict() if getattr(owner_snapshot, "exists", False) else None
+    if isinstance(owner_raw, dict):
+        collisions.update(_person_alias_values(owner_raw))
+    siblings = list(islice(people.limit(MAX_ALIAS_PEOPLE_SCAN + 1).stream(), MAX_ALIAS_PEOPLE_SCAN + 1))
+    if len(siblings) > MAX_ALIAS_PEOPLE_SCAN:
+        return EntityAliases(entity=entity, resolved=True, ambiguous=True)
+    for sibling in siblings:
+        if str(getattr(sibling, "id", "")) == entity.identifier:
+            continue
+        sibling_raw = sibling.to_dict()
+        if isinstance(sibling_raw, dict):
+            collisions.update(_person_alias_values(sibling_raw))
+    aliases = tuple(sorted(candidates - collisions))
+    return EntityAliases(entity=entity, values=aliases, resolved=True, ambiguous=aliases != tuple(sorted(candidates)))
+
+
+def _person_alias_values(raw: Dict[str, Any]) -> set[str]:
+    candidates: List[Any] = [raw.get("name"), raw.get("email")]
+    for field in ("aliases", "emails"):
+        values = raw.get(field)
+        if isinstance(values, (list, tuple)):
+            candidates.extend(values[:24])
+    return {alias for value in candidates if (alias := _normalize_alias(value)) is not None}
+
+
+def _participant_matches(value: Any, aliases: EntityAliases) -> bool:
+    if isinstance(value, dict):
+        return any(_normalize_alias(value.get(field)) in aliases.values for field in ("name", "email", "display_name"))
+    return _normalize_alias(value) in aliases.values
+
+
+def _text_contains_alias(value: Any, aliases: EntityAliases) -> bool:
+    normalized = _normalize_alias(value)
+    if normalized is None:
+        return False
+    for alias in aliases.values:
+        # Screen matching is deliberately exact-token/phrase based.  A stable
+        # entity is never inferred from fuzzy or semantic text similarity.
+        if len(alias) < 3 and "@" not in alias:
+            continue
+        if re.search(rf"(?<!\w){re.escape(alias)}(?!\w)", normalized):
+            return True
+    return False
+
+
+def _public_metadata_text(value: Any, *, fallback: str, limit: int) -> str:
+    """Project compact metadata without returning email addresses.
+
+    Email aliases are match inputs only. Titles and window metadata are still
+    user-authored strings, so strip any address-shaped value before rendering
+    rather than assuming the structured participant fields are the only place
+    one can appear.
+    """
+
+    # Firestore is schemaless at this boundary. Never stringify a malformed
+    # mapping/list into a field that is allowed to reach the agent: protected
+    # transcript, note, frame, or attendee data can otherwise hitchhike inside
+    # a nominal title/window value.
+    public_value = value if isinstance(value, str) else fallback
+    compact = " ".join(public_value.split())
+    # Redact the whole non-whitespace token around ``@``. This deliberately
+    # favors false-positive redaction over leaking Unicode/IDN addresses that
+    # an ASCII-TLD expression would miss.
+    without_emails = re.sub(r"\S*@\S*", "[redacted email]", compact)
+    return without_emails[:limit]
+
+
+def _datetime_value(value: Any) -> Optional[datetime]:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str) and value.strip():
+        try:
+            parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError:
+            try:
+                parsed = datetime.strptime(value.strip(), "%Y-%m-%d %H:%M:%S.%f").replace(tzinfo=timezone.utc)
+            except ValueError:
+                return None
+    else:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _in_range(value: datetime, start: Optional[datetime], end: Optional[datetime]) -> bool:
+    return not ((start is not None and value < start) or (end is not None and value > end))
+
+
 def _validate_bounds(limit: int, start: Optional[datetime], end: Optional[datetime]) -> int:
     if limit < 1 or limit > MAX_TIMELINE_LIMIT:
         raise ValueError(f"limit must be between 1 and {MAX_TIMELINE_LIMIT}")
@@ -156,6 +342,163 @@ def _evidence_refs(item: MemoryItem) -> Tuple[Tuple[str, ...], Tuple[str, ...]]:
         if evidence.source_id:
             source_refs.append(f"{evidence.source_type}:{evidence.source_id}")
     return tuple(sorted(set(evidence_refs))), tuple(sorted(set(source_refs)))
+
+
+def _ledger_entries(
+    items: Sequence[MemoryItem],
+    entity: EntityReference,
+    *,
+    include_history: bool,
+    include_rejected: bool,
+    start: Optional[datetime],
+    end: Optional[datetime],
+) -> List[TimelineEntry]:
+    visible_ids = {item.memory_id for item in _chat_visible_items(list(items))}
+    entries: List[TimelineEntry] = []
+    for item in items:
+        if item.kind != MemoryKind.fact or not _item_matches_entity(item, entity):
+            continue
+        occurred_at = _timeline_time(item)
+        if not _in_range(occurred_at, start, end):
+            continue
+        row = memory_item_to_memorydb(item)
+        is_current = item.memory_id in visible_ids and item.status == MemoryItemStatus.active
+        is_history = include_history and is_ledger_history_item(item, row)
+        if is_history and row.user_review is False and not include_rejected:
+            is_history = False
+        if not is_current and not is_history:
+            continue
+        evidence_refs, source_refs = _evidence_refs(item)
+        entries.append(
+            TimelineEntry(
+                source=TimelineSource.ledger,
+                record_id=item.memory_id,
+                memory_id=item.memory_id,
+                status=item.status,
+                content=item.content or "",
+                occurred_at=occurred_at,
+                valid_to=item.valid_to,
+                evidence_refs=evidence_refs,
+                source_refs=source_refs,
+            )
+        )
+    return entries
+
+
+def _calendar_participants(record: Dict[str, Any]) -> List[Any]:
+    participants: List[Any] = []
+    direct = record.get("participants")
+    if isinstance(direct, (list, tuple)):
+        participants.extend(direct)
+    external = record.get("external_data")
+    external_data = external if isinstance(external, dict) else {}
+    context = external_data.get("calendar_meeting_context") or record.get("calendar_meeting_context")
+    if isinstance(context, dict) and isinstance(context.get("participants"), (list, tuple)):
+        participants.extend(context["participants"])
+    event = record.get("calendar_event")
+    if isinstance(event, dict) and isinstance(event.get("attendees"), (list, tuple)):
+        participants.extend(event["attendees"])
+    return participants
+
+
+def _conversation_matches(record: Dict[str, Any], aliases: EntityAliases) -> bool:
+    segments = record.get("transcript_segments")
+    if isinstance(segments, list):
+        for segment in segments[:4096]:
+            if not isinstance(segment, dict):
+                continue
+            if aliases.entity.kind == "user" and segment.get("is_user") is True:
+                return True
+            person_id = str(segment.get("person_id") or "").strip().casefold()
+            if aliases.entity.kind == "person" and person_id in {
+                aliases.entity.identifier,
+                aliases.entity.key,
+            }:
+                return True
+    return bool(aliases.values) and any(
+        _participant_matches(value, aliases) for value in _calendar_participants(record)
+    )
+
+
+def _conversation_entry(record: Dict[str, Any], aliases: EntityAliases) -> Optional[TimelineEntry]:
+    if record.get("is_locked") is True or not _conversation_matches(record, aliases):
+        return None
+    record_id = str(record.get("id") or "").strip()
+    occurred_at = _datetime_value(record.get("started_at") or record.get("created_at"))
+    if not record_id or occurred_at is None or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._~-]*", record_id) is None:
+        return None
+    structured = record.get("structured")
+    summary = structured if isinstance(structured, dict) else {}
+    title = _public_metadata_text(summary.get("title"), fallback="Conversation", limit=160)
+    overview = _public_metadata_text(summary.get("overview"), fallback="", limit=400)
+    content = title if not overview else f"{title} — {overview}"
+    reference = f"conversation:{record_id}:summary"
+    return TimelineEntry(
+        source=TimelineSource.conversations,
+        record_id=record_id,
+        content=content,
+        occurred_at=occurred_at,
+        evidence_refs=(reference,),
+        source_refs=(f"conversation:{record_id}",),
+    )
+
+
+def _calendar_entry(record: Dict[str, Any], aliases: EntityAliases) -> Optional[TimelineEntry]:
+    if not aliases.values or not any(_participant_matches(value, aliases) for value in _calendar_participants(record)):
+        return None
+    record_id = str(record.get("id") or "").strip()
+    occurred_at = _datetime_value(record.get("start_time"))
+    if not record_id or occurred_at is None or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._~-]*", record_id) is None:
+        return None
+    title = _public_metadata_text(record.get("title"), fallback="Calendar meeting", limit=MAX_TIMELINE_CONTENT_CHARS)
+    reference = f"calendar-meeting:{record_id}"
+    return TimelineEntry(
+        source=TimelineSource.calendar,
+        record_id=record_id,
+        content=title,
+        occurred_at=occurred_at,
+        evidence_refs=(reference,),
+        source_refs=(reference,),
+    )
+
+
+def _screen_entry(record: Dict[str, Any], aliases: EntityAliases) -> Optional[TimelineEntry]:
+    if not aliases.values or not any(
+        _text_contains_alias(record.get(field), aliases) for field in ("ocrText", "windowTitle")
+    ):
+        return None
+    record_id = str(record.get("id") or "").strip()
+    occurred_at = _datetime_value(record.get("timestamp"))
+    if not record_id or occurred_at is None or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._~-]*", record_id) is None:
+        return None
+    app = _public_metadata_text(record.get("appName"), fallback="Screen activity", limit=120)
+    window = _public_metadata_text(record.get("windowTitle"), fallback="", limit=240)
+    content = app if not window else f"{app} — {window}"
+    reference = f"screen:{record_id}"
+    return TimelineEntry(
+        source=TimelineSource.screen,
+        record_id=record_id,
+        content=content,
+        occurred_at=occurred_at,
+        evidence_refs=(reference,),
+        source_refs=(reference,),
+    )
+
+
+def _merge_timeline_entries(
+    entries: Iterable[TimelineEntry],
+    *,
+    limit: int,
+) -> Tuple[Tuple[TimelineEntry, ...], bool]:
+    by_identity: Dict[Tuple[TimelineSource, str], TimelineEntry] = {}
+    for entry in entries:
+        by_identity[(entry.source, entry.record_id)] = entry
+    ordered = sorted(
+        by_identity.values(),
+        key=lambda entry: (entry.occurred_at, entry.source.value, entry.record_id),
+    )
+    truncated = len(ordered) > limit
+    return tuple(ordered[-limit:]), truncated
 
 
 def build_entity_timeline(
@@ -200,6 +543,8 @@ def build_entity_timeline(
         evidence_refs, source_refs = _evidence_refs(item)
         entries.append(
             TimelineEntry(
+                source=TimelineSource.ledger,
+                record_id=item.memory_id,
                 memory_id=item.memory_id,
                 status=item.status,
                 content=item.content or "",
@@ -214,6 +559,7 @@ def build_entity_timeline(
         entries=tuple(entries),
         truncated=truncated,
         scanned_count=scanned if scanned_count is None else scanned_count,
+        requested_sources=(TimelineSource.ledger,),
     )
 
 
@@ -233,11 +579,47 @@ def format_entity_timeline(timeline: EntityTimeline) -> str:
     """Render only bounded timeline facts and opaque/stable evidence refs."""
 
     if not timeline.entries:
-        return f"No entity timeline entries found for {timeline.entity.key}."
-    lines = [f"Entity timeline: {timeline.entity.key}", ""]
+        lines = [f"No entity timeline entries found for {timeline.entity.key}."]
+        if timeline.truncated_sources:
+            lines.append(
+                "[Source windows were partial: "
+                + ", ".join(source.value for source in timeline.truncated_sources)
+                + ".]"
+            )
+        if timeline.unavailable_sources:
+            lines.append(
+                "[Sources unavailable: " + ", ".join(source.value for source in timeline.unavailable_sources) + ".]"
+            )
+        if timeline.entity.kind == "person" and not timeline.aliases_resolved:
+            lines.append("[No owner-scoped alias record was found; only canonical-ID joins were attempted.]")
+        elif timeline.entity.kind == "person" and timeline.aliases_ambiguous:
+            lines.append("[Ambiguous owner-scoped aliases were suppressed; canonical-ID joins remain authoritative.]")
+        return "\n".join(lines)
+    source_names = ", ".join(source.value for source in timeline.requested_sources)
+    lines = [f"Entity timeline: {timeline.entity.key}", f"Sources: {source_names}", ""]
+    output_truncated = False
+    truncation_notice = "[Timeline output is bounded; ask for a narrower entity or date range.]"
+    postambles: List[str] = []
+    if timeline.truncated_sources:
+        postambles.append(
+            "[Source windows were partial: " + ", ".join(source.value for source in timeline.truncated_sources) + ".]"
+        )
+    if timeline.unavailable_sources:
+        postambles.append(
+            "[Sources unavailable: " + ", ".join(source.value for source in timeline.unavailable_sources) + ".]"
+        )
+    if timeline.entity.kind == "person" and not timeline.aliases_resolved:
+        postambles.append("[No owner-scoped alias record was found; only canonical-ID joins were attempted.]")
+    elif timeline.entity.kind == "person" and timeline.aliases_ambiguous:
+        postambles.append("[Ambiguous owner-scoped aliases were suppressed; canonical-ID joins remain authoritative.]")
+    # Always reserve the possible truncation notice plus every deterministic
+    # postamble. A result that needs all disclosures must still honor the hard
+    # transport cap.
+    reserved_chars = len(truncation_notice) + sum(len(value) + 1 for value in postambles) + 2
     for entry in timeline.entries:
+        status = f"/{entry.status.value}" if entry.status is not None else ""
         block = [
-            f"- {entry.occurred_at.isoformat()} [{entry.status.value}] {entry.memory_id}",
+            f"- {entry.occurred_at.isoformat()} [{entry.source.value}{status}] {entry.record_id}",
             f"  {entry.content}",
         ]
         if entry.valid_to:
@@ -247,11 +629,15 @@ def format_entity_timeline(timeline: EntityTimeline) -> str:
         if entry.source_refs:
             block.append("  sources: " + ", ".join(entry.source_refs))
         candidate = "\n".join(lines + block)
-        if len(candidate) > MAX_TIMELINE_RESULT_CHARS:
+        # Reserve room for the required disclosure when the character budget,
+        # rather than the entry-count budget, stops rendering.
+        if len(candidate) + reserved_chars > MAX_TIMELINE_RESULT_CHARS:
+            output_truncated = True
             break
         lines.extend(block)
-    if timeline.truncated or len(lines) < 3 + (len(timeline.entries) * 2):
-        lines.extend(["", "[Timeline output is bounded; ask for a narrower entity or date range.]"])
+    if timeline.truncated or output_truncated:
+        lines.extend(["", truncation_notice])
+    lines.extend(postambles)
     return "\n".join(lines).strip()
 
 
@@ -274,24 +660,38 @@ def _chat_visible_items(items: List[MemoryItem]) -> List[MemoryItem]:
 @tool
 def get_entity_timeline_tool(
     entity: str,
+    sources: Optional[List[str]] = None,
+    include_history: bool = False,
+    include_rejected: bool = False,
     limit: int = 20,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     config: RunnableConfig = None,  # type: ignore[reportAssignmentType]
 ) -> str:
-    """Read a bounded, current chat-visible timeline for one canonical entity.
+    """Read a bounded multi-source timeline for one canonical entity.
 
     ``entity`` must be ``user``/``me`` or a stable reference such as
-    ``person:alice`` or ``project:omi``.  The result contains fact entries and
-    stable evidence/source refs only; it never returns transcripts or profile
-    bodies.  Unsupported references fail closed before any data read.
+    ``person:<stable_person_id>`` or ``project:omi``. ``sources`` explicitly
+    selects any of ``ledger``, ``conversations``, ``calendar``, and ``screen``.
+    Set ``include_history`` only when current knowledge is insufficient and the
+    agent needs closed, superseded, episodic, or migrated-legacy ledger facts.
+    Rejected rows remain excluded unless the agent explicitly requests audit
+    mode with ``include_rejected``. No query-word heuristic enables history.
+
+    Person aliases are resolved by exact stable person ID from the owner's
+    people record, then joined exactly across completed conversations, calendar
+    participants, and screen metadata. The response never includes transcripts,
+    OCR text, alias emails, playbook bodies, or trigger conditions.
     """
 
     try:
         reference = parse_entity_reference(entity)
+        requested_sources = _parse_sources(sources)
         start = _parse_iso_date(start_date, "start_date")
         end = _parse_iso_date(end_date, "end_date")
         bounded_limit = _validate_bounds(limit, start, end)
+        if include_rejected and not include_history:
+            raise ValueError("include_rejected requires include_history")
     except ValueError as exc:
         return f"Error: unsupported or invalid entity timeline request: {exc}"
 
@@ -300,28 +700,134 @@ def get_entity_timeline_tool(
         return "Error: User ID not found in configuration"
 
     try:
-        from database._client import get_firestore_client
-
-        firestore_db = get_firestore_client()
-        stream = _iter_authoritative_items(uid, db_client=firestore_db, limit=MAX_TIMELINE_SCAN + 1)
-        # Keep the consumer boundary independently bounded even if a future
-        # reader implementation fails to honor its explicit storage limit.
-        scanned_rows = list(islice(stream, MAX_TIMELINE_SCAN + 1))
-        scan_truncated = len(scanned_rows) > MAX_TIMELINE_SCAN
-        timeline = build_entity_timeline(
-            _chat_visible_items(scanned_rows[:MAX_TIMELINE_SCAN]),
-            reference,
-            limit=bounded_limit,
-            start=start,
-            end=end,
-            scanned_count=len(scanned_rows[:MAX_TIMELINE_SCAN]),
-        )
-        if scan_truncated:
-            timeline = timeline.model_copy(update={"truncated": True})
-        return format_entity_timeline(timeline)
+        firestore_db = database_client.get_firestore_client()
     except Exception as exc:
-        logger.error("get_entity_timeline_tool failed error_type=%s", type(exc).__name__)
+        logger.error("get_entity_timeline_tool storage unavailable error_type=%s", type(exc).__name__)
         return f"Error reading entity timeline: {type(exc).__name__}"
+
+    try:
+        aliases = _resolve_entity_aliases(uid, reference, db_client=firestore_db)
+    except Exception as exc:
+        logger.warning("get_entity_timeline_tool alias resolution unavailable error_type=%s", type(exc).__name__)
+        aliases = EntityAliases(entity=reference)
+
+    entries: List[TimelineEntry] = []
+    truncated_sources: List[TimelineSource] = []
+    unavailable_sources: List[TimelineSource] = []
+    scanned_count = 0
+
+    if TimelineSource.ledger in requested_sources:
+        try:
+            stream = _iter_authoritative_items(uid, db_client=firestore_db, limit=MAX_TIMELINE_SCAN + 1)
+            rows = list(islice(stream, MAX_TIMELINE_SCAN + 1))
+            scanned_count += min(len(rows), MAX_TIMELINE_SCAN)
+            if len(rows) > MAX_TIMELINE_SCAN:
+                truncated_sources.append(TimelineSource.ledger)
+            entries.extend(
+                _ledger_entries(
+                    rows[:MAX_TIMELINE_SCAN],
+                    reference,
+                    include_history=include_history,
+                    include_rejected=include_rejected,
+                    start=start,
+                    end=end,
+                )
+            )
+        except Exception as exc:
+            logger.error("entity timeline ledger unavailable error_type=%s", type(exc).__name__)
+            unavailable_sources.append(TimelineSource.ledger)
+
+    if TimelineSource.conversations in requested_sources:
+        try:
+            rows = list(
+                islice(
+                    list_entity_timeline_conversations(
+                        uid,
+                        db_client=firestore_db,
+                        limit=MAX_TIMELINE_SOURCE_SCAN + 1,
+                        start_date=start,
+                        end_date=end,
+                    ),
+                    MAX_TIMELINE_SOURCE_SCAN + 1,
+                )
+            )
+            scanned_count += min(len(rows), MAX_TIMELINE_SOURCE_SCAN)
+            if len(rows) > MAX_TIMELINE_SOURCE_SCAN:
+                truncated_sources.append(TimelineSource.conversations)
+            entries.extend(
+                entry
+                for row in rows[:MAX_TIMELINE_SOURCE_SCAN]
+                if (entry := _conversation_entry(row, aliases)) is not None and _in_range(entry.occurred_at, start, end)
+            )
+        except Exception as exc:
+            logger.error("entity timeline conversations unavailable error_type=%s", type(exc).__name__)
+            unavailable_sources.append(TimelineSource.conversations)
+
+    if TimelineSource.calendar in requested_sources and aliases.values:
+        try:
+            rows = list(
+                islice(
+                    list_entity_timeline_meetings(
+                        uid,
+                        db_client=firestore_db,
+                        limit=MAX_TIMELINE_SOURCE_SCAN + 1,
+                        start_date=start,
+                        end_date=end,
+                    ),
+                    MAX_TIMELINE_SOURCE_SCAN + 1,
+                )
+            )
+            scanned_count += min(len(rows), MAX_TIMELINE_SOURCE_SCAN)
+            if len(rows) > MAX_TIMELINE_SOURCE_SCAN:
+                truncated_sources.append(TimelineSource.calendar)
+            entries.extend(
+                entry
+                for row in rows[:MAX_TIMELINE_SOURCE_SCAN]
+                if (entry := _calendar_entry(row, aliases)) is not None and _in_range(entry.occurred_at, start, end)
+            )
+        except Exception as exc:
+            logger.error("entity timeline calendar unavailable error_type=%s", type(exc).__name__)
+            unavailable_sources.append(TimelineSource.calendar)
+
+    if TimelineSource.screen in requested_sources and aliases.values:
+        try:
+            rows = list(
+                islice(
+                    list_entity_timeline_screen_activity(
+                        uid,
+                        db_client=firestore_db,
+                        limit=MAX_TIMELINE_SOURCE_SCAN + 1,
+                        start_date=start,
+                        end_date=end,
+                    ),
+                    MAX_TIMELINE_SOURCE_SCAN + 1,
+                )
+            )
+            scanned_count += min(len(rows), MAX_TIMELINE_SOURCE_SCAN)
+            if len(rows) > MAX_TIMELINE_SOURCE_SCAN:
+                truncated_sources.append(TimelineSource.screen)
+            entries.extend(
+                entry
+                for row in rows[:MAX_TIMELINE_SOURCE_SCAN]
+                if (entry := _screen_entry(row, aliases)) is not None and _in_range(entry.occurred_at, start, end)
+            )
+        except Exception as exc:
+            logger.error("entity timeline screen unavailable error_type=%s", type(exc).__name__)
+            unavailable_sources.append(TimelineSource.screen)
+
+    merged, result_truncated = _merge_timeline_entries(entries, limit=bounded_limit)
+    timeline = EntityTimeline(
+        entity=reference,
+        entries=merged,
+        truncated=result_truncated or bool(truncated_sources),
+        scanned_count=scanned_count,
+        aliases_resolved=aliases.resolved,
+        aliases_ambiguous=aliases.ambiguous,
+        requested_sources=requested_sources,
+        truncated_sources=tuple(truncated_sources),
+        unavailable_sources=tuple(unavailable_sources),
+    )
+    return format_entity_timeline(timeline)
 
 
 __all__ = [

--- a/docs/memory/knowledge_ledger.md
+++ b/docs/memory/knowledge_ledger.md
@@ -68,6 +68,23 @@ is an explicit second, owner-scoped lookup and admits only active primary-user
 documents. Historical ledger search remains gated on its separate retention
 and privacy policy, so these tools do not authorize a capture cutover.
 
+`get_entity_timeline` is a separate, owner-scoped multi-source read for an
+agent that has already selected a stable entity. The agent explicitly chooses
+ledger, conversation-summary, calendar-title, or screen-app/window sources;
+there is no query-word heuristic and the default remains the cheap ledger-only
+path. A people document ID is the entity authority. Current names, bounded
+retained names, and emails are exact match-only aliases and are never returned
+as timeline content. Aliases that collide with the owner or another bounded
+owner-scoped person record are suppressed; if the people scan is not exhaustive,
+alias joins fail closed while stable person-ID joins remain available. Source
+readers perform exact owner/entity joins, merge by
+stable time/source/record ordering, disclose unavailable or truncated sources,
+and return only compact source-appropriate facts, summaries, titles, and
+app/window metadata. Transcript text, calendar notes and attendees, OCR text,
+pixels, playbook bodies, and trigger payloads remain excluded. Closed or
+rejected ledger rows require the explicit history and audit flags; wording in
+the agent's query never enables them.
+
 The deterministic prompt view sorts open, intent-backed, primary-user slotted
 facts by descending curation weight, slot, validity time, and ID, then fits
 whole lines into 2,400 characters. The playbook index fits whole one-line

--- a/docs/product/invariants/intent-backed-knowledge-ledger.md
+++ b/docs/product/invariants/intent-backed-knowledge-ledger.md
@@ -55,6 +55,11 @@ capture cutover gate.
   remains intact while optional retrieval is card then bounded window
 - `backend/tests/unit/test_jit_memory_save_policy.py` — explicit save precision,
   provenance retention, and secret/third-party rejection
+- `backend/tests/unit/test_entity_timeline_tools.py` and
+  `backend/tests/unit/test_entity_timeline_source_readers.py` — explicit
+  source/history authority, exact owner-scoped entity aliases, deterministic
+  collision suppression, multi-source merge, partial-source disclosure, and
+  content minimization
 - `backend/tests/unit/test_atomicity_lifecycle_regressions.py` — agent preference
   writes use retry-stable ledger provenance and fail closed without user authority
 - `backend/tests/unit/test_jit_retrieval_eval.py` and

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -789,6 +789,28 @@
       ]
     },
     {
+      "collectionGroup": "conversations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "discarded",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "chat_first_deferrals",
       "queryScope": "COLLECTION",
       "fields": [


### PR DESCRIPTION
## Summary

- let the agent explicitly select bounded ledger, conversation-summary, calendar-title, and screen-metadata sources for a stable entity timeline
- retain exact owner-scoped person aliases across renames without returning alias emails or raw transcript, OCR, calendar-note, pixel, playbook, or trigger content
- share the canonical history admission policy, disclose partial/unavailable source windows, and register the serving Firestore query

## Product invariants affected

- INV-MEM-3
- INV-MEM-4
- INV-MEM-1
- INV-MEM-6

## Verification

- focused entity timeline, source-reader, person-alias, ledger-tool, universal-memory, and prompt-registration tests
- focused Pyright with zero errors
- generated Firestore index registry check
- stacked local pre-push gate against `origin/codex/jit-history-policy`

No production rollout, data migration, or deployment is authorized by this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

