### PR TITLE
fix(stt): count words in the text, not entries in the list, when verifying a speaker sample

### DIFF
--- a/backend/tests/unit/test_speaker_sample.py
+++ b/backend/tests/unit/test_speaker_sample.py
@@ -372,3 +372,84 @@ def test_verify_and_transcribe_sample_empty_transcript(monkeypatch):
     assert transcript is None
     assert is_valid is False
     assert reason == "insufficient_words: 0/5"
+
+
+# --- provider granularity: the counts are over words, not over list entries ------------------------
+#
+# A transcriber may return either granularity, and both are legitimate. Deepgram emits one entry per
+# word, so counting entries and counting words are the same number there. Parakeet emits one entry per
+# SEGMENT with the whole utterance inside — measured against a live parakeet on a 24.9s sample, its
+# /v2/transcribe response carries `segments: 1` and no `words` field at all. Counting entries therefore
+# read 1, and every parakeet-backed sample was rejected as `insufficient_words` whatever it contained;
+# the same miscount made the multi-speaker ratio 1.0 on a single entry, so that guard stopped rejecting
+# instead of stopping bad samples.
+
+
+def _make_segments(texts, speakers=None):
+    """One entry per segment, each carrying several words — what parakeet returns."""
+    segments = []
+    for index, text in enumerate(texts):
+        segment = {"text": text}
+        if speakers is not None:
+            segment["speaker"] = speakers[index]
+        segments.append(segment)
+    return segments
+
+
+def test_a_single_segment_is_counted_by_its_words_not_as_one_entry(monkeypatch):
+    segments = _make_segments(["hester prynne went one day to the mansion"], speakers=["SPEAKER_00"])
+
+    monkeypatch.setattr(speaker_sample, "deepgram_prerecorded_from_bytes", lambda *_a, **_k: segments)
+
+    transcript, is_valid, reason = asyncio.run(speaker_sample.verify_and_transcribe_sample(b"audio", 16000))
+
+    assert (is_valid, reason) == (True, "ok")
+    assert transcript == "hester prynne went one day to the mansion"
+
+
+def test_word_granular_and_segment_granular_agree_on_the_same_utterance(monkeypatch):
+    """The same eight words, split two ways, must produce the same verdict."""
+    words = " one two three four five six seven eight".split()
+
+    monkeypatch.setattr(speaker_sample, "deepgram_prerecorded_from_bytes", lambda *_a, **_k: _make_words(words))
+    per_word = asyncio.run(speaker_sample.verify_and_transcribe_sample(b"audio", 16000))
+
+    monkeypatch.setattr(
+        speaker_sample, "deepgram_prerecorded_from_bytes", lambda *_a, **_k: _make_segments([" ".join(words)])
+    )
+    per_segment = asyncio.run(speaker_sample.verify_and_transcribe_sample(b"audio", 16000))
+
+    assert per_word[1:] == per_segment[1:] == (True, "ok")
+
+
+def test_a_segment_short_of_the_floor_is_still_refused(monkeypatch):
+    """The fix must not turn the word floor off: four words in one entry still fail."""
+    monkeypatch.setattr(
+        speaker_sample,
+        "deepgram_prerecorded_from_bytes",
+        lambda *_a, **_k: _make_segments(["thanks for joining today"]),
+    )
+
+    transcript, is_valid, reason = asyncio.run(speaker_sample.verify_and_transcribe_sample(b"audio", 16000))
+
+    assert (transcript, is_valid) == (None, False)
+    assert reason == f"insufficient_words: 4/{speaker_sample.MIN_WORDS}"
+
+
+def test_the_dominant_ratio_weighs_segments_by_their_words(monkeypatch):
+    """Two segments, one long and one short: counting entries would call it a 50/50 split.
+
+    Entry counting gives ratio 0.50 and rejects a sample that is 90% one speaker; word counting
+    gives 0.90 and accepts it. The inverse case — one entry per speaker with equal weight — is what
+    used to let a genuinely mixed sample through on a single-segment provider.
+    """
+    segments = _make_segments(
+        ["one two three four five six seven eight nine", "interrupting"],
+        speakers=["SPEAKER_00", "SPEAKER_01"],
+    )
+
+    monkeypatch.setattr(speaker_sample, "deepgram_prerecorded_from_bytes", lambda *_a, **_k: segments)
+
+    _transcript, is_valid, reason = asyncio.run(speaker_sample.verify_and_transcribe_sample(b"audio", 16000))
+
+    assert (is_valid, reason) == (True, "ok")

--- a/backend/utils/speaker_sample.py
+++ b/backend/utils/speaker_sample.py
@@ -56,15 +56,26 @@ async def verify_and_transcribe_sample(
         raw_words = cast(Any, raw_words[0])
     words: List[Dict[str, Any]] = cast(List[Dict[str, Any]], raw_words)
 
-    if len(words) < MIN_WORDS:
-        return None, False, f"insufficient_words: {len(words)}/{MIN_WORDS}"
+    # Count words in the text, not entries in the list. A transcriber is free to return either
+    # granularity: Deepgram emits one entry per word, so the two are the same number there, but
+    # parakeet emits one entry per SEGMENT with the whole utterance inside. Measured on a 24.9s
+    # sample: parakeet returns segments=1 and no word field, so the entry count read 1 and every
+    # sample was rejected as `insufficient_words` no matter what it contained. The same miscount
+    # made the multi-speaker guard inert rather than strict — one entry means ratio 1.0, so a
+    # sample carrying two voices passed. Both are unchanged for a word-granular provider.
+    def _words_in(entry: Dict[str, Any]) -> int:
+        return len((entry.get('text') or '').split())
+
+    total_words = sum(_words_in(word) for word in words)
+
+    if total_words < MIN_WORDS:
+        return None, False, f"insufficient_words: {total_words}/{MIN_WORDS}"
 
     speaker_counts: Dict[str, int] = {}
     for word in words:
         speaker = word.get('speaker', 'SPEAKER_00')
-        speaker_counts[speaker] = speaker_counts.get(speaker, 0) + 1
+        speaker_counts[speaker] = speaker_counts.get(speaker, 0) + _words_in(word)
 
-    total_words = len(words)
     dominant_count = max(speaker_counts.values()) if speaker_counts else 0
     dominant_ratio = dominant_count / total_words if total_words > 0 else 0
 


### PR DESCRIPTION
`verify_and_transcribe_sample` decides a sample's fate with `len(words)`, where `words` is whatever
the pre-recorded transcriber returned. Deepgram emits one entry per word, so entry count and word
count are the same number there and everything works. Parakeet emits one entry per SEGMENT with the
whole utterance inside — a 24.9s sample comes back from its `/v2/transcribe` as `segments: 1`, with
no `words` field at all.

So with `STT_PRERECORDED_MODEL=parakeet` the count reads 1 and every sample is rejected as
`insufficient_words: 1/5` regardless of what it contains. Nothing is ever stored, no person reaches
`speech_samples_version >= 3`, and `routers/listen/speakers.py` therefore loads nobody: speaker
identification across conversations cannot work at all on that provider.

The same miscount runs the other way in the multi-speaker guard. `speaker_counts` adds 1 per entry,
so a single-segment sample has a dominant ratio of exactly 1.0 — the check meant to reject a sample
carrying two voices stops rejecting anything. That one is a false pass, which is the worse of the two.

Both now weigh each entry by the words in its text. For a word-granular provider this is arithmetic
that cannot change: each entry contributes 1, so every count is what it was. The sixteen existing
tests in test_speaker_sample.py pass untouched, which is the evidence that Deepgram behaviour is
unaffected.

## Source for the expected values

Measured against a live parakeet built from this repo's own `backend/parakeet/Dockerfile.oss`, not
inferred: `POST /v2/transcribe` with a 24.9s 16 kHz mono WAV returns
`{"text": ..., "segments": [{...}], "detected_language": ...}` — one segment, no `words` key. The
client at `utils/stt/pre_recorded.py:883-902` then builds one list entry per segment, which is
correct for what the API provides.

## Verification

- `tests/unit/test_speaker_sample.py` — 20 passed. The four new cases fail on this branch's
  merge-base and the sixteen existing ones pass on both sides.
- End to end on a live stack (parakeet + a pyannote diarizer), tagging a person in one conversation
  and asking for recognition in a second one built from a different half of the same 24.9s recording:
  before, `insufficient_words: 1/5` and nothing stored; after, the sample stores, the person reaches
  version 3, an embedding is written, the next session loads the person, and the segment matches.

Failure-Class: none


## Context

Found while reproducing #4455 ("Diarization doesn't work through different conversations throughout
the day") on a parakeet-backed deployment. This is not that issue — #4455 describes the user-visible
symptom and has other causes worth their own discussion (the one-sample-per-person cap, and nine
silent exits inside a background task that has already returned 200). This is one mechanism that
produces it, and it is provider-specific, so it is sent on its own.

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

