### PR TITLE
fix(deploy): render the desktop-backend expected env state its sidecar requires

### DIFF
--- a/.github/scripts/check-desktop-backend-release-policy.py
+++ b/.github/scripts/check-desktop-backend-release-policy.py
@@ -178,6 +178,32 @@ def validate_deploy_workflow(text: str, *, production: bool) -> list[str]:
     for fragment in required:
         if fragment not in text:
             errors.append(f"{workflow}: missing release boundary {fragment!r}")
+
+    # Bound to the step, not to the file. attach_cloud_run_gmp_sidecar.py made
+    # --expected-env-state required and only the backend caller was updated;
+    # argparse exits before the attach runs, so both desktop deploy paths failed
+    # at the same step while every fragment above was still present.
+    attach_name = (
+        "Attach Managed Prometheus sidecar to production candidate"
+        if production
+        else "Attach Managed Prometheus sidecar to development candidate"
+    )
+    attach_step = _step_block(text, attach_name)
+    if attach_step is None:
+        errors.append(f"{workflow}: missing step {attach_name!r}")
+    elif "--expected-env-state=" not in attach_step:
+        errors.append(
+            f"{workflow}: {attach_name!r} must pass --expected-env-state; the sidecar script requires it"
+        )
+
+    render_name = "Render desktop backend expected env state"
+    render_step = _step_block(text, render_name)
+    if render_step is None:
+        errors.append(f"{workflow}: missing step {render_name!r}")
+    elif "--desktop-state-output" not in render_step:
+        errors.append(f"{workflow}: {render_name!r} must render the state with --desktop-state-output")
+    elif attach_step is not None and text.find(render_name) > text.find(attach_name):
+        errors.append(f"{workflow}: {render_name!r} must run before {attach_name!r}")
     if ":latest" in "\n".join(line for line in text.splitlines() if "image:" in line or "tags:" in line):
         errors.append(f"{workflow}: deployment image must use an immutable source tag")
 

--- a/.github/scripts/test_check_desktop_backend_release_policy.py
+++ b/.github/scripts/test_check_desktop_backend_release_policy.py
@@ -103,6 +103,35 @@ class DesktopBackendReleasePolicyTests(unittest.TestCase):
 
 
 
+    def test_rejects_sidecar_attach_without_rendered_expected_env_state(self) -> None:
+        """#12098 made --expected-env-state required and updated only the backend caller.
+
+        Every other fragment this policy required was still present, so both
+        desktop deploy paths passed the check and then died at the attach step
+        with an argparse usage error. Bind the requirement to the step.
+        """
+        for workflow, production in ((self.dev, False), (self.prod, True)):
+            with self.subTest(production=production, mutation="drop --expected-env-state"):
+                errors = POLICY.validate_deploy_workflow(
+                    workflow.replace('            --expected-env-state=', '            --unused-arg=', 1),
+                    production=production,
+                )
+                self.assertTrue(any("--expected-env-state" in error for error in errors), errors)
+
+            with self.subTest(production=production, mutation="drop the render step"):
+                errors = POLICY.validate_deploy_workflow(
+                    workflow.replace("Render desktop backend expected env state", "Render something else"),
+                    production=production,
+                )
+                self.assertTrue(any("Render desktop backend expected env state" in e for e in errors), errors)
+
+            with self.subTest(production=production, mutation="render without --desktop-state-output"):
+                errors = POLICY.validate_deploy_workflow(
+                    workflow.replace('--desktop-state-output', '--state-output', 1),
+                    production=production,
+                )
+                self.assertTrue(any("--desktop-state-output" in error for error in errors), errors)
+
     def test_rejects_traffic_before_candidate_proof(self) -> None:
         mutated = self.dev.replace(
             "      - name: Prove candidate chat compatibility",

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -257,6 +257,17 @@ jobs:
             OMI_LLM_GATEWAY_SERVICE_TOKEN=OMI_LLM_GATEWAY_SERVICE_TOKEN:latest
             METRICS_SECRET=METRICS_SECRET:latest
 
+      # See desktop_backend_prod.yml: the expectation is rendered from the
+      # manifest so it cannot drift from the values actually deployed.
+      - name: Render desktop backend expected env state
+        id: desktop-expected-env
+        run: |
+          set -euo pipefail
+          python3 backend/scripts/render_backend_runtime_env.py \
+            --env dev \
+            --manifest backend/deploy/runtime_env.yaml \
+            --desktop-state-output "$RUNNER_TEMP/desktop-backend-runtime-env-state.json"
+
       - name: Attach Managed Prometheus sidecar to development candidate
         id: attach-gmp-sidecar
         run: |
@@ -268,6 +279,7 @@ jobs:
             --final-revision="${{ steps.candidate-identity.outputs.revision }}" \
             --ingress-container=desktop-backend-1 \
             --config=backend/deploy/cloud_run_gmp_sidecar.yaml \
+            --expected-env-state="$RUNNER_TEMP/desktop-backend-runtime-env-state.json" \
             --tag="$CANDIDATE_TAG"
 
       - name: Wait for no-traffic candidate readiness

--- a/.github/workflows/desktop_backend_prod.yml
+++ b/.github/workflows/desktop_backend_prod.yml
@@ -68,6 +68,8 @@ jobs:
           cp .workflow-source/.github/scripts/verify_desktop_backend_image_lineage.py "$controls/.github/scripts/"
           cp .workflow-source/backend/deploy/cloud_run_gmp_sidecar.yaml "$controls/backend/deploy/"
           cp .workflow-source/backend/scripts/attach_cloud_run_gmp_sidecar.py "$controls/backend/scripts/"
+          cp .workflow-source/backend/scripts/render_backend_runtime_env.py "$controls/backend/scripts/"
+          cp .workflow-source/backend/deploy/runtime_env.yaml "$controls/backend/deploy/"
           cp .workflow-source/backend/scripts/firebase_release_probe_token.py "$controls/backend/scripts/"
           cp .workflow-source/backend/scripts/resolve_cloud_run_tagged_url.py "$controls/backend/scripts/"
           cp .workflow-source/backend/scripts/wait_cloud_run_candidate_readiness.py "$controls/backend/scripts/"
@@ -341,6 +343,19 @@ jobs:
             OMI_LLM_GATEWAY_SERVICE_TOKEN=OMI_LLM_GATEWAY_SERVICE_TOKEN:latest
             METRICS_SECRET=METRICS_SECRET:latest
 
+      # The sidecar attach re-serialises the live Cloud Run export, so it verifies
+      # the ingress env it is about to rewrite against what the manifest says it
+      # should be. Render that expectation from the manifest rather than
+      # restating it here, so the guard cannot drift from its source.
+      - name: Render desktop backend expected env state
+        id: desktop-expected-env
+        run: |
+          set -euo pipefail
+          python3 "$DESKTOP_BACKEND_CONTROLS/backend/scripts/render_backend_runtime_env.py" \
+            --env prod \
+            --manifest "$DESKTOP_BACKEND_CONTROLS/backend/deploy/runtime_env.yaml" \
+            --desktop-state-output "$RUNNER_TEMP/desktop-backend-runtime-env-state.json"
+
       - name: Attach Managed Prometheus sidecar to production candidate
         id: attach-gmp-sidecar
         run: |
@@ -352,6 +367,7 @@ jobs:
             --final-revision="${{ steps.admitted-source.outputs.revision }}" \
             --ingress-container=desktop-backend-1 \
             --config="$DESKTOP_BACKEND_CONTROLS/backend/deploy/cloud_run_gmp_sidecar.yaml" \
+            --expected-env-state="$RUNNER_TEMP/desktop-backend-runtime-env-state.json" \
             --tag="$CANDIDATE_TAG"
 
       - name: Wait for no-traffic candidate readiness

--- a/backend/scripts/render_backend_runtime_env.py
+++ b/backend/scripts/render_backend_runtime_env.py
@@ -32,13 +32,36 @@ def main() -> int:
         type=Path,
         help='Write the exact rendered Cloud Run service env, secret refs, and flags as validator state JSON.',
     )
+    parser.add_argument(
+        '--desktop-state-output',
+        type=Path,
+        help=(
+            'Write the rendered desktop-backend env as expected-env-state JSON for '
+            'attach_cloud_run_gmp_sidecar.py --expected-env-state.'
+        ),
+    )
     args = parser.parse_args()
     if args.job and args.state_output:
         parser.error('--state-output is supported only for the full service render')
+    if args.job and args.desktop_state_output:
+        parser.error('--desktop-state-output is supported only for the full service render')
 
     manifest = _load_yaml(args.manifest)
     environments = _as_config_dict(manifest['environments']) or {}
     env_config = _as_config_dict(environments[args.env]) or {}
+
+    if args.desktop_state_output:
+        args.desktop_state_output.write_text(
+            json.dumps(_render_desktop_backend_state(env_config), indent=2, sort_keys=True) + '\n',
+            encoding='utf-8',
+        )
+        # desktop-backend deploys from its own workflow and does not set the
+        # backend service env this script otherwise requires. Rendering the
+        # sidecar guard must not force those callers to supply it, so stop here
+        # unless a backend render was also asked for.
+        if not args.state_output and not args.job:
+            return 0
+
     cloud_run = _as_config_dict(env_config['cloud_run']) or {}
 
     jobs = _as_config_dict(cloud_run.get('jobs')) or {}
@@ -223,6 +246,23 @@ def _render_state_env(config: ConfigDict) -> list[ConfigDict]:
         *_render_env_entries(_as_config_dict(config.get('env')) or {}),
         *_render_secret_entries(_as_config_dict(config.get('secrets')) or {}),
     ]
+
+
+def _render_desktop_backend_state(env_config: ConfigDict) -> ConfigDict:
+    """Build sidecar-guard state for desktop-backend from the same manifest values.
+
+    Deliberately separate from _render_cloud_run_state: that file is also read by
+    validate-backend-runtime-env.py, which walks cloud_run.services, and
+    desktop-backend is not one of those. Keeping them apart means adding this
+    guard cannot perturb the backend deploy path.
+
+    The manifest owns only part of desktop-backend's env today, and that is fine:
+    attach_cloud_run_gmp_sidecar.py checks the names it is given and ignores the
+    rest, so this asserts a real subset rather than nothing.
+    """
+    desktop_backend = _as_config_dict(env_config.get('desktop_backend')) or {}
+    env_entries = _render_env_entries(_as_config_dict(desktop_backend.get('env')) or {})
+    return {'services': {'desktop-backend': {'env': env_entries}}}
 
 
 def _runtime_value(name: str, entry: ConfigDict, *, allow_missing: bool = False) -> str | None:

--- a/backend/tests/unit/test_render_backend_runtime_env.py
+++ b/backend/tests/unit/test_render_backend_runtime_env.py
@@ -480,3 +480,55 @@ def test_state_output_covers_every_declared_job(env, monkeypatch):
     state = _MODULE['_render_cloud_run_state']({'cloud_run': {**cloud_run, 'services': {}}})
 
     assert set(state['jobs']) == set(cloud_run['jobs'])
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DESKTOP_WORKFLOWS = {
+    'dev': _REPO_ROOT / '.github/workflows/desktop_backend_auto_dev.yml',
+    'prod': _REPO_ROOT / '.github/workflows/desktop_backend_prod.yml',
+}
+
+
+@pytest.mark.parametrize('env_name', ('dev', 'prod'))
+def test_desktop_state_output_is_shaped_for_the_sidecar_guard(env_name, tmp_path):
+    """attach_cloud_run_gmp_sidecar.py reads state['services'][service]['env']."""
+    out = tmp_path / 'state.json'
+    env_config = _MODULE['_as_config_dict'](_MANIFEST['environments'][env_name])
+    state = _MODULE['_render_desktop_backend_state'](env_config)
+    out.write_text(json.dumps(state), encoding='utf-8')
+
+    entries = state['services']['desktop-backend']['env']
+    assert entries, 'an empty expectation would make the sidecar guard a no-op'
+    for entry in entries:
+        assert isinstance(entry['name'], str) and isinstance(entry['value'], str)
+
+    # Round-trip through the consumer so the two stay compatible by construction.
+    attach = runpy.run_path(
+        str(_REPO_ROOT / 'backend/scripts/attach_cloud_run_gmp_sidecar.py'),
+        run_name='attach_cloud_run_gmp_sidecar',
+    )
+    expected = attach['_expected_literal_env'](out, service_name='desktop-backend')
+    assert expected == {entry['name']: entry['value'] for entry in entries}
+
+
+@pytest.mark.parametrize('env_name', ('dev', 'prod'))
+def test_desktop_manifest_env_matches_what_the_workflow_deploys(env_name):
+    """The guard is only meaningful while both sources agree.
+
+    desktop-backend still sets most of its env inline in its deploy workflow, so
+    the manifest owns a subset. If a manifest value drifts from the deployed one,
+    the sidecar attach fails the deploy rather than the value silently differing —
+    catch that here instead, at review time.
+    """
+    env_config = _MODULE['_as_config_dict'](_MANIFEST['environments'][env_name])
+    state = _MODULE['_render_desktop_backend_state'](env_config)
+    workflow = _DESKTOP_WORKFLOWS[env_name].read_text(encoding='utf-8')
+
+    literal_project = {'dev': 'based-hardware-dev', 'prod': 'based-hardware'}[env_name]
+    for entry in state['services']['desktop-backend']['env']:
+        name, value = entry['name'], entry['value']
+        if value == literal_project:
+            # Supplied to the workflow as ${{ vars.GCP_PROJECT_ID }}.
+            assert f'{name}=${{{{ vars.GCP_PROJECT_ID }}}}' in workflow, name
+            continue
+        assert f'{name}={value}' in workflow, f'{env_name}: {name}={value} is not what the workflow deploys'


### PR DESCRIPTION
## Summary

`attach_cloud_run_gmp_sidecar.py` gained a required `--expected-env-state` argument in #12098, and only one of its three callers was updated. Both desktop-backend deploy paths — production and automatic dev — have been failing at the sidecar attach step ever since:

```
attach_cloud_run_gmp_sidecar.py: error: the following arguments are required: --expected-env-state
Process completed with exit code 2
```

| caller | passed it before | now |
| --- | --- | --- |
| `.github/actions/deploy-backend-stack/action.yml` | yes | yes |
| `.github/workflows/desktop_backend_prod.yml` | **no** | yes |
| `.github/workflows/desktop_backend_auto_dev.yml` | **no** | yes |

This is what failed production run 32690712862. It also explains something that read as a benign rollout state: dev's serving desktop-backend revision has no `collector` container because the last successful dev attach predates #12098 — dev was not waiting, it was failing every time.

## Approach

The guard is worth keeping — it is what catches the dialect-coercion class fixed in #12083 — so the fix supplies the argument rather than relaxing it.

The backend path renders its expectation from `backend/deploy/runtime_env.yaml` and hands the same file to the sidecar script, so the expectation cannot drift from the deploy. The desktop workflows set their env inline in `deploy-cloudrun`, so the obvious fix is to restate those values in a second place — which recreates the exact "two copies drift apart" shape that caused this.

Instead, `runtime_env.yaml` already owns a `desktop_backend.env` section in both environments (`USE_VERTEX_AI`, `GOOGLE_CLOUD_PROJECT`, `GCP_LOCATION`, `PROMETHEUS_SIDECAR_PORT`), and all four already match what the workflows deploy. So:

- `render_backend_runtime_env.py` gains `--desktop-state-output`, emitting `{"services": {"desktop-backend": {"env": [...]}}}` from that section.
- Both workflows render it and pass `--expected-env-state`.

Two deliberate constraints:

- **Separate from `--state-output`.** That file is also read by `validate-backend-runtime-env.py`, which walks `cloud_run.services`, and `desktop-backend` is not one of them. Keeping the builders apart means this cannot perturb the backend deploy path.
- **Standalone.** The full render requires the backend service env (`$CLOUD_RUN_VPC_NETWORK` and friends). `--desktop-state-output` writes and returns before that, so desktop callers do not inherit the backend's environment requirements.

The manifest owns a subset of desktop-backend's env today, and that is fine: `_expected_literal_env` checks only the names it is given. A subset guard is a real guard; the empty one it replaces was not. Moving the remaining inline values into the manifest is the follow-up.

## Why nothing caught it

`check-desktop-backend-release-policy.py` required the string `attach_cloud_run_gmp_sidecar.py` to appear *somewhere in the file*. It did. Every one of its ~30 required fragments still matched, all 26 fixtures passed, and the workflow was broken. The check triggers on `backend/**/*.py`, so it ran on #12098 — its contract was simply file-scoped where the defect was step-scoped.

The requirement is now bound to the step via the existing `_step_block` helper: the attach step must pass `--expected-env-state`, the render step must exist, must use `--desktop-state-output`, and must precede the attach.

## Verification

- `test_check_desktop_backend_release_policy.py`: **27 passed**, including three new mutation fixtures per environment — dropping the argument, dropping the render step, and rendering with the wrong flag each fail with the reason named.
- `test_render_backend_runtime_env.py`, `test_backend_runtime_env_validator.py`: **114 passed**. The renderer change leaves the backend path untouched.
- New `test_desktop_state_output_is_shaped_for_the_sidecar_guard` round-trips the rendered file through the consumer's own `_expected_literal_env`, so producer and consumer stay compatible by construction rather than by comment.
- New `test_desktop_manifest_env_matches_what_the_workflow_deploys` asserts every manifest-owned value is what the workflow actually deploys. Negative proof: changing the manifest's prod `PROMETHEUS_SIDECAR_PORT` to `9091` fails with `prod: PROMETHEUS_SIDECAR_PORT=9091 is not what the workflow deploys`. Without this, drift would surface as a failed production deploy instead of a failed review.
- Rendered output confirmed byte-for-byte against both environments' live values.

## Product invariants affected

- INV-DATA-1

No serving authority, routing pin, image lineage, or traffic-promotion rule is changed. This restores an argument to a deploy step and renders it from the manifest that already owned the values.

Failure-Class: FC-workflow-script-input-contract


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

