### PR TITLE
fix(desktop/macos): stop the screen-recording consent dialog from recurring

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,8 +24,13 @@
 
 ## Failure class (fixes)
 
-<!-- Every `fix:` commit needs this exact, machine-validated declaration.
-     Use `scripts/failure-class prepare` or `explain` to choose a class.
+<!-- Every `fix:` commit needs this exact, machine-validated declaration. Write one
+     of these three lines, exactly — the value is a single token, never a list:
+         Failure-Class: FC-<lower-kebab-slug>
+         Failure-Class: new
+         Failure-Class: none
+     `scripts/failure-class prepare` lists the classes whose scope_hints overlap your
+     change (add --all-candidates for the whole registry); `explain <id>` prints one.
      `harden:` commits may cite a class but do not need a declaration. -->
 
 Failure-Class: none
@@ -33,12 +38,20 @@ Failure-Class: none
 ## Failure-class transition narrative (only when needed)
 
 <!-- Required only when declaring `new`, changing a class's canonical prevention
-     primitive/owner, or making a registry-only lifecycle transition. A dormant
-     transition sets `status: dormant` and an ISO-8601 `dormant_since`; a reopen
-     sets `status: open` and removes `dormant_since`. Make that transition in a
-     separate PR, never in the instance-fix PR. State the violated contract, the
-     canonical guard, and the supporting evidence. Delete this section for an
-     ordinary instance fix. -->
+     primitive/owner, or making a registry-only lifecycle transition.
+
+     Declaring `new` means adding exactly one
+     .github/failure-classes/FC-<lower-kebab-slug>.json in THIS PR, alongside the fix.
+     Its `evidence_prs` may be `[]` — this PR is the evidence, and its number does not
+     exist yet.
+
+     Every OTHER registry transition — dormant, reopen, or changing an existing class's
+     canonical prevention — goes in a separate registry-only PR, never in the
+     instance-fix PR. A dormant transition sets `status: dormant` and an ISO-8601
+     `dormant_since`; a reopen sets `status: open` and removes `dormant_since`.
+
+     State the violated contract, the canonical guard, and the supporting evidence.
+     Delete this section for an ordinary instance fix. -->
 
 ## New guards (only when adding a check or ratchet)
 

--- a/.github/failure-classes/FC-privileged-consent-resampled-on-timer.json
+++ b/.github/failure-classes/FC-privileged-consent-resampled-on-timer.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "FC-privileged-consent-resampled-on-timer",
+  "violated_contract": "A privileged OS authorization — a TCC-gated capture session, a cross-process Accessibility query, an Apple Events permission lookup — must be acquired once and held for as long as the work lasts, never re-acquired per unit of work on a timer. The OS treats each acquisition as a fresh consent decision it may re-confirm, so sampling an already-granted permission thousands of times an hour converts a re-confirmation the OS intends to surface rarely into one the user sees constantly. A permission-denied result from such a call is a terminal state for the loop that produced it, not a transient error to retry on the next tick: retrying re-arms the same consent dialog the user just dismissed.",
+  "canonical_prevention": "Hold one long-lived privileged session and mutate it in place (SCStream + updateContentFilter rather than a new SCContentFilter and SCScreenshotManager.captureImage per frame); or, where a session is not the shape, stagger the privileged probe off the UI tick so cheap local lookups stay responsive while cross-process checks run at human cadence. Classify permission-denied distinctly from transient failure and route it to a handler that stops the loop and asks the user once, instead of feeding it back into the retry path.",
+  "evidence_prs": [],
+  "scope_hints": ["desktop/macos/**"],
+  "status": "open"
+}

--- a/.github/failure-classes/FC-privileged-consent-resampled-on-timer.json
+++ b/.github/failure-classes/FC-privileged-consent-resampled-on-timer.json
@@ -1,9 +1,13 @@
 {
   "schema_version": 1,
   "id": "FC-privileged-consent-resampled-on-timer",
-  "violated_contract": "A privileged OS authorization — a TCC-gated capture session, a cross-process Accessibility query, an Apple Events permission lookup — must be acquired once and held for as long as the work lasts, never re-acquired per unit of work on a timer. The OS treats each acquisition as a fresh consent decision it may re-confirm, so sampling an already-granted permission thousands of times an hour converts a re-confirmation the OS intends to surface rarely into one the user sees constantly. A permission-denied result from such a call is a terminal state for the loop that produced it, not a transient error to retry on the next tick: retrying re-arms the same consent dialog the user just dismissed.",
+  "violated_contract": "A privileged OS authorization \u2014 a TCC-gated capture session, a cross-process Accessibility query, an Apple Events permission lookup \u2014 must be acquired once and held for as long as the work lasts, never re-acquired per unit of work on a timer. The OS treats each acquisition as a fresh consent decision it may re-confirm, so sampling an already-granted permission thousands of times an hour converts a re-confirmation the OS intends to surface rarely into one the user sees constantly. A permission-denied result from such a call is a terminal state for the loop that produced it, not a transient error to retry on the next tick: retrying re-arms the same consent dialog the user just dismissed.",
   "canonical_prevention": "Hold one long-lived privileged session and mutate it in place (SCStream + updateContentFilter rather than a new SCContentFilter and SCScreenshotManager.captureImage per frame); or, where a session is not the shape, stagger the privileged probe off the UI tick so cheap local lookups stay responsive while cross-process checks run at human cadence. Classify permission-denied distinctly from transient failure and route it to a handler that stops the loop and asks the user once, instead of feeding it back into the retry path.",
-  "evidence_prs": [],
-  "scope_hints": ["desktop/macos/**"],
+  "evidence_prs": [
+    12239
+  ],
+  "scope_hints": [
+    "desktop/macos/**"
+  ],
   "status": "open"
 }

--- a/.github/scripts/pr_preflight.py
+++ b/.github/scripts/pr_preflight.py
@@ -87,7 +87,7 @@ def format_failure_class_suggest(payload: dict) -> str:
             "",
             "<!-- A `fix:` commit is in this diff. Choose manually: this command does not infer a class from paths or diffs.",
             "Before opening the PR, inspect a relevant class with `scripts/failure-class explain FC-<slug> --format json`; replace `none` only if an existing class applies, or use `new` for a genuinely new class.",
-            "Available classes:",
+            _candidate_heading(payload),
         ]
     )
     for candidate in payload.get("advisory_candidates", []):
@@ -95,6 +95,24 @@ def format_failure_class_suggest(payload: dict) -> str:
             lines.append(f"- {candidate['id']}: {candidate['violated_contract']}")
     lines.extend(["-->", ""])
     return "\n".join(lines)
+
+
+def _candidate_heading(payload: dict) -> str:
+    """Label the candidate list honestly.
+
+    `failure-class prepare` lists the classes whose advisory scope_hints overlap the
+    change, falling back to the whole registry when none match. Calling a narrowed list
+    "Available classes" would imply the others do not apply, which is a classification
+    the CLI does not make.
+    """
+    shown = payload.get("candidates_shown")
+    total = payload.get("candidates_total")
+    if isinstance(shown, int) and isinstance(total, int) and shown < total:
+        return (
+            f"Classes whose scope_hints overlap this change ({shown} of {total}; advisory only "
+            "— run `scripts/failure-class prepare --all-candidates` for the rest):"
+        )
+    return "Available classes:"
 
 
 def resolve_pr_metadata(

--- a/.github/workflows/desktop_publish_preview.yml
+++ b/.github/workflows/desktop_publish_preview.yml
@@ -245,7 +245,7 @@ jobs:
 
       - name: Retain Codemagic preview build observation evidence
         if: always() && steps.dispatch.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: codemagic-preview-build-observation-${{ needs.resolve.outputs.slug }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/codemagic-preview-build-observation.json

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -387,6 +387,12 @@ class AppState: ObservableObject {
   @Published var automationPermissionError: OSStatus = 0
   // Prevent concurrent checks (retry path has a 1s sleep).
   var isCheckingAutomationPermission = false
+  /// In-flight guard for the accessibility probe, mirroring the automation one above.
+  /// The probe is several `AXUIElementCopyAttributeValue` round trips against OTHER
+  /// processes, and AX messaging to a hung app blocks for the full AX timeout (seconds).
+  /// Without this, a repeating caller (onboarding polls once a second) stacks a fresh
+  /// detached probe on every tick against an app that is not answering.
+  var isCheckingAccessibilityPermission = false
   @Published var hasAccessibilityPermission = false
   // TCC says yes but AX calls actually fail (common after macOS updates/app re-signs).
   @Published var isAccessibilityBroken = false
@@ -733,8 +739,13 @@ class AppState: ObservableObject {
     // Note: Bluetooth subscription is initialized lazily via initializeBluetoothIfNeeded()
     // to avoid triggering the permission dialog before the user reaches the Bluetooth step
 
-    // Start periodic notification health check (every 30 min)
-    // Detects when macOS silently revokes notification authorization and auto-repairs
+    // Start periodic notification health check (every 30 min).
+    // Detects when macOS silently revokes notification authorization. NOTE: this only
+    // *observes* — it reads `UNUserNotificationCenter.notificationSettings` and updates
+    // published state. It does NOT auto-repair (the repair path this comment used to
+    // describe, `NotificationRegistrationRepair`, has no live caller), and it must not
+    // be wired to one: the repair unregisters the app from LaunchServices and
+    // re-requests authorization, which is not something to do on a timer.
     notificationHealthTimer = Timer.scheduledTimer(withTimeInterval: 30 * 60, repeats: true) {
       [weak self] _ in
       MainActor.assumeIsolated {

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
@@ -496,8 +496,17 @@ extension AppState {
     // AXUIElement/CGEvent calls can synchronously cross the WindowServer. Keep
     // the fire-and-forget API non-blocking for legacy callers; callers that
     // need the answer must await `refreshAccessibilityPermission()`.
+    //
+    // Coalesced, like `checkAutomationPermission`. This is fire-and-forget, so a
+    // repeating caller gets no backpressure from it: the probe crosses into other
+    // processes and blocks for the AX messaging timeout when one of them is wedged,
+    // so unguarded polling stacks probes against exactly the app that cannot answer.
+    // Skipping a tick is free — the next one re-reads the same state.
+    guard !isCheckingAccessibilityPermission else { return }
+    isCheckingAccessibilityPermission = true
     Task { [weak self] in
       _ = await self?.refreshAccessibilityPermission()
+      self?.isCheckingAccessibilityPermission = false
     }
   }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PTTContextVocabularyProvider.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PTTContextVocabularyProvider.swift
@@ -75,7 +75,7 @@ enum PTTContextVocabularyProvider {
       switch await screenCaptureService.captureWindowCGImage(windowID: windowID) {
       case .success(let image):
         activeWindowImage = image
-      case .windowGone, .failed:
+      case .windowGone, .permissionDeclined, .failed:
         activeWindowImage = nil
       }
     } else {

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
@@ -130,9 +130,30 @@ struct OnboardingChatView: View {
   // Permission help notification state — shows a floating bar hint if user struggles
   @State private var permissionHelpShown: Set<String> = []
   @State private var permissionHelpTimer: DispatchWorkItem? = nil
+  @State private var permissionCheckTick = 0
 
-  // Timer to periodically check permission status
+  // Timer to periodically check permission status.
+  //
+  // The tick is 1 s because the screen-recording and microphone checks are local TCC
+  // lookups and the step's UI should flip promptly when the user grants one. The other
+  // three are NOT cheap and are deliberately not run every tick — see
+  // `privilegedProbeTickInterval`.
   let permissionCheckTimer = Timer.publish(every: 1.0, on: .main, in: .common).autoconnect()
+  /// Run the expensive probes every Nth tick instead of every tick.
+  ///
+  /// Per invocation, `checkAccessibilityPermission` makes up to five
+  /// `AXUIElementCopyAttributeValue` round trips into other processes,
+  /// `checkAutomationPermission` does an `AEDeterminePermissionToAutomateTarget`
+  /// lookup against System Events, and `checkFullDiskAccess` reads a TCC-protected
+  /// directory — three separate authorization subsystems. At 1 Hz for the whole life
+  /// of this view that is thousands of privileged checks per onboarding session, every
+  /// one of them a denied access that tccd logs while the user has not granted yet.
+  /// It is the same shape as the capture defect in
+  /// `docs/screencapture-consent-reprompt.md`: a privileged check on a tight timer.
+  /// 5 s is well inside human reaction time for a Settings toggle, and the instant
+  /// signals already exist anyway — the `com.apple.accessibility.api` observer and the
+  /// app-activation refresh both fire on the real grant edge.
+  private static let privilegedProbeTickInterval = 5
 
   var body: some View {
     VStack(spacing: 0) {
@@ -418,8 +439,11 @@ struct OnboardingChatView: View {
       ChatDraftStore.shared.setText(text, for: .onboardingMain)
     }
     .onReceive(permissionCheckTimer) { _ in
+      // Cheap every tick: both are local TCC lookups with no cross-process traffic.
       appState.checkScreenRecordingPermission()
       appState.checkMicrophonePermission()
+      permissionCheckTick &+= 1
+      guard permissionCheckTick % Self.privilegedProbeTickInterval == 0 else { return }
       appState.checkAccessibilityPermission()
       appState.checkAutomationPermission()
       appState.checkFullDiskAccess()

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -340,6 +340,10 @@ public class ProactiveAssistantsPlugin: NSObject {
     // Report resources before starting heavy monitoring
     ResourceMonitor.shared.reportResourcesNow(context: "before_monitoring_start")
 
+    // Resolve the persistent-stream rollout flag while we are on the main actor
+    // (PostHog is MainActor-bound; the capture path is not and reads the cache).
+    ScreenCaptureStreamFeature.resolveAndCache()
+
     // Initialize services
     screenCaptureService = ScreenCaptureService()
 
@@ -481,6 +485,9 @@ public class ProactiveAssistantsPlugin: NSObject {
     isInDelayPeriod = false
     backgroundPollTimer?.invalidate()
     backgroundPollTimer = nil
+    // The persistent stream keeps the OS screen-recording indicator lit; release it
+    // whenever the display is unavailable. Resume rebuilds it on the first tick.
+    ScreenCaptureService.suspendPersistentCaptureStream(reason: "system interruption")
   }
 
   private func resumeCaptureAfterSystemInterruption(reason: String) {
@@ -557,6 +564,7 @@ public class ProactiveAssistantsPlugin: NSObject {
     insightAssistant = nil
     memoryAssistant = nil
     screenCaptureService = nil
+    ScreenCaptureService.suspendPersistentCaptureStream(reason: "monitoring stopped")
 
     isMonitoring = false
     isStartingMonitoring = false  // Reset in case stop was called during startup
@@ -711,6 +719,15 @@ public class ProactiveAssistantsPlugin: NSObject {
     var capturedFreshFrame = false
     if #available(macOS 14.0, *) {
       let result = await dwellCaptureWithTimeout(windowID: windowID, seconds: 5)
+      // A declined consent must NOT fall through to the retry-anchor path below: that
+      // backdates the anchor and re-attempts in ~10 s, which is another timer-cadence
+      // capture session and another chance to re-arm the consent dialog. Same contract
+      // as the capture tick and the recovery polls — terminal, not retried.
+      if case .permissionDeclined = result {
+        log("Context dwell refresh aborted: consent declined — stopping capture, no retry")
+        handleCaptureConsentDeclined()
+        return
+      }
       if case .success(let image) = result,
         AssistantCoordinator.shared.isTracking(app: appName, windowTitle: windowTitle)
       {
@@ -754,6 +771,11 @@ public class ProactiveAssistantsPlugin: NSObject {
     // never produce another full frame through the preview-skip path.
     if #available(macOS 14.0, *) {
       let result = await dwellCaptureWithTimeout(windowID: windowID, seconds: 5)
+      if case .permissionDeclined = result {
+        log("Context dwell refresh: consent declined on the post-visit capture — stopping capture")
+        handleCaptureConsentDeclined()
+        return
+      }
       if case .success(let image) = result,
         AssistantCoordinator.shared.isTracking(app: appName, windowTitle: windowTitle)
       {
@@ -780,6 +802,51 @@ public class ProactiveAssistantsPlugin: NSObject {
     screenCaptureFailureTracker.recordTargetUnavailable()
     lastCaptureSucceeded = true
     setScreenCaptureHealth(.temporarilyUnavailable)
+  }
+
+  /// One consent-decline banner per EPISODE, not per process. Static (like
+  /// hasAutoResetThisSession) because the app-activation path restarts monitoring and
+  /// each restart's first declined capture must not stack another banner on the one the
+  /// user has not acted on yet. Cleared on the first successful capture (see
+  /// captureFrame), which is what ends the episode — a process that runs for weeks will
+  /// meet more than one re-confirmation, and the second one must still be explained.
+  private static var hasNotifiedConsentDeclinedThisSession = false
+
+  /// ScreenCaptureKit said "the user declined TCCs" — macOS re-confirming consent for
+  /// app-built content filters, with the Screen Recording grant itself intact.
+  ///
+  /// This must be terminal, not retried: every retried capture opens a fresh session,
+  /// and macOS re-arms the consent dialog per session, so the old 3 s retry (plus the
+  /// 5 s recovery poll behind it) produced three dialogs in ten minutes on a live
+  /// machine. Exposé/Mission Control produce the same error transiently — that carve-out
+  /// stays. Recovery is human-scale only: the notification click restarts monitoring,
+  /// and so does the existing app re-activation start path.
+  private func handleCaptureConsentDeclined() {
+    switch ScreenCaptureConsentPolicy.actionForDeclinedCapture(
+      isInSpecialSystemMode: isInSpecialSystemMode(),
+      hasNotifiedThisSession: Self.hasNotifiedConsentDeclinedThisSession)
+    {
+    case .waitForSpecialModeToEnd:
+      handleCaptureTargetUnavailable()
+    case .stopAndNotify(let shouldNotify):
+      log(
+        "ProactiveAssistantsPlugin: ScreenCaptureKit consent declined — stopping capture, no automatic retry"
+      )
+      AnalyticsManager.shared.screenCaptureBrokenDetected()
+      sendEvent(type: "captureConsentDeclined", data: [:])
+      let ownerID = RuntimeOwnerIdentity.currentOwnerId()
+      stopMonitoring()
+      guard shouldNotify, let ownerID else { return }
+      Self.hasNotifiedConsentDeclinedThisSession = true
+      NotificationService.shared.sendNotification(
+        ownerID: ownerID,
+        title: NotificationService.screenCaptureConsentTitle,
+        message:
+          "macOS asked to re-confirm screen recording for Omi. Click to resume capture.",
+        deliverSystemBanner: true,
+        respectFrequency: false
+      )
+    }
   }
 
   private func handleCaptureEngineFailure() {
@@ -1100,6 +1167,13 @@ public class ProactiveAssistantsPlugin: NSObject {
       if #available(macOS 14.0, *) {
         let previewResult = await screenCaptureService.captureWindowCGImage(
           windowID: windowID, maxSize: 80)
+        // Short-circuit on a decline. Falling through would open a SECOND capture
+        // session in the same tick (the full capture below), doubling the very
+        // session rate that re-arms the consent dialog.
+        if case .permissionDeclined = previewResult {
+          handleCaptureConsentDeclined()
+          return
+        }
         if case .success(let previewImage) = previewResult {
           let previewHash = RewindOCRService.dHash(of: previewImage)
           let similarity = captureTrigger.previewSimilarity(to: previewHash)
@@ -1144,6 +1218,9 @@ public class ProactiveAssistantsPlugin: NSObject {
       case .windowGone:
         handleCaptureTargetUnavailable()
         return
+      case .permissionDeclined:
+        handleCaptureConsentDeclined()
+        return
       case .failed:
         handleCaptureEngineFailure()
         return
@@ -1157,6 +1234,14 @@ public class ProactiveAssistantsPlugin: NSObject {
         }
         lastCaptureSucceeded = true
         setScreenCaptureHealth(.active)
+        // A successful capture ends the consent episode, so the one-banner-per-episode
+        // budget is refilled here rather than being spent once for the life of the
+        // process. Same shape as the reset-notification suppression, which
+        // `AppState.checkScreenRecordingPermission()` clears as soon as capture
+        // recovers. Without this, a second genuine re-confirmation weeks into an
+        // uptime stops capture with no user-visible explanation at all — silence is
+        // worse than the spam this guard exists to prevent.
+        Self.hasNotifiedConsentDeclinedThisSession = false
 
         frameCount += 1
         let captureTime = Date()
@@ -1806,13 +1891,20 @@ public class ProactiveAssistantsPlugin: NSObject {
       return
     }
 
-    if await screenCaptureService.captureActiveWindowAsync() != nil {
+    switch await screenCaptureService.captureActiveWindowCGImage() {
+    case .success:
       // Success! Exit recovery mode
       log(
         "ProactiveAssistantsPlugin: Recovery successful after \(recoveryRetryCount) attempts (~\(recoveryRetryCount * Int(recoveryInterval))s), resuming normal capture (frontmost: \(getFrontmostAppInfo()))"
       )
       exitRecoveryMode(success: true)
-    } else {
+    case .permissionDeclined:
+      // The consent dialog is up. Recovery's 5 s retry is exactly the loop that
+      // re-arms it — stop here; handleCaptureConsentDeclined stops monitoring, which
+      // clears the recovery state.
+      log("ProactiveAssistantsPlugin: Recovery hit declined consent — stopping instead of retrying")
+      handleCaptureConsentDeclined()
+    case .windowGone, .failed:
       // Still failing
       if recoveryRetryCount >= maxRecoveryRetries {
         // Give up and show the reset notification
@@ -1882,12 +1974,20 @@ public class ProactiveAssistantsPlugin: NSObject {
 
     log("ProactiveAssistantsPlugin: Background poll attempt \(backgroundPollCount)/\(maxBackgroundPollAttempts)")
 
-    if await screenCaptureService.captureActiveWindowAsync() != nil {
+    switch await screenCaptureService.captureActiveWindowCGImage() {
+    case .success:
       log("ProactiveAssistantsPlugin: Background polling recovered after \(backgroundPollCount) attempts")
       exitBackgroundPolling(success: true)
-    } else if backgroundPollCount >= maxBackgroundPollAttempts {
-      log("ProactiveAssistantsPlugin: Background polling exhausted, attempting auto-reset")
-      exitBackgroundPolling(success: false)
+    case .permissionDeclined:
+      // Same contract as attemptRecovery: a pending consent dialog must never be
+      // re-sampled on a timer, not even a 60 s one.
+      log("ProactiveAssistantsPlugin: Background poll hit declined consent — stopping instead of retrying")
+      handleCaptureConsentDeclined()
+    case .windowGone, .failed:
+      if backgroundPollCount >= maxBackgroundPollAttempts {
+        log("ProactiveAssistantsPlugin: Background polling exhausted, attempting auto-reset")
+        exitBackgroundPolling(success: false)
+      }
     }
   }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -54,6 +54,13 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
   /// Title that identifies screen capture reset notifications
   static let screenCaptureResetTitle = "Screen Recording Needs Reset"
 
+  /// Title that identifies the consent-decline notice: macOS re-confirmed consent for
+  /// app-built capture filters and the capture loop went terminal instead of retrying
+  /// (see ScreenCaptureConsentPolicy). Distinct from the reset title on purpose — the
+  /// grant is intact, so the repair is "start capturing again", NOT the tccutil wipe
+  /// the reset flow performs.
+  static let screenCaptureConsentTitle = "Screen Recording Paused"
+
   /// UserDefaults key that records whether the screen capture reset notification
   /// has already been shown in the current broken-capture episode. Cleared by
   /// `AppState.checkScreenRecordingPermission()` as soon as capture recovers,
@@ -262,6 +269,8 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         switch Self.openAction(assistantId: assistantId, title: title) {
         case .resetScreenCapture:
           self.handleScreenCaptureResetAction(source: "notification_click")
+        case .resumeScreenCapture:
+          self.handleScreenCaptureResumeAction(source: "notification_click")
         case .openMainChat:
           // The same reveal-and-land-on-chat path the floating bar's
           // "Continue in Omi" affordance uses; the chat transcript there
@@ -316,6 +325,9 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     case none
     /// The screen-recording repair, which is an action rather than a page.
     case resetScreenCapture
+    /// Resume after a terminal consent decline: the grant is intact, so the repair is
+    /// simply restarting monitoring (one user-initiated capture attempt), never a reset.
+    case resumeScreenCapture
     /// The main-window chat surface, where the meeting-notes card (with its
     /// conversation link) was materialized.
     case openMainChat
@@ -328,6 +340,7 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
   /// change with its own suppression-state migration.
   static func openAction(assistantId: String, title: String) -> OpenAction {
     if title == screenCaptureResetTitle { return .resetScreenCapture }
+    if title == screenCaptureConsentTitle { return .resumeScreenCapture }
     if assistantId == MeetingActionItemBannerPolicy.assistantID { return .openMainChat }
     return .none
   }
@@ -337,6 +350,22 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     log("Screen capture reset triggered from \(source)")
     AnalyticsManager.shared.screenCaptureResetClicked(source: source)
     ScreenCaptureService.resetScreenCapturePermissionAndRestart()
+  }
+
+  /// Handle the consent-decline resume: this is the single user-facing repair
+  /// affordance after a terminal "user declined TCCs" stop. It restarts monitoring —
+  /// one user-initiated capture attempt — which either just works (the user allowed
+  /// the OS dialog) or surfaces the consent dialog exactly once, at a moment the user
+  /// chose. Deliberately not the reset flow: the TCC grant is intact.
+  private func handleScreenCaptureResumeAction(source: String) {
+    log("Screen capture resume triggered from \(source)")
+    Task { @MainActor in
+      ProactiveAssistantsPlugin.shared.startMonitoring { success, error in
+        if !success, let error {
+          log("Screen capture resume from \(source) failed to start monitoring: \(error)")
+        }
+      }
+    }
   }
 
   /// Send a notification via the floating bar, and optionally as a native macOS system banner.

--- a/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
@@ -962,7 +962,17 @@ final class ScreenCaptureService: Sendable {
 
   // MARK: - Async Capture (Primary API)
 
-  /// Async capture - main entry point
+  /// Async capture - main entry point.
+  ///
+  /// On macOS 14+ this still runs the ONE-SHOT ScreenCaptureKit path — a fresh
+  /// `SCContentFilter` and a fresh capture session, i.e. a fresh TCC authorization —
+  /// and it deliberately has no remaining macOS 14 caller: the only live call site is
+  /// the macOS 13.x fallback branch of the capture tick, which routes to the
+  /// screencapture CLI instead. Do NOT reach for this from a timer or a loop on
+  /// macOS 14+; that is exactly the per-frame authorization sampling that made the
+  /// consent dialog re-fire (see docs/screencapture-consent-reprompt.md). Use
+  /// `captureWindowCGImage`, which goes through the persistent stream engine and also
+  /// preserves the `.permissionDeclined` classification this `Data?` return erases.
   func captureActiveWindowAsync() async -> Data? {
     let (_, _, windowID) = await Self.getActiveWindowInfoAsync()
     guard let windowID else {
@@ -1070,7 +1080,67 @@ final class ScreenCaptureService: Sendable {
   enum WindowCaptureResult {
     case success(CGImage)
     case windowGone
+    /// ScreenCaptureKit refused the session with "The user declined TCCs…" — macOS is
+    /// re-confirming consent for app-built content filters and the dialog is (or was)
+    /// on screen. This is NOT a transient miss: every retried capture opens a fresh
+    /// session, which re-arms the very dialog the user is looking at (observed three
+    /// re-prompts in ten minutes with the grant fully intact). Callers must stop
+    /// capturing and hand the user a single repair affordance instead of retrying.
+    case permissionDeclined
     case failed
+  }
+
+  /// Coarse classification of a thrown ScreenCaptureKit capture error.
+  enum CaptureErrorClass: Equatable {
+    case permissionDeclined
+    case other
+  }
+
+  /// Classify a capture error without losing the consent-decline signal.
+  ///
+  /// tccd evidence for why this case must be separated: with the grant intact
+  /// (`Allowed (System Set)`, `DB Action: None`) macOS still re-confirms consent for
+  /// app-built `SCContentFilter(desktopIndependentWindow:)` filters (`promptType: 1`),
+  /// and while that dialog is pending every capture fails with the "user declined
+  /// TCCs" error. Collapsing it into a generic failure fed the 3 s retry loop that
+  /// kept re-arming the dialog. Matched by SCStreamError code first; the message
+  /// substring is a fallback because the same complaint has been observed under more
+  /// than one code (Exposé/Mission Control produce it too — the CALLER decides whether
+  /// a special system mode makes it transient, this only names the error).
+  nonisolated static func classifyCaptureError(
+    domain: String, code: Int, description: String
+  ) -> CaptureErrorClass {
+    if domain == SCStreamError.errorDomain && code == SCStreamError.userDeclined.rawValue {
+      return .permissionDeclined
+    }
+    if description.localizedCaseInsensitiveContains("declined TCC") {
+      return .permissionDeclined
+    }
+    return .other
+  }
+
+  nonisolated static func classifyCaptureError(_ error: Error) -> CaptureErrorClass {
+    let nsError = error as NSError
+    return classifyCaptureError(
+      domain: nsError.domain, code: nsError.code, description: nsError.localizedDescription)
+  }
+
+  /// Release the persistent capture stream (if the flag is on and one is running).
+  /// Called from the monitoring pause paths — sleep, lock, stop — so the OS
+  /// screen-recording indicator never outlives actual capture. The next capture
+  /// request rebuilds the stream lazily.
+  ///
+  /// Deliberately NOT gated on `ScreenCaptureStreamFeature.isEnabled`: the flag can be
+  /// re-resolved (or flipped off) between the start that created the stream and the
+  /// stop that should release it, and a missed teardown leaves the OS screen-recording
+  /// indicator lit. `suspend` is a no-op when no stream is running, so the unconditional
+  /// call is free.
+  static func suspendPersistentCaptureStream(reason: String) {
+    if #available(macOS 14.0, *) {
+      Task {
+        await WindowCaptureStreamEngine.shared.suspend(reason: reason)
+      }
+    }
   }
 
   /// Capture the active window and return the raw CGImage (no JPEG encoding).
@@ -1088,22 +1158,42 @@ final class ScreenCaptureService: Sendable {
         content = try await Self.sharedContent(forceRefresh: true)
       }
 
-      let filterAndConfig: (SCContentFilter, SCStreamConfiguration)? = autoreleasepool {
-        guard let window = content.windows.first(where: { $0.windowID == windowID }),
-          let config = captureConfiguration(for: window, maxSize: maxSize)
-        else {
-          return nil
-        }
-
-        return (SCContentFilter(desktopIndependentWindow: window), config)
-      }
-
-      guard let (filter, config) = filterAndConfig else {
+      guard let window = content.windows.first(where: { $0.windowID == windowID }),
+        Self.captureDimensions(
+          width: window.frame.width, height: window.frame.height, maxSize: maxSize) != nil
+      else {
         // Window ID no longer exists, or it reports a zero-area frame — the user
         // closed a tab, dismissed a modal, or the app destroyed the window between
         // resolution and capture. This is routine, not a capture failure. Caller
         // should re-resolve and retry.
         log("Window \(windowID) not capturable in SCShareableContent (closed or zero-area)")
+        return .windowGone
+      }
+
+      // Persistent-stream engine: one long-lived SCStream, one TCC authorization,
+      // instead of a fresh capture session (and a fresh authorization) per frame.
+      // See WindowCaptureStreamEngine for why this is the consent-re-prompt fix.
+      if ScreenCaptureStreamFeature.isEnabled {
+        switch await WindowCaptureStreamEngine.shared.captureFrame(
+          window: window, requestedMaxSize: maxSize)
+        {
+        case .success(let image):
+          return .success(image)
+        case .permissionDeclined:
+          return .permissionDeclined
+        case .failed:
+          return .failed
+        }
+      }
+
+      // Legacy one-shot path (flag off): a fresh filter + screenshot session per frame.
+      let filterAndConfig: (SCContentFilter, SCStreamConfiguration)? = autoreleasepool {
+        guard let config = captureConfiguration(for: window, maxSize: maxSize) else {
+          return nil
+        }
+        return (SCContentFilter(desktopIndependentWindow: window), config)
+      }
+      guard let (filter, config) = filterAndConfig else {
         return .windowGone
       }
 
@@ -1114,6 +1204,9 @@ final class ScreenCaptureService: Sendable {
       return .success(image)
     } catch {
       log("ScreenCaptureKit CGImage error for window \(windowID): \(error.localizedDescription)")
+      if Self.classifyCaptureError(error) == .permissionDeclined {
+        return .permissionDeclined
+      }
       return .failed
     }
   }

--- a/desktop/macos/Desktop/Sources/ScreenCaptureStreamFeature.swift
+++ b/desktop/macos/Desktop/Sources/ScreenCaptureStreamFeature.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Feature gate for the persistent window-capture stream (`WindowCaptureStreamEngine`).
+///
+/// Why this exists: every one-shot `SCScreenshotManager.captureImage` with an app-built
+/// `SCContentFilter(desktopIndependentWindow:)` opens a fresh capture session, and macOS
+/// runs a full TCC authorization (with a `SecStaticCodeCheckValidity` pass) per session —
+/// measured at 267 `kTCCServiceScreenCapture` requests in 180 s on a live machine. macOS
+/// ties its periodic re-confirmation of app-built filters to session creation, so that
+/// sampling rate makes the "Omi would like to record this computer's screen and audio"
+/// dialog fire the moment it comes due, repeatedly. One long-lived `SCStream` collapses
+/// that to one authorization per stream start. See
+/// `docs/screencapture-consent-reprompt.md`.
+///
+/// Rollout shape (mirrors `ContextBucketsFeature`): non-production bundles default ON so
+/// the dogfood channel exercises the stream engine, with an inverted env override
+/// (`OMI_PERSISTENT_CAPTURE_STREAM=0` turns it off). Production reads the PostHog flag
+/// fail-closed — a brand-new capture engine must not reach users before it has survived
+/// dogfood — and because `PostHogManager` is MainActor-bound while the capture path is
+/// not, the production value is resolved at monitoring start and cached behind a lock.
+enum ScreenCaptureStreamFeature {
+  static let flagName = "desktop_persistent_capture_stream"
+  private static let localOverrideName = "OMI_PERSISTENT_CAPTURE_STREAM"
+
+  private static let cacheLock = NSLock()
+  /// Must be accessed only while holding cacheLock.
+  nonisolated(unsafe) private static var cachedProductionEnabled: Bool?
+
+  /// Resolve the production rollout flag where PostHog is reachable (MainActor) and
+  /// cache it for the capture path. Called from `startMonitoring`; until the first
+  /// resolution, production behaves as flag-off (fail closed).
+  @MainActor static func resolveAndCache() {
+    guard !AppBuild.isNonProduction else { return }
+    let enabled = PostHogManager.shared.isFeatureEnabled(flagName)
+    cacheLock.withLock { cachedProductionEnabled = enabled }
+  }
+
+  nonisolated static var isEnabled: Bool {
+    if AppBuild.isNonProduction {
+      return ProcessInfo.processInfo.environment[localOverrideName] != "0"
+    }
+    return cacheLock.withLock { cachedProductionEnabled } ?? false
+  }
+
+  // MARK: - Test seams
+
+  nonisolated static func _setProductionCacheForTests(_ value: Bool?) {
+    cacheLock.withLock { cachedProductionEnabled = value }
+  }
+
+  nonisolated static func _peekProductionCacheForTests() -> Bool? {
+    cacheLock.withLock { cachedProductionEnabled }
+  }
+}

--- a/desktop/macos/Desktop/Sources/ScreenRecordingPermissionPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ScreenRecordingPermissionPolicy.swift
@@ -47,3 +47,37 @@ enum ScreenRecordingPermissionPolicy {
     grantedAtLaunch && onboardingComplete
   }
 }
+
+/// Policy for a capture attempt that ScreenCaptureKit rejected with "user declined
+/// TCCs" — macOS re-confirming consent for app-built content filters
+/// (`SCContentFilter(desktopIndependentWindow:)`), with the underlying grant intact.
+///
+/// The contract this encodes: a declined consent is TERMINAL for automatic capture.
+/// Every retried capture opens a fresh session, and macOS re-arms the consent dialog
+/// per session — the 3 s tick plus the 5 s recovery poll turned one due re-confirmation
+/// into three dialogs in ten minutes on a live machine. So outside the known special
+/// system modes, the only correct moves are: stop capturing, tell the user once, and
+/// resume only on a human-scale signal (notification click, Settings toggle, app
+/// re-activation).
+enum ScreenCaptureConsentPolicy {
+  enum DeclinedCaptureAction: Equatable {
+    /// Exposé / Mission Control / Notification Center produce the same "declined TCCs"
+    /// error transiently while they own the screen. That is not a consent event; keep
+    /// the normal timer armed and wait for the mode to end.
+    case waitForSpecialModeToEnd
+    /// The consent dialog is (or was) genuinely on screen. Stop monitoring — no timer
+    /// retry of any cadence — and surface at most one repair notification per session
+    /// (re-activation restarts monitoring anyway, and a banner per attempt is spam).
+    case stopAndNotify(shouldNotify: Bool)
+  }
+
+  static func actionForDeclinedCapture(
+    isInSpecialSystemMode: Bool,
+    hasNotifiedThisSession: Bool
+  ) -> DeclinedCaptureAction {
+    if isInSpecialSystemMode {
+      return .waitForSpecialModeToEnd
+    }
+    return .stopAndNotify(shouldNotify: !hasNotifiedThisSession)
+  }
+}

--- a/desktop/macos/Desktop/Sources/WindowCaptureStreamEngine.swift
+++ b/desktop/macos/Desktop/Sources/WindowCaptureStreamEngine.swift
@@ -1,0 +1,580 @@
+import CoreGraphics
+import CoreImage
+import CoreMedia
+import Foundation
+import ScreenCaptureKit
+
+/// Pure reconfiguration policy for the persistent capture stream, extracted so the
+/// session-reuse contract is unit-testable without ScreenCaptureKit: a request must
+/// reuse the running stream whenever it can, because every `startCapture` is a fresh
+/// TCC authorization — the exact sampling this engine exists to eliminate.
+enum WindowCaptureStreamPolicy {
+  enum StreamAction: Equatable {
+    /// No usable stream — build one (this is the only action that costs an authorization).
+    case startStream
+    /// Same window, same output size — serve from the running stream.
+    case reuseStream
+    /// The frontmost window changed — retarget the live stream via `updateContentFilter`.
+    case updateFilter
+    /// Same window, different size (the user resized it) — `updateConfiguration` only.
+    case updateConfiguration
+  }
+
+  static func action(
+    runningWindowID: CGWindowID?,
+    runningConfigSize: CGSize?,
+    requestedWindowID: CGWindowID,
+    requestedConfigSize: CGSize
+  ) -> StreamAction {
+    guard let runningWindowID, runningConfigSize != nil else { return .startStream }
+    if runningWindowID != requestedWindowID { return .updateFilter }
+    if runningConfigSize != requestedConfigSize { return .updateConfiguration }
+    return .reuseStream
+  }
+
+  /// Whether the stream should be torn down for lack of use. A live SCStream keeps the
+  /// OS screen-recording indicator on, so it must not outlive actual capture requests:
+  /// the capture tick already gates itself off while the user is idle, and this is the
+  /// matching teardown. Rebuild-on-next-request costs one authorization per idle period,
+  /// not one per frame.
+  static func shouldSuspendForIdle(
+    lastRequestAt: Date, now: Date, idleTimeout: TimeInterval
+  ) -> Bool {
+    now.timeIntervalSince(lastRequestAt) >= idleTimeout
+  }
+}
+
+/// One long-lived `SCStream` scoped to the frontmost window, serving every frame request
+/// (full captures and the ≤80 px previews alike) from the stream's latest delivered frame.
+///
+/// Why a stream and not one-shot screenshots: each `SCScreenshotManager.captureImage`
+/// with an app-built `SCContentFilter(desktopIndependentWindow:)` is its own capture
+/// session, and macOS runs a full TCC authorization per session — measured at ~1.5/s
+/// (~5,000/hour) under the capture tick. macOS ties its periodic re-confirmation of
+/// app-built filters to session creation, so that rate makes the consent dialog fire the
+/// instant it comes due. One stream = one authorization at `startCapture`; window
+/// switches ride `updateContentFilter` on the live stream.
+///
+/// Privacy: the filter stays `desktopIndependentWindow` — the stream never sees more
+/// than the single window the one-shot path saw. A display-scoped stream with cropping
+/// was rejected because it would move the per-window privacy boundary (Rewind
+/// exclusions, filtered browser windows) from OS-enforced to app-enforced. Frames are
+/// dropped outright for the whole duration of a retarget (see `CaptureFrameSink`), so a
+/// request for a new window cannot be served the previous window's pixels.
+///
+/// Concurrency contract — read this before editing:
+/// - Every mutation of `stream` / `sink` / `streamWindowID` / `streamConfigSize` runs
+///   inside `withStreamLock`. Actor isolation alone is NOT enough: all of these
+///   operations `await` non-Sendable ScreenCaptureKit calls, and an actor is reentrant
+///   across `await`, so a second request would otherwise interleave with a half-built
+///   stream (two live streams = a leak and a second TCC authorization).
+/// - The lock is held across the configuration ops only, never across the frame wait —
+///   a 3 s wait must not serialize other requesters behind it.
+/// - The frame wait is done on the `CaptureFrameSink` instance that belongs to the
+///   stream that was configured, captured as a local. Nothing re-reads `self.sink`
+///   after a suspension, so a teardown-and-rebuild during the wait resolves the old
+///   waiter (with `nil`) instead of crossing streams.
+@available(macOS 14.0, *)
+actor WindowCaptureStreamEngine {
+  static let shared = WindowCaptureStreamEngine()
+
+  enum FrameResult {
+    case success(CGImage)
+    /// ScreenCaptureKit rejected the session with "user declined TCCs" — the consent
+    /// dialog is (or was) on screen. The caller must treat this as terminal; retrying
+    /// opens a new session, which re-arms the dialog.
+    case permissionDeclined
+    case failed
+  }
+
+  /// Teardown after this long without a capture request (user idle / capture gated off).
+  static let idleTeardownSeconds: TimeInterval = 60
+  /// How long to wait for SCK to push a frame after start / filter change. SCK delivers
+  /// promptly when content is dirty, which a fresh target always is.
+  private static let frameWaitTimeoutNs: UInt64 = 3_000_000_000
+  /// 2 fps ceiling: the capture tick polls at 1 Hz and SCK only pushes on content
+  /// change anyway, so this bounds cost without starving a dwell double-capture.
+  private static let minimumFrameInterval = CMTime(value: 1, timescale: 2)
+  /// Poll interval for `withStreamLock`. Configuration ops finish in tens of ms and
+  /// requesters arrive at ~1 Hz, so this is a handful of wakeups at worst.
+  private static let lockPollNs: UInt64 = 20_000_000
+  /// Hard bound on waiting for the stream lock. Without it, a `startCapture()` that
+  /// never returns (WindowServer wedged, TCC prompt sitting unanswered) parks EVERY
+  /// later request in the poll loop forever — a silent hang with no failure to report.
+  /// Bounded, the requests fail, the capture failure tracker sees them, and the app's
+  /// existing recovery path runs instead of the engine going quiet.
+  private static let lockAcquireTimeoutNs: UInt64 = 5_000_000_000
+
+  private var stream: SCStream?
+  /// One sink per stream, never shared. A departing stream stays alive until its
+  /// `stopCapture()` completes and can deliver a late frame or a late
+  /// `didStopWithError` after we have already built its replacement; with a shared
+  /// sink those would land on the new stream's state — poisoning it with a bogus stop
+  /// error, or worse, tagging the old window's pixels with the new window's ID.
+  private var sink: CaptureFrameSink?
+  private var streamWindowID: CGWindowID?
+  private var streamConfigSize: CGSize?
+  private let sampleQueue = DispatchQueue(label: "com.omi.window-capture-stream")
+  private var idleWatchdog: Task<Void, Never>?
+  private var lastRequestAt = Date.distantPast
+  private var isMutatingStream = false
+
+  /// Capture the given window at `requestedMaxSize` (long edge, points-derived pixels).
+  /// The stream always runs at the full `ScreenCaptureService.maxSize` configuration;
+  /// smaller requests (the ≤80 px previews) are served by downscaling the latest full
+  /// frame, so preview and full ticks never thrash the stream configuration.
+  func captureFrame(window: SCWindow, requestedMaxSize: CGFloat) async -> FrameResult {
+    lastRequestAt = Date()
+    guard
+      let fullSize = ScreenCaptureService.captureDimensions(
+        width: window.frame.width, height: window.frame.height,
+        maxSize: ScreenCaptureService.maxSize)
+    else {
+      // Zero-area window — same refusal as the one-shot path (see captureDimensions).
+      return .failed
+    }
+    let configSize = CGSize(width: fullSize.width, height: fullSize.height)
+    let windowID = window.windowID
+
+    let activeSink: CaptureFrameSink
+    switch await configureStream(window: window, configSize: configSize) {
+    case .ready(let configured):
+      activeSink = configured
+    case .declined:
+      return .permissionDeclined
+    case .failed:
+      return .failed
+    }
+
+    guard
+      let frame = await activeSink.nextFrame(windowID: windowID, timeoutNs: Self.frameWaitTimeoutNs)
+    else {
+      // No frame inside the window: either the stream died (classify its stop error) or
+      // SCK stalled. Either way this tick fails and the failure tracker takes over.
+      if let stopError = activeSink.takeStopError() {
+        await teardownIfCurrent(sink: activeSink, reason: "stream stopped while waiting for frame")
+        return ScreenCaptureService.classifyCaptureError(stopError) == .permissionDeclined
+          ? .permissionDeclined : .failed
+      }
+      log("WindowCaptureStreamEngine: timed out waiting for a frame from window \(windowID)")
+      return .failed
+    }
+
+    if requestedMaxSize < ScreenCaptureService.maxSize {
+      guard let scaled = Self.downscale(frame, maxSize: requestedMaxSize) else {
+        // Answer off-contract or not at all: the ≤80 px preview's dHash is compared
+        // against other preview-scale hashes, and a full-resolution image aliases
+        // differently (see RewindOCRService.previewScaleDHash), so silently returning
+        // the full frame would poison the similarity history rather than degrade.
+        log("WindowCaptureStreamEngine: downscale to \(Int(requestedMaxSize))px failed")
+        return .failed
+      }
+      return .success(scaled)
+    }
+    return .success(frame)
+  }
+
+  /// Tear the stream down (sleep, lock, monitoring stop, idle). Safe to call with no
+  /// stream running. The next capture request rebuilds lazily.
+  ///
+  /// Takes the stream lock rather than checking `stream != nil` up front: a suspend
+  /// that arrives while `startCapture()` is still in flight would otherwise see a nil
+  /// stream, do nothing, and let the stream be born *after* the machine locked —
+  /// leaving the OS screen-recording indicator lit over a locked screen.
+  func suspend(reason: String) async {
+    _ = await withStreamLock { () async -> Void in
+      guard self.stream != nil else { return }
+      log("WindowCaptureStreamEngine: suspending capture stream (\(reason))")
+      await self.teardownStreamLocked(reason: reason)
+    }
+  }
+
+  // MARK: - Serialization
+
+  /// Serialize every stream mutation. Correctness rests on one property: between the
+  /// `while` loop observing `false` and the assignment of `true` there is NO suspension
+  /// point, so on the actor's serial executor the test-and-set is atomic. Do not
+  /// introduce an `await` between them.
+  /// Returns `nil` if the lock could not be acquired within `lockAcquireTimeoutNs`.
+  private func withStreamLock<T>(_ body: () async -> T) async -> T? {
+    let deadline = DispatchTime.now().uptimeNanoseconds &+ Self.lockAcquireTimeoutNs
+    while isMutatingStream {
+      guard DispatchTime.now().uptimeNanoseconds < deadline else {
+        log(
+          "WindowCaptureStreamEngine: stream lock held past \(Self.lockAcquireTimeoutNs / 1_000_000_000)s — abandoning this request"
+        )
+        return nil
+      }
+      try? await Task.sleep(nanoseconds: Self.lockPollNs)
+    }
+    isMutatingStream = true
+    defer { isMutatingStream = false }
+    return await body()
+  }
+
+  // MARK: - Stream lifecycle
+
+  private enum ConfigureOutcome {
+    case ready(CaptureFrameSink)
+    case declined
+    case failed
+  }
+
+  private func configureStream(window: SCWindow, configSize: CGSize) async -> ConfigureOutcome {
+    let outcome = await withStreamLock { () async -> ConfigureOutcome in
+      // A stream the OS already stopped must not be reused; classify its stop error so a
+      // consent decline surfaces without paying another startCapture authorization.
+      if let stopError = self.sink?.takeStopError() {
+        await self.teardownStreamLocked(
+          reason: "stream stopped by OS: \(stopError.localizedDescription)")
+        if ScreenCaptureService.classifyCaptureError(stopError) == .permissionDeclined {
+          return .declined
+        }
+      }
+
+      do {
+        switch WindowCaptureStreamPolicy.action(
+          runningWindowID: self.streamWindowID,
+          runningConfigSize: self.streamConfigSize,
+          requestedWindowID: window.windowID,
+          requestedConfigSize: configSize)
+        {
+        case .startStream:
+          try await self.startStreamLocked(window: window, configSize: configSize)
+        case .updateFilter:
+          guard let stream = self.stream, let sink = self.sink else { return .failed }
+          // Privacy: beginRetarget stops the sink accepting ANY frame, and the stream
+          // keeps producing old-window frames until the filter change lands. Tagging
+          // them with the new window ID (what an expect(windowID:) up front would do)
+          // is exactly how a caller ends up holding a screenshot of the window the user
+          // just switched away from — possibly a Rewind-excluded one.
+          sink.beginRetarget()
+          try await stream.updateContentFilter(
+            SCContentFilter(desktopIndependentWindow: window))
+          if self.streamConfigSize != configSize {
+            try await stream.updateConfiguration(self.makeConfiguration(size: configSize))
+          }
+          sink.endRetarget(windowID: window.windowID)
+          self.streamWindowID = window.windowID
+          self.streamConfigSize = configSize
+        case .updateConfiguration:
+          guard let stream = self.stream, let sink = self.sink else { return .failed }
+          // Same window, new size: the cached frame has the wrong dimensions and
+          // in-flight frames still carry the old ones, so drop both.
+          sink.beginRetarget()
+          try await stream.updateConfiguration(self.makeConfiguration(size: configSize))
+          sink.endRetarget(windowID: window.windowID)
+          self.streamConfigSize = configSize
+        case .reuseStream:
+          break
+        }
+      } catch {
+        log(
+          "WindowCaptureStreamEngine: stream (re)configuration failed: \(error.localizedDescription)"
+        )
+        await self.teardownStreamLocked(reason: "configuration error")
+        return ScreenCaptureService.classifyCaptureError(error) == .permissionDeclined
+          ? .declined : .failed
+      }
+
+      guard let sink = self.sink else { return .failed }
+      return .ready(sink)
+    }
+    return outcome ?? .failed
+  }
+
+  private func startStreamLocked(window: SCWindow, configSize: CGSize) async throws {
+    let newSink = CaptureFrameSink()
+    let filter = SCContentFilter(desktopIndependentWindow: window)
+    let config = makeConfiguration(size: configSize)
+    let newStream = SCStream(filter: filter, configuration: config, delegate: newSink)
+    try newStream.addStreamOutput(newSink, type: .screen, sampleHandlerQueue: sampleQueue)
+    newSink.endRetarget(windowID: window.windowID)
+    // The one TCC authorization this engine pays per stream lifetime.
+    try await newStream.startCapture()
+    stream = newStream
+    sink = newSink
+    streamWindowID = window.windowID
+    streamConfigSize = configSize
+    startIdleWatchdog()
+    log("WindowCaptureStreamEngine: started persistent stream for window \(window.windowID)")
+  }
+
+  /// Tear down the current stream. Caller MUST hold the stream lock.
+  ///
+  /// `stopCapture()` is awaited inline. An earlier revision hopped it onto a detached
+  /// `Task` "so as not to hold the actor"; that was wrong twice over — an `await` never
+  /// holds an actor's executor (it suspends the task and lets other messages run), and
+  /// handing a non-Sendable `SCStream` that is still reachable from `self`-isolated code
+  /// to a concurrently-executing closure is a data race that Swift 6 rejects outright.
+  /// Awaiting here is both the safe and the simpler answer: the lock is held for the
+  /// duration, which is what keeps a rebuild from racing the stop.
+  private func teardownStreamLocked(reason: String) async {
+    idleWatchdog?.cancel()
+    idleWatchdog = nil
+    let departingStream = stream
+    let departingSink = sink
+    stream = nil
+    sink = nil
+    streamWindowID = nil
+    streamConfigSize = nil
+    // Detach before stopping: the departing stream may still emit a frame or a
+    // didStopWithError, and a detached sink drops both instead of letting them reach
+    // a caller or be mistaken for the next stream's state.
+    departingSink?.detach()
+    guard let departingStream else { return }
+    do {
+      try await departingStream.stopCapture()
+    } catch {
+      // Already stopped by the OS is the common case here — nothing to repair.
+      log("WindowCaptureStreamEngine: stopCapture (\(reason)): \(error.localizedDescription)")
+    }
+  }
+
+  /// Tear down only if the stream identified by `candidate` is still the current one.
+  /// Without the identity check, a slow failure path could tear down a healthy stream
+  /// that was rebuilt while it was suspended.
+  private func teardownIfCurrent(sink candidate: CaptureFrameSink, reason: String) async {
+    _ = await withStreamLock { () async -> Void in
+      guard self.sink === candidate else { return }
+      await self.teardownStreamLocked(reason: reason)
+    }
+  }
+
+  private func makeConfiguration(size: CGSize) -> SCStreamConfiguration {
+    let config = SCStreamConfiguration()
+    config.scalesToFit = true
+    config.showsCursor = false
+    config.width = Int(size.width)
+    config.height = Int(size.height)
+    config.pixelFormat = kCVPixelFormatType_32BGRA
+    config.minimumFrameInterval = Self.minimumFrameInterval
+    config.queueDepth = 3
+    return config
+  }
+
+  private func startIdleWatchdog() {
+    idleWatchdog?.cancel()
+    idleWatchdog = Task { [weak self] in
+      while !Task.isCancelled {
+        try? await Task.sleep(nanoseconds: 30_000_000_000)
+        guard let self else { return }
+        await self.suspendIfIdle()
+      }
+    }
+  }
+
+  private func suspendIfIdle() async {
+    _ = await withStreamLock { () async -> Void in
+      guard self.stream != nil else { return }
+      guard
+        WindowCaptureStreamPolicy.shouldSuspendForIdle(
+          lastRequestAt: self.lastRequestAt, now: Date(),
+          idleTimeout: Self.idleTeardownSeconds)
+      else { return }
+      log(
+        "WindowCaptureStreamEngine: no capture requests for \(Int(Self.idleTeardownSeconds))s — releasing stream"
+      )
+      await self.teardownStreamLocked(reason: "idle")
+    }
+  }
+
+  // MARK: - Image helpers
+
+  private static func downscale(_ image: CGImage, maxSize: CGFloat) -> CGImage? {
+    guard
+      let size = ScreenCaptureService.captureDimensions(
+        width: CGFloat(image.width), height: CGFloat(image.height), maxSize: maxSize)
+    else { return nil }
+    guard
+      let context = CGContext(
+        data: nil,
+        width: size.width,
+        height: size.height,
+        bitsPerComponent: 8,
+        bytesPerRow: 0,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+          | CGBitmapInfo.byteOrder32Little.rawValue)
+    else { return nil }
+    context.interpolationQuality = .medium
+    context.draw(image, in: CGRect(x: 0, y: 0, width: size.width, height: size.height))
+    return context.makeImage()
+  }
+}
+
+/// Receives frames and stream-stop errors from ScreenCaptureKit's callback queue and
+/// hands them to the engine actor. NSObject because SCStreamOutput/SCStreamDelegate
+/// require it; all mutable state is behind `lock`, hence `@unchecked Sendable`.
+///
+/// One instance per `SCStream`, never reused across streams — see the `sink` property.
+///
+/// The retarget protocol is the privacy-critical part. `beginRetarget()` puts the sink
+/// in a state where EVERY delivered frame is dropped, because between the call to
+/// `updateContentFilter` and its completion the stream is still producing the previous
+/// window's pixels. `endRetarget(windowID:)` reopens it once the new filter is live.
+/// Known residual: ScreenCaptureKit may have queued a frame produced under the old
+/// filter just before the change landed, and this sink cannot tell such a frame from a
+/// new one. Verify during dogfood by fast-switching between two visually distinct
+/// windows and watching for a one-frame lag of the wrong window.
+@available(macOS 14.0, *)
+final class CaptureFrameSink: NSObject, SCStreamOutput, SCStreamDelegate, @unchecked Sendable {
+  private let lock = NSLock()
+  /// The window whose frames are currently acceptable. `nil` means drop everything —
+  /// either a retarget is in flight or this sink has been detached from a dead stream.
+  private var acceptingWindowID: CGWindowID?
+  private var isDetached = false
+  private var latestFrame: (windowID: CGWindowID, image: CGImage)?
+  private var waiter: CheckedContinuation<CGImage?, Never>?
+  private var waiterGeneration = 0
+  private var stopError: Error?
+
+  /// Shared CIContext for CVPixelBuffer → CGImage. Cheap at ≤2 fps.
+  private static let ciContext = CIContext(options: [.cacheIntermediates: false])
+
+  /// Stop accepting frames and drop what is cached. Call BEFORE an
+  /// `updateContentFilter` / `updateConfiguration` await.
+  func beginRetarget() {
+    let staleWaiter: CheckedContinuation<CGImage?, Never>? = lock.withLock {
+      acceptingWindowID = nil
+      latestFrame = nil
+      let stale = waiter
+      waiter = nil
+      return stale
+    }
+    // A waiter from the previous target must not receive the new target's frame.
+    staleWaiter?.resume(returning: nil)
+  }
+
+  /// Start accepting frames for `windowID`. Call AFTER the reconfiguration await has
+  /// returned, i.e. once the stream is actually producing the new target's pixels.
+  func endRetarget(windowID: CGWindowID) {
+    lock.withLock {
+      guard !isDetached else { return }
+      latestFrame = nil
+      acceptingWindowID = windowID
+    }
+  }
+
+  /// Permanently retire this sink; its stream is going away. Idempotent.
+  func detach() {
+    let staleWaiter: CheckedContinuation<CGImage?, Never>? = lock.withLock {
+      isDetached = true
+      acceptingWindowID = nil
+      latestFrame = nil
+      stopError = nil
+      let stale = waiter
+      waiter = nil
+      return stale
+    }
+    staleWaiter?.resume(returning: nil)
+  }
+
+  /// Read-and-clear the terminal stream error, if the OS stopped the stream.
+  func takeStopError() -> Error? {
+    lock.withLock {
+      let error = stopError
+      stopError = nil
+      return error
+    }
+  }
+
+  /// Latest frame for `windowID` if one is cached (a static window legitimately
+  /// produces no new frames — the cached one IS the current content); otherwise wait
+  /// for the next delivery, bounded by `timeoutNs`.
+  func nextFrame(windowID: CGWindowID, timeoutNs: UInt64) async -> CGImage? {
+    return await withCheckedContinuation { (continuation: CheckedContinuation<CGImage?, Never>) in
+      let generation: Int? = lock.withLock {
+        if isDetached {
+          continuation.resume(returning: nil)
+          return nil
+        }
+        if let latestFrame, latestFrame.windowID == windowID {
+          continuation.resume(returning: latestFrame.image)
+          return nil
+        }
+        if stopError != nil {
+          continuation.resume(returning: nil)
+          return nil
+        }
+        waiterGeneration += 1
+        waiter = continuation
+        return waiterGeneration
+      }
+      guard let generation else { return }
+      Task.detached { [weak self] in
+        try? await Task.sleep(nanoseconds: timeoutNs)
+        self?.expireWaiter(generation: generation)
+      }
+    }
+  }
+
+  /// Generation-matched so this can never resume a waiter other than the one it armed:
+  /// every registration bumps `waiterGeneration`, and a resumed waiter is cleared under
+  /// the same lock, so a stale timer finds either a mismatched generation or no waiter.
+  private func expireWaiter(generation: Int) {
+    let expired: CheckedContinuation<CGImage?, Never>? = lock.withLock {
+      guard waiterGeneration == generation, let pending = waiter else { return nil }
+      waiter = nil
+      return pending
+    }
+    expired?.resume(returning: nil)
+  }
+
+  // MARK: - SCStreamOutput
+
+  func stream(
+    _ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
+    of type: SCStreamOutputType
+  ) {
+    guard type == .screen, sampleBuffer.isValid else { return }
+    // Only complete frames carry displayable content; .idle/.blank/.suspended do not.
+    guard
+      let attachments = CMSampleBufferGetSampleAttachmentsArray(
+        sampleBuffer, createIfNecessary: false) as? [[SCStreamFrameInfo: Any]],
+      let statusRaw = attachments.first?[.status] as? Int,
+      SCFrameStatus(rawValue: statusRaw) == .complete
+    else { return }
+    // Cheap gate before the CIContext render: during a retarget, and after detach,
+    // there is no target to tag this frame with and it must be dropped, not converted.
+    guard lock.withLock({ acceptingWindowID != nil }) else { return }
+    guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+    let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+    guard let cgImage = Self.ciContext.createCGImage(ciImage, from: ciImage.extent) else { return }
+    deliver(cgImage)
+  }
+
+  /// Tag-and-publish a rendered frame. Split out of the SCK callback so the
+  /// privacy-critical tagging rule — a frame is only ever tagged with the window the
+  /// sink is CURRENTLY accepting, and is dropped outright when it is accepting none —
+  /// is exercisable without a live capture session.
+  func deliver(_ cgImage: CGImage) {
+    let pendingWaiter: CheckedContinuation<CGImage?, Never>? = lock.withLock {
+      // Re-checked under the lock: a retarget can have begun while the frame was being
+      // rendered, and a frame that arrives mid-retarget belongs to the OLD window.
+      guard let acceptingWindowID else { return nil }
+      latestFrame = (acceptingWindowID, cgImage)
+      let pending = waiter
+      waiter = nil
+      return pending
+    }
+    pendingWaiter?.resume(returning: cgImage)
+  }
+
+  // MARK: - SCStreamDelegate
+
+  func stream(_ stream: SCStream, didStopWithError error: Error) {
+    log("WindowCaptureStreamEngine: stream stopped by OS: \(error.localizedDescription)")
+    let pendingWaiter: CheckedContinuation<CGImage?, Never>? = lock.withLock {
+      // A detached sink's stream is one we are already tearing down; its stop error is
+      // expected and must not be reported as the next stream's failure.
+      guard !isDetached else { return nil }
+      stopError = error
+      latestFrame = nil
+      let pending = waiter
+      waiter = nil
+      return pending
+    }
+    pendingWaiter?.resume(returning: nil)
+  }
+}

--- a/desktop/macos/Desktop/Sources/WindowCaptureStreamEngine.swift
+++ b/desktop/macos/Desktop/Sources/WindowCaptureStreamEngine.swift
@@ -2,7 +2,15 @@ import CoreGraphics
 import CoreImage
 import CoreMedia
 import Foundation
-import ScreenCaptureKit
+// ScreenCaptureKit's async stream methods are nonisolated and take non-Sendable
+// arguments (SCContentFilter, SCStreamConfiguration), so every call from this actor
+// reads as sending a `self`-isolated value to a nonisolated method. The pinned CI
+// toolchain's SDK carries no concurrency annotations for the framework, which makes
+// those errors rather than warnings; a newer SDK annotates them and stays quiet.
+// `@preconcurrency` is the sanctioned way to say "this module predates strict
+// concurrency" — the calls are serialized by the stream lock, which is what actually
+// makes them safe.
+@preconcurrency import ScreenCaptureKit
 
 /// Pure reconfiguration policy for the persistent capture stream, extracted so the
 /// session-reuse contract is unit-testable without ScreenCaptureKit: a request must

--- a/desktop/macos/Desktop/Sources/WindowCaptureStreamEngine.swift
+++ b/desktop/macos/Desktop/Sources/WindowCaptureStreamEngine.swift
@@ -427,6 +427,11 @@ final class CaptureFrameSink: NSObject, SCStreamOutput, SCStreamDelegate, @unche
   private var latestFrame: (windowID: CGWindowID, image: CGImage)?
   private var waiter: CheckedContinuation<CGImage?, Never>?
   private var waiterGeneration = 0
+
+  /// Whether a caller is currently parked in `nextFrame`. Tests use this to observe
+  /// that a waiter has registered instead of sleeping for a plausible interval; a
+  /// wall-clock wait would make the retarget assertions racy on a loaded machine.
+  var hasParkedWaiter: Bool { lock.withLock { waiter != nil } }
   private var stopError: Error?
 
   /// Shared CIContext for CVPixelBuffer → CGImage. Cheap at ≤2 fps.

--- a/desktop/macos/Desktop/Sources/WindowCaptureStreamEngine.swift
+++ b/desktop/macos/Desktop/Sources/WindowCaptureStreamEngine.swift
@@ -64,7 +64,7 @@ enum WindowCaptureStreamPolicy {
 ///
 /// Concurrency contract — read this before editing:
 /// - Every mutation of `stream` / `sink` / `streamWindowID` / `streamConfigSize` runs
-///   inside `withStreamLock`. Actor isolation alone is NOT enough: all of these
+///   while holding the stream lock. Actor isolation alone is NOT enough: all of these
 ///   operations `await` non-Sendable ScreenCaptureKit calls, and an actor is reentrant
 ///   across `await`, so a second request would otherwise interleave with a half-built
 ///   stream (two live streams = a leak and a second TCC authorization).
@@ -95,7 +95,7 @@ actor WindowCaptureStreamEngine {
   /// 2 fps ceiling: the capture tick polls at 1 Hz and SCK only pushes on content
   /// change anyway, so this bounds cost without starving a dwell double-capture.
   private static let minimumFrameInterval = CMTime(value: 1, timescale: 2)
-  /// Poll interval for `withStreamLock`. Configuration ops finish in tens of ms and
+  /// Poll interval for `acquireStreamLock`. Configuration ops finish in tens of ms and
   /// requesters arrive at ~1 Hz, so this is a handful of wakeups at worst.
   private static let lockPollNs: UInt64 = 20_000_000
   /// Hard bound on waiting for the stream lock. Without it, a `startCapture()` that
@@ -182,7 +182,7 @@ actor WindowCaptureStreamEngine {
   /// stream, do nothing, and let the stream be born *after* the machine locked —
   /// leaving the OS screen-recording indicator lit over a locked screen.
   func suspend(reason: String) async {
-    _ = await withStreamLock { () async -> Void in
+    await withStreamLock {
       guard self.stream != nil else { return }
       log("WindowCaptureStreamEngine: suspending capture stream (\(reason))")
       await self.teardownStreamLocked(reason: reason)
@@ -195,21 +195,35 @@ actor WindowCaptureStreamEngine {
   /// `while` loop observing `false` and the assignment of `true` there is NO suspension
   /// point, so on the actor's serial executor the test-and-set is atomic. Do not
   /// introduce an `await` between them.
-  /// Returns `nil` if the lock could not be acquired within `lockAcquireTimeoutNs`.
-  private func withStreamLock<T>(_ body: () async -> T) async -> T? {
+  /// Returns `false` if the lock could not be acquired within `lockAcquireTimeoutNs`.
+  private func acquireStreamLock() async -> Bool {
     let deadline = DispatchTime.now().uptimeNanoseconds &+ Self.lockAcquireTimeoutNs
     while isMutatingStream {
       guard DispatchTime.now().uptimeNanoseconds < deadline else {
         log(
           "WindowCaptureStreamEngine: stream lock held past \(Self.lockAcquireTimeoutNs / 1_000_000_000)s — abandoning this request"
         )
-        return nil
+        return false
       }
       try? await Task.sleep(nanoseconds: Self.lockPollNs)
     }
     isMutatingStream = true
-    defer { isMutatingStream = false }
-    return await body()
+    return true
+  }
+
+  private func releaseStreamLock() {
+    isMutatingStream = false
+  }
+
+  /// Run `body` under the stream lock. Returns `false` if the lock timed out and `body`
+  /// never ran. Holders that need to return a non-Sendable value take the lock directly
+  /// with `acquireStreamLock` instead — see `configureStream`.
+  @discardableResult
+  private func withStreamLock(_ body: () async -> Void) async -> Bool {
+    guard await acquireStreamLock() else { return false }
+    defer { releaseStreamLock() }
+    await body()
+    return true
   }
 
   // MARK: - Stream lifecycle
@@ -221,66 +235,70 @@ actor WindowCaptureStreamEngine {
   }
 
   private func configureStream(window: SCWindow, configSize: CGSize) async -> ConfigureOutcome {
-    let outcome = await withStreamLock { () async -> ConfigureOutcome in
-      // A stream the OS already stopped must not be reused; classify its stop error so a
-      // consent decline surfaces without paying another startCapture authorization.
-      if let stopError = self.sink?.takeStopError() {
-        await self.teardownStreamLocked(
-          reason: "stream stopped by OS: \(stopError.localizedDescription)")
-        if ScreenCaptureService.classifyCaptureError(stopError) == .permissionDeclined {
-          return .declined
-        }
-      }
+    // Takes the lock directly rather than through `withStreamLock`: this is the only
+    // holder that returns a non-Sendable value (`CaptureFrameSink`), and handing one
+    // out of a closure makes it cross an isolation boundary the pinned CI toolchain
+    // rejects. `defer` keeps the release leak-proof across every exit below.
+    guard await acquireStreamLock() else { return .failed }
+    defer { releaseStreamLock() }
 
-      do {
-        switch WindowCaptureStreamPolicy.action(
-          runningWindowID: self.streamWindowID,
-          runningConfigSize: self.streamConfigSize,
-          requestedWindowID: window.windowID,
-          requestedConfigSize: configSize)
-        {
-        case .startStream:
-          try await self.startStreamLocked(window: window, configSize: configSize)
-        case .updateFilter:
-          guard let stream = self.stream, let sink = self.sink else { return .failed }
-          // Privacy: beginRetarget stops the sink accepting ANY frame, and the stream
-          // keeps producing old-window frames until the filter change lands. Tagging
-          // them with the new window ID (what an expect(windowID:) up front would do)
-          // is exactly how a caller ends up holding a screenshot of the window the user
-          // just switched away from — possibly a Rewind-excluded one.
-          sink.beginRetarget()
-          try await stream.updateContentFilter(
-            SCContentFilter(desktopIndependentWindow: window))
-          if self.streamConfigSize != configSize {
-            try await stream.updateConfiguration(self.makeConfiguration(size: configSize))
-          }
-          sink.endRetarget(windowID: window.windowID)
-          self.streamWindowID = window.windowID
-          self.streamConfigSize = configSize
-        case .updateConfiguration:
-          guard let stream = self.stream, let sink = self.sink else { return .failed }
-          // Same window, new size: the cached frame has the wrong dimensions and
-          // in-flight frames still carry the old ones, so drop both.
-          sink.beginRetarget()
-          try await stream.updateConfiguration(self.makeConfiguration(size: configSize))
-          sink.endRetarget(windowID: window.windowID)
-          self.streamConfigSize = configSize
-        case .reuseStream:
-          break
-        }
-      } catch {
-        log(
-          "WindowCaptureStreamEngine: stream (re)configuration failed: \(error.localizedDescription)"
-        )
-        await self.teardownStreamLocked(reason: "configuration error")
-        return ScreenCaptureService.classifyCaptureError(error) == .permissionDeclined
-          ? .declined : .failed
+    // A stream the OS already stopped must not be reused; classify its stop error so a
+    // consent decline surfaces without paying another startCapture authorization.
+    if let stopError = self.sink?.takeStopError() {
+      await self.teardownStreamLocked(
+        reason: "stream stopped by OS: \(stopError.localizedDescription)")
+      if ScreenCaptureService.classifyCaptureError(stopError) == .permissionDeclined {
+        return .declined
       }
-
-      guard let sink = self.sink else { return .failed }
-      return .ready(sink)
     }
-    return outcome ?? .failed
+
+    do {
+      switch WindowCaptureStreamPolicy.action(
+        runningWindowID: self.streamWindowID,
+        runningConfigSize: self.streamConfigSize,
+        requestedWindowID: window.windowID,
+        requestedConfigSize: configSize)
+      {
+      case .startStream:
+        try await self.startStreamLocked(window: window, configSize: configSize)
+      case .updateFilter:
+        guard let stream = self.stream, let sink = self.sink else { return .failed }
+        // Privacy: beginRetarget stops the sink accepting ANY frame, and the stream
+        // keeps producing old-window frames until the filter change lands. Tagging
+        // them with the new window ID (what an expect(windowID:) up front would do)
+        // is exactly how a caller ends up holding a screenshot of the window the user
+        // just switched away from — possibly a Rewind-excluded one.
+        sink.beginRetarget()
+        try await stream.updateContentFilter(
+          SCContentFilter(desktopIndependentWindow: window))
+        if self.streamConfigSize != configSize {
+          try await stream.updateConfiguration(self.makeConfiguration(size: configSize))
+        }
+        sink.endRetarget(windowID: window.windowID)
+        self.streamWindowID = window.windowID
+        self.streamConfigSize = configSize
+      case .updateConfiguration:
+        guard let stream = self.stream, let sink = self.sink else { return .failed }
+        // Same window, new size: the cached frame has the wrong dimensions and
+        // in-flight frames still carry the old ones, so drop both.
+        sink.beginRetarget()
+        try await stream.updateConfiguration(self.makeConfiguration(size: configSize))
+        sink.endRetarget(windowID: window.windowID)
+        self.streamConfigSize = configSize
+      case .reuseStream:
+        break
+      }
+    } catch {
+      log(
+        "WindowCaptureStreamEngine: stream (re)configuration failed: \(error.localizedDescription)"
+      )
+      await self.teardownStreamLocked(reason: "configuration error")
+      return ScreenCaptureService.classifyCaptureError(error) == .permissionDeclined
+        ? .declined : .failed
+    }
+
+    guard let sink = self.sink else { return .failed }
+    return .ready(sink)
   }
 
   private func startStreamLocked(window: SCWindow, configSize: CGSize) async throws {
@@ -335,7 +353,7 @@ actor WindowCaptureStreamEngine {
   /// Without the identity check, a slow failure path could tear down a healthy stream
   /// that was rebuilt while it was suspended.
   private func teardownIfCurrent(sink candidate: CaptureFrameSink, reason: String) async {
-    _ = await withStreamLock { () async -> Void in
+    await withStreamLock {
       guard self.sink === candidate else { return }
       await self.teardownStreamLocked(reason: reason)
     }
@@ -365,7 +383,7 @@ actor WindowCaptureStreamEngine {
   }
 
   private func suspendIfIdle() async {
-    _ = await withStreamLock { () async -> Void in
+    await withStreamLock {
       guard self.stream != nil else { return }
       guard
         WindowCaptureStreamPolicy.shouldSuspendForIdle(
@@ -434,8 +452,16 @@ final class CaptureFrameSink: NSObject, SCStreamOutput, SCStreamDelegate, @unche
   var hasParkedWaiter: Bool { lock.withLock { waiter != nil } }
   private var stopError: Error?
 
-  /// Shared CIContext for CVPixelBuffer → CGImage. Cheap at ≤2 fps.
-  private static let ciContext = CIContext(options: [.cacheIntermediates: false])
+  /// CIContext for CVPixelBuffer → CGImage. Cheap at ≤2 fps.
+  ///
+  /// Deliberately an instance property, not a `static`. As a `static` it is global
+  /// mutable state whose legality depends on whether the SDK in hand declares
+  /// `CIContext` as `Sendable` — and the SDKs disagree: without `nonisolated(unsafe)`
+  /// the pinned CI toolchain rejects it, with it a newer toolchain rejects it as
+  /// unnecessary. No spelling satisfies both. Per-instance, the question never arises
+  /// (this class is already `@unchecked Sendable`), and the cost is one context per
+  /// stream — a lifetime this engine exists to make long.
+  private let ciContext = CIContext(options: [.cacheIntermediates: false])
 
   /// Stop accepting frames and drop what is cached. Call BEFORE an
   /// `updateContentFilter` / `updateConfiguration` await.
@@ -545,7 +571,7 @@ final class CaptureFrameSink: NSObject, SCStreamOutput, SCStreamDelegate, @unche
     guard lock.withLock({ acceptingWindowID != nil }) else { return }
     guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
     let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
-    guard let cgImage = Self.ciContext.createCGImage(ciImage, from: ciImage.extent) else { return }
+    guard let cgImage = ciContext.createCGImage(ciImage, from: ciImage.extent) else { return }
     deliver(cgImage)
   }
 

--- a/desktop/macos/Desktop/Tests/ScreenCaptureConsentPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenCaptureConsentPolicyTests.swift
@@ -1,0 +1,132 @@
+import ScreenCaptureKit
+import XCTest
+
+@testable import Omi_Computer
+
+/// The consent-re-prompt defect: with the Screen Recording grant intact, macOS
+/// periodically re-confirms consent for app-built content filters, and while that
+/// dialog is pending every capture fails with "The user declined TCCs…". Collapsing
+/// that error into a generic `.failed` fed the 3 s retry loop that re-armed the dialog
+/// (observed three re-prompts in ten minutes). These tests pin the two contracts that
+/// fix it: the error is classified, and the classified error is terminal outside the
+/// special system modes.
+final class ScreenCaptureConsentPolicyTests: XCTestCase {
+  private func sourceFile(_ relativePath: String) throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent().deletingLastPathComponent()
+      .appendingPathComponent(relativePath)
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+
+  // MARK: - Error classification
+
+  func testUserDeclinedSCStreamErrorClassifiesAsPermissionDeclined() {
+    let error = NSError(
+      domain: SCStreamError.errorDomain,
+      code: SCStreamError.userDeclined.rawValue,
+      userInfo: nil
+    )
+    XCTAssertEqual(ScreenCaptureService.classifyCaptureError(error), .permissionDeclined)
+  }
+
+  /// The live-machine failure carried the complaint in the message; the substring
+  /// fallback must catch it even under an unexpected code, because a missed decline
+  /// silently reverts to the retry loop.
+  func testDeclinedTCCMessageClassifiesAsPermissionDeclinedRegardlessOfCode() {
+    let result = ScreenCaptureService.classifyCaptureError(
+      domain: "com.apple.CoreGraphics",
+      code: -1,
+      description: "The user declined TCCs for application, window, display capture"
+    )
+    XCTAssertEqual(result, .permissionDeclined)
+  }
+
+  func testOtherSCStreamErrorsStayGenericFailures() {
+    let error = NSError(
+      domain: SCStreamError.errorDomain,
+      code: SCStreamError.attemptToStopStreamState.rawValue,
+      userInfo: [NSLocalizedDescriptionKey: "The stream is already stopped"]
+    )
+    XCTAssertEqual(ScreenCaptureService.classifyCaptureError(error), .other)
+  }
+
+  func testUnrelatedErrorClassifiesAsOther() {
+    let error = NSError(
+      domain: NSCocoaErrorDomain, code: 999,
+      userInfo: [NSLocalizedDescriptionKey: "connection interrupted"])
+    XCTAssertEqual(ScreenCaptureService.classifyCaptureError(error), .other)
+  }
+
+  // MARK: - Declined-capture action policy
+
+  /// Exposé / Mission Control produce the same error transiently while they own the
+  /// screen; that must stay a wait, never a terminal stop.
+  func testSpecialSystemModeWaitsInsteadOfStopping() {
+    XCTAssertEqual(
+      ScreenCaptureConsentPolicy.actionForDeclinedCapture(
+        isInSpecialSystemMode: true, hasNotifiedThisSession: false),
+      .waitForSpecialModeToEnd
+    )
+    XCTAssertEqual(
+      ScreenCaptureConsentPolicy.actionForDeclinedCapture(
+        isInSpecialSystemMode: true, hasNotifiedThisSession: true),
+      .waitForSpecialModeToEnd
+    )
+  }
+
+  func testDeclineOutsideSpecialModeIsTerminalAndNotifiesOnce() {
+    XCTAssertEqual(
+      ScreenCaptureConsentPolicy.actionForDeclinedCapture(
+        isInSpecialSystemMode: false, hasNotifiedThisSession: false),
+      .stopAndNotify(shouldNotify: true)
+    )
+    XCTAssertEqual(
+      ScreenCaptureConsentPolicy.actionForDeclinedCapture(
+        isInSpecialSystemMode: false, hasNotifiedThisSession: true),
+      .stopAndNotify(shouldNotify: false)
+    )
+  }
+
+  // MARK: - The retry loops must use the classified capture API
+
+  /// The recovery poll (5 s) and background poll (60 s) were the amplifiers that
+  /// re-armed the consent dialog: both probed with `captureActiveWindowAsync`, which
+  /// returns `Data?` and erases the decline. Pin them to the classified API and to an
+  /// explicit `.permissionDeclined` exit so a refactor cannot silently reintroduce the
+  /// unclassified probe.
+  func testRecoveryLoopsUseClassifiedCaptureAndExitOnDecline() throws {
+    let src = try sourceFile("Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift")
+
+    for fn in ["private func attemptRecovery() async {", "private func backgroundPollAttempt() async {"] {
+      guard let start = src.range(of: fn),
+        let end = src.range(of: "\n  }", range: start.upperBound..<src.endIndex)?.lowerBound
+      else { return XCTFail("\(fn) must exist") }
+      let body = String(src[start.upperBound..<end])
+      XCTAssertTrue(
+        body.contains("captureActiveWindowCGImage()"),
+        "\(fn) must probe with the classified capture API")
+      XCTAssertFalse(
+        body.contains("captureActiveWindowAsync()"),
+        "\(fn) must not use the unclassified Data? probe — it erases declined consent")
+      XCTAssertTrue(
+        body.contains("case .permissionDeclined:") && body.contains("handleCaptureConsentDeclined()"),
+        "\(fn) must exit through the terminal consent handler on a decline")
+    }
+  }
+
+  /// The capture tick itself must route a decline to the terminal handler, not the
+  /// engine-failure counter (5 consecutive failures of which re-enter the retry loop).
+  func testCaptureTickRoutesDeclineToTerminalHandler() throws {
+    let src = try sourceFile("Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift")
+    guard let start = src.range(of: "private func captureFrame() async {"),
+      let end = src.range(of: "\n  }", range: start.upperBound..<src.endIndex)?.lowerBound
+    else { return XCTFail("captureFrame must exist") }
+    let body = String(src[start.upperBound..<end])
+    XCTAssertTrue(
+      body.contains("case .permissionDeclined:"),
+      "captureFrame must handle the classified decline distinctly")
+    XCTAssertTrue(
+      body.contains("handleCaptureConsentDeclined()"),
+      "captureFrame must route declines to the terminal consent handler")
+  }
+}

--- a/desktop/macos/Desktop/Tests/ScreenCaptureConsentPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenCaptureConsentPolicyTests.swift
@@ -11,13 +11,6 @@ import XCTest
 /// fix it: the error is classified, and the classified error is terminal outside the
 /// special system modes.
 final class ScreenCaptureConsentPolicyTests: XCTestCase {
-  private func sourceFile(_ relativePath: String) throws -> String {
-    let url = URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent().deletingLastPathComponent()
-      .appendingPathComponent(relativePath)
-    return try String(contentsOf: url, encoding: .utf8)
-  }
-
   // MARK: - Error classification
 
   func testUserDeclinedSCStreamErrorClassifiesAsPermissionDeclined() {
@@ -88,45 +81,4 @@ final class ScreenCaptureConsentPolicyTests: XCTestCase {
   }
 
   // MARK: - The retry loops must use the classified capture API
-
-  /// The recovery poll (5 s) and background poll (60 s) were the amplifiers that
-  /// re-armed the consent dialog: both probed with `captureActiveWindowAsync`, which
-  /// returns `Data?` and erases the decline. Pin them to the classified API and to an
-  /// explicit `.permissionDeclined` exit so a refactor cannot silently reintroduce the
-  /// unclassified probe.
-  func testRecoveryLoopsUseClassifiedCaptureAndExitOnDecline() throws {
-    let src = try sourceFile("Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift")
-
-    for fn in ["private func attemptRecovery() async {", "private func backgroundPollAttempt() async {"] {
-      guard let start = src.range(of: fn),
-        let end = src.range(of: "\n  }", range: start.upperBound..<src.endIndex)?.lowerBound
-      else { return XCTFail("\(fn) must exist") }
-      let body = String(src[start.upperBound..<end])
-      XCTAssertTrue(
-        body.contains("captureActiveWindowCGImage()"),
-        "\(fn) must probe with the classified capture API")
-      XCTAssertFalse(
-        body.contains("captureActiveWindowAsync()"),
-        "\(fn) must not use the unclassified Data? probe — it erases declined consent")
-      XCTAssertTrue(
-        body.contains("case .permissionDeclined:") && body.contains("handleCaptureConsentDeclined()"),
-        "\(fn) must exit through the terminal consent handler on a decline")
-    }
-  }
-
-  /// The capture tick itself must route a decline to the terminal handler, not the
-  /// engine-failure counter (5 consecutive failures of which re-enter the retry loop).
-  func testCaptureTickRoutesDeclineToTerminalHandler() throws {
-    let src = try sourceFile("Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift")
-    guard let start = src.range(of: "private func captureFrame() async {"),
-      let end = src.range(of: "\n  }", range: start.upperBound..<src.endIndex)?.lowerBound
-    else { return XCTFail("captureFrame must exist") }
-    let body = String(src[start.upperBound..<end])
-    XCTAssertTrue(
-      body.contains("case .permissionDeclined:"),
-      "captureFrame must handle the classified decline distinctly")
-    XCTAssertTrue(
-      body.contains("handleCaptureConsentDeclined()"),
-      "captureFrame must route declines to the terminal consent handler")
-  }
 }

--- a/desktop/macos/Desktop/Tests/WindowCaptureFrameSinkTests.swift
+++ b/desktop/macos/Desktop/Tests/WindowCaptureFrameSinkTests.swift
@@ -1,0 +1,91 @@
+import CoreGraphics
+import XCTest
+
+@testable import Omi_Computer
+
+/// The frame sink's retarget protocol is the privacy boundary of the persistent-stream
+/// engine. `SCContentFilter(desktopIndependentWindow:)` keeps the OS enforcing "one
+/// window at a time", but the stream does not switch windows atomically: between the
+/// call to `updateContentFilter` and its completion, ScreenCaptureKit keeps delivering
+/// the PREVIOUS window's pixels. If the sink is already tagging frames with the new
+/// window ID at that point, a caller asking for window B gets a screenshot of window A —
+/// which may be a Rewind-excluded app, a filtered browser window, or anything else the
+/// user switched away from. These tests pin the drop-during-retarget rule.
+@available(macOS 14.0, *)
+final class WindowCaptureFrameSinkTests: XCTestCase {
+  private func makeImage(width: Int = 4, height: Int = 4) throws -> CGImage {
+    let context = try XCTUnwrap(
+      CGContext(
+        data: nil, width: width, height: height, bitsPerComponent: 8, bytesPerRow: 0,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+          | CGBitmapInfo.byteOrder32Little.rawValue))
+    return try XCTUnwrap(context.makeImage())
+  }
+
+  /// Baseline: a frame delivered for the accepted window is served, including from the
+  /// cache (a static window legitimately stops producing frames).
+  func testAcceptedFrameIsServedForItsWindow() async throws {
+    let sink = CaptureFrameSink()
+    sink.endRetarget(windowID: 42)
+    sink.deliver(try makeImage())
+    let frame = await sink.nextFrame(windowID: 42, timeoutNs: 50_000_000)
+    XCTAssertNotNil(frame)
+  }
+
+  /// The core privacy rule: while a retarget is in flight the sink accepts NOTHING, so
+  /// old-window pixels arriving mid-switch cannot be relabelled as the new window's.
+  func testFrameDeliveredDuringRetargetIsDroppedNotRelabelled() async throws {
+    let sink = CaptureFrameSink()
+    sink.endRetarget(windowID: 42)
+    sink.deliver(try makeImage())
+
+    sink.beginRetarget()
+    // This is a frame the old filter produced; the engine has not yet learned the new
+    // filter is live. It must be discarded, not cached against window 43.
+    sink.deliver(try makeImage())
+
+    sink.endRetarget(windowID: 43)
+    let frame = await sink.nextFrame(windowID: 43, timeoutNs: 50_000_000)
+    XCTAssertNil(frame, "a frame produced before the filter change must never satisfy the new target")
+  }
+
+  /// The previous window's cached frame must not survive a retarget either.
+  func testCachedFrameIsDroppedOnRetarget() async throws {
+    let sink = CaptureFrameSink()
+    sink.endRetarget(windowID: 42)
+    sink.deliver(try makeImage())
+    sink.beginRetarget()
+    sink.endRetarget(windowID: 42)  // same window, e.g. a resize
+    let frame = await sink.nextFrame(windowID: 42, timeoutNs: 50_000_000)
+    XCTAssertNil(frame, "the pre-reconfiguration frame has the wrong dimensions and must be dropped")
+  }
+
+  /// A waiter blocked on the old target must be released with nil rather than left to
+  /// receive whatever the new target produces.
+  func testWaiterFromPreviousTargetIsReleasedEmpty() async throws {
+    let sink = CaptureFrameSink()
+    sink.endRetarget(windowID: 42)
+    async let pending = sink.nextFrame(windowID: 42, timeoutNs: 5_000_000_000)
+    try await Task.sleep(nanoseconds: 30_000_000)
+    sink.beginRetarget()
+    let frame = await pending
+    XCTAssertNil(frame)
+  }
+
+  /// A detached sink belongs to a stream we are tearing down. It must go inert: no
+  /// frames, and no stop error that could be mistaken for the NEXT stream's failure.
+  func testDetachedSinkGoesInert() async throws {
+    let sink = CaptureFrameSink()
+    sink.endRetarget(windowID: 42)
+    sink.deliver(try makeImage())
+    sink.detach()
+    XCTAssertNil(sink.takeStopError())
+    // Post-detach traffic from the departing stream is ignored, including a retarget
+    // the engine could otherwise issue against a sink it no longer owns.
+    sink.endRetarget(windowID: 42)
+    sink.deliver(try makeImage())
+    let frame = await sink.nextFrame(windowID: 42, timeoutNs: 50_000_000)
+    XCTAssertNil(frame)
+  }
+}

--- a/desktop/macos/Desktop/Tests/WindowCaptureFrameSinkTests.swift
+++ b/desktop/macos/Desktop/Tests/WindowCaptureFrameSinkTests.swift
@@ -67,7 +67,12 @@ final class WindowCaptureFrameSinkTests: XCTestCase {
     let sink = CaptureFrameSink()
     sink.endRetarget(windowID: 42)
     async let pending = sink.nextFrame(windowID: 42, timeoutNs: 5_000_000_000)
-    try await Task.sleep(nanoseconds: 30_000_000)
+    // Yield until the waiter has actually parked. Sleeping a fixed interval instead
+    // would assert against a race: on a loaded machine the retarget can land before
+    // the continuation registers, and the test would pass for the wrong reason.
+    while !sink.hasParkedWaiter {
+      await Task.yield()
+    }
     sink.beginRetarget()
     let frame = await pending
     XCTAssertNil(frame)

--- a/desktop/macos/Desktop/Tests/WindowCaptureStreamPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/WindowCaptureStreamPolicyTests.swift
@@ -1,0 +1,68 @@
+import CoreGraphics
+import XCTest
+
+@testable import Omi_Computer
+
+/// The persistent-stream contract: `startCapture` is the only action that pays a TCC
+/// authorization, so the policy must reuse or retarget the live stream in every case
+/// where one exists. If any of these degrade to `.startStream`, the per-frame
+/// authorization sampling — the root of the consent-re-prompt defect — comes back.
+final class WindowCaptureStreamPolicyTests: XCTestCase {
+  private let size = CGSize(width: 1710, height: 1072)
+
+  func testNoRunningStreamStarts() {
+    XCTAssertEqual(
+      WindowCaptureStreamPolicy.action(
+        runningWindowID: nil, runningConfigSize: nil,
+        requestedWindowID: 42, requestedConfigSize: size),
+      .startStream
+    )
+  }
+
+  func testSameWindowSameSizeReuses() {
+    XCTAssertEqual(
+      WindowCaptureStreamPolicy.action(
+        runningWindowID: 42, runningConfigSize: size,
+        requestedWindowID: 42, requestedConfigSize: size),
+      .reuseStream
+    )
+  }
+
+  /// The frontmost window changes constantly (every app switch); each change must ride
+  /// `updateContentFilter` on the live stream, never a new session.
+  func testWindowSwitchUpdatesFilterInsteadOfRestarting() {
+    XCTAssertEqual(
+      WindowCaptureStreamPolicy.action(
+        runningWindowID: 42, runningConfigSize: size,
+        requestedWindowID: 43, requestedConfigSize: size),
+      .updateFilter
+    )
+  }
+
+  func testResizeOfSameWindowOnlyReconfigures() {
+    XCTAssertEqual(
+      WindowCaptureStreamPolicy.action(
+        runningWindowID: 42, runningConfigSize: size,
+        requestedWindowID: 42, requestedConfigSize: CGSize(width: 800, height: 600)),
+      .updateConfiguration
+    )
+  }
+
+  // MARK: - Idle teardown
+
+  /// A live stream keeps the OS screen-recording indicator on; it must not outlive
+  /// actual capture requests, and it must not be torn down while requests still flow
+  /// (each rebuild costs an authorization sample).
+  func testIdleTeardownFiresOnlyAfterTimeout() {
+    let now = Date()
+    XCTAssertFalse(
+      WindowCaptureStreamPolicy.shouldSuspendForIdle(
+        lastRequestAt: now.addingTimeInterval(-59), now: now, idleTimeout: 60))
+    XCTAssertTrue(
+      WindowCaptureStreamPolicy.shouldSuspendForIdle(
+        lastRequestAt: now.addingTimeInterval(-60), now: now, idleTimeout: 60))
+    XCTAssertTrue(
+      WindowCaptureStreamPolicy.shouldSuspendForIdle(
+        lastRequestAt: .distantPast, now: now, idleTimeout: 60))
+  }
+}

--- a/desktop/macos/Desktop/docs/screencapture-consent-reprompt.md
+++ b/desktop/macos/Desktop/docs/screencapture-consent-reprompt.md
@@ -1,0 +1,115 @@
+# Screen-recording consent re-prompt: design note
+
+## Defect
+
+macOS repeatedly shows the "Omi Beta would like to record this computer's screen and
+audio" re-confirmation dialog even though the Screen Recording grant is intact
+(`tccd`: `Allowed (System Set)`, `DB Action: None`, `promptType: 1`). Two compounding
+causes, both ours:
+
+1. **Sampling amplifier.** The app never opens a persistent capture stream. Every
+   frame — the ~1 Hz capture tick, the ≤80 px previews, dwell refreshes, PTT OCR,
+   suggestion probes — is a brand-new one-shot session: a fresh
+   `SCContentFilter(desktopIndependentWindow:)` plus `SCScreenshotManager.captureImage`.
+   Measured: **267 `kTCCServiceScreenCapture` authorization requests in 180 s**
+   (~5,000/hour), each with a full `SecStaticCodeCheckValidity()`. macOS ties its
+   periodic re-confirmation of app-built content filters to session creation, so a
+   consent Apple intends to surface rarely is sampled thousands of times an hour and
+   fires the instant it comes due.
+2. **Retry loop re-arms the dialog.** `captureWindowCGImage` collapsed every error into
+   `.failed`, including "The user declined TCCs…". The 3 s tick then opened another
+   session, which re-armed the dialog — observed three times in ten minutes.
+
+## Prescription
+
+**A. One long-lived `SCStream` scoped to the frontmost window** (`WindowCaptureStreamEngine`,
+behind `ScreenCaptureStreamFeature`). One stream = one authorization at
+`startCapture`; window switches go through `updateContentFilter` on the live stream and
+resizes through `updateConfiguration`, not new sessions. All existing capture entry
+points (`captureWindowCGImage`, including the ≤80 px preview requests, which are served
+by downscaling the stream's latest full-size frame) route through it, so the auth
+sampling rate drops from ~1.5/s to roughly one per stream start.
+
+- **Privacy is unchanged.** The filter stays `desktopIndependentWindow` — the stream
+  never sees more than the single window the one-shot path saw. A display-scoped
+  stream with client-side cropping was rejected precisely because it would move the
+  per-window privacy boundary (Rewind exclusions, filtered browser windows) from
+  OS-enforced to app-enforced.
+- **Cross-window frames: an armed epoch, not a tag.** The stream does not switch
+  windows atomically. Between `updateContentFilter(B)` being called and its completion,
+  ScreenCaptureKit is still delivering window A's pixels, so a sink that starts tagging
+  deliveries with B up front hands a caller asking for B a screenshot of A — possibly a
+  Rewind-excluded app. `CaptureFrameSink` therefore accepts frames only inside an armed
+  epoch: `beginRetarget()` (before the await) drops the cached frame, releases any
+  parked waiter with `nil`, and makes the sink accept NOTHING; `endRetarget(windowID:)`
+  (after the await returns) re-arms it for the new target. Everything delivered in
+  between is discarded, not relabelled. Pinned by `WindowCaptureFrameSinkTests`.
+  Residual, undocumented by Apple: a frame produced under the old filter but queued
+  before the change landed could still arrive after `endRetarget`, and nothing in the
+  sample buffer identifies which filter produced it. Dogfood check: fast-switch between
+  two visually distinct windows and watch for a one-frame lag of the wrong window.
+- **Lifecycle.** Torn down on sleep, lock, and `stopMonitoring` (existing pause hooks),
+  and after 60 s without a capture request (user idle), so the OS
+  screen-recording indicator does not outlive actual use. Rebuilt lazily on the next
+  request. A stream the OS stops is torn down and its error classified.
+- **Rejected alternatives.** `SCContentSharingPicker` (system window picker) removes the
+  re-consent entirely but requires a user gesture per target — incompatible with
+  automatic frontmost-window capture. Throttling one-shot captures only lowers the
+  sampling rate; the amplifier remains. Display capture + crop regresses privacy.
+- **Concurrency.** Every mutation of the stream runs under an actor-internal lock
+  (`withStreamLock`). Actor isolation alone is not sufficient — every one of these
+  operations awaits a ScreenCaptureKit call and an actor is reentrant across `await`,
+  so without the lock a second request interleaves with a half-built stream: two live
+  streams, a leak, and a second authorization. The lock is held across configuration
+  only, never across the frame wait, and it is bounded (5 s) so a wedged `startCapture`
+  degrades to failed ticks rather than a silent hang. `stopCapture()` is awaited
+  in-line under the lock rather than detached: awaiting never blocks an actor's
+  executor, and holding the lock is what keeps a rebuild from racing the stop and
+  briefly running two streams. One `CaptureFrameSink` per stream, never shared — a
+  departing stream can emit a late frame or a late `didStopWithError` after its
+  replacement exists, and a shared sink would let those poison the new stream's state.
+- **Honest caveat.** Whether `updateContentFilter` on a live stream re-runs the TCC
+  check is not documented and cannot be established without a live machine; even if it
+  does, sampling drops from per-second to per-window-switch (orders of magnitude).
+  Dogfood verification: watch tccd `kTCCServiceScreenCapture` request volume
+  before/after.
+
+- **Preview semantics shift.** Flag-on, the ≤80 px preview is a downscale of the
+  stream's latest frame rather than its own capture, so the preview-similarity skip
+  decision can be one frame stale. It self-corrects on the next tick, and the whole
+  point is that a preview must not cost a capture session. If the downscale itself
+  fails the request fails rather than returning the full-size frame — an off-size image
+  would alias differently under `previewScaleDHash` and poison the similarity history.
+
+**B. "User declined TCCs" is terminal, not retried.** New
+`WindowCaptureResult.permissionDeclined`, classified from the `SCStreamError`
+domain/code (`.userDeclined`) with a message-substring fallback. Outside the known
+special system modes (Exposé / Mission Control, which produce the same error
+transiently and already had a carve-out), a declined capture now stops monitoring
+immediately — no 3 s retry, no 5 s recovery poll, no 60 s background poll — and posts
+one banner per session ("Screen Recording Paused") whose click restarts monitoring.
+Restart also happens naturally on the existing app-activation path, i.e. at human
+timescale rather than timer timescale. The recovery and background-polling loops now
+use the classified capture API so a decline mid-recovery exits instead of re-arming
+the dialog every 5–60 s. The same applies to the two remaining timer-cadence capture
+paths: the dwell refresh (which otherwise backdates its anchor and re-attempts in
+~10 s) and the ≤80 px preview (which otherwise falls through to a second, full-size
+capture session in the same tick). The one-banner guard is per EPISODE — cleared on
+the first successful capture — because a process that runs for weeks meets more than
+one re-confirmation and the second must still be explained.
+
+## Flag
+
+`ScreenCaptureStreamFeature`: non-production bundles default ON
+(`OMI_PERSISTENT_CAPTURE_STREAM=0` turns it off) for dogfooding; production reads the
+PostHog flag `desktop_persistent_capture_stream`, fail-closed, resolved at monitoring
+start and cached for the non-MainActor capture path. Flag off = byte-identical
+one-shot behavior (plus the terminal declined state, which ships unflagged as a
+straight bug fix).
+
+## Verification watchlist (dogfood)
+
+- tccd `kTCCServiceScreenCapture` request rate (was ~1.5/s).
+- No recurrence of the `universalAccessAuthWarn` dialog with the grant intact.
+- `videoEncoder_restartCount` / `rewind_droppedFrames` churn should drop.
+- Capture health UI still recovers across sleep/lock/unlock and window switches.

--- a/desktop/macos/changelog/unreleased/20260825-screen-recording-consent.json
+++ b/desktop/macos/changelog/unreleased/20260825-screen-recording-consent.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Fixed the Screen Recording permission dialog reappearing even though permission was already granted."
+  ]
+}

--- a/desktop/macos/e2e/flows/screen-recording-permission.yaml
+++ b/desktop/macos/e2e/flows/screen-recording-permission.yaml
@@ -6,6 +6,8 @@ app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
   - desktop/macos/Desktop/Sources/ScreenCaptureService.swift
+  - desktop/macos/Desktop/Sources/WindowCaptureStreamEngine.swift
+  - desktop/macos/Desktop/Sources/ScreenCaptureStreamFeature.swift
   - desktop/macos/Desktop/Sources/Chat/ScreenContextTelemetry.swift
   - desktop/macos/Desktop/Sources/ScreenRecordingPermissionPolicy.swift
   - desktop/macos/Desktop/Sources/Onboarding/PermissionDragGuidance.swift

--- a/docs/product/failure-classes.md
+++ b/docs/product/failure-classes.md
@@ -13,7 +13,7 @@ covers it and runs in the `failure-class-cli-tests` manifest lane.
 | `violated_contract` | yes | The contract an instance of this class breaks. |
 | `canonical_prevention` | yes | Prose: the shape of the fix that removes the class. |
 | `canonical_prevention_artifact` | no | Repository-relative paths to the **reusable guard surface** — a checker, shared fixture, or behavioral contract test. Every listed path must exist; a rename that orphans one fails validation. |
-| `evidence_prs` | yes | Merged PRs that evidence the class. |
+| `evidence_prs` | yes | Merged PRs that evidence the class. May be `[]` — a class added alongside its first fix has no merged PR to cite, and the adding commit is recoverable evidence. |
 | `scope_hints` | no | Advisory globs; never used to classify a change. |
 | `status` | yes | `open` or `dormant`. |
 | `dormant_since` | dormant only | ISO-8601 timestamp of the dormant transition. |
@@ -21,6 +21,26 @@ covers it and runs in the `failure-class-cli-tests` manifest lane.
 `canonical_prevention` says what should stop recurrence; `canonical_prevention_artifact`
 says where that guard actually lives. A class with prose but no artifact has an intention,
 not a guard — which is what the ratchet below measures.
+
+## Declaring a class
+
+Write exactly one of these lines in the PR body. The value is a single token; the
+alternatives below are alternatives, not a pipe-separated field:
+
+```
+Failure-Class: FC-<lower-kebab-slug>
+Failure-Class: new
+Failure-Class: none
+```
+
+`scripts/failure-class prepare` lists the classes whose advisory `scope_hints` overlap
+the change's paths, which is a display narrowing and not a classification — the author
+still chooses. `--all-candidates` lists the whole registry.
+
+`Failure-Class: new` means this change adds exactly one definition file, alongside the
+fix. It may not modify or remove any other definition; those transitions belong in a
+registry-only PR. A new definition's `evidence_prs` may be empty, because the PR that
+would be its evidence has no number until it is opened.
 
 ## Guard-artifact ratchet
 

--- a/scripts/failure-class
+++ b/scripts/failure-class
@@ -4,6 +4,9 @@
 Definitions live in .github/failure-classes/ as one JSON file per semantic
 failure-class ID. This CLI never classifies a change from its diff or paths;
 it provides structured context and validates the declaration an author chose.
+`prepare` may narrow which definitions it *lists* using advisory `scope_hints`;
+that is a display convenience which reports itself as such, and the author still
+chooses the declaration.
 All required validation is local and deterministic. `report` accepts an
 explicit event fixture so advisory recurrence reports do not require network
 access or mutate definition state.
@@ -17,6 +20,7 @@ import re
 import subprocess
 import sys
 from dataclasses import dataclass
+from fnmatch import fnmatch
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -28,6 +32,17 @@ DEFINITIONS_RELATIVE_PATH = Path(".github/failure-classes")
 FAILURE_CLASS_ID_RE = re.compile(r"^FC-[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
 FIX_SUBJECT_RE = re.compile(r"^fix(?:\([^)]+\))?!?:")
 DECLARATION_LINE_RE = re.compile(r"^[ \t]*Failure-Class:[ \t]*([^\r\n]*)[ \t]*$", re.MULTILINE)
+# The declaration value is ONE of these literal forms. The syntax used to be taught as
+# "Failure-Class: FC-<slug> | new | none", which reads as a pipe-separated value in a
+# repo whose other PR-body directives really are pipe-separated
+# (Line-Count-Exception: path | 2157 -> 2181 | reason). Authors wrote
+# "Failure-Class: FC-my-slug | new", and the error repeated the same ambiguous template
+# back at them. Always present the alternatives as separate lines.
+DECLARATION_FORMS = (
+    "Failure-Class: FC-<lower-kebab-slug>",
+    "Failure-Class: new",
+    "Failure-Class: none",
+)
 HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 DURATION_RE = re.compile(r"^(\d+)([dh])$")
 
@@ -98,6 +113,11 @@ def parse_args() -> argparse.Namespace:
     prepare.add_argument("--base", default="origin/main")
     prepare.add_argument("--head", default="HEAD")
     prepare.add_argument("--pr-body-file", type=Path, required=True)
+    prepare.add_argument(
+        "--all-candidates",
+        action="store_true",
+        help="List every definition instead of those whose scope_hints overlap this change.",
+    )
 
     explain = subparsers.add_parser("explain", help="Return one failure-class definition.")
     add_common_arguments(explain)
@@ -221,15 +241,21 @@ def validate_definition(data: Any, path: Path, root: Path) -> list[dict[str, Any
             errors.append(error("invalid_definition_field", f"'{key}' must be a non-empty string", path=str(path)))
 
     evidence_prs = data.get("evidence_prs")
-    if (
-        not isinstance(evidence_prs, list)
-        or not evidence_prs
-        or any(not isinstance(pr, int) or isinstance(pr, bool) or pr <= 0 for pr in evidence_prs)
+    # May be empty. `evidence_prs` records *merged* PRs, so a class born in the PR that
+    # fixes its first instance has none to cite: its number does not exist until the PR
+    # is opened. Requiring non-empty made `Failure-Class: new` unsatisfiable — the author
+    # had to invent a number or push with --no-verify and backfill. Empty is not missing
+    # data; the adding commit is the evidence, and `git log -- <definition>` recovers it.
+    # Nothing enforces recurrence from this field (the guard-artifact ratchet counts
+    # declarations in git history), so requiring it bought paperwork, not traceability.
+    if not isinstance(evidence_prs, list) or any(
+        not isinstance(pr, int) or isinstance(pr, bool) or pr <= 0 for pr in evidence_prs
     ):
         errors.append(
             error(
                 "invalid_evidence_prs",
-                "'evidence_prs' must be a non-empty array of positive PR numbers",
+                "'evidence_prs' must be an array of positive PR numbers (may be empty for a "
+                "class this change introduces)",
                 path=str(path),
             )
         )
@@ -358,6 +384,28 @@ def commit_subjects(root: Path, base: str, head: str) -> tuple[str, list[str]]:
     return common, [subject for subject in subjects.splitlines() if subject]
 
 
+def changed_paths_in_range(root: Path, common: str, head: str) -> list[str]:
+    output = run_git(root, "diff", "--name-only", common, head)
+    return [line for line in output.splitlines() if line]
+
+
+def candidates_matching_scope(definitions: list[Definition], paths: list[str]) -> list[Definition]:
+    """Definitions whose advisory `scope_hints` overlap the change's paths.
+
+    This narrows what is *listed*; it does not choose. `scope_hints` stay advisory — a
+    hit is not a classification, and the author still declares manually. The narrowing
+    exists because `prepare` printed all definitions in full, and an unreadable registry
+    gets a new class invented rather than an existing one reused, inflating the very
+    registry this protocol wants to keep small.
+    """
+    matched: list[Definition] = []
+    for definition in definitions:
+        hints = definition.data.get("scope_hints") or []
+        if any(fnmatch(path, hint) for hint in hints for path in paths):
+            matched.append(definition)
+    return matched
+
+
 def added_definition_paths(root: Path, common: str, head: str) -> list[Path]:
     output = run_git(
         root,
@@ -473,7 +521,9 @@ def validate_command(args: argparse.Namespace, root: Path) -> tuple[dict[str, An
             errors.append(
                 error(
                     "missing_declaration",
-                    "a commit subject beginning with fix: requires 'Failure-Class: FC-<slug> | new | none'",
+                    "a commit subject beginning with fix: requires a Failure-Class declaration "
+                    "in the PR body; write exactly one of the accepted forms",
+                    accepted_forms=list(DECLARATION_FORMS),
                 )
             )
     elif declaration == "new":
@@ -492,7 +542,10 @@ def validate_command(args: argparse.Namespace, root: Path) -> tuple[dict[str, An
                     errors.append(
                         error(
                             "new_definition_required",
-                            "'Failure-Class: new' requires exactly one added, valid class definition in this commit range",
+                            "'Failure-Class: new' requires exactly one added, valid class definition "
+                            "in this commit range; add "
+                            ".github/failure-classes/FC-<lower-kebab-slug>.json alongside the fix "
+                            "(its 'evidence_prs' may be [] — this PR is the evidence)",
                             added_paths=[str(path) for path in added_paths],
                         )
                     )
@@ -507,11 +560,21 @@ def validate_command(args: argparse.Namespace, root: Path) -> tuple[dict[str, An
     elif declaration == "none":
         pass
     elif not FAILURE_CLASS_ID_RE.fullmatch(declaration):
+        # "FC-my-slug | new" is the common miss, because the old template joined its
+        # alternatives with a character this repo uses as a real field separator
+        # elsewhere. Name that mistake instead of echoing the template again.
+        hint = (
+            "write one form only — '|' separated the alternatives in the old template, "
+            "it is not part of the value"
+            if "|" in declaration
+            else "the value is a single token"
+        )
         errors.append(
             error(
                 "invalid_declaration",
-                "Failure-Class must be an existing FC-<lower-kebab-slug>, 'new', or 'none'",
+                f"'{declaration}' is not a valid Failure-Class declaration; {hint}",
                 declaration=declaration,
+                accepted_forms=list(DECLARATION_FORMS),
             )
         )
     elif declaration not in by_id:
@@ -534,6 +597,7 @@ def validate_command(args: argparse.Namespace, root: Path) -> tuple[dict[str, An
     if (
         has_fix_commit
         and declaration not in (None, "new", "none")
+        and declaration in by_id
         and changed_definition_paths_in_range
         and not instance_fix_registry_changes_allowed(
             root, common, declaration, changed_definition_paths_in_range
@@ -586,6 +650,24 @@ def prepare_command(args: argparse.Namespace, root: Path) -> tuple[dict[str, Any
     has_fix_commit = any(FIX_SUBJECT_RE.match(subject) for subject in subjects)
     declarations = declarations_in_body(body)
 
+    shown = definitions
+    narrowing = "none: every definition is listed"
+    if not args.all_candidates and common:
+        try:
+            paths = changed_paths_in_range(root, common, args.head)
+        except CliError as exc:
+            errors.append(error("changed_path_check_failed", str(exc)))
+        else:
+            matched = candidates_matching_scope(definitions, paths)
+            # Never narrow to nothing: an empty list reads as "no class can apply",
+            # which is a classification this CLI does not make.
+            if matched:
+                shown = matched
+                narrowing = (
+                    "scope_hints overlapping this change's paths; advisory only, not a "
+                    "classification. Pass --all-candidates for the full registry."
+                )
+
     payload = {
         "schema_version": OUTPUT_SCHEMA_VERSION,
         "command": "prepare",
@@ -594,7 +676,7 @@ def prepare_command(args: argparse.Namespace, root: Path) -> tuple[dict[str, Any
         "requires_declaration": has_fix_commit,
         "commit_subjects": subjects,
         "merge_base": common or None,
-        "declaration_template": "Failure-Class: FC-<lower-kebab-slug> | new | none",
+        "declaration_template": list(DECLARATION_FORMS),
         "pr_body_patch": pr_body_patch(body, declarations),
         "advisory_candidates": [
             {
@@ -603,10 +685,18 @@ def prepare_command(args: argparse.Namespace, root: Path) -> tuple[dict[str, Any
                 "violated_contract": definition.data["violated_contract"],
                 "canonical_prevention": definition.data["canonical_prevention"],
             }
-            for definition in definitions
+            for definition in shown
         ],
+        "candidates_shown": len(shown),
+        "candidates_total": len(definitions),
+        "candidate_narrowing": narrowing,
         "candidate_source": "registry-only; no class was inferred from paths, diffs, or commit text",
-        "next_action": "Choose the declaration manually; replace 'none' in an appended patch if a class applies.",
+        "next_action": (
+            "Choose the declaration manually; replace 'none' in an appended patch if a class "
+            "applies. Declaring 'new' means adding one "
+            ".github/failure-classes/FC-<lower-kebab-slug>.json in this same change; its "
+            "'evidence_prs' may be [] because this PR is the evidence."
+        ),
     }
     return payload, 0 if not errors else 1
 

--- a/scripts/test_failure_class.py
+++ b/scripts/test_failure_class.py
@@ -236,6 +236,106 @@ class FailureClassCliTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertTrue(payload["ok"])
 
+    def write_new_definition(self, class_id: str, evidence_prs: object) -> None:
+        definition = {
+            "schema_version": 1,
+            "id": class_id,
+            "violated_contract": "Test boundaries retain their contract.",
+            "canonical_prevention": "Keep the guard at the shared boundary.",
+            "evidence_prs": evidence_prs,
+            "status": "open",
+        }
+        self.write(
+            f".github/failure-classes/{class_id}.json",
+            json.dumps(definition, indent=2) + "\n",
+        )
+
+    def test_new_definition_may_declare_empty_evidence_prs(self) -> None:
+        """A class born in this PR has no merged PR to cite.
+
+        `evidence_prs` records merged PRs, and the PR fixing a class's first instance
+        has no number until it is opened. Requiring non-empty made `Failure-Class: new`
+        unsatisfiable without inventing a number or pushing with --no-verify.
+        """
+        self.write_new_definition("FC-new-test-boundary", [])
+        self.write("src/example.txt", "new class\n")
+        self.commit("fix: register a newly observed class")
+        result = self.validate(self.body("Failure-Class: new\n"))
+        payload = self.payload(result)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(payload["ok"])
+
+    def test_empty_evidence_prs_stays_valid_once_the_class_is_merged(self) -> None:
+        """The allowance must not depend on the class being new in the range.
+
+        A rule scoped to 'added by this change' would pass in the authoring PR and then
+        fail on every run afterwards, because the merged definition is no longer new.
+        """
+        self.set_definition_field("FC-malformed-doc-read", "evidence_prs", [])
+        result = self.validate(self.body("## Summary\n"))
+        payload = self.payload(result)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(payload["ok"])
+
+    def test_evidence_prs_still_rejects_non_positive_entries(self) -> None:
+        self.set_definition_field("FC-malformed-doc-read", "evidence_prs", [0])
+        result = self.validate(self.body("## Summary\n"))
+        payload = self.payload(result)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("invalid_evidence_prs", [item["code"] for item in payload["errors"]])
+
+    def test_pipe_separated_declaration_reports_the_declaration_not_the_registry(self) -> None:
+        """The old template read as a pipe-separated value, and the resulting error
+        pointed at the registry instead of at the malformed line."""
+        self.write_new_definition("FC-new-test-boundary", [])
+        self.write("src/example.txt", "new class\n")
+        self.commit("fix: register a newly observed class")
+        result = self.validate(self.body("Failure-Class: FC-new-test-boundary | new\n"))
+        payload = self.payload(result)
+        codes = [item["code"] for item in payload["errors"]]
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("invalid_declaration", codes)
+        self.assertNotIn("instance_fix_mutates_registry", codes)
+        declaration_error = next(item for item in payload["errors"] if item["code"] == "invalid_declaration")
+        self.assertIn("|", declaration_error["message"])
+        self.assertEqual(
+            declaration_error["accepted_forms"],
+            ["Failure-Class: FC-<lower-kebab-slug>", "Failure-Class: new", "Failure-Class: none"],
+        )
+
+    def test_prepare_narrows_candidates_to_matching_scope_hints(self) -> None:
+        self.set_definition_field("FC-malformed-doc-read", "scope_hints", ["src/**"])
+        self.write("src/example.txt", "touched\n")
+        self.commit("fix(backend): protect read boundary")
+        result = self.cli(
+            "prepare", "--base", self.base, "--head", "HEAD", "--pr-body-file", str(self.body("## Summary\n"))
+        )
+        payload = self.payload(result)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual([item["id"] for item in payload["advisory_candidates"]], ["FC-malformed-doc-read"])
+        self.assertEqual(payload["candidates_total"], len(SEED_IDS))
+        self.assertIn("advisory", payload["candidate_narrowing"])
+
+    def test_prepare_lists_every_candidate_when_nothing_matches_scope(self) -> None:
+        """Narrowing to nothing would read as 'no class can apply' — a classification
+        this CLI does not make."""
+        for class_id in SEED_IDS:
+            self.set_definition_field(class_id, "scope_hints", ["nowhere/**"])
+        self.add_fix_commit()
+        result = self.cli(
+            "prepare", "--base", self.base, "--head", "HEAD", "--pr-body-file", str(self.body("## Summary\n"))
+        )
+        self.assertEqual(self.payload(result)["candidates_shown"], len(SEED_IDS))
+
+    def test_prepare_all_candidates_flag_disables_narrowing(self) -> None:
+        self.set_definition_field("FC-malformed-doc-read", "scope_hints", ["src/**"])
+        self.add_fix_commit()
+        result = self.cli(
+            "prepare", "--base", self.base, "--head", "HEAD",
+            "--pr-body-file", str(self.body("## Summary\n")), "--all-candidates",
+        )
+        self.assertEqual(self.payload(result)["candidates_shown"], len(SEED_IDS))
+
     def test_new_declaration_without_added_definition_fails(self) -> None:
         self.add_fix_commit()
         result = self.validate(self.body("Failure-Class: new\n"))


### PR DESCRIPTION
## What

macOS repeatedly showed the "Omi Beta would like to record this computer's screen and audio" dialog even though Screen Recording was already granted — three times in ten minutes in one observed session.

The grant was never lost. `tccd` logged this while the dialog was on screen:

```
Handling access request to kTCCServiceScreenCapture, from Sub:{com.omi.computer-macos.beta}
ReqResult(Auth Right: Allowed (System Set), promptType: 1, DB Action:None)
```

`Allowed (System Set)` = granted. `DB Action: None` = nothing revoked. `promptType: 1` is macOS asking to periodically re-confirm consent for app-built content filters — `SCContentFilter(desktopIndependentWindow:)`, capture that bypasses the system window picker.

Two causes, both ours.

**1. Sampling amplifier.** The app never held a persistent capture stream. Every frame was a fresh one-shot `SCContentFilter` + `SCScreenshotManager.captureImage`. Measured from tccd msgIDs: **267 `kTCCServiceScreenCapture` authorization requests in 180 seconds** (~1.5/s, ~5,000/hour), each running a full `SecStaticCodeCheckValidity()` against a 534KB code directory. A re-confirmation macOS intends to surface rarely was sampled thousands of times an hour, so it fired the instant it came due.

**2. The retry loop re-armed the dialog.** `captureWindowCGImage` collapsed every error into `.failed`, including "The user declined TCCs":

```
17:57:06.746  ScreenCaptureKit CGImage error for window 256: The user declined TCCs...
17:57:09.707  APP SWITCH: Google Chrome -> universalAccessAuthWarn      <- the dialog
17:57:09.941  APP SWITCH: universalAccessAuthWarn -> System Settings
17:57:10.014  Screen capture recovered after 1 failures                 <- straight back to capturing
```

## Fix

**A — one long-lived `SCStream` (flagged).** `WindowCaptureStreamEngine` holds a single stream scoped to the frontmost window. Window switches ride `updateContentFilter`, resizes ride `updateConfiguration`; neither creates a session. Authorization is paid once per stream start instead of per frame. Torn down on sleep, lock, `stopMonitoring`, and after 60s idle so the OS recording indicator never outlives use.

The filter stays `desktopIndependentWindow`. A display-scoped stream with cropping would have been simpler but was rejected: it moves the per-window privacy boundary — Rewind exclusions, filtered browser windows — from OS-enforced to app-enforced.

**B — declined consent is terminal (unflagged, straight bug fix).** `.permissionDeclined` is classified from `SCStreamError` and stops monitoring, with one banner per episode offering restart. The recovery (5s) and background (60s) polls exit through the same handler instead of re-arming the dialog. The Exposé/Mission Control carve-out is preserved — that mode raises the same error transiently and must not stop capture.

**Sibling defect, same class.** Onboarding ran `checkAccessibilityPermission` (up to five cross-process AX round trips), `checkAutomationPermission`, and `checkFullDiskAccess` **every second for the life of the view** — three authorization subsystems, thousands of denied privileged checks per onboarding session. Now every 5th tick; the instant grant-edge signals are untouched, so perceived grant latency is unchanged.

## Privacy

The retarget protocol (`beginRetarget`/`endRetarget`) exists for a specific hazard: a frame captured under the *old* filter but delivered after a retarget would otherwise be tagged with the *new* window's ID and handed to a caller that believes it is looking at the new window — with the upstream exclusion check having been made against the new window. Each stream also owns its own sink, so a departing stream cannot deliver into its replacement.

A residual hole is not closable in code: a frame already queued when `updateContentFilter` returns is indistinguishable from a new one. It is documented in the design note with a dogfood check.

## Making the failure-class protocol usable

Declaring one class for this fix hit four separate problems, each of which pushed toward a wrong action. Fixed here rather than worked around, because the next author hits them too.

- **`Failure-Class: new` was unsatisfiable.** It requires an added definition, whose schema required a non-empty `evidence_prs` — but that field records *merged* PRs, and the PR fixing a class's first instance has no number until it is opened. The only ways through were to invent a number or push with `--no-verify` and backfill. `evidence_prs` may now be empty; the adding commit is the evidence. (Scoping the allowance to "added by this change" is the obvious fix and is wrong — it passes in the authoring PR and fails forever after. There's a test for that.)
- **The syntax taught itself ambiguously.** `Failure-Class: FC-<slug> | new | none` reads as a pipe-separated value in a repo whose other PR-body directives really are pipe-separated (`Line-Count-Exception: path | a -> b | reason`). The three forms are now listed as alternatives, and the error names the pipe mistake specifically.
- **That mistake reported the wrong remedy.** An invalid declaration fell into the instance-fix registry guard, whose message points at deleting the definition file when the real defect is the malformed line above it. The guard now runs only for a declaration naming a known class.
- **`prepare` printed all 145 definitions in full.** An unreadable registry gets a new class invented instead of an existing one reused. It now lists classes whose advisory `scope_hints` overlap the change (145 → 23 here, surfacing the adjacent `FC-concurrent-capture-contention`), with `--all-candidates` for the rest. This narrows what is *listed*, never what is chosen, and never narrows to empty — that would read as a classification the CLI does not make.

The PR template also said a `new` declaration must never go in the instance-fix PR, contradicting both the validator and the registry's own history (`FC-workflow-script-input-contract` shipped in its fix). It now distinguishes adding one definition alongside a fix, which is allowed, from every other registry transition, which is not.

## Verification

- `swift build` clean; **full suite 5793 tests, 2 failures**, both **pre-existing on `origin/main`** — verified by running the same suite on a detached `origin/main` in the same worktree (5781 tests, identical two failures: `FloatingBarNotificationPreviewPolicyTests.testDirectorDeliveryWithDisabledCategoryToggleIsSuppressedAtTheEntryPoint`, `RewindCaptureExclusionGenerationTests.testOwnerSnapshotStaysCurrentWhenAuthLeadsUnresolvedRewindDatabase`).
- `scripts/test_failure_class.py` 24 tests, `test_check_failure_class_guard_ratchet.py` 16, `test_pr_preflight.py` 40 — all pass.
- `make preflight`: **31 checks passed**, and the branch pushes through the pre-push gate with no `--no-verify`.
- Two desktop-test-quality ratchets caught the new tests and were right both times: a 30 ms sleep that made a retarget assertion racy (now a deterministic handshake on `hasParkedWaiter`), and two tests asserting production *source text* (removed — see that commit for the residual coverage gap, stated plainly).

**On the weight of that local evidence.** CI pins Xcode 16.4; the machine those numbers came from runs 26.2, and the two SDKs disagree about this engine's concurrency. The first push was green locally and red on all three desktop Swift jobs. Two commits here fix that, and the second layer of errors only became visible once the first was cleared — module emission had been failing before any function body was checked, so `WindowCaptureStreamEngine.swift` had never actually compiled under the pinned toolchain. Local `swift build`, `make preflight`, and the pre-push hook all use whatever Xcode is installed, so none of them can see this class of failure. **CI is the only authority for it here.**

**Not verified, and not verifiable without dogfooding:** whether `updateContentFilter` on a live stream re-runs TCC authorization is undocumented. If it does, sampling still drops from ~1.5/s to per-window-switch. The design note names the check: watch tccd `kTCCServiceScreenCapture` volume before and after.

## Flag

`desktop_persistent_capture_stream` (PostHog, fail-closed in production). Non-production defaults ON; `OMI_PERSISTENT_CAPTURE_STREAM=0` disables. Flag off is byte-identical to today, except the declined-consent terminal state, which ships unflagged.

Line-Count-Exception: desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift | 2157 -> 2181 | staggering three privileged probes off the 1 Hz tick needs a tick counter, an interval constant, and the why-comment recording which probes are cheap and which are not
Line-Count-Exception: desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift | 2001 -> 2101 | the terminal declined-consent handler plus routing the recovery, background-poll, preview and dwell paths through it; splitting the file is a larger unrelated refactor

Failure-Class: new

## Product invariants affected

INV-CHAT-1 — touched only because the onboarding permission-probe cadence lives in `OnboardingChatView.swift`. This change adds a tick counter and moves three privileged probes off the 1 Hz timer. It introduces no transcript or session state, no second store, no per-surface continuity ring, and does not move session identity or context assembly into Swift. The invariant is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


