### PR TITLE
Fence trigger snapshots on final rollout authority

### DIFF
--- a/backend/routers/jit_rollout.py
+++ b/backend/routers/jit_rollout.py
@@ -80,6 +80,21 @@ class JITTriggerSnapshotEnvelope(BaseModel):
     failure_reason: str | None = None
 
 
+def _disabled_trigger_snapshot(uid: str) -> JITTriggerSnapshotEnvelope:
+    """Return a content-free receipt whenever trigger authority is absent."""
+
+    return JITTriggerSnapshotEnvelope(
+        owner_id=uid,
+        account_generation=0,
+        head_commit_id='',
+        commit_sequence=0,
+        snapshot_revision='',
+        complete=False,
+        rows=[],
+        failure_reason='rollout_not_enabled',
+    )
+
+
 @router.get(_DECISION_PATH, response_model=JITRolloutDecisionEnvelope)
 async def get_jit_rollout_decision(
     uid: str = Depends(get_current_user_uid),
@@ -98,17 +113,18 @@ async def get_jit_trigger_snapshot(
     response.headers['Cache-Control'] = 'no-store'
     decision = await resolve_jit_rollout(uid, stage=JITDecisionStage.READ_ONLY)
     if not decision.permits_work:
-        return JITTriggerSnapshotEnvelope(
-            owner_id=uid,
-            account_generation=0,
-            head_commit_id='',
-            commit_sequence=0,
-            snapshot_revision='',
-            complete=False,
-            rows=[],
-            failure_reason='rollout_not_enabled',
-        )
+        return _disabled_trigger_snapshot(uid)
     snapshot = await run_blocking(db_executor, read_authoritative_trigger_snapshot, uid)
+    # A flag or kill switch can flip while the blocking exhaustive scan is in
+    # flight. Re-resolve uncached immediately before releasing an actionable
+    # snapshot, matching the canonical prompt-snapshot authority fence.
+    final_decision = await resolve_jit_rollout(
+        uid,
+        stage=JITDecisionStage.READ_ONLY,
+        force_refresh=True,
+    )
+    if not final_decision.permits_work:
+        return _disabled_trigger_snapshot(uid)
     return JITTriggerSnapshotEnvelope(
         owner_id=snapshot.owner_id,
         account_generation=snapshot.account_generation,

--- a/backend/tests/unit/test_jit_rollout.py
+++ b/backend/tests/unit/test_jit_rollout.py
@@ -5,7 +5,7 @@ import threading
 from datetime import datetime, timezone
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
 from fastapi.testclient import TestClient
 
 import desktop_backend
@@ -257,6 +257,75 @@ async def test_posthog_decide_coalesces_same_uid_calls():
     results = await asyncio.gather(*tasks)
     assert client.calls == 1
     assert all(result.rollout == TriState.ENABLED for result in results)
+
+
+@pytest.mark.asyncio
+async def test_trigger_snapshot_final_refresh_bypasses_stale_posthog_call(monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+
+    class SequencedPostHog:
+        def __init__(self):
+            self.calls = 0
+
+        def get_feature_variants(self, _uid: str):
+            self.calls += 1
+            if self.calls == 1:
+                started.set()
+                release.wait(1)
+                return {'jit-processing-v1': True, 'jit-processing-kill-switch-v1': False}
+            return {'jit-processing-v1': True, 'jit-processing-kill-switch-v1': True}
+
+    client = SequencedPostHog()
+    provider = PostHogJITFlagProvider(timeout_seconds=1, client_factory=lambda: client)
+    authority = JITRolloutAuthority(provider)
+    stale_call = asyncio.create_task(provider('owner'))
+    for _ in range(100):
+        if started.is_set():
+            break
+        await asyncio.sleep(0.001)
+    assert started.is_set()
+
+    async def resolve(uid: str, *, stage: JITDecisionStage, force_refresh: bool = False):
+        if not force_refresh:
+            evaluation = JITFlagEvaluation(TriState.ENABLED, TriState.DISABLED, JITDecisionReason.EVALUATED)
+            return authority_module._effective_decision(evaluation, cache_hit=False, cache_ttl_seconds=20)
+        return await authority.resolve(uid, stage=stage, force_refresh=True)
+
+    snapshot = AuthoritativeTriggerSnapshot(
+        owner_id='owner',
+        account_generation=7,
+        head_commit_id='head',
+        commit_sequence=11,
+        snapshot_revision='secret-revision',
+        complete=True,
+        rows=(),
+    )
+
+    async def immediate(_executor, function, uid):
+        assert function is jit_rollout.read_authoritative_trigger_snapshot
+        assert uid == 'owner'
+        return snapshot
+
+    monkeypatch.setattr(jit_rollout, 'resolve_jit_rollout', resolve)
+    monkeypatch.setattr(jit_rollout, 'run_blocking', immediate)
+
+    try:
+        response = await asyncio.wait_for(
+            jit_rollout.get_jit_trigger_snapshot(Response(), uid='owner'),
+            timeout=1,
+        )
+    finally:
+        release.set()
+
+    stale_result = await stale_call
+    assert stale_result.rollout == TriState.ENABLED
+    assert stale_result.kill_switch == TriState.DISABLED
+    assert client.calls == 2
+    assert response.complete is False
+    assert response.rows == []
+    assert response.snapshot_revision == ''
+    assert response.failure_reason == 'rollout_not_enabled'
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_jit_rollout.py
+++ b/backend/tests/unit/test_jit_rollout.py
@@ -410,7 +410,10 @@ def test_trigger_snapshot_is_owner_authenticated_default_off_and_never_reads_mem
 
 
 def test_trigger_snapshot_serializes_exhaustive_action_receipt(monkeypatch):
+    observed: list[bool] = []
+
     async def resolve(uid: str, *, stage: JITDecisionStage, force_refresh: bool = False):
+        observed.append(force_refresh)
         evaluation = JITFlagEvaluation(TriState.ENABLED, TriState.DISABLED, JITDecisionReason.EVALUATED)
         return authority_module._effective_decision(evaluation, cache_hit=False, cache_ttl_seconds=20)
 
@@ -458,3 +461,104 @@ def test_trigger_snapshot_serializes_exhaustive_action_receipt(monkeypatch):
         'prompt': 'Give the next release step.',
     }
     assert '"action"' in payload['rows'][0]['trigger_condition_json']
+    assert observed == [False, True]
+
+
+@pytest.mark.parametrize(
+    ('rollout', 'kill_switch'),
+    [
+        (TriState.DISABLED, TriState.DISABLED),
+        (TriState.ENABLED, TriState.ENABLED),
+    ],
+    ids=['rollout-disabled-during-scan', 'kill-switch-enabled-during-scan'],
+)
+def test_trigger_snapshot_final_authority_fence_discards_scan_after_disable_or_kill(monkeypatch, rollout, kill_switch):
+    observed: list[bool] = []
+
+    async def resolve(uid: str, *, stage: JITDecisionStage, force_refresh: bool = False):
+        assert uid == 'owner'
+        observed.append(force_refresh)
+        evaluation = (
+            JITFlagEvaluation(TriState.ENABLED, TriState.DISABLED, JITDecisionReason.EVALUATED)
+            if not force_refresh
+            else JITFlagEvaluation(rollout, kill_switch, JITDecisionReason.EVALUATED)
+        )
+        return authority_module._effective_decision(evaluation, cache_hit=False, cache_ttl_seconds=20)
+
+    snapshot = AuthoritativeTriggerSnapshot(
+        owner_id='owner',
+        account_generation=7,
+        head_commit_id='head',
+        commit_sequence=11,
+        snapshot_revision='secret-revision',
+        complete=True,
+        rows=(),
+    )
+
+    async def immediate(_executor, function, uid):
+        assert function is jit_rollout.read_authoritative_trigger_snapshot
+        assert uid == 'owner'
+        return snapshot
+
+    monkeypatch.setattr(jit_rollout, 'resolve_jit_rollout', resolve)
+    monkeypatch.setattr(jit_rollout, 'run_blocking', immediate)
+    app = FastAPI()
+    app.include_router(jit_rollout.router)
+    app.dependency_overrides[get_current_user_uid] = lambda: 'owner'
+
+    payload = TestClient(app).get('/v1/jit/trigger-snapshot').json()
+
+    assert observed == [False, True]
+    assert payload == {
+        'owner_id': 'owner',
+        'account_generation': 0,
+        'head_commit_id': '',
+        'commit_sequence': 0,
+        'snapshot_revision': '',
+        'complete': False,
+        'rows': [],
+        'failure_reason': 'rollout_not_enabled',
+    }
+
+
+def test_trigger_snapshot_preserves_owner_generation_failure_as_non_actionable(monkeypatch):
+    observed: list[bool] = []
+
+    async def resolve(uid: str, *, stage: JITDecisionStage, force_refresh: bool = False):
+        assert uid == 'owner'
+        observed.append(force_refresh)
+        evaluation = JITFlagEvaluation(TriState.ENABLED, TriState.DISABLED, JITDecisionReason.EVALUATED)
+        return authority_module._effective_decision(evaluation, cache_hit=False, cache_ttl_seconds=20)
+
+    stale_snapshot = AuthoritativeTriggerSnapshot(
+        owner_id='owner',
+        account_generation=7,
+        head_commit_id='head-before-transition',
+        commit_sequence=11,
+        snapshot_revision='',
+        complete=False,
+        rows=(),
+        failure_reason='authority_changed',
+    )
+
+    async def immediate(_executor, function, uid):
+        assert function is jit_rollout.read_authoritative_trigger_snapshot
+        assert uid == 'owner'
+        return stale_snapshot
+
+    monkeypatch.setattr(jit_rollout, 'resolve_jit_rollout', resolve)
+    monkeypatch.setattr(jit_rollout, 'run_blocking', immediate)
+    app = FastAPI()
+    app.include_router(jit_rollout.router)
+    app.dependency_overrides[get_current_user_uid] = lambda: 'owner'
+
+    payload = TestClient(app).get('/v1/jit/trigger-snapshot').json()
+
+    assert observed == [False, True]
+    assert payload['owner_id'] == 'owner'
+    assert payload['account_generation'] == 7
+    assert payload['head_commit_id'] == 'head-before-transition'
+    assert payload['complete'] is False
+    assert payload['rows'] == []
+    assert payload['snapshot_revision'] == ''
+    assert payload['failure_reason'] == 'authority_changed'

--- a/backend/utils/jit_rollout.py
+++ b/backend/utils/jit_rollout.py
@@ -21,7 +21,7 @@ from collections.abc import Awaitable, Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 from utils.executors import run_blocking
 
@@ -130,6 +130,13 @@ class JITRolloutDecision:
 FlagProvider = Callable[[str], Awaitable[JITFlagEvaluation]]
 
 
+@runtime_checkable
+class _ForceRefreshProvider(Protocol):
+    """Optional provider seam for uncached authority reads."""
+
+    def force_refresh(self, uid: str) -> Awaitable[JITFlagEvaluation]: ...
+
+
 @dataclass(frozen=True)
 class _CacheEntry:
     evaluation: JITFlagEvaluation
@@ -208,7 +215,10 @@ class JITRolloutAuthority:
                     return decision
                 del self._cache[uid]
 
-        evaluation = await self._provider(uid)
+        if force_refresh and isinstance(self._provider, _ForceRefreshProvider):
+            evaluation = await self._provider.force_refresh(uid)
+        else:
+            evaluation = await self._provider(uid)
         finished_at = self._monotonic()
         # Cache only complete provider answers. Unknown/error snapshots retry on
         # the next request instead of extending an outage into an authorization.
@@ -325,6 +335,14 @@ class PostHogJITFlagProvider:
 
             in_flight.add_done_callback(forget)
         return await asyncio.shield(entry[0])
+
+    async def force_refresh(self, uid: str) -> JITFlagEvaluation:
+        """Read flags independently of any stale same-owner coalesced call."""
+
+        # A final authority fence must not join a request that started before a
+        # kill switch changed. Keep the bulkhead and provider timeout, but use a
+        # fresh in-flight task rather than the normal same-UID coalescer.
+        return await self._resolve_uncached(uid, asyncio.Event())
 
     async def _resolve_uncached(self, uid: str, control_done: asyncio.Event) -> JITFlagEvaluation:
         try:


### PR DESCRIPTION
## Summary

- re-check backend-owned rollout authority after the blocking trigger snapshot scan
- bypass stale same-owner PostHog in-flight work for that final authority fence
- fail closed with a content-free, non-authoritative snapshot if rollout disables, the kill switch activates, or owner/generation authority changes during the scan
- retain the existing bounded PostHog bulkhead, queue timeout, provider timeout, normal-request coalescing, and `Cache-Control: no-store`

## Product invariants

- No trigger content leaves the backend after final authority becomes disabled, killed, unknown, or stale.
- A final kill-switch check is an independent provider read, not a join to work that began before the switch changed.
- Normal rollout reads remain bounded and coalesced; this slice creates no cohort and changes no flag.
- Legacy context-bucket fallback and all default-off behavior remain intact.

## Product invariants affected

- INV-AGENT-*
- INV-AUTH-1
- INV-CHAT-1
- INV-DATA-1
- INV-MEM-3
- INV-MEM-1
- INV-MEM-4
- INV-TASK-2

## Failure class

Failure-Class: FC-split-mutation-authority

Line-Count-Exception: backend/database/conversations.py | 1926 -> 1938 | inherited unchanged from the stacked JIT conversation and first-open authority prerequisite
Line-Count-Exception: backend/database/memory_apply_store.py | 1932 -> 2063 | inherited unchanged from the stacked canonical ledger apply authority prerequisite
Line-Count-Exception: backend/routers/chat.py | 1913 -> 1928 | inherited unchanged from the stacked guarded ledger chat adoption prerequisite
Line-Count-Exception: backend/routers/conversations.py | 1849 -> 1886 | inherited unchanged from the stacked first-open dispatch prerequisite
Line-Count-Exception: backend/utils/conversations/process_conversation.py | 2311 -> 2400 | inherited unchanged from the stacked first-open convergence prerequisite
Line-Count-Exception: backend/utils/memory/canonical_memory_adapter.py | 2606 -> 2825 | inherited unchanged from the stacked canonical ledger compatibility prerequisite
Line-Count-Exception: backend/utils/memory/memory_service.py | 2891 -> 3433 | inherited unchanged from the stacked canonical ledger read-write authority prerequisite
Line-Count-Exception: backend/utils/retrieval/agentic.py | 1548 -> 1586 | inherited unchanged from the stacked bounded retrieval prerequisite
Line-Count-Exception: desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift | 3481 -> 3490 | inherited unchanged from the stacked JIT receipt prerequisite

## Verification

- publication head: `47f022fd2c`
- transplanted patch ID exactly matches independently reviewed head `0a67afd7be31ee9d97b6ee4febcced55b642545a`; all three changed file contents are byte-identical
- independent exact-tree review: no P0-P3 findings
- 30 combined rollout and trigger-snapshot tests passed
- stale same-owner timing falsification passed 12/12 repetitions
- focused coalescing, timeout, bulkhead, final-disable, final-kill, and owner/generation tests passed
- Black and `git diff --check` passed
- no PostHog mutation, cohort activation, deployment, migration, rollback execution, or deletion occurred


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

