### PR TITLE
fix(admin): tidy the Omi TV hero row and drop the duplicate trials tile

### DIFF
--- a/.github/scripts/test_check_admin_deploy_scope.py
+++ b/.github/scripts/test_check_admin_deploy_scope.py
@@ -345,9 +345,13 @@ class OmiTvDashboardContractTests(unittest.TestCase):
 
     def test_activation_panels_use_firestore_activation_selectors(self) -> None:
         panels = {panel["title"]: panel for panel in self.dashboard()["panels"]}
-        # The base (all-platform) board labels the Firestore-backed activation
-        # panels "(macOS)" because that route only covers macOS signups.
-        rate = panels["Activation rate (macOS)"]["targets"][0]
+        # The base (all-platform) board carries the macOS-only qualifier in the
+        # tile's description (the title is kept short enough to render on the
+        # TV wall) and in the series title, because that route only covers
+        # macOS signups.
+        rate_panel = panels["Activation"]
+        self.assertIn("macOS only", rate_panel["description"])
+        rate = rate_panel["targets"][0]
         self.assertEqual(rate["url"], "http://127.0.0.1:8899/api/omi/stats/activation?days=60")
         self.assertEqual([column["selector"] for column in rate["columns"]], ["rate"])
         self.assertNotIn("viral-metrics", rate["url"])

--- a/web/admin/grafana/build_dashboards.py
+++ b/web/admin/grafana/build_dashboards.py
@@ -401,8 +401,8 @@ def build_platform_board(base, scope: str) -> dict:
     # to every device a user has, so notification volume cannot be split by
     # platform either — those panels live on the All-platforms board only.
     drop_panels(dash, ACCOUNT_LEVEL_TITLES | {
-        "Users → 1M goal", "ARR", "Active subscriptions", "Trialing",
-        "Trials in pipeline", "Conversations", "MRR by product", "MRR over time",
+        "1M goal", "ARR", "Active subscriptions", "Trialing",
+        "Conversations", "MRR by product", "MRR over time",
         "New subscriptions / month", "Message ratings",
         "Infra cost by service — last 30 days",
     })
@@ -426,8 +426,8 @@ def build_platform_board(base, scope: str) -> dict:
     # the same person-deduped PostHog population as the all-time ticker, so
     # the cumulative chart ends exactly at the ticker value.
     viral_scoped = set_url_param(VIRAL_PATH, "platform", scope)
-    signups = panel_by_title(dash, "Signups — last 7 days")
-    signups["title"] = f"{label} signups — last 7 days"
+    signups = panel_by_title(dash, "Signups (7d)")
+    signups["title"] = f"{label} signups (7d)"
     set_compare(signups["targets"][0], "url",
                 path=viral_scoped, root="userGrowth", fields="users")
 
@@ -471,8 +471,12 @@ def build_platform_board(base, scope: str) -> dict:
     retarget_var(dash, "d_prev", fields=exact_field)
 
     if scope == "macos":
-        # Board context makes the (macOS) marker redundant.
-        panel_by_title(dash, "Activation rate (macOS)")["title"] = "Activation rate"
+        # The stat tile is already platform-neutral ("Activation"); board
+        # context makes the All board's "macOS only" marker redundant here.
+        panel_by_title(dash, "Activation")["description"] = (
+            "Firestore: % of signups with a conversation within 7 days — the aha "
+            "moment. Biggest controllable lever — first-5-minutes work."
+        )
         chart = panel_by_title(dash, "Activation (signup → activated, macOS)")
         chart["title"] = "Activation (signup → activated)" + (
             "  ·  " + chart["title"].split("  ·  ")[1] if "  ·  " in chart["title"] else "")
@@ -493,8 +497,12 @@ def build_platform_board(base, scope: str) -> dict:
         # days of a macOS signup); mobile activation uses PostHog telemetry
         # (first-seen → Memory Created within 7 days) via viral-metrics.
         viral_mobile = set_url_param(VIRAL_PATH, "platform", "mobile")
-        rate = panel_by_title(dash, "Activation rate (macOS)")
-        rate["title"] = "Activation rate"
+        rate = panel_by_title(dash, "Activation")
+        rate["description"] = (
+            "PostHog telemetry: % of first-seen mobile users with a Memory Created "
+            "within 7 days. Not the Firestore signup→conversation definition the "
+            "All and macOS boards use."
+        )
         set_stat_query(rate, viral_mobile, "summary", "activationRate", "Activation")
         chart = panel_by_title(dash, "Activation (signup → activated, macOS)")
         chart["title"] = "Activation (signup → activated)  ·  ${d_act}"

--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -191,7 +191,7 @@
           }
         }
       ],
-      "title": "Net WAU growth WoW",
+      "title": "WAU growth",
       "type": "stat"
     },
     {
@@ -314,7 +314,7 @@
           }
         }
       ],
-      "title": "macOS signups \u2014 last 7 days",
+      "title": "macOS signups (7d)",
       "type": "stat"
     },
     {
@@ -322,7 +322,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "% of signups reaching the aha moment on day 1. Biggest controllable lever \u2014 first-5-minutes work.",
+      "description": "Firestore: % of signups with a conversation within 7 days \u2014 the aha moment. Biggest controllable lever \u2014 first-5-minutes work.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -397,7 +397,7 @@
           }
         }
       ],
-      "title": "Activation rate",
+      "title": "Activation",
       "type": "stat"
     },
     {
@@ -693,7 +693,8 @@
               "mode": "none"
             }
           },
-          "unit": "short"
+          "unit": "short",
+          "min": 0
         },
         "overrides": [
           {
@@ -907,7 +908,8 @@
           "mode": "single",
           "sort": "none"
         },
-        "xTickLabelRotation": 0
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 100
       },
       "targets": [
         {
@@ -1269,7 +1271,7 @@
       "gridPos": {
         "x": 20,
         "y": 14,
-        "w": 3,
+        "w": 4,
         "h": 4
       },
       "id": 19,
@@ -1344,7 +1346,7 @@
       "gridPos": {
         "x": 0,
         "y": 22,
-        "w": 3,
+        "w": 4,
         "h": 4
       },
       "id": 20,
@@ -1418,9 +1420,9 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 3,
+        "x": 4,
         "y": 22,
-        "w": 3,
+        "w": 4,
         "h": 4
       },
       "id": 21,
@@ -1493,7 +1495,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 6,
+        "x": 8,
         "y": 22,
         "w": 3,
         "h": 4
@@ -1568,7 +1570,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 9,
+        "x": 11,
         "y": 22,
         "w": 3,
         "h": 4
@@ -1643,7 +1645,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 12,
+        "x": 14,
         "y": 22,
         "w": 3,
         "h": 4
@@ -1723,7 +1725,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 15,
+        "x": 17,
         "y": 22,
         "w": 3,
         "h": 4

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -191,7 +191,7 @@
           }
         }
       ],
-      "title": "Net WAU growth WoW",
+      "title": "WAU growth",
       "type": "stat"
     },
     {
@@ -314,7 +314,7 @@
           }
         }
       ],
-      "title": "Mobile signups \u2014 last 7 days",
+      "title": "Mobile signups (7d)",
       "type": "stat"
     },
     {
@@ -322,7 +322,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "% of signups reaching the aha moment on day 1. Biggest controllable lever \u2014 first-5-minutes work.",
+      "description": "PostHog telemetry: % of first-seen mobile users with a Memory Created within 7 days. Not the Firestore signup\u2192conversation definition the All and macOS boards use.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -397,7 +397,7 @@
           }
         }
       ],
-      "title": "Activation rate",
+      "title": "Activation",
       "type": "stat"
     },
     {
@@ -693,7 +693,8 @@
               "mode": "none"
             }
           },
-          "unit": "short"
+          "unit": "short",
+          "min": 0
         },
         "overrides": [
           {
@@ -907,7 +908,8 @@
           "mode": "single",
           "sort": "none"
         },
-        "xTickLabelRotation": 0
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 100
       },
       "targets": [
         {
@@ -1269,7 +1271,7 @@
       "gridPos": {
         "x": 20,
         "y": 14,
-        "w": 3,
+        "w": 4,
         "h": 4
       },
       "id": 19,
@@ -1344,7 +1346,7 @@
       "gridPos": {
         "x": 0,
         "y": 22,
-        "w": 3,
+        "w": 4,
         "h": 4
       },
       "id": 20,
@@ -1418,9 +1420,9 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 3,
+        "x": 4,
         "y": 22,
-        "w": 3,
+        "w": 4,
         "h": 4
       },
       "id": 21,
@@ -1493,7 +1495,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 6,
+        "x": 8,
         "y": 22,
         "w": 3,
         "h": 4
@@ -1568,7 +1570,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 9,
+        "x": 11,
         "y": 22,
         "w": 3,
         "h": 4
@@ -1622,7 +1624,7 @@
       "type": "text",
       "title": "Crash-free rate (today)",
       "gridPos": {
-        "x": 12,
+        "x": 14,
         "y": 22,
         "w": 3,
         "h": 4
@@ -1659,7 +1661,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 15,
+        "x": 17,
         "y": 22,
         "w": 3,
         "h": 4

--- a/web/admin/grafana/dashboards/omi-tv.json
+++ b/web/admin/grafana/dashboards/omi-tv.json
@@ -162,7 +162,7 @@
           }
         }
       ],
-      "title": "Users \u2192 1M goal",
+      "title": "1M goal",
       "type": "bargauge"
     },
     {
@@ -274,7 +274,7 @@
           }
         }
       ],
-      "title": "Net WAU growth WoW",
+      "title": "WAU growth",
       "type": "stat"
     },
     {
@@ -397,7 +397,7 @@
           }
         }
       ],
-      "title": "Signups \u2014 last 7 days",
+      "title": "Signups (7d)",
       "type": "stat"
     },
     {
@@ -405,7 +405,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "% of signups reaching the aha moment on day 1. Biggest controllable lever \u2014 first-5-minutes work.",
+      "description": "macOS only (Firestore): % of signups with a conversation within 7 days \u2014 the aha moment. Biggest controllable lever \u2014 first-5-minutes work.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -480,7 +480,7 @@
           }
         }
       ],
-      "title": "Activation rate (macOS)",
+      "title": "Activation",
       "type": "stat"
     },
     {
@@ -675,7 +675,8 @@
               "mode": "none"
             }
           },
-          "unit": "short"
+          "unit": "short",
+          "min": 0
         },
         "overrides": [
           {
@@ -889,7 +890,8 @@
           "mode": "single",
           "sort": "none"
         },
-        "xTickLabelRotation": 0
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 100
       },
       "targets": [
         {
@@ -1547,7 +1549,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 3,
+        "w": 4,
         "x": 0,
         "y": 18
       },
@@ -1622,8 +1624,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 3,
-        "x": 3,
+        "w": 4,
+        "x": 4,
         "y": 18
       },
       "id": 20,
@@ -1698,8 +1700,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 3,
-        "x": 6,
+        "w": 4,
+        "x": 8,
         "y": 18
       },
       "id": 21,
@@ -1774,7 +1776,7 @@
       "gridPos": {
         "h": 4,
         "w": 3,
-        "x": 9,
+        "x": 12,
         "y": 18
       },
       "id": 22,
@@ -1849,7 +1851,7 @@
       "gridPos": {
         "h": 4,
         "w": 3,
-        "x": 12,
+        "x": 15,
         "y": 18
       },
       "id": 23,
@@ -1924,7 +1926,7 @@
       "gridPos": {
         "h": 4,
         "w": 3,
-        "x": 15,
+        "x": 18,
         "y": 18
       },
       "id": 24,
@@ -2004,7 +2006,7 @@
       "gridPos": {
         "h": 4,
         "w": 3,
-        "x": 18,
+        "x": 21,
         "y": 18
       },
       "id": 25,
@@ -2049,80 +2051,6 @@
         }
       ],
       "title": "macOS active today",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "omi-admin-api"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "#0ea5e9",
-            "mode": "fixed"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "#0ea5e9",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 21,
-        "y": 18
-      },
-      "id": 26,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "columns": [
-            {
-              "selector": "trialingSubscriptions",
-              "text": "Trials",
-              "type": "number"
-            }
-          ],
-          "datasource": {
-            "type": "yesoreyeram-infinity-datasource",
-            "uid": "omi-admin-api"
-          },
-          "format": "table",
-          "parser": "backend",
-          "refId": "A",
-          "root_selector": "",
-          "source": "url",
-          "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/revenue",
-          "url_options": {
-            "data": "",
-            "method": "GET"
-          }
-        }
-      ],
-      "title": "Trials in pipeline",
       "type": "stat"
     },
     {


### PR DESCRIPTION
Presentation pass on the Omi TV board, which is read from across the room. Four hero titles were long enough to truncate at TV width, one metric was rendered twice, and one description described a definition the panel does not use.

## Changes

- **Hero titles shortened** so they stop truncating: `Users → 1M goal` → `1M goal`, `Net WAU growth WoW` → `WAU growth`, `Signups — last 7 days` → `Signups (7d)`, `Activation rate (macOS)` → `Activation`. The board switcher and the panel descriptions already carry the qualifiers those titles were spending characters on.
- **Duplicate tile removed.** `Trials in pipeline` (from `/api/omi/stats/revenue`) and `Trialing` (from `/api/omi/stats/subscriptions`) render the same number side by side — both read 29 against live prod data. The revenue copy is dropped, and the three freed grid columns go back to the health-ratio tiles so the row fills the grid again instead of leaving a hole.
- **Activation description corrected.** It claimed "% of signups reaching the aha moment on day 1"; the Firestore route it reads measures a conversation **within 7 days**. The mobile board now gets its own description rather than inheriting the Firestore one — that tile is repointed to PostHog telemetry (first-seen → `Memory Created` within 7 days), a different definition that was previously mislabelled.
- **Two chart readability fixes**: the WAU chart is clamped at zero (week-over-week movement was compressed against a floating axis) and the retention curve's x labels are thinned so the day numbers stop overlapping.

## Verification

`build_dashboards.py` regenerates the macOS/mobile boards from `omi-tv.json`; all three are committed. `test_build_dashboards.py` (manifest check `grafana-dashboard-build`) passes 23/23. All three boards were applied to a local copy of the prod Grafana image running against real prod data and inspected — hero titles fit, the duplicate is gone, the row fills the grid, and both charts render.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

