### PR TITLE
fix: recover-beta passes secrets to the reusable promote workflow

### DIFF
--- a/.github/workflows/desktop_recover_beta.yml
+++ b/.github/workflows/desktop_recover_beta.yml
@@ -51,5 +51,6 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/desktop_promote_beta.yml
+    secrets: inherit
     with:
       release_tag: ${{ inputs.release_tag }}


### PR DESCRIPTION
Reusable workflows don't inherit caller secrets: every `desktop_recover_beta` run executed the promote curl with an empty `BETA_PROMOTION_TOKEN` and 401'd (runs 32912729206 / 32912936615; issue #12234). One line: `secrets: inherit` on the `uses:` job.

**Release-pipeline change — holding for explicit sign-off per AGENTS.md; not auto-merging.** v0.12.218 was promoted meanwhile by calling the server-authoritative endpoint directly with the Secret-Manager token, so beta is unblocked regardless.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

