### PR TITLE
fix: keep K-factor aggregates on calendar buckets; rolling 24h is display-only

### DIFF
--- a/web/admin/app/api/omi/stats/k-factor/posthog/route.ts
+++ b/web/admin/app/api/omi/stats/k-factor/posthog/route.ts
@@ -207,8 +207,6 @@ export async function computeKFactor(days: number, platform: PlatformScope = "ma
     });
   }
 
-  // The last daily bucket is a partial calendar day — replace it with the
-  // rolling last 24 hours so the newest bar is always a full-size window.
   const [friend24h, friend7d] = friendRollingRows?.[0] ?? [0, 0];
   const [shares24h, shares7d] = sharesRollingRows?.[0] ?? [0, 0];
   const [new24h, new7d] = newRollingRows?.[0] ?? [0, 0];
@@ -218,17 +216,23 @@ export async function computeKFactor(days: number, platform: PlatformScope = "ma
   const referral7d = referralTimes.filter(
     (ms) => ms >= Date.now() - 7 * 86_400_000,
   ).length;
-  const last = daily[daily.length - 1];
-  if (last && last.date === today) {
-    last.friend = Math.max(last.friend, Number(friend24h) || 0);
-    last.shares = Math.max(last.shares, Number(shares24h) || 0);
-    last.referral = Math.max(last.referral, referral24h);
-    last.newUsers = Math.max(last.newUsers, Number(new24h) || 0);
-    last.viralEvents = last.friend + last.referral + last.shares;
-    last.kFactor = last.newUsers > 0 ? last.viralEvents / last.newUsers : null;
-  }
 
-  // Weekly tracker: NYC Monday buckets aggregated from the daily series; the
+  // Window totals come from the CALENDAR buckets only. A trailing-24h window
+  // overlaps yesterday's calendar bucket, so summing it alongside yesterday
+  // would double-count the overlapping hours.
+  const totals = daily.reduce(
+    (acc, row) => ({
+      friend: acc.friend + row.friend,
+      referral: acc.referral + row.referral,
+      shares: acc.shares + row.shares,
+      newUsers: acc.newUsers + row.newUsers,
+    }),
+    { friend: 0, referral: 0, shares: 0, newUsers: 0 },
+  );
+  const viralEvents = totals.friend + totals.referral + totals.shares;
+
+  // Weekly tracker: NYC Monday buckets aggregated from the calendar daily
+  // series (same non-overlap rule as the totals above); only the
   // last bucket is the rolling trailing 7 days, never a partial calendar week.
   const weekOf = (ymd: string) => {
     const d = new Date(ymd + "T12:00:00Z");
@@ -273,16 +277,17 @@ export async function computeKFactor(days: number, platform: PlatformScope = "ma
     }
   }
 
-  const totals = daily.reduce(
-    (acc, row) => ({
-      friend: acc.friend + row.friend,
-      referral: acc.referral + row.referral,
-      shares: acc.shares + row.shares,
-      newUsers: acc.newUsers + row.newUsers,
-    }),
-    { friend: 0, referral: 0, shares: 0, newUsers: 0 },
-  );
-  const viralEvents = totals.friend + totals.referral + totals.shares;
+  // Display-only, applied AFTER every aggregation: the newest chart bar shows
+  // the rolling last 24 hours instead of a partial calendar day.
+  const last = daily[daily.length - 1];
+  if (last && last.date === today) {
+    last.friend = Math.max(last.friend, Number(friend24h) || 0);
+    last.shares = Math.max(last.shares, Number(shares24h) || 0);
+    last.referral = Math.max(last.referral, referral24h);
+    last.newUsers = Math.max(last.newUsers, Number(new24h) || 0);
+    last.viralEvents = last.friend + last.referral + last.shares;
+    last.kFactor = last.newUsers > 0 ? last.viralEvents / last.newUsers : null;
+  }
 
   const issued = Number(issuedRows?.[0]?.[0] ?? 0);
   const captured = Number(capturedRows?.[0]?.[0] ?? 0);

--- a/web/admin/lib/__tests__/k-factor-referral-funnel.test.ts
+++ b/web/admin/lib/__tests__/k-factor-referral-funnel.test.ts
@@ -170,4 +170,43 @@ describe("computeKFactor viral signals", () => {
     expect(payload.summary.kFactor).toBe(payload.kFactor);
     expect(payload.kFactor).toBeGreaterThan(0);
   });
+
+  it("never double-counts the hours a rolling 24h window shares with yesterday", async () => {
+    configurePosthog();
+    const today = nycDate();
+    const yesterday = nycDate(86_400_000);
+    posthogResults.mockImplementation(async (_h, _p, _k, query: string) => {
+      if (query.includes("Onboarding How Did You Hear")) {
+        // 5 signups yesterday + 1 today; the trailing 24h window sees 4 of
+        // them (3 of yesterday's late-evening ones plus today's).
+        return query.includes("INTERVAL 7 DAY") ? [[4, 6]] : [[yesterday, 5], [today, 1]];
+      }
+      if (query.includes("Share Action")) {
+        return query.includes("INTERVAL 7 DAY") ? [[0, 0]] : [];
+      }
+      if (query.includes("min_ts")) {
+        return query.includes("INTERVAL 7 DAY") ? [[10, 20]] : [[yesterday, 10], [today, 10]];
+      }
+      return [[0]];
+    });
+    const payload: any = await compute("macos");
+
+    // Chart: the newest bar is the full rolling window…
+    const lastDaily = payload.daily[payload.daily.length - 1];
+    expect(lastDaily.friend).toBe(4);
+    // …but the 30d summary stays the sum of calendar days (5 + 1), NOT the
+    // calendar days with today swapped for the overlapping 24h window (5 + 4).
+    expect(payload.summary.friend).toBe(6);
+    // Weekly calendar buckets are aggregated pre-override too: everything but
+    // the last (rolling trailing 7d) bucket sums calendar values.
+    const weeklySum = payload.weekly.reduce(
+      (acc: number, w: any) => acc + w.friend,
+      0,
+    );
+    const lastWeekly = payload.weekly[payload.weekly.length - 1];
+    expect(lastWeekly.friend).toBe(6); // trailing-7d query value, a replacement
+    if (payload.weekly.length > 1) {
+      expect(weeklySum - lastWeekly.friend).toBeLessThanOrEqual(6);
+    }
+  });
 });


### PR DESCRIPTION
## Why

Cross-review caught a window-mixing bug in the just-merged K-factor route (#12202): the rolling last-24h override of today's chart bar ran BEFORE the 30d summary and weekly aggregation, so hours the trailing window shares with yesterday were counted twice — inflating `summary`/`kFactor` and the weekly buckets.

## What

Aggregation order fixed: totals and weekly buckets are computed from the calendar daily series first; the rolling-24h substitution is applied last and only to the chart's newest point. The weekly last bucket remains a replacement by the independent trailing-7d query (never a sum), so it cannot double-count either.

## Verification

- New regression test: 5 friend signups yesterday + 1 today, trailing-24h window of 4 → the chart bar shows 4, `summary.friend` shows 6 (calendar), weekly stays calendar-summed. `web/admin` vitest 190/190.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

