### PR TITLE
fix(backend): reclaim unreferenced audio when a generation is deleted as empty

### DIFF
--- a/backend/database/recording_sessions.py
+++ b/backend/database/recording_sessions.py
@@ -161,6 +161,7 @@ def tombstone_and_delete_empty_conversation(
     recording_session_id: str | None,
     *,
     firestore_client: Any = None,
+    deleted_conversation: dict[str, Any] | None = None,
 ) -> bool:
     """Atomically delete an empty live row and terminalize its bound session.
 
@@ -168,6 +169,12 @@ def tombstone_and_delete_empty_conversation(
     in transactions on this same parent document. Firestore therefore retries
     this transaction when a late content write wins, preventing cleanup from
     deleting user data based on a stale empty read.
+
+    ``deleted_conversation``, when supplied, receives the raw snapshot this
+    transaction actually deleted. Physical cleanup that has to reason about the
+    row's contents must read them from here rather than fetching the document
+    itself: by the time this returns the row is gone, and a fetch beforehand
+    would decide against a snapshot a concurrent write can still invalidate.
     """
     client = _client(firestore_client)
     conversation_ref = (
@@ -208,6 +215,11 @@ def tombstone_and_delete_empty_conversation(
                                 'updated_at': _now(),
                             },
                         )
+        if deleted_conversation is not None:
+            # A contended transaction re-runs this function, so publish the
+            # snapshot that belongs to the attempt that actually commits.
+            deleted_conversation.clear()
+            deleted_conversation.update(conversation)
         transaction.delete(conversation_ref)
         return True
 

--- a/backend/tests/unit/test_empty_conversation_audio_cleanup.py
+++ b/backend/tests/unit/test_empty_conversation_audio_cleanup.py
@@ -1,0 +1,133 @@
+"""Physical audio cleanup when a listen generation is deleted as empty (#11742).
+
+The emptiness guard that authorizes the delete consults transcript segments,
+photos and ``has_content`` — never ``audio_files``. A generation whose STT
+produced nothing while the provider was failing therefore reaches the delete
+with real, registered audio on it, so cleanup here cannot be unconditional.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from utils.conversations import lifecycle as lifecycle_mod
+
+
+def _tombstone_returning(deleted: bool, conversation: dict[str, Any] | None = None):
+    """Stand in for the transaction, honouring its published-snapshot contract."""
+
+    def _tombstone(
+        uid: str,
+        conversation_id: str,
+        recording_session_id: str | None,
+        *,
+        firestore_client: Any = None,
+        deleted_conversation: dict[str, Any] | None = None,
+    ) -> bool:
+        if deleted and deleted_conversation is not None:
+            deleted_conversation.clear()
+            deleted_conversation.update(conversation or {})
+        return deleted
+
+    return _tombstone
+
+
+@pytest.fixture
+def cleanup_seam(monkeypatch):
+    """Hold the two physical-cleanup boundaries and the fallback emitter."""
+    calls: dict[str, list[Any]] = {'audio': [], 'photos': [], 'fallback': []}
+
+    # raising=False so this file fails on the missing *behaviour* rather than on
+    # a missing attribute when run against a tree without the cleanup call.
+    monkeypatch.setattr(
+        lifecycle_mod,
+        'delete_conversation_audio_files',
+        lambda uid, conversation_id: calls['audio'].append((uid, conversation_id)),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        lifecycle_mod.conversations_db,
+        'delete_conversation_photos',
+        lambda uid, conversation_id: calls['photos'].append((uid, conversation_id)),
+    )
+    monkeypatch.setattr(
+        lifecycle_mod,
+        'record_fallback',
+        lambda **kwargs: calls['fallback'].append(kwargs),
+    )
+    return calls
+
+
+def test_empty_generation_without_registered_audio_reclaims_its_chunks(monkeypatch, cleanup_seam):
+    """Nothing ever referenced these bytes, and the row that could have is gone."""
+    monkeypatch.setattr(
+        lifecycle_mod.recording_sessions_db,
+        'tombstone_and_delete_empty_conversation',
+        _tombstone_returning(True, {'id': 'conversation', 'status': 'in_progress'}),
+    )
+
+    deleted = lifecycle_mod.delete_empty_recording_conversation('uid', 'conversation', 'recording')
+
+    assert deleted is True
+    assert cleanup_seam['audio'] == [('uid', 'conversation')]
+    assert cleanup_seam['photos'] == [('uid', 'conversation')]
+
+
+def test_empty_generation_with_registered_audio_keeps_its_recording(monkeypatch, cleanup_seam):
+    """The STT-failure case: the only surviving copy of a real recording stays."""
+    monkeypatch.setattr(
+        lifecycle_mod.recording_sessions_db,
+        'tombstone_and_delete_empty_conversation',
+        _tombstone_returning(
+            True,
+            {
+                'id': 'conversation',
+                'status': 'in_progress',
+                'audio_files': [{'path': 'chunks/uid/conversation/0.wav'}],
+            },
+        ),
+    )
+
+    deleted = lifecycle_mod.delete_empty_recording_conversation('uid', 'conversation', 'recording')
+
+    assert deleted is True
+    assert cleanup_seam['audio'] == []
+    # The row still goes away; only the bytes are spared.
+    assert cleanup_seam['photos'] == [('uid', 'conversation')]
+
+
+def test_a_refused_delete_never_touches_audio(monkeypatch, cleanup_seam):
+    """Late content won the transaction, so the conversation still owns its audio."""
+    monkeypatch.setattr(
+        lifecycle_mod.recording_sessions_db,
+        'tombstone_and_delete_empty_conversation',
+        _tombstone_returning(False),
+    )
+
+    deleted = lifecycle_mod.delete_empty_recording_conversation('uid', 'conversation', 'recording')
+
+    assert deleted is False
+    assert cleanup_seam['audio'] == []
+    assert cleanup_seam['photos'] == []
+
+
+def test_a_failed_sweep_is_reported_without_breaking_the_delete(monkeypatch, cleanup_seam):
+    """A GCS failure leaves the orphan behind; it must not resurrect the row."""
+
+    def _boom(uid: str, conversation_id: str) -> None:
+        raise RuntimeError('gcs unavailable')
+
+    monkeypatch.setattr(lifecycle_mod, 'delete_conversation_audio_files', _boom, raising=False)
+    monkeypatch.setattr(
+        lifecycle_mod.recording_sessions_db,
+        'tombstone_and_delete_empty_conversation',
+        _tombstone_returning(True, {'id': 'conversation', 'status': 'in_progress'}),
+    )
+
+    deleted = lifecycle_mod.delete_empty_recording_conversation('uid', 'conversation', 'recording')
+
+    assert deleted is True
+    assert len(cleanup_seam['fallback']) == 1
+    assert cleanup_seam['fallback'][0]['outcome'] == 'exhausted'

--- a/backend/tests/unit/test_recording_sessions.py
+++ b/backend/tests/unit/test_recording_sessions.py
@@ -501,3 +501,67 @@ async def test_resume_reuses_the_lifecycle_snapshot_instead_of_reading_twice(rec
         'conversation-old'
     ], f'expected exactly one get_conversation call, got {get_conversation_calls}'
     assert host.state.current_conversation_id == 'conversation-old'
+
+
+def _stored_conversation_with_audio(audio_files: list[dict[str, Any]]) -> dict[str, Any]:
+    """An empty generation that nonetheless registered private-cloud audio.
+
+    This is the shape STT failure leaves behind: the pusher landed real chunks
+    and registered them, but no segment ever arrived, so the emptiness guard
+    still authorizes the delete.
+    """
+    return conversations_db.encode_conversation_for_write(
+        'uid',
+        {
+            'id': 'conversation',
+            'status': 'in_progress',
+            'transcript_segments': [],
+            'audio_files': audio_files,
+        },
+        'standard',
+    )
+
+
+def test_empty_cleanup_publishes_the_snapshot_it_deleted(recording_store):
+    conversation_path = ('users', 'uid', 'conversations', 'conversation')
+    audio_files = [{'path': 'chunks/uid/conversation/0.wav'}]
+    recording_store.documents[conversation_path] = _stored_conversation_with_audio(audio_files)
+    recording_sessions.create_or_get_recording_session(
+        'uid', 'recording', 'conversation', firestore_client=recording_store
+    )
+
+    captured: dict[str, Any] = {}
+    deleted = recording_sessions.tombstone_and_delete_empty_conversation(
+        'uid',
+        'conversation',
+        'recording',
+        firestore_client=recording_store,
+        deleted_conversation=captured,
+    )
+
+    assert deleted is True
+    assert conversation_path not in recording_store.documents
+    # Physical cleanup can only see the row through this snapshot; the document
+    # itself is gone by the time the caller gets to decide anything.
+    assert captured['audio_files'] == audio_files
+
+
+def test_empty_cleanup_publishes_nothing_when_it_refuses_to_delete(recording_store):
+    conversation_path = ('users', 'uid', 'conversations', 'conversation')
+    recording_store.documents[conversation_path] = _stored_conversation([{'id': 'late', 'text': 'persisted'}])
+    recording_sessions.create_or_get_recording_session(
+        'uid', 'recording', 'conversation', firestore_client=recording_store
+    )
+
+    captured: dict[str, Any] = {}
+    deleted = recording_sessions.tombstone_and_delete_empty_conversation(
+        'uid',
+        'conversation',
+        'recording',
+        firestore_client=recording_store,
+        deleted_conversation=captured,
+    )
+
+    assert deleted is False
+    assert conversation_path in recording_store.documents
+    assert captured == {}

--- a/backend/utils/conversations/lifecycle.py
+++ b/backend/utils/conversations/lifecycle.py
@@ -32,6 +32,7 @@ from utils.conversations.finalization_decision import (
     decide_finalization,
 )
 from utils.observability.fallback import record_fallback
+from utils.other.storage import delete_conversation_audio_files
 from utils.journey_metrics_contract import bounded_client_kind
 from utils.observability.journeys import record_client_journey_accepted, record_journey_accepted
 
@@ -553,16 +554,61 @@ def delete_empty_recording_conversation(
     recording_session_id: str | None,
 ) -> bool:
     """Delete only a still-empty listen generation and tombstone it atomically."""
+    deleted_conversation: dict[str, Any] = {}
     deleted = recording_sessions_db.tombstone_and_delete_empty_conversation(
         uid,
         conversation_id,
         recording_session_id,
+        deleted_conversation=deleted_conversation,
     )
     if deleted:
         # Parent deletion is transactionally fenced with content writes; photos
         # are a subcollection and need their physical cleanup afterwards.
         conversations_db.delete_conversation_photos(uid, conversation_id)
+        _discard_unreferenced_audio(uid, conversation_id, deleted_conversation)
     return deleted
+
+
+def _discard_unreferenced_audio(
+    uid: str,
+    conversation_id: str,
+    deleted_conversation: Mapping[str, Any],
+) -> None:
+    """Reclaim private-cloud bytes the deleted row was the last owner of.
+
+    Emptiness here means no transcript segments, no photos and no ``has_content``
+    — it never consults ``audio_files``. A generation whose STT produced nothing
+    because the provider was failing is therefore deleted with real audio still
+    registered on it, and those bytes are the only surviving copy of that
+    recording, so they stay: the row is gone either way, and retained chunks can
+    still be reprocessed or restored. Only a generation that never registered any
+    audio can be leaving chunks nothing will ever reference again (#11742).
+    """
+    if deleted_conversation.get('audio_files'):
+        logger.info(
+            'Retained registered audio for empty conversation uid=%s conversation_id=%s',
+            uid,
+            conversation_id,
+        )
+        return
+    try:
+        delete_conversation_audio_files(uid, conversation_id)
+    except Exception:
+        # The row is already gone, so there is nothing left to keep consistent
+        # with; a failed sweep just leaves the orphan this call meant to reclaim.
+        logger.exception(
+            'Failed to reclaim unreferenced audio uid=%s conversation_id=%s',
+            uid,
+            conversation_id,
+        )
+        record_fallback(
+            component='other',
+            from_mode='private_cloud_sync',
+            to_mode='drop',
+            reason='other',
+            outcome='exhausted',
+            log=logger,
+        )
 
 
 def open_live_recording_session(

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -137,6 +137,22 @@ terminal parent; the listen handler opens one fresh generation and replays that
 buffer once. The first-segment `started_at` value commits in that same content
 transaction, so this recovery cannot leave a timestamp-only write behind.
 
+Deleting an empty generation also sweeps its private-cloud audio, but only
+when that generation never registered any. Emptiness is decided from
+transcript segments, photos and `has_content`; `audio_files` is deliberately
+not part of the test, so a recording whose STT produced nothing while the
+provider was failing still reaches this delete with real audio registered on
+it. Those bytes are the last surviving copy of that recording and are kept, at
+the cost of leaving a prefix under `chunks/{uid}/{conversation_id}/` that no
+Firestore row points at any more — the bucket has no lifecycle rule there, so
+retained audio is retained until something reclaims it deliberately. Only a
+generation with no registered audio is swept, because nothing else could have
+referenced those chunks. The decision reads the snapshot the delete
+transaction actually removed rather than re-fetching the document: a fetch
+beforehand races the pusher's own registration write, and losing that race in
+the other direction would delete a recording that had just become
+referenceable.
+
 ## Capture-device provenance
 
 Every capture client with WebSocket-upgrade header support sends


### PR DESCRIPTION
## What

When a listen generation is deleted as empty, its private-cloud audio is now reclaimed — but only when that generation never registered any.

- `utils/conversations/lifecycle.py` — `delete_empty_recording_conversation` cleaned up the Firestore row and the photos subcollection and stopped there. It now also sweeps `chunks/{uid}/{conversation_id}/` and `audio/{uid}/{conversation_id}/` via `delete_conversation_audio_files`, conditionally.
- `database/recording_sessions.py` — `tombstone_and_delete_empty_conversation` gains an optional keyword-only `deleted_conversation` out-parameter carrying the snapshot the transaction actually deleted. The `bool` return is unchanged.

## Why

From #11742, measured in prod on 2026-08-17: 17 of 41 sampled conversation prefixes under `gs://omi-private-cloud-sync/chunks/` (41%, 76.5 MB in a 15-uid sample) belong to conversations that no longer exist, and the bucket lifecycle policy covers only `merged/` and `playback/`.

#11860 fixed the prevention half — a live pusher session no longer keeps minting fresh orphans after the delete point. This is the ownership half it explicitly carved out: the delete path itself never released the bytes it was the last owner of. The two sibling deletes both do — `routers/conversations.py:938` (user-initiated) and `utils/conversations/merge_conversations.py:659,700` — which is what makes this an ownership gap rather than deliberate retention policy.

## Why the sweep is conditional

Not symmetric with those two paths, deliberately. Emptiness here is decided by `raw_conversation_has_content` (`database/conversations.py:253`), which reads `has_content`, `photos` and `transcript_segments` — and never `audio_files`. `has_content` is itself written only from segments (`conversations.py:1499`) and photos (`:1826`), never from audio. The caller (`routers/listen/conversations.py:150`) routes on `transcript_segments or photos` alone.

A recording whose STT produced no segments while the provider was failing therefore reaches this delete with real, registered, multi-MB audio on it. The row is going away either way, but those bytes are the last surviving copy of that recording, so they stay and remain reprocessable. Only a generation that registered no `audio_files` is swept, because nothing could ever have referenced those chunks.

The tradeoff, stated plainly: retained audio stays under a prefix no Firestore row points at, and `chunks/` has no lifecycle rule, so it is retained until something reclaims it deliberately. Reclaiming the existing backlog is a separate, bulk deletion over live user data and is not in this PR.

## Why an out-parameter rather than a read

The decision has to come from the same transactional snapshot that authorized the delete. Fetching the conversation beforehand would race the pusher's own `audio_files` registration write — which is precisely the race #11742 documents, not a theoretical one — and losing that race in this direction deletes a recording that had just become referenceable. By the time the transaction returns the row is gone, so the snapshot is published out of the transaction instead. It is cleared and repopulated inside the transactional function so a contended retry publishes the attempt that actually commits.

The `bool` return is kept because three call sites in `tests/unit/test_recording_sessions.py` and two in `scripts/listen_lifecycle_emulator_test.py` assert on it; widening the return type would have been a larger change than the fix.

## What this does not do

- **The existing orphan backlog is untouched.** This stops the path from creating new unreferenced prefixes; it does not reclaim the measured 76.5 MB.
- **One residual orphan per deleted conversation remains.** In `_flush_batch` the batch is uploaded to GCS before `update_conversation` returns `False`, so the batch that discovers the missing owner is already in the bucket. Closing that means deleting just-uploaded user audio, which belongs with the backlog decision rather than here.
- **#11860's `deleted_conversations` behaviour is not modified.** Its suite is in the blast radius below to prove that.

## Tested

New: `backend/tests/unit/test_empty_conversation_audio_cleanup.py` (4 tests) drives the real `delete_empty_recording_conversation` with the tombstone stubbed to honour the out-parameter contract, and the storage/photos boundaries faked.

Extended: `backend/tests/unit/test_recording_sessions.py` (+2) drives the **real** delete transaction over the file's existing fake Firestore, proving the out-parameter carries the deleted snapshot and stays empty when the transaction refuses.

- **RED on the parent commit**, behavioural rather than fixture-level (the seam is patched with `raising=False` so the file fails on missing behaviour, not a missing attribute):
  - `test_empty_generation_without_registered_audio_reclaims_its_chunks` — `AssertionError: assert [] == [('uid', 'conversation')]`
  - `test_a_failed_sweep_is_reported_without_breaking_the_delete` — `assert 0 == 1`
  - The two db-layer tests fail with `TypeError` on the unknown keyword.
- **GREEN here** — 33 passed across the new file and `test_recording_sessions.py`.
- **The two retention tests pass against unmodified code by construction.** They are forward guards against someone later making this sweep unconditional, not red-then-green evidence, and are labelled as such rather than counted as regression coverage.
- **Blast radius** — 147 passed across `test_merge_conversations_canonical_delete.py`, `test_merge_validation.py`, `test_batch_upload_storage.py`, `test_listen_persistence.py`, `test_conversation_lifecycle_contract.py`, `test_pusher_deleted_conversation_sync.py`, `test_listen_lifecycle_emulator_harness_wiring.py`, `test_atomicity_lifecycle_regressions.py`, `test_check_conversation_lifecycle_writes.py`, `test_recording_sessions.py` and the new file.
- `scripts/typecheck.sh` — 0 errors.
- `scripts/check_module_stub_pollution.py` — 0 violations. `scripts/scan_import_time_side_effects.py` — 0 violations.
- `scripts/check_fallback_instrumentation.py` on both changed production files — clean.

Three unit files fail identically with and without this change on my machine — `test_rendered_deployment_contract.py`, `test_verify_pusher_config_references.py`, `test_backend_runtime_env_validator.py` — all on `assert helm is not None, "helm must be installed for the rendered deployment contract"`. Helm is not installed locally; verified pre-existing by re-running them with the change stashed.

**Not reproduced against prod:** the Firestore-delete-races-a-live-GCS-bucket path cannot be exercised hermetically, so the evidence above is the real lifecycle function and the real delete transaction driven over a fake Firestore and a faked storage boundary — not a live session, and not a live bucket.

Failure-Class: none

No existing definition in `.github/failure-classes/` covers a delete path that releases its logical record while leaving the physical resource it was the last owner of. The nearest candidates do not fit: `FC-fallible-teardown-skips-required-finalizer` is about a finalizer sequenced behind fallible cleanup, and `FC-content-derived-identity-retired-by-deletion` is about identity reuse after deletion. Following the precedent set in #11860 for the sibling half of this same issue, one instance is not enough to mint a class, and `AGENTS.md` keeps registry lifecycle transitions in their own PRs.

Refs #11742

Note: #11742 was auto-closed as COMPLETED on 2026-08-20 citing #11860, but #11860's own description says "The issue stays open... This PR is the prevention half only." This PR is that remaining half; the issue may be worth reopening or re-closing on this.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

