### PR TITLE
ci: install redis-server through one shared composite action

### DIFF
--- a/.github/actions/install-redis-server/action.yml
+++ b/.github/actions/install-redis-server/action.yml
@@ -1,0 +1,28 @@
+name: Install Redis server
+description: >-
+  Install the redis-server package with bounded, retrying apt network attempts,
+  for jobs whose harness spawns its own redis-server binary.
+
+runs:
+  using: composite
+  steps:
+    # The harness spawns its own `redis-server` binary per test on an
+    # ephemeral port (see backend/testing/*/run.py), so this needs the
+    # actual package installed, not a `services:` container.
+    #
+    # apt against the default Azure-mirror apt source on hosted runners
+    # can silently stall (connects but never completes the transfer)
+    # instead of failing, which previously let this step hang until the
+    # job's 20-minute timeout killed it with an opaque "operation was
+    # canceled". Bound each apt network attempt and retry a few times so
+    # a stalled mirror fails over quickly.
+    #
+    # The 5-minute step backstop that used to sit beside these commands
+    # stays on the CALLER's `uses:` step: `timeout-minutes` is not a valid
+    # key on a composite-action step, so moving it in here would silently
+    # drop it and re-open the hang this step was hardened against.
+    - name: Install Redis server
+      shell: bash
+      run: |
+        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install --yes redis-server

--- a/.github/workflows/backend-hermetic-e2e.yml
+++ b/.github/workflows/backend-hermetic-e2e.yml
@@ -166,21 +166,11 @@ jobs:
           java-version: '21'
 
       - name: Install Redis server
-        # The harness spawns its own `redis-server` binary per test on an
-        # ephemeral port (see backend/testing/*/run.py), so this needs the
-        # actual package installed, not a `services:` container.
-        #
-        # apt against the default Azure-mirror apt source on hosted runners
-        # can silently stall (connects but never completes the transfer)
-        # instead of failing, which previously let this step hang until the
-        # job's 20-minute timeout killed it with an opaque "operation was
-        # canceled". Bound each apt network attempt and retry a few times so
-        # a stalled mirror fails over quickly, and cap the step itself as a
-        # backstop.
+        # `timeout-minutes` is not a valid key on a composite-action step, so
+        # the backstop that keeps a stalled apt mirror from riding the job's
+        # 20-minute timeout stays here, on the caller.
         timeout-minutes: 5
-        run: |
-          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install --yes redis-server
+        uses: ./.github/actions/install-redis-server
 
       - name: Run listen to pusher stack gauntlet
         run: npm run test:listen-pusher-stack:emulator -- --state-dir "$RUNNER_TEMP/listen-pusher-stack"
@@ -253,21 +243,11 @@ jobs:
           java-version: '21'
 
       - name: Install Redis server
-        # The harness spawns its own `redis-server` binary per test on an
-        # ephemeral port (see backend/testing/*/run.py), so this needs the
-        # actual package installed, not a `services:` container.
-        #
-        # apt against the default Azure-mirror apt source on hosted runners
-        # can silently stall (connects but never completes the transfer)
-        # instead of failing, which previously let this step hang until the
-        # job's 20-minute timeout killed it with an opaque "operation was
-        # canceled". Bound each apt network attempt and retry a few times so
-        # a stalled mirror fails over quickly, and cap the step itself as a
-        # backstop.
+        # `timeout-minutes` is not a valid key on a composite-action step, so
+        # the backstop that keeps a stalled apt mirror from riding the job's
+        # 20-minute timeout stays here, on the caller.
         timeout-minutes: 5
-        run: |
-          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install --yes redis-server
+        uses: ./.github/actions/install-redis-server
 
       - name: Run Sync Cloud Tasks stack gauntlet
         run: npm run test:sync-cloud-tasks-stack:emulator
@@ -317,21 +297,11 @@ jobs:
           java-version: '21'
 
       - name: Install Redis server
-        # The harness spawns its own `redis-server` binary per test on an
-        # ephemeral port (see backend/testing/*/run.py), so this needs the
-        # actual package installed, not a `services:` container.
-        #
-        # apt against the default Azure-mirror apt source on hosted runners
-        # can silently stall (connects but never completes the transfer)
-        # instead of failing, which previously let this step hang until the
-        # job's 20-minute timeout killed it with an opaque "operation was
-        # canceled". Bound each apt network attempt and retry a few times so
-        # a stalled mirror fails over quickly, and cap the step itself as a
-        # backstop.
+        # `timeout-minutes` is not a valid key on a composite-action step, so
+        # the backstop that keeps a stalled apt mirror from riding the job's
+        # 20-minute timeout stays here, on the caller.
         timeout-minutes: 5
-        run: |
-          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install --yes redis-server
+        uses: ./.github/actions/install-redis-server
 
       - name: Run Phase 0A replay harness feasibility experiment
         env:

--- a/backend/tests/unit/test_listen_pusher_stack_ci_wiring.py
+++ b/backend/tests/unit/test_listen_pusher_stack_ci_wiring.py
@@ -10,7 +10,14 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 # Unbounded `apt-get` against the hosted-runner Azure mirror can stall with no
 # output until the job ceiling. The hermetic gauntlets must keep Acquire
 # retries/timeouts on both update and install, plus a step-level timeout.
+#
+# Those two commands now live in one composite action rather than being copied
+# into each gauntlet job, so the bound is asserted against the action and the
+# jobs are asserted to route through it.  `test_hermetic_gauntlet_redis_apt_installs_are_bounded`
+# below is the single place that proves the pairing.
 _BOUNDED_APT_GET = 'sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10'
+_REDIS_ACTION = 'uses: ./.github/actions/install-redis-server'
+_REDIS_ACTION_FILE = Path('.github') / 'actions' / 'install-redis-server' / 'action.yml'
 
 
 def test_listen_pusher_stack_gauntlet_has_a_deterministic_hermetic_ci_job() -> None:
@@ -35,8 +42,7 @@ def test_listen_pusher_stack_gauntlet_has_a_deterministic_hermetic_ci_job() -> N
     assert 'for attempt in 1 2 3' in job
     assert 'uses: actions/setup-java@v5' in job
     assert "java-version: '21'" in job
-    assert f'{_BOUNDED_APT_GET} update' in job
-    assert f'{_BOUNDED_APT_GET} install --yes redis-server' in job
+    assert _REDIS_ACTION in job
     assert 'timeout-minutes: 5' in job
     assert 'npm run test:listen-pusher-stack:emulator -- --state-dir "$RUNNER_TEMP/listen-pusher-stack"' in job
     assert 'name: Show listen gauntlet process diagnostics on failure' in job
@@ -143,7 +149,22 @@ def test_hermetic_e2e_tokenizer_warmup_is_cached_and_bounded() -> None:
 
 def test_hermetic_gauntlet_redis_apt_installs_are_bounded() -> None:
     workflow = (_REPO_ROOT / '.github' / 'workflows' / 'backend-hermetic-e2e.yml').read_text(encoding='utf-8')
+    action = (_REPO_ROOT / _REDIS_ACTION_FILE).read_text(encoding='utf-8')
 
-    assert workflow.count(f'{_BOUNDED_APT_GET} update') == 3
-    assert workflow.count(f'{_BOUNDED_APT_GET} install --yes redis-server') == 3
-    assert 'sudo apt-get install --yes redis-server' not in workflow
+    # One definition of the bound, for the three jobs that need redis-server.
+    assert action.count(f'{_BOUNDED_APT_GET} update') == 1
+    assert action.count(f'{_BOUNDED_APT_GET} install --yes redis-server') == 1
+    # Fail closed: no apt-get anywhere may escape the Acquire retries/timeouts.
+    assert action.count('apt-get') == action.count(_BOUNDED_APT_GET) == 2
+    assert 'apt-get' not in workflow
+
+    # All three gauntlet jobs install redis-server through that action, and each
+    # carries its own step ceiling.  `timeout-minutes` is not a valid key on a
+    # composite-action step, so this backstop can only live on the caller: if it
+    # is ever "tidied" into the action it silently disappears, and a stalled apt
+    # mirror goes back to burning the job's 20-minute timeout.
+    assert workflow.count(_REDIS_ACTION) == 3
+    redis_steps = [step for step in workflow.split('\n      - ') if _REDIS_ACTION in step]
+    assert len(redis_steps) == 3
+    for step in redis_steps:
+        assert 'timeout-minutes: 5' in step

--- a/backend/tests/unit/test_sync_cloud_tasks_stack_ci_wiring.py
+++ b/backend/tests/unit/test_sync_cloud_tasks_stack_ci_wiring.py
@@ -12,9 +12,13 @@ from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 
-# Keep in lockstep with test_listen_pusher_stack_ci_wiring._BOUNDED_APT_GET:
-# unbounded apt-get is the hang that previously burned this job's timeout.
-_BOUNDED_APT_GET = 'sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10'
+# Keep in lockstep with test_listen_pusher_stack_ci_wiring._REDIS_ACTION: the
+# bounded apt-get that keeps a stalled mirror from burning this job's timeout
+# lives in the composite action, and
+# test_listen_pusher_stack_ci_wiring.test_hermetic_gauntlet_redis_apt_installs_are_bounded
+# proves the bound itself for all three gauntlet jobs.  Here we only prove that
+# this job routes through it and keeps its own step ceiling.
+_REDIS_ACTION = 'uses: ./.github/actions/install-redis-server'
 
 
 def test_sync_cloud_tasks_stack_gauntlet_has_a_deterministic_hermetic_ci_job() -> None:
@@ -40,8 +44,7 @@ def test_sync_cloud_tasks_stack_gauntlet_has_a_deterministic_hermetic_ci_job() -
     assert 'npm ci --ignore-scripts' in job
     assert 'uses: actions/setup-java@v5' in job
     assert "java-version: '21'" in job
-    assert f'{_BOUNDED_APT_GET} update' in job
-    assert f'{_BOUNDED_APT_GET} install --yes redis-server' in job
+    assert _REDIS_ACTION in job
     assert 'timeout-minutes: 5' in job
     assert 'npm run test:sync-cloud-tasks-stack:emulator' in job
 


### PR DESCRIPTION
Closes the deduplication half of #11848.

### What this changes

`.github/workflows/backend-hermetic-e2e.yml` carried **three byte-identical 17-line "Install Redis server" steps**. This extracts them into `.github/actions/install-redis-server` and calls it from all three.

One correction to the issue's job list, for the record: the three copies live in `listen-pusher-stack-gauntlet`, `sync-cloud-tasks-stack-gauntlet` and **`replay-harness-phase0a-gauntlet`** — not `hermetic-e2e`, which has no Redis step.

### Why now, and what is already done

The functional half of #11848 has landed since it was filed: all three copies already carry `timeout-minutes: 5` and the `Acquire::Retries` / `Acquire::*::Timeout` flags. What was still outstanding is the issue's own closing ask — that the fix *"land once in a shared step/action rather than patched three times across the duplicated jobs"*. Three copies of a hardening detail is exactly the shape that drifts on the next edit.

### The trap in this refactor, stated because it is silent

**`timeout-minutes` is not a valid key on a composite-action step.** Moving it into the action would have parsed fine, run fine, and quietly dropped the 5-minute backstop — re-opening the "rides the job's 20-minute timeout and dies with an opaque `operation was canceled`" failure the issue is about. So the backstop stays on each caller's `uses:` step, with a comment at all four sites saying why.

### Verification

- `actionlint` v1.7.7 on the workflow: **clean, and clean on pristine `main` too** — no new findings either way.
- Both `apt-get` invocations preserved **byte-for-byte**, flags included.
- Asserted after parsing the result: 3 callers, each pointing at the action, each still `timeout-minutes: 5`, and no `timeout-minutes` inside the composite.
- Each of the three jobs runs `actions/checkout` before the step (L120/L207/L284), so the local action resolves.

Net `-42/+40`, no behaviour change intended.

I have not touched the `hermetic-e2e` job or the other two directions the issue floated (caching/vendoring the package), since the retry+timeout direction is the one that shipped.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

---

*Disclosure: this patch was written and tested end to end by an autonomous AI agent; a human principal is accountable for it. [What this account is](https://github.com/sujeito-operator). Ask me anything about how it was produced and I will answer.*