### PR TITLE
Preserve closed ledger history in account export

### DIFF
--- a/backend/services/users/data_export.py
+++ b/backend/services/users/data_export.py
@@ -88,7 +88,7 @@ def _spool_export_memories_json(uid: str) -> IO[str]:
     try:
         spool.write("[\n")
         first = True
-        for memory in MemoryService().iter_export_memories(uid, include_archive=True):
+        for memory in MemoryService().iter_portability_export_memories(uid, include_archive=True):
             if not first:
                 spool.write(",\n")
             first = False

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -418,7 +418,7 @@ def test_export_all_user_data_returns_500_before_streaming_headers_when_memory_p
     monkeypatch.setattr(
         data_export,
         'MemoryService',
-        MagicMock(return_value=MagicMock(iter_export_memories=_failing_iter)),
+        MagicMock(return_value=MagicMock(iter_portability_export_memories=_failing_iter)),
     )
     app = FastAPI()
     app.include_router(users_router.router)

--- a/backend/tests/services/users/test_data_export.py
+++ b/backend/tests/services/users/test_data_export.py
@@ -28,7 +28,7 @@ def test_iter_user_data_export_streams_all_top_level_sections(monkeypatch):
     monkeypatch.setattr(data_export, "get_user_profile", MagicMock(return_value={"created_at": now}))
     memory_service = MagicMock()
     memory_service.export_memories.return_value = [MagicMock(model_dump=MagicMock(return_value={"id": "mem1"}))]
-    memory_service.iter_export_memories.return_value = iter(
+    memory_service.iter_portability_export_memories.return_value = iter(
         [MagicMock(model_dump=MagicMock(return_value={"id": "mem1"}))]
     )
     monkeypatch.setattr(data_export, "MemoryService", MagicMock(return_value=memory_service))
@@ -79,7 +79,7 @@ def test_iter_user_data_export_streams_all_top_level_sections(monkeypatch):
         },
         "chat_messages": [{"id": "msg1", "created_at": "2026-01-02T03:04:05+00:00"}],
     }
-    memory_service.iter_export_memories.assert_called_once_with("uid1", include_archive=True)
+    memory_service.iter_portability_export_memories.assert_called_once_with("uid1", include_archive=True)
     data_export.get_standalone_action_items.assert_called_once_with("uid1", limit=1000, offset=0)
     data_export.conversations_db.iter_all_conversations.assert_called_once_with("uid1", include_discarded=True)
     data_export.chat_db.iter_all_messages.assert_called_once_with("uid1")
@@ -90,7 +90,7 @@ def test_iter_user_data_export_uses_empty_profile_object(monkeypatch):
     monkeypatch.setattr(
         data_export,
         "MemoryService",
-        MagicMock(return_value=MagicMock(iter_export_memories=MagicMock(return_value=iter([])))),
+        MagicMock(return_value=MagicMock(iter_portability_export_memories=MagicMock(return_value=iter([])))),
     )
     monkeypatch.setattr(data_export, "get_people", MagicMock(return_value=[]))
     monkeypatch.setattr(data_export, "get_standalone_action_items", MagicMock(return_value=[]))
@@ -113,7 +113,7 @@ def test_iter_user_data_export_yields_before_heavy_reads(monkeypatch):
     monkeypatch.setattr(
         data_export,
         "MemoryService",
-        MagicMock(return_value=MagicMock(iter_export_memories=MagicMock(return_value=iter([])))),
+        MagicMock(return_value=MagicMock(iter_portability_export_memories=MagicMock(return_value=iter([])))),
     )
     monkeypatch.setattr(data_export, "get_people", MagicMock(return_value=[]))
     monkeypatch.setattr(data_export, "get_standalone_action_items", MagicMock(return_value=[]))
@@ -136,7 +136,7 @@ def test_json_default_raises_type_error_for_unsupported_types():
 
 
 def test_iter_user_data_export_does_not_call_list_export(monkeypatch):
-    """Large-account export must stream via iter_export_memories, not list materialization."""
+    """Large-account export must use the portability stream, not list materialization."""
     monkeypatch.setattr(data_export, "get_user_profile", MagicMock(return_value={}))
     monkeypatch.setattr(data_export, "get_people", MagicMock(return_value=[]))
     monkeypatch.setattr(data_export, "get_standalone_action_items", MagicMock(return_value=[]))
@@ -149,7 +149,7 @@ def test_iter_user_data_export_does_not_call_list_export(monkeypatch):
 
     memory = MagicMock(model_dump=MagicMock(return_value={"id": "mem-stream"}))
     memory_service = MagicMock()
-    memory_service.iter_export_memories.return_value = iter([memory])
+    memory_service.iter_portability_export_memories.return_value = iter([memory])
 
     def _boom(*_args, **_kwargs):
         raise AssertionError("export_memories list path must not be used by data export")
@@ -160,7 +160,7 @@ def test_iter_user_data_export_does_not_call_list_export(monkeypatch):
     payload = json.loads("".join(data_export.iter_user_data_export("uid1")))
 
     assert payload["memories"] == [{"id": "mem-stream"}]
-    memory_service.iter_export_memories.assert_called_once_with("uid1", include_archive=True)
+    memory_service.iter_portability_export_memories.assert_called_once_with("uid1", include_archive=True)
     memory_service.export_memories.assert_not_called()
 
 
@@ -193,7 +193,7 @@ def test_iter_user_data_export_skips_none_conversations_and_formats_arrays(monke
     monkeypatch.setattr(
         data_export,
         "MemoryService",
-        MagicMock(return_value=MagicMock(iter_export_memories=MagicMock(return_value=iter([])))),
+        MagicMock(return_value=MagicMock(iter_portability_export_memories=MagicMock(return_value=iter([])))),
     )
     monkeypatch.setattr(data_export, "get_people", MagicMock(return_value=[]))
     monkeypatch.setattr(data_export, "get_standalone_action_items", MagicMock(return_value=[]))
@@ -232,7 +232,7 @@ def test_iter_user_data_export_does_not_emit_partial_memories_on_iteration_failu
         yield good
         raise RuntimeError("memory page unavailable")
 
-    memory_service = MagicMock(iter_export_memories=_failing_iter)
+    memory_service = MagicMock(iter_portability_export_memories=_failing_iter)
     monkeypatch.setattr(data_export, "MemoryService", MagicMock(return_value=memory_service))
 
     with pytest.raises(RuntimeError, match="memory page unavailable"):
@@ -263,7 +263,7 @@ def test_memory_spool_is_streamed_in_bounded_chunks(monkeypatch):
     monkeypatch.setattr(
         data_export,
         "MemoryService",
-        MagicMock(return_value=MagicMock(iter_export_memories=MagicMock(return_value=iter([memory])))),
+        MagicMock(return_value=MagicMock(iter_portability_export_memories=MagicMock(return_value=iter([memory])))),
     )
 
     spool = data_export._spool_export_memories_json("uid1")
@@ -294,7 +294,7 @@ def test_iter_user_data_export_paginates_complete_collections(monkeypatch):
         [{"id": f"task-{i}"} for i in range(1000)],
         [{"id": "task-1000"}],
     ]
-    memory_service = MagicMock(iter_export_memories=MagicMock(return_value=iter(exported_memories)))
+    memory_service = MagicMock(iter_portability_export_memories=MagicMock(return_value=iter(exported_memories)))
     get_action_items = MagicMock(side_effect=action_item_pages)
     monkeypatch.setattr(data_export, "MemoryService", MagicMock(return_value=memory_service))
     monkeypatch.setattr(data_export, "get_standalone_action_items", get_action_items)
@@ -305,7 +305,7 @@ def test_iter_user_data_export_paginates_complete_collections(monkeypatch):
     assert payload["memories"][-1] == {"id": "mem-1000"}
     assert len(payload["action_items"]) == 1001
     assert payload["action_items"][-1] == {"id": "task-1000"}
-    memory_service.iter_export_memories.assert_called_once_with("uid1", include_archive=True)
+    memory_service.iter_portability_export_memories.assert_called_once_with("uid1", include_archive=True)
     assert get_action_items.call_args_list == [
         call("uid1", limit=1000, offset=0),
         call("uid1", limit=1000, offset=1000),

--- a/backend/tests/unit/test_lock_bypass_fixes.py
+++ b/backend/tests/unit/test_lock_bypass_fixes.py
@@ -988,7 +988,7 @@ class TestUsersLockEnforcement:
 
         memory_service = MagicMock()
         exported_memory = MagicMock(model_dump=MagicMock(return_value={"id": "mem-1"}))
-        memory_service.iter_export_memories.return_value = iter([exported_memory])
+        memory_service.iter_portability_export_memories.return_value = iter([exported_memory])
 
         # The export generator lives in services.users.data_export, which binds
         # these helpers at module level. Patch the service-level symbols so the
@@ -1000,23 +1000,19 @@ class TestUsersLockEnforcement:
                     "services.users.data_export.get_standalone_action_items",
                     return_value=[],
                 ):
-                    with patch("services.users.data_export.MemoryService", return_value=memory_service):
-                        from routers.users import export_all_user_data
+                    with patch("services.users.data_export._iter_user_subcollection", return_value=iter(())):
+                        with patch(
+                            "services.users.data_export._iter_user_nested_subcollection",
+                            return_value=iter(()),
+                        ):
+                            with patch("services.users.data_export.MemoryService", return_value=memory_service):
+                                from services.users.data_export import iter_user_data_export
 
-                        response = export_all_user_data(uid="test-uid")
-
-                        # Consume body inside patches — the generator is lazy.
-                        # StreamingResponse wraps sync generators as async iterators,
-                        # so iterate the underlying generator directly.
-                        import asyncio
-
-                        async def _consume():
-                            parts = []
-                            async for chunk in response.body_iterator:
-                                parts.append(chunk)
-                            return "".join(parts)
-
-                        body = asyncio.run(_consume())
+                                # Exercise the export producer directly and keep every
+                                # user-data source hermetic. This test module can be
+                                # collected after the real data-export module, so its
+                                # import-time dependency stubs are not reliable isolation.
+                                body = "".join(iter_user_data_export(uid="test-uid"))
 
         import json
 
@@ -1026,7 +1022,7 @@ class TestUsersLockEnforcement:
         assert data["conversations"][0]["is_locked"] is True
         assert data["conversations"][1]["id"] == "conv-2"
         assert data["memories"] == [{"id": "mem-1"}]
-        memory_service.iter_export_memories.assert_called_once_with("test-uid", include_archive=True)
+        memory_service.iter_portability_export_memories.assert_called_once_with("test-uid", include_archive=True)
 
 
 # =============================================================================

--- a/backend/tests/unit/test_memory_visibility_export_fixes.py
+++ b/backend/tests/unit/test_memory_visibility_export_fixes.py
@@ -7,6 +7,16 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from models.memory_evidence import ArtifactPreservationState, MemoryEvidence, SourceState
+from models.product_memory import (
+    LedgerWriteReason,
+    MemoryItem,
+    MemoryItemStatus,
+    MemoryKind,
+    MemoryLayer,
+    MemorySubjectScope,
+    ProcessingState,
+)
 from tests.unit.test_memory_service_parity import _load_memory_service, _sample_memory_dict
 
 
@@ -113,6 +123,134 @@ def test_iter_export_memories_streams_without_materializing_history(service_mod,
             assert seen_pages == [2]
 
     assert streamed == ["h-0", "h-1", "h-2"]
+
+
+def test_iter_export_memories_wraps_failure_raised_during_canonical_iteration(service_mod, monkeypatch):
+    def failing_rows(**_kwargs):
+        raise RuntimeError("provider unavailable")
+        yield  # pragma: no cover - preserves generator semantics
+
+    monkeypatch.setattr(service_mod, "iter_authoritative_product_memory_items", failing_rows)
+    service = service_mod.MemoryService(db_client=MagicMock())
+
+    with pytest.raises(service_mod.HTTPException) as error:
+        list(service.iter_portability_export_memories("uid-test"))
+
+    assert error.value.status_code == 503
+    assert error.value.detail == "Canonical memory unavailable"
+
+
+def _ledger_item(memory_id: str, **updates) -> MemoryItem:
+    now = datetime(2026, 8, 24, 12, tzinfo=timezone.utc)
+    evidence = MemoryEvidence(
+        evidence_id=f"evidence-{memory_id}",
+        source_type="chat_turn",
+        source_id=f"turn-{memory_id}",
+        source_version="v1",
+        artifact_preservation=ArtifactPreservationState.preserved,
+    )
+    payload = {
+        "memory_id": memory_id,
+        "uid": "uid-test",
+        "version": 1,
+        "tier": MemoryLayer.long_term,
+        "status": MemoryItemStatus.active,
+        "processing_state": ProcessingState.processed,
+        "content": f"content-{memory_id}",
+        "evidence": [evidence],
+        "source_state": SourceState.active,
+        "sensitivity_labels": [],
+        "visibility": "private",
+        "user_asserted": False,
+        "captured_at": now,
+        "updated_at": now,
+        "ledger_commit_id": f"commit-{memory_id}",
+        "ledger_sequence": 1,
+        "content_hash": f"hash-{memory_id}",
+        "ledger_schema_version": "knowledge_ledger.v1",
+        "kind": MemoryKind.fact,
+        "subject_scope": MemorySubjectScope.primary_user,
+        "valid_from": now,
+        "intent_backed": True,
+        "write_reason": LedgerWriteReason.agent_reusable_conclusion,
+    }
+    payload.update(updates)
+    return MemoryItem.model_validate(payload)
+
+
+def test_portability_export_preserves_closed_ledger_history_without_changing_compatibility_scan(
+    service_mod, monkeypatch
+):
+    now = datetime(2026, 8, 24, 12, tzinfo=timezone.utc)
+    active = _ledger_item("active")
+    closed = _ledger_item(
+        "closed",
+        status=MemoryItemStatus.superseded,
+        valid_to=now,
+        sensitivity_labels=["health"],
+        promotion={"is_locked": True},
+    )
+    migrated = _ledger_item(
+        "legacy-generated",
+        status=MemoryItemStatus.superseded,
+        valid_to=now,
+        intent_backed=False,
+        write_reason=LedgerWriteReason.legacy_migration,
+    )
+    active_purged = _ledger_item(
+        "active-purged",
+        source_state=SourceState.purged,
+    )
+    purged = _ledger_item(
+        "purged",
+        status=MemoryItemStatus.superseded,
+        valid_to=now,
+        source_state=SourceState.purged,
+    )
+    hidden = _ledger_item("hidden", status=MemoryItemStatus.hidden, valid_to=now)
+    non_ledger_closed = _ledger_item(
+        "legacy-closed",
+        status=MemoryItemStatus.superseded,
+        valid_to=now,
+        ledger_schema_version=None,
+    )
+    monkeypatch.setattr(
+        service_mod,
+        "iter_authoritative_product_memory_items",
+        lambda **_kwargs: iter([active, closed, migrated, active_purged, purged, hidden, non_ledger_closed]),
+    )
+    service = service_mod.MemoryService(db_client=MagicMock())
+    service.history.iter_all_live = MagicMock(return_value=iter(()))
+
+    compatibility_ids = [row.id for row in service.iter_export_memories("uid-test")]
+    portability_rows = list(service.iter_portability_export_memories("uid-test"))
+
+    assert compatibility_ids == ["active"]
+    assert [row.id for row in portability_rows] == ["active", "closed", "legacy-generated"]
+    closed_row = next(row for row in portability_rows if row.id == "closed")
+    assert closed_row.invalid_at == now
+    assert closed_row.is_locked is True
+    assert closed_row.content == "content-closed"
+
+
+def test_portability_export_closed_canonical_identity_suppresses_legacy_duplicate(service_mod, monkeypatch):
+    now = datetime(2026, 8, 24, 12, tzinfo=timezone.utc)
+    closed = _ledger_item("same-id", status=MemoryItemStatus.superseded, valid_to=now)
+    monkeypatch.setattr(
+        service_mod,
+        "iter_authoritative_product_memory_items",
+        lambda **_kwargs: iter([closed]),
+    )
+    duplicate = service_mod.HistoricalMemoryRecord(
+        memory=service_mod.MemoryDB.model_validate(_sample_memory_dict("same-id")),
+        locator=service_mod.MemoryLocator("uid-test", "legacy", "same-id"),
+    )
+    service = service_mod.MemoryService(db_client=MagicMock())
+    service.history.iter_all_live = MagicMock(return_value=iter([duplicate]))
+    service.canonical_statuses = MagicMock(return_value={"same-id": MemoryItemStatus.superseded})
+
+    assert [row.id for row in service.iter_portability_export_memories("uid-test")] == ["same-id"]
+    service.canonical_statuses.assert_not_called()
 
 
 def test_historical_export_iterator_uses_keysets_past_legacy_5000_window(service_mod):

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -2932,13 +2932,63 @@ class MemoryService:
         include_archive: bool = True,
         page_size: int = 500,
     ) -> Iterator[MemoryDB]:
-        """Stream each live logical memory once for account export.
+        """Stream each live logical memory once for compatibility consumers.
 
         Yields without building one giant merged list. Canonical active rows are
         emitted first; historical pages follow with per-page suppression checks.
         No export read performs materialization, LLM work, embedding, or graph
         admission.
         """
+        yield from self._iter_export_memories(
+            uid,
+            include_archive=include_archive,
+            page_size=page_size,
+            include_ledger_history=False,
+        )
+
+    def iter_portability_export_memories(
+        self,
+        uid: str,
+        *,
+        include_archive: bool = True,
+        page_size: int = 500,
+    ) -> Iterator[MemoryDB]:
+        """Stream owner-portable memories, including representable ledger history.
+
+        Compatibility readers and migration planning intentionally consume only
+        live rows through :meth:`iter_export_memories`. A user's data export has
+        a stronger preservation contract: superseded ledger rows and closed
+        ``legacy_migration`` history remain portable without becoming current
+        prompt authority. Hidden/tombstoned rows and source-purged content stay
+        excluded, while owner-visible locked or sensitive history is preserved.
+        """
+        yield from self._iter_export_memories(
+            uid,
+            include_archive=include_archive,
+            page_size=page_size,
+            include_ledger_history=True,
+        )
+
+    @staticmethod
+    def _is_portability_ledger_history(item: MemoryItem, row: MemoryDB) -> bool:
+        if item.ledger_schema_version != LEDGER_SCHEMA_VERSION:
+            return False
+        if item.status != MemoryItemStatus.superseded:
+            return False
+        if item.source_state in {SourceState.tombstoned, SourceState.purged}:
+            return False
+        # MemoryDB has no generic physical-status field. Admit only closure
+        # states represented honestly on the released wire shape.
+        return row.invalid_at is not None or row.superseded_by is not None
+
+    def _iter_export_memories(
+        self,
+        uid: str,
+        *,
+        include_archive: bool,
+        page_size: int,
+        include_ledger_history: bool,
+    ) -> Iterator[MemoryDB]:
         archive_explicit = include_archive
         page_size = max(1, min(int(page_size or 500), 500))
         client = self.db_client if self.db_client is not None else default_db_client
@@ -2948,13 +2998,24 @@ class MemoryService:
             raise HTTPException(status_code=503, detail="Canonical memory unavailable") from exc
 
         canonical_ids: set[str] = set()
-        for item in canonical_items:
+        while True:
+            try:
+                item = next(canonical_items)
+            except StopIteration:
+                break
+            except Exception as exc:
+                raise HTTPException(status_code=503, detail="Canonical memory unavailable") from exc
             canonical_ids.add(item.memory_id)
-            if item.status != MemoryItemStatus.active:
+            if item.source_state in {SourceState.tombstoned, SourceState.purged}:
                 continue
             if item.tier == MemoryTier.archive and not archive_explicit:
                 continue
-            yield memory_item_to_memorydb(item)
+            row = memory_item_to_memorydb(item)
+            if item.status == MemoryItemStatus.active:
+                yield row
+                continue
+            if include_ledger_history and self._is_portability_ledger_history(item, row):
+                yield row
 
         pending_historical: List[HistoricalMemoryRecord] = []
         for record in self.history.iter_all_live(uid, page_size=page_size):


### PR DESCRIPTION
## Summary

- keep existing compatibility and migration scans current-only
- add an owner-portability stream that preserves representable closed ledger history, including migrated legacy-generated rows
- keep hidden, tombstoned, source-purged, and non-ledger closed content out of export while retaining locked and sensitive owner history
- preflight the portability stream before response headers and keep canonical identity authoritative over legacy duplicates

## Product invariants affected

- INV-MEM-1
- INV-MEM-3
- INV-MEM-4

## Product invariants

- Closed and migrated user knowledge remains portable without becoming current prompt authority.
- A purged or tombstoned canonical identity cannot leak through export or resurrect a same-ID legacy row.
- Existing compatibility and migration consumers retain their current-only contract.
- Export remains bounded-memory and fails before committing a partial HTTP response.

Line-Count-Exception: backend/utils/memory/memory_service.py | 3474 -> 3535 | owner-portability history must share the canonical/legacy identity and suppression boundary used by compatibility export

## Verification

- 22 focused export, route-preflight, visibility, and locked-GDPR tests passed
- focused Pyright: 0 errors (existing warnings only)
- Black check passed for all six changed Python files
- `git diff --check` passed
- independent exact-head Sol re-review found no remaining P0-P3 findings and re-ran the 22-test hermetic set
- no migration execution, production rollout, cohort mutation, deployment, or deletion occurred


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

