### PR TITLE
feat: count every Firestore document read by collection and hit/miss

### DIFF
--- a/backend/database/_client.py
+++ b/backend/database/_client.py
@@ -82,6 +82,23 @@ def _install_query_stream_retry_compat() -> None:
 
 _install_query_stream_retry_compat()
 
+
+def _install_document_read_probe() -> None:
+    """Count every single-document read by collection pattern and hit/miss.
+
+    Same lazy-import discipline as the query retry shim above: the probe wraps
+    SDK classes that do not exist under the unit-test import stubs.
+    """
+    try:
+        from database.firestore_document_probe import install_document_read_probe
+    except ImportError:
+        return
+
+    install_document_read_probe()
+
+
+_install_document_read_probe()
+
 _firestore_client = None
 _firestore_client_lock = Lock()
 _customer_firestore_client = None

--- a/backend/database/firestore_document_probe.py
+++ b/backend/database/firestore_document_probe.py
@@ -1,0 +1,148 @@
+"""Collection-level accounting for every Firestore single-document read.
+
+Cloud Monitoring's ``firestore.googleapis.com/document/read_count`` carries no
+collection or document-path dimension -- every one of its 31 descriptors reports
+``module="__unknown__"`` for server SDKs -- so a read-volume regression is visible
+in the bill but not attributable to anything. Hand-placed call-site counters only
+ever cover the paths someone remembered to annotate, which is how the existing
+``omi_firestore_read_operations_total`` ended up describing five query families
+while production issued reads from several hundred sites.
+
+This probe instead wraps the SDK's own read entry points, so coverage is
+structural rather than remembered: a new call site is counted the day it is
+written, without touching it. It records only the collection *pattern* (document
+ids elided) and whether the document existed, which is exactly the pair needed to
+find waste -- a read that is billed but returns nothing.
+
+Cardinality is bounded by construction: ids are stripped, and any pattern outside
+the reviewed set collapses to ``other``. No uid, document id, or query text can
+reach a label.
+"""
+
+import logging
+from typing import Any
+
+from prometheus_client import Counter
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    'FIRESTORE_DOCUMENT_READS',
+    'collection_pattern',
+    'install_document_read_probe',
+]
+
+
+FIRESTORE_DOCUMENT_READS = Counter(
+    'omi_firestore_document_reads_total',
+    'Single-document Firestore reads by collection pattern and whether the document existed. '
+    'outcome="miss" is a billed read that returned nothing.',
+    ['collection', 'outcome'],
+)
+
+
+# Reviewed patterns. Anything else is folded into `other` so an unforeseen
+# collection cannot expand the label space. Add a pattern here only after
+# confirming it is a bounded, non-user-derived name.
+_KNOWN_PATTERNS = frozenset(
+    {
+        'users',
+        'users/conversations',
+        'users/memory_items',
+        'users/memory_outbox',
+        'users/memory_historical_overrides',
+        'users/memory_state',
+        'users/task_intelligence_control',
+        'users/recording_sessions',
+        'users/conversation_finalization_jobs',
+        'users/action_items',
+        'users/photos',
+        'users/fcm_tokens',
+        'users/chat_messages',
+        'users/people',
+        'users/facts',
+        'users/apps',
+        'users/calendar_meetings',
+        'users/payments',
+        'users/usage',
+        'account_deletions',
+        'testers',
+        'apps',
+        'plugins',
+        'migration_requests',
+    }
+)
+
+_OTHER = 'other'
+_UNKNOWN = 'unknown'
+
+
+def collection_pattern(path_parts: Any) -> str:
+    """Reduce a Firestore document path to its collection pattern.
+
+    ``('users', 'abc123', 'conversations', 'def456')`` -> ``'users/conversations'``.
+    Document ids sit at the odd indices and are dropped, so no user-derived value
+    survives into a label.
+    """
+    try:
+        parts = tuple(path_parts or ())
+        if not parts:
+            return _UNKNOWN
+        pattern = '/'.join(str(parts[i]) for i in range(0, len(parts), 2))
+    except Exception:
+        return _UNKNOWN
+    return pattern if pattern in _KNOWN_PATTERNS else _OTHER
+
+
+def _record(path_parts: Any, exists: bool) -> None:
+    """Count one document read. Never raises: telemetry must not break a read."""
+    try:
+        FIRESTORE_DOCUMENT_READS.labels(
+            collection=collection_pattern(path_parts),
+            outcome='hit' if exists else 'miss',
+        ).inc()
+    except Exception:
+        logger.warning('firestore document read probe failed to record', exc_info=True)
+
+
+_installed = False
+
+
+def install_document_read_probe() -> None:
+    """Wrap ``DocumentReference.get`` and ``Client.get_all`` to count reads.
+
+    Imported lazily and guarded on ImportError for the same reason the query
+    retry compat shim in ``_client`` is: unit-test harnesses stub the ``google``
+    namespace package, so there is no real SDK class to wrap and skipping is
+    correct.
+    """
+    global _installed
+    if _installed:
+        return
+    try:
+        from google.cloud.firestore_v1.document import DocumentReference
+        from google.cloud.firestore_v1.client import Client
+    except ImportError:
+        return
+
+    original_get = DocumentReference.get
+    original_get_all = Client.get_all
+
+    def get(self: Any, *args: Any, **kwargs: Any) -> Any:
+        snapshot = original_get(self, *args, **kwargs)
+        _record(getattr(self, '_path', ()), bool(getattr(snapshot, 'exists', False)))
+        return snapshot
+
+    def get_all(self: Any, references: Any, *args: Any, **kwargs: Any) -> Any:
+        # get_all streams; count each snapshot as it passes rather than
+        # materialising the generator, which would change the caller's memory
+        # profile on large batches.
+        refs = list(references)
+        for snapshot in original_get_all(self, refs, *args, **kwargs):
+            reference = getattr(snapshot, 'reference', None)
+            _record(getattr(reference, '_path', ()), bool(getattr(snapshot, 'exists', False)))
+            yield snapshot
+
+    setattr(DocumentReference, 'get', get)
+    setattr(Client, 'get_all', get_all)
+    _installed = True

--- a/backend/tests/unit/test_conversation_search_date_validation.py
+++ b/backend/tests/unit/test_conversation_search_date_validation.py
@@ -69,6 +69,11 @@ _stubs = [
     *sorted(package_submodule_stubs('utils.conversations', include_package=False)),
     'utils.executors',
     'utils.product_telemetry',
+    # routers.conversations imports emit_posthog_event from here at module scope.
+    # utils is an _AutoMockModule package in this file, so the real submodule is
+    # not importable and the name has to be stubbed like the rest -- without it
+    # collection fails with ModuleNotFoundError before any test runs.
+    'utils.integration_telemetry',
     'utils.llm.conversation_processing',
     'utils.speaker_identification',
     'utils.app_integrations',

--- a/backend/tests/unit/test_firestore_document_probe.py
+++ b/backend/tests/unit/test_firestore_document_probe.py
@@ -1,0 +1,128 @@
+"""The document-read probe must count every single-document read, and never break one."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import pytest  # noqa: E402
+
+from database.firestore_document_probe import (  # noqa: E402
+    FIRESTORE_DOCUMENT_READS,
+    collection_pattern,
+    install_document_read_probe,
+)
+
+
+def _count(collection: str, outcome: str) -> float:
+    value = FIRESTORE_DOCUMENT_READS.labels(collection=collection, outcome=outcome)._value.get()
+    return float(value or 0)
+
+
+class _Snapshot:
+    def __init__(self, exists, reference=None):
+        self.exists = exists
+        self.reference = reference
+
+
+class _Ref:
+    def __init__(self, path):
+        self._path = path
+
+
+def test_collection_pattern_strips_document_ids():
+    assert collection_pattern(('users', 'uid-abc', 'conversations', 'conv-def')) == 'users/conversations'
+    assert collection_pattern(('account_deletions', 'uid-abc')) == 'account_deletions'
+    assert collection_pattern(('users', 'uid-abc')) == 'users'
+
+
+def test_collection_pattern_bounds_cardinality():
+    # An unreviewed collection must not mint a new label value.
+    assert collection_pattern(('some_new_collection', 'id')) == 'other'
+    # A user-derived value can never survive into a label.
+    assert 'uid-abc' not in collection_pattern(('users', 'uid-abc', 'unreviewed', 'x'))
+    assert collection_pattern(()) == 'unknown'
+    assert collection_pattern(None) == 'unknown'
+
+
+def test_probe_counts_hit_and_miss_and_returns_snapshot_unchanged():
+    firestore_document = pytest.importorskip('google.cloud.firestore_v1.document')
+    DocumentReference = firestore_document.DocumentReference
+
+    calls = []
+
+    def fake_get(self, *args, **kwargs):
+        calls.append(self._path)
+        return _Snapshot(exists=self._path[-1] == 'present')
+
+    original = DocumentReference.get
+    setattr(DocumentReference, 'get', fake_get)
+    try:
+        install_document_read_probe.__globals__['_installed'] = False
+        install_document_read_probe()
+
+        hit_before = _count('users/conversations', 'hit')
+        miss_before = _count('users/conversations', 'miss')
+
+        present = DocumentReference.__new__(DocumentReference)
+        present._path = ('users', 'u1', 'conversations', 'present')
+        absent = DocumentReference.__new__(DocumentReference)
+        absent._path = ('users', 'u1', 'conversations', 'absent')
+
+        assert DocumentReference.get(present).exists is True
+        assert DocumentReference.get(absent).exists is False
+
+        assert _count('users/conversations', 'hit') == hit_before + 1
+        assert _count('users/conversations', 'miss') == miss_before + 1
+        # The underlying read still ran exactly twice: the probe observes, never skips.
+        assert len(calls) == 2
+    finally:
+        setattr(DocumentReference, 'get', original)
+        install_document_read_probe.__globals__['_installed'] = False
+
+
+def test_recording_failure_never_propagates(monkeypatch):
+    import database.firestore_document_probe as probe
+
+    class _Exploding:
+        def labels(self, **kwargs):
+            raise RuntimeError('registry unavailable')
+
+    monkeypatch.setattr(probe, 'FIRESTORE_DOCUMENT_READS', _Exploding())
+    # Must not raise: a telemetry fault may never break a Firestore read.
+    probe._record(('users', 'u1', 'conversations', 'c1'), True)
+
+
+def test_probe_counts_each_document_in_a_batch_read():
+    firestore_client_mod = pytest.importorskip('google.cloud.firestore_v1.client')
+    Client = firestore_client_mod.Client
+
+    def fake_get_all(self, references, *args, **kwargs):
+        for ref in references:
+            yield _Snapshot(exists=ref._path[-1] == 'present', reference=ref)
+
+    original = Client.get_all
+    setattr(Client, 'get_all', fake_get_all)
+    try:
+        install_document_read_probe.__globals__['_installed'] = False
+        install_document_read_probe()
+
+        hit_before = _count('users/conversations', 'hit')
+        miss_before = _count('users/conversations', 'miss')
+
+        refs = [
+            _Ref(('users', 'u1', 'conversations', 'present')),
+            _Ref(('users', 'u1', 'conversations', 'absent')),
+            _Ref(('users', 'u1', 'conversations', 'absent')),
+        ]
+        client = Client.__new__(Client)
+        snapshots = list(Client.get_all(client, refs))
+
+        # Every snapshot is still handed back, in order, unmodified.
+        assert [s.exists for s in snapshots] == [True, False, False]
+        # A batch read bills per document, so each one is counted.
+        assert _count('users/conversations', 'hit') == hit_before + 1
+        assert _count('users/conversations', 'miss') == miss_before + 2
+    finally:
+        setattr(Client, 'get_all', original)
+        install_document_read_probe.__globals__['_installed'] = False


### PR DESCRIPTION
## What

Counts **every** Firestore single-document read by collection pattern and whether the document existed, by wrapping the SDK's own read entry points rather than annotating call sites.

New metric:

```
omi_firestore_document_reads_total{collection, outcome}   # outcome = hit | miss
```

## Why

Production Firestore is doing **~936 NOT_FOUND document reads/sec** — reads that are billed and return nothing, roughly **$740/month** of pure waste. It stepped 2.6x on 2026-08-23 and the cause is still unidentified after two days of investigation.

The reason it stayed unidentified is that **nothing in the system can say which code path issues those reads**:

- Cloud Monitoring cannot. All 31 `firestore.googleapis.com/*` metric descriptors lack any collection or document-path dimension, and the `module`/`version` labels are App Engine-era fields that report `__unknown__` for server SDKs.
- The existing `omi_firestore_read_operations_total` cannot. It is a deliberately narrow, reviewed set — five query families across two files — while production issues single-document reads from several hundred sites. It currently accounts for ~82 operations/sec against a platform-measured ~986 `BatchGetDocuments` calls/sec.
- A one-off Firestore `DATA_READ` audit-log capture gave a snapshot (`users/{uid}/conversations/{id}` 38.3%, `account_deletions/{uid}` 26.8%), but audit logging is expensive to leave on and the capture cannot be re-run cheaply when the number moves.

Hand-placed counters only ever cover what someone remembered to annotate — which is exactly how the existing counter ended up at ~8% coverage. Wrapping the SDK makes coverage **structural**: a new call site is counted the day it is written, with no annotation.

## What the audit capture already showed, and why it needs a continuous signal

From 2000 captured `BatchGetDocuments` calls: **1997 of them requested exactly one document.** Batch hydration is not the volume driver — single-document gets are. Overall roughly **87% of every single-document reference in production misses**, and the misses are spread across many collections, not one:

| collection pattern | share of document references |
|---|---|
| `users/{}/conversations/{}` | 38.3% |
| `account_deletions/{}` | 26.8% |
| `users/{}` | 9.0% |
| `users/{}/memory_items/{}` | 5.7% |
| `users/{}/memory_outbox/{}` | 4.3% |
| `users/{}/memory_historical_overrides/{}` | 4.2% |
| `users/{}/task_intelligence_control/{}` | 3.5% |

That spread is the finding: this is not one leak but a pervasive pattern of reading optional, lazily-created per-user documents on hot paths. A snapshot cannot tell us whether a fix worked; this metric can.

## Design

- **Bounded cardinality by construction.** Document ids sit at odd indices in a Firestore path and are dropped, so no uid, document id, or query text can reach a label. Any pattern outside a reviewed allowlist collapses to `other`. Current label space is ~24 collections x 2 outcomes.
- **Observation only.** No read is added, removed, reordered, or skipped. The wrapper calls through and returns the snapshot unmodified.
- **Never breaks a read.** A recording failure is logged at warning and swallowed.
- **`get_all` is counted per document**, because Firestore bills per document and a batch of N with K missing produces K billed misses that the existing `if doc.exists` filters silently drop.
- **Same lazy-import discipline as the existing shim.** `backend/database/_client.py` already monkeypatches `Query._retry_query_after_exception` with an `ImportError` guard, because unit-test harnesses stub the `google` namespace package. This follows that precedent exactly.

## Verification

- 5 new unit tests: id stripping, cardinality bounding (including that a uid cannot survive into a label), hit/miss counting with the snapshot returned unchanged and the underlying read still executed, per-document counting across a mixed batch, and that a telemetry fault does not propagate.
- SDK assumptions checked against the installed `google-cloud-firestore` rather than assumed: `DocumentReference._path` is a tuple set in `__init__`, `Client.get_all` is a generator function, `DocumentSnapshot` exposes `.exists` and `.reference`.
- Existing suites re-run green: `test_account_deletion_auth_fence` (13), `test_account_deletion_projection_fence` (7), `test_action_item_ids_endpoint` (13), `test_bounded_firestore_list_reads` (11), `test_user_usage` (15).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

