### PR TITLE
fix(deploy): select desktop-backend's runtime image by container name

### DIFF
--- a/.github/scripts/test_check_desktop_backend_release_policy.py
+++ b/.github/scripts/test_check_desktop_backend_release_policy.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import re
+import shutil
+import subprocess
 import sys
 import unittest
 from pathlib import Path
@@ -497,6 +501,100 @@ class DesktopBackendReleasePolicyTests(unittest.TestCase):
         )
         errors = POLICY.validate_deploy_workflow(mutated, production=False)
         self.assertTrue(any("verify-image-lineage.outputs.runtime_digest" in error for error in errors), errors)
+
+    # RevisionStatus in the Cloud Run v1 API has no per-container digest map: its
+    # legacy image-digest field is a single-container scalar that is empty on any
+    # multi-container revision. The Managed Prometheus sidecar (#11998) made every
+    # desktop-backend candidate two-container, so both workflows switched to
+    # extracting the runtime image from the named "desktop-backend-1" container in
+    # `gcloud run revisions describe --format=json` instead. Regression-guard both
+    # properties: the legacy field must not come back, and the extraction filter
+    # actually resolves the right image out of a realistic two-container revision.
+
+    def test_neither_deploy_workflow_reads_the_legacy_single_container_digest_field(self) -> None:
+        legacy_field = "status" + "." + "imageDigest"
+        for name, text in (("dev", self.dev), ("prod", self.prod)):
+            with self.subTest(workflow=name):
+                self.assertNotIn(legacy_field, text)
+                self.assertIn('select(.name == "desktop-backend-1")', text)
+                self.assertIn("--format=json", text)
+
+    def _extract_runtime_image_jq_filter(self, text: str) -> str:
+        match = re.search(r"jq -er '(.*?)'\)\"", text, re.DOTALL)
+        assert match, "expected an inline jq filter selecting the desktop-backend-1 image"
+        return match.group(1)
+
+    def _run_runtime_image_filter(self, jq_filter: str, revision: dict[str, object]) -> subprocess.CompletedProcess:
+        assert shutil.which("jq"), "jq must be installed to exercise the workflow's extraction filter"
+        return subprocess.run(
+            ["jq", "-er", jq_filter],
+            input=json.dumps(revision),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_runtime_image_filter_selects_desktop_backend_container_on_two_container_revision(self) -> None:
+        expected_image = (
+            "gcr.io/based-hardware-dev/desktop-backend@sha256:"
+            "b6c51555ebd7274728ccb79e0f2957fd1f6761d469aa51d5eb999d2debc6b706"
+        )
+        # A realistic post-#11998 candidate revision: two containers, and the legacy
+        # status.imageDigest scalar left absent, exactly as Cloud Run returns it.
+        revision = {
+            "spec": {
+                "containers": [
+                    {
+                        "name": "collector",
+                        "image": "gcr.io/based-hardware-dev/collector@sha256:" + "a" * 64,
+                    },
+                    {
+                        "name": "desktop-backend-1",
+                        "image": expected_image,
+                    },
+                ]
+            },
+            "status": {},
+        }
+        for name, text in (("dev", self.dev), ("prod", self.prod)):
+            with self.subTest(workflow=name):
+                jq_filter = self._extract_runtime_image_jq_filter(text)
+                result = self._run_runtime_image_filter(jq_filter, revision)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout.strip(), expected_image)
+
+    def test_runtime_image_filter_rejects_missing_or_duplicated_desktop_backend_container(self) -> None:
+        image = "gcr.io/based-hardware-dev/desktop-backend@sha256:" + "b" * 64
+        cases = {
+            "no desktop-backend-1 container": {
+                "spec": {
+                    "containers": [
+                        {"name": "collector", "image": "gcr.io/based-hardware-dev/collector@sha256:" + "a" * 64}
+                    ]
+                },
+                "status": {},
+            },
+            "duplicated desktop-backend-1 container": {
+                "spec": {
+                    "containers": [
+                        {"name": "desktop-backend-1", "image": image},
+                        {"name": "desktop-backend-1", "image": image},
+                    ]
+                },
+                "status": {},
+            },
+            "empty image string": {
+                "spec": {"containers": [{"name": "desktop-backend-1", "image": ""}]},
+                "status": {},
+            },
+        }
+        for name, text in (("dev", self.dev), ("prod", self.prod)):
+            jq_filter = self._extract_runtime_image_jq_filter(text)
+            for case_name, revision in cases.items():
+                with self.subTest(workflow=name, case=case_name):
+                    result = self._run_runtime_image_filter(jq_filter, revision)
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn("expected exactly one desktop-backend-1 container image", result.stderr)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -301,10 +301,21 @@ jobs:
           PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
         run: |
           set -euo pipefail
-          runtime_image_ref="$(gcloud run revisions describe "${{ steps.candidate-identity.outputs.revision }}" \
-            --project="$PROJECT_ID" \
-            --region="$REGION" \
-            --format='value(status.imageDigest)')"
+          # The revision "status" block's legacy image-digest field is a single-container
+          # scalar in the Cloud Run v1 Revision API: RevisionStatus has no per-container
+          # digest map, so it comes back empty on multi-container revisions. The Managed
+          # Prometheus sidecar (#11998) made every desktop-backend candidate two-container,
+          # so that field went empty and the guard below started failing closed. Extract
+          # the image by container name instead, and assert there is exactly one match so
+          # the guard still fails closed if the container topology ever changes again.
+          runtime_image_ref="$(
+            gcloud run revisions describe "${{ steps.candidate-identity.outputs.revision }}" \
+              --project="$PROJECT_ID" \
+              --region="$REGION" \
+              --format=json |
+            jq -er '[.spec.containers[]? | select(.name == "desktop-backend-1") | .image] as $images |
+              if (($images | length) == 1 and ($images[0] | type) == "string" and ($images[0] | length) > 0)
+              then $images[0] else error("expected exactly one desktop-backend-1 container image") end')"
           runtime_digest="$(python3 .github/scripts/verify_desktop_backend_image_lineage.py \
             --build-image-ref="$BUILD_IMAGE_REF" \
             --runtime-image-ref="$runtime_image_ref" \

--- a/.github/workflows/desktop_backend_prod.yml
+++ b/.github/workflows/desktop_backend_prod.yml
@@ -389,10 +389,21 @@ jobs:
           PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
         run: |
           set -euo pipefail
-          runtime_image_ref="$(gcloud run revisions describe "${{ steps.admitted-source.outputs.revision }}" \
-            --project="$PROJECT_ID" \
-            --region="$REGION" \
-            --format='value(status.imageDigest)')"
+          # The revision "status" block's legacy image-digest field is a single-container
+          # scalar in the Cloud Run v1 Revision API: RevisionStatus has no per-container
+          # digest map, so it comes back empty on multi-container revisions. The Managed
+          # Prometheus sidecar (#11998) made every desktop-backend candidate two-container,
+          # so that field went empty and the guard below started failing closed. Extract
+          # the image by container name instead, and assert there is exactly one match so
+          # the guard still fails closed if the container topology ever changes again.
+          runtime_image_ref="$(
+            gcloud run revisions describe "${{ steps.admitted-source.outputs.revision }}" \
+              --project="$PROJECT_ID" \
+              --region="$REGION" \
+              --format=json |
+            jq -er '[.spec.containers[]? | select(.name == "desktop-backend-1") | .image] as $images |
+              if (($images | length) == 1 and ($images[0] | type) == "string" and ($images[0] | length) > 0)
+              then $images[0] else error("expected exactly one desktop-backend-1 container image") end')"
           runtime_digest="$(python3 "$DESKTOP_BACKEND_CONTROLS/.github/scripts/verify_desktop_backend_image_lineage.py" \
             --build-image-ref="$BUILD_IMAGE_REF" \
             --runtime-image-ref="$runtime_image_ref" \


### PR DESCRIPTION
## Summary

`desktop_backend_auto_dev.yml` and `desktop_backend_prod.yml` sourced the desktop-backend
candidate's runtime image reference from `gcloud run revisions describe
--format='value(status.imageDigest)'`. That field is the legacy single-container scalar
in the Cloud Run v1 Revision API — `RevisionStatus` has no per-container digest map, so
it is empty on any multi-container revision.

PR #11998 attached a Managed Prometheus `collector` sidecar to every desktop-backend
candidate, making them two-container revisions. Since then the field has come back
empty and the lineage guard has failed closed on every candidate with:

```
desktop-backend image lineage verification failed: image reference must use an exact sha256 digest: ''
```

Dev desktop-backend has not deployed since 2026-08-22T19:26:45Z as a result.

The guard itself is correct — it should fail closed on an unproven image. The bug is
that its input went missing, not that the check is wrong.

## Fix

Both workflows now extract the runtime image from `gcloud run revisions describe
--format=json` by selecting the container named `desktop-backend-1`, and assert there
is exactly one such container with a non-empty string image — so the check still fails
closed if the container topology becomes ambiguous again, instead of silently reading
an empty scalar.

This was verified against the live dev revision
`desktop-backend-4b8636e55fcf-32744822554-1`: the old field returned empty, the new
extraction returns
`gcr.io/based-hardware-dev/desktop-backend@sha256:b6c51555ebd7274728ccb79e0f2957fd1f6761d469aa51d5eb999d2debc6b706`.

This is not a tautology: `verify_desktop_backend_image_lineage.py` independently
derives the expected `linux/amd64` child digest from the registry index and compares it
against this container's spec image, so the real lineage property is still proven.

## Test plan

- [x] `.github/scripts/test_check_desktop_backend_release_policy.py` — added
  `test_neither_deploy_workflow_reads_the_legacy_single_container_digest_field` (both
  workflows no longer reference the legacy field and both select
  `desktop-backend-1` by name), plus
  `test_runtime_image_filter_selects_desktop_backend_container_on_two_container_revision`
  and `test_runtime_image_filter_rejects_missing_or_duplicated_desktop_backend_container`,
  which extract each workflow's actual `jq` filter and run it against realistic
  two-container Revision JSON (`desktop-backend-1` + `collector`, `status.imageDigest`
  absent) to prove the extraction selects the right image and still fails closed on a
  missing/duplicated/empty container.
- [x] `actionlint` on both modified workflow files.
- [x] Full local run of `.github/scripts/test_check_desktop_backend_release_policy.py`
  (30/30 passing).
- [ ] Dev `desktop_backend_auto_dev.yml` run on the merge commit — watched end to end
  after merge.

## Product invariants affected

- INV-DATA-1: this is a deploy-verification path, not a data-plane routing change —
  no serving-plane selection is touched. Naming it here because the guard exists to
  prove the digest running in a given environment is the one actually built, which
  underpins the continuity guarantee INV-DATA-1 depends on; the fix restores that proof
  rather than weakening it.

Failure-Class: FC-config-target-identified-by-count-not-identity


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

