### PR TITLE
fix(app+backend): first-party summaries labeled "Unknown App"; explicit template reprocess failed silently

### DIFF
--- a/app/lib/pages/conversation_detail/conversation_detail_provider.dart
+++ b/app/lib/pages/conversation_detail/conversation_detail_provider.dart
@@ -513,7 +513,12 @@ class ConversationDetailProvider extends ChangeNotifier with MessageNotifierMixi
     final suggestedApp = _cachedSuggestedApps.firstWhereOrNull((app) => app.id == appId);
     if (suggestedApp != null) return suggestedApp;
 
-    return null;
+    // The two caches above only fill after the summary sheet fetches. The durable
+    // app catalog (appProvider.apps) is loaded at startup, so a real app_id must
+    // resolve here instead of rendering "Unknown App" until the sheet is opened
+    // (SCA-359).
+    final providerApp = appProvider?.apps.firstWhereOrNull((app) => app.id == appId);
+    return providerApp;
   }
 
   /// Enables an app and updates the cached enabled apps list

--- a/app/lib/pages/conversation_detail/widgets.dart
+++ b/app/lib/pages/conversation_detail/widgets.dart
@@ -874,6 +874,15 @@ class _AppResultDetailWidgetState extends State<AppResultDetailWidget> {
     _exitEditing();
   }
 
+  /// Attribution label for the summary source. A first-party summary (notes v2
+  /// structured overview, `appId == null`) is Omi's own "Summary" — the same name
+  /// the bottom pill and desktop use; "Unknown App" is reserved for an app result
+  /// whose catalog lookup failed (SCA-359).
+  String _summarySourceLabel(BuildContext context) {
+    if (widget.app != null) return widget.app!.name.decodeString;
+    return widget.appResponse.appId == null ? context.l10n.summary : context.l10n.unknownApp;
+  }
+
   @override
   Widget build(BuildContext context) {
     final String content = widget.appResponse.content.trim().decodeString;
@@ -999,7 +1008,7 @@ class _AppResultDetailWidgetState extends State<AppResultDetailWidget> {
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
                                 Text(
-                                  widget.app != null ? widget.app!.name.decodeString : context.l10n.unknownApp,
+                                  _summarySourceLabel(context),
                                   maxLines: 1,
                                   style: const TextStyle(
                                     fontWeight: FontWeight.w500,
@@ -1427,7 +1436,7 @@ extension _AppResultDetailWidgetSliver on _AppResultDetailWidgetState {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          widget.app != null ? widget.app!.name.decodeString : context.l10n.unknownApp,
+                          _summarySourceLabel(context),
                           maxLines: 1,
                           style: const TextStyle(fontWeight: FontWeight.w500, color: Colors.white, fontSize: 14),
                         ),

--- a/app/lib/widgets/conversation_bottom_bar.dart
+++ b/app/lib/widgets/conversation_bottom_bar.dart
@@ -571,7 +571,7 @@ class _ConversationBottomBarState extends State<ConversationBottomBar> {
       }
     }
 
-    String displayName = 'Summary';
+    String displayName = context.l10n.summary;
     if (isReprocessing && reprocessingApp != null) {
       displayName = reprocessingApp.name;
     } else if (app != null) {

--- a/app/test/providers/conversation_detail_find_app_test.dart
+++ b/app/test/providers/conversation_detail_find_app_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/app.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
+import 'package:omi/providers/app_provider.dart';
+import 'package:omi/providers/conversation_provider.dart';
+
+App _app(String id, String name) => App(
+      id: id,
+      name: name,
+      author: 'tester',
+      description: 'test',
+      image: '',
+      capabilities: {'memories'},
+      status: 'approved',
+      category: 'test',
+      approved: true,
+      ratingCount: 0,
+      enabled: true,
+      deleted: false,
+      isPaid: false,
+      isUserPaid: false,
+    );
+
+ServerConversation _conversation() => ServerConversation(
+      id: 'conv-1',
+      createdAt: DateTime(2026, 7, 1, 9).toUtc(),
+      structured: Structured('Sprint sync', 'Short compatibility paragraph.'),
+    );
+
+ConversationDetailProvider _providerWithApps(List<App> apps) {
+  final provider = ConversationDetailProvider();
+  addTearDown(provider.dispose);
+  provider.selectedDate = conversationLocalDayKey(_conversation().createdAt);
+  provider.setCachedConversation(_conversation());
+  provider.appProvider = AppProvider()..apps = apps;
+  return provider;
+}
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  // SCA-359: findAppById used to search only the two sheet caches, which fill
+  // after the summary sheet fetch. A real app_id therefore rendered "Unknown
+  // App" until the sheet was opened. The durable appProvider.apps catalog —
+  // loaded at startup — is the fallback authority.
+  group('findAppById', () {
+    test('resolves an app from the durable provider catalog when sheet caches are empty', () {
+      final provider = _providerWithApps([_app('app-1', 'My Template')]);
+
+      final found = provider.findAppById('app-1');
+
+      expect(found, isNotNull);
+      expect(found!.name, 'My Template');
+    });
+
+    test('a null appId stays null so first-party summaries render as Summary', () {
+      final provider = _providerWithApps([_app('app-1', 'My Template')]);
+
+      expect(provider.findAppById(null), isNull);
+    });
+
+    test('an id present in no catalog still fails closed to null (Unknown App)', () {
+      final provider = _providerWithApps([_app('app-1', 'My Template')]);
+
+      expect(provider.findAppById('missing-app'), isNull);
+    });
+  });
+}

--- a/app/test/widgets/app_result_summary_source_label_test.dart
+++ b/app/test/widgets/app_result_summary_source_label_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/app.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/gen/conversation_wire.g.dart' as wire;
+import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/conversation_detail/widgets.dart';
+
+ServerConversation _conversationWithSections() {
+  final structured = Structured('Sprint sync', 'Short compatibility paragraph.', emoji: '🧠');
+  structured.sections = [
+    const wire.GeneratedSection(heading: 'Decisions', bodyMarkdown: 'Ship the beta on Friday'),
+  ];
+  return ServerConversation(
+    id: 'conv-1',
+    createdAt: DateTime(2026, 7, 1, 9).toUtc(),
+    structured: structured,
+  );
+}
+
+Future<void> _pumpSummary(WidgetTester tester, {App? app, AppResponse? response, bool asSliver = false}) async {
+  final conversation = _conversationWithSections();
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: ThemeData.dark(),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: asSliver
+            ? CustomScrollView(
+                slivers: [
+                  AppResultDetailWidget(
+                    appResponse: response ?? AppResponse(conversation.structured.overview, appId: null),
+                    app: app,
+                    conversation: conversation,
+                    asSliver: true,
+                  ),
+                ],
+              )
+            : AppResultDetailWidget(
+                appResponse: response ?? AppResponse(conversation.structured.overview, appId: null),
+                app: app,
+                conversation: conversation,
+              ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+App _templateApp() => App(
+      id: 'app-1',
+      name: 'My Template',
+      author: 'tester',
+      description: 'test',
+      image: '',
+      capabilities: {'memories'},
+      status: 'approved',
+      category: 'test',
+      approved: true,
+      ratingCount: 0,
+      enabled: true,
+      deleted: false,
+      isPaid: false,
+      isUserPaid: false,
+    );
+
+void main() {
+  // SCA-359: the summary attribution row used to render "Unknown App" for every
+  // first-party (notes v2) summary because findAppById(null) is null by design.
+  // First-party must label itself "Summary"; "Unknown App" is only for a
+  // non-null app id whose catalog lookup failed.
+  group('summary source label', () {
+    testWidgets('a first-party summary (appId == null) is labeled Summary, not Unknown App', (tester) async {
+      await _pumpSummary(tester, app: null, response: AppResponse('First-party overview', appId: null));
+
+      expect(find.text('Summary'), findsOneWidget);
+      expect(find.text('Unknown App'), findsNothing);
+    });
+
+    testWidgets('the sliver attribution labels a first-party summary Summary too', (tester) async {
+      await _pumpSummary(tester, app: null, asSliver: true);
+
+      expect(find.text('Summary'), findsOneWidget);
+      expect(find.text('Unknown App'), findsNothing);
+    });
+
+    testWidgets('an app result whose catalog lookup failed is Unknown App', (tester) async {
+      await _pumpSummary(tester, app: null, response: AppResponse('App summary', appId: 'missing-app'));
+
+      expect(find.text('Unknown App'), findsOneWidget);
+      expect(find.text('Summary'), findsNothing);
+    });
+
+    testWidgets('a resolved app result shows the app name', (tester) async {
+      await _pumpSummary(tester, app: _templateApp(), response: AppResponse('App summary', appId: 'app-1'));
+
+      expect(find.text('My Template'), findsOneWidget);
+      expect(find.text('Unknown App'), findsNothing);
+    });
+  });
+}

--- a/backend/tests/unit/test_process_conversation_usage_context.py
+++ b/backend/tests/unit/test_process_conversation_usage_context.py
@@ -507,6 +507,88 @@ def test_deferred_derived_effects_emit_nothing_until_runner_invoked(monkeypatch)
     assert submit.call_count >= 4  # vectors, memory, action items, goals, webhook
 
 
+def _explicit_selection_flow_conversation():
+    completed = MagicMock()
+    completed.id = "conversation-explicit-selection"
+    completed.dict.return_value = {"id": "conversation-explicit-selection", "status": "completed"}
+    completed.structured = None  # skip analytics counting
+    completed.apps_results = []
+    completed.suggested_summarization_apps = []
+    completed.private_cloud_sync_enabled = False
+    completed.folder_id = "existing-folder"  # skip folder assignment
+    return completed
+
+
+def _run_explicit_selection_flow(monkeypatch, trigger_apps, update_calls):
+    """Drive process_conversation for an explicit app selection; appends each write to update_calls."""
+    input_conversation = MagicMock()
+    input_conversation.source = "omi"
+    input_conversation.get_person_ids.return_value = []
+    completed = _explicit_selection_flow_conversation()
+
+    monkeypatch.setattr(process_conversation, "_get_structured", lambda *args, **kwargs: (MagicMock(), False))
+    monkeypatch.setattr(process_conversation, "_get_conversation_obj", lambda *args, **kwargs: completed)
+    monkeypatch.setattr(
+        process_conversation.lifecycle_service, "persist_processed_conversation", MagicMock(return_value=True)
+    )
+    monkeypatch.setattr(process_conversation, "submit_with_context", MagicMock())
+    monkeypatch.setattr(process_conversation, "_trigger_apps", trigger_apps)
+    monkeypatch.setattr(process_conversation, "_extract_memories", MagicMock())
+    monkeypatch.setattr(
+        process_conversation.conversations_db,
+        "update_conversation",
+        lambda uid, cid, updates: update_calls.append(updates),
+    )
+
+    return process_conversation.process_conversation(
+        "uid",
+        "en",
+        input_conversation,
+        is_reprocess=True,
+        app_id="selected-app",
+        explicit_app=SimpleNamespace(id="selected-app"),
+    )
+
+
+def test_explicit_selection_success_persists_that_apps_result(monkeypatch):
+    """SCA-359: opt-in + explicit app_id persists the selected app's non-empty result."""
+    monkeypatch.setenv('CONVERSATION_NOTES_V2_ENABLED', 'true')
+
+    def _successful_trigger_apps(uid, conversation, **kwargs):
+        conversation.apps_results.append(process_conversation.AppResult(app_id='selected-app', content='APP SUMMARY'))
+
+    update_calls: list = []
+    result = _run_explicit_selection_flow(monkeypatch, _successful_trigger_apps, update_calls)
+
+    assert result.apps_results == [process_conversation.AppResult(app_id='selected-app', content='APP SUMMARY')]
+    assert {
+        'apps_results': [{'app_id': 'selected-app', 'content': 'APP SUMMARY'}],
+        'suggested_summarization_apps': [],
+    } in (update_calls)
+
+
+def test_explicit_selection_failure_surfaces_a_real_error_and_persists_as_today(monkeypatch):
+    """SCA-359 contract: reprocess with app_id returns the app's result or a real error.
+
+    Never a 200 whose payload quietly substitutes first-party notes for the selected
+    app's summary. The persist-as-today write-back still runs (the ed2ba41c5b opt-in
+    empty persist that clears a stale selection) so the failure contract changes the
+    response, not the durable shape."""
+    monkeypatch.setenv('CONVERSATION_NOTES_V2_ENABLED', 'true')
+
+    def _failing_trigger_apps(uid, conversation, **kwargs):
+        conversation.apps_results = []  # execution failed: nothing appended
+        raise process_conversation.ExplicitAppSelectionFailedError('selected-app produced no summary content')
+
+    update_calls: list = []
+    with pytest.raises(HTTPException) as exc_info:
+        _run_explicit_selection_flow(monkeypatch, _failing_trigger_apps, update_calls)
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.detail == 'Error processing conversation, please try again later'
+    assert {'apps_results': [], 'suggested_summarization_apps': []} in update_calls
+
+
 def test_fresh_creation_uses_the_explicit_completed_lifecycle_owner(monkeypatch):
     new_request = CreateConversation(
         started_at=datetime(2026, 7, 14, tzinfo=timezone.utc),
@@ -1408,6 +1490,89 @@ def test_trigger_apps_does_not_count_non_user_reprocessing(is_reprocess):
     suggestion_mock.assert_not_called()
     app_result_mock.assert_called_once()
     record_usage.assert_not_called()
+
+
+def test_trigger_apps_opt_in_preferred_app_still_auto_runs(monkeypatch):
+    """SCA-359: under notes v2 the Redis preferred app remains the one automatic app run."""
+    monkeypatch.setenv('CONVERSATION_NOTES_V2_ENABLED', 'true')
+    preferred = _make_mock_app('preferred-app', 'PreferredApp')
+    _setup_trigger_apps_mocks(preferred_app_id='preferred-app', available_apps=[preferred])
+    conv = _make_trigger_conversation()
+
+    suggestion_mock, app_result_mock, p1, p2, p3, p4, p5, p6 = _trigger_apps_context()
+    p2 = patch.object(process_conversation, 'get_available_apps', return_value=[preferred])
+    with p1, p2, p3, p4, p5, p6:
+        process_conversation._trigger_apps('user-preferred-opt-in', conv)
+
+    suggestion_mock.assert_not_called()
+    app_result_mock.assert_called_once()
+    assert len(conv.apps_results) == 1
+
+
+def test_trigger_apps_explicit_selection_execution_failure_is_fail_closed(monkeypatch):
+    """SCA-359: an explicitly selected app whose execution fails must not read as success."""
+    monkeypatch.setenv('CONVERSATION_NOTES_V2_ENABLED', 'true')
+    selected = _make_mock_app('selected-app', 'SelectedApp')
+    _setup_trigger_apps_mocks(preferred_app_id=None)
+    conv = _make_trigger_conversation()
+
+    suggestion_mock, app_result_mock, p1, p2, p3, p4, p5, p6 = _trigger_apps_context()
+    app_result_mock.side_effect = RuntimeError('LLM unavailable')
+    with p1, p2, p3, p4, p5, p6:
+        with pytest.raises(process_conversation.ExplicitAppSelectionFailedError):
+            process_conversation._trigger_apps(
+                'user-explicit',
+                conv,
+                is_reprocess=True,
+                app_id=selected.id,
+                explicit_app=selected,
+                usage_attribution=process_conversation.AppUsageAttribution.EXPLICIT_SELECTION,
+            )
+
+    suggestion_mock.assert_not_called()
+    assert conv.apps_results == []
+
+
+def test_trigger_apps_explicit_selection_empty_content_is_fail_closed(monkeypatch):
+    """SCA-359: empty model output is a failed selection, not a silent notes fallback."""
+    monkeypatch.setenv('CONVERSATION_NOTES_V2_ENABLED', 'true')
+    selected = _make_mock_app('selected-app', 'SelectedApp')
+    _setup_trigger_apps_mocks(preferred_app_id=None)
+    conv = _make_trigger_conversation()
+
+    suggestion_mock, app_result_mock, p1, p2, p3, p4, p5, p6 = _trigger_apps_context()
+    app_result_mock.return_value = '   '
+    with p1, p2, p3, p4, p5, p6:
+        with pytest.raises(process_conversation.ExplicitAppSelectionFailedError):
+            process_conversation._trigger_apps(
+                'user-explicit',
+                conv,
+                is_reprocess=True,
+                app_id=selected.id,
+                explicit_app=selected,
+                usage_attribution=process_conversation.AppUsageAttribution.EXPLICIT_SELECTION,
+            )
+
+    # Persist-as-today shape: the whitespace result is still appended for the
+    # write-back; the failure contract is about the response, not the persist.
+    assert [(r.app_id, r.content) for r in conv.apps_results] == [('selected-app', '')]
+
+
+def test_trigger_apps_automatic_app_failure_stays_fail_open(monkeypatch):
+    """Only explicit selections fail closed; automatic runs keep log-and-continue."""
+    monkeypatch.setenv('CONVERSATION_NOTES_V2_ENABLED', 'true')
+    preferred = _make_mock_app('preferred-app', 'PreferredApp')
+    _setup_trigger_apps_mocks(preferred_app_id='preferred-app', available_apps=[preferred])
+    conv = _make_trigger_conversation()
+
+    suggestion_mock, app_result_mock, p1, p2, p3, p4, p5, p6 = _trigger_apps_context()
+    app_result_mock.side_effect = RuntimeError('LLM unavailable')
+    p2 = patch.object(process_conversation, 'get_available_apps', return_value=[preferred])
+    with p1, p2, p3, p4, p5, p6:
+        process_conversation._trigger_apps('user-automatic', conv)
+
+    app_result_mock.assert_called_once()
+    assert conv.apps_results == []
 
 
 def test_summary_pipeline_mode_cannot_reach_the_regressing_combination(monkeypatch):

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -180,6 +180,18 @@ class AppUsageAttribution(str, Enum):
     NON_USER_REPROCESS = 'non_user_reprocess'
 
 
+class ExplicitAppSelectionFailedError(RuntimeError):
+    """A reprocess that named one summarization app ended without its result.
+
+    Raised by `_trigger_apps` when an explicit `app_id` selection leaves no
+    non-empty result for that app — the execution failed (the executor loop
+    already logged the exception) or the model returned empty content.
+    First-party notes are a display fallback, not a substitute for the
+    selection the user made, so the reprocess boundary must surface a real
+    error instead of returning success with empty `apps_results` (SCA-359).
+    """
+
+
 def summary_pipeline_mode() -> SummaryPipelineMode:
     """Resolve the pipeline mode once. `CONVERSATION_NOTES_V2_ENABLED` is the only switch.
 
@@ -716,6 +728,14 @@ def _trigger_apps(
             future.result()
         except Exception as e:
             logger.error(f"Error executing app: {e}")
+
+    if app_id:
+        # Explicit selection is fail-closed: the client asked for THIS app's summary, so a
+        # missing result (execution failed above) or empty content must not masquerade as
+        # success while first-party notes shadow the selection the user made (SCA-359).
+        selected_result = next((r for r in conversation.apps_results if r.app_id == app_id), None)
+        if selected_result is None or not selected_result.content.strip():
+            raise ExplicitAppSelectionFailedError(f'Selected app {app_id} produced no summary content')
 
 
 def _update_goal_progress(uid: str, conversation: Conversation) -> None:
@@ -1939,6 +1959,12 @@ def process_conversation(
 
     # Wrap every post-persistence derived effect so the durable finalizer can
     # defer the bundle until it transactionally claims ownership (#10468 r5).
+    # Captured by _emit_derived_effects so an explicit-selection failure can fail the
+    # reprocess AFTER the derived-effect bundle (persist-as-today, action items, goals)
+    # instead of stranding it mid-way. Only reachable when `app_id` was set; automatic
+    # app selection stays fail-open (SCA-359).
+    explicit_selection_failures: list[ExplicitAppSelectionFailedError] = []
+
     def _emit_derived_effects() -> None:
         # Calendar auto-linking calls and mutates a user's Google Calendar during generic
         # conversation processing. Keep it opt-in so normal sync/reprocess jobs do not
@@ -2028,16 +2054,25 @@ def process_conversation(
             if insights_gained > 0:
                 record_usage(uid, insights_gained=insights_gained)
 
-            _trigger_apps(
-                uid,
-                conversation,
-                is_reprocess=is_reprocess,
-                app_id=app_id,
-                explicit_app=explicit_app,
-                usage_attribution=app_usage_attribution,
-                language_code=language_code,
-                people=people,
-            )
+            try:
+                _trigger_apps(
+                    uid,
+                    conversation,
+                    is_reprocess=is_reprocess,
+                    app_id=app_id,
+                    explicit_app=explicit_app,
+                    usage_attribution=app_usage_attribution,
+                    language_code=language_code,
+                    people=people,
+                )
+            except ExplicitAppSelectionFailedError as error:
+                # Fail closed without stranding the bundle: the write-back below still
+                # persists apps_results exactly as it does today (opt-in clears a stale
+                # selection) and the remaining derived effects still run; the error is
+                # re-raised after the bundle so the reprocess boundary returns a real
+                # failure instead of success-with-notes (SCA-359).
+                logger.error('Explicit app selection failed: %s', error)
+                explicit_selection_failures.append(error)
             # _trigger_apps only mutates the in-memory conversation and the durable write above already
             # happened, so persist its output the same way the calendar_event/folder_id/audio_files
             # write-backs do. Otherwise the app summary the LLM just produced is discarded.
@@ -2100,6 +2135,12 @@ def process_conversation(
             derived_effects_observer(_emit_derived_effects)
         return conversation
     _emit_derived_effects()
+    if explicit_selection_failures:
+        # Same contract the structured-summary boundary already enforces: a failed
+        # processing step is a real error, never a 200 whose payload quietly
+        # substitutes first-party notes for the selected app's summary (SCA-359).
+        failure = explicit_selection_failures[0]
+        raise conversation_processing_http_exception(failure) from failure
     logger.info(f'process_conversation completed conversation.id= {conversation.id}')
     return conversation
 


### PR DESCRIPTION
# fix(app+backend): first-party summaries labeled "Unknown App"; explicit template reprocess failed silently

Closes SCA-359

## What was wrong

Two user-visible failures on the beta/dev notes-v2 rollout, both verified on `origin/main` (`187dbe0779`) before the fix:

1. **"Unknown App" on first-party notes.** `getSummarizedApp()` fabricates `AppResponse(structured.overview, appId: null)` when no app result carries content; `findAppById(null)` is null by design; both `AppResultDetailWidget` title sites then render `context.l10n.unknownApp`. Every conversation whose visible summary is the notes-v2 structured overview shows an Omi logo next to the words "Unknown App".
2. **Custom summary templates "do not work".** `POST /v1/conversations/{id}/reprocess?app_id=` runs first-party `get_conversation_notes`, then the selected app — but `_trigger_apps` swallowed the app's execution exception and appended empty-content results silently. Under notes v2 the apps write-back guard (`opt_in_only or ...`) is tautologically true, so a failed run also durably persisted `apps_results: []` (wiping the previously stored app summary) and still returned HTTP 200. The client showed first-party notes + the mislabeled footer while the user's template selection quietly did nothing. A 409 (app not enabled) also surfaced only as a generic `REPROCESS_FAILED`.

A third, narrower display bug: `findAppById` searched only the two sheet caches (filled by the summary-sheet fetch), so even a real non-null `app_id` showed "Unknown App" until the sheet was opened.

## Product invariants (path-matched)

- `INV-MEM-4` (canonical promotion is the sole Long-term authority) — matched via `backend/utils/conversations/process_conversation.py`. Memory extraction/promotion flow is untouched; the only change inside `process_conversation` is capturing and re-raising the explicit-app-selection failure around the existing derived-effect bundle.
- `INV-TASK-2` (automatic task capture proposes, it never writes) — matched via `process_conversation.py` and `tests/unit/test_process_conversation_usage_context.py`. `_save_action_items` and the Candidate path are unchanged; the new tests exercise app-selection failure handling only.


## The fix

**Mobile** (`app/lib/pages/conversation_detail/widgets.dart`, `conversation_detail_provider.dart`, `widgets/conversation_bottom_bar.dart`):
- Attribution label is decided by the triad: resolved app → app name; `appId == null` (first-party) → `l10n.summary` ("Summary"); non-null id whose lookup failed → `unknownApp`. "Summary" is the existing l10n key the sheet's capability title, the bottom pill, and desktop's summary header already use — no third name invented.
- `findAppById` now falls back to the durable `appProvider.apps` catalog (loaded at startup) when the sheet caches are empty.
- The bottom pill's hardcoded English `'Summary'` fallback now uses `context.l10n.summary` so pill and footer agree in every locale.

**Backend** (`backend/utils/conversations/process_conversation.py`):
- `_trigger_apps` raises `ExplicitAppSelectionFailedError` when an explicit `app_id` selection ends with no non-empty result for that app (execution failure or empty model output).
- `process_conversation` captures that error around the derived-effect bundle — the persist-as-today `apps_results` write-back (the `ed2ba41c5b` opt-in empty persist that clears a stale selection), action items, and goal updates still run — then re-raises through `conversation_processing_http_exception`, the same generic-processing-error (500) contract the structured-summary boundary already enforces. The client surfaces `REPROCESS_FAILED` instead of fake success.
- Automatic selection (Redis preferred app under opt-in; suggestions under legacy) stays fail-open — no client is waiting on it.
- `get_conversation_notes` still always runs before the app (action items/events come from it); nothing in this PR changes pipeline ordering or flags. Production `CONVERSATION_NOTES_V2_ENABLED` remains **false** (dev overlay true) — untouched.

## Verification

- Backend (focused, hermetic — `backend/.venv`):
  `pytest tests/unit/test_process_conversation_usage_context.py tests/unit/test_reprocess_app_selection.py tests/routers/test_conversations_processing_rollback.py` → **62 passed** (7 new: explicit-selection execution failure fails closed; empty content fails closed; automatic app failure stays fail-open; opt-in preferred app still auto-runs; explicit success persists that app's result; explicit failure surfaces HTTP 500 with the generic processing error while the write-back still persists `apps_results: []`).
  Full `bash test.sh` selection was also started locally: 60 minutes in, every selected test that completed had passed (no failures observed) before the local run window elapsed; CI runs the same selection as the authoritative gate.
- Flutter (`bash test.sh`-scoped files): `flutter test test/widgets/app_result_summary_source_label_test.dart test/providers/conversation_detail_find_app_test.dart test/providers/conversation_detail_summary_selection_test.dart test/widgets/conversation_summary_sections_test.dart` → **15 passed** (7 new: first-party label is "Summary" not "Unknown App" in both box and sliver attribution; non-null unresolved id is "Unknown App"; resolved app shows its name; findAppById resolves from the provider catalog with empty sheet caches; null appId stays null; unknown id stays null).
- `app/scripts/analyze_ratchet.sh` → **Analyzer ratchet passed** (lint counts improved vs baseline).
- `scripts/pr-preflight --suggest` / `make preflight` output below.

## Failure-Class


Failure-Class: FC-denial-rendered-as-empty-success

Line-Count-Exception: backend/utils/conversations/process_conversation.py | 2311 -> 2352 | fail-closed explicit-app-selection capture reuses this file's existing composition boundary; splitting the 2300-line pipeline is tracked separately and out of scope for this focused fix

- Declared on the `fix(backend)` commit: the selected app's failure was returned as a successful empty `apps_results`, indistinguishable from a legitimately empty run; now classified once at the `_trigger_apps` boundary into raise-with-reason.
- `fix(app)` commits declare `none`: no existing class covers "a null identity rendered through the missing-identity branch"; first instance, guarded by the new triad tests rather than a registry entry (registering a new class needs a prior-PR evidence number).

## Out of scope (unchanged)

- Enabling notes v2 in prod (flags untouched: `backend/deploy/runtime_env.yaml` prod sections and `_base.yaml` false, `dev.overlay.yaml` true).
- Timezone picker (#4643), SCA-358 datetime injector (separate issue).
- Mobile reprocess error copy beyond the existing `REPROCESS_FAILED` toast.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

