### PR TITLE
test(desktop): isolate Rewind owner snapshot authority

### DIFF
--- a/desktop/macos/Desktop/Tests/RewindCaptureExclusionGenerationTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindCaptureExclusionGenerationTests.swift
@@ -191,21 +191,31 @@ final class RewindCaptureExclusionGenerationTests: XCTestCase {
   /// #11572: launch / CI window where `auth_userId` is set but RewindDatabase
   /// has not resolved `currentUserId` yet. Capture preferred auth; isCurrent
   /// used to compare only the DB id and permanently fail-closed.
-  func testOwnerSnapshotStaysCurrentWhenAuthLeadsUnresolvedRewindDatabase() {
-    let defaults = UserDefaults.standard
-    let previousAuth = defaults.object(forKey: .authUserId)
+  ///
+  /// #12039: establish the owner through the production transition boundary.
+  /// Mutating `auth_userId` directly makes the process-wide authorization
+  /// authority correctly revoke the out-of-band owner, so this test otherwise
+  /// depends on which owner-bound suite ran before it.
+  @MainActor
+  func testOwnerSnapshotStaysCurrentWhenAuthLeadsUnresolvedRewindDatabase() async {
+    let ownerFixture = RuntimeOwnerAuthorityTestFixture()
+    addTeardownBlock { @MainActor in
+      await ownerFixture.restore()
+    }
     let previousDB = RewindDatabase.currentUserId
     defer {
-      if let previousAuth {
-        defaults.set(previousAuth, forKey: .authUserId)
-      } else {
-        defaults.removeObject(forKey: .authUserId)
-      }
       RewindDatabase.currentUserId = previousDB
     }
 
+    // Reproduce the shared-state signature from #12039: another suite changed
+    // durable auth outside the transition boundary, so the authorization
+    // authority revoked itself before this test started.
+    await ownerFixture.establish(authOwnerID: "prior-owner-\(UUID().uuidString)")
+    UserDefaults.standard.set("out-of-band-owner-\(UUID().uuidString)", forKey: .authUserId)
+    XCTAssertNil(RuntimeOwnerIdentity.captureAuthorizationSnapshot())
+
     let authOwner = "auth-leading-\(UUID().uuidString)"
-    defaults.set(authOwner, forKey: .authUserId)
+    await ownerFixture.establish(authOwnerID: authOwner)
     RewindDatabase.currentUserId = nil
 
     guard let snapshot = RewindCaptureOwnerSnapshot.capture() else {


### PR DESCRIPTION
## What changed and why

Addresses the Rewind/auth occurrence reported in #12039. The regression test changed `auth_userId` directly even though runtime owner authorization is process-wide and deliberately revokes out-of-band owner changes. That made the result depend on which owner-bound suite ran first and produced the observed `anonymous` versus `auth-leading-…` failure.

The test now recreates that revoked-authority state deliberately, then establishes and restores its owner through `RuntimeOwnerAuthorityTestFixture`. This follows the same serialized transition boundary as production and automatically places the suite in the runner's derived owner-isolation cluster.

## Product invariants affected

none

## How it was verified

- `xcrun swift test --package-path desktop/macos/Desktop --filter 'RewindCaptureExclusionGenerationTests'` — 9/9 passed.
- Repeated the exact contamination-recovery regression 50 times with `--skip-build` — 50/50 passed.
- Ran the full 5,769-test macOS Swift process three times. The repaired test passed under real process-order contamination in every run; each full run retained one unrelated baseline failure elsewhere, consistent with #12039's broader multi-suite report.

This is test-harness isolation only; there is no user-facing path or physical-device behavior to exercise.

## Tests

`RewindCaptureExclusionGenerationTests.testOwnerSnapshotStaysCurrentWhenAuthLeadsUnresolvedRewindDatabase` now starts from the exact revoked authority that previously arrived nondeterministically, then proves the auth-leading owner remains current while `RewindDatabase.currentUserId` is unresolved.

## Failure class (fixes)

Failure-Class: FC-hand-listed-test-isolation-membership


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

