### PR TITLE
fix: K-factor measured from real viral signals with daily/weekly trackers

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -60,6 +60,7 @@ from utils.conversations.process_conversation import (
 from utils.conversations import lifecycle as lifecycle_service
 from utils.conversations import share_email
 from utils.conversations.meeting_receipt import record_and_persist_finalized_meeting_receipt
+from utils.integration_telemetry import emit_posthog_event
 from utils.executors import db_executor, llm_executor, postprocess_executor, run_blocking, submit_with_context
 from utils.memory.memory_service import MemoryService
 from utils.memory.retraction_scope import retraction_can_be_skipped
@@ -1483,6 +1484,13 @@ def send_conversation_share_email(
         # successful dispatch can trigger the visibility rollback (a delivered
         # email keeps a live link).
         share_email.send_summary_email(uid=uid, conversation=conversation, recipient_emails=to_dispatch)
+        # Viral-loop telemetry: summary shares feed the admin K-factor. Emitted
+        # only after the provider accepted, so the count is delivered shares.
+        emit_posthog_event(
+            uid,
+            'Conversation Summary Shared',
+            {'conversation_id': conversation_id, 'recipient_count': len(to_dispatch), 'channel': 'email'},
+        )
         try:
             conversations_db.confirm_share_email_recipients(uid, conversation_id, to_dispatch)
         except Exception:

--- a/backend/tests/unit/test_share_email_routes.py
+++ b/backend/tests/unit/test_share_email_routes.py
@@ -199,6 +199,49 @@ def test_share_email_success_publishes_and_sends(monkeypatch, _stub_data_layer):
     assert CONV_ID in _stub_data_layer['redis']
 
 
+def test_share_email_success_emits_summary_shared_telemetry(monkeypatch, _stub_data_layer):
+    """Delivered shares feed the admin K-factor; a successful send must emit
+    exactly one 'Conversation Summary Shared' event with the delivered count."""
+    monkeypatch.setattr(
+        conversations_router.share_email,
+        'send_summary_email',
+        lambda *, uid, conversation, recipient_emails: {'sent_to': recipient_emails},
+    )
+    events = []
+    monkeypatch.setattr(
+        conversations_router,
+        'emit_posthog_event',
+        lambda distinct_id, event, properties: events.append((distinct_id, event, properties)),
+    )
+    response = _client().post(
+        f'/v1/conversations/{CONV_ID}/share-email',
+        json={'recipient_emails': ['sarah@acme.com']},
+    )
+    assert response.status_code == 200
+    assert events == [
+        (UID, 'Conversation Summary Shared', {'conversation_id': CONV_ID, 'recipient_count': 1, 'channel': 'email'})
+    ]
+
+
+def test_share_email_failed_send_emits_no_telemetry(monkeypatch, _stub_data_layer):
+    def failing_send(*, uid, conversation, recipient_emails):
+        raise RuntimeError('email provider rejected the send')
+
+    monkeypatch.setattr(conversations_router.share_email, 'send_summary_email', failing_send)
+    events = []
+    monkeypatch.setattr(
+        conversations_router,
+        'emit_posthog_event',
+        lambda distinct_id, event, properties: events.append(event),
+    )
+    response = _client().post(
+        f'/v1/conversations/{CONV_ID}/share-email',
+        json={'recipient_emails': ['sarah@acme.com']},
+    )
+    assert response.status_code == 502
+    assert events == []
+
+
 def test_share_email_provider_failure_rolls_back_visibility(monkeypatch, _stub_data_layer):
     def failing_send(*, uid, conversation, recipient_emails):
         raise RuntimeError('email provider rejected the send')

--- a/web/admin/app/api/internal/precompute/route.ts
+++ b/web/admin/app/api/internal/precompute/route.ts
@@ -208,9 +208,12 @@ export async function POST(request: NextRequest) {
   });
 
   // k-factor: no payload cache — calling compute warms its posthogResults
-  // query cache (Firestore) so the GET serves fast from there.
+  // query cache (Firestore) so the GET serves fast from there. All three
+  // platform scopes are warmed because each Grafana board queries its own.
   await run("kFactor", async () => {
-    await computeKFactor(K_FACTOR_DAYS);
+    await computeKFactor(K_FACTOR_DAYS, "macos");
+    await computeKFactor(K_FACTOR_DAYS, "mobile");
+    await computeKFactor(K_FACTOR_DAYS, "all");
   });
 
   const failedNames = Object.keys(failed);

--- a/web/admin/app/api/omi/stats/k-factor/posthog/route.ts
+++ b/web/admin/app/api/omi/stats/k-factor/posthog/route.ts
@@ -1,13 +1,82 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
 import { posthogResults } from "@/lib/posthog";
+import { getDb } from "@/lib/firebase/admin";
+import {
+  parsePlatformScope,
+  scopeFilterAnd,
+  type PlatformScope,
+} from "@/lib/platform-scope";
 export const dynamic = "force-dynamic";
 export const maxDuration = 3600;
 
-// Run the referral funnel HogQL queries through posthogResults (Firestore
-// query-cache + 429 backoff + stale fallback) and shape the panel payload.
-// Exported so the precompute cron can warm the underlying query cache.
-export async function computeKFactor(days: number) {
+// The viral loop is measured from three concrete signals:
+//   friend   — onboarding "How did you hear about us?" answered "Friend"
+//              (macOS/Windows `Onboarding How Did You Hear`, source='Friend').
+//   referral — referral-trial redemptions. Firestore `users/{uid}.referral`
+//              (written transactionally on every granted claim) is the durable
+//              ledger; the PostHog funnel events only started firing 2026-08-25.
+//   shares   — conversation summaries shared: macOS `Share Action`
+//              category='conversation' (share-link copies) + server-side
+//              `Conversation Summary Shared` (delivered share emails) +
+//              mobile `Conversation Shared`.
+// K-factor = viral events per first-seen new user in the same window.
+const REFERRAL_PROGRAM = "desktop_operator_month_v1";
+const NYC_DAY = "toDate(toTimeZone(timestamp, 'America/New_York'))";
+
+type DailyRow = {
+  date: string;
+  friend: number;
+  referral: number;
+  shares: number;
+  viralEvents: number;
+  newUsers: number;
+  kFactor: number | null;
+};
+
+function shareEventsFilter(platform: PlatformScope): string {
+  // `Conversation Summary Shared` is emitted server-side (no $os_name); the
+  // share-email UI ships only on desktop, so it counts toward macos and all.
+  const macosShares = `((event = 'Share Action' AND properties.category = 'conversation' AND properties.$os_name = 'macOS') OR event = 'Conversation Summary Shared')`;
+  const mobileShares = `(event = 'Conversation Shared' ${scopeFilterAnd("mobile")})`;
+  if (platform === "macos") return macosShares;
+  if (platform === "mobile") return mobileShares;
+  return `(${macosShares} OR (event = 'Share Action' AND properties.category = 'conversation') OR event = 'Conversation Shared')`;
+}
+
+function friendFilter(platform: PlatformScope): string {
+  // Only macOS/Windows onboarding carries the source property; the mobile
+  // acquisition step reports step-reach without the answer, so the mobile
+  // scope is honestly zero rather than silently borrowing desktop data.
+  return `event = 'Onboarding How Did You Hear' AND properties.source = 'Friend' ${scopeFilterAnd(platform)}`;
+}
+
+async function referralClaimTimes(): Promise<number[]> {
+  // Firestore is the transactional record of granted referral trials
+  // (backend/database/referrals.py); claimed_at is epoch seconds.
+  const snapshot = await getDb()
+    .collection("users")
+    .where("referral.program", "==", REFERRAL_PROGRAM)
+    .limit(5000)
+    .get();
+  const times: number[] = [];
+  for (const doc of snapshot.docs) {
+    const claimedAt = doc.get("referral.claimed_at");
+    const seconds =
+      typeof claimedAt === "number" ? claimedAt : claimedAt?.seconds;
+    if (seconds) times.push(seconds * 1000);
+  }
+  return times;
+}
+
+function nycDateDaysAgo(daysAgo: number): string {
+  return new Date(Date.now() - daysAgo * 86_400_000).toLocaleDateString(
+    "en-CA",
+    { timeZone: "America/New_York" },
+  );
+}
+
+export async function computeKFactor(days: number, platform: PlatformScope = "macos") {
   const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
   const projectId = process.env.POSTHOG_PROJECT_ID;
   const host = (process.env.POSTHOG_HOST || "https://us.posthog.com").replace(
@@ -18,41 +87,202 @@ export async function computeKFactor(days: number) {
   if (!apiKey || !projectId) {
     return {
       days,
+      platform,
       available: false as const,
       kFactor: null,
       reason: "PostHog credentials not configured.",
     };
   }
 
-  const uniqueUsersQuery = (event: string, extraFilter = "") => `
-          SELECT uniq(COALESCE(person_id, distinct_id)) AS unique_users
-          FROM events
-          WHERE event = '${event}'
-            AND timestamp >= now() - INTERVAL ${days} DAY
-            AND properties.program = 'desktop_operator_month_v1'
-            ${extraFilter}
-        `;
+  const dailyCountQuery = (filter: string) => `
+        SELECT ${NYC_DAY} AS day, count() AS events
+        FROM events
+        WHERE ${filter}
+          AND timestamp >= now() - INTERVAL ${days} DAY
+        GROUP BY day
+        ORDER BY day
+      `;
+  // One query per signal covers both rolling windows: [24h, trailing 7d].
+  const rollingCountQuery = (filter: string) => `
+        SELECT
+          countIf(timestamp >= now() - INTERVAL 24 HOUR) AS h24,
+          count() AS d7
+        FROM events
+        WHERE ${filter}
+          AND timestamp >= now() - INTERVAL 7 DAY
+      `;
+  const firstSeenSubquery = `
+        SELECT COALESCE(person_id, distinct_id) AS actor, min(timestamp) AS min_ts
+        FROM events
+        WHERE 1 = 1
+          ${scopeFilterAnd(platform)}
+        GROUP BY actor
+      `;
+  const referralFunnelQuery = (event: string, extraFilter = "") => `
+        SELECT uniq(COALESCE(person_id, distinct_id)) AS unique_users
+        FROM events
+        WHERE event = '${event}'
+          AND timestamp >= now() - INTERVAL ${days} DAY
+          AND properties.program = '${REFERRAL_PROGRAM}'
+          ${extraFilter}
+      `;
 
-  const [issuedRows, capturedRows, grantedRows] = await Promise.all([
-    posthogResults(
-      host,
-      projectId,
-      apiKey,
-      uniqueUsersQuery("Referral Link Issued"),
-    ) as Promise<any[]>,
-    posthogResults(
-      host,
-      projectId,
-      apiKey,
-      uniqueUsersQuery("Referral Link Captured"),
-    ) as Promise<any[]>,
-    posthogResults(
-      host,
-      projectId,
-      apiKey,
-      uniqueUsersQuery("Referral Claimed", "AND properties.claimed = true"),
-    ) as Promise<any[]>,
+  const run = (query: string) =>
+    posthogResults(host, projectId, apiKey, query) as Promise<any[]>;
+
+  const [
+    friendDailyRows,
+    sharesDailyRows,
+    newDailyRows,
+    friendRollingRows,
+    sharesRollingRows,
+    newRollingRows,
+    issuedRows,
+    capturedRows,
+    grantedRows,
+    referralTimes,
+  ] = await Promise.all([
+    run(dailyCountQuery(friendFilter(platform))),
+    run(dailyCountQuery(shareEventsFilter(platform))),
+    run(`
+        SELECT toDate(toTimeZone(min_ts, 'America/New_York')) AS day, count(*) AS new_users
+        FROM (${firstSeenSubquery})
+        WHERE min_ts >= now() - INTERVAL ${days} DAY
+        GROUP BY day
+        ORDER BY day
+      `),
+    run(rollingCountQuery(friendFilter(platform))),
+    run(rollingCountQuery(shareEventsFilter(platform))),
+    run(`
+        SELECT
+          countIf(min_ts >= now() - INTERVAL 24 HOUR) AS h24,
+          count() AS d7
+        FROM (${firstSeenSubquery})
+        WHERE min_ts >= now() - INTERVAL 7 DAY
+      `),
+    run(referralFunnelQuery("Referral Link Issued")),
+    run(referralFunnelQuery("Referral Link Captured")),
+    run(referralFunnelQuery("Referral Claimed", "AND properties.claimed = true")),
+    // The referral program grants a desktop trial, so redemptions belong to
+    // the macos and all scopes; the mobile board honestly reports zero.
+    platform === "mobile" ? Promise.resolve([]) : referralClaimTimes(),
   ]);
+  const toNycDate = (ms: number) =>
+    new Date(ms).toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+
+  const toDayMap = (rows: any[]) => {
+    const map = new Map<string, number>();
+    for (const row of rows ?? []) {
+      map.set(String(row[0]).slice(0, 10), Number(row[1]) || 0);
+    }
+    return map;
+  };
+  const friendByDay = toDayMap(friendDailyRows);
+  const sharesByDay = toDayMap(sharesDailyRows);
+  const newByDay = toDayMap(newDailyRows);
+  const referralByDay = new Map<string, number>();
+  for (const ms of referralTimes) {
+    const date = toNycDate(ms);
+    referralByDay.set(date, (referralByDay.get(date) ?? 0) + 1);
+  }
+
+  const today = nycDateDaysAgo(0);
+  const daily: DailyRow[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const date = nycDateDaysAgo(i);
+    if (date > today) continue;
+    const friend = friendByDay.get(date) ?? 0;
+    const referral = referralByDay.get(date) ?? 0;
+    const shares = sharesByDay.get(date) ?? 0;
+    const newUsers = newByDay.get(date) ?? 0;
+    const viralEvents = friend + referral + shares;
+    daily.push({
+      date,
+      friend,
+      referral,
+      shares,
+      viralEvents,
+      newUsers,
+      kFactor: newUsers > 0 ? viralEvents / newUsers : null,
+    });
+  }
+
+  // The last daily bucket is a partial calendar day — replace it with the
+  // rolling last 24 hours so the newest bar is always a full-size window.
+  const [friend24h, friend7d] = friendRollingRows?.[0] ?? [0, 0];
+  const [shares24h, shares7d] = sharesRollingRows?.[0] ?? [0, 0];
+  const [new24h, new7d] = newRollingRows?.[0] ?? [0, 0];
+  const referral24h = referralTimes.filter(
+    (ms) => ms >= Date.now() - 86_400_000,
+  ).length;
+  const referral7d = referralTimes.filter(
+    (ms) => ms >= Date.now() - 7 * 86_400_000,
+  ).length;
+  const last = daily[daily.length - 1];
+  if (last && last.date === today) {
+    last.friend = Math.max(last.friend, Number(friend24h) || 0);
+    last.shares = Math.max(last.shares, Number(shares24h) || 0);
+    last.referral = Math.max(last.referral, referral24h);
+    last.newUsers = Math.max(last.newUsers, Number(new24h) || 0);
+    last.viralEvents = last.friend + last.referral + last.shares;
+    last.kFactor = last.newUsers > 0 ? last.viralEvents / last.newUsers : null;
+  }
+
+  // Weekly tracker: NYC Monday buckets aggregated from the daily series; the
+  // last bucket is the rolling trailing 7 days, never a partial calendar week.
+  const weekOf = (ymd: string) => {
+    const d = new Date(ymd + "T12:00:00Z");
+    const shift = (d.getUTCDay() + 6) % 7;
+    d.setUTCDate(d.getUTCDate() - shift);
+    return d.toISOString().slice(0, 10);
+  };
+  const weeklyMap = new Map<string, DailyRow>();
+  for (const row of daily) {
+    const week = weekOf(row.date);
+    const bucket =
+      weeklyMap.get(week) ??
+      ({ date: week, friend: 0, referral: 0, shares: 0, viralEvents: 0, newUsers: 0, kFactor: null } as DailyRow);
+    bucket.friend += row.friend;
+    bucket.referral += row.referral;
+    bucket.shares += row.shares;
+    bucket.viralEvents += row.viralEvents;
+    bucket.newUsers += row.newUsers;
+    weeklyMap.set(week, bucket);
+  }
+  const weekly = Array.from(weeklyMap.values())
+    .map(({ date, ...rest }) => ({ week: date, ...rest }))
+    .sort((a, b) => (a.week < b.week ? -1 : 1));
+  if (weekly.length > 0) {
+    const rolling = {
+      week: weekly[weekly.length - 1].week,
+      friend: Number(friend7d) || 0,
+      referral: referral7d,
+      shares: Number(shares7d) || 0,
+      viralEvents: 0,
+      newUsers: Number(new7d) || 0,
+      kFactor: null as number | null,
+    };
+    rolling.viralEvents = rolling.friend + rolling.referral + rolling.shares;
+    rolling.kFactor =
+      rolling.newUsers > 0 ? rolling.viralEvents / rolling.newUsers : null;
+    weekly[weekly.length - 1] = rolling;
+  }
+  for (const bucket of weekly) {
+    if (bucket.kFactor === null && bucket.newUsers > 0) {
+      bucket.kFactor = bucket.viralEvents / bucket.newUsers;
+    }
+  }
+
+  const totals = daily.reduce(
+    (acc, row) => ({
+      friend: acc.friend + row.friend,
+      referral: acc.referral + row.referral,
+      shares: acc.shares + row.shares,
+      newUsers: acc.newUsers + row.newUsers,
+    }),
+    { friend: 0, referral: 0, shares: 0, newUsers: 0 },
+  );
+  const viralEvents = totals.friend + totals.referral + totals.shares;
 
   const issued = Number(issuedRows?.[0]?.[0] ?? 0);
   const captured = Number(capturedRows?.[0]?.[0] ?? 0);
@@ -60,11 +290,22 @@ export async function computeKFactor(days: number) {
 
   return {
     days,
+    platform,
     available: true as const,
-    kFactor: issued > 0 ? granted / issued : null,
+    kFactor: totals.newUsers > 0 ? viralEvents / totals.newUsers : null,
     reason:
-      "Referral grants are measured from the server-side referral funnel.",
+      "K-factor = viral events (friend signups + referral redemptions + summary shares) per first-seen new user.",
     funnel: { issued, captured, granted },
+    summary: {
+      ...totals,
+      viralEvents,
+      kFactor: totals.newUsers > 0 ? viralEvents / totals.newUsers : null,
+      friend7d: Number(friend7d) || 0,
+      referral7d,
+      shares7d: Number(shares7d) || 0,
+    },
+    daily,
+    weekly,
   };
 }
 
@@ -74,9 +315,10 @@ export async function GET(request: NextRequest) {
 
   const searchParams = request.nextUrl.searchParams;
   const days = parseInt(searchParams.get("days") || "30", 10);
+  const platform = parsePlatformScope(searchParams.get("platform"));
 
   try {
-    const payload = await computeKFactor(days);
+    const payload = await computeKFactor(days, platform);
     return NextResponse.json(payload);
   } catch (error) {
     // PostHog still failing (e.g. 429 with no cached fallback) — degrade
@@ -84,6 +326,7 @@ export async function GET(request: NextRequest) {
     console.error("Error fetching PostHog k-factor proxy:", error);
     return NextResponse.json({
       days,
+      platform,
       available: false as const,
       kFactor: null,
       reason:

--- a/web/admin/grafana/build_dashboards.py
+++ b/web/admin/grafana/build_dashboards.py
@@ -358,15 +358,20 @@ def latest_release_stat(panel_id: int, scope: str) -> dict:
     }
 
 
-def set_share_tile_description(dash, platform_label: str) -> None:
-    """The share-rate proxy is platform-scoped per board; keep its description
-    honest about which population the denominator counts."""
+def set_kfactor_tile_description(dash, platform_label: str, scope: str = "all") -> None:
+    """The K-factor tile is platform-scoped per board; keep its description
+    honest about which signals and which population each board counts."""
+    mobile_note = (
+        " Mobile counts summary shares only — the friend-source answer and the "
+        "referral program are desktop-only signals."
+        if scope == "mobile"
+        else ""
+    )
     for panel in dash.get("panels", []):
-        if base_title(panel).startswith("Share rate"):
+        if base_title(panel).startswith("K-factor") and panel.get("type") == "stat":
             panel["description"] = (
-                f"Sharers ÷ new users, last 30d ({platform_label}). True K-factor needs "
-                "referral attribution — not instrumented yet, so this proxies the "
-                "share loop. 0% = no viral loop shipped."
+                f"Viral events (friend signups + referral redemptions + summary shares) "
+                f"÷ first-seen new users, last 30d ({platform_label}).{mobile_note}"
             )
 
 
@@ -435,11 +440,11 @@ def build_platform_board(base, scope: str) -> dict:
     user_growth_series(cumulative, scope, "cumulative", "Total users")
     retarget_var(dash, "d_cum", path=viral_scoped, root="userGrowth", fields="users")
 
-    set_share_tile_description(dash, label)
+    set_kfactor_tile_description(dash, label, scope)
     drop_panels(dash, {RELEASES_CHART_TITLE})
-    share_idx = next(i for i, p in enumerate(dash["panels"])
-                     if base_title(p).startswith("Share rate"))
-    dash["panels"].insert(share_idx + 1, latest_release_stat(990, scope))
+    kfactor_idx = next(i for i, p in enumerate(dash["panels"])
+                       if base_title(p).startswith("K-factor") and p.get("type") == "stat")
+    dash["panels"].insert(kfactor_idx + 1, latest_release_stat(990, scope))
 
     series_label = "Desktop" if scope == "macos" else "Mobile"
     for title, new_title, series in [
@@ -515,7 +520,7 @@ def main() -> None:
     if not any(base_title(p) == RELEASES_CHART_TITLE for p in base["panels"]):
         base["panels"].append(releases_chart_panel(991))
     apply_tzdates(base)
-    set_share_tile_description(base, "all platforms")
+    set_kfactor_tile_description(base, "all platforms")
     apply_platform(base, "all")
     # The two Firestore-backed activation panels are macOS-scoped by
     # definition; their delta var compares macOS activation to stay coherent.

--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -488,13 +488,13 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Sharers \u00f7 new users, last 30d (macOS). True K-factor needs referral attribution \u2014 not instrumented yet, so this proxies the share loop. 0% = no viral loop shipped.",
+      "description": "Viral events (friend signups + referral redemptions + summary shares) \u00f7 first-seen new users, last 30d (macOS).",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "decimals": 1,
+          "decimals": 2,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -504,15 +504,15 @@
               },
               {
                 "color": "#f59e0b",
-                "value": 10
+                "value": 0.05
               },
               {
                 "color": "#22c55e",
-                "value": 30
+                "value": 0.15
               }
             ]
           },
-          "unit": "percent"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -539,31 +539,31 @@
       },
       "targets": [
         {
-          "columns": [
-            {
-              "selector": "shareRatePct",
-              "text": "Sharers / new users",
-              "type": "number"
-            }
-          ],
+          "refId": "A",
           "datasource": {
             "type": "yesoreyeram-infinity-datasource",
             "uid": "omi-admin-api"
           },
-          "format": "table",
-          "parser": "backend",
-          "refId": "A",
-          "root_selector": "proxy",
-          "source": "url",
           "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "table",
           "url": "http://127.0.0.1:8899/api/omi/stats/k-factor/posthog?days=30&platform=macos",
           "url_options": {
-            "data": "",
-            "method": "GET"
-          }
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "summary",
+          "columns": [
+            {
+              "selector": "kFactor",
+              "text": "Viral events / new user",
+              "type": "number"
+            }
+          ]
         }
       ],
-      "title": "Share rate (K-factor proxy)",
+      "title": "K-factor  \u00b7  30d",
       "type": "stat"
     },
     {
@@ -3800,6 +3800,280 @@
       ],
       "timeFrom": "30d",
       "title": "Free \u2192 paid conversion (desktop)  \u00b7  ${d_conv}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "Main viral-loop trend: (friend signups + referral redemptions + summary shares) \u00f7 first-seen new users, per NYC day. Last bar = rolling last 24h.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#22c55e"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "none",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 74,
+        "w": 24,
+        "h": 7
+      },
+      "id": 992,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/k-factor/posthog?days=30&_tzdates=date&platform=macos",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "daily",
+          "columns": [
+            {
+              "selector": "date",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "kFactor",
+              "text": "K-factor",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "30d",
+      "title": "K-factor \u2014 daily",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "The three viral signals, per NYC day. Last bar = rolling last 24h.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 65,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 81,
+        "w": 12,
+        "h": 7
+      },
+      "id": 993,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/k-factor/posthog?days=30&_tzdates=date&platform=macos",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "daily",
+          "columns": [
+            {
+              "selector": "date",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "friend",
+              "text": "Friend signups",
+              "type": "number"
+            },
+            {
+              "selector": "referral",
+              "text": "Referral redemptions",
+              "type": "number"
+            },
+            {
+              "selector": "shares",
+              "text": "Summary shares",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "30d",
+      "title": "Viral loop \u2014 daily",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "The three viral signals, per NYC Monday week. Last bucket = rolling trailing 7 days.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 65,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 81,
+        "w": 12,
+        "h": 7
+      },
+      "id": 994,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/k-factor/posthog?days=30&_tzdates=week&platform=macos",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "weekly",
+          "columns": [
+            {
+              "selector": "week",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "friend",
+              "text": "Friend signups",
+              "type": "number"
+            },
+            {
+              "selector": "referral",
+              "text": "Referral redemptions",
+              "type": "number"
+            },
+            {
+              "selector": "shares",
+              "text": "Summary shares",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "8w",
+      "title": "Viral loop \u2014 weekly",
       "type": "timeseries"
     }
   ],

--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -4072,7 +4072,7 @@
           ]
         }
       ],
-      "timeFrom": "8w",
+      "timeFrom": "5w",
       "title": "Viral loop \u2014 weekly",
       "type": "timeseries"
     }

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -3546,7 +3546,7 @@
           ]
         }
       ],
-      "timeFrom": "8w",
+      "timeFrom": "5w",
       "title": "Viral loop \u2014 weekly",
       "type": "timeseries"
     }

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -488,13 +488,13 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Sharers \u00f7 new users, last 30d (Mobile). True K-factor needs referral attribution \u2014 not instrumented yet, so this proxies the share loop. 0% = no viral loop shipped.",
+      "description": "Viral events (friend signups + referral redemptions + summary shares) \u00f7 first-seen new users, last 30d (Mobile). Mobile counts summary shares only \u2014 the friend-source answer and the referral program are desktop-only signals.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "decimals": 1,
+          "decimals": 2,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -504,15 +504,15 @@
               },
               {
                 "color": "#f59e0b",
-                "value": 10
+                "value": 0.05
               },
               {
                 "color": "#22c55e",
-                "value": 30
+                "value": 0.15
               }
             ]
           },
-          "unit": "percent"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -539,31 +539,31 @@
       },
       "targets": [
         {
-          "columns": [
-            {
-              "selector": "shareRatePct",
-              "text": "Sharers / new users",
-              "type": "number"
-            }
-          ],
+          "refId": "A",
           "datasource": {
             "type": "yesoreyeram-infinity-datasource",
             "uid": "omi-admin-api"
           },
-          "format": "table",
-          "parser": "backend",
-          "refId": "A",
-          "root_selector": "proxy",
-          "source": "url",
           "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "table",
           "url": "http://127.0.0.1:8899/api/omi/stats/k-factor/posthog?days=30&platform=mobile",
           "url_options": {
-            "data": "",
-            "method": "GET"
-          }
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "summary",
+          "columns": [
+            {
+              "selector": "kFactor",
+              "text": "Viral events / new user",
+              "type": "number"
+            }
+          ]
         }
       ],
-      "title": "Share rate (K-factor proxy)",
+      "title": "K-factor  \u00b7  30d",
       "type": "stat"
     },
     {
@@ -3274,6 +3274,280 @@
       ],
       "timeFrom": "30d",
       "title": "Free \u2192 paid conversion (mobile)  \u00b7  ${d_conv}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "Main viral-loop trend: (friend signups + referral redemptions + summary shares) \u00f7 first-seen new users, per NYC day. Last bar = rolling last 24h.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#22c55e"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "none",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 74,
+        "w": 24,
+        "h": 7
+      },
+      "id": 992,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/k-factor/posthog?days=30&_tzdates=date&platform=mobile",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "daily",
+          "columns": [
+            {
+              "selector": "date",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "kFactor",
+              "text": "K-factor",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "30d",
+      "title": "K-factor \u2014 daily",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "The three viral signals, per NYC day. Last bar = rolling last 24h.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 65,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 81,
+        "w": 12,
+        "h": 7
+      },
+      "id": 993,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/k-factor/posthog?days=30&_tzdates=date&platform=mobile",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "daily",
+          "columns": [
+            {
+              "selector": "date",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "friend",
+              "text": "Friend signups",
+              "type": "number"
+            },
+            {
+              "selector": "referral",
+              "text": "Referral redemptions",
+              "type": "number"
+            },
+            {
+              "selector": "shares",
+              "text": "Summary shares",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "30d",
+      "title": "Viral loop \u2014 daily",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "The three viral signals, per NYC Monday week. Last bucket = rolling trailing 7 days.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 65,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 81,
+        "w": 12,
+        "h": 7
+      },
+      "id": 994,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/k-factor/posthog?days=30&_tzdates=week&platform=mobile",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "weekly",
+          "columns": [
+            {
+              "selector": "week",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "friend",
+              "text": "Friend signups",
+              "type": "number"
+            },
+            {
+              "selector": "referral",
+              "text": "Referral redemptions",
+              "type": "number"
+            },
+            {
+              "selector": "shares",
+              "text": "Summary shares",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "8w",
+      "title": "Viral loop \u2014 weekly",
       "type": "timeseries"
     }
   ],

--- a/web/admin/grafana/dashboards/omi-tv.json
+++ b/web/admin/grafana/dashboards/omi-tv.json
@@ -571,13 +571,13 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Sharers \u00f7 new users, last 30d (all platforms). True K-factor needs referral attribution \u2014 not instrumented yet, so this proxies the share loop. 0% = no viral loop shipped.",
+      "description": "Viral events (friend signups + referral redemptions + summary shares) \u00f7 first-seen new users, last 30d (all platforms).",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "decimals": 1,
+          "decimals": 2,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -587,15 +587,15 @@
               },
               {
                 "color": "#f59e0b",
-                "value": 10
+                "value": 0.05
               },
               {
                 "color": "#22c55e",
-                "value": 30
+                "value": 0.15
               }
             ]
           },
-          "unit": "percent"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -622,31 +622,31 @@
       },
       "targets": [
         {
-          "columns": [
-            {
-              "selector": "shareRatePct",
-              "text": "Sharers / new users",
-              "type": "number"
-            }
-          ],
+          "refId": "A",
           "datasource": {
             "type": "yesoreyeram-infinity-datasource",
             "uid": "omi-admin-api"
           },
-          "format": "table",
-          "parser": "backend",
-          "refId": "A",
-          "root_selector": "proxy",
-          "source": "url",
           "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "table",
           "url": "http://127.0.0.1:8899/api/omi/stats/k-factor/posthog?days=30&platform=all",
           "url_options": {
-            "data": "",
-            "method": "GET"
-          }
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "summary",
+          "columns": [
+            {
+              "selector": "kFactor",
+              "text": "Viral events / new user",
+              "type": "number"
+            }
+          ]
         }
       ],
-      "title": "Share rate (K-factor proxy)",
+      "title": "K-factor  \u00b7  30d",
       "type": "stat"
     },
     {
@@ -5276,6 +5276,280 @@
       ],
       "title": "Infra cost by service \u2014 last 30 days",
       "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "Main viral-loop trend: (friend signups + referral redemptions + summary shares) \u00f7 first-seen new users, per NYC day. Last bar = rolling last 24h.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#22c55e"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "none",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 990
+      },
+      "id": 992,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/k-factor/posthog?days=30&_tzdates=date&platform=all",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "daily",
+          "columns": [
+            {
+              "selector": "date",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "kFactor",
+              "text": "K-factor",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "30d",
+      "title": "K-factor \u2014 daily",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "The three viral signals, per NYC day. Last bar = rolling last 24h.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 65,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 991
+      },
+      "id": 993,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/k-factor/posthog?days=30&_tzdates=date&platform=all",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "daily",
+          "columns": [
+            {
+              "selector": "date",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "friend",
+              "text": "Friend signups",
+              "type": "number"
+            },
+            {
+              "selector": "referral",
+              "text": "Referral redemptions",
+              "type": "number"
+            },
+            {
+              "selector": "shares",
+              "text": "Summary shares",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "30d",
+      "title": "Viral loop \u2014 daily",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "The three viral signals, per NYC Monday week. Last bucket = rolling trailing 7 days.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 65,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 991
+      },
+      "id": 994,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/k-factor/posthog?days=30&_tzdates=week&platform=all",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "weekly",
+          "columns": [
+            {
+              "selector": "week",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "friend",
+              "text": "Friend signups",
+              "type": "number"
+            },
+            {
+              "selector": "referral",
+              "text": "Referral redemptions",
+              "type": "number"
+            },
+            {
+              "selector": "shares",
+              "text": "Summary shares",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "8w",
+      "title": "Viral loop \u2014 weekly",
+      "type": "timeseries"
     },
     {
       "id": 991,

--- a/web/admin/grafana/dashboards/omi-tv.json
+++ b/web/admin/grafana/dashboards/omi-tv.json
@@ -5547,7 +5547,7 @@
           ]
         }
       ],
-      "timeFrom": "8w",
+      "timeFrom": "5w",
       "title": "Viral loop \u2014 weekly",
       "type": "timeseries"
     },

--- a/web/admin/grafana/test_build_dashboards.py
+++ b/web/admin/grafana/test_build_dashboards.py
@@ -273,13 +273,59 @@ class ReleasePanelTests(unittest.TestCase):
             self.assertNotEqual(stat["targets"][0]["root_selector"], absent, uid)
 
 
-class ShareTileDescriptionTests(unittest.TestCase):
-    def test_share_tile_description_names_its_board_scope(self) -> None:
+class KFactorTests(unittest.TestCase):
+    """The K-factor surface: stat tile + daily graph + daily/weekly trackers,
+    platform-scoped per board, reading the rebuilt viral-signals payload."""
+
+    def test_kfactor_tile_reads_summary_and_names_its_board_scope(self) -> None:
         for uid, label in [("omi-tv", "all platforms"), ("omi-tv-macos", "macOS"),
                            ("omi-tv-mobile", "Mobile")]:
             panel = next(p for p in load(uid)["panels"]
-                         if build_dashboards.base_title(p).startswith("Share rate"))
+                         if build_dashboards.base_title(p).startswith("K-factor")
+                         and p.get("type") == "stat")
             self.assertIn(f"last 30d ({label})", panel["description"], uid)
+            target = panel["targets"][0]
+            self.assertEqual(target["root_selector"], "summary", uid)
+            self.assertEqual([c["selector"] for c in target["columns"]], ["kFactor"], uid)
+
+    def test_mobile_kfactor_tile_admits_shares_only(self) -> None:
+        panel = next(p for p in load("omi-tv-mobile")["panels"]
+                     if build_dashboards.base_title(p).startswith("K-factor")
+                     and p.get("type") == "stat")
+        self.assertIn("desktop-only", panel["description"])
+
+    def test_every_board_has_the_viral_tracker_panels(self) -> None:
+        for uid, scope in [("omi-tv", "all"), ("omi-tv-macos", "macos"),
+                           ("omi-tv-mobile", "mobile")]:
+            dash = load(uid)
+            for title, root in [("K-factor — daily", "daily"),
+                                ("Viral loop — daily", "daily"),
+                                ("Viral loop — weekly", "weekly")]:
+                panel = next(p for p in dash["panels"]
+                             if build_dashboards.base_title(p) == title)
+                target = panel["targets"][0]
+                self.assertEqual(target["root_selector"], root, f"{uid} {title}")
+                params = urllib.parse.parse_qs(
+                    urllib.parse.urlparse(target["url"]).query)
+                self.assertEqual(params["platform"], [scope], f"{uid} {title}")
+                # The date/week column is routed through the proxy's NYC
+                # rewrite, never parsed as a bare UTC-midnight day.
+                ts_cols = [c for c in target["columns"] if c["type"] == "timestamp"]
+                self.assertEqual(len(ts_cols), 1, f"{uid} {title}")
+                self.assertEqual(ts_cols[0]["timestampFormat"],
+                                 build_dashboards.RFC3339, f"{uid} {title}")
+                self.assertEqual(params["_tzdates"], [ts_cols[0]["selector"]],
+                                 f"{uid} {title}")
+
+    def test_viral_trackers_chart_all_three_signals(self) -> None:
+        for uid in ["omi-tv", "omi-tv-macos", "omi-tv-mobile"]:
+            for title in ["Viral loop — daily", "Viral loop — weekly"]:
+                panel = next(p for p in load(uid)["panels"]
+                             if build_dashboards.base_title(p) == title)
+                selectors = [c["selector"] for c in panel["targets"][0]["columns"]
+                             if c.get("type") != "timestamp"]
+                self.assertEqual(selectors, ["friend", "referral", "shares"],
+                                 f"{uid} {title}")
 
 
 class ExactRevenueTests(unittest.TestCase):

--- a/web/admin/lib/__tests__/k-factor-referral-funnel.test.ts
+++ b/web/admin/lib/__tests__/k-factor-referral-funnel.test.ts
@@ -1,8 +1,28 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const posthogResults = vi.fn();
-
 vi.mock("@/lib/posthog", () => ({ posthogResults }));
+
+// Firestore referral ledger: two granted claims, one inside the last 24h.
+const RECENT_CLAIM_MS = Date.now() - 3_600_000;
+const OLD_CLAIM_MS = Date.now() - 10 * 86_400_000;
+const referralDocs = [
+  { get: (f: string) => (f === "referral.claimed_at" ? RECENT_CLAIM_MS / 1000 : null) },
+  { get: (f: string) => (f === "referral.claimed_at" ? OLD_CLAIM_MS / 1000 : null) },
+];
+const firestoreGet = vi.fn(async () => ({ docs: referralDocs }));
+vi.mock("@/lib/firebase/admin", () => ({
+  getDb: () => ({
+    collection: () => ({
+      where: (field: string, op: string, value: string) => {
+        firestoreGet.mock.calls; // keep signature honest below via assertion
+        expect(field).toBe("referral.program");
+        expect(value).toBe("desktop_operator_month_v1");
+        return { limit: () => ({ get: firestoreGet }) };
+      },
+    }),
+  }),
+}));
 
 const ENV_KEYS = [
   "POSTHOG_PERSONAL_API_KEY",
@@ -19,23 +39,38 @@ function configurePosthog() {
   process.env.POSTHOG_HOST = "https://posthog.test";
 }
 
+function nycDate(msAgo = 0): string {
+  return new Date(Date.now() - msAgo).toLocaleDateString("en-CA", {
+    timeZone: "America/New_York",
+  });
+}
+
 afterEach(() => {
   vi.resetModules();
   posthogResults.mockReset();
+  firestoreGet.mockClear();
   for (const key of ENV_KEYS) {
     if (originalEnv[key] == null) delete process.env[key];
     else process.env[key] = originalEnv[key];
   }
 });
 
-describe("computeKFactor referral funnel", () => {
+async function compute(platform?: "all" | "macos" | "mobile") {
+  const { computeKFactor } = await import(
+    "@/app/api/omi/stats/k-factor/posthog/route"
+  );
+  return computeKFactor(30, platform);
+}
+
+function capturedQueries(): string[] {
+  return posthogResults.mock.calls.map(([, , , query]) => query as string);
+}
+
+describe("computeKFactor viral signals", () => {
   it("is unavailable when PostHog credentials are missing", async () => {
     delete process.env.POSTHOG_PERSONAL_API_KEY;
     delete process.env.POSTHOG_PROJECT_ID;
-    const { computeKFactor } =
-      await import("@/app/api/omi/stats/k-factor/posthog/route");
-
-    await expect(computeKFactor(30)).resolves.toMatchObject({
+    await expect(compute()).resolves.toMatchObject({
       available: false,
       kFactor: null,
       reason: "PostHog credentials not configured.",
@@ -43,39 +78,96 @@ describe("computeKFactor referral funnel", () => {
     expect(posthogResults).not.toHaveBeenCalled();
   });
 
-  it("is available with a zero-count funnel", async () => {
+  it("keeps the legacy referral funnel fields for the classic dashboard tile", async () => {
     configurePosthog();
     posthogResults.mockResolvedValue([]);
-    const { computeKFactor } =
-      await import("@/app/api/omi/stats/k-factor/posthog/route");
-
-    await expect(computeKFactor(30)).resolves.toMatchObject({
+    await expect(compute("macos")).resolves.toMatchObject({
       available: true,
-      kFactor: null,
       funnel: { issued: 0, captured: 0, granted: 0 },
     });
-    expect(posthogResults).toHaveBeenCalledTimes(3);
+    const funnelQueries = capturedQueries().filter((q) =>
+      q.includes("desktop_operator_month_v1"),
+    );
+    expect(funnelQueries).toHaveLength(3);
+    expect(funnelQueries.join("\n")).toContain("properties.claimed = true");
+    for (const q of funnelQueries) expect(q).not.toContain("$os_name");
   });
 
-  it("computes granted users divided by issued users", async () => {
+  it("scopes the macOS board to macOS client events with NYC day buckets", async () => {
     configurePosthog();
-    posthogResults
-      .mockResolvedValueOnce([[12]])
-      .mockResolvedValueOnce([[9]])
-      .mockResolvedValueOnce([[3]]);
-    const { computeKFactor } =
-      await import("@/app/api/omi/stats/k-factor/posthog/route");
-
-    await expect(computeKFactor(30)).resolves.toMatchObject({
-      available: true,
-      kFactor: 0.25,
-      funnel: { issued: 12, captured: 9, granted: 3 },
-    });
-    expect(posthogResults.mock.calls[2][3]).toContain(
-      "properties.claimed = true",
-    );
-    for (const [, , , query] of posthogResults.mock.calls) {
-      expect(query).not.toContain("$os_name");
+    posthogResults.mockResolvedValue([]);
+    await compute("macos");
+    const queries = capturedQueries();
+    const friendQuery = queries.find((q) =>
+      q.includes("Onboarding How Did You Hear"),
+    )!;
+    expect(friendQuery).toContain("properties.source = 'Friend'");
+    expect(friendQuery).toContain("properties.$os_name = 'macOS'");
+    const sharesQuery = queries.find((q) => q.includes("Share Action"))!;
+    expect(sharesQuery).toContain("properties.category = 'conversation'");
+    // Delivered share emails are recorded server-side without an OS — the
+    // event name itself is the platform scope.
+    expect(sharesQuery).toContain("Conversation Summary Shared");
+    for (const q of queries.filter((q) => q.includes("toDate"))) {
+      expect(q).toContain("America/New_York");
     }
+  });
+
+  it("scopes the mobile board to mobile shares and zero desktop-only signals", async () => {
+    configurePosthog();
+    posthogResults.mockResolvedValue([]);
+    const payload = await compute("mobile");
+    const queries = capturedQueries();
+    const sharesQuery = queries.find((q) => q.includes("Conversation Shared"))!;
+    expect(sharesQuery).toContain("'iOS', 'Android', 'iPadOS'");
+    expect(sharesQuery).not.toContain("Conversation Summary Shared");
+    // The referral program grants a desktop trial — the mobile board must not
+    // read the Firestore ledger at all.
+    expect(firestoreGet).not.toHaveBeenCalled();
+    expect((payload as any).summary.referral).toBe(0);
+  });
+
+  it("computes k-factor as viral events per new user and exposes daily and weekly trackers", async () => {
+    configurePosthog();
+    const today = nycDate();
+    posthogResults.mockImplementation(async (_h, _p, _k, query: string) => {
+      if (query.includes("Onboarding How Did You Hear")) {
+        return query.includes("INTERVAL 7 DAY") ? [[1, 3]] : [[today, 2]].map((r) => r);
+      }
+      if (query.includes("Share Action") || query.includes("Conversation Shared")) {
+        return query.includes("INTERVAL 7 DAY") ? [[2, 6]] : [[today, 4]];
+      }
+      if (query.includes("min_ts")) {
+        return query.includes("INTERVAL 7 DAY") ? [[10, 40]] : [[today, 10]];
+      }
+      return [[0]]; // funnel queries
+    });
+    const payload: any = await compute("macos");
+
+    const lastDaily = payload.daily[payload.daily.length - 1];
+    expect(lastDaily.date).toBe(today);
+    // Rolling last-24h replaces the partial calendar day, and the Firestore
+    // claim from the last hour is counted as a referral.
+    expect(lastDaily.friend).toBe(2);
+    expect(lastDaily.shares).toBe(4);
+    expect(lastDaily.referral).toBe(1);
+    expect(lastDaily.viralEvents).toBe(7);
+    expect(lastDaily.newUsers).toBe(10);
+    expect(lastDaily.kFactor).toBeCloseTo(0.7);
+
+    // Weekly tracker exists and its last bucket is the rolling trailing 7d.
+    const lastWeekly = payload.weekly[payload.weekly.length - 1];
+    expect(lastWeekly.friend).toBe(3);
+    expect(lastWeekly.shares).toBe(6);
+    // Only the claim from the last hour is inside the trailing 7 days; the
+    // 10-day-old claim still counts toward the 30d summary below.
+    expect(lastWeekly.referral).toBe(1);
+    expect(lastWeekly.newUsers).toBe(40);
+    expect(lastWeekly.kFactor).toBeCloseTo(10 / 40);
+    expect(payload.summary.referral).toBe(2);
+
+    // Window k-factor = total viral events / total new users.
+    expect(payload.summary.kFactor).toBe(payload.kFactor);
+    expect(payload.kFactor).toBeGreaterThan(0);
   });
 });

--- a/web/admin/lib/__tests__/platform-scope-routes.test.ts
+++ b/web/admin/lib/__tests__/platform-scope-routes.test.ts
@@ -21,6 +21,14 @@ vi.mock("@/lib/posthog", () => ({
     return [];
   }),
 }));
+// k-factor reads the Firestore referral ledger alongside PostHog.
+vi.mock("@/lib/firebase/admin", () => ({
+  getDb: () => ({
+    collection: () => ({
+      where: () => ({ limit: () => ({ get: async () => ({ docs: [] }) }) }),
+    }),
+  }),
+}));
 
 const MACOS_FILTER = "$os_name = 'macOS'";
 const MOBILE_FILTER = "$os_name IN ('iOS', 'Android', 'iPadOS')";
@@ -88,13 +96,22 @@ describe.each(ROUTES)("%s route", (_name, loadRoute, baseUrl) => {
 });
 
 describe("k-factor route", () => {
-  it("does not require a client OS for server-emitted referral funnel events", async () => {
+  it("scopes client viral signals to the board's OS but never the server-emitted events", async () => {
     const queries = await capture(
       () => import("@/app/api/omi/stats/k-factor/posthog/route"),
       "/api/omi/stats/k-factor/posthog?days=30&platform=macos",
     );
-    expect(queries).toHaveLength(3);
-    expectScoped(queries, "all");
+    // Client-side signals (friend answer, share actions, first-seen new
+    // users) carry the macOS scope…
+    const friend = queries.filter((q) => q.includes("Onboarding How Did You Hear"));
+    expect(friend.length).toBeGreaterThan(0);
+    for (const q of friend) expect(q).toContain(MACOS_FILTER);
+    expect(queries.some((q) => q.includes("min_ts") && q.includes(MACOS_FILTER))).toBe(true);
+    // …while the server-emitted referral funnel and share-email events have
+    // no client OS and must not be OS-filtered.
+    const funnel = queries.filter((q) => q.includes("desktop_operator_month_v1"));
+    expect(funnel).toHaveLength(3);
+    for (const q of funnel) expect(q).not.toContain("$os_name");
   });
 });
 


### PR DESCRIPTION
## Why

The admin K-factor "doesn't work": the Grafana tile still read `proxy.shareRatePct`, a field #12170 removed, and the referral funnel events the rewritten route counts only started firing on prod 2026-08-25 (zero events in 180 days of history) — so all three boards showed a dead red 0.0% regardless of viral activity. The share-email path had no telemetry at all.

## What

K-factor is now measured from the three concrete viral signals and platform-scoped per board:

1. **Friend signups** — `Onboarding How Did You Hear` with `source='Friend'` (macOS/Windows onboarding).
2. **Referral redemptions** — the Firestore `users/{uid}.referral` ledger (transactional record of every granted claim); the PostHog funnel stays for the issued/captured tile.
3. **Summary shares** — macOS `Share Action` `category='conversation'` + new server-side `Conversation Summary Shared` (emitted after a delivered share email) + mobile `Conversation Shared`.

`K-factor = (friend + referral + shares) / first-seen new users`. The route returns `daily[]` and `weekly[]` trackers plus `summary`; the boards gain the main **K-factor — daily** graph and **Viral loop — daily / weekly** stacked trackers on all three boards, and the KPI tile now reads `summary.kFactor`. Last daily bar = rolling last 24h; last weekly bucket = rolling trailing 7d; all buckets NYC days. Precompute warms all three platform scopes. Legacy `funnel`/`kFactor` fields kept for the classic dashboard tile.

## Verification

- `web/admin` vitest 189/189 (k-factor contracts rewritten: platform scoping, rolling buckets, Firestore ledger, legacy fields; platform-scope harness asserts client signals get the board OS filter while server-emitted events never do).
- `test_build_dashboards.py` 23/23 (K-factor tile selector + description per board, tracker panels present with pinned `platform=` and NYC `_tzdates` on all three boards).
- `backend/tests/unit/test_share_email_routes.py` 21/21 (success emits exactly one telemetry event with delivered count; failed send emits nothing).
- Real-path: ran web/admin locally against prod PostHog + Firestore through the auth proxy — macOS k=0.182 (97 friend + 2 referral + 53 shares / 836 new users, 30d), all=0.404, mobile=0.374 (shares-only, honest zeros for the desktop-only signals); rendered all three boards in a local Grafana and visually confirmed the tile, the daily K-factor graph, and both trackers populate with real data.

Failure-Class: none

Line-Count-Exception: backend/routers/conversations.py | 1895 -> 1903 | one telemetry emission (with its constraint comment) inside the existing share-email send closure; splitting the router is out of scope for a K-factor fix


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

