### PR TITLE
feat: PostHog referral funnel and admin grants tile

### DIFF
--- a/backend/database/referrals.py
+++ b/backend/database/referrals.py
@@ -14,23 +14,23 @@ def claim_referral_trial(
     *,
     is_new_user: bool,
     firestore_client: Any | None = None,
-) -> bool:
+) -> tuple[bool, str]:
     """Atomically grant the referred account its one-time 30-day Operator entitlement."""
     client = firestore_client or get_customer_firestore_client()
     user_ref = client.collection('users').document(referred_uid)
 
     @firestore.transactional
-    def apply(transaction: Any) -> bool:
+    def apply(transaction: Any) -> tuple[bool, str]:
         snapshot = user_ref.get(transaction=transaction)
-        patch = referral_claim_patch(
+        patch, reason = referral_claim_patch(
             referred_uid=referred_uid,
             referrer_uid=referrer_uid,
             is_new_user=is_new_user,
             user_data=snapshot.to_dict() if snapshot.exists else None,
         )
         if patch is None:
-            return False
+            return False, reason
         transaction.set(user_ref, patch, merge=True)
-        return True
+        return True, reason
 
-    return bool(run_transactional(client, apply))
+    return run_transactional(client, apply)

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -22,7 +22,8 @@ from utils.http_client import get_auth_client
 from utils.log_sanitizer import sanitize
 from utils.metrics import AUTH_FLOW_DURATION_SECONDS, AUTH_FLOW_EVENTS
 from utils.observability.fallback import record_fallback
-from utils.referrals import REFERRAL_COOKIE_NAME, ReferralCodeError, referrer_uid_from_code
+from utils.integration_telemetry import emit_posthog_event
+from utils.referrals import REFERRAL_COOKIE_NAME, REFERRAL_PROGRAM, ReferralCodeError, referrer_uid_from_code
 import logging
 
 logger = logging.getLogger(__name__)
@@ -1109,12 +1110,17 @@ async def _generate_custom_token(
         if referral_code and result.get('isNewUser') is True:
             try:
                 referrer_uid = referrer_uid_from_code(referral_code)
-                await run_blocking(
+                claimed, reason = await run_blocking(
                     db_executor,
                     claim_referral_trial,
                     firebase_uid,
                     referrer_uid,
                     is_new_user=True,
+                )
+                emit_posthog_event(
+                    firebase_uid,
+                    'Referral Claimed',
+                    {'program': REFERRAL_PROGRAM, 'claimed': claimed, 'reason': reason},
                 )
             except Exception as error:
                 logger.error("Referral entitlement grant failed (non-fatal): %s", sanitize(str(error)))

--- a/backend/routers/referrals.py
+++ b/backend/routers/referrals.py
@@ -8,6 +8,7 @@ from utils.other import endpoints as auth
 from utils.referrals import (
     REFERRAL_COOKIE_MAX_AGE_SECONDS,
     REFERRAL_COOKIE_NAME,
+    REFERRAL_PROGRAM,
     REFERRAL_TRIAL_DAYS,
     ReferralCodeError,
     is_new_referral_account,
@@ -15,6 +16,7 @@ from utils.referrals import (
     referral_signup_url,
     referrer_uid_from_code,
 )
+from utils.integration_telemetry import emit_posthog_event
 
 router = APIRouter(tags=['referrals'])
 
@@ -35,15 +37,17 @@ class ReferralClaimResponse(BaseModel):
 @router.get('/v1/users/me/referral', response_model=ReferralLinkResponse)
 def get_referral_link(uid: str = Depends(auth.get_current_user_uid)) -> ReferralLinkResponse:
     try:
-        return ReferralLinkResponse(referral_url=referral_link(uid))
+        response = ReferralLinkResponse(referral_url=referral_link(uid))
     except ReferralCodeError as error:
         raise HTTPException(status_code=503, detail='Referral links are temporarily unavailable') from error
+    emit_posthog_event(uid, 'Referral Link Issued', {'program': REFERRAL_PROGRAM})
+    return response
 
 
 @router.get('/r/{code}', response_class=RedirectResponse)
 def capture_referral(code: str) -> RedirectResponse:
     try:
-        referrer_uid_from_code(code)
+        referrer_uid = referrer_uid_from_code(code)
     except ReferralCodeError as error:
         raise HTTPException(status_code=404, detail='Referral link not found') from error
 
@@ -57,6 +61,7 @@ def capture_referral(code: str) -> RedirectResponse:
         samesite='lax',
         path='/',
     )
+    emit_posthog_event(referrer_uid, 'Referral Link Captured', {'program': REFERRAL_PROGRAM})
     return response
 
 
@@ -72,9 +77,14 @@ def claim_referral(
 
     user = firebase_admin.auth.get_user(uid)
     creation_timestamp = getattr(getattr(user, 'user_metadata', None), 'creation_timestamp', None)
-    claimed = claim_referral_trial(
+    claimed, reason = claim_referral_trial(
         uid,
         referrer_uid,
         is_new_user=is_new_referral_account(creation_timestamp),
+    )
+    emit_posthog_event(
+        uid,
+        'Referral Claimed',
+        {'program': REFERRAL_PROGRAM, 'claimed': claimed, 'reason': reason},
     )
     return ReferralClaimResponse(claimed=claimed, trial_days=REFERRAL_TRIAL_DAYS)

--- a/backend/tests/unit/test_referrals.py
+++ b/backend/tests/unit/test_referrals.py
@@ -190,9 +190,17 @@ def test_referral_claim_marks_an_existing_authenticated_account_ineligible(monke
     ]
 
 
-def test_referral_claim_emits_self_refer_reason(monkeypatch):
+@pytest.mark.parametrize(
+    ('uid', 'referrer_uid', 'reason'),
+    [
+        ('same-user', 'same-user', 'self_refer'),
+        ('paid-user', 'referrer-123', 'paid'),
+        ('claimed-user', 'referrer-123', 'already_claimed'),
+    ],
+)
+def test_referral_claim_emits_ineligible_reason(monkeypatch, uid, referrer_uid, reason):
     monkeypatch.setenv('ENCRYPTION_SECRET', TEST_SECRET.decode())
-    code = create_referral_code('same-user')
+    code = create_referral_code(referrer_uid)
     now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
 
     with _loaded_referrals_router() as referrals:
@@ -202,16 +210,16 @@ def test_referral_claim_emits_self_refer_reason(monkeypatch):
             'get_user',
             lambda _uid: SimpleNamespace(user_metadata=SimpleNamespace(creation_timestamp=now_ms)),
         )
-        monkeypatch.setattr(referrals, 'claim_referral_trial', lambda *_args, **_kwargs: (False, 'self_refer'))
+        monkeypatch.setattr(referrals, 'claim_referral_trial', lambda *_args, **_kwargs: (False, reason))
         monkeypatch.setattr(referrals, 'emit_posthog_event', lambda *event: events.append(event))
-        response = referrals.claim_referral(referrals.ReferralClaimRequest(code=code), 'same-user')
+        response = referrals.claim_referral(referrals.ReferralClaimRequest(code=code), uid)
 
     assert response.claimed is False
     assert events == [
         (
-            'same-user',
+            uid,
             'Referral Claimed',
-            {'program': 'desktop_operator_month_v1', 'claimed': False, 'reason': 'self_refer'},
+            {'program': 'desktop_operator_month_v1', 'claimed': False, 'reason': reason},
         )
     ]
 

--- a/backend/tests/unit/test_referrals.py
+++ b/backend/tests/unit/test_referrals.py
@@ -42,7 +42,7 @@ def test_referral_code_round_trips_and_rejects_tampering():
 def test_referral_claim_grants_exactly_30_days_of_operator():
     now = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
 
-    patch = referral_claim_patch(
+    patch, reason = referral_claim_patch(
         referred_uid='new-user',
         referrer_uid='referrer',
         is_new_user=True,
@@ -51,6 +51,7 @@ def test_referral_claim_grants_exactly_30_days_of_operator():
     )
 
     assert patch is not None
+    assert reason == 'granted'
     assert patch['subscription']['plan'] == 'operator'
     assert patch['subscription']['status'] == 'active'
     assert patch['subscription']['cancel_at_period_end'] is True
@@ -60,26 +61,25 @@ def test_referral_claim_grants_exactly_30_days_of_operator():
 
 
 @pytest.mark.parametrize(
-    ('referred_uid', 'referrer_uid', 'is_new_user', 'user_data'),
+    ('referred_uid', 'referrer_uid', 'is_new_user', 'user_data', 'expected_reason'),
     [
-        ('same-user', 'same-user', True, {}),
-        ('existing-user', 'referrer', False, {}),
-        ('paid-user', 'referrer', True, {'subscription': {'plan': 'operator'}}),
-        ('claimed-user', 'referrer', True, {'referral': {'program': 'desktop_operator_month_v1'}}),
+        ('same-user', 'same-user', True, {}, 'self_refer'),
+        ('existing-user', 'referrer', False, {}, 'existing_account'),
+        ('paid-user', 'referrer', True, {'subscription': {'plan': 'operator'}}, 'paid'),
+        ('claimed-user', 'referrer', True, {'referral': {'program': 'desktop_operator_month_v1'}}, 'already_claimed'),
     ],
 )
 def test_referral_claim_never_self_refers_rewards_existing_users_or_overwrites_paid_accounts(
-    referred_uid, referrer_uid, is_new_user, user_data
+    referred_uid, referrer_uid, is_new_user, user_data, expected_reason
 ):
-    assert (
-        referral_claim_patch(
-            referred_uid=referred_uid,
-            referrer_uid=referrer_uid,
-            is_new_user=is_new_user,
-            user_data=user_data,
-        )
-        is None
+    patch, reason = referral_claim_patch(
+        referred_uid=referred_uid,
+        referrer_uid=referrer_uid,
+        is_new_user=is_new_user,
+        user_data=user_data,
     )
+    assert patch is None
+    assert reason == expected_reason
 
 
 def test_referral_link_captures_secure_cookie_and_opens_signup_before_download(monkeypatch):
@@ -88,6 +88,8 @@ def test_referral_link_captures_secure_cookie_and_opens_signup_before_download(m
     code = create_referral_code('referrer-123')
 
     with _loaded_referrals_router() as referrals:
+        events = []
+        monkeypatch.setattr(referrals, 'emit_posthog_event', lambda *event: events.append(event))
         response = referrals.capture_referral(code)
 
     assert response.status_code == 302
@@ -97,6 +99,21 @@ def test_referral_link_captures_secure_cookie_and_opens_signup_before_download(m
     assert 'HttpOnly' in cookie
     assert 'Secure' in cookie
     assert 'SameSite=lax' in cookie
+    assert events == [('referrer-123', 'Referral Link Captured', {'program': 'desktop_operator_month_v1'})]
+
+
+def test_unknown_referral_link_does_not_emit_capture(monkeypatch):
+    monkeypatch.setenv('ENCRYPTION_SECRET', TEST_SECRET.decode())
+
+    with _loaded_referrals_router() as referrals:
+        events = []
+        monkeypatch.setattr(referrals, 'emit_posthog_event', lambda *event: events.append(event))
+
+        with pytest.raises(HTTPException) as error:
+            referrals.capture_referral('invalid')
+
+    assert error.value.status_code == 404
+    assert events == []
 
 
 def test_dev_referral_opens_signup_against_the_dev_backend(monkeypatch):
@@ -115,6 +132,7 @@ def test_referral_claim_grants_trial_only_to_a_fresh_authenticated_account(monke
     code = create_referral_code('referrer-123')
     now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
     claims = []
+    events = []
 
     with _loaded_referrals_router() as referrals:
         monkeypatch.setattr(
@@ -126,13 +144,17 @@ def test_referral_claim_grants_trial_only_to_a_fresh_authenticated_account(monke
             referrals,
             'claim_referral_trial',
             lambda referred_uid, referrer_uid, *, is_new_user: claims.append((referred_uid, referrer_uid, is_new_user))
-            or True,
+            or (True, 'granted'),
         )
+        monkeypatch.setattr(referrals, 'emit_posthog_event', lambda *event: events.append(event))
         response = referrals.claim_referral(referrals.ReferralClaimRequest(code=code), 'new-user')
 
     assert response.claimed is True
     assert response.trial_days == 30
     assert claims == [('new-user', 'referrer-123', True)]
+    assert events == [
+        ('new-user', 'Referral Claimed', {'program': 'desktop_operator_month_v1', 'claimed': True, 'reason': 'granted'})
+    ]
 
 
 def test_referral_claim_marks_an_existing_authenticated_account_ineligible(monkeypatch):
@@ -140,6 +162,7 @@ def test_referral_claim_marks_an_existing_authenticated_account_ineligible(monke
     code = create_referral_code('referrer-123')
     old_ms = int(datetime(2025, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
     claims = []
+    events = []
 
     with _loaded_referrals_router() as referrals:
         monkeypatch.setattr(
@@ -151,12 +174,46 @@ def test_referral_claim_marks_an_existing_authenticated_account_ineligible(monke
             referrals,
             'claim_referral_trial',
             lambda referred_uid, referrer_uid, *, is_new_user: claims.append((referred_uid, referrer_uid, is_new_user))
-            or False,
+            or (False, 'existing_account'),
         )
+        monkeypatch.setattr(referrals, 'emit_posthog_event', lambda *event: events.append(event))
         response = referrals.claim_referral(referrals.ReferralClaimRequest(code=code), 'existing-user')
 
     assert response.claimed is False
     assert claims == [('existing-user', 'referrer-123', False)]
+    assert events == [
+        (
+            'existing-user',
+            'Referral Claimed',
+            {'program': 'desktop_operator_month_v1', 'claimed': False, 'reason': 'existing_account'},
+        )
+    ]
+
+
+def test_referral_claim_emits_self_refer_reason(monkeypatch):
+    monkeypatch.setenv('ENCRYPTION_SECRET', TEST_SECRET.decode())
+    code = create_referral_code('same-user')
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+
+    with _loaded_referrals_router() as referrals:
+        events = []
+        monkeypatch.setattr(
+            referrals.firebase_admin.auth,
+            'get_user',
+            lambda _uid: SimpleNamespace(user_metadata=SimpleNamespace(creation_timestamp=now_ms)),
+        )
+        monkeypatch.setattr(referrals, 'claim_referral_trial', lambda *_args, **_kwargs: (False, 'self_refer'))
+        monkeypatch.setattr(referrals, 'emit_posthog_event', lambda *event: events.append(event))
+        response = referrals.claim_referral(referrals.ReferralClaimRequest(code=code), 'same-user')
+
+    assert response.claimed is False
+    assert events == [
+        (
+            'same-user',
+            'Referral Claimed',
+            {'program': 'desktop_operator_month_v1', 'claimed': False, 'reason': 'self_refer'},
+        )
+    ]
 
 
 def test_referral_claim_rejects_an_invalid_code_before_loading_the_user(monkeypatch):
@@ -187,6 +244,8 @@ def test_authenticated_referrer_receives_a_stable_unique_https_link(monkeypatch)
     monkeypatch.delenv('REFERRAL_PUBLIC_BASE_URL', raising=False)
 
     with _loaded_referrals_router() as referrals:
+        events = []
+        monkeypatch.setattr(referrals, 'emit_posthog_event', lambda *event: events.append(event))
         first = referrals.get_referral_link('referrer-123').referral_url
         second = referrals.get_referral_link('referrer-123').referral_url
         other = referrals.get_referral_link('another-user').referral_url
@@ -194,6 +253,11 @@ def test_authenticated_referrer_receives_a_stable_unique_https_link(monkeypatch)
     assert first == second
     assert first != other
     assert first.startswith('https://omi.me/r/ref1.')
+    assert events == [
+        ('referrer-123', 'Referral Link Issued', {'program': 'desktop_operator_month_v1'}),
+        ('referrer-123', 'Referral Link Issued', {'program': 'desktop_operator_month_v1'}),
+        ('another-user', 'Referral Link Issued', {'program': 'desktop_operator_month_v1'}),
+    ]
 
 
 def test_authenticated_referrer_uses_configured_dev_public_origin(monkeypatch):
@@ -229,6 +293,7 @@ async def test_new_user_auth_redeems_captured_referral(monkeypatch):
     monkeypatch.setenv('FIREBASE_API_KEY', 'test-key')
     referral_code = create_referral_code('referrer-123')
     claims = []
+    events = []
 
     class Response:
         status_code = 200
@@ -245,13 +310,14 @@ async def test_new_user_auth_redeems_captured_referral(monkeypatch):
 
     def claim(referred_uid, referrer_uid, *, is_new_user):
         claims.append((referred_uid, referrer_uid, is_new_user))
-        return True
+        return True, 'granted'
 
     async def run_inline(_executor, function, *args, **kwargs):
         return function(*args, **kwargs)
 
     monkeypatch.setattr(auth, 'get_auth_client', lambda: Client())
     monkeypatch.setattr(auth, 'claim_referral_trial', claim)
+    monkeypatch.setattr(auth, 'emit_posthog_event', lambda *event: events.append(event))
     monkeypatch.setattr(auth, 'run_blocking', run_inline)
     monkeypatch.setattr(auth.firebase_admin.auth, 'create_custom_token', lambda _uid: b'custom-token', raising=False)
 
@@ -259,6 +325,9 @@ async def test_new_user_auth_redeems_captured_referral(monkeypatch):
 
     assert token == 'custom-token'
     assert claims == [('new-user', 'referrer-123', True)]
+    assert events == [
+        ('new-user', 'Referral Claimed', {'program': 'desktop_operator_month_v1', 'claimed': True, 'reason': 'granted'})
+    ]
 
 
 @pytest.mark.asyncio

--- a/backend/utils/referrals.py
+++ b/backend/utils/referrals.py
@@ -16,6 +16,7 @@ REFERRAL_COOKIE_MAX_AGE_SECONDS = 30 * 24 * 60 * 60
 REFERRAL_TRIAL_DAYS = 30
 REFERRAL_SIGNUP_URL = 'https://app.omi.me/login'
 REFERRAL_NEW_USER_WINDOW_SECONDS = 15 * 60
+REFERRAL_PROGRAM = 'desktop_operator_month_v1'
 
 _CODE_PREFIX = 'ref1'
 _UID_PATTERN = re.compile(r'^[A-Za-z0-9:_-]{1,128}$')
@@ -119,18 +120,20 @@ def referral_claim_patch(
     is_new_user: bool,
     user_data: Optional[dict[str, Any]],
     now: Optional[datetime] = None,
-) -> Optional[dict[str, Any]]:
-    """Return the one-time referral entitlement, or None when the account is ineligible."""
-    if not is_new_user or referred_uid == referrer_uid:
-        return None
+) -> tuple[Optional[dict[str, Any]], str]:
+    """Return the referral entitlement patch and its privacy-safe outcome reason."""
+    if not is_new_user:
+        return None, 'existing_account'
+    if referred_uid == referrer_uid:
+        return None, 'self_refer'
 
     existing = user_data or {}
     if existing.get('referral'):
-        return None
+        return None, 'already_claimed'
 
     subscription = existing.get('subscription')
     if isinstance(subscription, dict) and subscription.get('plan') in _PAID_PLAN_VALUES:
-        return None
+        return None, 'paid'
 
     started_at = now or datetime.now(timezone.utc)
     if started_at.tzinfo is None:
@@ -146,9 +149,9 @@ def referral_claim_patch(
             'cancel_at_period_end': True,
         },
         'referral': {
-            'program': 'desktop_operator_month_v1',
+            'program': REFERRAL_PROGRAM,
             'referrer_uid': referrer_uid,
             'claimed_at': started_epoch,
             'trial_ends_at': ends_epoch,
         },
-    }
+    }, 'granted'

--- a/web/admin/app/(protected)/dashboard/classic/page.tsx
+++ b/web/admin/app/(protected)/dashboard/classic/page.tsx
@@ -121,7 +121,12 @@ interface DailyNewUsersData {
 }
 
 interface MessageRatingsData {
-  data: { date: string; thumbs_up: number; thumbs_down: number; ratio: number }[];
+  data: {
+    date: string;
+    thumbs_up: number;
+    thumbs_down: number;
+    ratio: number;
+  }[];
   days: number;
 }
 
@@ -203,7 +208,12 @@ interface DauTrendsData {
 }
 
 interface CrashRateData {
-  data: { date: string; crashes: number; users: number; crashFreeRate: number }[];
+  data: {
+    date: string;
+    crashes: number;
+    users: number;
+    crashFreeRate: number;
+  }[];
   days: number;
 }
 
@@ -224,8 +234,18 @@ interface ViralMetrics {
   }[];
   dailyDau: { date: string; dau: number }[];
   powerUserCurve: { daysActive: number; users: number; pct: number }[];
-  activation: { date: string; signups: number; activated: number; rate: number }[];
-  activationDaily?: { date: string; signups: number; activated: number; rate: number }[];
+  activation: {
+    date: string;
+    signups: number;
+    activated: number;
+    rate: number;
+  }[];
+  activationDaily?: {
+    date: string;
+    signups: number;
+    activated: number;
+    rate: number;
+  }[];
   activationBucket?: "day" | "week";
   summary: {
     quickRatio: number | null;
@@ -258,14 +278,7 @@ interface KFactorData {
   available: boolean;
   kFactor: number | null;
   reason: string;
-  proxy?: {
-    newUsers: number;
-    sharers: number;
-    shareEvents: number;
-    shareRatePct: number;
-    sharesPerSharer: number;
-    sharesPerNewUser: number;
-  };
+  funnel?: { issued: number; captured: number; granted: number };
 }
 
 interface MacosVersionBreakdown {
@@ -363,7 +376,11 @@ function formatCompact(value: number): string {
 
 function formatCohortDate(dateStr: string): string {
   const d = new Date(dateStr + "T00:00:00");
-  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
 }
 
 function shortDate(v: string): string {
@@ -373,7 +390,11 @@ function shortDate(v: string): string {
 
 function fullDate(v: string): string {
   const d = new Date(v + "T00:00:00");
-  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
 }
 
 function formatWeek(v: string): string {
@@ -392,16 +413,31 @@ function weekStartKey(dateStr: string): string {
 
 function formatHourKey(v: string): string {
   const d = new Date(v + ":00:00Z");
-  const mon = d.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+  const mon = d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
   const hour = d.getUTCHours();
-  const label = hour === 0 ? "12am" : hour === 12 ? "12pm" : hour < 12 ? `${hour}am` : `${hour - 12}pm`;
+  const label =
+    hour === 0
+      ? "12am"
+      : hour === 12
+        ? "12pm"
+        : hour < 12
+          ? `${hour}am`
+          : `${hour - 12}pm`;
   return `${mon} ${label}`;
 }
 
 function formatHourTick(v: string): string {
   const d = new Date(v + ":00:00Z");
   return d.getUTCHours() === 0
-    ? d.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" })
+    ? d.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        timeZone: "UTC",
+      })
     : "";
 }
 
@@ -436,64 +472,142 @@ export default function AnalyticsPage() {
   const [months, setMonths] = useState(12);
   const [retentionDays, setRetentionDays] = useState(30);
   const [retentionPlatform, setRetentionPlatform] = useState("macos");
-  const [retentionView, setRetentionView] = useState<"average" | "cohorts">("average");
-  const [cumulativeWindow, setCumulativeWindow] = useState<"7d" | "30d" | "all">("all");
+  const [retentionView, setRetentionView] = useState<"average" | "cohorts">(
+    "average",
+  );
+  const [cumulativeWindow, setCumulativeWindow] = useState<
+    "7d" | "30d" | "all"
+  >("all");
   const [profitDays, setProfitDays] = useState<30 | 60 | 90>(30);
   const [desktopCostInput, setDesktopCostInput] = useState("1.20");
   const [mobileCostInput, setMobileCostInput] = useState("0.30");
 
   const swrOpts = { revalidateOnFocus: false };
 
-  const { data: revenue, isLoading: revenueLoading, error: revenueError } = useSWR<RevenueData>(
-    token ? ["/api/omi/stats/revenue", token] : null, authFetcher, swrOpts
+  const {
+    data: revenue,
+    isLoading: revenueLoading,
+    error: revenueError,
+  } = useSWR<RevenueData>(
+    token ? ["/api/omi/stats/revenue", token] : null,
+    authFetcher,
+    swrOpts,
   );
 
-  const { data: mrrTrends, isLoading: mrrLoading, error: mrrError } = useSWR<{
+  const {
+    data: mrrTrends,
+    isLoading: mrrLoading,
+    error: mrrError,
+  } = useSWR<{
     data: MrrTrendPoint[];
-  }>(token ? [`/api/omi/stats/mrr-trends?months=${months}`, token] : null, authFetcher, swrOpts);
+  }>(
+    token ? [`/api/omi/stats/mrr-trends?months=${months}`, token] : null,
+    authFetcher,
+    swrOpts,
+  );
 
-  const { data: subTrends, isLoading: subTrendsLoading, error: subTrendsError } = useSWR<{
+  const {
+    data: subTrends,
+    isLoading: subTrendsLoading,
+    error: subTrendsError,
+  } = useSWR<{
     data: SubscriptionTrendPoint[];
-  }>(token ? [`/api/omi/stats/subscription-trends?months=${months}`, token] : null, authFetcher, swrOpts);
+  }>(
+    token
+      ? [`/api/omi/stats/subscription-trends?months=${months}`, token]
+      : null,
+    authFetcher,
+    swrOpts,
+  );
 
-  const { data: subCounts, isLoading: subCountsLoading, error: subCountsError } =
-    useSWR<SubscriptionCounts>(token ? ["/api/omi/stats/subscriptions", token] : null, authFetcher, swrOpts);
+  const {
+    data: subCounts,
+    isLoading: subCountsLoading,
+    error: subCountsError,
+  } = useSWR<SubscriptionCounts>(
+    token ? ["/api/omi/stats/subscriptions", token] : null,
+    authFetcher,
+    swrOpts,
+  );
 
-  const { data: convCount, isLoading: convLoading, error: convError } =
-    useSWR<ConversationCount>(token ? ["/api/omi/stats/conversation-count", token] : null, authFetcher, swrOpts);
+  const {
+    data: convCount,
+    isLoading: convLoading,
+    error: convError,
+  } = useSWR<ConversationCount>(
+    token ? ["/api/omi/stats/conversation-count", token] : null,
+    authFetcher,
+    swrOpts,
+  );
 
   const { data: dailyNewUsers, isLoading: dailyNewUsersLoading } =
-    useSWR<DailyNewUsersData>(token ? ["/api/omi/stats/daily-new-users?days=all", token] : null, authFetcher, swrOpts);
+    useSWR<DailyNewUsersData>(
+      token ? ["/api/omi/stats/daily-new-users?days=all", token] : null,
+      authFetcher,
+      swrOpts,
+    );
 
-  const { data: dauTrends, isLoading: dauLoading } =
-    useSWR<DauTrendsData>(token ? ["/api/omi/stats/dau-trends?days=60", token] : null, authFetcher, swrOpts);
+  const { data: dauTrends, isLoading: dauLoading } = useSWR<DauTrendsData>(
+    token ? ["/api/omi/stats/dau-trends?days=60", token] : null,
+    authFetcher,
+    swrOpts,
+  );
 
   const { data: messageRatings, isLoading: ratingsLoading } =
-    useSWR<MessageRatingsData>(token ? ["/api/omi/stats/message-ratings?days=30", token] : null, authFetcher, swrOpts);
+    useSWR<MessageRatingsData>(
+      token ? ["/api/omi/stats/message-ratings?days=30", token] : null,
+      authFetcher,
+      swrOpts,
+    );
 
   const { data: floatingBarUsage, isLoading: fbUsageLoading } =
-    useSWR<FloatingBarUsageData>(token ? ["/api/omi/stats/floating-bar-usage?days=30", token] : null, authFetcher, swrOpts);
+    useSWR<FloatingBarUsageData>(
+      token ? ["/api/omi/stats/floating-bar-usage?days=30", token] : null,
+      authFetcher,
+      swrOpts,
+    );
 
   const { data: notificationStats, isLoading: notificationStatsLoading } =
-    useSWR<NotificationStats>(token ? ["/api/omi/stats/notifications?days=30", token] : null, authFetcher, swrOpts);
+    useSWR<NotificationStats>(
+      token ? ["/api/omi/stats/notifications?days=30", token] : null,
+      authFetcher,
+      swrOpts,
+    );
 
-  const { data: viralMetrics, isLoading: viralLoading } =
-    useSWR<ViralMetrics>(token ? ["/api/omi/stats/viral-metrics?days=60", token] : null, authFetcher, swrOpts);
+  const { data: viralMetrics, isLoading: viralLoading } = useSWR<ViralMetrics>(
+    token ? ["/api/omi/stats/viral-metrics?days=60", token] : null,
+    authFetcher,
+    swrOpts,
+  );
 
-  const { data: kFactorData, isLoading: kFactorLoading } =
-    useSWR<KFactorData>(token ? ["/api/omi/stats/k-factor/posthog?days=30", token] : null, authFetcher, swrOpts);
+  const { data: kFactorData, isLoading: kFactorLoading } = useSWR<KFactorData>(
+    token ? ["/api/omi/stats/k-factor/posthog?days=30&platform=all", token] : null,
+    authFetcher,
+    swrOpts,
+  );
 
   // Activation comes from Firestore conversation records, not from the desktop
   // `Memory Created` event in viral-metrics: older builds cannot emit that
   // event, so the PostHog figure tracks build age rather than behaviour.
-  const { data: activationStats } =
-    useSWR<ActivationStats>(token ? ["/api/omi/stats/activation?days=60", token] : null, authFetcher, swrOpts);
+  const { data: activationStats } = useSWR<ActivationStats>(
+    token ? ["/api/omi/stats/activation?days=60", token] : null,
+    authFetcher,
+    swrOpts,
+  );
 
   const { data: macosVersionStats, isLoading: macosVersionStatsLoading } =
-    useSWR<MacosVersionStatsData>(token ? ["/api/omi/stats/macos-versions", token] : null, authFetcher, swrOpts);
+    useSWR<MacosVersionStatsData>(
+      token ? ["/api/omi/stats/macos-versions", token] : null,
+      authFetcher,
+      swrOpts,
+    );
 
   const { data: crashRate, isLoading: crashRateLoading } =
-    useSWR<CrashRateData>(token ? ["/api/omi/stats/crash-rate?days=30", token] : null, authFetcher, swrOpts);
+    useSWR<CrashRateData>(
+      token ? ["/api/omi/stats/crash-rate?days=30", token] : null,
+      authFetcher,
+      swrOpts,
+    );
 
   const profitQuery = useMemo(() => {
     const dc = parseFloat(desktopCostInput);
@@ -503,12 +617,15 @@ export default function AnalyticsPage() {
     return `days=${profitDays}&desktop_cost=${dcSafe}&mobile_cost=${mcSafe}`;
   }, [profitDays, desktopCostInput, mobileCostInput]);
 
-  const { data: profitability, isLoading: profitLoading, error: profitError } =
-    useSWR<ProfitabilityData>(
-      token ? [`/api/omi/stats/profitability?${profitQuery}`, token] : null,
-      authFetcher,
-      swrOpts,
-    );
+  const {
+    data: profitability,
+    isLoading: profitLoading,
+    error: profitError,
+  } = useSWR<ProfitabilityData>(
+    token ? [`/api/omi/stats/profitability?${profitQuery}`, token] : null,
+    authFetcher,
+    swrOpts,
+  );
 
   interface InfraCostsData {
     breakdown: Array<{
@@ -519,7 +636,11 @@ export default function AnalyticsPage() {
       mobileProjectionUsd: number;
     }>;
     summary: {
-      assumptions: { overheadMonthlyUsd: number; desktopShare: number; mobileShare: number };
+      assumptions: {
+        overheadMonthlyUsd: number;
+        desktopShare: number;
+        mobileShare: number;
+      };
     };
   }
   const { data: infraCosts } = useSWR<InfraCostsData>(
@@ -528,17 +649,29 @@ export default function AnalyticsPage() {
     swrOpts,
   );
 
-  const retentionPlatformParam = retentionPlatform ? `&platform=${retentionPlatform}` : '';
+  const retentionPlatformParam = retentionPlatform
+    ? `&platform=${retentionPlatform}`
+    : "";
 
-  const { data: retention, isLoading: retLoading } =
-    useSWR<RetentionData>(
-      token ? [`/api/omi/stats/retention/posthog?days=${retentionDays}&intervals=${retentionDays}${retentionPlatformParam}`, token] : null,
-      authFetcher, swrOpts
-    );
+  const { data: retention, isLoading: retLoading } = useSWR<RetentionData>(
+    token
+      ? [
+          `/api/omi/stats/retention/posthog?days=${retentionDays}&intervals=${retentionDays}${retentionPlatformParam}`,
+          token,
+        ]
+      : null,
+    authFetcher,
+    swrOpts,
+  );
 
   const { data: growthRetention, isLoading: growthRetentionLoading } =
     useSWR<RetentionData>(
-      token ? ["/api/omi/stats/retention/posthog?days=30&intervals=30&platform=macos", token] : null,
+      token
+        ? [
+            "/api/omi/stats/retention/posthog?days=30&intervals=30&platform=macos",
+            token,
+          ]
+        : null,
       authFetcher,
       swrOpts,
     );
@@ -550,14 +683,20 @@ export default function AnalyticsPage() {
     subCountsLoading ||
     convLoading;
 
-  const hasError = revenueError || mrrError || subTrendsError || subCountsError || convError;
+  const hasError =
+    revenueError || mrrError || subTrendsError || subCountsError || convError;
 
   const mrr = revenue?.mrr ?? 0;
   const arr = revenue?.arr ?? 0;
   const totalSubs = subCounts?.totalSubscriptions ?? 0;
   const monthlySubs = subCounts?.monthly ?? 0;
   const annualSubs = subCounts?.annual ?? 0;
-  const hasPartialData = !!(revenue?.partial || subCounts?.partial || (mrrTrends as any)?.partial || (subTrends as any)?.partial);
+  const hasPartialData = !!(
+    revenue?.partial ||
+    subCounts?.partial ||
+    (mrrTrends as any)?.partial ||
+    (subTrends as any)?.partial
+  );
   const totalConversations = convCount?.totalConversations ?? 0;
   const mrrData = mrrTrends?.data ?? [];
   const subData = subTrends?.data ?? [];
@@ -579,13 +718,17 @@ export default function AnalyticsPage() {
 
   // Cumulative Users chart fetches the full history since the first
   // signup so the growth curve is meaningful.
-  const allDailyData = useMemo(() => dailyNewUsers?.data ?? [], [dailyNewUsers]);
+  const allDailyData = useMemo(
+    () => dailyNewUsers?.data ?? [],
+    [dailyNewUsers],
+  );
   const dauData = dauTrends?.data?.slice(-30) ?? [];
   const ratingsData = messageRatings?.data ?? [];
   const totalThumbsUp = ratingsData.reduce((s, d) => s + d.thumbs_up, 0);
   const totalThumbsDown = ratingsData.reduce((s, d) => s + d.thumbs_down, 0);
   const totalRatings = totalThumbsUp + totalThumbsDown;
-  const overallRatio = totalRatings > 0 ? Math.round((totalThumbsUp / totalRatings) * 100) : 0;
+  const overallRatio =
+    totalRatings > 0 ? Math.round((totalThumbsUp / totalRatings) * 100) : 0;
   const fbUsageData = floatingBarUsage?.data ?? [];
   const fbSummary = floatingBarUsage?.summary;
   const notificationDailyData = notificationStats?.dailyData ?? [];
@@ -596,8 +739,14 @@ export default function AnalyticsPage() {
   const macosChannelData = macosVersionStats?.channelBreakdown ?? [];
   const macosVersionData = macosVersionStats?.versionBreakdown ?? [];
   const notificationLast7Days = notificationDailyData.slice(-7);
-  const notificationMentorLast7 = notificationLast7Days.reduce((sum, day) => sum + day.mentorSent, 0);
-  const notificationMarketplaceLast7 = notificationLast7Days.reduce((sum, day) => sum + day.marketplaceMentorSent, 0);
+  const notificationMentorLast7 = notificationLast7Days.reduce(
+    (sum, day) => sum + day.mentorSent,
+    0,
+  );
+  const notificationMarketplaceLast7 = notificationLast7Days.reduce(
+    (sum, day) => sum + day.marketplaceMentorSent,
+    0,
+  );
   const floatingBarCtrSummary = floatingBarCtr?.summary;
   const notificationDailyCombined = notificationDailyData.map((day) => ({
     ...day,
@@ -610,7 +759,10 @@ export default function AnalyticsPage() {
     totalUniqueUsers: week.uniqueUsersMentor + week.uniqueUsersMarketplace,
   }));
   const weeklyRatingsData = useMemo(() => {
-    const buckets = new Map<string, { thumbs_up: number; thumbs_down: number }>();
+    const buckets = new Map<
+      string,
+      { thumbs_up: number; thumbs_down: number }
+    >();
     for (const point of ratingsData) {
       const key = weekStartKey(point.date);
       const bucket = buckets.get(key) ?? { thumbs_up: 0, thumbs_down: 0 };
@@ -650,18 +802,23 @@ export default function AnalyticsPage() {
 
   // 7-day rolling average for daily new users
   const dailyWithRollingAvg = useMemo(() => {
-    return allDailyData.map((point, i) => {
-      if (i < 6) return { ...point, rollingAvg: undefined };
-      const slice = allDailyData.slice(i - 6, i + 1);
-      const avg = slice.reduce((s, p) => s + p.users, 0) / 7;
-      return { ...point, rollingAvg: Math.round(avg * 10) / 10 };
-    }).slice(-30);
+    return allDailyData
+      .map((point, i) => {
+        if (i < 6) return { ...point, rollingAvg: undefined };
+        const slice = allDailyData.slice(i - 6, i + 1);
+        const avg = slice.reduce((s, p) => s + p.users, 0) / 7;
+        return { ...point, rollingAvg: Math.round(avg * 10) / 10 };
+      })
+      .slice(-30);
   }, [allDailyData]);
 
   // Retention values for summary cards
-  const retentionD1 = retention?.data?.find((p) => p.day === 1)?.retention ?? null;
-  const retentionD7 = retention?.data?.find((p) => p.day === 7)?.retention ?? null;
-  const retentionW4 = retention?.data?.find((p) => p.day === 28)?.retention ?? null;
+  const retentionD1 =
+    retention?.data?.find((p) => p.day === 1)?.retention ?? null;
+  const retentionD7 =
+    retention?.data?.find((p) => p.day === 7)?.retention ?? null;
+  const retentionW4 =
+    retention?.data?.find((p) => p.day === 28)?.retention ?? null;
 
   // Viral metrics
   const vm = viralMetrics;
@@ -700,15 +857,22 @@ export default function AnalyticsPage() {
     const costData = profitability?.cost ?? [];
     const costPerUserData = (profitability as any)?.costPerUser ?? [];
     const conversionData = profitability?.conversion ?? [];
-    const costSource = (summary?.assumptions as any)?.costSource as string | undefined;
-    const avgCostDesktop = (summary as any)?.avgCostPerUserDesktop as number | undefined;
-    const avgCostMobile = (summary as any)?.avgCostPerUserMobile as number | undefined;
+    const costSource = (summary?.assumptions as any)?.costSource as
+      string | undefined;
+    const avgCostDesktop = (summary as any)?.avgCostPerUserDesktop as
+      number | undefined;
+    const avgCostMobile = (summary as any)?.avgCostPerUserMobile as
+      number | undefined;
 
     return [
       {
         id: "profit-users",
         title: "New users / day",
-        periodChange: latestPeriodChange(usersData, (point) => point.total, "vs previous day"),
+        periodChange: latestPeriodChange(
+          usersData,
+          (point) => point.total,
+          "vs previous day",
+        ),
         subtitle: summary
           ? `Desktop ${summary.totalNewDesktop.toLocaleString()} · Mobile ${summary.totalNewMobile.toLocaleString()}`
           : "Per-platform signups",
@@ -718,11 +882,27 @@ export default function AnalyticsPage() {
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={usersData}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-              <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} minTickGap={30} />
-              <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={formatCompact} width={40} />
+              <XAxis
+                dataKey="date"
+                className="text-xs"
+                tick={{ fill: "hsl(var(--muted-foreground))" }}
+                tickFormatter={shortDate}
+                minTickGap={30}
+              />
+              <YAxis
+                className="text-xs"
+                tick={{ fill: "hsl(var(--muted-foreground))" }}
+                tickFormatter={formatCompact}
+                width={40}
+              />
               <Tooltip contentStyle={tooltipStyle} labelFormatter={fullDate} />
               <Legend wrapperStyle={{ fontSize: 11 }} />
-              <Bar dataKey="desktop" stackId="u" fill="#6366f1" name="Desktop" />
+              <Bar
+                dataKey="desktop"
+                stackId="u"
+                fill="#6366f1"
+                name="Desktop"
+              />
               <Bar dataKey="mobile" stackId="u" fill="#22c55e" name="Mobile" />
             </BarChart>
           </ResponsiveContainer>
@@ -731,7 +911,11 @@ export default function AnalyticsPage() {
       {
         id: "profit-revenue",
         title: "Revenue / day (est.)",
-        periodChange: latestPeriodChange(revenueData, (point) => point.total, "vs previous day"),
+        periodChange: latestPeriodChange(
+          revenueData,
+          (point) => point.total,
+          "vs previous day",
+        ),
         subtitle: "Daily MRR share by platform active-user ratio",
         icon: <DollarSign className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -739,22 +923,65 @@ export default function AnalyticsPage() {
           <ResponsiveContainer width="100%" height="100%">
             <AreaChart data={revenueData}>
               <defs>
-                <linearGradient id="profitRevDesktop" x1="0" y1="0" x2="0" y2="1">
+                <linearGradient
+                  id="profitRevDesktop"
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2="1"
+                >
                   <stop offset="5%" stopColor="#6366f1" stopOpacity={0.4} />
                   <stop offset="95%" stopColor="#6366f1" stopOpacity={0} />
                 </linearGradient>
-                <linearGradient id="profitRevMobile" x1="0" y1="0" x2="0" y2="1">
+                <linearGradient
+                  id="profitRevMobile"
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2="1"
+                >
                   <stop offset="5%" stopColor="#22c55e" stopOpacity={0.4} />
                   <stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
                 </linearGradient>
               </defs>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-              <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} minTickGap={30} />
-              <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `$${formatCompact(v)}`} width={50} />
-              <Tooltip contentStyle={tooltipStyle} labelFormatter={fullDate} formatter={(v: number, name) => [formatCurrency(v), name]} />
+              <XAxis
+                dataKey="date"
+                className="text-xs"
+                tick={{ fill: "hsl(var(--muted-foreground))" }}
+                tickFormatter={shortDate}
+                minTickGap={30}
+              />
+              <YAxis
+                className="text-xs"
+                tick={{ fill: "hsl(var(--muted-foreground))" }}
+                tickFormatter={(v) => `$${formatCompact(v)}`}
+                width={50}
+              />
+              <Tooltip
+                contentStyle={tooltipStyle}
+                labelFormatter={fullDate}
+                formatter={(v: number, name) => [formatCurrency(v), name]}
+              />
               <Legend wrapperStyle={{ fontSize: 11 }} />
-              <Area type="monotone" dataKey="desktop" stackId="r" stroke="#6366f1" strokeWidth={2} fill="url(#profitRevDesktop)" name="Desktop" />
-              <Area type="monotone" dataKey="mobile" stackId="r" stroke="#22c55e" strokeWidth={2} fill="url(#profitRevMobile)" name="Mobile" />
+              <Area
+                type="monotone"
+                dataKey="desktop"
+                stackId="r"
+                stroke="#6366f1"
+                strokeWidth={2}
+                fill="url(#profitRevDesktop)"
+                name="Desktop"
+              />
+              <Area
+                type="monotone"
+                dataKey="mobile"
+                stackId="r"
+                stroke="#22c55e"
+                strokeWidth={2}
+                fill="url(#profitRevMobile)"
+                name="Mobile"
+              />
             </AreaChart>
           </ResponsiveContainer>
         ),
@@ -762,22 +989,59 @@ export default function AnalyticsPage() {
       {
         id: "profit-cost-per-user",
         title: `Cost / user / day${costSource === "real" ? "" : " (est.)"}`,
-        periodChange: latestPeriodChange(costPerUserData, (point: ProfitabilityPoint) => point.total, "vs previous day"),
-        subtitle: avgCostDesktop != null && avgCostMobile != null
-          ? `Avg: Desktop $${avgCostDesktop.toFixed(2)} · Mobile $${avgCostMobile.toFixed(2)}`
-          : "Daily infra spend ÷ active users, per platform",
+        periodChange: latestPeriodChange(
+          costPerUserData,
+          (point: ProfitabilityPoint) => point.total,
+          "vs previous day",
+        ),
+        subtitle:
+          avgCostDesktop != null && avgCostMobile != null
+            ? `Avg: Desktop $${avgCostDesktop.toFixed(2)} · Mobile $${avgCostMobile.toFixed(2)}`
+            : "Daily infra spend ÷ active users, per platform",
         icon: <Activity className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
         render: () => (
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={costPerUserData}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-              <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} minTickGap={30} />
-              <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `$${Number(v).toFixed(2)}`} width={56} />
-              <Tooltip contentStyle={tooltipStyle} labelFormatter={fullDate} formatter={(v: number, name) => [`$${Number(v).toFixed(2)}`, name]} />
+              <XAxis
+                dataKey="date"
+                className="text-xs"
+                tick={{ fill: "hsl(var(--muted-foreground))" }}
+                tickFormatter={shortDate}
+                minTickGap={30}
+              />
+              <YAxis
+                className="text-xs"
+                tick={{ fill: "hsl(var(--muted-foreground))" }}
+                tickFormatter={(v) => `$${Number(v).toFixed(2)}`}
+                width={56}
+              />
+              <Tooltip
+                contentStyle={tooltipStyle}
+                labelFormatter={fullDate}
+                formatter={(v: number, name) => [
+                  `$${Number(v).toFixed(2)}`,
+                  name,
+                ]}
+              />
               <Legend wrapperStyle={{ fontSize: 11 }} />
-              <Line type="monotone" dataKey="desktop" stroke="#f59e0b" strokeWidth={2} dot={false} name="Desktop $/user" />
-              <Line type="monotone" dataKey="mobile" stroke="#ef4444" strokeWidth={2} dot={false} name="Mobile $/user" />
+              <Line
+                type="monotone"
+                dataKey="desktop"
+                stroke="#f59e0b"
+                strokeWidth={2}
+                dot={false}
+                name="Desktop $/user"
+              />
+              <Line
+                type="monotone"
+                dataKey="mobile"
+                stroke="#ef4444"
+                strokeWidth={2}
+                dot={false}
+                name="Mobile $/user"
+              />
             </LineChart>
           </ResponsiveContainer>
         ),
@@ -785,21 +1049,46 @@ export default function AnalyticsPage() {
       {
         id: "profit-cost",
         title: `Total infra cost / day${costSource === "real" ? "" : " (est.)"}`,
-        periodChange: latestPeriodChange(costData, (point) => point.total, "vs previous day"),
-        subtitle: summary?.totalCostUsd != null
-          ? `Total last ${profitability?.days ?? 30}d: ${formatCurrency(summary.totalCostUsd)}`
-          : "Desktop + mobile daily burn",
+        periodChange: latestPeriodChange(
+          costData,
+          (point) => point.total,
+          "vs previous day",
+        ),
+        subtitle:
+          summary?.totalCostUsd != null
+            ? `Total last ${profitability?.days ?? 30}d: ${formatCurrency(summary.totalCostUsd)}`
+            : "Desktop + mobile daily burn",
         icon: <DollarSign className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
         render: () => (
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={costData}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-              <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} minTickGap={30} />
-              <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `$${formatCompact(v)}`} width={50} />
-              <Tooltip contentStyle={tooltipStyle} labelFormatter={fullDate} formatter={(v: number, name) => [formatCurrency(v), name]} />
+              <XAxis
+                dataKey="date"
+                className="text-xs"
+                tick={{ fill: "hsl(var(--muted-foreground))" }}
+                tickFormatter={shortDate}
+                minTickGap={30}
+              />
+              <YAxis
+                className="text-xs"
+                tick={{ fill: "hsl(var(--muted-foreground))" }}
+                tickFormatter={(v) => `$${formatCompact(v)}`}
+                width={50}
+              />
+              <Tooltip
+                contentStyle={tooltipStyle}
+                labelFormatter={fullDate}
+                formatter={(v: number, name) => [formatCurrency(v), name]}
+              />
               <Legend wrapperStyle={{ fontSize: 11 }} />
-              <Bar dataKey="desktop" stackId="c" fill="#f59e0b" name="Desktop" />
+              <Bar
+                dataKey="desktop"
+                stackId="c"
+                fill="#f59e0b"
+                name="Desktop"
+              />
               <Bar dataKey="mobile" stackId="c" fill="#ef4444" name="Mobile" />
             </BarChart>
           </ResponsiveContainer>
@@ -808,7 +1097,11 @@ export default function AnalyticsPage() {
       {
         id: "profit-conversion",
         title: "Free → paid %",
-        periodChange: latestPeriodChange(conversionData, (point) => point.total, "vs previous day"),
+        periodChange: latestPeriodChange(
+          conversionData,
+          (point) => point.total,
+          "vs previous day",
+        ),
         subtitle: "New paid subs / new users",
         icon: <Percent className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -816,12 +1109,41 @@ export default function AnalyticsPage() {
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={conversionData}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-              <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} minTickGap={30} />
-              <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `${v}%`} width={40} />
-              <Tooltip contentStyle={tooltipStyle} labelFormatter={fullDate} formatter={(v: number, name) => [`${v}%`, name]} />
+              <XAxis
+                dataKey="date"
+                className="text-xs"
+                tick={{ fill: "hsl(var(--muted-foreground))" }}
+                tickFormatter={shortDate}
+                minTickGap={30}
+              />
+              <YAxis
+                className="text-xs"
+                tick={{ fill: "hsl(var(--muted-foreground))" }}
+                tickFormatter={(v) => `${v}%`}
+                width={40}
+              />
+              <Tooltip
+                contentStyle={tooltipStyle}
+                labelFormatter={fullDate}
+                formatter={(v: number, name) => [`${v}%`, name]}
+              />
               <Legend wrapperStyle={{ fontSize: 11 }} />
-              <Line type="monotone" dataKey="desktop" stroke="#6366f1" strokeWidth={2} dot={false} name="Desktop" />
-              <Line type="monotone" dataKey="mobile" stroke="#22c55e" strokeWidth={2} dot={false} name="Mobile" />
+              <Line
+                type="monotone"
+                dataKey="desktop"
+                stroke="#6366f1"
+                strokeWidth={2}
+                dot={false}
+                name="Desktop"
+              />
+              <Line
+                type="monotone"
+                dataKey="mobile"
+                stroke="#22c55e"
+                strokeWidth={2}
+                dot={false}
+                name="Mobile"
+              />
             </LineChart>
           </ResponsiveContainer>
         ),
@@ -845,36 +1167,69 @@ export default function AnalyticsPage() {
           }
           const totalMtd = rows.reduce((s, r) => s + r.mtdUsd, 0);
           const totalProj = rows.reduce((s, r) => s + r.aprProjectionUsd, 0);
-          const totalDesktopProj = rows.reduce((s, r) => s + r.desktopProjectionUsd, 0);
-          const totalMobileProj = rows.reduce((s, r) => s + r.mobileProjectionUsd, 0);
+          const totalDesktopProj = rows.reduce(
+            (s, r) => s + r.desktopProjectionUsd,
+            0,
+          );
+          const totalMobileProj = rows.reduce(
+            (s, r) => s + r.mobileProjectionUsd,
+            0,
+          );
           return (
             <div className="h-full overflow-auto">
               <table className="w-full text-sm">
                 <thead className="sticky top-0 bg-card">
                   <tr className="border-b text-xs uppercase text-muted-foreground">
                     <th className="px-3 py-2 text-left font-medium">Service</th>
-                    <th className="px-3 py-2 text-right font-medium">Gross MTD</th>
-                    <th className="px-3 py-2 text-right font-medium">Last 30 days</th>
-                    <th className="px-3 py-2 text-right font-medium text-indigo-500">Desktop</th>
-                    <th className="px-3 py-2 text-right font-medium text-green-500">Mobile</th>
+                    <th className="px-3 py-2 text-right font-medium">
+                      Gross MTD
+                    </th>
+                    <th className="px-3 py-2 text-right font-medium">
+                      Last 30 days
+                    </th>
+                    <th className="px-3 py-2 text-right font-medium text-indigo-500">
+                      Desktop
+                    </th>
+                    <th className="px-3 py-2 text-right font-medium text-green-500">
+                      Mobile
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
                   {rows.map((r) => (
-                    <tr key={r.service} className="border-b border-border/40 last:border-b-0">
+                    <tr
+                      key={r.service}
+                      className="border-b border-border/40 last:border-b-0"
+                    >
                       <td className="px-3 py-2 font-medium">{r.service}</td>
-                      <td className="px-3 py-2 text-right tabular-nums">{formatCurrency(r.mtdUsd)}</td>
-                      <td className="px-3 py-2 text-right tabular-nums">{formatCurrency(r.aprProjectionUsd)}</td>
-                      <td className="px-3 py-2 text-right tabular-nums text-indigo-500">{formatCurrency(r.desktopProjectionUsd)}</td>
-                      <td className="px-3 py-2 text-right tabular-nums text-red-500">{formatCurrency(r.mobileProjectionUsd)}</td>
+                      <td className="px-3 py-2 text-right tabular-nums">
+                        {formatCurrency(r.mtdUsd)}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums">
+                        {formatCurrency(r.aprProjectionUsd)}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums text-indigo-500">
+                        {formatCurrency(r.desktopProjectionUsd)}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums text-red-500">
+                        {formatCurrency(r.mobileProjectionUsd)}
+                      </td>
                     </tr>
                   ))}
                   <tr className="border-t-2 border-border/60 font-semibold">
                     <td className="px-3 py-2">Total</td>
-                    <td className="px-3 py-2 text-right tabular-nums">{formatCurrency(totalMtd)}</td>
-                    <td className="px-3 py-2 text-right tabular-nums">{formatCurrency(totalProj)}</td>
-                    <td className="px-3 py-2 text-right tabular-nums text-indigo-500">{formatCurrency(totalDesktopProj)}</td>
-                    <td className="px-3 py-2 text-right tabular-nums text-red-500">{formatCurrency(totalMobileProj)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums">
+                      {formatCurrency(totalMtd)}
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums">
+                      {formatCurrency(totalProj)}
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums text-indigo-500">
+                      {formatCurrency(totalDesktopProj)}
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums text-red-500">
+                      {formatCurrency(totalMobileProj)}
+                    </td>
                   </tr>
                 </tbody>
               </table>
@@ -890,36 +1245,79 @@ export default function AnalyticsPage() {
       {
         id: "rev-cumulative",
         title: "Cumulative users",
-        periodChange: latestPeriodChange(cumulativeSeries, (point) => point.cumulative, "vs previous day"),
+        periodChange: latestPeriodChange(
+          cumulativeSeries,
+          (point) => point.cumulative,
+          "vs previous day",
+        ),
         subtitle: "Total users across all platforms",
         icon: <Users className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
-        render: () => (
+        render: () =>
           cumulativeSeries.length > 0 ? (
             <ResponsiveContainer width="100%" height="100%">
               <AreaChart data={cumulativeSeries}>
                 <defs>
-                  <linearGradient id="cumulativeGradientRev" x1="0" y1="0" x2="0" y2="1">
+                  <linearGradient
+                    id="cumulativeGradientRev"
+                    x1="0"
+                    y1="0"
+                    x2="0"
+                    y2="1"
+                  >
                     <stop offset="5%" stopColor="#22c55e" stopOpacity={0.3} />
                     <stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
                   </linearGradient>
                 </defs>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} minTickGap={40} />
-                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={formatCompact} domain={cumulativeYDomain} allowDataOverflow={false} width={56} />
-                <Tooltip formatter={(value: number) => [value.toLocaleString(), "Total Users"]} labelFormatter={fullDate} contentStyle={tooltipStyle} />
-                <Area type="monotone" dataKey="cumulative" stroke="#22c55e" strokeWidth={2} fill="url(#cumulativeGradientRev)" dot={false} activeDot={{ r: 4 }} />
+                <XAxis
+                  dataKey="date"
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  tickFormatter={shortDate}
+                  minTickGap={40}
+                />
+                <YAxis
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  tickFormatter={formatCompact}
+                  domain={cumulativeYDomain}
+                  allowDataOverflow={false}
+                  width={56}
+                />
+                <Tooltip
+                  formatter={(value: number) => [
+                    value.toLocaleString(),
+                    "Total Users",
+                  ]}
+                  labelFormatter={fullDate}
+                  contentStyle={tooltipStyle}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="cumulative"
+                  stroke="#22c55e"
+                  strokeWidth={2}
+                  fill="url(#cumulativeGradientRev)"
+                  dot={false}
+                  activeDot={{ r: 4 }}
+                />
               </AreaChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex h-full items-center justify-center text-muted-foreground text-sm">No data available</div>
-          )
-        ),
+            <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+              No data available
+            </div>
+          ),
       },
       {
         id: "rev-mrr",
         title: "MRR over time",
-        periodChange: latestPeriodChange(mrrData, (point) => point.mrr, "vs previous month"),
+        periodChange: latestPeriodChange(
+          mrrData,
+          (point) => point.mrr,
+          "vs previous month",
+        ),
         subtitle: "Monthly recurring revenue from Stripe",
         icon: <DollarSign className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -933,10 +1331,29 @@ export default function AnalyticsPage() {
                 </linearGradient>
               </defs>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-              <XAxis dataKey="month" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
-              <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `$${formatCompact(v)}`} />
-              <Tooltip formatter={(value: number) => [formatCurrency(value), "MRR"]} contentStyle={tooltipStyle} />
-              <Area type="monotone" dataKey="mrr" stroke={COLORS.mrr} strokeWidth={2} fill="url(#mrrGradientRev)" dot={{ r: 3, fill: COLORS.mrr }} activeDot={{ r: 5 }} />
+              <XAxis
+                dataKey="month"
+                className="text-xs"
+                tick={{ fill: "hsl(var(--muted-foreground))" }}
+              />
+              <YAxis
+                className="text-xs"
+                tick={{ fill: "hsl(var(--muted-foreground))" }}
+                tickFormatter={(v) => `$${formatCompact(v)}`}
+              />
+              <Tooltip
+                formatter={(value: number) => [formatCurrency(value), "MRR"]}
+                contentStyle={tooltipStyle}
+              />
+              <Area
+                type="monotone"
+                dataKey="mrr"
+                stroke={COLORS.mrr}
+                strokeWidth={2}
+                fill="url(#mrrGradientRev)"
+                dot={{ r: 3, fill: COLORS.mrr }}
+                activeDot={{ r: 5 }}
+              />
             </AreaChart>
           </ResponsiveContainer>
         ),
@@ -944,7 +1361,11 @@ export default function AnalyticsPage() {
       {
         id: "rev-subs",
         title: "New subscriptions",
-        periodChange: latestPeriodChange(subData, (point) => point.monthly + point.annual, "vs previous month"),
+        periodChange: latestPeriodChange(
+          subData,
+          (point) => point.monthly + point.annual,
+          "vs previous month",
+        ),
         subtitle: "Monthly vs annual subscriptions created each month",
         icon: <TrendingUp className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -952,12 +1373,31 @@ export default function AnalyticsPage() {
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={subData}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-              <XAxis dataKey="month" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
-              <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+              <XAxis
+                dataKey="month"
+                className="text-xs"
+                tick={{ fill: "hsl(var(--muted-foreground))" }}
+              />
+              <YAxis
+                className="text-xs"
+                tick={{ fill: "hsl(var(--muted-foreground))" }}
+              />
               <Tooltip contentStyle={tooltipStyle} />
               <Legend />
-              <Bar dataKey="monthly" name="Monthly" fill={COLORS.monthly} radius={[2, 2, 0, 0]} stackId="a" />
-              <Bar dataKey="annual" name="Annual" fill={COLORS.annual} radius={[2, 2, 0, 0]} stackId="a" />
+              <Bar
+                dataKey="monthly"
+                name="Monthly"
+                fill={COLORS.monthly}
+                radius={[2, 2, 0, 0]}
+                stackId="a"
+              />
+              <Bar
+                dataKey="annual"
+                name="Annual"
+                fill={COLORS.annual}
+                radius={[2, 2, 0, 0]}
+                stackId="a"
+              />
             </BarChart>
           </ResponsiveContainer>
         ),
@@ -977,13 +1417,19 @@ export default function AnalyticsPage() {
           <div className="flex h-full flex-col">
             <div className="mb-3 flex items-center justify-end">
               <div className="text-right">
-                <div className="text-2xl font-bold">{macosVersionStats?.activeUsers?.toLocaleString() ?? "--"}</div>
-                <p className="text-xs text-muted-foreground">active macOS users today</p>
+                <div className="text-2xl font-bold">
+                  {macosVersionStats?.activeUsers?.toLocaleString() ?? "--"}
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  active macOS users today
+                </p>
               </div>
             </div>
             <div className="grid gap-6 lg:grid-cols-2">
               <div>
-                <h3 className="text-sm font-medium text-muted-foreground mb-3">Beta vs Production</h3>
+                <h3 className="text-sm font-medium text-muted-foreground mb-3">
+                  Beta vs Production
+                </h3>
                 <div className="h-[280px]">
                   {macosVersionStatsLoading ? (
                     <div className="h-full flex items-center justify-center">
@@ -1005,14 +1451,20 @@ export default function AnalyticsPage() {
                           paddingAngle={3}
                           dataKey="value"
                           nameKey="label"
-                          label={({ label, percent }) => `${label} ${(percent * 100).toFixed(0)}%`}
+                          label={({ label, percent }) =>
+                            `${label} ${(percent * 100).toFixed(0)}%`
+                          }
                         >
                           {macosChannelData.map((entry) => (
                             <Cell key={entry.label} fill={entry.color} />
                           ))}
                         </Pie>
                         <Tooltip
-                          formatter={(value: number, _name, entry: { payload?: MacosVersionBreakdown }) => [
+                          formatter={(
+                            value: number,
+                            _name,
+                            entry: { payload?: MacosVersionBreakdown },
+                          ) => [
                             Number(value).toLocaleString(),
                             entry?.payload?.label ?? "Users",
                           ]}
@@ -1024,7 +1476,9 @@ export default function AnalyticsPage() {
                 </div>
               </div>
               <div>
-                <h3 className="text-sm font-medium text-muted-foreground mb-3">By Version</h3>
+                <h3 className="text-sm font-medium text-muted-foreground mb-3">
+                  By Version
+                </h3>
                 <div className="h-[280px]">
                   {macosVersionStatsLoading ? (
                     <div className="h-full flex items-center justify-center">
@@ -1052,7 +1506,11 @@ export default function AnalyticsPage() {
                           ))}
                         </Pie>
                         <Tooltip
-                          formatter={(value: number, _name, entry: { payload?: MacosVersionBreakdown }) => [
+                          formatter={(
+                            value: number,
+                            _name,
+                            entry: { payload?: MacosVersionBreakdown },
+                          ) => [
                             Number(value).toLocaleString(),
                             entry?.payload?.label ?? "Version",
                           ]}
@@ -1072,12 +1530,20 @@ export default function AnalyticsPage() {
                 </div>
                 <div className="space-y-3">
                   {macosChannelData.map((entry) => (
-                    <div key={entry.label} className="flex items-center justify-between">
+                    <div
+                      key={entry.label}
+                      className="flex items-center justify-between"
+                    >
                       <div className="flex items-center gap-3">
-                        <div className="w-3 h-3 rounded-full" style={{ backgroundColor: entry.color }} />
+                        <div
+                          className="w-3 h-3 rounded-full"
+                          style={{ backgroundColor: entry.color }}
+                        />
                         <span className="text-sm">{entry.label}</span>
                       </div>
-                      <span className="text-sm font-medium">{entry.value.toLocaleString()}</span>
+                      <span className="text-sm font-medium">
+                        {entry.value.toLocaleString()}
+                      </span>
                     </div>
                   ))}
                 </div>
@@ -1086,12 +1552,20 @@ export default function AnalyticsPage() {
                 <h3 className="font-medium mb-3">Version Counts</h3>
                 <div className="space-y-3 max-h-[220px] overflow-y-auto pr-1">
                   {macosVersionData.map((entry) => (
-                    <div key={entry.label} className="flex items-center justify-between">
+                    <div
+                      key={entry.label}
+                      className="flex items-center justify-between"
+                    >
                       <div className="flex items-center gap-3">
-                        <div className="w-3 h-3 rounded-full" style={{ backgroundColor: entry.color }} />
+                        <div
+                          className="w-3 h-3 rounded-full"
+                          style={{ backgroundColor: entry.color }}
+                        />
                         <span className="text-sm">{entry.label}</span>
                       </div>
-                      <span className="text-sm font-medium">{entry.value.toLocaleString()}</span>
+                      <span className="text-sm font-medium">
+                        {entry.value.toLocaleString()}
+                      </span>
                     </div>
                   ))}
                 </div>
@@ -1103,15 +1577,24 @@ export default function AnalyticsPage() {
       {
         id: "macos-fb-sessions-per-user",
         title: "Floating Bar Sessions per User",
-        periodChange: latestPeriodChange(fbUsageData, (point) => point.avg_sessions_per_user, "vs previous day"),
-        subtitle: "Times floating bar was opened and a question asked, per user per day (follow-ups don't count)",
+        periodChange: latestPeriodChange(
+          fbUsageData,
+          (point) => point.avg_sessions_per_user,
+          "vs previous day",
+        ),
+        subtitle:
+          "Times floating bar was opened and a question asked, per user per day (follow-ups don't count)",
         icon: <Activity className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
         render: () => (
           <div className="flex h-full flex-col">
             {fbSummary && (
               <div className="mb-2 text-right text-sm text-muted-foreground">
-                Avg: <span className="font-medium text-foreground">{fbSummary.overallAvgPerUserPerDay ?? "—"}</span> sessions/user/day
+                Avg:{" "}
+                <span className="font-medium text-foreground">
+                  {fbSummary.overallAvgPerUserPerDay ?? "—"}
+                </span>{" "}
+                sessions/user/day
               </div>
             )}
             <div className="min-h-0 flex-1">
@@ -1126,12 +1609,18 @@ export default function AnalyticsPage() {
               ) : (
                 <ResponsiveContainer width="100%" height="100%">
                   <LineChart data={fbUsageData}>
-                    <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
+                    <CartesianGrid
+                      strokeDasharray="3 3"
+                      className="opacity-30"
+                    />
                     <XAxis
                       dataKey="date"
                       tickFormatter={(v) => {
                         const d = new Date(v + "T00:00:00");
-                        return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+                        return d.toLocaleDateString("en-US", {
+                          month: "short",
+                          day: "numeric",
+                        });
                       }}
                       tick={{ fontSize: 11 }}
                     />
@@ -1139,11 +1628,21 @@ export default function AnalyticsPage() {
                     <Tooltip
                       labelFormatter={(v) => {
                         const d = new Date(v + "T00:00:00");
-                        return d.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" });
+                        return d.toLocaleDateString("en-US", {
+                          month: "long",
+                          day: "numeric",
+                          year: "numeric",
+                        });
                       }}
                     />
                     <Legend />
-                    <Line dataKey="avg_sessions_per_user" name="Sessions/User" stroke="#6366f1" strokeWidth={2} dot={false} />
+                    <Line
+                      dataKey="avg_sessions_per_user"
+                      name="Sessions/User"
+                      stroke="#6366f1"
+                      strokeWidth={2}
+                      dot={false}
+                    />
                   </LineChart>
                 </ResponsiveContainer>
               )}
@@ -1152,17 +1651,29 @@ export default function AnalyticsPage() {
         ),
       },
     ];
-  }, [macosVersionStats, macosVersionStatsLoading, macosChannelData, macosVersionData, fbSummary, fbUsageLoading, fbUsageData]);
+  }, [
+    macosVersionStats,
+    macosVersionStatsLoading,
+    macosChannelData,
+    macosVersionData,
+    fbSummary,
+    fbUsageLoading,
+    fbUsageData,
+  ]);
 
   const notificationCharts = useMemo<ChartItem[]>(() => {
     return [
       {
         id: "notif-daily-sent",
         title: "Daily Notifications Sent",
-        periodChange: latestPeriodChange(notificationDailyCombined, (point) => point.totalSent, "vs previous day"),
+        periodChange: latestPeriodChange(
+          notificationDailyCombined,
+          (point) => point.totalSent,
+          "vs previous day",
+        ),
         initialLayout: { cols: 12, rows: 4 },
         icon: <Send className="h-4 w-4" />,
-        render: () => (
+        render: () =>
           notificationStatsLoading ? (
             <div className="h-full flex items-center justify-center">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -1171,54 +1682,111 @@ export default function AnalyticsPage() {
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={notificationDailyCombined}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis dataKey="date" tickFormatter={shortDate} className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
-                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
-                <Tooltip labelFormatter={fullDate} contentStyle={tooltipStyle} />
+                <XAxis
+                  dataKey="date"
+                  tickFormatter={shortDate}
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                />
+                <YAxis
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                />
+                <Tooltip
+                  labelFormatter={fullDate}
+                  contentStyle={tooltipStyle}
+                />
                 <Legend />
-                <Bar dataKey="mentorSent" name="Omi says (built-in)" fill="#6366f1" radius={[2, 2, 0, 0]} stackId="a" />
-                <Bar dataKey="marketplaceMentorSent" name="Marketplace Mentor" fill="#f59e0b" radius={[2, 2, 0, 0]} stackId="a" />
+                <Bar
+                  dataKey="mentorSent"
+                  name="Omi says (built-in)"
+                  fill="#6366f1"
+                  radius={[2, 2, 0, 0]}
+                  stackId="a"
+                />
+                <Bar
+                  dataKey="marketplaceMentorSent"
+                  name="Marketplace Mentor"
+                  fill="#f59e0b"
+                  radius={[2, 2, 0, 0]}
+                  stackId="a"
+                />
               </BarChart>
             </ResponsiveContainer>
-          )
-        ),
+          ),
       },
       {
         id: "notif-hourly-168h",
         title: "Notifications Sent, Last 168 Hours",
-        periodChange: latestPeriodChange(notificationHourlyData, (point) => point.total, "vs previous hour"),
+        periodChange: latestPeriodChange(
+          notificationHourlyData,
+          (point) => point.total,
+          "vs previous hour",
+        ),
         subtitle: "Hourly volume, with dates marked at midnight UTC.",
         icon: <Send className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
-        render: () => (
+        render: () =>
           notificationStatsLoading ? (
             <div className="h-full flex items-center justify-center">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
             </div>
           ) : (
             <ResponsiveContainer width="100%" height="100%">
-              <BarChart data={notificationHourlyData} barCategoryGap={0} barGap={0}>
+              <BarChart
+                data={notificationHourlyData}
+                barCategoryGap={0}
+                barGap={0}
+              >
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis dataKey="hour" tickFormatter={formatHourTick} className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} interval={0} minTickGap={40} />
-                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
-                <Tooltip labelFormatter={(value) => formatHourKey(value as string)} contentStyle={tooltipStyle} />
+                <XAxis
+                  dataKey="hour"
+                  tickFormatter={formatHourTick}
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  interval={0}
+                  minTickGap={40}
+                />
+                <YAxis
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                />
+                <Tooltip
+                  labelFormatter={(value) => formatHourKey(value as string)}
+                  contentStyle={tooltipStyle}
+                />
                 <Legend />
-                <Bar dataKey="mentor" name="Omi Says" fill="#6366f1" stackId="a" />
-                <Bar dataKey="marketplace" name="Marketplace Mentor" fill="#f59e0b" stackId="a" />
+                <Bar
+                  dataKey="mentor"
+                  name="Omi Says"
+                  fill="#6366f1"
+                  stackId="a"
+                />
+                <Bar
+                  dataKey="marketplace"
+                  name="Marketplace Mentor"
+                  fill="#f59e0b"
+                  stackId="a"
+                />
               </BarChart>
             </ResponsiveContainer>
-          )
-        ),
+          ),
       },
       {
         id: "notif-fb-ctr",
         title: "Floating Bar Notification CTR",
-        periodChange: latestPeriodChange(floatingBarCtr?.dailyData ?? [], (point) => point.ctr, "vs previous day"),
-        subtitle: floatingBarCtrSummary?.mode === "surface_tagged"
-          ? "Sent vs clicked proactive notifications in the desktop floating bar."
-          : "Surface-tagged floating-bar events are not populated yet, so this is currently using all desktop notification clicks as a fallback.",
+        periodChange: latestPeriodChange(
+          floatingBarCtr?.dailyData ?? [],
+          (point) => point.ctr,
+          "vs previous day",
+        ),
+        subtitle:
+          floatingBarCtrSummary?.mode === "surface_tagged"
+            ? "Sent vs clicked proactive notifications in the desktop floating bar."
+            : "Surface-tagged floating-bar events are not populated yet, so this is currently using all desktop notification clicks as a fallback.",
         icon: <MousePointerClick className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
-        render: () => (
+        render: () =>
           notificationStatsLoading ? (
             <div className="h-full flex items-center justify-center">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -1227,31 +1795,73 @@ export default function AnalyticsPage() {
             <ResponsiveContainer width="100%" height="100%">
               <ComposedChart data={floatingBarCtr?.dailyData ?? []}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis dataKey="date" tickFormatter={shortDate} className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
-                <YAxis yAxisId="left" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
-                <YAxis yAxisId="right" orientation="right" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `${v}%`} />
+                <XAxis
+                  dataKey="date"
+                  tickFormatter={shortDate}
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                />
+                <YAxis
+                  yAxisId="left"
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                />
+                <YAxis
+                  yAxisId="right"
+                  orientation="right"
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  tickFormatter={(v) => `${v}%`}
+                />
                 <Tooltip
                   labelFormatter={fullDate}
-                  formatter={(value: number, name: string) => name === "CTR" ? [`${value}%`, name] : [value.toLocaleString(), name]}
+                  formatter={(value: number, name: string) =>
+                    name === "CTR"
+                      ? [`${value}%`, name]
+                      : [value.toLocaleString(), name]
+                  }
                   contentStyle={tooltipStyle}
                 />
                 <Legend />
-                <Bar yAxisId="left" dataKey="sent" name="Sent" fill="#6366f1" radius={[2, 2, 0, 0]} />
-                <Bar yAxisId="left" dataKey="clicked" name="Clicked" fill="#22c55e" radius={[2, 2, 0, 0]} />
-                <Line yAxisId="right" type="monotone" dataKey="ctr" name="CTR" stroke="#f59e0b" strokeWidth={2} dot={{ r: 3 }} />
+                <Bar
+                  yAxisId="left"
+                  dataKey="sent"
+                  name="Sent"
+                  fill="#6366f1"
+                  radius={[2, 2, 0, 0]}
+                />
+                <Bar
+                  yAxisId="left"
+                  dataKey="clicked"
+                  name="Clicked"
+                  fill="#22c55e"
+                  radius={[2, 2, 0, 0]}
+                />
+                <Line
+                  yAxisId="right"
+                  type="monotone"
+                  dataKey="ctr"
+                  name="CTR"
+                  stroke="#f59e0b"
+                  strokeWidth={2}
+                  dot={{ r: 3 }}
+                />
               </ComposedChart>
             </ResponsiveContainer>
-          )
-        ),
+          ),
       },
       {
         id: "notif-weekly-reach",
         title: "Weekly Notification Reach",
-        periodChange: latestPeriodChange(notificationWeeklyCombined, (point) => point.totalUniqueUsers, "vs previous week"),
+        periodChange: latestPeriodChange(
+          notificationWeeklyCombined,
+          (point) => point.totalUniqueUsers,
+          "vs previous week",
+        ),
         subtitle: "Volume and unique recipients in one view.",
         icon: <Users className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
-        render: () => (
+        render: () =>
           notificationStatsLoading ? (
             <div className="h-full flex items-center justify-center">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -1260,24 +1870,71 @@ export default function AnalyticsPage() {
             <ResponsiveContainer width="100%" height="100%">
               <ComposedChart data={notificationWeeklyCombined}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis dataKey="week" tickFormatter={formatWeek} className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
-                <YAxis yAxisId="left" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
-                <YAxis yAxisId="right" orientation="right" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
-                <Tooltip labelFormatter={formatWeek} contentStyle={tooltipStyle} />
+                <XAxis
+                  dataKey="week"
+                  tickFormatter={formatWeek}
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                />
+                <YAxis
+                  yAxisId="left"
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                />
+                <YAxis
+                  yAxisId="right"
+                  orientation="right"
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                />
+                <Tooltip
+                  labelFormatter={formatWeek}
+                  contentStyle={tooltipStyle}
+                />
                 <Legend />
-                <Bar yAxisId="left" dataKey="mentorSent" name="Omi says sent" fill="#6366f1" radius={[2, 2, 0, 0]} stackId="a" />
-                <Bar yAxisId="left" dataKey="marketplaceMentorSent" name="Marketplace sent" fill="#f59e0b" radius={[2, 2, 0, 0]} stackId="a" />
-                <Line yAxisId="right" type="monotone" dataKey="uniqueUsersMentor" name="Omi says unique users" stroke="#14b8a6" strokeWidth={2} dot={false} />
-                <Line yAxisId="right" type="monotone" dataKey="uniqueUsersMarketplace" name="Marketplace unique users" stroke="#fbbf24" strokeWidth={2} dot={false} />
+                <Bar
+                  yAxisId="left"
+                  dataKey="mentorSent"
+                  name="Omi says sent"
+                  fill="#6366f1"
+                  radius={[2, 2, 0, 0]}
+                  stackId="a"
+                />
+                <Bar
+                  yAxisId="left"
+                  dataKey="marketplaceMentorSent"
+                  name="Marketplace sent"
+                  fill="#f59e0b"
+                  radius={[2, 2, 0, 0]}
+                  stackId="a"
+                />
+                <Line
+                  yAxisId="right"
+                  type="monotone"
+                  dataKey="uniqueUsersMentor"
+                  name="Omi says unique users"
+                  stroke="#14b8a6"
+                  strokeWidth={2}
+                  dot={false}
+                />
+                <Line
+                  yAxisId="right"
+                  type="monotone"
+                  dataKey="uniqueUsersMarketplace"
+                  name="Marketplace unique users"
+                  stroke="#fbbf24"
+                  strokeWidth={2}
+                  dot={false}
+                />
               </ComposedChart>
             </ResponsiveContainer>
-          )
-        ),
+          ),
       },
       {
         id: "notif-settings",
         title: "Notification Settings",
-        subtitle: "Based on the desktop notifications_enabled toggle. Missing values default to enabled.",
+        subtitle:
+          "Based on the desktop notifications_enabled toggle. Missing values default to enabled.",
         icon: <Bell className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
         render: () => (
@@ -1285,14 +1942,26 @@ export default function AnalyticsPage() {
             <div className="rounded-lg border border-border/60 bg-muted/20 p-4">
               <div className="flex items-end justify-between gap-4">
                 <div>
-                  <div className="text-sm text-muted-foreground">Enabled share</div>
+                  <div className="text-sm text-muted-foreground">
+                    Enabled share
+                  </div>
                   <div className="text-3xl font-semibold">
-                    {notificationEnabledDisabled ? `${((notificationEnabledDisabled.enabled / notificationEnabledDisabled.total) * 100).toFixed(1)}%` : "--"}
+                    {notificationEnabledDisabled
+                      ? `${((notificationEnabledDisabled.enabled / notificationEnabledDisabled.total) * 100).toFixed(1)}%`
+                      : "--"}
                   </div>
                 </div>
                 <div className="text-right text-sm text-muted-foreground">
-                  <div>{notificationEnabledDisabled?.enabled?.toLocaleString() ?? "--"} enabled</div>
-                  <div>{notificationEnabledDisabled?.disabled?.toLocaleString() ?? "--"} disabled</div>
+                  <div>
+                    {notificationEnabledDisabled?.enabled?.toLocaleString() ??
+                      "--"}{" "}
+                    enabled
+                  </div>
+                  <div>
+                    {notificationEnabledDisabled?.disabled?.toLocaleString() ??
+                      "--"}{" "}
+                    disabled
+                  </div>
                 </div>
               </div>
               <div className="mt-4 h-3 overflow-hidden rounded-full bg-muted">
@@ -1330,14 +1999,19 @@ export default function AnalyticsPage() {
           (point) => point.thumbs_up + point.thumbs_down,
           "vs previous week",
         ),
-        subtitle: "Weekly thumbs up/down from macOS floating bar. The overall positive rate is shown above.",
+        subtitle:
+          "Weekly thumbs up/down from macOS floating bar. The overall positive rate is shown above.",
         icon: <MessageSquare className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
         render: () => (
           <div className="flex h-full flex-col">
             <div className="mb-2 flex items-center justify-end gap-4 text-sm text-muted-foreground">
-              <span className="text-green-500 font-medium">{totalThumbsUp} up</span>
-              <span className="text-red-500 font-medium">{totalThumbsDown} down</span>
+              <span className="text-green-500 font-medium">
+                {totalThumbsUp} up
+              </span>
+              <span className="text-red-500 font-medium">
+                {totalThumbsDown} down
+              </span>
               <span>{overallRatio}% positive</span>
             </div>
             <div className="min-h-0 flex-1">
@@ -1352,7 +2026,10 @@ export default function AnalyticsPage() {
               ) : (
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart data={weeklyRatingsData}>
-                    <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
+                    <CartesianGrid
+                      strokeDasharray="3 3"
+                      className="opacity-30"
+                    />
                     <XAxis
                       dataKey="week"
                       tickFormatter={formatWeek}
@@ -1361,11 +2038,24 @@ export default function AnalyticsPage() {
                     <YAxis tick={{ fontSize: 11 }} />
                     <Tooltip
                       labelFormatter={formatWeek}
-                      formatter={(value: number, name: string) => [value, name === "thumbs_up" ? "Thumbs Up" : "Thumbs Down"]}
+                      formatter={(value: number, name: string) => [
+                        value,
+                        name === "thumbs_up" ? "Thumbs Up" : "Thumbs Down",
+                      ]}
                     />
                     <Legend />
-                    <Bar dataKey="thumbs_up" name="Thumbs Up" fill="#22c55e" radius={[2, 2, 0, 0]} />
-                    <Bar dataKey="thumbs_down" name="Thumbs Down" fill="#ef4444" radius={[2, 2, 0, 0]} />
+                    <Bar
+                      dataKey="thumbs_up"
+                      name="Thumbs Up"
+                      fill="#22c55e"
+                      radius={[2, 2, 0, 0]}
+                    />
+                    <Bar
+                      dataKey="thumbs_down"
+                      name="Thumbs Down"
+                      fill="#ef4444"
+                      radius={[2, 2, 0, 0]}
+                    />
                   </BarChart>
                 </ResponsiveContainer>
               )}
@@ -1376,7 +2066,11 @@ export default function AnalyticsPage() {
       {
         id: "fb-usage-text-voice",
         title: "Floating Bar Usage",
-        periodChange: latestPeriodChange(fbUsageData, (point) => point.total_queries, "vs previous day"),
+        periodChange: latestPeriodChange(
+          fbUsageData,
+          (point) => point.total_queries,
+          "vs previous day",
+        ),
         subtitle: "Daily queries by input type — text vs voice (last 30 days)",
         icon: <Activity className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
@@ -1385,8 +2079,12 @@ export default function AnalyticsPage() {
             {fbSummary && (
               <div className="mb-2 flex items-center justify-end gap-4 text-sm text-muted-foreground">
                 <span>{fbSummary.totalQueries} total</span>
-                <span className="text-blue-500 font-medium">{fbSummary.totalText} text</span>
-                <span className="text-orange-500 font-medium">{fbSummary.totalVoice} voice</span>
+                <span className="text-blue-500 font-medium">
+                  {fbSummary.totalText} text
+                </span>
+                <span className="text-orange-500 font-medium">
+                  {fbSummary.totalVoice} voice
+                </span>
               </div>
             )}
             <div className="min-h-0 flex-1">
@@ -1401,12 +2099,18 @@ export default function AnalyticsPage() {
               ) : (
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart data={fbUsageData}>
-                    <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
+                    <CartesianGrid
+                      strokeDasharray="3 3"
+                      className="opacity-30"
+                    />
                     <XAxis
                       dataKey="date"
                       tickFormatter={(v) => {
                         const d = new Date(v + "T00:00:00");
-                        return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+                        return d.toLocaleDateString("en-US", {
+                          month: "short",
+                          day: "numeric",
+                        });
                       }}
                       tick={{ fontSize: 11 }}
                     />
@@ -1414,12 +2118,28 @@ export default function AnalyticsPage() {
                     <Tooltip
                       labelFormatter={(v) => {
                         const d = new Date(v + "T00:00:00");
-                        return d.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" });
+                        return d.toLocaleDateString("en-US", {
+                          month: "long",
+                          day: "numeric",
+                          year: "numeric",
+                        });
                       }}
                     />
                     <Legend />
-                    <Bar dataKey="text_queries" name="Text" stackId="queries" fill="#6366f1" radius={[0, 0, 0, 0]} />
-                    <Bar dataKey="voice_queries" name="Voice" stackId="queries" fill="#f97316" radius={[2, 2, 0, 0]} />
+                    <Bar
+                      dataKey="text_queries"
+                      name="Text"
+                      stackId="queries"
+                      fill="#6366f1"
+                      radius={[0, 0, 0, 0]}
+                    />
+                    <Bar
+                      dataKey="voice_queries"
+                      name="Voice"
+                      stackId="queries"
+                      fill="#f97316"
+                      radius={[2, 2, 0, 0]}
+                    />
                   </BarChart>
                 </ResponsiveContainer>
               )}
@@ -1430,15 +2150,24 @@ export default function AnalyticsPage() {
       {
         id: "fb-avg-per-user",
         title: "Avg Queries per User per Day",
-        periodChange: latestPeriodChange(fbUsageData, (point) => point.avg_per_user, "vs previous day"),
-        subtitle: "Average floating bar queries per active user, daily (last 30 days)",
+        periodChange: latestPeriodChange(
+          fbUsageData,
+          (point) => point.avg_per_user,
+          "vs previous day",
+        ),
+        subtitle:
+          "Average floating bar queries per active user, daily (last 30 days)",
         icon: <Activity className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
         render: () => (
           <div className="flex h-full flex-col">
             {fbSummary && (
               <div className="mb-2 text-right text-sm text-muted-foreground">
-                Overall: <span className="font-medium text-foreground">{fbSummary.overallAvgPerUserPerDay}</span> queries/user/day
+                Overall:{" "}
+                <span className="font-medium text-foreground">
+                  {fbSummary.overallAvgPerUserPerDay}
+                </span>{" "}
+                queries/user/day
               </div>
             )}
             <div className="min-h-0 flex-1">
@@ -1453,30 +2182,58 @@ export default function AnalyticsPage() {
               ) : (
                 <ResponsiveContainer width="100%" height="100%">
                   <ComposedChart data={fbUsageData}>
-                    <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
+                    <CartesianGrid
+                      strokeDasharray="3 3"
+                      className="opacity-30"
+                    />
                     <XAxis
                       dataKey="date"
                       tickFormatter={(v) => {
                         const d = new Date(v + "T00:00:00");
-                        return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+                        return d.toLocaleDateString("en-US", {
+                          month: "short",
+                          day: "numeric",
+                        });
                       }}
                       tick={{ fontSize: 11 }}
                     />
                     <YAxis yAxisId="avg" tick={{ fontSize: 11 }} />
-                    <YAxis yAxisId="users" orientation="right" tick={{ fontSize: 11 }} />
+                    <YAxis
+                      yAxisId="users"
+                      orientation="right"
+                      tick={{ fontSize: 11 }}
+                    />
                     <Tooltip
                       labelFormatter={(v) => {
                         const d = new Date(v + "T00:00:00");
-                        return d.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" });
+                        return d.toLocaleDateString("en-US", {
+                          month: "long",
+                          day: "numeric",
+                          year: "numeric",
+                        });
                       }}
                       formatter={(value: number, name: string) => {
-                        if (name === "Avg/User") return [value, "Avg queries per user"];
+                        if (name === "Avg/User")
+                          return [value, "Avg queries per user"];
                         return [value, "Active users"];
                       }}
                     />
                     <Legend />
-                    <Bar yAxisId="users" dataKey="unique_users" name="Active Users" fill="#e2e8f0" radius={[2, 2, 0, 0]} />
-                    <Line yAxisId="avg" dataKey="avg_per_user" name="Avg/User" stroke="#6366f1" strokeWidth={2} dot={false} />
+                    <Bar
+                      yAxisId="users"
+                      dataKey="unique_users"
+                      name="Active Users"
+                      fill="#e2e8f0"
+                      radius={[2, 2, 0, 0]}
+                    />
+                    <Line
+                      yAxisId="avg"
+                      dataKey="avg_per_user"
+                      name="Avg/User"
+                      stroke="#6366f1"
+                      strokeWidth={2}
+                      dot={false}
+                    />
                   </ComposedChart>
                 </ResponsiveContainer>
               )}
@@ -1485,57 +2242,142 @@ export default function AnalyticsPage() {
         ),
       },
     ];
-  }, [ratingsLoading, weeklyRatingsData, totalThumbsUp, totalThumbsDown, overallRatio, fbSummary, fbUsageLoading, fbUsageData]);
+  }, [
+    ratingsLoading,
+    weeklyRatingsData,
+    totalThumbsUp,
+    totalThumbsDown,
+    overallRatio,
+    fbSummary,
+    fbUsageLoading,
+    fbUsageData,
+  ]);
 
   const viralCharts = useMemo<ChartItem[]>(() => {
     return [
       {
         id: "viral-growth-accounting",
         title: "Net Weekly Active User Growth",
-        periodChange: latestPeriodChange(completedGrowthAccounting, (point) => point.active, "vs previous complete week"),
-        subtitle: "WAU trend with new + resurrected − churned users · completed weeks",
+        periodChange: latestPeriodChange(
+          completedGrowthAccounting,
+          (point) => point.active,
+          "vs previous complete week",
+        ),
+        subtitle:
+          "WAU trend with new + resurrected − churned users · completed weeks",
         icon: <TrendingUp className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
-        render: () => (
+        render: () =>
           viralLoading ? (
             <div className="flex items-center justify-center h-full">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
             </div>
           ) : completedGrowthAccounting.length > 0 ? (
             <ResponsiveContainer width="100%" height="100%">
-              <ComposedChart data={completedGrowthAccounting} stackOffset="sign">
+              <ComposedChart
+                data={completedGrowthAccounting}
+                stackOffset="sign"
+              >
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis dataKey="week" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
-                <YAxis yAxisId="users" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
-                <Tooltip contentStyle={tooltipStyle} labelFormatter={fullDate} formatter={(value: number, name: string) => {
-                  const labels: Record<string, string> = { active: "WAU", newUsers: "New", retained: "Retained", resurrected: "Resurrected", churned: "Churned" };
-                  return [Math.abs(value), labels[name] || name];
-                }} />
-                <Legend formatter={(value) => {
-                  const labels: Record<string, string> = { active: "WAU", newUsers: "New", retained: "Retained", resurrected: "Resurrected", churned: "Churned" };
-                  return labels[value] || value;
-                }} />
-                <ReferenceLine yAxisId="users" y={0} stroke="hsl(var(--muted-foreground))" />
-                <Bar yAxisId="users" dataKey="newUsers" stackId="a" fill="#22c55e" radius={[2, 2, 0, 0]} />
-                <Bar yAxisId="users" dataKey="resurrected" stackId="a" fill="#3b82f6" radius={[2, 2, 0, 0]} />
-                <Bar yAxisId="users" dataKey="retained" stackId="a" fill="#64748b" radius={[2, 2, 0, 0]} />
-                <Bar yAxisId="users" dataKey="churned" stackId="a" fill="#ef4444" radius={[0, 0, 2, 2]} />
-                <Line yAxisId="users" type="monotone" dataKey="active" name="WAU" stroke="#f59e0b" strokeWidth={3} dot={{ r: 3 }} />
+                <XAxis
+                  dataKey="week"
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  tickFormatter={shortDate}
+                />
+                <YAxis
+                  yAxisId="users"
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                />
+                <Tooltip
+                  contentStyle={tooltipStyle}
+                  labelFormatter={fullDate}
+                  formatter={(value: number, name: string) => {
+                    const labels: Record<string, string> = {
+                      active: "WAU",
+                      newUsers: "New",
+                      retained: "Retained",
+                      resurrected: "Resurrected",
+                      churned: "Churned",
+                    };
+                    return [Math.abs(value), labels[name] || name];
+                  }}
+                />
+                <Legend
+                  formatter={(value) => {
+                    const labels: Record<string, string> = {
+                      active: "WAU",
+                      newUsers: "New",
+                      retained: "Retained",
+                      resurrected: "Resurrected",
+                      churned: "Churned",
+                    };
+                    return labels[value] || value;
+                  }}
+                />
+                <ReferenceLine
+                  yAxisId="users"
+                  y={0}
+                  stroke="hsl(var(--muted-foreground))"
+                />
+                <Bar
+                  yAxisId="users"
+                  dataKey="newUsers"
+                  stackId="a"
+                  fill="#22c55e"
+                  radius={[2, 2, 0, 0]}
+                />
+                <Bar
+                  yAxisId="users"
+                  dataKey="resurrected"
+                  stackId="a"
+                  fill="#3b82f6"
+                  radius={[2, 2, 0, 0]}
+                />
+                <Bar
+                  yAxisId="users"
+                  dataKey="retained"
+                  stackId="a"
+                  fill="#64748b"
+                  radius={[2, 2, 0, 0]}
+                />
+                <Bar
+                  yAxisId="users"
+                  dataKey="churned"
+                  stackId="a"
+                  fill="#ef4444"
+                  radius={[0, 0, 2, 2]}
+                />
+                <Line
+                  yAxisId="users"
+                  type="monotone"
+                  dataKey="active"
+                  name="WAU"
+                  stroke="#f59e0b"
+                  strokeWidth={3}
+                  dot={{ r: 3 }}
+                />
               </ComposedChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex items-center justify-center h-full text-muted-foreground">No data available</div>
-          )
-        ),
+            <div className="flex items-center justify-center h-full text-muted-foreground">
+              No data available
+            </div>
+          ),
       },
       {
         id: "viral-dau",
         title: "Daily Active Users",
-        periodChange: latestPeriodChange(dauData, (point) => point.dau, "vs previous day"),
+        periodChange: latestPeriodChange(
+          dauData,
+          (point) => point.dau,
+          "vs previous day",
+        ),
         subtitle: "Unique macOS users per day",
         icon: <Activity className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
-        render: () => (
+        render: () =>
           dauLoading ? (
             <div className="flex items-center justify-center h-full">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -1544,21 +2386,43 @@ export default function AnalyticsPage() {
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={dauData}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
-                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
-                <Tooltip formatter={(value: number) => [value.toLocaleString(), "DAU"]} labelFormatter={fullDate} contentStyle={tooltipStyle} />
-                <Bar dataKey="dau" name="DAU" fill="#f59e0b" radius={[2, 2, 0, 0]} />
+                <XAxis
+                  dataKey="date"
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  tickFormatter={shortDate}
+                />
+                <YAxis
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                />
+                <Tooltip
+                  formatter={(value: number) => [value.toLocaleString(), "DAU"]}
+                  labelFormatter={fullDate}
+                  contentStyle={tooltipStyle}
+                />
+                <Bar
+                  dataKey="dau"
+                  name="DAU"
+                  fill="#f59e0b"
+                  radius={[2, 2, 0, 0]}
+                />
               </BarChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex items-center justify-center h-full text-muted-foreground">No data available</div>
-          )
-        ),
+            <div className="flex items-center justify-center h-full text-muted-foreground">
+              No data available
+            </div>
+          ),
       },
       {
         id: "viral-crash-rate",
         title: "App Stability",
-        periodChange: latestPeriodChange(crashRate?.data ?? [], (point) => point.crashFreeRate, "vs previous day"),
+        periodChange: latestPeriodChange(
+          crashRate?.data ?? [],
+          (point) => point.crashFreeRate,
+          "vs previous day",
+        ),
         subtitle: "Daily crashes vs active users (last 30 days)",
         icon: <AlertTriangle className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -1568,13 +2432,18 @@ export default function AnalyticsPage() {
             const recent = crashRate.data.slice(-7);
             const totalCrashes = recent.reduce((s, d) => s + d.crashes, 0);
             const totalUsers = recent.reduce((s, d) => s + d.users, 0);
-            const rate = totalUsers > 0 ? ((1 - totalCrashes / totalUsers) * 100).toFixed(1) : "100.0";
+            const rate =
+              totalUsers > 0
+                ? ((1 - totalCrashes / totalUsers) * 100).toFixed(1)
+                : "100.0";
             return `${rate}% crash-free (7d) · ${totalCrashes} crashes`;
           })();
           return (
             <div className="flex h-full flex-col">
               {summaryLine && (
-                <div className="mb-2 text-right text-sm text-muted-foreground">{summaryLine}</div>
+                <div className="mb-2 text-right text-sm text-muted-foreground">
+                  {summaryLine}
+                </div>
               )}
               <div className="min-h-0 flex-1">
                 {crashRateLoading ? (
@@ -1584,23 +2453,66 @@ export default function AnalyticsPage() {
                 ) : (crashRate?.data?.length ?? 0) > 0 ? (
                   <ResponsiveContainer width="100%" height="100%">
                     <ComposedChart data={crashRate!.data}>
-                      <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                      <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
-                      <YAxis yAxisId="left" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
-                      <YAxis yAxisId="right" orientation="right" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `${v}%`} domain={[90, 100]} />
+                      <CartesianGrid
+                        strokeDasharray="3 3"
+                        className="stroke-muted"
+                      />
+                      <XAxis
+                        dataKey="date"
+                        className="text-xs"
+                        tick={{ fill: "hsl(var(--muted-foreground))" }}
+                        tickFormatter={shortDate}
+                      />
+                      <YAxis
+                        yAxisId="left"
+                        className="text-xs"
+                        tick={{ fill: "hsl(var(--muted-foreground))" }}
+                      />
+                      <YAxis
+                        yAxisId="right"
+                        orientation="right"
+                        className="text-xs"
+                        tick={{ fill: "hsl(var(--muted-foreground))" }}
+                        tickFormatter={(v) => `${v}%`}
+                        domain={[90, 100]}
+                      />
                       <Tooltip
                         formatter={(value: number, name: string) => {
-                          if (name === "crashFreeRate") return [`${value}%`, "Crash-Free Rate"];
-                          if (name === "crashes") return [value.toLocaleString(), "Crashes"];
+                          if (name === "crashFreeRate")
+                            return [`${value}%`, "Crash-Free Rate"];
+                          if (name === "crashes")
+                            return [value.toLocaleString(), "Crashes"];
                           return [value.toLocaleString(), "Active Users"];
                         }}
                         labelFormatter={fullDate}
                         contentStyle={tooltipStyle}
                       />
                       <Legend />
-                      <Bar yAxisId="left" dataKey="crashes" name="Crashes" fill="#ef4444" radius={[2, 2, 0, 0]} />
-                      <Bar yAxisId="left" dataKey="users" name="Active Users" fill="#6366f1" radius={[2, 2, 0, 0]} opacity={0.3} />
-                      <Line yAxisId="right" type="monotone" dataKey="crashFreeRate" name="Crash-Free Rate" stroke="#22c55e" strokeWidth={2} dot={false} activeDot={{ r: 4 }} />
+                      <Bar
+                        yAxisId="left"
+                        dataKey="crashes"
+                        name="Crashes"
+                        fill="#ef4444"
+                        radius={[2, 2, 0, 0]}
+                      />
+                      <Bar
+                        yAxisId="left"
+                        dataKey="users"
+                        name="Active Users"
+                        fill="#6366f1"
+                        radius={[2, 2, 0, 0]}
+                        opacity={0.3}
+                      />
+                      <Line
+                        yAxisId="right"
+                        type="monotone"
+                        dataKey="crashFreeRate"
+                        name="Crash-Free Rate"
+                        stroke="#22c55e"
+                        strokeWidth={2}
+                        dot={false}
+                        activeDot={{ r: 4 }}
+                      />
                     </ComposedChart>
                   </ResponsiveContainer>
                 ) : (
@@ -1616,7 +2528,11 @@ export default function AnalyticsPage() {
       {
         id: "viral-daily-new-users",
         title: "Daily New Users",
-        periodChange: latestPeriodChange(dailyWithRollingAvg, (point) => point.rollingAvg, "vs previous day"),
+        periodChange: latestPeriodChange(
+          dailyWithRollingAvg,
+          (point) => point.rollingAvg,
+          "vs previous day",
+        ),
         subtitle: "First-time sign-ins with 7-day rolling average",
         icon: <Users className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
@@ -1624,7 +2540,10 @@ export default function AnalyticsPage() {
           <div className="flex h-full flex-col">
             {dailyWithRollingAvg.length > 0 && (
               <div className="mb-2 text-right text-sm text-muted-foreground">
-                {dailyWithRollingAvg.reduce((s, p) => s + p.users, 0).toLocaleString()} in last 30d
+                {dailyWithRollingAvg
+                  .reduce((s, p) => s + p.users, 0)
+                  .toLocaleString()}{" "}
+                in last 30d
               </div>
             )}
             <div className="min-h-0 flex-1">
@@ -1635,21 +2554,51 @@ export default function AnalyticsPage() {
               ) : dailyWithRollingAvg.length > 0 ? (
                 <ResponsiveContainer width="100%" height="100%">
                   <ComposedChart data={dailyWithRollingAvg}>
-                    <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                    <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
-                    <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                    <CartesianGrid
+                      strokeDasharray="3 3"
+                      className="stroke-muted"
+                    />
+                    <XAxis
+                      dataKey="date"
+                      className="text-xs"
+                      tick={{ fill: "hsl(var(--muted-foreground))" }}
+                      tickFormatter={shortDate}
+                    />
+                    <YAxis
+                      className="text-xs"
+                      tick={{ fill: "hsl(var(--muted-foreground))" }}
+                    />
                     <Tooltip
-                      formatter={(value: number, name: string) => [value.toLocaleString(), name === "rollingAvg" ? "7-Day Avg" : "New Users"]}
+                      formatter={(value: number, name: string) => [
+                        value.toLocaleString(),
+                        name === "rollingAvg" ? "7-Day Avg" : "New Users",
+                      ]}
                       labelFormatter={fullDate}
                       contentStyle={tooltipStyle}
                     />
                     <Legend />
-                    <Bar dataKey="users" name="New Users" fill="#6366f1" radius={[2, 2, 0, 0]} />
-                    <Line type="monotone" dataKey="rollingAvg" name="7-Day Avg" stroke="#f97316" strokeWidth={2} dot={false} activeDot={{ r: 4 }} connectNulls={false} />
+                    <Bar
+                      dataKey="users"
+                      name="New Users"
+                      fill="#6366f1"
+                      radius={[2, 2, 0, 0]}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="rollingAvg"
+                      name="7-Day Avg"
+                      stroke="#f97316"
+                      strokeWidth={2}
+                      dot={false}
+                      activeDot={{ r: 4 }}
+                      connectNulls={false}
+                    />
                   </ComposedChart>
                 </ResponsiveContainer>
               ) : (
-                <div className="flex items-center justify-center h-full text-muted-foreground">No data available</div>
+                <div className="flex items-center justify-center h-full text-muted-foreground">
+                  No data available
+                </div>
               )}
             </div>
           </div>
@@ -1658,11 +2607,15 @@ export default function AnalyticsPage() {
       {
         id: "viral-stickiness",
         title: "Stickiness (DAU/WAU)",
-        periodChange: latestPeriodChange(stickinessData, (point) => point.dauWau, "vs previous week"),
+        periodChange: latestPeriodChange(
+          stickinessData,
+          (point) => point.dauWau,
+          "vs previous week",
+        ),
         subtitle: "How often weekly users come back daily (good: 30%+)",
         icon: <Zap className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
-        render: () => (
+        render: () =>
           viralLoading ? (
             <div className="flex items-center justify-center h-full">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -1671,17 +2624,44 @@ export default function AnalyticsPage() {
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={stickinessData}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis dataKey="week" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
-                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `${v}%`} domain={[0, "auto"]} />
-                <Tooltip formatter={(value: number) => [`${value}%`, "DAU/WAU"]} labelFormatter={(l) => `Week of ${fullDate(l)}`} contentStyle={tooltipStyle} />
-                <ReferenceLine y={30} stroke="#22c55e" strokeDasharray="3 3" label={{ value: "Good", fill: "#22c55e", fontSize: 11 }} />
-                <Line type="monotone" dataKey="dauWau" stroke="#6366f1" strokeWidth={2} dot={{ r: 3, fill: "#6366f1" }} activeDot={{ r: 5 }} />
+                <XAxis
+                  dataKey="week"
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  tickFormatter={shortDate}
+                />
+                <YAxis
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  tickFormatter={(v) => `${v}%`}
+                  domain={[0, "auto"]}
+                />
+                <Tooltip
+                  formatter={(value: number) => [`${value}%`, "DAU/WAU"]}
+                  labelFormatter={(l) => `Week of ${fullDate(l)}`}
+                  contentStyle={tooltipStyle}
+                />
+                <ReferenceLine
+                  y={30}
+                  stroke="#22c55e"
+                  strokeDasharray="3 3"
+                  label={{ value: "Good", fill: "#22c55e", fontSize: 11 }}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="dauWau"
+                  stroke="#6366f1"
+                  strokeWidth={2}
+                  dot={{ r: 3, fill: "#6366f1" }}
+                  activeDot={{ r: 5 }}
+                />
               </LineChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex items-center justify-center h-full text-muted-foreground">No data available</div>
-          )
-        ),
+            <div className="flex items-center justify-center h-full text-muted-foreground">
+              No data available
+            </div>
+          ),
       },
       {
         id: "viral-power-curve",
@@ -1689,7 +2669,7 @@ export default function AnalyticsPage() {
         subtitle: "Days active per user in last 30 days (right-skew = healthy)",
         icon: <Zap className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
-        render: () => (
+        render: () =>
           viralLoading ? (
             <div className="flex items-center justify-center h-full">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -1698,29 +2678,65 @@ export default function AnalyticsPage() {
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={powerCurve}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis dataKey="daysActive" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} label={{ value: "Days Active", position: "insideBottom", offset: -5, fill: "hsl(var(--muted-foreground))", fontSize: 11 }} />
-                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
-                <Tooltip formatter={(value: number, _: string, entry: any) => [`${value} users (${entry.payload.pct}%)`, "Users"]} labelFormatter={(l) => `${l} days active`} contentStyle={tooltipStyle} />
+                <XAxis
+                  dataKey="daysActive"
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  label={{
+                    value: "Days Active",
+                    position: "insideBottom",
+                    offset: -5,
+                    fill: "hsl(var(--muted-foreground))",
+                    fontSize: 11,
+                  }}
+                />
+                <YAxis
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                />
+                <Tooltip
+                  formatter={(value: number, _: string, entry: any) => [
+                    `${value} users (${entry.payload.pct}%)`,
+                    "Users",
+                  ]}
+                  labelFormatter={(l) => `${l} days active`}
+                  contentStyle={tooltipStyle}
+                />
                 <Bar dataKey="users" radius={[2, 2, 0, 0]}>
                   {powerCurve.map((entry, index) => (
-                    <Cell key={index} fill={entry.daysActive >= 20 ? "#22c55e" : entry.daysActive >= 10 ? "#3b82f6" : "#6366f1"} />
+                    <Cell
+                      key={index}
+                      fill={
+                        entry.daysActive >= 20
+                          ? "#22c55e"
+                          : entry.daysActive >= 10
+                            ? "#3b82f6"
+                            : "#6366f1"
+                      }
+                    />
                   ))}
                 </Bar>
               </BarChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex items-center justify-center h-full text-muted-foreground">No data available</div>
-          )
-        ),
+            <div className="flex items-center justify-center h-full text-muted-foreground">
+              No data available
+            </div>
+          ),
       },
       {
         id: "viral-activation",
         title: "New Activated Users / Week",
-        periodChange: latestPeriodChange(weeklyActivationData, (point) => point.activated, "vs previous mature cohort week"),
-        subtitle: "Conversation created within 7 days of signup · fully matured cohorts only",
+        periodChange: latestPeriodChange(
+          weeklyActivationData,
+          (point) => point.activated,
+          "vs previous mature cohort week",
+        ),
+        subtitle:
+          "Conversation created within 7 days of signup · fully matured cohorts only",
         icon: <Target className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
-        render: () => (
+        render: () =>
           viralLoading ? (
             <div className="flex items-center justify-center h-full">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -1729,31 +2745,83 @@ export default function AnalyticsPage() {
             <ResponsiveContainer width="100%" height="100%">
               <ComposedChart data={weeklyActivationData}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis dataKey="week" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
-                <YAxis yAxisId="left" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
-                <YAxis yAxisId="right" orientation="right" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `${v}%`} domain={[0, 100]} />
+                <XAxis
+                  dataKey="week"
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  tickFormatter={shortDate}
+                />
+                <YAxis
+                  yAxisId="left"
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                />
+                <YAxis
+                  yAxisId="right"
+                  orientation="right"
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  tickFormatter={(v) => `${v}%`}
+                  domain={[0, 100]}
+                />
                 <Tooltip
                   contentStyle={tooltipStyle}
                   labelFormatter={(value) => `Week of ${fullDate(value)}`}
                   formatter={(value: number, name: string) => {
-                    if (name === "rate") return [`${value}%`, "Activation Rate"];
+                    if (name === "rate")
+                      return [`${value}%`, "Activation Rate"];
                     if (name === "activated") return [value, "Activated"];
                     return [value, "Signups"];
                   }}
                 />
                 <Legend />
-                <Bar yAxisId="left" dataKey="signups" name="Signups" fill="#3b82f6" radius={[2, 2, 0, 0]} opacity={0.5} />
-                <Bar yAxisId="left" dataKey="activated" name="Activated" fill="#22c55e" radius={[2, 2, 0, 0]} />
-                <Line yAxisId="right" type="monotone" dataKey="rate" name="Activation %" stroke="#f97316" strokeWidth={2} dot={{ r: 2 }} activeDot={{ r: 4 }} />
+                <Bar
+                  yAxisId="left"
+                  dataKey="signups"
+                  name="Signups"
+                  fill="#3b82f6"
+                  radius={[2, 2, 0, 0]}
+                  opacity={0.5}
+                />
+                <Bar
+                  yAxisId="left"
+                  dataKey="activated"
+                  name="Activated"
+                  fill="#22c55e"
+                  radius={[2, 2, 0, 0]}
+                />
+                <Line
+                  yAxisId="right"
+                  type="monotone"
+                  dataKey="rate"
+                  name="Activation %"
+                  stroke="#f97316"
+                  strokeWidth={2}
+                  dot={{ r: 2 }}
+                  activeDot={{ r: 4 }}
+                />
               </ComposedChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex items-center justify-center h-full text-muted-foreground">No data available</div>
-          )
-        ),
+            <div className="flex items-center justify-center h-full text-muted-foreground">
+              No data available
+            </div>
+          ),
       },
     ];
-  }, [viralLoading, completedGrowthAccounting, dauLoading, dauData, crashRate, crashRateLoading, dailyWithRollingAvg, dailyNewUsersLoading, stickinessData, powerCurve, weeklyActivationData]);
+  }, [
+    viralLoading,
+    completedGrowthAccounting,
+    dauLoading,
+    dauData,
+    crashRate,
+    crashRateLoading,
+    dailyWithRollingAvg,
+    dailyNewUsersLoading,
+    stickinessData,
+    powerCurve,
+    weeklyActivationData,
+  ]);
 
   const retentionCharts = useMemo<ChartItem[]>(() => {
     if (retentionView !== "average") return [];
@@ -1761,26 +2829,49 @@ export default function AnalyticsPage() {
       {
         id: "retention-avg-curve",
         title: "Activity Retention (W1 → W4)",
-        subtitle: retention?.totalUsers != null
-          ? `D7 ${retentionD7?.toFixed(1) ?? "--"}% · W4 ${retentionW4?.toFixed(1) ?? "--"}% · ${retention.totalCohorts} cohorts · activity-based, not activation-filtered`
-          : "Activity-based retention; activated-only cohorts are not instrumented yet",
+        subtitle:
+          retention?.totalUsers != null
+            ? `D7 ${retentionD7?.toFixed(1) ?? "--"}% · W4 ${retentionW4?.toFixed(1) ?? "--"}% · ${retention.totalCohorts} cohorts · activity-based, not activation-filtered`
+            : "Activity-based retention; activated-only cohorts are not instrumented yet",
         icon: <TrendingUp className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
-        render: () => (
+        render: () =>
           retention?.data && retention.data.length > 0 ? (
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={retention.data}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis dataKey="day" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `D${v}`} />
-                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `${v}%`} domain={[0, 100]} />
-                <Tooltip formatter={(value: number) => [`${value}%`, "Retention"]} labelFormatter={(label) => `Day ${label}`} contentStyle={tooltipStyle} />
-                <Line type="monotone" dataKey="retention" stroke="#f97316" strokeWidth={2} dot={{ r: 2, fill: "#f97316" }} activeDot={{ r: 5 }} />
+                <XAxis
+                  dataKey="day"
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  tickFormatter={(v) => `D${v}`}
+                />
+                <YAxis
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  tickFormatter={(v) => `${v}%`}
+                  domain={[0, 100]}
+                />
+                <Tooltip
+                  formatter={(value: number) => [`${value}%`, "Retention"]}
+                  labelFormatter={(label) => `Day ${label}`}
+                  contentStyle={tooltipStyle}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="retention"
+                  stroke="#f97316"
+                  strokeWidth={2}
+                  dot={{ r: 2, fill: "#f97316" }}
+                  activeDot={{ r: 5 }}
+                />
               </LineChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex items-center justify-center h-full text-muted-foreground">No retention data available</div>
-          )
-        ),
+            <div className="flex items-center justify-center h-full text-muted-foreground">
+              No retention data available
+            </div>
+          ),
       },
     ];
   }, [retentionView, retention, retentionD7, retentionW4]);
@@ -1799,9 +2890,10 @@ export default function AnalyticsPage() {
   const cpuMobile = profitability?.summary.avgCostPerUserMobile ?? null;
   const cpuDesktop = profitability?.summary.avgCostPerUserDesktop ?? null;
   const totalFirebaseUsers = dailyNewUsers?.totalUsers ?? null;
-  const goalProgressPct = totalFirebaseUsers != null
-    ? Math.min(100, (totalFirebaseUsers / SOFTWARE_USER_GOAL) * 100)
-    : null;
+  const goalProgressPct =
+    totalFirebaseUsers != null
+      ? Math.min(100, (totalFirebaseUsers / SOFTWARE_USER_GOAL) * 100)
+      : null;
 
   // Net WAU: compare the last two FULL weeks — the trailing
   // growth-accounting bucket is the current partial week.
@@ -1809,28 +2901,40 @@ export default function AnalyticsPage() {
     () => (vm?.growthAccounting ?? []).slice(0, -1),
     [vm],
   );
-  const netWauNow = fullGrowthWeeks.length >= 1 ? fullGrowthWeeks[fullGrowthWeeks.length - 1].active : null;
-  const netWauPrev = fullGrowthWeeks.length >= 2 ? fullGrowthWeeks[fullGrowthWeeks.length - 2].active : null;
-  const netWauDelta = netWauNow != null && netWauPrev != null ? netWauNow - netWauPrev : null;
-  const netWauChange = calculatePeriodChange(netWauNow, netWauPrev, "vs previous complete week");
+  const netWauNow =
+    fullGrowthWeeks.length >= 1
+      ? fullGrowthWeeks[fullGrowthWeeks.length - 1].active
+      : null;
+  const netWauPrev =
+    fullGrowthWeeks.length >= 2
+      ? fullGrowthWeeks[fullGrowthWeeks.length - 2].active
+      : null;
+  const netWauDelta =
+    netWauNow != null && netWauPrev != null ? netWauNow - netWauPrev : null;
+  const netWauChange = calculatePeriodChange(
+    netWauNow,
+    netWauPrev,
+    "vs previous complete week",
+  );
 
   const growthGoalItems = useMemo<ChartItem[]>(() => {
-    const kFactorValue = kFactorData?.available && kFactorData.kFactor != null
-      ? kFactorData.kFactor.toFixed(2)
-      : "Not tracked";
-    const kFactorSubtitle = kFactorData?.available && kFactorData.kFactor != null
-      ? "Target ≥0.60"
-      : kFactorData?.proxy
-        ? `${kFactorData.proxy.sharesPerNewUser.toFixed(2)} shares/user · conversion missing`
-        : "Referral conversion is not instrumented yet";
+    const referralGrants = kFactorData?.funnel?.granted;
+    const kFactorValue =
+      kFactorData?.available && referralGrants != null
+        ? referralGrants.toLocaleString()
+        : "Not tracked";
+    const kFactorSubtitle = kFactorData?.funnel
+      ? `${kFactorData.funnel.issued} issued / ${kFactorData.funnel.captured} captured / ${kFactorData.funnel.granted} granted`
+      : (kFactorData?.reason ?? "Referral funnel is unavailable");
 
     return [
       {
         id: "header-1m-growth",
         title: "Path to 1M Software Users",
-        subtitle: totalFirebaseUsers != null && goalProgressPct != null
-          ? `${totalFirebaseUsers.toLocaleString()} of ${SOFTWARE_USER_GOAL.toLocaleString()} (${goalProgressPct.toFixed(1)}%) · acquisition → activation → retention → virality`
-          : `Goal: ${SOFTWARE_USER_GOAL.toLocaleString()} software users · acquisition → activation → retention → virality`,
+        subtitle:
+          totalFirebaseUsers != null && goalProgressPct != null
+            ? `${totalFirebaseUsers.toLocaleString()} of ${SOFTWARE_USER_GOAL.toLocaleString()} (${goalProgressPct.toFixed(1)}%) · acquisition → activation → retention → virality`
+            : `Goal: ${SOFTWARE_USER_GOAL.toLocaleString()} software users · acquisition → activation → retention → virality`,
         variant: "header",
         initialLayout: { cols: 12, rows: 1 },
         removable: false,
@@ -1846,7 +2950,9 @@ export default function AnalyticsPage() {
         render: () => (
           <div>
             <div className="text-2xl font-bold text-green-600">
-              {totalFirebaseUsers != null ? totalFirebaseUsers.toLocaleString() : "--"}
+              {totalFirebaseUsers != null
+                ? totalFirebaseUsers.toLocaleString()
+                : "--"}
             </div>
             <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-muted">
               <div
@@ -1855,7 +2961,9 @@ export default function AnalyticsPage() {
               />
             </div>
             <p className="mt-1 truncate text-xs text-muted-foreground">
-              {goalProgressPct != null ? `${goalProgressPct.toFixed(1)}% of 1M` : "of 1M"}
+              {goalProgressPct != null
+                ? `${goalProgressPct.toFixed(1)}% of 1M`
+                : "of 1M"}
             </p>
           </div>
         ),
@@ -1870,15 +2978,26 @@ export default function AnalyticsPage() {
         removable: false,
         render: () => (
           <div>
-            <div className={`text-2xl font-bold ${
-              netWauDelta == null ? "" : netWauDelta > 0 ? "text-green-600" : netWauDelta < 0 ? "text-red-600" : ""
-            }`}>
+            <div
+              className={`text-2xl font-bold ${
+                netWauDelta == null
+                  ? ""
+                  : netWauDelta > 0
+                    ? "text-green-600"
+                    : netWauDelta < 0
+                      ? "text-red-600"
+                      : ""
+              }`}
+            >
               {netWauDelta != null
                 ? `${netWauDelta > 0 ? "+" : ""}${netWauDelta.toLocaleString()}`
                 : "--"}
             </div>
             <p className="truncate text-xs text-muted-foreground">
-              {netWauNow != null ? `WAU ${netWauNow.toLocaleString()} last full week` : "new + resurrected − churned"} · target ≥7% WoW
+              {netWauNow != null
+                ? `WAU ${netWauNow.toLocaleString()} last full week`
+                : "new + resurrected − churned"}{" "}
+              · target ≥7% WoW
             </p>
           </div>
         ),
@@ -1888,7 +3007,11 @@ export default function AnalyticsPage() {
         title: "Weekly New Users",
         variant: "kpi",
         icon: <Users className="h-3.5 w-3.5" />,
-        periodChange: latestPeriodChange(weeklyNewUsersData, (point) => point.users, "vs previous complete week"),
+        periodChange: latestPeriodChange(
+          weeklyNewUsersData,
+          (point) => point.users,
+          "vs previous complete week",
+        ),
         initialLayout: { cols: 3, rows: 1 },
         removable: false,
         render: () => (
@@ -1896,7 +3019,9 @@ export default function AnalyticsPage() {
             <div className="text-2xl font-bold">
               {latestWeeklyNewUsers?.users.toLocaleString() ?? "--"}
             </div>
-            <p className="truncate text-xs text-muted-foreground">All signups · target +7–10% WoW</p>
+            <p className="truncate text-xs text-muted-foreground">
+              All signups · target +7–10% WoW
+            </p>
           </div>
         ),
       },
@@ -1905,7 +3030,11 @@ export default function AnalyticsPage() {
         title: "Weekly Activated Users",
         variant: "kpi",
         icon: <Target className="h-3.5 w-3.5" />,
-        periodChange: latestPeriodChange(weeklyActivationData, (point) => point.activated, "vs previous mature cohort week"),
+        periodChange: latestPeriodChange(
+          weeklyActivationData,
+          (point) => point.activated,
+          "vs previous mature cohort week",
+        ),
         initialLayout: { cols: 3, rows: 1 },
         removable: false,
         render: () => (
@@ -1930,36 +3059,44 @@ export default function AnalyticsPage() {
         removable: false,
         render: () => (
           <div>
-            <div className={`text-2xl font-bold ${
-              growthRetentionW4 == null
-                ? ""
-                : growthRetentionW4 >= 40
-                  ? "text-green-600"
-                  : growthRetentionW4 < 25
-                    ? "text-red-600"
-                    : ""
-            }`}>
+            <div
+              className={`text-2xl font-bold ${
+                growthRetentionW4 == null
+                  ? ""
+                  : growthRetentionW4 >= 40
+                    ? "text-green-600"
+                    : growthRetentionW4 < 25
+                      ? "text-red-600"
+                      : ""
+              }`}
+            >
               {growthRetentionLoading
                 ? "..."
                 : growthRetentionW4 != null
                   ? `${growthRetentionW4.toFixed(1)}%`
                   : "--"}
             </div>
-            <p className="truncate text-xs text-muted-foreground">macOS activity · not activation-filtered</p>
+            <p className="truncate text-xs text-muted-foreground">
+              macOS activity · not activation-filtered
+            </p>
           </div>
         ),
       },
       {
         id: "kpi-k-factor",
-        title: "K-Factor",
+        title: "Referral grants",
         variant: "kpi",
         icon: <Share2 className="h-3.5 w-3.5" />,
         initialLayout: { cols: 3, rows: 1 },
         removable: false,
         render: () => (
           <div>
-            <div className="text-2xl font-bold">{kFactorLoading ? "..." : kFactorValue}</div>
-            <p className="truncate text-xs text-muted-foreground">{kFactorSubtitle}</p>
+            <div className="text-2xl font-bold">
+              {kFactorLoading ? "..." : kFactorValue}
+            </div>
+            <p className="truncate text-xs text-muted-foreground">
+              {kFactorSubtitle}
+            </p>
           </div>
         ),
       },
@@ -1968,10 +3105,14 @@ export default function AnalyticsPage() {
         title: "Weekly New Software Users",
         subtitle: "All-software Firebase signups · latest 12 completed weeks",
         icon: <Users className="h-4 w-4" />,
-        periodChange: latestPeriodChange(weeklyNewUsersData, (point) => point.users, "vs previous complete week"),
+        periodChange: latestPeriodChange(
+          weeklyNewUsersData,
+          (point) => point.users,
+          "vs previous complete week",
+        ),
         initialLayout: { cols: 12, rows: 4 },
         removable: false,
-        render: () => (
+        render: () =>
           dailyNewUsersLoading ? (
             <div className="flex h-full items-center justify-center">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -1980,23 +3121,56 @@ export default function AnalyticsPage() {
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={weeklyNewUsersData}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis dataKey="week" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
-                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={formatCompact} />
-                <Tooltip contentStyle={tooltipStyle} labelFormatter={(value) => `Week of ${fullDate(value)}`}
-                  formatter={(value: number) => [value.toLocaleString(), "New users"]} />
-                <Bar dataKey="users" name="New users" fill="#3b82f6" radius={[3, 3, 0, 0]} />
+                <XAxis
+                  dataKey="week"
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  tickFormatter={shortDate}
+                />
+                <YAxis
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  tickFormatter={formatCompact}
+                />
+                <Tooltip
+                  contentStyle={tooltipStyle}
+                  labelFormatter={(value) => `Week of ${fullDate(value)}`}
+                  formatter={(value: number) => [
+                    value.toLocaleString(),
+                    "New users",
+                  ]}
+                />
+                <Bar
+                  dataKey="users"
+                  name="New users"
+                  fill="#3b82f6"
+                  radius={[3, 3, 0, 0]}
+                />
               </BarChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex h-full items-center justify-center text-muted-foreground">No completed-week data available</div>
-          )
-        ),
+            <div className="flex h-full items-center justify-center text-muted-foreground">
+              No completed-week data available
+            </div>
+          ),
       },
     ];
-  }, [dailyNewUsersLoading, goalProgressPct, growthRetentionLoading, growthRetentionW4,
-    kFactorData, kFactorLoading, latestWeeklyActivation, latestWeeklyNewUsers,
-    netWauChange, netWauDelta, netWauNow,
-    totalFirebaseUsers, weeklyActivationData, weeklyNewUsersData]);
+  }, [
+    dailyNewUsersLoading,
+    goalProgressPct,
+    growthRetentionLoading,
+    growthRetentionW4,
+    kFactorData,
+    kFactorLoading,
+    latestWeeklyActivation,
+    latestWeeklyNewUsers,
+    netWauChange,
+    netWauDelta,
+    netWauNow,
+    totalFirebaseUsers,
+    weeklyActivationData,
+    weeklyNewUsersData,
+  ]);
 
   const topKpiAndNewWidgets = useMemo<ChartItem[]>(() => {
     return [
@@ -2018,8 +3192,11 @@ export default function AnalyticsPage() {
           <div>
             <div className="text-2xl font-bold">{formatCurrency(mrr)}</div>
             {mrrGrowthPct !== null && (
-              <p className={`text-xs ${mrrGrowthPct >= 0 ? "text-green-600" : "text-red-600"}`}>
-                {mrrGrowthPct >= 0 ? "+" : ""}{mrrGrowthPct.toFixed(1)}% from last month
+              <p
+                className={`text-xs ${mrrGrowthPct >= 0 ? "text-green-600" : "text-red-600"}`}
+              >
+                {mrrGrowthPct >= 0 ? "+" : ""}
+                {mrrGrowthPct.toFixed(1)}% from last month
               </p>
             )}
           </div>
@@ -2034,7 +3211,9 @@ export default function AnalyticsPage() {
         render: () => (
           <div>
             <div className="text-2xl font-bold">{formatCurrency(arr)}</div>
-            <p className="text-xs text-muted-foreground">Based on current MRR</p>
+            <p className="text-xs text-muted-foreground">
+              Based on current MRR
+            </p>
           </div>
         ),
       },
@@ -2046,8 +3225,12 @@ export default function AnalyticsPage() {
         initialLayout: { cols: 3, rows: 1 },
         render: () => (
           <div>
-            <div className="text-2xl font-bold">{totalSubs.toLocaleString()}</div>
-            <p className="text-xs text-muted-foreground">{monthlySubs} monthly · {annualSubs} annual</p>
+            <div className="text-2xl font-bold">
+              {totalSubs.toLocaleString()}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {monthlySubs} monthly · {annualSubs} annual
+            </p>
           </div>
         ),
       },
@@ -2059,7 +3242,9 @@ export default function AnalyticsPage() {
         initialLayout: { cols: 3, rows: 1 },
         render: () => (
           <div>
-            <div className="text-2xl font-bold">{formatCompact(totalConversations)}</div>
+            <div className="text-2xl font-bold">
+              {formatCompact(totalConversations)}
+            </div>
             <p className="text-xs text-muted-foreground">All time</p>
           </div>
         ),
@@ -2075,7 +3260,9 @@ export default function AnalyticsPage() {
             <div className="text-2xl font-bold">
               {cpuMobile != null ? `$${cpuMobile.toFixed(3)}` : "--"}
             </div>
-            <p className="text-xs text-muted-foreground">avg / day · last {profitDays}d</p>
+            <p className="text-xs text-muted-foreground">
+              avg / day · last {profitDays}d
+            </p>
           </div>
         ),
       },
@@ -2090,42 +3277,90 @@ export default function AnalyticsPage() {
             <div className="text-2xl font-bold">
               {cpuDesktop != null ? `$${cpuDesktop.toFixed(3)}` : "--"}
             </div>
-            <p className="text-xs text-muted-foreground">avg / day · last {profitDays}d</p>
+            <p className="text-xs text-muted-foreground">
+              avg / day · last {profitDays}d
+            </p>
           </div>
         ),
       },
       {
         id: "chart-total-users-cumulative",
         title: "Total Users — All-time growth",
-        periodChange: latestPeriodChange(allDailyData, (point) => point.cumulative, "vs previous day"),
+        periodChange: latestPeriodChange(
+          allDailyData,
+          (point) => point.cumulative,
+          "vs previous day",
+        ),
         subtitle: "Cumulative signups (Firebase Auth)",
         variant: "card",
         initialLayout: { cols: 6, rows: 4 },
-        render: () => (
+        render: () =>
           allDailyData.length > 0 ? (
             <ResponsiveContainer width="100%" height="100%">
               <AreaChart data={allDailyData}>
                 <defs>
-                  <linearGradient id="totalUsersGradient" x1="0" y1="0" x2="0" y2="1">
+                  <linearGradient
+                    id="totalUsersGradient"
+                    x1="0"
+                    y1="0"
+                    x2="0"
+                    y2="1"
+                  >
                     <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.5} />
                     <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
                   </linearGradient>
                 </defs>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }}
-                  tickFormatter={(v) => new Date(v).toLocaleDateString("en-US", { month: "short", year: "2-digit" })} />
-                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => formatCompact(v)} />
-                <Tooltip contentStyle={tooltipStyle} formatter={(v: number) => v.toLocaleString()} />
-                <Area type="monotone" dataKey="cumulative" name="Total users" stroke="#3b82f6" strokeWidth={2} fill="url(#totalUsersGradient)" />
+                <XAxis
+                  dataKey="date"
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  tickFormatter={(v) =>
+                    new Date(v).toLocaleDateString("en-US", {
+                      month: "short",
+                      year: "2-digit",
+                    })
+                  }
+                />
+                <YAxis
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  tickFormatter={(v) => formatCompact(v)}
+                />
+                <Tooltip
+                  contentStyle={tooltipStyle}
+                  formatter={(v: number) => v.toLocaleString()}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="cumulative"
+                  name="Total users"
+                  stroke="#3b82f6"
+                  strokeWidth={2}
+                  fill="url(#totalUsersGradient)"
+                />
               </AreaChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex h-full items-center justify-center text-muted-foreground">No data</div>
-          )
-        ),
+            <div className="flex h-full items-center justify-center text-muted-foreground">
+              No data
+            </div>
+          ),
       },
     ];
-  }, [mrr, arr, totalSubs, monthlySubs, annualSubs, totalConversations, mrrGrowthPct, cpuMobile, cpuDesktop, profitDays, allDailyData]);
+  }, [
+    mrr,
+    arr,
+    totalSubs,
+    monthlySubs,
+    annualSubs,
+    totalConversations,
+    mrrGrowthPct,
+    cpuMobile,
+    cpuDesktop,
+    profitDays,
+    allDailyData,
+  ]);
 
   // Section headers + per-section control widgets that sit inline between
   // groups of charts. They are full-width by default so the user sees a
@@ -2154,22 +3389,36 @@ export default function AnalyticsPage() {
               key={d}
               onClick={() => setProfitDays(d)}
               className={`px-2.5 py-1 text-xs font-medium transition-colors ${
-                profitDays === d ? "bg-primary text-primary-foreground" : "bg-background text-muted-foreground hover:bg-accent"
+                profitDays === d
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-background text-muted-foreground hover:bg-accent"
               }`}
-            >{d}d</button>
+            >
+              {d}d
+            </button>
           ))}
         </div>
         <label className="flex items-center gap-1 text-xs text-muted-foreground">
           Desktop $/user/day
-          <input type="number" step="0.01" min="0" value={desktopCostInput}
+          <input
+            type="number"
+            step="0.01"
+            min="0"
+            value={desktopCostInput}
             onChange={(e) => setDesktopCostInput(e.target.value)}
-            className="w-16 rounded-md border border-input bg-background px-2 py-1 text-xs" />
+            className="w-16 rounded-md border border-input bg-background px-2 py-1 text-xs"
+          />
         </label>
         <label className="flex items-center gap-1 text-xs text-muted-foreground">
           Mobile $/user/day
-          <input type="number" step="0.01" min="0" value={mobileCostInput}
+          <input
+            type="number"
+            step="0.01"
+            min="0"
+            value={mobileCostInput}
             onChange={(e) => setMobileCostInput(e.target.value)}
-            className="w-16 rounded-md border border-input bg-background px-2 py-1 text-xs" />
+            className="w-16 rounded-md border border-input bg-background px-2 py-1 text-xs"
+          />
         </label>
         {profitability?.summary.partial && (
           <span className="ml-auto inline-flex items-center gap-1 rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-xs text-amber-800">
@@ -2195,14 +3444,25 @@ export default function AnalyticsPage() {
     initialLayout: { cols: 6, rows: 1 },
     render: () => (
       <div className="flex h-full items-center gap-2">
-        <span className="text-xs text-muted-foreground">Cumulative window:</span>
+        <span className="text-xs text-muted-foreground">
+          Cumulative window:
+        </span>
         <div className="flex overflow-hidden rounded-md border border-input">
           {(["7d", "30d", "all"] as const).map((w) => (
-            <button key={w} onClick={() => setCumulativeWindow(w)}
+            <button
+              key={w}
+              onClick={() => setCumulativeWindow(w)}
               className={`px-2.5 py-1 text-xs font-medium transition-colors ${
-                cumulativeWindow === w ? "bg-primary text-primary-foreground" : "bg-background text-muted-foreground hover:bg-accent"
-              }`}>
-              {w === "7d" ? "Last week" : w === "30d" ? "Last month" : "All time"}
+                cumulativeWindow === w
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-background text-muted-foreground hover:bg-accent"
+              }`}
+            >
+              {w === "7d"
+                ? "Last week"
+                : w === "30d"
+                  ? "Last month"
+                  : "All time"}
             </button>
           ))}
         </div>
@@ -2218,111 +3478,150 @@ export default function AnalyticsPage() {
     render: () => null,
   };
 
-  const macosKpis = useMemo<ChartItem[]>(() => [
-    {
-      id: "kpi-total-users-macos",
-      title: "Total Users (macOS)",
-      variant: "kpi",
-      icon: <Monitor className="h-3.5 w-3.5" />,
-      initialLayout: { cols: 2, rows: 1 },
-      render: () => (
-        <div>
-          <div className="text-2xl font-bold">
-            {profitability?.summary.totalUsersDesktop != null
-              ? profitability.summary.totalUsersDesktop.toLocaleString()
-              : "--"}
+  const macosKpis = useMemo<ChartItem[]>(
+    () => [
+      {
+        id: "kpi-total-users-macos",
+        title: "Total Users (macOS)",
+        variant: "kpi",
+        icon: <Monitor className="h-3.5 w-3.5" />,
+        initialLayout: { cols: 2, rows: 1 },
+        render: () => (
+          <div>
+            <div className="text-2xl font-bold">
+              {profitability?.summary.totalUsersDesktop != null
+                ? profitability.summary.totalUsersDesktop.toLocaleString()
+                : "--"}
+            </div>
+            <p className="text-xs text-muted-foreground">All-time signups</p>
           </div>
-          <p className="text-xs text-muted-foreground">All-time signups</p>
-        </div>
-      ),
-    },
-    {
-      id: "kpi-total-users-mobile",
-      title: "Total Users (Mobile)",
-      variant: "kpi",
-      icon: <Smartphone className="h-3.5 w-3.5" />,
-      initialLayout: { cols: 2, rows: 1 },
-      render: () => (
-        <div>
-          <div className="text-2xl font-bold">
-            {profitability?.summary.totalUsersMobile != null
-              ? profitability.summary.totalUsersMobile.toLocaleString()
-              : "--"}
+        ),
+      },
+      {
+        id: "kpi-total-users-mobile",
+        title: "Total Users (Mobile)",
+        variant: "kpi",
+        icon: <Smartphone className="h-3.5 w-3.5" />,
+        initialLayout: { cols: 2, rows: 1 },
+        render: () => (
+          <div>
+            <div className="text-2xl font-bold">
+              {profitability?.summary.totalUsersMobile != null
+                ? profitability.summary.totalUsersMobile.toLocaleString()
+                : "--"}
+            </div>
+            <p className="text-xs text-muted-foreground">All-time signups</p>
           </div>
-          <p className="text-xs text-muted-foreground">All-time signups</p>
-        </div>
-      ),
-    },
-    {
-      id: "kpi-dau", title: "DAU", variant: "kpi", icon: <Activity className="h-3.5 w-3.5" />,
-      initialLayout: { cols: 2, rows: 1 },
-      render: () => (
-        <div><div className="text-2xl font-bold">{vm?.summary.dau ?? "--"}</div>
-          <p className="text-xs text-muted-foreground">avg last 7 days</p></div>
-      ),
-    },
-    {
-      id: "kpi-wau", title: "WAU", variant: "kpi", icon: <Users className="h-3.5 w-3.5" />,
-      initialLayout: { cols: 2, rows: 1 },
-      render: () => (
-        <div><div className="text-2xl font-bold">{vm?.summary.wau ?? "--"}</div>
-          <p className="text-xs text-muted-foreground">last 7 days</p></div>
-      ),
-    },
-    {
-      id: "kpi-mau", title: "MAU", variant: "kpi", icon: <Users className="h-3.5 w-3.5" />,
-      initialLayout: { cols: 2, rows: 1 },
-      render: () => (
-        <div><div className="text-2xl font-bold">{vm?.summary.mau ?? "--"}</div>
-          <p className="text-xs text-muted-foreground">last 30 days</p></div>
-      ),
-    },
-    {
-      id: "kpi-dau-mau", title: "DAU/MAU", variant: "kpi", icon: <Zap className="h-3.5 w-3.5" />,
-      initialLayout: { cols: 2, rows: 1 },
-      render: () => (
-        <div>
-          <div className={`text-2xl font-bold ${(vm?.summary.dauMau ?? 0) >= 20 ? "text-green-600" : ""}`}>
-            {vm?.summary.dauMau != null ? `${vm.summary.dauMau}%` : "--"}
+        ),
+      },
+      {
+        id: "kpi-dau",
+        title: "DAU",
+        variant: "kpi",
+        icon: <Activity className="h-3.5 w-3.5" />,
+        initialLayout: { cols: 2, rows: 1 },
+        render: () => (
+          <div>
+            <div className="text-2xl font-bold">{vm?.summary.dau ?? "--"}</div>
+            <p className="text-xs text-muted-foreground">avg last 7 days</p>
           </div>
-          <p className="text-xs text-muted-foreground">Stickiness (good: 20%+)</p>
-        </div>
-      ),
-    },
-    {
-      id: "kpi-quick-ratio", title: "Quick Ratio", variant: "kpi", icon: <TrendingUp className="h-3.5 w-3.5" />,
-      initialLayout: { cols: 2, rows: 1 },
-      render: () => (
-        <div>
-          <div className={`text-2xl font-bold ${(vm?.summary.quickRatio ?? 0) >= 1 ? "text-green-600" : "text-red-600"}`}>
-            {vm?.summary.quickRatio != null ? `${vm.summary.quickRatio}x` : "--"}
+        ),
+      },
+      {
+        id: "kpi-wau",
+        title: "WAU",
+        variant: "kpi",
+        icon: <Users className="h-3.5 w-3.5" />,
+        initialLayout: { cols: 2, rows: 1 },
+        render: () => (
+          <div>
+            <div className="text-2xl font-bold">{vm?.summary.wau ?? "--"}</div>
+            <p className="text-xs text-muted-foreground">last 7 days</p>
           </div>
-          <p className="text-xs text-muted-foreground">Growing if &gt;1x</p>
-        </div>
-      ),
-    },
-    {
-      id: "kpi-activation", title: "Activation", variant: "kpi", icon: <Target className="h-3.5 w-3.5" />,
-      initialLayout: { cols: 2, rows: 1 },
-      render: () => (
-        <div>
-          <div className={`text-2xl font-bold ${(activationStats?.rate ?? 0) >= 50 ? "text-green-600" : ""}`}>
-            {activationStats?.rate != null ? `${activationStats.rate}%` : "--"}
+        ),
+      },
+      {
+        id: "kpi-mau",
+        title: "MAU",
+        variant: "kpi",
+        icon: <Users className="h-3.5 w-3.5" />,
+        initialLayout: { cols: 2, rows: 1 },
+        render: () => (
+          <div>
+            <div className="text-2xl font-bold">{vm?.summary.mau ?? "--"}</div>
+            <p className="text-xs text-muted-foreground">last 30 days</p>
           </div>
-          <p className="text-xs text-muted-foreground">
-            {activationStats?.rate != null
-              ? `Conversation within 7d · n=${activationStats.signups.toLocaleString()}`
-              : "Conversation within 7 days of signup"}
-          </p>
-          {(activationStats?.erroredUsers ?? 0) > 0 && (
-            <p className="text-xs text-amber-600">
-              {activationStats?.erroredUsers} users unreadable this run
+        ),
+      },
+      {
+        id: "kpi-dau-mau",
+        title: "DAU/MAU",
+        variant: "kpi",
+        icon: <Zap className="h-3.5 w-3.5" />,
+        initialLayout: { cols: 2, rows: 1 },
+        render: () => (
+          <div>
+            <div
+              className={`text-2xl font-bold ${(vm?.summary.dauMau ?? 0) >= 20 ? "text-green-600" : ""}`}
+            >
+              {vm?.summary.dauMau != null ? `${vm.summary.dauMau}%` : "--"}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Stickiness (good: 20%+)
             </p>
-          )}
-        </div>
-      ),
-    },
-  ], [vm, profitability, activationStats]);
+          </div>
+        ),
+      },
+      {
+        id: "kpi-quick-ratio",
+        title: "Quick Ratio",
+        variant: "kpi",
+        icon: <TrendingUp className="h-3.5 w-3.5" />,
+        initialLayout: { cols: 2, rows: 1 },
+        render: () => (
+          <div>
+            <div
+              className={`text-2xl font-bold ${(vm?.summary.quickRatio ?? 0) >= 1 ? "text-green-600" : "text-red-600"}`}
+            >
+              {vm?.summary.quickRatio != null
+                ? `${vm.summary.quickRatio}x`
+                : "--"}
+            </div>
+            <p className="text-xs text-muted-foreground">Growing if &gt;1x</p>
+          </div>
+        ),
+      },
+      {
+        id: "kpi-activation",
+        title: "Activation",
+        variant: "kpi",
+        icon: <Target className="h-3.5 w-3.5" />,
+        initialLayout: { cols: 2, rows: 1 },
+        render: () => (
+          <div>
+            <div
+              className={`text-2xl font-bold ${(activationStats?.rate ?? 0) >= 50 ? "text-green-600" : ""}`}
+            >
+              {activationStats?.rate != null
+                ? `${activationStats.rate}%`
+                : "--"}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {activationStats?.rate != null
+                ? `Conversation within 7d · n=${activationStats.signups.toLocaleString()}`
+                : "Conversation within 7 days of signup"}
+            </p>
+            {(activationStats?.erroredUsers ?? 0) > 0 && (
+              <p className="text-xs text-amber-600">
+                {activationStats?.erroredUsers} users unreadable this run
+              </p>
+            )}
+          </div>
+        ),
+      },
+    ],
+    [vm, profitability, activationStats],
+  );
 
   const notificationsHeader: ChartItem = {
     id: "header-notifications",
@@ -2332,72 +3631,116 @@ export default function AnalyticsPage() {
     render: () => null,
   };
 
-  const notificationKpis = useMemo<ChartItem[]>(() => [
-    {
-      id: "kpi-notif-enabled", title: "Notifications Enabled", variant: "kpi", icon: <Bell className="h-3.5 w-3.5" />,
-      initialLayout: { cols: 2, rows: 1 },
-      render: () => (
-        <div>
-          <div className="text-2xl font-bold">{notificationEnabledDisabled?.enabled?.toLocaleString() ?? "--"}</div>
-          <p className="text-xs text-muted-foreground">
-            {notificationEnabledDisabled
-              ? `${((notificationEnabledDisabled.enabled / notificationEnabledDisabled.total) * 100).toFixed(1)}% of users`
-              : "Loading"}
-          </p>
-        </div>
-      ),
-    },
-    {
-      id: "kpi-notif-disabled", title: "Notifications Disabled", variant: "kpi", icon: <BellOff className="h-3.5 w-3.5" />,
-      initialLayout: { cols: 2, rows: 1 },
-      render: () => (
-        <div>
-          <div className="text-2xl font-bold">{notificationEnabledDisabled?.disabled?.toLocaleString() ?? "--"}</div>
-          <p className="text-xs text-muted-foreground">Explicitly disabled</p>
-        </div>
-      ),
-    },
-    {
-      id: "kpi-omi-says-7d", title: '"Omi says" (7d)', variant: "kpi", icon: <Send className="h-3.5 w-3.5" />,
-      initialLayout: { cols: 2, rows: 1 },
-      render: () => (
-        <div>
-          <div className="text-2xl font-bold">{notificationMentorLast7.toLocaleString()}</div>
-          <p className="text-xs text-muted-foreground">Built-in mentor</p>
-        </div>
-      ),
-    },
-    {
-      id: "kpi-marketplace-mentor-7d", title: "Marketplace Mentor (7d)", variant: "kpi", icon: <Users className="h-3.5 w-3.5" />,
-      initialLayout: { cols: 2, rows: 1 },
-      render: () => (
-        <div>
-          <div className="text-2xl font-bold">{notificationMarketplaceLast7.toLocaleString()}</div>
-          <p className="text-xs text-muted-foreground">Marketplace app</p>
-        </div>
-      ),
-    },
-    {
-      id: "kpi-fb-clicks", title: "Floating Bar Clicks", variant: "kpi", icon: <MousePointerClick className="h-3.5 w-3.5" />,
-      initialLayout: { cols: 2, rows: 1 },
-      render: () => (
-        <div>
-          <div className="text-2xl font-bold">{floatingBarCtrSummary?.clicked?.toLocaleString() ?? "0"}</div>
-          <p className="text-xs text-muted-foreground">Notification opens</p>
-        </div>
-      ),
-    },
-    {
-      id: "kpi-fb-ctr", title: "Floating Bar CTR", variant: "kpi", icon: <Percent className="h-3.5 w-3.5" />,
-      initialLayout: { cols: 2, rows: 1 },
-      render: () => (
-        <div>
-          <div className="text-2xl font-bold">{floatingBarCtrSummary ? `${floatingBarCtrSummary.ctr.toFixed(1)}%` : "0.0%"}</div>
-          <p className="text-xs text-muted-foreground">{floatingBarCtrSummary?.mode === "surface_tagged" ? "Tagged sends" : "Fallback"}</p>
-        </div>
-      ),
-    },
-  ], [notificationEnabledDisabled, notificationMentorLast7, notificationMarketplaceLast7, floatingBarCtrSummary]);
+  const notificationKpis = useMemo<ChartItem[]>(
+    () => [
+      {
+        id: "kpi-notif-enabled",
+        title: "Notifications Enabled",
+        variant: "kpi",
+        icon: <Bell className="h-3.5 w-3.5" />,
+        initialLayout: { cols: 2, rows: 1 },
+        render: () => (
+          <div>
+            <div className="text-2xl font-bold">
+              {notificationEnabledDisabled?.enabled?.toLocaleString() ?? "--"}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {notificationEnabledDisabled
+                ? `${((notificationEnabledDisabled.enabled / notificationEnabledDisabled.total) * 100).toFixed(1)}% of users`
+                : "Loading"}
+            </p>
+          </div>
+        ),
+      },
+      {
+        id: "kpi-notif-disabled",
+        title: "Notifications Disabled",
+        variant: "kpi",
+        icon: <BellOff className="h-3.5 w-3.5" />,
+        initialLayout: { cols: 2, rows: 1 },
+        render: () => (
+          <div>
+            <div className="text-2xl font-bold">
+              {notificationEnabledDisabled?.disabled?.toLocaleString() ?? "--"}
+            </div>
+            <p className="text-xs text-muted-foreground">Explicitly disabled</p>
+          </div>
+        ),
+      },
+      {
+        id: "kpi-omi-says-7d",
+        title: '"Omi says" (7d)',
+        variant: "kpi",
+        icon: <Send className="h-3.5 w-3.5" />,
+        initialLayout: { cols: 2, rows: 1 },
+        render: () => (
+          <div>
+            <div className="text-2xl font-bold">
+              {notificationMentorLast7.toLocaleString()}
+            </div>
+            <p className="text-xs text-muted-foreground">Built-in mentor</p>
+          </div>
+        ),
+      },
+      {
+        id: "kpi-marketplace-mentor-7d",
+        title: "Marketplace Mentor (7d)",
+        variant: "kpi",
+        icon: <Users className="h-3.5 w-3.5" />,
+        initialLayout: { cols: 2, rows: 1 },
+        render: () => (
+          <div>
+            <div className="text-2xl font-bold">
+              {notificationMarketplaceLast7.toLocaleString()}
+            </div>
+            <p className="text-xs text-muted-foreground">Marketplace app</p>
+          </div>
+        ),
+      },
+      {
+        id: "kpi-fb-clicks",
+        title: "Floating Bar Clicks",
+        variant: "kpi",
+        icon: <MousePointerClick className="h-3.5 w-3.5" />,
+        initialLayout: { cols: 2, rows: 1 },
+        render: () => (
+          <div>
+            <div className="text-2xl font-bold">
+              {floatingBarCtrSummary?.clicked?.toLocaleString() ?? "0"}
+            </div>
+            <p className="text-xs text-muted-foreground">Notification opens</p>
+          </div>
+        ),
+      },
+      {
+        id: "kpi-fb-ctr",
+        title: "Floating Bar CTR",
+        variant: "kpi",
+        icon: <Percent className="h-3.5 w-3.5" />,
+        initialLayout: { cols: 2, rows: 1 },
+        render: () => (
+          <div>
+            <div className="text-2xl font-bold">
+              {floatingBarCtrSummary
+                ? `${floatingBarCtrSummary.ctr.toFixed(1)}%`
+                : "0.0%"}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {floatingBarCtrSummary?.mode === "surface_tagged"
+                ? "Tagged sends"
+                : "Fallback"}
+            </p>
+          </div>
+        ),
+      },
+    ],
+    [
+      notificationEnabledDisabled,
+      notificationMentorLast7,
+      notificationMarketplaceLast7,
+      floatingBarCtrSummary,
+    ],
+  );
 
   const ratingsHeader: ChartItem = {
     id: "header-ratings",
@@ -2423,24 +3766,43 @@ export default function AnalyticsPage() {
     render: () => (
       <div className="flex h-full flex-wrap items-center gap-2">
         <div className="flex rounded-md border border-input overflow-hidden">
-          <button onClick={() => setRetentionView("average")}
+          <button
+            onClick={() => setRetentionView("average")}
             className={`px-3 py-1 text-xs font-medium transition-colors ${
-              retentionView === "average" ? "bg-primary text-primary-foreground" : "bg-background text-muted-foreground hover:bg-accent"
-            }`}>Average</button>
-          <button onClick={() => setRetentionView("cohorts")}
+              retentionView === "average"
+                ? "bg-primary text-primary-foreground"
+                : "bg-background text-muted-foreground hover:bg-accent"
+            }`}
+          >
+            Average
+          </button>
+          <button
+            onClick={() => setRetentionView("cohorts")}
             className={`px-3 py-1 text-xs font-medium transition-colors ${
-              retentionView === "cohorts" ? "bg-primary text-primary-foreground" : "bg-background text-muted-foreground hover:bg-accent"
-            }`}>By Cohort</button>
+              retentionView === "cohorts"
+                ? "bg-primary text-primary-foreground"
+                : "bg-background text-muted-foreground hover:bg-accent"
+            }`}
+          >
+            By Cohort
+          </button>
         </div>
         <Select value={retentionPlatform} onValueChange={setRetentionPlatform}>
-          <SelectTrigger className="h-7 w-[120px] text-xs"><SelectValue /></SelectTrigger>
+          <SelectTrigger className="h-7 w-[120px] text-xs">
+            <SelectValue />
+          </SelectTrigger>
           <SelectContent>
             <SelectItem value="macos">macOS</SelectItem>
             <SelectItem value="all">All Platforms</SelectItem>
           </SelectContent>
         </Select>
-        <Select value={String(retentionDays)} onValueChange={(v) => setRetentionDays(parseInt(v, 10))}>
-          <SelectTrigger className="h-7 w-[110px] text-xs"><SelectValue /></SelectTrigger>
+        <Select
+          value={String(retentionDays)}
+          onValueChange={(v) => setRetentionDays(parseInt(v, 10))}
+        >
+          <SelectTrigger className="h-7 w-[110px] text-xs">
+            <SelectValue />
+          </SelectTrigger>
           <SelectContent>
             <SelectItem value="14">14 days</SelectItem>
             <SelectItem value="30">30 days</SelectItem>
@@ -2449,8 +3811,18 @@ export default function AnalyticsPage() {
           </SelectContent>
         </Select>
         <div className="ml-auto flex gap-2 text-xs">
-          <span className="rounded-md bg-muted px-2 py-1">D1: <span className="font-semibold">{retentionD1 !== null ? `${retentionD1.toFixed(1)}%` : "--"}</span></span>
-          <span className="rounded-md bg-muted px-2 py-1">D7: <span className="font-semibold">{retentionD7 !== null ? `${retentionD7.toFixed(1)}%` : "--"}</span></span>
+          <span className="rounded-md bg-muted px-2 py-1">
+            D1:{" "}
+            <span className="font-semibold">
+              {retentionD1 !== null ? `${retentionD1.toFixed(1)}%` : "--"}
+            </span>
+          </span>
+          <span className="rounded-md bg-muted px-2 py-1">
+            D7:{" "}
+            <span className="font-semibold">
+              {retentionD7 !== null ? `${retentionD7.toFixed(1)}%` : "--"}
+            </span>
+          </span>
         </div>
       </div>
     ),
@@ -2466,10 +3838,17 @@ export default function AnalyticsPage() {
         <table className="w-full text-sm border-collapse">
           <thead>
             <tr className="border-b">
-              <th className="sticky left-0 z-10 bg-card px-4 py-3 text-left font-medium text-muted-foreground whitespace-nowrap">Date</th>
-              <th className="px-3 py-3 text-right font-medium text-muted-foreground whitespace-nowrap">Users</th>
+              <th className="sticky left-0 z-10 bg-card px-4 py-3 text-left font-medium text-muted-foreground whitespace-nowrap">
+                Date
+              </th>
+              <th className="px-3 py-3 text-right font-medium text-muted-foreground whitespace-nowrap">
+                Users
+              </th>
               {Array.from({ length: cohortMaxDays }, (_, i) => (
-                <th key={i} className="px-3 py-3 text-center font-medium text-muted-foreground whitespace-nowrap min-w-[64px]">
+                <th
+                  key={i}
+                  className="px-3 py-3 text-center font-medium text-muted-foreground whitespace-nowrap min-w-[64px]"
+                >
                   {i === 0 ? "< 1 Day" : `Day ${i}`}
                 </th>
               ))}
@@ -2478,24 +3857,53 @@ export default function AnalyticsPage() {
           <tbody>
             {retention?.data && retention.data.length > 0 && (
               <tr className="border-b font-semibold">
-                <td className="sticky left-0 z-10 bg-card px-4 py-2.5 whitespace-nowrap">Weighted Avg</td>
-                <td className="px-3 py-2.5 text-right text-muted-foreground">{retention.totalUsers.toLocaleString()}</td>
+                <td className="sticky left-0 z-10 bg-card px-4 py-2.5 whitespace-nowrap">
+                  Weighted Avg
+                </td>
+                <td className="px-3 py-2.5 text-right text-muted-foreground">
+                  {retention.totalUsers.toLocaleString()}
+                </td>
                 {retention.data.map((p) => (
-                  <td key={p.day} className="px-3 py-2.5 text-center" style={{ backgroundColor: retentionHeatColor(p.retention) }}>
-                    <span className={p.retention > 50 ? "text-white" : ""}>{p.retention.toFixed(1)}%</span>
+                  <td
+                    key={p.day}
+                    className="px-3 py-2.5 text-center"
+                    style={{ backgroundColor: retentionHeatColor(p.retention) }}
+                  >
+                    <span className={p.retention > 50 ? "text-white" : ""}>
+                      {p.retention.toFixed(1)}%
+                    </span>
                   </td>
                 ))}
               </tr>
             )}
             {cohorts.map((c) => (
-              <tr key={c.date} className="border-b last:border-b-0 hover:bg-muted/30">
-                <td className="sticky left-0 z-10 bg-card px-4 py-2 whitespace-nowrap">{formatCohortDate(c.date)}</td>
-                <td className="px-3 py-2 text-right text-muted-foreground">{c.users}</td>
+              <tr
+                key={c.date}
+                className="border-b last:border-b-0 hover:bg-muted/30"
+              >
+                <td className="sticky left-0 z-10 bg-card px-4 py-2 whitespace-nowrap">
+                  {formatCohortDate(c.date)}
+                </td>
+                <td className="px-3 py-2 text-right text-muted-foreground">
+                  {c.users}
+                </td>
                 {Array.from({ length: cohortMaxDays }, (_, i) => {
                   const val = i < c.data.length ? c.data[i].retention : null;
                   return (
-                    <td key={i} className="px-3 py-2 text-center" style={val !== null ? { backgroundColor: retentionHeatColor(val) } : {}}>
-                      {val !== null ? <span className={val > 50 ? "text-white" : ""}>{val.toFixed(1)}%</span> : null}
+                    <td
+                      key={i}
+                      className="px-3 py-2 text-center"
+                      style={
+                        val !== null
+                          ? { backgroundColor: retentionHeatColor(val) }
+                          : {}
+                      }
+                    >
+                      {val !== null ? (
+                        <span className={val > 50 ? "text-white" : ""}>
+                          {val.toFixed(1)}%
+                        </span>
+                      ) : null}
                     </td>
                   );
                 })}
@@ -2519,10 +3927,15 @@ export default function AnalyticsPage() {
   // Everything remains draggable; orderRevision applies this priority once
   // without discarding a user's saved sizes or later rearrangements.
   const unifiedItems = useMemo<ChartItem[]>(() => {
-    const activationChart = viralCharts.find((item) => item.id === "viral-activation");
-    const growthAccountingChart = viralCharts.find((item) => item.id === "viral-growth-accounting");
+    const activationChart = viralCharts.find(
+      (item) => item.id === "viral-activation",
+    );
+    const growthAccountingChart = viralCharts.find(
+      (item) => item.id === "viral-growth-accounting",
+    );
     const remainingViralCharts = viralCharts.filter(
-      (item) => item.id !== "viral-activation" && item.id !== "viral-growth-accounting",
+      (item) =>
+        item.id !== "viral-activation" && item.id !== "viral-growth-accounting",
     );
 
     return [
@@ -2561,13 +3974,26 @@ export default function AnalyticsPage() {
       ...chatRatingsItems,
     ];
   }, [
-    growthGoalItems, responseReliabilityItems, topKpiAndNewWidgets, profitCharts, revenueCharts,
-    macosKpis, macosGrowthCharts,
-    notificationKpis, notificationCharts, ratingsAndUsageCharts, viralCharts,
-    retentionView, retentionCharts, chatRatingsItems,
+    growthGoalItems,
+    responseReliabilityItems,
+    topKpiAndNewWidgets,
+    profitCharts,
+    revenueCharts,
+    macosKpis,
+    macosGrowthCharts,
+    notificationKpis,
+    notificationCharts,
+    ratingsAndUsageCharts,
+    viralCharts,
+    retentionView,
+    retentionCharts,
+    chatRatingsItems,
     // Inline header/control items capture state via closures; React's
     // dep tracking is handled by the per-item render callbacks.
-    profitabilityControls, revenueControls, retentionControls, cohortTableItem,
+    profitabilityControls,
+    revenueControls,
+    retentionControls,
+    cohortTableItem,
   ]);
 
   if (isLoading) {
@@ -2603,7 +4029,9 @@ export default function AnalyticsPage() {
 
       {hasError && (
         <Card className="p-4 border-destructive/50 bg-destructive/5">
-          <p className="text-sm text-destructive">Some data failed to load. Showing available data.</p>
+          <p className="text-sm text-destructive">
+            Some data failed to load. Showing available data.
+          </p>
         </Card>
       )}
 
@@ -2611,7 +4039,9 @@ export default function AnalyticsPage() {
       {hasPartialData && (
         <div className="flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
           <AlertTriangle className="h-4 w-4 shrink-0" />
-          <span>Some data sources failed to load. Numbers may be incomplete.</span>
+          <span>
+            Some data sources failed to load. Numbers may be incomplete.
+          </span>
         </div>
       )}
       <ResizableChartGrid
@@ -2626,23 +4056,53 @@ export default function AnalyticsPage() {
 
 // --- Chat Ratings Chart (Firebase analytics collection) ---
 
-interface RatingWeek { week: string; thumbs_up: number; thumbs_down: number }
-interface RatingVersion { version: string; thumbs_up: number; thumbs_down: number }
-interface ChatRatingsWeekData { weeks: RatingWeek[]; total_up: number; total_down: number }
-interface ChatRatingsVersionData { versions: RatingVersion[]; total_up: number; total_down: number }
+interface RatingWeek {
+  week: string;
+  thumbs_up: number;
+  thumbs_down: number;
+}
+interface RatingVersion {
+  version: string;
+  thumbs_up: number;
+  thumbs_down: number;
+}
+interface ChatRatingsWeekData {
+  weeks: RatingWeek[];
+  total_up: number;
+  total_down: number;
+}
+interface ChatRatingsVersionData {
+  versions: RatingVersion[];
+  total_up: number;
+  total_down: number;
+}
 
 function useChatRatingsItems({ token }: { token: string | null }): ChartItem[] {
-  const [platform, setPlatform] = useState<"all" | "desktop" | "mobile">("desktop");
+  const [platform, setPlatform] = useState<"all" | "desktop" | "mobile">(
+    "desktop",
+  );
   const [groupBy, setGroupBy] = useState<"week" | "version">("week");
 
-  const { data: weekData, isLoading: weekLoading } = useSWR<ChatRatingsWeekData>(
-    token && groupBy === "week" ? [`/api/omi/chat-lab/ratings?platform=${platform}&group_by=week`, token] : null,
-    authenticatedFetcher
-  );
-  const { data: versionData, isLoading: versionLoading } = useSWR<ChatRatingsVersionData>(
-    token && groupBy === "version" ? [`/api/omi/chat-lab/ratings?platform=${platform}&group_by=version`, token] : null,
-    authenticatedFetcher
-  );
+  const { data: weekData, isLoading: weekLoading } =
+    useSWR<ChatRatingsWeekData>(
+      token && groupBy === "week"
+        ? [
+            `/api/omi/chat-lab/ratings?platform=${platform}&group_by=week`,
+            token,
+          ]
+        : null,
+      authenticatedFetcher,
+    );
+  const { data: versionData, isLoading: versionLoading } =
+    useSWR<ChatRatingsVersionData>(
+      token && groupBy === "version"
+        ? [
+            `/api/omi/chat-lab/ratings?platform=${platform}&group_by=version`,
+            token,
+          ]
+        : null,
+      authenticatedFetcher,
+    );
 
   const isLoading = groupBy === "week" ? weekLoading : versionLoading;
 
@@ -2651,7 +4111,12 @@ function useChatRatingsItems({ token }: { token: string | null }): ChartItem[] {
     if (!d) return { total: 0, up: 0, down: 0, pct: 0 };
     const { total_up: up, total_down: down } = d;
     const total = up + down;
-    return { total, up, down, pct: total > 0 ? Math.round((up / total) * 100) : 0 };
+    return {
+      total,
+      up,
+      down,
+      pct: total > 0 ? Math.round((up / total) * 100) : 0,
+    };
   }, [weekData, versionData, groupBy]);
 
   const chartData = useMemo(() => {
@@ -2660,101 +4125,147 @@ function useChatRatingsItems({ token }: { token: string | null }): ChartItem[] {
       return versionData.versions
         .filter((v) => v.version !== "unknown")
         .map((v) => ({
-          ...v, label: v.version.replace("0.11.", "v"),
-          satisfaction: v.thumbs_up + v.thumbs_down > 0 ? Math.round((v.thumbs_up / (v.thumbs_up + v.thumbs_down)) * 100) : 0,
+          ...v,
+          label: v.version.replace("0.11.", "v"),
+          satisfaction:
+            v.thumbs_up + v.thumbs_down > 0
+              ? Math.round((v.thumbs_up / (v.thumbs_up + v.thumbs_down)) * 100)
+              : 0,
         }));
     }
     if (!weekData?.weeks) return [];
     return weekData.weeks.map((w) => ({
-      ...w, label: w.week,
-      satisfaction: w.thumbs_up + w.thumbs_down > 0 ? Math.round((w.thumbs_up / (w.thumbs_up + w.thumbs_down)) * 100) : 0,
+      ...w,
+      label: w.week,
+      satisfaction:
+        w.thumbs_up + w.thumbs_down > 0
+          ? Math.round((w.thumbs_up / (w.thumbs_up + w.thumbs_down)) * 100)
+          : 0,
     }));
   }, [weekData, versionData, groupBy]);
 
-  const items = useMemo<ChartItem[]>(() => [
-    {
-      id: "chat-ratings",
-      title: "Chat Response Ratings",
-      periodChange: groupBy === "week"
-        ? latestPeriodChange<{ thumbs_up: number; thumbs_down: number }>(
-            chartData,
-            (point) => point.thumbs_up + point.thumbs_down,
-            "vs previous week",
-          )
-        : null,
-      subtitle:
-        stats.total > 0
-          ? `${stats.up} 👍 · ${stats.down} 👎 · ${stats.pct}% positive`
-          : undefined,
-      initialLayout: { cols: 12, rows: 5 },
-      render: () => (
-        <div className="flex h-full flex-col gap-3">
-          <div className="flex flex-wrap items-center gap-2">
-            <div className="flex rounded-md overflow-hidden border border-border text-xs font-medium">
-              {(["all", "desktop", "mobile"] as const).map((p) => (
-                <button
-                  key={p}
-                  onClick={() => setPlatform(p)}
-                  className={`px-3 py-1 transition-colors ${
-                    platform === p
-                      ? "bg-primary text-primary-foreground"
-                      : "bg-muted text-muted-foreground hover:bg-accent"
-                  }`}
-                >
-                  {p === "all" ? "All" : p === "desktop" ? "Desktop" : "Mobile"}
-                </button>
-              ))}
+  const items = useMemo<ChartItem[]>(
+    () => [
+      {
+        id: "chat-ratings",
+        title: "Chat Response Ratings",
+        periodChange:
+          groupBy === "week"
+            ? latestPeriodChange<{ thumbs_up: number; thumbs_down: number }>(
+                chartData,
+                (point) => point.thumbs_up + point.thumbs_down,
+                "vs previous week",
+              )
+            : null,
+        subtitle:
+          stats.total > 0
+            ? `${stats.up} 👍 · ${stats.down} 👎 · ${stats.pct}% positive`
+            : undefined,
+        initialLayout: { cols: 12, rows: 5 },
+        render: () => (
+          <div className="flex h-full flex-col gap-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="flex rounded-md overflow-hidden border border-border text-xs font-medium">
+                {(["all", "desktop", "mobile"] as const).map((p) => (
+                  <button
+                    key={p}
+                    onClick={() => setPlatform(p)}
+                    className={`px-3 py-1 transition-colors ${
+                      platform === p
+                        ? "bg-primary text-primary-foreground"
+                        : "bg-muted text-muted-foreground hover:bg-accent"
+                    }`}
+                  >
+                    {p === "all"
+                      ? "All"
+                      : p === "desktop"
+                        ? "Desktop"
+                        : "Mobile"}
+                  </button>
+                ))}
+              </div>
+              <div className="flex rounded-md overflow-hidden border border-border text-xs font-medium">
+                {(["week", "version"] as const).map((g) => (
+                  <button
+                    key={g}
+                    onClick={() => setGroupBy(g)}
+                    className={`px-3 py-1 transition-colors ${
+                      groupBy === g
+                        ? "bg-primary text-primary-foreground"
+                        : "bg-muted text-muted-foreground hover:bg-accent"
+                    }`}
+                  >
+                    {g === "week" ? "By Week" : "By Version"}
+                  </button>
+                ))}
+              </div>
             </div>
-            <div className="flex rounded-md overflow-hidden border border-border text-xs font-medium">
-              {(["week", "version"] as const).map((g) => (
-                <button
-                  key={g}
-                  onClick={() => setGroupBy(g)}
-                  className={`px-3 py-1 transition-colors ${
-                    groupBy === g
-                      ? "bg-primary text-primary-foreground"
-                      : "bg-muted text-muted-foreground hover:bg-accent"
-                  }`}
-                >
-                  {g === "week" ? "By Week" : "By Version"}
-                </button>
-              ))}
+            <div className="min-h-0 flex-1">
+              {isLoading ? (
+                <div className="flex h-full items-center justify-center text-muted-foreground">
+                  <Loader2 className="h-6 w-6 animate-spin mr-2" /> Loading
+                  ratings...
+                </div>
+              ) : !chartData.length ? (
+                <div className="flex h-full items-center justify-center text-center text-muted-foreground py-8">
+                  {groupBy === "version"
+                    ? "No version-tagged ratings yet."
+                    : "No chat ratings data available"}
+                </div>
+              ) : (
+                <ResponsiveContainer width="100%" height="100%">
+                  <ComposedChart data={chartData}>
+                    <CartesianGrid strokeDasharray="3 3" opacity={0.1} />
+                    <XAxis dataKey="label" tick={{ fontSize: 11 }} />
+                    <YAxis yAxisId="count" tick={{ fontSize: 11 }} />
+                    <YAxis
+                      yAxisId="pct"
+                      orientation="right"
+                      tick={{ fontSize: 11 }}
+                      domain={[0, 100]}
+                      unit="%"
+                    />
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: "#1a1a2e",
+                        border: "1px solid #333",
+                        borderRadius: 8,
+                      }}
+                      labelStyle={{ color: "#ccc" }}
+                    />
+                    <Legend />
+                    <Bar
+                      yAxisId="count"
+                      dataKey="thumbs_up"
+                      name="👍 Likes"
+                      fill="#22c55e"
+                      radius={[4, 4, 0, 0]}
+                    />
+                    <Bar
+                      yAxisId="count"
+                      dataKey="thumbs_down"
+                      name="👎 Dislikes"
+                      fill="#ef4444"
+                      radius={[4, 4, 0, 0]}
+                    />
+                    <Line
+                      yAxisId="pct"
+                      dataKey="satisfaction"
+                      name="Satisfaction %"
+                      stroke="#f59e0b"
+                      strokeWidth={2}
+                      dot={{ r: 3 }}
+                    />
+                  </ComposedChart>
+                </ResponsiveContainer>
+              )}
             </div>
           </div>
-          <div className="min-h-0 flex-1">
-            {isLoading ? (
-              <div className="flex h-full items-center justify-center text-muted-foreground">
-                <Loader2 className="h-6 w-6 animate-spin mr-2" /> Loading ratings...
-              </div>
-            ) : !chartData.length ? (
-              <div className="flex h-full items-center justify-center text-center text-muted-foreground py-8">
-                {groupBy === "version"
-                  ? "No version-tagged ratings yet."
-                  : "No chat ratings data available"}
-              </div>
-            ) : (
-              <ResponsiveContainer width="100%" height="100%">
-                <ComposedChart data={chartData}>
-                  <CartesianGrid strokeDasharray="3 3" opacity={0.1} />
-                  <XAxis dataKey="label" tick={{ fontSize: 11 }} />
-                  <YAxis yAxisId="count" tick={{ fontSize: 11 }} />
-                  <YAxis yAxisId="pct" orientation="right" tick={{ fontSize: 11 }} domain={[0, 100]} unit="%" />
-                  <Tooltip
-                    contentStyle={{ backgroundColor: "#1a1a2e", border: "1px solid #333", borderRadius: 8 }}
-                    labelStyle={{ color: "#ccc" }}
-                  />
-                  <Legend />
-                  <Bar yAxisId="count" dataKey="thumbs_up" name="👍 Likes" fill="#22c55e" radius={[4, 4, 0, 0]} />
-                  <Bar yAxisId="count" dataKey="thumbs_down" name="👎 Dislikes" fill="#ef4444" radius={[4, 4, 0, 0]} />
-                  <Line yAxisId="pct" dataKey="satisfaction" name="Satisfaction %" stroke="#f59e0b" strokeWidth={2} dot={{ r: 3 }} />
-                </ComposedChart>
-              </ResponsiveContainer>
-            )}
-          </div>
-        </div>
-      ),
-    },
-  ], [platform, groupBy, isLoading, chartData, stats]);
+        ),
+      },
+    ],
+    [platform, groupBy, isLoading, chartData, stats],
+  );
 
   return items;
 }

--- a/web/admin/app/(protected)/dashboard/classic/page.tsx
+++ b/web/admin/app/(protected)/dashboard/classic/page.tsx
@@ -121,12 +121,7 @@ interface DailyNewUsersData {
 }
 
 interface MessageRatingsData {
-  data: {
-    date: string;
-    thumbs_up: number;
-    thumbs_down: number;
-    ratio: number;
-  }[];
+  data: { date: string; thumbs_up: number; thumbs_down: number; ratio: number }[];
   days: number;
 }
 
@@ -208,12 +203,7 @@ interface DauTrendsData {
 }
 
 interface CrashRateData {
-  data: {
-    date: string;
-    crashes: number;
-    users: number;
-    crashFreeRate: number;
-  }[];
+  data: { date: string; crashes: number; users: number; crashFreeRate: number }[];
   days: number;
 }
 
@@ -234,18 +224,8 @@ interface ViralMetrics {
   }[];
   dailyDau: { date: string; dau: number }[];
   powerUserCurve: { daysActive: number; users: number; pct: number }[];
-  activation: {
-    date: string;
-    signups: number;
-    activated: number;
-    rate: number;
-  }[];
-  activationDaily?: {
-    date: string;
-    signups: number;
-    activated: number;
-    rate: number;
-  }[];
+  activation: { date: string; signups: number; activated: number; rate: number }[];
+  activationDaily?: { date: string; signups: number; activated: number; rate: number }[];
   activationBucket?: "day" | "week";
   summary: {
     quickRatio: number | null;
@@ -376,11 +356,7 @@ function formatCompact(value: number): string {
 
 function formatCohortDate(dateStr: string): string {
   const d = new Date(dateStr + "T00:00:00");
-  return d.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 }
 
 function shortDate(v: string): string {
@@ -390,11 +366,7 @@ function shortDate(v: string): string {
 
 function fullDate(v: string): string {
   const d = new Date(v + "T00:00:00");
-  return d.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
 }
 
 function formatWeek(v: string): string {
@@ -413,31 +385,16 @@ function weekStartKey(dateStr: string): string {
 
 function formatHourKey(v: string): string {
   const d = new Date(v + ":00:00Z");
-  const mon = d.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    timeZone: "UTC",
-  });
+  const mon = d.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
   const hour = d.getUTCHours();
-  const label =
-    hour === 0
-      ? "12am"
-      : hour === 12
-        ? "12pm"
-        : hour < 12
-          ? `${hour}am`
-          : `${hour - 12}pm`;
+  const label = hour === 0 ? "12am" : hour === 12 ? "12pm" : hour < 12 ? `${hour}am` : `${hour - 12}pm`;
   return `${mon} ${label}`;
 }
 
 function formatHourTick(v: string): string {
   const d = new Date(v + ":00:00Z");
   return d.getUTCHours() === 0
-    ? d.toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        timeZone: "UTC",
-      })
+    ? d.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" })
     : "";
 }
 
@@ -472,142 +429,64 @@ export default function AnalyticsPage() {
   const [months, setMonths] = useState(12);
   const [retentionDays, setRetentionDays] = useState(30);
   const [retentionPlatform, setRetentionPlatform] = useState("macos");
-  const [retentionView, setRetentionView] = useState<"average" | "cohorts">(
-    "average",
-  );
-  const [cumulativeWindow, setCumulativeWindow] = useState<
-    "7d" | "30d" | "all"
-  >("all");
+  const [retentionView, setRetentionView] = useState<"average" | "cohorts">("average");
+  const [cumulativeWindow, setCumulativeWindow] = useState<"7d" | "30d" | "all">("all");
   const [profitDays, setProfitDays] = useState<30 | 60 | 90>(30);
   const [desktopCostInput, setDesktopCostInput] = useState("1.20");
   const [mobileCostInput, setMobileCostInput] = useState("0.30");
 
   const swrOpts = { revalidateOnFocus: false };
 
-  const {
-    data: revenue,
-    isLoading: revenueLoading,
-    error: revenueError,
-  } = useSWR<RevenueData>(
-    token ? ["/api/omi/stats/revenue", token] : null,
-    authFetcher,
-    swrOpts,
+  const { data: revenue, isLoading: revenueLoading, error: revenueError } = useSWR<RevenueData>(
+    token ? ["/api/omi/stats/revenue", token] : null, authFetcher, swrOpts
   );
 
-  const {
-    data: mrrTrends,
-    isLoading: mrrLoading,
-    error: mrrError,
-  } = useSWR<{
+  const { data: mrrTrends, isLoading: mrrLoading, error: mrrError } = useSWR<{
     data: MrrTrendPoint[];
-  }>(
-    token ? [`/api/omi/stats/mrr-trends?months=${months}`, token] : null,
-    authFetcher,
-    swrOpts,
-  );
+  }>(token ? [`/api/omi/stats/mrr-trends?months=${months}`, token] : null, authFetcher, swrOpts);
 
-  const {
-    data: subTrends,
-    isLoading: subTrendsLoading,
-    error: subTrendsError,
-  } = useSWR<{
+  const { data: subTrends, isLoading: subTrendsLoading, error: subTrendsError } = useSWR<{
     data: SubscriptionTrendPoint[];
-  }>(
-    token
-      ? [`/api/omi/stats/subscription-trends?months=${months}`, token]
-      : null,
-    authFetcher,
-    swrOpts,
-  );
+  }>(token ? [`/api/omi/stats/subscription-trends?months=${months}`, token] : null, authFetcher, swrOpts);
 
-  const {
-    data: subCounts,
-    isLoading: subCountsLoading,
-    error: subCountsError,
-  } = useSWR<SubscriptionCounts>(
-    token ? ["/api/omi/stats/subscriptions", token] : null,
-    authFetcher,
-    swrOpts,
-  );
+  const { data: subCounts, isLoading: subCountsLoading, error: subCountsError } =
+    useSWR<SubscriptionCounts>(token ? ["/api/omi/stats/subscriptions", token] : null, authFetcher, swrOpts);
 
-  const {
-    data: convCount,
-    isLoading: convLoading,
-    error: convError,
-  } = useSWR<ConversationCount>(
-    token ? ["/api/omi/stats/conversation-count", token] : null,
-    authFetcher,
-    swrOpts,
-  );
+  const { data: convCount, isLoading: convLoading, error: convError } =
+    useSWR<ConversationCount>(token ? ["/api/omi/stats/conversation-count", token] : null, authFetcher, swrOpts);
 
   const { data: dailyNewUsers, isLoading: dailyNewUsersLoading } =
-    useSWR<DailyNewUsersData>(
-      token ? ["/api/omi/stats/daily-new-users?days=all", token] : null,
-      authFetcher,
-      swrOpts,
-    );
+    useSWR<DailyNewUsersData>(token ? ["/api/omi/stats/daily-new-users?days=all", token] : null, authFetcher, swrOpts);
 
-  const { data: dauTrends, isLoading: dauLoading } = useSWR<DauTrendsData>(
-    token ? ["/api/omi/stats/dau-trends?days=60", token] : null,
-    authFetcher,
-    swrOpts,
-  );
+  const { data: dauTrends, isLoading: dauLoading } =
+    useSWR<DauTrendsData>(token ? ["/api/omi/stats/dau-trends?days=60", token] : null, authFetcher, swrOpts);
 
   const { data: messageRatings, isLoading: ratingsLoading } =
-    useSWR<MessageRatingsData>(
-      token ? ["/api/omi/stats/message-ratings?days=30", token] : null,
-      authFetcher,
-      swrOpts,
-    );
+    useSWR<MessageRatingsData>(token ? ["/api/omi/stats/message-ratings?days=30", token] : null, authFetcher, swrOpts);
 
   const { data: floatingBarUsage, isLoading: fbUsageLoading } =
-    useSWR<FloatingBarUsageData>(
-      token ? ["/api/omi/stats/floating-bar-usage?days=30", token] : null,
-      authFetcher,
-      swrOpts,
-    );
+    useSWR<FloatingBarUsageData>(token ? ["/api/omi/stats/floating-bar-usage?days=30", token] : null, authFetcher, swrOpts);
 
   const { data: notificationStats, isLoading: notificationStatsLoading } =
-    useSWR<NotificationStats>(
-      token ? ["/api/omi/stats/notifications?days=30", token] : null,
-      authFetcher,
-      swrOpts,
-    );
+    useSWR<NotificationStats>(token ? ["/api/omi/stats/notifications?days=30", token] : null, authFetcher, swrOpts);
 
-  const { data: viralMetrics, isLoading: viralLoading } = useSWR<ViralMetrics>(
-    token ? ["/api/omi/stats/viral-metrics?days=60", token] : null,
-    authFetcher,
-    swrOpts,
-  );
+  const { data: viralMetrics, isLoading: viralLoading } =
+    useSWR<ViralMetrics>(token ? ["/api/omi/stats/viral-metrics?days=60", token] : null, authFetcher, swrOpts);
 
-  const { data: kFactorData, isLoading: kFactorLoading } = useSWR<KFactorData>(
-    token ? ["/api/omi/stats/k-factor/posthog?days=30&platform=all", token] : null,
-    authFetcher,
-    swrOpts,
-  );
+  const { data: kFactorData, isLoading: kFactorLoading } =
+    useSWR<KFactorData>(token ? ["/api/omi/stats/k-factor/posthog?days=30", token] : null, authFetcher, swrOpts);
 
   // Activation comes from Firestore conversation records, not from the desktop
   // `Memory Created` event in viral-metrics: older builds cannot emit that
   // event, so the PostHog figure tracks build age rather than behaviour.
-  const { data: activationStats } = useSWR<ActivationStats>(
-    token ? ["/api/omi/stats/activation?days=60", token] : null,
-    authFetcher,
-    swrOpts,
-  );
+  const { data: activationStats } =
+    useSWR<ActivationStats>(token ? ["/api/omi/stats/activation?days=60", token] : null, authFetcher, swrOpts);
 
   const { data: macosVersionStats, isLoading: macosVersionStatsLoading } =
-    useSWR<MacosVersionStatsData>(
-      token ? ["/api/omi/stats/macos-versions", token] : null,
-      authFetcher,
-      swrOpts,
-    );
+    useSWR<MacosVersionStatsData>(token ? ["/api/omi/stats/macos-versions", token] : null, authFetcher, swrOpts);
 
   const { data: crashRate, isLoading: crashRateLoading } =
-    useSWR<CrashRateData>(
-      token ? ["/api/omi/stats/crash-rate?days=30", token] : null,
-      authFetcher,
-      swrOpts,
-    );
+    useSWR<CrashRateData>(token ? ["/api/omi/stats/crash-rate?days=30", token] : null, authFetcher, swrOpts);
 
   const profitQuery = useMemo(() => {
     const dc = parseFloat(desktopCostInput);
@@ -617,15 +496,12 @@ export default function AnalyticsPage() {
     return `days=${profitDays}&desktop_cost=${dcSafe}&mobile_cost=${mcSafe}`;
   }, [profitDays, desktopCostInput, mobileCostInput]);
 
-  const {
-    data: profitability,
-    isLoading: profitLoading,
-    error: profitError,
-  } = useSWR<ProfitabilityData>(
-    token ? [`/api/omi/stats/profitability?${profitQuery}`, token] : null,
-    authFetcher,
-    swrOpts,
-  );
+  const { data: profitability, isLoading: profitLoading, error: profitError } =
+    useSWR<ProfitabilityData>(
+      token ? [`/api/omi/stats/profitability?${profitQuery}`, token] : null,
+      authFetcher,
+      swrOpts,
+    );
 
   interface InfraCostsData {
     breakdown: Array<{
@@ -636,11 +512,7 @@ export default function AnalyticsPage() {
       mobileProjectionUsd: number;
     }>;
     summary: {
-      assumptions: {
-        overheadMonthlyUsd: number;
-        desktopShare: number;
-        mobileShare: number;
-      };
+      assumptions: { overheadMonthlyUsd: number; desktopShare: number; mobileShare: number };
     };
   }
   const { data: infraCosts } = useSWR<InfraCostsData>(
@@ -649,29 +521,17 @@ export default function AnalyticsPage() {
     swrOpts,
   );
 
-  const retentionPlatformParam = retentionPlatform
-    ? `&platform=${retentionPlatform}`
-    : "";
+  const retentionPlatformParam = retentionPlatform ? `&platform=${retentionPlatform}` : '';
 
-  const { data: retention, isLoading: retLoading } = useSWR<RetentionData>(
-    token
-      ? [
-          `/api/omi/stats/retention/posthog?days=${retentionDays}&intervals=${retentionDays}${retentionPlatformParam}`,
-          token,
-        ]
-      : null,
-    authFetcher,
-    swrOpts,
-  );
+  const { data: retention, isLoading: retLoading } =
+    useSWR<RetentionData>(
+      token ? [`/api/omi/stats/retention/posthog?days=${retentionDays}&intervals=${retentionDays}${retentionPlatformParam}`, token] : null,
+      authFetcher, swrOpts
+    );
 
   const { data: growthRetention, isLoading: growthRetentionLoading } =
     useSWR<RetentionData>(
-      token
-        ? [
-            "/api/omi/stats/retention/posthog?days=30&intervals=30&platform=macos",
-            token,
-          ]
-        : null,
+      token ? ["/api/omi/stats/retention/posthog?days=30&intervals=30&platform=macos", token] : null,
       authFetcher,
       swrOpts,
     );
@@ -683,20 +543,14 @@ export default function AnalyticsPage() {
     subCountsLoading ||
     convLoading;
 
-  const hasError =
-    revenueError || mrrError || subTrendsError || subCountsError || convError;
+  const hasError = revenueError || mrrError || subTrendsError || subCountsError || convError;
 
   const mrr = revenue?.mrr ?? 0;
   const arr = revenue?.arr ?? 0;
   const totalSubs = subCounts?.totalSubscriptions ?? 0;
   const monthlySubs = subCounts?.monthly ?? 0;
   const annualSubs = subCounts?.annual ?? 0;
-  const hasPartialData = !!(
-    revenue?.partial ||
-    subCounts?.partial ||
-    (mrrTrends as any)?.partial ||
-    (subTrends as any)?.partial
-  );
+  const hasPartialData = !!(revenue?.partial || subCounts?.partial || (mrrTrends as any)?.partial || (subTrends as any)?.partial);
   const totalConversations = convCount?.totalConversations ?? 0;
   const mrrData = mrrTrends?.data ?? [];
   const subData = subTrends?.data ?? [];
@@ -718,17 +572,13 @@ export default function AnalyticsPage() {
 
   // Cumulative Users chart fetches the full history since the first
   // signup so the growth curve is meaningful.
-  const allDailyData = useMemo(
-    () => dailyNewUsers?.data ?? [],
-    [dailyNewUsers],
-  );
+  const allDailyData = useMemo(() => dailyNewUsers?.data ?? [], [dailyNewUsers]);
   const dauData = dauTrends?.data?.slice(-30) ?? [];
   const ratingsData = messageRatings?.data ?? [];
   const totalThumbsUp = ratingsData.reduce((s, d) => s + d.thumbs_up, 0);
   const totalThumbsDown = ratingsData.reduce((s, d) => s + d.thumbs_down, 0);
   const totalRatings = totalThumbsUp + totalThumbsDown;
-  const overallRatio =
-    totalRatings > 0 ? Math.round((totalThumbsUp / totalRatings) * 100) : 0;
+  const overallRatio = totalRatings > 0 ? Math.round((totalThumbsUp / totalRatings) * 100) : 0;
   const fbUsageData = floatingBarUsage?.data ?? [];
   const fbSummary = floatingBarUsage?.summary;
   const notificationDailyData = notificationStats?.dailyData ?? [];
@@ -739,14 +589,8 @@ export default function AnalyticsPage() {
   const macosChannelData = macosVersionStats?.channelBreakdown ?? [];
   const macosVersionData = macosVersionStats?.versionBreakdown ?? [];
   const notificationLast7Days = notificationDailyData.slice(-7);
-  const notificationMentorLast7 = notificationLast7Days.reduce(
-    (sum, day) => sum + day.mentorSent,
-    0,
-  );
-  const notificationMarketplaceLast7 = notificationLast7Days.reduce(
-    (sum, day) => sum + day.marketplaceMentorSent,
-    0,
-  );
+  const notificationMentorLast7 = notificationLast7Days.reduce((sum, day) => sum + day.mentorSent, 0);
+  const notificationMarketplaceLast7 = notificationLast7Days.reduce((sum, day) => sum + day.marketplaceMentorSent, 0);
   const floatingBarCtrSummary = floatingBarCtr?.summary;
   const notificationDailyCombined = notificationDailyData.map((day) => ({
     ...day,
@@ -759,10 +603,7 @@ export default function AnalyticsPage() {
     totalUniqueUsers: week.uniqueUsersMentor + week.uniqueUsersMarketplace,
   }));
   const weeklyRatingsData = useMemo(() => {
-    const buckets = new Map<
-      string,
-      { thumbs_up: number; thumbs_down: number }
-    >();
+    const buckets = new Map<string, { thumbs_up: number; thumbs_down: number }>();
     for (const point of ratingsData) {
       const key = weekStartKey(point.date);
       const bucket = buckets.get(key) ?? { thumbs_up: 0, thumbs_down: 0 };
@@ -802,23 +643,18 @@ export default function AnalyticsPage() {
 
   // 7-day rolling average for daily new users
   const dailyWithRollingAvg = useMemo(() => {
-    return allDailyData
-      .map((point, i) => {
-        if (i < 6) return { ...point, rollingAvg: undefined };
-        const slice = allDailyData.slice(i - 6, i + 1);
-        const avg = slice.reduce((s, p) => s + p.users, 0) / 7;
-        return { ...point, rollingAvg: Math.round(avg * 10) / 10 };
-      })
-      .slice(-30);
+    return allDailyData.map((point, i) => {
+      if (i < 6) return { ...point, rollingAvg: undefined };
+      const slice = allDailyData.slice(i - 6, i + 1);
+      const avg = slice.reduce((s, p) => s + p.users, 0) / 7;
+      return { ...point, rollingAvg: Math.round(avg * 10) / 10 };
+    }).slice(-30);
   }, [allDailyData]);
 
   // Retention values for summary cards
-  const retentionD1 =
-    retention?.data?.find((p) => p.day === 1)?.retention ?? null;
-  const retentionD7 =
-    retention?.data?.find((p) => p.day === 7)?.retention ?? null;
-  const retentionW4 =
-    retention?.data?.find((p) => p.day === 28)?.retention ?? null;
+  const retentionD1 = retention?.data?.find((p) => p.day === 1)?.retention ?? null;
+  const retentionD7 = retention?.data?.find((p) => p.day === 7)?.retention ?? null;
+  const retentionW4 = retention?.data?.find((p) => p.day === 28)?.retention ?? null;
 
   // Viral metrics
   const vm = viralMetrics;
@@ -857,22 +693,15 @@ export default function AnalyticsPage() {
     const costData = profitability?.cost ?? [];
     const costPerUserData = (profitability as any)?.costPerUser ?? [];
     const conversionData = profitability?.conversion ?? [];
-    const costSource = (summary?.assumptions as any)?.costSource as
-      string | undefined;
-    const avgCostDesktop = (summary as any)?.avgCostPerUserDesktop as
-      number | undefined;
-    const avgCostMobile = (summary as any)?.avgCostPerUserMobile as
-      number | undefined;
+    const costSource = (summary?.assumptions as any)?.costSource as string | undefined;
+    const avgCostDesktop = (summary as any)?.avgCostPerUserDesktop as number | undefined;
+    const avgCostMobile = (summary as any)?.avgCostPerUserMobile as number | undefined;
 
     return [
       {
         id: "profit-users",
         title: "New users / day",
-        periodChange: latestPeriodChange(
-          usersData,
-          (point) => point.total,
-          "vs previous day",
-        ),
+        periodChange: latestPeriodChange(usersData, (point) => point.total, "vs previous day"),
         subtitle: summary
           ? `Desktop ${summary.totalNewDesktop.toLocaleString()} · Mobile ${summary.totalNewMobile.toLocaleString()}`
           : "Per-platform signups",
@@ -882,27 +711,11 @@ export default function AnalyticsPage() {
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={usersData}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-              <XAxis
-                dataKey="date"
-                className="text-xs"
-                tick={{ fill: "hsl(var(--muted-foreground))" }}
-                tickFormatter={shortDate}
-                minTickGap={30}
-              />
-              <YAxis
-                className="text-xs"
-                tick={{ fill: "hsl(var(--muted-foreground))" }}
-                tickFormatter={formatCompact}
-                width={40}
-              />
+              <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} minTickGap={30} />
+              <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={formatCompact} width={40} />
               <Tooltip contentStyle={tooltipStyle} labelFormatter={fullDate} />
               <Legend wrapperStyle={{ fontSize: 11 }} />
-              <Bar
-                dataKey="desktop"
-                stackId="u"
-                fill="#6366f1"
-                name="Desktop"
-              />
+              <Bar dataKey="desktop" stackId="u" fill="#6366f1" name="Desktop" />
               <Bar dataKey="mobile" stackId="u" fill="#22c55e" name="Mobile" />
             </BarChart>
           </ResponsiveContainer>
@@ -911,11 +724,7 @@ export default function AnalyticsPage() {
       {
         id: "profit-revenue",
         title: "Revenue / day (est.)",
-        periodChange: latestPeriodChange(
-          revenueData,
-          (point) => point.total,
-          "vs previous day",
-        ),
+        periodChange: latestPeriodChange(revenueData, (point) => point.total, "vs previous day"),
         subtitle: "Daily MRR share by platform active-user ratio",
         icon: <DollarSign className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -923,65 +732,22 @@ export default function AnalyticsPage() {
           <ResponsiveContainer width="100%" height="100%">
             <AreaChart data={revenueData}>
               <defs>
-                <linearGradient
-                  id="profitRevDesktop"
-                  x1="0"
-                  y1="0"
-                  x2="0"
-                  y2="1"
-                >
+                <linearGradient id="profitRevDesktop" x1="0" y1="0" x2="0" y2="1">
                   <stop offset="5%" stopColor="#6366f1" stopOpacity={0.4} />
                   <stop offset="95%" stopColor="#6366f1" stopOpacity={0} />
                 </linearGradient>
-                <linearGradient
-                  id="profitRevMobile"
-                  x1="0"
-                  y1="0"
-                  x2="0"
-                  y2="1"
-                >
+                <linearGradient id="profitRevMobile" x1="0" y1="0" x2="0" y2="1">
                   <stop offset="5%" stopColor="#22c55e" stopOpacity={0.4} />
                   <stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
                 </linearGradient>
               </defs>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-              <XAxis
-                dataKey="date"
-                className="text-xs"
-                tick={{ fill: "hsl(var(--muted-foreground))" }}
-                tickFormatter={shortDate}
-                minTickGap={30}
-              />
-              <YAxis
-                className="text-xs"
-                tick={{ fill: "hsl(var(--muted-foreground))" }}
-                tickFormatter={(v) => `$${formatCompact(v)}`}
-                width={50}
-              />
-              <Tooltip
-                contentStyle={tooltipStyle}
-                labelFormatter={fullDate}
-                formatter={(v: number, name) => [formatCurrency(v), name]}
-              />
+              <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} minTickGap={30} />
+              <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `$${formatCompact(v)}`} width={50} />
+              <Tooltip contentStyle={tooltipStyle} labelFormatter={fullDate} formatter={(v: number, name) => [formatCurrency(v), name]} />
               <Legend wrapperStyle={{ fontSize: 11 }} />
-              <Area
-                type="monotone"
-                dataKey="desktop"
-                stackId="r"
-                stroke="#6366f1"
-                strokeWidth={2}
-                fill="url(#profitRevDesktop)"
-                name="Desktop"
-              />
-              <Area
-                type="monotone"
-                dataKey="mobile"
-                stackId="r"
-                stroke="#22c55e"
-                strokeWidth={2}
-                fill="url(#profitRevMobile)"
-                name="Mobile"
-              />
+              <Area type="monotone" dataKey="desktop" stackId="r" stroke="#6366f1" strokeWidth={2} fill="url(#profitRevDesktop)" name="Desktop" />
+              <Area type="monotone" dataKey="mobile" stackId="r" stroke="#22c55e" strokeWidth={2} fill="url(#profitRevMobile)" name="Mobile" />
             </AreaChart>
           </ResponsiveContainer>
         ),
@@ -989,59 +755,22 @@ export default function AnalyticsPage() {
       {
         id: "profit-cost-per-user",
         title: `Cost / user / day${costSource === "real" ? "" : " (est.)"}`,
-        periodChange: latestPeriodChange(
-          costPerUserData,
-          (point: ProfitabilityPoint) => point.total,
-          "vs previous day",
-        ),
-        subtitle:
-          avgCostDesktop != null && avgCostMobile != null
-            ? `Avg: Desktop $${avgCostDesktop.toFixed(2)} · Mobile $${avgCostMobile.toFixed(2)}`
-            : "Daily infra spend ÷ active users, per platform",
+        periodChange: latestPeriodChange(costPerUserData, (point: ProfitabilityPoint) => point.total, "vs previous day"),
+        subtitle: avgCostDesktop != null && avgCostMobile != null
+          ? `Avg: Desktop $${avgCostDesktop.toFixed(2)} · Mobile $${avgCostMobile.toFixed(2)}`
+          : "Daily infra spend ÷ active users, per platform",
         icon: <Activity className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
         render: () => (
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={costPerUserData}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-              <XAxis
-                dataKey="date"
-                className="text-xs"
-                tick={{ fill: "hsl(var(--muted-foreground))" }}
-                tickFormatter={shortDate}
-                minTickGap={30}
-              />
-              <YAxis
-                className="text-xs"
-                tick={{ fill: "hsl(var(--muted-foreground))" }}
-                tickFormatter={(v) => `$${Number(v).toFixed(2)}`}
-                width={56}
-              />
-              <Tooltip
-                contentStyle={tooltipStyle}
-                labelFormatter={fullDate}
-                formatter={(v: number, name) => [
-                  `$${Number(v).toFixed(2)}`,
-                  name,
-                ]}
-              />
+              <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} minTickGap={30} />
+              <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `$${Number(v).toFixed(2)}`} width={56} />
+              <Tooltip contentStyle={tooltipStyle} labelFormatter={fullDate} formatter={(v: number, name) => [`$${Number(v).toFixed(2)}`, name]} />
               <Legend wrapperStyle={{ fontSize: 11 }} />
-              <Line
-                type="monotone"
-                dataKey="desktop"
-                stroke="#f59e0b"
-                strokeWidth={2}
-                dot={false}
-                name="Desktop $/user"
-              />
-              <Line
-                type="monotone"
-                dataKey="mobile"
-                stroke="#ef4444"
-                strokeWidth={2}
-                dot={false}
-                name="Mobile $/user"
-              />
+              <Line type="monotone" dataKey="desktop" stroke="#f59e0b" strokeWidth={2} dot={false} name="Desktop $/user" />
+              <Line type="monotone" dataKey="mobile" stroke="#ef4444" strokeWidth={2} dot={false} name="Mobile $/user" />
             </LineChart>
           </ResponsiveContainer>
         ),
@@ -1049,46 +778,21 @@ export default function AnalyticsPage() {
       {
         id: "profit-cost",
         title: `Total infra cost / day${costSource === "real" ? "" : " (est.)"}`,
-        periodChange: latestPeriodChange(
-          costData,
-          (point) => point.total,
-          "vs previous day",
-        ),
-        subtitle:
-          summary?.totalCostUsd != null
-            ? `Total last ${profitability?.days ?? 30}d: ${formatCurrency(summary.totalCostUsd)}`
-            : "Desktop + mobile daily burn",
+        periodChange: latestPeriodChange(costData, (point) => point.total, "vs previous day"),
+        subtitle: summary?.totalCostUsd != null
+          ? `Total last ${profitability?.days ?? 30}d: ${formatCurrency(summary.totalCostUsd)}`
+          : "Desktop + mobile daily burn",
         icon: <DollarSign className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
         render: () => (
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={costData}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-              <XAxis
-                dataKey="date"
-                className="text-xs"
-                tick={{ fill: "hsl(var(--muted-foreground))" }}
-                tickFormatter={shortDate}
-                minTickGap={30}
-              />
-              <YAxis
-                className="text-xs"
-                tick={{ fill: "hsl(var(--muted-foreground))" }}
-                tickFormatter={(v) => `$${formatCompact(v)}`}
-                width={50}
-              />
-              <Tooltip
-                contentStyle={tooltipStyle}
-                labelFormatter={fullDate}
-                formatter={(v: number, name) => [formatCurrency(v), name]}
-              />
+              <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} minTickGap={30} />
+              <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `$${formatCompact(v)}`} width={50} />
+              <Tooltip contentStyle={tooltipStyle} labelFormatter={fullDate} formatter={(v: number, name) => [formatCurrency(v), name]} />
               <Legend wrapperStyle={{ fontSize: 11 }} />
-              <Bar
-                dataKey="desktop"
-                stackId="c"
-                fill="#f59e0b"
-                name="Desktop"
-              />
+              <Bar dataKey="desktop" stackId="c" fill="#f59e0b" name="Desktop" />
               <Bar dataKey="mobile" stackId="c" fill="#ef4444" name="Mobile" />
             </BarChart>
           </ResponsiveContainer>
@@ -1097,11 +801,7 @@ export default function AnalyticsPage() {
       {
         id: "profit-conversion",
         title: "Free → paid %",
-        periodChange: latestPeriodChange(
-          conversionData,
-          (point) => point.total,
-          "vs previous day",
-        ),
+        periodChange: latestPeriodChange(conversionData, (point) => point.total, "vs previous day"),
         subtitle: "New paid subs / new users",
         icon: <Percent className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -1109,41 +809,12 @@ export default function AnalyticsPage() {
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={conversionData}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-              <XAxis
-                dataKey="date"
-                className="text-xs"
-                tick={{ fill: "hsl(var(--muted-foreground))" }}
-                tickFormatter={shortDate}
-                minTickGap={30}
-              />
-              <YAxis
-                className="text-xs"
-                tick={{ fill: "hsl(var(--muted-foreground))" }}
-                tickFormatter={(v) => `${v}%`}
-                width={40}
-              />
-              <Tooltip
-                contentStyle={tooltipStyle}
-                labelFormatter={fullDate}
-                formatter={(v: number, name) => [`${v}%`, name]}
-              />
+              <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} minTickGap={30} />
+              <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `${v}%`} width={40} />
+              <Tooltip contentStyle={tooltipStyle} labelFormatter={fullDate} formatter={(v: number, name) => [`${v}%`, name]} />
               <Legend wrapperStyle={{ fontSize: 11 }} />
-              <Line
-                type="monotone"
-                dataKey="desktop"
-                stroke="#6366f1"
-                strokeWidth={2}
-                dot={false}
-                name="Desktop"
-              />
-              <Line
-                type="monotone"
-                dataKey="mobile"
-                stroke="#22c55e"
-                strokeWidth={2}
-                dot={false}
-                name="Mobile"
-              />
+              <Line type="monotone" dataKey="desktop" stroke="#6366f1" strokeWidth={2} dot={false} name="Desktop" />
+              <Line type="monotone" dataKey="mobile" stroke="#22c55e" strokeWidth={2} dot={false} name="Mobile" />
             </LineChart>
           </ResponsiveContainer>
         ),
@@ -1167,69 +838,36 @@ export default function AnalyticsPage() {
           }
           const totalMtd = rows.reduce((s, r) => s + r.mtdUsd, 0);
           const totalProj = rows.reduce((s, r) => s + r.aprProjectionUsd, 0);
-          const totalDesktopProj = rows.reduce(
-            (s, r) => s + r.desktopProjectionUsd,
-            0,
-          );
-          const totalMobileProj = rows.reduce(
-            (s, r) => s + r.mobileProjectionUsd,
-            0,
-          );
+          const totalDesktopProj = rows.reduce((s, r) => s + r.desktopProjectionUsd, 0);
+          const totalMobileProj = rows.reduce((s, r) => s + r.mobileProjectionUsd, 0);
           return (
             <div className="h-full overflow-auto">
               <table className="w-full text-sm">
                 <thead className="sticky top-0 bg-card">
                   <tr className="border-b text-xs uppercase text-muted-foreground">
                     <th className="px-3 py-2 text-left font-medium">Service</th>
-                    <th className="px-3 py-2 text-right font-medium">
-                      Gross MTD
-                    </th>
-                    <th className="px-3 py-2 text-right font-medium">
-                      Last 30 days
-                    </th>
-                    <th className="px-3 py-2 text-right font-medium text-indigo-500">
-                      Desktop
-                    </th>
-                    <th className="px-3 py-2 text-right font-medium text-green-500">
-                      Mobile
-                    </th>
+                    <th className="px-3 py-2 text-right font-medium">Gross MTD</th>
+                    <th className="px-3 py-2 text-right font-medium">Last 30 days</th>
+                    <th className="px-3 py-2 text-right font-medium text-indigo-500">Desktop</th>
+                    <th className="px-3 py-2 text-right font-medium text-green-500">Mobile</th>
                   </tr>
                 </thead>
                 <tbody>
                   {rows.map((r) => (
-                    <tr
-                      key={r.service}
-                      className="border-b border-border/40 last:border-b-0"
-                    >
+                    <tr key={r.service} className="border-b border-border/40 last:border-b-0">
                       <td className="px-3 py-2 font-medium">{r.service}</td>
-                      <td className="px-3 py-2 text-right tabular-nums">
-                        {formatCurrency(r.mtdUsd)}
-                      </td>
-                      <td className="px-3 py-2 text-right tabular-nums">
-                        {formatCurrency(r.aprProjectionUsd)}
-                      </td>
-                      <td className="px-3 py-2 text-right tabular-nums text-indigo-500">
-                        {formatCurrency(r.desktopProjectionUsd)}
-                      </td>
-                      <td className="px-3 py-2 text-right tabular-nums text-red-500">
-                        {formatCurrency(r.mobileProjectionUsd)}
-                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums">{formatCurrency(r.mtdUsd)}</td>
+                      <td className="px-3 py-2 text-right tabular-nums">{formatCurrency(r.aprProjectionUsd)}</td>
+                      <td className="px-3 py-2 text-right tabular-nums text-indigo-500">{formatCurrency(r.desktopProjectionUsd)}</td>
+                      <td className="px-3 py-2 text-right tabular-nums text-red-500">{formatCurrency(r.mobileProjectionUsd)}</td>
                     </tr>
                   ))}
                   <tr className="border-t-2 border-border/60 font-semibold">
                     <td className="px-3 py-2">Total</td>
-                    <td className="px-3 py-2 text-right tabular-nums">
-                      {formatCurrency(totalMtd)}
-                    </td>
-                    <td className="px-3 py-2 text-right tabular-nums">
-                      {formatCurrency(totalProj)}
-                    </td>
-                    <td className="px-3 py-2 text-right tabular-nums text-indigo-500">
-                      {formatCurrency(totalDesktopProj)}
-                    </td>
-                    <td className="px-3 py-2 text-right tabular-nums text-red-500">
-                      {formatCurrency(totalMobileProj)}
-                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums">{formatCurrency(totalMtd)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums">{formatCurrency(totalProj)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums text-indigo-500">{formatCurrency(totalDesktopProj)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums text-red-500">{formatCurrency(totalMobileProj)}</td>
                   </tr>
                 </tbody>
               </table>
@@ -1245,79 +883,36 @@ export default function AnalyticsPage() {
       {
         id: "rev-cumulative",
         title: "Cumulative users",
-        periodChange: latestPeriodChange(
-          cumulativeSeries,
-          (point) => point.cumulative,
-          "vs previous day",
-        ),
+        periodChange: latestPeriodChange(cumulativeSeries, (point) => point.cumulative, "vs previous day"),
         subtitle: "Total users across all platforms",
         icon: <Users className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
-        render: () =>
+        render: () => (
           cumulativeSeries.length > 0 ? (
             <ResponsiveContainer width="100%" height="100%">
               <AreaChart data={cumulativeSeries}>
                 <defs>
-                  <linearGradient
-                    id="cumulativeGradientRev"
-                    x1="0"
-                    y1="0"
-                    x2="0"
-                    y2="1"
-                  >
+                  <linearGradient id="cumulativeGradientRev" x1="0" y1="0" x2="0" y2="1">
                     <stop offset="5%" stopColor="#22c55e" stopOpacity={0.3} />
                     <stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
                   </linearGradient>
                 </defs>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis
-                  dataKey="date"
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                  tickFormatter={shortDate}
-                  minTickGap={40}
-                />
-                <YAxis
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                  tickFormatter={formatCompact}
-                  domain={cumulativeYDomain}
-                  allowDataOverflow={false}
-                  width={56}
-                />
-                <Tooltip
-                  formatter={(value: number) => [
-                    value.toLocaleString(),
-                    "Total Users",
-                  ]}
-                  labelFormatter={fullDate}
-                  contentStyle={tooltipStyle}
-                />
-                <Area
-                  type="monotone"
-                  dataKey="cumulative"
-                  stroke="#22c55e"
-                  strokeWidth={2}
-                  fill="url(#cumulativeGradientRev)"
-                  dot={false}
-                  activeDot={{ r: 4 }}
-                />
+                <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} minTickGap={40} />
+                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={formatCompact} domain={cumulativeYDomain} allowDataOverflow={false} width={56} />
+                <Tooltip formatter={(value: number) => [value.toLocaleString(), "Total Users"]} labelFormatter={fullDate} contentStyle={tooltipStyle} />
+                <Area type="monotone" dataKey="cumulative" stroke="#22c55e" strokeWidth={2} fill="url(#cumulativeGradientRev)" dot={false} activeDot={{ r: 4 }} />
               </AreaChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
-              No data available
-            </div>
-          ),
+            <div className="flex h-full items-center justify-center text-muted-foreground text-sm">No data available</div>
+          )
+        ),
       },
       {
         id: "rev-mrr",
         title: "MRR over time",
-        periodChange: latestPeriodChange(
-          mrrData,
-          (point) => point.mrr,
-          "vs previous month",
-        ),
+        periodChange: latestPeriodChange(mrrData, (point) => point.mrr, "vs previous month"),
         subtitle: "Monthly recurring revenue from Stripe",
         icon: <DollarSign className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -1331,29 +926,10 @@ export default function AnalyticsPage() {
                 </linearGradient>
               </defs>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-              <XAxis
-                dataKey="month"
-                className="text-xs"
-                tick={{ fill: "hsl(var(--muted-foreground))" }}
-              />
-              <YAxis
-                className="text-xs"
-                tick={{ fill: "hsl(var(--muted-foreground))" }}
-                tickFormatter={(v) => `$${formatCompact(v)}`}
-              />
-              <Tooltip
-                formatter={(value: number) => [formatCurrency(value), "MRR"]}
-                contentStyle={tooltipStyle}
-              />
-              <Area
-                type="monotone"
-                dataKey="mrr"
-                stroke={COLORS.mrr}
-                strokeWidth={2}
-                fill="url(#mrrGradientRev)"
-                dot={{ r: 3, fill: COLORS.mrr }}
-                activeDot={{ r: 5 }}
-              />
+              <XAxis dataKey="month" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+              <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `$${formatCompact(v)}`} />
+              <Tooltip formatter={(value: number) => [formatCurrency(value), "MRR"]} contentStyle={tooltipStyle} />
+              <Area type="monotone" dataKey="mrr" stroke={COLORS.mrr} strokeWidth={2} fill="url(#mrrGradientRev)" dot={{ r: 3, fill: COLORS.mrr }} activeDot={{ r: 5 }} />
             </AreaChart>
           </ResponsiveContainer>
         ),
@@ -1361,11 +937,7 @@ export default function AnalyticsPage() {
       {
         id: "rev-subs",
         title: "New subscriptions",
-        periodChange: latestPeriodChange(
-          subData,
-          (point) => point.monthly + point.annual,
-          "vs previous month",
-        ),
+        periodChange: latestPeriodChange(subData, (point) => point.monthly + point.annual, "vs previous month"),
         subtitle: "Monthly vs annual subscriptions created each month",
         icon: <TrendingUp className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -1373,31 +945,12 @@ export default function AnalyticsPage() {
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={subData}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-              <XAxis
-                dataKey="month"
-                className="text-xs"
-                tick={{ fill: "hsl(var(--muted-foreground))" }}
-              />
-              <YAxis
-                className="text-xs"
-                tick={{ fill: "hsl(var(--muted-foreground))" }}
-              />
+              <XAxis dataKey="month" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+              <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
               <Tooltip contentStyle={tooltipStyle} />
               <Legend />
-              <Bar
-                dataKey="monthly"
-                name="Monthly"
-                fill={COLORS.monthly}
-                radius={[2, 2, 0, 0]}
-                stackId="a"
-              />
-              <Bar
-                dataKey="annual"
-                name="Annual"
-                fill={COLORS.annual}
-                radius={[2, 2, 0, 0]}
-                stackId="a"
-              />
+              <Bar dataKey="monthly" name="Monthly" fill={COLORS.monthly} radius={[2, 2, 0, 0]} stackId="a" />
+              <Bar dataKey="annual" name="Annual" fill={COLORS.annual} radius={[2, 2, 0, 0]} stackId="a" />
             </BarChart>
           </ResponsiveContainer>
         ),
@@ -1417,19 +970,13 @@ export default function AnalyticsPage() {
           <div className="flex h-full flex-col">
             <div className="mb-3 flex items-center justify-end">
               <div className="text-right">
-                <div className="text-2xl font-bold">
-                  {macosVersionStats?.activeUsers?.toLocaleString() ?? "--"}
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  active macOS users today
-                </p>
+                <div className="text-2xl font-bold">{macosVersionStats?.activeUsers?.toLocaleString() ?? "--"}</div>
+                <p className="text-xs text-muted-foreground">active macOS users today</p>
               </div>
             </div>
             <div className="grid gap-6 lg:grid-cols-2">
               <div>
-                <h3 className="text-sm font-medium text-muted-foreground mb-3">
-                  Beta vs Production
-                </h3>
+                <h3 className="text-sm font-medium text-muted-foreground mb-3">Beta vs Production</h3>
                 <div className="h-[280px]">
                   {macosVersionStatsLoading ? (
                     <div className="h-full flex items-center justify-center">
@@ -1451,20 +998,14 @@ export default function AnalyticsPage() {
                           paddingAngle={3}
                           dataKey="value"
                           nameKey="label"
-                          label={({ label, percent }) =>
-                            `${label} ${(percent * 100).toFixed(0)}%`
-                          }
+                          label={({ label, percent }) => `${label} ${(percent * 100).toFixed(0)}%`}
                         >
                           {macosChannelData.map((entry) => (
                             <Cell key={entry.label} fill={entry.color} />
                           ))}
                         </Pie>
                         <Tooltip
-                          formatter={(
-                            value: number,
-                            _name,
-                            entry: { payload?: MacosVersionBreakdown },
-                          ) => [
+                          formatter={(value: number, _name, entry: { payload?: MacosVersionBreakdown }) => [
                             Number(value).toLocaleString(),
                             entry?.payload?.label ?? "Users",
                           ]}
@@ -1476,9 +1017,7 @@ export default function AnalyticsPage() {
                 </div>
               </div>
               <div>
-                <h3 className="text-sm font-medium text-muted-foreground mb-3">
-                  By Version
-                </h3>
+                <h3 className="text-sm font-medium text-muted-foreground mb-3">By Version</h3>
                 <div className="h-[280px]">
                   {macosVersionStatsLoading ? (
                     <div className="h-full flex items-center justify-center">
@@ -1506,11 +1045,7 @@ export default function AnalyticsPage() {
                           ))}
                         </Pie>
                         <Tooltip
-                          formatter={(
-                            value: number,
-                            _name,
-                            entry: { payload?: MacosVersionBreakdown },
-                          ) => [
+                          formatter={(value: number, _name, entry: { payload?: MacosVersionBreakdown }) => [
                             Number(value).toLocaleString(),
                             entry?.payload?.label ?? "Version",
                           ]}
@@ -1530,20 +1065,12 @@ export default function AnalyticsPage() {
                 </div>
                 <div className="space-y-3">
                   {macosChannelData.map((entry) => (
-                    <div
-                      key={entry.label}
-                      className="flex items-center justify-between"
-                    >
+                    <div key={entry.label} className="flex items-center justify-between">
                       <div className="flex items-center gap-3">
-                        <div
-                          className="w-3 h-3 rounded-full"
-                          style={{ backgroundColor: entry.color }}
-                        />
+                        <div className="w-3 h-3 rounded-full" style={{ backgroundColor: entry.color }} />
                         <span className="text-sm">{entry.label}</span>
                       </div>
-                      <span className="text-sm font-medium">
-                        {entry.value.toLocaleString()}
-                      </span>
+                      <span className="text-sm font-medium">{entry.value.toLocaleString()}</span>
                     </div>
                   ))}
                 </div>
@@ -1552,20 +1079,12 @@ export default function AnalyticsPage() {
                 <h3 className="font-medium mb-3">Version Counts</h3>
                 <div className="space-y-3 max-h-[220px] overflow-y-auto pr-1">
                   {macosVersionData.map((entry) => (
-                    <div
-                      key={entry.label}
-                      className="flex items-center justify-between"
-                    >
+                    <div key={entry.label} className="flex items-center justify-between">
                       <div className="flex items-center gap-3">
-                        <div
-                          className="w-3 h-3 rounded-full"
-                          style={{ backgroundColor: entry.color }}
-                        />
+                        <div className="w-3 h-3 rounded-full" style={{ backgroundColor: entry.color }} />
                         <span className="text-sm">{entry.label}</span>
                       </div>
-                      <span className="text-sm font-medium">
-                        {entry.value.toLocaleString()}
-                      </span>
+                      <span className="text-sm font-medium">{entry.value.toLocaleString()}</span>
                     </div>
                   ))}
                 </div>
@@ -1577,24 +1096,15 @@ export default function AnalyticsPage() {
       {
         id: "macos-fb-sessions-per-user",
         title: "Floating Bar Sessions per User",
-        periodChange: latestPeriodChange(
-          fbUsageData,
-          (point) => point.avg_sessions_per_user,
-          "vs previous day",
-        ),
-        subtitle:
-          "Times floating bar was opened and a question asked, per user per day (follow-ups don't count)",
+        periodChange: latestPeriodChange(fbUsageData, (point) => point.avg_sessions_per_user, "vs previous day"),
+        subtitle: "Times floating bar was opened and a question asked, per user per day (follow-ups don't count)",
         icon: <Activity className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
         render: () => (
           <div className="flex h-full flex-col">
             {fbSummary && (
               <div className="mb-2 text-right text-sm text-muted-foreground">
-                Avg:{" "}
-                <span className="font-medium text-foreground">
-                  {fbSummary.overallAvgPerUserPerDay ?? "—"}
-                </span>{" "}
-                sessions/user/day
+                Avg: <span className="font-medium text-foreground">{fbSummary.overallAvgPerUserPerDay ?? "—"}</span> sessions/user/day
               </div>
             )}
             <div className="min-h-0 flex-1">
@@ -1609,18 +1119,12 @@ export default function AnalyticsPage() {
               ) : (
                 <ResponsiveContainer width="100%" height="100%">
                   <LineChart data={fbUsageData}>
-                    <CartesianGrid
-                      strokeDasharray="3 3"
-                      className="opacity-30"
-                    />
+                    <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
                     <XAxis
                       dataKey="date"
                       tickFormatter={(v) => {
                         const d = new Date(v + "T00:00:00");
-                        return d.toLocaleDateString("en-US", {
-                          month: "short",
-                          day: "numeric",
-                        });
+                        return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
                       }}
                       tick={{ fontSize: 11 }}
                     />
@@ -1628,21 +1132,11 @@ export default function AnalyticsPage() {
                     <Tooltip
                       labelFormatter={(v) => {
                         const d = new Date(v + "T00:00:00");
-                        return d.toLocaleDateString("en-US", {
-                          month: "long",
-                          day: "numeric",
-                          year: "numeric",
-                        });
+                        return d.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" });
                       }}
                     />
                     <Legend />
-                    <Line
-                      dataKey="avg_sessions_per_user"
-                      name="Sessions/User"
-                      stroke="#6366f1"
-                      strokeWidth={2}
-                      dot={false}
-                    />
+                    <Line dataKey="avg_sessions_per_user" name="Sessions/User" stroke="#6366f1" strokeWidth={2} dot={false} />
                   </LineChart>
                 </ResponsiveContainer>
               )}
@@ -1651,29 +1145,17 @@ export default function AnalyticsPage() {
         ),
       },
     ];
-  }, [
-    macosVersionStats,
-    macosVersionStatsLoading,
-    macosChannelData,
-    macosVersionData,
-    fbSummary,
-    fbUsageLoading,
-    fbUsageData,
-  ]);
+  }, [macosVersionStats, macosVersionStatsLoading, macosChannelData, macosVersionData, fbSummary, fbUsageLoading, fbUsageData]);
 
   const notificationCharts = useMemo<ChartItem[]>(() => {
     return [
       {
         id: "notif-daily-sent",
         title: "Daily Notifications Sent",
-        periodChange: latestPeriodChange(
-          notificationDailyCombined,
-          (point) => point.totalSent,
-          "vs previous day",
-        ),
+        periodChange: latestPeriodChange(notificationDailyCombined, (point) => point.totalSent, "vs previous day"),
         initialLayout: { cols: 12, rows: 4 },
         icon: <Send className="h-4 w-4" />,
-        render: () =>
+        render: () => (
           notificationStatsLoading ? (
             <div className="h-full flex items-center justify-center">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -1682,111 +1164,54 @@ export default function AnalyticsPage() {
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={notificationDailyCombined}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis
-                  dataKey="date"
-                  tickFormatter={shortDate}
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                />
-                <YAxis
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                />
-                <Tooltip
-                  labelFormatter={fullDate}
-                  contentStyle={tooltipStyle}
-                />
+                <XAxis dataKey="date" tickFormatter={shortDate} className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                <Tooltip labelFormatter={fullDate} contentStyle={tooltipStyle} />
                 <Legend />
-                <Bar
-                  dataKey="mentorSent"
-                  name="Omi says (built-in)"
-                  fill="#6366f1"
-                  radius={[2, 2, 0, 0]}
-                  stackId="a"
-                />
-                <Bar
-                  dataKey="marketplaceMentorSent"
-                  name="Marketplace Mentor"
-                  fill="#f59e0b"
-                  radius={[2, 2, 0, 0]}
-                  stackId="a"
-                />
+                <Bar dataKey="mentorSent" name="Omi says (built-in)" fill="#6366f1" radius={[2, 2, 0, 0]} stackId="a" />
+                <Bar dataKey="marketplaceMentorSent" name="Marketplace Mentor" fill="#f59e0b" radius={[2, 2, 0, 0]} stackId="a" />
               </BarChart>
             </ResponsiveContainer>
-          ),
+          )
+        ),
       },
       {
         id: "notif-hourly-168h",
         title: "Notifications Sent, Last 168 Hours",
-        periodChange: latestPeriodChange(
-          notificationHourlyData,
-          (point) => point.total,
-          "vs previous hour",
-        ),
+        periodChange: latestPeriodChange(notificationHourlyData, (point) => point.total, "vs previous hour"),
         subtitle: "Hourly volume, with dates marked at midnight UTC.",
         icon: <Send className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
-        render: () =>
+        render: () => (
           notificationStatsLoading ? (
             <div className="h-full flex items-center justify-center">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
             </div>
           ) : (
             <ResponsiveContainer width="100%" height="100%">
-              <BarChart
-                data={notificationHourlyData}
-                barCategoryGap={0}
-                barGap={0}
-              >
+              <BarChart data={notificationHourlyData} barCategoryGap={0} barGap={0}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis
-                  dataKey="hour"
-                  tickFormatter={formatHourTick}
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                  interval={0}
-                  minTickGap={40}
-                />
-                <YAxis
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                />
-                <Tooltip
-                  labelFormatter={(value) => formatHourKey(value as string)}
-                  contentStyle={tooltipStyle}
-                />
+                <XAxis dataKey="hour" tickFormatter={formatHourTick} className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} interval={0} minTickGap={40} />
+                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                <Tooltip labelFormatter={(value) => formatHourKey(value as string)} contentStyle={tooltipStyle} />
                 <Legend />
-                <Bar
-                  dataKey="mentor"
-                  name="Omi Says"
-                  fill="#6366f1"
-                  stackId="a"
-                />
-                <Bar
-                  dataKey="marketplace"
-                  name="Marketplace Mentor"
-                  fill="#f59e0b"
-                  stackId="a"
-                />
+                <Bar dataKey="mentor" name="Omi Says" fill="#6366f1" stackId="a" />
+                <Bar dataKey="marketplace" name="Marketplace Mentor" fill="#f59e0b" stackId="a" />
               </BarChart>
             </ResponsiveContainer>
-          ),
+          )
+        ),
       },
       {
         id: "notif-fb-ctr",
         title: "Floating Bar Notification CTR",
-        periodChange: latestPeriodChange(
-          floatingBarCtr?.dailyData ?? [],
-          (point) => point.ctr,
-          "vs previous day",
-        ),
-        subtitle:
-          floatingBarCtrSummary?.mode === "surface_tagged"
-            ? "Sent vs clicked proactive notifications in the desktop floating bar."
-            : "Surface-tagged floating-bar events are not populated yet, so this is currently using all desktop notification clicks as a fallback.",
+        periodChange: latestPeriodChange(floatingBarCtr?.dailyData ?? [], (point) => point.ctr, "vs previous day"),
+        subtitle: floatingBarCtrSummary?.mode === "surface_tagged"
+          ? "Sent vs clicked proactive notifications in the desktop floating bar."
+          : "Surface-tagged floating-bar events are not populated yet, so this is currently using all desktop notification clicks as a fallback.",
         icon: <MousePointerClick className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
-        render: () =>
+        render: () => (
           notificationStatsLoading ? (
             <div className="h-full flex items-center justify-center">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -1795,73 +1220,31 @@ export default function AnalyticsPage() {
             <ResponsiveContainer width="100%" height="100%">
               <ComposedChart data={floatingBarCtr?.dailyData ?? []}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis
-                  dataKey="date"
-                  tickFormatter={shortDate}
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                />
-                <YAxis
-                  yAxisId="left"
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                />
-                <YAxis
-                  yAxisId="right"
-                  orientation="right"
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                  tickFormatter={(v) => `${v}%`}
-                />
+                <XAxis dataKey="date" tickFormatter={shortDate} className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                <YAxis yAxisId="left" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                <YAxis yAxisId="right" orientation="right" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `${v}%`} />
                 <Tooltip
                   labelFormatter={fullDate}
-                  formatter={(value: number, name: string) =>
-                    name === "CTR"
-                      ? [`${value}%`, name]
-                      : [value.toLocaleString(), name]
-                  }
+                  formatter={(value: number, name: string) => name === "CTR" ? [`${value}%`, name] : [value.toLocaleString(), name]}
                   contentStyle={tooltipStyle}
                 />
                 <Legend />
-                <Bar
-                  yAxisId="left"
-                  dataKey="sent"
-                  name="Sent"
-                  fill="#6366f1"
-                  radius={[2, 2, 0, 0]}
-                />
-                <Bar
-                  yAxisId="left"
-                  dataKey="clicked"
-                  name="Clicked"
-                  fill="#22c55e"
-                  radius={[2, 2, 0, 0]}
-                />
-                <Line
-                  yAxisId="right"
-                  type="monotone"
-                  dataKey="ctr"
-                  name="CTR"
-                  stroke="#f59e0b"
-                  strokeWidth={2}
-                  dot={{ r: 3 }}
-                />
+                <Bar yAxisId="left" dataKey="sent" name="Sent" fill="#6366f1" radius={[2, 2, 0, 0]} />
+                <Bar yAxisId="left" dataKey="clicked" name="Clicked" fill="#22c55e" radius={[2, 2, 0, 0]} />
+                <Line yAxisId="right" type="monotone" dataKey="ctr" name="CTR" stroke="#f59e0b" strokeWidth={2} dot={{ r: 3 }} />
               </ComposedChart>
             </ResponsiveContainer>
-          ),
+          )
+        ),
       },
       {
         id: "notif-weekly-reach",
         title: "Weekly Notification Reach",
-        periodChange: latestPeriodChange(
-          notificationWeeklyCombined,
-          (point) => point.totalUniqueUsers,
-          "vs previous week",
-        ),
+        periodChange: latestPeriodChange(notificationWeeklyCombined, (point) => point.totalUniqueUsers, "vs previous week"),
         subtitle: "Volume and unique recipients in one view.",
         icon: <Users className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
-        render: () =>
+        render: () => (
           notificationStatsLoading ? (
             <div className="h-full flex items-center justify-center">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -1870,71 +1253,24 @@ export default function AnalyticsPage() {
             <ResponsiveContainer width="100%" height="100%">
               <ComposedChart data={notificationWeeklyCombined}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis
-                  dataKey="week"
-                  tickFormatter={formatWeek}
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                />
-                <YAxis
-                  yAxisId="left"
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                />
-                <YAxis
-                  yAxisId="right"
-                  orientation="right"
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                />
-                <Tooltip
-                  labelFormatter={formatWeek}
-                  contentStyle={tooltipStyle}
-                />
+                <XAxis dataKey="week" tickFormatter={formatWeek} className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                <YAxis yAxisId="left" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                <YAxis yAxisId="right" orientation="right" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                <Tooltip labelFormatter={formatWeek} contentStyle={tooltipStyle} />
                 <Legend />
-                <Bar
-                  yAxisId="left"
-                  dataKey="mentorSent"
-                  name="Omi says sent"
-                  fill="#6366f1"
-                  radius={[2, 2, 0, 0]}
-                  stackId="a"
-                />
-                <Bar
-                  yAxisId="left"
-                  dataKey="marketplaceMentorSent"
-                  name="Marketplace sent"
-                  fill="#f59e0b"
-                  radius={[2, 2, 0, 0]}
-                  stackId="a"
-                />
-                <Line
-                  yAxisId="right"
-                  type="monotone"
-                  dataKey="uniqueUsersMentor"
-                  name="Omi says unique users"
-                  stroke="#14b8a6"
-                  strokeWidth={2}
-                  dot={false}
-                />
-                <Line
-                  yAxisId="right"
-                  type="monotone"
-                  dataKey="uniqueUsersMarketplace"
-                  name="Marketplace unique users"
-                  stroke="#fbbf24"
-                  strokeWidth={2}
-                  dot={false}
-                />
+                <Bar yAxisId="left" dataKey="mentorSent" name="Omi says sent" fill="#6366f1" radius={[2, 2, 0, 0]} stackId="a" />
+                <Bar yAxisId="left" dataKey="marketplaceMentorSent" name="Marketplace sent" fill="#f59e0b" radius={[2, 2, 0, 0]} stackId="a" />
+                <Line yAxisId="right" type="monotone" dataKey="uniqueUsersMentor" name="Omi says unique users" stroke="#14b8a6" strokeWidth={2} dot={false} />
+                <Line yAxisId="right" type="monotone" dataKey="uniqueUsersMarketplace" name="Marketplace unique users" stroke="#fbbf24" strokeWidth={2} dot={false} />
               </ComposedChart>
             </ResponsiveContainer>
-          ),
+          )
+        ),
       },
       {
         id: "notif-settings",
         title: "Notification Settings",
-        subtitle:
-          "Based on the desktop notifications_enabled toggle. Missing values default to enabled.",
+        subtitle: "Based on the desktop notifications_enabled toggle. Missing values default to enabled.",
         icon: <Bell className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
         render: () => (
@@ -1942,26 +1278,14 @@ export default function AnalyticsPage() {
             <div className="rounded-lg border border-border/60 bg-muted/20 p-4">
               <div className="flex items-end justify-between gap-4">
                 <div>
-                  <div className="text-sm text-muted-foreground">
-                    Enabled share
-                  </div>
+                  <div className="text-sm text-muted-foreground">Enabled share</div>
                   <div className="text-3xl font-semibold">
-                    {notificationEnabledDisabled
-                      ? `${((notificationEnabledDisabled.enabled / notificationEnabledDisabled.total) * 100).toFixed(1)}%`
-                      : "--"}
+                    {notificationEnabledDisabled ? `${((notificationEnabledDisabled.enabled / notificationEnabledDisabled.total) * 100).toFixed(1)}%` : "--"}
                   </div>
                 </div>
                 <div className="text-right text-sm text-muted-foreground">
-                  <div>
-                    {notificationEnabledDisabled?.enabled?.toLocaleString() ??
-                      "--"}{" "}
-                    enabled
-                  </div>
-                  <div>
-                    {notificationEnabledDisabled?.disabled?.toLocaleString() ??
-                      "--"}{" "}
-                    disabled
-                  </div>
+                  <div>{notificationEnabledDisabled?.enabled?.toLocaleString() ?? "--"} enabled</div>
+                  <div>{notificationEnabledDisabled?.disabled?.toLocaleString() ?? "--"} disabled</div>
                 </div>
               </div>
               <div className="mt-4 h-3 overflow-hidden rounded-full bg-muted">
@@ -1999,19 +1323,14 @@ export default function AnalyticsPage() {
           (point) => point.thumbs_up + point.thumbs_down,
           "vs previous week",
         ),
-        subtitle:
-          "Weekly thumbs up/down from macOS floating bar. The overall positive rate is shown above.",
+        subtitle: "Weekly thumbs up/down from macOS floating bar. The overall positive rate is shown above.",
         icon: <MessageSquare className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
         render: () => (
           <div className="flex h-full flex-col">
             <div className="mb-2 flex items-center justify-end gap-4 text-sm text-muted-foreground">
-              <span className="text-green-500 font-medium">
-                {totalThumbsUp} up
-              </span>
-              <span className="text-red-500 font-medium">
-                {totalThumbsDown} down
-              </span>
+              <span className="text-green-500 font-medium">{totalThumbsUp} up</span>
+              <span className="text-red-500 font-medium">{totalThumbsDown} down</span>
               <span>{overallRatio}% positive</span>
             </div>
             <div className="min-h-0 flex-1">
@@ -2026,10 +1345,7 @@ export default function AnalyticsPage() {
               ) : (
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart data={weeklyRatingsData}>
-                    <CartesianGrid
-                      strokeDasharray="3 3"
-                      className="opacity-30"
-                    />
+                    <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
                     <XAxis
                       dataKey="week"
                       tickFormatter={formatWeek}
@@ -2038,24 +1354,11 @@ export default function AnalyticsPage() {
                     <YAxis tick={{ fontSize: 11 }} />
                     <Tooltip
                       labelFormatter={formatWeek}
-                      formatter={(value: number, name: string) => [
-                        value,
-                        name === "thumbs_up" ? "Thumbs Up" : "Thumbs Down",
-                      ]}
+                      formatter={(value: number, name: string) => [value, name === "thumbs_up" ? "Thumbs Up" : "Thumbs Down"]}
                     />
                     <Legend />
-                    <Bar
-                      dataKey="thumbs_up"
-                      name="Thumbs Up"
-                      fill="#22c55e"
-                      radius={[2, 2, 0, 0]}
-                    />
-                    <Bar
-                      dataKey="thumbs_down"
-                      name="Thumbs Down"
-                      fill="#ef4444"
-                      radius={[2, 2, 0, 0]}
-                    />
+                    <Bar dataKey="thumbs_up" name="Thumbs Up" fill="#22c55e" radius={[2, 2, 0, 0]} />
+                    <Bar dataKey="thumbs_down" name="Thumbs Down" fill="#ef4444" radius={[2, 2, 0, 0]} />
                   </BarChart>
                 </ResponsiveContainer>
               )}
@@ -2066,11 +1369,7 @@ export default function AnalyticsPage() {
       {
         id: "fb-usage-text-voice",
         title: "Floating Bar Usage",
-        periodChange: latestPeriodChange(
-          fbUsageData,
-          (point) => point.total_queries,
-          "vs previous day",
-        ),
+        periodChange: latestPeriodChange(fbUsageData, (point) => point.total_queries, "vs previous day"),
         subtitle: "Daily queries by input type — text vs voice (last 30 days)",
         icon: <Activity className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
@@ -2079,12 +1378,8 @@ export default function AnalyticsPage() {
             {fbSummary && (
               <div className="mb-2 flex items-center justify-end gap-4 text-sm text-muted-foreground">
                 <span>{fbSummary.totalQueries} total</span>
-                <span className="text-blue-500 font-medium">
-                  {fbSummary.totalText} text
-                </span>
-                <span className="text-orange-500 font-medium">
-                  {fbSummary.totalVoice} voice
-                </span>
+                <span className="text-blue-500 font-medium">{fbSummary.totalText} text</span>
+                <span className="text-orange-500 font-medium">{fbSummary.totalVoice} voice</span>
               </div>
             )}
             <div className="min-h-0 flex-1">
@@ -2099,18 +1394,12 @@ export default function AnalyticsPage() {
               ) : (
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart data={fbUsageData}>
-                    <CartesianGrid
-                      strokeDasharray="3 3"
-                      className="opacity-30"
-                    />
+                    <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
                     <XAxis
                       dataKey="date"
                       tickFormatter={(v) => {
                         const d = new Date(v + "T00:00:00");
-                        return d.toLocaleDateString("en-US", {
-                          month: "short",
-                          day: "numeric",
-                        });
+                        return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
                       }}
                       tick={{ fontSize: 11 }}
                     />
@@ -2118,28 +1407,12 @@ export default function AnalyticsPage() {
                     <Tooltip
                       labelFormatter={(v) => {
                         const d = new Date(v + "T00:00:00");
-                        return d.toLocaleDateString("en-US", {
-                          month: "long",
-                          day: "numeric",
-                          year: "numeric",
-                        });
+                        return d.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" });
                       }}
                     />
                     <Legend />
-                    <Bar
-                      dataKey="text_queries"
-                      name="Text"
-                      stackId="queries"
-                      fill="#6366f1"
-                      radius={[0, 0, 0, 0]}
-                    />
-                    <Bar
-                      dataKey="voice_queries"
-                      name="Voice"
-                      stackId="queries"
-                      fill="#f97316"
-                      radius={[2, 2, 0, 0]}
-                    />
+                    <Bar dataKey="text_queries" name="Text" stackId="queries" fill="#6366f1" radius={[0, 0, 0, 0]} />
+                    <Bar dataKey="voice_queries" name="Voice" stackId="queries" fill="#f97316" radius={[2, 2, 0, 0]} />
                   </BarChart>
                 </ResponsiveContainer>
               )}
@@ -2150,24 +1423,15 @@ export default function AnalyticsPage() {
       {
         id: "fb-avg-per-user",
         title: "Avg Queries per User per Day",
-        periodChange: latestPeriodChange(
-          fbUsageData,
-          (point) => point.avg_per_user,
-          "vs previous day",
-        ),
-        subtitle:
-          "Average floating bar queries per active user, daily (last 30 days)",
+        periodChange: latestPeriodChange(fbUsageData, (point) => point.avg_per_user, "vs previous day"),
+        subtitle: "Average floating bar queries per active user, daily (last 30 days)",
         icon: <Activity className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
         render: () => (
           <div className="flex h-full flex-col">
             {fbSummary && (
               <div className="mb-2 text-right text-sm text-muted-foreground">
-                Overall:{" "}
-                <span className="font-medium text-foreground">
-                  {fbSummary.overallAvgPerUserPerDay}
-                </span>{" "}
-                queries/user/day
+                Overall: <span className="font-medium text-foreground">{fbSummary.overallAvgPerUserPerDay}</span> queries/user/day
               </div>
             )}
             <div className="min-h-0 flex-1">
@@ -2182,58 +1446,30 @@ export default function AnalyticsPage() {
               ) : (
                 <ResponsiveContainer width="100%" height="100%">
                   <ComposedChart data={fbUsageData}>
-                    <CartesianGrid
-                      strokeDasharray="3 3"
-                      className="opacity-30"
-                    />
+                    <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
                     <XAxis
                       dataKey="date"
                       tickFormatter={(v) => {
                         const d = new Date(v + "T00:00:00");
-                        return d.toLocaleDateString("en-US", {
-                          month: "short",
-                          day: "numeric",
-                        });
+                        return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
                       }}
                       tick={{ fontSize: 11 }}
                     />
                     <YAxis yAxisId="avg" tick={{ fontSize: 11 }} />
-                    <YAxis
-                      yAxisId="users"
-                      orientation="right"
-                      tick={{ fontSize: 11 }}
-                    />
+                    <YAxis yAxisId="users" orientation="right" tick={{ fontSize: 11 }} />
                     <Tooltip
                       labelFormatter={(v) => {
                         const d = new Date(v + "T00:00:00");
-                        return d.toLocaleDateString("en-US", {
-                          month: "long",
-                          day: "numeric",
-                          year: "numeric",
-                        });
+                        return d.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" });
                       }}
                       formatter={(value: number, name: string) => {
-                        if (name === "Avg/User")
-                          return [value, "Avg queries per user"];
+                        if (name === "Avg/User") return [value, "Avg queries per user"];
                         return [value, "Active users"];
                       }}
                     />
                     <Legend />
-                    <Bar
-                      yAxisId="users"
-                      dataKey="unique_users"
-                      name="Active Users"
-                      fill="#e2e8f0"
-                      radius={[2, 2, 0, 0]}
-                    />
-                    <Line
-                      yAxisId="avg"
-                      dataKey="avg_per_user"
-                      name="Avg/User"
-                      stroke="#6366f1"
-                      strokeWidth={2}
-                      dot={false}
-                    />
+                    <Bar yAxisId="users" dataKey="unique_users" name="Active Users" fill="#e2e8f0" radius={[2, 2, 0, 0]} />
+                    <Line yAxisId="avg" dataKey="avg_per_user" name="Avg/User" stroke="#6366f1" strokeWidth={2} dot={false} />
                   </ComposedChart>
                 </ResponsiveContainer>
               )}
@@ -2242,142 +1478,57 @@ export default function AnalyticsPage() {
         ),
       },
     ];
-  }, [
-    ratingsLoading,
-    weeklyRatingsData,
-    totalThumbsUp,
-    totalThumbsDown,
-    overallRatio,
-    fbSummary,
-    fbUsageLoading,
-    fbUsageData,
-  ]);
+  }, [ratingsLoading, weeklyRatingsData, totalThumbsUp, totalThumbsDown, overallRatio, fbSummary, fbUsageLoading, fbUsageData]);
 
   const viralCharts = useMemo<ChartItem[]>(() => {
     return [
       {
         id: "viral-growth-accounting",
         title: "Net Weekly Active User Growth",
-        periodChange: latestPeriodChange(
-          completedGrowthAccounting,
-          (point) => point.active,
-          "vs previous complete week",
-        ),
-        subtitle:
-          "WAU trend with new + resurrected − churned users · completed weeks",
+        periodChange: latestPeriodChange(completedGrowthAccounting, (point) => point.active, "vs previous complete week"),
+        subtitle: "WAU trend with new + resurrected − churned users · completed weeks",
         icon: <TrendingUp className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
-        render: () =>
+        render: () => (
           viralLoading ? (
             <div className="flex items-center justify-center h-full">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
             </div>
           ) : completedGrowthAccounting.length > 0 ? (
             <ResponsiveContainer width="100%" height="100%">
-              <ComposedChart
-                data={completedGrowthAccounting}
-                stackOffset="sign"
-              >
+              <ComposedChart data={completedGrowthAccounting} stackOffset="sign">
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis
-                  dataKey="week"
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                  tickFormatter={shortDate}
-                />
-                <YAxis
-                  yAxisId="users"
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                />
-                <Tooltip
-                  contentStyle={tooltipStyle}
-                  labelFormatter={fullDate}
-                  formatter={(value: number, name: string) => {
-                    const labels: Record<string, string> = {
-                      active: "WAU",
-                      newUsers: "New",
-                      retained: "Retained",
-                      resurrected: "Resurrected",
-                      churned: "Churned",
-                    };
-                    return [Math.abs(value), labels[name] || name];
-                  }}
-                />
-                <Legend
-                  formatter={(value) => {
-                    const labels: Record<string, string> = {
-                      active: "WAU",
-                      newUsers: "New",
-                      retained: "Retained",
-                      resurrected: "Resurrected",
-                      churned: "Churned",
-                    };
-                    return labels[value] || value;
-                  }}
-                />
-                <ReferenceLine
-                  yAxisId="users"
-                  y={0}
-                  stroke="hsl(var(--muted-foreground))"
-                />
-                <Bar
-                  yAxisId="users"
-                  dataKey="newUsers"
-                  stackId="a"
-                  fill="#22c55e"
-                  radius={[2, 2, 0, 0]}
-                />
-                <Bar
-                  yAxisId="users"
-                  dataKey="resurrected"
-                  stackId="a"
-                  fill="#3b82f6"
-                  radius={[2, 2, 0, 0]}
-                />
-                <Bar
-                  yAxisId="users"
-                  dataKey="retained"
-                  stackId="a"
-                  fill="#64748b"
-                  radius={[2, 2, 0, 0]}
-                />
-                <Bar
-                  yAxisId="users"
-                  dataKey="churned"
-                  stackId="a"
-                  fill="#ef4444"
-                  radius={[0, 0, 2, 2]}
-                />
-                <Line
-                  yAxisId="users"
-                  type="monotone"
-                  dataKey="active"
-                  name="WAU"
-                  stroke="#f59e0b"
-                  strokeWidth={3}
-                  dot={{ r: 3 }}
-                />
+                <XAxis dataKey="week" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
+                <YAxis yAxisId="users" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                <Tooltip contentStyle={tooltipStyle} labelFormatter={fullDate} formatter={(value: number, name: string) => {
+                  const labels: Record<string, string> = { active: "WAU", newUsers: "New", retained: "Retained", resurrected: "Resurrected", churned: "Churned" };
+                  return [Math.abs(value), labels[name] || name];
+                }} />
+                <Legend formatter={(value) => {
+                  const labels: Record<string, string> = { active: "WAU", newUsers: "New", retained: "Retained", resurrected: "Resurrected", churned: "Churned" };
+                  return labels[value] || value;
+                }} />
+                <ReferenceLine yAxisId="users" y={0} stroke="hsl(var(--muted-foreground))" />
+                <Bar yAxisId="users" dataKey="newUsers" stackId="a" fill="#22c55e" radius={[2, 2, 0, 0]} />
+                <Bar yAxisId="users" dataKey="resurrected" stackId="a" fill="#3b82f6" radius={[2, 2, 0, 0]} />
+                <Bar yAxisId="users" dataKey="retained" stackId="a" fill="#64748b" radius={[2, 2, 0, 0]} />
+                <Bar yAxisId="users" dataKey="churned" stackId="a" fill="#ef4444" radius={[0, 0, 2, 2]} />
+                <Line yAxisId="users" type="monotone" dataKey="active" name="WAU" stroke="#f59e0b" strokeWidth={3} dot={{ r: 3 }} />
               </ComposedChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex items-center justify-center h-full text-muted-foreground">
-              No data available
-            </div>
-          ),
+            <div className="flex items-center justify-center h-full text-muted-foreground">No data available</div>
+          )
+        ),
       },
       {
         id: "viral-dau",
         title: "Daily Active Users",
-        periodChange: latestPeriodChange(
-          dauData,
-          (point) => point.dau,
-          "vs previous day",
-        ),
+        periodChange: latestPeriodChange(dauData, (point) => point.dau, "vs previous day"),
         subtitle: "Unique macOS users per day",
         icon: <Activity className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
-        render: () =>
+        render: () => (
           dauLoading ? (
             <div className="flex items-center justify-center h-full">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -2386,43 +1537,21 @@ export default function AnalyticsPage() {
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={dauData}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis
-                  dataKey="date"
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                  tickFormatter={shortDate}
-                />
-                <YAxis
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                />
-                <Tooltip
-                  formatter={(value: number) => [value.toLocaleString(), "DAU"]}
-                  labelFormatter={fullDate}
-                  contentStyle={tooltipStyle}
-                />
-                <Bar
-                  dataKey="dau"
-                  name="DAU"
-                  fill="#f59e0b"
-                  radius={[2, 2, 0, 0]}
-                />
+                <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
+                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                <Tooltip formatter={(value: number) => [value.toLocaleString(), "DAU"]} labelFormatter={fullDate} contentStyle={tooltipStyle} />
+                <Bar dataKey="dau" name="DAU" fill="#f59e0b" radius={[2, 2, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex items-center justify-center h-full text-muted-foreground">
-              No data available
-            </div>
-          ),
+            <div className="flex items-center justify-center h-full text-muted-foreground">No data available</div>
+          )
+        ),
       },
       {
         id: "viral-crash-rate",
         title: "App Stability",
-        periodChange: latestPeriodChange(
-          crashRate?.data ?? [],
-          (point) => point.crashFreeRate,
-          "vs previous day",
-        ),
+        periodChange: latestPeriodChange(crashRate?.data ?? [], (point) => point.crashFreeRate, "vs previous day"),
         subtitle: "Daily crashes vs active users (last 30 days)",
         icon: <AlertTriangle className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
@@ -2432,18 +1561,13 @@ export default function AnalyticsPage() {
             const recent = crashRate.data.slice(-7);
             const totalCrashes = recent.reduce((s, d) => s + d.crashes, 0);
             const totalUsers = recent.reduce((s, d) => s + d.users, 0);
-            const rate =
-              totalUsers > 0
-                ? ((1 - totalCrashes / totalUsers) * 100).toFixed(1)
-                : "100.0";
+            const rate = totalUsers > 0 ? ((1 - totalCrashes / totalUsers) * 100).toFixed(1) : "100.0";
             return `${rate}% crash-free (7d) · ${totalCrashes} crashes`;
           })();
           return (
             <div className="flex h-full flex-col">
               {summaryLine && (
-                <div className="mb-2 text-right text-sm text-muted-foreground">
-                  {summaryLine}
-                </div>
+                <div className="mb-2 text-right text-sm text-muted-foreground">{summaryLine}</div>
               )}
               <div className="min-h-0 flex-1">
                 {crashRateLoading ? (
@@ -2453,66 +1577,23 @@ export default function AnalyticsPage() {
                 ) : (crashRate?.data?.length ?? 0) > 0 ? (
                   <ResponsiveContainer width="100%" height="100%">
                     <ComposedChart data={crashRate!.data}>
-                      <CartesianGrid
-                        strokeDasharray="3 3"
-                        className="stroke-muted"
-                      />
-                      <XAxis
-                        dataKey="date"
-                        className="text-xs"
-                        tick={{ fill: "hsl(var(--muted-foreground))" }}
-                        tickFormatter={shortDate}
-                      />
-                      <YAxis
-                        yAxisId="left"
-                        className="text-xs"
-                        tick={{ fill: "hsl(var(--muted-foreground))" }}
-                      />
-                      <YAxis
-                        yAxisId="right"
-                        orientation="right"
-                        className="text-xs"
-                        tick={{ fill: "hsl(var(--muted-foreground))" }}
-                        tickFormatter={(v) => `${v}%`}
-                        domain={[90, 100]}
-                      />
+                      <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                      <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
+                      <YAxis yAxisId="left" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                      <YAxis yAxisId="right" orientation="right" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `${v}%`} domain={[90, 100]} />
                       <Tooltip
                         formatter={(value: number, name: string) => {
-                          if (name === "crashFreeRate")
-                            return [`${value}%`, "Crash-Free Rate"];
-                          if (name === "crashes")
-                            return [value.toLocaleString(), "Crashes"];
+                          if (name === "crashFreeRate") return [`${value}%`, "Crash-Free Rate"];
+                          if (name === "crashes") return [value.toLocaleString(), "Crashes"];
                           return [value.toLocaleString(), "Active Users"];
                         }}
                         labelFormatter={fullDate}
                         contentStyle={tooltipStyle}
                       />
                       <Legend />
-                      <Bar
-                        yAxisId="left"
-                        dataKey="crashes"
-                        name="Crashes"
-                        fill="#ef4444"
-                        radius={[2, 2, 0, 0]}
-                      />
-                      <Bar
-                        yAxisId="left"
-                        dataKey="users"
-                        name="Active Users"
-                        fill="#6366f1"
-                        radius={[2, 2, 0, 0]}
-                        opacity={0.3}
-                      />
-                      <Line
-                        yAxisId="right"
-                        type="monotone"
-                        dataKey="crashFreeRate"
-                        name="Crash-Free Rate"
-                        stroke="#22c55e"
-                        strokeWidth={2}
-                        dot={false}
-                        activeDot={{ r: 4 }}
-                      />
+                      <Bar yAxisId="left" dataKey="crashes" name="Crashes" fill="#ef4444" radius={[2, 2, 0, 0]} />
+                      <Bar yAxisId="left" dataKey="users" name="Active Users" fill="#6366f1" radius={[2, 2, 0, 0]} opacity={0.3} />
+                      <Line yAxisId="right" type="monotone" dataKey="crashFreeRate" name="Crash-Free Rate" stroke="#22c55e" strokeWidth={2} dot={false} activeDot={{ r: 4 }} />
                     </ComposedChart>
                   </ResponsiveContainer>
                 ) : (
@@ -2528,11 +1609,7 @@ export default function AnalyticsPage() {
       {
         id: "viral-daily-new-users",
         title: "Daily New Users",
-        periodChange: latestPeriodChange(
-          dailyWithRollingAvg,
-          (point) => point.rollingAvg,
-          "vs previous day",
-        ),
+        periodChange: latestPeriodChange(dailyWithRollingAvg, (point) => point.rollingAvg, "vs previous day"),
         subtitle: "First-time sign-ins with 7-day rolling average",
         icon: <Users className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
@@ -2540,10 +1617,7 @@ export default function AnalyticsPage() {
           <div className="flex h-full flex-col">
             {dailyWithRollingAvg.length > 0 && (
               <div className="mb-2 text-right text-sm text-muted-foreground">
-                {dailyWithRollingAvg
-                  .reduce((s, p) => s + p.users, 0)
-                  .toLocaleString()}{" "}
-                in last 30d
+                {dailyWithRollingAvg.reduce((s, p) => s + p.users, 0).toLocaleString()} in last 30d
               </div>
             )}
             <div className="min-h-0 flex-1">
@@ -2554,51 +1628,21 @@ export default function AnalyticsPage() {
               ) : dailyWithRollingAvg.length > 0 ? (
                 <ResponsiveContainer width="100%" height="100%">
                   <ComposedChart data={dailyWithRollingAvg}>
-                    <CartesianGrid
-                      strokeDasharray="3 3"
-                      className="stroke-muted"
-                    />
-                    <XAxis
-                      dataKey="date"
-                      className="text-xs"
-                      tick={{ fill: "hsl(var(--muted-foreground))" }}
-                      tickFormatter={shortDate}
-                    />
-                    <YAxis
-                      className="text-xs"
-                      tick={{ fill: "hsl(var(--muted-foreground))" }}
-                    />
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                    <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
+                    <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
                     <Tooltip
-                      formatter={(value: number, name: string) => [
-                        value.toLocaleString(),
-                        name === "rollingAvg" ? "7-Day Avg" : "New Users",
-                      ]}
+                      formatter={(value: number, name: string) => [value.toLocaleString(), name === "rollingAvg" ? "7-Day Avg" : "New Users"]}
                       labelFormatter={fullDate}
                       contentStyle={tooltipStyle}
                     />
                     <Legend />
-                    <Bar
-                      dataKey="users"
-                      name="New Users"
-                      fill="#6366f1"
-                      radius={[2, 2, 0, 0]}
-                    />
-                    <Line
-                      type="monotone"
-                      dataKey="rollingAvg"
-                      name="7-Day Avg"
-                      stroke="#f97316"
-                      strokeWidth={2}
-                      dot={false}
-                      activeDot={{ r: 4 }}
-                      connectNulls={false}
-                    />
+                    <Bar dataKey="users" name="New Users" fill="#6366f1" radius={[2, 2, 0, 0]} />
+                    <Line type="monotone" dataKey="rollingAvg" name="7-Day Avg" stroke="#f97316" strokeWidth={2} dot={false} activeDot={{ r: 4 }} connectNulls={false} />
                   </ComposedChart>
                 </ResponsiveContainer>
               ) : (
-                <div className="flex items-center justify-center h-full text-muted-foreground">
-                  No data available
-                </div>
+                <div className="flex items-center justify-center h-full text-muted-foreground">No data available</div>
               )}
             </div>
           </div>
@@ -2607,15 +1651,11 @@ export default function AnalyticsPage() {
       {
         id: "viral-stickiness",
         title: "Stickiness (DAU/WAU)",
-        periodChange: latestPeriodChange(
-          stickinessData,
-          (point) => point.dauWau,
-          "vs previous week",
-        ),
+        periodChange: latestPeriodChange(stickinessData, (point) => point.dauWau, "vs previous week"),
         subtitle: "How often weekly users come back daily (good: 30%+)",
         icon: <Zap className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
-        render: () =>
+        render: () => (
           viralLoading ? (
             <div className="flex items-center justify-center h-full">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -2624,44 +1664,17 @@ export default function AnalyticsPage() {
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={stickinessData}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis
-                  dataKey="week"
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                  tickFormatter={shortDate}
-                />
-                <YAxis
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                  tickFormatter={(v) => `${v}%`}
-                  domain={[0, "auto"]}
-                />
-                <Tooltip
-                  formatter={(value: number) => [`${value}%`, "DAU/WAU"]}
-                  labelFormatter={(l) => `Week of ${fullDate(l)}`}
-                  contentStyle={tooltipStyle}
-                />
-                <ReferenceLine
-                  y={30}
-                  stroke="#22c55e"
-                  strokeDasharray="3 3"
-                  label={{ value: "Good", fill: "#22c55e", fontSize: 11 }}
-                />
-                <Line
-                  type="monotone"
-                  dataKey="dauWau"
-                  stroke="#6366f1"
-                  strokeWidth={2}
-                  dot={{ r: 3, fill: "#6366f1" }}
-                  activeDot={{ r: 5 }}
-                />
+                <XAxis dataKey="week" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
+                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `${v}%`} domain={[0, "auto"]} />
+                <Tooltip formatter={(value: number) => [`${value}%`, "DAU/WAU"]} labelFormatter={(l) => `Week of ${fullDate(l)}`} contentStyle={tooltipStyle} />
+                <ReferenceLine y={30} stroke="#22c55e" strokeDasharray="3 3" label={{ value: "Good", fill: "#22c55e", fontSize: 11 }} />
+                <Line type="monotone" dataKey="dauWau" stroke="#6366f1" strokeWidth={2} dot={{ r: 3, fill: "#6366f1" }} activeDot={{ r: 5 }} />
               </LineChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex items-center justify-center h-full text-muted-foreground">
-              No data available
-            </div>
-          ),
+            <div className="flex items-center justify-center h-full text-muted-foreground">No data available</div>
+          )
+        ),
       },
       {
         id: "viral-power-curve",
@@ -2669,7 +1682,7 @@ export default function AnalyticsPage() {
         subtitle: "Days active per user in last 30 days (right-skew = healthy)",
         icon: <Zap className="h-4 w-4" />,
         initialLayout: { cols: 6, rows: 4 },
-        render: () =>
+        render: () => (
           viralLoading ? (
             <div className="flex items-center justify-center h-full">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -2678,65 +1691,29 @@ export default function AnalyticsPage() {
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={powerCurve}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis
-                  dataKey="daysActive"
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                  label={{
-                    value: "Days Active",
-                    position: "insideBottom",
-                    offset: -5,
-                    fill: "hsl(var(--muted-foreground))",
-                    fontSize: 11,
-                  }}
-                />
-                <YAxis
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                />
-                <Tooltip
-                  formatter={(value: number, _: string, entry: any) => [
-                    `${value} users (${entry.payload.pct}%)`,
-                    "Users",
-                  ]}
-                  labelFormatter={(l) => `${l} days active`}
-                  contentStyle={tooltipStyle}
-                />
+                <XAxis dataKey="daysActive" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} label={{ value: "Days Active", position: "insideBottom", offset: -5, fill: "hsl(var(--muted-foreground))", fontSize: 11 }} />
+                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                <Tooltip formatter={(value: number, _: string, entry: any) => [`${value} users (${entry.payload.pct}%)`, "Users"]} labelFormatter={(l) => `${l} days active`} contentStyle={tooltipStyle} />
                 <Bar dataKey="users" radius={[2, 2, 0, 0]}>
                   {powerCurve.map((entry, index) => (
-                    <Cell
-                      key={index}
-                      fill={
-                        entry.daysActive >= 20
-                          ? "#22c55e"
-                          : entry.daysActive >= 10
-                            ? "#3b82f6"
-                            : "#6366f1"
-                      }
-                    />
+                    <Cell key={index} fill={entry.daysActive >= 20 ? "#22c55e" : entry.daysActive >= 10 ? "#3b82f6" : "#6366f1"} />
                   ))}
                 </Bar>
               </BarChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex items-center justify-center h-full text-muted-foreground">
-              No data available
-            </div>
-          ),
+            <div className="flex items-center justify-center h-full text-muted-foreground">No data available</div>
+          )
+        ),
       },
       {
         id: "viral-activation",
         title: "New Activated Users / Week",
-        periodChange: latestPeriodChange(
-          weeklyActivationData,
-          (point) => point.activated,
-          "vs previous mature cohort week",
-        ),
-        subtitle:
-          "Conversation created within 7 days of signup · fully matured cohorts only",
+        periodChange: latestPeriodChange(weeklyActivationData, (point) => point.activated, "vs previous mature cohort week"),
+        subtitle: "Conversation created within 7 days of signup · fully matured cohorts only",
         icon: <Target className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
-        render: () =>
+        render: () => (
           viralLoading ? (
             <div className="flex items-center justify-center h-full">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -2745,83 +1722,31 @@ export default function AnalyticsPage() {
             <ResponsiveContainer width="100%" height="100%">
               <ComposedChart data={weeklyActivationData}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis
-                  dataKey="week"
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                  tickFormatter={shortDate}
-                />
-                <YAxis
-                  yAxisId="left"
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                />
-                <YAxis
-                  yAxisId="right"
-                  orientation="right"
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                  tickFormatter={(v) => `${v}%`}
-                  domain={[0, 100]}
-                />
+                <XAxis dataKey="week" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
+                <YAxis yAxisId="left" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                <YAxis yAxisId="right" orientation="right" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `${v}%`} domain={[0, 100]} />
                 <Tooltip
                   contentStyle={tooltipStyle}
                   labelFormatter={(value) => `Week of ${fullDate(value)}`}
                   formatter={(value: number, name: string) => {
-                    if (name === "rate")
-                      return [`${value}%`, "Activation Rate"];
+                    if (name === "rate") return [`${value}%`, "Activation Rate"];
                     if (name === "activated") return [value, "Activated"];
                     return [value, "Signups"];
                   }}
                 />
                 <Legend />
-                <Bar
-                  yAxisId="left"
-                  dataKey="signups"
-                  name="Signups"
-                  fill="#3b82f6"
-                  radius={[2, 2, 0, 0]}
-                  opacity={0.5}
-                />
-                <Bar
-                  yAxisId="left"
-                  dataKey="activated"
-                  name="Activated"
-                  fill="#22c55e"
-                  radius={[2, 2, 0, 0]}
-                />
-                <Line
-                  yAxisId="right"
-                  type="monotone"
-                  dataKey="rate"
-                  name="Activation %"
-                  stroke="#f97316"
-                  strokeWidth={2}
-                  dot={{ r: 2 }}
-                  activeDot={{ r: 4 }}
-                />
+                <Bar yAxisId="left" dataKey="signups" name="Signups" fill="#3b82f6" radius={[2, 2, 0, 0]} opacity={0.5} />
+                <Bar yAxisId="left" dataKey="activated" name="Activated" fill="#22c55e" radius={[2, 2, 0, 0]} />
+                <Line yAxisId="right" type="monotone" dataKey="rate" name="Activation %" stroke="#f97316" strokeWidth={2} dot={{ r: 2 }} activeDot={{ r: 4 }} />
               </ComposedChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex items-center justify-center h-full text-muted-foreground">
-              No data available
-            </div>
-          ),
+            <div className="flex items-center justify-center h-full text-muted-foreground">No data available</div>
+          )
+        ),
       },
     ];
-  }, [
-    viralLoading,
-    completedGrowthAccounting,
-    dauLoading,
-    dauData,
-    crashRate,
-    crashRateLoading,
-    dailyWithRollingAvg,
-    dailyNewUsersLoading,
-    stickinessData,
-    powerCurve,
-    weeklyActivationData,
-  ]);
+  }, [viralLoading, completedGrowthAccounting, dauLoading, dauData, crashRate, crashRateLoading, dailyWithRollingAvg, dailyNewUsersLoading, stickinessData, powerCurve, weeklyActivationData]);
 
   const retentionCharts = useMemo<ChartItem[]>(() => {
     if (retentionView !== "average") return [];
@@ -2829,49 +1754,26 @@ export default function AnalyticsPage() {
       {
         id: "retention-avg-curve",
         title: "Activity Retention (W1 → W4)",
-        subtitle:
-          retention?.totalUsers != null
-            ? `D7 ${retentionD7?.toFixed(1) ?? "--"}% · W4 ${retentionW4?.toFixed(1) ?? "--"}% · ${retention.totalCohorts} cohorts · activity-based, not activation-filtered`
-            : "Activity-based retention; activated-only cohorts are not instrumented yet",
+        subtitle: retention?.totalUsers != null
+          ? `D7 ${retentionD7?.toFixed(1) ?? "--"}% · W4 ${retentionW4?.toFixed(1) ?? "--"}% · ${retention.totalCohorts} cohorts · activity-based, not activation-filtered`
+          : "Activity-based retention; activated-only cohorts are not instrumented yet",
         icon: <TrendingUp className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
-        render: () =>
+        render: () => (
           retention?.data && retention.data.length > 0 ? (
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={retention.data}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis
-                  dataKey="day"
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                  tickFormatter={(v) => `D${v}`}
-                />
-                <YAxis
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                  tickFormatter={(v) => `${v}%`}
-                  domain={[0, 100]}
-                />
-                <Tooltip
-                  formatter={(value: number) => [`${value}%`, "Retention"]}
-                  labelFormatter={(label) => `Day ${label}`}
-                  contentStyle={tooltipStyle}
-                />
-                <Line
-                  type="monotone"
-                  dataKey="retention"
-                  stroke="#f97316"
-                  strokeWidth={2}
-                  dot={{ r: 2, fill: "#f97316" }}
-                  activeDot={{ r: 5 }}
-                />
+                <XAxis dataKey="day" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `D${v}`} />
+                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `${v}%`} domain={[0, 100]} />
+                <Tooltip formatter={(value: number) => [`${value}%`, "Retention"]} labelFormatter={(label) => `Day ${label}`} contentStyle={tooltipStyle} />
+                <Line type="monotone" dataKey="retention" stroke="#f97316" strokeWidth={2} dot={{ r: 2, fill: "#f97316" }} activeDot={{ r: 5 }} />
               </LineChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex items-center justify-center h-full text-muted-foreground">
-              No retention data available
-            </div>
-          ),
+            <div className="flex items-center justify-center h-full text-muted-foreground">No retention data available</div>
+          )
+        ),
       },
     ];
   }, [retentionView, retention, retentionD7, retentionW4]);
@@ -2890,10 +1792,9 @@ export default function AnalyticsPage() {
   const cpuMobile = profitability?.summary.avgCostPerUserMobile ?? null;
   const cpuDesktop = profitability?.summary.avgCostPerUserDesktop ?? null;
   const totalFirebaseUsers = dailyNewUsers?.totalUsers ?? null;
-  const goalProgressPct =
-    totalFirebaseUsers != null
-      ? Math.min(100, (totalFirebaseUsers / SOFTWARE_USER_GOAL) * 100)
-      : null;
+  const goalProgressPct = totalFirebaseUsers != null
+    ? Math.min(100, (totalFirebaseUsers / SOFTWARE_USER_GOAL) * 100)
+    : null;
 
   // Net WAU: compare the last two FULL weeks — the trailing
   // growth-accounting bucket is the current partial week.
@@ -2901,40 +1802,27 @@ export default function AnalyticsPage() {
     () => (vm?.growthAccounting ?? []).slice(0, -1),
     [vm],
   );
-  const netWauNow =
-    fullGrowthWeeks.length >= 1
-      ? fullGrowthWeeks[fullGrowthWeeks.length - 1].active
-      : null;
-  const netWauPrev =
-    fullGrowthWeeks.length >= 2
-      ? fullGrowthWeeks[fullGrowthWeeks.length - 2].active
-      : null;
-  const netWauDelta =
-    netWauNow != null && netWauPrev != null ? netWauNow - netWauPrev : null;
-  const netWauChange = calculatePeriodChange(
-    netWauNow,
-    netWauPrev,
-    "vs previous complete week",
-  );
+  const netWauNow = fullGrowthWeeks.length >= 1 ? fullGrowthWeeks[fullGrowthWeeks.length - 1].active : null;
+  const netWauPrev = fullGrowthWeeks.length >= 2 ? fullGrowthWeeks[fullGrowthWeeks.length - 2].active : null;
+  const netWauDelta = netWauNow != null && netWauPrev != null ? netWauNow - netWauPrev : null;
+  const netWauChange = calculatePeriodChange(netWauNow, netWauPrev, "vs previous complete week");
 
   const growthGoalItems = useMemo<ChartItem[]>(() => {
     const referralGrants = kFactorData?.funnel?.granted;
-    const kFactorValue =
-      kFactorData?.available && referralGrants != null
-        ? referralGrants.toLocaleString()
-        : "Not tracked";
+    const kFactorValue = kFactorData?.available && referralGrants != null
+      ? referralGrants.toLocaleString()
+      : "Not tracked";
     const kFactorSubtitle = kFactorData?.funnel
       ? `${kFactorData.funnel.issued} issued / ${kFactorData.funnel.captured} captured / ${kFactorData.funnel.granted} granted`
-      : (kFactorData?.reason ?? "Referral funnel is unavailable");
+      : kFactorData?.reason ?? "Referral funnel is unavailable";
 
     return [
       {
         id: "header-1m-growth",
         title: "Path to 1M Software Users",
-        subtitle:
-          totalFirebaseUsers != null && goalProgressPct != null
-            ? `${totalFirebaseUsers.toLocaleString()} of ${SOFTWARE_USER_GOAL.toLocaleString()} (${goalProgressPct.toFixed(1)}%) · acquisition → activation → retention → virality`
-            : `Goal: ${SOFTWARE_USER_GOAL.toLocaleString()} software users · acquisition → activation → retention → virality`,
+        subtitle: totalFirebaseUsers != null && goalProgressPct != null
+          ? `${totalFirebaseUsers.toLocaleString()} of ${SOFTWARE_USER_GOAL.toLocaleString()} (${goalProgressPct.toFixed(1)}%) · acquisition → activation → retention → virality`
+          : `Goal: ${SOFTWARE_USER_GOAL.toLocaleString()} software users · acquisition → activation → retention → virality`,
         variant: "header",
         initialLayout: { cols: 12, rows: 1 },
         removable: false,
@@ -2950,9 +1838,7 @@ export default function AnalyticsPage() {
         render: () => (
           <div>
             <div className="text-2xl font-bold text-green-600">
-              {totalFirebaseUsers != null
-                ? totalFirebaseUsers.toLocaleString()
-                : "--"}
+              {totalFirebaseUsers != null ? totalFirebaseUsers.toLocaleString() : "--"}
             </div>
             <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-muted">
               <div
@@ -2961,9 +1847,7 @@ export default function AnalyticsPage() {
               />
             </div>
             <p className="mt-1 truncate text-xs text-muted-foreground">
-              {goalProgressPct != null
-                ? `${goalProgressPct.toFixed(1)}% of 1M`
-                : "of 1M"}
+              {goalProgressPct != null ? `${goalProgressPct.toFixed(1)}% of 1M` : "of 1M"}
             </p>
           </div>
         ),
@@ -2978,26 +1862,15 @@ export default function AnalyticsPage() {
         removable: false,
         render: () => (
           <div>
-            <div
-              className={`text-2xl font-bold ${
-                netWauDelta == null
-                  ? ""
-                  : netWauDelta > 0
-                    ? "text-green-600"
-                    : netWauDelta < 0
-                      ? "text-red-600"
-                      : ""
-              }`}
-            >
+            <div className={`text-2xl font-bold ${
+              netWauDelta == null ? "" : netWauDelta > 0 ? "text-green-600" : netWauDelta < 0 ? "text-red-600" : ""
+            }`}>
               {netWauDelta != null
                 ? `${netWauDelta > 0 ? "+" : ""}${netWauDelta.toLocaleString()}`
                 : "--"}
             </div>
             <p className="truncate text-xs text-muted-foreground">
-              {netWauNow != null
-                ? `WAU ${netWauNow.toLocaleString()} last full week`
-                : "new + resurrected − churned"}{" "}
-              · target ≥7% WoW
+              {netWauNow != null ? `WAU ${netWauNow.toLocaleString()} last full week` : "new + resurrected − churned"} · target ≥7% WoW
             </p>
           </div>
         ),
@@ -3007,11 +1880,7 @@ export default function AnalyticsPage() {
         title: "Weekly New Users",
         variant: "kpi",
         icon: <Users className="h-3.5 w-3.5" />,
-        periodChange: latestPeriodChange(
-          weeklyNewUsersData,
-          (point) => point.users,
-          "vs previous complete week",
-        ),
+        periodChange: latestPeriodChange(weeklyNewUsersData, (point) => point.users, "vs previous complete week"),
         initialLayout: { cols: 3, rows: 1 },
         removable: false,
         render: () => (
@@ -3019,9 +1888,7 @@ export default function AnalyticsPage() {
             <div className="text-2xl font-bold">
               {latestWeeklyNewUsers?.users.toLocaleString() ?? "--"}
             </div>
-            <p className="truncate text-xs text-muted-foreground">
-              All signups · target +7–10% WoW
-            </p>
+            <p className="truncate text-xs text-muted-foreground">All signups · target +7–10% WoW</p>
           </div>
         ),
       },
@@ -3030,11 +1897,7 @@ export default function AnalyticsPage() {
         title: "Weekly Activated Users",
         variant: "kpi",
         icon: <Target className="h-3.5 w-3.5" />,
-        periodChange: latestPeriodChange(
-          weeklyActivationData,
-          (point) => point.activated,
-          "vs previous mature cohort week",
-        ),
+        periodChange: latestPeriodChange(weeklyActivationData, (point) => point.activated, "vs previous mature cohort week"),
         initialLayout: { cols: 3, rows: 1 },
         removable: false,
         render: () => (
@@ -3059,26 +1922,22 @@ export default function AnalyticsPage() {
         removable: false,
         render: () => (
           <div>
-            <div
-              className={`text-2xl font-bold ${
-                growthRetentionW4 == null
-                  ? ""
-                  : growthRetentionW4 >= 40
-                    ? "text-green-600"
-                    : growthRetentionW4 < 25
-                      ? "text-red-600"
-                      : ""
-              }`}
-            >
+            <div className={`text-2xl font-bold ${
+              growthRetentionW4 == null
+                ? ""
+                : growthRetentionW4 >= 40
+                  ? "text-green-600"
+                  : growthRetentionW4 < 25
+                    ? "text-red-600"
+                    : ""
+            }`}>
               {growthRetentionLoading
                 ? "..."
                 : growthRetentionW4 != null
                   ? `${growthRetentionW4.toFixed(1)}%`
                   : "--"}
             </div>
-            <p className="truncate text-xs text-muted-foreground">
-              macOS activity · not activation-filtered
-            </p>
+            <p className="truncate text-xs text-muted-foreground">macOS activity · not activation-filtered</p>
           </div>
         ),
       },
@@ -3091,12 +1950,8 @@ export default function AnalyticsPage() {
         removable: false,
         render: () => (
           <div>
-            <div className="text-2xl font-bold">
-              {kFactorLoading ? "..." : kFactorValue}
-            </div>
-            <p className="truncate text-xs text-muted-foreground">
-              {kFactorSubtitle}
-            </p>
+            <div className="text-2xl font-bold">{kFactorLoading ? "..." : kFactorValue}</div>
+            <p className="truncate text-xs text-muted-foreground">{kFactorSubtitle}</p>
           </div>
         ),
       },
@@ -3105,14 +1960,10 @@ export default function AnalyticsPage() {
         title: "Weekly New Software Users",
         subtitle: "All-software Firebase signups · latest 12 completed weeks",
         icon: <Users className="h-4 w-4" />,
-        periodChange: latestPeriodChange(
-          weeklyNewUsersData,
-          (point) => point.users,
-          "vs previous complete week",
-        ),
+        periodChange: latestPeriodChange(weeklyNewUsersData, (point) => point.users, "vs previous complete week"),
         initialLayout: { cols: 12, rows: 4 },
         removable: false,
-        render: () =>
+        render: () => (
           dailyNewUsersLoading ? (
             <div className="flex h-full items-center justify-center">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -3121,56 +1972,23 @@ export default function AnalyticsPage() {
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={weeklyNewUsersData}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis
-                  dataKey="week"
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                  tickFormatter={shortDate}
-                />
-                <YAxis
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                  tickFormatter={formatCompact}
-                />
-                <Tooltip
-                  contentStyle={tooltipStyle}
-                  labelFormatter={(value) => `Week of ${fullDate(value)}`}
-                  formatter={(value: number) => [
-                    value.toLocaleString(),
-                    "New users",
-                  ]}
-                />
-                <Bar
-                  dataKey="users"
-                  name="New users"
-                  fill="#3b82f6"
-                  radius={[3, 3, 0, 0]}
-                />
+                <XAxis dataKey="week" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
+                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={formatCompact} />
+                <Tooltip contentStyle={tooltipStyle} labelFormatter={(value) => `Week of ${fullDate(value)}`}
+                  formatter={(value: number) => [value.toLocaleString(), "New users"]} />
+                <Bar dataKey="users" name="New users" fill="#3b82f6" radius={[3, 3, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex h-full items-center justify-center text-muted-foreground">
-              No completed-week data available
-            </div>
-          ),
+            <div className="flex h-full items-center justify-center text-muted-foreground">No completed-week data available</div>
+          )
+        ),
       },
     ];
-  }, [
-    dailyNewUsersLoading,
-    goalProgressPct,
-    growthRetentionLoading,
-    growthRetentionW4,
-    kFactorData,
-    kFactorLoading,
-    latestWeeklyActivation,
-    latestWeeklyNewUsers,
-    netWauChange,
-    netWauDelta,
-    netWauNow,
-    totalFirebaseUsers,
-    weeklyActivationData,
-    weeklyNewUsersData,
-  ]);
+  }, [dailyNewUsersLoading, goalProgressPct, growthRetentionLoading, growthRetentionW4,
+    kFactorData, kFactorLoading, latestWeeklyActivation, latestWeeklyNewUsers,
+    netWauChange, netWauDelta, netWauNow,
+    totalFirebaseUsers, weeklyActivationData, weeklyNewUsersData]);
 
   const topKpiAndNewWidgets = useMemo<ChartItem[]>(() => {
     return [
@@ -3192,11 +2010,8 @@ export default function AnalyticsPage() {
           <div>
             <div className="text-2xl font-bold">{formatCurrency(mrr)}</div>
             {mrrGrowthPct !== null && (
-              <p
-                className={`text-xs ${mrrGrowthPct >= 0 ? "text-green-600" : "text-red-600"}`}
-              >
-                {mrrGrowthPct >= 0 ? "+" : ""}
-                {mrrGrowthPct.toFixed(1)}% from last month
+              <p className={`text-xs ${mrrGrowthPct >= 0 ? "text-green-600" : "text-red-600"}`}>
+                {mrrGrowthPct >= 0 ? "+" : ""}{mrrGrowthPct.toFixed(1)}% from last month
               </p>
             )}
           </div>
@@ -3211,9 +2026,7 @@ export default function AnalyticsPage() {
         render: () => (
           <div>
             <div className="text-2xl font-bold">{formatCurrency(arr)}</div>
-            <p className="text-xs text-muted-foreground">
-              Based on current MRR
-            </p>
+            <p className="text-xs text-muted-foreground">Based on current MRR</p>
           </div>
         ),
       },
@@ -3225,12 +2038,8 @@ export default function AnalyticsPage() {
         initialLayout: { cols: 3, rows: 1 },
         render: () => (
           <div>
-            <div className="text-2xl font-bold">
-              {totalSubs.toLocaleString()}
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {monthlySubs} monthly · {annualSubs} annual
-            </p>
+            <div className="text-2xl font-bold">{totalSubs.toLocaleString()}</div>
+            <p className="text-xs text-muted-foreground">{monthlySubs} monthly · {annualSubs} annual</p>
           </div>
         ),
       },
@@ -3242,9 +2051,7 @@ export default function AnalyticsPage() {
         initialLayout: { cols: 3, rows: 1 },
         render: () => (
           <div>
-            <div className="text-2xl font-bold">
-              {formatCompact(totalConversations)}
-            </div>
+            <div className="text-2xl font-bold">{formatCompact(totalConversations)}</div>
             <p className="text-xs text-muted-foreground">All time</p>
           </div>
         ),
@@ -3260,9 +2067,7 @@ export default function AnalyticsPage() {
             <div className="text-2xl font-bold">
               {cpuMobile != null ? `$${cpuMobile.toFixed(3)}` : "--"}
             </div>
-            <p className="text-xs text-muted-foreground">
-              avg / day · last {profitDays}d
-            </p>
+            <p className="text-xs text-muted-foreground">avg / day · last {profitDays}d</p>
           </div>
         ),
       },
@@ -3277,90 +2082,42 @@ export default function AnalyticsPage() {
             <div className="text-2xl font-bold">
               {cpuDesktop != null ? `$${cpuDesktop.toFixed(3)}` : "--"}
             </div>
-            <p className="text-xs text-muted-foreground">
-              avg / day · last {profitDays}d
-            </p>
+            <p className="text-xs text-muted-foreground">avg / day · last {profitDays}d</p>
           </div>
         ),
       },
       {
         id: "chart-total-users-cumulative",
         title: "Total Users — All-time growth",
-        periodChange: latestPeriodChange(
-          allDailyData,
-          (point) => point.cumulative,
-          "vs previous day",
-        ),
+        periodChange: latestPeriodChange(allDailyData, (point) => point.cumulative, "vs previous day"),
         subtitle: "Cumulative signups (Firebase Auth)",
         variant: "card",
         initialLayout: { cols: 6, rows: 4 },
-        render: () =>
+        render: () => (
           allDailyData.length > 0 ? (
             <ResponsiveContainer width="100%" height="100%">
               <AreaChart data={allDailyData}>
                 <defs>
-                  <linearGradient
-                    id="totalUsersGradient"
-                    x1="0"
-                    y1="0"
-                    x2="0"
-                    y2="1"
-                  >
+                  <linearGradient id="totalUsersGradient" x1="0" y1="0" x2="0" y2="1">
                     <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.5} />
                     <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
                   </linearGradient>
                 </defs>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis
-                  dataKey="date"
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                  tickFormatter={(v) =>
-                    new Date(v).toLocaleDateString("en-US", {
-                      month: "short",
-                      year: "2-digit",
-                    })
-                  }
-                />
-                <YAxis
-                  className="text-xs"
-                  tick={{ fill: "hsl(var(--muted-foreground))" }}
-                  tickFormatter={(v) => formatCompact(v)}
-                />
-                <Tooltip
-                  contentStyle={tooltipStyle}
-                  formatter={(v: number) => v.toLocaleString()}
-                />
-                <Area
-                  type="monotone"
-                  dataKey="cumulative"
-                  name="Total users"
-                  stroke="#3b82f6"
-                  strokeWidth={2}
-                  fill="url(#totalUsersGradient)"
-                />
+                <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  tickFormatter={(v) => new Date(v).toLocaleDateString("en-US", { month: "short", year: "2-digit" })} />
+                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => formatCompact(v)} />
+                <Tooltip contentStyle={tooltipStyle} formatter={(v: number) => v.toLocaleString()} />
+                <Area type="monotone" dataKey="cumulative" name="Total users" stroke="#3b82f6" strokeWidth={2} fill="url(#totalUsersGradient)" />
               </AreaChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex h-full items-center justify-center text-muted-foreground">
-              No data
-            </div>
-          ),
+            <div className="flex h-full items-center justify-center text-muted-foreground">No data</div>
+          )
+        ),
       },
     ];
-  }, [
-    mrr,
-    arr,
-    totalSubs,
-    monthlySubs,
-    annualSubs,
-    totalConversations,
-    mrrGrowthPct,
-    cpuMobile,
-    cpuDesktop,
-    profitDays,
-    allDailyData,
-  ]);
+  }, [mrr, arr, totalSubs, monthlySubs, annualSubs, totalConversations, mrrGrowthPct, cpuMobile, cpuDesktop, profitDays, allDailyData]);
 
   // Section headers + per-section control widgets that sit inline between
   // groups of charts. They are full-width by default so the user sees a
@@ -3389,36 +2146,22 @@ export default function AnalyticsPage() {
               key={d}
               onClick={() => setProfitDays(d)}
               className={`px-2.5 py-1 text-xs font-medium transition-colors ${
-                profitDays === d
-                  ? "bg-primary text-primary-foreground"
-                  : "bg-background text-muted-foreground hover:bg-accent"
+                profitDays === d ? "bg-primary text-primary-foreground" : "bg-background text-muted-foreground hover:bg-accent"
               }`}
-            >
-              {d}d
-            </button>
+            >{d}d</button>
           ))}
         </div>
         <label className="flex items-center gap-1 text-xs text-muted-foreground">
           Desktop $/user/day
-          <input
-            type="number"
-            step="0.01"
-            min="0"
-            value={desktopCostInput}
+          <input type="number" step="0.01" min="0" value={desktopCostInput}
             onChange={(e) => setDesktopCostInput(e.target.value)}
-            className="w-16 rounded-md border border-input bg-background px-2 py-1 text-xs"
-          />
+            className="w-16 rounded-md border border-input bg-background px-2 py-1 text-xs" />
         </label>
         <label className="flex items-center gap-1 text-xs text-muted-foreground">
           Mobile $/user/day
-          <input
-            type="number"
-            step="0.01"
-            min="0"
-            value={mobileCostInput}
+          <input type="number" step="0.01" min="0" value={mobileCostInput}
             onChange={(e) => setMobileCostInput(e.target.value)}
-            className="w-16 rounded-md border border-input bg-background px-2 py-1 text-xs"
-          />
+            className="w-16 rounded-md border border-input bg-background px-2 py-1 text-xs" />
         </label>
         {profitability?.summary.partial && (
           <span className="ml-auto inline-flex items-center gap-1 rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-xs text-amber-800">
@@ -3444,25 +2187,14 @@ export default function AnalyticsPage() {
     initialLayout: { cols: 6, rows: 1 },
     render: () => (
       <div className="flex h-full items-center gap-2">
-        <span className="text-xs text-muted-foreground">
-          Cumulative window:
-        </span>
+        <span className="text-xs text-muted-foreground">Cumulative window:</span>
         <div className="flex overflow-hidden rounded-md border border-input">
           {(["7d", "30d", "all"] as const).map((w) => (
-            <button
-              key={w}
-              onClick={() => setCumulativeWindow(w)}
+            <button key={w} onClick={() => setCumulativeWindow(w)}
               className={`px-2.5 py-1 text-xs font-medium transition-colors ${
-                cumulativeWindow === w
-                  ? "bg-primary text-primary-foreground"
-                  : "bg-background text-muted-foreground hover:bg-accent"
-              }`}
-            >
-              {w === "7d"
-                ? "Last week"
-                : w === "30d"
-                  ? "Last month"
-                  : "All time"}
+                cumulativeWindow === w ? "bg-primary text-primary-foreground" : "bg-background text-muted-foreground hover:bg-accent"
+              }`}>
+              {w === "7d" ? "Last week" : w === "30d" ? "Last month" : "All time"}
             </button>
           ))}
         </div>
@@ -3478,150 +2210,111 @@ export default function AnalyticsPage() {
     render: () => null,
   };
 
-  const macosKpis = useMemo<ChartItem[]>(
-    () => [
-      {
-        id: "kpi-total-users-macos",
-        title: "Total Users (macOS)",
-        variant: "kpi",
-        icon: <Monitor className="h-3.5 w-3.5" />,
-        initialLayout: { cols: 2, rows: 1 },
-        render: () => (
-          <div>
-            <div className="text-2xl font-bold">
-              {profitability?.summary.totalUsersDesktop != null
-                ? profitability.summary.totalUsersDesktop.toLocaleString()
-                : "--"}
-            </div>
-            <p className="text-xs text-muted-foreground">All-time signups</p>
+  const macosKpis = useMemo<ChartItem[]>(() => [
+    {
+      id: "kpi-total-users-macos",
+      title: "Total Users (macOS)",
+      variant: "kpi",
+      icon: <Monitor className="h-3.5 w-3.5" />,
+      initialLayout: { cols: 2, rows: 1 },
+      render: () => (
+        <div>
+          <div className="text-2xl font-bold">
+            {profitability?.summary.totalUsersDesktop != null
+              ? profitability.summary.totalUsersDesktop.toLocaleString()
+              : "--"}
           </div>
-        ),
-      },
-      {
-        id: "kpi-total-users-mobile",
-        title: "Total Users (Mobile)",
-        variant: "kpi",
-        icon: <Smartphone className="h-3.5 w-3.5" />,
-        initialLayout: { cols: 2, rows: 1 },
-        render: () => (
-          <div>
-            <div className="text-2xl font-bold">
-              {profitability?.summary.totalUsersMobile != null
-                ? profitability.summary.totalUsersMobile.toLocaleString()
-                : "--"}
-            </div>
-            <p className="text-xs text-muted-foreground">All-time signups</p>
+          <p className="text-xs text-muted-foreground">All-time signups</p>
+        </div>
+      ),
+    },
+    {
+      id: "kpi-total-users-mobile",
+      title: "Total Users (Mobile)",
+      variant: "kpi",
+      icon: <Smartphone className="h-3.5 w-3.5" />,
+      initialLayout: { cols: 2, rows: 1 },
+      render: () => (
+        <div>
+          <div className="text-2xl font-bold">
+            {profitability?.summary.totalUsersMobile != null
+              ? profitability.summary.totalUsersMobile.toLocaleString()
+              : "--"}
           </div>
-        ),
-      },
-      {
-        id: "kpi-dau",
-        title: "DAU",
-        variant: "kpi",
-        icon: <Activity className="h-3.5 w-3.5" />,
-        initialLayout: { cols: 2, rows: 1 },
-        render: () => (
-          <div>
-            <div className="text-2xl font-bold">{vm?.summary.dau ?? "--"}</div>
-            <p className="text-xs text-muted-foreground">avg last 7 days</p>
+          <p className="text-xs text-muted-foreground">All-time signups</p>
+        </div>
+      ),
+    },
+    {
+      id: "kpi-dau", title: "DAU", variant: "kpi", icon: <Activity className="h-3.5 w-3.5" />,
+      initialLayout: { cols: 2, rows: 1 },
+      render: () => (
+        <div><div className="text-2xl font-bold">{vm?.summary.dau ?? "--"}</div>
+          <p className="text-xs text-muted-foreground">avg last 7 days</p></div>
+      ),
+    },
+    {
+      id: "kpi-wau", title: "WAU", variant: "kpi", icon: <Users className="h-3.5 w-3.5" />,
+      initialLayout: { cols: 2, rows: 1 },
+      render: () => (
+        <div><div className="text-2xl font-bold">{vm?.summary.wau ?? "--"}</div>
+          <p className="text-xs text-muted-foreground">last 7 days</p></div>
+      ),
+    },
+    {
+      id: "kpi-mau", title: "MAU", variant: "kpi", icon: <Users className="h-3.5 w-3.5" />,
+      initialLayout: { cols: 2, rows: 1 },
+      render: () => (
+        <div><div className="text-2xl font-bold">{vm?.summary.mau ?? "--"}</div>
+          <p className="text-xs text-muted-foreground">last 30 days</p></div>
+      ),
+    },
+    {
+      id: "kpi-dau-mau", title: "DAU/MAU", variant: "kpi", icon: <Zap className="h-3.5 w-3.5" />,
+      initialLayout: { cols: 2, rows: 1 },
+      render: () => (
+        <div>
+          <div className={`text-2xl font-bold ${(vm?.summary.dauMau ?? 0) >= 20 ? "text-green-600" : ""}`}>
+            {vm?.summary.dauMau != null ? `${vm.summary.dauMau}%` : "--"}
           </div>
-        ),
-      },
-      {
-        id: "kpi-wau",
-        title: "WAU",
-        variant: "kpi",
-        icon: <Users className="h-3.5 w-3.5" />,
-        initialLayout: { cols: 2, rows: 1 },
-        render: () => (
-          <div>
-            <div className="text-2xl font-bold">{vm?.summary.wau ?? "--"}</div>
-            <p className="text-xs text-muted-foreground">last 7 days</p>
+          <p className="text-xs text-muted-foreground">Stickiness (good: 20%+)</p>
+        </div>
+      ),
+    },
+    {
+      id: "kpi-quick-ratio", title: "Quick Ratio", variant: "kpi", icon: <TrendingUp className="h-3.5 w-3.5" />,
+      initialLayout: { cols: 2, rows: 1 },
+      render: () => (
+        <div>
+          <div className={`text-2xl font-bold ${(vm?.summary.quickRatio ?? 0) >= 1 ? "text-green-600" : "text-red-600"}`}>
+            {vm?.summary.quickRatio != null ? `${vm.summary.quickRatio}x` : "--"}
           </div>
-        ),
-      },
-      {
-        id: "kpi-mau",
-        title: "MAU",
-        variant: "kpi",
-        icon: <Users className="h-3.5 w-3.5" />,
-        initialLayout: { cols: 2, rows: 1 },
-        render: () => (
-          <div>
-            <div className="text-2xl font-bold">{vm?.summary.mau ?? "--"}</div>
-            <p className="text-xs text-muted-foreground">last 30 days</p>
+          <p className="text-xs text-muted-foreground">Growing if &gt;1x</p>
+        </div>
+      ),
+    },
+    {
+      id: "kpi-activation", title: "Activation", variant: "kpi", icon: <Target className="h-3.5 w-3.5" />,
+      initialLayout: { cols: 2, rows: 1 },
+      render: () => (
+        <div>
+          <div className={`text-2xl font-bold ${(activationStats?.rate ?? 0) >= 50 ? "text-green-600" : ""}`}>
+            {activationStats?.rate != null ? `${activationStats.rate}%` : "--"}
           </div>
-        ),
-      },
-      {
-        id: "kpi-dau-mau",
-        title: "DAU/MAU",
-        variant: "kpi",
-        icon: <Zap className="h-3.5 w-3.5" />,
-        initialLayout: { cols: 2, rows: 1 },
-        render: () => (
-          <div>
-            <div
-              className={`text-2xl font-bold ${(vm?.summary.dauMau ?? 0) >= 20 ? "text-green-600" : ""}`}
-            >
-              {vm?.summary.dauMau != null ? `${vm.summary.dauMau}%` : "--"}
-            </div>
-            <p className="text-xs text-muted-foreground">
-              Stickiness (good: 20%+)
+          <p className="text-xs text-muted-foreground">
+            {activationStats?.rate != null
+              ? `Conversation within 7d · n=${activationStats.signups.toLocaleString()}`
+              : "Conversation within 7 days of signup"}
+          </p>
+          {(activationStats?.erroredUsers ?? 0) > 0 && (
+            <p className="text-xs text-amber-600">
+              {activationStats?.erroredUsers} users unreadable this run
             </p>
-          </div>
-        ),
-      },
-      {
-        id: "kpi-quick-ratio",
-        title: "Quick Ratio",
-        variant: "kpi",
-        icon: <TrendingUp className="h-3.5 w-3.5" />,
-        initialLayout: { cols: 2, rows: 1 },
-        render: () => (
-          <div>
-            <div
-              className={`text-2xl font-bold ${(vm?.summary.quickRatio ?? 0) >= 1 ? "text-green-600" : "text-red-600"}`}
-            >
-              {vm?.summary.quickRatio != null
-                ? `${vm.summary.quickRatio}x`
-                : "--"}
-            </div>
-            <p className="text-xs text-muted-foreground">Growing if &gt;1x</p>
-          </div>
-        ),
-      },
-      {
-        id: "kpi-activation",
-        title: "Activation",
-        variant: "kpi",
-        icon: <Target className="h-3.5 w-3.5" />,
-        initialLayout: { cols: 2, rows: 1 },
-        render: () => (
-          <div>
-            <div
-              className={`text-2xl font-bold ${(activationStats?.rate ?? 0) >= 50 ? "text-green-600" : ""}`}
-            >
-              {activationStats?.rate != null
-                ? `${activationStats.rate}%`
-                : "--"}
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {activationStats?.rate != null
-                ? `Conversation within 7d · n=${activationStats.signups.toLocaleString()}`
-                : "Conversation within 7 days of signup"}
-            </p>
-            {(activationStats?.erroredUsers ?? 0) > 0 && (
-              <p className="text-xs text-amber-600">
-                {activationStats?.erroredUsers} users unreadable this run
-              </p>
-            )}
-          </div>
-        ),
-      },
-    ],
-    [vm, profitability, activationStats],
-  );
+          )}
+        </div>
+      ),
+    },
+  ], [vm, profitability, activationStats]);
 
   const notificationsHeader: ChartItem = {
     id: "header-notifications",
@@ -3631,116 +2324,72 @@ export default function AnalyticsPage() {
     render: () => null,
   };
 
-  const notificationKpis = useMemo<ChartItem[]>(
-    () => [
-      {
-        id: "kpi-notif-enabled",
-        title: "Notifications Enabled",
-        variant: "kpi",
-        icon: <Bell className="h-3.5 w-3.5" />,
-        initialLayout: { cols: 2, rows: 1 },
-        render: () => (
-          <div>
-            <div className="text-2xl font-bold">
-              {notificationEnabledDisabled?.enabled?.toLocaleString() ?? "--"}
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {notificationEnabledDisabled
-                ? `${((notificationEnabledDisabled.enabled / notificationEnabledDisabled.total) * 100).toFixed(1)}% of users`
-                : "Loading"}
-            </p>
-          </div>
-        ),
-      },
-      {
-        id: "kpi-notif-disabled",
-        title: "Notifications Disabled",
-        variant: "kpi",
-        icon: <BellOff className="h-3.5 w-3.5" />,
-        initialLayout: { cols: 2, rows: 1 },
-        render: () => (
-          <div>
-            <div className="text-2xl font-bold">
-              {notificationEnabledDisabled?.disabled?.toLocaleString() ?? "--"}
-            </div>
-            <p className="text-xs text-muted-foreground">Explicitly disabled</p>
-          </div>
-        ),
-      },
-      {
-        id: "kpi-omi-says-7d",
-        title: '"Omi says" (7d)',
-        variant: "kpi",
-        icon: <Send className="h-3.5 w-3.5" />,
-        initialLayout: { cols: 2, rows: 1 },
-        render: () => (
-          <div>
-            <div className="text-2xl font-bold">
-              {notificationMentorLast7.toLocaleString()}
-            </div>
-            <p className="text-xs text-muted-foreground">Built-in mentor</p>
-          </div>
-        ),
-      },
-      {
-        id: "kpi-marketplace-mentor-7d",
-        title: "Marketplace Mentor (7d)",
-        variant: "kpi",
-        icon: <Users className="h-3.5 w-3.5" />,
-        initialLayout: { cols: 2, rows: 1 },
-        render: () => (
-          <div>
-            <div className="text-2xl font-bold">
-              {notificationMarketplaceLast7.toLocaleString()}
-            </div>
-            <p className="text-xs text-muted-foreground">Marketplace app</p>
-          </div>
-        ),
-      },
-      {
-        id: "kpi-fb-clicks",
-        title: "Floating Bar Clicks",
-        variant: "kpi",
-        icon: <MousePointerClick className="h-3.5 w-3.5" />,
-        initialLayout: { cols: 2, rows: 1 },
-        render: () => (
-          <div>
-            <div className="text-2xl font-bold">
-              {floatingBarCtrSummary?.clicked?.toLocaleString() ?? "0"}
-            </div>
-            <p className="text-xs text-muted-foreground">Notification opens</p>
-          </div>
-        ),
-      },
-      {
-        id: "kpi-fb-ctr",
-        title: "Floating Bar CTR",
-        variant: "kpi",
-        icon: <Percent className="h-3.5 w-3.5" />,
-        initialLayout: { cols: 2, rows: 1 },
-        render: () => (
-          <div>
-            <div className="text-2xl font-bold">
-              {floatingBarCtrSummary
-                ? `${floatingBarCtrSummary.ctr.toFixed(1)}%`
-                : "0.0%"}
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {floatingBarCtrSummary?.mode === "surface_tagged"
-                ? "Tagged sends"
-                : "Fallback"}
-            </p>
-          </div>
-        ),
-      },
-    ],
-    [
-      notificationEnabledDisabled,
-      notificationMentorLast7,
-      notificationMarketplaceLast7,
-      floatingBarCtrSummary,
-    ],
-  );
+  const notificationKpis = useMemo<ChartItem[]>(() => [
+    {
+      id: "kpi-notif-enabled", title: "Notifications Enabled", variant: "kpi", icon: <Bell className="h-3.5 w-3.5" />,
+      initialLayout: { cols: 2, rows: 1 },
+      render: () => (
+        <div>
+          <div className="text-2xl font-bold">{notificationEnabledDisabled?.enabled?.toLocaleString() ?? "--"}</div>
+          <p className="text-xs text-muted-foreground">
+            {notificationEnabledDisabled
+              ? `${((notificationEnabledDisabled.enabled / notificationEnabledDisabled.total) * 100).toFixed(1)}% of users`
+              : "Loading"}
+          </p>
+        </div>
+      ),
+    },
+    {
+      id: "kpi-notif-disabled", title: "Notifications Disabled", variant: "kpi", icon: <BellOff className="h-3.5 w-3.5" />,
+      initialLayout: { cols: 2, rows: 1 },
+      render: () => (
+        <div>
+          <div className="text-2xl font-bold">{notificationEnabledDisabled?.disabled?.toLocaleString() ?? "--"}</div>
+          <p className="text-xs text-muted-foreground">Explicitly disabled</p>
+        </div>
+      ),
+    },
+    {
+      id: "kpi-omi-says-7d", title: '"Omi says" (7d)', variant: "kpi", icon: <Send className="h-3.5 w-3.5" />,
+      initialLayout: { cols: 2, rows: 1 },
+      render: () => (
+        <div>
+          <div className="text-2xl font-bold">{notificationMentorLast7.toLocaleString()}</div>
+          <p className="text-xs text-muted-foreground">Built-in mentor</p>
+        </div>
+      ),
+    },
+    {
+      id: "kpi-marketplace-mentor-7d", title: "Marketplace Mentor (7d)", variant: "kpi", icon: <Users className="h-3.5 w-3.5" />,
+      initialLayout: { cols: 2, rows: 1 },
+      render: () => (
+        <div>
+          <div className="text-2xl font-bold">{notificationMarketplaceLast7.toLocaleString()}</div>
+          <p className="text-xs text-muted-foreground">Marketplace app</p>
+        </div>
+      ),
+    },
+    {
+      id: "kpi-fb-clicks", title: "Floating Bar Clicks", variant: "kpi", icon: <MousePointerClick className="h-3.5 w-3.5" />,
+      initialLayout: { cols: 2, rows: 1 },
+      render: () => (
+        <div>
+          <div className="text-2xl font-bold">{floatingBarCtrSummary?.clicked?.toLocaleString() ?? "0"}</div>
+          <p className="text-xs text-muted-foreground">Notification opens</p>
+        </div>
+      ),
+    },
+    {
+      id: "kpi-fb-ctr", title: "Floating Bar CTR", variant: "kpi", icon: <Percent className="h-3.5 w-3.5" />,
+      initialLayout: { cols: 2, rows: 1 },
+      render: () => (
+        <div>
+          <div className="text-2xl font-bold">{floatingBarCtrSummary ? `${floatingBarCtrSummary.ctr.toFixed(1)}%` : "0.0%"}</div>
+          <p className="text-xs text-muted-foreground">{floatingBarCtrSummary?.mode === "surface_tagged" ? "Tagged sends" : "Fallback"}</p>
+        </div>
+      ),
+    },
+  ], [notificationEnabledDisabled, notificationMentorLast7, notificationMarketplaceLast7, floatingBarCtrSummary]);
 
   const ratingsHeader: ChartItem = {
     id: "header-ratings",
@@ -3766,43 +2415,24 @@ export default function AnalyticsPage() {
     render: () => (
       <div className="flex h-full flex-wrap items-center gap-2">
         <div className="flex rounded-md border border-input overflow-hidden">
-          <button
-            onClick={() => setRetentionView("average")}
+          <button onClick={() => setRetentionView("average")}
             className={`px-3 py-1 text-xs font-medium transition-colors ${
-              retentionView === "average"
-                ? "bg-primary text-primary-foreground"
-                : "bg-background text-muted-foreground hover:bg-accent"
-            }`}
-          >
-            Average
-          </button>
-          <button
-            onClick={() => setRetentionView("cohorts")}
+              retentionView === "average" ? "bg-primary text-primary-foreground" : "bg-background text-muted-foreground hover:bg-accent"
+            }`}>Average</button>
+          <button onClick={() => setRetentionView("cohorts")}
             className={`px-3 py-1 text-xs font-medium transition-colors ${
-              retentionView === "cohorts"
-                ? "bg-primary text-primary-foreground"
-                : "bg-background text-muted-foreground hover:bg-accent"
-            }`}
-          >
-            By Cohort
-          </button>
+              retentionView === "cohorts" ? "bg-primary text-primary-foreground" : "bg-background text-muted-foreground hover:bg-accent"
+            }`}>By Cohort</button>
         </div>
         <Select value={retentionPlatform} onValueChange={setRetentionPlatform}>
-          <SelectTrigger className="h-7 w-[120px] text-xs">
-            <SelectValue />
-          </SelectTrigger>
+          <SelectTrigger className="h-7 w-[120px] text-xs"><SelectValue /></SelectTrigger>
           <SelectContent>
             <SelectItem value="macos">macOS</SelectItem>
             <SelectItem value="all">All Platforms</SelectItem>
           </SelectContent>
         </Select>
-        <Select
-          value={String(retentionDays)}
-          onValueChange={(v) => setRetentionDays(parseInt(v, 10))}
-        >
-          <SelectTrigger className="h-7 w-[110px] text-xs">
-            <SelectValue />
-          </SelectTrigger>
+        <Select value={String(retentionDays)} onValueChange={(v) => setRetentionDays(parseInt(v, 10))}>
+          <SelectTrigger className="h-7 w-[110px] text-xs"><SelectValue /></SelectTrigger>
           <SelectContent>
             <SelectItem value="14">14 days</SelectItem>
             <SelectItem value="30">30 days</SelectItem>
@@ -3811,18 +2441,8 @@ export default function AnalyticsPage() {
           </SelectContent>
         </Select>
         <div className="ml-auto flex gap-2 text-xs">
-          <span className="rounded-md bg-muted px-2 py-1">
-            D1:{" "}
-            <span className="font-semibold">
-              {retentionD1 !== null ? `${retentionD1.toFixed(1)}%` : "--"}
-            </span>
-          </span>
-          <span className="rounded-md bg-muted px-2 py-1">
-            D7:{" "}
-            <span className="font-semibold">
-              {retentionD7 !== null ? `${retentionD7.toFixed(1)}%` : "--"}
-            </span>
-          </span>
+          <span className="rounded-md bg-muted px-2 py-1">D1: <span className="font-semibold">{retentionD1 !== null ? `${retentionD1.toFixed(1)}%` : "--"}</span></span>
+          <span className="rounded-md bg-muted px-2 py-1">D7: <span className="font-semibold">{retentionD7 !== null ? `${retentionD7.toFixed(1)}%` : "--"}</span></span>
         </div>
       </div>
     ),
@@ -3838,17 +2458,10 @@ export default function AnalyticsPage() {
         <table className="w-full text-sm border-collapse">
           <thead>
             <tr className="border-b">
-              <th className="sticky left-0 z-10 bg-card px-4 py-3 text-left font-medium text-muted-foreground whitespace-nowrap">
-                Date
-              </th>
-              <th className="px-3 py-3 text-right font-medium text-muted-foreground whitespace-nowrap">
-                Users
-              </th>
+              <th className="sticky left-0 z-10 bg-card px-4 py-3 text-left font-medium text-muted-foreground whitespace-nowrap">Date</th>
+              <th className="px-3 py-3 text-right font-medium text-muted-foreground whitespace-nowrap">Users</th>
               {Array.from({ length: cohortMaxDays }, (_, i) => (
-                <th
-                  key={i}
-                  className="px-3 py-3 text-center font-medium text-muted-foreground whitespace-nowrap min-w-[64px]"
-                >
+                <th key={i} className="px-3 py-3 text-center font-medium text-muted-foreground whitespace-nowrap min-w-[64px]">
                   {i === 0 ? "< 1 Day" : `Day ${i}`}
                 </th>
               ))}
@@ -3857,53 +2470,24 @@ export default function AnalyticsPage() {
           <tbody>
             {retention?.data && retention.data.length > 0 && (
               <tr className="border-b font-semibold">
-                <td className="sticky left-0 z-10 bg-card px-4 py-2.5 whitespace-nowrap">
-                  Weighted Avg
-                </td>
-                <td className="px-3 py-2.5 text-right text-muted-foreground">
-                  {retention.totalUsers.toLocaleString()}
-                </td>
+                <td className="sticky left-0 z-10 bg-card px-4 py-2.5 whitespace-nowrap">Weighted Avg</td>
+                <td className="px-3 py-2.5 text-right text-muted-foreground">{retention.totalUsers.toLocaleString()}</td>
                 {retention.data.map((p) => (
-                  <td
-                    key={p.day}
-                    className="px-3 py-2.5 text-center"
-                    style={{ backgroundColor: retentionHeatColor(p.retention) }}
-                  >
-                    <span className={p.retention > 50 ? "text-white" : ""}>
-                      {p.retention.toFixed(1)}%
-                    </span>
+                  <td key={p.day} className="px-3 py-2.5 text-center" style={{ backgroundColor: retentionHeatColor(p.retention) }}>
+                    <span className={p.retention > 50 ? "text-white" : ""}>{p.retention.toFixed(1)}%</span>
                   </td>
                 ))}
               </tr>
             )}
             {cohorts.map((c) => (
-              <tr
-                key={c.date}
-                className="border-b last:border-b-0 hover:bg-muted/30"
-              >
-                <td className="sticky left-0 z-10 bg-card px-4 py-2 whitespace-nowrap">
-                  {formatCohortDate(c.date)}
-                </td>
-                <td className="px-3 py-2 text-right text-muted-foreground">
-                  {c.users}
-                </td>
+              <tr key={c.date} className="border-b last:border-b-0 hover:bg-muted/30">
+                <td className="sticky left-0 z-10 bg-card px-4 py-2 whitespace-nowrap">{formatCohortDate(c.date)}</td>
+                <td className="px-3 py-2 text-right text-muted-foreground">{c.users}</td>
                 {Array.from({ length: cohortMaxDays }, (_, i) => {
                   const val = i < c.data.length ? c.data[i].retention : null;
                   return (
-                    <td
-                      key={i}
-                      className="px-3 py-2 text-center"
-                      style={
-                        val !== null
-                          ? { backgroundColor: retentionHeatColor(val) }
-                          : {}
-                      }
-                    >
-                      {val !== null ? (
-                        <span className={val > 50 ? "text-white" : ""}>
-                          {val.toFixed(1)}%
-                        </span>
-                      ) : null}
+                    <td key={i} className="px-3 py-2 text-center" style={val !== null ? { backgroundColor: retentionHeatColor(val) } : {}}>
+                      {val !== null ? <span className={val > 50 ? "text-white" : ""}>{val.toFixed(1)}%</span> : null}
                     </td>
                   );
                 })}
@@ -3927,15 +2511,10 @@ export default function AnalyticsPage() {
   // Everything remains draggable; orderRevision applies this priority once
   // without discarding a user's saved sizes or later rearrangements.
   const unifiedItems = useMemo<ChartItem[]>(() => {
-    const activationChart = viralCharts.find(
-      (item) => item.id === "viral-activation",
-    );
-    const growthAccountingChart = viralCharts.find(
-      (item) => item.id === "viral-growth-accounting",
-    );
+    const activationChart = viralCharts.find((item) => item.id === "viral-activation");
+    const growthAccountingChart = viralCharts.find((item) => item.id === "viral-growth-accounting");
     const remainingViralCharts = viralCharts.filter(
-      (item) =>
-        item.id !== "viral-activation" && item.id !== "viral-growth-accounting",
+      (item) => item.id !== "viral-activation" && item.id !== "viral-growth-accounting",
     );
 
     return [
@@ -3974,26 +2553,13 @@ export default function AnalyticsPage() {
       ...chatRatingsItems,
     ];
   }, [
-    growthGoalItems,
-    responseReliabilityItems,
-    topKpiAndNewWidgets,
-    profitCharts,
-    revenueCharts,
-    macosKpis,
-    macosGrowthCharts,
-    notificationKpis,
-    notificationCharts,
-    ratingsAndUsageCharts,
-    viralCharts,
-    retentionView,
-    retentionCharts,
-    chatRatingsItems,
+    growthGoalItems, responseReliabilityItems, topKpiAndNewWidgets, profitCharts, revenueCharts,
+    macosKpis, macosGrowthCharts,
+    notificationKpis, notificationCharts, ratingsAndUsageCharts, viralCharts,
+    retentionView, retentionCharts, chatRatingsItems,
     // Inline header/control items capture state via closures; React's
     // dep tracking is handled by the per-item render callbacks.
-    profitabilityControls,
-    revenueControls,
-    retentionControls,
-    cohortTableItem,
+    profitabilityControls, revenueControls, retentionControls, cohortTableItem,
   ]);
 
   if (isLoading) {
@@ -4029,9 +2595,7 @@ export default function AnalyticsPage() {
 
       {hasError && (
         <Card className="p-4 border-destructive/50 bg-destructive/5">
-          <p className="text-sm text-destructive">
-            Some data failed to load. Showing available data.
-          </p>
+          <p className="text-sm text-destructive">Some data failed to load. Showing available data.</p>
         </Card>
       )}
 
@@ -4039,9 +2603,7 @@ export default function AnalyticsPage() {
       {hasPartialData && (
         <div className="flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
           <AlertTriangle className="h-4 w-4 shrink-0" />
-          <span>
-            Some data sources failed to load. Numbers may be incomplete.
-          </span>
+          <span>Some data sources failed to load. Numbers may be incomplete.</span>
         </div>
       )}
       <ResizableChartGrid
@@ -4056,53 +2618,23 @@ export default function AnalyticsPage() {
 
 // --- Chat Ratings Chart (Firebase analytics collection) ---
 
-interface RatingWeek {
-  week: string;
-  thumbs_up: number;
-  thumbs_down: number;
-}
-interface RatingVersion {
-  version: string;
-  thumbs_up: number;
-  thumbs_down: number;
-}
-interface ChatRatingsWeekData {
-  weeks: RatingWeek[];
-  total_up: number;
-  total_down: number;
-}
-interface ChatRatingsVersionData {
-  versions: RatingVersion[];
-  total_up: number;
-  total_down: number;
-}
+interface RatingWeek { week: string; thumbs_up: number; thumbs_down: number }
+interface RatingVersion { version: string; thumbs_up: number; thumbs_down: number }
+interface ChatRatingsWeekData { weeks: RatingWeek[]; total_up: number; total_down: number }
+interface ChatRatingsVersionData { versions: RatingVersion[]; total_up: number; total_down: number }
 
 function useChatRatingsItems({ token }: { token: string | null }): ChartItem[] {
-  const [platform, setPlatform] = useState<"all" | "desktop" | "mobile">(
-    "desktop",
-  );
+  const [platform, setPlatform] = useState<"all" | "desktop" | "mobile">("desktop");
   const [groupBy, setGroupBy] = useState<"week" | "version">("week");
 
-  const { data: weekData, isLoading: weekLoading } =
-    useSWR<ChatRatingsWeekData>(
-      token && groupBy === "week"
-        ? [
-            `/api/omi/chat-lab/ratings?platform=${platform}&group_by=week`,
-            token,
-          ]
-        : null,
-      authenticatedFetcher,
-    );
-  const { data: versionData, isLoading: versionLoading } =
-    useSWR<ChatRatingsVersionData>(
-      token && groupBy === "version"
-        ? [
-            `/api/omi/chat-lab/ratings?platform=${platform}&group_by=version`,
-            token,
-          ]
-        : null,
-      authenticatedFetcher,
-    );
+  const { data: weekData, isLoading: weekLoading } = useSWR<ChatRatingsWeekData>(
+    token && groupBy === "week" ? [`/api/omi/chat-lab/ratings?platform=${platform}&group_by=week`, token] : null,
+    authenticatedFetcher
+  );
+  const { data: versionData, isLoading: versionLoading } = useSWR<ChatRatingsVersionData>(
+    token && groupBy === "version" ? [`/api/omi/chat-lab/ratings?platform=${platform}&group_by=version`, token] : null,
+    authenticatedFetcher
+  );
 
   const isLoading = groupBy === "week" ? weekLoading : versionLoading;
 
@@ -4111,12 +2643,7 @@ function useChatRatingsItems({ token }: { token: string | null }): ChartItem[] {
     if (!d) return { total: 0, up: 0, down: 0, pct: 0 };
     const { total_up: up, total_down: down } = d;
     const total = up + down;
-    return {
-      total,
-      up,
-      down,
-      pct: total > 0 ? Math.round((up / total) * 100) : 0,
-    };
+    return { total, up, down, pct: total > 0 ? Math.round((up / total) * 100) : 0 };
   }, [weekData, versionData, groupBy]);
 
   const chartData = useMemo(() => {
@@ -4125,147 +2652,101 @@ function useChatRatingsItems({ token }: { token: string | null }): ChartItem[] {
       return versionData.versions
         .filter((v) => v.version !== "unknown")
         .map((v) => ({
-          ...v,
-          label: v.version.replace("0.11.", "v"),
-          satisfaction:
-            v.thumbs_up + v.thumbs_down > 0
-              ? Math.round((v.thumbs_up / (v.thumbs_up + v.thumbs_down)) * 100)
-              : 0,
+          ...v, label: v.version.replace("0.11.", "v"),
+          satisfaction: v.thumbs_up + v.thumbs_down > 0 ? Math.round((v.thumbs_up / (v.thumbs_up + v.thumbs_down)) * 100) : 0,
         }));
     }
     if (!weekData?.weeks) return [];
     return weekData.weeks.map((w) => ({
-      ...w,
-      label: w.week,
-      satisfaction:
-        w.thumbs_up + w.thumbs_down > 0
-          ? Math.round((w.thumbs_up / (w.thumbs_up + w.thumbs_down)) * 100)
-          : 0,
+      ...w, label: w.week,
+      satisfaction: w.thumbs_up + w.thumbs_down > 0 ? Math.round((w.thumbs_up / (w.thumbs_up + w.thumbs_down)) * 100) : 0,
     }));
   }, [weekData, versionData, groupBy]);
 
-  const items = useMemo<ChartItem[]>(
-    () => [
-      {
-        id: "chat-ratings",
-        title: "Chat Response Ratings",
-        periodChange:
-          groupBy === "week"
-            ? latestPeriodChange<{ thumbs_up: number; thumbs_down: number }>(
-                chartData,
-                (point) => point.thumbs_up + point.thumbs_down,
-                "vs previous week",
-              )
-            : null,
-        subtitle:
-          stats.total > 0
-            ? `${stats.up} 👍 · ${stats.down} 👎 · ${stats.pct}% positive`
-            : undefined,
-        initialLayout: { cols: 12, rows: 5 },
-        render: () => (
-          <div className="flex h-full flex-col gap-3">
-            <div className="flex flex-wrap items-center gap-2">
-              <div className="flex rounded-md overflow-hidden border border-border text-xs font-medium">
-                {(["all", "desktop", "mobile"] as const).map((p) => (
-                  <button
-                    key={p}
-                    onClick={() => setPlatform(p)}
-                    className={`px-3 py-1 transition-colors ${
-                      platform === p
-                        ? "bg-primary text-primary-foreground"
-                        : "bg-muted text-muted-foreground hover:bg-accent"
-                    }`}
-                  >
-                    {p === "all"
-                      ? "All"
-                      : p === "desktop"
-                        ? "Desktop"
-                        : "Mobile"}
-                  </button>
-                ))}
-              </div>
-              <div className="flex rounded-md overflow-hidden border border-border text-xs font-medium">
-                {(["week", "version"] as const).map((g) => (
-                  <button
-                    key={g}
-                    onClick={() => setGroupBy(g)}
-                    className={`px-3 py-1 transition-colors ${
-                      groupBy === g
-                        ? "bg-primary text-primary-foreground"
-                        : "bg-muted text-muted-foreground hover:bg-accent"
-                    }`}
-                  >
-                    {g === "week" ? "By Week" : "By Version"}
-                  </button>
-                ))}
-              </div>
+  const items = useMemo<ChartItem[]>(() => [
+    {
+      id: "chat-ratings",
+      title: "Chat Response Ratings",
+      periodChange: groupBy === "week"
+        ? latestPeriodChange<{ thumbs_up: number; thumbs_down: number }>(
+            chartData,
+            (point) => point.thumbs_up + point.thumbs_down,
+            "vs previous week",
+          )
+        : null,
+      subtitle:
+        stats.total > 0
+          ? `${stats.up} 👍 · ${stats.down} 👎 · ${stats.pct}% positive`
+          : undefined,
+      initialLayout: { cols: 12, rows: 5 },
+      render: () => (
+        <div className="flex h-full flex-col gap-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="flex rounded-md overflow-hidden border border-border text-xs font-medium">
+              {(["all", "desktop", "mobile"] as const).map((p) => (
+                <button
+                  key={p}
+                  onClick={() => setPlatform(p)}
+                  className={`px-3 py-1 transition-colors ${
+                    platform === p
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-muted text-muted-foreground hover:bg-accent"
+                  }`}
+                >
+                  {p === "all" ? "All" : p === "desktop" ? "Desktop" : "Mobile"}
+                </button>
+              ))}
             </div>
-            <div className="min-h-0 flex-1">
-              {isLoading ? (
-                <div className="flex h-full items-center justify-center text-muted-foreground">
-                  <Loader2 className="h-6 w-6 animate-spin mr-2" /> Loading
-                  ratings...
-                </div>
-              ) : !chartData.length ? (
-                <div className="flex h-full items-center justify-center text-center text-muted-foreground py-8">
-                  {groupBy === "version"
-                    ? "No version-tagged ratings yet."
-                    : "No chat ratings data available"}
-                </div>
-              ) : (
-                <ResponsiveContainer width="100%" height="100%">
-                  <ComposedChart data={chartData}>
-                    <CartesianGrid strokeDasharray="3 3" opacity={0.1} />
-                    <XAxis dataKey="label" tick={{ fontSize: 11 }} />
-                    <YAxis yAxisId="count" tick={{ fontSize: 11 }} />
-                    <YAxis
-                      yAxisId="pct"
-                      orientation="right"
-                      tick={{ fontSize: 11 }}
-                      domain={[0, 100]}
-                      unit="%"
-                    />
-                    <Tooltip
-                      contentStyle={{
-                        backgroundColor: "#1a1a2e",
-                        border: "1px solid #333",
-                        borderRadius: 8,
-                      }}
-                      labelStyle={{ color: "#ccc" }}
-                    />
-                    <Legend />
-                    <Bar
-                      yAxisId="count"
-                      dataKey="thumbs_up"
-                      name="👍 Likes"
-                      fill="#22c55e"
-                      radius={[4, 4, 0, 0]}
-                    />
-                    <Bar
-                      yAxisId="count"
-                      dataKey="thumbs_down"
-                      name="👎 Dislikes"
-                      fill="#ef4444"
-                      radius={[4, 4, 0, 0]}
-                    />
-                    <Line
-                      yAxisId="pct"
-                      dataKey="satisfaction"
-                      name="Satisfaction %"
-                      stroke="#f59e0b"
-                      strokeWidth={2}
-                      dot={{ r: 3 }}
-                    />
-                  </ComposedChart>
-                </ResponsiveContainer>
-              )}
+            <div className="flex rounded-md overflow-hidden border border-border text-xs font-medium">
+              {(["week", "version"] as const).map((g) => (
+                <button
+                  key={g}
+                  onClick={() => setGroupBy(g)}
+                  className={`px-3 py-1 transition-colors ${
+                    groupBy === g
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-muted text-muted-foreground hover:bg-accent"
+                  }`}
+                >
+                  {g === "week" ? "By Week" : "By Version"}
+                </button>
+              ))}
             </div>
           </div>
-        ),
-      },
-    ],
-    [platform, groupBy, isLoading, chartData, stats],
-  );
+          <div className="min-h-0 flex-1">
+            {isLoading ? (
+              <div className="flex h-full items-center justify-center text-muted-foreground">
+                <Loader2 className="h-6 w-6 animate-spin mr-2" /> Loading ratings...
+              </div>
+            ) : !chartData.length ? (
+              <div className="flex h-full items-center justify-center text-center text-muted-foreground py-8">
+                {groupBy === "version"
+                  ? "No version-tagged ratings yet."
+                  : "No chat ratings data available"}
+              </div>
+            ) : (
+              <ResponsiveContainer width="100%" height="100%">
+                <ComposedChart data={chartData}>
+                  <CartesianGrid strokeDasharray="3 3" opacity={0.1} />
+                  <XAxis dataKey="label" tick={{ fontSize: 11 }} />
+                  <YAxis yAxisId="count" tick={{ fontSize: 11 }} />
+                  <YAxis yAxisId="pct" orientation="right" tick={{ fontSize: 11 }} domain={[0, 100]} unit="%" />
+                  <Tooltip
+                    contentStyle={{ backgroundColor: "#1a1a2e", border: "1px solid #333", borderRadius: 8 }}
+                    labelStyle={{ color: "#ccc" }}
+                  />
+                  <Legend />
+                  <Bar yAxisId="count" dataKey="thumbs_up" name="👍 Likes" fill="#22c55e" radius={[4, 4, 0, 0]} />
+                  <Bar yAxisId="count" dataKey="thumbs_down" name="👎 Dislikes" fill="#ef4444" radius={[4, 4, 0, 0]} />
+                  <Line yAxisId="pct" dataKey="satisfaction" name="Satisfaction %" stroke="#f59e0b" strokeWidth={2} dot={{ r: 3 }} />
+                </ComposedChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+        </div>
+      ),
+    },
+  ], [platform, groupBy, isLoading, chartData, stats]);
 
   return items;
 }

--- a/web/admin/app/api/omi/stats/k-factor/posthog/route.ts
+++ b/web/admin/app/api/omi/stats/k-factor/posthog/route.ts
@@ -1,21 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
 import { posthogResults } from "@/lib/posthog";
-import {
-  parsePlatformScope,
-  scopeFilterAnd,
-  type PlatformScope,
-} from "@/lib/platform-scope";
 export const dynamic = "force-dynamic";
 export const maxDuration = 3600;
 
 // Run the referral funnel HogQL queries through posthogResults (Firestore
 // query-cache + 429 backoff + stale fallback) and shape the panel payload.
 // Exported so the precompute cron can warm the underlying query cache.
-export async function computeKFactor(
-  days: number,
-  platform: PlatformScope = "macos",
-) {
+export async function computeKFactor(days: number) {
   const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
   const projectId = process.env.POSTHOG_PROJECT_ID;
   const host = (process.env.POSTHOG_HOST || "https://us.posthog.com").replace(
@@ -39,7 +31,6 @@ export async function computeKFactor(
             AND timestamp >= now() - INTERVAL ${days} DAY
             AND properties.program = 'desktop_operator_month_v1'
             ${extraFilter}
-            ${scopeFilterAnd(platform, "properties.$os_name")}
         `;
 
   const [issuedRows, capturedRows, grantedRows] = await Promise.all([
@@ -83,10 +74,9 @@ export async function GET(request: NextRequest) {
 
   const searchParams = request.nextUrl.searchParams;
   const days = parseInt(searchParams.get("days") || "30", 10);
-  const platform = parsePlatformScope(searchParams.get("platform") ?? "macos");
 
   try {
-    const payload = await computeKFactor(days, platform);
+    const payload = await computeKFactor(days);
     return NextResponse.json(payload);
   } catch (error) {
     // PostHog still failing (e.g. 429 with no cached fallback) — degrade

--- a/web/admin/app/api/omi/stats/k-factor/posthog/route.ts
+++ b/web/admin/app/api/omi/stats/k-factor/posthog/route.ts
@@ -1,77 +1,79 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { verifyAdmin } from '@/lib/auth';
-import { posthogResults } from '@/lib/posthog';
-import { parsePlatformScope, scopeFilterAnd, type PlatformScope } from '@/lib/platform-scope';
-export const dynamic = 'force-dynamic';
+import { NextRequest, NextResponse } from "next/server";
+import { verifyAdmin } from "@/lib/auth";
+import { posthogResults } from "@/lib/posthog";
+import {
+  parsePlatformScope,
+  scopeFilterAnd,
+  type PlatformScope,
+} from "@/lib/platform-scope";
+export const dynamic = "force-dynamic";
 export const maxDuration = 3600;
 
-// Run the k-factor proxy HogQL query through posthogResults (Firestore
+// Run the referral funnel HogQL queries through posthogResults (Firestore
 // query-cache + 429 backoff + stale fallback) and shape the panel payload.
 // Exported so the precompute cron can warm the underlying query cache.
-export async function computeKFactor(days: number, platform: PlatformScope = 'macos') {
+export async function computeKFactor(
+  days: number,
+  platform: PlatformScope = "macos",
+) {
   const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
   const projectId = process.env.POSTHOG_PROJECT_ID;
-  const host = (process.env.POSTHOG_HOST || 'https://us.posthog.com').replace(/\/$/, '');
+  const host = (process.env.POSTHOG_HOST || "https://us.posthog.com").replace(
+    /\/$/,
+    "",
+  );
 
   if (!apiKey || !projectId) {
     return {
       days,
       available: false as const,
       kFactor: null,
-      reason: 'PostHog credentials not configured.',
+      reason: "PostHog credentials not configured.",
     };
   }
 
-  const shareQuery = `
-          SELECT
-            uniq(COALESCE(person_id, distinct_id)) AS unique_users,
-            count() AS total_events
+  const uniqueUsersQuery = (event: string, extraFilter = "") => `
+          SELECT uniq(COALESCE(person_id, distinct_id)) AS unique_users
           FROM events
-          WHERE event = 'Memory Share Button Clicked'
+          WHERE event = '${event}'
             AND timestamp >= now() - INTERVAL ${days} DAY
-            ${scopeFilterAnd(platform, 'properties.$os_name')}
-        `;
-  // First-seen on this platform inside the window — mobile never emits
-  // `Sign In Completed`, and every acquisition metric uses this definition.
-  const newUserQuery = `
-          SELECT count(*)
-          FROM (
-            SELECT COALESCE(person_id, distinct_id) AS actor, min(timestamp) AS first_ts
-            FROM events
-            WHERE 1 = 1
-              ${scopeFilterAnd(platform, 'properties.$os_name')}
-            GROUP BY actor
-          )
-          WHERE first_ts >= now() - INTERVAL ${days} DAY
+            AND properties.program = 'desktop_operator_month_v1'
+            ${extraFilter}
+            ${scopeFilterAnd(platform, "properties.$os_name")}
         `;
 
-  const [shareRows, newUserRows] = await Promise.all([
-    posthogResults(host, projectId, apiKey, shareQuery) as Promise<any[]>,
-    posthogResults(host, projectId, apiKey, newUserQuery) as Promise<any[]>,
+  const [issuedRows, capturedRows, grantedRows] = await Promise.all([
+    posthogResults(
+      host,
+      projectId,
+      apiKey,
+      uniqueUsersQuery("Referral Link Issued"),
+    ) as Promise<any[]>,
+    posthogResults(
+      host,
+      projectId,
+      apiKey,
+      uniqueUsersQuery("Referral Link Captured"),
+    ) as Promise<any[]>,
+    posthogResults(
+      host,
+      projectId,
+      apiKey,
+      uniqueUsersQuery("Referral Claimed", "AND properties.claimed = true"),
+    ) as Promise<any[]>,
   ]);
 
-  const newUsers = Number(newUserRows?.[0]?.[0] ?? 0);
-  const sharers = Number(shareRows?.[0]?.[0] ?? 0);
-  const shareEvents = Number(shareRows?.[0]?.[1] ?? 0);
-
-  const shareRatePct = newUsers > 0 ? (sharers / newUsers) * 100 : 0;
-  const sharesPerSharer = sharers > 0 ? shareEvents / sharers : 0;
-  const sharesPerNewUser = newUsers > 0 ? shareEvents / newUsers : 0;
+  const issued = Number(issuedRows?.[0]?.[0] ?? 0);
+  const captured = Number(capturedRows?.[0]?.[0] ?? 0);
+  const granted = Number(grantedRows?.[0]?.[0] ?? 0);
 
   return {
     days,
-    available: false as const,
-    kFactor: null,
+    available: true as const,
+    kFactor: issued > 0 ? granted / issued : null,
     reason:
-      'Referral attribution is not instrumented on macOS yet. Current desktop analytics only expose sharing activity, not invite acceptance or referred sign-ups.',
-    proxy: {
-      newUsers,
-      sharers,
-      shareEvents,
-      shareRatePct: Math.round(shareRatePct * 10) / 10,
-      sharesPerSharer: Math.round(sharesPerSharer * 100) / 100,
-      sharesPerNewUser: Math.round(sharesPerNewUser * 100) / 100,
-    },
+      "Referral grants are measured from the server-side referral funnel.",
+    funnel: { issued, captured, granted },
   };
 }
 
@@ -80,8 +82,8 @@ export async function GET(request: NextRequest) {
   if (authResult instanceof NextResponse) return authResult;
 
   const searchParams = request.nextUrl.searchParams;
-  const days = parseInt(searchParams.get('days') || '30', 10);
-  const platform = parsePlatformScope(searchParams.get('platform') ?? 'macos');
+  const days = parseInt(searchParams.get("days") || "30", 10);
+  const platform = parsePlatformScope(searchParams.get("platform") ?? "macos");
 
   try {
     const payload = await computeKFactor(days, platform);
@@ -89,12 +91,13 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     // PostHog still failing (e.g. 429 with no cached fallback) — degrade
     // gracefully so the panel never hard-errors with a 502/500.
-    console.error('Error fetching PostHog k-factor proxy:', error);
+    console.error("Error fetching PostHog k-factor proxy:", error);
     return NextResponse.json({
       days,
       available: false as const,
       kFactor: null,
-      reason: 'PostHog data is temporarily unavailable (rate-limited). Try again shortly.',
+      reason:
+        "PostHog data is temporarily unavailable (rate-limited). Try again shortly.",
     });
   }
 }

--- a/web/admin/lib/__tests__/k-factor-referral-funnel.test.ts
+++ b/web/admin/lib/__tests__/k-factor-referral-funnel.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const posthogResults = vi.fn();
+
+vi.mock("@/lib/posthog", () => ({ posthogResults }));
+
+const ENV_KEYS = [
+  "POSTHOG_PERSONAL_API_KEY",
+  "POSTHOG_PROJECT_ID",
+  "POSTHOG_HOST",
+] as const;
+const originalEnv = Object.fromEntries(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+
+function configurePosthog() {
+  process.env.POSTHOG_PERSONAL_API_KEY = "phx_test";
+  process.env.POSTHOG_PROJECT_ID = "1";
+  process.env.POSTHOG_HOST = "https://posthog.test";
+}
+
+afterEach(() => {
+  vi.resetModules();
+  posthogResults.mockReset();
+  for (const key of ENV_KEYS) {
+    if (originalEnv[key] == null) delete process.env[key];
+    else process.env[key] = originalEnv[key];
+  }
+});
+
+describe("computeKFactor referral funnel", () => {
+  it("is unavailable when PostHog credentials are missing", async () => {
+    delete process.env.POSTHOG_PERSONAL_API_KEY;
+    delete process.env.POSTHOG_PROJECT_ID;
+    const { computeKFactor } =
+      await import("@/app/api/omi/stats/k-factor/posthog/route");
+
+    await expect(computeKFactor(30)).resolves.toMatchObject({
+      available: false,
+      kFactor: null,
+      reason: "PostHog credentials not configured.",
+    });
+    expect(posthogResults).not.toHaveBeenCalled();
+  });
+
+  it("is available with a zero-count funnel", async () => {
+    configurePosthog();
+    posthogResults.mockResolvedValue([]);
+    const { computeKFactor } =
+      await import("@/app/api/omi/stats/k-factor/posthog/route");
+
+    await expect(computeKFactor(30, "all")).resolves.toMatchObject({
+      available: true,
+      kFactor: null,
+      funnel: { issued: 0, captured: 0, granted: 0 },
+    });
+    expect(posthogResults).toHaveBeenCalledTimes(3);
+  });
+
+  it("computes granted users divided by issued users", async () => {
+    configurePosthog();
+    posthogResults
+      .mockResolvedValueOnce([[12]])
+      .mockResolvedValueOnce([[9]])
+      .mockResolvedValueOnce([[3]]);
+    const { computeKFactor } =
+      await import("@/app/api/omi/stats/k-factor/posthog/route");
+
+    await expect(computeKFactor(30, "macos")).resolves.toMatchObject({
+      available: true,
+      kFactor: 0.25,
+      funnel: { issued: 12, captured: 9, granted: 3 },
+    });
+    expect(posthogResults.mock.calls[2][3]).toContain(
+      "properties.claimed = true",
+    );
+  });
+});

--- a/web/admin/lib/__tests__/k-factor-referral-funnel.test.ts
+++ b/web/admin/lib/__tests__/k-factor-referral-funnel.test.ts
@@ -49,7 +49,7 @@ describe("computeKFactor referral funnel", () => {
     const { computeKFactor } =
       await import("@/app/api/omi/stats/k-factor/posthog/route");
 
-    await expect(computeKFactor(30, "all")).resolves.toMatchObject({
+    await expect(computeKFactor(30)).resolves.toMatchObject({
       available: true,
       kFactor: null,
       funnel: { issued: 0, captured: 0, granted: 0 },
@@ -66,7 +66,7 @@ describe("computeKFactor referral funnel", () => {
     const { computeKFactor } =
       await import("@/app/api/omi/stats/k-factor/posthog/route");
 
-    await expect(computeKFactor(30, "macos")).resolves.toMatchObject({
+    await expect(computeKFactor(30)).resolves.toMatchObject({
       available: true,
       kFactor: 0.25,
       funnel: { issued: 12, captured: 9, granted: 3 },
@@ -74,5 +74,8 @@ describe("computeKFactor referral funnel", () => {
     expect(posthogResults.mock.calls[2][3]).toContain(
       "properties.claimed = true",
     );
+    for (const [, , , query] of posthogResults.mock.calls) {
+      expect(query).not.toContain("$os_name");
+    }
   });
 });

--- a/web/admin/lib/__tests__/platform-scope-routes.test.ts
+++ b/web/admin/lib/__tests__/platform-scope-routes.test.ts
@@ -63,7 +63,6 @@ const ROUTES: [string, () => Promise<any>, string][] = [
   ["dau-trends", () => import("@/app/api/omi/stats/dau-trends/route"), "/api/omi/stats/dau-trends?days=30"],
   ["viral-metrics", () => import("@/app/api/omi/stats/viral-metrics/route"), "/api/omi/stats/viral-metrics?days=30"],
   ["retention", () => import("@/app/api/omi/stats/retention/posthog/route"), "/api/omi/stats/retention/posthog?days=14&intervals=10"],
-  ["k-factor", () => import("@/app/api/omi/stats/k-factor/posthog/route"), "/api/omi/stats/k-factor/posthog?days=30"],
 ];
 
 describe.each(ROUTES)("%s route", (_name, loadRoute, baseUrl) => {
@@ -85,6 +84,17 @@ describe.each(ROUTES)("%s route", (_name, loadRoute, baseUrl) => {
     // macOS semantics when unparameterized. The boards always pass platform=.
     const queries = await capture(loadRoute, baseUrl);
     expectScoped(queries, _name === "retention" ? "all" : "macos");
+  });
+});
+
+describe("k-factor route", () => {
+  it("does not require a client OS for server-emitted referral funnel events", async () => {
+    const queries = await capture(
+      () => import("@/app/api/omi/stats/k-factor/posthog/route"),
+      "/api/omi/stats/k-factor/posthog?days=30&platform=macos",
+    );
+    expect(queries).toHaveLength(3);
+    expectScoped(queries, "all");
   });
 });
 


### PR DESCRIPTION
## Summary

- Emit fail-open server-side PostHog events for `Referral Link Issued`, `Referral Link Captured`, and `Referral Claimed` without referral codes, URLs, emails, or cookie data.
- Record claim outcomes as `granted`, `existing_account`, `self_refer`, `already_claimed`, or `paid`; the HTTP response remains `claimed` plus `trial_days`.
- Replace the classic admin K-Factor proxy with 30-day issued / captured / granted unique-user funnel counts and a referral-grants tile.

`User-Agent: Bun/1.3.14` on backend claims is the Next.js web-app proxy, not a synthetic test client, so this instrumentation does not filter it.

## Verification

- `cd backend && pytest tests/unit/test_referrals.py -q`
- `cd web/admin && npm run typecheck`
- `cd web/admin && npm test -- --run lib/__tests__/k-factor-referral-funnel.test.ts lib/__tests__/platform-scope-routes.test.ts`
- `make preflight`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

