### PR TITLE
fix(backend): desktop quota display reads dev Firestore while chat enforcement reads prod

### DIFF
--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -22,6 +22,7 @@ from database import (
     llm_usage as llm_usage_db,
     users as users_db,
 )
+from database._client import get_customer_firestore_client
 from database.sync_jobs import release_job_run_lock, try_acquire_job_run_lock
 from services.users.data_export import iter_user_data_export
 from services.users.account_deletion import background_wipe_user_data, start_account_deletion
@@ -1407,7 +1408,14 @@ def get_user_chat_usage_quota(
             reset_at=None,
         )
 
-    snapshot = get_chat_quota_snapshot(uid, platform=x_app_platform)
+    # This is the desktop-only quota display (see docstring), so it must read the
+    # same customer Firestore project that enforce_desktop_chat_quota() enforces
+    # against — otherwise a named dev/named bundle shows the dev project's plan
+    # here while /v2/chat/completions gates on the customer project's, and the
+    # two disagree for the same uid (#11199).
+    snapshot = get_chat_quota_snapshot(
+        uid, platform=x_app_platform, firestore_client=get_customer_firestore_client(), provision=False
+    )
     plan = snapshot['plan']
 
     if snapshot['limit'] is not None and snapshot['limit'] > 0:

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -522,3 +522,32 @@ def test_subscription_endpoint_falls_back_to_basic_when_no_valid_subscription():
         )
 
     assert response.subscription.plan == users_router.PlanType.basic
+
+
+def test_usage_quota_endpoint_reads_customer_firestore_like_desktop_enforcement():
+    # GET /v1/users/me/usage-quota (routers/users.py:1386) is the desktop app's own
+    # quota display and called get_chat_quota_snapshot() with no firestore_client,
+    # which defaults to the compute-local project. enforce_desktop_chat_quota() --
+    # the function that actually gates POST /v2/chat/completions -- always forces
+    # get_customer_firestore_client(). On a named dev/desktop bundle those are two
+    # different Firestore projects, so this endpoint could report `allowed: true`
+    # for the same uid that the chat endpoint 402s (#11199).
+    sentinel_customer_client = object()
+    snapshot_mock = MagicMock(
+        return_value={
+            'plan': users_router.PlanType.basic,
+            'used': 1.0,
+            'limit': 30.0,
+            'unit': 'questions',
+            'allowed': True,
+            'reset_at': None,
+        }
+    )
+    with patch.object(users_router.users_db, 'is_byok_active', MagicMock(return_value=False)), patch.object(
+        users_router, 'get_customer_firestore_client', MagicMock(return_value=sentinel_customer_client)
+    ), patch.object(users_router, 'get_chat_quota_snapshot', snapshot_mock):
+        users_router.get_user_chat_usage_quota(uid='uid1', x_app_platform='desktop')
+
+    snapshot_mock.assert_called_once_with(
+        'uid1', platform='desktop', firestore_client=sentinel_customer_client, provision=False
+    )


### PR DESCRIPTION
## What

`GET /v1/users/me/usage-quota` — the desktop app's own chat-quota display — called
`get_chat_quota_snapshot(uid, platform=x_app_platform)` with no `firestore_client`,
which defaults to the compute-local Firestore project (`based-hardware-dev` on the
dev Cloud Run service). `enforce_desktop_chat_quota()` — the function that actually
gates `POST /v2/chat/completions` — always forces
`firestore_client=get_customer_firestore_client()` (the prod customer project); this
is documented as intentional in `get_user_valid_subscription()`'s docstring
("Desktop-backend quota must use that mode against the customer Firestore so a miss
cannot stamp `plan: basic` onto a paying user").

Fix: point the desktop quota-display endpoint at the same customer Firestore client
and `provision=False` mode that desktop chat enforcement already uses, so both lanes
resolve the same subscription record for the same uid.

## Why

On a named dev/desktop bundle (production Firebase auth identity, dev data plane —
per the issue, any bundle id outside the production family routes to the dev
backend while auth stays on the production Firebase project), the quota-display
endpoint and the chat-enforcement path read two different Firestore projects for
the same uid: the display lane can report an `Operator` plan snapshot with
`allowed=true` from the dev project's data, while the enforcement lane finds no
subscription in prod, falls back to the hard-capped Free plan, and returns 402 on
`/v2/chat/completions` — milliseconds apart, for the same user. Evidence from the
issue: prod logs show `plan=Operator used=57 limit=500 allowed=true` from the quota
lane 9ms before a 402 from the chat lane, reproduced across two Cloud Run revisions
~10h apart. Every chat turn on a named dev/desktop bundle fails despite the quota UI
showing headroom, which has blocked live verification of chat streaming on dev.

## What I tested

- Reverting just the router fix (keeping the new test) turns the new test red with
  `AttributeError: routers.users does not have the attribute 'get_customer_firestore_client'`
  proving the test exercises the fixed code path.
- `backend/.venv/bin/python -m pytest tests/routers/test_users.py tests/unit/test_chat_quota.py -q`
  → 43 passed.
- `PYTHON=.venv/bin/python bash backend/test-preflight.sh` → 17 passed, 0 failed.
- `black --line-length 120 --skip-string-normalization` on both touched files (no changes needed after the pre-commit hook ran it).

Failure-Class: none

Line-Count-Exception: backend/routers/users.py | 2193 -> 2201 | one-line fix (new import + firestore_client/provision kwargs) plus a 6-line comment explaining why this endpoint must match enforce_desktop_chat_quota's Firestore client; no extraction target in this diff's scope.

fixes #11199

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

