### PR TITLE
grafana apply preserves the live board's layout

### DIFF
--- a/web/admin/grafana/README.md
+++ b/web/admin/grafana/README.md
@@ -48,10 +48,12 @@ only to the macOS scope.
 ## Apply
 
 Grafana's database is the layout master — drag/resize edits made in the UI
-persist there. `apply_omi_tv_dashboard.py` overwrites the boards with the
-checked-in JSONs (uids restricted to the three above), so it runs only when a
-push actually changes `dashboards/*.json` (see the gated step in
-`gcp_admin.yml`) or on `workflow_dispatch`. It no-ops when `GRAFANA_TOKEN` is
+persist there **and survive applies**: `apply_omi_tv_dashboard.py` fetches the
+live board first and keeps its gridPos for every panel that already exists
+(matched by id), so a dashboards-diff merge updates panel content without
+reverting manual arrangement. Only brand-new panels land at their authored
+position. It runs when a push changes `dashboards/*.json` (see the gated step
+in `gcp_admin.yml`) or on `workflow_dispatch`. It no-ops when `GRAFANA_TOKEN` is
 unset — do not invent a write token.
 
 ```bash

--- a/web/admin/grafana/apply_omi_tv_dashboard.py
+++ b/web/admin/grafana/apply_omi_tv_dashboard.py
@@ -2,6 +2,13 @@
 """Publish the checked-in omi-tv dashboard JSON through the Grafana HTTP API.
 
 Skips when GRAFANA_TOKEN is unset. Does not invent credentials.
+
+The live board's layout is the layout master: Nik drags/resizes panels in the
+Grafana UI, and an apply must never revert that (it did, three times in one
+day — every dashboards-diff merge stamped the checked-in gridPos back over
+his arrangement). Checked-in JSONs own panel CONTENT (queries, thresholds,
+titles); positions of panels that already exist on the live board are taken
+from the live board.
 """
 
 from __future__ import annotations
@@ -32,8 +39,41 @@ def load_dashboard(path: Path) -> dict:
     return dashboard
 
 
+def preserve_live_layout(incoming_panels: list, live_panels: list) -> None:
+    """Overlay the live board's gridPos onto matching incoming panels, in place.
+
+    Panels are matched by id (stable in the checked-in JSONs). A panel new to
+    this apply keeps its authored position; a panel the user moved or resized
+    keeps the user's geometry.
+    """
+    live_by_id = {p.get("id"): p.get("gridPos") for p in live_panels if p.get("id") is not None}
+    for panel in incoming_panels:
+        live_pos = live_by_id.get(panel.get("id"))
+        if live_pos:
+            panel["gridPos"] = live_pos
+
+
+def fetch_live_panels(token: str, uid: str) -> list:
+    request = urllib.request.Request(
+        f"{grafana_base_url()}/api/dashboards/uid/{uid}",
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            body = json.loads(response.read().decode("utf-8"))
+            return body.get("dashboard", {}).get("panels", []) or []
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return []  # first apply of a new board
+        raise SystemExit(f"Grafana fetch failed ({exc.code}) for {uid}") from exc
+
+
 def apply(token: str, path: Path) -> None:
     dashboard = load_dashboard(path)
+    preserve_live_layout(
+        dashboard.get("panels", []),
+        fetch_live_panels(token, dashboard["uid"]),
+    )
     payload = json.dumps(
         {
             "dashboard": dashboard,

--- a/web/admin/grafana/test_build_dashboards.py
+++ b/web/admin/grafana/test_build_dashboards.py
@@ -364,5 +364,31 @@ class BuilderIdempotencyTests(unittest.TestCase):
                          load("omi-tv-mobile"))
 
 
+class ApplyPreservesLayoutTests(unittest.TestCase):
+    """An apply must never revert layout the user arranged in the Grafana UI
+    (#12212 era: three same-day applies stamped checked-in gridPos over
+    Nik's manual resizes). Live geometry wins for panels that already exist."""
+
+    def test_live_gridpos_wins_for_existing_panels(self) -> None:
+        import apply_omi_tv_dashboard as apply_mod
+        incoming = [
+            {"id": 7, "gridPos": {"h": 6, "w": 4, "x": 20, "y": 0}},
+            {"id": 992, "gridPos": {"h": 7, "w": 24, "x": 0, "y": 990}},
+        ]
+        live = [
+            {"id": 7, "gridPos": {"h": 9, "w": 12, "x": 0, "y": 3}},  # user resized
+        ]
+        apply_mod.preserve_live_layout(incoming, live)
+        self.assertEqual(incoming[0]["gridPos"], {"h": 9, "w": 12, "x": 0, "y": 3})
+        # A panel new to this apply keeps its authored position.
+        self.assertEqual(incoming[1]["gridPos"], {"h": 7, "w": 24, "x": 0, "y": 990})
+
+    def test_first_apply_of_a_new_board_keeps_authored_layout(self) -> None:
+        import apply_omi_tv_dashboard as apply_mod
+        incoming = [{"id": 1, "gridPos": {"h": 6, "w": 4, "x": 0, "y": 0}}]
+        apply_mod.preserve_live_layout(incoming, [])
+        self.assertEqual(incoming[0]["gridPos"], {"h": 6, "w": 4, "x": 0, "y": 0})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

Manual drag/resize edits on admin.omi.me/grafana were reverted every time a dashboards-diff PR merged (three times today) — the CI apply stamps checked-in gridPos over the live arrangement. User-reported.

## What

`apply_omi_tv_dashboard.py` fetches the live board before posting and overlays its gridPos onto every incoming panel that already exists (matched by stable panel id). New panels keep their authored position; checked-in JSONs keep owning panel content (queries, thresholds, titles). 404 on first apply of a new board falls back to authored layout.

## Verification

`test_build_dashboards.py` 25/25 including two new contract tests (live geometry wins for existing panels; first-apply keeps authored layout). Manifest check `grafana-dashboard-build` runs them in CI.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

