### PR TITLE
fix: read the whole referral ledger, not the first 5,000 unordered docs

### DIFF
--- a/web/admin/app/api/omi/stats/k-factor/posthog/route.ts
+++ b/web/admin/app/api/omi/stats/k-factor/posthog/route.ts
@@ -51,22 +51,32 @@ function friendFilter(platform: PlatformScope): string {
   return `event = 'Onboarding How Did You Hear' AND properties.source = 'Friend' ${scopeFilterAnd(platform)}`;
 }
 
+export const REFERRAL_LEDGER_PAGE_SIZE = 1000;
+
 async function referralClaimTimes(): Promise<number[]> {
   // Firestore is the transactional record of granted referral trials
-  // (backend/database/referrals.py); claimed_at is epoch seconds.
-  const snapshot = await getDb()
+  // (backend/database/referrals.py); claimed_at is epoch seconds. Cursor
+  // pagination (document-ID order, no composite index needed) reads the WHOLE
+  // ledger — a bare unordered limit() silently dropped arbitrary claims once
+  // the ledger outgrew it.
+  const base = getDb()
     .collection("users")
-    .where("referral.program", "==", REFERRAL_PROGRAM)
-    .limit(5000)
-    .get();
+    .where("referral.program", "==", REFERRAL_PROGRAM);
   const times: number[] = [];
-  for (const doc of snapshot.docs) {
-    const claimedAt = doc.get("referral.claimed_at");
-    const seconds =
-      typeof claimedAt === "number" ? claimedAt : claimedAt?.seconds;
-    if (seconds) times.push(seconds * 1000);
+  let cursor: any = null;
+  for (;;) {
+    let query = base.limit(REFERRAL_LEDGER_PAGE_SIZE);
+    if (cursor) query = query.startAfter(cursor);
+    const snapshot = await query.get();
+    for (const doc of snapshot.docs) {
+      const claimedAt = doc.get("referral.claimed_at");
+      const seconds =
+        typeof claimedAt === "number" ? claimedAt : claimedAt?.seconds;
+      if (seconds) times.push(seconds * 1000);
+    }
+    if (snapshot.docs.length < REFERRAL_LEDGER_PAGE_SIZE) return times;
+    cursor = snapshot.docs[snapshot.docs.length - 1];
   }
-  return times;
 }
 
 function nycDateDaysAgo(daysAgo: number): string {

--- a/web/admin/lib/__tests__/k-factor-referral-funnel.test.ts
+++ b/web/admin/lib/__tests__/k-factor-referral-funnel.test.ts
@@ -10,15 +10,23 @@ const referralDocs = [
   { get: (f: string) => (f === "referral.claimed_at" ? RECENT_CLAIM_MS / 1000 : null) },
   { get: (f: string) => (f === "referral.claimed_at" ? OLD_CLAIM_MS / 1000 : null) },
 ];
-const firestoreGet = vi.fn(async () => ({ docs: referralDocs }));
+// Pages served in order — pagination tests enqueue a full page plus a tail.
+let firestorePages: Array<Array<{ get: (f: string) => unknown }>> = [referralDocs];
+const firestoreGet = vi.fn(async () => ({
+  docs: firestorePages.shift() ?? [],
+}));
 vi.mock("@/lib/firebase/admin", () => ({
   getDb: () => ({
     collection: () => ({
       where: (field: string, op: string, value: string) => {
-        firestoreGet.mock.calls; // keep signature honest below via assertion
         expect(field).toBe("referral.program");
         expect(value).toBe("desktop_operator_month_v1");
-        return { limit: () => ({ get: firestoreGet }) };
+        const query = {
+          limit: () => query,
+          startAfter: () => query,
+          get: firestoreGet,
+        };
+        return query;
       },
     }),
   }),
@@ -49,6 +57,7 @@ afterEach(() => {
   vi.resetModules();
   posthogResults.mockReset();
   firestoreGet.mockClear();
+  firestorePages = [referralDocs];
   for (const key of ENV_KEYS) {
     if (originalEnv[key] == null) delete process.env[key];
     else process.env[key] = originalEnv[key];
@@ -169,6 +178,21 @@ describe("computeKFactor viral signals", () => {
     // Window k-factor = total viral events / total new users.
     expect(payload.summary.kFactor).toBe(payload.kFactor);
     expect(payload.kFactor).toBeGreaterThan(0);
+  });
+
+  it("reads the whole referral ledger past the first Firestore page", async () => {
+    configurePosthog();
+    posthogResults.mockResolvedValue([]);
+    const { REFERRAL_LEDGER_PAGE_SIZE } = await import(
+      "@/app/api/omi/stats/k-factor/posthog/route"
+    );
+    const claim = { get: (f: string) => (f === "referral.claimed_at" ? RECENT_CLAIM_MS / 1000 : null) };
+    // A full first page must NOT terminate the read: the claim on page two
+    // has to reach the summary.
+    firestorePages = [Array(REFERRAL_LEDGER_PAGE_SIZE).fill(claim), [claim]];
+    const payload: any = await compute("macos");
+    expect(firestoreGet).toHaveBeenCalledTimes(2);
+    expect(payload.summary.referral).toBe(REFERRAL_LEDGER_PAGE_SIZE + 1);
   });
 
   it("never double-counts the hours a rolling 24h window shares with yesterday", async () => {


### PR DESCRIPTION
## Why

Cross-review: `referralClaimTimes()` read an unordered `.limit(5000)` — past 5,000 claims, arbitrary docs (including the newest) silently vanish from every daily/weekly/summary K-factor number.

## What

Cursor pagination over the equality-filtered query (document-ID order — no composite index, so no registry entry; `firestore-query-coverage` unaffected) reads the whole ledger, `REFERRAL_LEDGER_PAGE_SIZE` (1000) per page.

## Verification

k-factor suite 7/7 — the new regression enqueues a FULL first page plus a one-claim second page and asserts two Firestore reads with `summary.referral == PAGE_SIZE + 1`; full admin vitest 195/195.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

