### PR TITLE
fix(deploy): treat a Cloud Run literal env var with no value key as empty

### DIFF
--- a/backend/scripts/attach_cloud_run_gmp_sidecar.py
+++ b/backend/scripts/attach_cloud_run_gmp_sidecar.py
@@ -245,8 +245,20 @@ def _ingress_literal_env(service: Mapping[str, Any], *, ingress_container_name: 
         raise ValueError('Cloud Run ingress env was not a list')
     actual: dict[str, str] = {}
     for raw_entry in raw_env:
-        if isinstance(raw_entry, dict) and isinstance(raw_entry.get('name'), str) and 'value' in raw_entry:
-            actual[raw_entry['name']] = _cloud_run_string(raw_entry['value'])
+        if not isinstance(raw_entry, dict) or not isinstance(raw_entry.get('name'), str):
+            continue
+        if 'valueFrom' in raw_entry:
+            # Secret-backed reference, not a literal value -- must not be folded
+            # into the literal-env map (and must not be coerced to '').
+            continue
+        # Cloud Run's export omits the `value` key entirely for an env var whose
+        # literal value is the empty string -- it does not write `value: ''`.
+        # Reading a missing key as None here would make a legitimately empty
+        # literal look identical to a var that was never set at all, which is
+        # exactly the false-positive "<missing>" this check reported for
+        # OMI_PARITY_PACK_ALLOWED_PRINCIPALS. Absence of the key on a literal
+        # entry means empty string, not absence of the variable.
+        actual[raw_entry['name']] = _cloud_run_string(raw_entry.get('value', ''))
     return actual
 
 

--- a/backend/tests/unit/test_attach_cloud_run_gmp_sidecar.py
+++ b/backend/tests/unit/test_attach_cloud_run_gmp_sidecar.py
@@ -391,6 +391,211 @@ spec:
     assert secret_calls == []
 
 
+def test_ingress_literal_env_treats_a_missing_value_key_as_empty_string():
+    """Cloud Run's export omits the `value` key entirely for an empty-string literal.
+
+    It never writes `value: ''`. Before the fix, an entry without a `value` key
+    was skipped outright, so a var legitimately set to '' vanished from the
+    literal-env map instead of resolving to ''. This is the exact shape of
+    OMI_PARITY_PACK_ALLOWED_PRINCIPALS in the live dev backend service.
+    """
+    module = _load_module()
+    service = {
+        'spec': {
+            'template': {
+                'spec': {
+                    'containers': [
+                        {
+                            'name': 'backend-1',
+                            'env': [
+                                {'name': 'SAFE', 'value': 'kept'},
+                                {'name': 'OMI_PARITY_PACK_ALLOWED_PRINCIPALS'},
+                            ],
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    actual = module._ingress_literal_env(service, ingress_container_name='backend-1')
+
+    assert actual == {'SAFE': 'kept', 'OMI_PARITY_PACK_ALLOWED_PRINCIPALS': ''}
+
+
+def test_ingress_literal_env_excludes_valueFrom_secret_references():
+    """A secret-backed env var is not a literal and must not be coerced to ''.
+
+    Before the fix these were excluded only by accident, because they never
+    carry a `value` key either. The exclusion must stay deliberate now that a
+    missing `value` key means '' for a real literal.
+    """
+    module = _load_module()
+    service = {
+        'spec': {
+            'template': {
+                'spec': {
+                    'containers': [
+                        {
+                            'name': 'backend-1',
+                            'env': [
+                                {
+                                    'name': 'OPENAI_API_KEY',
+                                    'valueFrom': {'secretKeyRef': {'name': 'openai-api-key', 'key': 'latest'}},
+                                },
+                            ],
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    actual = module._ingress_literal_env(service, ingress_container_name='backend-1')
+
+    assert actual == {}
+    assert 'OPENAI_API_KEY' not in actual
+
+
+def test_validate_expected_literal_env_accepts_empty_string_matching_a_missing_value_key():
+    module = _load_module()
+    service = {
+        'spec': {
+            'template': {
+                'spec': {
+                    'containers': [
+                        {'name': 'backend-1', 'env': [{'name': 'OMI_PARITY_PACK_ALLOWED_PRINCIPALS'}]},
+                    ]
+                }
+            }
+        }
+    }
+
+    # Must not raise.
+    module._validate_expected_literal_env(
+        service,
+        expected={'OMI_PARITY_PACK_ALLOWED_PRINCIPALS': ''},
+        ingress_container_name='backend-1',
+        phase='exported base revision',
+    )
+
+
+def test_validate_expected_literal_env_still_fails_closed_for_a_genuinely_absent_var():
+    """This guard exists to catch real env drift before a sidecar replace.
+
+    The fix must make it read Cloud Run correctly, not make it more permissive
+    about genuine drift: a var that is not present in the export at all must
+    still report <missing> and raise.
+    """
+    module = _load_module()
+    service = {
+        'spec': {
+            'template': {
+                'spec': {
+                    'containers': [
+                        {'name': 'backend-1', 'env': [{'name': 'SAFE', 'value': 'kept'}]},
+                    ]
+                }
+            }
+        }
+    }
+
+    with pytest.raises(ValueError, match="expected '', found '<missing>'"):
+        module._validate_expected_literal_env(
+            service,
+            expected={'OMI_PARITY_PACK_ALLOWED_PRINCIPALS': ''},
+            ingress_container_name='backend-1',
+            phase='exported base revision',
+        )
+
+
+def test_attach_accepts_a_literal_cloud_run_omits_for_being_empty(monkeypatch, tmp_path) -> None:
+    """End-to-end regression for the production failure blocking dev deploys.
+
+    ``ValueError: exported base revision env OMI_PARITY_PACK_ALLOWED_PRINCIPALS
+    mismatch ... expected '', found '<missing>'`` -- the export legitimately
+    omits `value` for this var because it is set to '', and Cloud Run never
+    writes `value: ''`. attach_sidecar must complete instead of refusing.
+    """
+    module = _load_module()
+    expected_state = tmp_path / 'runtime-env-state.json'
+    expected_state.write_text(
+        json.dumps(
+            {
+                'services': {
+                    'backend': {
+                        'env': [
+                            {'name': 'OMI_PARITY_PACK_ALLOWED_PRINCIPALS', 'value': ''},
+                        ]
+                    }
+                }
+            }
+        ),
+        encoding='utf-8',
+    )
+    config = tmp_path / 'cloud-run-gmp-sidecar.yaml'
+    config.write_text('kind: RunMonitoring\n', encoding='utf-8')
+
+    export = """\
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: backend
+spec:
+  template:
+    metadata: {}
+    spec:
+      containers:
+      - name: backend-1
+        env:
+        - name: OMI_PARITY_PACK_ALLOWED_PRINCIPALS
+        - name: OPENAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: openai-api-key
+              key: latest
+  traffic:
+  - latestRevision: false
+    revisionName: backend-serving
+    percent: 100
+"""
+
+    calls: list[list[str]] = []
+
+    def fake_run(args, *, capture_output=False):
+        calls.append(list(args))
+        if '--format=export' in args:
+            return module.subprocess.CompletedProcess(args, 0, export, '')
+        if '--format=value(status.latestCreatedRevisionName)' in args:
+            return module.subprocess.CompletedProcess(args, 0, 'backend-base\n', '')
+        if args[1:4] == ['run', 'services', 'replace']:
+            return module.subprocess.CompletedProcess(args, 0, '{}', '')
+        if '--format=value(status.url)' in args:
+            return module.subprocess.CompletedProcess(args, 0, 'https://backend.example\n', '')
+        raise AssertionError(args)
+
+    monkeypatch.setattr(module, 'ensure_config_secret', lambda **kwargs: '7')
+    monkeypatch.setattr(module, '_project_number', lambda _project: '1031333818730')
+    monkeypatch.setattr(module, '_run', fake_run)
+
+    module.attach_sidecar(
+        SimpleNamespace(
+            project='based-hardware',
+            region='us-central1',
+            service='backend',
+            base_revision='backend-base',
+            final_revision='backend-final',
+            ingress_container='backend-1',
+            config=config,
+            config_secret='cloud-run-gmp-config',
+            expected_env_state=expected_state,
+            tag='',
+        )
+    )
+
+    assert any(args[1:4] == ['run', 'services', 'replace'] for args in calls)
+
+
 # A project ID in run.googleapis.com/secrets crashes the NEXT gcloud run deploy.
 # Cloud Run accepts the ID and stores it, so nothing fails at attach time and the
 # breakage lands on whoever deploys next. Production carried


### PR DESCRIPTION
## Summary

- Fix `_ingress_literal_env` in `backend/scripts/attach_cloud_run_gmp_sidecar.py` so an env entry with no `value` key resolves to `''` when it is a literal, instead of being dropped from the literal-env map and reported as `<missing>`.
- `valueFrom` (secret-backed) entries remain excluded, but now the exclusion is explicit rather than an accident of the `'value' in raw_entry` test.

## Root cause

Cloud Run's `gcloud run services describe --format=export` omits the `value` key entirely for an env var whose literal value is the empty string -- it never writes `value: ''`. `_ingress_literal_env` treated a missing `value` key as "this entry has no literal value" and skipped it, so `actual.get(name)` came back `None` and `_validate_expected_literal_env` reported the variable as `<missing>` against an expected `''`, raising:

```
ValueError: exported base revision env OMI_PARITY_PACK_ALLOWED_PRINCIPALS mismatch
before GMP sidecar replace: expected '', found '<missing>'
```

This blocked every dev backend deploy that reached the GMP sidecar attach step. Verified against the live dev `backend` service export: of 168 env entries, exactly 3 (`dg-nova-3`, `modulate-velma-2`, `OMI_PARITY_PACK_ALLOWED_PRINCIPALS`) carry neither `value` nor `valueFrom` -- all three are legitimately empty-string literals. A further 60 entries use `valueFrom` for secret references and must stay excluded from the literal map.

## Fix

```python
for raw_entry in raw_env:
    if not isinstance(raw_entry, dict) or not isinstance(raw_entry.get('name'), str):
        continue
    if 'valueFrom' in raw_entry:
        continue  # secret-backed reference, not a literal value
    actual[raw_entry['name']] = _cloud_run_string(raw_entry.get('value', ''))
```

## Tests

Added to `backend/tests/unit/test_attach_cloud_run_gmp_sidecar.py`:

- `test_ingress_literal_env_treats_a_missing_value_key_as_empty_string` -- an entry with a `name` and no `value` key resolves to `''`.
- `test_ingress_literal_env_excludes_valueFrom_secret_references` -- a `valueFrom` entry stays out of the literal map and is not coerced to `''`.
- `test_validate_expected_literal_env_accepts_empty_string_matching_a_missing_value_key` -- the exact production comparison (`expected ''`, entry has no `value` key) no longer raises.
- `test_validate_expected_literal_env_still_fails_closed_for_a_genuinely_absent_var` -- a var that is not in the export at all still reports `<missing>` and still raises.
- `test_attach_accepts_a_literal_cloud_run_omits_for_being_empty` -- end-to-end through `attach_sidecar` with an export shaped like the live dev service (an empty-string literal with no `value` key, plus a `valueFrom` secret entry) proceeds to `services replace` instead of refusing.

Confirmed the new tests fail with the pre-fix reader (reproducing the exact production error message) and pass after the fix; the rest of the suite (31 tests total) is unaffected.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

