### PR TITLE
feat: Firestore cost alerts for spend, per-family steps, and metric liveness

### DIFF
--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -10744,5 +10744,103 @@
       "receiver": "Omi - Services Alerting (Telegram)"
     },
     "record": null
+  },
+  {
+    "uid": "omi-firestore-metric-absent",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Firestore Cost",
+    "title": "Firestore - read-volume metric stopped being collected",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "absent(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"})",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-08-25T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "30m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "summary": "The Firestore read-volume series (stackdriver_firestore_instance_firestore_googleapis_com_document_read_count, type=\"NOT_FOUND\") has been absent from Prometheus for 30m, so both Firestore cost alerts are blind.",
+      "threshold": "absent(...) for 30m",
+      "user_impact": "No direct user impact. This is a watchdog for the cost alerts themselves. Both Firestore cost rules are written as `expr > threshold`, which returns an empty vector when not firing; with noDataState=OK, a metric that stops arriving is indistinguishable from a healthy one. This rule is what makes that difference visible.",
+      "scope": "The stackdriver-exporter series for firestore.googleapis.com/document/read_count in prod Prometheus.",
+      "verification": "Query stackdriver_firestore_instance_firestore_googleapis_com_document_read_count in the linked datasource. Expect 3 series (type=LOOKUP|NOT_FOUND|QUERY). Zero series means the exporter is not publishing.",
+      "safe_next_action": "This has a known cause with a known fix. Check the exporter pod for scrape errors: at monitoring.descriptor-cache-ttl=0s the exporter re-runs ListMetricDescriptors every scrape and Cloud Monitoring answers with 503 cpu-protection, which drops all series. Also check that stackdriver.metrics.interval still exceeds the ~2.4min Firestore ingestion lag -- a window shorter than the lag is always empty and yields no series at all. Both settings live in backend/charts/monitoring/prometheus-stackdriver-exporter/prod_omi_stackdriver_exporter.yaml and are applied manually per that chart README; no workflow deploys them."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "observability",
+      "alert_identity": "omi-firestore-metric-absent",
+      "component": "firestore",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
   }
 ]

--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -10842,5 +10842,299 @@
       "receiver": "Omi - Services Alerting (Telegram)"
     },
     "record": null
+  },
+  {
+    "uid": "omi-firestore-read-spend-daily",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Firestore Cost",
+    "title": "Firestore - projected read spend per day above ceiling",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 21600,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "avg_over_time(sum(avg by (type) (stackdriver_firestore_instance_firestore_googleapis_com_document_read_count))[6h:5m]) / 60 * 86400 / 100000 * 0.03 > 500",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-08-25T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "3h",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "summary": "Projected Firestore document-read spend has exceeded $500/day on a 6h rolling mean. Measured baseline on 2026-08-25 was $344-368/day (~14,200 reads/sec), so this is ~40% headroom.",
+      "threshold": "avg_over_time(...)[6h:5m] / 60 * 86400 / 100000 * $0.03 > $500/day, sustained 3h",
+      "user_impact": "No direct user impact; this is the money rule. Unlike the NOT_FOUND rules it is shape-agnostic -- it catches a regression in LOOKUP, QUERY, or NOT_FOUND reads, from application code OR from a Firebase Extension, which the app-side probe cannot see. On 2026-08-25 QUERY reads were ~13,000/sec against NOT_FOUND ~920/sec, so a NOT_FOUND-only alert watches ~7% of the bill.",
+      "scope": "All firestore.googleapis.com/document/read_count types across based-hardware production.",
+      "verification": "Run the expression in the linked datasource. The $0.03/100k rate is an ASSUMPTION, not a verified Omi contract price -- re-derive from the billing export before quoting the dollar figure. The ratio and the trend are the durable signal.",
+      "safe_next_action": "Break down by family with sum by (family) (rate(omi_firestore_documents_per_operation_sum[1h])). On 2026-08-25 action_items_list alone was 5,079 reads/sec, ~36% of all Firestore read spend. See omi-knowledge-base/projects/gcp-cost-efficiency/candidates/C006-action-items-list-polling.md. Thresholds are measured, not guessed, and each expression was proven to return a series at a lowered threshold and nothing at its real one before shipping -- see FC-alert-never-provably-fired. stackdriver_* series are DELTA published as GAUGES (per-60s counts), so rate() on them is meaningless; omi_* _total series are real counters and rate() is correct."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "observability",
+      "alert_identity": "omi-firestore-read-spend-daily",
+      "component": "firestore",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-firestore-family-read-step",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Firestore Cost",
+    "title": "Firestore - a read family doubled day-over-day",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 90000,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(sum by (family) (rate(omi_firestore_documents_per_operation_sum[2h])) > 2 * sum by (family) (rate(omi_firestore_documents_per_operation_sum[2h] offset 24h))) and (sum by (family) (rate(omi_firestore_documents_per_operation_sum[2h])) > 100)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-08-25T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "1h",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "summary": "An instrumented Firestore read family is reading more than 2x the documents per second it read at the same time yesterday, and is above 100 docs/sec in absolute terms.",
+      "threshold": "per-family rate > 2x the same rate offset 24h, AND > 100 docs/sec, sustained 1h",
+      "user_impact": "No direct user impact; cost signal. This is the rule that names WHICH read path regressed -- the platform metric cannot, because all 31 firestore.googleapis.com descriptors lack any collection dimension. The 100 docs/sec floor stops small families from flapping; the 2x factor matches the measured day-over-day envelope (normal peaks reached 1.94x over 2026-08-18..25).",
+      "scope": "Families instrumented via omi_firestore_read_operations_total / omi_firestore_documents_per_operation. Coverage is partial by design; a path with no family label is invisible here.",
+      "verification": "sum by (family) (rate(omi_firestore_documents_per_operation_sum[2h])) against the same expression offset 24h. Baseline 2026-08-25: action_items_list 5,079/sec, listen_monthly_usage 89/sec, chat_quota_monthly_usage 13/sec.",
+      "safe_next_action": "Identify the family, then find its callers. Note that \"bounded\" in FirestoreReadMode means a bound was applied, NOT that a cache exists -- action_items_list is bounded at limit=500 and still reads ~5,000 docs/sec because every client poll re-reads the list. Thresholds are measured, not guessed, and each expression was proven to return a series at a lowered threshold and nothing at its real one before shipping -- see FC-alert-never-provably-fired. stackdriver_* series are DELTA published as GAUGES (per-60s counts), so rate() on them is meaningless; omi_* _total series are real counters and rate() is correct."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "observability",
+      "alert_identity": "omi-firestore-family-read-step",
+      "component": "firestore",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-firestore-metric-stale",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Firestore Cost",
+    "title": "Firestore - read-volume metric is stale",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "time() - max(timestamp(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"})) > 900",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-08-25T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "30m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "summary": "The Firestore read-volume series is still present but has not been updated in over 15 minutes, so the cost alerts are running on frozen data.",
+      "threshold": "time() - max(timestamp(...)) > 900s, sustained 30m",
+      "user_impact": "No direct user impact; this is a watchdog for the cost alerts. It is the companion to omi-firestore-metric-absent: absent() catches a series that vanished, this catches a series that is present but wedged. Every other cost rule here is written as `expr > threshold`, which returns empty when not firing, and with noDataState=OK a frozen or missing metric is indistinguishable from a healthy one.",
+      "scope": "The stackdriver-exporter series for firestore.googleapis.com/document/read_count in prod Prometheus.",
+      "verification": "time() - max(timestamp(...)) -- healthy is under ~240s given the exporter scrape interval plus the ~2.4min Cloud Monitoring sample lag. Measured 134-143s on 2026-08-25.",
+      "safe_next_action": "Check the exporter pod for scrape errors and 503 cpu-protection throttling, and confirm stackdriver.metrics.interval still exceeds the Firestore ingestion lag. Both settings live in backend/charts/monitoring/prometheus-stackdriver-exporter/prod_omi_stackdriver_exporter.yaml and are applied MANUALLY per that chart README -- no workflow deploys them. Thresholds are measured, not guessed, and each expression was proven to return a series at a lowered threshold and nothing at its real one before shipping -- see FC-alert-never-provably-fired. stackdriver_* series are DELTA published as GAUGES (per-60s counts), so rate() on them is meaningless; omi_* _total series are real counters and rate() is correct."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "observability",
+      "alert_identity": "omi-firestore-metric-stale",
+      "component": "firestore",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
   }
 ]

--- a/backend/charts/monitoring/alerts/firestore.json
+++ b/backend/charts/monitoring/alerts/firestore.json
@@ -194,5 +194,103 @@
       "receiver": "Omi - Services Alerting (Telegram)"
     },
     "record": null
+  },
+  {
+    "uid": "omi-firestore-metric-absent",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Firestore Cost",
+    "title": "Firestore - read-volume metric stopped being collected",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "absent(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"})",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-08-25T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "30m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "summary": "The Firestore read-volume series (stackdriver_firestore_instance_firestore_googleapis_com_document_read_count, type=\"NOT_FOUND\") has been absent from Prometheus for 30m, so both Firestore cost alerts are blind.",
+      "threshold": "absent(...) for 30m",
+      "user_impact": "No direct user impact. This is a watchdog for the cost alerts themselves. Both Firestore cost rules are written as `expr > threshold`, which returns an empty vector when not firing; with noDataState=OK, a metric that stops arriving is indistinguishable from a healthy one. This rule is what makes that difference visible.",
+      "scope": "The stackdriver-exporter series for firestore.googleapis.com/document/read_count in prod Prometheus.",
+      "verification": "Query stackdriver_firestore_instance_firestore_googleapis_com_document_read_count in the linked datasource. Expect 3 series (type=LOOKUP|NOT_FOUND|QUERY). Zero series means the exporter is not publishing.",
+      "safe_next_action": "This has a known cause with a known fix. Check the exporter pod for scrape errors: at monitoring.descriptor-cache-ttl=0s the exporter re-runs ListMetricDescriptors every scrape and Cloud Monitoring answers with 503 cpu-protection, which drops all series. Also check that stackdriver.metrics.interval still exceeds the ~2.4min Firestore ingestion lag -- a window shorter than the lag is always empty and yields no series at all. Both settings live in backend/charts/monitoring/prometheus-stackdriver-exporter/prod_omi_stackdriver_exporter.yaml and are applied manually per that chart README; no workflow deploys them."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "observability",
+      "alert_identity": "omi-firestore-metric-absent",
+      "component": "firestore",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
   }
 ]

--- a/backend/charts/monitoring/alerts/firestore.json
+++ b/backend/charts/monitoring/alerts/firestore.json
@@ -292,5 +292,299 @@
       "receiver": "Omi - Services Alerting (Telegram)"
     },
     "record": null
+  },
+  {
+    "uid": "omi-firestore-read-spend-daily",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Firestore Cost",
+    "title": "Firestore - projected read spend per day above ceiling",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 21600,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "avg_over_time(sum(avg by (type) (stackdriver_firestore_instance_firestore_googleapis_com_document_read_count))[6h:5m]) / 60 * 86400 / 100000 * 0.03 > 500",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-08-25T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "3h",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "summary": "Projected Firestore document-read spend has exceeded $500/day on a 6h rolling mean. Measured baseline on 2026-08-25 was $344-368/day (~14,200 reads/sec), so this is ~40% headroom.",
+      "threshold": "avg_over_time(...)[6h:5m] / 60 * 86400 / 100000 * $0.03 > $500/day, sustained 3h",
+      "user_impact": "No direct user impact; this is the money rule. Unlike the NOT_FOUND rules it is shape-agnostic -- it catches a regression in LOOKUP, QUERY, or NOT_FOUND reads, from application code OR from a Firebase Extension, which the app-side probe cannot see. On 2026-08-25 QUERY reads were ~13,000/sec against NOT_FOUND ~920/sec, so a NOT_FOUND-only alert watches ~7% of the bill.",
+      "scope": "All firestore.googleapis.com/document/read_count types across based-hardware production.",
+      "verification": "Run the expression in the linked datasource. The $0.03/100k rate is an ASSUMPTION, not a verified Omi contract price -- re-derive from the billing export before quoting the dollar figure. The ratio and the trend are the durable signal.",
+      "safe_next_action": "Break down by family with sum by (family) (rate(omi_firestore_documents_per_operation_sum[1h])). On 2026-08-25 action_items_list alone was 5,079 reads/sec, ~36% of all Firestore read spend. See omi-knowledge-base/projects/gcp-cost-efficiency/candidates/C006-action-items-list-polling.md. Thresholds are measured, not guessed, and each expression was proven to return a series at a lowered threshold and nothing at its real one before shipping -- see FC-alert-never-provably-fired. stackdriver_* series are DELTA published as GAUGES (per-60s counts), so rate() on them is meaningless; omi_* _total series are real counters and rate() is correct."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "observability",
+      "alert_identity": "omi-firestore-read-spend-daily",
+      "component": "firestore",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-firestore-family-read-step",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Firestore Cost",
+    "title": "Firestore - a read family doubled day-over-day",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 90000,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(sum by (family) (rate(omi_firestore_documents_per_operation_sum[2h])) > 2 * sum by (family) (rate(omi_firestore_documents_per_operation_sum[2h] offset 24h))) and (sum by (family) (rate(omi_firestore_documents_per_operation_sum[2h])) > 100)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-08-25T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "1h",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "summary": "An instrumented Firestore read family is reading more than 2x the documents per second it read at the same time yesterday, and is above 100 docs/sec in absolute terms.",
+      "threshold": "per-family rate > 2x the same rate offset 24h, AND > 100 docs/sec, sustained 1h",
+      "user_impact": "No direct user impact; cost signal. This is the rule that names WHICH read path regressed -- the platform metric cannot, because all 31 firestore.googleapis.com descriptors lack any collection dimension. The 100 docs/sec floor stops small families from flapping; the 2x factor matches the measured day-over-day envelope (normal peaks reached 1.94x over 2026-08-18..25).",
+      "scope": "Families instrumented via omi_firestore_read_operations_total / omi_firestore_documents_per_operation. Coverage is partial by design; a path with no family label is invisible here.",
+      "verification": "sum by (family) (rate(omi_firestore_documents_per_operation_sum[2h])) against the same expression offset 24h. Baseline 2026-08-25: action_items_list 5,079/sec, listen_monthly_usage 89/sec, chat_quota_monthly_usage 13/sec.",
+      "safe_next_action": "Identify the family, then find its callers. Note that \"bounded\" in FirestoreReadMode means a bound was applied, NOT that a cache exists -- action_items_list is bounded at limit=500 and still reads ~5,000 docs/sec because every client poll re-reads the list. Thresholds are measured, not guessed, and each expression was proven to return a series at a lowered threshold and nothing at its real one before shipping -- see FC-alert-never-provably-fired. stackdriver_* series are DELTA published as GAUGES (per-60s counts), so rate() on them is meaningless; omi_* _total series are real counters and rate() is correct."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "observability",
+      "alert_identity": "omi-firestore-family-read-step",
+      "component": "firestore",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-firestore-metric-stale",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Firestore Cost",
+    "title": "Firestore - read-volume metric is stale",
+    "condition": "B",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "time() - max(timestamp(stackdriver_firestore_instance_firestore_googleapis_com_document_read_count{type=\"NOT_FOUND\"})) > 900",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-08-25T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "30m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "summary": "The Firestore read-volume series is still present but has not been updated in over 15 minutes, so the cost alerts are running on frozen data.",
+      "threshold": "time() - max(timestamp(...)) > 900s, sustained 30m",
+      "user_impact": "No direct user impact; this is a watchdog for the cost alerts. It is the companion to omi-firestore-metric-absent: absent() catches a series that vanished, this catches a series that is present but wedged. Every other cost rule here is written as `expr > threshold`, which returns empty when not firing, and with noDataState=OK a frozen or missing metric is indistinguishable from a healthy one.",
+      "scope": "The stackdriver-exporter series for firestore.googleapis.com/document/read_count in prod Prometheus.",
+      "verification": "time() - max(timestamp(...)) -- healthy is under ~240s given the exporter scrape interval plus the ~2.4min Cloud Monitoring sample lag. Measured 134-143s on 2026-08-25.",
+      "safe_next_action": "Check the exporter pod for scrape errors and 503 cpu-protection throttling, and confirm stackdriver.metrics.interval still exceeds the Firestore ingestion lag. Both settings live in backend/charts/monitoring/prometheus-stackdriver-exporter/prod_omi_stackdriver_exporter.yaml and are applied MANUALLY per that chart README -- no workflow deploys them. Thresholds are measured, not guessed, and each expression was proven to return a series at a lowered threshold and nothing at its real one before shipping -- see FC-alert-never-provably-fired. stackdriver_* series are DELTA published as GAUGES (per-60s counts), so rate() on them is meaningless; omi_* _total series are real counters and rate() is correct."
+    },
+    "labels": {
+      "severity": "warning",
+      "instatus_component": "observability",
+      "alert_identity": "omi-firestore-metric-stale",
+      "component": "firestore",
+      "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
   }
 ]

--- a/backend/tests/unit/test_monitoring_alert_rule_contract.py
+++ b/backend/tests/unit/test_monitoring_alert_rule_contract.py
@@ -87,6 +87,36 @@ def _all_rule_exports() -> dict[str, dict[str, dict]]:
     }
 
 
+COUNTER_FN_ON_GAUGE_DEBT = {
+    # Pre-existing rules that apply rate() to a stackdriver_ GAUGE. The exporter
+    # publishes Cloud Monitoring DELTA metrics as gauges whose value is the count
+    # for one alignment window, so rate() over them is not a per-second rate.
+    #
+    # Measured 2026-08-25 on the backend-listen LB: rate(...[5m]) read 1.82 where
+    # the correct avg_over_time(avg(...))/60 read 0.63 req/sec -- wrong by ~3x, and
+    # the error scales with the series' volatility rather than being a fixed factor.
+    #
+    # These are NOT being rewritten here. Their thresholds were calibrated
+    # empirically against the wrong values, so a mechanical rewrite would silently
+    # re-tune 14 rules, 6 of which page. That needs its own change with a human
+    # deciding each threshold. This set is a RATCHET: it may shrink, never grow.
+    "cew923rcn3ncwb",
+    "aew926uoh6o00c",  # critical, pages
+    "dew91uem0dnggb",
+    "dew9ala448r9cc",
+    "few9anlyv16v4a",  # critical, pages
+    "bew9aeqgx2w3kf",
+    "eew9ai0vlsyrke",
+    "dfpgfzd3t1m9sf",  # critical, pages
+    "efpossz9hmsqod",  # critical, pages
+    "efpgg049laqyof",
+    "efpgg1kfjglj4d",
+    "bevzeigrns5xca",
+    "cevzen5b94z5sb",  # critical, pages
+    "tz_backend_listen_lb_zero",  # critical, pages
+}
+
+
 def test_stackdriver_error_count_rules_treat_no_data_as_zero_errors():
     """Grafana's Stackdriver empty result is healthy for these error counters."""
     rules = _rules(MONITORING / "alert-rules.json")
@@ -477,3 +507,36 @@ def test_liveness_exemptions_are_documented_in_the_runbook():
 
     for journey in LIVENESS_EXEMPT_JOURNEYS:
         assert journey in runbook, f"{journey} is exempt from liveness coverage but the runbook does not say why"
+
+
+def test_no_alert_applies_a_counter_function_to_a_stackdriver_gauge():
+    """rate()/increase()/irate() over a stackdriver_ series is always a bug.
+
+    stackdriver_exporter publishes Cloud Monitoring DELTA metrics as GAUGES whose
+    value is the count for one alignment window. A counter function over that
+    returns a plausible wrong number instead of an error -- which is exactly how
+    two Firestore cost alerts shipped in #12193 that could never cross their
+    thresholds: rate() read 75.7 where real volume was ~936/sec. Read volume must
+    be recovered with avg_over_time(avg(...))/60.
+
+    Failure-Class: FC-alert-never-provably-fired
+    """
+    offenders = set()
+    counter_fn_over_stackdriver = re.compile(r"\b(?:rate|irate|increase)\s*\(\s*[^)]*\bstackdriver_")
+    for _export_name, rules in _all_rule_exports().items():
+        for uid, rule in rules.items():
+            for node in rule.get("data", []):
+                expr = (node.get("model") or {}).get("expr")
+                if isinstance(expr, str) and counter_fn_over_stackdriver.search(expr):
+                    offenders.add(uid)
+    new_offenders = offenders - COUNTER_FN_ON_GAUGE_DEBT
+    assert not new_offenders, (
+        "rate()/irate()/increase() applied to a stackdriver_ gauge in: "
+        + ", ".join(sorted(new_offenders))
+        + ". Use avg_over_time(avg(<metric>)[<window>:<step>]) / 60 for a per-second rate."
+    )
+    stale = COUNTER_FN_ON_GAUGE_DEBT - offenders
+    assert not stale, (
+        "these UIDs were fixed or removed -- delete them from COUNTER_FN_ON_GAUGE_DEBT so the "
+        "ratchet keeps tightening: " + ", ".join(sorted(stale))
+    )


### PR DESCRIPTION
## What

Three new Firestore cost alerts, plus a CI ratchet that blocks the specific authoring bug that produced two dead alerts earlier this week.

| rule | fires when | why it exists |
|---|---|---|
| `omi-firestore-read-spend-daily` | projected read spend > **$500/day** (6h mean), 3h | the money rule — shape-agnostic |
| `omi-firestore-family-read-step` | a read family **doubles** day-over-day and is > 100 docs/sec, 1h | names *which* path regressed |
| `omi-firestore-metric-stale` | the series is present but **> 15 min old**, 30m | companion to `absent()` |

## Why these three

Investigating the NOT_FOUND leak turned up that **it is not the money**:

| source | rate | est. $/month |
|---|---|---|
| **`action_items_list`** | 5,079–5,549 docs/sec | **~$4,315** |
| NOT_FOUND leak | 920 docs/sec | ~$715 |
| Typesense extension | 138 docs/sec | ~$107 |

Total Firestore read spend measured **$344–368/day (~$11k/month)**, and `action_items_list` alone is ~36% of it. `GET /v1/action-items` is **66% of all real backend API traffic** (excluding health checks) at **65 req/sec**, every client calling it twice with `limit=500`.

Every Firestore rule shipped before this PR watches `type="NOT_FOUND"` only — about **7% of read volume**. Nothing would have noticed `action_items_list` doubling. `omi-firestore-read-spend-daily` is denominated in dollars and is agnostic to read shape, so it also covers the Firebase Extension principal that the app-side probe structurally cannot see.

The `$0.03/100k` rate is an **assumption**, not a verified contract price — the annotation says so and points at the billing export.

## Fireability, proven

Per `FC-alert-never-provably-fired`, each expression was run against live prod at its real threshold and at a lowered one:

| rule | at real threshold | at lowered threshold |
|---|---|---|
| spend/day | silent ($344 < $500) | fires, returns `344.0` |
| family step | silent (nothing doubled) | fires, returns `action_items_list` = 5,229 |
| staleness | silent (134s < 900s) | fires, returns `142.7` |

## The ratchet

`test_no_alert_applies_a_counter_function_to_a_stackdriver_gauge` fails any *new* rule applying `rate()`/`irate()`/`increase()` to a `stackdriver_` series. That is exactly the bug behind #12193's two inert alerts: the exporter publishes DELTA metrics as **gauges** whose value is a per-alignment-window count, so `rate()` returns a plausible wrong number rather than an error.

It found **14 pre-existing rules doing this, 6 of which page.** They are recorded in `COUNTER_FN_ON_GAUGE_DEBT` rather than rewritten. Measured on the backend-listen LB: `rate(...[5m])` reads **1.82** where the correct `avg_over_time(avg(...))/60` reads **0.63 req/sec** — wrong by ~3x, with the error scaling with volatility rather than being a fixed factor.

Those thresholds were calibrated empirically against the wrong values, so a mechanical rewrite would silently re-tune 14 rules including 6 paging ones. **That needs its own change with a human deciding each threshold.** The set may shrink, never grow — the test also fails if a UID is fixed but left in the list.

## Verification

- 23 tests pass in `backend/tests/unit/test_monitoring_alert_rule_contract.py` (22 existing + the ratchet).
- All three UIDs ≤ 30 chars, inside the 40-char Grafana cap.
- 588 insertions, **0 deletions** — every pre-existing rule is byte-unchanged.
- Rules also POSTed to prod Grafana, which is the live source; the repo is only a mirror.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

