### PR TITLE
fix(observability): the finalization backlog panel said 25,000; the real number was 414

### DIFF
--- a/backend/charts/monitoring/README.md
+++ b/backend/charts/monitoring/README.md
@@ -208,7 +208,7 @@ Each component has dev and prod values:
 
 45 dashboards on prod Grafana (`monitor.omi.me`), organized by folder.
 
-### General (32) — kube-prometheus-stack defaults + custom
+### General (33) — kube-prometheus-stack defaults + custom
 
 Most are bundled with kube-prometheus-stack and auto-provisioned. Custom dashboards are noted.
 
@@ -241,6 +241,7 @@ Most are bundled with kube-prometheus-stack and auto-provisioned. Custom dashboa
 | Kubernetes / Scheduler | `2e6b6a3b4bddf1427b3a55aa1311c656` | `kubernetes-mixin` | Bundled |
 | Node Exporter / AIX | `7e0a61e486f727d763fb1d86fdd629c2` | `node-exporter-mixin` | Bundled |
 | Node Exporter / MacOS | `629701ea43bf69291922ea45f4a87d37` | `node-exporter-mixin` | Bundled |
+| Omi Core Features | `omi-core-features` | — | **Custom** — user-outcome view: journeys, subscriptions, LLM gateway, capture pipeline. The finalization gauges it reads are one global value republished by every backend-listen replica: aggregate with `max()`, never `sum()`. |
 | Node Exporter / Nodes | `7d57716318ee0dddbac5a7f451fb7753` | `node-exporter-mixin` | Bundled |
 | Node Exporter / USE Method / Cluster | `3e97d1d02672cdd0861f4c97c64f89b2` | `node-exporter-mixin` | Bundled |
 | Node Exporter / USE Method / Node | `fac67cfbe174d3ef53eb473d73d9212f` | `node-exporter-mixin` | Bundled |
@@ -287,9 +288,9 @@ Folder: `Omi Services` (folder UID: `betdycdziadc0e`)
 | Category | Count | Source | Version-controlled |
 |----------|------:|--------|--------------------|
 | Bundled (kube-prometheus-stack) | 28 | Helm chart sidecar | Yes (via chart defaults) |
-| Custom (Omi-specific) | 17 | Exported from Grafana UI | Yes — `dashboards/` directory |
+| Custom (Omi-specific) | 18 | Exported from Grafana UI | Yes — `dashboards/` directory |
 
-All 17 custom dashboards are exported to `dashboards/` as provisioning-ready JSON (`.id` and `.version` stripped). The K8s Node Metrics dashboard (`your_custom_uid_X0dfg`) is a community import bundled with the chart and not separately exported.
+All 18 custom dashboards are exported to `dashboards/` as provisioning-ready JSON (`.id` and `.version` stripped). The K8s Node Metrics dashboard (`your_custom_uid_X0dfg`) is a community import bundled with the chart and not separately exported.
 
 ## Developer Guide
 

--- a/backend/charts/monitoring/dashboards/general/omi-core-features.json
+++ b/backend/charts/monitoring/dashboards/general/omi-core-features.json
@@ -1,0 +1,1816 @@
+{
+  "description": "User-facing feature health for Omi, grounded only in metric families that exist in production Prometheus. Three journeys carry the real user outcomes; the two sections below them are the subsystems those journeys depend on.",
+  "graphTooltip": 1,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Omi TV \u2014 growth & revenue",
+      "tooltip": "MRR, ARR, active subscriptions, trials, new subs/month. Sourced live from Stripe, not Prometheus \u2014 subscription and cancellation data does not exist in this Prometheus.",
+      "type": "link",
+      "url": "https://admin.omi.me/grafana/d/omi-tv/omi-tv"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Feature health \u2014 did the user get an outcome?",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Share of settled attempts that succeeded, over the dashboard's selected time range. Denominator is success+failure only: 'cancelled' is user-initiated and 'stale' means the outcome was never recorded, so neither belongs in a success rate. Deliberately has no clamp on the denominator: with no traffic this reads 'no traffic' rather than a red 0%, because absence and total failure are different states.",
+      "fieldConfig": {
+        "defaults": {
+          "max": 100,
+          "min": 0,
+          "noValue": "no traffic",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 95
+              },
+              {
+                "color": "green",
+                "value": 99
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * sum(rate(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=\"success\"}[$__range])) / sum(rate(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=~\"success|failure\"}[$__range]))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Voice capture \u2192 conversation",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Share of settled attempts that succeeded, over the dashboard's selected time range. Denominator is success+failure only: 'cancelled' is user-initiated and 'stale' means the outcome was never recorded, so neither belongs in a success rate. Deliberately has no clamp on the denominator: with no traffic this reads 'no traffic' rather than a red 0%, because absence and total failure are different states.",
+      "fieldConfig": {
+        "defaults": {
+          "max": 100,
+          "min": 0,
+          "noValue": "no traffic",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 95
+              },
+              {
+                "color": "green",
+                "value": 99
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * sum(rate(omi_journey_terminal_total{journey=\"pusher_session\",outcome=\"success\"}[$__range])) / sum(rate(omi_journey_terminal_total{journey=\"pusher_session\",outcome=~\"success|failure\"}[$__range]))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Live session (pusher)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Share of settled attempts that succeeded, over the dashboard's selected time range. Denominator is success+failure only: 'cancelled' is user-initiated and 'stale' means the outcome was never recorded, so neither belongs in a success rate. Deliberately has no clamp on the denominator: with no traffic this reads 'no traffic' rather than a red 0%, because absence and total failure are different states.",
+      "fieldConfig": {
+        "defaults": {
+          "max": 100,
+          "min": 0,
+          "noValue": "no traffic",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 95
+              },
+              {
+                "color": "green",
+                "value": 99
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * sum(rate(omi_journey_terminal_total{journey=\"chat_response\",outcome=\"success\"}[$__range])) / sum(rate(omi_journey_terminal_total{journey=\"chat_response\",outcome=~\"success|failure\"}[$__range]))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Chat response",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "How many of the three journeys emitted anything in the last hour. A journey that stops reporting looks identical to a journey with no failures, which is the failure mode omi-journey-signal-dead exists to catch.",
+      "fieldConfig": {
+        "defaults": {
+          "max": 3,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 2
+              },
+              {
+                "color": "green",
+                "value": 3
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "count(count by (journey) (increase(omi_journey_accepted_total[$__range]) > 0)) or vector(0)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Journeys reporting (of 3)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Every settled attempt, split by how it ended. Stacked so total throughput and the failure share read together.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (journey,outcome) (rate(omi_journey_terminal_total[5m]))",
+          "legendFormat": "{{journey}} \u00b7 {{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Terminal outcomes by journey",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "A persistent gap between accepted and settled means attempts are being started and never resolved \u2014 the post-200 failure shape.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (journey) (rate(omi_journey_accepted_total[5m]))",
+          "legendFormat": "accepted \u00b7 {{journey}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (journey) (rate(omi_journey_terminal_total[5m]))",
+          "legendFormat": "settled \u00b7 {{journey}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Accepted vs settled",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "'stale' means the attempt was accepted but no terminal outcome was ever written, so it was swept. These are invisible to a success rate \u2014 the request may well have returned HTTP 200 first. capture_finalization has been running a large stale share, which is worth watching here.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (journey) (rate(omi_journey_terminal_total{outcome=\"stale\"}[5m]))",
+          "legendFormat": "{{journey}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Attempts whose outcome was never recorded (stale)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "95th percentile time from accepted to terminal, per journey.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le,journey) (rate(omi_journey_latency_seconds_bucket[5m])))",
+          "legendFormat": "{{journey}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Journey latency p95",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Subscription lifecycle \u2014 did the user stay?",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 11,
+      "options": {
+        "content": "**Rates and deltas, not levels.** This row tracks subscription *events* (created, cancellation requested/reverted, ended, payment failed) as they happen. It does not show absolute MRR/ARR or active-subscription counts \u2014 those levels live on the **[Omi TV](https://admin.omi.me/grafana/d/omi-tv/omi-tv)** board (see the dashboard links menu), sourced live from Stripe. `cancellation_requested` is the leading indicator \u2014 the moment a user decided to leave. `ended` is lagging, up to a month later. `payment_failed` is involuntary churn, operationally distinct from voluntary cancellation. Counts are webhook deliveries, which Stripe may retry \u2014 this is an operational trend signal, not billing-grade numbers. Stripe (via the Omi TV board) remains source of truth.",
+        "mode": "markdown"
+      },
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "The leading churn indicator: the moment a user set cancel_at_period_end, before the subscription actually ends. Counts are webhook deliveries, which Stripe may retry \u2014 this is an operational trend signal, not billing-grade numbers. Stripe (via the Omi TV board) remains source of truth.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 31
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "round(sum(increase(omi_subscription_events_total{event=\"cancellation_requested\"}[$__range]))) or vector(0)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cancellation requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "New subscriptions started over the selected time range. Counts are webhook deliveries, which Stripe may retry \u2014 this is an operational trend signal, not billing-grade numbers. Stripe (via the Omi TV board) remains source of truth.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 31
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "round(sum(increase(omi_subscription_events_total{event=\"created\"}[$__range]))) or vector(0)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "New subscriptions",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Created minus ended over the selected time range. `ended` lags the decision to leave by up to a month, so this is a trailing net, not a real-time one. Counts are webhook deliveries, which Stripe may retry \u2014 this is an operational trend signal, not billing-grade numbers. Stripe (via the Omi TV board) remains source of truth.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 31
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "round(sum(increase(omi_subscription_events_total{event=\"created\"}[$__range])) or vector(0)) - round(sum(increase(omi_subscription_events_total{event=\"ended\"}[$__range])) or vector(0))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Net change",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Win-backs: a user who requested cancellation and then reverted it. Counts are webhook deliveries, which Stripe may retry \u2014 this is an operational trend signal, not billing-grade numbers. Stripe (via the Omi TV board) remains source of truth.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 31
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "round(sum(increase(omi_subscription_events_total{event=\"cancellation_reverted\"}[$__range]))) or vector(0)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Saves",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "All subscription lifecycle events by type. Placed directly under Feature health so lifecycle shifts can be read against the same window as journey/gateway/capture health above. Counts are webhook deliveries, which Stripe may retry \u2014 this is an operational trend signal, not billing-grade numbers. Stripe (via the Omi TV board) remains source of truth.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (event) (rate(omi_subscription_events_total[1h]))",
+          "legendFormat": "{{event}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Lifecycle events over time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Separates voluntary churn (ended after a cancellation request) from involuntary churn (payment_failed / payment_disputed). Different problems, different owners. Counts are webhook deliveries, which Stripe may retry \u2014 this is an operational trend signal, not billing-grade numbers. Stripe (via the Omi TV board) remains source of truth.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (event, reason) (rate(omi_subscription_events_total{event=~\"ended|payment_failed\"}[1h]))",
+          "legendFormat": "{{event}} \u00b7 {{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Cancellations by reason (voluntary vs involuntary)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Where the leading churn signal is concentrated by plan tier. Counts are webhook deliveries, which Stripe may retry \u2014 this is an operational trend signal, not billing-grade numbers. Stripe (via the Omi TV board) remains source of truth.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (plan) (rate(omi_subscription_events_total{event=\"cancellation_requested\"}[1h]))",
+          "legendFormat": "{{plan}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Cancellation requests by plan",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 50
+      },
+      "id": 19,
+      "panels": [],
+      "title": "AI responses \u2014 the LLM gateway behind chat and extraction",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "All gateway requests over the dashboard's selected time range.",
+      "fieldConfig": {
+        "defaults": {
+          "max": 100,
+          "min": 0,
+          "noValue": "no traffic",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 95
+              },
+              {
+                "color": "green",
+                "value": 99
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 51
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * sum(rate(llm_gateway_requests_total{outcome=\"success\"}[$__range])) / sum(rate(llm_gateway_requests_total[$__range]))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway success rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "1 when the gateway has tripped its breaker; requests are being shed.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 51
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(llm_gateway_circuit_open) or vector(0)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Circuit open",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Time to first byte on streamed responses \u2014 what the user actually waits through before text appears.",
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "no streams",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 2
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 51
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(llm_gateway_stream_ttfb_seconds_bucket[$__range])))",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Stream TTFB p95",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Requests refused before reaching a provider.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 51
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "round(sum(increase(llm_gateway_request_rejections_total[$__range]))) or vector(0)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Rejections",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 55
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (model,outcome) (rate(llm_gateway_requests_total[5m]))",
+          "legendFormat": "{{model}} \u00b7 {{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway requests by model",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 55
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le,model) (rate(llm_gateway_request_latency_seconds_bucket[5m])))",
+          "legendFormat": "{{model}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway latency p95 by model",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Empty is the healthy state here.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 63
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (api_surface,error_class) (rate(llm_gateway_request_rejections_total[5m]))",
+          "legendFormat": "{{api_surface}} \u00b7 {{error_class}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Rejections by class",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 70
+      },
+      "id": 27,
+      "panels": [],
+      "title": "Capture pipeline \u2014 audio in, conversation out",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Live capture sessions currently connected.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 71
+      },
+      "id": 28,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(pusher_active_ws_connections)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active WS connections",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Non-zero means the pusher breaker has tripped.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 71
+      },
+      "id": 29,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(pusher_circuit_breaker_state) or vector(0)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pusher breaker",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Age of the oldest finalization job that has not reached a terminal state \u2014 a conversation the user is still waiting on. Aggregated with max(), not sum(): every backend-listen replica publishes the same global value.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 900
+              },
+              {
+                "color": "red",
+                "value": 3600
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 71
+      },
+      "id": 30,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(listen_finalization_oldest_nonterminal_age_seconds) or vector(0)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Oldest unfinished job",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Finalization jobs that exhausted all 5 attempts, over the selected range. NOT the same as conversations lost: the discard is guarded on the conversation still being in `processing`, and measured over 14d only ~15% of dead letters actually discarded a conversation \u2014 the rest had already been finalized inline. There is no metric for the discarded subset yet.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 71
+      },
+      "id": 31,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "round(sum(increase(listen_finalization_dead_letter_total[$__range]))) or vector(0)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Finalization gave up (dead letters)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Jobs that have not reached a terminal state. max(), not sum(): this is one global Firestore-derived value that every backend-listen replica republishes, so sum() multiplies it by the replica count. dead_letter is deliberately excluded \u2014 it is a cumulative all-time total that only ever rises, not a backlog (see the dead-letter panel for its rate). Undercount: the projection generation starts 2026-07-25 and is not backfilled, so jobs created before that date are not in these numbers.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 75
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max by (status) (listen_finalization_jobs{status=~\"queued|leased|blocked_byok\"})",
+          "instant": false,
+          "legendFormat": "{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Unfinished finalization jobs",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Dead letters are the destructive terminal. The retries series is structurally zero on the live-capture lane: LISTEN_FINALIZATION_RETRIES_TOTAL is only incremented by the Cloud Tasks worker, and inline pusher retries are not counted \u2014 a flat retries line is not evidence of health.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 75
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(listen_finalization_retries_total[5m]))",
+          "legendFormat": "retries (Cloud Tasks lane only \u2014 never rises on live capture)",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(listen_finalization_dead_letter_total[5m]))",
+          "legendFormat": "dead letters",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (outcome) (rate(omi_capture_finalization_reconciliations_total[5m]))",
+          "legendFormat": "reconciliation \u00b7 {{outcome}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Retries, dead letters, reconciliations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Durable terminal outcomes newly recorded in each 30m window. `stale` means the job was fenced \u2014 a discard or a newer lifecycle generation won before fanout \u2014 not an error, and it runs at roughly the same rate as success. `failure` is the dead-lettered path and is normally flat at zero; any sustained non-zero value here is captures being given up on.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 75
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(clamp_min(delta((max by (state) (listen_finalization_durable_jobs{state=\"success\"}))[30m:]), 0))",
+          "instant": false,
+          "legendFormat": "success",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(clamp_min(delta((max by (state) (listen_finalization_durable_jobs{state=\"stale\"}))[30m:]), 0))",
+          "instant": false,
+          "legendFormat": "stale (fenced)",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(clamp_min(delta((max by (state) (listen_finalization_durable_jobs{state=\"failure\"}))[30m:]), 0))",
+          "instant": false,
+          "legendFormat": "failure (dead-lettered)",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "How finalizations settle (30m)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 41,
+  "tags": [
+    "omi",
+    "core-features",
+    "production"
+  ],
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Omi Core Features",
+  "uid": "omi-core-features"
+}

--- a/backend/database/conversation_finalization_jobs.py
+++ b/backend/database/conversation_finalization_jobs.py
@@ -18,7 +18,10 @@ from google.cloud.firestore_v1 import FieldFilter
 from database import conversations as conversations_db
 from database._client import document_id_from_seed, get_firestore_client
 from database.firestore_transaction_retry import run_with_transaction_contention_retry
-from database.firestore_index_registry import MEETING_RECEIPTS_DUE_QUERY
+from database.firestore_index_registry import (
+    FINALIZATION_OLDEST_NONTERMINAL_QUERY,
+    MEETING_RECEIPTS_DUE_QUERY,
+)
 
 CONVERSATIONS_COLLECTION = 'conversations'
 FINALIZATION_JOBS_COLLECTION = 'conversation_finalization_jobs'
@@ -1670,7 +1673,7 @@ def reacquire_deferred_processing(uid: str, conversation_id: str, *, firestore_c
 
 
 def get_finalization_job_summary(*, firestore_client: Any = None) -> dict[str, float | int]:
-    """Read one generation's fixed shard fan-in plus a bounded overdue-age sample.
+    """Read one generation's fixed shard fan-in plus the oldest unfinished job.
 
     This deliberately never aggregates ``conversation_finalization_jobs``. A
     backend-listen replica performs exactly ``FINALIZATION_PROJECTION_SHARD_COUNT``
@@ -1710,13 +1713,29 @@ def get_finalization_job_summary(*, firestore_client: Any = None) -> dict[str, f
             if isinstance(value, (int, float)):
                 totals[name] += int(value)
 
+    # The age of the oldest unfinished job is asked of ``status`` directly, one
+    # ordered single-document read per nonterminal status.  The previous
+    # implementation paged ``reconcile_after_at <= now`` instead, which made the
+    # gauge structurally unable to see the population it exists to report:
+    # ``reconcile_after_at`` is deleted outright on the BYOK resume and BYOK
+    # retry paths, so every BYOK job was invisible to it and the gauge read 0
+    # while hundreds of jobs sat unfinished for weeks.  Ordering by
+    # ``created_at`` also makes this the actual oldest row rather than the
+    # oldest of an arbitrary page.  Cost stays bounded and independent of
+    # terminal history: one indexed read per nonterminal status.
     oldest_age_seconds = 0.0
-    # The bounded due page prevents historical terminal rows from making the
-    # periodic metric collection an ever-growing Firestore scan.
-    for snapshot in jobs_collection.where('reconcile_after_at', '<=', now).limit(100).stream():
-        created_at = (snapshot.to_dict() or {}).get('created_at')
-        if isinstance(created_at, datetime):
-            oldest_age_seconds = max(oldest_age_seconds, max(0.0, (now - created_at).total_seconds()))
+    for status in sorted(NONTERMINAL_JOB_STATUSES):
+        oldest_query = (
+            FINALIZATION_OLDEST_NONTERMINAL_QUERY.build(
+                jobs_collection, {'status': status}, field_filter_factory=FieldFilter
+            )
+            .order_by('created_at')
+            .limit(1)
+        )
+        for snapshot in oldest_query.stream():
+            created_at = (snapshot.to_dict() or {}).get('created_at')
+            if isinstance(created_at, datetime):
+                oldest_age_seconds = max(oldest_age_seconds, max(0.0, (now - created_at).total_seconds()))
     return {
         'accepted': totals['accepted'],
         'success': totals['success'],

--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -813,6 +813,14 @@ HOURLY_USAGE_PLAN_ATTRIBUTION_QUERY = FirestoreQuerySpec(
     ),
 )
 
+FINALIZATION_OLDEST_NONTERMINAL_QUERY = FirestoreQuerySpec(
+    identifier='conversation_finalization_jobs_oldest_nonterminal',
+    collection_group='conversation_finalization_jobs',
+    query_scope='COLLECTION',
+    filters=(FirestoreQueryFilter('status', '==', 'status'),),
+    index_fields=(_asc('status'), _asc('created_at'), _asc('__name__')),
+)
+
 QUERY_SPECS = (
     ACTION_ITEMS_COMPLETION_ID_SCAN_QUERY,
     ACTION_ITEMS_COMPLETED_DUE_RANGE_QUERY,
@@ -852,6 +860,7 @@ QUERY_SPECS = (
     HOURLY_USAGE_PLAN_ATTRIBUTION_QUERY,
     MESSAGES_BY_APP_ORDERED_QUERY,
     CONVERSATIONS_ACTIVE_ORDERED_QUERY,
+    FINALIZATION_OLDEST_NONTERMINAL_QUERY,
 )
 
 _INDEX_ONLY_REQUIREMENT_SIGNATURES = frozenset(requirement.signature for requirement in INDEX_ONLY_REQUIREMENTS)

--- a/backend/tests/unit/test_conversation_finalization_jobs.py
+++ b/backend/tests/unit/test_conversation_finalization_jobs.py
@@ -934,29 +934,39 @@ def test_durable_summary_reads_a_fixed_projection_shard_set_without_job_aggregat
             return Ref()
 
     class JobQuery:
-        def where(self, field, operator, _value):
-            assert (field, operator) == ('reconcile_after_at', '<=')
+        def __init__(self):
+            self.filtered_statuses: list[str] = []
+
+        def where(self, *, filter):
+            assert (filter.field_path, filter.op_string) == ('status', '==')
+            self.filtered_statuses.append(filter.value)
+            return self
+
+        def order_by(self, field):
+            assert field == 'created_at'
             return self
 
         def limit(self, value):
-            assert value == 100
+            assert value == 1
             return self
 
         def stream(self):
             return iter(())
 
     projection = Projection()
+    job_query = JobQuery()
 
     class Client:
         def collection(self, name):
             if name == jobs.FINALIZATION_PROJECTION_COLLECTION:
                 return projection
             assert name == jobs.FINALIZATION_JOBS_COLLECTION
-            return JobQuery()
+            return job_query
 
     summary = jobs.get_finalization_job_summary(firestore_client=Client())
 
     assert len(projection.read_ids) == jobs.FINALIZATION_PROJECTION_SHARD_COUNT
+    assert sorted(job_query.filtered_statuses) == sorted(jobs.NONTERMINAL_JOB_STATUSES)
     assert summary == {
         'accepted': 8,
         'success': 1,
@@ -971,6 +981,64 @@ def test_durable_summary_reads_a_fixed_projection_shard_set_without_job_aggregat
         'terminal_unknown': 0,
         'oldest_nonterminal_age_seconds': 0.0,
     }
+
+
+def test_oldest_nonterminal_age_sees_jobs_that_carry_no_reconcile_after_at():
+    """A BYOK job is invisible to ``reconcile_after_at`` and must still age.
+
+    ``_resume_blocked_byok_job_txn`` and the BYOK retry path delete
+    ``reconcile_after_at`` outright, so the old due-page implementation reported
+    0 while those jobs sat unfinished indefinitely.  Asking ``status`` directly
+    is what makes them visible.
+    """
+
+    created_at = datetime.now(timezone.utc) - timedelta(days=30)
+
+    class Snapshot:
+        def __init__(self, data):
+            self.exists = data is not None
+            self._data = data
+
+        def to_dict(self):
+            return self._data
+
+    class Projection:
+        def document(self, doc_id):
+            class Ref:
+                def get(self):
+                    return Snapshot(None)
+
+            return Ref()
+
+    class JobQuery:
+        def __init__(self):
+            self._status: str | None = None
+
+        def where(self, *, filter):
+            self._status = filter.value
+            return self
+
+        def order_by(self, field):
+            return self
+
+        def limit(self, value):
+            return self
+
+        def stream(self):
+            if self._status != 'queued':
+                return iter(())
+            # No ``reconcile_after_at`` key at all — exactly the resumed BYOK shape.
+            return iter([Snapshot({'status': 'queued', 'requires_byok': True, 'created_at': created_at})])
+
+    class Client:
+        def collection(self, name):
+            if name == jobs.FINALIZATION_PROJECTION_COLLECTION:
+                return Projection()
+            return JobQuery()
+
+    summary = jobs.get_finalization_job_summary(firestore_client=Client())
+
+    assert summary['oldest_nonterminal_age_seconds'] > 29 * 24 * 3600
 
 
 class _BoundedReplayCollection:

--- a/backend/tests/unit/test_conversation_search_date_validation.py
+++ b/backend/tests/unit/test_conversation_search_date_validation.py
@@ -60,6 +60,9 @@ _stubs = [
     # metric; utils is an _AutoMockModule package here, so the real submodule
     # is not importable and the name has to be stubbed like the rest.
     'utils.journey_metrics_contract',
+    # routers.conversations emits Conversation Summary Shared telemetry on
+    # delivered share emails; same _AutoMockModule reasoning as above.
+    'utils.integration_telemetry',
     'utils.other.endpoints',
     'utils.other.list_budget',
     'utils.other.storage',

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -137,20 +137,28 @@ for _journey in CLIENT_JOURNEYS:
     for _outcome in CLIENT_JOURNEY_OUTCOMES:
         OMI_CLIENT_JOURNEY_DURATION_SECONDS.labels(journey=_journey, outcome=_outcome)
 
+# The three gauges below report one GLOBAL Firestore-derived quantity, and every
+# replica publishes the same value. Aggregate them with max(), never sum(): a
+# sum() multiplies the real number by the replica count and, while replicas run
+# different images, mixes two different answers to the same question.
 LISTEN_FINALIZATION_OLDEST_NONTERMINAL_AGE_SECONDS = Gauge(
     'listen_finalization_oldest_nonterminal_age_seconds',
-    'Age of the oldest queued, leased, or blocked listen finalization job',
+    'Global age of the oldest queued, leased, or blocked listen finalization job; '
+    'replicated per process, aggregate with max() not sum()',
 )
 
 LISTEN_FINALIZATION_JOB_STATUS = Gauge(
     'listen_finalization_jobs',
-    'Current durable listen finalization job count by non-success status',
+    'Global durable listen finalization job count by non-success status; replicated '
+    'per process, aggregate with max() not sum(). dead_letter is cumulative and only '
+    'ever rises: it is an all-time terminal total, not a backlog',
     ['status'],
 )
 
 LISTEN_FINALIZATION_DURABLE_JOBS = Gauge(
     'listen_finalization_durable_jobs',
-    'Authoritative Firestore finalization jobs by closed durable lifecycle state',
+    'Global authoritative Firestore finalization jobs by closed durable lifecycle '
+    'state; replicated per process, aggregate with max() not sum()',
     ['state'],
 )
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1065,6 +1065,24 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "conversation_finalization_jobs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": [


### PR DESCRIPTION
## The dashboard said 25,000. The real number was 414.

The "Capture pipeline" row of the **Omi Core Features** board (prod Grafana, `monitor.omi.me`) showed a finalization backlog of ~25k jobs climbing steadily. Investigating it turned up three independent defects: two in the metrics themselves and one in the panel that reads them.

### 1. `sum()` on a global gauge (panel)

`listen_finalization_jobs` is **one global Firestore-derived value that every backend-listen replica republishes**. The panel read `sum by (status) (listen_finalization_jobs)`, which multiplies the true value by the replica count.

Measured against prod Prometheus:

```
count by (status) (listen_finalization_jobs)  ->  21     # one series per backend-listen pod
sum   by (status) (listen_finalization_jobs)  ->  queued=6919   dead_letter=18657
max   by (status) (listen_finalization_jobs)  ->  queued=408    dead_letter=1185
```

A Firestore aggregation count of `conversation_finalization_jobs` returns **queued=408, leased=2, blocked_byok=0, dead_letter=1185** — `max` is exact, `sum` is off by 17x.

It is worse than a constant factor right now: 12 of the 21 pods (`velma-canary`, `parakeet`) run a July-18 image that computes the gauge with a direct Firestore `.count()`, while the other 9 read the projection shards whose generation starts 2026-07-25 and is not backfilled. The two populations report **1185 vs 493** for the same quantity, so the sum was blending two different answers to the same question.

The repo's own checked-in board already does this correctly — `resilience-fallbacks.json` uses `max by (state) (listen_finalization_durable_jobs)`. The Omi Core Features board was Grafana-DB-only and never got that treatment.

### 2. Stacking a cumulative counter on a live backlog (panel)

`dead_letter` inside `listen_finalization_jobs` is only ever incremented — no code path decrements it, and job rows are never deleted (712,832 `completed` rows are still in the collection). It is an **all-time terminal total**, and it was ~19k of the phantom 25k. Stacked under `queued`, a flat backlog read as a growing crisis.

### 3. `listen_finalization_oldest_nonterminal_age_seconds` read 0 while 408 jobs sat unfinished for up to 36 days (metric)

The gauge paged `reconcile_after_at <= now` and took the max `created_at` of an arbitrary 100 rows. Two defects in one query:

- **`reconcile_after_at` is deleted outright** on the BYOK resume path (`_resume_blocked_byok_job_txn`) and the BYOK retry path (`_mark_finalization_retryable_txn`) — by design, so the credential-free Cloud Tasks reconciler never replays a BYOK job. In prod, **all 408 currently-queued jobs are `requires_byok=true` with no `reconcile_after_at`**, so the gauge was structurally incapable of seeing the exact population it exists to report. It could only ever read 0.
- `.limit(100)` with no ordering returns an arbitrary page, so even for rows it could see it reported the oldest of a sample, not the oldest.

This is the same failure shape as the 2026-08-20 macOS chat outage: a signal that is green because it cannot represent the failure.

## What this changes

**Metrics** (`backend/`)

- `get_finalization_job_summary` asks `status` directly — one ordered single-document read per nonterminal status, through a registered query spec (`FINALIZATION_OLDEST_NONTERMINAL_QUERY`) and its composite index. Cost stays bounded and independent of terminal history, which is the property the projection fan-in was built for.
- The `sum()` trap is now stated in the HELP text of all three replicated gauges, so it is visible in Grafana's own metric browser, along with the fact that `dead_letter` is cumulative.

**Dashboard** (`backend/charts/monitoring/dashboards/general/omi-core-features.json`, new)

- *Finalization jobs by status* → **Unfinished finalization jobs**: `max by (status)`, nonterminal statuses only, unstacked. Description states the max-not-sum rule and the pre-2026-07-25 projection undercount.
- *Dead letters* → **Finalization gave up (dead letters)**. The query was already right (a range `increase` on the counter); the description was not. It claimed each dead letter is a conversation the user never got — measured over 14d, only ~15% of dead letters actually discard a conversation, because the discard is guarded on the conversation still being in `processing`.
- The retries series legend now says it only ever rises on the Cloud Tasks lane. `LISTEN_FINALIZATION_RETRIES_TOTAL` is not incremented by inline pusher retries, so a flat line there is not evidence of health — which is exactly what the panel's "retries rising before dead letters is the early warning" note implied it was.
- New **How finalizations settle (30m)**: success vs stale (fenced) vs failure. The outcome mix was not visible anywhere, and `failure` going non-zero is the signal that captures are being given up on.
- The board is now version-controlled instead of living only in Grafana's DB.

## What this does NOT do

It does not fix the 408 stranded BYOK jobs — it only makes them visible. That leak (they are invisible to both the Cloud Tasks worker and the reconciler once the live pusher session ends) is a separate change.

## Verification

- `max by (status) (listen_finalization_jobs{status=~"queued|leased|blocked_byok"})` returns `queued=408, leased=2..6, blocked_byok=0`, matching a Firestore aggregation count of the collection exactly.
- Every new panel expression was executed against prod Prometheus and the panels rendered before/after.
- Applied to prod Grafana as version 8; the checked-in JSON is the export of that version.
- `backend/test-preflight.sh`: 18 passed, 0 failed. Targeted suites green: `test_conversation_finalization_jobs.py`, `test_firestore_query_contract.py`, `test_journey_observability.py`, `test_monitoring_telemetry_contract.py` (115 passed).
- Full `backend/test.sh` (918 files): 4 files fail in this local environment — `test_optional_audio_codecs`, `test_share_email`, `test_atomicity_lifecycle_regressions`, `test_backend_runtime_env_validator`. **These same 4 fail identically on a pristine `origin/main` in the same worktree**, so they are pre-existing/environment-dependent, not caused by this change. CI is the authority.

Line-Count-Exception: backend/database/conversation_finalization_jobs.py | 1735 -> 1754 | The replacement age query is a per-status ordered read (9 lines vs the 3-line unordered page) plus the comment recording why the old `reconcile_after_at` page could never see BYOK jobs. Splitting this 1735-line file is real work that belongs in its own change, not smuggled into an observability fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Failure class

Failure-Class: FC-alert-never-provably-fired

Both defects are that contract: an expression that is silently wrong for how the metric is actually exposed reads as healthy. The panel's `sum()` was wrong for a gauge every replica republishes; the age gauge's `reconcile_after_at` filter was wrong for a population defined by not carrying that field, and returned 0, which is indistinguishable from healthy. Prevention applied as the class prescribes: every expression in this change was run against the real prod series and reconciled against a Firestore aggregation count before it shipped.

The metric-side half — a health signal derived from a bookkeeping field that the unhealthy population is defined by not carrying — is arguably its own class, but a new definition requires a non-empty `evidence_prs`, which this PR cannot supply before it exists. Worth defining in a follow-up with this PR as the evidence.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

