### PR TITLE
Fix/web app tasks UI

### DIFF
--- a/web/app/src/components/tasks/TaskListView.tsx
+++ b/web/app/src/components/tasks/TaskListView.tsx
@@ -84,7 +84,7 @@ export function TaskListView({
   return (
     <div className="flex flex-col">
       {/* Pending tasks - flat list */}
-      <div className="border border-bg-tertiary rounded-lg overflow-hidden">
+      <div className="border border-bg-tertiary rounded-lg">
         <AnimatePresence mode="popLayout">
           {filteredPending.map((task, index) => (
             <TaskRow

--- a/web/app/src/components/tasks/TaskRow.tsx
+++ b/web/app/src/components/tasks/TaskRow.tsx
@@ -355,6 +355,7 @@ export function TaskRow({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.1 }}
+            onDoubleClick={(e) => e.stopPropagation()}
             className="flex items-center gap-0.5 flex-shrink-0"
           >
             <button

--- a/web/app/src/components/tasks/__tests__/TaskRow.test.tsx
+++ b/web/app/src/components/tasks/__tests__/TaskRow.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { TaskRow } from '@/components/tasks/TaskRow';
+import type { ActionItem } from '@/types/conversation';
+
+function task(overrides: Partial<ActionItem> = {}): ActionItem {
+  return {
+    id: 'task-1',
+    description: 'Preview task',
+    completed: false,
+    due_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('TaskRow', () => {
+  it('does not enter selection mode when double-clicking +1d', async () => {
+    const onSnooze = vi.fn();
+    const onEnterSelectionMode = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <TaskRow
+        task={task()}
+        onToggleComplete={vi.fn()}
+        onSnooze={onSnooze}
+        onDelete={vi.fn()}
+        onEnterSelectionMode={onEnterSelectionMode}
+      />,
+    );
+
+    await user.hover(screen.getByText('Preview task'));
+    await user.dblClick(screen.getByTitle('Snooze 1 day'));
+
+    expect(onSnooze).toHaveBeenCalledWith('task-1', 1);
+    expect(onEnterSelectionMode).not.toHaveBeenCalled();
+  });
+});

--- a/web/app/src/hooks/__tests__/useActionItems.test.tsx
+++ b/web/app/src/hooks/__tests__/useActionItems.test.tsx
@@ -1,0 +1,62 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { invalidateCache, invalidationPatterns } from '@/lib/cache';
+
+vi.mock('@/lib/api', () => ({
+  getActionItems: vi.fn(),
+  createActionItem: vi.fn(),
+  toggleActionItemCompleted: vi.fn(),
+  updateActionItemDueDate: vi.fn(),
+  updateActionItemDescription: vi.fn(),
+  deleteActionItem: vi.fn(),
+}));
+
+const { getActionItems } = await import('@/lib/api');
+const { useActionItems } = await import('@/hooks/useActionItems');
+
+function item(id: string) {
+  return { id, description: id, completed: false, created_at: '2026-01-01T00:00:00Z' };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useActionItems', () => {
+  it('keeps the loaded list visible while a cache-invalidation refetch is in flight', async () => {
+    let resolveRefresh: (value: {
+      items: ReturnType<typeof item>[];
+      hasMore: boolean;
+    }) => void = () => undefined;
+
+    vi.mocked(getActionItems)
+      .mockResolvedValueOnce({ items: [item('a'), item('b')], hasMore: false } as never)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRefresh = resolve;
+          }),
+      );
+
+    const { result } = renderHook(() => useActionItems());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.items.map((task) => task.id)).toEqual(['a', 'b']);
+
+    act(() => {
+      invalidateCache(invalidationPatterns.actionItems);
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.items.map((task) => task.id)).toEqual(['a', 'b']);
+
+    await act(async () => {
+      resolveRefresh({ items: [item('a')], hasMore: false });
+    });
+
+    await waitFor(() =>
+      expect(result.current.items.map((task) => task.id)).toEqual(['a']),
+    );
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/web/app/src/hooks/useActionItems.ts
+++ b/web/app/src/hooks/useActionItems.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import {
   getActionItems,
   createActionItem,
@@ -153,7 +153,10 @@ function groupActionItems(items: ActionItem[]): GroupedActionItems {
 /**
  * Calculate task counts for a specific date
  */
-function getTaskCountsForDate(items: ActionItem[], date: Date): { pending: number; completed: number } {
+function getTaskCountsForDate(
+  items: ActionItem[],
+  date: Date,
+): { pending: number; completed: number } {
   if (!Array.isArray(items)) {
     return { pending: 0, completed: 0 };
   }
@@ -232,19 +235,28 @@ export function useActionItems(): UseActionItemsReturn {
   const [items, setItems] = useState<ActionItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // First paint only. A later refetch (cache invalidation after delete/snooze)
+  // must not flip `loading` — TaskHub unmounts the list when `loading` is true
+  // even if `items` is already populated.
+  const hasLoadedRef = useRef(false);
 
   // Fetch action items
   const fetchItems = useCallback(async () => {
     try {
-      setLoading(true);
+      if (!hasLoadedRef.current) {
+        setLoading(true);
+      }
       setError(null);
       const { items: data } = await getActionItems({ limit: 500 });
       // Ensure we always set an array
       setItems(Array.isArray(data) ? data : []);
+      hasLoadedRef.current = true;
     } catch (err) {
       console.error('Failed to fetch action items:', err);
       setError(err instanceof Error ? err.message : 'Failed to load tasks');
-      setItems([]); // Reset to empty array on error
+      if (!hasLoadedRef.current) {
+        setItems([]);
+      }
     } finally {
       setLoading(false);
     }
@@ -270,12 +282,12 @@ export function useActionItems(): UseActionItemsReturn {
 
   // Calculate stats
   const stats = useMemo(() => {
-    const completed = items.filter(i => i.completed).length;
-    const pending = items.filter(i => !i.completed).length;
+    const completed = items.filter((i) => i.completed).length;
+    const pending = items.filter((i) => !i.completed).length;
     const overdue = groupedItems.overdue.length;
     const noDueDateCount = groupedItems.noDueDate.length;
-    const todayItems = items.filter(i => i.due_at && isToday(new Date(i.due_at)));
-    const todayCompleted = todayItems.filter(i => i.completed).length;
+    const todayItems = items.filter((i) => i.due_at && isToday(new Date(i.due_at)));
+    const todayCompleted = todayItems.filter((i) => i.completed).length;
 
     // Calculate weekly stats (last 7 days)
     const today = new Date();
@@ -283,21 +295,21 @@ export function useActionItems(): UseActionItemsReturn {
     const weekAgo = new Date(today);
     weekAgo.setDate(weekAgo.getDate() - 7);
 
-    const weekItems = items.filter(i => {
+    const weekItems = items.filter((i) => {
       if (!i.due_at) return false;
       const dueDate = new Date(i.due_at);
       dueDate.setHours(0, 0, 0, 0);
       return dueDate >= weekAgo && dueDate <= today;
     });
-    const weekCompleted = weekItems.filter(i => i.completed).length;
-    const weekPending = weekItems.filter(i => !i.completed).length;
+    const weekCompleted = weekItems.filter((i) => i.completed).length;
+    const weekPending = weekItems.filter((i) => !i.completed).length;
 
     // Calculate streak (consecutive days with at least one completion)
     let streak = 0;
     const checkDate = new Date(today);
 
     // Check if we completed anything today first
-    const todayHasCompletion = items.some(i => {
+    const todayHasCompletion = items.some((i) => {
       if (!i.completed || !i.completed_at) return false;
       const completedDate = new Date(i.completed_at);
       return completedDate.toDateString() === today.toDateString();
@@ -310,7 +322,7 @@ export function useActionItems(): UseActionItemsReturn {
       // Count backwards from yesterday
       while (true) {
         const dateStr = checkDate.toDateString();
-        const hasCompletion = items.some(i => {
+        const hasCompletion = items.some((i) => {
           if (!i.completed || !i.completed_at) return false;
           const completedDate = new Date(i.completed_at);
           return completedDate.toDateString() === dateStr;
@@ -356,7 +368,10 @@ export function useActionItems(): UseActionItemsReturn {
 
       days.push({
         date,
-        dayName: i === 0 ? 'TODAY' : date.toLocaleDateString('en-US', { weekday: 'short' }).toUpperCase(),
+        dayName:
+          i === 0
+            ? 'TODAY'
+            : date.toLocaleDateString('en-US', { weekday: 'short' }).toUpperCase(),
         dayNumber: date.getDate(),
         isToday: i === 0,
         pending: counts.pending,
@@ -369,8 +384,8 @@ export function useActionItems(): UseActionItemsReturn {
 
   // Sorted flat list for list view (pending sorted by due date, no-date items last)
   const sortedFlatList = useMemo(() => {
-    const pending = items.filter(i => !i.completed);
-    const completed = items.filter(i => i.completed);
+    const pending = items.filter((i) => !i.completed);
+    const completed = items.filter((i) => i.completed);
 
     // Sort pending: by due date (soonest first), items without due date go last
     pending.sort((a, b) => {
@@ -398,27 +413,34 @@ export function useActionItems(): UseActionItemsReturn {
   }, [items]);
 
   // Add new item
-  const addItem = useCallback(async (params: CreateActionItemParams): Promise<ActionItem | null> => {
-    try {
-      const newItem = await createActionItem(params);
-      setItems(prev => [newItem, ...prev]);
-      return newItem;
-    } catch (err) {
-      console.error('Failed to create action item:', err);
-      setError(err instanceof Error ? err.message : 'Failed to create task');
-      return null;
-    }
-  }, []);
+  const addItem = useCallback(
+    async (params: CreateActionItemParams): Promise<ActionItem | null> => {
+      try {
+        const newItem = await createActionItem(params);
+        setItems((prev) => [newItem, ...prev]);
+        return newItem;
+      } catch (err) {
+        console.error('Failed to create action item:', err);
+        setError(err instanceof Error ? err.message : 'Failed to create task');
+        return null;
+      }
+    },
+    [],
+  );
 
   // Toggle completion
   const toggleComplete = useCallback(async (id: string, completed: boolean) => {
     // Optimistic update
-    setItems(prev =>
-      prev.map(item =>
+    setItems((prev) =>
+      prev.map((item) =>
         item.id === id
-          ? { ...item, completed, completed_at: completed ? new Date().toISOString() : null }
-          : item
-      )
+          ? {
+              ...item,
+              completed,
+              completed_at: completed ? new Date().toISOString() : null,
+            }
+          : item,
+      ),
     );
 
     try {
@@ -426,199 +448,217 @@ export function useActionItems(): UseActionItemsReturn {
     } catch (err) {
       console.error('Failed to toggle completion:', err);
       // Revert on error
-      setItems(prev =>
-        prev.map(item =>
-          item.id === id ? { ...item, completed: !completed, completed_at: null } : item
-        )
+      setItems((prev) =>
+        prev.map((item) =>
+          item.id === id ? { ...item, completed: !completed, completed_at: null } : item,
+        ),
       );
       setError(err instanceof Error ? err.message : 'Failed to update task');
     }
   }, []);
 
   // Snooze (add days to due date)
-  const snooze = useCallback(async (id: string, days: number) => {
-    const item = items.find(i => i.id === id);
-    if (!item) return;
+  const snooze = useCallback(
+    async (id: string, days: number) => {
+      const item = items.find((i) => i.id === id);
+      if (!item) return;
 
-    const newDate = new Date();
-    if (item.due_at) {
-      const currentDate = new Date(item.due_at);
-      // If current date is in the past, start from today
-      if (currentDate < newDate) {
-        newDate.setDate(newDate.getDate() + days);
+      const newDate = new Date();
+      if (item.due_at) {
+        const currentDate = new Date(item.due_at);
+        // If current date is in the past, start from today
+        if (currentDate < newDate) {
+          newDate.setDate(newDate.getDate() + days);
+        } else {
+          newDate.setTime(currentDate.getTime());
+          newDate.setDate(newDate.getDate() + days);
+        }
       } else {
-        newDate.setTime(currentDate.getTime());
         newDate.setDate(newDate.getDate() + days);
       }
-    } else {
-      newDate.setDate(newDate.getDate() + days);
-    }
 
-    // Optimistic update
-    const newDueAt = newDate.toISOString();
-    setItems(prev =>
-      prev.map(i => (i.id === id ? { ...i, due_at: newDueAt } : i))
-    );
+      // Optimistic update
+      const newDueAt = newDate.toISOString();
+      setItems((prev) => prev.map((i) => (i.id === id ? { ...i, due_at: newDueAt } : i)));
 
-    try {
-      await updateActionItemDueDate(id, newDueAt);
-    } catch (err) {
-      console.error('Failed to snooze task:', err);
-      // Revert on error
-      setItems(prev =>
-        prev.map(i => (i.id === id ? { ...i, due_at: item.due_at } : i))
-      );
-      setError(err instanceof Error ? err.message : 'Failed to snooze task');
-    }
-  }, [items]);
+      try {
+        await updateActionItemDueDate(id, newDueAt);
+      } catch (err) {
+        console.error('Failed to snooze task:', err);
+        // Revert on error
+        setItems((prev) =>
+          prev.map((i) => (i.id === id ? { ...i, due_at: item.due_at } : i)),
+        );
+        setError(err instanceof Error ? err.message : 'Failed to snooze task');
+      }
+    },
+    [items],
+  );
 
   // Set specific due date
-  const setDueDate = useCallback(async (id: string, date: Date | null) => {
-    const item = items.find(i => i.id === id);
-    if (!item) return;
+  const setDueDate = useCallback(
+    async (id: string, date: Date | null) => {
+      const item = items.find((i) => i.id === id);
+      if (!item) return;
 
-    const newDueAt = date ? date.toISOString() : null;
+      const newDueAt = date ? date.toISOString() : null;
 
-    // Optimistic update
-    setItems(prev =>
-      prev.map(i => (i.id === id ? { ...i, due_at: newDueAt } : i))
-    );
+      // Optimistic update
+      setItems((prev) => prev.map((i) => (i.id === id ? { ...i, due_at: newDueAt } : i)));
 
-    try {
-      await updateActionItemDueDate(id, newDueAt);
-    } catch (err) {
-      console.error('Failed to update due date:', err);
-      // Revert on error
-      setItems(prev =>
-        prev.map(i => (i.id === id ? { ...i, due_at: item.due_at } : i))
-      );
-      setError(err instanceof Error ? err.message : 'Failed to update due date');
-    }
-  }, [items]);
+      try {
+        await updateActionItemDueDate(id, newDueAt);
+      } catch (err) {
+        console.error('Failed to update due date:', err);
+        // Revert on error
+        setItems((prev) =>
+          prev.map((i) => (i.id === id ? { ...i, due_at: item.due_at } : i)),
+        );
+        setError(err instanceof Error ? err.message : 'Failed to update due date');
+      }
+    },
+    [items],
+  );
 
   // Update description
-  const updateDescription = useCallback(async (id: string, description: string) => {
-    const item = items.find(i => i.id === id);
-    if (!item) return;
+  const updateDescription = useCallback(
+    async (id: string, description: string) => {
+      const item = items.find((i) => i.id === id);
+      if (!item) return;
 
-    const oldDescription = item.description;
+      const oldDescription = item.description;
 
-    // Optimistic update
-    setItems(prev =>
-      prev.map(i => (i.id === id ? { ...i, description } : i))
-    );
+      // Optimistic update
+      setItems((prev) => prev.map((i) => (i.id === id ? { ...i, description } : i)));
 
-    try {
-      await updateActionItemDescription(id, description);
-    } catch (err) {
-      console.error('Failed to update description:', err);
-      // Revert on error
-      setItems(prev =>
-        prev.map(i => (i.id === id ? { ...i, description: oldDescription } : i))
-      );
-      setError(err instanceof Error ? err.message : 'Failed to update task');
-    }
-  }, [items]);
+      try {
+        await updateActionItemDescription(id, description);
+      } catch (err) {
+        console.error('Failed to update description:', err);
+        // Revert on error
+        setItems((prev) =>
+          prev.map((i) => (i.id === id ? { ...i, description: oldDescription } : i)),
+        );
+        setError(err instanceof Error ? err.message : 'Failed to update task');
+      }
+    },
+    [items],
+  );
 
   // Remove item
-  const removeItem = useCallback(async (id: string) => {
-    const item = items.find(i => i.id === id);
-    if (!item) return;
+  const removeItem = useCallback(
+    async (id: string) => {
+      const item = items.find((i) => i.id === id);
+      if (!item) return;
 
-    // Optimistic update
-    setItems(prev => prev.filter(i => i.id !== id));
+      // Optimistic update
+      setItems((prev) => prev.filter((i) => i.id !== id));
 
-    try {
-      await deleteActionItem(id);
-    } catch (err) {
-      console.error('Failed to delete task:', err);
-      // Revert on error
-      setItems(prev => [...prev, item]);
-      setError(err instanceof Error ? err.message : 'Failed to delete task');
-    }
-  }, [items]);
+      try {
+        await deleteActionItem(id);
+      } catch (err) {
+        console.error('Failed to delete task:', err);
+        // Revert on error
+        setItems((prev) => [...prev, item]);
+        setError(err instanceof Error ? err.message : 'Failed to delete task');
+      }
+    },
+    [items],
+  );
 
   // Bulk complete
-  const bulkComplete = useCallback(async (ids: string[]) => {
-    // Optimistic update
-    setItems(prev =>
-      prev.map(item =>
-        ids.includes(item.id)
-          ? { ...item, completed: true, completed_at: new Date().toISOString() }
-          : item
-      )
-    );
+  const bulkComplete = useCallback(
+    async (ids: string[]) => {
+      // Optimistic update
+      setItems((prev) =>
+        prev.map((item) =>
+          ids.includes(item.id)
+            ? { ...item, completed: true, completed_at: new Date().toISOString() }
+            : item,
+        ),
+      );
 
-    try {
-      await Promise.all(ids.map(id => toggleActionItemCompleted(id, true)));
-    } catch (err) {
-      console.error('Failed to bulk complete:', err);
-      // Refresh to get correct state
-      fetchItems();
-      setError(err instanceof Error ? err.message : 'Failed to complete tasks');
-    }
-  }, [fetchItems]);
+      try {
+        await Promise.all(ids.map((id) => toggleActionItemCompleted(id, true)));
+      } catch (err) {
+        console.error('Failed to bulk complete:', err);
+        // Refresh to get correct state
+        fetchItems();
+        setError(err instanceof Error ? err.message : 'Failed to complete tasks');
+      }
+    },
+    [fetchItems],
+  );
 
   // Bulk delete
-  const bulkDelete = useCallback(async (ids: string[]) => {
-    const deletedItems = items.filter(i => ids.includes(i.id));
+  const bulkDelete = useCallback(
+    async (ids: string[]) => {
+      const deletedItems = items.filter((i) => ids.includes(i.id));
 
-    // Optimistic update
-    setItems(prev => prev.filter(i => !ids.includes(i.id)));
+      // Optimistic update
+      setItems((prev) => prev.filter((i) => !ids.includes(i.id)));
 
-    try {
-      await Promise.all(ids.map(id => deleteActionItem(id)));
-    } catch (err) {
-      console.error('Failed to bulk delete:', err);
-      // Revert on error
-      setItems(prev => [...prev, ...deletedItems]);
-      setError(err instanceof Error ? err.message : 'Failed to delete tasks');
-    }
-  }, [items]);
+      try {
+        await Promise.all(ids.map((id) => deleteActionItem(id)));
+      } catch (err) {
+        console.error('Failed to bulk delete:', err);
+        // Revert on error
+        setItems((prev) => [...prev, ...deletedItems]);
+        setError(err instanceof Error ? err.message : 'Failed to delete tasks');
+      }
+    },
+    [items],
+  );
 
   // Bulk snooze
-  const bulkSnooze = useCallback(async (ids: string[], days: number) => {
-    const newDate = new Date();
-    newDate.setDate(newDate.getDate() + days);
-    const newDueAt = newDate.toISOString();
+  const bulkSnooze = useCallback(
+    async (ids: string[], days: number) => {
+      const newDate = new Date();
+      newDate.setDate(newDate.getDate() + days);
+      const newDueAt = newDate.toISOString();
 
-    // Optimistic update
-    setItems(prev =>
-      prev.map(item =>
-        ids.includes(item.id) ? { ...item, due_at: newDueAt } : item
-      )
-    );
+      // Optimistic update
+      setItems((prev) =>
+        prev.map((item) =>
+          ids.includes(item.id) ? { ...item, due_at: newDueAt } : item,
+        ),
+      );
 
-    try {
-      await Promise.all(ids.map(id => updateActionItemDueDate(id, newDueAt)));
-    } catch (err) {
-      console.error('Failed to bulk snooze:', err);
-      // Refresh to get correct state
-      fetchItems();
-      setError(err instanceof Error ? err.message : 'Failed to snooze tasks');
-    }
-  }, [fetchItems]);
+      try {
+        await Promise.all(ids.map((id) => updateActionItemDueDate(id, newDueAt)));
+      } catch (err) {
+        console.error('Failed to bulk snooze:', err);
+        // Refresh to get correct state
+        fetchItems();
+        setError(err instanceof Error ? err.message : 'Failed to snooze tasks');
+      }
+    },
+    [fetchItems],
+  );
 
   // Bulk set due date (for no-due-date items)
-  const bulkSetDueDate = useCallback(async (ids: string[], date: Date | null) => {
-    const newDueAt = date ? date.toISOString() : null;
+  const bulkSetDueDate = useCallback(
+    async (ids: string[], date: Date | null) => {
+      const newDueAt = date ? date.toISOString() : null;
 
-    // Optimistic update
-    setItems(prev =>
-      prev.map(item =>
-        ids.includes(item.id) ? { ...item, due_at: newDueAt } : item
-      )
-    );
+      // Optimistic update
+      setItems((prev) =>
+        prev.map((item) =>
+          ids.includes(item.id) ? { ...item, due_at: newDueAt } : item,
+        ),
+      );
 
-    try {
-      await Promise.all(ids.map(id => updateActionItemDueDate(id, newDueAt)));
-    } catch (err) {
-      console.error('Failed to bulk set due date:', err);
-      // Refresh to get correct state
-      fetchItems();
-      setError(err instanceof Error ? err.message : 'Failed to set due dates');
-    }
-  }, [fetchItems]);
+      try {
+        await Promise.all(ids.map((id) => updateActionItemDueDate(id, newDueAt)));
+      } catch (err) {
+        console.error('Failed to bulk set due date:', err);
+        // Refresh to get correct state
+        fetchItems();
+        setError(err instanceof Error ? err.message : 'Failed to set due dates');
+      }
+    },
+    [fetchItems],
+  );
 
   return {
     items,


### PR DESCRIPTION
<!-- Keep this short and honest. Reviewers read the Verification section first. -->

## What changed and why

Three Tasks UI bugs on `web/app` `/tasks`: the due-date popover was clipped by `overflow-hidden`, a double-click on `+1d` entered row selection because `click` `stopPropagation` does not stop `dblclick`, and deleting a task unmounted the whole list because cache-invalidation refetch flipped `loading` to true.

## Product invariants affected

none

## How it was verified

- `cd web/app && bun run typecheck` — pass
- `bunx vitest run --config vitest.config.mts src/components/tasks/__tests__/TaskRow.test.tsx src/hooks/__tests__/useActionItems.test.tsx` — 2 files, pass
- `NODE_OPTIONS=--no-experimental-webstorage bun run check` — typecheck + 328 tests pass (local Node 25 needs that flag; CI Bun 1.3.14 is the suite authority)
- `bun run build` — pass (firebase SW generated, 26 routes)
- Pre-push `scripts/pre-push` — pass; pushed `fix/web-app-tasks-ui`

Manual: exercised the list-view date picker (popover no longer clipped), double-click on `+1d` (snooze without selection mode), and delete (remaining rows stay on screen). Could not sign in against production Firebase from a contributor env; those checks were on the local Tasks UI with loaded tasks.

## Tests

- Date picker clip: no test — CSS `overflow-hidden` on the pending-list wrapper; clipping only shows in layout. Asserting a class string would be a static tripwire.
- Double-click `+1d`: `web/app/src/components/tasks/__tests__/TaskRow.test.tsx` — dblclick snooze does not call `onEnterSelectionMode`.
- Delete unmount: `web/app/src/hooks/__tests__/useActionItems.test.tsx` — cache-invalidation refetch keeps `loading === false` and existing items mounted.

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

