### PR TITLE
fix(monitoring): drop the exporter probe block the chart never reads

### DIFF
--- a/backend/charts/monitoring/prometheus-stackdriver-exporter/dev_omi_cloud_run_metrics_exporter.yaml
+++ b/backend/charts/monitoring/prometheus-stackdriver-exporter/dev_omi_cloud_run_metrics_exporter.yaml
@@ -30,14 +30,13 @@ resources:
     cpu: '2'
     memory: 2Gi
 
-# This exporter collects from Cloud Monitoring at scrape time, so a slow upstream
-# makes the whole HTTP server slow, including '/'. Probes must outlast a scrape
-# or they turn a slow collection into a crash loop.
-livenessProbe:
-  timeoutSeconds: 25
-  periodSeconds: 30
-  failureThreshold: 5
-readinessProbe:
-  timeoutSeconds: 25
-  periodSeconds: 30
-  failureThreshold: 5
+# Do not add livenessProbe/readinessProbe here. prometheus-stackdriver-exporter
+# hardcodes both probes in its Deployment template -- path /, timeoutSeconds 10 --
+# and exposes no values key for them, in 4.8.3 and in every later 4.x. A probe
+# block in this file renders nothing and reverts silently on the next upgrade,
+# which is worse than not having one: it reads as configuration.
+#
+# That makes CPU the only lever over probe survival. Both probes hit '/', which is
+# trivial to serve, so they only ever time out when the process is starved --
+# which is exactly what a 200m limit did while a collection was in flight. With
+# headroom, an in-cluster scrape completes in ~4.8s against the fixed 10s budget.

--- a/backend/charts/monitoring/prometheus-stackdriver-exporter/prod_omi_cloud_run_metrics_exporter.yaml
+++ b/backend/charts/monitoring/prometheus-stackdriver-exporter/prod_omi_cloud_run_metrics_exporter.yaml
@@ -30,14 +30,13 @@ resources:
     cpu: '2'
     memory: 2Gi
 
-# This exporter collects from Cloud Monitoring at scrape time, so a slow upstream
-# makes the whole HTTP server slow, including '/'. Probes must outlast a scrape
-# or they turn a slow collection into a crash loop.
-livenessProbe:
-  timeoutSeconds: 25
-  periodSeconds: 30
-  failureThreshold: 5
-readinessProbe:
-  timeoutSeconds: 25
-  periodSeconds: 30
-  failureThreshold: 5
+# Do not add livenessProbe/readinessProbe here. prometheus-stackdriver-exporter
+# hardcodes both probes in its Deployment template -- path /, timeoutSeconds 10 --
+# and exposes no values key for them, in 4.8.3 and in every later 4.x. A probe
+# block in this file renders nothing and reverts silently on the next upgrade,
+# which is worse than not having one: it reads as configuration.
+#
+# That makes CPU the only lever over probe survival. Both probes hit '/', which is
+# trivial to serve, so they only ever time out when the process is starved --
+# which is exactly what a 200m limit did while a collection was in flight. With
+# headroom, an in-cluster scrape completes in ~4.8s against the fixed 10s budget.

--- a/backend/tests/unit/test_monitoring_telemetry_contract.py
+++ b/backend/tests/unit/test_monitoring_telemetry_contract.py
@@ -181,10 +181,14 @@ def test_cloud_run_metrics_exporter_can_outlast_its_own_scrape(path):
     ), f'{path.name}: measured steady state is ~238m and a scrape needs ~1 core'
     assert _memory_mebibytes(limits['memory']) >= 1024, f'{path.name}: measured steady state is ~331Mi'
 
+    # The chart hardcodes both probes and reads no probe values, so a probe block
+    # here would render nothing while looking like configuration. Reject it, and
+    # keep capacity as the lever that actually decides whether a probe survives.
     for probe in ('livenessProbe', 'readinessProbe'):
-        assert (
-            values[probe]['timeoutSeconds'] >= 20
-        ), f'{path.name}: {probe} must outlast a slow scrape or it turns latency into a crash loop'
+        assert probe not in values, (
+            f'{path.name}: prometheus-stackdriver-exporter templates {probe} with a fixed 10s timeout and '
+            f'exposes no values key for it; this block would be inert'
+        )
 
 
 @pytest.mark.parametrize('path', (CLOUD_RUN_EXPORTER, CLOUD_RUN_EXPORTER_DEV), ids=('prod', 'dev'))


### PR DESCRIPTION
## Summary

The probe block I added in #12146 is inert. `prometheus-stackdriver-exporter` hardcodes both probes in its Deployment template — `path: /`, `timeoutSeconds: 10` — and exposes no values key for them. I confirmed it renders identically in 4.8.3, 4.9.0, and 5.0.0.

Caught it on the live cluster rather than by reading the chart: after the dev egress reconcile the exporter had picked up the new `cpu: 2` / `memory: 2Gi` limits and was still serving `timeoutSeconds: 10`.

```
limits: {'cpu': '2', 'memory': '2Gi'} | liveness timeout: 10
```

So #12146 shipped a stanza that reads as configuration, renders nothing, and would revert silently on any upgrade — and a contract test asserting a value that never reaches a cluster. That is the same defect this whole thread has been about, in the fix for it: a declaration that looks satisfied everywhere except where it has to take effect.

## Changes

- Remove `livenessProbe`/`readinessProbe` from both exporter values files, replaced by a comment recording that the chart owns them and that CPU is therefore the only lever over probe survival.
- Invert the contract test: it now asserts these keys are **absent**, so re-adding an inert block fails with the reason. Negative proof — appending `livenessProbe: {timeoutSeconds: 25}` fails with `this block would be inert`.

## What this does not change

The fix in #12146 still holds, because capacity was always the operative half. Both probes hit `/`, which is trivial to serve; they only time out when the process is starved, which is exactly what a 200m limit did with a collection in flight and steady-state usage of 238m. With headroom an in-cluster scrape completes in ~4.8s against the fixed 10s budget, and prod has held for 25+ minutes at 0 restarts.

The residual risk is real and worth stating: the 10s probe budget is now fixed and unadjustable, so a slow Cloud Monitoring day or continued growth in Cloud Run series can still push a collection past it. The levers left are fewer series or a narrower prefix, not a longer timeout. `omi-cloud-run-egress-down` is what will say so.

## Verification

- `test_monitoring_telemetry_contract.py`: **26 passed**.
- Live confirmation that the removed block was inert, quoted above.
- Chart templates inspected at 4.8.3, 4.9.0 and 5.0.0: probes hardcoded in all three, no values key.

## Product invariants affected

- INV-DATA-1

Monitoring-only; no serving authority is touched.

Failure-Class: FC-bridge-liveness-without-data-path-proof


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

