### PR TITLE
fix(app): do not prompt location on HomePage open

### DIFF
--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -1685,7 +1685,9 @@ class CaptureController extends ChangeNotifier
     // Product: recording is the tap; location is metadata. Do not block
     // device connect/start on the OS location dialog. Location still PATCHes
     // when the grant/fix lands; a short conversation can miss coords.
-    unawaited(_conversationLocationCapture.captureAndUpload());
+    // HomePage calls this with device == null on every entry — check-only so
+    // a fresh install cannot hit deniedForever before the user records.
+    unawaited(_conversationLocationCapture.captureAndUpload(promptIfDenied: device != null));
 
     await _resetStateVariables();
     await _resetState();

--- a/app/lib/services/capture/conversation_location_capture.dart
+++ b/app/lib/services/capture/conversation_location_capture.dart
@@ -75,7 +75,11 @@ class ConversationLocationCapture {
     return !age.isNegative && age <= lastKnownMaxAge;
   }
 
-  Future<bool> captureAndUpload() async {
+  /// [promptIfDenied] is true on record/device start so a skipped onboarding
+  /// page still gets a while-in-use prompt. HomePage's no-device check-only
+  /// path passes false so plain home-page entry cannot walk the user into
+  /// deniedForever. deniedForever is never re-prompted either way.
+  Future<bool> captureAndUpload({bool promptIfDenied = true}) async {
     var timedOut = false;
     try {
       if (!await _isLocationServiceEnabled()) {
@@ -86,6 +90,10 @@ class ConversationLocationCapture {
       var permission = await _checkPermission();
       var newlyGranted = false;
       if (permission == LocationPermission.denied) {
+        if (!promptIfDenied) {
+          Logger.log('Location permission not granted, skipping conversation location');
+          return false;
+        }
         // Prompt at record start so a skipped onboarding page still gets a fix
         // when the activity is visible. deniedForever is not re-prompted.
         permission = await _requestPermission();

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -152,10 +152,12 @@ class _CountingSocketCaptureProvider extends CaptureProvider {
 
 class _CountingConversationLocationCapture extends ConversationLocationCapture {
   int calls = 0;
+  final List<bool> promptIfDeniedArgs = [];
 
   @override
-  Future<bool> captureAndUpload() async {
+  Future<bool> captureAndUpload({bool promptIfDenied = true}) async {
     calls++;
+    promptIfDeniedArgs.add(promptIfDenied);
     return true;
   }
 }
@@ -165,7 +167,7 @@ class _HangingConversationLocationCapture extends ConversationLocationCapture {
   final Completer<bool> _done = Completer<bool>();
 
   @override
-  Future<bool> captureAndUpload() async {
+  Future<bool> captureAndUpload({bool promptIfDenied = true}) async {
     calls++;
     return _done.future;
   }
@@ -279,6 +281,18 @@ void main() {
         );
     expect(locationCapture.calls, 1);
     locationCapture.complete();
+    provider.dispose();
+  });
+
+  test('homepage no-device streamDeviceRecording is check-only', () async {
+    final locationCapture = _CountingConversationLocationCapture();
+    final provider = CaptureProvider(
+      conversationLocationCapture: locationCapture,
+    );
+
+    await provider.streamDeviceRecording();
+    expect(locationCapture.calls, 1);
+    expect(locationCapture.promptIfDeniedArgs, [false]);
     provider.dispose();
   });
 

--- a/app/test/unit/conversation_location_capture_test.dart
+++ b/app/test/unit/conversation_location_capture_test.dart
@@ -50,6 +50,53 @@ void main() {
     expect(currentCalls, 0);
   });
 
+  test('homepage check-only path does not request permission when denied', () async {
+    var requests = 0;
+    var uploads = 0;
+    final capture = ConversationLocationCapture(
+      isLocationServiceEnabled: () async => true,
+      checkPermission: () async => LocationPermission.denied,
+      requestPermission: () async {
+        requests++;
+        return LocationPermission.whileInUse;
+      },
+      getCurrentPosition: () async => _position(latitude: 1, longitude: 2),
+      getLastKnownPosition: () async => null,
+      upload: (_) async {
+        uploads++;
+        return true;
+      },
+    );
+
+    expect(await capture.captureAndUpload(promptIfDenied: false), isFalse);
+    expect(requests, 0);
+    expect(uploads, 0);
+  });
+
+  test('homepage check-only path still uploads when permission is already granted', () async {
+    var requests = 0;
+    Geolocation? uploaded;
+    final capture = ConversationLocationCapture(
+      isLocationServiceEnabled: () async => true,
+      checkPermission: () async => LocationPermission.whileInUse,
+      requestPermission: () async {
+        requests++;
+        return LocationPermission.whileInUse;
+      },
+      getCurrentPosition: () async => _position(latitude: 35.6895, longitude: 139.6917),
+      getLastKnownPosition: () async => null,
+      upload: (geolocation) async {
+        uploaded = geolocation;
+        return true;
+      },
+    );
+
+    expect(await capture.captureAndUpload(promptIfDenied: false), isTrue);
+    expect(requests, 0);
+    expect(uploaded?.latitude, 35.6895);
+    expect(uploaded?.longitude, 139.6917);
+  });
+
   test('does not upload without location permission', () async {
     var uploads = 0;
     var requests = 0;
@@ -76,6 +123,29 @@ void main() {
     expect(uploads, 0);
     expect(requests, 0);
     expect(grants, 0);
+  });
+
+  test('deniedForever never prompts on the homepage check-only path', () async {
+    var requests = 0;
+    var uploads = 0;
+    final capture = ConversationLocationCapture(
+      isLocationServiceEnabled: () async => true,
+      checkPermission: () async => LocationPermission.deniedForever,
+      requestPermission: () async {
+        requests++;
+        return LocationPermission.deniedForever;
+      },
+      getCurrentPosition: () async => _position(latitude: 1, longitude: 2),
+      getLastKnownPosition: () async => null,
+      upload: (_) async {
+        uploads++;
+        return true;
+      },
+    );
+
+    expect(await capture.captureAndUpload(promptIfDenied: false), isFalse);
+    expect(requests, 0);
+    expect(uploads, 0);
   });
 
   test('requests while-in-use at record start when permission is denied', () async {


### PR DESCRIPTION
Follow-up to #12179 / Git-on-my-level 5411651527.

HomePage `streamDeviceRecording(device==null)` was still prompting for location when permission was denied. A fresh-install deny-twice could lock the user in `deniedForever`.

Now the no-device / HomePage path is check-only (`promptIfDenied: false`). Record and device start still prompt when denied.

Failure-Class: none

## Test plan
- [x] 13 location unit tests (`flutter test test/unit/conversation_location_capture_test.dart`)
- [ ] Deny location on homepage does not request permission

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only gating of location prompts on home entry; record/device flows keep existing prompt behavior and fail-open skip when denied.
> 
> **Overview**
> **HomePage entry no longer shows the OS location permission dialog** when permission is still denied. Opening home via `streamDeviceRecording(device == null)` now calls conversation location capture in **check-only** mode (`promptIfDenied: false`).
> 
> `ConversationLocationCapture.captureAndUpload` accepts **`promptIfDenied`** (default **true**). If permission is `denied` and prompting is off, it skips `requestPermission` and returns without uploading. **Recording and device connect** still pass `promptIfDenied: true` so users who skipped onboarding location can be prompted at record start. **`deniedForever`** is never re-prompted on either path.
> 
> Unit and provider tests cover the homepage path, granted-permission uploads without prompts, and `deniedForever` on check-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa7bce6598bcd7496f0acb874312660cd57dc20f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->