### PR TITLE
fix(desktop-windows): use pnpm, not npm, in LINUX.md's Run from source

### DIFF
--- a/desktop/windows/LINUX.md
+++ b/desktop/windows/LINUX.md
@@ -16,8 +16,8 @@ codebase; only OS-specific adapters branch on `process.platform`.
 ```bash
 cd desktop/windows
 cp .env.example .env          # public Firebase/PostHog config; sign-in works as-is
-npm install
-npm run dev                   # launch on an X11 session (DISPLAY set)
+pnpm install --frozen-lockfile
+pnpm run dev                   # launch on an X11 session (DISPLAY set)
 ```
 
 ## Runtime dependencies (Debian/Ubuntu)


### PR DESCRIPTION
## Summary

\`LINUX.md\`'s "Run from source" section told users to run \`npm install\` and \`npm run dev\`. The project is pinned to pnpm — \`npm install\` produces a different lockfile and silently mismatches versions. Fixed to \`pnpm install\` / \`pnpm run dev\`.

## Test plan

- Docs-only change; verified the commands match \`README.md\` and \`package.json\` scripts

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KADKRuaPJdho9CDE7nLXQP