### PR TITLE
fix: every chat surface commits question analytics at send acceptance

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Components/TaskChatPanel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/TaskChatPanel.swift
@@ -95,11 +95,14 @@ struct TaskChatPanel: View {
             // Input area
             ChatInputView(
               onSend: { text in
-                AnalyticsManager.shared.chatMessageSent(messageLength: text.count, source: "task_chat")
                 Task {
                   await taskState.sendMessage(
                     text,
-                    taskContext: coordinator.activeContextPacket
+                    taskContext: coordinator.activeContextPacket,
+                    onAccepted: {
+                      AnalyticsManager.shared.chatMessageSent(
+                        messageLength: text.count, source: "task_chat")
+                    }
                   )
                   await coordinator.refreshActiveThread()
                 }

--- a/desktop/macos/Desktop/Sources/MainWindow/OnboardingOpenerView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/OnboardingOpenerView.swift
@@ -55,11 +55,16 @@ struct OnboardingOpenerView: View {
   }
 
   private func startFromOpener(_ question: String) {
-    AnalyticsManager.shared.chatMessageSent(
-      messageLength: question.count, hasSelectedAppContext: false, source: "onboarding_opener")
     PostOnboardingPromptSuggestions.consume()
     chatProvider.dismissOnboardingOpener()
-    Task { await chatProvider.sendMainDraft(question) }
+    Task {
+      await chatProvider.sendMainDraft(
+        question,
+        onAccepted: {
+          AnalyticsManager.shared.chatMessageSent(
+            messageLength: question.count, hasSelectedAppContext: false, source: "onboarding_opener")
+        })
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -652,12 +652,17 @@ struct DashboardPage: View {
       ChatDraftScope(draft: chatProvider.composerDraft) { draft in
         ChatInputView(
           onSend: { text in
-            AnalyticsManager.shared.chatMessageSent(
-              messageLength: text.count,
-              hasSelectedAppContext: selectedApp != nil,
-              source: "dashboard_chat"
-            )
-            Task { await chatProvider.sendMainDraft(text) }
+            Task {
+              await chatProvider.sendMainDraft(
+                text,
+                onAccepted: {
+                  AnalyticsManager.shared.chatMessageSent(
+                    messageLength: text.count,
+                    hasSelectedAppContext: selectedApp != nil,
+                    source: "dashboard_chat"
+                  )
+                })
+            }
           },
           onStop: {
             chatProvider.stopAgent(owner: .mainChat)
@@ -1393,27 +1398,32 @@ struct DashboardPage: View {
     if let onOpenPrimaryChat {
       onOpenPrimaryChat()
       guard !chatProvider.isSending else { return }
-      AnalyticsManager.shared.chatMessageSent(
-        messageLength: text.count,
-        hasSelectedAppContext: selectedApp != nil,
-        source: "home_ask_bar"
-      )
-      Task { await chatProvider.sendMainDraft(draft) }
+      Task {
+        await chatProvider.sendMainDraft(
+          draft,
+          onAccepted: {
+            AnalyticsManager.shared.chatMessageSent(
+              messageLength: text.count,
+              hasSelectedAppContext: selectedApp != nil,
+              source: "home_ask_bar"
+            )
+          })
+      }
       return
     }
     openHomeChat(focusInput: false)
-    AnalyticsManager.shared.chatMessageSent(
-      messageLength: text.count,
-      hasSelectedAppContext: selectedApp != nil,
-      source: "home_ask_bar",
-      // The busy early-return below drops this send — it must not count as
-      // an asked question for the rating-prompt trigger.
-      countsAsQuestion: !chatProvider.isSending
-    )
-    if chatProvider.isSending {
-      return
-    } else {
-      Task { await chatProvider.sendMainDraft(draft) }
+    if !chatProvider.isSending {
+      Task {
+        await chatProvider.sendMainDraft(
+          draft,
+          onAccepted: {
+            AnalyticsManager.shared.chatMessageSent(
+              messageLength: text.count,
+              hasSelectedAppContext: selectedApp != nil,
+              source: "home_ask_bar"
+            )
+          })
+      }
     }
   }
 
@@ -1421,21 +1431,31 @@ struct DashboardPage: View {
     if let onOpenPrimaryChat {
       onOpenPrimaryChat()
       guard !chatProvider.isSending else { return }
-      AnalyticsManager.shared.chatMessageSent(
-        messageLength: suggestion.count,
-        hasSelectedAppContext: selectedApp != nil,
-        source: "home_suggested_question"
-      )
-      Task { await chatProvider.sendMessage(suggestion) }
+      Task {
+        _ = await chatProvider.sendMessage(
+          suggestion,
+          onAccepted: {
+            AnalyticsManager.shared.chatMessageSent(
+              messageLength: suggestion.count,
+              hasSelectedAppContext: selectedApp != nil,
+              source: "home_suggested_question"
+            )
+          })
+      }
       return
     }
     openHomeChat(focusInput: false)
-    AnalyticsManager.shared.chatMessageSent(
-      messageLength: suggestion.count,
-      hasSelectedAppContext: selectedApp != nil,
-      source: "home_suggested_question"
-    )
-    Task { await chatProvider.sendMessage(suggestion) }
+    Task {
+      _ = await chatProvider.sendMessage(
+        suggestion,
+        onAccepted: {
+          AnalyticsManager.shared.chatMessageSent(
+            messageLength: suggestion.count,
+            hasSelectedAppContext: selectedApp != nil,
+            source: "home_suggested_question"
+          )
+        })
+    }
   }
 
   @ViewBuilder

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
@@ -527,7 +527,9 @@ class TaskChatState: ObservableObject {
 
   // MARK: - Send Message
 
-  func sendMessage(_ text: String, taskContext: String? = nil) async {
+  func sendMessage(
+    _ text: String, taskContext: String? = nil, onAccepted: (@MainActor () -> Void)? = nil
+  ) async {
     guard let lease = captureOwnerLease() else { return }
     let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmedText.isEmpty else { return }
@@ -536,6 +538,8 @@ class TaskChatState: ObservableObject {
       return
     }
 
+    // Every rejection guard has passed — the send is really happening.
+    onAccepted?()
     isSending = true
     errorMessage = nil
 

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -5626,11 +5626,12 @@ class ChatProvider: ObservableObject {
   /// was accepted into the timeline. Preflight failures leave it untouched,
   /// and typing a new draft while acceptance is pending is never overwritten.
   @discardableResult
-  func sendMainDraft(_ text: String) async -> String? {
+  func sendMainDraft(_ text: String, onAccepted: (@MainActor () -> Void)? = nil) async -> String? {
     let submittedRevision = composerDraft.revision
     return await sendMessage(
       text,
       onAccepted: { [weak self] in
+        onAccepted?()
         guard let self,
           self.composerDraft.revision == submittedRevision,
           self.draftText == text

--- a/desktop/macos/Desktop/Tests/RatingPromptCountingTests.swift
+++ b/desktop/macos/Desktop/Tests/RatingPromptCountingTests.swift
@@ -127,6 +127,26 @@ final class RatingPromptCountingTests: XCTestCase {
     XCTAssertEqual(ledger.planRetry()?.countsAsQuestion, false)
   }
 
+  /// Non-QueryShell surfaces (home ask bar, dashboard chat, onboarding
+  /// opener) all send through sendMainDraft, which forwards onAccepted to the
+  /// same sendMessage guard chain — a REAL rejection must emit nothing there
+  /// either.
+  func testRealSendMainDraftRejectionEmitsNothing() async {
+    let provider = ChatProvider()
+    var accepted = false
+    let result = await provider.sendMainDraft(
+      "ask bar question",
+      onAccepted: {
+        accepted = true
+        AnalyticsManager.shared.chatMessageSent(
+          messageLength: 16, source: "home_ask_bar")
+      })
+    XCTAssertNil(result)
+    XCTAssertFalse(accepted)
+    await drainCounterHops()
+    XCTAssertEqual(RatingPromptManager.shared.questionCount, 0)
+  }
+
   func testQueryShellLedgerRejectsRetryBeforeAnySubmitAndEmptySubmits() {
     let ledger = QueryShellSendLedger()
     XCTAssertNil(ledger.planRetry())

--- a/desktop/macos/changelog/unreleased/20260825-rating-count-all-surfaces.json
+++ b/desktop/macos/changelog/unreleased/20260825-rating-count-all-surfaces.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Every chat surface now records a question only once the assistant actually accepts the send."
+  ]
+}

--- a/desktop/macos/e2e/flows/task-thread.yaml
+++ b/desktop/macos/e2e/flows/task-thread.yaml
@@ -7,6 +7,7 @@ covers:
   # scenario-13-task-thread-e2e.sh opens the real TaskChatPanel for first,
   # second, and resumed workstream projections and captures each mounted UI.
   - desktop/macos/Desktop/Sources/MainWindow/Components/TaskChatPanel.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatState.swift
   # The panel the scenario opens is driven by TaskChatCoordinator: it resolves
   # the workstream, mounts the thread, and sends into it. The first/second/
   # resumed projections above are its behaviour.


### PR DESCRIPTION
## Why

Cross-review follow-through on #12231: QueryShell was fixed, but the home ask bar, dashboard chat, home suggestions, task chat, and onboarding opener still emitted `Chat Message Sent` (and advanced the rating-prompt counter) before `ChatProvider`/`TaskChatState` ran their rejection guards — the same failure class on the remaining surfaces.

## What

`sendMainDraft` and `TaskChatState.sendMessage` forward `onAccepted` from their existing guard chains (invoked only after every rejection guard passes; TaskChat's fires after lease/empty/busy checks). Every chat surface moved its analytics emission inside that callback, deleting the hand-mapped `countsAsQuestion: !isSending` at the ask bar — the boundary now computes the outcome everywhere. Onboarding/system sends (`OnboardingChatView` button actions) never emitted question analytics and remain uncounted.

## Verification

Rating suite 13/13 — new test drives a REAL `sendMainDraft` rejection through the production seam (fresh provider, the exact call the ask bar/dashboard/opener make): `onAccepted` never fires, count stays 0. QueryShell rejection + acceptance tests unchanged and green. Swiftlint 0 violations; swift build green.

Failure-Class: none

Product invariants affected: INV-CHAT-1 — no send path added or removed; emissions moved inside each provider's own acceptance callback.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

