### PR TITLE
fix(desktop-windows): wire chat quota gate into main-window send path (#10240)

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-08-chat-quota-gate.json
+++ b/desktop/windows/changelog/unreleased/2026-08-chat-quota-gate.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "The main chat window now blocks a send before it fires when your quota is exhausted, matching the bar's behavior — you see the upgrade prompt immediately instead of after the server replies."
+  ]
+}

--- a/desktop/windows/src/renderer/src/components/settings/billing/UsageLimitTriggerHost.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/billing/UsageLimitTriggerHost.tsx
@@ -1,29 +1,20 @@
 import { useEffect, useRef } from 'react'
 import { useAppState } from '../../../state/appState'
-import { maybeTriggerChatQuotaPopup } from '../../../lib/usageLimit'
-import { fetchChatQuota } from '../../../lib/billing'
+import { mainChatQuotaGate } from '../../../hooks/useChat'
 
 /**
- * Raises the usage-limit popup when a chat send finishes against an exhausted
- * quota. It observes the ONE app-wide chat engine's `sending` flag (via
- * useAppState) rather than touching the chat send path itself — on the
- * busy→idle edge (a reply just completed) it probes the chat quota once. The
- * probe is cheap, silent on error, and shows the popup at most once per session
- * (guards live in lib/usageLimit). Mounted once at the app root, main window
- * only.
+ * Refreshes the main-window chat quota snapshot after each completed reply so
+ * the next pre-send gate check in useChat.send() reads a fresh verdict without
+ * a network round trip. Mounted once at the app root, main window only.
  */
 export function UsageLimitTriggerHost(): null {
-  // TODO(#10240 stream-1 chat integration — see docs/mac-parity-audit/PARALLEL-PLAN.md
-  // §Stream 1): replace this spinner-flag inference with an explicit
-  // quota-exceeded signal from the chat engine once fix/windows-wiring-criticals'
-  // useChat changes merge.
   const { chat } = useAppState()
   const wasSending = useRef(chat.sending)
 
   useEffect(() => {
     const finishedReply = wasSending.current && !chat.sending
     wasSending.current = chat.sending
-    if (finishedReply) void maybeTriggerChatQuotaPopup(fetchChatQuota)
+    if (finishedReply) void mainChatQuotaGate.sync()
   }, [chat.sending])
 
   return null

--- a/desktop/windows/src/renderer/src/hooks/useChat.test.tsx
+++ b/desktop/windows/src/renderer/src/hooks/useChat.test.tsx
@@ -70,6 +70,25 @@ vi.mock('../lib/desktopChatMessages', () => ({
   saveDesktopMessage: (r: unknown) => saveDesktopMessageSpy(r)
 }))
 
+// Chat quota gate — default allow (blocked: false) so existing tests are unaffected.
+const gateMocks = vi.hoisted(() => ({
+  check: vi.fn<() => Promise<{ blocked: false } | { blocked: true; message: string }>>().mockResolvedValue({
+    blocked: false
+  }),
+  recordQuery: vi.fn(),
+  sync: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  checkSync: vi.fn().mockReturnValue({ blocked: false }),
+  applyQuota: vi.fn(),
+  isLimitReached: vi.fn().mockReturnValue(false)
+}))
+vi.mock('../lib/chatQuotaGate', () => ({ createChatQuotaGate: () => gateMocks }))
+const showUsageLimitSpy = vi.hoisted(() => vi.fn())
+vi.mock('../lib/usageLimit', () => ({
+  showUsageLimit: showUsageLimitSpy,
+  dismissUsageLimit: vi.fn(),
+  onUsageLimit: vi.fn(() => () => {})
+}))
+
 import {
   useChat,
   CHAT_STREAM_TIMEOUT_MS,
@@ -1107,5 +1126,34 @@ describe('useChat — rehydrate preserves attachments', () => {
     expect(userAttachmentsOf(result.current.history)).toEqual([
       { id: 'srv-y', name: 'y.pdf', mimeType: 'application/pdf' }
     ])
+  })
+})
+
+describe('useChat — chat quota gate (Mac AgentBridge.quotaExceeded parity)', () => {
+  it('blocks a send when the quota is exhausted — popup shown, no fetch, no history entry', async () => {
+    gateMocks.check.mockResolvedValueOnce({ blocked: true, message: "You've reached your limit." })
+    const { result } = renderHook(() => useChat())
+    await act(async () => {
+      await result.current.send('hello')
+    })
+    expect(showUsageLimitSpy).toHaveBeenCalledWith('chat')
+    expect(global.fetch).not.toHaveBeenCalled()
+    expect(result.current.history).toHaveLength(0)
+    expect(result.current.sending).toBe(false)
+  })
+
+  it('lets an in-quota send through and records the query optimistically', async () => {
+    const { result } = renderHook(() => useChat())
+    void act(async () => {
+      await result.current.send('hello')
+    })
+    await waitForStream(0)
+    streams[0].close()
+    await act(async () => {
+      await flush()
+    })
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    expect(gateMocks.recordQuery).toHaveBeenCalledTimes(1)
+    expect(showUsageLimitSpy).not.toHaveBeenCalled()
   })
 })

--- a/desktop/windows/src/renderer/src/hooks/useChat.ts
+++ b/desktop/windows/src/renderer/src/hooks/useChat.ts
@@ -41,6 +41,13 @@ import {
 import { trackEvent } from '../lib/analytics'
 import { mergeAgentCards } from '../lib/chat/agentThreadCards'
 import type { ChatContentBlock } from '../../../shared/chatContent'
+import { createChatQuotaGate, type ChatQuotaGate } from '../lib/chatQuotaGate'
+import { showUsageLimit } from '../lib/usageLimit'
+
+// Main-window pre-send quota gate (Mac AgentBridge.quotaExceeded parity).
+// Exported so UsageLimitTriggerHost can call sync() after each completed reply
+// to refresh the snapshot for the next send's check().
+export const mainChatQuotaGate: ChatQuotaGate = createChatQuotaGate()
 
 export type ChatMsg = {
   id?: string
@@ -982,6 +989,16 @@ export function useChat(): UseChat {
     // attachment-only sends); only a truly empty send is dropped. The file_ids
     // are drained from the pending list below.
     if ((!text.trim() && getPendingAttachments().length === 0) || sendingRef.current) return
+    // Pre-send quota gate (Mac AgentBridge.quotaExceeded parity). A signed-out
+    // user has no quota to gate; fail-open so a forced-reauth can't lock the send.
+    if (auth.currentUser) {
+      const verdict = await mainChatQuotaGate.check()
+      if (verdict.blocked) {
+        showUsageLimit('chat')
+        return
+      }
+      mainChatQuotaGate.recordQuery()
+    }
     const fromVoice = !!opts?.fromVoice
     setBusy(true)
     // Open a new generation. reset()/dismiss bumps genRef, so `isCurrent()` goes

--- a/desktop/windows/src/renderer/src/lib/usageLimit.test.ts
+++ b/desktop/windows/src/renderer/src/lib/usageLimit.test.ts
@@ -9,20 +9,10 @@ import {
   onUsageLimit,
   showUsageLimit,
   dismissUsageLimit,
-  maybeTriggerChatQuotaPopup,
   maybeTriggerTranscriptionQuotaPopup,
   __resetUsageLimitSession,
   type UsageLimitReason
 } from './usageLimit'
-import type { ChatUsageQuota } from './omiApi.generated'
-
-const quota = (p: Partial<ChatUsageQuota>): ChatUsageQuota => ({
-  plan: 'basic',
-  plan_type: 'free',
-  unit: 'questions',
-  used: 0,
-  ...p
-})
 
 beforeEach(() => {
   __resetUsageLimitSession()
@@ -38,31 +28,6 @@ describe('usage-limit pub/sub', () => {
     dismissUsageLimit()
     off()
     expect(seen).toEqual([null, 'transcription', null])
-  })
-})
-
-describe('maybeTriggerChatQuotaPopup', () => {
-  it('shows the popup once when the quota is exhausted', async () => {
-    const seen: (UsageLimitReason | null)[] = []
-    onUsageLimit((r) => seen.push(r))
-    const fetchQuota = vi.fn().mockResolvedValue(quota({ used: 30, limit: 30, allowed: false }))
-
-    expect(await maybeTriggerChatQuotaPopup(fetchQuota)).toBe(true)
-    expect(seen.at(-1)).toBe('chat')
-
-    // Second call in the same session is a no-op (no nagging).
-    expect(await maybeTriggerChatQuotaPopup(fetchQuota)).toBe(false)
-    expect(fetchQuota).toHaveBeenCalledTimes(1)
-  })
-
-  it('does nothing when the quota still allows sending', async () => {
-    const fetchQuota = vi.fn().mockResolvedValue(quota({ used: 5, limit: 30, allowed: true }))
-    expect(await maybeTriggerChatQuotaPopup(fetchQuota)).toBe(false)
-  })
-
-  it('stays silent when the quota probe fails', async () => {
-    const fetchQuota = vi.fn().mockRejectedValue(new Error('network'))
-    expect(await maybeTriggerChatQuotaPopup(fetchQuota)).toBe(false)
   })
 })
 

--- a/desktop/windows/src/renderer/src/lib/usageLimit.ts
+++ b/desktop/windows/src/renderer/src/lib/usageLimit.ts
@@ -1,4 +1,3 @@
-import type { ChatUsageQuota } from './omiApi.generated'
 import type { LiveStatus } from './liveConversation'
 import { isQuotaExhaustedMessage } from './transcriptionClient'
 import { isByokActiveCached } from './byokKeys'
@@ -23,43 +22,10 @@ export function dismissUsageLimit(): void {
   signal.set(null)
 }
 
-// ── Chat-quota trigger ──────────────────────────────────────────────────────
-// The chat send path lives on another branch, so rather than rewire it we watch
-// the quota from the outside: after a send settles, a cheap GET usage-quota that
-// reports allowed=false raises the popup. Fired at most once per app session so
-// a user who keeps trying isn't nagged repeatedly.
-
-let chatQuotaPopupShown = false
-
 /** Test-only: reset the once-per-session guards. */
 export function __resetUsageLimitSession(): void {
-  chatQuotaPopupShown = false
   transcriptionQuotaPopupShown = false
   signal.set(null)
-}
-
-/**
- * Check the chat quota and, if it is exhausted, raise the 'chat' popup — but
- * only the first time in a session. Returns true iff the popup was shown by this
- * call. `fetchQuota` is injected so callers/tests control the network.
- */
-export async function maybeTriggerChatQuotaPopup(
-  fetchQuota: () => Promise<ChatUsageQuota>
-): Promise<boolean> {
-  if (chatQuotaPopupShown) return false
-  let quota: ChatUsageQuota
-  try {
-    quota = await fetchQuota()
-  } catch {
-    // A quota probe must never surface an error to the user — stay silent.
-    return false
-  }
-  if (quota.allowed === false) {
-    chatQuotaPopupShown = true
-    showUsageLimit('chat')
-    return true
-  }
-  return false
 }
 
 // ── Transcription-quota trigger ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #10240.

The main-window send path had no pre-send quota check — it fired the request, received the server's canned "You've reached your limit" reply as a chat message, and then `UsageLimitTriggerHost` polled the quota endpoint post-hoc to show the upgrade popup. This is now replaced with a proper pre-send gate matching Mac's `AgentBridge.quotaExceeded` parity and the bar's existing `FloatingBarUsageLimiter` parity:

- `useChat.send()` calls `mainChatQuotaGate.check()` before the request fires. If blocked: `showUsageLimit('chat')` is raised immediately and the send returns — no request sent, no history entry, no canned server reply.
- `UsageLimitTriggerHost` now calls `chatQuotaGate.sync()` on the busy→idle edge to refresh the snapshot for the next send's check, instead of polling `maybeTriggerChatQuotaPopup`.
- `maybeTriggerChatQuotaPopup` removed from `usageLimit.ts` (no remaining callers).

## Test plan

- `node_modules/.bin/vitest run src/renderer/src/lib/usageLimit.test.ts src/renderer/src/lib/chatQuotaGate.test.ts src/renderer/src/hooks/useChat.test.tsx` — 68/68 pass
- New `describe('useChat — chat quota gate')` covers: blocked send (popup shown, no fetch, no history entry) and allowed send (proceeds, `recordQuery` called)

## Product invariants affected

- **INV-CHAT-1** (one shared transcript across surfaces): this change adds a pre-send quota gate to the main-window send path, maintaining the same chat flow invariant as Mac and the bar.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->