### PR TITLE
fix(monitoring): size the Cloud Run metrics exporter for a real collection

### DIFF
--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -9700,6 +9700,147 @@
     "record": null
   },
   {
+    "uid": "omi-cloud-run-egress-down",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Cloud Run Ingestion",
+    "title": "Cloud Run metrics - egress exporter is down",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "min(up{job=\"cloud-run-application-metrics\"}) or vector(0)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  1
+                ],
+                "type": "lt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-08-21T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "15m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "summary": "The Cloud Run metrics exporter is not being scraped, so no omi_ series can reach Prometheus",
+      "threshold": "up < 1 on the cloud-run-application-metrics job for 15m; an absent job counts as down",
+      "user_impact": "No direct user impact, but every Cloud Run journey metric stops arriving. This is the case the query-rejected alert cannot see: a crashlooping or unscraped exporter publishes no error metric at all, so an error-based rule reads healthy while nothing is ingested and panels render as no traffic.",
+      "scope": "The <env>-omi-cloud-run-metrics-exporter Deployment and the Prometheus job that scrapes it.",
+      "verification": "kubectl get pods -n <env>-omi-monitoring for the exporter. CrashLoopBackOff with \"Liveness probe failed: context deadline exceeded\" means a collection is outrunning the probe or scrape budget; compare scrape_duration_seconds against the job scrape_timeout.",
+      "safe_next_action": "Check whether the exporter is being killed mid-collection rather than failing: this path collects from Cloud Monitoring inline, so growth in Cloud Run series makes scrapes longer, and CPU limits or probe timeouts sized for an idle exporter will kill it once real data arrives. Raise capacity and the scrape budget in the exporter values and re-run Deploy Cloud Run Metrics Egress. Read-only egress, so nothing needs rolling back.",
+      "runbook": "backend/docs/runbooks/cloud-run-metrics-ingestion.md"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "observability",
+      "alert_identity": "omi-cloud-run-egress-down",
+      "component": "observability",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
     "uid": "omi-llm-gateway-invalid-requests",
     "orgID": 1,
     "folderUID": "betdycdziadc0e",

--- a/backend/charts/monitoring/alerts/cloud-run-ingestion.json
+++ b/backend/charts/monitoring/alerts/cloud-run-ingestion.json
@@ -280,5 +280,146 @@
       "receiver": "Omi - Services Alerting (Telegram)"
     },
     "record": null
+  },
+  {
+    "uid": "omi-cloud-run-egress-down",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Cloud Run Ingestion",
+    "title": "Cloud Run metrics - egress exporter is down",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "min(up{job=\"cloud-run-application-metrics\"}) or vector(0)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  1
+                ],
+                "type": "lt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-08-21T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "15m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "summary": "The Cloud Run metrics exporter is not being scraped, so no omi_ series can reach Prometheus",
+      "threshold": "up < 1 on the cloud-run-application-metrics job for 15m; an absent job counts as down",
+      "user_impact": "No direct user impact, but every Cloud Run journey metric stops arriving. This is the case the query-rejected alert cannot see: a crashlooping or unscraped exporter publishes no error metric at all, so an error-based rule reads healthy while nothing is ingested and panels render as no traffic.",
+      "scope": "The <env>-omi-cloud-run-metrics-exporter Deployment and the Prometheus job that scrapes it.",
+      "verification": "kubectl get pods -n <env>-omi-monitoring for the exporter. CrashLoopBackOff with \"Liveness probe failed: context deadline exceeded\" means a collection is outrunning the probe or scrape budget; compare scrape_duration_seconds against the job scrape_timeout.",
+      "safe_next_action": "Check whether the exporter is being killed mid-collection rather than failing: this path collects from Cloud Monitoring inline, so growth in Cloud Run series makes scrapes longer, and CPU limits or probe timeouts sized for an idle exporter will kill it once real data arrives. Raise capacity and the scrape budget in the exporter values and re-run Deploy Cloud Run Metrics Egress. Read-only egress, so nothing needs rolling back.",
+      "runbook": "backend/docs/runbooks/cloud-run-metrics-ingestion.md"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "observability",
+      "alert_identity": "omi-cloud-run-egress-down",
+      "component": "observability",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
   }
 ]

--- a/backend/charts/monitoring/kube-prometheus-stack/dev_omi_monitoring_values.yaml
+++ b/backend/charts/monitoring/kube-prometheus-stack/dev_omi_monitoring_values.yaml
@@ -236,7 +236,12 @@ prometheus:
             regex: "(.*)-prometheus-stackdriver-exporter"
             action: keep
       - job_name: cloud-run-application-metrics
-        scrape_interval: 30s
+        # A prod scrape is ~28MB and takes 6-10s because the exporter queries
+        # Cloud Monitoring inline. The default 10s scrape_timeout cut every
+        # collection off mid-flight and recorded 0 samples, so the budget has to
+        # exceed a slow scrape, and the interval has to exceed the budget.
+        scrape_interval: 60s
+        scrape_timeout: 45s
         metrics_path: /metrics
         scheme: http
         kubernetes_sd_configs:
@@ -262,6 +267,14 @@ prometheus:
             regex: "stackdriver_prometheus_target_prometheus_googleapis_com_(omi_.+?)_(counter|gauge|histogram|summary|untyped|unknown)(_bucket|_sum|_count)?"
             target_label: __name__
             replacement: "${1}${3}"
+          # Prometheus client libraries emit a _created timestamp gauge beside every
+          # counter. They survive the rewrite above as omi_*_created and are 36% of
+          # everything this job imports (19,087 of 52,607 prod series) while
+          # answering no question any alert or dashboard asks. Drop them after the
+          # rename so the rule reads in the plain namespace people query.
+          - source_labels: [__name__]
+            regex: "omi_.*_created"
+            action: drop
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/backend/charts/monitoring/kube-prometheus-stack/prod_omi_monitoring_values.yaml
+++ b/backend/charts/monitoring/kube-prometheus-stack/prod_omi_monitoring_values.yaml
@@ -221,7 +221,12 @@ prometheus:
             regex: "(.*)-prometheus-stackdriver-exporter"
             action: keep
       - job_name: cloud-run-application-metrics
-        scrape_interval: 30s
+        # A prod scrape is ~28MB and takes 6-10s because the exporter queries
+        # Cloud Monitoring inline. The default 10s scrape_timeout cut every
+        # collection off mid-flight and recorded 0 samples, so the budget has to
+        # exceed a slow scrape, and the interval has to exceed the budget.
+        scrape_interval: 60s
+        scrape_timeout: 45s
         metrics_path: /metrics
         scheme: http
         kubernetes_sd_configs:
@@ -247,6 +252,14 @@ prometheus:
             regex: "stackdriver_prometheus_target_prometheus_googleapis_com_(omi_.+?)_(counter|gauge|histogram|summary|untyped|unknown)(_bucket|_sum|_count)?"
             target_label: __name__
             replacement: "${1}${3}"
+          # Prometheus client libraries emit a _created timestamp gauge beside every
+          # counter. They survive the rewrite above as omi_*_created and are 36% of
+          # everything this job imports (19,087 of 52,607 prod series) while
+          # answering no question any alert or dashboard asks. Drop them after the
+          # rename so the rule reads in the plain namespace people query.
+          - source_labels: [__name__]
+            regex: "omi_.*_created"
+            action: drop
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/backend/charts/monitoring/prometheus-stackdriver-exporter/dev_omi_cloud_run_metrics_exporter.yaml
+++ b/backend/charts/monitoring/prometheus-stackdriver-exporter/dev_omi_cloud_run_metrics_exporter.yaml
@@ -15,10 +15,29 @@ serviceAccount:
   create: false
   name: "dev-omi-prometheus-stackdriver-exporter"
 
+# Sized from measurement, not from the idle case. A prod scrape returns ~28MB /
+# ~52k series and takes 6-10s of mostly-CPU work, and steady-state usage is
+# ~238m CPU / ~331Mi -- already above the previous 200m/256Mi ceiling. Under that
+# ceiling the process was throttled hard enough to miss both the 10s scrape
+# timeout and the 10s liveness timeout, so kubelet killed it before it could ever
+# deliver a sample: 120 restarts, up=0, scrape_samples_scraped=0. It looked
+# healthy for a day only because prod had no Cloud Run metrics to collect yet.
 resources:
   requests:
-    cpu: 50m
-    memory: 64Mi
-  limits:
     cpu: 200m
     memory: 256Mi
+  limits:
+    cpu: '2'
+    memory: 2Gi
+
+# This exporter collects from Cloud Monitoring at scrape time, so a slow upstream
+# makes the whole HTTP server slow, including '/'. Probes must outlast a scrape
+# or they turn a slow collection into a crash loop.
+livenessProbe:
+  timeoutSeconds: 25
+  periodSeconds: 30
+  failureThreshold: 5
+readinessProbe:
+  timeoutSeconds: 25
+  periodSeconds: 30
+  failureThreshold: 5

--- a/backend/charts/monitoring/prometheus-stackdriver-exporter/prod_omi_cloud_run_metrics_exporter.yaml
+++ b/backend/charts/monitoring/prometheus-stackdriver-exporter/prod_omi_cloud_run_metrics_exporter.yaml
@@ -15,10 +15,29 @@ serviceAccount:
   create: false
   name: "prod-omi-prometheus-stackdriver-exporter"
 
+# Sized from measurement, not from the idle case. A prod scrape returns ~28MB /
+# ~52k series and takes 6-10s of mostly-CPU work, and steady-state usage is
+# ~238m CPU / ~331Mi -- already above the previous 200m/256Mi ceiling. Under that
+# ceiling the process was throttled hard enough to miss both the 10s scrape
+# timeout and the 10s liveness timeout, so kubelet killed it before it could ever
+# deliver a sample: 120 restarts, up=0, scrape_samples_scraped=0. It looked
+# healthy for a day only because prod had no Cloud Run metrics to collect yet.
 resources:
   requests:
-    cpu: 50m
-    memory: 64Mi
-  limits:
     cpu: 200m
     memory: 256Mi
+  limits:
+    cpu: '2'
+    memory: 2Gi
+
+# This exporter collects from Cloud Monitoring at scrape time, so a slow upstream
+# makes the whole HTTP server slow, including '/'. Probes must outlast a scrape
+# or they turn a slow collection into a crash loop.
+livenessProbe:
+  timeoutSeconds: 25
+  periodSeconds: 30
+  failureThreshold: 5
+readinessProbe:
+  timeoutSeconds: 25
+  periodSeconds: 30
+  failureThreshold: 5

--- a/backend/tests/unit/test_monitoring_telemetry_contract.py
+++ b/backend/tests/unit/test_monitoring_telemetry_contract.py
@@ -27,6 +27,19 @@ CLOUD_RUN_EXPORTER = MONITORING / 'prometheus-stackdriver-exporter' / 'prod_omi_
 CLOUD_RUN_EXPORTER_DEV = MONITORING / 'prometheus-stackdriver-exporter' / 'dev_omi_cloud_run_metrics_exporter.yaml'
 
 
+def _cpu_millicores(value: object) -> float:
+    text = str(value)
+    return float(text[:-1]) if text.endswith('m') else float(text) * 1000
+
+
+def _memory_mebibytes(value: object) -> float:
+    text = str(value)
+    for suffix, factor in (('Gi', 1024), ('Mi', 1), ('G', 953.7), ('M', 0.9537)):
+        if text.endswith(suffix):
+            return float(text[: -len(suffix)]) * factor
+    return float(text) / (1024 * 1024)
+
+
 def _load_inventory() -> dict[str, Any]:
     loaded = yaml.safe_load(INVENTORY_PATH.read_text(encoding='utf-8'))
     assert isinstance(loaded, dict)
@@ -148,6 +161,30 @@ def test_cloud_run_metrics_exporter_is_scoped_and_rate_limited(path, project_id,
         'create': False,
         'name': service_account,
     }
+
+
+@pytest.mark.parametrize('path', (CLOUD_RUN_EXPORTER, CLOUD_RUN_EXPORTER_DEV), ids=('prod', 'dev'))
+def test_cloud_run_metrics_exporter_can_outlast_its_own_scrape(path):
+    """The exporter collects from Cloud Monitoring inline, so it must be sized for it.
+
+    A prod scrape is ~28MB / ~52k series and takes 6-10s. Under a 200m CPU ceiling
+    and a 10s probe timeout the process was killed mid-collection 120 times, held
+    up=0, and recorded scrape_samples_scraped=0 -- while reporting a Deployment
+    that had simply never had anything to collect. Floors, not exact values, so
+    capacity can be raised without editing this test.
+    """
+    values = yaml.safe_load(path.read_text(encoding='utf-8'))
+
+    limits = values['resources']['limits']
+    assert (
+        _cpu_millicores(limits['cpu']) >= 1000
+    ), f'{path.name}: measured steady state is ~238m and a scrape needs ~1 core'
+    assert _memory_mebibytes(limits['memory']) >= 1024, f'{path.name}: measured steady state is ~331Mi'
+
+    for probe in ('livenessProbe', 'readinessProbe'):
+        assert (
+            values[probe]['timeoutSeconds'] >= 20
+        ), f'{path.name}: {probe} must outlast a slow scrape or it turns latency into a crash loop'
 
 
 @pytest.mark.parametrize('path', (CLOUD_RUN_EXPORTER, CLOUD_RUN_EXPORTER_DEV), ids=('prod', 'dev'))


### PR DESCRIPTION
## Summary

The Cloud Run metrics exporter was sized for an exporter that had nothing to collect. The moment prod actually had Cloud Run metrics, it died — 120 restarts, `up=0`, `scrape_samples_scraped=0` — and every `omi_*` series stopped at the bridge.

This sizes it from measurement, gives the scrape a budget that fits a real collection, drops 36% of the imported series as pure noise, and adds the alert that would have caught it.

## What happened

`prod-omi-cloud-run-metrics-exporter` was installed on 2026-08-23 at 18:01 and looked healthy for a day, because prod Cloud Monitoring had zero `omi_*` descriptors — there was nothing to fetch. When prod `backend` began serving a GMP sidecar revision at 05:58 the next morning, 27 descriptors appeared and the exporter started doing real work. Measured, on the live pod:

| Signal | Value |
| --- | --- |
| `scrape_duration_seconds` | **10.013s** — exactly the Prometheus scrape timeout |
| `scrape_samples_scraped` | **0** |
| `up{job="cloud-run-application-metrics"}` | **0** |
| pod state | `CrashLoopBackOff`, **120 restarts** |
| kubelet event | `Liveness probe failed: ... context deadline exceeded` |
| steady-state usage | **238m CPU / 331Mi** — above the 200m/256Mi ceiling |
| one real scrape | **6.2s / 6.5s / 10.6s**, ~28MB, 52,662 series |

This exporter queries Cloud Monitoring *inline, at scrape time*, so a large collection makes the entire HTTP server slow — including the `/` path both probes hit. Under a 200m CPU ceiling the process was throttled hard enough to miss the 10s liveness timeout, and kubelet killed it mid-collection before it could deliver a single sample.

## Changes

**Capacity, both environments.** Requests 50m/64Mi → 200m/256Mi; limits 200m/256Mi → 2 CPU/2Gi. The measured steady state already exceeded the old ceiling. For reference, the sibling `*-omi-prometheus-stackdriver-exporter` that has run healthily for six days has **no limits at all**.

**Probes, both environments.** `timeoutSeconds` 10 → 25, `periodSeconds` 10 → 30, `failureThreshold` 3 → 5. A probe shorter than a scrape converts latency into a crash loop.

**Scrape budget, both environments.** `scrape_interval` 30s → 60s and an explicit `scrape_timeout: 45s`. The default 10s timeout cut every prod collection off mid-flight.

**Drop `_created`.** Client libraries emit a `_created` timestamp beside every counter. They survive the rename as `omi_*_created` and are **19,087 of 52,607 prod series (36%)** while answering no question any alert or dashboard asks.

**New alert `omi-cloud-run-egress-down`** on `up < 1` for 15m, absent-counts-as-down.

## Why the existing alert did not catch this

`omi-cloud-run-egress-query-rejected` — added two PRs ago for exactly this class — watches `stackdriver_monitoring_last_scrape_error`. A crashlooping exporter publishes **no metric at all**, so `or vector(0)` evaluates to 0 and the rule reads healthy. An error-based rule cannot see a process that never gets far enough to report an error. That is the same "healthy because it has nothing to do" shape as the outage itself, reproduced inside the alert written to prevent it. Hence a liveness rule alongside the error rule, with absence treated as down rather than as no-data.

## Verification

- Applied live to prod before this PR, to end the outage and to source the numbers: `up` 0 → 1, `scrape_duration_seconds` 10.013 → 4.79, and **52,607 `omi_*` series** now import under their plain names with zero un-normalized leak. Real traffic confirmed, not just series existence: `mobile_chat` and `app_webhook_delivery` successes over 15m.
- `test_cloud_run_metrics_exporter_can_outlast_its_own_scrape` asserts capacity and probe floors in both environments. Floors rather than exact values, so capacity can be raised later without editing the test.
- Negative proof: restoring `cpu: 200m` fails that test with the measured reason attached.
- `test_monitoring_telemetry_contract.py`, `test_monitoring_alert_rule_contract.py`, `test_cloud_run_metrics_egress_workflow.py`: **51 passed**.
- `alert-rules.json` verified structurally: 73 → 74 rules, exactly one UID added, zero pre-existing rules altered, split source byte-identical, all UIDs within Grafana's 40-character limit.
- Dev is measured at 2.97s / 3.54s / **6.26s** per scrape against its old 10s budget — 63% consumed, on the same trajectory. It gets the same treatment here rather than after it also breaks.

## Product invariants affected

- INV-DATA-1

Monitoring-only. No serving authority, routing pin, or application surface is touched; this changes the capacity of a read-only metrics reader and the Prometheus job that scrapes it.

Failure-Class: FC-bridge-liveness-without-data-path-proof


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

