### PR TITLE
feat: remote kill switch for the desktop rating prompt

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RatingPrompt.swift
@@ -19,6 +19,7 @@ extension DesktopAutomationActionRegistry {
           "submitted_rating": "\(manager.submittedRating)",
           "dismissed": manager.isDismissed ? "true" : "false",
           "thank_you": "\(manager.thankYouRating ?? 0)",
+          "remotely_disabled": manager.isRemotelyDisabled ? "true" : "false",
         ]
       }
     }

--- a/desktop/macos/Desktop/Sources/RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/RatingPrompt.swift
@@ -8,9 +8,15 @@ import SwiftUI
 /// asked their 3rd question, and never again after a submit or a dismiss.
 enum RatingPromptPolicy {
   static let questionThreshold = 3
+  /// Remote kill switch (PostHog feature flag, preloaded at analytics init).
+  /// Kill-switch polarity: enabling the flag DISABLES the prompt, so an unset
+  /// or unreachable flag (dev builds never initialize PostHog) changes nothing.
+  static let killSwitchFlag = "desktop-rating-prompt-disabled"
 
-  static func shouldShow(questionCount: Int, submittedRating: Int, dismissed: Bool) -> Bool {
-    questionCount >= questionThreshold && submittedRating == 0 && !dismissed
+  static func shouldShow(
+    questionCount: Int, submittedRating: Int, dismissed: Bool, remotelyDisabled: Bool = false
+  ) -> Bool {
+    !remotelyDisabled && questionCount >= questionThreshold && submittedRating == 0 && !dismissed
   }
 }
 
@@ -91,11 +97,16 @@ final class RatingPromptManager: ObservableObject {
     refresh()
   }
 
+  var isRemotelyDisabled: Bool {
+    PostHogManager.shared.isFeatureEnabled(RatingPromptPolicy.killSwitchFlag)
+  }
+
   private func refresh() {
     isVisible = RatingPromptPolicy.shouldShow(
       questionCount: questionCount,
       submittedRating: submittedRating,
-      dismissed: isDismissed)
+      dismissed: isDismissed,
+      remotelyDisabled: isRemotelyDisabled)
   }
 }
 

--- a/desktop/macos/Desktop/Tests/RatingPromptPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/RatingPromptPolicyTests.swift
@@ -20,4 +20,13 @@ final class RatingPromptPolicyTests: XCTestCase {
   func testDismissalSilencesThePromptForever() {
     XCTAssertFalse(RatingPromptPolicy.shouldShow(questionCount: 10, submittedRating: 0, dismissed: true))
   }
+
+  func testRemoteKillSwitchOverridesADuePrompt() {
+    XCTAssertTrue(
+      RatingPromptPolicy.shouldShow(
+        questionCount: 3, submittedRating: 0, dismissed: false, remotelyDisabled: false))
+    XCTAssertFalse(
+      RatingPromptPolicy.shouldShow(
+        questionCount: 3, submittedRating: 0, dismissed: false, remotelyDisabled: true))
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260825-rating-prompt-killswitch.json
+++ b/desktop/macos/changelog/unreleased/20260825-rating-prompt-killswitch.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Added a remote kill switch for the in-app rating prompt."
+  ]
+}


### PR DESCRIPTION
## Why

The rating prompt ships to production in desktop v0.12.217; Nik wants a fleet-wide off switch that needs no new build.

## What

`RatingPromptPolicy.shouldShow` now takes `remotelyDisabled`, fed from the PostHog feature flag `desktop-rating-prompt-disabled` (already-preloaded flag infrastructure; kill-switch polarity so an unset/unreachable flag — including dev builds, which never initialize PostHog — changes nothing). Bridge `rating_prompt_state` reports `remotely_disabled` for observability.

**Kill procedure** (no deploy): PostHog project 302298 → Feature Flags → create/enable `desktop-rating-prompt-disabled` at 100% rollout. Clients honor it from their next flag refresh/app launch.

## Verification

`RatingPromptPolicyTests` 4/4 — new test asserts the kill switch overrides an otherwise-due prompt and that flag-off keeps current behavior. Swift build green. UNVERIFIED (narrow): a live flag flip wasn't exercised — the personal PostHog API key lacks `feature_flag:write`, so the flag gets created in the UI at kill time; the client read path is the same preloaded `isFeatureEnabled` every existing flag uses.

Failure-Class: none

Product invariants affected: none — no navigation, shell chrome, or destination changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

