### PR TITLE
fix(repo): reject Git identities that can never be attributed

### DIFF
--- a/.github/failure-classes/FC-guard-encodes-incident-literals.json
+++ b/.github/failure-classes/FC-guard-encodes-incident-literals.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "id": "FC-guard-encodes-incident-literals",
+  "violated_contract": "A guard authored in response to an incident must assert the property that made that incident wrong, never the literal values it happened to carry. A predicate built from the observed spelling passes the next instance of the same class while reporting success, which is worse than no guard: the incident recurs behind a green check nobody re-examines. check_git_author_identity.py was written after PR #11525 minted `Ratchet Test <ratchet-test@example.invalid>` from a clone-local user.email, and it learned that display name, that local-part, and three reserved TLDs. PR #12239 hit the identical mechanism with `r <r@r>`; the guard ran on all 66 commits over five days and printed \"OK: Git author identity is not a test fixture\" every time, because email_tld(\"r@r\") returns \"r\" — the domain has no dot to split on.",
+  "canonical_prevention": "State the invariant as a decidable property of the value and test it against an instance the original incident did not contain. Here: an address whose domain cannot resolve can never be delivered or attributed to anyone, whatever it is named — one predicate that covers both incidents and needs no allowlist to maintain. When a guard must enumerate (a genuine allowlist), the enumeration belongs in data with a test asserting the general rule still rejects a novel member of the class.",
+  "canonical_prevention_artifact": [
+    ".github/scripts/test_check_git_author_identity.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    ".github/scripts/check_git_author_identity.py",
+    ".github/failure-classes"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/check_git_author_identity.py
+++ b/.github/scripts/check_git_author_identity.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python3
-"""Reject test-fixture Git identities on real commits and repo-local config.
+"""Reject unattributable Git identities on real commits and repo-local config.
 
 PR #11525's commits were minted as ``Ratchet Test <ratchet-test@example.invalid>``
 because a leftover ``user.email`` in the clone's ``.git/config`` overrode the
 global identity. GitHub maps avatars by author email, so those commits did not
 belong to the person who opened the PR.
+
+PR #12239 hit the same failure with a different value: a clone-local
+``r <r@r>`` authored 66 commits over five days, and this guard passed every one
+of them. It was enumerating the previous incident's literal fixture name and
+reserved TLDs, so an address that was merely impossible slipped straight
+through. The rule is now the property that actually matters — an address whose
+domain cannot resolve can never be attributed to anyone, whatever it is called.
 
 Fixture identities belong only in temporary test repositories. Never write
 ``user.name`` / ``user.email`` into this clone's local config.
@@ -90,6 +97,32 @@ def fixture_reason(name: str, email: str) -> str | None:
     return None
 
 
+def undeliverable_reason(email: str) -> str | None:
+    """Why this address can never reach anyone, or None if it might.
+
+    Deliberately weaker than "is this a real mailbox" — that is not decidable
+    here. It rejects only addresses that are impossible under any DNS: no ``@``,
+    an empty domain, or a domain with no dot, which cannot be a registrable
+    name. ``r@r`` is the whole reason this exists. A real address, including a
+    GitHub ``users.noreply.github.com`` one, always passes.
+    """
+    if not email:
+        return None
+    if "@" not in email:
+        return "no @ in the address"
+    domain = email.rsplit("@", 1)[1]
+    if not domain:
+        return "empty domain"
+    if "." not in domain:
+        return f"domain '{domain}' has no dot, so it can never resolve"
+    return None
+
+
+def rejection_reason(name: str, email: str) -> str | None:
+    """Why this identity must never author a commit, or None if it may."""
+    return fixture_reason(name, email) or undeliverable_reason(email)
+
+
 def local_config_identities(root: Path | None) -> list[Identity]:
     identities: list[Identity] = []
     for key in ("user.name", "user.email"):
@@ -134,7 +167,7 @@ def range_identities(root: Path | None, base: str, head: str) -> list[Identity]:
 def failures_for(identities: list[Identity]) -> list[str]:
     failures: list[str] = []
     for identity in identities:
-        reason = fixture_reason(identity.name, identity.email)
+        reason = rejection_reason(identity.name, identity.email)
         if reason is None:
             continue
         who = identity.name or identity.email or "(empty)"
@@ -148,9 +181,9 @@ def failures_for(identities: list[Identity]) -> list[str]:
 
 def report(failures: list[str]) -> int:
     if not failures:
-        print("OK: Git author identity is not a test fixture.")
+        print("OK: Git author identity is attributable.")
         return 0
-    print("FAIL: test-fixture Git identity would mint unattributed commits.", file=sys.stderr)
+    print("FAIL: unattributable Git identity would mint commits owned by nobody.", file=sys.stderr)
     for failure in failures:
         print(f"- {failure}", file=sys.stderr)
     print(

--- a/.github/scripts/test_check_git_author_identity.py
+++ b/.github/scripts/test_check_git_author_identity.py
@@ -52,6 +52,47 @@ class GitAuthorIdentityTests(unittest.TestCase):
         self.assertIsNone(CHECKER.fixture_reason("David Zhang", "david.d.zhang@gmail.com"))
         self.assertIsNone(CHECKER.fixture_reason("github-actions[bot]", "41898282+github-actions[bot]@users.noreply.github.com"))
 
+    def test_rejects_an_address_whose_domain_cannot_resolve(self) -> None:
+        """PR #12239: `r <r@r>` authored 66 commits and this guard passed all of them.
+
+        It is not a fixture by name and carries no reserved TLD, so every
+        enumerated rule missed it. What makes it wrong is that `r` cannot be a
+        registrable domain, so the address can never be delivered or attributed.
+        """
+        self.assertIsNone(CHECKER.fixture_reason("r", "r@r"))
+        self.assertIsNotNone(CHECKER.rejection_reason("r", "r@r"))
+        self.assertIsNotNone(CHECKER.rejection_reason("x", "x@x"))
+
+    def test_keeps_real_addresses_including_github_noreply(self) -> None:
+        for email in (
+            "david.d.zhang@gmail.com",
+            "git-on-my-level@users.noreply.github.com",
+            "41898282+github-actions[bot]@users.noreply.github.com",
+        ):
+            self.assertIsNone(CHECKER.rejection_reason("Someone", email), email)
+
+    def test_a_name_only_identity_is_not_judged_on_its_absent_email(self) -> None:
+        """`local_config_identities` emits user.name with an empty email; that is
+        an absent address, not an undeliverable one, and must not fail on its own."""
+        self.assertIsNone(CHECKER.rejection_reason("David Zhang", ""))
+
+    def test_rejects_a_repo_local_unroutable_override(self) -> None:
+        """The clone-local override is the mechanism both incidents shared."""
+        self.git("config", "--local", "user.email", "r@r")
+        self.git("config", "--local", "user.name", "r")
+        failures = CHECKER.failures_for(CHECKER.local_config_identities(self.root))
+        self.assertTrue(failures)
+        self.assertTrue(any("local-config" in item and "r@r" in item for item in failures))
+
+    def test_rejects_unroutable_authors_in_the_commit_range(self) -> None:
+        """The CI lane never sees the clone's config, so the commit range is the
+        only unbypassable place this can be caught."""
+        base = self.commit("seed", name="David Zhang", email="david.d.zhang@gmail.com")
+        self.commit("bad", name="r", email="r@r")
+        failures = CHECKER.failures_for(CHECKER.range_identities(self.root, base, "HEAD"))
+        self.assertTrue(failures)
+        self.assertTrue(any("r@r" in item for item in failures))
+
     def test_rejects_a_repo_local_fixture_override(self) -> None:
         self.git("config", "--local", "user.email", "ratchet-test@example.invalid")
         self.git("config", "--local", "user.name", "Ratchet Test")


### PR DESCRIPTION
## What broke

[PR #12239](https://github.com/BasedHardware/omi/pull/12239) was authored entirely by `r <r@r>` — a stale clone-local `user.email` shadowing the global identity. GitHub attributes commits by author email, so every commit landed with a generic avatar, unlinked to any account. 66 commits over five days carried it.

`check_git_author_identity.py` ran on all of them and printed `OK: Git author identity is not a test fixture` every time.

## Why the guard missed it

The guard exists *because of this exact failure*. After #11525 minted `Ratchet Test <ratchet-test@example.invalid>` from a clone-local override, it learned that display name, that local-part, and three reserved TLDs.

`r@r` is none of those. `email_tld("r@r")` returns `"r"` — the domain has no dot to split on, so there is no TLD to match.

The guard encoded the previous incident rather than the invariant. That is its own failure class, added here as `FC-guard-encodes-incident-literals`: a check built from an incident's literal values passes the next instance of the same class *while reporting success*, which is worse than no check — the incident recurs behind a green tick nobody re-examines.

## The fix

One predicate, stated as a property rather than a list: **an address whose domain cannot resolve can never be delivered or attributed to anyone, whatever it is named.**

```
r@r                          -> domain 'r' has no dot, so it can never resolve   (NEW)
ratchet-test@example.invalid -> reserved test TLD .invalid                       (existing)
david.d.zhang@gmail.com      -> ok
git-on-my-level@users.noreply.github.com -> ok
```

Deliberately weaker than "is this a real mailbox", which is not decidable here. It rejects only what is impossible under any DNS, so it needs no allowlist to maintain.

`failures_for` already applied its predicate to clone-local config as well as to the commit range, so this one change covers every lane:

- **pre-commit** (`--pending`) rejects the override before a commit is minted
- **local lane** of `git-author-identity` rejects it again before push
- **CI lane** never sees a developer's `.git/config` — the commit range is the only unbypassable place this can be caught, and it now is

I also fixed the report wording. `OK: ... is not a test fixture` is precisely what let a non-fixture bad identity read as a pass; it now says *attributable*.

## What I considered and rejected

The module docstring already states a stronger rule — *"Never write `user.name` / `user.email` into this clone's local config"* — which is stated but not enforced. Enforcing presence-as-failure would also have caught this, a day earlier.

I did not do it. It would break contributors who legitimately set a per-repo `users.noreply.github.com` address for privacy, and that is a policy call, not a bug fix. The predicate above closes the actual gap without imposing it. Easy to add later if the team wants it.

## Verification

- 9 tests pass (5 new). `test_rejects_an_address_whose_domain_cannot_resolve` asserts both halves: `fixture_reason("r","r@r")` is still `None` — documenting exactly why the old guard passed — while `rejection_reason` rejects it.
- Both lanes covered by tests: clone-local override, and an `r@r`-authored commit range.
- Real addresses, including `users.noreply.github.com` and `github-actions[bot]`, are asserted unaffected. A name-only identity carries an empty email and is not judged on it.
- Verified end-to-end through the real CLI: a simulated `r@r` override now fails `--pending` with all three identities named and the unset command as the remedy.

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

