### PR TITLE
fix: query-shell counting commits at the provider acceptance boundary

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
@@ -434,11 +434,27 @@ struct QueryShellHome: View {
   /// the same provider and never a second send path (INV-6). The ledger owns whether the emission
   /// counts toward the rating-prompt trigger (submits do, retries never re-count).
   private func send(_ plan: QueryShellSendLedger.Plan) {
-    AnalyticsManager.shared.chatMessageSent(
-      messageLength: plan.question.count, hasSelectedAppContext: false, source: "query_shell",
-      countsAsQuestion: plan.countsAsQuestion)
     chatProvider.dismissOnboardingOpener()
-    Task { await chatProvider.sendMessage(plan.question) }
+    Task {
+      // Analytics, question counting, and retry state all commit at the
+      // provider's own acceptance boundary — a send it rejects (busy race,
+      // signed-out) emits nothing and changes nothing.
+      var accepted = false
+      _ = await chatProvider.sendMessage(
+        plan.question,
+        onAccepted: {
+          accepted = true
+          AnalyticsManager.shared.chatMessageSent(
+            messageLength: plan.question.count, hasSelectedAppContext: false,
+            source: "query_shell", countsAsQuestion: plan.countsAsQuestion)
+          sendLedger.recordAccepted(plan)
+        })
+      if !accepted, chatProvider.draftText.isEmpty {
+        // The provider refused the send — give the typed question back
+        // instead of losing it to a cleared field.
+        chatProvider.draftText = plan.question
+      }
+    }
   }
 
   /// Re-sends the question that failed, not whatever the bar holds now — the send emptied it.

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
@@ -274,11 +274,20 @@ struct QueryShellSendLedger: Equatable, Sendable {
   /// A resolved submission — the one place a NEW question enters the send path.
   /// A busy provider yields no plan at all: Return during an active send would
   /// be rejected by ChatProvider anyway, so it must neither dispatch nor count
-  /// (nor overwrite the question 'Try again' would re-send).
-  mutating func planSubmit(_ question: String?, providerBusy: Bool = false) -> Plan? {
+  /// (nor overwrite the question 'Try again' would re-send). Planning mutates
+  /// nothing — only `recordAccepted` commits state, so a send ChatProvider
+  /// rejects asynchronously leaves the ledger exactly as it was.
+  func planSubmit(_ question: String?, providerBusy: Bool = false) -> Plan? {
     guard !providerBusy, let question, !question.isEmpty else { return nil }
-    lastAskedQuestion = question
     return Plan(question: question, countsAsQuestion: true)
+  }
+
+  /// Called from ChatProvider's `onAccepted` — the send is really in flight,
+  /// so NOW the question becomes what 'Try again' re-sends.
+  mutating func recordAccepted(_ plan: Plan) {
+    if plan.countsAsQuestion {
+      lastAskedQuestion = plan.question
+    }
   }
 
   /// `Try again` on a failed turn: the same logical question, so it keeps the

--- a/desktop/macos/Desktop/Tests/RatingPromptCountingTests.swift
+++ b/desktop/macos/Desktop/Tests/RatingPromptCountingTests.swift
@@ -37,6 +37,7 @@ final class RatingPromptCountingTests: XCTestCase {
     AnalyticsManager.shared.chatMessageSent(
       messageLength: submit.question.count, source: "query_shell",
       countsAsQuestion: submit.countsAsQuestion)
+    ledger.recordAccepted(submit)
 
     // The turn fails; the user presses 'Try again' twice.
     for _ in 0..<2 {
@@ -57,7 +58,7 @@ final class RatingPromptCountingTests: XCTestCase {
   /// outcome — no plan, so nothing dispatches and nothing is emitted (the test
   /// mirrors the view: analytics fire only when a plan exists).
   func testReturnDuringActiveSendNeitherDispatchesNorCounts() async {
-    var ledger = QueryShellSendLedger()
+    let ledger = QueryShellSendLedger()
 
     if let plan = ledger.planSubmit("while the agent is busy", providerBusy: true) {
       AnalyticsManager.shared.chatMessageSent(
@@ -84,12 +85,56 @@ final class RatingPromptCountingTests: XCTestCase {
     XCTAssertEqual(RatingPromptManager.shared.questionCount, 1)
   }
 
-  func testQueryShellLedgerRejectsRetryBeforeAnySubmitAndEmptySubmits() {
+  /// A REAL ChatProvider rejection through the production sendMessage seam: a
+  /// fresh provider has no runtime owner, so sendMessage refuses before any
+  /// network work and never invokes onAccepted (the only place analytics,
+  /// counting, and retry state now commit — ChatProvider.swift invokes
+  /// onAccepted only after every rejection guard has passed).
+  func testRealProviderRejectionEmitsNothingAndPreservesLedger() async {
+    let provider = ChatProvider()
     var ledger = QueryShellSendLedger()
+    guard let plan = ledger.planSubmit("did I miss anything?", providerBusy: provider.isSending)
+    else {
+      return XCTFail("an idle provider must yield a plan")
+    }
+
+    var accepted = false
+    let result = await provider.sendMessage(
+      plan.question,
+      onAccepted: {
+        accepted = true
+        AnalyticsManager.shared.chatMessageSent(
+          messageLength: plan.question.count, source: "query_shell",
+          countsAsQuestion: plan.countsAsQuestion)
+        ledger.recordAccepted(plan)
+      })
+
+    XCTAssertNil(result)
+    XCTAssertFalse(accepted, "a refused send must never reach onAccepted")
+    await drainCounterHops()
+    XCTAssertEqual(RatingPromptManager.shared.questionCount, 0)
+    // The rejected question must not become what 'Try again' re-sends.
+    XCTAssertNil(ledger.planRetry())
+
+    // The acceptance path commits everything the rejection skipped.
+    ledger.recordAccepted(plan)
+    AnalyticsManager.shared.chatMessageSent(
+      messageLength: plan.question.count, source: "query_shell",
+      countsAsQuestion: plan.countsAsQuestion)
+    await drainCounterHops()
+    XCTAssertEqual(RatingPromptManager.shared.questionCount, 1)
+    XCTAssertEqual(ledger.planRetry()?.question, "did I miss anything?")
+    XCTAssertEqual(ledger.planRetry()?.countsAsQuestion, false)
+  }
+
+  func testQueryShellLedgerRejectsRetryBeforeAnySubmitAndEmptySubmits() {
+    let ledger = QueryShellSendLedger()
     XCTAssertNil(ledger.planRetry())
     XCTAssertNil(ledger.planSubmit(nil))
     XCTAssertNil(ledger.planSubmit(""))
     XCTAssertEqual(ledger.planSubmit("q")?.countsAsQuestion, true)
+    // Planning alone commits nothing; only acceptance does.
+    XCTAssertNil(ledger.planRetry())
   }
 
   func testRetriesAndBusySendsNeverCount() async {

--- a/desktop/macos/changelog/unreleased/20260825-rating-count-on-accept.json
+++ b/desktop/macos/changelog/unreleased/20260825-rating-count-on-accept.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "A chat send the assistant refuses no longer loses your typed question or miscounts toward the rating prompt."
+  ]
+}


### PR DESCRIPTION
## Why

Cross-review on #12228: the busy precheck was not the send-acceptance boundary — after planning cleared the draft and emitted analytics, `ChatProvider.sendMessage` could still reject via `canAcceptSend`, its send lock, or a missing runtime owner, so a refused question was counted and lost.

## What

Analytics, rating-prompt counting, and "Try again" state now commit inside `sendMessage`'s existing `onAccepted` callback — invoked only after every rejection guard has passed. `planSubmit` no longer mutates the ledger (only `recordAccepted` does), and a refused send restores the typed question to the draft instead of losing it. Retry keeps `countsAsQuestion: false`.

## Verification

Rating suite 12/12. `testRealProviderRejectionEmitsNothingAndPreservesLedger` drives a REAL `ChatProvider` rejection through the production `sendMessage` seam (fresh provider without a runtime owner — the same guard chain a busy race hits): result nil, `onAccepted` never fires, count 0, retry state untouched; then the acceptance path counts exactly once and retry re-sends the same question without re-counting. No hand-passed counting boolean anywhere. Swiftlint 0 violations.

Failure-Class: none

Product invariants affected: INV-CHAT-1 — the single-send contract is unchanged; commits moved inside the provider's own acceptance callback on that same path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

