### PR TITLE
fix(observability): the core-features dashboard renders a dead reporter as a healthy green zero

### DIFF
--- a/backend/charts/monitoring/dashboards/general/omi-core-features.json
+++ b/backend/charts/monitoring/dashboards/general/omi-core-features.json
@@ -821,7 +821,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Separates voluntary churn (ended after a cancellation request) from involuntary churn (payment_failed / payment_disputed). Different problems, different owners. Counts are webhook deliveries, which Stripe may retry \u2014 this is an operational trend signal, not billing-grade numbers. Stripe (via the Omi TV board) remains source of truth.",
+      "description": "Separates voluntary churn (ended after a cancellation request) from involuntary churn (payment_failed / payment_disputed). Different problems, different owners. Counts are webhook deliveries, which Stripe may retry \u2014 this is an operational trend signal, not billing-grade numbers. Stripe (via the Omi TV board) remains source of truth. `reason` is Stripe cancellation_details.reason and is only ever populated on `ended`; `payment_failed` is involuntary by construction and always carries reason=\"none\".",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -1007,15 +1007,20 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "1 when the gateway has tripped its breaker; requests are being shed.",
+      "description": "1 when the gateway has tripped its breaker; requests are being shed. A blank panel means no replica published this series at all: that is \"the reporter is gone\", not \"the value is zero\", and the two must never render the same.",
       "fieldConfig": {
         "defaults": {
+          "noValue": "not reporting",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
+              },
+              {
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1052,7 +1057,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "max(llm_gateway_circuit_open) or vector(0)",
+          "expr": "max(llm_gateway_circuit_open)",
           "instant": true,
           "refId": "A"
         }
@@ -1128,15 +1133,20 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Requests refused before reaching a provider.",
+      "description": "Requests refused before reaching a provider. This counter has no series until the first rejection, so a rejection-free window is empty. The 0 is supplied by llm_gateway_config_info, which every gateway pod publishes at startup: if the gateway stops reporting the panel goes blank instead of showing a green 0.",
       "fieldConfig": {
         "defaults": {
+          "noValue": "gateway not reporting",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
+              },
+              {
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "orange",
@@ -1173,7 +1183,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "round(sum(increase(llm_gateway_request_rejections_total[$__range]))) or vector(0)",
+          "expr": "round(sum(increase(llm_gateway_request_rejections_total[$__range]))) or (max(llm_gateway_config_info) * 0)",
           "instant": true,
           "refId": "A"
         }
@@ -1415,15 +1425,20 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Non-zero means the pusher breaker has tripped.",
+      "description": "Non-zero means the pusher breaker has tripped. A blank panel means no replica published this series at all: that is \"the reporter is gone\", not \"the value is zero\", and the two must never render the same.",
       "fieldConfig": {
         "defaults": {
+          "noValue": "not reporting",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
+              },
+              {
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1460,7 +1475,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "max(pusher_circuit_breaker_state) or vector(0)",
+          "expr": "max(pusher_circuit_breaker_state)",
           "instant": true,
           "refId": "A"
         }
@@ -1473,15 +1488,20 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Age of the oldest finalization job that has not reached a terminal state \u2014 a conversation the user is still waiting on. Aggregated with max(), not sum(): every backend-listen replica publishes the same global value.",
+      "description": "Age of the oldest finalization job that has not reached a terminal state \u2014 a conversation the user is still waiting on. Aggregated with max(), not sum(): every backend-listen replica publishes the same global value. A blank panel means no replica published this series at all: that is \"the reporter is gone\", not \"the value is zero\", and the two must never render the same.",
       "fieldConfig": {
         "defaults": {
+          "noValue": "not reporting",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
+              },
+              {
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "orange",
@@ -1522,7 +1542,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "max(listen_finalization_oldest_nonterminal_age_seconds) or vector(0)",
+          "expr": "max(listen_finalization_oldest_nonterminal_age_seconds)",
           "instant": true,
           "refId": "A"
         }
@@ -1535,15 +1555,20 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Finalization jobs that exhausted all 5 attempts, over the selected range. NOT the same as conversations lost: the discard is guarded on the conversation still being in `processing`, and measured over 14d only ~15% of dead letters actually discarded a conversation \u2014 the rest had already been finalized inline. There is no metric for the discarded subset yet.",
+      "description": "Finalization jobs that exhausted all 5 attempts, over the selected range. NOT the same as conversations lost: the discard is guarded on the conversation still being in `processing`, and measured over 14d only ~15% of dead letters actually discarded a conversation \u2014 the rest had already been finalized inline. There is no metric for the discarded subset yet. A blank panel means no replica published this series at all: that is \"the reporter is gone\", not \"the value is zero\", and the two must never render the same.",
       "fieldConfig": {
         "defaults": {
+          "noValue": "not reporting",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
+              },
+              {
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1580,7 +1605,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "round(sum(increase(listen_finalization_dead_letter_total[$__range]))) or vector(0)",
+          "expr": "round(sum(increase(listen_finalization_dead_letter_total[$__range])))",
           "instant": true,
           "refId": "A"
         }

--- a/backend/tests/unit/test_monitoring_dashboard_absence_contract.py
+++ b/backend/tests/unit/test_monitoring_dashboard_absence_contract.py
@@ -1,0 +1,113 @@
+"""Static contract: a Grafana stat panel must never paint absence as healthy.
+
+`or vector(C)` substitutes a constant for an empty query result, which is what a
+metric family looks like when the process that emits it is gone. When C also
+lands in the panel's healthy threshold band, a dead reporter and a healthy
+system render as the same number in the same colour, and the operator reads the
+one that means "fine". That is the dashboard form of `noDataState: OK`.
+
+The rule below is deliberately narrow so it can be mechanical: it does not ban
+constant fallbacks, it bans the specific combination where the substituted
+constant is coloured green. A counter with no series until its first event
+legitimately needs a 0 — but it must either be coloured neutrally or, better,
+draw its 0 from a series that proves the reporter is alive (`or (<gauge> * 0)`),
+which is not a bare constant and is therefore not matched here.
+"""
+
+import json
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+DASHBOARDS = REPO / "backend/charts/monitoring/dashboards"
+
+# A bare constant fallback: `or vector(0)`, not `or (max(foo) * 0)`.
+BARE_VECTOR_FALLBACK = re.compile(r"\bor\s+vector\s*\(\s*(-?\d+(?:\.\d+)?)\s*\)")
+HEALTHY_COLORS = {
+    "green",
+    "dark-green",
+    "semi-dark-green",
+    "light-green",
+    "super-light-green",
+}
+# Only `stat` panels: the threshold colour is the whole signal there, because a
+# single number stands in for "is this healthy". A timeseries renders its shape
+# regardless of thresholds, and its thresholds are not drawn at all unless
+# `thresholdsStyle` opts in.
+GUARDED_PANEL_TYPE = "stat"
+
+
+def _iter_panels(panels):
+    for panel in panels:
+        if panel.get("type") == "row":
+            yield from _iter_panels(panel.get("panels", []))
+            continue
+        yield panel
+        yield from _iter_panels(panel.get("panels", []))
+
+
+def threshold_color_for(steps, value):
+    """The colour Grafana paints `value`, given a threshold step list.
+
+    The base step carries `value: null`, meaning negative infinity; a step
+    applies from its own value upward until the next one starts.
+    """
+
+    color = None
+    for step in sorted(steps, key=lambda s: (s.get("value") is not None, s.get("value") or 0)):
+        bound = step.get("value")
+        if bound is None or value >= bound:
+            color = step.get("color")
+    return color
+
+
+def bare_fallback_offenses():
+    offenses = []
+    for path in sorted(DASHBOARDS.rglob("*.json")):
+        dashboard = json.loads(path.read_text())
+        for panel in _iter_panels(dashboard.get("panels", [])):
+            if panel.get("type") != GUARDED_PANEL_TYPE:
+                continue
+            steps = (panel.get("fieldConfig", {}).get("defaults", {}).get("thresholds") or {}).get("steps") or []
+            for target in panel.get("targets", []):
+                for match in BARE_VECTOR_FALLBACK.finditer(target.get("expr") or ""):
+                    constant = float(match.group(1))
+                    color = threshold_color_for(steps, constant)
+                    if color in HEALTHY_COLORS:
+                        offenses.append(
+                            f"{path.relative_to(REPO)} :: {panel.get('title')!r} substitutes "
+                            f"{match.group(1)} for an absent series and paints it {color!r}"
+                        )
+    return offenses
+
+
+def test_no_stat_panel_paints_a_constant_absence_fallback_green():
+    offenses = bare_fallback_offenses()
+    assert offenses == [], (
+        "A stat panel falls back to a constant that renders in a healthy colour, so a dead "
+        "reporter is indistinguishable from a healthy system:\n  " + "\n  ".join(offenses)
+    )
+
+
+def test_guard_rejects_the_historical_shape_it_exists_to_catch():
+    """The pre-fix 'Circuit open' panel: `or vector(0)` over a green base band."""
+
+    steps = [{"color": "green", "value": None}, {"color": "red", "value": 1}]
+    assert threshold_color_for(steps, 0) == "green"
+    assert BARE_VECTOR_FALLBACK.search("max(llm_gateway_circuit_open) or vector(0)")
+
+
+def test_guard_accepts_a_fallback_anchored_to_a_live_series():
+    """The fix: the 0 exists only while something is still reporting."""
+
+    anchored = (
+        "round(sum(increase(llm_gateway_request_rejections_total[$__range]))) or (max(llm_gateway_config_info) * 0)"
+    )
+    assert BARE_VECTOR_FALLBACK.search(anchored) is None
+
+
+def test_guard_accepts_a_constant_fallback_that_is_not_healthy_coloured():
+    """'Journeys reporting (of 3)': absence falls to 0, which is red, not green."""
+
+    steps = [{"color": "red", "value": None}, {"color": "orange", "value": 2}, {"color": "green", "value": 3}]
+    assert threshold_color_for(steps, 0) == "red"

--- a/backend/tests/unit/test_subscription_events_metrics.py
+++ b/backend/tests/unit/test_subscription_events_metrics.py
@@ -23,7 +23,14 @@ import logging
 from pathlib import Path
 
 from utils.metrics import OMI_SUBSCRIPTION_EVENTS
-from utils.observability.subscription_events import record_subscription_event
+from utils.observability.subscription_events import (
+    _EVENTS,
+    _INTERVALS,
+    _PLANS,
+    _REASONS,
+    _reachable_reasons,
+    record_subscription_event,
+)
 
 # Real, currently-recognized catalog prices (backend/config/plan_catalog.json),
 # one per plan, so plan/interval resolution is exercised against the actual
@@ -376,3 +383,92 @@ def test_webhook_calls_the_recorder_inside_the_subscription_event_branch():
     assert 'record_subscription_event(' in branch_body
     assert "stripe_event_type=event['type']" in branch_body
     assert "previous_attributes=event.get('data', {}).get('previous_attributes')" in branch_body
+
+
+# ---------------------------------------------------------------------------
+# Born-at-zero. A Counter child does not exist until its first ``.inc()``, so an
+# uninitialized labelled series is first scraped already holding 1 and is never
+# observed at 0. ``increase()``/``rate()`` measure movement inside the query
+# window, so a series that appears at 1 and stays there contributes exactly 0 —
+# the first event for a label combination is invisible to every panel and rule
+# built on them. Subscription events are rare enough, and ``plan`` x
+# ``interval`` x one process per Cloud Run instance wide enough, that almost
+# every event is the first for its combination.
+# ---------------------------------------------------------------------------
+
+_PLUS_YEAR_PRICE = 'price_1TuHCw1F8wnoWYvwZvKu86sI'
+
+_Series = tuple[str, str, str, str]
+
+
+def _exported_series() -> dict[_Series, float]:
+    return {
+        (
+            sample.labels['event'],
+            sample.labels['plan'],
+            sample.labels['interval'],
+            sample.labels['reason'],
+        ): sample.value
+        for family in OMI_SUBSCRIPTION_EVENTS.collect()
+        for sample in family.samples
+        if sample.name == 'omi_subscription_events_total'
+    }
+
+
+def _reachable_series() -> set[_Series]:
+    return {
+        (event, plan, interval, reason)
+        for event in _EVENTS
+        for plan in _PLANS
+        for interval in _INTERVALS
+        for reason in _reachable_reasons(event)
+    }
+
+
+def test_every_reachable_label_combination_is_exported_before_its_first_event():
+    exported = set(_exported_series())
+
+    missing = sorted(_reachable_series() - exported)
+    assert missing == [], (
+        'These label combinations have no series until their first event, so that first event '
+        f'would be invisible to increase(): {missing}'
+    )
+
+
+def test_zero_initialization_stays_inside_the_space_recording_can_emit():
+    exported = set(_exported_series())
+    reachable = _reachable_series()
+
+    # 4 reason-free events x 7 plans x 3 intervals, plus `ended` x 7 x 3 x 4 reasons.
+    assert len(reachable) == 168
+    # Both the initialization and the recording path read the same label sets,
+    # so neither can grow a combination the other does not know about.
+    assert exported - reachable == set()
+
+
+def test_only_ended_can_ever_carry_a_cancellation_reason():
+    for event in _EVENTS:
+        if event == 'ended':
+            assert set(_reachable_reasons(event)) == set(_REASONS)
+        else:
+            assert _reachable_reasons(event) == ('none',)
+
+
+def test_a_first_event_steps_a_series_that_was_already_exported_at_zero():
+    """The shape increase() needs: a step up from an existing sample, not an appearance at 1."""
+
+    series: _Series = ('cancellation_requested', 'plus', 'year', 'none')
+    before = _exported_series()
+    assert series in before
+
+    record_subscription_event(
+        stripe_event_type='customer.subscription.updated',
+        subscription_obj=_subscription_obj(
+            price_id=_PLUS_YEAR_PRICE,
+            interval='year',
+            cancel_at_period_end=True,
+        ),
+        previous_attributes={'cancel_at_period_end': False},
+    )
+
+    assert _exported_series()[series] == before[series] + 1

--- a/backend/utils/observability/subscription_events.py
+++ b/backend/utils/observability/subscription_events.py
@@ -39,6 +39,44 @@ _REASONS = frozenset({'cancellation_requested', 'payment_failure', 'payment_disp
 
 _PAYMENT_FAILED_STATUSES = frozenset({'past_due', 'unpaid'})
 
+# `reason` describes why a subscription ended, so only this event can ever carry
+# one; every other event pins 'none'. Both the recording path and the zero
+# initialization below read this, so the reachable label space cannot drift from
+# what is actually emitted.
+_REASON_BEARING_EVENT = 'ended'
+
+
+def _reachable_reasons(event: str) -> tuple[str, ...]:
+    return tuple(sorted(_REASONS)) if event == _REASON_BEARING_EVENT else ('none',)
+
+
+def _zero_initialize_label_children() -> None:
+    """Create every reachable label child so each series is born at 0, not at 1.
+
+    A prometheus_client Counter child does not exist until its first ``.inc()``,
+    so a labelled series is first scraped already holding 1 and is never observed
+    at 0. ``increase()`` and ``rate()`` measure movement inside the query window,
+    and a series that appears at 1 and stays there has not moved — so the first
+    event for a label combination contributes exactly nothing to every panel and
+    rule built on them. Subscription events are rare and the labels are wide
+    enough (``plan`` x ``interval``, one process per Cloud Run instance) that
+    almost every event is the first for its combination, which is how a real
+    cancellation renders as a confident 0.
+
+    The reachable space is 4 non-``ended`` events x plans x intervals, plus
+    ``ended`` x plans x intervals x reasons — bounded and closed by construction,
+    which is the property the label sets above exist to guarantee.
+    """
+
+    for event in sorted(_EVENTS):
+        for plan in sorted(_PLANS):
+            for interval in sorted(_INTERVALS):
+                for reason in _reachable_reasons(event):
+                    OMI_SUBSCRIPTION_EVENTS.labels(event=event, plan=plan, interval=interval, reason=reason)
+
+
+_zero_initialize_label_children()
+
 
 def _determine_event(
     stripe_event_type: str,
@@ -150,6 +188,6 @@ def _record(
 
     plan = _resolve_plan(subscription_obj)
     interval = _resolve_interval(subscription_obj)
-    reason = _resolve_cancellation_reason(subscription_obj) if event == 'ended' else 'none'
+    reason = _resolve_cancellation_reason(subscription_obj) if event == _REASON_BEARING_EVENT else 'none'
 
     OMI_SUBSCRIPTION_EVENTS.labels(event=event, plan=plan, interval=interval, reason=reason).inc()


### PR DESCRIPTION
## What breaks

Two independent defects on the **Omi Core Features** dashboard (`monitor.omi.me/d/omi-core-features`) make a dead reporter and a healthy system render identically.

### 1. Absence renders as healthy green

Five `stat` panels ended their expression in `or vector(0)` while `0` was also the **green** threshold band. `or vector(0)` substitutes a constant when the query returns nothing — which is exactly what the metric family looks like when the process that emits it is gone. Verified against prod:

```
query=max(a_metric_that_does_not_exist_xyz) or vector(0)   ->  0
query=max(a_metric_that_does_not_exist_xyz)                ->  [] (empty)
```

So "the llm-gateway is dead" and "the breaker is closed" both painted a green `0`. This is `noDataState: OK` wearing a different hat.

Affected: `Circuit open`, `Pusher breaker`, `Oldest unfinished job`, `Finalization gave up (dead letters)`, `Rejections`.

### 2. Subscription counters are structurally undercounted

`omi_subscription_events_total` is a `prometheus_client.Counter` with labels `event/plan/interval/reason`. A Counter **child does not exist until its first `.inc()`**, so a labelled series is first scraped already holding `1` and is **never observed at 0**. `increase()`/`rate()` measure movement inside the window, and a series that appears at 1 and stays there has not moved — so it contributes exactly `0`.

Measured against prod (`job="cloud-run-application-metrics"`, `service_name="backend"`), per-series `min_over_time`/`max_over_time` over the full retained window:

| event | series | flat at 1 | sum of per-series max | `sum(increase(...))` |
|---|---|---|---|---|
| `cancellation_requested` | 14 | **14** | 14 | **0** |
| `cancellation_reverted` | 1 | **1** | 1 | **0** |
| `payment_failed` | 7 | **7** | 7 | **0** |
| `created` | 25 | 18 | 37 | 12.0 |
| `ended` | 7 | 6 | 8 | 1.0 |

`min_over_time` is `1` on **every one of the 54 series**, including ones with 1215 samples (≈20h of 60s scrapes). Not one was ever scraped at 0.

The timeseries panels in that row have the same defect, not just the stat tiles: `Cancellation requests by plan` is **identically zero at every one of 409 evaluated points**.

## Why the obvious alternative explanations do not hold

- **"The pipeline drops zero-valued samples."** It does not. 16 other metric names under the same `job`/`service_name` currently export zero-valued series (`omi_journey_terminal_total` alone has 467). Zeros survive the Cloud Run GMP sidecar end to end.
- **"Cloud Run instance churn / `exported_instance` cardinality."** Churn is real (series live 0–19h) and it *amplifies* the defect — each new instance re-births every child at 1 — but it is not the cause. Churn would still show `0` on a long-lived instance before its first event; none ever does.
- **"Counter resets."** `increase()` handles resets. There are none: `min == max` on the flat series.
- **"`increase()` extrapolates a series that starts mid-window."** Only when the series moved. Prometheus' `extrapolatedRate` guards zero-point extrapolation on `resultValue > 0`; a flat series yields `resultValue == 0` and no extrapolation.

## The fixes

### Dashboard — state gauges vs event counters are different problems

`llm_gateway_circuit_open`, `pusher_circuit_breaker_state`, `listen_finalization_oldest_nonterminal_age_seconds` and `listen_finalization_dead_letter_total` are all **label-free** (`backend/utils/metrics.py`), so their series exist from process start on all 35 replicas. They need no fallback at all: dropped `or vector(0)`, added `noValue: "not reporting"`, and moved the base threshold band from `green` to `text` with an explicit `green` step at `0`. A real `0` is still green; an absent series is now neutral text that says so.

`llm_gateway_request_rejections_total` is the one that genuinely needs a `0`: `api_surface`/`error_class` are sanitized free-form, not a closed set, so the counter has no series at all until the first rejection and "zero rejections, all good" really is an empty result. Its `0` is now drawn from a series that proves the reporter is alive:

```promql
round(sum(increase(llm_gateway_request_rejections_total[$__range]))) or (max(llm_gateway_config_info) * 0)
```

`llm_gateway_config_info` is published at startup by every llm-gateway pod and by nothing else. Verified against prod:

```
round(sum(increase(no_such_counter_zzz[24h]))) or (max(llm_gateway_config_info) * 0)  ->  0
round(sum(increase(no_such_counter_zzz[24h]))) or (max(no_such_gauge_zzz)      * 0)  ->  [] (empty)
```

Rejection-free window with a live gateway → green `0`. Gateway gone → blank, `"gateway not reporting"`.

### Backend — make the counter born at zero

`_zero_initialize_label_children()` in `backend/utils/observability/subscription_events.py` materializes the whole reachable label space at import so each series is born at `0` and the first increment is a real step that `increase()` can see. The reachable space is **168 series** per process (4 reason-free events × 7 plans × 3 intervals, plus `ended` × 7 × 3 × 4 reasons) — bounded and closed by construction, which is what the `_EVENTS`/`_PLANS`/`_INTERVALS`/`_REASONS` frozensets already existed to guarantee. At ~10 backend instances that is ~1.7k series against the 24.9k the service already exports.

The "only `ended` carries a reason" rule was duplicated between the recording path and the label space; it is now one constant (`_REASON_BEARING_EVENT`) that both read, so the initialization cannot drift from what is actually emitted.

A query-side workaround was considered and rejected: no expression can recover an event that was never observed at 0.

### Guard surface

`backend/tests/unit/test_monitoring_dashboard_absence_contract.py` is a new repo-wide static contract over every dashboard under `backend/charts/monitoring/dashboards/`: **a `stat` panel may not substitute a bare constant for an absent series and paint that constant in a healthy colour.** It does not ban constant fallbacks — `Journeys reporting (of 3)` falls back to `0` in a *red* band, which is honest, and passes. Run against the pre-fix JSON it names all five offending panels and nothing else.

## Verification

```
$ backend/.venv/bin/python -m pytest tests/unit/test_subscription_events_metrics.py \
    tests/unit/test_monitoring_dashboard_absence_contract.py \
    tests/unit/test_monitoring_alert_rule_contract.py \
    tests/unit/test_monitoring_telemetry_contract.py -q
81 passed
```

Both guards were shown to fail on the historical input:

- Reverting only the dashboard JSON: `test_no_stat_panel_paints_a_constant_absence_fallback_green` fails, listing `Circuit open`, `Rejections`, `Pusher breaker`, `Oldest unfinished job`, `Finalization gave up (dead letters)` — exactly the five panels, found independently of the report.
- Commenting out the `_zero_initialize_label_children()` call: `test_every_reachable_label_combination_is_exported_before_its_first_event` and `test_a_first_event_steps_a_series_that_was_already_exported_at_zero` fail, and the failure output shows the born-at-1 shape directly (`('cancellation_requested', 'unlimited', 'month', 'none'): 1.0`).

All prod evidence came from read-only `/api/v1/query` and `/api/v1/query_range` against `monitor.omi.me`. Nothing was written to Grafana and nothing was deployed.

## Not changed, deliberately

**`Cancellations by reason (voluntary vs involuntary)`.** The `reason` label is `none` on 45 of 49 series repo-wide, but that statistic is taken over *all* events; the panel's own selector is `event=~"ended|payment_failed"`, and within it 6 of 7 `ended` series carry `reason="cancellation_requested"`. The split works where it is queried. `payment_failed` can never carry a reason — the recording path pins `'none'` for every event but `ended` — but it does not need one, because the event name already says involuntary. The panel's real problem was the `rate()` defect above. Its description now states where `reason` comes from, so the next reader does not re-derive this.

**The `or vector(0)` on the four subscription stat panels.** Their base threshold band is `text`, not `green`, so the specific defect above does not apply. Removing the fallback only becomes correct *after* the backend change is deployed; until then it would render "not reporting" while the backend is reporting fine.

## Deploy ordering

The backend change only takes effect on instances started after a backend deploy, and the dashboard is not auto-provisioned — the repo JSON is applied to Grafana by hand (`backend/charts/monitoring/README.md`). Neither was performed in this PR.

1. Merge.
2. Deploy `backend` — new Cloud Run instances export the 168 zero-valued children. Series born before the deploy stay broken until their instance is replaced.
3. Apply the dashboard JSON to `monitor.omi.me` (`POST /api/dashboards/db`, `uid=omi-core-features`, folder `general`). The live board is currently version 8 and byte-identical to the pre-fix repo copy, so this is a clean overwrite.

Failure-Class: FC-alert-never-provably-fired


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

