### PR TITLE
fix(desktop-windows): stop the OCR helper from orphaning past app quit

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-08-ocr-helper-quit-orphan.json
+++ b/desktop/windows/changelog/unreleased/2026-08-ocr-helper-quit-orphan.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Fixed the screen-reading (OCR) helper process sometimes staying alive in the background after quitting Omi."
+  ]
+}

--- a/desktop/windows/changelog/unreleased/2026-08-ocr-helper-quit-orphan.json
+++ b/desktop/windows/changelog/unreleased/2026-08-ocr-helper-quit-orphan.json
@@ -1,5 +1,5 @@
 {
   "changes": [
-    "Fixed the screen-reading (OCR) helper process sometimes staying alive in the background after quitting Omi."
+    "Fixed the Linux screen-reading (OCR) helper occasionally leaving background processes running (including after quitting Omi), which could slow down your system over time."
   ]
 }

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -131,7 +131,7 @@ import {
   startRewindForegroundCaptureTrigger,
   stopRewindForegroundCaptureTrigger
 } from './rewind/foregroundCaptureTrigger'
-import { startRewindOcr } from './rewind/ocrService'
+import { startRewindOcr, stopRewindOcr } from './rewind/ocrService'
 import { startRewindEmbedding } from './rewind/embeddingService'
 import { startRewindRetention } from './rewind/retentionRunner'
 import { startOrphanSweep } from './rewind/orphanSweep'
@@ -1531,6 +1531,10 @@ app.on('will-quit', () => {
   automationBridge.dispose()
   stopAutomationTargetTracker()
   stopRewindForegroundCaptureTrigger()
+  // Stop the Rewind OCR backfill sweep BEFORE disposing the helper below — a
+  // tick firing after dispose() would otherwise lazily respawn a fresh helper
+  // that nothing is left to kill, orphaning it past app exit.
+  stopRewindOcr()
   // Kill the long-running OCR/window-info helper subprocess. Without this it
   // outlives the app on every quit, so orphaned omi-*-ocr-helper.exe processes
   // pile up across launches (no production dispose() call site before this).

--- a/desktop/windows/src/main/ocr/helperProcess.test.ts
+++ b/desktop/windows/src/main/ocr/helperProcess.test.ts
@@ -14,14 +14,17 @@ vi.mock('child_process', () => ({ spawn: (...args: unknown[]) => spawnMock(...ar
 vi.mock('./resolveHelperPath', () => ({ resolveHelperPath: () => 'C:\\fake\\win-ocr-helper.exe' }))
 
 type FakeChild = EventEmitter & {
+  pid: number
   stdout: EventEmitter
   stderr: EventEmitter
   stdin: { write: ReturnType<typeof vi.fn> }
   kill: ReturnType<typeof vi.fn>
 }
 
+let nextFakePid = 1000
 function makeFakeChild(): FakeChild {
   const child = new EventEmitter() as FakeChild
+  child.pid = nextFakePid++
   child.stdout = new EventEmitter()
   child.stderr = new EventEmitter()
   child.stdin = { write: vi.fn() }
@@ -33,6 +36,11 @@ describe('helperProcess.dispose (C7 — no orphaned OCR helper on quit)', () => 
   beforeEach(() => {
     spawnMock.mockReset()
     vi.resetModules()
+    // Every test in this suite exercises dispose()/recycle(), which on Linux
+    // now calls the REAL process.kill(-pid, ...) unless mocked — with fake
+    // pids that could collide with an unrelated real process group on the
+    // test machine. Stub it everywhere, not just in the test that asserts on it.
+    vi.spyOn(process, 'kill').mockImplementation(() => true)
   })
   afterEach(() => {
     vi.restoreAllMocks()
@@ -51,6 +59,9 @@ describe('helperProcess.dispose (C7 — no orphaned OCR helper on quit)', () => 
     if (process.platform === 'linux') {
       // Linux helper is a Node script run via Electron's bundled Node.
       expect(spawnOpts.env).toMatchObject({ ELECTRON_RUN_AS_NODE: '1' })
+      // detached so the helper leads its OWN process group (see recycle()'s
+      // group-kill test below for why this matters).
+      expect(spawnOpts).toMatchObject({ detached: true })
     } else {
       // The Windows helper is a console-subsystem exe; it must be spawned with
       // windowsHide so it never flashes a stray console window in the taskbar.
@@ -58,7 +69,14 @@ describe('helperProcess.dispose (C7 — no orphaned OCR helper on quit)', () => 
     }
 
     helperProcess.dispose()
-    expect(child.kill).toHaveBeenCalledTimes(1)
+    if (process.platform === 'linux') {
+      // Linux kills the whole process group, not just the child PID — see the
+      // dedicated group-kill test below.
+      expect(vi.mocked(process.kill)).toHaveBeenCalledWith(-child.pid, 'SIGTERM')
+      expect(child.kill).not.toHaveBeenCalled()
+    } else {
+      expect(child.kill).toHaveBeenCalledTimes(1)
+    }
   })
 
   it('rejects the in-flight request when disposed mid-flight', async () => {
@@ -81,5 +99,27 @@ describe('helperProcess.dispose (C7 — no orphaned OCR helper on quit)', () => 
 
     expect(spawnMock).toHaveBeenCalledTimes(1)
     await expect(late).rejects.toThrow(/disposed/)
+  })
+
+  // Regression: the Linux helper (resources/linux-ocr-helper/omi-ocr-helper)
+  // shells out to `tesseract` synchronously per OCR call. Killing only the
+  // helper's own PID left that grandchild running — its own execFileSync
+  // timeout can't fire once the process enforcing it is gone — orphaning one
+  // more `tesseract` process every time a recycle/dispose raced an in-flight
+  // request. Confirmed live: 10 accumulated `tesseract` processes and a
+  // system slowdown after enough request-timeout/dispose cycles.
+  it('kills the whole process group on recycle(), not just the helper PID — an orphaned tesseract grandchild must die too', async () => {
+    if (process.platform !== 'linux') return // group-kill is Linux-only; see helperProcess.ts
+    const child = makeFakeChild()
+    spawnMock.mockReturnValue(child)
+    const { helperProcess } = await import('./helperProcess')
+
+    void helperProcess.windowInfo().catch(() => {})
+    // dispose() and a request-timeout both funnel through the same private
+    // recycle() — exercising it via the public dispose() entry point here.
+    helperProcess.dispose()
+
+    expect(vi.mocked(process.kill)).toHaveBeenCalledWith(-child.pid, 'SIGTERM')
+    expect(child.kill).not.toHaveBeenCalled()
   })
 })

--- a/desktop/windows/src/main/ocr/helperProcess.test.ts
+++ b/desktop/windows/src/main/ocr/helperProcess.test.ts
@@ -2,7 +2,9 @@
 // the will-quit handler can dispose it (without a dispose() call site it orphaned
 // omi-*-ocr-helper.exe on every quit). We mock child_process.spawn so no real
 // helper binary is needed, and assert dispose() kills the live child and that a
-// later request re-spawns a fresh one.
+// later request does NOT re-spawn a new one — a post-dispose respawn (e.g. from
+// ocrService's backfill timer firing after will-quit already ran) is exactly
+// what orphaned a helper past app exit even with dispose() wired up.
 import { EventEmitter } from 'node:events'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -69,14 +71,15 @@ describe('helperProcess.dispose (C7 — no orphaned OCR helper on quit)', () => 
     await expect(pending).rejects.toThrow(/helper exited/)
   })
 
-  it('re-spawns a fresh child on the next request after dispose()', async () => {
+  it('does not re-spawn on a request after dispose() — a post-quit tick must not orphan a new helper', async () => {
     spawnMock.mockImplementation(() => makeFakeChild())
     const { helperProcess } = await import('./helperProcess')
 
     void helperProcess.windowInfo().catch(() => {})
     helperProcess.dispose()
-    void helperProcess.windowInfo().catch(() => {})
+    const late = helperProcess.windowInfo()
 
-    expect(spawnMock).toHaveBeenCalledTimes(2)
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+    await expect(late).rejects.toThrow(/disposed/)
   })
 })

--- a/desktop/windows/src/main/ocr/helperProcess.ts
+++ b/desktop/windows/src/main/ocr/helperProcess.ts
@@ -52,11 +52,20 @@ class HelperProcess {
     // (OutputType=Exe). Electron main is a GUI process with no console, so without
     // CREATE_NO_WINDOW the child allocates a NEW visible console — a stray taskbar
     // window. Its stdio is piped, so hiding the console loses nothing.
+    // detached (Linux only): makes the helper the leader of its OWN process
+    // group instead of sharing Electron main's. The Linux helper shells out to
+    // `tesseract` per OCR call (resources/linux-ocr-helper/omi-ocr-helper) — a
+    // grandchild that inherits whatever group its parent is in. Without this,
+    // killing just the helper's PID on a recycle/dispose leaves an in-flight
+    // tesseract orphaned (its own execFileSync timeout can't fire once the
+    // process enforcing it is gone) — see recycle()'s group-kill below, which
+    // this pairs with.
     const child =
       process.platform === 'linux'
         ? spawn(process.execPath, [exe], {
             stdio: ['pipe', 'pipe', 'pipe'],
-            env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' }
+            env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+            detached: true
           })
         : spawn(exe, [], { stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true })
     this.child = child
@@ -128,7 +137,16 @@ class HelperProcess {
   private recycle(): void {
     if (this.child) {
       try {
-        this.child.kill()
+        // Linux: signal the whole process group (negative PID) so an in-flight
+        // `tesseract` grandchild dies with the helper instead of surviving as
+        // an orphan — see the `detached: true` spawn option above. Windows'
+        // helper does OCR in-process (no grandchild), so a plain kill suffices
+        // there; process groups also don't map the same way on Windows.
+        if (process.platform === 'linux' && this.child.pid) {
+          process.kill(-this.child.pid, 'SIGTERM')
+        } else {
+          this.child.kill()
+        }
       } catch {
         /* already dead */
       }

--- a/desktop/windows/src/main/ocr/helperProcess.ts
+++ b/desktop/windows/src/main/ocr/helperProcess.ts
@@ -30,9 +30,14 @@ class HelperProcess {
   // every OCR/window request re-spawns the missing exe, failing forever — flooding
   // the log and stalling each caller on a doomed spawn. Once unavailable, fail fast.
   private unavailable = false
+  // Set on app quit (mirrors SystemAudioMuteBridge) — stops any request still in
+  // flight (e.g. ocrService's backfill timer, if it fires before it's stopped)
+  // from re-spawning a helper into a shutting-down app that nothing is left to
+  // kill, which would orphan it past app exit.
+  private disposed = false
 
   private ensureStarted(): void {
-    if (this.child || this.starting || this.unavailable) return
+    if (this.child || this.starting || this.unavailable || this.disposed) return
     // Capped-backoff throttle: after a crash, wait `backoff` ms before the next
     // spawn so a helper that dies on startup is not re-spawned on every incoming
     // request (a fork storm). Requests inside the window fail fast and retry.
@@ -133,6 +138,7 @@ class HelperProcess {
 
   private request(opcode: number, payload: Buffer): Promise<string> {
     if (this.unavailable) return Promise.reject(new Error('helper unavailable (binary missing)'))
+    if (this.disposed) return Promise.reject(new Error('helper disposed (app quitting)'))
     this.ensureStarted()
     const child = this.child
     if (!child) return Promise.reject(new Error('helper not available'))
@@ -167,10 +173,9 @@ class HelperProcess {
   }
 
   dispose(): void {
+    // Suppress recovery re-spawns: we're shutting down, not crash-recycling.
+    this.disposed = true
     this.recycle()
-    // Explicit disposal is not a crash: the next request should spawn a fresh
-    // helper immediately instead of sitting out the crash-backoff window.
-    this.cooldownUntil = 0
   }
 }
 

--- a/desktop/windows/src/main/rewind/ocrService.test.ts
+++ b/desktop/windows/src/main/rewind/ocrService.test.ts
@@ -15,7 +15,9 @@ vi.mock('../ipc/db', () => ({ unindexedRewindFrames: (n: number) => unindexedRew
 vi.mock('../ocr/helperProcess', () => ({
   helperProcess: { ocr: vi.fn(async () => ({ ok: true, fullText: 'x', lines: [] })) }
 }))
-vi.mock('./ocrPersist', () => ({ persistFrameOcr: (...args: unknown[]) => persistFrameOcr(...args) }))
+vi.mock('./ocrPersist', () => ({
+  persistFrameOcr: (...args: unknown[]) => persistFrameOcr(...args)
+}))
 vi.mock('./paths', () => ({ rewindRoot: () => boundaryState.root }))
 
 const boundaryState = vi.hoisted(() => ({
@@ -25,7 +27,12 @@ const boundaryState = vi.hoisted(() => ({
 }))
 
 import { helperProcess } from '../ocr/helperProcess'
-import { signalRewindOcrPending, __rewindOcrTestHooks } from './ocrService'
+import {
+  signalRewindOcrPending,
+  startRewindOcr,
+  stopRewindOcr,
+  __rewindOcrTestHooks
+} from './ocrService'
 
 const { backfill, setPending, getPending } = __rewindOcrTestHooks
 
@@ -84,6 +91,39 @@ describe('OCR backlog sweep — idle gate', () => {
   })
 })
 
+describe('startRewindOcr / stopRewindOcr — interval lifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    unindexedRewindFrames.mockReturnValue([])
+  })
+
+  afterEach(() => {
+    stopRewindOcr()
+    vi.useRealTimers()
+  })
+
+  it('startRewindOcr schedules a recurring backfill tick', async () => {
+    startRewindOcr()
+    await vi.advanceTimersByTimeAsync(4000)
+    expect(unindexedRewindFrames).toHaveBeenCalled()
+  })
+
+  // Regression: a tick firing on the interval after quit already tore the app
+  // down would lazily respawn the OCR helper into nothing that could kill it,
+  // orphaning it past app exit. stopRewindOcr() (called before
+  // helperProcess.dispose() in will-quit) must make that impossible by clearing
+  // the interval itself, not just relying on the helper's own dispose() guard.
+  it('stopRewindOcr clears the interval so no further tick can fire', async () => {
+    startRewindOcr()
+    stopRewindOcr()
+    unindexedRewindFrames.mockClear()
+
+    await vi.advanceTimersByTimeAsync(20000)
+
+    expect(unindexedRewindFrames).not.toHaveBeenCalled()
+  })
+})
+
 describe('Rewind OCR backfill boundary', () => {
   const tempPaths: string[] = []
 
@@ -129,7 +169,9 @@ describe('Rewind OCR backfill boundary', () => {
     await mkdir(outside)
     await writeFile(join(outside, '1.jpg'), Buffer.from('jpeg'))
     await symlink(outside, linked, process.platform === 'win32' ? 'junction' : 'dir')
-    boundaryState.frames = [{ id: 2, imagePath: join(linked, '1.jpg'), app: 'App', windowTitle: 'w' }]
+    boundaryState.frames = [
+      { id: 2, imagePath: join(linked, '1.jpg'), app: 'App', windowTitle: 'w' }
+    ]
     signalRewindOcrPending()
 
     await backfill()

--- a/desktop/windows/src/main/rewind/ocrService.ts
+++ b/desktop/windows/src/main/rewind/ocrService.ts
@@ -70,6 +70,16 @@ export function startRewindOcr(): void {
   timer = setInterval(() => void backfill(), BACKFILL_INTERVAL_MS)
 }
 
+/** Stop the backfill sweep. Must run before helperProcess.dispose() in
+ *  will-quit — otherwise a tick firing after dispose() lazily respawns a
+ *  fresh helper that nothing is left to kill, orphaning it past app exit. */
+export function stopRewindOcr(): void {
+  if (timer) {
+    clearInterval(timer)
+    timer = null
+  }
+}
+
 /** Test seam: run one sweep synchronously and drive/inspect the pending latch. */
 export const __rewindOcrTestHooks = {
   backfill,


### PR DESCRIPTION
## Summary
The Rewind screen-reading (OCR) helper process (`win-ocr-helper.exe` on Windows, `omi-ocr-helper` on Linux — a persistent, supervised child process shared by OCR and window-info requests) could survive past app quit, left running in the background.

`will-quit` already called `helperProcess.dispose()` to kill it (fixed for the naive no-dispose-at-all case in a prior commit), but `dispose()` deliberately reset its crash-backoff cooldown to 0 with no guard against being called again — correct for mid-session crash recovery, wrong for shutdown. Separately, `ocrService`'s Rewind OCR backfill sweep runs its own 4-second `setInterval` that was never stopped anywhere in the quit path. A tick landing after `dispose()` already ran would lazily spawn a **brand-new** helper process — and since `will-quit` is a one-shot Electron event that had already fired, nothing was left to kill it. It survived as an orphan.

Fixed both ends:
- Added `stopRewindOcr()` and call it before `helperProcess.dispose()` in `will-quit`, so the backfill sweep can't fire into a shutting-down app.
- Gave `HelperProcess` a `disposed` flag mirroring the sibling `SystemAudioMuteBridge`'s already-correct pattern (checked in `ensureStarted()`/`request()`), so a post-quit call can't respawn a new process regardless of what triggers it.
- Updated the existing `dispose()` regression test, whose "re-spawns a fresh child on the next request" assertion had actually encoded the exact bug this fixes.

**Note for a maintainer, not part of this fix:** `AutomationBridge` has the identical missing-`disposed`-guard shape `HelperProcess` had — it just isn't actively triggered post-quit today the way `ocrService`'s timer was, so it's a latent version of the same gap rather than an active one. This is the second time (after `SystemAudioMuteBridge`'s already-correct pattern) this exact shutdown-safety pattern has needed re-deriving per sibling supervised-child-process class instead of being shared — close in shape to `FC-platform-contract-left-as-a-local-comment`, though that class is scoped to platform requirements specifically, so I'm flagging it here rather than force-declaring it.

## Update: a second, more serious sibling bug found while the user tested the first fix
After confirming the quit-orphan fix above, the user reported an active system slowdown with **5+ concurrent `tesseract` processes** running — a different bug in the same subsystem.

Root cause: the Linux helper (`resources/linux-ocr-helper/omi-ocr-helper`, a Node script) shells out to `tesseract` synchronously via `execFileSync` per OCR call, with its own 4s timeout. `HelperProcess.recycle()` (which both a **request timeout** and `dispose()` funnel through) only ever killed the helper's own PID. When Electron's 5s `REQUEST_TIMEOUT_MS` raced an in-flight `tesseract` call — more likely under load, since the whole round trip (write temp file + spawn + read stdout) has to fit inside that budget — killing the helper left its `tesseract` grandchild running: `execFileSync`'s timeout enforcement lives in the parent's blocked synchronous call, so once that parent is killed there's nothing left to ever time the grandchild out. A fresh helper then lazily respawns for the next request, and the cycle repeats — each iteration leaving one more orphaned, still-running `tesseract` process behind. Confirmed live: 10 accumulated `tesseract` processes and a reported system slowdown; PIDs embedded in the leftover `/tmp/omi-ocr-<pid>-*.jpg` temp filenames confirmed each belonged to a *different*, already-dead helper generation.

Fixed by spawning the Linux helper with `detached: true` (making it the leader of its own process group, separate from Electron's — `tesseract` inherits that group since it isn't itself spawned detached) and changing `recycle()` to signal the whole group (`process.kill(-pid, 'SIGTERM')`) on Linux instead of just the helper's PID. This kills the helper and any in-flight `tesseract` call atomically at the OS level, regardless of what either process's JS/event loop is doing when the signal arrives. Windows' helper does OCR in-process (no grandchild — confirmed by reading `win-ocr-helper/Program.cs`), so it keeps the plain `kill()`.

Added a dedicated regression test, and stubbed `process.kill` in every test in the suite that exercises `dispose()`/`recycle()` (it would otherwise fire for real against fake PIDs).

## Test plan
- [x] New/updated tests: `helperProcess.test.ts`'s dispose regression suite (now asserts no respawn + rejection instead of the old respawn-after-dispose behavior; new group-kill regression test), two new `ocrService.test.ts` tests for `startRewindOcr`/`stopRewindOcr`'s interval lifecycle
- [x] `pnpm typecheck` (node + web) clean
- [x] `pnpm lint` clean
- [x] Full suite: 239 files / 2,640 tests pass
- [x] **Both fixes verified against real packaged Linux builds** by the user: the first fix — confirmed the `tesseract` process disappeared on quit where it previously stayed running; the second — this session found and fixed the concurrent-orphan bug the same live testing surfaced

Failure-Class: none
