### PR TITLE
fix: correct Firestore cost alerts that could never fire

### DIFF
--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -10561,7 +10561,7 @@
         "refId": "A",
         "queryType": "",
         "relativeTimeRange": {
-          "from": 3600,
+          "from": 90000,
           "to": 0
         },
         "datasourceUid": "prometheus",
@@ -10570,7 +10570,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[1h])) > 1.5 * sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[1h] offset 24h))",
+          "expr": "avg_over_time(avg(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"})[1h:1m]) > 2.0 * avg_over_time(avg(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"})[1h:1m] offset 24h)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -10627,11 +10627,11 @@
     "for": "2h",
     "keep_firing_for": "0s",
     "annotations": {
-      "summary": "Firestore document read_count (metric stackdriver_firestore_instance_firestore_googleapis_com_document_read_count, type=\"NOT_FOUND\") is running more than 1.5x its rate from the same hour yesterday, sustained for 2h.",
-      "threshold": "sum(rate(...[1h])) > 1.5x sum(rate(...[1h] offset 24h)), sustained 2h",
-      "user_impact": "No direct user impact; this is a cost signal, not an outage. NOT_FOUND reads are Firestore reads for documents that do not exist, so they are near-pure waste: the read is billed but returns nothing. The day-over-day comparison survives organic growth and diurnal swing, so a sustained step here is a regression.",
+      "summary": "Firestore document read_count (metric stackdriver_firestore_instance_firestore_googleapis_com_document_read_count, type=\"NOT_FOUND\") is running more than 2x its volume from the same hour yesterday, sustained for 2h.",
+      "threshold": "avg_over_time(avg(...)[1h:1m]) > 2x the same expression offset 24h, sustained 2h",
+      "user_impact": "No direct user impact; this is a cost signal, not an outage. NOT_FOUND reads are Firestore reads for documents that do not exist, so they are near-pure waste: the read is billed but returns nothing. The day-over-day comparison survives organic growth and diurnal swing, so a sustained step here is a regression rather than load.",
       "scope": "Firestore document reads across the based-hardware production project, type=\"NOT_FOUND\" only.",
-      "verification": "Compare sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[1h])) against the same query with `offset 24h` in the linked query; a ratio holding above 1.5x for the full 2h window is a step, not normal diurnal variation.",
+      "verification": "Compare avg_over_time(avg(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"})[1h:1m]) against the same expression with `offset 24h`. The 2x factor is measured, not guessed: across 2026-08-18..25 excluding the incident window, normal day-over-day ratios peaked at 1.94x for a single hour, while the 2026-08-23 step held 2.4-3.4x for 24h straight. A 1.5x threshold would have false-positived on 2026-08-20 and 2026-08-21. The stackdriver exporter publishes this DELTA metric as a GAUGE whose value is the per-60s-window count, so rate() is meaningless on it -- read volume must be recovered with avg_over_time(...)/60 instead. avg() (not sum()) aggregates across exporter replicas, which all report the same Cloud Monitoring series.",
       "safe_next_action": "This alert flags read volume, not cause. The Cloud Monitoring series carries module=\"__unknown__\", so attribution needs either extending omi_firestore_read_operations_total call-site coverage or enabling a short window of Firestore DATA_READ audit logging to find the caller before making any code change."
     },
     "labels": {
@@ -10659,7 +10659,7 @@
         "refId": "A",
         "queryType": "",
         "relativeTimeRange": {
-          "from": 1800,
+          "from": 21600,
           "to": 0
         },
         "datasourceUid": "prometheus",
@@ -10668,7 +10668,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[30m])) > 600",
+          "expr": "avg_over_time(avg(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"})[6h:5m]) / 60 > 750",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -10722,14 +10722,14 @@
     "updated": "2026-08-25T00:00:00Z",
     "noDataState": "OK",
     "execErrState": "Error",
-    "for": "2h",
+    "for": "30m",
     "keep_firing_for": "0s",
     "annotations": {
-      "summary": "Firestore document read_count (metric stackdriver_firestore_instance_firestore_googleapis_com_document_read_count, type=\"NOT_FOUND\") has been sustained above 600 reads/sec for 2h -- above the ~361/sec healthy baseline measured before the 2026-08-23 cost incident, below the ~936/sec the leak reached.",
-      "threshold": "sum(rate(...[30m])) > 600/sec, sustained 2h",
-      "user_impact": "No direct user impact; this is a cost signal, not an outage. NOT_FOUND reads are Firestore reads for documents that do not exist, so they are near-pure waste: the read is billed but returns nothing. This is the backstop for a leak that is already running at a steady elevated rate, which the day-over-day step detector cannot see because both sides of its comparison are equally elevated.",
+      "summary": "Firestore document read_count (metric stackdriver_firestore_instance_firestore_googleapis_com_document_read_count, type=\"NOT_FOUND\") has averaged more than 750 reads/sec over a rolling 6h window. Measured separation over 2026-08-18..25: the highest pre-incident 6h mean was 668/sec and the lowest post-incident 6h mean was 899/sec, so this threshold sits in a clean gap with ~12% margin on each side.",
+      "threshold": "avg_over_time(avg(...)[6h:5m]) / 60 > 750 reads/sec, sustained 30m",
+      "user_impact": "No direct user impact; this is a cost signal, not an outage. NOT_FOUND reads are Firestore reads for documents that do not exist, so they are near-pure waste: the read is billed but returns nothing. At the 2026-08-23 incident rate of ~950/sec this class of read alone costs roughly $740/month. This is the backstop for a leak already running at a steady elevated rate, which the day-over-day step detector cannot see because both sides of its comparison are equally elevated.",
       "scope": "Firestore document reads across the based-hardware production project, type=\"NOT_FOUND\" only.",
-      "verification": "Check sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[30m])) in the linked query against the 600/sec threshold; healthy baseline is ~361/sec, the 2026-08-23 incident ran ~936/sec.",
+      "verification": "Run avg_over_time(avg(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"})[6h:5m]) / 60 in the linked query. Healthy 6h means run 347-668/sec; the 2026-08-23 leak holds 899-1049/sec. A 6h window is used deliberately: hourly values are extremely spiky (single healthy hours reach 1124/sec), so any shorter window false-positives. The stackdriver exporter publishes this DELTA metric as a GAUGE whose value is the per-60s-window count, so rate() is meaningless on it -- read volume must be recovered with avg_over_time(...)/60 instead. avg() (not sum()) aggregates across exporter replicas, which all report the same Cloud Monitoring series.",
       "safe_next_action": "This alert flags read volume, not cause. The Cloud Monitoring series carries module=\"__unknown__\", so attribution needs either extending omi_firestore_read_operations_total call-site coverage or enabling a short window of Firestore DATA_READ audit logging to find the caller before making any code change."
     },
     "labels": {

--- a/backend/charts/monitoring/alerts/firestore.json
+++ b/backend/charts/monitoring/alerts/firestore.json
@@ -11,7 +11,7 @@
         "refId": "A",
         "queryType": "",
         "relativeTimeRange": {
-          "from": 3600,
+          "from": 90000,
           "to": 0
         },
         "datasourceUid": "prometheus",
@@ -20,7 +20,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[1h])) > 1.5 * sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[1h] offset 24h))",
+          "expr": "avg_over_time(avg(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"})[1h:1m]) > 2.0 * avg_over_time(avg(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"})[1h:1m] offset 24h)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -77,11 +77,11 @@
     "for": "2h",
     "keep_firing_for": "0s",
     "annotations": {
-      "summary": "Firestore document read_count (metric stackdriver_firestore_instance_firestore_googleapis_com_document_read_count, type=\"NOT_FOUND\") is running more than 1.5x its rate from the same hour yesterday, sustained for 2h.",
-      "threshold": "sum(rate(...[1h])) > 1.5x sum(rate(...[1h] offset 24h)), sustained 2h",
-      "user_impact": "No direct user impact; this is a cost signal, not an outage. NOT_FOUND reads are Firestore reads for documents that do not exist, so they are near-pure waste: the read is billed but returns nothing. The day-over-day comparison survives organic growth and diurnal swing, so a sustained step here is a regression.",
+      "summary": "Firestore document read_count (metric stackdriver_firestore_instance_firestore_googleapis_com_document_read_count, type=\"NOT_FOUND\") is running more than 2x its volume from the same hour yesterday, sustained for 2h.",
+      "threshold": "avg_over_time(avg(...)[1h:1m]) > 2x the same expression offset 24h, sustained 2h",
+      "user_impact": "No direct user impact; this is a cost signal, not an outage. NOT_FOUND reads are Firestore reads for documents that do not exist, so they are near-pure waste: the read is billed but returns nothing. The day-over-day comparison survives organic growth and diurnal swing, so a sustained step here is a regression rather than load.",
       "scope": "Firestore document reads across the based-hardware production project, type=\"NOT_FOUND\" only.",
-      "verification": "Compare sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[1h])) against the same query with `offset 24h` in the linked query; a ratio holding above 1.5x for the full 2h window is a step, not normal diurnal variation.",
+      "verification": "Compare avg_over_time(avg(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"})[1h:1m]) against the same expression with `offset 24h`. The 2x factor is measured, not guessed: across 2026-08-18..25 excluding the incident window, normal day-over-day ratios peaked at 1.94x for a single hour, while the 2026-08-23 step held 2.4-3.4x for 24h straight. A 1.5x threshold would have false-positived on 2026-08-20 and 2026-08-21. The stackdriver exporter publishes this DELTA metric as a GAUGE whose value is the per-60s-window count, so rate() is meaningless on it -- read volume must be recovered with avg_over_time(...)/60 instead. avg() (not sum()) aggregates across exporter replicas, which all report the same Cloud Monitoring series.",
       "safe_next_action": "This alert flags read volume, not cause. The Cloud Monitoring series carries module=\"__unknown__\", so attribution needs either extending omi_firestore_read_operations_total call-site coverage or enabling a short window of Firestore DATA_READ audit logging to find the caller before making any code change."
     },
     "labels": {
@@ -109,7 +109,7 @@
         "refId": "A",
         "queryType": "",
         "relativeTimeRange": {
-          "from": 1800,
+          "from": 21600,
           "to": 0
         },
         "datasourceUid": "prometheus",
@@ -118,7 +118,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[30m])) > 600",
+          "expr": "avg_over_time(avg(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"})[6h:5m]) / 60 > 750",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -172,14 +172,14 @@
     "updated": "2026-08-25T00:00:00Z",
     "noDataState": "OK",
     "execErrState": "Error",
-    "for": "2h",
+    "for": "30m",
     "keep_firing_for": "0s",
     "annotations": {
-      "summary": "Firestore document read_count (metric stackdriver_firestore_instance_firestore_googleapis_com_document_read_count, type=\"NOT_FOUND\") has been sustained above 600 reads/sec for 2h -- above the ~361/sec healthy baseline measured before the 2026-08-23 cost incident, below the ~936/sec the leak reached.",
-      "threshold": "sum(rate(...[30m])) > 600/sec, sustained 2h",
-      "user_impact": "No direct user impact; this is a cost signal, not an outage. NOT_FOUND reads are Firestore reads for documents that do not exist, so they are near-pure waste: the read is billed but returns nothing. This is the backstop for a leak that is already running at a steady elevated rate, which the day-over-day step detector cannot see because both sides of its comparison are equally elevated.",
+      "summary": "Firestore document read_count (metric stackdriver_firestore_instance_firestore_googleapis_com_document_read_count, type=\"NOT_FOUND\") has averaged more than 750 reads/sec over a rolling 6h window. Measured separation over 2026-08-18..25: the highest pre-incident 6h mean was 668/sec and the lowest post-incident 6h mean was 899/sec, so this threshold sits in a clean gap with ~12% margin on each side.",
+      "threshold": "avg_over_time(avg(...)[6h:5m]) / 60 > 750 reads/sec, sustained 30m",
+      "user_impact": "No direct user impact; this is a cost signal, not an outage. NOT_FOUND reads are Firestore reads for documents that do not exist, so they are near-pure waste: the read is billed but returns nothing. At the 2026-08-23 incident rate of ~950/sec this class of read alone costs roughly $740/month. This is the backstop for a leak already running at a steady elevated rate, which the day-over-day step detector cannot see because both sides of its comparison are equally elevated.",
       "scope": "Firestore document reads across the based-hardware production project, type=\"NOT_FOUND\" only.",
-      "verification": "Check sum(rate(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"}[30m])) in the linked query against the 600/sec threshold; healthy baseline is ~361/sec, the 2026-08-23 incident ran ~936/sec.",
+      "verification": "Run avg_over_time(avg(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"})[6h:5m]) / 60 in the linked query. Healthy 6h means run 347-668/sec; the 2026-08-23 leak holds 899-1049/sec. A 6h window is used deliberately: hourly values are extremely spiky (single healthy hours reach 1124/sec), so any shorter window false-positives. The stackdriver exporter publishes this DELTA metric as a GAUGE whose value is the per-60s-window count, so rate() is meaningless on it -- read volume must be recovered with avg_over_time(...)/60 instead. avg() (not sum()) aggregates across exporter replicas, which all report the same Cloud Monitoring series.",
       "safe_next_action": "This alert flags read volume, not cause. The Cloud Monitoring series carries module=\"__unknown__\", so attribution needs either extending omi_firestore_read_operations_total call-site coverage or enabling a short window of Firestore DATA_READ audit logging to find the caller before making any code change."
     },
     "labels": {

--- a/backend/charts/monitoring/prometheus-stackdriver-exporter/dev_omi_stackdriver_exporter.yaml
+++ b/backend/charts/monitoring/prometheus-stackdriver-exporter/dev_omi_stackdriver_exporter.yaml
@@ -1,6 +1,12 @@
 stackdriver:
   projectIds:
     - "based-hardware-dev"
+  # Cloud Monitoring answers descriptor lookups for this project with 503
+  # "Task is overloaded (cpu-protection)" and 10s timeouts. Give each request
+  # more room and let 503s retry instead of failing the whole scrape.
+  httpTimeout: 30s
+  maxRetries: 3
+  retryStatuses: 503
   metrics:
     prefixes:
       - 'loadbalancing.googleapis.com/https/backend_request_count'
@@ -15,7 +21,12 @@ stackdriver:
     # https://cloud.google.com/monitoring/api/v3/filters
     filters:
       - 'loadbalancing.googleapis.com/https/backend_request_count:resource.labels.backend_target_name="dev-backend-listen"'
-    interval: '1m'
+    # Query window is [now-offset-interval, now-offset]. Measured Firestore
+    # ingestion lag is ~2.4 min, so the previous 1m/1m window ([now-2m, now-1m])
+    # was always empty for firestore.googleapis.com/document/read_count and the
+    # exporter emitted no series at all despite scraping cleanly. 3m/1m covers
+    # lag between 1 and 4 minutes.
+    interval: '3m'
     offset: '1m'
     # ingestDelay: true
 
@@ -26,3 +37,12 @@ serviceAccount:
   create: true
   annotations:
     iam.gke.io/gcp-service-account: "dev-omi-prom-stackdriver-gsa@based-hardware-dev.iam.gserviceaccount.com"
+
+# Descriptor discovery, not sample collection, is what throttles here. At the 0s
+# default the exporter re-runs ListMetricDescriptors for every prefix on every
+# scrape -- ~2 calls/sec project-wide -- which is why adding the firestore prefix
+# returned no series at all: its descriptor lookup timed out every time. Metric
+# descriptors change approximately never, so an hour of caching removes the
+# throttling and the ListMetricDescriptors spend without making samples staler.
+extraArgs:
+  monitoring.descriptor-cache-ttl: 1h

--- a/backend/charts/monitoring/prometheus-stackdriver-exporter/prod_omi_stackdriver_exporter.yaml
+++ b/backend/charts/monitoring/prometheus-stackdriver-exporter/prod_omi_stackdriver_exporter.yaml
@@ -1,6 +1,12 @@
 stackdriver:
   projectIds:
     - "based-hardware"
+  # Cloud Monitoring answers descriptor lookups for this project with 503
+  # "Task is overloaded (cpu-protection)" and 10s timeouts. Give each request
+  # more room and let 503s retry instead of failing the whole scrape.
+  httpTimeout: 30s
+  maxRetries: 3
+  retryStatuses: 503
   metrics:
     prefixes:
       - 'loadbalancing.googleapis.com/https/backend_request_count'
@@ -12,10 +18,24 @@ stackdriver:
       - 'firestore.googleapis.com/document/read_count'
     filters:
       - 'loadbalancing.googleapis.com/https/backend_request_count:resource.labels.backend_target_name="custom-domains-api-omi-me-backend-listen-49a4-be"'
-    interval: '1m'
+    # Query window is [now-offset-interval, now-offset]. Measured Firestore
+    # ingestion lag is ~2.4 min, so the previous 1m/1m window ([now-2m, now-1m])
+    # was always empty for firestore.googleapis.com/document/read_count and the
+    # exporter emitted no series at all despite scraping cleanly. 3m/1m covers
+    # lag between 1 and 4 minutes.
+    interval: '3m'
     offset: '1m'
 
 serviceAccount:
   create: true
   annotations:
     iam.gke.io/gcp-service-account: "prod-omi-prom-stackdriver-gsa@based-hardware.iam.gserviceaccount.com"
+
+# Descriptor discovery, not sample collection, is what throttles here. At the 0s
+# default the exporter re-runs ListMetricDescriptors for every prefix on every
+# scrape -- ~2 calls/sec project-wide -- which is why adding the firestore prefix
+# returned no series at all: its descriptor lookup timed out every time. Metric
+# descriptors change approximately never, so an hour of caching removes the
+# throttling and the ListMetricDescriptors spend without making samples staler.
+extraArgs:
+  monitoring.descriptor-cache-ttl: 1h


### PR DESCRIPTION
## What

Corrects the two Firestore cost alerts merged in #12193 — **neither one could ever have fired** — and codifies the stackdriver-exporter configuration that is already live in prod at helm revision 7 but was never committed.

## The defect

The alerts merged in #12193 use `rate()`:

```promql
sum(rate(stackdriver_..._document_read_count{type="NOT_FOUND"}[1h])) > 1.5 * sum(rate(...[1h] offset 24h))
sum(rate(stackdriver_..._document_read_count{type="NOT_FOUND"}[30m])) > 600
```

`stackdriver_exporter` publishes this DELTA metric as a **gauge** whose value is the per-60s-window count, not as a counter. `rate()` on a gauge is meaningless — it returned `75.7` where true read volume was `~936/sec`. Both rules evaluated cleanly, provisioned cleanly, and showed green. Neither would ever have crossed its threshold.

Two further problems surfaced once I measured the metric's actual distribution over 2026-08-18..25 instead of trusting a remembered baseline:

- **The `1.5x` day-over-day factor was inside normal noise.** Excluding the incident window, ordinary day-over-day ratios reach **1.94x** (2026-08-22T03), with three consecutive hours above 1.5x on 2026-08-20. The real step held **2.4–3.4x for 24h straight**. Corrected to `2.0x`.
- **The `600/sec` ceiling was inside the pre-incident range.** Pre-incident hours reached **603.9/sec** and **1124/sec**. Hourly values are far too spiky to threshold at all.

## The corrections

```promql
# ceiling
avg_over_time(avg(...{type="NOT_FOUND"})[6h:5m]) / 60 > 750     for: 30m
# day-over-day step
avg_over_time(avg(...{type="NOT_FOUND"})[1h:1m])
  > 2.0 * avg_over_time(avg(...{type="NOT_FOUND"})[1h:1m] offset 24h)   for: 2h
```

A **6h rolling mean separates the two regimes cleanly**, where hourly values do not:

| 6h rolling mean, NOT_FOUND reads/sec | min | median | max |
|---|---|---|---|
| pre-incident (113h) | 347 | 463 | **668** |
| post-incident (44h) | **899** | 970 | 1049 |

`750` sits in that gap with ~12% margin on each side. Verified live: the ceiling expression currently evaluates to **821/sec**, i.e. it fires on the leak that is actually running.

`avg()` rather than `sum()` aggregates across exporter replicas — all replicas report the same Cloud Monitoring series, so `sum()` would multiply the reading by the replica count.

## Exporter config (already live in prod, not previously committed)

Applied manually per the chart README at helm revision 7; no workflow deploys `*_omi_stackdriver_exporter.yaml`, so this file was drifting from the cluster.

- `monitoring.descriptor-cache-ttl: 1h` — the `0s` default re-runs `ListMetricDescriptors` on every scrape, which Cloud Monitoring answered with 503 `cpu-protection`. Scrape errors went **52/1576 → 0/1069**.
- `httpTimeout: 30s`, `maxRetries: 3`, `retryStatuses: 503`.
- `interval: 1m → 3m` — measured Firestore ingestion lag is ~2.4 min, so the old `[now-2m, now-1m]` window was always empty and the exporter emitted **zero** firestore series despite scraping cleanly.

## Verification

- Both corrected expressions executed against live prod Prometheus: ceiling returns `821.02`, step returns empty (no 24h history yet — the metric began collecting today; `noDataState: OK`).
- `backend/tests/unit/test_monitoring_alert_rule_contract.py` — 22 passed.
- Split and combined rule files verified identical per-UID; the combined file was edited by verbatim substring replacement, so all 74 other rules are byte-unchanged.

Failure-Class: FC-alert-never-provably-fired


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

