### PR TITLE
fix: rating prompt counts each accepted question exactly once

### DIFF
--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -694,11 +694,18 @@ class AnalyticsManager {
 
   // MARK: - Chat Events
 
-  func chatMessageSent(messageLength: Int, hasSelectedAppContext: Bool = false, source: String) {
+  func chatMessageSent(
+    messageLength: Int, hasSelectedAppContext: Bool = false, source: String,
+    countsAsQuestion: Bool = true
+  ) {
     PostHogManager.shared.chatMessageSent(
       messageLength: messageLength, hasSelectedAppContext: hasSelectedAppContext, source: source)
     // Every chat surface funnels through here, which makes it the one place
-    // that can count "questions asked" for the rating-prompt trigger.
+    // that can count "questions asked" for the rating-prompt trigger. Callers
+    // pass countsAsQuestion: false for sends that are not a NEW accepted
+    // question (retries of a failed turn, busy no-op paths) so the one-time
+    // prompt trigger counts each logical question exactly once.
+    guard countsAsQuestion else { return }
     Task { @MainActor in
       RatingPromptManager.shared.recordQuestionAsked()
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -1405,7 +1405,10 @@ struct DashboardPage: View {
     AnalyticsManager.shared.chatMessageSent(
       messageLength: text.count,
       hasSelectedAppContext: selectedApp != nil,
-      source: "home_ask_bar"
+      source: "home_ask_bar",
+      // The busy early-return below drops this send — it must not count as
+      // an asked question for the rating-prompt trigger.
+      countsAsQuestion: !chatProvider.isSending
     )
     if chatProvider.isSending {
       return

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
@@ -428,10 +428,12 @@ struct QueryShellHome: View {
   }
 
   /// The one send. `Try again` on a failed turn enters here too, so a retry is the same turn through
-  /// the same provider and never a second send path (INV-6).
-  private func send(_ question: String) {
+  /// the same provider and never a second send path (INV-6). A retry is the SAME logical question,
+  /// so it keeps the analytics event but never re-counts toward the rating-prompt trigger.
+  private func send(_ question: String, isRetry: Bool = false) {
     AnalyticsManager.shared.chatMessageSent(
-      messageLength: question.count, hasSelectedAppContext: false, source: "query_shell")
+      messageLength: question.count, hasSelectedAppContext: false, source: "query_shell",
+      countsAsQuestion: !isRetry)
     chatProvider.dismissOnboardingOpener()
     Task { await chatProvider.sendMessage(question) }
   }
@@ -439,7 +441,7 @@ struct QueryShellHome: View {
   /// Re-sends the question that failed, not whatever the bar holds now — the send emptied it.
   private func retry() {
     guard !lastAskedQuestion.isEmpty else { return }
-    send(lastAskedQuestion)
+    send(lastAskedQuestion, isRetry: true)
   }
 
   /// Asks for the caret. Monotonic, so a claim is never swallowed for already having been made — the

--- a/desktop/macos/Desktop/Tests/RatingPromptCountingTests.swift
+++ b/desktop/macos/Desktop/Tests/RatingPromptCountingTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// The rating-prompt trigger must count each accepted logical question exactly
+/// once: retries of a failed turn and busy no-op sends keep their analytics
+/// event but never advance the one-time prompt trigger.
+@MainActor
+final class RatingPromptCountingTests: XCTestCase {
+  override func setUp() async throws {
+    RatingPromptManager.shared.resetForTesting()
+  }
+
+  override func tearDown() async throws {
+    RatingPromptManager.shared.resetForTesting()
+  }
+
+  private func drainCounterHops() async {
+    for _ in 0..<20 { await Task.yield() }
+  }
+
+  func testAcceptedQuestionsCountExactlyOnce() async {
+    AnalyticsManager.shared.chatMessageSent(messageLength: 5, source: "query_shell")
+    await drainCounterHops()
+    XCTAssertEqual(RatingPromptManager.shared.questionCount, 1)
+  }
+
+  func testRetriesAndBusySendsNeverCount() async {
+    AnalyticsManager.shared.chatMessageSent(messageLength: 5, source: "query_shell")
+    await drainCounterHops()
+    // A retry of the same failed turn (countsAsQuestion: false).
+    AnalyticsManager.shared.chatMessageSent(
+      messageLength: 5, source: "query_shell", countsAsQuestion: false)
+    // A busy no-op send from the home ask bar.
+    AnalyticsManager.shared.chatMessageSent(
+      messageLength: 9, source: "home_ask_bar", countsAsQuestion: false)
+    await drainCounterHops()
+    XCTAssertEqual(RatingPromptManager.shared.questionCount, 1)
+    XCTAssertFalse(RatingPromptManager.shared.isVisible)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260825-rating-count-accuracy.json
+++ b/desktop/macos/changelog/unreleased/20260825-rating-count-accuracy.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "The rating prompt now counts each question exactly once (retries and busy sends no longer advance it)."
+  ]
+}


### PR DESCRIPTION
## Why

Cross-review on the rating-prompt trigger: `AnalyticsManager.chatMessageSent` counted every emission, so a QueryShell "Try again" re-counted the same failed turn and the home ask bar's busy early-return counted a send that never dispatched — the one-time prompt could fire a question early.

## What

`chatMessageSent` gains `countsAsQuestion` (default true). QueryShell's retry passes `false` (same logical question — the analytics event is kept, matching its pre-existing semantics), and the home ask bar passes `!chatProvider.isSending` so the busy-dropped send never counts. Dashboard's other sites already guard on `isSending` before emitting; accepted-send surfaces (ChatInputView onSend, task chat, onboarding opener) are unchanged — each is a real accepted question.

## Verification

`RatingPromptCountingTests` 2/2 at the real AnalyticsManager boundary (an accepted question counts exactly once; a retry plus a busy no-op advance nothing and never arm the prompt); full rating suite 8/8; swift build green.

Failure-Class: none

Product invariants affected: none.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

