### PR TITLE
fix(desktop): bound database init with a timeout so startup can't hang forever (#12145)

### DIFF
--- a/desktop/macos/Desktop/Sources/Startup/StartupWarmupPolicy.swift
+++ b/desktop/macos/Desktop/Sources/Startup/StartupWarmupPolicy.swift
@@ -93,6 +93,13 @@ enum StartupWarmupPolicy {
   static let deferredWarmupDelay: TimeInterval = 2.0
   static let databaseRetryInitialDelay: TimeInterval = 1.0
   static let databaseRetryMaxDelay: TimeInterval = 30.0
+  /// Bounds `RewindDatabase.initialize()` so a wedged open/migration (e.g. a
+  /// stalled disk, an actor deadlock) can't strand the app on the "Preparing
+  /// your data…" screen forever. On timeout, startup treats init as failed —
+  /// the UI unblocks and the existing exponential-backoff retry loop takes
+  /// over. Generous relative to typical (sub-second to low-single-digit-second)
+  /// opens so it never false-trips a merely slow first-launch migration.
+  static let databaseInitTimeout: Duration = .seconds(30)
   static let mcpKeyWarmupDelay: TimeInterval = 0.5
   static let dashboardNetworkRefreshDelay: TimeInterval = 4.0
   static let initialSettingsSyncDelay: TimeInterval = 5.0

--- a/desktop/macos/Desktop/Sources/ViewModelContainer.swift
+++ b/desktop/macos/Desktop/Sources/ViewModelContainer.swift
@@ -83,13 +83,7 @@ class ViewModelContainer: ObservableObject {
     // Pre-initialize database so local SQLite reads are instant
     let dbInitStart = CFAbsoluteTimeGetCurrent()
     let hadUncleanShutdown = await RewindDatabase.shared.hadUncleanShutdown()
-    do {
-      try await RewindDatabase.shared.initialize()
-      databaseInitFailed = false
-    } catch {
-      logError("ViewModelContainer: Database pre-init failed, DB-dependent loads will be skipped", error: error)
-      databaseInitFailed = true
-    }
+    databaseInitFailed = !(await initializeDatabaseWithTimeout())
     let dbInitDuration = CFAbsoluteTimeGetCurrent() - dbInitStart
 
     // Database is ready (or failed) — dismiss the loading screen
@@ -164,18 +158,39 @@ class ViewModelContainer: ObservableObject {
     guard databaseInitFailed else { return true }
     log("ViewModelContainer: Retrying database initialization...")
 
-    do {
-      try await RewindDatabase.shared.initialize()
-      databaseInitFailed = false
-      await homeStatusStore.databaseDidBecomeReady()
-      warmupCoordinator.markDatabaseRetryComplete()
-      TranscriptionRetryService.shared.resumeAfterDatabaseRecovery()
-      log("ViewModelContainer: Database retry succeeded, scheduling staged startup warmup")
-      schedulePostInteractiveWarmup(dbAvailable: true)
-      return true
-    } catch {
-      logError("ViewModelContainer: Database retry failed", error: error)
+    guard await initializeDatabaseWithTimeout() else {
       return false
     }
+    databaseInitFailed = false
+    await homeStatusStore.databaseDidBecomeReady()
+    warmupCoordinator.markDatabaseRetryComplete()
+    TranscriptionRetryService.shared.resumeAfterDatabaseRecovery()
+    log("ViewModelContainer: Database retry succeeded, scheduling staged startup warmup")
+    schedulePostInteractiveWarmup(dbAvailable: true)
+    return true
+  }
+
+  /// Race `RewindDatabase.initialize()` against `StartupWarmupPolicy.databaseInitTimeout` so a
+  /// wedged open/migration (stalled disk, actor deadlock) can't strand the caller forever —
+  /// see the "Preparing your data…" hang this guards against. Must stay on `awaitWithTimeout`'s
+  /// unstructured-task implementation: a `withTaskGroup`-based timeout awaits the wedged child
+  /// task at scope exit and would hang the timeout itself.
+  private func initializeDatabaseWithTimeout() async -> Bool {
+    let succeeded = await awaitWithTimeout(StartupWarmupPolicy.databaseInitTimeout) { () -> Bool in
+      do {
+        try await RewindDatabase.shared.initialize()
+        return true
+      } catch {
+        logError("ViewModelContainer: Database init failed, DB-dependent loads will be skipped", error: error)
+        return false
+      }
+    }
+    guard let succeeded else {
+      logError(
+        "ViewModelContainer: Database init did not complete within \(StartupWarmupPolicy.databaseInitTimeout) — treating as failed so startup can proceed"
+      )
+      return false
+    }
+    return succeeded
   }
 }

--- a/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/StartupWarmupPolicyTests.swift
@@ -471,6 +471,50 @@ final class StartupWarmupPolicyTests: XCTestCase {
     }
   }
 
+  /// Ratchet for the "Preparing your data…" indefinite-hang fix (a wedged
+  /// `RewindDatabase.initialize()` — stalled disk, actor deadlock — left the
+  /// loading screen up forever with no crash and no CPU). Both database-init
+  /// call sites must go through the single timeout-bounded helper.
+  func testViewModelContainerBoundsDatabaseInitWithATimeout() throws {
+    let source = try viewModelContainerSource()
+
+    XCTAssertTrue(
+      source.contains("private func initializeDatabaseWithTimeout() async -> Bool"),
+      "Database init must be routed through a single timeout-bounded helper")
+    XCTAssertTrue(
+      source.contains("awaitWithTimeout(StartupWarmupPolicy.databaseInitTimeout"),
+      "Database init must race against StartupWarmupPolicy.databaseInitTimeout, not await RewindDatabase.initialize() unboundedly"
+    )
+
+    guard let helperRange = source.range(of: "private func initializeDatabaseWithTimeout() async -> Bool") else {
+      return XCTFail("initializeDatabaseWithTimeout() not found")
+    }
+    let helperBody = String(source[helperRange.lowerBound...])
+    XCTAssertFalse(
+      helperBody.contains("withThrowingTaskGroup") || helperBody.contains("withTaskGroup"),
+      """
+      A withTaskGroup-based timeout awaits the wedged child task at scope exit and would hang \
+      the timeout itself — see AwaitWithTimeoutTests.
+      """)
+  }
+
+  func testLoadAllDataAndRetryBothRouteThroughTheDatabaseTimeoutHelper() throws {
+    let source = try viewModelContainerSource()
+    XCTAssertGreaterThanOrEqual(
+      source.components(separatedBy: "await initializeDatabaseWithTimeout()").count - 1,
+      2,
+      "Both the initial load path and retryDatabaseInit() must use the timeout-bounded helper")
+  }
+
+  private func viewModelContainerSource() throws -> String {
+    let testsURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    let sourceURL =
+      testsURL
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/ViewModelContainer.swift")
+    return try String(contentsOf: sourceURL, encoding: .utf8)
+  }
+
   func testAuthSignInFetchesFloatingBarPlanImmediately() throws {
     let testsURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
     let authURL =

--- a/desktop/macos/changelog/unreleased/20260824-database-init-hang.json
+++ b/desktop/macos/changelog/unreleased/20260824-database-init-hang.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the app hanging indefinitely on \"Preparing your data...\" during startup"
+}


### PR DESCRIPTION
## Summary
- Fixes #12145: `RewindDatabase.initialize()` was awaited with no timeout in `ViewModelContainer.loadAllData()` and `retryDatabaseInit()`, so a wedged open/migration (stalled disk, actor deadlock) left `isInitialLoadComplete` false forever — the app is stuck on "Preparing your data…" indefinitely, with no crash and no CPU.
- Routes both call sites through a new `initializeDatabaseWithTimeout()` helper that races `RewindDatabase.initialize()` against a new `StartupWarmupPolicy.databaseInitTimeout` (30s) using the existing `awaitWithTimeout` primitive (already used for the automation bridge's `/state` hang fix). That primitive is deliberately built on an unstructured task + continuation rather than `withTaskGroup`, so it returns at the timeout even when the wedged operation is non-cancellable — a `withTaskGroup`-based timeout would await the wedged child at scope exit and hang the timeout itself.
- On timeout, init is treated as failed exactly like a thrown `initialize()` error: the loading screen still clears (`databaseInitFailed = true`) and the existing exponential-backoff retry loop in `StartupWarmupCoordinator` takes over.
- Root cause of the reporter's specific stall is unconfirmed (they ruled out permission, corrupt install, stale lock file, OS state, and DB corruption); this closes the underlying "any DB-init hang leaves the app invisibly stuck forever" class rather than one specific trigger, matching the issue's stated expected behavior ("fail visibly ... rather than hang indefinitely").

## Test plan
- [x] `xcrun swift build -c debug --package-path Desktop` — clean build
- [x] `xcrun swift test -c debug --package-path Desktop --filter "StartupWarmupPolicyTests|AwaitWithTimeoutTests"` — 45 tests, 0 failures (includes 2 new wiring-guard tests added in this PR)
- [x] Ran a named dev bundle (`omi-watchdog-12145`) end to end: log confirms `RewindDatabase: Initialized successfully` via the new timeout-wrapped helper and the app reaches the normal signed-out UI (no regression to the happy path)
- [ ] Could not reproduce the reporter's actual wedged-disk/deadlock hang locally, so the timeout-firing branch itself is covered by the existing `AwaitWithTimeoutTests` behavioral suite (which proves `awaitWithTimeout` returns at the deadline even for a genuinely blocked, non-cancellable operation) rather than a live repro

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

