### PR TITLE
fix(web-app): stop Home from snapping chat history back down

### DIFF
--- a/web/app/src/components/chat/ChatTranscript.tsx
+++ b/web/app/src/components/chat/ChatTranscript.tsx
@@ -6,6 +6,11 @@ import Image from '@tschk/moonshine-next/image';
 import { Brain } from 'lucide-react';
 import type { ClientMessage } from '@/types/conversation';
 import { cn } from '@/lib/utils';
+import {
+  nearestVerticalScroller,
+  scrollEdgesOf,
+  shouldFollowLiveEdge,
+} from '@/lib/scrollEdges';
 import { ChatMarkdown } from './ChatMarkdown';
 
 /**
@@ -65,11 +70,31 @@ export function ChatTranscript({
   autoScroll = true,
 }: ChatTranscriptProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const placedExchangeRef = useRef(false);
 
-  // Scroll to bottom when messages change or streaming text updates
+  // Follow the live edge only while the reader is already there. Home's
+  // history sits in the same overflow ancestor, so a blanket scrollIntoView
+  // here is what yanks an upward history gesture back down.
   useEffect(() => {
-    if (autoScroll) messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [autoScroll, messages, streamingText]);
+    if (!autoScroll) {
+      placedExchangeRef.current = false;
+      return;
+    }
+    const end = messagesEndRef.current;
+    if (!end) return;
+    const scroller = nearestVerticalScroller(end.parentElement);
+    const pinnedToBottom = scroller
+      ? scrollEdgesOf({
+          scrollTop: scroller.scrollTop,
+          scrollHeight: scroller.scrollHeight,
+          clientHeight: scroller.clientHeight,
+        }).atBottom
+      : true;
+    const force = !placedExchangeRef.current;
+    if (!shouldFollowLiveEdge({ pinnedToBottom, force })) return;
+    placedExchangeRef.current = true;
+    end.scrollIntoView({ behavior: force ? 'auto' : 'smooth' });
+  }, [autoScroll, messages, streamingText, isStreaming, currentThinking]);
 
   if (isLoading && messages.length === 0) {
     return (

--- a/web/app/src/components/chat/__tests__/ChatTranscript.test.tsx
+++ b/web/app/src/components/chat/__tests__/ChatTranscript.test.tsx
@@ -1,0 +1,132 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatTranscript } from '@/components/chat/ChatTranscript';
+import type { ClientMessage } from '@/types/conversation';
+
+vi.mock('@tschk/moonshine-next/image', () => ({
+  default: ({ alt }: React.ComponentProps<'img'>) => <img alt={alt} />,
+}));
+vi.mock('@/components/chat/ChatMarkdown', () => ({
+  ChatMarkdown: ({ children }: { children: string }) => <div>{children}</div>,
+}));
+
+function message(id: string, text: string): ClientMessage {
+  return {
+    id,
+    sender: 'ai',
+    text,
+    created_at: '2026-08-11T00:00:00Z',
+    type: 'text',
+    from_external_integration: false,
+    files: [],
+    memories: [],
+    ask_for_nps: false,
+  };
+}
+
+function Scroller({
+  children,
+  scrollTop,
+}: {
+  children: React.ReactNode;
+  scrollTop: number;
+}) {
+  return (
+    <div
+      data-testid="scroller"
+      style={{ overflowY: 'auto', height: 800 }}
+      ref={(node) => {
+        if (!node) return;
+        Object.defineProperty(node, 'scrollHeight', { value: 2000, configurable: true });
+        Object.defineProperty(node, 'clientHeight', { value: 800, configurable: true });
+        node.scrollTop = scrollTop;
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+describe('ChatTranscript live-edge following', () => {
+  it('places a new exchange even when the scroller is not yet at the bottom', () => {
+    render(
+      <Scroller scrollTop={100}>
+        <ChatTranscript
+          messages={[message('ai-1', 'Hello')]}
+          isLoading={false}
+          isStreaming={false}
+          streamingText=""
+          currentThinking=""
+        />
+      </Scroller>,
+    );
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it('does not follow a stream once the reader has left the live edge', () => {
+    const { rerender } = render(
+      <Scroller scrollTop={100}>
+        <ChatTranscript
+          messages={[message('ai-1', 'Hello')]}
+          isLoading={false}
+          isStreaming
+          streamingText=""
+          currentThinking=""
+        />
+      </Scroller>,
+    );
+
+    const scrollIntoView = Element.prototype.scrollIntoView as ReturnType<typeof vi.fn>;
+    scrollIntoView.mockClear();
+
+    rerender(
+      <Scroller scrollTop={100}>
+        <ChatTranscript
+          messages={[message('ai-1', 'Hello')]}
+          isLoading={false}
+          isStreaming
+          streamingText="Hello there"
+          currentThinking=""
+        />
+      </Scroller>,
+    );
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('keeps following while the scroller stays pinned to the live edge', () => {
+    const { rerender } = render(
+      <Scroller scrollTop={1200}>
+        <ChatTranscript
+          messages={[message('ai-1', 'Hello')]}
+          isLoading={false}
+          isStreaming
+          streamingText=""
+          currentThinking=""
+        />
+      </Scroller>,
+    );
+
+    const scrollIntoView = Element.prototype.scrollIntoView as ReturnType<typeof vi.fn>;
+    scrollIntoView.mockClear();
+
+    rerender(
+      <Scroller scrollTop={1200}>
+        <ChatTranscript
+          messages={[message('ai-1', 'Hello')]}
+          isLoading={false}
+          isStreaming
+          streamingText="Hello there"
+          currentThinking=""
+        />
+      </Scroller>,
+    );
+
+    expect(scrollIntoView).toHaveBeenCalled();
+  });
+});

--- a/web/app/src/components/home/HomePage.tsx
+++ b/web/app/src/components/home/HomePage.tsx
@@ -84,6 +84,12 @@ export function HomePage() {
   const { ref: scrollRef, edges } = useScrollEdges<HTMLDivElement>();
   const live = useGeminiLive({ messages, onExchange: appendRealtimeExchange });
   const isLive = live.state !== 'idle';
+  const loadHistoryRef = useRef(loadHistory);
+  loadHistoryRef.current = loadHistory;
+  // Launch places Currents in view once. After that the reader owns the
+  // scroller: a later no-op loadHistory, a task/goal rerender, or a stream
+  // must not scrollIntoView the hub and yank them out of history.
+  const readerOwnsViewportRef = useRef(false);
 
   // Track the goal by id, not by value, so the sheet keeps showing live data
   // after an optimistic write replaces the object.
@@ -91,17 +97,23 @@ export function HomePage() {
 
   useEffect(() => {
     let active = true;
+    readerOwnsViewportRef.current = false;
     setExchangeStart(null);
-    void loadHistory().finally(() => {
-      if (!active) return;
-      window.requestAnimationFrame(() =>
-        currentsRef.current?.scrollIntoView?.({ block: 'start' }),
-      );
+    void loadHistoryRef.current().finally(() => {
+      if (!active || readerOwnsViewportRef.current) return;
+      window.requestAnimationFrame(() => {
+        if (!active || readerOwnsViewportRef.current) return;
+        currentsRef.current?.scrollIntoView?.({ block: 'start' });
+      });
     });
     return () => {
       active = false;
     };
-  }, [loadHistory, selectedAppId, selectedChatSessionId]);
+  }, [selectedAppId, selectedChatSessionId]);
+
+  const markReaderOwned = () => {
+    readerOwnsViewportRef.current = true;
+  };
 
   useEffect(() => {
     askRef.current?.focus();
@@ -158,7 +170,13 @@ export function HomePage() {
             edges.atBottom ? 'opacity-0' : 'opacity-100',
           )}
         />
-        <div ref={scrollRef} className="no-scrollbar h-full overflow-y-auto">
+        <div
+          ref={scrollRef}
+          className="no-scrollbar h-full overflow-y-auto [overflow-anchor:none]"
+          onWheel={markReaderOwned}
+          onTouchMove={markReaderOwned}
+          onPointerDown={markReaderOwned}
+        >
           {isLoading && messages.length === 0 ? (
             <div className="mx-auto max-w-3xl px-4 py-5 sm:px-6 sm:py-6">
               <ChatTranscript

--- a/web/app/src/components/home/__tests__/HomePage.test.tsx
+++ b/web/app/src/components/home/__tests__/HomePage.test.tsx
@@ -118,6 +118,8 @@ vi.mock('@/components/chat/RecordingStage', () => ({ RecordingStage: () => null 
 
 beforeEach(() => {
   vi.clearAllMocks();
+  loadHistory.mockReset();
+  loadHistory.mockResolvedValue(undefined);
   Element.prototype.scrollIntoView = vi.fn();
   window.requestAnimationFrame = (callback) => {
     callback(0);
@@ -159,5 +161,33 @@ describe('Home Currents ordering', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Start live test' }));
 
     expect(startLive).toHaveBeenCalledTimes(1);
+  });
+
+  it('places Currents in view after history loads', async () => {
+    render(<HomePage />);
+
+    await waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(1));
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it('does not snap Currents back into view after the reader scrolls history', async () => {
+    let resolveHistory!: (value: undefined) => void;
+    loadHistory.mockImplementation(
+      () =>
+        new Promise<undefined>((resolve) => {
+          resolveHistory = resolve;
+        }),
+    );
+
+    render(<HomePage />);
+    const history = await screen.findByRole('region', { name: 'Chat history' });
+    fireEvent.wheel(history);
+
+    const scrollIntoView = Element.prototype.scrollIntoView as ReturnType<typeof vi.fn>;
+    scrollIntoView.mockClear();
+    resolveHistory(undefined);
+
+    await waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(1));
+    expect(scrollIntoView).not.toHaveBeenCalled();
   });
 });

--- a/web/app/src/lib/__tests__/scrollEdges.test.ts
+++ b/web/app/src/lib/__tests__/scrollEdges.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { scrollEdgesOf } from '@/lib/scrollEdges';
+import { scrollEdgesOf, shouldFollowLiveEdge } from '@/lib/scrollEdges';
 
 describe('scrollEdgesOf', () => {
   it('reports both ends for content that does not fill the scroller', () => {
@@ -39,5 +39,19 @@ describe('scrollEdgesOf', () => {
     expect(
       scrollEdgesOf({ scrollTop: 1199.66, scrollHeight: 2000, clientHeight: 800 }),
     ).toMatchObject({ atBottom: true });
+  });
+});
+
+describe('shouldFollowLiveEdge', () => {
+  it('follows while the scroller is already at the live edge', () => {
+    expect(shouldFollowLiveEdge({ pinnedToBottom: true })).toBe(true);
+  });
+
+  it('does not steal the viewport once the reader has left the live edge', () => {
+    expect(shouldFollowLiveEdge({ pinnedToBottom: false })).toBe(false);
+  });
+
+  it('places a newly opened exchange even if the scroller is not at the bottom yet', () => {
+    expect(shouldFollowLiveEdge({ pinnedToBottom: false, force: true })).toBe(true);
   });
 });

--- a/web/app/src/lib/scrollEdges.ts
+++ b/web/app/src/lib/scrollEdges.ts
@@ -30,3 +30,34 @@ export function scrollEdgesOf({
     atBottom: scrollTop + clientHeight >= scrollHeight - SCROLL_EDGE_EPSILON,
   };
 }
+
+/**
+ * Whether a live transcript may move the scroller.
+ *
+ * `scrollIntoView` walks every overflow ancestor. On Home that ancestor is the
+ * page scroller that also holds chat history, so following a stream while the
+ * reader is in history snaps them back down. Follow only while they are already
+ * at the live edge, or when they just opened this exchange.
+ */
+export function shouldFollowLiveEdge({
+  pinnedToBottom,
+  force,
+}: {
+  pinnedToBottom: boolean;
+  force?: boolean;
+}): boolean {
+  return Boolean(force) || pinnedToBottom;
+}
+
+/** Closest ancestor that actually scrolls vertically, if there is one. */
+export function nearestVerticalScroller(start: HTMLElement | null): HTMLElement | null {
+  let node: HTMLElement | null = start;
+  while (node) {
+    const overflowY = window.getComputedStyle(node).overflowY;
+    if (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay') {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return null;
+}


### PR DESCRIPTION
<!-- Keep this short and honest. Reviewers read the Verification section first. -->

## What changed and why

Home shares one scroller for history, Currents, and the live exchange. After history loaded it called `scrollIntoView` on Currents, and live-edge follow used `scrollIntoView` on the same ancestor, so scrolling history upward yanked the viewport back down. Launch placement now runs once per session and yields as soon as the reader moves; live follow only runs while pinned to the bottom (or on a newly opened exchange).

## Product invariants affected

none

## How it was verified

- Scrolled chat history up on `/home` (worktree at http://localhost:3000): the viewport stayed on the history instead of snapping back to Currents.
- `cd web/app && NODE_OPTIONS=--no-experimental-webstorage bun run check` — typecheck clean, 334 tests passed.
- Pre-push: 15 manifest checks passed, including `web-app-checks` and `failure-class-protocol`.

## Tests

- `web/app/src/components/home/__tests__/HomePage.test.tsx` — after a wheel on history, delayed `loadHistory` must not `scrollIntoView` Currents.
- `web/app/src/components/chat/__tests__/ChatTranscript.test.tsx` — autoScroll does not follow a stream once the scroller has left the live edge; it still places a new exchange and follows while pinned.
- `web/app/src/lib/__tests__/scrollEdges.test.ts` — `shouldFollowLiveEdge` pins the follow/force cases without a DOM.

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

