### PR TITLE
docs(backend): trim duplicate content from AGENTS.md to stay under budget

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -86,7 +86,6 @@ backend/
   diarizer/              # Subservice: speaker audio analysis (separate Docker, GPU/CUDA)
   nllb_translation/      # Subservice: self-hosted NLLB translation (separate Docker, GPU/CUDA)
   modal/                 # Serverless GPU services (deployed on Modal) + Cloud Run Jobs
-                          #   Per-subservice internals: backend/docs/subservice-internals.md
   tests/unit/            # 50+ unit tests (no external service deps)
   tests/integration/     # Integration tests (need Redis, Firebase, API keys)
   scripts/run-unit-ci.sh # Full CI unit-test contract
@@ -169,7 +168,7 @@ Runtime-selected providers must keep model-token parsing and required environmen
 
 ## Database
 
-**Firestore** (primary store): use `get_firestore_client()` from `database._client` at call time, and add optional keyword-only `firestore_client` parameters on converted database helpers so tests can inject fake clients. `db` remains a legacy lazy compatibility proxy only; do not use it in new code. Never construct Firestore clients at import time. Collection group queries need explicit indexes (will 500 with no useful error). Segments are encrypted at rest — direct Firestore reads return opaque blobs. Feature gating via user fields: e.g., translation requires `users/{uid}.language` non-empty — silently disabled if missing.
+**Firestore** (primary store): use `get_firestore_client()` from `database._client` at call time, and add optional keyword-only `firestore_client` parameters on converted database helpers so tests can inject fake clients. `db` remains a legacy lazy compatibility proxy only; do not use it in new code. Never construct Firestore clients at import time. Segments are encrypted at rest — direct Firestore reads return opaque blobs. Feature gating via user fields: e.g., translation requires `users/{uid}.language` non-empty — silently disabled if missing.
 
 **Redis** (cache/rate-limiting/locks): `from database import redis_db` — **fail-open** (all errors caught and logged, requests proceed). Rate limiting via Lua scripts. `try_acquire_listen_lock(uid)` prevents duplicate WS connections.
 


### PR DESCRIPTION
## Summary
`backend/AGENTS.md` was 39,120 bytes against `.github/scripts/check_agents_md_lean.py`'s 39,000-byte budget (lines were fine: 308/350). Since the checker scans every `AGENTS.md` in the repo rather than just the files a PR touched, this was silently failing the `agents-md-lean` check (as `Hygiene`/`PR Metadata Preflight`) on *any* PR that happened to touch a different `AGENTS.md` file — surfaced by #12159.

Removed two exact duplicates rather than any unique information:
- The Directory Structure tree's "Per-subservice internals: backend/docs/subservice-internals.md" pointer appeared twice (once was enough).
- The Database section's "collection group queries need explicit indexes (will 500 with no useful error)" repeated Common Gotchas item 7 word-for-word.

Now 307 lines / 38,947 bytes.

## Test plan
- [x] `python3 .github/scripts/check_agents_md_lean.py` → `ok: 9 AGENTS.md files within budget`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

