### PR TITLE
docs(desktop-windows): surface pnpm/Wayland/verification notes from AGENTS.md into README

### DIFF
--- a/desktop/windows/README.md
+++ b/desktop/windows/README.md
@@ -25,9 +25,33 @@ cp .env.example .env
 pnpm run dev
 ```
 
+This directory is pnpm-managed — running `npm install` instead will corrupt
+`package.json`/`pnpm-lock.yaml`/`pnpm-workspace.yaml` (npm doesn't understand
+pnpm-workspace semantics) and leave a stray, untracked `package-lock.json`
+behind. If you see unexplained diffs in those three files with no matching
+commit, this is almost certainly why — `git restore` them and reinstall with
+pnpm.
+
+CI pins pnpm to major version **10**. If your system `pnpm --version` is a
+different major (e.g. 8 or 11+), `.npmrc`'s `node-linker=hoisted` setting can
+be silently ignored, breaking postinstall with a confusing "closure
+package(s) do not resolve on disk" error — use `npx pnpm@10 <command>`
+instead of downgrading a system-managed pnpm install.
+
 `.env` is gitignored. `.env.example` ships with Omi's **public** Firebase + PostHog
 config, so after `cp .env.example .env` the app runs and sign-in works with no extra
 keys to obtain.
+
+### Linux (Wayland compositors)
+
+On native Wayland compositors with limited XWayland support (e.g. niri),
+`pnpm dev` can fail to map the main window at all — the tray icon appears but
+no window does. Set `OMI_OZONE=wayland` to run under native Wayland instead
+(global shortcuts and active-window detection won't work in that mode). If
+the window still comes up blank rather than missing, also add
+`OMI_DEV_HW_GPU=1`. See [docs/multi-worktree-dev.md](docs/multi-worktree-dev.md)
+for the full dev-only environment variable reference and parallel-worktree
+port/profile isolation.
 
 ## Authentication
 
@@ -92,6 +116,14 @@ pnpm run build:linux
 
 Vite inlines the `.env` values at build time, so a packaged installer needs no `.env` —
 the config is compiled into the binary.
+
+## Verify your changes
+
+```bash
+pnpm typecheck   # tsc, node + web configs
+pnpm lint        # ESLint (blocking in CI; Prettier formatting is not)
+pnpm test        # vitest, ~550 tests, runs against an Electron stub
+```
 
 ## Floating bar
 

--- a/desktop/windows/README.md
+++ b/desktop/windows/README.md
@@ -13,18 +13,6 @@ range; Node 24+ breaks the jsdom test suites — see `scripts/check-node-version
 With [nvm](https://github.com/nvm-sh/nvm) installed, `nvm use` in this directory
 picks up the pinned version from `.nvmrc` automatically.
 
-```bash
-# 1. Install dependencies
-nvm use   # or: nvm install (first time)
-pnpm install --frozen-lockfile
-
-# 2. Create your local env file (required — the app won't start without it)
-cp .env.example .env
-
-# 3. Start the app
-pnpm run dev
-```
-
 This directory is pnpm-managed — running `npm install` instead will corrupt
 `package.json`/`pnpm-lock.yaml`/`pnpm-workspace.yaml` (npm doesn't understand
 pnpm-workspace semantics) and leave a stray, untracked `package-lock.json`
@@ -37,6 +25,18 @@ different major (e.g. 8 or 11+), `.npmrc`'s `node-linker=hoisted` setting can
 be silently ignored, breaking postinstall with a confusing "closure
 package(s) do not resolve on disk" error — use `npx pnpm@10 <command>`
 instead of downgrading a system-managed pnpm install.
+
+```bash
+# 1. Install dependencies
+nvm use   # or: nvm install (first time)
+pnpm install --frozen-lockfile
+
+# 2. Create your local env file (required — the app won't start without it)
+cp .env.example .env
+
+# 3. Start the app
+pnpm run dev
+```
 
 `.env` is gitignored. `.env.example` ships with Omi's **public** Firebase + PostHog
 config, so after `cp .env.example .env` the app runs and sign-in works with no extra


### PR DESCRIPTION
## Summary

Developer-facing notes that lived only in `AGENTS.md` (pnpm-vs-npm warning, Wayland ozone flag, post-run verification steps) are now surfaced in `README.md` where first-time contributors will actually look. Also moves the pnpm warning above the install command so it's seen before the mistake is made.

No code changes.

## Test plan

- Docs-only; reviewed for accuracy against `package.json` scripts and current Wayland setup

## Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

