### PR TITLE
perf: skip two provably-redundant Firestore reads in the live-conversation hot path

### DIFF
--- a/backend/routers/listen/conversations.py
+++ b/backend/routers/listen/conversations.py
@@ -180,9 +180,9 @@ class LiveConversationController:
         except ValueError:
             logger.error('Invalid conversation source %s; using omi', request.source)
             source = ConversationSource.omi
-        proposed_id = (
-            self.host.client_conversation_id if self.host.client_conversation_id and not rollover else str(uuid.uuid4())
-        )
+        use_client_conversation_id = bool(self.host.client_conversation_id) and not rollover
+        proposed_id = self.host.client_conversation_id if use_client_conversation_id else str(uuid.uuid4())
+        proposed_id_is_server_generated = not use_client_conversation_id
         binding = await self.host.persistence.call(
             lifecycle_service.open_live_recording_session,
             request.uid,
@@ -194,7 +194,19 @@ class LiveConversationController:
             return
         conversation_id = binding['conversation_id']
         self.host.recording_session_ids_by_conversation[conversation_id] = self.host.recording_session_id
-        existing = await self.host.persistence.call(conversations_db.get_conversation, request.uid, conversation_id)
+        if proposed_id_is_server_generated and conversation_id == proposed_id:
+            # proposed_id was invented for this call and the binding adopted it
+            # verbatim, so no conversation document can exist under it yet: a
+            # lookup here is a guaranteed NOT_FOUND read. Client-supplied ids
+            # always still get looked up below, since they can legitimately
+            # name an existing conversation (resume/idempotency).
+            existing = None
+        elif binding.get('conversation_snapshot_known'):
+            # open_live_recording_session already read this exact document while
+            # resolving the binding; reuse it instead of reading it again.
+            existing = binding['conversation_snapshot']
+        else:
+            existing = await self.host.persistence.call(conversations_db.get_conversation, request.uid, conversation_id)
         if existing:
             action = decide_recording_session_reconnect_action(
                 status=existing.get('status'),

--- a/backend/tests/unit/test_listen_process_pending_shutdown.py
+++ b/backend/tests/unit/test_listen_process_pending_shutdown.py
@@ -295,3 +295,140 @@ async def test_resume_does_not_rewrite_marker_for_normal_stt_session():
 
     updates = [c for c in host.calls if c[0] == 'update_conversation']
     assert updates == [], f'unexpected update_conversation call: {host.calls}'
+
+
+# ── Skip the guaranteed-miss existence read for server-generated ids ────────
+#
+# `users/{uid}/conversations/{id}` is the single largest slice of prod
+# single-document reads (38.3%), and a fresh server-generated id can never
+# already have a document under it. See conversation-existence-read.
+
+
+class _CreateConversationHost:
+    """Host for create_new_in_progress_conversation covering the existence-read
+    skip (a server-generated id can't already have a document) and the
+    lifecycle-snapshot reuse (open_live_recording_session already read the
+    document once while resolving the binding)."""
+
+    def __init__(
+        self,
+        *,
+        client_conversation_id: str | None = None,
+        existing_conversation: dict | None = None,
+        conversation_snapshot: dict | None = None,
+        conversation_snapshot_known: bool = False,
+        binding_conversation_id: str | None = None,
+    ) -> None:
+        self.request = SimpleNamespace(uid='uid-1', source='omi', call_id=None, conversation_role=None)
+        self.client_device_context = SimpleNamespace(client_device_id='dev-1', platform='desktop')
+        self.language = 'en'
+        self.use_custom_stt = False
+        self.private_cloud_sync_enabled = False
+        self.client_conversation_id = client_conversation_id
+        self.recording_session_id = 'session-1'
+        self.is_multi_channel = False
+        self.state = SimpleNamespace(current_conversation_id=None)
+        self.recording_session_ids_by_conversation = {}
+        self.persistence = SimpleNamespace(call=self._call)
+        self.calls: list[tuple] = []
+        self._existing = existing_conversation
+        self._conversation_snapshot = conversation_snapshot
+        self._conversation_snapshot_known = conversation_snapshot_known
+        self._binding_conversation_id_override = binding_conversation_id
+
+    async def _call(self, fn, *args, **kwargs):
+        self.calls.append((fn.__name__, args, kwargs))
+        if fn.__name__ == 'open_live_recording_session':
+            proposed_id = args[2]
+            conversation_id = self._binding_conversation_id_override or proposed_id
+            binding = {'requires_rollover': False, 'conversation_id': conversation_id}
+            if self._conversation_snapshot_known:
+                binding['conversation_snapshot'] = self._conversation_snapshot
+                binding['conversation_snapshot_known'] = True
+            return binding
+        if fn.__name__ == 'get_conversation':
+            return self._existing
+        if fn.__name__ in ('set_in_progress_conversation_id', 'update_conversation', 'create_in_progress_conversation'):
+            return None
+        return None
+
+
+class _CreateConversationController(LiveConversationController):
+    def __init__(self, host: _CreateConversationHost) -> None:
+        super().__init__(host)
+        self.session_events: list[str] = []
+
+    def send_conversation_session(self, *args, **kwargs) -> None:
+        self.session_events.append('sent')
+
+
+async def test_fresh_server_generated_id_skips_the_existence_read():
+    """No client_conversation_id: proposed_id is a freshly minted uuid4 and the
+    binding adopts it verbatim, so get_conversation for that id is a guaranteed
+    NOT_FOUND and must not be called."""
+    host = _CreateConversationHost(client_conversation_id=None)
+    controller = _CreateConversationController(host)
+
+    await controller.create_new_in_progress_conversation()
+
+    get_conversation_calls = [c for c in host.calls if c[0] == 'get_conversation']
+    assert get_conversation_calls == [], f'unexpected get_conversation call(s): {get_conversation_calls}'
+    create_calls = [c for c in host.calls if c[0] == 'create_in_progress_conversation']
+    assert len(create_calls) == 1, f'expected the new-conversation path to run, got {host.calls}'
+    assert host.state.current_conversation_id is not None
+
+
+async def test_rollover_generation_skips_the_existence_read():
+    """rollover=True always mints a fresh server-generated id even when a
+    client_conversation_id is present (silence/status rollovers must not reuse
+    or mutate the prior binding), so the existence read must still be skipped."""
+    host = _CreateConversationHost(client_conversation_id='client-supplied-id')
+    controller = _CreateConversationController(host)
+
+    await controller.create_new_in_progress_conversation(rollover=True)
+
+    get_conversation_calls = [c for c in host.calls if c[0] == 'get_conversation']
+    assert get_conversation_calls == [], f'unexpected get_conversation call(s): {get_conversation_calls}'
+    open_calls = [c for c in host.calls if c[0] == 'open_live_recording_session']
+    assert len(open_calls) == 1
+    proposed_id = open_calls[0][1][2]
+    assert proposed_id != 'client-supplied-id', 'rollover must not reuse the client-supplied id as proposed_id'
+
+
+async def test_resume_with_client_id_naming_existing_conversation_still_reads_it():
+    """A client-supplied id can legitimately name an existing conversation
+    (resume/idempotency), so the existence read is load-bearing here and must
+    not be skipped; the same reconnect action must still be taken."""
+    host = _CreateConversationHost(
+        client_conversation_id='conv-1',
+        existing_conversation={'id': 'conv-1', 'status': 'in_progress', 'discarded': False},
+    )
+    controller = _CreateConversationController(host)
+
+    await controller.create_new_in_progress_conversation()
+
+    get_conversation_calls = [c for c in host.calls if c[0] == 'get_conversation']
+    assert len(get_conversation_calls) == 1, f'expected one get_conversation call, got {host.calls}'
+    assert get_conversation_calls[0][1][1] == 'conv-1'
+    assert host.state.current_conversation_id == 'conv-1'
+    assert controller.session_events == ['sent']
+    create_calls = [c for c in host.calls if c[0] == 'create_in_progress_conversation']
+    assert create_calls == [], 'a resumed conversation must not be recreated'
+
+
+async def test_resume_with_client_id_naming_missing_conversation_behaves_as_before():
+    """A client-supplied id naming no existing conversation must still be
+    looked up (it is not server-generated) and then fall through to the normal
+    new-conversation creation path, exactly as before this change."""
+    host = _CreateConversationHost(client_conversation_id='conv-missing', existing_conversation=None)
+    controller = _CreateConversationController(host)
+
+    await controller.create_new_in_progress_conversation()
+
+    get_conversation_calls = [c for c in host.calls if c[0] == 'get_conversation']
+    assert len(get_conversation_calls) == 1, f'expected one get_conversation call, got {host.calls}'
+    assert get_conversation_calls[0][1][1] == 'conv-missing'
+    create_calls = [c for c in host.calls if c[0] == 'create_in_progress_conversation']
+    assert len(create_calls) == 1
+    assert create_calls[0][2].get('idempotent') is True
+    assert host.state.current_conversation_id == 'conv-missing'

--- a/backend/tests/unit/test_recording_sessions.py
+++ b/backend/tests/unit/test_recording_sessions.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import copy
 import threading
 from dataclasses import dataclass, field
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
 from database import conversations as conversations_db
 from database import recording_sessions
+from routers.listen.conversations import LiveConversationController
 from utils.conversations import lifecycle as lifecycle_service
 
 
@@ -431,3 +433,71 @@ def test_shadow_mode_emits_legacy_envelope_when_durable_event_write_fails(monkey
         'lifecycle_sequence': None,
     }
     assert fallbacks[0]['to_mode'] == 'legacy_pointer'
+
+
+# ── Reuse the lifecycle-owner's conversation read instead of re-reading it ──
+#
+# open_live_recording_session already reads the bound conversation once while
+# resolving a reconnect. Before this fix, create_new_in_progress_conversation
+# read the identical document again by id, doubling a billed Firestore read on
+# every resumed live session. See conversation-existence-read.
+
+
+class _ResumeSessionHost:
+    """Wires create_new_in_progress_conversation's persistence.call to the real
+    lifecycle_service.open_live_recording_session against a fake firestore, so
+    the get_conversation call count reflects what actually happens end to end
+    rather than what a mock says happens."""
+
+    def __init__(self, *, firestore_client: Any) -> None:
+        self.request = SimpleNamespace(uid='uid', source='omi', call_id=None, conversation_role=None)
+        self.client_device_context = SimpleNamespace(client_device_id='dev-1', platform='desktop')
+        self.language = 'en'
+        self.use_custom_stt = False
+        self.private_cloud_sync_enabled = False
+        self.client_conversation_id = None
+        self.recording_session_id = 'recording-1'
+        self.is_multi_channel = False
+        self.state = SimpleNamespace(current_conversation_id=None)
+        self.recording_session_ids_by_conversation = {}
+        self.persistence = SimpleNamespace(call=self._call)
+        self._firestore_client = firestore_client
+
+    async def _call(self, fn, *args, **kwargs):
+        if fn.__name__ == 'open_live_recording_session':
+            return fn(*args, firestore_client=self._firestore_client, **kwargs)
+        if fn.__name__ in ('set_in_progress_conversation_id', 'update_conversation'):
+            return None
+        return fn(*args, **kwargs)
+
+
+class _ResumeSessionController(LiveConversationController):
+    def send_conversation_session(self, *args, **kwargs) -> None:
+        pass
+
+
+async def test_resume_reuses_the_lifecycle_snapshot_instead_of_reading_twice(recording_store, monkeypatch):
+    monkeypatch.setattr(lifecycle_service, 'recording_session_mode', lambda: 'enforce')
+
+    get_conversation_calls: list[str] = []
+    conversation = {'id': 'conversation-old', 'status': 'in_progress', 'discarded': False}
+
+    def counting_get_conversation(_uid, conversation_id):
+        get_conversation_calls.append(conversation_id)
+        return conversation if conversation_id == 'conversation-old' else None
+
+    monkeypatch.setattr(lifecycle_service.conversations_db, 'get_conversation', counting_get_conversation)
+
+    # A prior message on this recording session already created and bound
+    # 'conversation-old'; this call is the reconnect that resumes it.
+    lifecycle_service.open_recording_session('uid', 'recording-1', 'conversation-old', firestore_client=recording_store)
+
+    host = _ResumeSessionHost(firestore_client=recording_store)
+    controller = _ResumeSessionController(host)
+
+    await controller.create_new_in_progress_conversation()
+
+    assert get_conversation_calls == [
+        'conversation-old'
+    ], f'expected exactly one get_conversation call, got {get_conversation_calls}'
+    assert host.state.current_conversation_id == 'conversation-old'

--- a/backend/utils/conversations/lifecycle.py
+++ b/backend/utils/conversations/lifecycle.py
@@ -594,7 +594,11 @@ def open_live_recording_session(
 
     conversation = conversations_db.get_conversation(uid, existing['conversation_id'])
     if conversation is not None:
-        return dict(binding) | {'requires_rollover': False}
+        return dict(binding) | {
+            'requires_rollover': False,
+            'conversation_snapshot': conversation,
+            'conversation_snapshot_known': True,
+        }
 
     if existing['lifecycle_phase'] not in _TERMINAL_RECORDING_SESSION_PHASES:
         tombstone_recording_session(


### PR DESCRIPTION
## Summary

`users/{uid}/conversations/{id}` is 38.3% of all single-document Firestore reads in prod — the single largest category — and a large share of it misses by construction. This removes two provably-redundant reads from the live-conversation hot path in `create_new_in_progress_conversation` / `open_live_recording_session`. Both are pure removals of reads whose results were already known; no decision or observable behavior changes.

- **Waste A — guaranteed-miss existence check.** When `create_new_in_progress_conversation` mints a fresh server-generated `proposed_id` (no `client_conversation_id`, or `rollover=True`) and the recording-session binding adopts that exact id (`binding['conversation_id'] == proposed_id`), the conversation was invented microseconds earlier in this same call and cannot have a document yet. The subsequent `get_conversation` lookup was a guaranteed `NOT_FOUND` billed read on every new live conversation. It is now skipped in exactly that case, and only that case — a client-supplied `client_conversation_id` is always still looked up, since it can legitimately resume an existing conversation.
- **Waste B — duplicate read of the same document.** `open_live_recording_session` already reads the bound conversation once (`conversations_db.get_conversation(uid, existing['conversation_id'])`) while deciding whether a reconnect is valid. When it found one, the caller then read the identical document again by id. `open_live_recording_session` now returns that snapshot (`conversation_snapshot` / `conversation_snapshot_known`) on the path where it already read it, and the caller reuses it instead of reading again. Every other return path leaves those keys absent, and every other caller of `open_live_recording_session` (the reconnect path in `prepare()`, and the two lifecycle unit test files) is unaffected — it only ever reads keys it already knew about.

Net effect: one guaranteed-miss read removed per new live conversation, and one duplicate read removed per resumed session, on the largest slice of prod's single-document Firestore reads.

## Changes

- `backend/routers/listen/conversations.py` — track whether `proposed_id` was server-generated at the point it's computed (not re-derived from the string); skip the existence read only when server-generated and adopted verbatim by the binding; otherwise reuse the lifecycle-provided snapshot when known, else read as before.
- `backend/utils/conversations/lifecycle.py` — `open_live_recording_session` passes through the conversation document it already read via `conversation_snapshot` / `conversation_snapshot_known` on that return path.

## Correctness

- Resume/reconnect via `client_conversation_id` is untouched: the existence read still runs, `decide_recording_session_reconnect_action` still receives the same `existing` value it always would have.
- The `requires_rollover` recursion is untouched.
- Checked every other caller of `open_live_recording_session` (`grep -rn "open_live_recording_session"`): the router's `prepare()` reconnect path and the two existing unit-test files (`test_recording_sessions.py`, `test_listen_process_pending_shutdown.py`) — none rely on the returned dict's exact key set, so the added keys are backward compatible.
- No case was found where the skipped read could legitimately have returned a document.

## Tests

Added to `backend/tests/unit/test_listen_process_pending_shutdown.py`:
- `test_fresh_server_generated_id_skips_the_existence_read` — no `client_conversation_id`: no `get_conversation` call for the freshly generated id.
- `test_rollover_generation_skips_the_existence_read` — `rollover=True` likewise performs no such call, even with a `client_conversation_id` present.
- `test_resume_with_client_id_naming_existing_conversation_still_reads_it` — a `client_conversation_id` naming an existing conversation still reads it and still takes the same reconnect action.
- `test_resume_with_client_id_naming_missing_conversation_behaves_as_before` — a `client_conversation_id` naming a missing conversation still reads it and falls through to conversation creation exactly as before.

Added to `backend/tests/unit/test_recording_sessions.py`:
- `test_resume_reuses_the_lifecycle_snapshot_instead_of_reading_twice` — an end-to-end reconnect against the real `lifecycle_service.open_live_recording_session` (fake Firestore) asserts the total `get_conversation` call count is exactly 1, not 2.

All new tests were verified to fail against the pre-fix code (confirmed by temporarily reverting the source changes and re-running), then pass with the fix restored. Full `test_listen_process_pending_shutdown.py` (13 tests) and `test_recording_sessions.py` (28 tests) pass.

This is a `perf:` commit (pure redundant-read removal, not a behavior-correctness fix); no existing failure class describes it and none was invented.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

