### PR TITLE
Define current and historical ledger query semantics

### DIFF
--- a/backend/database/memory_vector_metadata.py
+++ b/backend/database/memory_vector_metadata.py
@@ -5,9 +5,15 @@ from __future__ import annotations
 import hashlib
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, Optional, cast
+from typing import Any, Collection, Dict, Optional, cast
 
 from models.memory_search_gateway import SearchDecision, SearchVectorHit
+from models.knowledge_ledger_search import (
+    LEDGER_INDEX_VERSION,
+    LEDGER_SEARCH_KINDS,
+    build_ledger_index_metadata,
+    validate_ledger_kinds,
+)
 from models.product_memory import RESTRICTED_SENSITIVITY_LABELS, MemoryTier, MemoryItem
 
 MEMORY_VECTOR_SCHEMA_VERSION = 1
@@ -102,11 +108,13 @@ def build_memory_vector_metadata(
     shared = _shared_memory_vector_metadata_fields(
         item, projection_commit_id=projection_commit_id, vector_updated_at=vector_updated_at
     )
-    return {
+    metadata = {
         "memory_schema_version": MEMORY_VECTOR_SCHEMA_VERSION,
         "memory_layer": item.tier.value,
         **shared,
     }
+    metadata.update(build_ledger_index_metadata(item))
+    return metadata
 
 
 def strip_null_metadata_values(metadata: Dict[str, Any]) -> Dict[str, Any]:
@@ -118,6 +126,22 @@ def build_default_memory_vector_filter(uid: str) -> Dict[str, Any]:
     return _base_memory_vector_filter(
         uid, {"memory_layer": {"$in": [MemoryTier.short_term.value, MemoryTier.long_term.value]}}
     )
+
+
+def build_ledger_memory_vector_filter(uid: str, kinds: Collection[str] = LEDGER_SEARCH_KINDS) -> Dict[str, Any]:
+    """Build a provider filter for open, versioned ledger rows only."""
+
+    parsed_kinds = validate_ledger_kinds(kinds)
+    result = build_default_memory_vector_filter(uid)
+    result["$and"].extend(
+        [
+            {"ledger_index_version": {"$eq": LEDGER_INDEX_VERSION}},
+            {"ledger_schema_version": {"$eq": "knowledge_ledger.v1"}},
+            {"ledger_row_state": {"$eq": "open"}},
+            {"ledger_kind": {"$in": sorted(parsed_kinds)}},
+        ]
+    )
+    return result
 
 
 def build_archive_memory_vector_filter(uid: str) -> Dict[str, Any]:
@@ -252,6 +276,7 @@ __all__ = [
     "build_archive_memory_vector_filter",
     "build_canonical_memory_vector_delete_filter",
     "build_default_memory_vector_filter",
+    "build_ledger_memory_vector_filter",
     "build_memory_vector_metadata",
     "canonical_memory_provider_id",
     "parse_memory_search_vector_hit",

--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -15,6 +15,7 @@ from database.memory_vector_metadata import (
     build_archive_memory_vector_filter,
     build_canonical_memory_vector_delete_filter,
     build_default_memory_vector_filter,
+    build_ledger_memory_vector_filter,
     build_memory_vector_metadata,
     canonical_memory_provider_id,
     parse_memory_search_vector_hit,
@@ -615,22 +616,31 @@ def delete_canonical_memory_vectors(uid: str, memory_id: str | None = None) -> b
 
 
 def query_memory_vector_candidates(
-    uid: str, query: str, *, mode: SearchMode = SearchMode.default, limit: int = 10
+    uid: str,
+    query: str,
+    *,
+    mode: SearchMode = SearchMode.default,
+    limit: int = 10,
+    ledger_kinds: Optional[List[str]] = None,
 ) -> VectorCandidateQueryResult:
     """Query ns2 for canonical neutral-metadata memory vector candidates."""
     if index is None:
         logger.warning('Pinecone index not initialized, skipping canonical memory vector candidate search')
         return VectorCandidateQueryResult()
 
+    bounded_limit = max(1, min(int(limit or 10), 60))
     vector = embeddings.embed_query(query)
-    filter_data = (
-        build_archive_memory_vector_filter(uid)
-        if mode == SearchMode.archive_explicit
-        else build_default_memory_vector_filter(uid)
-    )
+    if ledger_kinds is not None and mode == SearchMode.default:
+        filter_data = build_ledger_memory_vector_filter(uid, ledger_kinds)
+    else:
+        filter_data = (
+            build_archive_memory_vector_filter(uid)
+            if mode == SearchMode.archive_explicit
+            else build_default_memory_vector_filter(uid)
+        )
     response = index.query(
         vector=vector,
-        top_k=limit,
+        top_k=bounded_limit,
         include_metadata=True,
         include_values=False,
         filter=filter_data,

--- a/backend/models/knowledge_ledger_search.py
+++ b/backend/models/knowledge_ledger_search.py
@@ -1,0 +1,243 @@
+"""Fail-closed search contract for ``knowledge_ledger.v1`` rows.
+
+The ledger has two deliberately different retrieval surfaces:
+
+* ``current`` searches open, intent-backed rows only.  Unslotted facts are
+  searchable, but they are not profile inputs; documents expose their compact
+  handle and triggers expose their description, never their private payload.
+* ``history`` is an explicit, fact-only surface for closed rows and preserved
+  generated legacy data.  Rejected rows are audit-only and must be requested
+  explicitly.
+
+This module is pure so the canonical reader, keyword projection, and vector
+projection can share the same lifecycle and privacy gates.  Provider hits are
+always candidates: callers still hydrate the authoritative row before
+returning content.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Collection, FrozenSet, Mapping, Optional
+
+from models.memory_evidence import SourceState
+from models.product_memory import (
+    RESTRICTED_SENSITIVITY_LABELS,
+    LedgerWriteReason,
+    MemoryItemStatus,
+    MemoryKind,
+    ProcessingState,
+)
+
+LEDGER_INDEX_VERSION = 1
+LEDGER_SEARCH_KINDS: FrozenSet[str] = frozenset(kind.value for kind in MemoryKind)
+
+
+class LedgerSearchSurface(str, Enum):
+    current = "current"
+    history = "history"
+
+
+class LedgerRowIndexState(str, Enum):
+    not_ledger = "not_ledger"
+    open = "open"
+    closed = "closed"
+
+
+def _value(row: Any, name: str, default: Any = None) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(name, default)
+    return getattr(row, name, default)
+
+
+def ledger_kind_value(row: Any) -> str:
+    value = _value(row, "kind", "")
+    return value.value if isinstance(value, MemoryKind) else str(value or "")
+
+
+def ledger_schema_is_current(row: Any) -> bool:
+    return _value(row, "ledger_schema_version") == "knowledge_ledger.v1"
+
+
+def ledger_row_is_locked(row: Any) -> bool:
+    if _value(row, "is_locked") is True:
+        return True
+    promotion = _value(row, "promotion") or {}
+    return isinstance(promotion, Mapping) and promotion.get("is_locked") is True
+
+
+def ledger_row_is_rejected(row: Any) -> bool:
+    if _value(row, "user_review") is False:
+        return True
+    promotion = _value(row, "promotion") or {}
+    return isinstance(promotion, Mapping) and promotion.get("user_review") is False
+
+
+def ledger_row_has_restricted_sensitivity(row: Any) -> bool:
+    labels = _value(row, "sensitivity_labels") or []
+    return bool(set(labels).intersection(RESTRICTED_SENSITIVITY_LABELS))
+
+
+def ledger_row_source_is_readable(row: Any) -> bool:
+    source_state = _value(row, "source_state")
+    if source_state in {SourceState.tombstoned, SourceState.purged, "tombstoned", "purged"}:
+        return False
+    # A generated MemoryItem that claims an active source must carry active
+    # evidence unless it is a direct user assertion.  MemoryDB compatibility
+    # rows do not carry evidence, so the absence of this field is permitted.
+    evidence = _value(row, "evidence")
+    if (
+        source_state in {SourceState.active, "active"}
+        and isinstance(evidence, list)
+        and not _value(row, "user_asserted")
+    ):
+        return any(_value(entry, "source_state") in {SourceState.active, "active"} for entry in evidence)
+    return True
+
+
+def _is_active_status(row: Any) -> bool:
+    status = _value(row, "status")
+    if status is None:
+        # MemoryDB is a compatibility projection.  Its lifecycle is carried by
+        # invalid_at/superseded_by and is checked below.
+        return _value(row, "invalid_at") is None and not _value(row, "superseded_by")
+    return status in {MemoryItemStatus.active, MemoryItemStatus.active.value}
+
+
+def _is_closed_status(row: Any) -> bool:
+    status = _value(row, "status")
+    return (
+        status in {MemoryItemStatus.superseded, MemoryItemStatus.superseded.value}
+        or _value(row, "invalid_at") is not None
+        or _value(row, "valid_to") is not None
+        or bool(_value(row, "superseded_by"))
+    )
+
+
+def _is_processed(row: Any) -> bool:
+    state = _value(row, "processing_state")
+    return state is None or state in {ProcessingState.processed, ProcessingState.processed.value}
+
+
+def _is_hidden_or_tombstoned(row: Any) -> bool:
+    status = _value(row, "status")
+    return status in {
+        MemoryItemStatus.hidden,
+        MemoryItemStatus.hidden.value,
+        MemoryItemStatus.tombstoned,
+        MemoryItemStatus.tombstoned.value,
+    }
+
+
+def _is_legacy_migrated(row: Any) -> bool:
+    reason = _value(row, "write_reason")
+    reason_value = reason.value if isinstance(reason, LedgerWriteReason) else str(reason or "")
+    return _value(row, "intent_backed") is not True and reason_value == LedgerWriteReason.legacy_migration.value
+
+
+def is_ledger_row_admissible(
+    row: Any,
+    *,
+    uid: Optional[str],
+    surface: LedgerSearchSurface,
+    kinds: Collection[str] = LEDGER_SEARCH_KINDS,
+    include_rejected: bool = False,
+) -> bool:
+    """Return whether one authoritative row may enter a ledger search.
+
+    The owner check is intentionally mandatory.  A missing owner, unknown
+    schema/kind, malformed lifecycle, locked/restricted source, or rejected
+    row on the default surface fails closed rather than being treated as a
+    permissive compatibility case.
+    """
+
+    if not uid or _value(row, "uid") != uid:
+        return False
+    if not ledger_schema_is_current(row) or ledger_kind_value(row) not in set(kinds):
+        return False
+    if not (_value(row, "content") or "").strip():
+        return False
+    if ledger_row_is_locked(row) or ledger_row_has_restricted_sensitivity(row):
+        return False
+    if not ledger_row_source_is_readable(row) or not _is_processed(row) or _is_hidden_or_tombstoned(row):
+        return False
+    if surface is LedgerSearchSurface.current:
+        if _value(row, "intent_backed") is not True or not _is_active_status(row):
+            return False
+        if _value(row, "valid_to") is not None or _value(row, "invalid_at") is not None:
+            return False
+        if _value(row, "superseded_by"):
+            return False
+        if ledger_row_is_rejected(row):
+            return False
+        # Playbook bodies are private progressive-disclosure data and are only
+        # ever searchable for primary-user documents.  Facts may retain their
+        # own subject scope; profile rendering applies the stricter primary
+        # user scope separately.
+        subject_scope = _value(row, "subject_scope")
+        subject_scope_value = subject_scope.value if hasattr(subject_scope, "value") else subject_scope
+        if ledger_kind_value(row) == MemoryKind.document.value and subject_scope_value != "primary_user":
+            return False
+        return True
+
+    # History is intentionally narrower than the current surface: only facts
+    # have a public historical wire representation today.  Preserved legacy
+    # generated rows remain available as labelled history, but arbitrary
+    # passive rows do not become searchable by accident.
+    if ledger_kind_value(row) != MemoryKind.fact.value:
+        return False
+    if not (_value(row, "intent_backed") is True or _is_legacy_migrated(row)):
+        return False
+    if not include_rejected and ledger_row_is_rejected(row):
+        return False
+    return _is_legacy_migrated(row) or ledger_row_is_rejected(row) or _is_closed_status(row)
+
+
+def ledger_row_index_state(row: Any) -> LedgerRowIndexState:
+    """Classify metadata written to keyword/vector projections."""
+
+    if not ledger_schema_is_current(row) or ledger_kind_value(row) not in LEDGER_SEARCH_KINDS:
+        return LedgerRowIndexState.not_ledger
+    return (
+        LedgerRowIndexState.open
+        if is_ledger_row_admissible(row, uid=_value(row, "uid"), surface=LedgerSearchSurface.current)
+        else LedgerRowIndexState.closed
+    )
+
+
+def build_ledger_index_metadata(row: Any) -> dict[str, Any]:
+    """Return non-content metadata shared by keyword and vector projections."""
+
+    if not ledger_schema_is_current(row) or ledger_kind_value(row) not in LEDGER_SEARCH_KINDS:
+        return {}
+    slot = _value(row, "slot")
+    subject_scope = _value(row, "subject_scope")
+    return {
+        "ledger_index_version": LEDGER_INDEX_VERSION,
+        "ledger_schema_version": "knowledge_ledger.v1",
+        "ledger_kind": ledger_kind_value(row),
+        "ledger_row_state": ledger_row_index_state(row).value,
+        "ledger_has_slot": bool(isinstance(slot, str) and slot.strip()),
+        "ledger_subject_scope": subject_scope.value if hasattr(subject_scope, "value") else str(subject_scope or ""),
+    }
+
+
+def validate_ledger_kinds(kinds: Collection[str]) -> FrozenSet[str]:
+    parsed = frozenset(str(kind).strip().casefold() for kind in kinds if str(kind).strip())
+    if not parsed or not parsed.issubset(LEDGER_SEARCH_KINDS):
+        raise ValueError("kinds must contain only fact, document, or trigger")
+    return parsed
+
+
+__all__ = [
+    "LEDGER_INDEX_VERSION",
+    "LEDGER_SEARCH_KINDS",
+    "LedgerRowIndexState",
+    "LedgerSearchSurface",
+    "build_ledger_index_metadata",
+    "is_ledger_row_admissible",
+    "ledger_kind_value",
+    "ledger_row_index_state",
+    "ledger_schema_is_current",
+    "validate_ledger_kinds",
+]

--- a/backend/tests/unit/test_knowledge_ledger_search.py
+++ b/backend/tests/unit/test_knowledge_ledger_search.py
@@ -1,0 +1,271 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from database.memory_vector_metadata import build_ledger_memory_vector_filter
+from utils.memory.product_memory_read_service import fetch_authoritative_product_memory_items_by_ids
+from utils.memory.atom_keyword_index import keyword_search_ledger_memory_ids
+from models.knowledge_ledger_search import (
+    LEDGER_INDEX_VERSION,
+    LedgerRowIndexState,
+    LedgerSearchSurface,
+    build_ledger_index_metadata,
+    is_ledger_row_admissible,
+    ledger_row_index_state,
+    validate_ledger_kinds,
+)
+from models.memory_evidence import ArtifactPreservationState, MemoryEvidence, SourceState
+from models.product_memory import (
+    LedgerWriteReason,
+    MemoryItem,
+    MemoryItemStatus,
+    MemoryKind,
+    MemoryLayer,
+    ProcessingState,
+)
+
+
+def _row(**updates):
+    payload = {
+        "uid": "u1",
+        "ledger_schema_version": "knowledge_ledger.v1",
+        "kind": MemoryKind.fact,
+        "content": "The user works at Omi",
+        "intent_backed": True,
+        "write_reason": LedgerWriteReason.direct_user_statement,
+        "status": MemoryItemStatus.active,
+        "processing_state": ProcessingState.processed,
+        "source_state": SourceState.active,
+        "sensitivity_labels": [],
+        "promotion": {},
+        "user_asserted": True,
+        "subject_scope": "primary_user",
+        "valid_to": None,
+        "invalid_at": None,
+        "superseded_by": None,
+    }
+    payload.update(updates)
+    return SimpleNamespace(**payload)
+
+
+def _canonical_item_payload(memory_id: str, *, uid: str = "u1"):
+    now = datetime(2026, 8, 24, tzinfo=timezone.utc)
+    return MemoryItem(
+        memory_id=memory_id,
+        uid=uid,
+        version=1,
+        tier=MemoryLayer.long_term,
+        status=MemoryItemStatus.active,
+        processing_state=ProcessingState.processed,
+        content=f"content-{memory_id}",
+        evidence=[
+            MemoryEvidence(
+                evidence_id=f"ev-{memory_id}",
+                source_type="conversation",
+                source_id="conversation-1",
+                source_version="v1",
+                conversation_id="conversation-1",
+                artifact_preservation=ArtifactPreservationState.preserved,
+            )
+        ],
+        source_state=SourceState.active,
+        sensitivity_labels=[],
+        visibility="private",
+        user_asserted=False,
+        captured_at=now,
+        updated_at=now,
+        ledger_commit_id=f"commit-{memory_id}",
+        ledger_sequence=1,
+        ledger_schema_version="knowledge_ledger.v1",
+        kind=MemoryKind.fact,
+        intent_backed=True,
+        write_reason=LedgerWriteReason.agent_reusable_conclusion,
+    ).model_dump(mode="python")
+
+
+def test_current_search_admits_open_unslotted_facts_documents_and_triggers():
+    for kind, extra in (
+        (MemoryKind.fact, {"slot": None}),
+        (MemoryKind.document, {"subject_scope": "primary_user", "body": "private body"}),
+        (MemoryKind.trigger, {"subject_scope": "primary_user", "trigger_condition": {"keyword": "release"}}),
+    ):
+        assert is_ledger_row_admissible(
+            _row(kind=kind, **extra),
+            uid="u1",
+            surface=LedgerSearchSurface.current,
+            kinds={kind.value},
+        )
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"uid": "u2"},
+        {"status": MemoryItemStatus.superseded},
+        {"valid_to": "closed"},
+        {"intent_backed": False, "write_reason": LedgerWriteReason.daily_reconciliation},
+        {"promotion": {"user_review": False}},
+        {"promotion": {"is_locked": True}},
+        {"sensitivity_labels": ["financial"]},
+        {"source_state": SourceState.tombstoned},
+        {"kind": MemoryKind.document, "subject_scope": "third_party"},
+    ],
+)
+def test_current_search_fails_closed_for_owner_lifecycle_and_privacy_boundaries(updates):
+    assert not is_ledger_row_admissible(
+        _row(**updates),
+        uid="u1",
+        surface=LedgerSearchSurface.current,
+    )
+
+
+def test_history_is_fact_only_and_preserves_legacy_generated_data():
+    closed = _row(status=MemoryItemStatus.superseded)
+    legacy = _row(intent_backed=False, write_reason=LedgerWriteReason.legacy_migration)
+    active = _row()
+    document = _row(kind=MemoryKind.document, status=MemoryItemStatus.superseded, subject_scope="primary_user")
+
+    assert is_ledger_row_admissible(closed, uid="u1", surface=LedgerSearchSurface.history, kinds={"fact"})
+    assert is_ledger_row_admissible(legacy, uid="u1", surface=LedgerSearchSurface.history, kinds={"fact"})
+    assert not is_ledger_row_admissible(active, uid="u1", surface=LedgerSearchSurface.history, kinds={"fact"})
+    assert not is_ledger_row_admissible(document, uid="u1", surface=LedgerSearchSurface.history, kinds={"fact"})
+
+
+def test_history_rejected_rows_are_audit_only():
+    rejected = _row(status=MemoryItemStatus.superseded, promotion={"user_review": False})
+    assert not is_ledger_row_admissible(rejected, uid="u1", surface=LedgerSearchSurface.history)
+    assert is_ledger_row_admissible(
+        rejected,
+        uid="u1",
+        surface=LedgerSearchSurface.history,
+        include_rejected=True,
+    )
+
+
+def test_index_metadata_versions_and_labels_open_vs_closed_rows():
+    open_metadata = build_ledger_index_metadata(_row(kind=MemoryKind.fact, slot=None))
+    closed_metadata = build_ledger_index_metadata(_row(status=MemoryItemStatus.superseded))
+
+    assert open_metadata == {
+        "ledger_index_version": LEDGER_INDEX_VERSION,
+        "ledger_schema_version": "knowledge_ledger.v1",
+        "ledger_kind": "fact",
+        "ledger_row_state": "open",
+        "ledger_has_slot": False,
+        "ledger_subject_scope": "primary_user",
+    }
+    assert closed_metadata["ledger_row_state"] == "closed"
+    assert ledger_row_index_state(_row(ledger_schema_version=None)) is LedgerRowIndexState.not_ledger
+
+
+def test_vector_filter_requires_versioned_open_ledger_metadata():
+    vector_filter = build_ledger_memory_vector_filter("u1", {"document", "fact"})
+    clauses = vector_filter["$and"]
+    assert {"uid": {"$eq": "u1"}} in clauses
+    assert {"ledger_index_version": {"$eq": LEDGER_INDEX_VERSION}} in clauses
+    assert {"ledger_schema_version": {"$eq": "knowledge_ledger.v1"}} in clauses
+    assert {"ledger_row_state": {"$eq": "open"}} in clauses
+    assert {"ledger_kind": {"$in": ["document", "fact"]}} in clauses
+
+
+def test_kind_validation_fails_closed_for_unknown_kinds():
+    assert validate_ledger_kinds(["fact", "trigger"]) == frozenset({"fact", "trigger"})
+    with pytest.raises(ValueError, match="only fact, document, or trigger"):
+        validate_ledger_kinds(["screen"])
+
+
+def test_bounded_authoritative_hydration_reads_only_requested_ids_and_checks_owner():
+    class Snapshot:
+        def __init__(self, document_id, payload):
+            self.id = document_id
+            self.exists = payload is not None
+            self._payload = payload
+
+        def to_dict(self):
+            return self._payload
+
+    class Ref:
+        def __init__(self, db, path):
+            self.db = db
+            self.path = path
+
+    class Db:
+        def __init__(self):
+            self.payloads = {
+                "candidate": _canonical_item_payload("candidate"),
+                "lineage": _canonical_item_payload("lineage", uid="u2"),
+                "unrelated": _canonical_item_payload("unrelated"),
+            }
+            self.requested_paths = []
+
+        def document(self, path):
+            self.requested_paths.append(path)
+            return Ref(self, path)
+
+        def get_all(self, refs):
+            return [
+                Snapshot(ref.path.rsplit("/", 1)[-1], self.payloads.get(ref.path.rsplit("/", 1)[-1])) for ref in refs
+            ]
+
+    db = Db()
+    items = fetch_authoritative_product_memory_items_by_ids(
+        "u1",
+        ["candidate", "lineage"],
+        db_client=db,
+    )
+
+    assert db.requested_paths == ["users/u1/memory_items/candidate", "users/u1/memory_items/lineage"]
+    assert [item.memory_id for item in items] == ["candidate"]
+
+
+def test_keyword_search_requires_versioned_open_ledger_filter_and_bound(monkeypatch):
+    fields = [
+        {"name": name}
+        for name in (
+            "memory_id",
+            "userId",
+            "content",
+            "category",
+            "layer",
+            "status",
+            "schema_version",
+            "entity_terms",
+            "predicate",
+            "created_at",
+            "ledger_index_version",
+            "ledger_schema_version",
+            "ledger_kind",
+            "ledger_row_state",
+            "ledger_has_slot",
+            "ledger_subject_scope",
+        )
+    ]
+    documents = MagicMock()
+    documents.search.return_value = {"hits": [{"document": {"memory_id": "mem-open"}}]}
+    collection = MagicMock()
+    collection.retrieve.return_value = {"fields": fields}
+    collection.documents = documents
+    client = MagicMock()
+    client.collections.__getitem__.return_value = collection
+    monkeypatch.setattr("utils.memory.atom_keyword_index._typesense_client", lambda: client)
+    monkeypatch.setattr("utils.memory.atom_keyword_index.user_allows_atom_keyword_index", lambda *args, **kwargs: True)
+
+    assert keyword_search_ledger_memory_ids("u1", "release", kinds={"fact", "trigger"}, limit=10_000) == ["mem-open"]
+    params = documents.search.call_args.args[0]
+    assert params["per_page"] == 60
+    assert "ledger_index_version:=1" in params["filter_by"]
+    assert "ledger_row_state:=`open`" in params["filter_by"]
+    assert "ledger_kind:=[`fact`,`trigger`]" in params["filter_by"]
+
+
+def test_keyword_search_returns_no_rows_when_ledger_schema_is_not_adopted(monkeypatch):
+    client = MagicMock()
+    collection = MagicMock()
+    collection.retrieve.return_value = {"fields": [{"name": "userId"}]}
+    client.collections.__getitem__.return_value = collection
+    monkeypatch.setattr("utils.memory.atom_keyword_index._typesense_client", lambda: client)
+    monkeypatch.setattr("utils.memory.atom_keyword_index.user_allows_atom_keyword_index", lambda *args, **kwargs: True)
+
+    assert keyword_search_ledger_memory_ids("u1", "release") == []

--- a/backend/tests/unit/test_knowledge_ledger_tools.py
+++ b/backend/tests/unit/test_knowledge_ledger_tools.py
@@ -87,7 +87,8 @@ def test_search_current_knowledge_returns_only_requested_current_ledger_kinds(mo
         def __init__(self, *, db_client):
             assert db_client == "db"
 
-        def search(self, uid, query, *, limit, canonical_item_filter, result_filter):
+        def search(self, uid, query, *, limit, canonical_item_filter, result_filter, ledger_kinds=None):
+            assert ledger_kinds == frozenset({"document", "trigger"})
             assert (uid, query, limit) == ("u1", "release", 8)
             assert canonical_item_filter(_playbook()) is True
             assert canonical_item_filter(_playbook().model_copy(update={"kind": MemoryKind.fact})) is False

--- a/backend/tests/unit/test_universal_memory_service.py
+++ b/backend/tests/unit/test_universal_memory_service.py
@@ -1744,6 +1744,7 @@ def test_search_deduplicates_canonical_and_historical_candidates(service_mod):
     result = service.search("uid-test", "query", limit=10)
     assert [match.memory.id for match in result] == ["same", "legacy"]
     assert result[0].memory.content == "canonical"
+    service.history.search.assert_called_once()
 
 
 def test_search_applies_result_filter_before_final_limit(service_mod):
@@ -1765,6 +1766,68 @@ def test_search_applies_result_filter_before_final_limit(service_mod):
 
     assert [match.memory.id for match in result] == ["ledger-document"]
     assert service._canonical.search.call_args.kwargs["item_filter"] is not None
+
+
+def test_ledger_search_never_merges_stamped_legacy_rows(service_mod):
+    service = service_mod.MemoryService(db_client=_Db())
+    canonical = _memory(service_mod, "canonical-ledger").model_copy(
+        update={
+            "ledger_schema_version": "knowledge_ledger.v1",
+            "kind": MemoryKind.fact,
+            "intent_backed": True,
+        }
+    )
+    stamped_legacy = _memory(service_mod, "stamped-legacy").model_copy(
+        update={
+            "ledger_schema_version": "knowledge_ledger.v1",
+            "kind": MemoryKind.fact,
+            "intent_backed": True,
+        }
+    )
+    service._canonical.search = MagicMock(return_value=[service_mod.MemorySearchMatch(canonical, 0.9)])
+    service.history.search = MagicMock(return_value=[service_mod.MemorySearchMatch(stamped_legacy, 0.99)])
+
+    result = service.search(
+        "uid-test",
+        "query",
+        limit=5,
+        canonical_item_filter=lambda item: True,
+        result_filter=lambda memory: service_mod.is_ledger_row_admissible(
+            memory,
+            uid="uid-test",
+            surface=service_mod.LedgerSearchSurface.current,
+            kinds={MemoryKind.fact.value},
+        ),
+        ledger_kinds={MemoryKind.fact.value},
+    )
+
+    assert [match.memory.id for match in result] == ["canonical-ledger"]
+    service.history.search.assert_not_called()
+
+
+def test_ledger_search_survives_legacy_provider_outage(service_mod):
+    service = service_mod.MemoryService(db_client=_Db())
+    canonical = _memory(service_mod, "canonical-ledger").model_copy(
+        update={
+            "ledger_schema_version": "knowledge_ledger.v1",
+            "kind": MemoryKind.fact,
+            "intent_backed": True,
+        }
+    )
+    service._canonical.search = MagicMock(return_value=[service_mod.MemorySearchMatch(canonical, 0.9)])
+    service.history.search = MagicMock(side_effect=RuntimeError("legacy vector unavailable"))
+
+    result = service.search(
+        "uid-test",
+        "query",
+        limit=5,
+        canonical_item_filter=lambda item: True,
+        result_filter=lambda memory: memory.id == "canonical-ledger",
+        ledger_kinds={MemoryKind.fact.value},
+    )
+
+    assert [match.memory.id for match in result] == ["canonical-ledger"]
+    service.history.search.assert_not_called()
 
 
 def test_canonical_search_preserves_order_as_relevance_when_provider_omits_score(service_mod, monkeypatch):

--- a/backend/tests/unit/test_vector_filters.py
+++ b/backend/tests/unit/test_vector_filters.py
@@ -97,3 +97,14 @@ def test_query_memory_vector_candidates_requires_explicit_archive_mode_for_archi
     vector_db.query_memory_vector_candidates("uid-1", "query text", mode=SearchMode.archive_explicit)
 
     assert {"memory_layer": {"$eq": "archive"}} in fake_index.queries[0]["filter"]["$and"]
+
+
+def test_query_memory_vector_candidates_bounds_provider_top_k(monkeypatch):
+    vector_db = _load_vector_db_with_stubs()
+    fake_index = _FakeIndex()
+    monkeypatch.setattr(vector_db, "index", fake_index)
+    monkeypatch.setattr(vector_db, "embeddings", _FakeEmbeddings())
+
+    vector_db.query_memory_vector_candidates("uid-1", "query text", limit=10_000)
+
+    assert fake_index.queries[0]["top_k"] == 60

--- a/backend/tests/unit/test_ws_m_atom_keyword_index.py
+++ b/backend/tests/unit/test_ws_m_atom_keyword_index.py
@@ -90,7 +90,14 @@ ensure_utils_memory_packages_importable(str(BACKEND_DIR))
 from database.memory_vector_metadata import canonical_memory_provider_id
 from models.memory_apply import MemoryControlState
 from models.memory_evidence import ArtifactPreservationState, MemoryEvidence, SourceState
-from models.product_memory import MemoryItemStatus, MemoryKind, MemoryTier, ProcessingState, MemoryItem
+from models.product_memory import (
+    LedgerWriteReason,
+    MemoryItemStatus,
+    MemoryKind,
+    MemoryTier,
+    ProcessingState,
+    MemoryItem,
+)
 from utils.memory.atom_keyword_index import (
     AtomKeywordRebuildReport,
     build_atom_keyword_document,
@@ -173,6 +180,66 @@ def _data_protection_db(level: str = "enhanced") -> MagicMock:
     db_client = MagicMock()
     db_client.document.return_value = MagicMock(get=lambda: user_doc)
     return db_client
+
+
+def _run_bounded_ledger_search(
+    monkeypatch,
+    items: list[MemoryItem],
+    candidate_id: str,
+    *,
+    payload_overrides: dict[str, dict] | None = None,
+):
+    payloads = {item.memory_id: item.model_dump(mode="python") for item in items}
+    for payload in payloads.values():
+        if payload.get("ledger_schema_version") == "knowledge_ledger.v1" and not payload.get("write_reason"):
+            payload["write_reason"] = LedgerWriteReason.agent_reusable_conclusion.value
+    payloads.update(payload_overrides or {})
+    for payload in payloads.values():
+        if payload.get("ledger_schema_version") == "knowledge_ledger.v1" and not payload.get("write_reason"):
+            payload["write_reason"] = LedgerWriteReason.agent_reusable_conclusion.value
+    read_ids: list[str] = []
+
+    class _Snapshot:
+        def __init__(self, document_id: str, payload):
+            self.id = document_id
+            self.exists = payload is not None
+            self._payload = payload
+
+        def to_dict(self):
+            return self._payload
+
+    class _Ref:
+        def __init__(self, path: str):
+            self.path = path
+
+    class _Db:
+        def document(self, path: str):
+            read_ids.append(path.rsplit("/", 1)[-1])
+            return _Ref(path)
+
+        def get_all(self, refs):
+            return [_Snapshot(ref.path.rsplit("/", 1)[-1], payloads.get(ref.path.rsplit("/", 1)[-1])) for ref in refs]
+
+        def collection(self, _path):
+            pytest.fail("ledger search must not scan the canonical collection")
+
+    monkeypatch.setattr(
+        "utils.memory.atom_keyword_index.keyword_search_ledger_memory_ids",
+        lambda *args, **kwargs: [candidate_id],
+    )
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.fetch_authoritative_product_memory_items",
+        lambda **kwargs: pytest.fail("ledger search must not materialize all canonical items"),
+    )
+    results = search_canonical_memories(
+        CANONICAL_UID,
+        NEEDLE,
+        limit=5,
+        vector_query=_empty_vector_query,
+        db_client=_Db(),
+        ledger_kinds={MemoryKind.fact.value},
+    )
+    return results, read_ids
 
 
 def test_user_rejected_long_term_item_is_not_rebuild_or_vector_eligible():
@@ -421,6 +488,164 @@ class TestKeywordSearchAndHybrid:
         assert len(results) == 1
         assert results[0]["memory_id"] == item.memory_id
         assert NEEDLE in results[0]["content"]
+
+    def test_ledger_search_hydrates_only_candidate_and_lineage_ids(self, monkeypatch):
+        candidate = _long_term_item(memory_id="mem-ledger-candidate").model_copy(
+            update={
+                "ledger_schema_version": "knowledge_ledger.v1",
+                "kind": MemoryKind.fact,
+                "intent_backed": True,
+                "canonical_memory_id": "mem-ledger-root",
+            }
+        )
+        root = _long_term_item(memory_id="mem-ledger-root", content=f"Root {NEEDLE}").model_copy(
+            update={
+                "ledger_schema_version": "knowledge_ledger.v1",
+                "kind": MemoryKind.fact,
+                "intent_backed": True,
+            }
+        )
+        by_id = {candidate.memory_id: candidate, root.memory_id: root}
+        read_batches = []
+
+        def _read_by_ids(uid, memory_ids, *, db_client):
+            assert uid == CANONICAL_UID
+            read_batches.append(tuple(memory_ids))
+            return [by_id[memory_id] for memory_id in memory_ids if memory_id in by_id]
+
+        monkeypatch.setattr(
+            "utils.memory.atom_keyword_index.keyword_search_ledger_memory_ids",
+            lambda *args, **kwargs: [candidate.memory_id],
+        )
+        monkeypatch.setattr(
+            "utils.memory.canonical_memory_adapter.fetch_authoritative_product_memory_items_by_ids",
+            _read_by_ids,
+        )
+        monkeypatch.setattr(
+            "utils.memory.canonical_memory_adapter.fetch_authoritative_product_memory_items",
+            lambda **kwargs: pytest.fail("ledger search must not scan the canonical collection"),
+        )
+
+        results = search_canonical_memories(
+            CANONICAL_UID,
+            NEEDLE,
+            limit=5,
+            vector_query=_empty_vector_query,
+            db_client=_data_protection_db(),
+            ledger_kinds={MemoryKind.fact.value},
+        )
+
+        assert [row["memory_id"] for row in results] == [root.memory_id]
+        assert read_batches == [(candidate.memory_id,), (root.memory_id,)]
+
+    def test_ledger_search_omits_candidate_with_missing_lineage_target(self, monkeypatch):
+        candidate = _long_term_item(memory_id="mem-ledger-missing").model_copy(
+            update={
+                "ledger_schema_version": "knowledge_ledger.v1",
+                "kind": MemoryKind.fact,
+                "intent_backed": True,
+                "canonical_memory_id": "mem-ledger-not-found",
+            }
+        )
+
+        results, read_ids = _run_bounded_ledger_search(monkeypatch, [candidate], candidate.memory_id)
+
+        assert results == []
+        assert read_ids == [candidate.memory_id, "mem-ledger-not-found"]
+
+    def test_ledger_search_preserves_closed_cycle_lineage_behavior(self, monkeypatch):
+        candidate = _long_term_item(memory_id="mem-ledger-cycle-candidate").model_copy(
+            update={
+                "ledger_schema_version": "knowledge_ledger.v1",
+                "kind": MemoryKind.fact,
+                "intent_backed": True,
+                "canonical_memory_id": "mem-ledger-cycle-peer",
+            }
+        )
+        peer = _long_term_item(memory_id="mem-ledger-cycle-peer").model_copy(
+            update={
+                "ledger_schema_version": "knowledge_ledger.v1",
+                "kind": MemoryKind.fact,
+                "intent_backed": True,
+                "canonical_memory_id": candidate.memory_id,
+            }
+        )
+
+        results, read_ids = _run_bounded_ledger_search(monkeypatch, [candidate, peer], candidate.memory_id)
+
+        assert len(results) == 1
+        assert results[0]["memory_id"] in {candidate.memory_id, peer.memory_id}
+        assert read_ids == [candidate.memory_id, peer.memory_id]
+
+    def test_ledger_search_omits_candidate_with_cross_owner_lineage_target(self, monkeypatch):
+        candidate = _long_term_item(memory_id="mem-ledger-cross-owner").model_copy(
+            update={
+                "ledger_schema_version": "knowledge_ledger.v1",
+                "kind": MemoryKind.fact,
+                "intent_backed": True,
+                "canonical_memory_id": "mem-ledger-other-owner",
+            }
+        )
+        other_owner = _long_term_item(uid="uid-other", memory_id="mem-ledger-other-owner").model_copy(
+            update={
+                "ledger_schema_version": "knowledge_ledger.v1",
+                "kind": MemoryKind.fact,
+                "intent_backed": True,
+            }
+        )
+
+        results, read_ids = _run_bounded_ledger_search(monkeypatch, [candidate, other_owner], candidate.memory_id)
+
+        assert results == []
+        assert read_ids == [candidate.memory_id, other_owner.memory_id]
+
+    def test_ledger_search_omits_candidate_with_payload_id_mismatch_lineage_target(self, monkeypatch):
+        candidate = _long_term_item(memory_id="mem-ledger-id-mismatch").model_copy(
+            update={
+                "ledger_schema_version": "knowledge_ledger.v1",
+                "kind": MemoryKind.fact,
+                "intent_backed": True,
+                "canonical_memory_id": "mem-ledger-target",
+            }
+        )
+        wrong_payload = _long_term_item(memory_id="mem-ledger-wrong-payload").model_copy(
+            update={
+                "ledger_schema_version": "knowledge_ledger.v1",
+                "kind": MemoryKind.fact,
+                "intent_backed": True,
+            }
+        )
+
+        results, read_ids = _run_bounded_ledger_search(
+            monkeypatch,
+            [candidate],
+            candidate.memory_id,
+            payload_overrides={"mem-ledger-target": wrong_payload.model_dump(mode="python")},
+        )
+
+        assert results == []
+        assert read_ids == [candidate.memory_id, "mem-ledger-target"]
+
+    def test_ledger_search_omits_candidate_when_lineage_exceeds_bounded_hops(self, monkeypatch):
+        chain = []
+        for index in range(14):
+            memory_id = f"mem-ledger-hop-{index}"
+            target_id = f"mem-ledger-hop-{index + 1}" if index < 13 else None
+            chain.append(
+                _long_term_item(memory_id=memory_id).model_copy(
+                    update={
+                        "ledger_schema_version": "knowledge_ledger.v1",
+                        "kind": MemoryKind.fact,
+                        "intent_backed": True,
+                        "canonical_memory_id": target_id,
+                    }
+                )
+            )
+
+        results, read_ids = _run_bounded_ledger_search(monkeypatch, chain, chain[0].memory_id)
+
+        assert results == []
+        assert read_ids == [item.memory_id for item in chain[:13]]
 
     def test_search_excludes_superseded_long_term_items(self, mock_typesense, monkeypatch):
         active = _long_term_item(memory_id="mem_active", content=f"Active {NEEDLE}")

--- a/backend/utils/memory/atom_keyword_index.py
+++ b/backend/utils/memory/atom_keyword_index.py
@@ -11,10 +11,16 @@ import logging
 import os
 from dataclasses import dataclass
 from datetime import timezone
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Collection, Dict, List, Optional, cast
 
 from database._client import db as default_db_client
 from database.memory_vector_metadata import canonical_memory_provider_id
+from models.knowledge_ledger_search import (
+    LEDGER_INDEX_VERSION,
+    LEDGER_SEARCH_KINDS,
+    build_ledger_index_metadata,
+    validate_ledger_kinds,
+)
 from models.memory_evidence import SourceState
 from models.product_memory import (
     RESTRICTED_SENSITIVITY_LABELS,
@@ -46,6 +52,14 @@ _REQUIRED_SCHEMA_FIELDS = {
     "entity_terms",
     "predicate",
     "created_at",
+}
+_LEDGER_SCHEMA_FIELDS = {
+    "ledger_index_version",
+    "ledger_schema_version",
+    "ledger_kind",
+    "ledger_row_state",
+    "ledger_has_slot",
+    "ledger_subject_scope",
 }
 
 
@@ -159,7 +173,7 @@ def _predicate_for_item(item: MemoryItem) -> str:
 
 def build_atom_keyword_document(item: MemoryItem) -> Dict[str, Any]:
     """Build a Typesense document for one indexable long-term atom."""
-    return {
+    document = {
         "id": canonical_memory_provider_id(item.uid, item.memory_id),
         "memory_id": item.memory_id,
         "userId": item.uid,
@@ -172,6 +186,11 @@ def build_atom_keyword_document(item: MemoryItem) -> Dict[str, Any]:
         "predicate": _predicate_for_item(item),
         "created_at": _created_at_epoch(item),
     }
+    # Generic atom rows remain backwards compatible.  Ledger rows carry an
+    # explicit version/state discriminator so a ledger query never treats an
+    # unlabelled legacy Typesense hit as canonical ledger evidence.
+    document.update(build_ledger_index_metadata(item))
+    return document
 
 
 def merge_memory_search_ids(keyword_ids: List[str], vector_ids: List[str]) -> List[str]:
@@ -197,6 +216,12 @@ def ensure_memories_collection() -> None:
                 {"name": "schema_version", "type": "int32", "facet": True},
                 {"name": "entity_terms", "type": "string", "optional": True},
                 {"name": "predicate", "type": "string", "optional": True},
+                {"name": "ledger_index_version", "type": "int32", "facet": True, "optional": True},
+                {"name": "ledger_schema_version", "type": "string", "facet": True, "optional": True},
+                {"name": "ledger_kind", "type": "string", "facet": True, "optional": True},
+                {"name": "ledger_row_state", "type": "string", "facet": True, "optional": True},
+                {"name": "ledger_has_slot", "type": "bool", "facet": True, "optional": True},
+                {"name": "ledger_subject_scope", "type": "string", "facet": True, "optional": True},
                 {"name": "created_at", "type": "int64"},
             ],
             "default_sorting_field": "created_at",
@@ -211,6 +236,20 @@ def ensure_memories_collection() -> None:
             f"Typesense collection {collection_name!r} is incompatible with canonical memory atoms; "
             f"missing fields: {missing}"
         )
+
+
+def ensure_ledger_keyword_schema() -> None:
+    """Fail closed when the provider has not adopted the ledger index fields."""
+
+    collection_name = memories_collection_name()
+    try:
+        schema = _payload_or_empty(_typesense_client().collections[collection_name].retrieve())
+    except Exception as exc:
+        raise RuntimeError("ledger keyword schema unavailable") from exc
+    actual_fields = {str(field.get("name")) for field in _payload_list(schema.get("fields")) if field.get("name")}
+    missing = sorted(_LEDGER_SCHEMA_FIELDS - actual_fields)
+    if missing:
+        raise RuntimeError(f"Typesense ledger keyword schema is missing fields: {missing}")
 
 
 def upsert_atom_keyword_doc(item: MemoryItem, *, db_client: Any = None) -> bool:
@@ -229,6 +268,8 @@ def upsert_atom_keyword_doc(item: MemoryItem, *, db_client: Any = None) -> bool:
         return False
     try:
         ensure_memories_collection()
+        if item.ledger_schema_version == "knowledge_ledger.v1":
+            ensure_ledger_keyword_schema()
         doc = build_atom_keyword_document(item)
         documents = _typesense_client().collections[memories_collection_name()].documents
         # Remove the former bare ``memory_id`` identity and any previous
@@ -351,6 +392,60 @@ def keyword_search_memory_ids(
         return memory_ids
     except Exception as exc:
         logger.warning("keyword_search_memory_ids failed uid=%s, falling back to vector-only: %s", uid, exc)
+        return []
+
+
+def keyword_search_ledger_memory_ids(
+    uid: str,
+    query: str,
+    *,
+    kinds: Collection[str] = LEDGER_SEARCH_KINDS,
+    limit: int = 5,
+    db_client: Any = None,
+) -> List[str]:
+    """Search only open ledger rows through the versioned keyword projection.
+
+    Older generic atom collections may not have the ledger fields.  Returning
+    no keyword candidates in that state is intentional: an unlabelled
+    provider document must never be promoted to canonical ledger evidence.
+    """
+
+    parsed_kinds = validate_ledger_kinds(kinds)
+    if not user_allows_atom_keyword_index(uid, db_client=db_client) or not (query or "").strip():
+        return []
+    try:
+        ensure_ledger_keyword_schema()
+        filter_by = (
+            f"userId:={_typesense_filter_literal(uid)} && layer:={MemoryLayer.long_term.value} "
+            f"&& status:={MemoryItemStatus.active.value} && schema_version:=1 "
+            f"&& ledger_index_version:={LEDGER_INDEX_VERSION} "
+            "&& ledger_schema_version:=`knowledge_ledger.v1` "
+            "&& ledger_row_state:=`open` "
+            f"&& ledger_kind:=[{','.join(_typesense_filter_literal(kind) for kind in sorted(parsed_kinds))}]"
+        )
+        results = _payload_or_empty(
+            _typesense_client()
+            .collections[memories_collection_name()]
+            .documents.search(
+                {
+                    "q": query,
+                    "query_by": "content,entity_terms,predicate",
+                    "filter_by": filter_by,
+                    "sort_by": "created_at:desc",
+                    "per_page": max(1, min(limit, 60)),
+                    "page": 1,
+                }
+            )
+        )
+        memory_ids: List[str] = []
+        for hit in _payload_list(results.get("hits")):
+            doc = _payload_or_empty(hit.get("document"))
+            memory_id = doc.get("memory_id") or doc.get("id")
+            if memory_id:
+                memory_ids.append(str(memory_id))
+        return memory_ids
+    except Exception as exc:
+        logger.warning("ledger keyword search failed closed uid=%s error_type=%s", uid, type(exc).__name__)
         return []
 
 

--- a/backend/utils/memory/canonical_memory_adapter.py
+++ b/backend/utils/memory/canonical_memory_adapter.py
@@ -7,8 +7,9 @@ import hashlib
 import json
 import logging
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, cast
+from typing import Any, Callable, Collection, Dict, List, Optional, Sequence, Tuple, cast
 
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
@@ -90,6 +91,7 @@ from utils.retrieval.hybrid import rrf_rerank
 from utils.memory.canonical_vector_sync import delete_canonical_memory_vector
 from utils.memory.product_memory_read_service import (
     fetch_authoritative_product_memory_items,
+    fetch_authoritative_product_memory_items_by_ids,
     fetch_authoritative_product_memory_items_for_source,
     fetch_authoritative_superseded_memory_items_for_targets,
 )
@@ -505,8 +507,18 @@ def read_canonical_memories(
 
 _CANONICAL_SCAN_PAGE_MAX = 500
 _CANONICAL_SCAN_LINEAGE_MAX_HOPS = 12
+_LEDGER_SEARCH_MAX_PROVIDER_CANDIDATES = 60
 CanonicalScanCursor = tuple[datetime, str]
 CanonicalScanSlot = tuple[Optional[MemoryDB], CanonicalScanCursor]
+
+
+@dataclass(frozen=True)
+class BoundedLedgerSearchHydration:
+    """Named result for bounded provider-candidate and lineage hydration."""
+
+    candidate_items: Tuple[MemoryItem, ...]
+    lineage_items_by_id: Dict[str, MemoryItem]
+    survivor_items_by_id: Dict[str, MemoryItem]
 
 
 def _coerce_scan_updated_at(value: datetime) -> datetime:
@@ -586,6 +598,90 @@ def _read_canonical_memory_item_for_lineage(
     if item.uid != uid:
         raise ValueError(f"canonical memory uid mismatch: expected {uid}, got {item.uid}")
     return item
+
+
+def _hydrate_bounded_ledger_search_items(
+    uid: str,
+    candidate_ids: Sequence[str],
+    *,
+    db_client: Any,
+    policy: MemoryAccessPolicy,
+    now: datetime,
+    device_scope: str,
+    client_device_id: Optional[str],
+) -> BoundedLedgerSearchHydration:
+    """Hydrate provider candidates plus a bounded canonical lineage closure.
+
+    Ledger search must never turn a provider candidate into an account-wide
+    canonical collection scan. Candidate rows are read in one bounded batch;
+    each of at most twelve lineage hops reads only the next ids referenced by
+    that batch. Every point is checked against both the owning path and the
+    Firestore document id by the read-service seam.
+    """
+
+    requested_ids = list(dict.fromkeys(memory_id for memory_id in candidate_ids if memory_id))[
+        :_LEDGER_SEARCH_MAX_PROVIDER_CANDIDATES
+    ]
+    if not requested_ids:
+        return BoundedLedgerSearchHydration(
+            candidate_items=(),
+            lineage_items_by_id={},
+            survivor_items_by_id={},
+        )
+
+    hydrated_by_id: Dict[str, MemoryItem] = {}
+    frontier = fetch_authoritative_product_memory_items_by_ids(uid, requested_ids, db_client=db_client)
+    for item in frontier:
+        hydrated_by_id[item.memory_id] = item
+
+    seen_ids = set(requested_ids)
+    for _ in range(_CANONICAL_SCAN_LINEAGE_MAX_HOPS):
+        next_ids = [
+            target_id
+            for item in frontier
+            if (target_id := (item.canonical_memory_id or item.superseded_by or "").strip())
+            and target_id not in seen_ids
+        ]
+        next_ids = list(dict.fromkeys(next_ids))[:_LEDGER_SEARCH_MAX_PROVIDER_CANDIDATES]
+        if not next_ids:
+            break
+        seen_ids.update(next_ids)
+        frontier = fetch_authoritative_product_memory_items_by_ids(uid, next_ids, db_client=db_client)
+        for item in frontier:
+            hydrated_by_id[item.memory_id] = item
+
+    all_items = list(hydrated_by_id.values())
+    visible_items = filter_canonical_default_visible_items(all_items, policy=policy, now=now)
+    scoped_items = filter_items_by_device_scope(
+        visible_items,
+        device_scope=device_scope if device_scope in ("current", "all", "explicit") else "all",
+        client_device_id=client_device_id,
+    )
+    return BoundedLedgerSearchHydration(
+        candidate_items=tuple(hydrated_by_id[memory_id] for memory_id in requested_ids if memory_id in hydrated_by_id),
+        lineage_items_by_id=hydrated_by_id,
+        survivor_items_by_id={item.memory_id: item for item in scoped_items},
+    )
+
+
+def _ledger_search_lineage_is_complete(item: MemoryItem, *, lineage_items_by_id: Dict[str, MemoryItem]) -> bool:
+    """Require a candidate's canonical lineage to terminate in bounded data."""
+
+    current = item
+    visited: set[str] = set()
+    for _ in range(_CANONICAL_SCAN_LINEAGE_MAX_HOPS + 1):
+        if current.memory_id in visited:
+            return True
+        visited.add(current.memory_id)
+        target_id = (current.canonical_memory_id or current.superseded_by or "").strip()
+        if not target_id or target_id == current.memory_id:
+            return True
+        target = lineage_items_by_id.get(target_id)
+        if target is None:
+            return False
+        current = target
+    # The closure was bounded before a terminating root was observed.
+    return False
 
 
 def _canonical_scan_lineage_suppressed(
@@ -781,6 +877,7 @@ def search_canonical_memories(
     vector_query: Any = None,
     device_scope_request: Optional[DeviceScopeRequest] = None,
     item_filter: Optional[Callable[[MemoryItem], bool]] = None,
+    ledger_kinds: Optional[Collection[str]] = None,
 ) -> List[Dict[str, Any]]:
     """Hybrid search over default-visible Short-term and Long-term memories."""
     client = db_client if db_client is not None else default_db_client
@@ -791,6 +888,8 @@ def search_canonical_memories(
     normalized_query = (query or "").strip()
 
     if not normalized_query:
+        if ledger_kinds is not None:
+            return []
         memories = read_canonical_memories(
             uid,
             limit=capped_limit,
@@ -810,16 +909,37 @@ def search_canonical_memories(
             for memory in memories[:capped_limit]
         ]
 
-    from utils.memory.atom_keyword_index import keyword_search_memory_ids, merge_memory_search_ids
+    from utils.memory.atom_keyword_index import (
+        keyword_search_ledger_memory_ids,
+        keyword_search_memory_ids,
+        merge_memory_search_ids,
+    )
 
-    keyword_ids = keyword_search_memory_ids(uid, normalized_query, limit=fetch_limit, db_client=client)
+    if ledger_kinds is None:
+        keyword_ids = keyword_search_memory_ids(uid, normalized_query, limit=fetch_limit, db_client=client)
+    else:
+        keyword_ids = keyword_search_ledger_memory_ids(
+            uid,
+            normalized_query,
+            kinds=ledger_kinds,
+            limit=fetch_limit,
+            db_client=client,
+        )
     if vector_query is None:
         from database.vector_db import query_memory_vector_candidates
 
         vector_query_fn = query_memory_vector_candidates
     else:
         vector_query_fn = vector_query
-    vector_result = vector_query_fn(uid, normalized_query, limit=fetch_limit)
+    if ledger_kinds is None:
+        vector_result = vector_query_fn(uid, normalized_query, limit=fetch_limit)
+    else:
+        vector_result = vector_query_fn(
+            uid,
+            normalized_query,
+            limit=fetch_limit,
+            ledger_kinds=sorted(ledger_kinds),
+        )
     vector_ids = [hit.memory_id for hit in vector_result.hits if hit.memory_id]
     merged_ids = merge_memory_search_ids(keyword_ids, vector_ids)
     if not merged_ids:
@@ -827,19 +947,40 @@ def search_canonical_memories(
 
     now = datetime.now(timezone.utc)
     policy = MemoryAccessPolicy.for_omi_chat(archive_capability=False)
-    all_items = fetch_authoritative_product_memory_items(uid=uid, db_client=client)
-    visible_items = filter_canonical_default_visible_items(all_items, policy=policy, now=now)
-    scoped_items = filter_items_by_device_scope(
-        visible_items,
-        device_scope=device_scope if device_scope in ("current", "all", "explicit") else "all",
-        client_device_id=client_device_id,
-    )
-    lineage_items_by_id = {item.memory_id: item for item in all_items}
-    survivor_items_by_id = {item.memory_id: item for item in scoped_items}
+    if ledger_kinds is None:
+        all_items = fetch_authoritative_product_memory_items(uid=uid, db_client=client)
+        visible_items = filter_canonical_default_visible_items(all_items, policy=policy, now=now)
+        scoped_items = filter_items_by_device_scope(
+            visible_items,
+            device_scope=device_scope if device_scope in ("current", "all", "explicit") else "all",
+            client_device_id=client_device_id,
+        )
+        lineage_items_by_id = {item.memory_id: item for item in all_items}
+        survivor_items_by_id = {item.memory_id: item for item in scoped_items}
+        candidate_ids = merged_ids
+    else:
+        hydration = _hydrate_bounded_ledger_search_items(
+            uid,
+            merged_ids,
+            db_client=client,
+            policy=policy,
+            now=now,
+            device_scope=device_scope,
+            client_device_id=client_device_id,
+        )
+        candidate_items = list(hydration.candidate_items)
+        lineage_items_by_id = hydration.lineage_items_by_id
+        survivor_items_by_id = hydration.survivor_items_by_id
+        candidate_items = [
+            item
+            for item in candidate_items
+            if _ledger_search_lineage_is_complete(item, lineage_items_by_id=lineage_items_by_id)
+        ]
+        candidate_ids = [item.memory_id for item in candidate_items]
     vector_scores = {hit.memory_id: float(hit.score or 0.0) for hit in vector_result.hits}
 
     candidates: List[Payload] = []
-    for memory_id in merged_ids:
+    for memory_id in candidate_ids:
         item = survivor_items_by_id.get(memory_id)
         if item is None or (item_filter is not None and not item_filter(item)):
             continue

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -7,7 +7,7 @@ import re
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, Iterator, List, Literal, NoReturn, Optional, Set, Tuple, cast
+from typing import Any, Callable, Collection, Dict, Iterator, List, Literal, NoReturn, Optional, Set, Tuple, cast
 from uuid import UUID
 
 from fastapi import HTTPException
@@ -32,6 +32,7 @@ from models.product_memory import (
     RESTRICTED_SENSITIVITY_LABELS,
     SourceState,
 )
+from models.knowledge_ledger_search import LedgerSearchSurface, is_ledger_row_admissible
 from utils.log_sanitizer import sanitize_validation_error
 from utils.other.list_budget import ListReadBudget, ListReadBudgetExhausted, budgeted_get_all
 from utils.memory.canonical_memory_adapter import (
@@ -399,14 +400,20 @@ class CanonicalMemoryBackend:
         limit: int = 5,
         device_scope_request: Optional[DeviceScopeRequest] = None,
         item_filter: Optional[Callable[[MemoryItem], bool]] = None,
+        ledger_kinds: Optional[Collection[str]] = None,
     ) -> List[MemorySearchMatch]:
+        search_kwargs: Dict[str, Any] = {
+            "limit": limit,
+            "db_client": self._db_client,
+            "device_scope_request": device_scope_request,
+            "item_filter": item_filter,
+        }
+        if ledger_kinds is not None:
+            search_kwargs["ledger_kinds"] = ledger_kinds
         items = search_canonical_memories(
             uid,
             query,
-            limit=limit,
-            db_client=self._db_client,
-            device_scope_request=device_scope_request,
-            item_filter=item_filter,
+            **search_kwargs,
         )
         results: List[MemorySearchMatch] = []
         for rank, item in enumerate(items):
@@ -2590,26 +2597,39 @@ class MemoryService:
         device_scope_request: Optional[DeviceScopeRequest] = None,
         canonical_item_filter: Optional[Callable[[MemoryItem], bool]] = None,
         result_filter: Optional[Callable[[MemoryDB], bool]] = None,
+        ledger_kinds: Optional[Collection[str]] = None,
     ) -> List[MemorySearchMatch]:
         capped = max(1, min(int(limit or 5), 20))
         try:
+            canonical_kwargs: Dict[str, Any] = {
+                "limit": min(capped * 3, 60),
+                "device_scope_request": device_scope_request,
+                "item_filter": canonical_item_filter,
+            }
+            if ledger_kinds is not None:
+                canonical_kwargs["ledger_kinds"] = ledger_kinds
             canonical = self._canonical.search(
                 uid,
                 query,
-                limit=min(capped * 3, 60),
-                device_scope_request=device_scope_request,
-                item_filter=canonical_item_filter,
+                **canonical_kwargs,
             )
         except HTTPException:
             raise
         except Exception as exc:
             raise HTTPException(status_code=503, detail="Canonical memory search unavailable") from exc
-        historical = self.history.search(
-            uid,
-            query,
-            limit=min(capped * 3, 60),
-            device_scope_request=device_scope_request,
-        )
+        if ledger_kinds is not None:
+            # The ledger agent surface is explicitly canonical-only. Legacy
+            # vector/storage search is a separate historical tool and must not
+            # be merged here: aside from leaking stamped compatibility rows,
+            # its provider outage would make current ledger search unavailable.
+            historical: List[MemorySearchMatch] = []
+        else:
+            historical = self.history.search(
+                uid,
+                query,
+                limit=min(capped * 3, 60),
+                device_scope_request=device_scope_request,
+            )
         by_id: Dict[str, MemorySearchMatch] = {}
         for match in canonical:
             by_id[match.memory.id] = match
@@ -2636,33 +2656,18 @@ class MemoryService:
     @staticmethod
     def _is_ledger_history_item(item: MemoryItem, row: MemoryDB) -> bool:
         """Keep history reads canonical, privacy-filtered, and wire-representable."""
-
-        if item.ledger_schema_version != LEDGER_SCHEMA_VERSION:
-            return False
-        # User-directed facts are ordinary history. Exact migration provenance
-        # is the sole exception for preserved generated legacy data: it remains
-        # available only through this explicit history seam, never default
-        # reads or prompt projection.
-        is_preserved_legacy_history = not item.intent_backed and item.write_reason == LedgerWriteReason.legacy_migration
-        if not item.intent_backed and not is_preserved_legacy_history:
-            return False
-        if item.status in {MemoryItemStatus.hidden, MemoryItemStatus.tombstoned}:
-            return False
-        if item.processing_state != ProcessingState.processed:
-            return False
-        if item.source_state in {SourceState.tombstoned, SourceState.purged}:
-            return False
-        if set(item.sensitivity_labels).intersection(RESTRICTED_SENSITIVITY_LABELS):
-            return False
-        if row.is_locked:
-            return False
-        # Admit only states the public MemoryDB wire shape can represent. A
-        # status-only superseded row would otherwise serialize as current.
-        return (
-            is_preserved_legacy_history
-            or row.user_review is False
-            or row.invalid_at is not None
-            or row.superseded_by is not None
+        return is_ledger_row_admissible(
+            item,
+            uid=item.uid,
+            surface=LedgerSearchSurface.history,
+            kinds={MemoryKind.fact.value},
+            include_rejected=True,
+        ) and is_ledger_row_admissible(
+            row,
+            uid=row.uid,
+            surface=LedgerSearchSurface.history,
+            kinds={MemoryKind.fact.value},
+            include_rejected=True,
         )
 
     def read_ledger_history_page(

--- a/backend/utils/memory/product_memory_read_service.py
+++ b/backend/utils/memory/product_memory_read_service.py
@@ -193,6 +193,63 @@ def fetch_authoritative_product_memory_items(
     )
 
 
+def fetch_authoritative_product_memory_items_by_ids(
+    uid: str,
+    memory_ids: Iterable[str],
+    *,
+    db_client: Any,
+) -> List[MemoryItem]:
+    """Load a bounded, owner- and document-id-checked canonical subset.
+
+    Search providers return candidates, not authority. This seam hydrates only
+    requested document ids so bounded ledger search does not scan or
+    materialize an entire user's canonical collection. Missing, malformed,
+    cross-owner, and payload/document-id-mismatched rows fail closed.
+    """
+
+    normalized_ids = list(
+        dict.fromkeys(
+            memory_id.strip() for memory_id in memory_ids if memory_id and memory_id.strip() and "/" not in memory_id
+        )
+    )
+    if len(normalized_ids) > MAX_PRODUCT_MEMORY_READ_LIMIT:
+        raise ValueError(f"memory_ids must contain at most {MAX_PRODUCT_MEMORY_READ_LIMIT} entries")
+    if not normalized_ids:
+        return []
+
+    collection_path = MemoryCollections(uid=uid).memory_items
+    refs = [db_client.document(f"{collection_path}/{memory_id}") for memory_id in normalized_ids]
+    get_all = getattr(db_client, "get_all", None)
+    snapshots: Iterable[Any]
+    if callable(get_all):
+        snapshots = cast(Iterable[Any], get_all(refs))
+    else:
+        # A point-read-capable fake/client may not expose get_all. Keep the
+        # same bounded identity fence without falling back to a collection
+        # scan; production Firestore uses the batch path above.
+        snapshots = (ref.get() for ref in refs)
+
+    expected_ids = set(normalized_ids)
+    items: List[MemoryItem] = []
+    for snapshot in snapshots:
+        document_id = getattr(snapshot, "id", None)
+        if not isinstance(document_id, str) or document_id not in expected_ids:
+            continue
+        if not getattr(snapshot, "exists", False):
+            continue
+        raw_payload: object = snapshot.to_dict()
+        payload = cast(Dict[str, Any], raw_payload) if isinstance(raw_payload, dict) else {}
+        try:
+            item = MemoryItem.model_validate(payload)
+        except Exception:
+            continue
+        if item.uid != uid or item.memory_id != document_id:
+            continue
+        items.append(item)
+    by_id = {item.memory_id: item for item in items}
+    return [by_id[memory_id] for memory_id in normalized_ids if memory_id in by_id]
+
+
 def fetch_authoritative_product_memory_items_for_source(
     uid: str,
     source_id: str,

--- a/backend/utils/retrieval/tools/knowledge_ledger_tools.py
+++ b/backend/utils/retrieval/tools/knowledge_ledger_tools.py
@@ -30,6 +30,11 @@ from models.product_memory import (
     MemoryKind,
     MemorySubjectScope,
 )
+from models.knowledge_ledger_search import (
+    LedgerSearchSurface,
+    is_ledger_row_admissible,
+    validate_ledger_kinds,
+)
 from utils.memory.canonical_memory_adapter import read_canonical_memory_item
 from utils.memory.canonical_visibility_filter import filter_canonical_default_visible_items
 from utils.memory.knowledge_ledger import LEDGER_SCHEMA_VERSION
@@ -79,40 +84,24 @@ def _resolve_uid(config: RunnableConfig | None) -> Optional[str]:
 def _parse_kinds(kinds: Optional[str]) -> frozenset[str]:
     if kinds is None or not kinds.strip():
         return _LEDGER_KINDS
-    parsed = frozenset(part.strip().casefold() for part in kinds.split(",") if part.strip())
-    if not parsed or not parsed.issubset(_LEDGER_KINDS):
-        raise ValueError("kinds must contain only fact, document, or trigger")
-    return parsed
+    return validate_ledger_kinds(kinds.split(","))
 
 
 def _is_current_ledger_memory(memory: MemoryDB, *, kinds: frozenset[str]) -> bool:
-    kind = memory.kind.value if isinstance(memory.kind, MemoryKind) else str(memory.kind or "")
-    subject_scope = (
-        memory.subject_scope.value
-        if isinstance(memory.subject_scope, MemorySubjectScope)
-        else str(memory.subject_scope or "")
-    )
-    return (
-        memory.ledger_schema_version == LEDGER_SCHEMA_VERSION
-        and kind in kinds
-        and memory.intent_backed
-        and memory.invalid_at is None
-        and memory.user_review is not False
-        and not memory.is_locked
-        and (kind != MemoryKind.document.value or subject_scope == MemorySubjectScope.primary_user.value)
+    return is_ledger_row_admissible(
+        memory,
+        uid=memory.uid,
+        surface=LedgerSearchSurface.current,
+        kinds=kinds,
     )
 
 
 def _is_current_ledger_item(item: MemoryItem, *, kinds: frozenset[str]) -> bool:
-    promotion = item.promotion or {}
-    return (
-        item.ledger_schema_version == LEDGER_SCHEMA_VERSION
-        and item.kind.value in kinds
-        and item.intent_backed
-        and item.valid_to is None
-        and promotion.get("is_locked") is not True
-        and promotion.get("user_review") is not False
-        and (item.kind != MemoryKind.document or item.subject_scope == MemorySubjectScope.primary_user)
+    return is_ledger_row_admissible(
+        item,
+        uid=item.uid,
+        surface=LedgerSearchSurface.current,
+        kinds=kinds,
     )
 
 
@@ -156,6 +145,7 @@ def search_current_knowledge(
         limit=limit,
         canonical_item_filter=lambda item: _is_current_ledger_item(item, kinds=kinds),
         result_filter=lambda memory: _is_current_ledger_memory(memory, kinds=kinds),
+        ledger_kinds=kinds,
     )
     return [
         match.memory
@@ -167,26 +157,12 @@ def search_current_knowledge(
 def _is_historical_fact_memory(memory: MemoryDB, *, uid: str, include_rejected: bool) -> bool:
     """Keep the agent seam fact-only even if the service grows new history kinds."""
 
-    kind = memory.kind.value if isinstance(memory.kind, MemoryKind) else str(memory.kind or "")
-    write_reason = (
-        memory.write_reason.value
-        if isinstance(memory.write_reason, LedgerWriteReason)
-        else str(memory.write_reason or "")
-    )
-    is_preserved_legacy_history = not memory.intent_backed and write_reason == LedgerWriteReason.legacy_migration.value
-    return (
-        memory.uid == uid
-        and memory.ledger_schema_version == LEDGER_SCHEMA_VERSION
-        and kind == MemoryKind.fact.value
-        and (memory.intent_backed or is_preserved_legacy_history)
-        and not memory.is_locked
-        and (include_rejected or memory.user_review is not False)
-        and (
-            is_preserved_legacy_history
-            or memory.user_review is False
-            or memory.invalid_at is not None
-            or memory.superseded_by is not None
-        )
+    return is_ledger_row_admissible(
+        memory,
+        uid=uid,
+        surface=LedgerSearchSurface.history,
+        kinds={MemoryKind.fact.value},
+        include_rejected=include_rejected,
     )
 
 


### PR DESCRIPTION
## Summary

- define one shared, fail-closed policy for current versus historical knowledge-ledger search
- require versioned open-ledger metadata and bounded provider candidates, then hydrate and re-authorize canonical rows before returning them
- expose exact legacy-migration fact history without mixing legacy fallback into current ledger results
- omit incomplete, cross-owner, payload-mismatched, or over-depth canonical lineages without scanning the collection

## Compatibility and rollout

- generic and flag-off searches retain the established behavior
- current ledger queries are canonical-only; historical access remains an explicit agent/tool choice
- Typesense schema adoption plus keyword/vector reindexing is required before enabling this surface; stale indexes intentionally fail closed
- this PR does not deploy, enable a cohort, migrate data, or delete legacy data

## Verification

- 267 affected backend tests passed during implementation
- independent exact-tree review passed with no P0-P3 findings; reviewer reran 163 focused tests
- focused Pyright: 0 errors
- Black, diff hygiene, and bounded repository preflight passed with the exceptions below

## Product invariants affected

- INV-MEM-3
- INV-MEM-4
- INV-MEM-1
- INV-MEM-2

Line-Count-Exception: backend/utils/memory/canonical_memory_adapter.py | 2970 -> 3111 | bounded canonical hydration integration remains beside the adapter's existing owner and payload fences; extracting it separately would duplicate or weaken the storage boundary in this slice

Line-Count-Exception: backend/utils/memory/memory_service.py | 3474 -> 3479 | five-line routing seam keeps generic flag-off behavior unchanged while opting ledger calls into the shared policy

## Stack

Base: #12160 (`codex/jit-writer-rollback-contract`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

