### PR TITLE
fix(desktop): keep quiet agent turns alive

### DIFF
--- a/.github/failure-classes/FC-output-silence-misclassified-as-runtime-death.json
+++ b/.github/failure-classes/FC-output-silence-misclassified-as-runtime-death.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-output-silence-misclassified-as-runtime-death",
+  "violated_contract": "A long-running request can remain healthy while its provider emits no user-visible content. The absence of text, thinking, or tool events proves only output silence; it does not prove that the query-owning runtime or its transport is dead. A watchdog that treats those states as equivalent terminates legitimate quiet work at its fixed boundary and can erase the turn before the first partial response exists.",
+  "canonical_prevention": "Let the authoritative active-query registration own a bounded, correlated, content-free activity lease. Refresh bridge liveness only from that typed lease or genuine runtime events, cancel the lease on every terminal or revoked path, and preserve a negative control proving that a frozen runtime stops renewing the lease and still reaches the existing watchdog.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/agent/src/runtime/jsonl-transport.ts",
+    "desktop/macos/agent/tests/jsonl-transport.test.ts",
+    "desktop/macos/Desktop/Tests/StallDetectorTests.swift"
+  ],
+  "evidence_prs": [11458],
+  "scope_hints": [
+    "desktop/macos/agent/**",
+    "desktop/macos/Desktop/Sources/Chat/**",
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
@@ -645,6 +645,7 @@ actor AgentBridge {
   typealias TextDeltaHandler = @Sendable (String) -> Void
   typealias ToolCallHandler = @Sendable (String, String, [String: Any]) async -> String
   typealias ToolActivityHandler = @Sendable (String, String, String?, [String: Any]?) -> Void
+  typealias TurnActivityHandler = @Sendable () -> Void
   typealias ThinkingDeltaHandler = @Sendable (String) -> Void
   typealias ToolResultDisplayHandler = @Sendable (String, String, String) -> Void
   typealias AuthRequiredHandler = @Sendable ([[String: Any]], String?) -> Void
@@ -1585,6 +1586,7 @@ actor AgentBridge {
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil,
     onTextDelta: @escaping TextDeltaHandler,
     onToolActivity: @escaping ToolActivityHandler,
+    onTurnActivity: @escaping TurnActivityHandler = {},
     onThinkingDelta: @escaping ThinkingDeltaHandler = { _ in },
     onToolResultDisplay: @escaping ToolResultDisplayHandler = { _, _, _ in },
     onAuthRequired: @escaping AuthRequiredHandler = { _, _ in },
@@ -1617,6 +1619,7 @@ actor AgentBridge {
       authorizationSnapshot: authorization,
       onTextDelta: onTextDelta,
       onToolActivity: onToolActivity,
+      onTurnActivity: onTurnActivity,
       onThinkingDelta: onThinkingDelta,
       onToolResultDisplay: onToolResultDisplay,
       onAuthRequired: onAuthRequired,
@@ -1637,6 +1640,7 @@ actor AgentBridge {
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil,
     onTextDelta: @escaping TextDeltaHandler,
     onToolActivity: @escaping ToolActivityHandler,
+    onTurnActivity: @escaping TurnActivityHandler = {},
     onThinkingDelta: @escaping ThinkingDeltaHandler = { _ in },
     onToolResultDisplay: @escaping ToolResultDisplayHandler = { _, _, _ in },
     onAuthRequired: @escaping AuthRequiredHandler = { _, _ in },
@@ -1707,6 +1711,10 @@ actor AgentBridge {
       bridgeOutputTracker.markOutput()
       onToolActivity(name, status, toolUseId, input)
     }
+    let trackedTurnActivity: TurnActivityHandler = {
+      guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorization) else { return }
+      onTurnActivity()
+    }
     let trackedThinkingDelta: ThinkingDeltaHandler = { delta in
       guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorization) else { return }
       if !delta.isEmpty { bridgeOutputTracker.markOutput() }
@@ -1737,6 +1745,7 @@ actor AgentBridge {
         authorizationSnapshot: authorization,
         onTextDelta: trackedTextDelta,
         onToolActivity: trackedToolActivity,
+        onTurnActivity: trackedTurnActivity,
         onThinkingDelta: trackedThinkingDelta,
         onToolResultDisplay: trackedToolResultDisplay,
         onAuthRequired: guardedAuthRequired,
@@ -1777,6 +1786,7 @@ actor AgentBridge {
         authorizationSnapshot: authorization,
         onTextDelta: trackedTextDelta,
         onToolActivity: trackedToolActivity,
+        onTurnActivity: trackedTurnActivity,
         onThinkingDelta: trackedThinkingDelta,
         onToolResultDisplay: trackedToolResultDisplay,
         onAuthRequired: guardedAuthRequired,

--- a/desktop/macos/Desktop/Sources/Chat/AgentClient.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentClient.swift
@@ -56,6 +56,7 @@ enum AgentClient {
   typealias TextDeltaHandler = AgentBridge.TextDeltaHandler
   typealias ToolCallHandler = AgentBridge.ToolCallHandler
   typealias ToolActivityHandler = AgentBridge.ToolActivityHandler
+  typealias TurnActivityHandler = AgentBridge.TurnActivityHandler
   typealias ThinkingDeltaHandler = AgentBridge.ThinkingDeltaHandler
   typealias ToolResultDisplayHandler = AgentBridge.ToolResultDisplayHandler
   typealias AuthRequiredHandler = AgentBridge.AuthRequiredHandler
@@ -517,6 +518,7 @@ enum AgentClient {
       reasoningEffort: String? = nil,
       onTextDelta: @escaping TextDeltaHandler,
       onToolActivity: @escaping ToolActivityHandler,
+      onTurnActivity: @escaping TurnActivityHandler = {},
       onThinkingDelta: @escaping ThinkingDeltaHandler = { _ in },
       onToolResultDisplay: @escaping ToolResultDisplayHandler = { _, _, _ in },
       onAuthRequired: @escaping AuthRequiredHandler = { _, _ in },
@@ -535,6 +537,7 @@ enum AgentClient {
         reasoningEffort: reasoningEffort,
         onTextDelta: onTextDelta,
         onToolActivity: onToolActivity,
+        onTurnActivity: onTurnActivity,
         onThinkingDelta: onThinkingDelta,
         onToolResultDisplay: onToolResultDisplay,
         onAuthRequired: onAuthRequired,
@@ -555,6 +558,7 @@ enum AgentClient {
       reasoningEffort: String? = nil,
       onTextDelta: @escaping TextDeltaHandler,
       onToolActivity: @escaping ToolActivityHandler,
+      onTurnActivity: @escaping TurnActivityHandler = {},
       onThinkingDelta: @escaping ThinkingDeltaHandler = { _ in },
       onToolResultDisplay: @escaping ToolResultDisplayHandler = { _, _, _ in },
       onAuthRequired: @escaping AuthRequiredHandler = { _, _ in },
@@ -585,6 +589,7 @@ enum AgentClient {
               reasoningEffort: reasoningEffort,
               onTextDelta: onTextDelta,
               onToolActivity: onToolActivity,
+              onTurnActivity: onTurnActivity,
               onThinkingDelta: onThinkingDelta,
               onToolResultDisplay: onToolResultDisplay,
               onAuthRequired: onAuthRequired,
@@ -614,6 +619,7 @@ enum AgentClient {
     onTextDelta: @escaping TextDeltaHandler = { _ in },
     onToolCall _: @escaping ToolCallHandler = { _, _, _ in "" },
     onToolActivity: @escaping ToolActivityHandler = { _, _, _, _ in },
+    onTurnActivity: @escaping TurnActivityHandler = {},
     onThinkingDelta: @escaping ThinkingDeltaHandler = { _ in },
     onToolResultDisplay: @escaping ToolResultDisplayHandler = { _, _, _ in },
     onAuthRequired: @escaping AuthRequiredHandler = { _, _ in },
@@ -677,6 +683,7 @@ enum AgentClient {
         expectedContext: snapshot.freshness,
         onTextDelta: onTextDelta,
         onToolActivity: onToolActivity,
+        onTurnActivity: onTurnActivity,
         onThinkingDelta: onThinkingDelta,
         onToolResultDisplay: onToolResultDisplay,
         onAuthRequired: onAuthRequired,

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeMessageKind.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeMessageKind.swift
@@ -1,0 +1,38 @@
+extension AgentRuntimeProcess.RuntimeMessage {
+  /// Closed routing taxonomy for messages received from the JSONL runtime.
+  /// Kept beside the protocol boundary instead of growing the process owner.
+  enum Kind: Equatable {
+    case initMessage
+    case textDelta
+    case thinkingDelta
+    case toolUse
+    case authorizedToolExecution
+    case toolActivity
+    case turnActivity
+    case toolResultDisplay
+    case result
+    case error
+    case authRequired
+    case authSuccess
+    case cancelAck
+    case controlToolResult
+    case journalOperationResult
+    case journalTurnChanged
+    case journalBackendSync
+    case journalBackendDelete
+    case journalBackendReconcile
+    case chatFirstDeferralDelivery
+    case defaultExecutionProfileConfigured
+    case surfaceSessionResolved
+    case sessionExecutionProfileMigrated
+    case contextSourceUpdated
+    case contextSnapshot
+    case legacyMainChatSessionsImported
+    case externalSurfaceRunBeginResult
+    case externalSurfaceToolResult
+    case externalSurfaceRunCompleteResult
+    case chatFirstHarnessExecutorResult
+    case ownerRuntimeRevoked
+    case unknown(String)
+  }
+}

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -312,40 +312,6 @@ actor AgentRuntimeProcess {
       let requestId: String
     }
 
-    enum Kind: Equatable {
-      case initMessage
-      case textDelta
-      case thinkingDelta
-      case toolUse
-      case authorizedToolExecution
-      case toolActivity
-      case toolResultDisplay
-      case result
-      case error
-      case authRequired
-      case authSuccess
-      case cancelAck
-      case controlToolResult
-      case journalOperationResult
-      case journalTurnChanged
-      case journalBackendSync
-      case journalBackendDelete
-      case journalBackendReconcile
-      case chatFirstDeferralDelivery
-      case defaultExecutionProfileConfigured
-      case surfaceSessionResolved
-      case sessionExecutionProfileMigrated
-      case contextSourceUpdated
-      case contextSnapshot
-      case legacyMainChatSessionsImported
-      case externalSurfaceRunBeginResult
-      case externalSurfaceToolResult
-      case externalSurfaceRunCompleteResult
-      case chatFirstHarnessExecutorResult
-      case ownerRuntimeRevoked
-      case unknown(String)
-    }
-
     let kind: Kind
     let requestId: String?
     let clientId: String?
@@ -381,6 +347,7 @@ actor AgentRuntimeProcess {
       case "tool_use": return .toolUse
       case "authorized_tool_execution": return .authorizedToolExecution
       case "tool_activity": return .toolActivity
+      case "turn_activity": return .turnActivity
       case "tool_result_display": return .toolResultDisplay
       case "result": return .result
       case "error": return .error
@@ -454,6 +421,7 @@ actor AgentRuntimeProcess {
     let originatingUserText: String?
     let onTextDelta: AgentBridge.TextDeltaHandler
     let onToolActivity: AgentBridge.ToolActivityHandler
+    let onTurnActivity: AgentBridge.TurnActivityHandler
     let onThinkingDelta: AgentBridge.ThinkingDeltaHandler
     let onToolResultDisplay: AgentBridge.ToolResultDisplayHandler
     let onAuthRequired: AgentBridge.AuthRequiredHandler
@@ -2294,7 +2262,7 @@ actor AgentRuntimeProcess {
   /// process. With the process paused it emits no further events, so an in-flight
   /// chat send stalls exactly like a hung ACP subprocess — driving the
   /// StallDetector to `.stalled` (20s) and, if held long enough, ChatProvider's
-  /// 180s send watchdog (CHAT-02). A safety auto-resume fires after `durationMs`
+  /// 60s send watchdog (CHAT-02). A safety auto-resume fires after `durationMs`
   /// (hard-capped) so the process can never stay frozen if `debugResumeStream`
   /// is never called. Non-production bundles only.
   func debugSuspendStream(durationMs: Int) -> [String: String] {
@@ -2383,6 +2351,7 @@ actor AgentRuntimeProcess {
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot,
     onTextDelta: @escaping AgentBridge.TextDeltaHandler,
     onToolActivity: @escaping AgentBridge.ToolActivityHandler,
+    onTurnActivity: @escaping AgentBridge.TurnActivityHandler,
     onThinkingDelta: @escaping AgentBridge.ThinkingDeltaHandler,
     onToolResultDisplay: @escaping AgentBridge.ToolResultDisplayHandler,
     onAuthRequired: @escaping AgentBridge.AuthRequiredHandler,
@@ -2400,6 +2369,7 @@ actor AgentRuntimeProcess {
         originatingUserText: prompt.trimmingCharacters(in: .whitespacesAndNewlines),
         onTextDelta: onTextDelta,
         onToolActivity: onToolActivity,
+        onTurnActivity: onTurnActivity,
         onThinkingDelta: onThinkingDelta,
         onToolResultDisplay: onToolResultDisplay,
         onAuthRequired: onAuthRequired,
@@ -3244,6 +3214,9 @@ actor AgentRuntimeProcess {
         message.payload["toolUseId"] as? String,
         message.payload["input"] as? [String: Any]
       )
+
+    case .turnActivity:
+      routedRequest(for: message)?.onTurnActivity()
 
     case .toolResultDisplay:
       routedRequest(for: message)?.onToolResultDisplay(

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeStatusStore.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeStatusStore.swift
@@ -278,7 +278,7 @@ final class AgentRuntimeStatusStore: ObservableObject {
 
   func ingest(message: AgentRuntimeProcess.RuntimeMessage, surface: AgentSurfaceReference) {
     switch message.kind {
-    case .textDelta, .thinkingDelta:
+    case .textDelta, .thinkingDelta, .turnActivity:
       update(surface: surface, status: .running, statusText: nil, terminal: false, payload: message.payload)
     case .toolActivity:
       let name = message.payload["name"] as? String

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -2133,9 +2133,9 @@ final class DesktopAutomationActionRegistry {
       guard AppBuild.isNonProduction else {
         return ["error": "suspend_agent_stream is disabled on production bundles"]
       }
-      // Default just past the 180s send watchdog so CHAT-02 can assert the
+      // Default just past the 60s send watchdog so CHAT-02 can assert the
       // "Response took too long" error + recoverable retry; capped at 300s.
-      let durationMs = intParam(params["durationMs"], default: 190_000)
+      let durationMs = intParam(params["durationMs"], default: 70_000)
       return await AgentRuntimeProcess.shared.debugSuspendStream(durationMs: durationMs)
     }
 

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -4796,6 +4796,16 @@ class ChatProvider: ObservableObject {
           self.applyStallTransitions(messageId: aiMessageId, transitions: transitions)
         }
       }
+      let turnActivityHandler: AgentClient.TurnActivityHandler = { [weak self] in
+        callbackQueue.submit { @MainActor [weak self] in
+          guard let self else { return }
+          let transitions = await stallDetector.step(
+            kind: .other,
+            atMs: ChatProvider.monotonicNowMs()
+          )
+          self.applyStallTransitions(messageId: aiMessageId, transitions: transitions)
+        }
+      }
       let thinkingDeltaHandler: AgentClient.ThinkingDeltaHandler = { [weak self] text in
         callbackQueue.submit { @MainActor [weak self] in
           guard let self else { return }
@@ -4957,6 +4967,7 @@ class ChatProvider: ObservableObject {
           reasoningEffort: turnOwner.reasoningEffort,
           onTextDelta: textDeltaHandler,
           onToolActivity: toolActivityHandler,
+          onTurnActivity: turnActivityHandler,
           onThinkingDelta: thinkingDeltaHandler,
           onToolResultDisplay: toolResultDisplayHandler,
           onAuthRequired: { [weak self] methods, authUrl in

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -597,6 +597,21 @@ final class AgentRuntimeProcessTests: XCTestCase {
     XCTAssertEqual(message?.payload["terminalStatus"] as? String, "succeeded")
   }
 
+  func testTurnActivityParsingPreservesRequestCorrelationWithoutContent() throws {
+    let message = try XCTUnwrap(
+      AgentRuntimeProcess.RuntimeMessage.parse(
+        #"{"type":"turn_activity","phase":"running","protocolVersion":2,"requestId":"quiet-1","clientId":"client-1","sessionId":"omi-1","runId":"run-1","attemptId":"attempt-1"}"#
+      ))
+
+    XCTAssertEqual(message.kind, .turnActivity)
+    XCTAssertEqual(
+      message.requestKey,
+      AgentRuntimeProcess.RuntimeMessage.RequestKey(clientId: "client-1", requestId: "quiet-1")
+    )
+    XCTAssertEqual(message.payload["phase"] as? String, "running")
+    XCTAssertNil(message.payload["text"])
+  }
+
   func testCancelAckRoutesByRequestId() {
     let message = AgentRuntimeProcess.RuntimeMessage.parse(
       #"{"type":"cancel_ack","protocolVersion":2,"requestId":"cancel-me","clientId":"client-1","accepted":true,"dispatchAttempted":true,"adapterAcknowledged":false}"#

--- a/desktop/macos/Desktop/Tests/ChatStallWatchdogTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatStallWatchdogTests.swift
@@ -41,6 +41,18 @@ final class ChatStallWatchdogTests: XCTestCase {
       "An active tool owns its no-progress timeout before the generic bridge watchdog can fire")
   }
 
+  func testTurnActivityRefreshesTheSilentBridgeClock() throws {
+    let source = try chatProviderSource()
+    XCTAssertNotNil(
+      source.range(
+        of:
+          #"let\s+turnActivityHandler[\s\S]*?stallDetector\.step\([\s\S]*?kind:\s*\.other[\s\S]*?onTurnActivity:\s*turnActivityHandler"#,
+        options: .regularExpression
+      ),
+      "content-free runtime activity must refresh the detector and reach the active query"
+    )
+  }
+
   // MARK: - Source-invariant: the marker is set before interrupt() and consumed by the catch
 
   func testWatchdogMarksGenerationBeforeInterrupting() throws {

--- a/desktop/macos/Desktop/Tests/StallDetectorTests.swift
+++ b/desktop/macos/Desktop/Tests/StallDetectorTests.swift
@@ -70,6 +70,32 @@ final class StallDetectorTests: XCTestCase {
     XCTAssertEqual(state, .running)
   }
 
+  func testRuntimeActivityLeaseKeepsAQuietTurnBelowTheBridgeWatchdog() async {
+    let detector = StallDetector(thresholds: thresholds, startedAtMs: 0)
+
+    _ = await detector.step(kind: .other, atMs: 15_000)
+    _ = await detector.step(kind: .other, atMs: 30_000)
+    _ = await detector.step(kind: .other, atMs: 45_000)
+    _ = await detector.step(kind: .other, atMs: 60_000)
+
+    let beforeLeaseExpiry = await detector.isSilentWithoutActiveTools(
+      durationMs: 60_000,
+      atMs: 119_999
+    )
+    let atLeaseExpiry = await detector.isSilentWithoutActiveTools(
+      durationMs: 60_000,
+      atMs: 120_000
+    )
+    XCTAssertFalse(
+      beforeLeaseExpiry,
+      "a responsive runtime may legitimately wait on a quiet provider round"
+    )
+    XCTAssertTrue(
+      atLeaseExpiry,
+      "once the runtime lease stops, the existing bridge watchdog must still recover the turn"
+    )
+  }
+
   func testStepAlsoEvaluatesElapsedTime() async {
     let detector = StallDetector(thresholds: thresholds, startedAtMs: 0)
     // No prior event observed; step at slowGapMs both records the

--- a/desktop/macos/agent/src/protocol.ts
+++ b/desktop/macos/agent/src/protocol.ts
@@ -825,6 +825,16 @@ export interface ToolActivityMessage extends QueryScopedOutbound {
   input?: Record<string, unknown>;
 }
 
+/**
+ * Content-free proof that the query-owning runtime is still servicing an
+ * admitted turn. Swift uses this lease to distinguish a quiet provider round
+ * from a frozen JSONL bridge; it must never be rendered as assistant output.
+ */
+export interface TurnActivityMessage extends QueryScopedOutbound {
+  type: "turn_activity";
+  phase: "running";
+}
+
 export interface ToolResultDisplayMessage extends QueryScopedOutbound {
   type: "tool_result_display";
   toolUseId: string;
@@ -1178,6 +1188,7 @@ export type OutboundMessage =
   | TextDeltaMessage
   | ToolUseMessage
   | ToolActivityMessage
+  | TurnActivityMessage
   | ToolResultDisplayMessage
   | ThinkingDeltaMessage
   | ResultMessage
@@ -1218,6 +1229,7 @@ export type OutboundMessageDraft =
   | DraftEnvelope<TextDeltaMessage>
   | DraftEnvelope<ToolUseMessage>
   | DraftEnvelope<ToolActivityMessage>
+  | DraftEnvelope<TurnActivityMessage>
   | DraftEnvelope<ToolResultDisplayMessage>
   | DraftEnvelope<ThinkingDeltaMessage>
   | DraftEnvelope<ResultMessage>

--- a/desktop/macos/agent/src/runtime/jsonl-transport.ts
+++ b/desktop/macos/agent/src/runtime/jsonl-transport.ts
@@ -52,6 +52,15 @@ export type McpServerBuilder = (
 
 export type RecoverableErrorPredicate = (error: unknown, adapterId: string) => boolean;
 export type RecoverableErrorHandler = (error: unknown, adapterId: string) => Promise<void>;
+export type QueryActivityLeaseScheduler = (emit: () => void) => () => void;
+
+const QUERY_ACTIVITY_LEASE_INTERVAL_MS = 15_000;
+
+function scheduleQueryActivityLease(emit: () => void): () => void {
+  const timer = setInterval(emit, QUERY_ACTIVITY_LEASE_INTERVAL_MS);
+  timer.unref();
+  return () => clearInterval(timer);
+}
 
 export interface JsonlTransportOptions {
   kernel: AgentRuntimeKernel;
@@ -66,6 +75,7 @@ export interface JsonlTransportOptions {
   onRecoverableError?: RecoverableErrorHandler;
   maxRecoverableRetries?: number;
   activeOwnerId?: () => string;
+  scheduleQueryActivity?: QueryActivityLeaseScheduler;
 }
 
 interface ActiveRequestContext {
@@ -123,6 +133,7 @@ export class JsonlTransport {
   private readonly onRecoverableError?: RecoverableErrorHandler;
   private readonly maxRecoverableRetries: number;
   private readonly activeOwnerId: () => string;
+  private readonly scheduleQueryActivity: QueryActivityLeaseScheduler;
   private readonly activeByRequest = new Map<string, ActiveRequestContext>();
   private readonly activeByRun = new Map<string, ActiveRequestContext>();
   private readonly latestRunByClient = new Map<string, string>();
@@ -141,6 +152,7 @@ export class JsonlTransport {
     this.onRecoverableError = options.onRecoverableError;
     this.maxRecoverableRetries = Math.max(0, options.maxRecoverableRetries ?? 0);
     this.activeOwnerId = options.activeOwnerId ?? (() => this.ownerId);
+    this.scheduleQueryActivity = options.scheduleQueryActivity ?? scheduleQueryActivityLease;
     this.kernel.subscribe((event) => this.handleKernelEvent(event));
   }
 
@@ -162,6 +174,16 @@ export class JsonlTransport {
       revoked: false,
     };
     this.activeByRequest.set(key, context);
+    const stopQueryActivity = this.scheduleQueryActivity(() => {
+      // The callback is deliberately owned by this live request registration.
+      // A scheduler callback racing with terminal cleanup cannot extend a
+      // completed or owner-revoked turn.
+      if (context.revoked || !this.activeByRequest.has(key)) return;
+      this.send(this.withCorrelation({
+        type: "turn_activity",
+        phase: "running",
+      }, context));
+    });
 
     try {
       const result = await this.kernel.executeRun(input);
@@ -202,6 +224,7 @@ export class JsonlTransport {
       };
       this.send(this.withCorrelation(errorMessage, context));
     } finally {
+      stopQueryActivity();
       this.activeByRequest.delete(this.activeRequestKey(context.requestId, context.clientId));
       if (context.runId) {
         this.activeByRun.delete(context.runId);

--- a/desktop/macos/agent/tests/jsonl-transport.test.ts
+++ b/desktop/macos/agent/tests/jsonl-transport.test.ts
@@ -5,7 +5,11 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import type { OutboundMessageDraft, QueryMessage } from "../src/protocol.js";
-import { JsonlTransport, type McpServerBuilder } from "../src/runtime/jsonl-transport.js";
+import {
+  JsonlTransport,
+  type McpServerBuilder,
+  type QueryActivityLeaseScheduler,
+} from "../src/runtime/jsonl-transport.js";
 import { updateContextSource } from "../src/runtime/context-snapshot.js";
 import { recordJournalTurn, terminalizeJournalTurn } from "../src/runtime/conversation-journal.js";
 import { createKernelHarness, waitUntil } from "./kernel-fakes.js";
@@ -16,7 +20,10 @@ afterEach(() => {
   while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true });
 });
 
-function fixture(buildMcpServers?: McpServerBuilder) {
+function fixture(
+  buildMcpServers?: McpServerBuilder,
+  scheduleQueryActivity?: QueryActivityLeaseScheduler,
+) {
   const root = mkdtempSync(join(tmpdir(), "omi-jsonl-"));
   roots.push(root);
   const { store, adapter, kernel } = createKernelHarness(join(root, "agent.sqlite"), "fake");
@@ -38,6 +45,7 @@ function fixture(buildMcpServers?: McpServerBuilder) {
     activeOwnerId: () => activeOwner,
     send: (message) => sent.push(message),
     buildMcpServers,
+    scheduleQueryActivity,
   });
   return {
     store,
@@ -66,6 +74,43 @@ function query(sessionId: string, overrides: Partial<QueryMessage> = {}): QueryM
 }
 
 describe("JsonlTransport kernel-owned query contract", () => {
+  it("leases a quiet admitted query until its terminal result", async () => {
+    let emitActivity: (() => void) | undefined;
+    let leaseStops = 0;
+    const scheduleQueryActivity: QueryActivityLeaseScheduler = (emit) => {
+      emitActivity = emit;
+      return () => { leaseStops += 1; };
+    };
+    const { store, adapter, session, sent, transport } = fixture(undefined, scheduleQueryActivity);
+    adapter.deferResult();
+
+    const running = transport.handleQuery(query(session.sessionId, {
+      requestId: "request-quiet-round",
+    }));
+    await waitUntil(() => adapter.executed.length === 1);
+    sent.splice(0);
+
+    expect(emitActivity).toBeTypeOf("function");
+    emitActivity?.();
+    expect(sent).toContainEqual(expect.objectContaining({
+      type: "turn_activity",
+      phase: "running",
+      protocolVersion: 2,
+      requestId: "request-quiet-round",
+      clientId: "client-1",
+      sessionId: session.sessionId,
+    }));
+
+    adapter.resolveDeferred({ terminalStatus: "succeeded", text: "finished after a quiet round" });
+    await running;
+    expect(leaseStops).toBe(1);
+
+    const terminalMessageCount = sent.length;
+    emitActivity?.();
+    expect(sent).toHaveLength(terminalMessageCount);
+    store.close();
+  });
+
   it("accepts the reasoningEffort wire field and threads it into run metadata", async () => {
     const { store, session, transport } = fixture();
     await transport.handleQuery(query(session.sessionId, {

--- a/desktop/macos/changelog/unreleased/20260825-chat-quiet-turn-watchdog.json
+++ b/desktop/macos/changelog/unreleased/20260825-chat-quiet-turn-watchdog.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed longer Assistant replies being cancelled when the agent was still working through a quiet step."
+}

--- a/desktop/macos/e2e/SKILL.md
+++ b/desktop/macos/e2e/SKILL.md
@@ -184,11 +184,11 @@ the read-only `defaults read` in `auth-06`.
 The HTTP fault harness (§2c) can't stall the **agent** stream — that's a node/stdio
 bridge, not HTTP. Two non-prod bridge actions freeze it so the chat stall path can be
 exercised end-to-end (CHAT-02): a slow/stalled annotation at 8s/20s (`StallDetector`),
-and ChatProvider's **180s send watchdog** which force-releases `isSending` and surfaces
+and ChatProvider's **60s send watchdog** which force-releases `isSending` and surfaces
 "Response took too long. Try again." (recoverable — the next send works).
 
 - `suspend_agent_stream` — SIGSTOP the agent process so it emits no events; `durationMs`
-  (default `190000`, just past the 180s watchdog; capped at `300000`) auto-resumes it, so
+  (default `70000`, just past the 60s watchdog; capped at `300000`) auto-resumes it, so
   a forgotten resume can never wedge the agent.
 - `resume_agent_stream` — SIGCONT immediately (early clear).
 
@@ -199,10 +199,10 @@ cd desktop/macos
 # 1. start a chat turn so a send is in flight
 ./scripts/omi-ctl action ask query="write a long detailed answer" &
 sleep 2
-# 2. freeze the agent stream past the 180s watchdog
-./scripts/omi-ctl action suspend_agent_stream durationMs=190000
-# 3. within <=180s the send watchdog fires: assert the error + that sending is released
-sleep 185
+# 2. freeze the agent stream past the 60s watchdog
+./scripts/omi-ctl action suspend_agent_stream durationMs=70000
+# 3. within <=60s the send watchdog fires: assert the error + that sending is released
+sleep 65
 ./scripts/omi-ctl action main_chat_snapshot | python3 -c 'import json,sys; d=json.load(sys.stdin)["result"]; print("error:", d.get("has_error"), d.get("error_message")); print("is_sending:", d.get("is_sending"))'
 #   expect has_error=true / "Response took too long…" and is_sending=false (recoverable)
 # 4. resume + prove recovery with a fresh turn

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -57,6 +57,7 @@ covers:
   - desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeBridgeLifecycle.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeJournalContracts.swift
+  - desktop/macos/Desktop/Sources/Chat/AgentRuntimeMessageKind.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeBridgeLifecycle.swift
 preconditions:


### PR DESCRIPTION
## What changed and why

Closes #11458.

Desktop chat treated 60 seconds without a rendered bridge event as proof that the agent runtime was frozen. A healthy provider/model round can remain quiet for longer than that, so the watchdog interrupted an admitted turn before its first content event and the turn disappeared with `partial_response=false`.

The Node runtime now emits a correlated, content-free `turn_activity` lease every 15 seconds while it owns an active query. Swift routes that lease through the owner-authorized request callback and refreshes only the bridge-silence detector. The lease is never rendered, never counted as model output, does not reset an active tool's independent 90-second no-progress clock, and is cancelled on terminal cleanup or owner revocation. If Node/JSONL actually freezes, leases stop and the existing 60-second recovery still fires.

The non-production `suspend_agent_stream` hook and E2E recipe were also corrected from the stale 180-second value to a 70-second safety resume around the real 60-second watchdog.

## Product invariants affected

- INV-AGENT-*
- INV-AUTH-1
- INV-CHAT-1

## How it was verified

- `npm test -- --run tests/jsonl-transport.test.ts` — 24/24 passed, including an admitted quiet query, correlated lease emission, terminal cancellation, and a rejected late tick.
- `npm run build` — the JSONL protocol/runtime TypeScript built successfully.
- `xcrun swift test --package-path desktop/macos/Desktop --filter 'StallDetectorTests|ChatStallWatchdogTests|AgentRuntimeProcessTests'` — 99/99 passed.
- `desktop/macos/scripts/agent-logic-harness.sh` — authoritative lifecycle/state, runtime, and pi-mono package lanes passed.
- Changed-file `swift-format` lint, desktop test-quality guard, runtime-convergence ratchet, and `git diff --check` passed.
- `OMI_APP_NAME=omi-11458-watchdog OMI_AUTOMATION_PORT=47858 ./run.sh --yolo` built, signed, installed, launched, and returned healthy automation identity for isolated bundle `com.omi.omi-11458-watchdog`.

The isolated bundle had no reusable Omi Dev auth token and launched signed out, so I could not honestly claim a cloud-backed live chat turn. The quiet-runtime and frozen-runtime distinction is exercised deterministically at the production JSONL and Swift watchdog seams; no physical device is involved in this macOS-only fix.

## Tests

- `JsonlTransport` behaviorally proves a live query emits a content-free correlated lease and stops it at terminal cleanup.
- `StallDetectorTests` proves repeated leases keep a healthy quiet turn alive beyond 60 seconds, then proves the watchdog becomes eligible exactly 60 seconds after the final lease.
- `AgentRuntimeProcessTests` proves the wire event preserves request correlation and carries no content.
- `ChatStallWatchdogTests` guards the production callback wiring from the runtime lease into the detector.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative (only when needed)

Registers `FC-output-silence-misclassified-as-runtime-death`.

Violated contract: absence of assistant content is not proof that the query-owning runtime is dead; a watchdog may terminate a turn only after the runtime itself stops proving progress.

Canonical guard: the authoritative query registration owns a bounded, typed activity lease; consumers refresh liveness only from that correlated lease, and regression coverage proves both halves of the boundary — a quiet responsive runtime stays alive, while a stopped lease still reaches the existing watchdog.

## Line-count exceptions

Line-Count-Exception: desktop/macos/Desktop/Sources/Chat/AgentBridge.swift | 2214 -> 2224 | The owner-authorized query boundary must accept, guard, and forward the typed activity callback through both normal and auth-retry attempts; extracting those lifecycle-local lines would split authorization from delivery.

Line-Count-Exception: desktop/macos/Desktop/Sources/Providers/ChatProvider.swift | 6858 -> 6869 | The activity callback must share the active turn's callback queue, stall detector, message identity, and transition application; moving it out would separate generation-scoped state from the send lifecycle.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

