### PR TITLE
fix(admin): k-factor from real viral signals + daily graph

### DIFF
--- a/web/admin/app/(protected)/dashboard/classic/page.tsx
+++ b/web/admin/app/(protected)/dashboard/classic/page.tsx
@@ -255,12 +255,26 @@ interface ActivationStats {
   freshAt?: number;
 }
 
+interface KFactorSignalTotals {
+  friends: number;
+  referrals: number;
+  shares: number;
+  total: number;
+}
 interface KFactorData {
   days: number;
   available: boolean;
   kFactor: number | null;
   reason: string;
-  funnel?: { issued: number; captured: number; granted: number };
+  daily?: {
+    date: string;
+    friends: number;
+    referrals: number;
+    shares: number;
+    total: number;
+  }[];
+  totals?: KFactorSignalTotals;
+  weekly?: KFactorSignalTotals;
 }
 
 interface MacosVersionBreakdown {
@@ -1814,13 +1828,15 @@ export default function AnalyticsPage() {
   const netWauChange = calculatePeriodChange(netWauNow, netWauPrev, "vs previous complete week");
 
   const growthGoalItems = useMemo<ChartItem[]>(() => {
-    const referralGrants = kFactorData?.funnel?.granted;
-    const kFactorValue = kFactorData?.available && referralGrants != null
-      ? referralGrants.toLocaleString()
+    const kTotals = kFactorData?.totals;
+    const kWeekly = kFactorData?.weekly;
+    const kFactorValue = kFactorData?.available && kTotals != null
+      ? kTotals.total.toLocaleString()
       : "Not tracked";
-    const kFactorSubtitle = kFactorData?.funnel
-      ? `${kFactorData.funnel.issued} issued / ${kFactorData.funnel.captured} captured / ${kFactorData.funnel.granted} granted`
-      : kFactorData?.reason ?? "Referral funnel is unavailable";
+    const kFactorSubtitle = kTotals
+      ? `${kTotals.friends} friend · ${kTotals.referrals} referral · ${kTotals.shares} share (30d) · ${(kWeekly?.total ?? 0).toLocaleString()}/wk`
+      : kFactorData?.reason ?? "K-factor signals unavailable";
+    const kFactorDaily = kFactorData?.daily ?? [];
 
     return [
       {
@@ -1949,7 +1965,7 @@ export default function AnalyticsPage() {
       },
       {
         id: "kpi-k-factor",
-        title: "Referral grants",
+        title: "K-Factor (30d)",
         variant: "kpi",
         icon: <Share2 className="h-3.5 w-3.5" />,
         initialLayout: { cols: 3, rows: 1 },
@@ -1958,6 +1974,47 @@ export default function AnalyticsPage() {
           <div>
             <div className="text-2xl font-bold">{kFactorLoading ? "..." : kFactorValue}</div>
             <p className="truncate text-xs text-muted-foreground">{kFactorSubtitle}</p>
+          </div>
+        ),
+      },
+      {
+        id: "kfactor-daily",
+        title: "K-Factor · Daily Viral Signals",
+        subtitle: "friend sign-ups + referral opens + conversation shares",
+        icon: <Share2 className="h-4 w-4" />,
+        periodChange: latestPeriodChange(kFactorDaily, (point) => point.total, "vs previous day"),
+        initialLayout: { cols: 12, rows: 4 },
+        removable: false,
+        render: () => (
+          <div className="flex h-full flex-col">
+            {kFactorDaily.length > 0 && (
+              <div className="mb-2 text-right text-sm text-muted-foreground">
+                {kFactorDaily.reduce((s, p) => s + p.total, 0).toLocaleString()} signals · last {kFactorDaily.length}d
+              </div>
+            )}
+            <div className="min-h-0 flex-1">
+              {kFactorLoading ? (
+                <div className="flex items-center justify-center h-full">
+                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                </div>
+              ) : kFactorDaily.length > 0 ? (
+                <ResponsiveContainer width="100%" height="100%">
+                  <ComposedChart data={kFactorDaily}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                    <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
+                    <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                    <Tooltip labelFormatter={fullDate} contentStyle={tooltipStyle} />
+                    <Legend />
+                    <Bar dataKey="friends" name="Friend sign-ups" stackId="k" fill="#6366f1" />
+                    <Bar dataKey="referrals" name="Referral opens" stackId="k" fill="#22c55e" />
+                    <Bar dataKey="shares" name="Conversation shares" stackId="k" fill="#f97316" radius={[2, 2, 0, 0]} />
+                    <Line type="monotone" dataKey="total" name="K-Factor (total)" stroke="#e11d48" strokeWidth={2} dot={false} activeDot={{ r: 4 }} />
+                  </ComposedChart>
+                </ResponsiveContainer>
+              ) : (
+                <div className="flex items-center justify-center h-full text-muted-foreground">No data available</div>
+              )}
+            </div>
           </div>
         ),
       },

--- a/web/admin/app/api/omi/stats/k-factor/posthog/route.ts
+++ b/web/admin/app/api/omi/stats/k-factor/posthog/route.ts
@@ -4,9 +4,22 @@ import { posthogResults } from "@/lib/posthog";
 export const dynamic = "force-dynamic";
 export const maxDuration = 3600;
 
-// Run the referral funnel HogQL queries through posthogResults (Firestore
-// query-cache + 429 backoff + stale fallback) and shape the panel payload.
+// K-factor is measured as the daily sum of three word-of-mouth signals, each a
+// real, server-observed PostHog event:
+//   1) friend  — "Onboarding How Did You Hear" with source = 'Friend'
+//   2) referral — "Referral Program Opened" (referral system usage)
+//   3) share    — "Conversation Shared" (sharing conversation summaries)
+// Older builds queried "Referral Link Issued/Claimed", which are never emitted,
+// so the panel always read null. These event names are verified against live data.
 // Exported so the precompute cron can warm the underlying query cache.
+export interface KFactorDaily {
+  date: string;
+  friends: number;
+  referrals: number;
+  shares: number;
+  total: number;
+}
+
 export async function computeKFactor(days: number) {
   const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
   const projectId = process.env.POSTHOG_PROJECT_ID;
@@ -24,47 +37,88 @@ export async function computeKFactor(days: number) {
     };
   }
 
-  const uniqueUsersQuery = (event: string, extraFilter = "") => `
-          SELECT uniq(COALESCE(person_id, distinct_id)) AS unique_users
+  const dailySeries = (event: string, extraFilter = "") => `
+          SELECT toDate(timestamp) AS day, count() AS n
           FROM events
           WHERE event = '${event}'
             AND timestamp >= now() - INTERVAL ${days} DAY
-            AND properties.program = 'desktop_operator_month_v1'
             ${extraFilter}
+          GROUP BY day
+          ORDER BY day
         `;
 
-  const [issuedRows, capturedRows, grantedRows] = await Promise.all([
+  const [friendRows, referralRows, shareRows] = await Promise.all([
     posthogResults(
       host,
       projectId,
       apiKey,
-      uniqueUsersQuery("Referral Link Issued"),
+      dailySeries("Onboarding How Did You Hear", "AND properties.source = 'Friend'"),
     ) as Promise<any[]>,
     posthogResults(
       host,
       projectId,
       apiKey,
-      uniqueUsersQuery("Referral Link Captured"),
+      dailySeries("Referral Program Opened"),
     ) as Promise<any[]>,
     posthogResults(
       host,
       projectId,
       apiKey,
-      uniqueUsersQuery("Referral Claimed", "AND properties.claimed = true"),
+      dailySeries("Conversation Shared"),
     ) as Promise<any[]>,
   ]);
 
-  const issued = Number(issuedRows?.[0]?.[0] ?? 0);
-  const captured = Number(capturedRows?.[0]?.[0] ?? 0);
-  const granted = Number(grantedRows?.[0]?.[0] ?? 0);
+  const toMap = (rows: any[]) => {
+    const m = new Map<string, number>();
+    for (const r of rows ?? []) {
+      const day = String(r?.[0] ?? "").slice(0, 10);
+      if (day) m.set(day, Number(r?.[1] ?? 0));
+    }
+    return m;
+  };
+  const fMap = toMap(friendRows);
+  const rMap = toMap(referralRows);
+  const sMap = toMap(shareRows);
+
+  // Continuous day axis so the daily graph has no gaps.
+  const daily: KFactorDaily[] = [];
+  const today = new Date();
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(today);
+    d.setUTCDate(d.getUTCDate() - i);
+    const key = d.toISOString().slice(0, 10);
+    const friends = fMap.get(key) ?? 0;
+    const referrals = rMap.get(key) ?? 0;
+    const shares = sMap.get(key) ?? 0;
+    daily.push({ date: key, friends, referrals, shares, total: friends + referrals + shares });
+  }
+
+  const windowSum = (sel: (p: KFactorDaily) => number, n = days) =>
+    daily.slice(-n).reduce((s, p) => s + sel(p), 0);
+
+  const totals = {
+    friends: windowSum((p) => p.friends),
+    referrals: windowSum((p) => p.referrals),
+    shares: windowSum((p) => p.shares),
+    total: windowSum((p) => p.total),
+  };
+  const weekly = {
+    friends: windowSum((p) => p.friends, 7),
+    referrals: windowSum((p) => p.referrals, 7),
+    shares: windowSum((p) => p.shares, 7),
+    total: windowSum((p) => p.total, 7),
+  };
 
   return {
     days,
     available: true as const,
-    kFactor: issued > 0 ? granted / issued : null,
+    // Headline k-factor = total viral signals over the window (sum of all three).
+    kFactor: totals.total,
+    daily,
+    totals,
+    weekly,
     reason:
-      "Referral grants are measured from the server-side referral funnel.",
-    funnel: { issued, captured, granted },
+      "K-factor = friend sign-ups + referral opens + conversation shares (server-side PostHog).",
   };
 }
 


### PR DESCRIPTION
## Part A of the k-factor / rating work

**Problem:** the k-factor panel queried `Referral Link Issued/Claimed` events that are **never emitted** (0 in PostHog), scoped to a dead program `desktop_operator_month_v1`, so it always read `null`.

**Fix:** recompute k-factor as the **daily sum of three live signals** (all verified against live PostHog data):
- friend sign-ups — `Onboarding How Did You Hear` (source=Friend) · 30/14d
- referral opens — `Referral Program Opened` · 627/30d
- conversation shares — `Conversation Shared` · 1574/30d

Adds a **daily viral-signals graph** (stacked signals + total k-factor line) and a per-signal **30d + weekly** breakdown to the classic dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

