### PR TITLE
fix(web): report signed-out state when Firebase is unconfigured

### DIFF
--- a/web/app/src/components/auth/__tests__/AuthProvider.test.tsx
+++ b/web/app/src/components/auth/__tests__/AuthProvider.test.tsx
@@ -1,0 +1,129 @@
+import { createElement } from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `AuthProvider` starts at `loading: true` and only leaves it when the auth
+ * subscription reports a state. `ProtectedRoute` renders a full-screen spinner
+ * for the whole of `loading`, so a subscription that never reports is a blank
+ * app, not a degraded one.
+ *
+ * That is the shape of a local preview build: `.env.local` carries the
+ * `preview` / `preview.local` placeholders `lib/firebase.ts` recognises, no
+ * Firebase app is created, and every route — including `/login`, which ships a
+ * "Sign-in is not configured in this local preview." message for exactly this
+ * case — sits on the spinner.
+ */
+
+const PREVIEW_ENV = {
+  NEXT_PUBLIC_FIREBASE_API_KEY: 'preview',
+  NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: 'preview.local',
+  NEXT_PUBLIC_FIREBASE_PROJECT_ID: 'preview',
+  NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: 'preview',
+  NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: 'preview',
+  NEXT_PUBLIC_FIREBASE_APP_ID: 'preview',
+};
+
+const CONFIGURED_ENV = {
+  NEXT_PUBLIC_FIREBASE_API_KEY: 'test-api-key',
+  NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: 'test.firebaseapp.com',
+  NEXT_PUBLIC_FIREBASE_PROJECT_ID: 'test-project',
+  NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: 'test-project.appspot.com',
+  NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: '1234567890',
+  NEXT_PUBLIC_FIREBASE_APP_ID: '1:1234567890:web:abcdef',
+};
+
+const firebaseAuth = vi.hoisted(() => ({
+  onAuthStateChanged: vi.fn(
+    (_auth: unknown, _callback: (user: unknown) => void): (() => void) =>
+      () => {},
+  ),
+}));
+
+vi.mock('firebase/app', () => ({
+  initializeApp: () => ({ name: 'test-app' }),
+  getApps: () => [],
+}));
+
+vi.mock('firebase/auth', () => ({
+  getAuth: () => ({}),
+  GoogleAuthProvider: class {
+    setCustomParameters() {}
+  },
+  OAuthProvider: class {
+    addScope() {}
+  },
+  signInWithPopup: vi.fn(),
+  signOut: vi.fn(),
+  onAuthStateChanged: firebaseAuth.onAuthStateChanged,
+}));
+
+vi.mock('firebase/messaging', () => ({
+  getMessaging: vi.fn(),
+  getToken: vi.fn(),
+  onMessage: vi.fn(),
+  isSupported: async () => false,
+}));
+
+vi.mock('@/lib/analytics/mixpanel', () => ({
+  MixpanelManager: {
+    init: vi.fn(),
+    identify: vi.fn(),
+    track: vi.fn(),
+    reset: vi.fn(),
+  },
+}));
+
+function stubEnvironment(values: Record<string, string>): void {
+  for (const [key, value] of Object.entries(values)) vi.stubEnv(key, value);
+}
+
+async function renderProvider() {
+  const { AuthProvider, useAuth } = await import('../AuthProvider');
+
+  function Probe() {
+    const { user, loading } = useAuth();
+    return createElement(
+      'div',
+      { 'data-testid': 'probe' },
+      `${loading ? 'loading' : 'settled'}:${user?.uid ?? 'anonymous'}`,
+    );
+  }
+
+  render(createElement(AuthProvider, null, createElement(Probe)));
+  return screen.getByTestId('probe');
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  firebaseAuth.onAuthStateChanged.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllEnvs();
+});
+
+describe('AuthProvider', () => {
+  it('settles as signed out when the preview placeholders leave Firebase unconfigured', async () => {
+    stubEnvironment(PREVIEW_ENV);
+
+    const probe = await renderProvider();
+
+    await waitFor(() => expect(probe).toHaveTextContent('settled:anonymous'));
+    expect(firebaseAuth.onAuthStateChanged).not.toHaveBeenCalled();
+  });
+
+  it('reports the signed-in user when Firebase is configured', async () => {
+    stubEnvironment(CONFIGURED_ENV);
+    firebaseAuth.onAuthStateChanged.mockImplementation((_auth, callback) => {
+      callback({ uid: 'user-1' });
+      return () => {};
+    });
+
+    const probe = await renderProvider();
+
+    await waitFor(() => expect(probe).toHaveTextContent('settled:user-1'));
+    expect(firebaseAuth.onAuthStateChanged).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/app/src/lib/firebase.ts
+++ b/web/app/src/lib/firebase.ts
@@ -135,7 +135,15 @@ export const getIdToken = async (): Promise<string | null> => {
  * Subscribe to auth state changes
  */
 export const onAuthStateChange = (callback: (user: User | null) => void) => {
-  if (!app) return () => {};
+  // No Firebase app means no session can exist, and that is an answer the
+  // subscriber is owed. Returning a bare unsubscribe emits nothing, so
+  // `AuthProvider` never leaves `loading`, `ProtectedRoute` renders its
+  // spinner forever, and the local preview build (`apiKey=preview`) boots to a
+  // blank page instead of the login screen it ships a message for.
+  if (!app) {
+    queueMicrotask(() => callback(null));
+    return () => {};
+  }
   return onAuthStateChanged(auth, callback);
 };
 


### PR DESCRIPTION
## What changed and why

`onAuthStateChange` in `web/app/src/lib/firebase.ts` returned a bare unsubscribe when no Firebase app had been created, so the callback never ran. `AuthProvider` only leaves `loading` from that callback, and `ProtectedRoute` renders a full-screen spinner for the whole of `loading`. A build without Firebase credentials therefore boots to a blank page on **every** route — including `/login`, which already ships a "Sign-in is not configured in this local preview." message for exactly this case, and which `lib/firebase.ts` already recognises via the `preview` / `preview.local` placeholders.

No Firebase app means no session can exist, and that is an answer the subscriber is owed. The fix emits `null` once, then hands back the same no-op unsubscribe. Nothing changes when Firebase is configured — that path still delegates to `onAuthStateChanged`.

This came up on Discord: a contributor wanted to fix UI bugs on `/tasks` and could not get `web/app` to run at all without the Omi Firebase config.

## Product invariants affected

none (`scripts/pr-preflight --suggest` reports no invariant path matches for this diff)

## How it was verified

Exercised the real user-facing path in a clean worktree off `main`, with `.env.local` carrying the placeholders the code already recognises (`NEXT_PUBLIC_FIREBASE_API_KEY=preview`, `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=preview.local`, every other `NEXT_PUBLIC_*` set to a non-empty string):

```bash
cd web/app && bun install && bun run build && PORT=3100 bun .moonshine/server.ts
```

- **Before:** `/login` and `/tasks` both render only the spinner — DOM stays at `<div class="... animate-spin">`, no console errors, so it looks like a silent hang.
- **After:** `/login` renders with sign-in disabled and the existing "Sign-in is not configured in this local preview." message; navigating to `/tasks` redirects to `/login` as `ProtectedRoute` intends.

Gates:

```bash
cd web/app && bun run check     # typecheck clean; 5 moonshine smoke + 331 vitest tests pass
make preflight                   # 15 manifest checks pass (incl. web-app-checks)
```

## Tests

`web/app/src/components/auth/__tests__/AuthProvider.test.tsx` — renders the real `AuthProvider` over the real `lib/firebase.ts`, mocking only the Firebase SDK and the `NEXT_PUBLIC_*` values, so the assertion runs production behavior rather than a source scrape.

- Preview placeholders → the provider settles to `loading: false` / `user: null`, and `onAuthStateChanged` is never called.
- Real config → the provider reports the signed-in user and subscribes exactly once.

Confirmed it is a regression test, not a companion: with the fix stashed, the first case fails (`waitFor` times out waiting for `settled:anonymous`); with the fix, both pass.

## Failure class (fixes)

Failure-Class: none

<!-- Validated with: scripts/failure-class prepare --base main --head HEAD --pr-body-file <this file> -> patch operation=none -->

## Note on docs

`web/app/AGENTS.md` would be the natural place to write down "how to run this without Firebase credentials", but the file sits at 2367/2400 bytes and 55/55 lines against the `agents-md-lean` budget, and that check is a ratchet. Rather than shrink unrelated prose inside a bug fix, I left it out — happy to follow up with a docs-only PR that moves the setup detail into `docs/agents/` and links it, if maintainers want that.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

