### PR TITLE
feat: add Firestore read-volume instrumentation and alerting

### DIFF
--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -10639,7 +10639,7 @@
       "instatus_component": "observability",
       "alert_identity": "omi-firestore-notfound-dod-step",
       "component": "firestore",
-      "impact": "product"
+      "impact": "infrastructure"
     },
     "isPaused": false,
     "notification_settings": {
@@ -10737,7 +10737,7 @@
       "instatus_component": "observability",
       "alert_identity": "omi-firestore-notfound-ceiling",
       "component": "firestore",
-      "impact": "product"
+      "impact": "infrastructure"
     },
     "isPaused": false,
     "notification_settings": {

--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -10548,5 +10548,201 @@
       "receiver": "Omi - Services Alerting (Telegram)"
     },
     "record": null
+  },
+  {
+    "uid": "omi-firestore-notfound-dod-step",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Firestore Cost",
+    "title": "Firestore - NOT_FOUND read volume day-over-day step",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 3600,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[1h])) > 1.5 * sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[1h] offset 24h))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-08-25T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "2h",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "summary": "Firestore document read_count (metric stackdriver_firestore_instance_firestore_googleapis_com_document_read_count, type=\"NOT_FOUND\") is running more than 1.5x its rate from the same hour yesterday, sustained for 2h.",
+      "threshold": "sum(rate(...[1h])) > 1.5x sum(rate(...[1h] offset 24h)), sustained 2h",
+      "user_impact": "No direct user impact; this is a cost signal, not an outage. NOT_FOUND reads are Firestore reads for documents that do not exist, so they are near-pure waste: the read is billed but returns nothing. The day-over-day comparison survives organic growth and diurnal swing, so a sustained step here is a regression.",
+      "scope": "Firestore document reads across the based-hardware production project, type=\"NOT_FOUND\" only.",
+      "verification": "Compare sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[1h])) against the same query with `offset 24h` in the linked query; a ratio holding above 1.5x for the full 2h window is a step, not normal diurnal variation.",
+      "safe_next_action": "This alert flags read volume, not cause. The Cloud Monitoring series carries module=\"__unknown__\", so attribution needs either extending omi_firestore_read_operations_total call-site coverage or enabling a short window of Firestore DATA_READ audit logging to find the caller before making any code change."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "observability",
+      "alert_identity": "omi-firestore-notfound-dod-step",
+      "component": "firestore",
+      "impact": "product"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-firestore-notfound-ceiling",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Firestore Cost",
+    "title": "Firestore - NOT_FOUND read volume above absolute ceiling",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[30m])) > 600",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-08-25T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "2h",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "summary": "Firestore document read_count (metric stackdriver_firestore_instance_firestore_googleapis_com_document_read_count, type=\"NOT_FOUND\") has been sustained above 600 reads/sec for 2h -- above the ~361/sec healthy baseline measured before the 2026-08-23 cost incident, below the ~936/sec the leak reached.",
+      "threshold": "sum(rate(...[30m])) > 600/sec, sustained 2h",
+      "user_impact": "No direct user impact; this is a cost signal, not an outage. NOT_FOUND reads are Firestore reads for documents that do not exist, so they are near-pure waste: the read is billed but returns nothing. This is the backstop for a leak that is already running at a steady elevated rate, which the day-over-day step detector cannot see because both sides of its comparison are equally elevated.",
+      "scope": "Firestore document reads across the based-hardware production project, type=\"NOT_FOUND\" only.",
+      "verification": "Check sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[30m])) in the linked query against the 600/sec threshold; healthy baseline is ~361/sec, the 2026-08-23 incident ran ~936/sec.",
+      "safe_next_action": "This alert flags read volume, not cause. The Cloud Monitoring series carries module=\"__unknown__\", so attribution needs either extending omi_firestore_read_operations_total call-site coverage or enabling a short window of Firestore DATA_READ audit logging to find the caller before making any code change."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "observability",
+      "alert_identity": "omi-firestore-notfound-ceiling",
+      "component": "firestore",
+      "impact": "product"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
   }
 ]

--- a/backend/charts/monitoring/alerts/firestore.json
+++ b/backend/charts/monitoring/alerts/firestore.json
@@ -1,0 +1,198 @@
+[
+  {
+    "uid": "omi-firestore-notfound-dod-step",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Firestore Cost",
+    "title": "Firestore - NOT_FOUND read volume day-over-day step",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 3600,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[1h])) > 1.5 * sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[1h] offset 24h))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-08-25T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "2h",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "summary": "Firestore document read_count (metric stackdriver_firestore_instance_firestore_googleapis_com_document_read_count, type=\"NOT_FOUND\") is running more than 1.5x its rate from the same hour yesterday, sustained for 2h.",
+      "threshold": "sum(rate(...[1h])) > 1.5x sum(rate(...[1h] offset 24h)), sustained 2h",
+      "user_impact": "No direct user impact; this is a cost signal, not an outage. NOT_FOUND reads are Firestore reads for documents that do not exist, so they are near-pure waste: the read is billed but returns nothing. The day-over-day comparison survives organic growth and diurnal swing, so a sustained step here is a regression.",
+      "scope": "Firestore document reads across the based-hardware production project, type=\"NOT_FOUND\" only.",
+      "verification": "Compare sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[1h])) against the same query with `offset 24h` in the linked query; a ratio holding above 1.5x for the full 2h window is a step, not normal diurnal variation.",
+      "safe_next_action": "This alert flags read volume, not cause. The Cloud Monitoring series carries module=\"__unknown__\", so attribution needs either extending omi_firestore_read_operations_total call-site coverage or enabling a short window of Firestore DATA_READ audit logging to find the caller before making any code change."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "observability",
+      "alert_identity": "omi-firestore-notfound-dod-step",
+      "component": "firestore",
+      "impact": "product"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-firestore-notfound-ceiling",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Firestore Cost",
+    "title": "Firestore - NOT_FOUND read volume above absolute ceiling",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[30m])) > 600",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-08-25T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "2h",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "summary": "Firestore document read_count (metric stackdriver_firestore_instance_firestore_googleapis_com_document_read_count, type=\"NOT_FOUND\") has been sustained above 600 reads/sec for 2h -- above the ~361/sec healthy baseline measured before the 2026-08-23 cost incident, below the ~936/sec the leak reached.",
+      "threshold": "sum(rate(...[30m])) > 600/sec, sustained 2h",
+      "user_impact": "No direct user impact; this is a cost signal, not an outage. NOT_FOUND reads are Firestore reads for documents that do not exist, so they are near-pure waste: the read is billed but returns nothing. This is the backstop for a leak that is already running at a steady elevated rate, which the day-over-day step detector cannot see because both sides of its comparison are equally elevated.",
+      "scope": "Firestore document reads across the based-hardware production project, type=\"NOT_FOUND\" only.",
+      "verification": "Check sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[30m])) in the linked query against the 600/sec threshold; healthy baseline is ~361/sec, the 2026-08-23 incident ran ~936/sec.",
+      "safe_next_action": "This alert flags read volume, not cause. The Cloud Monitoring series carries module=\"__unknown__\", so attribution needs either extending omi_firestore_read_operations_total call-site coverage or enabling a short window of Firestore DATA_READ audit logging to find the caller before making any code change."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "observability",
+      "alert_identity": "omi-firestore-notfound-ceiling",
+      "component": "firestore",
+      "impact": "product"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  }
+]

--- a/backend/charts/monitoring/alerts/firestore.json
+++ b/backend/charts/monitoring/alerts/firestore.json
@@ -89,7 +89,7 @@
       "instatus_component": "observability",
       "alert_identity": "omi-firestore-notfound-dod-step",
       "component": "firestore",
-      "impact": "product"
+      "impact": "infrastructure"
     },
     "isPaused": false,
     "notification_settings": {
@@ -187,7 +187,7 @@
       "instatus_component": "observability",
       "alert_identity": "omi-firestore-notfound-ceiling",
       "component": "firestore",
-      "impact": "product"
+      "impact": "infrastructure"
     },
     "isPaused": false,
     "notification_settings": {

--- a/backend/charts/monitoring/prometheus-stackdriver-exporter/dev_omi_stackdriver_exporter.yaml
+++ b/backend/charts/monitoring/prometheus-stackdriver-exporter/dev_omi_stackdriver_exporter.yaml
@@ -5,6 +5,11 @@ stackdriver:
     prefixes:
       - 'loadbalancing.googleapis.com/https/backend_request_count'
       - 'loadbalancing.googleapis.com/https/internal/backend_latencies'
+      # firestore.googleapis.com/document/read_count: 3 series (type=LOOKUP|NOT_FOUND|QUERY),
+      # resource type firestore_instance, DELTA/INT64, single page (no pagination). Marginal
+      # cost is ~1,440 extra ListTimeSeries calls/day (~$0.43/month) against ~$728/month of
+      # Firestore read-volume waste it makes visible -- do not remove as "extra scraping cost".
+      - 'firestore.googleapis.com/document/read_count'
     # The filters to refine the metrics query by using Filter objects that Google provides.
     # Filter objects: project, group.id, resource.type, resource.labels.[KEY], metric.type, metric.labels.[KEY]
     # https://cloud.google.com/monitoring/api/v3/filters

--- a/backend/charts/monitoring/prometheus-stackdriver-exporter/prod_omi_stackdriver_exporter.yaml
+++ b/backend/charts/monitoring/prometheus-stackdriver-exporter/prod_omi_stackdriver_exporter.yaml
@@ -5,6 +5,11 @@ stackdriver:
     prefixes:
       - 'loadbalancing.googleapis.com/https/backend_request_count'
       - 'loadbalancing.googleapis.com/https/internal/backend_latencies'
+      # firestore.googleapis.com/document/read_count: 3 series (type=LOOKUP|NOT_FOUND|QUERY),
+      # resource type firestore_instance, DELTA/INT64, single page (no pagination). Marginal
+      # cost is ~1,440 extra ListTimeSeries calls/day (~$0.43/month) against ~$728/month of
+      # Firestore read-volume waste it makes visible -- do not remove as "extra scraping cost".
+      - 'firestore.googleapis.com/document/read_count'
     filters:
       - 'loadbalancing.googleapis.com/https/backend_request_count:resource.labels.backend_target_name="custom-domains-api-omi-me-backend-listen-49a4-be"'
     interval: '1m'

--- a/backend/tests/unit/test_monitoring_telemetry_contract.py
+++ b/backend/tests/unit/test_monitoring_telemetry_contract.py
@@ -23,6 +23,7 @@ PROD_VALUES = MONITORING / 'kube-prometheus-stack' / 'prod_omi_monitoring_values
 ALERT_RULES = MONITORING / 'alert-rules.json'
 PARAKEET_SERVICEMONITOR = REPO / 'backend/charts/parakeet' / 'templates' / 'servicemonitor.yaml'
 STACKDRIVER_EXPORTER = MONITORING / 'prometheus-stackdriver-exporter' / 'prod_omi_stackdriver_exporter.yaml'
+STACKDRIVER_EXPORTER_DEV = MONITORING / 'prometheus-stackdriver-exporter' / 'dev_omi_stackdriver_exporter.yaml'
 CLOUD_RUN_EXPORTER = MONITORING / 'prometheus-stackdriver-exporter' / 'prod_omi_cloud_run_metrics_exporter.yaml'
 CLOUD_RUN_EXPORTER_DEV = MONITORING / 'prometheus-stackdriver-exporter' / 'dev_omi_cloud_run_metrics_exporter.yaml'
 
@@ -125,6 +126,31 @@ def test_stackdriver_exporter_values_present():
     assert STACKDRIVER_EXPORTER.is_file()
     inventory = _load_inventory()
     assert any(job['name'] == 'prometheus-stackdriver-metrics' for job in inventory['scrape_jobs'])
+
+
+@pytest.mark.parametrize(
+    'path',
+    (STACKDRIVER_EXPORTER, STACKDRIVER_EXPORTER_DEV),
+    ids=('prod', 'dev'),
+)
+def test_stackdriver_exporter_ingests_firestore_read_count(path):
+    """A Firestore cost runaway is invisible unless this prefix is scraped.
+
+    document/read_count was absent from every Prometheus metric name during the
+    2026-08-23 cost incident, so nothing could alert on it. Both environments
+    are asserted: the dev values file is what the automatic post-merge rollout
+    installs, so leaving it unpinned lets dev drift away from the contract prod
+    is held to (same rationale as the Cloud Run exporter parametrization above).
+    """
+    values = yaml.safe_load(path.read_text(encoding='utf-8'))
+    prefixes = values['stackdriver']['metrics']['prefixes']
+
+    assert (
+        'firestore.googleapis.com/document/read_count' in prefixes
+    ), f'{path.name}: missing the firestore.googleapis.com/document/read_count prefix'
+    # The existing loadbalancing prefixes must survive the edit untouched.
+    assert 'loadbalancing.googleapis.com/https/backend_request_count' in prefixes
+    assert 'loadbalancing.googleapis.com/https/internal/backend_latencies' in prefixes
 
 
 # Cloud Monitoring rejects a filter that mixes AND with OR across resource.labels


### PR DESCRIPTION
## Summary

A Firestore cost runaway has been burning ~$728/month since 2026-08-23 and was structurally invisible: GCP's `document/read_count` is absent from all 1,705 Prometheus metric names, 0 of 48 Grafana dashboards mention Firestore/cost, and 0 of 62 alert rules cover it. This change makes Firestore read volume visible and alertable.

- **Ingest the metric.** Add `firestore.googleapis.com/document/read_count` to the Stackdriver exporter's metric prefixes in both `prod_omi_stackdriver_exporter.yaml` and `dev_omi_stackdriver_exporter.yaml`. Measured: 3 series (`type`=`LOOKUP`/`NOT_FOUND`/`QUERY`), resource type `firestore_instance`, DELTA/INT64, single page. Marginal cost ~1,440 extra `ListTimeSeries` calls/day (~$0.43/month) against ~$728/month of waste it makes visible.
- **Two Grafana alert rules** (mirrored in `backend/charts/monitoring/alerts/firestore.json` and the combined `alert-rules.json` export), both `severity=warning` (cost signal, not an outage — the hermes prod watchdog pages on any active `severity=critical`):
  - `omi-firestore-notfound-dod-step` — day-over-day step detector: `sum(rate(...NOT_FOUND...[1h])) > 1.5 * sum(rate(...[1h] offset 24h))`, sustained 2h. Survives organic growth and diurnal swing.
  - `omi-firestore-notfound-ceiling` — absolute ceiling backstop: `sum(rate(...NOT_FOUND...[30m])) > 600`, sustained 2h. Catches a leak that is *already* running and steady, which the day-over-day comparison cannot see (both sides equally elevated). Measured baseline ~361/sec before the incident, ~936/sec during it; 600/sec sits between the two.
  - Annotations name the metric, explain that `NOT_FOUND` reads are documents that don't exist (near-pure waste), and note that attribution requires either extending `omi_firestore_read_operations_total` coverage or a short window of Firestore `DATA_READ` audit logging, since the Cloud Monitoring series carries `module="__unknown__"`.
- **Contract test** in `backend/tests/unit/test_monitoring_telemetry_contract.py` asserting both exporter values files declare the Firestore prefix. The existing `test_alert_uids_are_short_enough_for_grafana_to_accept` in `test_monitoring_alert_rule_contract.py` automatically covers the two new UIDs (31 and 30 chars, well under the 40-char Grafana limit).

## Test plan

- [x] `backend/.venv/bin/python -m pytest backend/tests/unit/test_monitoring_telemetry_contract.py backend/tests/unit/test_monitoring_alert_rule_contract.py -q` — 50 passed
- [x] `make preflight` — 26 checks passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

