### PR TITLE
feat(desktop-windows): main-chat typing indicator + agent-card provider brand marks

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-08-agent-card-brand-mark-typing-indicator.json
+++ b/desktop/windows/changelog/unreleased/2026-08-agent-card-brand-mark-typing-indicator.json
@@ -1,0 +1,6 @@
+{
+  "changes": [
+    "The main chat window now shows the same animated spinner as the floating bar while waiting for a reply, instead of a plain '…'.",
+    "Background-agent cards in chat now show which agent (Hermes, OpenClaw, Claude Code, Codex, or Omi) ran, instead of a generic bot icon."
+  ]
+}

--- a/desktop/windows/src/main/agentKernel/agentThreadCards.test.ts
+++ b/desktop/windows/src/main/agentKernel/agentThreadCards.test.ts
@@ -71,6 +71,7 @@ function stampFor(conversationId: string): AgentCardStamp {
     producingChatId: 'default',
     producingSurfaceKind: 'main_chat',
     pillId: 'pill-1',
+    provider: 'openclaw',
     title: 'Build X',
     objective: 'Build feature X end to end'
   }
@@ -110,6 +111,48 @@ describe('agent thread cards — the exactly-two boundary', () => {
     if (cards[1].block.type === 'agentCompletion') {
       expect(cards[1].block).toMatchObject({ runId: 'run_1', status: 'succeeded', output: 'done' })
     }
+  })
+
+  // The spawn call's resolved adapter id rides the stamp so the terminal
+  // subscriber (which only ever sees runId/status) can still agree with the
+  // launch card on which provider ran — read back from the SAME stamp object,
+  // not re-derived, so a run whose default adapter changed mid-flight can't
+  // produce two disagreeing cards.
+  it('carries the spawn adapter id through to both the spawn and completion cards', () => {
+    const store = newStore()
+    const conversationId = newConversation(store)
+    const stamp = stampFor(conversationId) // provider: 'openclaw'
+
+    materializeAgentSpawnCard(store, { runId: 'run_1', sessionId: 'sess_1', stamp, nowMs: 1000 })
+    materializeAgentCompletionCard(store, {
+      run: {
+        runId: 'run_1',
+        sessionId: 'sess_1',
+        status: 'succeeded',
+        finalText: '',
+        errorMessage: null
+      },
+      stamp,
+      nowMs: 1001
+    })
+
+    const cards = listAgentThreadCards(store, conversationId)
+    expect(cards[0].block).toMatchObject({ provider: 'openclaw' })
+    expect(cards[1].block).toMatchObject({ provider: 'openclaw' })
+  })
+
+  // A producing surface stamped before this field existed (or a spawn that
+  // recorded no adapter) must not crash card materialization — the card just
+  // omits `provider`, and the renderer falls back to its generic icon.
+  it('omits `provider` from the card when the stamp carries none', () => {
+    const store = newStore()
+    const conversationId = newConversation(store)
+    const stamp: AgentCardStamp = { ...stampFor(conversationId), provider: null }
+
+    materializeAgentSpawnCard(store, { runId: 'run_1', sessionId: 'sess_1', stamp, nowMs: 1000 })
+
+    const cards = listAgentThreadCards(store, conversationId)
+    expect(cards[0].block).not.toHaveProperty('provider')
   })
 
   it('is idempotent: a repeat spawn and a retried terminal never add a second card', () => {

--- a/desktop/windows/src/main/agentKernel/agentThreadCards.ts
+++ b/desktop/windows/src/main/agentKernel/agentThreadCards.ts
@@ -57,6 +57,12 @@ export interface AgentCardStamp {
   producingChatId: string | null
   producingSurfaceKind: string
   pillId: string | null
+  /** The resolved coding-agent adapter id at spawn time (e.g. 'acp', 'openclaw',
+   *  'hermes', 'codex', 'pi-mono') — read back verbatim for the completion card
+   *  too, so both cards for a run agree on which adapter actually ran it. Null
+   *  when the spawn call recorded no adapter (should not happen in practice,
+   *  but the stamp read path degrades to the card's Bot-icon fallback). */
+  provider: string | null
   title: string
   objective: string
 }
@@ -105,6 +111,7 @@ export function readAgentCardStamp(metadata: unknown): AgentCardStamp | null {
     producingSurfaceKind:
       typeof s.producingSurfaceKind === 'string' ? s.producingSurfaceKind : 'main_chat',
     pillId: typeof s.pillId === 'string' ? s.pillId : null,
+    provider: typeof s.provider === 'string' && s.provider ? s.provider : null,
     title: typeof s.title === 'string' && s.title ? s.title : 'Background agent',
     objective: typeof s.objective === 'string' ? s.objective : ''
   }
@@ -250,6 +257,7 @@ export function materializeAgentSpawnCard(
     type: 'agentSpawn',
     id: randomUUID(),
     ...(stamp.pillId ? { pillId: stamp.pillId } : {}),
+    ...(stamp.provider ? { provider: stamp.provider } : {}),
     sessionId: input.sessionId,
     runId: input.runId,
     title: stamp.title,
@@ -279,6 +287,7 @@ export function materializeAgentCompletionCard(
     type: 'agentCompletion',
     id: randomUUID(),
     ...(stamp.pillId ? { pillId: stamp.pillId } : {}),
+    ...(stamp.provider ? { provider: stamp.provider } : {}),
     sessionId: run.sessionId,
     runId: run.runId,
     title: stamp.title,

--- a/desktop/windows/src/main/agentKernel/controlTools.ts
+++ b/desktop/windows/src/main/agentKernel/controlTools.ts
@@ -912,6 +912,11 @@ export async function handleAgentControlToolCall(
               producingChatId: producingSurface.chatId,
               producingSurfaceKind: producingSurface.surfaceKind,
               pillId: visiblePillExternalRefId ?? null,
+              // The resolved adapter, not the narrower `parsed.provider` selector
+              // (which only ever carries 'openclaw'/'hermes') — this covers all
+              // five adapters so the card's brand mark isn't gapped for acp/codex/
+              // pi-mono spawns.
+              provider: adapterId,
               title: cardTitle,
               objective: parsed.objective
             })

--- a/desktop/windows/src/renderer/src/components/chat/AgentThreadCard.tsx
+++ b/desktop/windows/src/renderer/src/components/chat/AgentThreadCard.tsx
@@ -1,4 +1,5 @@
 import { AlertCircle, Bot, CheckCircle2, CircleSlash, Loader2 } from 'lucide-react'
+import { ConnectorBrandMark, type ConnectorBrand } from '../home/hub/connections/ConnectorBrandMark'
 import type { AgentThreadCardBlock } from '../../../../shared/types'
 
 // Shared-thread agent cards (B4, INV-CHAT-1). The two durable artifacts a
@@ -16,6 +17,39 @@ const STATUS: Record<CompletionStatus, { label: string; dot: string; Icon: typeo
 
 function coerceStatus(status: string): CompletionStatus {
   return status === 'succeeded' || status === 'stopped' || status === 'failed' ? status : 'failed'
+}
+
+// Maps the spawn's resolved coding-agent adapter id (adapterRegistry.ts's
+// ProductionAdapterId) to the connections panel's brand mark, so the card
+// shows which agent actually ran instead of a generic bot glyph. Not every
+// adapter has a dedicated asset: codex reuses the OpenAI mark (same vendor as
+// ChatGPT), acp (Claude Code) reuses the Claude mark — both real brand marks,
+// just not adapter-specific ones. `provider` is absent on cards from before
+// this field existed, or when the producing surface stamped no provenance —
+// those fall back to the plain Bot icon below, same as always.
+const PROVIDER_BRAND: Partial<Record<string, ConnectorBrand>> = {
+  acp: 'claude',
+  openclaw: 'openclaw',
+  hermes: 'hermes',
+  codex: 'chatgpt',
+  'pi-mono': 'omi'
+}
+
+function AgentIcon({
+  provider,
+  compact
+}: {
+  provider?: string
+  compact: boolean
+}): React.JSX.Element {
+  const size = compact ? 'h-3.5 w-3.5' : 'h-4 w-4'
+  const brand = provider ? PROVIDER_BRAND[provider] : undefined
+  if (!brand) return <Bot className={`${size} shrink-0 text-white/70`} />
+  return (
+    <span className={`flex ${size} shrink-0 items-center justify-center`}>
+      <ConnectorBrandMark brand={brand} />
+    </span>
+  )
 }
 
 /**
@@ -39,7 +73,7 @@ export function AgentThreadCard({
     return (
       <div className={`bubble-in ${shell}`}>
         <div className="flex items-center gap-2">
-          <Bot className={`${compact ? 'h-3.5 w-3.5' : 'h-4 w-4'} shrink-0 text-white/70`} />
+          <AgentIcon provider={block.provider} compact={compact} />
           <span className={titleCls}>{block.title}</span>
           <span className="ml-1 flex shrink-0 items-center gap-1 text-white/45">
             <Loader2 className="h-3 w-3 animate-spin" />
@@ -58,7 +92,7 @@ export function AgentThreadCard({
   return (
     <div className={`bubble-in ${shell}`}>
       <div className="flex items-center gap-2">
-        <Bot className={`${compact ? 'h-3.5 w-3.5' : 'h-4 w-4'} shrink-0 text-white/70`} />
+        <AgentIcon provider={block.provider} compact={compact} />
         <span className={titleCls}>{block.title}</span>
         <span className={`ml-1 flex shrink-0 items-center gap-1 ${dot}`}>
           <Icon className="h-3.5 w-3.5" />

--- a/desktop/windows/src/renderer/src/components/chat/ChatMessages.test.tsx
+++ b/desktop/windows/src/renderer/src/components/chat/ChatMessages.test.tsx
@@ -78,36 +78,37 @@ describe('ChatMessages copy button', () => {
   )
 })
 
-describe('ChatMessages [overlay] — pending spinner', () => {
-  it('shows the standalone spinning Omi mark (not a bubble) while the reply is pending', () => {
-    const { container } = render(
-      <ChatMessages messages={[user('hi'), assistant('')]} sending={true} variant="overlay" />
-    )
-    const spinner = screen.getByRole('status', { name: 'Omi is thinking' })
-    expect(spinner.querySelector('svg.omi-thinking-spin')).not.toBeNull()
-    // The loader is NOT itself a message bubble: only the user turn is a bubble,
-    // the pending assistant turn is the standalone spinner.
-    expect(container.querySelectorAll('[class*="group/msg"]').length).toBe(1)
-  })
+describe('ChatMessages — pending spinner (main + overlay)', () => {
+  it.each(['overlay', 'main'] as const)(
+    'shows the standalone spinning Omi mark (not a bubble) while the reply is pending [%s]',
+    (variant) => {
+      const { container } = render(
+        <ChatMessages messages={[user('hi'), assistant('')]} sending={true} variant={variant} />
+      )
+      const spinner = screen.getByRole('status', { name: 'Omi is thinking' })
+      expect(spinner.querySelector('svg.omi-thinking-spin')).not.toBeNull()
+      // The loader is NOT itself a message bubble: only the user turn is a bubble,
+      // the pending assistant turn is the standalone spinner.
+      expect(container.querySelectorAll('[class*="group/msg"]').length).toBe(1)
+    }
+  )
 
-  it('swaps the spinner for a bubble once the reply has content', () => {
-    const { container } = render(
-      <ChatMessages
-        messages={[user('hi'), assistant('here is your answer')]}
-        sending={true}
-        variant="overlay"
-      />
-    )
-    expect(screen.queryByRole('status', { name: 'Omi is thinking' })).toBeNull()
-    // Both turns are now bubbles (the assistant bubble carries bubble-in for the
-    // pop-in); the loader is gone.
-    expect(container.querySelectorAll('[class*="group/msg"]').length).toBe(2)
-  })
-
-  it('does not use the bar spinner in the main window (keeps its own indicator)', () => {
-    render(<ChatMessages messages={[user('hi'), assistant('')]} sending={true} variant="main" />)
-    expect(screen.queryByRole('status', { name: 'Omi is thinking' })).toBeNull()
-  })
+  it.each(['overlay', 'main'] as const)(
+    'swaps the spinner for a bubble once the reply has content [%s]',
+    (variant) => {
+      const { container } = render(
+        <ChatMessages
+          messages={[user('hi'), assistant('here is your answer')]}
+          sending={true}
+          variant={variant}
+        />
+      )
+      expect(screen.queryByRole('status', { name: 'Omi is thinking' })).toBeNull()
+      // Both turns are now bubbles (the assistant bubble carries bubble-in for the
+      // pop-in); the loader is gone.
+      expect(container.querySelectorAll('[class*="group/msg"]').length).toBe(2)
+    }
+  )
 })
 
 const image = {
@@ -165,7 +166,7 @@ describe.each(['main', 'overlay'] as const)('ChatMessages [%s] — attachments',
 
 // Shared-thread agent cards (B4, INV-CHAT-1): an assistant message carrying an
 // agentSpawn / agentCompletion block renders as a card, not a text bubble.
-const spawnCard = (): ChatMsg => ({
+const spawnCard = (provider?: string): ChatMsg => ({
   id: 'spawn-1',
   role: 'assistant',
   content: '',
@@ -174,6 +175,7 @@ const spawnCard = (): ChatMsg => ({
       type: 'agentSpawn',
       id: 'spawn-1',
       pillId: 'pill-1',
+      ...(provider ? { provider } : {}),
       sessionId: 'sess_1',
       runId: 'run_1',
       title: 'Build the report',
@@ -209,6 +211,25 @@ describe('ChatMessages — shared-thread agent cards (B4)', () => {
     expect(screen.getByText('Running')).not.toBeNull()
     // A card is not a copyable text bubble.
     expect(screen.queryByRole('button', { name: 'Copy message' })).toBeNull()
+  })
+
+  // Quick win: the card used to show a generic Bot icon for every provider —
+  // the block now carries the resolved adapter id, so a recognized provider
+  // shows its real brand mark instead.
+  it('shows the provider brand mark instead of the generic Bot icon when the block carries one', () => {
+    const { container } = render(
+      <ChatMessages messages={[spawnCard('hermes')]} sending={false} variant="main" />
+    )
+    // BrandImage (PNG-backed marks like hermes) renders an <img>; the Bot
+    // fallback is an inline lucide <svg>, never an <img>.
+    expect(container.querySelector('img')).not.toBeNull()
+  })
+
+  it('falls back to the generic Bot icon when the block carries no provider', () => {
+    const { container } = render(
+      <ChatMessages messages={[spawnCard()]} sending={false} variant="main" />
+    )
+    expect(container.querySelector('img')).toBeNull()
   })
 
   it('renders the completion card with a status label and its output', () => {

--- a/desktop/windows/src/renderer/src/components/chat/ChatMessages.tsx
+++ b/desktop/windows/src/renderer/src/components/chat/ChatMessages.tsx
@@ -119,12 +119,13 @@ const MessageRow = memo(function MessageRow({
       )
     }
   }
-  // Bar chat (overlay): while Omi's reply is still pending — the last
-  // assistant turn exists as an empty placeholder — show a standalone
-  // spinning Omi mark instead of a bubble of dots. A distinct element type means
-  // the real bubble mounts fresh (bubble-in pop-in) the moment content lands and
-  // this loader is unmounted. The main window keeps its own indicators.
-  if (variant === 'overlay' && isLast && sending && m.role === 'assistant' && !m.content) {
+  // While Omi's reply is still pending — the last assistant turn exists as an
+  // empty placeholder — show a standalone spinning Omi mark instead of a
+  // bubble of dots. A distinct element type means the real bubble mounts
+  // fresh (bubble-in pop-in) the moment content lands and this loader is
+  // unmounted. Both surfaces are dark (main's assistant bubble is white-on-
+  // dark, same as overlay's), so the spinner's dot color reads fine on either.
+  if (isLast && sending && m.role === 'assistant' && !m.content) {
     return <OmiThinkingSpinner />
   }
   // Never offer copy on the reply that is still streaming in (or on an

--- a/desktop/windows/src/renderer/src/components/chat/OmiThinkingSpinner.tsx
+++ b/desktop/windows/src/renderer/src/components/chat/OmiThinkingSpinner.tsx
@@ -1,9 +1,9 @@
-// The bar chat's "waiting for Omi's reply" loader: the Omi dot-ring mark, spun
-// fast (see .omi-thinking-spin in globals.css). It stands ALONE — deliberately
-// NOT wrapped in a message bubble — left-aligned where the assistant reply will
-// land, so when the reply arrives the bubble simply pops in (bubble-in) and this
-// loader is unmounted. Replaces the old bubble-of-dots ("…") pending indicator in
-// the floating bar's inline conversation (overlay variant only).
+// The chat's "waiting for Omi's reply" loader (both the main window and the
+// floating bar): the Omi dot-ring mark, spun fast (see .omi-thinking-spin in
+// globals.css). It stands ALONE — deliberately NOT wrapped in a message bubble
+// — left-aligned where the assistant reply will land, so when the reply
+// arrives the bubble simply pops in (bubble-in) and this loader is unmounted.
+// Replaces the old bubble-of-dots ("…") pending indicator on both surfaces.
 //
 // The eight-dot ring mirrors the shipped omi-mark.png glyph (the same mark
 // ConnectorBrandMark's OmiMark / macOS HomeOmiMarkIcon draw), rendered inline so

--- a/desktop/windows/src/shared/chatContent.ts
+++ b/desktop/windows/src/shared/chatContent.ts
@@ -52,6 +52,10 @@ export type ChatContentBlock =
       type: 'agentSpawn'
       id: string
       pillId?: string
+      /** The resolved coding-agent adapter id ('acp' | 'openclaw' | 'hermes' |
+       *  'codex' | 'pi-mono'), for the card's brand mark. Absent when the run
+       *  predates this field or its producing surface stamped no provenance. */
+      provider?: string
       sessionId: string
       runId: string
       title: string
@@ -62,6 +66,7 @@ export type ChatContentBlock =
       type: 'agentCompletion'
       id: string
       pillId?: string
+      provider?: string
       sessionId?: string
       runId?: string
       title: string


### PR DESCRIPTION
## Summary
Two quick wins from the mac-parity audit (`docs/mac-parity-audit/00-INDEX.md`'s "Quick wins — already built, just unwired or disabled" section).

**1. Main-chat typing indicator.** The main chat window's pending-reply placeholder was a literal `'…'` string — the real 8-dot `OmiThinkingSpinner` already existed and was used on the floating bar, but was gated to `variant === 'overlay'` only. Dropped that restriction; both surfaces render assistant bubbles as white-on-dark, so the spinner's dot color reads correctly on either. Flipped the one test that had pinned the old "main window keeps its own indicator" behavior as intended.

**2. Agent-card provider brand marks.** Shared-thread agent cards (`AgentThreadCard`) always showed a generic Bot icon regardless of which coding-agent adapter actually ran a background agent. The `ConnectorBrandMark` component and Hermes/OpenClaw/etc. brand assets already existed (used by the Connections panel), but nothing fed them a provider — this turned out to need real plumbing, not just a rendering swap:
- Added an optional `provider` field to the `agentSpawn`/`agentCompletion` block types (`shared/chatContent.ts`).
- Threaded the already-resolved coding-agent `adapterId` through `AgentCardStamp` at the one `spawn_agent` call site (`controlTools.ts`) — deliberately using the resolved adapter, not the narrower `provider` selector param (which only ever carries `'openclaw'`/`'hermes'`), so all five adapters get covered.
- The completion card reads the same field back automatically via the existing stamp-read mechanism (`readAgentCardStamp`) already used for `pillId`/`title`/`objective` — no separate plumbing needed for that side.
- Renderer maps all five adapters to a brand mark: `acp`→claude, `openclaw`→openclaw, `hermes`→hermes, `codex`→chatgpt (same vendor, no dedicated codex asset), `pi-mono`→omi. Falls back to the original Bot icon when a card carries no provider (older cards, or a producing surface with no stamped provenance).

## Test plan
- [x] New/updated tests: `ChatMessages.test.tsx` (typing-indicator parametrized across both variants + 2 new brand-mark tests), `agentThreadCards.test.ts` (2 new tests: provider flows to both cards via the same stamp, and is safely omitted when absent)
- [x] `pnpm typecheck` (node + web) clean
- [x] `pnpm lint` clean
- [x] Full suite: 546 files / 5,416 tests pass


## Product invariants affected

**INV-CHAT-1** (one shared transcript across surfaces): Both changes are display-only. The typing indicator swaps the `'…'` placeholder for `OmiThinkingSpinner` in the pending-reply bubble — no state, store, or turn identity touched. The agent-card brand mark adds an optional `provider` field to the `agentSpawn`/`agentCompletion` stamp types and threads the resolved adapter ID through the one `spawn_agent` call site — display metadata only, no transcript fork, no second store, no session identity change.

## Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
