### PR TITLE
fix(testing): let the Phase 0A storage fake take the kwargs the real Blob takes

### DIFF
--- a/backend/testing/replay_harness_phase0a/apps.py
+++ b/backend/testing/replay_harness_phase0a/apps.py
@@ -61,18 +61,18 @@ class _LocalBlob:
         self.name = name
         self._path = bucket._root / name
 
-    def upload_from_filename(self, filename: str) -> None:
+    def upload_from_filename(self, filename: str, *_args: Any, **_kwargs: Any) -> None:
         import shutil
 
         self._path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(filename, self._path)
 
-    def upload_from_string(self, data: str | bytes) -> None:
+    def upload_from_string(self, data: str | bytes, *_args: Any, **_kwargs: Any) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
         raw = data.encode() if isinstance(data, str) else data
         self._path.write_bytes(raw)
 
-    def download_to_filename(self, filename: str) -> None:
+    def download_to_filename(self, filename: str, *_args: Any, **_kwargs: Any) -> None:
         import shutil
 
         shutil.copy2(self._path, filename)


### PR DESCRIPTION
## What changed and why

`_LocalBlob` in the Phase 0A replay harness accepts only the positional argument on
`upload_from_filename`, `upload_from_string` and `download_to_filename`. The real
`google.cloud.storage.Blob` it stands in for accepts more — `content_type` among them — so a caller
that passes one dies inside the harness with a bare `TypeError`, surfacing three layers away as an
HTTP 503 from the sync router with nothing pointing at the fake:

```
ERROR routers.sync: event=sync_dispatch outcome=staging_failed lane=fresh exception_type=TypeError
POST /v2/sync-local-files ... 503 Service Unavailable
{"code":"sync_dispatch_unavailable","detail":"Sync dispatch is temporarily unavailable; ..."}
FEASIBILITY OUTCOME: BLOCKED
```

The file's own comment (line 48) calls itself a *"copy of sync_cloud_tasks_stack pattern, not
import"*. That original — `backend/testing/sync_cloud_tasks_stack/storage.py`, backing the
**blocking** gauntlet — already tolerates `*_args, **_kwargs` on all three methods. The copy dropped
it. This restores it, and nothing else: three signatures, no behaviour change.

Closes #12186.

## Product invariants affected

none

## How it was verified

The defect is latent on `main` today — `upload_syncing_temporal_file` calls the blob with no keyword —
so "revert the fix and watch a test go red" would prove nothing. Verified the other way, by adding a
caller that uses the real API (`content_type='application/octet-stream'`) and running the harness:

| worktree state | `npm run test:replay-harness-phase0a:emulator` |
|---|---|
| `main` + that caller, fake **unfixed** | `FEASIBILITY OUTCOME: BLOCKED` (base, mutant-unguarded, mutant-guarded) |
| `main` + that caller, fake fixed | `FEASIBILITY OUTCOME: GREEN/BOUNDED` |
| this branch as it ships (caller reverted, fix only) | `FEASIBILITY OUTCOME: GREEN/BOUNDED` |

So the change is load-bearing for any caller that uses the documented API, and inert for `main` as it
stands. Ran against the real Firestore emulator and a real `redis-server`, the same way the CI job
does; the probe caller was reverted before committing and is not part of the diff.

`python3 .github/scripts/run_checks.py --base upstream/main --head HEAD --lane ci` passes.

## Tests

No test change. The fake lives in `backend/testing/replay_harness_phase0a/apps.py`, which installs the
egress guard and rebinds `google.auth` at import time — importing it from a unit test would pollute
`sys.modules`, which `tests/unit/test_sys_modules_hermeticity.py` exists to prevent. The behavioural
coverage is the harness run itself, shown above. Happy to add a test if you would rather the fake were
extracted into an importable module, but that seemed like more surface than this fix warrants.

## Failure class (fixes)

Failure-Class: none

<!-- Considered FC-mirrored-model-omits-new-member, which is the closest: a hand-written mirror of a
     source of truth restating membership by hand. It does not fit — its contract turns on the member
     being "dropped in silence: no decode error, no unhandled case, no failing test", and this failure
     is loud, only misattributed. Declaring it would dilute a class whose whole value is that silence. -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

