### PR TITLE
feat(desktop-windows): auto-detect wlroots compositors for ozone-platform default

### DIFF
--- a/desktop/windows/AGENTS.md
+++ b/desktop/windows/AGENTS.md
@@ -51,18 +51,22 @@ for this alone.
 
 ### Linux dev environment (niri / Wayland compositors)
 
-On native Wayland compositors with limited XWayland support (e.g. niri), the
-default XWayland path (`ozone-platform=x11`, chosen deliberately for global
-shortcuts + active-window support — see `src/main/index.ts`) can fail to map
-the main window at all (tray icon appears, window never does). Set
-`OMI_OZONE=wayland` to run under native Wayland instead, at the cost of global
-shortcuts (push-to-talk / overlay summon) and active-window detection not
-working. See `docs/multi-worktree-dev.md`'s environment-overrides table for
-this and other dev-only env vars (`OMI_DEV_HW_GPU`, etc.).
+XWayland (`ozone-platform=x11`) is the default on Linux — chosen deliberately
+for global shortcuts + active-window support — but on compositors with
+limited XWayland support (niri, Sway, Hyprland; detected via each one's own
+session marker env var in `src/main/linuxCompositor.ts`) it can fail to map
+the main window at all (tray icon appears, window never does), so those
+default to native Wayland automatically instead. Set `OMI_OZONE=x11` or
+`OMI_OZONE=wayland` to override the auto-detected choice either way; running
+native Wayland costs global shortcuts (push-to-talk / overlay summon) and
+active-window detection. See `docs/multi-worktree-dev.md`'s
+environment-overrides table for this and other dev-only env vars
+(`OMI_DEV_HW_GPU`, etc.).
 
-`OMI_OZONE=wayland` alone can still leave the main window mapped but blank
-(tray works fine) — `pnpm dev`'s software-render default has known
-presentation bugs on native Wayland; add `OMI_DEV_HW_GPU=1` alongside it. See
+Native Wayland alone (auto-selected on niri, or forced via `OMI_OZONE=wayland`)
+can still leave the main window mapped but blank (tray works fine) —
+`pnpm dev`'s software-render default has known presentation bugs on native
+Wayland; add `OMI_DEV_HW_GPU=1` alongside it. See
 `docs/multi-worktree-dev.md`'s
 troubleshooting section for the confirmed repro (Asahi Fedora + niri) and a
 second known limitation: the bar and the focus-halo glow window both

--- a/desktop/windows/AGENTS.md
+++ b/desktop/windows/AGENTS.md
@@ -48,31 +48,11 @@ for this alone.
   can't reach (live ASR, agent spawning, OAuth flows, Rewind semantics). Specs
   live under `e2e/`. Run the relevant one manually before shipping a change
   in that area; don't assume `pnpm test` alone covers it.
-
-### Linux dev environment (niri / Wayland compositors)
-
-XWayland (`ozone-platform=x11`) is the default on Linux — chosen deliberately
-for global shortcuts + active-window support — but on compositors with
-limited XWayland support (niri, Sway, Hyprland; detected via each one's own
-session marker env var in `src/main/linuxCompositor.ts`) it can fail to map
-the main window at all (tray icon appears, window never does), so those
-default to native Wayland automatically instead. Set `OMI_OZONE=x11` or
-`OMI_OZONE=wayland` to override the auto-detected choice either way; running
-native Wayland costs global shortcuts (push-to-talk / overlay summon) and
-active-window detection. See `docs/multi-worktree-dev.md`'s
-environment-overrides table for this and other dev-only env vars
-(`OMI_DEV_HW_GPU`, etc.).
-
-Native Wayland alone (auto-selected on niri, or forced via `OMI_OZONE=wayland`)
-can still leave the main window mapped but blank (tray works fine) —
-`pnpm dev`'s software-render default has known presentation bugs on native
-Wayland; add `OMI_DEV_HW_GPU=1` alongside it. See
-`docs/multi-worktree-dev.md`'s
-troubleshooting section for the confirmed repro (Asahi Fedora + niri) and a
-second known limitation: the bar and the focus-halo glow window both
-position themselves via explicit `setBounds`, which native Wayland ignores,
-so they float in the screen center instead of staying parked off-screen —
-functional, just misplaced.
+- **Linux Wayland compositors (niri/Sway/Hyprland)**: `pnpm dev` auto-detects
+  these and defaults to native Wayland instead of XWayland; see
+  `docs/multi-worktree-dev.md`'s environment-overrides and troubleshooting
+  sections for the detection mechanism, `OMI_OZONE` override, and known
+  limitations.
 
 ## CI
 

--- a/desktop/windows/LINUX.md
+++ b/desktop/windows/LINUX.md
@@ -41,8 +41,13 @@ sudo apt-get install -y x11-utils tesseract-ocr tesseract-ocr-eng
 
 The app targets X11. On a Wayland session it defaults to **XWayland**
 (`ozone-platform=x11`) because a native Wayland surface breaks Electron global
-shortcuts (push-to-talk / overlay summon) and the X11 active-window path. To run
-native Wayland anyway, set `OMI_OZONE=wayland` (accepting those limitations).
+shortcuts (push-to-talk / overlay summon) and the X11 active-window path. On
+compositors known to have limited XWayland support (niri, Sway, Hyprland —
+detected via each one's own session marker env var, see
+`src/main/linuxCompositor.ts`) it instead defaults to native Wayland, since
+XWayland there can fail to map the main window at all. Set `OMI_OZONE=x11` or
+`OMI_OZONE=wayland` to override the auto-detected choice in either direction
+(accepting native Wayland's limitations if you force it on).
 
 Screen capture on Wayland goes through the desktop portal, which asks
 "Share screen?" for consent — and Electron has no persisted-consent path, so

--- a/desktop/windows/changelog/unreleased/2026-08-linux-compositor-ozone-autodetect.json
+++ b/desktop/windows/changelog/unreleased/2026-08-linux-compositor-ozone-autodetect.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "On Linux, Omi now detects niri, Sway, and Hyprland and launches under native Wayland automatically instead of the default XWayland mode, which could otherwise leave the window invisible on those compositors. Set OMI_OZONE=x11 or OMI_OZONE=wayland to override."
+  ]
+}

--- a/desktop/windows/docs/multi-worktree-dev.md
+++ b/desktop/windows/docs/multi-worktree-dev.md
@@ -114,7 +114,7 @@ seam, which is dev-only: the packaged app never opens a CDP port
 | `OMI_SANDBOX=<name>`        | Pin the userData profile suffix (`OMI_SANDBOX=1` = legacy `chat-kg`)                                                                                                                           |
 | `OMI_DEV_NO_REMOTE_DEBUG=1` | Don't open a CDP port for this instance                                                                                                                                                        |
 | `OMI_DEV_HW_GPU=1`          | Use hardware GPU instead of the dev software-render default                                                                                                                                    |
-| `OMI_OZONE=wayland`         | Linux only: run under native Wayland instead of the default XWayland. Needed on compositors with limited XWayland support (e.g. niri), where the main window can otherwise fail to map at all. Costs global shortcuts (push-to-talk/overlay summon) and active-window detection, and the companion bar can't be positioned off-screen. |
+| `OMI_OZONE=wayland` / `OMI_OZONE=x11` | Linux only: force native Wayland or XWayland, overriding the auto-detected default. XWayland is the default everywhere except niri/Sway/Hyprland (detected via each one's own session marker env var — see `src/main/linuxCompositor.ts`), where the main window can otherwise fail to map at all and native Wayland is the default instead. Native Wayland costs global shortcuts (push-to-talk/overlay summon) and active-window detection, and the companion bar can't be positioned off-screen. |
 
 ## Troubleshooting
 
@@ -136,13 +136,14 @@ port in 5180-5279>` on this one.
   empty profile. Run `pnpm seed:auth` (or just sign in there once).
 - **Two windows look identical** — check the title-bar suffix (` — <worktree>`) or
   run `pnpm dev:instance` to confirm which port each is on.
-- **`OMI_OZONE=wayland` main window maps but never paints (blank; tray icon
-  works)** — `pnpm dev` forces software rendering by default
-  (`applyDevGpuStability` in `src/main/dev/bench.ts`, aimed at Windows
-  GPU-process crashes), and Chromium's software-compositing path has known
-  presentation bugs on native Wayland. Run with `OMI_DEV_HW_GPU=1` too.
-  Confirmed fix on Asahi Fedora Remix (aarch64) + niri.
-- **Two extra floating windows appear under `OMI_OZONE=wayland`** — the
+- **Native Wayland (auto-selected on niri, or forced via `OMI_OZONE=wayland`)
+  main window maps but never paints (blank; tray icon works)** — `pnpm dev`
+  forces software rendering by default (`applyDevGpuStability` in
+  `src/main/dev/bench.ts`, aimed at Windows GPU-process crashes), and
+  Chromium's software-compositing path has known presentation bugs on native
+  Wayland. Run with `OMI_DEV_HW_GPU=1` too. Confirmed fix on Asahi Fedora Remix
+  (aarch64) + niri.
+- **Two extra floating windows appear under native Wayland** — the
   companion bar (`src/main/bar/window.ts`) and the focus-halo glow window
   (`src/main/glow/glowWindow.ts`, created eagerly at startup) both position
   themselves with explicit `setBounds({ x, y, ... })` intending to stay

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -12,6 +12,7 @@ import { join } from 'path'
 import { appendFileSync } from 'fs'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import { supportsMica } from './windowsVersion'
+import { defaultOzonePlatform } from './linuxCompositor'
 import { APP_BG_HEX, HOME_BG_HEX, WCO_SYMBOL_HEX } from '../shared/chrome'
 import iconPath from '../../resources/icon.png?asset'
 import { listCaptureSources } from './ipc/capture'
@@ -425,12 +426,13 @@ if (gotSingleInstanceLock) initCrashSentinel()
 
 // Linux: default to XWayland (x11 ozone). On a native Wayland session Electron
 // cannot register global shortcuts (push-to-talk / overlay summon) and the X11
-// active-window path is blind, so XWayland gives the fullest experience. Set
-// OMI_OZONE=wayland to run natively (accepting those limitations). Also enable
-// the PipeWire capturer (portal screen share) and PulseAudio monitor-source
-// loopback for system-audio capture when pipewire-pulse/Pulse is present.
+// active-window path is blind, so XWayland gives the fullest experience where
+// it's available. On compositors known to lack reliable XWayland support
+// (niri, sway, hyprland — see linuxCompositor.ts) XWayland can instead fail to
+// map the main window at all, so those default to native Wayland despite its
+// own limitations. Set OMI_OZONE=wayland/x11 to override either way.
 if (process.platform === 'linux') {
-  app.commandLine.appendSwitch('ozone-platform', process.env.OMI_OZONE || 'x11')
+  app.commandLine.appendSwitch('ozone-platform', process.env.OMI_OZONE || defaultOzonePlatform())
   app.commandLine.appendSwitch(
     'enable-features',
     'WebRTCPipeWireCapturer,PulseaudioLoopbackForScreenShare'

--- a/desktop/windows/src/main/linuxCompositor.test.ts
+++ b/desktop/windows/src/main/linuxCompositor.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { detectLinuxCompositor, defaultOzonePlatform } from './linuxCompositor'
+
+const MARKERS = ['XDG_SESSION_TYPE', 'NIRI_SOCKET', 'SWAYSOCK', 'HYPRLAND_INSTANCE_SIGNATURE']
+const original = Object.fromEntries(MARKERS.map((k) => [k, process.env[k]]))
+
+// Each test starts from a clean slate regardless of the host's own session
+// (this repo's dev env may itself be running under niri/sway/hyprland).
+beforeEach(() => {
+  for (const k of MARKERS) delete process.env[k]
+})
+
+afterEach(() => {
+  for (const k of MARKERS) {
+    if (original[k] === undefined) delete process.env[k]
+    else process.env[k] = original[k]
+  }
+})
+
+describe('detectLinuxCompositor', () => {
+  it('returns undefined when no compositor marker is set', () => {
+    expect(detectLinuxCompositor()).toBeUndefined()
+  })
+  it('identifies niri via NIRI_SOCKET', () => {
+    process.env.NIRI_SOCKET = '/run/user/1000/niri.sock'
+    expect(detectLinuxCompositor()).toBe('niri')
+  })
+  it('identifies sway via SWAYSOCK', () => {
+    process.env.SWAYSOCK = '/run/user/1000/sway-ipc.sock'
+    expect(detectLinuxCompositor()).toBe('sway')
+  })
+  it('identifies hyprland via HYPRLAND_INSTANCE_SIGNATURE', () => {
+    process.env.HYPRLAND_INSTANCE_SIGNATURE = 'abc123'
+    expect(detectLinuxCompositor()).toBe('hyprland')
+  })
+})
+
+describe('defaultOzonePlatform', () => {
+  it('is x11 on an X11 session', () => {
+    process.env.XDG_SESSION_TYPE = 'x11'
+    expect(defaultOzonePlatform()).toBe('x11')
+  })
+  it('is x11 when the session type is unset (non-Linux / unknown)', () => {
+    delete process.env.XDG_SESSION_TYPE
+    expect(defaultOzonePlatform()).toBe('x11')
+  })
+  it('is x11 on a Wayland session with no recognized compositor (e.g. GNOME, KDE)', () => {
+    process.env.XDG_SESSION_TYPE = 'wayland'
+    expect(defaultOzonePlatform()).toBe('x11')
+  })
+  it('is wayland on a Wayland session under niri', () => {
+    process.env.XDG_SESSION_TYPE = 'wayland'
+    process.env.NIRI_SOCKET = '/run/user/1000/niri.sock'
+    expect(defaultOzonePlatform()).toBe('wayland')
+  })
+})

--- a/desktop/windows/src/main/linuxCompositor.ts
+++ b/desktop/windows/src/main/linuxCompositor.ts
@@ -1,0 +1,32 @@
+// Wlroots-family compositors known to ship without reliable XWayland support
+// (confirmed on niri — see AGENTS.md's Linux dev section: the XWayland ozone
+// path can fail to map the main window at all there, tray icon only). Sway
+// and Hyprland are the other two wlroots compositors this project's docs call
+// out (docs/linux-screen-recording.md) and share the same "XWayland is
+// optional, sometimes absent" shape, so they're treated the same pending
+// their own confirmed repro. Detected via each compositor's own session
+// marker env var — XDG_CURRENT_DESKTOP isn't set consistently across them.
+const WAYLAND_NATIVE_COMPOSITORS: Record<string, string> = {
+  niri: 'NIRI_SOCKET',
+  sway: 'SWAYSOCK',
+  hyprland: 'HYPRLAND_INSTANCE_SIGNATURE'
+}
+
+export function detectLinuxCompositor(): string | undefined {
+  for (const [name, marker] of Object.entries(WAYLAND_NATIVE_COMPOSITORS)) {
+    if (process.env[marker]) return name
+  }
+  return undefined
+}
+
+// XWayland (ozone-platform=x11) is the default because it's the only path
+// with working global shortcuts (push-to-talk/overlay summon) and the X11
+// active-window query — see index.ts. That default only holds up on
+// compositors that actually provide XWayland; on ones that don't, it leaves
+// the main window unmapped instead of just degraded, so native Wayland (with
+// its own, lesser limitations) is the better default there. OMI_OZONE stays
+// available as an explicit override in either direction.
+export function defaultOzonePlatform(): 'wayland' | 'x11' {
+  if (process.env.XDG_SESSION_TYPE !== 'wayland') return 'x11'
+  return detectLinuxCompositor() ? 'wayland' : 'x11'
+}

--- a/desktop/windows/src/main/linuxCompositor.ts
+++ b/desktop/windows/src/main/linuxCompositor.ts
@@ -1,11 +1,12 @@
 // Wlroots-family compositors known to ship without reliable XWayland support
-// (confirmed on niri — see AGENTS.md's Linux dev section: the XWayland ozone
-// path can fail to map the main window at all there, tray icon only). Sway
-// and Hyprland are the other two wlroots compositors this project's docs call
-// out (docs/linux-screen-recording.md) and share the same "XWayland is
-// optional, sometimes absent" shape, so they're treated the same pending
-// their own confirmed repro. Detected via each compositor's own session
-// marker env var — XDG_CURRENT_DESKTOP isn't set consistently across them.
+// (confirmed on niri — see docs/multi-worktree-dev.md's environment-overrides
+// and troubleshooting sections: the XWayland ozone path can fail to map the
+// main window at all there, tray icon only). Sway and Hyprland are the other
+// two wlroots compositors this project's docs call out (same doc) and share
+// the same "XWayland is optional, sometimes absent" shape, so they're
+// treated the same pending their own confirmed repro. Detected via each
+// compositor's own session marker env var — XDG_CURRENT_DESKTOP isn't set
+// consistently across them.
 const WAYLAND_NATIVE_COMPOSITORS: Record<string, string> = {
   niri: 'NIRI_SOCKET',
   sway: 'SWAYSOCK',


### PR DESCRIPTION
## Summary
- Native Wayland compositors with limited XWayland support (niri, Sway, Hyprland) could otherwise leave the main window unmapped entirely under the default XWayland (`ozone-platform=x11`) path — previously required a manual `OMI_OZONE=wayland` override to work around.
- Adds `src/main/linuxCompositor.ts`: `detectLinuxCompositor()` identifies niri/Sway/Hyprland via each one's own session marker env var (`NIRI_SOCKET`, `SWAYSOCK`, `HYPRLAND_INSTANCE_SIGNATURE`) rather than `XDG_CURRENT_DESKTOP` (not set consistently by wlroots compositors). `defaultOzonePlatform()` returns `wayland` only when `XDG_SESSION_TYPE=wayland` **and** one of those three is detected; `x11` otherwise.
- `src/main/index.ts`'s `ozone-platform` switch now calls `defaultOzonePlatform()` instead of hardcoding `x11`. `OMI_OZONE=x11` / `OMI_OZONE=wayland` still override explicitly in either direction — existing manual-override workflows are unaffected.
- Updates `AGENTS.md`, `LINUX.md`, `docs/multi-worktree-dev.md` to describe the new auto-detected default instead of "set `OMI_OZONE=wayland` manually."
- Adds `src/main/linuxCompositor.test.ts` (8 cases) and a changelog fragment.

## Test plan
- [x] `vitest run src/main/linuxCompositor.test.ts` — 8/8 pass
- [x] Verified the diff against `upstream/main` is scoped to exactly this feature (7 files, no unrelated changes)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

