### PR TITLE
feat: add Prometheus instrumentation for Stripe subscription lifecycle events

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -37,6 +37,7 @@ from utils.subscription import (
     price_ids_match_plan_and_interval,
 )
 from utils.observability.fallback import record_fallback
+from utils.observability.subscription_events import record_subscription_event
 from database.users import (
     get_stripe_connect_account_id,
     set_stripe_connect_account_id,
@@ -1036,6 +1037,11 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
         'customer.subscription.created',
     ]:
         subscription_obj = event['data']['object']
+        record_subscription_event(
+            stripe_event_type=event['type'],
+            subscription_obj=subscription_obj,
+            previous_attributes=event.get('data', {}).get('previous_attributes'),
+        )
         uid = subscription_obj.get('metadata', {}).get('uid')
 
         if not uid:

--- a/backend/tests/unit/test_payment_promotion_codes.py
+++ b/backend/tests/unit/test_payment_promotion_codes.py
@@ -285,6 +285,10 @@ def _setup_payment_module(include_client: bool = True) -> Any:
     fallback_mod.record_fallback = MagicMock()
     sys.modules["utils.observability.fallback"] = fallback_mod
 
+    subscription_events_mod = types.ModuleType("utils.observability.subscription_events")
+    subscription_events_mod.record_subscription_event = MagicMock()
+    sys.modules["utils.observability.subscription_events"] = subscription_events_mod
+
     stripe_utils_mod = sys.modules["utils.stripe"]
     stripe_utils_mod.base_url = "http://test/"
     stripe_utils_mod.create_subscription_checkout_session = MagicMock()

--- a/backend/tests/unit/test_subscription_events_metrics.py
+++ b/backend/tests/unit/test_subscription_events_metrics.py
@@ -1,0 +1,378 @@
+"""Stripe subscription lifecycle event metric — mapping, bounds, and fail-open behavior.
+
+Cancellations are otherwise invisible in real time (no system tracks them), so
+``record_subscription_event`` in ``utils.observability.subscription_events`` is
+the seam that turns ``customer.subscription.*`` webhook deliveries into the
+bounded ``omi_subscription_events_total`` counter. The mapping from a raw
+Stripe event to a metric event is the part most likely to silently drift, so
+it is exercised here against realistic event/subscription payload shapes
+rather than through the full webhook route (which needs a heavy Firestore
+import chain unavailable to this test process; see
+``test_stripe_webhook_none_guard.py`` for that same constraint).
+
+Two invariants matter as much as the mapping itself: instrumentation must
+never raise into the caller (a malformed payload or a resolver exception is
+swallowed and logged, not propagated), and every label stays inside its
+closed, low-cardinality set — never a uid, customer id, subscription id,
+price id, or email.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from utils.metrics import OMI_SUBSCRIPTION_EVENTS
+from utils.observability.subscription_events import record_subscription_event
+
+# Real, currently-recognized catalog prices (backend/config/plan_catalog.json),
+# one per plan, so plan/interval resolution is exercised against the actual
+# resolver rather than a stand-in mapping.
+_UNLIMITED_MONTH_PRICE = 'price_1RrxXL1F8wnoWYvwIddzR902'
+_UNLIMITED_YEAR_PRICE = 'price_1RrxXL1F8wnoWYvw3kDbWmjs'
+_ARCHITECT_MONTH_PRICE = 'price_1TLFXK1F8wnoWYvwG1TaUkZ3'
+
+# A customer/uid deliberately shaped to fail the test if it ever leaked into a label.
+_SECRET_CUSTOMER_ID = 'cus_SHOULD_NEVER_APPEAR'
+_SECRET_UID = 'uid_SHOULD_NEVER_APPEAR'
+
+
+def _price(price_id: str, interval: str = 'month') -> dict:
+    return {'id': price_id, 'recurring': {'interval': interval}}
+
+
+def _subscription_obj(
+    *,
+    price_id: str = _UNLIMITED_MONTH_PRICE,
+    interval: str = 'month',
+    status: str = 'active',
+    cancel_at_period_end: bool = False,
+    cancellation_details: dict | None = None,
+) -> dict:
+    return {
+        'id': 'sub_test_123',
+        'status': status,
+        'cancel_at_period_end': cancel_at_period_end,
+        'items': {'data': [{'price': _price(price_id, interval)}]},
+        'cancellation_details': cancellation_details or {},
+        'customer': _SECRET_CUSTOMER_ID,
+        'metadata': {'uid': _SECRET_UID},
+    }
+
+
+def _count(**labels) -> float:
+    return OMI_SUBSCRIPTION_EVENTS.labels(**labels)._value.get()
+
+
+def _total() -> float:
+    return sum(
+        sample.value
+        for family in OMI_SUBSCRIPTION_EVENTS.collect()
+        for sample in family.samples
+        if sample.name == 'omi_subscription_events_total'
+    )
+
+
+def _all_recorded_label_values() -> set[str]:
+    values: set[str] = set()
+    for family in OMI_SUBSCRIPTION_EVENTS.collect():
+        for sample in family.samples:
+            values.update(sample.labels.values())
+    return values
+
+
+def test_bounded_label_surface_is_exactly_event_plan_interval_reason():
+    assert set(OMI_SUBSCRIPTION_EVENTS._labelnames) == {'event', 'plan', 'interval', 'reason'}
+
+
+def test_created_event_maps_to_created_with_plan_and_interval():
+    before = _count(event='created', plan='unlimited', interval='month', reason='none')
+
+    record_subscription_event(
+        stripe_event_type='customer.subscription.created',
+        subscription_obj=_subscription_obj(price_id=_UNLIMITED_MONTH_PRICE, interval='month'),
+    )
+
+    assert _count(event='created', plan='unlimited', interval='month', reason='none') == before + 1
+
+
+def test_deleted_event_maps_to_ended_with_cancellation_reason():
+    before = _count(event='ended', plan='architect', interval='month', reason='cancellation_requested')
+
+    record_subscription_event(
+        stripe_event_type='customer.subscription.deleted',
+        subscription_obj=_subscription_obj(
+            price_id=_ARCHITECT_MONTH_PRICE,
+            interval='month',
+            status='canceled',
+            cancellation_details={'reason': 'cancellation_requested'},
+        ),
+    )
+
+    assert _count(event='ended', plan='architect', interval='month', reason='cancellation_requested') == before + 1
+
+
+def test_deleted_event_with_no_cancellation_reason_records_none():
+    before = _count(event='ended', plan='unlimited', interval='year', reason='none')
+
+    record_subscription_event(
+        stripe_event_type='customer.subscription.deleted',
+        subscription_obj=_subscription_obj(
+            price_id=_UNLIMITED_YEAR_PRICE, interval='year', status='canceled', cancellation_details=None
+        ),
+    )
+
+    assert _count(event='ended', plan='unlimited', interval='year', reason='none') == before + 1
+
+
+def test_updated_cancel_at_period_end_false_to_true_is_cancellation_requested():
+    before = _count(event='cancellation_requested', plan='unlimited', interval='month', reason='none')
+
+    record_subscription_event(
+        stripe_event_type='customer.subscription.updated',
+        subscription_obj=_subscription_obj(cancel_at_period_end=True),
+        previous_attributes={'cancel_at_period_end': False},
+    )
+
+    assert _count(event='cancellation_requested', plan='unlimited', interval='month', reason='none') == before + 1
+
+
+def test_updated_cancel_at_period_end_true_to_false_is_cancellation_reverted():
+    before = _count(event='cancellation_reverted', plan='unlimited', interval='month', reason='none')
+
+    record_subscription_event(
+        stripe_event_type='customer.subscription.updated',
+        subscription_obj=_subscription_obj(cancel_at_period_end=False),
+        previous_attributes={'cancel_at_period_end': True},
+    )
+
+    assert _count(event='cancellation_reverted', plan='unlimited', interval='month', reason='none') == before + 1
+
+
+def test_updated_status_change_to_past_due_or_unpaid_is_payment_failed():
+    for new_status in ('past_due', 'unpaid'):
+        before = _count(event='payment_failed', plan='unlimited', interval='month', reason='none')
+
+        record_subscription_event(
+            stripe_event_type='customer.subscription.updated',
+            subscription_obj=_subscription_obj(status=new_status),
+            previous_attributes={'status': 'active'},
+        )
+
+        assert (
+            _count(event='payment_failed', plan='unlimited', interval='month', reason='none') == before + 1
+        ), new_status
+
+
+def test_updated_status_change_to_active_is_not_payment_failed():
+    """A status change back to active (e.g. dunning recovery) is not itself a tracked event."""
+    total_before = _total()
+
+    record_subscription_event(
+        stripe_event_type='customer.subscription.updated',
+        subscription_obj=_subscription_obj(status='active'),
+        previous_attributes={'status': 'past_due'},
+    )
+
+    assert _total() == total_before
+
+
+def test_updated_with_unrelated_previous_attributes_records_nothing():
+    total_before = _total()
+
+    record_subscription_event(
+        stripe_event_type='customer.subscription.updated',
+        subscription_obj=_subscription_obj(),
+        previous_attributes={'items': 'changed', 'default_payment_method': 'pm_old'},
+    )
+
+    assert _total() == total_before
+
+
+def test_updated_with_no_previous_attributes_records_nothing():
+    total_before = _total()
+
+    record_subscription_event(
+        stripe_event_type='customer.subscription.updated',
+        subscription_obj=_subscription_obj(),
+        previous_attributes=None,
+    )
+    record_subscription_event(
+        stripe_event_type='customer.subscription.updated',
+        subscription_obj=_subscription_obj(),
+        previous_attributes={},
+    )
+
+    assert _total() == total_before
+
+
+def test_unrelated_event_type_records_nothing():
+    total_before = _total()
+
+    record_subscription_event(
+        stripe_event_type='invoice.payment_succeeded',
+        subscription_obj=_subscription_obj(),
+        previous_attributes={},
+    )
+
+    assert _total() == total_before
+
+
+def test_unresolvable_price_id_falls_back_to_unknown_plan():
+    """Plan resolution fails independently of interval: interval is read directly
+    off the price object and stays known even when the price id itself is not
+    in the catalog."""
+    before = _count(event='created', plan='unknown', interval='month', reason='none')
+
+    record_subscription_event(
+        stripe_event_type='customer.subscription.created',
+        subscription_obj=_subscription_obj(price_id='price_does_not_exist_in_catalog', interval='month'),
+    )
+
+    assert _count(event='created', plan='unknown', interval='month', reason='none') == before + 1
+
+
+def test_missing_price_falls_back_to_unknown_plan():
+    before = _count(event='created', plan='unknown', interval='unknown', reason='none')
+
+    record_subscription_event(
+        stripe_event_type='customer.subscription.created',
+        subscription_obj={'id': 'sub_no_items', 'status': 'active', 'items': {'data': []}},
+    )
+
+    assert _count(event='created', plan='unknown', interval='unknown', reason='none') == before + 1
+
+
+def test_price_resolver_raising_unexpected_exception_falls_back_to_unknown(monkeypatch):
+    from utils.observability import subscription_events
+
+    def _boom(_price_id):
+        raise RuntimeError('stripe catalog exploded')
+
+    monkeypatch.setattr(subscription_events, 'resolve_stripe_price_plan', _boom)
+    before = _count(event='created', plan='unknown', interval='month', reason='none')
+
+    record_subscription_event(
+        stripe_event_type='customer.subscription.created',
+        subscription_obj=_subscription_obj(price_id=_UNLIMITED_MONTH_PRICE, interval='month'),
+    )
+
+    assert _count(event='created', plan='unknown', interval='month', reason='none') == before + 1
+
+
+def test_unrecognized_cancellation_reason_falls_back_to_none():
+    before = _count(event='ended', plan='unlimited', interval='month', reason='none')
+
+    record_subscription_event(
+        stripe_event_type='customer.subscription.deleted',
+        subscription_obj=_subscription_obj(
+            status='canceled', cancellation_details={'reason': 'some_future_stripe_reason'}
+        ),
+    )
+
+    assert _count(event='ended', plan='unlimited', interval='month', reason='none') == before + 1
+
+
+def test_none_subscription_object_does_not_raise(caplog):
+    total_before = _total()
+
+    with caplog.at_level(logging.WARNING):
+        record_subscription_event(stripe_event_type='customer.subscription.created', subscription_obj=None)
+
+    # A created event with no subscription data still resolves to created/unknown/unknown/none.
+    assert _total() == total_before + 1
+
+
+def test_malformed_non_mapping_subscription_object_does_not_raise(caplog):
+    total_before = _total()
+
+    with caplog.at_level(logging.WARNING, logger='utils.observability.subscription_events'):
+        record_subscription_event(
+            stripe_event_type='customer.subscription.updated',
+            subscription_obj='not-a-mapping',
+            previous_attributes={'cancel_at_period_end': False},
+        )
+
+    assert _total() == total_before
+    assert any('subscription_event_record_failed' in record.message for record in caplog.records)
+
+
+def test_malformed_items_shape_does_not_raise():
+    total_before = _total()
+
+    record_subscription_event(
+        stripe_event_type='customer.subscription.created',
+        subscription_obj={'id': 'sub_x', 'status': 'active', 'items': 'not-a-dict'},
+    )
+
+    # Falls back to unknown/unknown rather than raising.
+    assert _total() == total_before + 1
+
+
+def test_no_uid_or_customer_id_ever_appears_in_a_recorded_label():
+    record_subscription_event(
+        stripe_event_type='customer.subscription.created',
+        subscription_obj=_subscription_obj(price_id=_UNLIMITED_MONTH_PRICE),
+    )
+    record_subscription_event(
+        stripe_event_type='customer.subscription.deleted',
+        subscription_obj=_subscription_obj(
+            price_id=_ARCHITECT_MONTH_PRICE, status='canceled', cancellation_details={'reason': 'payment_failure'}
+        ),
+    )
+
+    recorded_values = _all_recorded_label_values()
+    assert _SECRET_CUSTOMER_ID not in recorded_values
+    assert _SECRET_UID not in recorded_values
+    assert 'sub_test_123' not in recorded_values
+    assert _UNLIMITED_MONTH_PRICE not in recorded_values
+    assert _ARCHITECT_MONTH_PRICE not in recorded_values
+
+
+def test_all_recorded_labels_stay_within_the_bounded_sets():
+    allowed_events = {'created', 'cancellation_requested', 'cancellation_reverted', 'ended', 'payment_failed'}
+    allowed_plans = {'basic', 'unlimited', 'architect', 'operator', 'plus', 'unlimited_v2', 'unknown'}
+    allowed_intervals = {'month', 'year', 'unknown'}
+    allowed_reasons = {'cancellation_requested', 'payment_failure', 'payment_disputed', 'none'}
+
+    for family in OMI_SUBSCRIPTION_EVENTS.collect():
+        for sample in family.samples:
+            if sample.name != 'omi_subscription_events_total':
+                continue
+            assert sample.labels['event'] in allowed_events
+            assert sample.labels['plan'] in allowed_plans
+            assert sample.labels['interval'] in allowed_intervals
+            assert sample.labels['reason'] in allowed_reasons
+
+
+# ---------------------------------------------------------------------------
+# routers/payment.py cannot be imported in this test process — it pulls in the
+# full Firestore/firebase_admin chain (see test_stripe_webhook_none_guard.py).
+# The wiring into the customer.subscription.* branch is verified at source
+# level instead: the recorder is imported and called inside that branch with
+# both the raw Stripe event type and previous_attributes.
+# ---------------------------------------------------------------------------
+
+
+def _payment_router_source() -> str:
+    return (Path(__file__).resolve().parents[2] / 'routers' / 'payment.py').read_text(encoding='utf-8')
+
+
+def test_webhook_imports_the_subscription_event_recorder():
+    source = _payment_router_source()
+    assert 'from utils.observability.subscription_events import record_subscription_event' in source
+
+
+def test_webhook_calls_the_recorder_inside_the_subscription_event_branch():
+    source = _payment_router_source()
+    branch_marker = "'customer.subscription.created',\n    ]:"
+    branch_start = source.index(branch_marker) + len(branch_marker)
+    # Look at the handler body immediately following the type-check block, before
+    # the next top-level branch, so the call is confirmed inside this branch
+    # rather than merely present somewhere later in the file.
+    next_branch = source.index("if event['type'] in [", branch_start)
+    branch_body = source[branch_start:next_branch]
+
+    assert 'record_subscription_event(' in branch_body
+    assert "stripe_event_type=event['type']" in branch_body
+    assert "previous_attributes=event.get('data', {}).get('previous_attributes')" in branch_body

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -414,6 +414,14 @@ AUTH_FLOW_DURATION_SECONDS = Histogram(
     ['provider', 'terminal_state'],
 )
 
+OMI_SUBSCRIPTION_EVENTS = Counter(
+    'omi_subscription_events_total',
+    'Stripe subscription lifecycle events observed via webhook. Counts webhook '
+    'deliveries, which Stripe may retry, so treat these as an operational trend '
+    'signal rather than a billing-grade figure; Stripe remains source of truth.',
+    ['event', 'plan', 'interval', 'reason'],
+)
+
 
 # Pusher readiness / drain gauges. Label-free (low cardinality) so they scrape
 # cheaply. Initialized to serving below so an idle healthy pod reads

--- a/backend/utils/observability/subscription_events.py
+++ b/backend/utils/observability/subscription_events.py
@@ -1,0 +1,153 @@
+"""Bounded, privacy-safe counters for Stripe subscription lifecycle events.
+
+Cancellations are otherwise invisible in real time: subscription and MRR state
+lives only on a separate Grafana that queries Stripe live, and cancellations
+are not tracked anywhere. This module turns the ``customer.subscription.*``
+webhook deliveries already handled in ``routers.payment`` into one bounded
+counter so a cancellation trend is visible next to feature health.
+
+Recording must never break the webhook it observes: every public entry point
+here swallows unexpected errors and logs at warning instead of raising.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from config.plan_catalog import PlanType, resolve_stripe_price_plan
+from utils.metrics import OMI_SUBSCRIPTION_EVENTS
+
+logger = logging.getLogger(__name__)
+
+# Closed label surfaces. Never widen these with a uid, customer id,
+# subscription id, price id, or email — those are unbounded and would turn
+# this counter into an unbounded cardinality leak.
+_EVENTS = frozenset(
+    {
+        'created',
+        'cancellation_requested',
+        'cancellation_reverted',
+        'ended',
+        'payment_failed',
+    }
+)
+_PLANS = frozenset({plan.value for plan in PlanType}) | {'unknown'}
+_INTERVALS = frozenset({'month', 'year', 'unknown'})
+_REASONS = frozenset({'cancellation_requested', 'payment_failure', 'payment_disputed', 'none'})
+
+_PAYMENT_FAILED_STATUSES = frozenset({'past_due', 'unpaid'})
+
+
+def _determine_event(
+    stripe_event_type: str,
+    subscription_obj: Mapping[str, Any],
+    previous_attributes: Mapping[str, Any],
+) -> str | None:
+    """Map one Stripe subscription event to a bounded lifecycle event, or None.
+
+    ``previous_attributes`` is populated by Stripe with the *prior* value of
+    only the fields that changed on ``customer.subscription.updated``. A plain
+    update whose changed fields are not one of the tracked transitions below
+    records nothing — that is deliberate noise suppression, not a bug.
+    """
+
+    if stripe_event_type == 'customer.subscription.created':
+        return 'created'
+    if stripe_event_type == 'customer.subscription.deleted':
+        return 'ended'
+    if stripe_event_type != 'customer.subscription.updated':
+        return None
+
+    if 'cancel_at_period_end' in previous_attributes:
+        previous_value = previous_attributes.get('cancel_at_period_end')
+        current_value = subscription_obj.get('cancel_at_period_end')
+        if not previous_value and current_value:
+            return 'cancellation_requested'
+        if previous_value and not current_value:
+            return 'cancellation_reverted'
+
+    if 'status' in previous_attributes:
+        current_status = subscription_obj.get('status')
+        if current_status in _PAYMENT_FAILED_STATUSES:
+            return 'payment_failed'
+
+    return None
+
+
+def _first_item_price(subscription_obj: Mapping[str, Any]) -> Mapping[str, Any]:
+    items = subscription_obj.get('items')
+    if not isinstance(items, Mapping):
+        return {}
+    data = items.get('data')
+    if not isinstance(data, list) or not data:
+        return {}
+    first = data[0]
+    if not isinstance(first, Mapping):
+        return {}
+    price = first.get('price')
+    return price if isinstance(price, Mapping) else {}
+
+
+def _resolve_plan(subscription_obj: Mapping[str, Any]) -> str:
+    price_id = _first_item_price(subscription_obj).get('id')
+    if not price_id:
+        return 'unknown'
+    try:
+        plan = resolve_stripe_price_plan(price_id)
+    except Exception:
+        return 'unknown'
+    value = plan.value if isinstance(plan, PlanType) else str(plan)
+    return value if value in _PLANS else 'unknown'
+
+
+def _resolve_interval(subscription_obj: Mapping[str, Any]) -> str:
+    recurring = _first_item_price(subscription_obj).get('recurring')
+    interval = recurring.get('interval') if isinstance(recurring, Mapping) else None
+    return interval if interval in _INTERVALS else 'unknown'
+
+
+def _resolve_cancellation_reason(subscription_obj: Mapping[str, Any]) -> str:
+    details = subscription_obj.get('cancellation_details')
+    reason = details.get('reason') if isinstance(details, Mapping) else None
+    return reason if reason in _REASONS else 'none'
+
+
+def record_subscription_event(
+    *,
+    stripe_event_type: str,
+    subscription_obj: Mapping[str, Any] | None,
+    previous_attributes: Mapping[str, Any] | None = None,
+) -> None:
+    """Record one bounded subscription lifecycle event from a webhook delivery.
+
+    Never raises. A payload this cannot make sense of is recorded as nothing
+    rather than guessed at, and any unexpected failure is logged at warning
+    and swallowed so instrumentation can never break the webhook path.
+    """
+
+    try:
+        _record(stripe_event_type, subscription_obj or {}, previous_attributes or {})
+    except Exception:
+        logger.warning(
+            'subscription_event_record_failed stripe_event_type=%s',
+            stripe_event_type,
+            exc_info=True,
+        )
+
+
+def _record(
+    stripe_event_type: str,
+    subscription_obj: Mapping[str, Any],
+    previous_attributes: Mapping[str, Any],
+) -> None:
+    event = _determine_event(stripe_event_type, subscription_obj, previous_attributes)
+    if event is None or event not in _EVENTS:
+        return
+
+    plan = _resolve_plan(subscription_obj)
+    interval = _resolve_interval(subscription_obj)
+    reason = _resolve_cancellation_reason(subscription_obj) if event == 'ended' else 'none'
+
+    OMI_SUBSCRIPTION_EVENTS.labels(event=event, plan=plan, interval=interval, reason=reason).inc()

--- a/backend/utils/observability/subscription_events.py
+++ b/backend/utils/observability/subscription_events.py
@@ -98,8 +98,10 @@ def _resolve_plan(subscription_obj: Mapping[str, Any]) -> str:
         plan = resolve_stripe_price_plan(price_id)
     except Exception:
         return 'unknown'
-    value = plan.value if isinstance(plan, PlanType) else str(plan)
-    return value if value in _PLANS else 'unknown'
+    # resolve_stripe_price_plan is typed to always return PlanType; still bound
+    # the result against the closed label set rather than trusting the type
+    # contract, in case the catalog ever adds a member this metric doesn't know.
+    return plan.value if plan.value in _PLANS else 'unknown'
 
 
 def _resolve_interval(subscription_obj: Mapping[str, Any]) -> str:


### PR DESCRIPTION
## Summary

Prod Prometheus carries 1,706 metric names and zero business metrics. Subscription/MRR state is visible only on a separate Grafana (admin.omi.me) that queries Stripe live via an Infinity datasource, and cancellations are not tracked anywhere in any system today.

This adds a single bounded counter, `omi_subscription_events_total`, driven off the `customer.subscription.*` webhook Stripe already delivers to `backend/routers/payment.py`, so cancellation and payment-failure trends are visible in real time next to feature health metrics. A dashboard is being built against this exact contract in parallel — the metric name, label set, and event mapping below are load-bearing and were specified up front.

## What's instrumented

`OMI_SUBSCRIPTION_EVENTS` (`backend/utils/metrics.py`), labeled `event`, `plan`, `interval`, `reason` — all four are closed, bounded sets; none of them can ever carry a uid, customer id, subscription id, price id, or email.

- `event`: `created`, `cancellation_requested`, `cancellation_reverted`, `ended`, `payment_failed`
- `plan`: a `PlanType` value (`basic`, `unlimited`, `architect`, `operator`, `plus`, `unlimited_v2`) or `unknown`
- `interval`: `month`, `year`, or `unknown`
- `reason`: Stripe's `cancellation_details.reason` (`cancellation_requested`, `payment_failure`, `payment_disputed`) or `none`

Mapping from the raw Stripe event, in `backend/utils/observability/subscription_events.py`:

- `customer.subscription.created` → `created`
- `customer.subscription.deleted` → `ended`, with `reason` from `cancellation_details.reason`
- `customer.subscription.updated` → inspected against `previous_attributes` (the prior value of only the fields Stripe says changed):
  - `cancel_at_period_end` false→true → `cancellation_requested`
  - `cancel_at_period_end` true→false → `cancellation_reverted`
  - `status` changed and the new status is `past_due` or `unpaid` → `payment_failed`
  - anything else → nothing recorded (plain updates are noise, not a catch-all event)

`plan`/`interval` reuse the existing price-id resolver (`config.plan_catalog.resolve_stripe_price_plan`, the same function `backend/utils/subscription.get_plan_type_from_price_id` wraps) rather than adding a second price mapping. Interval is read directly off the subscription's price object, independent of whether the plan itself resolved — so an unrecognized price still surfaces a known interval.

The recorder never raises into the webhook: a malformed or partial payload, or an unexpected exception from price resolution, is logged at warning and swallowed, recording nothing rather than guessing.

## Why webhook deliveries, not billing state

These counters count webhook deliveries, which Stripe may retry — a retried delivery increments the counter again even though nothing changed for the subscriber. Treat this as an operational trend signal, not a billing-grade figure; Stripe remains source of truth for actual subscription state. That caveat is in the counter's own Prometheus help text, not just this description, so it stays visible to anyone querying it directly.

Deliberately not included: a churn *percentage*. The active-subscription denominator that a percentage needs lives in Stripe, not in this counter. Computing one here would mean either querying Stripe from the metrics path (defeating the point of a local counter) or approximating the denominator from other backend state, which would drift from Stripe and become a second, quietly-wrong source of truth. This counter gives numerators (event counts) only; rate/percentage math against the real subscriber base belongs on the Grafana side that already queries Stripe live.

## Files changed

- `backend/utils/metrics.py` — new `OMI_SUBSCRIPTION_EVENTS` counter
- `backend/utils/observability/subscription_events.py` — new recorder + event mapping (mirrors the shape of `backend/utils/observability/journeys.py`)
- `backend/routers/payment.py` — one call to `record_subscription_event(...)` inside the existing `customer.subscription.*` webhook branch
- `backend/tests/unit/test_subscription_events_metrics.py` — new unit tests
- `backend/tests/unit/test_payment_promotion_codes.py` — one-line addition to that test's synthetic module-stub harness (`_setup_payment_module`) so it stubs the new `utils.observability.subscription_events` import the same way it already stubs `utils.observability.fallback`; without it, a previously-untouched submodule import forces the package `__init__.py` to run against that test's intentionally incomplete fallback stub

## Test plan

- [x] `backend/tests/unit/test_subscription_events_metrics.py` (22 tests, new): each of the five events from a realistic Stripe payload, plain updates recording nothing, cancellation_requested vs. cancellation_reverted, unresolvable price id → `plan=unknown`, malformed/partial payloads not raising, bounded label sets, no uid/customer id/subscription id/price id ever in a recorded label, and the webhook wiring itself (source-level, since `routers.payment` needs a Firestore import chain unavailable to this test process — same constraint documented in `test_stripe_webhook_none_guard.py`)
- [x] Full existing payment/subscription/metrics-adjacent unit test files re-run individually, no regressions beyond the one pre-existing fix noted above (`test_subscription_restructure.py`'s 32 failures are pre-existing on `origin/main`, unrelated to this change — confirmed by running it unmodified)
- [x] `uvx black==24.4.2 --line-length=120 --skip-string-normalization` on all changed files
- [x] `make preflight`

Line-Count-Exception: backend/routers/payment.py | 1549 -> 1555 | one recorder call (import + 5-line invocation) wired into the existing customer.subscription.* webhook branch; the metric contract and event mapping are specified up front for a dashboard being built in parallel, and splitting payment.py is out of scope for this change

Failure-Class: none

The second commit (`fix: drop redundant isinstance check flagged by backend pyright lane`) fixes a `reportUnnecessaryIsInstance` finding pyright raised against this PR's own new code — a static-typing nitpick in code that has never shipped, not an instance of a recorded product failure class.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

