### PR TITLE
refactor: query-shell send accounting behind an executable ledger

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
@@ -80,7 +80,7 @@ struct QueryShellHome: View {
   @State private var didCopyTranscript = false
   /// The last question that actually went. `Try again` re-sends *that* — the composer is emptied by
   /// the send now, so re-reading the bar would retry an empty string.
-  @State private var lastAskedQuestion = ""
+  @State private var sendLedger = QueryShellSendLedger()
   /// The composer's measured height, so the panel's body can end inside the window.
   ///
   /// Measured rather than assumed: the composer is at its resting height most of the time but grows
@@ -422,26 +422,25 @@ struct QueryShellHome: View {
     if chatProvider.draftText != submission.text { chatProvider.draftText = submission.text }
     guard submission.mode != nil else { return }
     claimCaret()
-    guard let question = submission.question else { return }
-    lastAskedQuestion = question
-    send(question)
+    guard let plan = sendLedger.planSubmit(submission.question) else { return }
+    send(plan)
   }
 
   /// The one send. `Try again` on a failed turn enters here too, so a retry is the same turn through
-  /// the same provider and never a second send path (INV-6). A retry is the SAME logical question,
-  /// so it keeps the analytics event but never re-counts toward the rating-prompt trigger.
-  private func send(_ question: String, isRetry: Bool = false) {
+  /// the same provider and never a second send path (INV-6). The ledger owns whether the emission
+  /// counts toward the rating-prompt trigger (submits do, retries never re-count).
+  private func send(_ plan: QueryShellSendLedger.Plan) {
     AnalyticsManager.shared.chatMessageSent(
-      messageLength: question.count, hasSelectedAppContext: false, source: "query_shell",
-      countsAsQuestion: !isRetry)
+      messageLength: plan.question.count, hasSelectedAppContext: false, source: "query_shell",
+      countsAsQuestion: plan.countsAsQuestion)
     chatProvider.dismissOnboardingOpener()
-    Task { await chatProvider.sendMessage(question) }
+    Task { await chatProvider.sendMessage(plan.question) }
   }
 
   /// Re-sends the question that failed, not whatever the bar holds now — the send emptied it.
   private func retry() {
-    guard !lastAskedQuestion.isEmpty else { return }
-    send(lastAskedQuestion, isRetry: true)
+    guard let plan = sendLedger.planRetry() else { return }
+    send(plan)
   }
 
   /// Asks for the caret. Monotonic, so a claim is never swallowed for already having been made — the

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
@@ -255,6 +255,37 @@ struct QueryShellSubmission: Equatable, Sendable {
   }
 }
 
+// MARK: - Send accounting
+
+/// **The submit/retry ledger for the query shell's single send path.** The view
+/// delegates every send decision here so the exactly-once question accounting
+/// the rating prompt depends on is executable in tests, not view-private glue:
+/// a resolved submit counts as one asked question and remembers itself for
+/// `Try again`; a retry re-sends that SAME question and never counts again.
+struct QueryShellSendLedger: Equatable, Sendable {
+  struct Plan: Equatable, Sendable {
+    let question: String
+    /// Whether this emission advances the rating-prompt question counter.
+    let countsAsQuestion: Bool
+  }
+
+  private(set) var lastAskedQuestion = ""
+
+  /// A resolved submission — the one place a NEW question enters the send path.
+  mutating func planSubmit(_ question: String?) -> Plan? {
+    guard let question, !question.isEmpty else { return nil }
+    lastAskedQuestion = question
+    return Plan(question: question, countsAsQuestion: true)
+  }
+
+  /// `Try again` on a failed turn: the same logical question, so it keeps the
+  /// analytics event but never re-counts toward the rating prompt.
+  func planRetry() -> Plan? {
+    guard !lastAskedQuestion.isEmpty else { return nil }
+    return Plan(question: lastAskedQuestion, countsAsQuestion: false)
+  }
+}
+
 // MARK: - Where Home's controls send you
 
 /// **Every way out of Home, as a value.** Home shows rows it does not own: a conversation, a memory,

--- a/desktop/macos/Desktop/Tests/RatingPromptCountingTests.swift
+++ b/desktop/macos/Desktop/Tests/RatingPromptCountingTests.swift
@@ -25,6 +25,42 @@ final class RatingPromptCountingTests: XCTestCase {
     XCTAssertEqual(RatingPromptManager.shared.questionCount, 1)
   }
 
+  /// Drives the PRODUCTION submit/retry ledger the query shell delegates to —
+  /// the same sequence a user produces with a failed turn and 'Try again'.
+  func testQueryShellRetrySequenceCountsTheQuestionExactlyOnce() async {
+    var ledger = QueryShellSendLedger()
+
+    guard let submit = ledger.planSubmit("what changed today?") else {
+      return XCTFail("a resolved submit must produce a send plan")
+    }
+    XCTAssertTrue(submit.countsAsQuestion)
+    AnalyticsManager.shared.chatMessageSent(
+      messageLength: submit.question.count, source: "query_shell",
+      countsAsQuestion: submit.countsAsQuestion)
+
+    // The turn fails; the user presses 'Try again' twice.
+    for _ in 0..<2 {
+      guard let retry = ledger.planRetry() else {
+        return XCTFail("retry after a submit must produce a send plan")
+      }
+      XCTAssertEqual(retry.question, "what changed today?")
+      XCTAssertFalse(retry.countsAsQuestion)
+      AnalyticsManager.shared.chatMessageSent(
+        messageLength: retry.question.count, source: "query_shell",
+        countsAsQuestion: retry.countsAsQuestion)
+    }
+    await drainCounterHops()
+    XCTAssertEqual(RatingPromptManager.shared.questionCount, 1)
+  }
+
+  func testQueryShellLedgerRejectsRetryBeforeAnySubmitAndEmptySubmits() {
+    var ledger = QueryShellSendLedger()
+    XCTAssertNil(ledger.planRetry())
+    XCTAssertNil(ledger.planSubmit(nil))
+    XCTAssertNil(ledger.planSubmit(""))
+    XCTAssertEqual(ledger.planSubmit("q")?.countsAsQuestion, true)
+  }
+
   func testRetriesAndBusySendsNeverCount() async {
     AnalyticsManager.shared.chatMessageSent(messageLength: 5, source: "query_shell")
     await drainCounterHops()

--- a/desktop/macos/changelog/unreleased/20260825-rating-count-seam.json
+++ b/desktop/macos/changelog/unreleased/20260825-rating-count-seam.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Hardened rating-prompt question accounting behind an executable submit/retry ledger."
+  ]
+}


### PR DESCRIPTION
## Why

Cross-review on #12220: the counting tests passed `countsAsQuestion: false` by hand, proving the boolean guard rather than the production send accounting — a regression at the QueryShell retry site would not have been caught.

## What

`QueryShellSendLedger` (QueryShellModel.swift, next to `QueryShellSubmission`) now owns the submit/retry accounting the view used to hold in private state: `planSubmit` counts a resolved question exactly once and remembers it for "Try again"; `planRetry` re-sends that same question with `countsAsQuestion: false`; empty submits and retry-before-any-submit yield nothing. `QueryShellHome` delegates both paths to the ledger, leaving only glue in the view.

## Verification

Rating suite 10/10 — `testQueryShellRetrySequenceCountsTheQuestionExactlyOnce` drives the production ledger through submit → failed turn → two retries and asserts `RatingPromptManager.questionCount == 1` at the real AnalyticsManager boundary; ledger edge cases covered (retry before submit, empty submit). Swift build green. The home-ask-bar busy gate (`countsAsQuestion: !isSending`, mirroring the adjacent early-return) is one expression and remains covered by the boundary test.

Failure-Class: none

Product invariants affected: INV-CHAT-1 — the single-send contract is preserved: submit and retry still funnel through the one send() into the same provider; only the accounting moved into a value type.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

