### PR TITLE
fix: desktop-ratings HogQL used a ClickHouse-only function name

### DIFF
--- a/web/admin/app/api/omi/stats/desktop-ratings/route.ts
+++ b/web/admin/app/api/omi/stats/desktop-ratings/route.ts
@@ -25,7 +25,7 @@ export async function computeDesktopRatings(days: number) {
     `
       SELECT
         toDate(toTimeZone(timestamp, 'America/New_York')) AS day,
-        round(avg(toFloat64OrZero(toString(properties.rating))), 2) AS avg_rating,
+        round(avg(toFloatOrZero(toString(properties.rating))), 2) AS avg_rating,
         count() AS ratings
       FROM events
       WHERE event = 'Desktop Rating Submitted'

--- a/web/admin/lib/__tests__/desktop-ratings.test.ts
+++ b/web/admin/lib/__tests__/desktop-ratings.test.ts
@@ -38,6 +38,11 @@ describe("computeDesktopRatings", () => {
       "toTimeZone(timestamp, 'America/New_York')",
     );
     expect(posthogResults.mock.calls[0][3]).toContain("Desktop Rating Submitted");
+    // HogQL rejects ClickHouse's toFloat64OrZero with a validation_error
+    // ("Unsupported function call ... Perhaps you meant 'toFloatOrZero'") —
+    // observed live on prod PostHog 2026-08-25.
+    expect(posthogResults.mock.calls[0][3]).toContain("toFloatOrZero(");
+    expect(posthogResults.mock.calls[0][3]).not.toContain("toFloat64OrZero");
     expect(payload.daily).toEqual([
       { date: "2026-08-24", avgRating: 5, count: 1 },
       { date: "2026-08-25", avgRating: 3, count: 3 },


### PR DESCRIPTION
PostHog HogQL rejects `toFloat64OrZero` (validation_error observed live on prod: *Perhaps you meant 'toFloatOrZero'*), so `/api/omi/stats/desktop-ratings` always degraded to `available:false` and the board panel showed an error triangle.

## Verification
Corrected query validated directly against prod PostHog (clean empty result set until the first ratings arrive from desktop v0.12.217). vitest 2/2 with the accepted function name pinned, citing the live validation error as the external source.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

