### PR TITLE
fix: Return during an active send neither dispatches nor counts

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
@@ -419,10 +419,14 @@ struct QueryShellHome: View {
   /// the mode change cannot drift away from the value that defines them.
   private func submit() {
     let submission = QueryShellSubmission.resolve(text: chatProvider.draftText)
+    // Plan before mutating anything: a busy provider rejects the send, so
+    // Return during an active turn must leave the typed draft intact and
+    // neither dispatch nor advance the rating-prompt count.
+    guard submission.mode != nil,
+      let plan = sendLedger.planSubmit(submission.question, providerBusy: chatProvider.isSending)
+    else { return }
     if chatProvider.draftText != submission.text { chatProvider.draftText = submission.text }
-    guard submission.mode != nil else { return }
     claimCaret()
-    guard let plan = sendLedger.planSubmit(submission.question) else { return }
     send(plan)
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
@@ -272,8 +272,11 @@ struct QueryShellSendLedger: Equatable, Sendable {
   private(set) var lastAskedQuestion = ""
 
   /// A resolved submission — the one place a NEW question enters the send path.
-  mutating func planSubmit(_ question: String?) -> Plan? {
-    guard let question, !question.isEmpty else { return nil }
+  /// A busy provider yields no plan at all: Return during an active send would
+  /// be rejected by ChatProvider anyway, so it must neither dispatch nor count
+  /// (nor overwrite the question 'Try again' would re-send).
+  mutating func planSubmit(_ question: String?, providerBusy: Bool = false) -> Plan? {
+    guard !providerBusy, let question, !question.isEmpty else { return nil }
     lastAskedQuestion = question
     return Plan(question: question, countsAsQuestion: true)
   }

--- a/desktop/macos/Desktop/Tests/RatingPromptCountingTests.swift
+++ b/desktop/macos/Desktop/Tests/RatingPromptCountingTests.swift
@@ -53,6 +53,37 @@ final class RatingPromptCountingTests: XCTestCase {
     XCTAssertEqual(RatingPromptManager.shared.questionCount, 1)
   }
 
+  /// Return pressed during an active send: the production ledger computes the
+  /// outcome — no plan, so nothing dispatches and nothing is emitted (the test
+  /// mirrors the view: analytics fire only when a plan exists).
+  func testReturnDuringActiveSendNeitherDispatchesNorCounts() async {
+    var ledger = QueryShellSendLedger()
+
+    if let plan = ledger.planSubmit("while the agent is busy", providerBusy: true) {
+      AnalyticsManager.shared.chatMessageSent(
+        messageLength: plan.question.count, source: "query_shell",
+        countsAsQuestion: plan.countsAsQuestion)
+      XCTFail("a busy provider must not produce a send plan")
+    }
+    // The dropped submit also must not poison 'Try again' with a question
+    // that never dispatched.
+    XCTAssertNil(ledger.planRetry())
+    await drainCounterHops()
+    XCTAssertEqual(RatingPromptManager.shared.questionCount, 0)
+    XCTAssertFalse(RatingPromptManager.shared.isVisible)
+
+    // The same question submitted once the provider is free counts normally.
+    if let plan = ledger.planSubmit("while the agent is busy", providerBusy: false) {
+      AnalyticsManager.shared.chatMessageSent(
+        messageLength: plan.question.count, source: "query_shell",
+        countsAsQuestion: plan.countsAsQuestion)
+    } else {
+      XCTFail("a free provider must produce a send plan")
+    }
+    await drainCounterHops()
+    XCTAssertEqual(RatingPromptManager.shared.questionCount, 1)
+  }
+
   func testQueryShellLedgerRejectsRetryBeforeAnySubmitAndEmptySubmits() {
     var ledger = QueryShellSendLedger()
     XCTAssertNil(ledger.planRetry())

--- a/desktop/macos/changelog/unreleased/20260825-rating-busy-gate.json
+++ b/desktop/macos/changelog/unreleased/20260825-rating-busy-gate.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Pressing Return while the assistant is still answering no longer clears your draft or miscounts a question."
+  ]
+}


### PR DESCRIPTION
## Why

Cross-review on #12222: the editor's Return handler still reaches `submit()` while an answer is streaming (the send button shows Stop, but Return is live) — the ledger planned the question, analytics counted it with `countsAsQuestion: true`, then `ChatProvider` rejected the busy send. A counted question that never dispatched, plus the typed draft was cleared for nothing.

## What

`QueryShellSendLedger.planSubmit` now takes `providerBusy` and yields no plan when busy — the ledger computes the counting outcome instead of call sites passing booleans. `QueryShellHome.submit()` plans before mutating anything, so Return during an active send leaves the draft intact, dispatches nothing, counts nothing, and does not overwrite the question "Try again" re-sends.

## Verification

Rating suite 11/11 — the new regression drives the production ledger with a busy provider (no plan produced; emission only happens when a plan exists, mirroring the view; count stays 0; retry stays nil) and then the same question on a free provider (counts exactly once). No hand-passed counting boolean anywhere in the test. Swiftlint 0 violations; swift build green.

Failure-Class: none

Product invariants affected: INV-CHAT-1 — the single-send contract is unchanged; the busy gate only decides whether a plan exists before the one send path runs.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

