### PR TITLE
fix(android): attach GPS location on recordings

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -28,6 +28,9 @@
     <uses-permission
         android:name="android.permission.BLUETOOTH_ADMIN"
         android:maxSdkVersion="30" />
+    <!-- while-in-use is enough for conversation GPS: capture runs in the
+         visible activity, and the periodic refresh uses FOREGROUND_SERVICE_LOCATION.
+         Do not add ACCESS_BACKGROUND_LOCATION (Play Store prominent-disclosure). -->
     <uses-permission
         android:name="android.permission.ACCESS_FINE_LOCATION" />
 

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -28,6 +28,7 @@ import 'package:omi/services/capture/capture_external_actions.dart';
 import 'package:omi/services/capture/capture_metrics_tracker.dart';
 import 'package:omi/services/capture/conversation_source_for_device.dart';
 import 'package:omi/services/capture/conversation_location_capture.dart';
+import 'package:omi/utils/audio/foreground.dart';
 import 'package:omi/services/capture/freemium_threshold_tracker.dart';
 import 'package:omi/services/connectivity_service.dart';
 import 'package:omi/services/services.dart';
@@ -187,7 +188,8 @@ class CaptureController extends ChangeNotifier
     Future<void> Function()? inProgressConversationLoader,
     Future<BleAudioCodec> Function(String deviceId)? audioCodecLoader,
   })  : externalActions = externalActions ?? const NoopCaptureExternalActions(),
-        _conversationLocationCapture = conversationLocationCapture ?? ConversationLocationCapture(),
+        _conversationLocationCapture = conversationLocationCapture ??
+            ConversationLocationCapture(onNewlyGranted: _startAndroidLocationForegroundTask),
         _inProgressConversationLoader = inProgressConversationLoader,
         _audioCodecLoader = audioCodecLoader {
     // Restore a persisted device mute so it survives an app kill/restart. When
@@ -198,6 +200,12 @@ class CaptureController extends ChangeNotifier
       onConnectionStateChanged(isConnected);
     });
     BleBridge.instance.addBatchRecordingFinalizedListener(_onOfflineRecordingFinalized);
+  }
+
+  static Future<void> _startAndroidLocationForegroundTask() async {
+    if (!Platform.isAndroid) return;
+    await ForegroundUtil.initializeForegroundService();
+    await ForegroundUtil.startForegroundTask();
   }
 
   // True while the audio session is interrupted (phone call, Siri, alarm).

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -1478,11 +1478,6 @@ class CaptureController extends ChangeNotifier
   }
 
   streamRecording() async {
-    // The backend snapshots its cached location when finalizing a conversation.
-    // Complete this bounded update before any live or batch capture path can
-    // create/finalize that conversation.
-    await _conversationLocationCapture.captureAndUpload();
-
     // Mode is fixed for the whole session at start. On iOS and Android the phone
     // mic can capture Transcribe Later (batch) audio: explicitly when the user
     // enabled it, or automatically as an offline fallback when there is no
@@ -1494,6 +1489,12 @@ class CaptureController extends ChangeNotifier
     );
     if (mode != PhoneMicSessionMode.live) {
       await _startPhoneMicBatch(auto: mode == PhoneMicSessionMode.batchAuto);
+      if (_phoneMicBatchActive) {
+        // Product: recording is the tap; location is metadata. Do not hold
+        // record-start for the OS location dialog. Location PATCHes when the
+        // grant/fix lands.
+        unawaited(_conversationLocationCapture.captureAndUpload());
+      }
       return;
     }
 
@@ -1545,6 +1546,11 @@ class CaptureController extends ChangeNotifier
             onStalled: _onMicStalled,
             onInterruption: _onMicInterruption,
           );
+      // Product: recording is the tap; location is metadata. Do not hold
+      // RecordingState.initialising for the OS location dialog, and do not
+      // prompt location before the microphone. Location still PATCHes when
+      // the grant/fix lands.
+      unawaited(_conversationLocationCapture.captureAndUpload());
     } catch (e, st) {
       // Typed native failures (permission_denied, engine_start_failed, ...) or
       // mic contention — fail visibly instead of recording silence.
@@ -1676,9 +1682,10 @@ class CaptureController extends ChangeNotifier
 
     bool wasPaused = _isPaused;
 
-    // Ensure even very short device recordings have a location in Redis before
-    // the backend is able to finalize their conversation.
-    await _conversationLocationCapture.captureAndUpload();
+    // Product: recording is the tap; location is metadata. Do not block
+    // device connect/start on the OS location dialog. Location still PATCHes
+    // when the grant/fix lands; a short conversation can miss coords.
+    unawaited(_conversationLocationCapture.captureAndUpload());
 
     await _resetStateVariables();
     await _resetState();
@@ -2323,9 +2330,9 @@ class CaptureController extends ChangeNotifier
 
     if (segments.isEmpty && !_isLoadingInProgressConversation) {
       _isLoadingInProgressConversation = true;
-      // Refresh the location at the first transcript without relying on the
-      // long-lived foreground-task isolate. This is fail-open and does not
-      // delay segment processing.
+      // Product: recording is the tap; location is metadata. Refresh at the
+      // first transcript without relying on the long-lived foreground-task
+      // isolate. Fail-open: do not delay segment processing.
       unawaited(_conversationLocationCapture.captureAndUpload());
       try {
         if (_inProgressConversationLoader != null) {

--- a/app/lib/services/capture/conversation_location_capture.dart
+++ b/app/lib/services/capture/conversation_location_capture.dart
@@ -8,34 +8,61 @@ import 'package:omi/utils/logger.dart';
 
 typedef LocationServiceEnabled = Future<bool> Function();
 typedef LocationPermissionReader = Future<LocationPermission> Function();
+typedef LocationPermissionRequester = Future<LocationPermission> Function();
 typedef CurrentPositionReader = Future<Position> Function();
 typedef LastPositionReader = Future<Position?> Function();
 typedef GeolocationUploader = Future<bool> Function(Geolocation geolocation);
 
 /// Captures the location that belongs to a recording before the backend can
 /// finalize its conversation.
+///
+/// Foreground recording only needs while-in-use / ACCESS_FINE_LOCATION (or
+/// coarse). Android does **not** need ACCESS_BACKGROUND_LOCATION for this
+/// path: capture runs on the UI isolate while the activity is visible, and
+/// the optional periodic refresh runs inside FOREGROUND_SERVICE_LOCATION.
+/// ACCESS_BACKGROUND_LOCATION is intentionally not requested (Play Store
+/// prominent-disclosure). iOS "Always" is requested separately for BGTask
+/// windows and is not required for an in-app recorder start.
 class ConversationLocationCapture {
   ConversationLocationCapture({
     LocationServiceEnabled? isLocationServiceEnabled,
     LocationPermissionReader? checkPermission,
+    LocationPermissionRequester? requestPermission,
     CurrentPositionReader? getCurrentPosition,
     LastPositionReader? getLastKnownPosition,
     GeolocationUploader? upload,
-    this.currentPositionTimeout = const Duration(seconds: 1),
+    this.currentPositionTimeout = const Duration(seconds: 2),
     this.totalTimeout = const Duration(seconds: 3),
   })  : _isLocationServiceEnabled = isLocationServiceEnabled ?? Geolocator.isLocationServiceEnabled,
         _checkPermission = checkPermission ?? Geolocator.checkPermission,
-        _getCurrentPosition = getCurrentPosition ?? Geolocator.getCurrentPosition,
-        _getLastKnownPosition = getLastKnownPosition ?? Geolocator.getLastKnownPosition,
+        _requestPermission = requestPermission ?? Geolocator.requestPermission,
+        _getCurrentPosition = getCurrentPosition ?? _defaultCurrentPosition,
+        _getLastKnownPosition = getLastKnownPosition ?? _defaultLastKnownPosition,
         _upload = upload ?? ((geolocation) => updateUserGeolocation(geolocation: geolocation));
 
   final LocationServiceEnabled _isLocationServiceEnabled;
   final LocationPermissionReader _checkPermission;
+  final LocationPermissionRequester _requestPermission;
   final CurrentPositionReader _getCurrentPosition;
   final LastPositionReader _getLastKnownPosition;
   final GeolocationUploader _upload;
   final Duration currentPositionTimeout;
   final Duration totalTimeout;
+
+  /// Medium accuracy maps to Android PRIORITY_BALANCED_POWER_ACCURACY so a
+  /// while-in-use / approximate grant can still return a fix. Default "best"
+  /// is HIGH_ACCURACY GPS and routinely exceeds the recording-start budget
+  /// on Android, after which last-known is also often null.
+  static Future<Position> _defaultCurrentPosition() {
+    return Geolocator.getCurrentPosition(
+      locationSettings: const LocationSettings(accuracy: LocationAccuracy.medium),
+    );
+  }
+
+  static Future<Position?> _defaultLastKnownPosition() async {
+    return await Geolocator.getLastKnownPosition() ??
+        await Geolocator.getLastKnownPosition(forceAndroidLocationManager: true);
+  }
 
   Future<bool> captureAndUpload() async {
     try {
@@ -55,7 +82,12 @@ class ConversationLocationCapture {
       return false;
     }
 
-    final permission = await _checkPermission();
+    var permission = await _checkPermission();
+    if (permission == LocationPermission.denied) {
+      // Prompt at record start so a skipped onboarding page still gets a fix
+      // when the activity is visible. deniedForever is not re-prompted.
+      permission = await _requestPermission();
+    }
     if (permission == LocationPermission.denied || permission == LocationPermission.deniedForever) {
       Logger.log('Location permission not granted, skipping conversation location');
       return false;
@@ -63,11 +95,18 @@ class ConversationLocationCapture {
 
     Position? position;
     try {
-      position = await _getCurrentPosition().timeout(currentPositionTimeout);
-    } on TimeoutException {
-      // A recent OS fix is preferable to losing the conversation location when
-      // a fresh GPS fix is slow indoors.
       position = await _getLastKnownPosition();
+    } catch (e) {
+      Logger.log('Last-known conversation location failed: $e');
+    }
+
+    if (position == null) {
+      try {
+        position = await _getCurrentPosition().timeout(currentPositionTimeout);
+      } catch (e) {
+        Logger.log('Fresh conversation location fix failed: $e');
+        return false;
+      }
     }
     if (position == null) return false;
 

--- a/app/lib/services/capture/conversation_location_capture.dart
+++ b/app/lib/services/capture/conversation_location_capture.dart
@@ -12,6 +12,7 @@ typedef LocationPermissionRequester = Future<LocationPermission> Function();
 typedef CurrentPositionReader = Future<Position> Function();
 typedef LastPositionReader = Future<Position?> Function();
 typedef GeolocationUploader = Future<bool> Function(Geolocation geolocation);
+typedef LocationGrantHandler = Future<void> Function();
 
 /// Captures the location that belongs to a recording before the backend can
 /// finalize its conversation.
@@ -31,14 +32,17 @@ class ConversationLocationCapture {
     CurrentPositionReader? getCurrentPosition,
     LastPositionReader? getLastKnownPosition,
     GeolocationUploader? upload,
+    LocationGrantHandler? onNewlyGranted,
     this.currentPositionTimeout = const Duration(seconds: 2),
     this.totalTimeout = const Duration(seconds: 3),
+    this.lastKnownMaxAge = const Duration(minutes: 5),
   })  : _isLocationServiceEnabled = isLocationServiceEnabled ?? Geolocator.isLocationServiceEnabled,
         _checkPermission = checkPermission ?? Geolocator.checkPermission,
         _requestPermission = requestPermission ?? Geolocator.requestPermission,
         _getCurrentPosition = getCurrentPosition ?? _defaultCurrentPosition,
         _getLastKnownPosition = getLastKnownPosition ?? _defaultLastKnownPosition,
-        _upload = upload ?? ((geolocation) => updateUserGeolocation(geolocation: geolocation));
+        _upload = upload ?? ((geolocation) => updateUserGeolocation(geolocation: geolocation)),
+        _onNewlyGranted = onNewlyGranted;
 
   final LocationServiceEnabled _isLocationServiceEnabled;
   final LocationPermissionReader _checkPermission;
@@ -46,8 +50,10 @@ class ConversationLocationCapture {
   final CurrentPositionReader _getCurrentPosition;
   final LastPositionReader _getLastKnownPosition;
   final GeolocationUploader _upload;
+  final LocationGrantHandler? _onNewlyGranted;
   final Duration currentPositionTimeout;
   final Duration totalTimeout;
+  final Duration lastKnownMaxAge;
 
   /// Medium accuracy maps to Android PRIORITY_BALANCED_POWER_ACCURACY so a
   /// while-in-use / approximate grant can still return a fix. Default "best"
@@ -64,7 +70,13 @@ class ConversationLocationCapture {
         await Geolocator.getLastKnownPosition(forceAndroidLocationManager: true);
   }
 
+  bool _isFresh(Position position) {
+    final age = DateTime.now().toUtc().difference(position.timestamp.toUtc());
+    return !age.isNegative && age <= lastKnownMaxAge;
+  }
+
   Future<bool> captureAndUpload() async {
+    var timedOut = false;
     try {
       if (!await _isLocationServiceEnabled()) {
         Logger.log('Location service is not enabled, skipping conversation location');
@@ -72,18 +84,34 @@ class ConversationLocationCapture {
       }
 
       var permission = await _checkPermission();
+      var newlyGranted = false;
       if (permission == LocationPermission.denied) {
         // Prompt at record start so a skipped onboarding page still gets a fix
         // when the activity is visible. deniedForever is not re-prompted.
         permission = await _requestPermission();
+        newlyGranted = permission == LocationPermission.whileInUse || permission == LocationPermission.always;
       }
       if (permission == LocationPermission.denied || permission == LocationPermission.deniedForever) {
         Logger.log('Location permission not granted, skipping conversation location');
         return false;
       }
+      if (newlyGranted) {
+        try {
+          await _onNewlyGranted?.call();
+        } catch (e) {
+          Logger.log('Post-grant location hook failed: $e');
+        }
+      }
 
-      return await _captureAndUpload().timeout(totalTimeout);
+      return await _captureAndUpload(isCancelled: () => timedOut).timeout(
+        totalTimeout,
+        onTimeout: () {
+          timedOut = true;
+          throw TimeoutException('conversation location');
+        },
+      );
     } on TimeoutException {
+      timedOut = true;
       Logger.log('Conversation location capture timed out; recording will continue');
       return false;
     } catch (e) {
@@ -92,23 +120,28 @@ class ConversationLocationCapture {
     }
   }
 
-  Future<bool> _captureAndUpload() async {
-    Position? position;
+  Future<bool> _captureAndUpload({required bool Function() isCancelled}) async {
+    Position? lastKnown;
     try {
-      position = await _getLastKnownPosition();
+      lastKnown = await _getLastKnownPosition();
     } catch (e) {
       Logger.log('Last-known conversation location failed: $e');
     }
 
-    if (position == null) {
+    late final Position position;
+    if (lastKnown != null && _isFresh(lastKnown)) {
+      position = lastKnown;
+    } else {
       try {
         position = await _getCurrentPosition().timeout(currentPositionTimeout);
       } catch (e) {
         Logger.log('Fresh conversation location fix failed: $e');
-        return false;
+        if (lastKnown == null) return false;
+        position = lastKnown;
       }
     }
-    if (position == null) return false;
+
+    if (isCancelled()) return false;
 
     return _upload(
       Geolocation(

--- a/app/lib/services/capture/conversation_location_capture.dart
+++ b/app/lib/services/capture/conversation_location_capture.dart
@@ -66,6 +66,22 @@ class ConversationLocationCapture {
 
   Future<bool> captureAndUpload() async {
     try {
+      if (!await _isLocationServiceEnabled()) {
+        Logger.log('Location service is not enabled, skipping conversation location');
+        return false;
+      }
+
+      var permission = await _checkPermission();
+      if (permission == LocationPermission.denied) {
+        // Prompt at record start so a skipped onboarding page still gets a fix
+        // when the activity is visible. deniedForever is not re-prompted.
+        permission = await _requestPermission();
+      }
+      if (permission == LocationPermission.denied || permission == LocationPermission.deniedForever) {
+        Logger.log('Location permission not granted, skipping conversation location');
+        return false;
+      }
+
       return await _captureAndUpload().timeout(totalTimeout);
     } on TimeoutException {
       Logger.log('Conversation location capture timed out; recording will continue');
@@ -77,22 +93,6 @@ class ConversationLocationCapture {
   }
 
   Future<bool> _captureAndUpload() async {
-    if (!await _isLocationServiceEnabled()) {
-      Logger.log('Location service is not enabled, skipping conversation location');
-      return false;
-    }
-
-    var permission = await _checkPermission();
-    if (permission == LocationPermission.denied) {
-      // Prompt at record start so a skipped onboarding page still gets a fix
-      // when the activity is visible. deniedForever is not re-prompted.
-      permission = await _requestPermission();
-    }
-    if (permission == LocationPermission.denied || permission == LocationPermission.deniedForever) {
-      Logger.log('Location permission not granted, skipping conversation location');
-      return false;
-    }
-
     Position? position;
     try {
       position = await _getLastKnownPosition();

--- a/app/lib/utils/audio/foreground.dart
+++ b/app/lib/utils/audio/foreground.dart
@@ -21,10 +21,31 @@ class _ForegroundFirstTaskHandler extends TaskHandler {
   }
 
   Future _locationInBackground() async {
+    // Periodic refresh from FOREGROUND_SERVICE_LOCATION. while-in-use is
+    // enough; do not request ACCESS_BACKGROUND_LOCATION (Play Store
+    // prominent-disclosure). This isolate has no Activity, so it never prompts.
     if (await Geolocator.isLocationServiceEnabled()) {
       final permission = await Geolocator.checkPermission();
       if (permission == LocationPermission.always || permission == LocationPermission.whileInUse) {
-        var locationData = await Geolocator.getCurrentPosition();
+        Position? locationData;
+        try {
+          locationData = await Geolocator.getLastKnownPosition() ??
+              await Geolocator.getLastKnownPosition(forceAndroidLocationManager: true);
+        } catch (_) {}
+        try {
+          locationData ??= await Geolocator.getCurrentPosition(
+            locationSettings: const LocationSettings(accuracy: LocationAccuracy.medium),
+          ).timeout(const Duration(seconds: 8));
+        } catch (e) {
+          Object loc = {'error': 'Location fix failed: $e'};
+          FlutterForegroundTask.sendDataToMain(loc);
+          return;
+        }
+        if (locationData == null) {
+          Object loc = {'error': 'Location fix unavailable'};
+          FlutterForegroundTask.sendDataToMain(loc);
+          return;
+        }
         if (_locationUpdatedAt == null ||
             _locationUpdatedAt!.isBefore(DateTime.now().subtract(const Duration(minutes: 5)))) {
           Object loc = {

--- a/app/lib/utils/audio/foreground.dart
+++ b/app/lib/utils/audio/foreground.dart
@@ -14,6 +14,13 @@ void _startForegroundCallback() {
 class _ForegroundFirstTaskHandler extends TaskHandler {
   DateTime? _locationUpdatedAt;
 
+  static const Duration _lastKnownMaxAge = Duration(minutes: 5);
+
+  bool _isLastKnownFresh(Position position) {
+    final age = DateTime.now().toUtc().difference(position.timestamp.toUtc());
+    return !age.isNegative && age <= _lastKnownMaxAge;
+  }
+
   @override
   Future<void> onStart(DateTime timestamp, TaskStarter taskStarter) async {
     Logger.debug("Starting foreground task");
@@ -27,24 +34,27 @@ class _ForegroundFirstTaskHandler extends TaskHandler {
     if (await Geolocator.isLocationServiceEnabled()) {
       final permission = await Geolocator.checkPermission();
       if (permission == LocationPermission.always || permission == LocationPermission.whileInUse) {
-        Position? locationData;
+        Position? lastKnown;
         try {
-          locationData = await Geolocator.getLastKnownPosition() ??
+          lastKnown = await Geolocator.getLastKnownPosition() ??
               await Geolocator.getLastKnownPosition(forceAndroidLocationManager: true);
         } catch (_) {}
-        try {
-          locationData ??= await Geolocator.getCurrentPosition(
-            locationSettings: const LocationSettings(accuracy: LocationAccuracy.medium),
-          ).timeout(const Duration(seconds: 8));
-        } catch (e) {
-          Object loc = {'error': 'Location fix failed: $e'};
-          FlutterForegroundTask.sendDataToMain(loc);
-          return;
-        }
-        if (locationData == null) {
-          Object loc = {'error': 'Location fix unavailable'};
-          FlutterForegroundTask.sendDataToMain(loc);
-          return;
+        late final Position locationData;
+        if (lastKnown != null && _isLastKnownFresh(lastKnown)) {
+          locationData = lastKnown;
+        } else {
+          try {
+            locationData = await Geolocator.getCurrentPosition(
+              locationSettings: const LocationSettings(accuracy: LocationAccuracy.medium),
+            ).timeout(const Duration(seconds: 8));
+          } catch (e) {
+            if (lastKnown == null) {
+              Object loc = {'error': 'Location fix failed: $e'};
+              FlutterForegroundTask.sendDataToMain(loc);
+              return;
+            }
+            locationData = lastKnown;
+          }
         }
         if (_locationUpdatedAt == null ||
             _locationUpdatedAt!.isBefore(DateTime.now().subtract(const Duration(minutes: 5)))) {

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -160,6 +160,21 @@ class _CountingConversationLocationCapture extends ConversationLocationCapture {
   }
 }
 
+class _HangingConversationLocationCapture extends ConversationLocationCapture {
+  int calls = 0;
+  final Completer<bool> _done = Completer<bool>();
+
+  @override
+  Future<bool> captureAndUpload() async {
+    calls++;
+    return _done.future;
+  }
+
+  void complete() {
+    if (!_done.isCompleted) _done.complete(true);
+  }
+}
+
 /// Minimal EnvFields stub so Env-backed code paths (e.g. native BLE stream
 /// config reading Env.apiBaseUrl) don't hit a LateInitializationError.
 class _TestEnvFields implements EnvFields {
@@ -249,6 +264,21 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     expect(locationCapture.calls, 1);
+    provider.dispose();
+  });
+
+  test('streamDeviceRecording does not wait for location capture', () async {
+    final locationCapture = _HangingConversationLocationCapture();
+    final provider = CaptureProvider(
+      conversationLocationCapture: locationCapture,
+    );
+
+    await provider.streamDeviceRecording().timeout(
+          const Duration(seconds: 2),
+          onTimeout: () => fail('streamDeviceRecording blocked on location capture'),
+        );
+    expect(locationCapture.calls, 1);
+    locationCapture.complete();
     provider.dispose();
   });
 

--- a/app/test/unit/conversation_location_capture_test.dart
+++ b/app/test/unit/conversation_location_capture_test.dart
@@ -26,12 +26,16 @@ void main() {
     expect(uploaded?.longitude, 77.2090);
   });
 
-  test('uses the last known position when a fresh fix is slow', () async {
+  test('uploads last-known immediately when a fresh fix would be slow', () async {
+    var currentCalls = 0;
     Geolocation? uploaded;
     final capture = ConversationLocationCapture(
       isLocationServiceEnabled: () async => true,
       checkPermission: () async => LocationPermission.whileInUse,
-      getCurrentPosition: () => Completer<Position>().future,
+      getCurrentPosition: () {
+        currentCalls++;
+        return Completer<Position>().future;
+      },
       getLastKnownPosition: () async => _position(latitude: 51.5072, longitude: -0.1276),
       upload: (geolocation) async {
         uploaded = geolocation;
@@ -43,14 +47,82 @@ void main() {
     expect(await capture.captureAndUpload(), isTrue);
     expect(uploaded?.latitude, 51.5072);
     expect(uploaded?.longitude, -0.1276);
+    expect(currentCalls, 0);
   });
 
   test('does not upload without location permission', () async {
     var uploads = 0;
+    var requests = 0;
+    final capture = ConversationLocationCapture(
+      isLocationServiceEnabled: () async => true,
+      checkPermission: () async => LocationPermission.deniedForever,
+      requestPermission: () async {
+        requests++;
+        return LocationPermission.deniedForever;
+      },
+      getCurrentPosition: () async => _position(latitude: 1, longitude: 2),
+      getLastKnownPosition: () async => null,
+      upload: (_) async {
+        uploads++;
+        return true;
+      },
+    );
+
+    expect(await capture.captureAndUpload(), isFalse);
+    expect(uploads, 0);
+    expect(requests, 0);
+  });
+
+  test('requests while-in-use at record start when permission is denied', () async {
+    var requests = 0;
+    Geolocation? uploaded;
     final capture = ConversationLocationCapture(
       isLocationServiceEnabled: () async => true,
       checkPermission: () async => LocationPermission.denied,
-      getCurrentPosition: () async => _position(latitude: 1, longitude: 2),
+      requestPermission: () async {
+        requests++;
+        return LocationPermission.whileInUse;
+      },
+      getCurrentPosition: () async => _position(latitude: 37.7749, longitude: -122.4194),
+      getLastKnownPosition: () async => null,
+      upload: (geolocation) async {
+        uploaded = geolocation;
+        return true;
+      },
+    );
+
+    expect(await capture.captureAndUpload(), isTrue);
+    expect(requests, 1);
+    expect(uploaded?.latitude, 37.7749);
+    expect(uploaded?.longitude, -122.4194);
+  });
+
+  test('uses last-known when a fresh fix throws', () async {
+    Geolocation? uploaded;
+    final capture = ConversationLocationCapture(
+      isLocationServiceEnabled: () async => true,
+      checkPermission: () async => LocationPermission.whileInUse,
+      getCurrentPosition: () async => throw TimeoutException('gps'),
+      getLastKnownPosition: () async => _position(latitude: 1.3521, longitude: 103.8198),
+      upload: (geolocation) async {
+        uploaded = geolocation;
+        return true;
+      },
+    );
+
+    expect(await capture.captureAndUpload(), isTrue);
+    expect(uploaded?.latitude, 1.3521);
+    expect(uploaded?.longitude, 103.8198);
+  });
+
+  test('falls back to last-known after a fresh-fix error when last-known is the only fix', () async {
+    // last-known is tried first; if it is null, a failed current fix must not
+    // upload. This guards the Android cold-start case.
+    var uploads = 0;
+    final capture = ConversationLocationCapture(
+      isLocationServiceEnabled: () async => true,
+      checkPermission: () async => LocationPermission.whileInUse,
+      getCurrentPosition: () async => throw TimeoutException('gps'),
       getLastKnownPosition: () async => null,
       upload: (_) async {
         uploads++;

--- a/app/test/unit/conversation_location_capture_test.dart
+++ b/app/test/unit/conversation_location_capture_test.dart
@@ -97,6 +97,32 @@ void main() {
     expect(uploaded?.longitude, -122.4194);
   });
 
+  test('does not time out while the user answers the location permission prompt', () async {
+    var requests = 0;
+    Geolocation? uploaded;
+    final capture = ConversationLocationCapture(
+      isLocationServiceEnabled: () async => true,
+      checkPermission: () async => LocationPermission.denied,
+      requestPermission: () async {
+        requests++;
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        return LocationPermission.whileInUse;
+      },
+      getCurrentPosition: () async => _position(latitude: 40.7128, longitude: -74.0060),
+      getLastKnownPosition: () async => null,
+      upload: (geolocation) async {
+        uploaded = geolocation;
+        return true;
+      },
+      totalTimeout: const Duration(milliseconds: 10),
+    );
+
+    expect(await capture.captureAndUpload(), isTrue);
+    expect(requests, 1);
+    expect(uploaded?.latitude, 40.7128);
+    expect(uploaded?.longitude, -74.0060);
+  });
+
   test('uses last-known when a fresh fix throws', () async {
     Geolocation? uploaded;
     final capture = ConversationLocationCapture(

--- a/app/test/unit/conversation_location_capture_test.dart
+++ b/app/test/unit/conversation_location_capture_test.dart
@@ -53,6 +53,7 @@ void main() {
   test('does not upload without location permission', () async {
     var uploads = 0;
     var requests = 0;
+    var grants = 0;
     final capture = ConversationLocationCapture(
       isLocationServiceEnabled: () async => true,
       checkPermission: () async => LocationPermission.deniedForever,
@@ -62,6 +63,9 @@ void main() {
       },
       getCurrentPosition: () async => _position(latitude: 1, longitude: 2),
       getLastKnownPosition: () async => null,
+      onNewlyGranted: () async {
+        grants++;
+      },
       upload: (_) async {
         uploads++;
         return true;
@@ -71,10 +75,12 @@ void main() {
     expect(await capture.captureAndUpload(), isFalse);
     expect(uploads, 0);
     expect(requests, 0);
+    expect(grants, 0);
   });
 
   test('requests while-in-use at record start when permission is denied', () async {
     var requests = 0;
+    var grants = 0;
     Geolocation? uploaded;
     final capture = ConversationLocationCapture(
       isLocationServiceEnabled: () async => true,
@@ -85,6 +91,9 @@ void main() {
       },
       getCurrentPosition: () async => _position(latitude: 37.7749, longitude: -122.4194),
       getLastKnownPosition: () async => null,
+      onNewlyGranted: () async {
+        grants++;
+      },
       upload: (geolocation) async {
         uploaded = geolocation;
         return true;
@@ -93,8 +102,27 @@ void main() {
 
     expect(await capture.captureAndUpload(), isTrue);
     expect(requests, 1);
+    expect(grants, 1);
     expect(uploaded?.latitude, 37.7749);
     expect(uploaded?.longitude, -122.4194);
+  });
+
+  test('does not start a post-grant hook when permission was already granted', () async {
+    var grants = 0;
+    final capture = ConversationLocationCapture(
+      isLocationServiceEnabled: () async => true,
+      checkPermission: () async => LocationPermission.whileInUse,
+      requestPermission: () async => LocationPermission.whileInUse,
+      getCurrentPosition: () async => _position(latitude: 1, longitude: 2),
+      getLastKnownPosition: () async => _position(latitude: 1, longitude: 2),
+      onNewlyGranted: () async {
+        grants++;
+      },
+      upload: (_) async => true,
+    );
+
+    expect(await capture.captureAndUpload(), isTrue);
+    expect(grants, 0);
   });
 
   test('does not time out while the user answers the location permission prompt', () async {
@@ -159,13 +187,68 @@ void main() {
     expect(await capture.captureAndUpload(), isFalse);
     expect(uploads, 0);
   });
+
+  test('refreshes a stale last-known position before upload', () async {
+    var currentCalls = 0;
+    Geolocation? uploaded;
+    final capture = ConversationLocationCapture(
+      isLocationServiceEnabled: () async => true,
+      checkPermission: () async => LocationPermission.whileInUse,
+      getCurrentPosition: () async {
+        currentCalls++;
+        return _position(latitude: 48.8566, longitude: 2.3522);
+      },
+      getLastKnownPosition: () async => _position(
+        latitude: 51.5072,
+        longitude: -0.1276,
+        timestamp: DateTime.now().toUtc().subtract(const Duration(minutes: 10)),
+      ),
+      upload: (geolocation) async {
+        uploaded = geolocation;
+        return true;
+      },
+      lastKnownMaxAge: const Duration(minutes: 5),
+    );
+
+    expect(await capture.captureAndUpload(), isTrue);
+    expect(currentCalls, 1);
+    expect(uploaded?.latitude, 48.8566);
+    expect(uploaded?.longitude, 2.3522);
+  });
+
+  test('uses a stale last-known when the current fix fails', () async {
+    Geolocation? uploaded;
+    final capture = ConversationLocationCapture(
+      isLocationServiceEnabled: () async => true,
+      checkPermission: () async => LocationPermission.whileInUse,
+      getCurrentPosition: () async => throw TimeoutException('gps'),
+      getLastKnownPosition: () async => _position(
+        latitude: 35.6762,
+        longitude: 139.6503,
+        timestamp: DateTime.now().toUtc().subtract(const Duration(hours: 2)),
+      ),
+      upload: (geolocation) async {
+        uploaded = geolocation;
+        return true;
+      },
+      lastKnownMaxAge: const Duration(minutes: 5),
+    );
+
+    expect(await capture.captureAndUpload(), isTrue);
+    expect(uploaded?.latitude, 35.6762);
+    expect(uploaded?.longitude, 139.6503);
+  });
 }
 
-Position _position({required double latitude, required double longitude}) {
+Position _position({
+  required double latitude,
+  required double longitude,
+  DateTime? timestamp,
+}) {
   return Position(
     latitude: latitude,
     longitude: longitude,
-    timestamp: DateTime.utc(2026, 7, 21),
+    timestamp: timestamp ?? DateTime.now().toUtc(),
     accuracy: 8,
     altitude: 220,
     altitudeAccuracy: 2,


### PR DESCRIPTION
## Report
Android conversation/recording JSON always had `geolocation: null` / `location=nil`. The reporter suspected a missing always-on / `ACCESS_BACKGROUND_LOCATION` grant. They also left the app in the foreground, turned on the recorder, and still got nil.

## Root cause
Not missing always-on. The attach path already exists (`ConversationLocationCapture` → `PATCH /v1/users/geolocation` → Redis snapshot on finalize) and is awaited on phone-mic and device record start.

What actually dropped Android coordinates:

1. **Never requested location at record start.** Capture only *checked* permission. A skipped onboarding page or a first-run Android 12+ grant left the path on `denied`, so it uploaded nothing even with the activity visible.
2. **1s high-accuracy GPS then last-known.** Default Geolocator accuracy is Android `PRIORITY_HIGH_ACCURACY`. A cold GPS fix routinely exceeds 1s. `getLastKnownPosition()` is often null on Android until this app has received a fix, so both legs failed in the foreground.
3. **Non-timeout errors skipped last-known.** A SecurityException / settings failure from high-accuracy GPS (common with approximate-only grants) never fell back.

Background/always-on is **not** required for a visible recorder. Android already declares `FOREGROUND_SERVICE_LOCATION` and only asks for while-in-use. `ACCESS_BACKGROUND_LOCATION` is still **not** requested (Play Store prominent-disclosure). iOS "Always" remains iOS-only for BGTask windows.

## Fix
- Request while-in-use at record start when permission is `denied` (not `deniedForever`).
- Prefer last-known (including Android LocationManager fallback), then a medium-accuracy current fix with a 2s budget.
- Treat any current-fix error as a miss, not only `TimeoutException`.
- Use the same last-known + medium-accuracy path in the Android foreground-task isolate.
- Document in the capture class and AndroidManifest that always-on / `ACCESS_BACKGROUND_LOCATION` is intentionally not used.

## Test plan
- [x] `flutter test test/unit/conversation_location_capture_test.dart` (no device)
  - uploads a fresh position when last-known is empty
  - uploads last-known immediately (does not wait on a hanging current fix)
  - does not prompt or upload on `deniedForever`
  - requests while-in-use at record start when `denied`
  - uses last-known when a fresh fix would throw
  - uploads nothing when both last-known and current fail
- [ ] Manual Android: grant while-in-use (not Always), keep the app visible, start the phone-mic recorder, finish a short conversation, confirm `geolocation` on the conversation JSON
- [ ] Manual Android: approximate-only grant still attaches coordinates
- [ ] Manual Android: deny location → record → system prompt → grant → location attached
- [ ] Confirm Settings → Permissions still does not ask for Android Always / background location


## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes permission prompts and location acquisition at recording start and in the foreground location service; scope is limited to geolocation attach, not new background permissions.
> 
> **Overview**
> Fixes **null conversation geolocation on Android** when recording in the foreground with only while-in-use location—not missing `ACCESS_BACKGROUND_LOCATION`.
> 
> **`ConversationLocationCapture`** now **requests while-in-use permission at record start** when status is `denied` (not `deniedForever`). Capture **tries last-known first** (with Android LocationManager fallback), then a **medium-accuracy** current fix with a **2s** budget; any current-fix failure is handled without blocking recording. Docs in code and **AndroidManifest** state that background location is intentionally not requested.
> 
> The **foreground-service location refresh** uses the same last-known → medium-accuracy pattern, with errors reported to the main isolate.
> 
> Unit tests cover permission prompting, last-known-first behavior, and failure paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 138043e6ac601ebad0b39a5a4c4cd9766ff903e4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
