### PR TITLE
fix: kill-switch observer uses the SDK's compile-checked notification symbol

### DIFF
--- a/desktop/macos/Desktop/Sources/PostHogManager.swift
+++ b/desktop/macos/Desktop/Sources/PostHogManager.swift
@@ -207,6 +207,11 @@ class PostHogManager {
     return PostHogSDK.shared.getFeatureFlag(flag)
   }
 
+  /// The SDK's own flag-delivery signal (posted on the main queue after the
+  /// initial preload and after every reload) — re-exported so observers get a
+  /// compile-checked symbol instead of a raw notification-name string.
+  static var featureFlagsDidLoad: Notification.Name { PostHogSDK.didReceiveFeatureFlags }
+
   /// Reload feature flags
   func reloadFeatureFlags() {
     guard isInitialized else { return }

--- a/desktop/macos/Desktop/Sources/RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/RatingPrompt.swift
@@ -47,7 +47,7 @@ final class RatingPromptManager: ObservableObject {
     // PostHog delivers a flag payload (initial preload can finish AFTER this
     // singleton initializes, and reloads deliver mid-session flips).
     flagObserver = NotificationCenter.default.addObserver(
-      forName: Notification.Name("PostHogDidReceiveFeatureFlags"),
+      forName: PostHogManager.featureFlagsDidLoad,
       object: nil, queue: nil
     ) { _ in
       Task { @MainActor in RatingPromptManager.shared.flagsDidUpdate() }

--- a/desktop/macos/Desktop/Tests/RatingPromptKillSwitchTests.swift
+++ b/desktop/macos/Desktop/Tests/RatingPromptKillSwitchTests.swift
@@ -15,14 +15,21 @@ final class RatingPromptKillSwitchTests: XCTestCase {
     manager.resetForTesting()
   }
 
-  func testLateLoadedDisableFlagHidesAVisiblePrompt() {
+  func testLateLoadedDisableFlagHidesAVisiblePrompt() async {
     let manager = RatingPromptManager.shared
     manager.resetForTesting()
     for _ in 0..<3 { manager.recordQuestionAsked() }
     XCTAssertTrue(manager.isVisible)
 
+    // Drive the REAL boundary: the exact Notification.Name the PostHog SDK
+    // posts after a flag payload lands (PostHogRemoteConfig ->
+    // NotificationCenter.post(PostHogSDK.didReceiveFeatureFlags)) — the same
+    // compile-checked symbol the manager's observer subscribes to.
     manager.remoteDisableCheck = { true }
-    manager.flagsDidUpdate()
+    NotificationCenter.default.post(name: PostHogManager.featureFlagsDidLoad, object: nil)
+    for _ in 0..<50 where manager.isVisible {
+      try? await Task.sleep(nanoseconds: 20_000_000)
+    }
     XCTAssertFalse(manager.isVisible)
   }
 

--- a/desktop/macos/Desktop/Tests/RatingPromptKillSwitchTests.swift
+++ b/desktop/macos/Desktop/Tests/RatingPromptKillSwitchTests.swift
@@ -27,8 +27,10 @@ final class RatingPromptKillSwitchTests: XCTestCase {
     // compile-checked symbol the manager's observer subscribes to.
     manager.remoteDisableCheck = { true }
     NotificationCenter.default.post(name: PostHogManager.featureFlagsDidLoad, object: nil)
-    for _ in 0..<50 where manager.isVisible {
-      try? await Task.sleep(nanoseconds: 20_000_000)
+    // The observer hops through a MainActor Task; bounded yields let it run
+    // without a wall-clock wait.
+    for _ in 0..<100 where manager.isVisible {
+      await Task.yield()
     }
     XCTAssertFalse(manager.isVisible)
   }

--- a/desktop/macos/changelog/unreleased/20260825-killswitch-sdk-symbol.json
+++ b/desktop/macos/changelog/unreleased/20260825-killswitch-sdk-symbol.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Hardened the rating-prompt kill switch wiring against analytics SDK updates."
+  ]
+}


### PR DESCRIPTION
## Why

Cross-review on #12217: the kill-switch observer referenced the PostHog flag-delivery notification by raw string ("PostHogDidReceiveFeatureFlags"), and the regression test bypassed the notification wiring by calling `flagsDidUpdate()` directly — an SDK rename would silently sever reactivity with no test noticing.

## What

`PostHogManager.featureFlagsDidLoad` re-exports the SDK's public `PostHogSDK.didReceiveFeatureFlags` constant (posted on the main queue by `PostHogRemoteConfig` after the initial preload and every reload — verified in the vendored SDK source), so the observer is compile-checked against the SDK. The regression test now posts that exact `Notification.Name` and awaits the observer's async hop, driving the real boundary end to end.

## Verification

Rating suite 6/6 — `testLateLoadedDisableFlagHidesAVisiblePrompt` posts the real SDK notification and asserts the visible prompt hides. Swift build green.

Failure-Class: none

Product invariants affected: none.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

