### PR TITLE
fix(desktop-windows): treat pi-mono's agent_settled as advisory, not unknown

### DIFF
--- a/desktop/windows/src/main/codingAgent/piMono.test.ts
+++ b/desktop/windows/src/main/codingAgent/piMono.test.ts
@@ -58,6 +58,7 @@ function newFakeProc(): FakeProc {
 // and inspect internal state without `any` (lint forbids explicit any).
 interface PiInternals {
   sendCommand: (cmd: Record<string, unknown>) => void
+  handleEvent: (line: string) => void
   handleTurnEnd: (event: Record<string, unknown>) => void
   handleToolStart: (event: Record<string, unknown>) => void
   handleToolEnd: (event: Record<string, unknown>) => void
@@ -401,6 +402,29 @@ describe('PiMonoAdapter prompt correlation', () => {
       cacheWriteTokens: 2
     })
     expect(events.some((event) => event.type === 'result')).toBe(false)
+  })
+
+  it('treats agent_settled as advisory and waits for the authoritative turn_end', async () => {
+    const { adapter } = createAdapter()
+    seedSessions(adapter, 'session-1')
+
+    const prompt = adapter.sendPrompt(
+      'session-1',
+      [{ type: 'text', text: 'wait for the child' }],
+      [],
+      'act',
+      () => {},
+      async () => ''
+    )
+
+    internals(adapter).handleEvent(JSON.stringify({ type: 'agent_settled' }))
+
+    expect(internals(adapter).activePromptGeneration).toBe(1)
+    expect(internals(adapter).pendingRequests.size).toBe(1)
+
+    internals(adapter).handleTurnEnd(makeTurnEndEvent('authoritative terminal result'))
+
+    await expect(prompt).resolves.toMatchObject({ text: 'authoritative terminal result' })
   })
 
   it('rejects turn_end errors instead of resolving success', async () => {

--- a/desktop/windows/src/main/codingAgent/piMono.ts
+++ b/desktop/windows/src/main/codingAgent/piMono.ts
@@ -1115,6 +1115,10 @@ export class PiMonoAdapter {
         this.handleTurnEnd(event)
         break
 
+      case 'agent_settled':
+        // Advisory upstream event; turn_end remains authoritative for completion.
+        break
+
       case 'agent_start':
       case 'agent_end':
       case 'turn_start':


### PR DESCRIPTION
## Summary
`PiMonoAdapter.handleEvent`'s dispatch switch had no case for the `agent_settled` protocol event, so it fell through to the `default` branch and logged `[pi-mono] unknown event type: agent_settled` — even though the adapter already treats several other protocol-control events (`agent_start`, `agent_end`, `turn_start`, etc.) as observed-but-ignored no-ops. `agent_settled` is an advisory upstream event; `turn_end` is what actually resolves or rejects the pending prompt via `handleTurnEnd`, and that behavior is unchanged.

Added an explicit no-op case alongside the others, plus a test exercising `handleEvent`'s real JSON-string dispatch path (not just `handleTurnEnd` directly) confirming a prompt stays pending across `agent_settled` and only completes on the subsequent `turn_end` — matching the equivalent coverage `desktop/macos`'s pi-mono adapter already has.

No functional/user-visible behavior changed (the pending prompt already correctly waited for `turn_end` either way); this only removes a spurious stderr log line and closes a Windows/macOS test-coverage gap.

## Test plan
- [x] New test: `treats agent_settled as advisory and waits for the authoritative turn_end`
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — full suite passes (5,411 passed / 27 skipped)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

