### PR TITLE
fix(backend): install google-cloud-kms in the runtime image

### DIFF
--- a/backend/pylock.macos-x86_64.toml
+++ b/backend/pylock.macos-x86_64.toml
@@ -429,6 +429,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/ce/9b/7c2f746cd8ec3f08d
 wheels = [{ url = "https://files.pythonhosted.org/packages/80/3f/52fd16f3de3ed4ac2e3b7c728fb3b29b081791cf6292b74e4301ad489737/google_cloud_firestore-2.20.0-py2.py3-none-any.whl", upload-time = 2025-01-13T21:39:40Z, size = 337765, hashes = { sha256 = "505ef6951b56ea91f6762d99b3429ca6def6dceb254b4ba1ffc85e69b71414d7" } }]
 
 [[packages]]
+name = "google-cloud-kms"
+version = "3.6.0"
+sdist = { url = "https://files.pythonhosted.org/packages/73/8a/ee0569d6dd4f4bb99fdf2a28466f1914a3f2849506c75b620c213feb043b/google_cloud_kms-3.6.0.tar.gz", upload-time = 2025-09-22T16:51:16Z, size = 329923, hashes = { sha256 = "c0f7f2474e35e99e6a36651520a26fdba4bb8e73b7cd0d9bff8c8bd92737afcc" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/7c/82/686bde4666b72e821f724dc2d143ad0b9a50af7c145ecba1e57ccb9aeb97/google_cloud_kms-3.6.0-py3-none-any.whl", upload-time = 2025-09-22T16:51:00Z, size = 272683, hashes = { sha256 = "1dc389f327cce288ac3091860497ab50b2d166fb71603e632bc4bfd1b2b74cd5" } }]
+
+[[packages]]
 name = "google-cloud-storage"
 version = "2.18.0"
 sdist = { url = "https://files.pythonhosted.org/packages/26/00/9d17394eba3e214ba3748d16eeac4b060d35a45da86061b3e3268077cc55/google_cloud_storage-2.18.0.tar.gz", upload-time = 2024-07-22T22:21:52Z, size = 5532490, hashes = { sha256 = "0aa3f7c57f3632f81b455d91558d2b27ada96eee2de3aaa17f689db1470d9578" } }

--- a/backend/pylock.macos.toml
+++ b/backend/pylock.macos.toml
@@ -428,6 +428,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/ce/9b/7c2f746cd8ec3f08d
 wheels = [{ url = "https://files.pythonhosted.org/packages/80/3f/52fd16f3de3ed4ac2e3b7c728fb3b29b081791cf6292b74e4301ad489737/google_cloud_firestore-2.20.0-py2.py3-none-any.whl", upload-time = 2025-01-13T21:39:40Z, size = 337765, hashes = { sha256 = "505ef6951b56ea91f6762d99b3429ca6def6dceb254b4ba1ffc85e69b71414d7" } }]
 
 [[packages]]
+name = "google-cloud-kms"
+version = "3.6.0"
+sdist = { url = "https://files.pythonhosted.org/packages/73/8a/ee0569d6dd4f4bb99fdf2a28466f1914a3f2849506c75b620c213feb043b/google_cloud_kms-3.6.0.tar.gz", upload-time = 2025-09-22T16:51:16Z, size = 329923, hashes = { sha256 = "c0f7f2474e35e99e6a36651520a26fdba4bb8e73b7cd0d9bff8c8bd92737afcc" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/7c/82/686bde4666b72e821f724dc2d143ad0b9a50af7c145ecba1e57ccb9aeb97/google_cloud_kms-3.6.0-py3-none-any.whl", upload-time = 2025-09-22T16:51:00Z, size = 272683, hashes = { sha256 = "1dc389f327cce288ac3091860497ab50b2d166fb71603e632bc4bfd1b2b74cd5" } }]
+
+[[packages]]
 name = "google-cloud-storage"
 version = "2.18.0"
 sdist = { url = "https://files.pythonhosted.org/packages/26/00/9d17394eba3e214ba3748d16eeac4b060d35a45da86061b3e3268077cc55/google_cloud_storage-2.18.0.tar.gz", upload-time = 2024-07-22T22:21:52Z, size = 5532490, hashes = { sha256 = "0aa3f7c57f3632f81b455d91558d2b27ada96eee2de3aaa17f689db1470d9578" } }

--- a/backend/pylock.runtime.toml
+++ b/backend/pylock.runtime.toml
@@ -407,6 +407,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/ce/9b/7c2f746cd8ec3f08d
 wheels = [{ url = "https://files.pythonhosted.org/packages/80/3f/52fd16f3de3ed4ac2e3b7c728fb3b29b081791cf6292b74e4301ad489737/google_cloud_firestore-2.20.0-py2.py3-none-any.whl", upload-time = 2025-01-13T21:39:40Z, size = 337765, hashes = { sha256 = "505ef6951b56ea91f6762d99b3429ca6def6dceb254b4ba1ffc85e69b71414d7" } }]
 
 [[packages]]
+name = "google-cloud-kms"
+version = "3.6.0"
+sdist = { url = "https://files.pythonhosted.org/packages/73/8a/ee0569d6dd4f4bb99fdf2a28466f1914a3f2849506c75b620c213feb043b/google_cloud_kms-3.6.0.tar.gz", upload-time = 2025-09-22T16:51:16Z, size = 329923, hashes = { sha256 = "c0f7f2474e35e99e6a36651520a26fdba4bb8e73b7cd0d9bff8c8bd92737afcc" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/7c/82/686bde4666b72e821f724dc2d143ad0b9a50af7c145ecba1e57ccb9aeb97/google_cloud_kms-3.6.0-py3-none-any.whl", upload-time = 2025-09-22T16:51:00Z, size = 272683, hashes = { sha256 = "1dc389f327cce288ac3091860497ab50b2d166fb71603e632bc4bfd1b2b74cd5" } }]
+
+[[packages]]
 name = "google-cloud-storage"
 version = "2.18.0"
 sdist = { url = "https://files.pythonhosted.org/packages/26/00/9d17394eba3e214ba3748d16eeac4b060d35a45da86061b3e3268077cc55/google_cloud_storage-2.18.0.tar.gz", upload-time = 2024-07-22T22:21:52Z, size = 5532490, hashes = { sha256 = "0aa3f7c57f3632f81b455d91558d2b27ada96eee2de3aaa17f689db1470d9578" } }

--- a/backend/pylock.toml
+++ b/backend/pylock.toml
@@ -425,6 +425,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/ce/9b/7c2f746cd8ec3f08d
 wheels = [{ url = "https://files.pythonhosted.org/packages/80/3f/52fd16f3de3ed4ac2e3b7c728fb3b29b081791cf6292b74e4301ad489737/google_cloud_firestore-2.20.0-py2.py3-none-any.whl", upload-time = 2025-01-13T21:39:40Z, size = 337765, hashes = { sha256 = "505ef6951b56ea91f6762d99b3429ca6def6dceb254b4ba1ffc85e69b71414d7" } }]
 
 [[packages]]
+name = "google-cloud-kms"
+version = "3.6.0"
+sdist = { url = "https://files.pythonhosted.org/packages/73/8a/ee0569d6dd4f4bb99fdf2a28466f1914a3f2849506c75b620c213feb043b/google_cloud_kms-3.6.0.tar.gz", upload-time = 2025-09-22T16:51:16Z, size = 329923, hashes = { sha256 = "c0f7f2474e35e99e6a36651520a26fdba4bb8e73b7cd0d9bff8c8bd92737afcc" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/7c/82/686bde4666b72e821f724dc2d143ad0b9a50af7c145ecba1e57ccb9aeb97/google_cloud_kms-3.6.0-py3-none-any.whl", upload-time = 2025-09-22T16:51:00Z, size = 272683, hashes = { sha256 = "1dc389f327cce288ac3091860497ab50b2d166fb71603e632bc4bfd1b2b74cd5" } }]
+
+[[packages]]
 name = "google-cloud-storage"
 version = "2.18.0"
 sdist = { url = "https://files.pythonhosted.org/packages/26/00/9d17394eba3e214ba3748d16eeac4b060d35a45da86061b3e3268077cc55/google_cloud_storage-2.18.0.tar.gz", upload-time = 2024-07-22T22:21:52Z, size = 5532490, hashes = { sha256 = "0aa3f7c57f3632f81b455d91558d2b27ada96eee2de3aaa17f689db1470d9578" } }

--- a/backend/pylock.windows.toml
+++ b/backend/pylock.windows.toml
@@ -430,6 +430,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/ce/9b/7c2f746cd8ec3f08d
 wheels = [{ url = "https://files.pythonhosted.org/packages/80/3f/52fd16f3de3ed4ac2e3b7c728fb3b29b081791cf6292b74e4301ad489737/google_cloud_firestore-2.20.0-py2.py3-none-any.whl", upload-time = 2025-01-13T21:39:40Z, size = 337765, hashes = { sha256 = "505ef6951b56ea91f6762d99b3429ca6def6dceb254b4ba1ffc85e69b71414d7" } }]
 
 [[packages]]
+name = "google-cloud-kms"
+version = "3.6.0"
+sdist = { url = "https://files.pythonhosted.org/packages/73/8a/ee0569d6dd4f4bb99fdf2a28466f1914a3f2849506c75b620c213feb043b/google_cloud_kms-3.6.0.tar.gz", upload-time = 2025-09-22T16:51:16Z, size = 329923, hashes = { sha256 = "c0f7f2474e35e99e6a36651520a26fdba4bb8e73b7cd0d9bff8c8bd92737afcc" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/7c/82/686bde4666b72e821f724dc2d143ad0b9a50af7c145ecba1e57ccb9aeb97/google_cloud_kms-3.6.0-py3-none-any.whl", upload-time = 2025-09-22T16:51:00Z, size = 272683, hashes = { sha256 = "1dc389f327cce288ac3091860497ab50b2d166fb71603e632bc4bfd1b2b74cd5" } }]
+
+[[packages]]
 name = "google-cloud-storage"
 version = "2.18.0"
 sdist = { url = "https://files.pythonhosted.org/packages/26/00/9d17394eba3e214ba3748d16eeac4b060d35a45da86061b3e3268077cc55/google_cloud_storage-2.18.0.tar.gz", upload-time = 2024-07-22T22:21:52Z, size = 5532490, hashes = { sha256 = "0aa3f7c57f3632f81b455d91558d2b27ada96eee2de3aaa17f689db1470d9578" } }

--- a/backend/tests/unit/test_conversation_search_date_validation.py
+++ b/backend/tests/unit/test_conversation_search_date_validation.py
@@ -48,6 +48,10 @@ _stubs = [
     'database.redis_db',
     'database.users',
     'database.vector_db',
+    # routers.conversations imports FirestoreReadSite from here at module scope.
+    # database is stubbed submodule-by-submodule in this file, so a new one has to
+    # be listed or collection fails with ModuleNotFoundError before any test runs.
+    'database.firestore_read_metrics',
     'firebase_admin',
     'firebase_admin.messaging',
     'firebase_admin.auth',


### PR DESCRIPTION
## What

Adds `google-cloud-kms==3.6.0` to the five checked-in uv pylocks. One package added, **zero removed, zero version changes** across all five files.

## Why — every backend deploy is currently failing

[#12135](https://github.com/BasedHardware/omi/pull/12135) added `google-cloud-kms==3.6.0` to `backend/requirements.txt` and imports `google.cloud.kms_v1` in `backend/utils/screen_frames/approval.py`. But `backend/Dockerfile` installs from `backend/pylock.runtime.toml`, **not** from `requirements.txt`, and the lock was never regenerated. The module is therefore absent from the built image.

The deploy's dependency smoke check catches it:

```
Smoke checking backend's 299 reachable third-party modules in gcr.io/based-hardware-dev/backend:b731473
AssertionError: missing installed dependency modules: ['google.cloud.kms_v1']
```

This blocks **dev and prod backend deploys alike**. It went unnoticed because the deploy job had not actually executed since #12135 merged: the intervening auto-dev runs either failed earlier at `firestore_readiness` (a separate, now-fixed missing Firestore index) or skipped the deploy job entirely.

## Why this is a real defect, not just a CI annoyance

The import is lazy and function-local, reached only when `SCREEN_FRAME_KMS_KEY` is set:

```python
def _get_client(self):
    if self._client is None:
        from google.cloud import kms_v1
        self._client = kms_v1.KeyManagementServiceClient()
```

So it does not crash at import. It would crash at **first use in production**, the moment anyone enables the KMS signer. #12135's own docstring states the library "is not installed in the environment this was built in" — the declaration in `requirements.txt` was correct in intent and simply never reached the artifact that gets deployed.

## How

`backend/scripts/update-python-lock.sh`, which runs `uv pip compile` **without** `--upgrade`, so existing pins are respected and only the missing dependency resolves.

## Verification

Per-file package diff, `origin/main` vs this branch:

| lock | added | removed | version-changed |
| --- | --- | --- | --- |
| `pylock.runtime.toml` | `google-cloud-kms 3.6.0` | 0 | 0 |
| `pylock.toml` | `google-cloud-kms` | 0 | 0 |
| `pylock.macos.toml` | `google-cloud-kms` | 0 | 0 |
| `pylock.macos-x86_64.toml` | `google-cloud-kms` | 0 | 0 |
| `pylock.windows.toml` | `google-cloud-kms` | 0 | 0 |

`pylock.runtime.toml` goes from 260 to 261 packages.

## Failure class

The contract of `FC-runtime-image-boundary` is exactly this defect: *"Every deployable runtime image must contain the reachable first-party source modules and installed third-party modules required by its declared entrypoint."* Its canonical prevention names the offline image smoke check — which is the gate that caught this, working as designed.

Failure-Class: FC-runtime-image-boundary


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

