### PR TITLE
fix: rating-prompt kill switch reacts to flag delivery

### DIFF
--- a/desktop/macos/Desktop/Sources/RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/RatingPrompt.swift
@@ -33,8 +33,28 @@ final class RatingPromptManager: ObservableObject {
   @Published private(set) var isVisible = false
 
   private let defaults = UserDefaults.standard
+  private var flagObserver: NSObjectProtocol?
+  private var flagPollTask: Task<Void, Never>?
+
+  /// Injectable for tests; production reads the preloaded PostHog flag.
+  var remoteDisableCheck: () -> Bool = {
+    PostHogManager.shared.isFeatureEnabled(RatingPromptPolicy.killSwitchFlag)
+  }
 
   private init() {
+    refresh()
+    // The kill switch must not wait for the next question: recompute whenever
+    // PostHog delivers a flag payload (initial preload can finish AFTER this
+    // singleton initializes, and reloads deliver mid-session flips).
+    flagObserver = NotificationCenter.default.addObserver(
+      forName: Notification.Name("PostHogDidReceiveFeatureFlags"),
+      object: nil, queue: nil
+    ) { _ in
+      Task { @MainActor in RatingPromptManager.shared.flagsDidUpdate() }
+    }
+  }
+
+  func flagsDidUpdate() {
     refresh()
   }
 
@@ -98,7 +118,7 @@ final class RatingPromptManager: ObservableObject {
   }
 
   var isRemotelyDisabled: Bool {
-    PostHogManager.shared.isFeatureEnabled(RatingPromptPolicy.killSwitchFlag)
+    remoteDisableCheck()
   }
 
   private func refresh() {
@@ -107,6 +127,20 @@ final class RatingPromptManager: ObservableObject {
       submittedRating: submittedRating,
       dismissed: isDismissed,
       remotelyDisabled: isRemotelyDisabled)
+    // While the prompt is on screen, poll for a remote disable so an active
+    // kill switch takes effect within minutes, not at the next app launch.
+    if isVisible, flagPollTask == nil {
+      flagPollTask = Task { @MainActor [weak self] in
+        while let self, self.isVisible, !Task.isCancelled {
+          try? await Task.sleep(nanoseconds: 5 * 60 * 1_000_000_000)
+          PostHogManager.shared.reloadFeatureFlags()
+        }
+        self?.flagPollTask = nil
+      }
+    } else if !isVisible {
+      flagPollTask?.cancel()
+      flagPollTask = nil
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Tests/RatingPromptKillSwitchTests.swift
+++ b/desktop/macos/Desktop/Tests/RatingPromptKillSwitchTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// The remote kill switch must not wait for the user's next question: a flag
+/// payload arriving AFTER the prompt is on screen (late preload, or a
+/// mid-session reload delivering the disable) hides it immediately.
+@MainActor
+final class RatingPromptKillSwitchTests: XCTestCase {
+  override func tearDown() async throws {
+    let manager = RatingPromptManager.shared
+    manager.remoteDisableCheck = {
+      PostHogManager.shared.isFeatureEnabled(RatingPromptPolicy.killSwitchFlag)
+    }
+    manager.resetForTesting()
+  }
+
+  func testLateLoadedDisableFlagHidesAVisiblePrompt() {
+    let manager = RatingPromptManager.shared
+    manager.resetForTesting()
+    for _ in 0..<3 { manager.recordQuestionAsked() }
+    XCTAssertTrue(manager.isVisible)
+
+    manager.remoteDisableCheck = { true }
+    manager.flagsDidUpdate()
+    XCTAssertFalse(manager.isVisible)
+  }
+
+  func testFlagPayloadWithoutTheDisableKeepsThePromptVisible() {
+    let manager = RatingPromptManager.shared
+    manager.resetForTesting()
+    for _ in 0..<3 { manager.recordQuestionAsked() }
+
+    manager.remoteDisableCheck = { false }
+    manager.flagsDidUpdate()
+    XCTAssertTrue(manager.isVisible)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260825-rating-killswitch-reactive.json
+++ b/desktop/macos/changelog/unreleased/20260825-rating-killswitch-reactive.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "The rating-prompt kill switch now takes effect within minutes, without waiting for another question."
+  ]
+}


### PR DESCRIPTION
## Why

Cross-review finding on #12216: the kill switch was only evaluated inside refresh(), which runs at init or on the next question — a prompt already on screen (or initialized before PostHog finished preloading flags) ignored an activated kill switch.

## What

RatingPromptManager recomputes visibility on every PostHogDidReceiveFeatureFlags notification (the SDK posts it for the initial preload and every reload), and while the prompt is visible it reloads flags every 5 minutes — so enabling desktop-rating-prompt-disabled hides an on-screen prompt within minutes, no app relaunch.

## Verification

RatingPromptKillSwitchTests 2/2 through the injectable remoteDisableCheck seam (a late-arriving disable hides a visible prompt; a payload without the disable keeps it visible); full rating suite 6/6; swift build green.

Failure-Class: none

Product invariants affected: none — no navigation or shell chrome changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

