### PR TITLE
chore: register FC-alert-never-provably-fired

### DIFF
--- a/.github/failure-classes/FC-alert-never-provably-fired.json
+++ b/.github/failure-classes/FC-alert-never-provably-fired.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-alert-never-provably-fired",
+  "violated_contract": "A newly authored alert counts as coverage only once its expression has been evaluated against real historical data spanning both a known-bad and a known-good period. Valid PromQL, successful provisioning, and a green evaluation state are all satisfied by an alert that can never fire: an expression that is silently mistyped for how the metric is actually exposed returns empty, and empty is indistinguishable from healthy. A threshold picked from a remembered baseline rather than from the metric's measured distribution fails the same way in the other direction, firing on ordinary noise or sitting inside it.",
+  "canonical_prevention": "Before merging an alert, run its exact expression against the real series over a window that contains the incident it is meant to catch, and record two numbers in the rule's own annotations: what it evaluates to during the bad period and during the good period. If the two are not separated by the threshold, the rule is not finished. Check the exposed representation of the metric -- not its upstream semantics -- because an exporter may publish a DELTA counter as a gauge, which makes rate() return a plausible wrong number rather than an error.",
+  "canonical_prevention_artifact": [
+    "backend/charts/monitoring/alerts/firestore.json"
+  ],
+  "evidence_prs": [12193],
+  "scope_hints": [
+    "backend/charts/monitoring/alerts/",
+    "backend/charts/monitoring/alert-rules.json",
+    "backend/charts/monitoring/prometheus-stackdriver-exporter/"
+  ],
+  "status": "open"
+}


### PR DESCRIPTION
Registry-only lifecycle PR, per `instance_fix_mutates_registry`.

Adds one failure-class definition. No code or config changes.

## Why a new class

The two Firestore cost alerts merged in #12193 use `rate()` on a metric that `stackdriver_exporter` publishes as a **gauge**, not a counter. Both rules are valid PromQL, provisioned cleanly, and evaluate green — and neither could ever have crossed its threshold. `rate()` returned `75.7` where actual read volume was `~936/sec`.

The same authoring gap produced a second, independent defect in the same rules: thresholds chosen from a remembered baseline rather than the metric's measured distribution. `1.5x` day-over-day sits **below** ordinary noise (which reaches `1.94x`), and the `600/sec` ceiling sits **inside** the pre-incident range (which reached `603.9/sec` and `1124/sec`).

Both share one root: the alert was authored from assumptions about the data instead of from the data, and nothing in provisioning, testing, or evaluation state can distinguish an alert that is quiet because the system is healthy from one that is quiet because it cannot fire.

The nearest existing class, `FC-bridge-liveness-without-data-path-proof`, covers a data path whose liveness is asserted without an end-to-end datum. This is about the monitor itself being the inert artifact.

The instance fix is in a separate PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

