### PR TITLE
feat(action-items): task cleanup — preview/execute endpoints + Windows desktop UI

### DIFF
--- a/backend/config/task_intelligence_sources_v1.json
+++ b/backend/config/task_intelligence_sources_v1.json
@@ -13,7 +13,8 @@
         "app/lib/pages/action_items/widgets/action_item_form_sheet.dart",
         "app/lib/pages/conversation_detail/widgets.dart",
         "app/lib/pages/conversations/widgets/goals_widget.dart",
-        "backend/routers/action_items.py"
+        "backend/routers/action_items.py",
+        "backend/routers/action_items_cleanup.py"
       ],
       "test_adapter": "direct_command_contract",
       "writer_anchors": [
@@ -23,7 +24,8 @@
         {"path": "backend/routers/action_items.py", "symbol": "action_items_db.delete_action_items_batch", "discover": true},
         {"path": "backend/routers/action_items.py", "symbol": "action_items_db.delete_action_items_for_conversation", "discover": true},
         {"path": "backend/routers/action_items.py", "symbol": "action_items_db.mark_action_item_completed", "discover": true},
-        {"path": "backend/routers/action_items.py", "symbol": "action_items_db.update_action_item", "discover": true}
+        {"path": "backend/routers/action_items.py", "symbol": "action_items_db.update_action_item", "discover": true},
+        {"path": "backend/routers/action_items_cleanup.py", "symbol": "action_items_db.delete_action_items_batch", "discover": true}
       ]
     },
     {

--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -500,6 +500,18 @@ def get_action_item(uid: str, action_item_id: str) -> Optional[Dict[str, Any]]:
 # Hard safety caps for list reads. Unbounded streams + in-process sort caused prod GET
 # /v1/action-items to hit HTTP_GET_TIMEOUT (30s) → 504 on large accounts.
 _ACTION_ITEMS_LIST_HARD_MAX = 2000
+
+
+def get_action_items_list_scan_cap() -> int:
+    """Public accessor for _ACTION_ITEMS_LIST_HARD_MAX.
+
+    Lets a caller of get_action_items() (e.g. cleanup preview) tell whether the
+    2000-item scan cap may have left tasks out of what it read, without reaching
+    into a private module constant.
+    """
+    return _ACTION_ITEMS_LIST_HARD_MAX
+
+
 # Slack so a handful of soft-deleted rows in a Firestore prefix still fill the page.
 _ACTION_ITEMS_LIST_DELETED_SLACK = 32
 # Lean projection for GET /v1/action-items. Omit `provenance` (evidence arrays dominate
@@ -983,6 +995,34 @@ def get_action_items_count_by_conversation(uid: str, conversation_id: str) -> Di
     # between them can leave completed > total. Cap it so the three values stay internally consistent.
     completed = min(completed, total)
     return {'total': total, 'completed': completed, 'incomplete': max(0, total - completed)}
+
+
+def get_open_action_items_count(uid: str) -> int:
+    """Return the true count of open (incomplete) action items for a user.
+
+    Uses Firestore count() aggregation — no document reads, no _ACTION_ITEMS_LIST_HARD_MAX
+    cap — so callers (e.g. cleanup preview) can tell whether get_action_items()'s 2000-item
+    scan cap left tasks out of what it actually read. "Open" is derived as total minus
+    completed (not a completed==False equality filter) so legacy docs with a missing/null
+    completed field count as open, matching get_action_items' own treatment of them.
+    """
+    base = db.collection('users').document(uid).collection(action_items_collection)
+    total = int(base.count().get()[0][0].value)
+    completed = int(base.where(filter=FieldFilter('completed', '==', True)).count().get()[0][0].value)
+
+    # Exclude soft-retired items, same trade-off as get_action_items_count_by_conversation:
+    # stream just the (rare) deleted subset and subtract, rather than requiring a filtered
+    # composite index.
+    deleted_total = 0
+    deleted_completed = 0
+    for doc in base.where(filter=FieldFilter('deleted', '==', True)).stream():
+        deleted_total += 1
+        if (doc.to_dict() or {}).get('completed'):
+            deleted_completed += 1
+
+    total = max(0, total - deleted_total)
+    completed = max(0, min(completed - deleted_completed, total))
+    return max(0, total - completed)
 
 
 def get_action_items_by_ids(uid: str, action_item_ids: List[str]) -> List[Dict[str, Any]]:

--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -1,7 +1,5 @@
 from dataclasses import dataclass, field
 from datetime import datetime, timezone, timedelta
-import base64
-import json
 import logging
 from typing import Any, Dict, Iterable, List, Optional, Protocol, cast
 
@@ -18,7 +16,6 @@ from database.firestore_transaction_retry import run_with_transaction_contention
 from database.firestore_read_metrics import FirestoreReadFamily, FirestoreReadMode, record_firestore_read
 from database.firestore_index_registry import (
     ACTION_ITEMS_CANONICAL_COMPLETION_COUNT_QUERY,
-    ACTION_ITEMS_CLEANUP_OPEN_CREATED_SCAN_QUERY,
     ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY,
     ACTION_ITEMS_COMPLETED_DUE_RANGE_QUERY,
     ACTION_ITEMS_COMPLETION_ID_SCAN_QUERY,
@@ -504,17 +501,6 @@ def get_action_item(uid: str, action_item_id: str) -> Optional[Dict[str, Any]]:
 # /v1/action-items to hit HTTP_GET_TIMEOUT (30s) → 504 on large accounts.
 _ACTION_ITEMS_LIST_HARD_MAX = 2000
 
-
-def get_action_items_list_scan_cap() -> int:
-    """Public accessor for _ACTION_ITEMS_LIST_HARD_MAX.
-
-    Lets a caller of get_action_items() (e.g. cleanup preview) tell whether the
-    2000-item scan cap may have left tasks out of what it read, without reaching
-    into a private module constant.
-    """
-    return _ACTION_ITEMS_LIST_HARD_MAX
-
-
 # Slack so a handful of soft-deleted rows in a Firestore prefix still fill the page.
 _ACTION_ITEMS_LIST_DELETED_SLACK = 32
 # Lean projection for GET /v1/action-items. Omit `provenance` (evidence arrays dominate
@@ -998,95 +984,6 @@ def get_action_items_count_by_conversation(uid: str, conversation_id: str) -> Di
     # between them can leave completed > total. Cap it so the three values stay internally consistent.
     completed = min(completed, total)
     return {'total': total, 'completed': completed, 'incomplete': max(0, total - completed)}
-
-
-def get_open_action_items_count(uid: str) -> int:
-    """Return the true count of open (incomplete) action items for a user.
-
-    Uses Firestore count() aggregation — no document reads, no _ACTION_ITEMS_LIST_HARD_MAX
-    cap — so callers (e.g. cleanup preview) can tell whether get_action_items()'s 2000-item
-    scan cap left tasks out of what it actually read. "Open" is derived as total minus
-    completed (not a completed==False equality filter) so legacy docs with a missing/null
-    completed field count as open, matching get_action_items' own treatment of them.
-    """
-    base = db.collection('users').document(uid).collection(action_items_collection)
-    total = int(base.count().get()[0][0].value)
-    completed = int(base.where(filter=FieldFilter('completed', '==', True)).count().get()[0][0].value)
-
-    # Exclude soft-retired items, same trade-off as get_action_items_count_by_conversation:
-    # stream just the (rare) deleted subset and subtract, rather than requiring a filtered
-    # composite index.
-    deleted_total = 0
-    deleted_completed = 0
-    for doc in base.where(filter=FieldFilter('deleted', '==', True)).stream():
-        deleted_total += 1
-        if (doc.to_dict() or {}).get('completed'):
-            deleted_completed += 1
-
-    total = max(0, total - deleted_total)
-    completed = max(0, min(completed - deleted_completed, total))
-    return max(0, total - completed)
-
-
-def _parse_cleanup_scan_created_at(value: Any) -> datetime:
-    if value is None:
-        return datetime.min.replace(tzinfo=timezone.utc)
-    if isinstance(value, datetime):
-        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
-    if isinstance(value, str):
-        return datetime.fromisoformat(value.rstrip('Z')).replace(tzinfo=timezone.utc)
-    if hasattr(value, 'timestamp'):
-        return datetime.fromtimestamp(value.timestamp(), tz=timezone.utc)
-    return datetime.min.replace(tzinfo=timezone.utc)
-
-
-def encode_cleanup_scan_cursor(created_at: datetime, doc_id: str) -> str:
-    """Encode the last scanned open task for deterministic cleanup pagination."""
-    normalized = created_at if created_at.tzinfo else created_at.replace(tzinfo=timezone.utc)
-    payload = {'created_at': normalized.astimezone(timezone.utc).isoformat(), 'id': doc_id}
-    return base64.urlsafe_b64encode(json.dumps(payload, separators=(',', ':')).encode()).decode()
-
-
-def decode_cleanup_scan_cursor(cursor: str) -> tuple[datetime, str]:
-    try:
-        payload = json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
-        return _parse_cleanup_scan_created_at(payload['created_at']), str(payload['id'])
-    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
-        raise ValueError('Invalid cleanup scan cursor') from exc
-
-
-def list_open_action_items_for_cleanup(
-    uid: str,
-    *,
-    limit: Optional[int] = None,
-    cursor: Optional[str] = None,
-) -> tuple[List[Dict[str, Any]], Optional[str], int]:
-    """Return one oldest-first page of open action items for cleanup strategies.
-
-    Uses a deterministic ``created_at`` + document-id ordering so repeated preview
-    runs can advance through large accounts via ``cursor`` instead of rescanning
-    the same arbitrary Firestore prefix.
-    """
-    row_cap = min(limit or _ACTION_ITEMS_LIST_HARD_MAX, _ACTION_ITEMS_LIST_HARD_MAX)
-    coll = db.collection('users').document(uid).collection(action_items_collection)
-    query = ACTION_ITEMS_CLEANUP_OPEN_CREATED_SCAN_QUERY.build(
-        coll.select(list(_ACTION_ITEMS_LIST_SELECT_FIELDS)),
-        {'completed': False},
-        field_filter_factory=FieldFilter,
-    ).order_by('created_at', direction=firestore.Query.ASCENDING)
-
-    if cursor:
-        created_at, doc_id = decode_cleanup_scan_cursor(cursor)
-        query = query.start_after({'created_at': created_at, '__name__': coll.document(doc_id)})
-
-    items, docs_read = _stream_action_items_bounded(query, max_docs=_list_scan_budget(row_cap))
-    items.sort(key=lambda item: (_parse_cleanup_scan_created_at(item.get('created_at')), item['id']))
-    page_items = items[:row_cap]
-    next_cursor = None
-    if page_items and (len(items) > row_cap or docs_read >= _list_scan_budget(row_cap)):
-        last = page_items[-1]
-        next_cursor = encode_cleanup_scan_cursor(_parse_cleanup_scan_created_at(last.get('created_at')), last['id'])
-    return page_items, next_cursor, len(page_items)
 
 
 def get_action_items_by_ids(uid: str, action_item_ids: List[str]) -> List[Dict[str, Any]]:
@@ -1664,3 +1561,10 @@ def get_scores(uid: str, date: Optional[str] = None, *, firestore_client: Any = 
         'default_tab': default_tab,
         'date': day.strftime('%Y-%m-%d'),
     }
+
+
+from database.action_items_cleanup_scan import (  # noqa: E402
+    get_action_items_list_scan_cap,
+    get_open_action_items_count,
+    list_open_action_items_for_cleanup,
+)

--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -1563,8 +1563,32 @@ def get_scores(uid: str, date: Optional[str] = None, *, firestore_client: Any = 
     }
 
 
+# Public read-only accessors for sibling modules (action_items_cleanup_scan) so
+# they never have to reach into module-private symbols (pyright reportPrivateUsage).
+def get_action_items_list_hard_max() -> int:
+    return _ACTION_ITEMS_LIST_HARD_MAX
+
+
+def get_action_items_list_select_fields() -> tuple:
+    return _ACTION_ITEMS_LIST_SELECT_FIELDS
+
+
+def list_scan_budget(row_budget: int) -> int:
+    return _list_scan_budget(row_budget)
+
+
+def stream_action_items_bounded(
+    query: Any,
+    *,
+    max_docs: int,
+    budget: Optional[ListReadBudget] = None,
+) -> tuple[List[Dict[str, Any]], int]:
+    return _stream_action_items_bounded(query, max_docs=max_docs, budget=budget)
+
+
+# Explicit re-export form so pyright does not flag these as unused imports.
 from database.action_items_cleanup_scan import (  # noqa: E402
-    get_action_items_list_scan_cap,
-    get_open_action_items_count,
-    list_open_action_items_for_cleanup,
+    get_action_items_list_scan_cap as get_action_items_list_scan_cap,
+    get_open_action_items_count as get_open_action_items_count,
+    list_open_action_items_for_cleanup as list_open_action_items_for_cleanup,
 )

--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, field
 from datetime import datetime, timezone, timedelta
+import base64
+import json
 import logging
 from typing import Any, Dict, Iterable, List, Optional, Protocol, cast
 
@@ -16,6 +18,7 @@ from database.firestore_transaction_retry import run_with_transaction_contention
 from database.firestore_read_metrics import FirestoreReadFamily, FirestoreReadMode, record_firestore_read
 from database.firestore_index_registry import (
     ACTION_ITEMS_CANONICAL_COMPLETION_COUNT_QUERY,
+    ACTION_ITEMS_CLEANUP_OPEN_CREATED_SCAN_QUERY,
     ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY,
     ACTION_ITEMS_COMPLETED_DUE_RANGE_QUERY,
     ACTION_ITEMS_COMPLETION_ID_SCAN_QUERY,
@@ -1023,6 +1026,67 @@ def get_open_action_items_count(uid: str) -> int:
     total = max(0, total - deleted_total)
     completed = max(0, min(completed - deleted_completed, total))
     return max(0, total - completed)
+
+
+def _parse_cleanup_scan_created_at(value: Any) -> datetime:
+    if value is None:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str):
+        return datetime.fromisoformat(value.rstrip('Z')).replace(tzinfo=timezone.utc)
+    if hasattr(value, 'timestamp'):
+        return datetime.fromtimestamp(value.timestamp(), tz=timezone.utc)
+    return datetime.min.replace(tzinfo=timezone.utc)
+
+
+def encode_cleanup_scan_cursor(created_at: datetime, doc_id: str) -> str:
+    """Encode the last scanned open task for deterministic cleanup pagination."""
+    normalized = created_at if created_at.tzinfo else created_at.replace(tzinfo=timezone.utc)
+    payload = {'created_at': normalized.astimezone(timezone.utc).isoformat(), 'id': doc_id}
+    return base64.urlsafe_b64encode(json.dumps(payload, separators=(',', ':')).encode()).decode()
+
+
+def decode_cleanup_scan_cursor(cursor: str) -> tuple[datetime, str]:
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
+        return _parse_cleanup_scan_created_at(payload['created_at']), str(payload['id'])
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError('Invalid cleanup scan cursor') from exc
+
+
+def list_open_action_items_for_cleanup(
+    uid: str,
+    *,
+    limit: Optional[int] = None,
+    cursor: Optional[str] = None,
+) -> tuple[List[Dict[str, Any]], Optional[str], int]:
+    """Return one oldest-first page of open action items for cleanup strategies.
+
+    Uses a deterministic ``created_at`` + document-id ordering so repeated preview
+    runs can advance through large accounts via ``cursor`` instead of rescanning
+    the same arbitrary Firestore prefix.
+    """
+    row_cap = min(limit or _ACTION_ITEMS_LIST_HARD_MAX, _ACTION_ITEMS_LIST_HARD_MAX)
+    coll = db.collection('users').document(uid).collection(action_items_collection)
+    query = ACTION_ITEMS_CLEANUP_OPEN_CREATED_SCAN_QUERY.build(
+        coll.select(list(_ACTION_ITEMS_LIST_SELECT_FIELDS)),
+        {'completed': False},
+        field_filter_factory=FieldFilter,
+    ).order_by('created_at', direction=firestore.Query.ASCENDING)
+
+    if cursor:
+        created_at, doc_id = decode_cleanup_scan_cursor(cursor)
+        query = query.start_after({'created_at': created_at, '__name__': coll.document(doc_id)})
+
+    items, docs_read = _stream_action_items_bounded(query, max_docs=_list_scan_budget(row_cap))
+    items.sort(key=lambda item: (_parse_cleanup_scan_created_at(item.get('created_at')), item['id']))
+    page_items = items[:row_cap]
+    next_cursor = None
+    if page_items and (len(items) > row_cap or docs_read >= _list_scan_budget(row_cap)):
+        last = page_items[-1]
+        next_cursor = encode_cleanup_scan_cursor(_parse_cleanup_scan_created_at(last.get('created_at')), last['id'])
+    return page_items, next_cursor, len(page_items)
 
 
 def get_action_items_by_ids(uid: str, action_item_ids: List[str]) -> List[Dict[str, Any]]:

--- a/backend/database/action_items_cleanup_scan.py
+++ b/backend/database/action_items_cleanup_scan.py
@@ -1,0 +1,116 @@
+"""Firestore scan helpers for action-item cleanup preview.
+
+Split out of database/action_items.py because that module is already at the
+repo product-file line-count ratchet (THRESHOLD 1500) and may not grow further
+without a declared exception. Cleanup preview needs oldest-first pagination,
+open-count aggregation, and scan-cap disclosure — one cohesive block to extract.
+"""
+
+import base64
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from google.cloud import firestore
+from google.cloud.firestore_v1 import FieldFilter
+
+from database.firestore_index_registry import ACTION_ITEMS_CLEANUP_OPEN_CREATED_SCAN_QUERY
+from database import action_items as action_items_db
+
+logger = logging.getLogger(__name__)
+
+
+def get_action_items_list_scan_cap() -> int:
+    """Public accessor for the action-items list hard max."""
+    return action_items_db._ACTION_ITEMS_LIST_HARD_MAX
+
+
+def get_open_action_items_count(uid: str) -> int:
+    """Return the true count of open (incomplete) action items for a user.
+
+    Uses Firestore count() aggregation — no document reads, no list hard-max cap —
+    so callers (e.g. cleanup preview) can tell whether a bounded scan left tasks
+    out of what it actually read.
+    """
+    base = action_items_db.db.collection('users').document(uid).collection(action_items_db.action_items_collection)
+    total = int(base.count().get()[0][0].value)
+    completed = int(base.where(filter=FieldFilter('completed', '==', True)).count().get()[0][0].value)
+
+    deleted_total = 0
+    deleted_completed = 0
+    for doc in base.where(filter=FieldFilter('deleted', '==', True)).stream():
+        deleted_total += 1
+        if (doc.to_dict() or {}).get('completed'):
+            deleted_completed += 1
+
+    total = max(0, total - deleted_total)
+    completed = max(0, min(completed - deleted_completed, total))
+    return max(0, total - completed)
+
+
+def _parse_cleanup_scan_created_at(value: Any) -> datetime:
+    if value is None:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str):
+        return datetime.fromisoformat(value.rstrip('Z')).replace(tzinfo=timezone.utc)
+    if hasattr(value, 'timestamp'):
+        return datetime.fromtimestamp(value.timestamp(), tz=timezone.utc)
+    return datetime.min.replace(tzinfo=timezone.utc)
+
+
+def encode_cleanup_scan_cursor(created_at: datetime, doc_id: str) -> str:
+    """Encode the last scanned open task for deterministic cleanup pagination."""
+    normalized = created_at if created_at.tzinfo else created_at.replace(tzinfo=timezone.utc)
+    payload = {'created_at': normalized.astimezone(timezone.utc).isoformat(), 'id': doc_id}
+    return base64.urlsafe_b64encode(json.dumps(payload, separators=(',', ':')).encode()).decode()
+
+
+def decode_cleanup_scan_cursor(cursor: str) -> tuple[datetime, str]:
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
+        return _parse_cleanup_scan_created_at(payload['created_at']), str(payload['id'])
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError('Invalid cleanup scan cursor') from exc
+
+
+def list_open_action_items_for_cleanup(
+    uid: str,
+    *,
+    limit: Optional[int] = None,
+    cursor: Optional[str] = None,
+) -> tuple[List[Dict[str, Any]], Optional[str], int]:
+    """Return one oldest-first page of open action items for cleanup strategies."""
+    hard_max = action_items_db._ACTION_ITEMS_LIST_HARD_MAX
+    row_cap = min(limit or hard_max, hard_max)
+    coll = action_items_db.db.collection('users').document(uid).collection(action_items_db.action_items_collection)
+    query = ACTION_ITEMS_CLEANUP_OPEN_CREATED_SCAN_QUERY.build(
+        coll.select(list(action_items_db._ACTION_ITEMS_LIST_SELECT_FIELDS)),
+        {'completed': False},
+        field_filter_factory=FieldFilter,
+    ).order_by('created_at', direction=firestore.Query.ASCENDING)
+
+    if cursor:
+        created_at, doc_id = decode_cleanup_scan_cursor(cursor)
+        query = query.start_after({'created_at': created_at, '__name__': coll.document(doc_id)})
+
+    items, docs_read = action_items_db._stream_action_items_bounded(
+        query,
+        max_docs=action_items_db._list_scan_budget(row_cap),
+    )
+    items.sort(key=lambda item: (_parse_cleanup_scan_created_at(item.get('created_at')), item['id']))
+    page_items = items[:row_cap]
+    next_cursor = None
+    if page_items and (len(items) > row_cap or docs_read >= action_items_db._list_scan_budget(row_cap)):
+        last = page_items[-1]
+        next_cursor = encode_cleanup_scan_cursor(_parse_cleanup_scan_created_at(last.get('created_at')), last['id'])
+    logger.debug(
+        'list_open_action_items_for_cleanup uid=%s page=%s docs_read=%s has_next=%s',
+        uid,
+        len(page_items),
+        docs_read,
+        bool(next_cursor),
+    )
+    return page_items, next_cursor, len(page_items)

--- a/backend/database/action_items_cleanup_scan.py
+++ b/backend/database/action_items_cleanup_scan.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 def get_action_items_list_scan_cap() -> int:
     """Public accessor for the action-items list hard max."""
-    return action_items_db._ACTION_ITEMS_LIST_HARD_MAX
+    return action_items_db.get_action_items_list_hard_max()
 
 
 def get_open_action_items_count(uid: str) -> int:
@@ -83,11 +83,11 @@ def list_open_action_items_for_cleanup(
     cursor: Optional[str] = None,
 ) -> tuple[List[Dict[str, Any]], Optional[str], int]:
     """Return one oldest-first page of open action items for cleanup strategies."""
-    hard_max = action_items_db._ACTION_ITEMS_LIST_HARD_MAX
+    hard_max = action_items_db.get_action_items_list_hard_max()
     row_cap = min(limit or hard_max, hard_max)
     coll = action_items_db.db.collection('users').document(uid).collection(action_items_db.action_items_collection)
     query = ACTION_ITEMS_CLEANUP_OPEN_CREATED_SCAN_QUERY.build(
-        coll.select(list(action_items_db._ACTION_ITEMS_LIST_SELECT_FIELDS)),
+        coll.select(list(action_items_db.get_action_items_list_select_fields())),
         {'completed': False},
         field_filter_factory=FieldFilter,
     ).order_by('created_at', direction=firestore.Query.ASCENDING)
@@ -96,14 +96,14 @@ def list_open_action_items_for_cleanup(
         created_at, doc_id = decode_cleanup_scan_cursor(cursor)
         query = query.start_after({'created_at': created_at, '__name__': coll.document(doc_id)})
 
-    items, docs_read = action_items_db._stream_action_items_bounded(
+    items, docs_read = action_items_db.stream_action_items_bounded(
         query,
-        max_docs=action_items_db._list_scan_budget(row_cap),
+        max_docs=action_items_db.list_scan_budget(row_cap),
     )
     items.sort(key=lambda item: (_parse_cleanup_scan_created_at(item.get('created_at')), item['id']))
     page_items = items[:row_cap]
     next_cursor = None
-    if page_items and (len(items) > row_cap or docs_read >= action_items_db._list_scan_budget(row_cap)):
+    if page_items and (len(items) > row_cap or docs_read >= action_items_db.list_scan_budget(row_cap)):
         last = page_items[-1]
         next_cursor = encode_cleanup_scan_cursor(_parse_cleanup_scan_created_at(last.get('created_at')), last['id'])
     logger.debug(

--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -1030,6 +1030,14 @@ ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY = FirestoreQuerySpec(
     index_fields=(_asc('completed'), _asc('created_at'), _asc('__name__')),
 )
 
+ACTION_ITEMS_CLEANUP_OPEN_CREATED_SCAN_QUERY = FirestoreQuerySpec(
+    identifier='action_items_cleanup_open_created_scan',
+    collection_group='action_items',
+    query_scope='COLLECTION',
+    filters=(FirestoreQueryFilter('completed', '==', 'completed'),),
+    index_fields=(_asc('completed'), _asc('created_at'), _asc('__name__')),
+)
+
 CHAT_FIRST_DEFERRALS_DUE_QUERY = FirestoreQuerySpec(
     identifier='chat_first_deferrals_due',
     collection_group='chat_first_deferrals',
@@ -1305,6 +1313,7 @@ QUERY_SPECS = (
     ACTION_ITEMS_COMPLETED_DUE_RANGE_QUERY,
     ACTION_ITEMS_CREATED_RANGE_QUERY,
     ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY,
+    ACTION_ITEMS_CLEANUP_OPEN_CREATED_SCAN_QUERY,
     MEMORIES_CREATED_RANGE_QUERY,
     CANONICAL_MEMORIES_CAPTURED_RANGE_QUERY,
     CANDIDATES_COMPATIBILITY_QUERY,

--- a/backend/database/generic_cache.py
+++ b/backend/database/generic_cache.py
@@ -1,0 +1,47 @@
+"""Path-keyed Redis cache helpers (GET/SET/DELETE/GETDEL).
+
+Split out of database/redis_db.py because that module sits at the product-file
+line-count ratchet threshold and may not grow further without a declared
+exception. pop_generic_cache was added for atomic cleanup session consumption.
+"""
+
+import base64
+import json
+from typing import Any, Optional
+
+from database.redis_db import r, try_catch_decorator
+
+
+@try_catch_decorator
+def get_generic_cache(path: str) -> Any:
+    key = base64.b64encode(f'{path}'.encode('utf-8'))
+    key = key.decode('utf-8')
+
+    data = r.get(f'cache:{key}')
+    return json.loads(data) if data else None
+
+
+@try_catch_decorator
+def set_generic_cache(path: str, data: object, ttl: Optional[int] = None) -> None:
+    key = base64.b64encode(f'{path}'.encode('utf-8'))
+    key = key.decode('utf-8')
+
+    r.set(f'cache:{key}', json.dumps(data, default=str))
+    if ttl:
+        r.expire(f'cache:{key}', ttl)
+
+
+@try_catch_decorator
+def delete_generic_cache(path: str) -> None:
+    key = base64.b64encode(f'{path}'.encode('utf-8'))
+    key = key.decode('utf-8')
+    r.delete(f'cache:{key}')
+
+
+@try_catch_decorator
+def pop_generic_cache(path: str) -> Any:
+    """Atomically read and remove a generic cache entry (Redis GETDEL)."""
+    key = base64.b64encode(f'{path}'.encode('utf-8'))
+    key = key.decode('utf-8')
+    data = r.getdel(f'cache:{key}')
+    return json.loads(data) if data else None

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -79,40 +79,13 @@ def try_catch_decorator(func: Callable[..., T]) -> Callable[..., Optional[T]]:
     return wrapper
 
 
-@try_catch_decorator
-def get_generic_cache(path: str) -> Any:
-    key = base64.b64encode(f'{path}'.encode('utf-8'))
-    key = key.decode('utf-8')
-
-    data = r.get(f'cache:{key}')
-    return json.loads(data) if data else None
-
-
-@try_catch_decorator
-def set_generic_cache(path: str, data: object, ttl: Optional[int] = None) -> None:
-    key = base64.b64encode(f'{path}'.encode('utf-8'))
-    key = key.decode('utf-8')
-
-    r.set(f'cache:{key}', json.dumps(data, default=str))
-    if ttl:
-        r.expire(f'cache:{key}', ttl)
-
-
-@try_catch_decorator
-def delete_generic_cache(path: str) -> None:
-    key = base64.b64encode(f'{path}'.encode('utf-8'))
-    key = key.decode('utf-8')
-    r.delete(f'cache:{key}')
-
-
-@try_catch_decorator
-def pop_generic_cache(path: str) -> Any:
-    """Atomically read and remove a generic cache entry (Redis GETDEL)."""
-    key = base64.b64encode(f'{path}'.encode('utf-8'))
-    key = key.decode('utf-8')
-    data = r.getdel(f'cache:{key}')
-    return json.loads(data) if data else None
-
+# Re-exported from generic_cache so existing callers keep importing database.redis_db.
+from database.generic_cache import (  # noqa: E402
+    delete_generic_cache,
+    get_generic_cache,
+    pop_generic_cache,
+    set_generic_cache,
+)
 
 # ******************************************************
 # ********************* APP BY ID **********************

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -105,6 +105,15 @@ def delete_generic_cache(path: str) -> None:
     r.delete(f'cache:{key}')
 
 
+@try_catch_decorator
+def pop_generic_cache(path: str) -> Any:
+    """Atomically read and remove a generic cache entry (Redis GETDEL)."""
+    key = base64.b64encode(f'{path}'.encode('utf-8'))
+    key = key.decode('utf-8')
+    data = r.getdel(f'cache:{key}')
+    return json.loads(data) if data else None
+
+
 # ******************************************************
 # ********************* APP BY ID **********************
 # ******************************************************

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -1,5 +1,4 @@
 import ast
-import base64
 import json
 import os
 import secrets
@@ -79,12 +78,13 @@ def try_catch_decorator(func: Callable[..., T]) -> Callable[..., Optional[T]]:
     return wrapper
 
 
-# Re-exported from generic_cache so existing callers keep importing database.redis_db.
+# Explicit re-export form so pyright does not flag these as unused imports.
+# Existing callers import from database.redis_db; generic_cache is the new home.
 from database.generic_cache import (  # noqa: E402
-    delete_generic_cache,
-    get_generic_cache,
-    pop_generic_cache,
-    set_generic_cache,
+    delete_generic_cache as delete_generic_cache,
+    get_generic_cache as get_generic_cache,
+    pop_generic_cache as pop_generic_cache,
+    set_generic_cache as set_generic_cache,
 )
 
 # ******************************************************

--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -1003,7 +1003,7 @@ def delete_action_item_vectors_batch(uid: str, action_item_ids: List[str]) -> No
 
 def fetch_action_item_vectors(uid: str, action_item_ids: List[str]) -> dict[str, List[float]]:
     """
-    Bulk-fetch action item vectors from Pinecone in batches of 1000.
+    Bulk-fetch action item vectors from Pinecone in batches of 100.
     Returns a map of action_item_id → embedding values.
     Missing vectors (not yet indexed) are silently omitted.
     """

--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -1013,7 +1013,7 @@ def fetch_action_item_vectors(uid: str, action_item_ids: List[str]) -> dict[str,
     result = {}
     batch_size = 100  # Pinecone fetch uses GET; keep IDs per call small to avoid 414
     for i in range(0, len(action_item_ids), batch_size):
-        batch_ids = action_item_ids[i:i + batch_size]
+        batch_ids = action_item_ids[i : i + batch_size]
         vector_ids = [f'{uid}-ai-{aid}' for aid in batch_ids]
         try:
             response = index.fetch(ids=vector_ids, namespace=ACTION_ITEMS_NAMESPACE)

--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -1001,6 +1001,31 @@ def delete_action_item_vectors_batch(uid: str, action_item_ids: List[str]) -> No
     logger.info(f'delete_action_item_vectors_batch count={len(vector_ids)}')
 
 
+def fetch_action_item_vectors(uid: str, action_item_ids: List[str]) -> dict[str, List[float]]:
+    """
+    Bulk-fetch action item vectors from Pinecone in batches of 1000.
+    Returns a map of action_item_id → embedding values.
+    Missing vectors (not yet indexed) are silently omitted.
+    """
+    if index is None or not action_item_ids:
+        return {}
+
+    result = {}
+    batch_size = 100  # Pinecone fetch uses GET; keep IDs per call small to avoid 414
+    for i in range(0, len(action_item_ids), batch_size):
+        batch_ids = action_item_ids[i:i + batch_size]
+        vector_ids = [f'{uid}-ai-{aid}' for aid in batch_ids]
+        try:
+            response = index.fetch(ids=vector_ids, namespace=ACTION_ITEMS_NAMESPACE)
+            for vid, vec in response.vectors.items():
+                aid = vid.replace(f'{uid}-ai-', '', 1)
+                result[aid] = vec.values
+        except Exception as e:
+            logger.warning(f'fetch_action_item_vectors batch failed: {e}')
+    logger.info(f'fetch_action_item_vectors uid={uid} requested={len(action_item_ids)} fetched={len(result)}')
+    return result
+
+
 def delete_conversation_vectors_batch(uid: str, conversation_ids: List[str]) -> None:
     """Delete a user's conversation vectors (ns1) in one batched, chunked call.
 

--- a/backend/diarizer/Dockerfile
+++ b/backend/diarizer/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/based-hardware-dev/python:3.11-slim-forky AS builder
+FROM python:3.11-slim-bookworm AS builder
 
 ENV PATH="/opt/venv/bin:$PATH"
 RUN python -m venv /opt/venv
@@ -6,8 +6,8 @@ RUN python -m venv /opt/venv
 COPY backend/diarizer/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
-FROM gcr.io/based-hardware-dev/python:3.11-slim-forky
-# Python 3.11 on Debian 14 (Forky)
+FROM python:3.11-slim-bookworm
+# Python 3.11 on Debian 12 (Bookworm)
 
 WORKDIR /app
 ENV PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/opt/venv/bin:$PATH"

--- a/backend/diarizer/Dockerfile
+++ b/backend/diarizer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm AS builder
+FROM gcr.io/based-hardware-dev/python:3.11-slim-forky AS builder
 
 ENV PATH="/opt/venv/bin:$PATH"
 RUN python -m venv /opt/venv
@@ -6,8 +6,8 @@ RUN python -m venv /opt/venv
 COPY backend/diarizer/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
-FROM python:3.11-slim-bookworm
-# Python 3.11 on Debian 12 (Bookworm)
+FROM gcr.io/based-hardware-dev/python:3.11-slim-forky
+# Python 3.11 on Debian 14 (Forky)
 
 WORKDIR /app
 ENV PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/opt/venv/bin:$PATH"

--- a/backend/main.py
+++ b/backend/main.py
@@ -50,6 +50,7 @@ from routers import (
     oauth,
     auth,
     action_items,
+    action_items_cleanup,
     account_cutover,
     candidates,
     chat_first,
@@ -186,6 +187,7 @@ app.include_router(auto_model.router)
 app.include_router(conversations.router)
 app.include_router(public_shared_conversation_chat.router)
 app.include_router(action_items.router)
+app.include_router(action_items_cleanup.router)
 app.include_router(account_cutover.router)
 app.include_router(candidates.router)
 app.include_router(chat_first.router)

--- a/backend/modal/Dockerfile
+++ b/backend/modal/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/based-hardware-dev/python:3.11-slim-forky AS builder
+FROM python:3.11-slim-bookworm AS builder
 
 ENV PATH="/opt/venv/bin:$PATH"
 RUN python -m venv /opt/venv
@@ -12,8 +12,8 @@ COPY backend/requirements.txt /tmp/reqs/requirements.txt
 COPY backend/modal/requirements.txt /tmp/reqs/modal/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/reqs/modal/requirements.txt
 
-FROM gcr.io/based-hardware-dev/python:3.11-slim-forky
-# Python 3.11 on Debian 14 (Forky)
+FROM python:3.11-slim-bookworm
+# Python 3.11 on Debian 12 (Bookworm)
 
 WORKDIR /app
 ENV PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/opt/venv/bin:$PATH"

--- a/backend/modal/Dockerfile
+++ b/backend/modal/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm AS builder
+FROM gcr.io/based-hardware-dev/python:3.11-slim-forky AS builder
 
 ENV PATH="/opt/venv/bin:$PATH"
 RUN python -m venv /opt/venv
@@ -12,8 +12,8 @@ COPY backend/requirements.txt /tmp/reqs/requirements.txt
 COPY backend/modal/requirements.txt /tmp/reqs/modal/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/reqs/modal/requirements.txt
 
-FROM python:3.11-slim-bookworm
-# Python 3.11 on Debian 12 (Bookworm)
+FROM gcr.io/based-hardware-dev/python:3.11-slim-forky
+# Python 3.11 on Debian 14 (Forky)
 
 WORKDIR /app
 ENV PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/opt/venv/bin:$PATH"

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -2377,6 +2377,52 @@ routes:
         state: active
       owner: backend
   - route_type: http
+    method: POST
+    path: /v1/action-items/cleanup/preview
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - firebase_id_token
+        placement: dependency
+        scopes: []
+      byok: not_applicable
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: first_party
+      data_domain: action_items
+      deprecation:
+        state: active
+      owner: backend
+  - route_type: http
+    method: POST
+    path: /v1/action-items/cleanup/execute
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - firebase_id_token
+        placement: dependency
+        scopes: []
+      byok: not_applicable
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: first_party
+      data_domain: action_items
+      deprecation:
+        state: active
+      owner: backend
+  - route_type: http
     method: GET
     path: /v1/knowledge-graph/canonical
     policy:

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -2388,10 +2388,10 @@ routes:
         scopes: []
       byok: not_applicable
       rate_limit:
-        policy_name: none
-        key_subject: none
-        enforcement: none
-        placement: none
+        policy_name: action_items:cleanup_preview
+        key_subject: uid
+        enforcement: fail_open
+        placement: wrapper
       timeout_class: default_method
       surface: first_party_app
       visibility: first_party
@@ -2411,10 +2411,10 @@ routes:
         scopes: []
       byok: not_applicable
       rate_limit:
-        policy_name: none
-        key_subject: none
-        enforcement: none
-        placement: none
+        policy_name: action_items:cleanup_execute
+        key_subject: uid
+        enforcement: fail_closed
+        placement: wrapper
       timeout_class: default_method
       surface: first_party_app
       visibility: first_party

--- a/backend/routers/action_items_cleanup.py
+++ b/backend/routers/action_items_cleanup.py
@@ -68,6 +68,14 @@ class CleanupPreviewResponse(BaseModel):
     candidate_ids: List[str]
     candidate_meta: List[CleanupCandidateMeta]
     expires_in_seconds: int
+    total_open_action_items: int = Field(
+        description="True count of the user's open action items, independent of any scan cap"
+    )
+    scan_cap: int = Field(description="Per-strategy Firestore scan cap (see _ACTION_ITEMS_LIST_HARD_MAX)")
+    scan_truncated: bool = Field(
+        description="True if total_open_action_items exceeds scan_cap, so strategies may not "
+        "have considered every open task as a candidate"
+    )
 
 
 class CleanupExecuteRequest(BaseModel):
@@ -133,6 +141,10 @@ def cleanup_preview(
     if 'vague' in request.strategies:
         strategy_fns['vague'] = lambda: candidates_vague(uid)
 
+    total_open = action_items_db.get_open_action_items_count(uid)
+    scan_cap = action_items_db.get_action_items_list_scan_cap()
+    scan_truncated = total_open > scan_cap
+
     if not strategy_fns:
         return CleanupPreviewResponse(
             session_id='',
@@ -142,6 +154,9 @@ def cleanup_preview(
             candidate_ids=[],
             candidate_meta=[],
             expires_in_seconds=_SESSION_TTL,
+            total_open_action_items=total_open,
+            scan_cap=scan_cap,
+            scan_truncated=scan_truncated,
         )
 
     results: dict[str, list] = {}
@@ -189,6 +204,9 @@ def cleanup_preview(
             CleanupCandidateMeta(id=c['id'], strategy=c['strategy'], description=c['description']) for c in candidates
         ],
         expires_in_seconds=_SESSION_TTL,
+        total_open_action_items=total_open,
+        scan_cap=scan_cap,
+        scan_truncated=scan_truncated,
     )
 
 

--- a/backend/routers/action_items_cleanup.py
+++ b/backend/routers/action_items_cleanup.py
@@ -108,7 +108,10 @@ def _delete_session(uid: str, session_id: str) -> None:
 
 
 @router.post('/v1/action-items/cleanup/preview', response_model=CleanupPreviewResponse, tags=['action-items'])
-def cleanup_preview(request: CleanupPreviewRequest, uid: str = Depends(auth.get_current_user_uid)):
+def cleanup_preview(
+    request: CleanupPreviewRequest,
+    uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, 'action_items:cleanup_preview')),
+):
     """
     Compute cleanup candidates and stage them server-side.
     Returns a session_id, summary counts, and a small sample for user review.
@@ -190,7 +193,10 @@ def cleanup_preview(request: CleanupPreviewRequest, uid: str = Depends(auth.get_
 
 
 @router.post('/v1/action-items/cleanup/execute', response_model=CleanupExecuteResponse, tags=['action-items'])
-def cleanup_execute(request: CleanupExecuteRequest, uid: str = Depends(auth.get_current_user_uid)):
+def cleanup_execute(
+    request: CleanupExecuteRequest,
+    uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, 'action_items:cleanup_execute')),
+):
     """
     Delete the candidates staged by a prior preview call.
     Falls back to recomputing if the session has expired.

--- a/backend/routers/action_items_cleanup.py
+++ b/backend/routers/action_items_cleanup.py
@@ -11,7 +11,15 @@ import database.redis_db as redis_db
 from database.vector_db import delete_action_item_vectors_batch
 from utils.other import endpoints as auth
 from utils.notifications import send_action_items_batch_deletion_message
-from utils.action_item_cleanup import candidates_stale_age, candidates_overdue, candidates_semantic_dedup, candidates_llm_relevance, candidates_conversation_context, candidates_vague, merge_candidates
+from utils.action_item_cleanup import (
+    candidates_stale_age,
+    candidates_overdue,
+    candidates_semantic_dedup,
+    candidates_llm_relevance,
+    candidates_conversation_context,
+    candidates_vague,
+    merge_candidates,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +33,7 @@ _SAMPLE_PER_STRATEGY = 5
 # Request / response models
 # ---------------------------------------------------------------------------
 
+
 class CleanupPreviewRequest(BaseModel):
     strategies: List[str] = Field(
         default=['stale_age'],
@@ -32,8 +41,12 @@ class CleanupPreviewRequest(BaseModel):
     )
     age_days: int = Field(default=30, ge=1, le=365, description="Threshold for stale_age strategy")
     overdue_days: int = Field(default=7, ge=1, le=365, description="Threshold for overdue strategy")
-    similarity_threshold: float = Field(default=0.92, ge=0.5, le=1.0, description="Similarity threshold for semantic_dedup")
-    llm_confidence_threshold: float = Field(default=0.92, ge=0.5, le=1.0, description="Confidence threshold for llm_relevance")
+    similarity_threshold: float = Field(
+        default=0.92, ge=0.5, le=1.0, description="Similarity threshold for semantic_dedup"
+    )
+    llm_confidence_threshold: float = Field(
+        default=0.92, ge=0.5, le=1.0, description="Confidence threshold for llm_relevance"
+    )
 
 
 class CleanupSampleItem(BaseModel):
@@ -68,6 +81,7 @@ class CleanupExecuteResponse(BaseModel):
 # Redis session helpers
 # ---------------------------------------------------------------------------
 
+
 def _session_key(uid: str, session_id: str) -> str:
     return f'cleanup_session:{uid}:{session_id}'
 
@@ -88,6 +102,7 @@ def _delete_session(uid: str, session_id: str) -> None:
 # Endpoints
 # ---------------------------------------------------------------------------
 
+
 @router.post('/v1/action-items/cleanup/preview', response_model=CleanupPreviewResponse, tags=['action-items'])
 def cleanup_preview(request: CleanupPreviewRequest, uid: str = Depends(auth.get_current_user_uid)):
     """
@@ -105,7 +120,9 @@ def cleanup_preview(request: CleanupPreviewRequest, uid: str = Depends(auth.get_
     if 'llm_relevance' in request.strategies:
         strategy_fns['llm_relevance'] = lambda: candidates_llm_relevance(uid, request.llm_confidence_threshold)
     if 'conversation_context' in request.strategies:
-        strategy_fns['conversation_context'] = lambda: candidates_conversation_context(uid, request.llm_confidence_threshold)
+        strategy_fns['conversation_context'] = lambda: candidates_conversation_context(
+            uid, request.llm_confidence_threshold
+        )
     if 'vague' in request.strategies:
         strategy_fns['vague'] = lambda: candidates_vague(uid)
 
@@ -137,11 +154,15 @@ def cleanup_preview(request: CleanupPreviewRequest, uid: str = Depends(auth.get_
     candidates = merge_candidates(candidate_lists)
 
     session_id = str(uuid.uuid4())
-    _save_session(uid, session_id, {
-        'ids': [c['id'] for c in candidates],
-        'strategies': request.strategies,
-        'age_days': request.age_days,
-    })
+    _save_session(
+        uid,
+        session_id,
+        {
+            'ids': [c['id'] for c in candidates],
+            'strategies': request.strategies,
+            'age_days': request.age_days,
+        },
+    )
 
     seen_per_strategy: dict[str, int] = {}
     sample = []

--- a/backend/routers/action_items_cleanup.py
+++ b/backend/routers/action_items_cleanup.py
@@ -111,6 +111,17 @@ def cleanup_preview(request: CleanupPreviewRequest, uid: str = Depends(auth.get_
     if 'vague' in request.strategies:
         strategy_fns['vague'] = lambda: candidates_vague(uid)
 
+    if not strategy_fns:
+        return CleanupPreviewResponse(
+            session_id='',
+            total_candidates=0,
+            breakdown={},
+            sample=[],
+            candidate_ids=[],
+            candidate_meta=[],
+            expires_in_seconds=_SESSION_TTL,
+        )
+
     results: dict[str, list] = {}
     with ThreadPoolExecutor(max_workers=len(strategy_fns)) as pool:
         futures = {pool.submit(fn): name for name, fn in strategy_fns.items()}

--- a/backend/routers/action_items_cleanup.py
+++ b/backend/routers/action_items_cleanup.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import List, Optional
+from concurrent.futures import as_completed
+from typing import Callable, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 import database.action_items as action_items_db
 import database.redis_db as redis_db
 from database.vector_db import delete_action_item_vectors_batch
+from utils.executors import postprocess_executor
 from utils.other import endpoints as auth
 from utils.notifications import send_action_items_batch_deletion_message
 from utils.action_item_cleanup import (
@@ -27,6 +28,9 @@ router = APIRouter()
 
 _SESSION_TTL = 300  # 5 minutes
 _SAMPLE_PER_STRATEGY = 5
+_VALID_STRATEGIES = frozenset(
+    {'stale_age', 'overdue', 'semantic_dedup', 'llm_relevance', 'conversation_context', 'vague'}
+)
 
 
 # ---------------------------------------------------------------------------
@@ -46,6 +50,10 @@ class CleanupPreviewRequest(BaseModel):
     )
     llm_confidence_threshold: float = Field(
         default=0.92, ge=0.5, le=1.0, description="Confidence threshold for llm_relevance"
+    )
+    scan_cursor: Optional[str] = Field(
+        default=None,
+        description="Resume token from a prior cleanup preview to scan the next oldest open tasks",
     )
 
 
@@ -73,8 +81,11 @@ class CleanupPreviewResponse(BaseModel):
     )
     scan_cap: int = Field(description="Per-strategy Firestore scan cap (see _ACTION_ITEMS_LIST_HARD_MAX)")
     scan_truncated: bool = Field(
-        description="True if total_open_action_items exceeds scan_cap, so strategies may not "
-        "have considered every open task as a candidate"
+        description="True when more open tasks remain beyond this preview's oldest-first scan window"
+    )
+    next_scan_cursor: Optional[str] = Field(
+        default=None,
+        description="Pass on the next preview to continue scanning from the oldest remaining open tasks",
     )
 
 
@@ -98,16 +109,67 @@ def _session_key(uid: str, session_id: str) -> str:
     return f'cleanup_session:{uid}:{session_id}'
 
 
+def _result_key(uid: str, session_id: str) -> str:
+    return f'cleanup_result:{uid}:{session_id}'
+
+
 def _save_session(uid: str, session_id: str, data: dict) -> None:
     redis_db.set_generic_cache(_session_key(uid, session_id), data, ttl=_SESSION_TTL)
 
 
-def _load_session(uid: str, session_id: str) -> Optional[dict]:
-    return redis_db.get_generic_cache(_session_key(uid, session_id))
+def _claim_session(uid: str, session_id: str) -> Optional[dict]:
+    return redis_db.pop_generic_cache(_session_key(uid, session_id))
 
 
-def _delete_session(uid: str, session_id: str) -> None:
-    redis_db.delete_generic_cache(_session_key(uid, session_id))
+def _save_terminal_result(uid: str, session_id: str, deleted_count: int) -> None:
+    redis_db.set_generic_cache(
+        _result_key(uid, session_id),
+        {'deleted_count': deleted_count},
+        ttl=_SESSION_TTL,
+    )
+
+
+def _load_terminal_result(uid: str, session_id: str) -> Optional[dict]:
+    return redis_db.get_generic_cache(_result_key(uid, session_id))
+
+
+def _preflight_unlocked_ids(uid: str, action_item_ids: List[str]) -> None:
+    for i in range(0, len(action_item_ids), 500):
+        chunk = action_item_ids[i : i + 500]
+        existing_items = action_items_db.get_action_items_by_ids(uid, chunk)
+        if any(item.get('is_locked', False) for item in existing_items):
+            raise HTTPException(
+                status_code=402,
+                detail='A paid plan is required to delete locked action items.',
+            )
+
+
+def _validate_strategies(strategies: List[str]) -> None:
+    unknown = sorted(set(strategies) - _VALID_STRATEGIES)
+    if unknown:
+        raise HTTPException(
+            status_code=422,
+            detail=f'Unknown cleanup strategies: {unknown}',
+        )
+
+
+def _run_strategies(
+    strategy_fns: dict[str, Callable[[], tuple[list[dict], Optional[str]]]],
+) -> tuple[dict[str, list], Optional[str]]:
+    results: dict[str, list] = {}
+    next_cursor: Optional[str] = None
+    futures = {postprocess_executor.submit(fn): name for name, fn in strategy_fns.items()}
+    for future in as_completed(futures):
+        name = futures[future]
+        try:
+            candidates, strategy_next_cursor = future.result()
+            results[name] = candidates
+            if strategy_next_cursor:
+                next_cursor = strategy_next_cursor
+        except Exception as e:
+            logger.error(f'Strategy {name} failed: {e}')
+            results[name] = []
+    return results, next_cursor
 
 
 # ---------------------------------------------------------------------------
@@ -125,25 +187,31 @@ def cleanup_preview(
     Returns a session_id, summary counts, and a small sample for user review.
     Does not delete anything.
     """
-    strategy_fns = {}
+    _validate_strategies(request.strategies)
+
+    strategy_fns: dict[str, Callable[[], tuple[list[dict], Optional[str]]]] = {}
+    scan_cursor = request.scan_cursor
     if 'stale_age' in request.strategies:
-        strategy_fns['stale_age'] = lambda: candidates_stale_age(uid, request.age_days)
+        strategy_fns['stale_age'] = lambda: candidates_stale_age(uid, request.age_days, scan_cursor=scan_cursor)
     if 'overdue' in request.strategies:
-        strategy_fns['overdue'] = lambda: candidates_overdue(uid, request.overdue_days)
+        strategy_fns['overdue'] = lambda: candidates_overdue(uid, request.overdue_days, scan_cursor=scan_cursor)
     if 'semantic_dedup' in request.strategies:
-        strategy_fns['semantic_dedup'] = lambda: candidates_semantic_dedup(uid, request.similarity_threshold)
+        strategy_fns['semantic_dedup'] = lambda: candidates_semantic_dedup(
+            uid, request.similarity_threshold, scan_cursor=scan_cursor
+        )
     if 'llm_relevance' in request.strategies:
-        strategy_fns['llm_relevance'] = lambda: candidates_llm_relevance(uid, request.llm_confidence_threshold)
+        strategy_fns['llm_relevance'] = lambda: candidates_llm_relevance(
+            uid, request.llm_confidence_threshold, scan_cursor=scan_cursor
+        )
     if 'conversation_context' in request.strategies:
         strategy_fns['conversation_context'] = lambda: candidates_conversation_context(
-            uid, request.llm_confidence_threshold
+            uid, request.llm_confidence_threshold, scan_cursor=scan_cursor
         )
     if 'vague' in request.strategies:
-        strategy_fns['vague'] = lambda: candidates_vague(uid)
+        strategy_fns['vague'] = lambda: candidates_vague(uid, scan_cursor=scan_cursor)
 
     total_open = action_items_db.get_open_action_items_count(uid)
     scan_cap = action_items_db.get_action_items_list_scan_cap()
-    scan_truncated = total_open > scan_cap
 
     if not strategy_fns:
         return CleanupPreviewResponse(
@@ -156,23 +224,15 @@ def cleanup_preview(
             expires_in_seconds=_SESSION_TTL,
             total_open_action_items=total_open,
             scan_cap=scan_cap,
-            scan_truncated=scan_truncated,
+            scan_truncated=total_open > scan_cap,
+            next_scan_cursor=None,
         )
 
-    results: dict[str, list] = {}
-    with ThreadPoolExecutor(max_workers=len(strategy_fns)) as pool:
-        futures = {pool.submit(fn): name for name, fn in strategy_fns.items()}
-        for future in as_completed(futures):
-            name = futures[future]
-            try:
-                results[name] = future.result()
-            except Exception as e:
-                logger.error(f'Strategy {name} failed: {e}')
-                results[name] = []
+    results, next_scan_cursor = _run_strategies(strategy_fns)
+    scan_truncated = next_scan_cursor is not None
 
     candidate_lists = [results[name] for name in request.strategies if name in results]
     breakdown = {name: len(results.get(name, [])) for name in request.strategies}
-
     candidates = merge_candidates(candidate_lists)
 
     session_id = str(uuid.uuid4())
@@ -183,6 +243,7 @@ def cleanup_preview(
             'ids': [c['id'] for c in candidates],
             'strategies': request.strategies,
             'age_days': request.age_days,
+            'scan_cursor': request.scan_cursor,
         },
     )
 
@@ -207,6 +268,7 @@ def cleanup_preview(
         total_open_action_items=total_open,
         scan_cap=scan_cap,
         scan_truncated=scan_truncated,
+        next_scan_cursor=next_scan_cursor,
     )
 
 
@@ -215,34 +277,34 @@ def cleanup_execute(
     request: CleanupExecuteRequest,
     uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, 'action_items:cleanup_execute')),
 ):
-    """
-    Delete the candidates staged by a prior preview call.
-    Falls back to recomputing if the session has expired.
-    """
-    session = _load_session(uid, request.session_id)
+    """Delete the candidates staged by a prior preview call."""
+    terminal = _load_terminal_result(uid, request.session_id)
+    if terminal is not None:
+        return CleanupExecuteResponse(deleted_count=int(terminal['deleted_count']))
 
-    if session:
-        excluded = set(request.excluded_ids)
-        ids = [i for i in session['ids'] if i not in excluded]
-        _delete_session(uid, request.session_id)
-    else:
-        # Session expired — recompute from stored parameters
-        # For now surface an error; once all strategies are implemented
-        # we can reconstruct the full candidate list from parameters.
+    session = _claim_session(uid, request.session_id)
+    if not session:
         raise HTTPException(
             status_code=410,
             detail='Cleanup session expired. Please run preview again.',
         )
 
+    excluded = set(request.excluded_ids)
+    ids = [item_id for item_id in session['ids'] if item_id not in excluded]
+
     if not ids:
+        _save_terminal_result(uid, request.session_id, 0)
         return CleanupExecuteResponse(deleted_count=0)
 
+    _preflight_unlocked_ids(uid, ids)
     deleted_ids = action_items_db.delete_action_items_batch(uid, ids)
 
     if deleted_ids:
         delete_action_item_vectors_batch(uid, deleted_ids)
         send_action_items_batch_deletion_message(user_id=uid, action_item_ids=deleted_ids)
 
-    logger.info(f'cleanup_execute uid={uid} requested={len(ids)} deleted={len(deleted_ids)}')
+    deleted_count = len(deleted_ids)
+    _save_terminal_result(uid, request.session_id, deleted_count)
+    logger.info(f'cleanup_execute uid={uid} requested={len(ids)} deleted={deleted_count}')
 
-    return CleanupExecuteResponse(deleted_count=len(deleted_ids))
+    return CleanupExecuteResponse(deleted_count=deleted_count)

--- a/backend/routers/action_items_cleanup.py
+++ b/backend/routers/action_items_cleanup.py
@@ -1,0 +1,187 @@
+import json
+import logging
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+import database.action_items as action_items_db
+import database.redis_db as redis_db
+from database.vector_db import delete_action_item_vectors_batch
+from utils.other import endpoints as auth
+from utils.notifications import send_action_items_batch_deletion_message
+from utils.action_item_cleanup import candidates_stale_age, candidates_overdue, candidates_semantic_dedup, candidates_llm_relevance, candidates_conversation_context, candidates_vague, merge_candidates
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_SESSION_TTL = 300  # 5 minutes
+_SAMPLE_PER_STRATEGY = 5
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+class CleanupPreviewRequest(BaseModel):
+    strategies: List[str] = Field(
+        default=['stale_age'],
+        description="Strategies to apply: stale_age, overdue, semantic_dedup, llm_relevance, conversation_context, vague",
+    )
+    age_days: int = Field(default=30, ge=1, le=365, description="Threshold for stale_age strategy")
+    overdue_days: int = Field(default=7, ge=1, le=365, description="Threshold for overdue strategy")
+    similarity_threshold: float = Field(default=0.92, ge=0.5, le=1.0, description="Similarity threshold for semantic_dedup")
+    llm_confidence_threshold: float = Field(default=0.92, ge=0.5, le=1.0, description="Confidence threshold for llm_relevance")
+
+
+class CleanupSampleItem(BaseModel):
+    description: str
+    strategy: str
+
+
+class CleanupCandidateMeta(BaseModel):
+    id: str
+    strategy: str
+
+
+class CleanupPreviewResponse(BaseModel):
+    session_id: str
+    total_candidates: int
+    breakdown: dict
+    sample: List[CleanupSampleItem]
+    candidate_ids: List[str]
+    candidate_meta: List[CleanupCandidateMeta]
+    expires_in_seconds: int
+
+
+class CleanupExecuteRequest(BaseModel):
+    session_id: str
+
+
+class CleanupExecuteResponse(BaseModel):
+    deleted_count: int
+
+
+# ---------------------------------------------------------------------------
+# Redis session helpers
+# ---------------------------------------------------------------------------
+
+def _session_key(uid: str, session_id: str) -> str:
+    return f'cleanup_session:{uid}:{session_id}'
+
+
+def _save_session(uid: str, session_id: str, data: dict) -> None:
+    redis_db.set_generic_cache(_session_key(uid, session_id), data, ttl=_SESSION_TTL)
+
+
+def _load_session(uid: str, session_id: str) -> Optional[dict]:
+    return redis_db.get_generic_cache(_session_key(uid, session_id))
+
+
+def _delete_session(uid: str, session_id: str) -> None:
+    redis_db.delete_generic_cache(_session_key(uid, session_id))
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.post('/v1/action-items/cleanup/preview', response_model=CleanupPreviewResponse, tags=['action-items'])
+def cleanup_preview(request: CleanupPreviewRequest, uid: str = Depends(auth.get_current_user_uid)):
+    """
+    Compute cleanup candidates and stage them server-side.
+    Returns a session_id, summary counts, and a small sample for user review.
+    Does not delete anything.
+    """
+    strategy_fns = {}
+    if 'stale_age' in request.strategies:
+        strategy_fns['stale_age'] = lambda: candidates_stale_age(uid, request.age_days)
+    if 'overdue' in request.strategies:
+        strategy_fns['overdue'] = lambda: candidates_overdue(uid, request.overdue_days)
+    if 'semantic_dedup' in request.strategies:
+        strategy_fns['semantic_dedup'] = lambda: candidates_semantic_dedup(uid, request.similarity_threshold)
+    if 'llm_relevance' in request.strategies:
+        strategy_fns['llm_relevance'] = lambda: candidates_llm_relevance(uid, request.llm_confidence_threshold)
+    if 'conversation_context' in request.strategies:
+        strategy_fns['conversation_context'] = lambda: candidates_conversation_context(uid, request.llm_confidence_threshold)
+    if 'vague' in request.strategies:
+        strategy_fns['vague'] = lambda: candidates_vague(uid)
+
+    results: dict[str, list] = {}
+    with ThreadPoolExecutor(max_workers=len(strategy_fns)) as pool:
+        futures = {pool.submit(fn): name for name, fn in strategy_fns.items()}
+        for future in as_completed(futures):
+            name = futures[future]
+            try:
+                results[name] = future.result()
+            except Exception as e:
+                logger.error(f'Strategy {name} failed: {e}')
+                results[name] = []
+
+    candidate_lists = [results[name] for name in request.strategies if name in results]
+    breakdown = {name: len(results.get(name, [])) for name in request.strategies}
+
+    candidates = merge_candidates(candidate_lists)
+
+    session_id = str(uuid.uuid4())
+    _save_session(uid, session_id, {
+        'ids': [c['id'] for c in candidates],
+        'strategies': request.strategies,
+        'age_days': request.age_days,
+    })
+
+    seen_per_strategy: dict[str, int] = {}
+    sample = []
+    for c in candidates:
+        s = c['strategy']
+        if seen_per_strategy.get(s, 0) < _SAMPLE_PER_STRATEGY:
+            sample.append(CleanupSampleItem(description=c['description'], strategy=c['strategy']))
+            seen_per_strategy[s] = seen_per_strategy.get(s, 0) + 1
+
+    return CleanupPreviewResponse(
+        session_id=session_id,
+        total_candidates=len(candidates),
+        breakdown=breakdown,
+        sample=sample,
+        candidate_ids=[c['id'] for c in candidates],
+        candidate_meta=[CleanupCandidateMeta(id=c['id'], strategy=c['strategy']) for c in candidates],
+        expires_in_seconds=_SESSION_TTL,
+    )
+
+
+@router.post('/v1/action-items/cleanup/execute', response_model=CleanupExecuteResponse, tags=['action-items'])
+def cleanup_execute(request: CleanupExecuteRequest, uid: str = Depends(auth.get_current_user_uid)):
+    """
+    Delete the candidates staged by a prior preview call.
+    Falls back to recomputing if the session has expired.
+    """
+    session = _load_session(uid, request.session_id)
+
+    if session:
+        ids = session['ids']
+        _delete_session(uid, request.session_id)
+    else:
+        # Session expired — recompute from stored parameters
+        # For now surface an error; once all strategies are implemented
+        # we can reconstruct the full candidate list from parameters.
+        raise HTTPException(
+            status_code=410,
+            detail='Cleanup session expired. Please run preview again.',
+        )
+
+    if not ids:
+        return CleanupExecuteResponse(deleted_count=0)
+
+    deleted_ids = action_items_db.delete_action_items_batch(uid, ids)
+
+    if deleted_ids:
+        delete_action_item_vectors_batch(uid, deleted_ids)
+        send_action_items_batch_deletion_message(user_id=uid, action_item_ids=deleted_ids)
+
+    logger.info(f'cleanup_execute uid={uid} requested={len(ids)} deleted={len(deleted_ids)}')
+
+    return CleanupExecuteResponse(deleted_count=len(deleted_ids))

--- a/backend/routers/action_items_cleanup.py
+++ b/backend/routers/action_items_cleanup.py
@@ -1,8 +1,6 @@
-import json
 import logging
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime, timezone
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException

--- a/backend/routers/action_items_cleanup.py
+++ b/backend/routers/action_items_cleanup.py
@@ -57,6 +57,7 @@ class CleanupSampleItem(BaseModel):
 class CleanupCandidateMeta(BaseModel):
     id: str
     strategy: str
+    description: str
 
 
 class CleanupPreviewResponse(BaseModel):
@@ -71,6 +72,9 @@ class CleanupPreviewResponse(BaseModel):
 
 class CleanupExecuteRequest(BaseModel):
     session_id: str
+    excluded_ids: List[str] = Field(
+        default_factory=list, description="Candidate IDs from the preview to keep (not delete)"
+    )
 
 
 class CleanupExecuteResponse(BaseModel):
@@ -178,7 +182,9 @@ def cleanup_preview(request: CleanupPreviewRequest, uid: str = Depends(auth.get_
         breakdown=breakdown,
         sample=sample,
         candidate_ids=[c['id'] for c in candidates],
-        candidate_meta=[CleanupCandidateMeta(id=c['id'], strategy=c['strategy']) for c in candidates],
+        candidate_meta=[
+            CleanupCandidateMeta(id=c['id'], strategy=c['strategy'], description=c['description']) for c in candidates
+        ],
         expires_in_seconds=_SESSION_TTL,
     )
 
@@ -192,7 +198,8 @@ def cleanup_execute(request: CleanupExecuteRequest, uid: str = Depends(auth.get_
     session = _load_session(uid, request.session_id)
 
     if session:
-        ids = session['ids']
+        excluded = set(request.excluded_ids)
+        ids = [i for i in session['ids'] if i not in excluded]
         _delete_session(uid, request.session_id)
     else:
         # Session expired — recompute from stored parameters

--- a/backend/tests/unit/test_action_item_cleanup_strategies.py
+++ b/backend/tests/unit/test_action_item_cleanup_strategies.py
@@ -1,0 +1,302 @@
+"""
+Tests for rule-based cleanup strategy functions in utils/action_item_cleanup.py.
+
+Contract: strategies must correctly identify candidates for removal without
+false-positives. A false deletion is worse than a missed stale task.
+
+Heavy deps (Pinecone, Firebase, LangChain, database clients) are stubbed
+before the module loads so no real infra is required.
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+from testing.import_isolation import AutoMockModule, load_module_fresh, stub_modules
+
+_BACKEND = Path(__file__).resolve().parents[2]
+
+
+def _dt(days_ago: int) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=days_ago)
+
+
+def _item(id_, *, description="do something", due_at=None, created_at=None, conversation_id=None):
+    return {
+        "id": id_,
+        "description": description,
+        "completed": False,
+        "due_at": due_at,
+        "created_at": created_at if created_at is not None else _dt(0),
+        "conversation_id": conversation_id,
+    }
+
+
+@pytest.fixture(scope="module")
+def cleanup():
+    """Load utils/action_item_cleanup.py fresh against faked heavy deps."""
+    langchain_pkg = AutoMockModule("langchain_core")
+    langchain_pkg.__path__ = []
+
+    fakes = {
+        "langchain_core": langchain_pkg,
+        "langchain_core.prompts": AutoMockModule("langchain_core.prompts"),
+        "database.action_items": AutoMockModule("database.action_items"),
+        "database.conversations": AutoMockModule("database.conversations"),
+        "database.vector_db": AutoMockModule("database.vector_db"),
+        "utils.llm.clients": AutoMockModule("utils.llm.clients"),
+    }
+    with stub_modules(fakes):
+        module = load_module_fresh(
+            "utils.action_item_cleanup",
+            os.path.join(str(_BACKEND), "utils", "action_item_cleanup.py"),
+        )
+        yield module
+
+
+# ---------------------------------------------------------------------------
+# _is_vague
+# ---------------------------------------------------------------------------
+
+class TestIsVague:
+    def test_short_description_with_dangling_pronoun(self, cleanup):
+        # "it" + "away" — unresolved referent
+        assert cleanup._is_vague("put it away") is True
+
+    def test_bare_demonstrative_pronoun(self, cleanup):
+        assert cleanup._is_vague("fix those") is True
+
+    def test_speaker_label_pattern(self, cleanup):
+        assert cleanup._is_vague("Attend ultrasound with Speaker 1") is True
+
+    def test_normal_task_not_vague(self, cleanup):
+        assert cleanup._is_vague("Call the dentist to reschedule") is False
+
+    def test_long_description_with_pronoun_not_vague(self, cleanup):
+        # "it" appears in context — description is specific enough
+        assert cleanup._is_vague("Review the Q3 budget report with Sarah before it closes") is False
+
+    def test_two_word_dangling_task(self, cleanup):
+        assert cleanup._is_vague("Send it") is True
+
+    def test_empty_string_not_vague(self, cleanup):
+        assert cleanup._is_vague("") is False
+
+
+# ---------------------------------------------------------------------------
+# candidates_stale_age
+# ---------------------------------------------------------------------------
+
+class TestCandidatesStaleAge:
+    def test_old_task_without_due_date_is_candidate(self, cleanup, monkeypatch):
+        items = [_item("old-1", created_at=_dt(100))]
+        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+        monkeypatch.setattr(cleanup.conversations_db, "get_conversation", lambda *a, **kw: None)
+
+        result = cleanup.candidates_stale_age("uid", age_days=90)
+
+        assert [c["id"] for c in result] == ["old-1"]
+        assert result[0]["strategy"] == "stale_age"
+
+    def test_young_task_not_a_candidate(self, cleanup, monkeypatch):
+        items = [_item("young-1", created_at=_dt(10))]
+        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+        monkeypatch.setattr(cleanup.conversations_db, "get_conversation", lambda *a, **kw: None)
+
+        result = cleanup.candidates_stale_age("uid", age_days=90)
+
+        assert result == []
+
+    def test_old_task_with_due_date_skipped(self, cleanup, monkeypatch):
+        # Tasks with a due date are actively scheduled — never stale-age candidates.
+        items = [_item("old-due", created_at=_dt(100), due_at=_dt(-5))]
+        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+        monkeypatch.setattr(cleanup.conversations_db, "get_conversation", lambda *a, **kw: None)
+
+        result = cleanup.candidates_stale_age("uid", age_days=90)
+
+        assert result == []
+
+    def test_uses_conversation_date_when_linked(self, cleanup, monkeypatch):
+        # Task itself is recent but linked to an old conversation → candidate
+        items = [_item("linked-1", created_at=_dt(5), conversation_id="conv-old")]
+        conv = {"started_at": _dt(120)}
+        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+        monkeypatch.setattr(
+            cleanup.conversations_db, "get_conversation",
+            lambda uid, cid: conv if cid == "conv-old" else None,
+        )
+
+        result = cleanup.candidates_stale_age("uid", age_days=90)
+
+        assert [c["id"] for c in result] == ["linked-1"]
+
+    def test_young_conversation_suppresses_old_task(self, cleanup, monkeypatch):
+        # Task itself is old but its conversation is recent → not a candidate
+        items = [_item("linked-2", created_at=_dt(150), conversation_id="conv-new")]
+        conv = {"started_at": _dt(5)}
+        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+        monkeypatch.setattr(
+            cleanup.conversations_db, "get_conversation",
+            lambda uid, cid: conv if cid == "conv-new" else None,
+        )
+
+        result = cleanup.candidates_stale_age("uid", age_days=90)
+
+        assert result == []
+
+    def test_task_with_none_created_at_skipped(self, cleanup, monkeypatch):
+        item = _item("no-date")
+        item["created_at"] = None
+        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: [item])
+        monkeypatch.setattr(cleanup.conversations_db, "get_conversation", lambda *a, **kw: None)
+
+        result = cleanup.candidates_stale_age("uid", age_days=90)
+
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# candidates_overdue
+# ---------------------------------------------------------------------------
+
+class TestCandidatesOverdue:
+    def test_db_returned_task_with_due_at_is_candidate(self, cleanup, monkeypatch):
+        # The DB enforces the date cut-off via due_end_date; this confirms the
+        # function wraps whatever the DB returns into a candidate dict.
+        items = [_item("overdue-1", due_at=_dt(45))]
+        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+
+        result = cleanup.candidates_overdue("uid", overdue_days=30)
+
+        assert [c["id"] for c in result] == ["overdue-1"]
+        assert result[0]["strategy"] == "overdue"
+
+    def test_passes_due_end_date_cutoff_to_db(self, cleanup, monkeypatch):
+        # The date filter lives in the DB query, not in Python logic.
+        # Verify the cutoff kwarg is forwarded so the DB can do its job.
+        captured = {}
+
+        def fake_get(uid, **kw):
+            captured.update(kw)
+            return []
+
+        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", fake_get)
+
+        cleanup.candidates_overdue("uid", overdue_days=30)
+
+        assert "due_end_date" in captured, "due_end_date must be forwarded to the DB"
+        from datetime import timezone
+        assert captured["due_end_date"].tzinfo is not None, "cutoff must be timezone-aware"
+
+    def test_task_without_due_at_skipped(self, cleanup, monkeypatch):
+        # Explicit guard: even if DB leaks a no-due task, the guard filters it
+        items = [_item("no-due", due_at=None)]
+        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+
+        result = cleanup.candidates_overdue("uid", overdue_days=30)
+
+        assert result == []
+
+    def test_empty_list_returns_empty(self, cleanup, monkeypatch):
+        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: [])
+
+        result = cleanup.candidates_overdue("uid", overdue_days=30)
+
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# candidates_vague
+# ---------------------------------------------------------------------------
+
+class TestCandidatesVague:
+    def test_vague_task_is_candidate(self, cleanup, monkeypatch):
+        items = [_item("vague-1", description="put it away")]
+        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+
+        result = cleanup.candidates_vague("uid")
+
+        assert [c["id"] for c in result] == ["vague-1"]
+        assert result[0]["strategy"] == "vague"
+
+    def test_clear_task_not_candidate(self, cleanup, monkeypatch):
+        items = [_item("clear-1", description="Call the dentist to reschedule")]
+        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+
+        result = cleanup.candidates_vague("uid")
+
+        assert result == []
+
+    def test_empty_task_list(self, cleanup, monkeypatch):
+        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: [])
+
+        result = cleanup.candidates_vague("uid")
+
+        assert result == []
+
+    def test_mixed_list_filters_correctly(self, cleanup, monkeypatch):
+        items = [
+            _item("v1", description="fix those"),
+            _item("c1", description="Schedule dentist for Monday"),
+            _item("v2", description="Send it"),
+        ]
+        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+
+        result = cleanup.candidates_vague("uid")
+
+        assert {c["id"] for c in result} == {"v1", "v2"}
+
+
+# ---------------------------------------------------------------------------
+# merge_candidates
+# ---------------------------------------------------------------------------
+
+class TestMergeCandidates:
+    def test_deduplicates_same_id_across_lists(self, cleanup):
+        a = [{"id": "t1", "description": "x", "strategy": "stale_age"}]
+        b = [{"id": "t1", "description": "x", "strategy": "vague"}]
+
+        result = cleanup.merge_candidates([a, b])
+
+        assert len(result) == 1
+        assert result[0]["id"] == "t1"
+
+    def test_preserves_order_across_lists(self, cleanup):
+        a = [
+            {"id": "t1", "description": "x", "strategy": "stale_age"},
+            {"id": "t2", "description": "y", "strategy": "stale_age"},
+        ]
+        b = [{"id": "t3", "description": "z", "strategy": "vague"}]
+
+        result = cleanup.merge_candidates([a, b])
+
+        assert [c["id"] for c in result] == ["t1", "t2", "t3"]
+
+    def test_empty_input_returns_empty(self, cleanup):
+        assert cleanup.merge_candidates([]) == []
+
+    def test_all_unique_ids_included(self, cleanup):
+        a = [{"id": "t1", "description": "x", "strategy": "stale_age"}]
+        b = [{"id": "t2", "description": "y", "strategy": "overdue"}]
+
+        result = cleanup.merge_candidates([a, b])
+
+        assert {c["id"] for c in result} == {"t1", "t2"}
+
+    def test_later_list_duplicate_not_added(self, cleanup):
+        a = [{"id": "t1", "description": "x", "strategy": "stale_age"}]
+        b = [
+            {"id": "t1", "description": "x", "strategy": "overdue"},
+            {"id": "t2", "description": "y", "strategy": "overdue"},
+        ]
+
+        result = cleanup.merge_candidates([a, b])
+
+        ids = [c["id"] for c in result]
+        assert ids.count("t1") == 1
+        assert "t2" in ids

--- a/backend/tests/unit/test_action_item_cleanup_strategies.py
+++ b/backend/tests/unit/test_action_item_cleanup_strategies.py
@@ -62,6 +62,7 @@ def cleanup():
 # _is_vague
 # ---------------------------------------------------------------------------
 
+
 class TestIsVague:
     def test_short_description_with_dangling_pronoun(self, cleanup):
         # "it" + "away" — unresolved referent
@@ -90,6 +91,7 @@ class TestIsVague:
 # ---------------------------------------------------------------------------
 # candidates_stale_age
 # ---------------------------------------------------------------------------
+
 
 class TestCandidatesStaleAge:
     def test_old_task_without_due_date_is_candidate(self, cleanup, monkeypatch):
@@ -127,7 +129,8 @@ class TestCandidatesStaleAge:
         conv = {"started_at": _dt(120)}
         monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
         monkeypatch.setattr(
-            cleanup.conversations_db, "get_conversation",
+            cleanup.conversations_db,
+            "get_conversation",
             lambda uid, cid: conv if cid == "conv-old" else None,
         )
 
@@ -141,7 +144,8 @@ class TestCandidatesStaleAge:
         conv = {"started_at": _dt(5)}
         monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
         monkeypatch.setattr(
-            cleanup.conversations_db, "get_conversation",
+            cleanup.conversations_db,
+            "get_conversation",
             lambda uid, cid: conv if cid == "conv-new" else None,
         )
 
@@ -163,6 +167,7 @@ class TestCandidatesStaleAge:
 # ---------------------------------------------------------------------------
 # candidates_overdue
 # ---------------------------------------------------------------------------
+
 
 class TestCandidatesOverdue:
     def test_db_returned_task_with_due_at_is_candidate(self, cleanup, monkeypatch):
@@ -191,6 +196,7 @@ class TestCandidatesOverdue:
 
         assert "due_end_date" in captured, "due_end_date must be forwarded to the DB"
         from datetime import timezone
+
         assert captured["due_end_date"].tzinfo is not None, "cutoff must be timezone-aware"
 
     def test_task_without_due_at_skipped(self, cleanup, monkeypatch):
@@ -213,6 +219,7 @@ class TestCandidatesOverdue:
 # ---------------------------------------------------------------------------
 # candidates_vague
 # ---------------------------------------------------------------------------
+
 
 class TestCandidatesVague:
     def test_vague_task_is_candidate(self, cleanup, monkeypatch):
@@ -255,6 +262,7 @@ class TestCandidatesVague:
 # ---------------------------------------------------------------------------
 # merge_candidates
 # ---------------------------------------------------------------------------
+
 
 class TestMergeCandidates:
     def test_deduplicates_same_id_across_lists(self, cleanup):

--- a/backend/tests/unit/test_action_item_cleanup_strategies.py
+++ b/backend/tests/unit/test_action_item_cleanup_strategies.py
@@ -87,6 +87,22 @@ class TestIsVague:
     def test_empty_string_not_vague(self, cleanup):
         assert cleanup._is_vague("") is False
 
+    @pytest.mark.parametrize(
+        "description",
+        [
+            "Clean the kitchen",
+            "Fix the sink",
+            "Sort the laundry",
+            "Change the oil",
+            "Check the mail",
+            "Return the library books",
+        ],
+    )
+    def test_verb_plus_concrete_the_noun_not_vague(self, cleanup, description):
+        # "the <noun>" names a concrete object — it's not a dangling reference like
+        # "it"/"them"/"that", so these should not be flagged as vague.
+        assert cleanup._is_vague(description) is False
+
 
 # ---------------------------------------------------------------------------
 # candidates_stale_age

--- a/backend/tests/unit/test_action_item_cleanup_strategies.py
+++ b/backend/tests/unit/test_action_item_cleanup_strategies.py
@@ -48,6 +48,7 @@ def cleanup():
         "database.action_items": AutoMockModule("database.action_items"),
         "database.conversations": AutoMockModule("database.conversations"),
         "database.vector_db": AutoMockModule("database.vector_db"),
+        "utils.executors": AutoMockModule("utils.executors"),
         "utils.llm.clients": AutoMockModule("utils.llm.clients"),
     }
     with stub_modules(fakes):
@@ -104,38 +105,41 @@ class TestIsVague:
         assert cleanup._is_vague(description) is False
 
 
-# ---------------------------------------------------------------------------
-# candidates_stale_age
-# ---------------------------------------------------------------------------
+def _mock_cleanup_page(cleanup, monkeypatch, items, next_cursor=None):
+    monkeypatch.setattr(
+        cleanup.action_items_db,
+        "list_open_action_items_for_cleanup",
+        lambda uid, cursor=None, limit=None: (items, next_cursor, len(items)),
+    )
 
 
 class TestCandidatesStaleAge:
     def test_old_task_without_due_date_is_candidate(self, cleanup, monkeypatch):
         items = [_item("old-1", created_at=_dt(100))]
-        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+        _mock_cleanup_page(cleanup, monkeypatch, items)
         monkeypatch.setattr(cleanup.conversations_db, "get_conversation", lambda *a, **kw: None)
 
-        result = cleanup.candidates_stale_age("uid", age_days=90)
+        result, _ = cleanup.candidates_stale_age("uid", age_days=90)
 
         assert [c["id"] for c in result] == ["old-1"]
         assert result[0]["strategy"] == "stale_age"
 
     def test_young_task_not_a_candidate(self, cleanup, monkeypatch):
         items = [_item("young-1", created_at=_dt(10))]
-        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+        _mock_cleanup_page(cleanup, monkeypatch, items)
         monkeypatch.setattr(cleanup.conversations_db, "get_conversation", lambda *a, **kw: None)
 
-        result = cleanup.candidates_stale_age("uid", age_days=90)
+        result, _ = cleanup.candidates_stale_age("uid", age_days=90)
 
         assert result == []
 
     def test_old_task_with_due_date_skipped(self, cleanup, monkeypatch):
         # Tasks with a due date are actively scheduled — never stale-age candidates.
         items = [_item("old-due", created_at=_dt(100), due_at=_dt(-5))]
-        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+        _mock_cleanup_page(cleanup, monkeypatch, items)
         monkeypatch.setattr(cleanup.conversations_db, "get_conversation", lambda *a, **kw: None)
 
-        result = cleanup.candidates_stale_age("uid", age_days=90)
+        result, _ = cleanup.candidates_stale_age("uid", age_days=90)
 
         assert result == []
 
@@ -143,14 +147,14 @@ class TestCandidatesStaleAge:
         # Task itself is recent but linked to an old conversation → candidate
         items = [_item("linked-1", created_at=_dt(5), conversation_id="conv-old")]
         conv = {"started_at": _dt(120)}
-        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+        _mock_cleanup_page(cleanup, monkeypatch, items)
         monkeypatch.setattr(
             cleanup.conversations_db,
             "get_conversation",
             lambda uid, cid: conv if cid == "conv-old" else None,
         )
 
-        result = cleanup.candidates_stale_age("uid", age_days=90)
+        result, _ = cleanup.candidates_stale_age("uid", age_days=90)
 
         assert [c["id"] for c in result] == ["linked-1"]
 
@@ -158,24 +162,24 @@ class TestCandidatesStaleAge:
         # Task itself is old but its conversation is recent → not a candidate
         items = [_item("linked-2", created_at=_dt(150), conversation_id="conv-new")]
         conv = {"started_at": _dt(5)}
-        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+        _mock_cleanup_page(cleanup, monkeypatch, items)
         monkeypatch.setattr(
             cleanup.conversations_db,
             "get_conversation",
             lambda uid, cid: conv if cid == "conv-new" else None,
         )
 
-        result = cleanup.candidates_stale_age("uid", age_days=90)
+        result, _ = cleanup.candidates_stale_age("uid", age_days=90)
 
         assert result == []
 
     def test_task_with_none_created_at_skipped(self, cleanup, monkeypatch):
         item = _item("no-date")
         item["created_at"] = None
-        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: [item])
+        _mock_cleanup_page(cleanup, monkeypatch, [item])
         monkeypatch.setattr(cleanup.conversations_db, "get_conversation", lambda *a, **kw: None)
 
-        result = cleanup.candidates_stale_age("uid", age_days=90)
+        result, _ = cleanup.candidates_stale_age("uid", age_days=90)
 
         assert result == []
 
@@ -186,48 +190,44 @@ class TestCandidatesStaleAge:
 
 
 class TestCandidatesOverdue:
-    def test_db_returned_task_with_due_at_is_candidate(self, cleanup, monkeypatch):
-        # The DB enforces the date cut-off via due_end_date; this confirms the
-        # function wraps whatever the DB returns into a candidate dict.
+    def test_overdue_task_is_candidate(self, cleanup, monkeypatch):
         items = [_item("overdue-1", due_at=_dt(45))]
-        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+        _mock_cleanup_page(cleanup, monkeypatch, items)
 
-        result = cleanup.candidates_overdue("uid", overdue_days=30)
+        result, _ = cleanup.candidates_overdue("uid", overdue_days=30)
 
         assert [c["id"] for c in result] == ["overdue-1"]
         assert result[0]["strategy"] == "overdue"
 
-    def test_passes_due_end_date_cutoff_to_db(self, cleanup, monkeypatch):
-        # The date filter lives in the DB query, not in Python logic.
-        # Verify the cutoff kwarg is forwarded so the DB can do its job.
-        captured = {}
+    def test_recent_due_date_not_candidate(self, cleanup, monkeypatch):
+        items = [_item("recent-1", due_at=_dt(5))]
+        _mock_cleanup_page(cleanup, monkeypatch, items)
 
-        def fake_get(uid, **kw):
-            captured.update(kw)
-            return []
+        result, _ = cleanup.candidates_overdue("uid", overdue_days=30)
 
-        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", fake_get)
-
-        cleanup.candidates_overdue("uid", overdue_days=30)
-
-        assert "due_end_date" in captured, "due_end_date must be forwarded to the DB"
-        from datetime import timezone
-
-        assert captured["due_end_date"].tzinfo is not None, "cutoff must be timezone-aware"
+        assert result == []
 
     def test_task_without_due_at_skipped(self, cleanup, monkeypatch):
-        # Explicit guard: even if DB leaks a no-due task, the guard filters it
         items = [_item("no-due", due_at=None)]
-        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+        _mock_cleanup_page(cleanup, monkeypatch, items)
 
-        result = cleanup.candidates_overdue("uid", overdue_days=30)
+        result, _ = cleanup.candidates_overdue("uid", overdue_days=30)
 
         assert result == []
 
     def test_empty_list_returns_empty(self, cleanup, monkeypatch):
-        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: [])
+        _mock_cleanup_page(cleanup, monkeypatch, [])
 
-        result = cleanup.candidates_overdue("uid", overdue_days=30)
+        result, _ = cleanup.candidates_overdue("uid", overdue_days=30)
+
+        assert result == []
+
+    def test_locked_task_skipped(self, cleanup, monkeypatch):
+        locked = _item("locked-1", due_at=_dt(45))
+        locked["is_locked"] = True
+        _mock_cleanup_page(cleanup, monkeypatch, [locked])
+
+        result, _ = cleanup.candidates_overdue("uid", overdue_days=30)
 
         assert result == []
 
@@ -240,25 +240,25 @@ class TestCandidatesOverdue:
 class TestCandidatesVague:
     def test_vague_task_is_candidate(self, cleanup, monkeypatch):
         items = [_item("vague-1", description="put it away")]
-        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+        _mock_cleanup_page(cleanup, monkeypatch, items)
 
-        result = cleanup.candidates_vague("uid")
+        result, _ = cleanup.candidates_vague("uid")
 
         assert [c["id"] for c in result] == ["vague-1"]
         assert result[0]["strategy"] == "vague"
 
     def test_clear_task_not_candidate(self, cleanup, monkeypatch):
         items = [_item("clear-1", description="Call the dentist to reschedule")]
-        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+        _mock_cleanup_page(cleanup, monkeypatch, items)
 
-        result = cleanup.candidates_vague("uid")
+        result, _ = cleanup.candidates_vague("uid")
 
         assert result == []
 
     def test_empty_task_list(self, cleanup, monkeypatch):
-        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: [])
+        _mock_cleanup_page(cleanup, monkeypatch, [])
 
-        result = cleanup.candidates_vague("uid")
+        result, _ = cleanup.candidates_vague("uid")
 
         assert result == []
 
@@ -268,9 +268,9 @@ class TestCandidatesVague:
             _item("c1", description="Schedule dentist for Monday"),
             _item("v2", description="Send it"),
         ]
-        monkeypatch.setattr(cleanup.action_items_db, "get_action_items", lambda *a, **kw: items)
+        _mock_cleanup_page(cleanup, monkeypatch, items)
 
-        result = cleanup.candidates_vague("uid")
+        result, _ = cleanup.candidates_vague("uid")
 
         assert {c["id"] for c in result} == {"v1", "v2"}
 

--- a/backend/tests/unit/test_action_items_cleanup_router.py
+++ b/backend/tests/unit/test_action_items_cleanup_router.py
@@ -38,6 +38,13 @@ def router():
     utils_other_pkg = AutoMockModule("utils.other")
     utils_other_pkg.__path__ = []
 
+    action_items_db_mock = AutoMockModule("database.action_items")
+    # Sane defaults so every test that doesn't care about scan-truncation
+    # (i.e. all of them except TestCleanupPreviewScanTruncation) doesn't have
+    # to monkeypatch these two calls just to avoid comparing MagicMocks.
+    action_items_db_mock.get_open_action_items_count = lambda uid: 0
+    action_items_db_mock.get_action_items_list_scan_cap = lambda: 2000
+
     fakes = {
         "langchain_core": langchain_pkg,
         "langchain_core.prompts": AutoMockModule("langchain_core.prompts"),
@@ -45,7 +52,7 @@ def router():
         "utils.notifications": AutoMockModule("utils.notifications"),
         "utils.other": utils_other_pkg,
         "utils.other.endpoints": AutoMockModule("utils.other.endpoints"),
-        "database.action_items": AutoMockModule("database.action_items"),
+        "database.action_items": action_items_db_mock,
         "database.redis_db": AutoMockModule("database.redis_db"),
         "database.vector_db": AutoMockModule("database.vector_db"),
     }
@@ -190,6 +197,53 @@ class TestCleanupPreview:
 
         assert len(result.candidate_meta) == 10
         assert {(m.id, m.description) for m in result.candidate_meta} == {(f"t{i}", f"task {i}") for i in range(10)}
+
+
+# ---------------------------------------------------------------------------
+# Scan-truncation reporting (get_action_items' 2000-item hard cap means
+# strategies can silently skip tasks on large accounts — surface that instead
+# of staying quiet about it)
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupPreviewScanTruncation:
+    def test_not_truncated_when_open_count_within_cap(self, router, monkeypatch):
+        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: _three_candidates())
+        monkeypatch.setattr(router, "merge_candidates", lambda lists: lists[0] if lists else [])
+        monkeypatch.setattr(router, "_save_session", lambda *a, **kw: None)
+        monkeypatch.setattr(router.action_items_db, "get_open_action_items_count", lambda uid: 1500)
+        monkeypatch.setattr(router.action_items_db, "get_action_items_list_scan_cap", lambda: 2000)
+
+        req = router.CleanupPreviewRequest(strategies=["stale_age"])
+        result = router.cleanup_preview(req, uid="uid-1")
+
+        assert result.total_open_action_items == 1500
+        assert result.scan_cap == 2000
+        assert result.scan_truncated is False
+
+    def test_truncated_when_open_count_exceeds_cap(self, router, monkeypatch):
+        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: _three_candidates())
+        monkeypatch.setattr(router, "merge_candidates", lambda lists: lists[0] if lists else [])
+        monkeypatch.setattr(router, "_save_session", lambda *a, **kw: None)
+        monkeypatch.setattr(router.action_items_db, "get_open_action_items_count", lambda uid: 45000)
+        monkeypatch.setattr(router.action_items_db, "get_action_items_list_scan_cap", lambda: 2000)
+
+        req = router.CleanupPreviewRequest(strategies=["stale_age"])
+        result = router.cleanup_preview(req, uid="uid-1")
+
+        assert result.total_open_action_items == 45000
+        assert result.scan_cap == 2000
+        assert result.scan_truncated is True
+
+    def test_truncation_fields_present_on_empty_strategies_short_circuit(self, router, monkeypatch):
+        monkeypatch.setattr(router.action_items_db, "get_open_action_items_count", lambda uid: 5000)
+        monkeypatch.setattr(router.action_items_db, "get_action_items_list_scan_cap", lambda: 2000)
+
+        req = router.CleanupPreviewRequest(strategies=[])
+        result = router.cleanup_preview(req, uid="uid-1")
+
+        assert result.total_open_action_items == 5000
+        assert result.scan_truncated is True
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_action_items_cleanup_router.py
+++ b/backend/tests/unit/test_action_items_cleanup_router.py
@@ -50,15 +50,13 @@ def router():
 
 
 def _three_candidates(strategy: str = "stale_age"):
-    return [
-        {"id": f"t{i}", "description": f"task {i}", "strategy": strategy}
-        for i in range(3)
-    ]
+    return [{"id": f"t{i}", "description": f"task {i}", "strategy": strategy} for i in range(3)]
 
 
 # ---------------------------------------------------------------------------
 # Preview endpoint
 # ---------------------------------------------------------------------------
+
 
 class TestCleanupPreview:
     def test_returns_session_id_breakdown_and_total(self, router, monkeypatch):
@@ -144,16 +142,19 @@ class TestCleanupPreview:
 # Execute endpoint
 # ---------------------------------------------------------------------------
 
+
 class TestCleanupExecute:
     def test_deletes_staged_ids_and_returns_count(self, router, monkeypatch):
         ids = ["t1", "t2", "t3"]
         monkeypatch.setattr(
-            router, "_load_session",
+            router,
+            "_load_session",
             lambda uid, sid: {"ids": ids, "strategies": ["stale_age"], "age_days": 90},
         )
         monkeypatch.setattr(router, "_delete_session", lambda *a, **kw: None)
         monkeypatch.setattr(
-            router.action_items_db, "delete_action_items_batch",
+            router.action_items_db,
+            "delete_action_items_batch",
             lambda uid, id_list: id_list,
         )
         monkeypatch.setattr(router, "delete_action_item_vectors_batch", lambda *a, **kw: None)
@@ -175,13 +176,15 @@ class TestCleanupExecute:
 
     def test_empty_candidate_list_returns_zero_without_calling_delete(self, router, monkeypatch):
         monkeypatch.setattr(
-            router, "_load_session",
+            router,
+            "_load_session",
             lambda uid, sid: {"ids": [], "strategies": ["stale_age"], "age_days": 90},
         )
         monkeypatch.setattr(router, "_delete_session", lambda *a, **kw: None)
         delete_called = []
         monkeypatch.setattr(
-            router.action_items_db, "delete_action_items_batch",
+            router.action_items_db,
+            "delete_action_items_batch",
             lambda *a, **kw: delete_called.append(True) or [],
         )
 
@@ -194,21 +197,25 @@ class TestCleanupExecute:
     def test_vectors_and_notifications_only_on_non_empty_deleted(self, router, monkeypatch):
         ids = ["t1"]
         monkeypatch.setattr(
-            router, "_load_session",
+            router,
+            "_load_session",
             lambda uid, sid: {"ids": ids, "strategies": ["stale_age"], "age_days": 90},
         )
         monkeypatch.setattr(router, "_delete_session", lambda *a, **kw: None)
         monkeypatch.setattr(
-            router.action_items_db, "delete_action_items_batch",
+            router.action_items_db,
+            "delete_action_items_batch",
             lambda uid, id_list: id_list,
         )
         vector_calls, notify_calls = [], []
         monkeypatch.setattr(
-            router, "delete_action_item_vectors_batch",
+            router,
+            "delete_action_item_vectors_batch",
             lambda uid, deleted_ids: vector_calls.append(deleted_ids),
         )
         monkeypatch.setattr(
-            router, "send_action_items_batch_deletion_message",
+            router,
+            "send_action_items_batch_deletion_message",
             lambda **kw: notify_calls.append(kw),
         )
 

--- a/backend/tests/unit/test_action_items_cleanup_router.py
+++ b/backend/tests/unit/test_action_items_cleanup_router.py
@@ -1,0 +1,220 @@
+"""
+Tests for preview + execute endpoints in routers/action_items_cleanup.py.
+
+Verifies: session staging, breakdown shape, sample capping, deletion delegation,
+410 on expired session, and empty-list short-circuit.
+
+Strategy functions and Redis are replaced by in-memory fakes; the route
+handlers are called directly (bypassing FastAPI DI) so auth is passed as a kwarg.
+"""
+
+import os
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from testing.import_isolation import AutoMockModule, load_module_fresh, stub_modules
+
+_BACKEND = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(scope="module")
+def router():
+    """Load routers/action_items_cleanup.py fresh against faked heavy deps."""
+    langchain_pkg = AutoMockModule("langchain_core")
+    langchain_pkg.__path__ = []
+
+    utils_other_pkg = AutoMockModule("utils.other")
+    utils_other_pkg.__path__ = []
+
+    fakes = {
+        "langchain_core": langchain_pkg,
+        "langchain_core.prompts": AutoMockModule("langchain_core.prompts"),
+        "utils.action_item_cleanup": AutoMockModule("utils.action_item_cleanup"),
+        "utils.notifications": AutoMockModule("utils.notifications"),
+        "utils.other": utils_other_pkg,
+        "utils.other.endpoints": AutoMockModule("utils.other.endpoints"),
+        "database.action_items": AutoMockModule("database.action_items"),
+        "database.redis_db": AutoMockModule("database.redis_db"),
+        "database.vector_db": AutoMockModule("database.vector_db"),
+    }
+    with stub_modules(fakes):
+        module = load_module_fresh(
+            "routers.action_items_cleanup",
+            os.path.join(str(_BACKEND), "routers", "action_items_cleanup.py"),
+        )
+        yield module
+
+
+def _three_candidates(strategy: str = "stale_age"):
+    return [
+        {"id": f"t{i}", "description": f"task {i}", "strategy": strategy}
+        for i in range(3)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Preview endpoint
+# ---------------------------------------------------------------------------
+
+class TestCleanupPreview:
+    def test_returns_session_id_breakdown_and_total(self, router, monkeypatch):
+        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: _three_candidates())
+        monkeypatch.setattr(router, "merge_candidates", lambda lists: lists[0] if lists else [])
+
+        store = {}
+        monkeypatch.setattr(router, "_save_session", lambda uid, sid, data: store.update({sid: data}))
+
+        req = router.CleanupPreviewRequest(strategies=["stale_age"])
+        result = router.cleanup_preview(req, uid="uid-1")
+
+        assert result.total_candidates == 3
+        assert result.breakdown == {"stale_age": 3}
+        assert result.session_id
+        assert result.session_id in store
+        assert result.expires_in_seconds == router._SESSION_TTL
+
+    def test_session_stores_candidate_ids(self, router, monkeypatch):
+        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: _three_candidates())
+        monkeypatch.setattr(router, "merge_candidates", lambda lists: lists[0] if lists else [])
+
+        store = {}
+        monkeypatch.setattr(router, "_save_session", lambda uid, sid, data: store.update({sid: data}))
+
+        req = router.CleanupPreviewRequest(strategies=["stale_age"])
+        result = router.cleanup_preview(req, uid="uid-1")
+
+        session_data = store[result.session_id]
+        assert set(session_data["ids"]) == {"t0", "t1", "t2"}
+
+    def test_sample_capped_per_strategy(self, router, monkeypatch):
+        # 10 candidates for one strategy → sample must be ≤ _SAMPLE_PER_STRATEGY
+        many = [{"id": f"t{i}", "description": f"task {i}", "strategy": "stale_age"} for i in range(10)]
+        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: many)
+        monkeypatch.setattr(router, "merge_candidates", lambda lists: lists[0] if lists else [])
+        monkeypatch.setattr(router, "_save_session", lambda *a, **kw: None)
+
+        req = router.CleanupPreviewRequest(strategies=["stale_age"])
+        result = router.cleanup_preview(req, uid="uid-1")
+
+        assert len(result.sample) <= router._SAMPLE_PER_STRATEGY
+
+    def test_breakdown_only_shows_requested_strategies(self, router, monkeypatch):
+        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: _three_candidates())
+        monkeypatch.setattr(router, "merge_candidates", lambda lists: lists[0] if lists else [])
+        monkeypatch.setattr(router, "_save_session", lambda *a, **kw: None)
+
+        req = router.CleanupPreviewRequest(strategies=["stale_age"])
+        result = router.cleanup_preview(req, uid="uid-1")
+
+        assert set(result.breakdown.keys()) == {"stale_age"}
+
+    def test_failed_strategy_contributes_zero_to_breakdown(self, router, monkeypatch):
+        def _raise(*a, **kw):
+            raise RuntimeError("simulated strategy error")
+
+        monkeypatch.setattr(router, "candidates_stale_age", _raise)
+        monkeypatch.setattr(router, "merge_candidates", lambda lists: [])
+        monkeypatch.setattr(router, "_save_session", lambda *a, **kw: None)
+
+        req = router.CleanupPreviewRequest(strategies=["stale_age"])
+        result = router.cleanup_preview(req, uid="uid-1")
+
+        assert result.total_candidates == 0
+        assert result.breakdown == {"stale_age": 0}
+
+    def test_two_strategies_each_appear_in_breakdown(self, router, monkeypatch):
+        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: _three_candidates("stale_age"))
+        monkeypatch.setattr(router, "candidates_vague", lambda *a, **kw: _three_candidates("vague"))
+        monkeypatch.setattr(router, "merge_candidates", lambda lists: lists[0] + lists[1] if lists else [])
+        monkeypatch.setattr(router, "_save_session", lambda *a, **kw: None)
+
+        req = router.CleanupPreviewRequest(strategies=["stale_age", "vague"])
+        result = router.cleanup_preview(req, uid="uid-1")
+
+        assert set(result.breakdown.keys()) == {"stale_age", "vague"}
+        assert result.breakdown["stale_age"] == 3
+        assert result.breakdown["vague"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Execute endpoint
+# ---------------------------------------------------------------------------
+
+class TestCleanupExecute:
+    def test_deletes_staged_ids_and_returns_count(self, router, monkeypatch):
+        ids = ["t1", "t2", "t3"]
+        monkeypatch.setattr(
+            router, "_load_session",
+            lambda uid, sid: {"ids": ids, "strategies": ["stale_age"], "age_days": 90},
+        )
+        monkeypatch.setattr(router, "_delete_session", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            router.action_items_db, "delete_action_items_batch",
+            lambda uid, id_list: id_list,
+        )
+        monkeypatch.setattr(router, "delete_action_item_vectors_batch", lambda *a, **kw: None)
+        monkeypatch.setattr(router, "send_action_items_batch_deletion_message", lambda **kw: None)
+
+        req = router.CleanupExecuteRequest(session_id="sess-1")
+        result = router.cleanup_execute(req, uid="uid-1")
+
+        assert result.deleted_count == 3
+
+    def test_raises_410_when_session_expired(self, router, monkeypatch):
+        monkeypatch.setattr(router, "_load_session", lambda *a, **kw: None)
+
+        req = router.CleanupExecuteRequest(session_id="expired-sess")
+        with pytest.raises(HTTPException) as exc_info:
+            router.cleanup_execute(req, uid="uid-1")
+
+        assert exc_info.value.status_code == 410
+
+    def test_empty_candidate_list_returns_zero_without_calling_delete(self, router, monkeypatch):
+        monkeypatch.setattr(
+            router, "_load_session",
+            lambda uid, sid: {"ids": [], "strategies": ["stale_age"], "age_days": 90},
+        )
+        monkeypatch.setattr(router, "_delete_session", lambda *a, **kw: None)
+        delete_called = []
+        monkeypatch.setattr(
+            router.action_items_db, "delete_action_items_batch",
+            lambda *a, **kw: delete_called.append(True) or [],
+        )
+
+        req = router.CleanupExecuteRequest(session_id="sess-empty")
+        result = router.cleanup_execute(req, uid="uid-1")
+
+        assert result.deleted_count == 0
+        assert delete_called == [], "delete must not be called when candidate list is empty"
+
+    def test_vectors_and_notifications_only_on_non_empty_deleted(self, router, monkeypatch):
+        ids = ["t1"]
+        monkeypatch.setattr(
+            router, "_load_session",
+            lambda uid, sid: {"ids": ids, "strategies": ["stale_age"], "age_days": 90},
+        )
+        monkeypatch.setattr(router, "_delete_session", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            router.action_items_db, "delete_action_items_batch",
+            lambda uid, id_list: id_list,
+        )
+        vector_calls, notify_calls = [], []
+        monkeypatch.setattr(
+            router, "delete_action_item_vectors_batch",
+            lambda uid, deleted_ids: vector_calls.append(deleted_ids),
+        )
+        monkeypatch.setattr(
+            router, "send_action_items_batch_deletion_message",
+            lambda **kw: notify_calls.append(kw),
+        )
+
+        req = router.CleanupExecuteRequest(session_id="sess-1")
+        router.cleanup_execute(req, uid="uid-1")
+
+        assert len(vector_calls) == 1
+        assert len(notify_calls) == 1
+        assert notify_calls[0]["user_id"] == "uid-1"

--- a/backend/tests/unit/test_action_items_cleanup_router.py
+++ b/backend/tests/unit/test_action_items_cleanup_router.py
@@ -11,8 +11,7 @@ handlers are called directly (bypassing FastAPI DI) so auth is passed as a kwarg
 import os
 import re
 from pathlib import Path
-from types import ModuleType
-from unittest.mock import MagicMock
+from concurrent.futures import Future
 
 import pytest
 from fastapi import HTTPException
@@ -44,16 +43,35 @@ def router():
     # to monkeypatch these two calls just to avoid comparing MagicMocks.
     action_items_db_mock.get_open_action_items_count = lambda uid: 0
     action_items_db_mock.get_action_items_list_scan_cap = lambda: 2000
+    action_items_db_mock.get_action_items_by_ids = lambda uid, ids: [{'id': item_id} for item_id in ids]
+
+    executors_mock = AutoMockModule("utils.executors")
+
+    def _submit(fn):
+        future = Future()
+        try:
+            future.set_result(fn())
+        except Exception as exc:
+            future.set_exception(exc)
+        return future
+
+    executors_mock.postprocess_executor.submit = _submit
+
+    redis_db_mock = AutoMockModule("database.redis_db")
+    redis_db_mock.get_generic_cache = lambda path: None
+    redis_db_mock.pop_generic_cache = lambda path: None
+    redis_db_mock.set_generic_cache = lambda *a, **kw: None
 
     fakes = {
         "langchain_core": langchain_pkg,
         "langchain_core.prompts": AutoMockModule("langchain_core.prompts"),
         "utils.action_item_cleanup": AutoMockModule("utils.action_item_cleanup"),
+        "utils.executors": executors_mock,
         "utils.notifications": AutoMockModule("utils.notifications"),
         "utils.other": utils_other_pkg,
         "utils.other.endpoints": AutoMockModule("utils.other.endpoints"),
         "database.action_items": action_items_db_mock,
-        "database.redis_db": AutoMockModule("database.redis_db"),
+        "database.redis_db": redis_db_mock,
         "database.vector_db": AutoMockModule("database.vector_db"),
     }
     with stub_modules(fakes):
@@ -66,6 +84,10 @@ def router():
 
 def _three_candidates(strategy: str = "stale_age"):
     return [{"id": f"t{i}", "description": f"task {i}", "strategy": strategy} for i in range(3)]
+
+
+def _strategy_page(candidates):
+    return candidates, None
 
 
 # ---------------------------------------------------------------------------
@@ -107,7 +129,7 @@ class TestCleanupRateLimitWiring:
 
 class TestCleanupPreview:
     def test_returns_session_id_breakdown_and_total(self, router, monkeypatch):
-        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: _three_candidates())
+        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: _strategy_page(_three_candidates()))
         monkeypatch.setattr(router, "merge_candidates", lambda lists: lists[0] if lists else [])
 
         store = {}
@@ -123,7 +145,7 @@ class TestCleanupPreview:
         assert result.expires_in_seconds == router._SESSION_TTL
 
     def test_session_stores_candidate_ids(self, router, monkeypatch):
-        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: _three_candidates())
+        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: _strategy_page(_three_candidates()))
         monkeypatch.setattr(router, "merge_candidates", lambda lists: lists[0] if lists else [])
 
         store = {}
@@ -138,7 +160,7 @@ class TestCleanupPreview:
     def test_sample_capped_per_strategy(self, router, monkeypatch):
         # 10 candidates for one strategy → sample must be ≤ _SAMPLE_PER_STRATEGY
         many = [{"id": f"t{i}", "description": f"task {i}", "strategy": "stale_age"} for i in range(10)]
-        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: many)
+        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: _strategy_page(many))
         monkeypatch.setattr(router, "merge_candidates", lambda lists: lists[0] if lists else [])
         monkeypatch.setattr(router, "_save_session", lambda *a, **kw: None)
 
@@ -148,7 +170,7 @@ class TestCleanupPreview:
         assert len(result.sample) <= router._SAMPLE_PER_STRATEGY
 
     def test_breakdown_only_shows_requested_strategies(self, router, monkeypatch):
-        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: _three_candidates())
+        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: _strategy_page(_three_candidates()))
         monkeypatch.setattr(router, "merge_candidates", lambda lists: lists[0] if lists else [])
         monkeypatch.setattr(router, "_save_session", lambda *a, **kw: None)
 
@@ -172,8 +194,10 @@ class TestCleanupPreview:
         assert result.breakdown == {"stale_age": 0}
 
     def test_two_strategies_each_appear_in_breakdown(self, router, monkeypatch):
-        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: _three_candidates("stale_age"))
-        monkeypatch.setattr(router, "candidates_vague", lambda *a, **kw: _three_candidates("vague"))
+        monkeypatch.setattr(
+            router, "candidates_stale_age", lambda *a, **kw: _strategy_page(_three_candidates("stale_age"))
+        )
+        monkeypatch.setattr(router, "candidates_vague", lambda *a, **kw: _strategy_page(_three_candidates("vague")))
         monkeypatch.setattr(router, "merge_candidates", lambda lists: lists[0] + lists[1] if lists else [])
         monkeypatch.setattr(router, "_save_session", lambda *a, **kw: None)
 
@@ -188,7 +212,7 @@ class TestCleanupPreview:
         # candidate_meta backs per-item review/exclusion in the UI, so it must carry
         # the full description for every candidate, not just the capped sample.
         many = [{"id": f"t{i}", "description": f"task {i}", "strategy": "stale_age"} for i in range(10)]
-        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: many)
+        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: _strategy_page(many))
         monkeypatch.setattr(router, "merge_candidates", lambda lists: lists[0] if lists else [])
         monkeypatch.setattr(router, "_save_session", lambda *a, **kw: None)
 
@@ -207,12 +231,11 @@ class TestCleanupPreview:
 
 
 class TestCleanupPreviewScanTruncation:
-    def test_not_truncated_when_open_count_within_cap(self, router, monkeypatch):
-        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: _three_candidates())
+    def test_not_truncated_when_scan_window_is_complete(self, router, monkeypatch):
+        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: _strategy_page(_three_candidates()))
         monkeypatch.setattr(router, "merge_candidates", lambda lists: lists[0] if lists else [])
         monkeypatch.setattr(router, "_save_session", lambda *a, **kw: None)
         monkeypatch.setattr(router.action_items_db, "get_open_action_items_count", lambda uid: 1500)
-        monkeypatch.setattr(router.action_items_db, "get_action_items_list_scan_cap", lambda: 2000)
 
         req = router.CleanupPreviewRequest(strategies=["stale_age"])
         result = router.cleanup_preview(req, uid="uid-1")
@@ -220,13 +243,17 @@ class TestCleanupPreviewScanTruncation:
         assert result.total_open_action_items == 1500
         assert result.scan_cap == 2000
         assert result.scan_truncated is False
+        assert result.next_scan_cursor is None
 
-    def test_truncated_when_open_count_exceeds_cap(self, router, monkeypatch):
-        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: _three_candidates())
+    def test_truncated_when_next_scan_cursor_present(self, router, monkeypatch):
+        monkeypatch.setattr(
+            router,
+            "candidates_stale_age",
+            lambda *a, **kw: (_three_candidates(), "cursor-page-2"),
+        )
         monkeypatch.setattr(router, "merge_candidates", lambda lists: lists[0] if lists else [])
         monkeypatch.setattr(router, "_save_session", lambda *a, **kw: None)
         monkeypatch.setattr(router.action_items_db, "get_open_action_items_count", lambda uid: 45000)
-        monkeypatch.setattr(router.action_items_db, "get_action_items_list_scan_cap", lambda: 2000)
 
         req = router.CleanupPreviewRequest(strategies=["stale_age"])
         result = router.cleanup_preview(req, uid="uid-1")
@@ -234,6 +261,7 @@ class TestCleanupPreviewScanTruncation:
         assert result.total_open_action_items == 45000
         assert result.scan_cap == 2000
         assert result.scan_truncated is True
+        assert result.next_scan_cursor == "cursor-page-2"
 
     def test_truncation_fields_present_on_empty_strategies_short_circuit(self, router, monkeypatch):
         monkeypatch.setattr(router.action_items_db, "get_open_action_items_count", lambda uid: 5000)
@@ -256,10 +284,9 @@ class TestCleanupExecute:
         ids = ["t1", "t2", "t3"]
         monkeypatch.setattr(
             router,
-            "_load_session",
+            "_claim_session",
             lambda uid, sid: {"ids": ids, "strategies": ["stale_age"], "age_days": 90},
         )
-        monkeypatch.setattr(router, "_delete_session", lambda *a, **kw: None)
         monkeypatch.setattr(
             router.action_items_db,
             "delete_action_items_batch",
@@ -274,7 +301,8 @@ class TestCleanupExecute:
         assert result.deleted_count == 3
 
     def test_raises_410_when_session_expired(self, router, monkeypatch):
-        monkeypatch.setattr(router, "_load_session", lambda *a, **kw: None)
+        monkeypatch.setattr(router, "_claim_session", lambda *a, **kw: None)
+        monkeypatch.setattr(router, "_load_terminal_result", lambda *a, **kw: None)
 
         req = router.CleanupExecuteRequest(session_id="expired-sess")
         with pytest.raises(HTTPException) as exc_info:
@@ -285,10 +313,10 @@ class TestCleanupExecute:
     def test_empty_candidate_list_returns_zero_without_calling_delete(self, router, monkeypatch):
         monkeypatch.setattr(
             router,
-            "_load_session",
+            "_claim_session",
             lambda uid, sid: {"ids": [], "strategies": ["stale_age"], "age_days": 90},
         )
-        monkeypatch.setattr(router, "_delete_session", lambda *a, **kw: None)
+        monkeypatch.setattr(router, "_save_terminal_result", lambda *a, **kw: None)
         delete_called = []
         monkeypatch.setattr(
             router.action_items_db,
@@ -306,10 +334,9 @@ class TestCleanupExecute:
         ids = ["t1"]
         monkeypatch.setattr(
             router,
-            "_load_session",
+            "_claim_session",
             lambda uid, sid: {"ids": ids, "strategies": ["stale_age"], "age_days": 90},
         )
-        monkeypatch.setattr(router, "_delete_session", lambda *a, **kw: None)
         monkeypatch.setattr(
             router.action_items_db,
             "delete_action_items_batch",
@@ -338,10 +365,9 @@ class TestCleanupExecute:
         ids = ["t1", "t2", "t3"]
         monkeypatch.setattr(
             router,
-            "_load_session",
+            "_claim_session",
             lambda uid, sid: {"ids": ids, "strategies": ["stale_age"], "age_days": 90},
         )
-        monkeypatch.setattr(router, "_delete_session", lambda *a, **kw: None)
         deleted_arg = []
         monkeypatch.setattr(
             router.action_items_db,
@@ -361,10 +387,9 @@ class TestCleanupExecute:
         ids = ["t1", "t2"]
         monkeypatch.setattr(
             router,
-            "_load_session",
+            "_claim_session",
             lambda uid, sid: {"ids": ids, "strategies": ["stale_age"], "age_days": 90},
         )
-        monkeypatch.setattr(router, "_delete_session", lambda *a, **kw: None)
         delete_called = []
         monkeypatch.setattr(
             router.action_items_db,
@@ -377,3 +402,50 @@ class TestCleanupExecute:
 
         assert result.deleted_count == 0
         assert delete_called == [], "delete must not be called when every candidate is excluded"
+
+
+class TestCleanupPreviewValidation:
+    def test_unknown_strategy_returns_422(self, router):
+        req = router.CleanupPreviewRequest(strategies=["stale_age", "not_a_strategy"])
+        with pytest.raises(HTTPException) as exc_info:
+            router.cleanup_preview(req, uid="uid-1")
+
+        assert exc_info.value.status_code == 422
+
+
+class TestCleanupExecuteBoundaries:
+    def test_rejects_locked_items_before_delete(self, router, monkeypatch):
+        monkeypatch.setattr(
+            router,
+            "_claim_session",
+            lambda uid, sid: {"ids": ["locked-1"], "strategies": ["stale_age"], "age_days": 90},
+        )
+        monkeypatch.setattr(
+            router.action_items_db,
+            "get_action_items_by_ids",
+            lambda uid, ids: [{"id": ids[0], "is_locked": True}],
+        )
+        delete_called = []
+        monkeypatch.setattr(
+            router.action_items_db,
+            "delete_action_items_batch",
+            lambda *a, **kw: delete_called.append(True) or [],
+        )
+
+        req = router.CleanupExecuteRequest(session_id="sess-locked")
+        with pytest.raises(HTTPException) as exc_info:
+            router.cleanup_execute(req, uid="uid-1")
+
+        assert exc_info.value.status_code == 402
+        assert delete_called == []
+
+    def test_returns_terminal_result_without_reclaiming_session(self, router, monkeypatch):
+        monkeypatch.setattr(router, "_load_terminal_result", lambda *a, **kw: {"deleted_count": 7})
+        claim_called = []
+        monkeypatch.setattr(router, "_claim_session", lambda *a, **kw: claim_called.append(True))
+
+        req = router.CleanupExecuteRequest(session_id="sess-done")
+        result = router.cleanup_execute(req, uid="uid-1")
+
+        assert result.deleted_count == 7
+        assert claim_called == []

--- a/backend/tests/unit/test_action_items_cleanup_router.py
+++ b/backend/tests/unit/test_action_items_cleanup_router.py
@@ -9,6 +9,7 @@ handlers are called directly (bypassing FastAPI DI) so auth is passed as a kwarg
 """
 
 import os
+import re
 from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock
@@ -17,8 +18,15 @@ import pytest
 from fastapi import HTTPException
 
 from testing.import_isolation import AutoMockModule, load_module_fresh, stub_modules
+from utils.rate_limit_config import RATE_POLICIES
 
 _BACKEND = Path(__file__).resolve().parents[2]
+_ROUTER_PATH = _BACKEND / "routers" / "action_items_cleanup.py"
+
+
+def _grep_router(pattern: str) -> list[str]:
+    with open(_ROUTER_PATH, encoding="utf-8") as f:
+        return [line.strip() for line in f if re.search(pattern, line)]
 
 
 @pytest.fixture(scope="module")
@@ -51,6 +59,38 @@ def router():
 
 def _three_candidates(strategy: str = "stale_age"):
     return [{"id": f"t{i}", "description": f"task {i}", "strategy": strategy} for i in range(3)]
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupRateLimitPolicies:
+    def test_cleanup_preview_policy_exists(self):
+        assert "action_items:cleanup_preview" in RATE_POLICIES
+        max_req, window = RATE_POLICIES["action_items:cleanup_preview"]
+        assert max_req == 15
+        assert window == 3600
+
+    def test_cleanup_execute_policy_exists(self):
+        assert "action_items:cleanup_execute" in RATE_POLICIES
+        max_req, window = RATE_POLICIES["action_items:cleanup_execute"]
+        assert max_req == 10
+        assert window == 3600
+
+
+class TestCleanupRateLimitWiring:
+    # Source-level check (not a live-router test): the strategy/Redis fakes in
+    # the `router` fixture stub out utils.other.endpoints entirely, so this
+    # verifies the actual on-disk wiring instead of the mocked module.
+    def test_preview_endpoint_has_rate_limit(self):
+        matches = _grep_router(r"with_rate_limit.*action_items:cleanup_preview")
+        assert len(matches) == 1, f"POST cleanup/preview must have action_items:cleanup_preview, found: {matches}"
+
+    def test_execute_endpoint_has_rate_limit(self):
+        matches = _grep_router(r"with_rate_limit.*action_items:cleanup_execute")
+        assert len(matches) == 1, f"POST cleanup/execute must have action_items:cleanup_execute, found: {matches}"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_action_items_cleanup_router.py
+++ b/backend/tests/unit/test_action_items_cleanup_router.py
@@ -137,6 +137,20 @@ class TestCleanupPreview:
         assert result.breakdown["stale_age"] == 3
         assert result.breakdown["vague"] == 3
 
+    def test_candidate_meta_includes_description_for_every_candidate(self, router, monkeypatch):
+        # candidate_meta backs per-item review/exclusion in the UI, so it must carry
+        # the full description for every candidate, not just the capped sample.
+        many = [{"id": f"t{i}", "description": f"task {i}", "strategy": "stale_age"} for i in range(10)]
+        monkeypatch.setattr(router, "candidates_stale_age", lambda *a, **kw: many)
+        monkeypatch.setattr(router, "merge_candidates", lambda lists: lists[0] if lists else [])
+        monkeypatch.setattr(router, "_save_session", lambda *a, **kw: None)
+
+        req = router.CleanupPreviewRequest(strategies=["stale_age"])
+        result = router.cleanup_preview(req, uid="uid-1")
+
+        assert len(result.candidate_meta) == 10
+        assert {(m.id, m.description) for m in result.candidate_meta} == {(f"t{i}", f"task {i}") for i in range(10)}
+
 
 # ---------------------------------------------------------------------------
 # Execute endpoint
@@ -225,3 +239,47 @@ class TestCleanupExecute:
         assert len(vector_calls) == 1
         assert len(notify_calls) == 1
         assert notify_calls[0]["user_id"] == "uid-1"
+
+    def test_excluded_ids_are_kept_out_of_deletion(self, router, monkeypatch):
+        ids = ["t1", "t2", "t3"]
+        monkeypatch.setattr(
+            router,
+            "_load_session",
+            lambda uid, sid: {"ids": ids, "strategies": ["stale_age"], "age_days": 90},
+        )
+        monkeypatch.setattr(router, "_delete_session", lambda *a, **kw: None)
+        deleted_arg = []
+        monkeypatch.setattr(
+            router.action_items_db,
+            "delete_action_items_batch",
+            lambda uid, id_list: deleted_arg.append(id_list) or id_list,
+        )
+        monkeypatch.setattr(router, "delete_action_item_vectors_batch", lambda *a, **kw: None)
+        monkeypatch.setattr(router, "send_action_items_batch_deletion_message", lambda **kw: None)
+
+        req = router.CleanupExecuteRequest(session_id="sess-1", excluded_ids=["t2"])
+        result = router.cleanup_execute(req, uid="uid-1")
+
+        assert deleted_arg == [["t1", "t3"]]
+        assert result.deleted_count == 2
+
+    def test_excluding_every_candidate_deletes_nothing(self, router, monkeypatch):
+        ids = ["t1", "t2"]
+        monkeypatch.setattr(
+            router,
+            "_load_session",
+            lambda uid, sid: {"ids": ids, "strategies": ["stale_age"], "age_days": 90},
+        )
+        monkeypatch.setattr(router, "_delete_session", lambda *a, **kw: None)
+        delete_called = []
+        monkeypatch.setattr(
+            router.action_items_db,
+            "delete_action_items_batch",
+            lambda *a, **kw: delete_called.append(True) or [],
+        )
+
+        req = router.CleanupExecuteRequest(session_id="sess-1", excluded_ids=["t1", "t2"])
+        result = router.cleanup_execute(req, uid="uid-1")
+
+        assert result.deleted_count == 0
+        assert delete_called == [], "delete must not be called when every candidate is excluded"

--- a/backend/tests/unit/test_open_action_items_count.py
+++ b/backend/tests/unit/test_open_action_items_count.py
@@ -1,0 +1,81 @@
+"""Unit tests for get_open_action_items_count / get_action_items_list_scan_cap.
+
+Cleanup preview (routers/action_items_cleanup.py) uses these to tell a caller
+whether get_action_items()'s 2000-item scan cap (_ACTION_ITEMS_LIST_HARD_MAX)
+left tasks unscanned on large accounts, instead of silently truncating. These
+pin the count() aggregation arithmetic and the deleted-exclusion, mirroring
+test_conversation_action_items_count.py's per-conversation counterpart.
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+import database.action_items as ai_db  # noqa: E402
+
+
+def _count(value):
+    return [[SimpleNamespace(value=value)]]
+
+
+def _deleted_doc(completed):
+    doc = MagicMock()
+    doc.to_dict.return_value = {"completed": completed, "deleted": True}
+    return doc
+
+
+def _base(fake_db):
+    # db.collection(...).document(...).collection(...) -> base (no conversation filter)
+    return fake_db.collection.return_value.document.return_value.collection.return_value
+
+
+def test_open_count_is_total_minus_completed():
+    fake_db = MagicMock()
+    base = _base(fake_db)
+    base.count.return_value.get.return_value = _count(10)  # total
+    base.where.return_value.count.return_value.get.return_value = _count(4)  # completed
+    base.where.return_value.stream.return_value = []  # no soft-retired items
+
+    with patch.object(ai_db, "db", fake_db):
+        result = ai_db.get_open_action_items_count("u1")
+
+    assert result == 6
+
+
+def test_open_count_never_negative_on_racing_writes():
+    fake_db = MagicMock()
+    base = _base(fake_db)
+    base.count.return_value.get.return_value = _count(1)
+    base.where.return_value.count.return_value.get.return_value = _count(4)  # exceeds total
+    base.where.return_value.stream.return_value = []
+
+    with patch.object(ai_db, "db", fake_db):
+        result = ai_db.get_open_action_items_count("u1")
+
+    assert result == 0
+
+
+def test_open_count_excludes_soft_retired():
+    fake_db = MagicMock()
+    base = _base(fake_db)
+    base.count.return_value.get.return_value = _count(6)  # 6 total, 2 of which are deleted
+    base.where.return_value.count.return_value.get.return_value = _count(3)  # 3 completed, 1 deleted
+    base.where.return_value.stream.return_value = [
+        _deleted_doc(completed=True),
+        _deleted_doc(completed=False),
+    ]
+
+    with patch.object(ai_db, "db", fake_db):
+        result = ai_db.get_open_action_items_count("u1")
+
+    # visible total = 6 - 2 = 4; visible completed = 3 - 1 = 2; open = 4 - 2 = 2
+    assert result == 2
+
+
+def test_scan_cap_matches_hard_max_constant():
+    assert ai_db.get_action_items_list_scan_cap() == ai_db._ACTION_ITEMS_LIST_HARD_MAX

--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -64,6 +64,10 @@ def _rate_limit_stubs():
     redis_db_stub = ModuleType("database.redis_db")
     redis_db_stub._RATE_LIMIT_LUA = MagicMock(return_value=[1, 3600])
     redis_db_stub.try_acquire_listen_lock = MagicMock(return_value=True)
+    redis_db_stub.r = MagicMock()
+    # generic_cache.py imports try_catch_decorator from redis_db; passthrough so
+    # decorated functions remain callable under the stub.
+    redis_db_stub.try_catch_decorator = lambda f: f
 
     def _check_rate_limit(key, policy, max_requests, window):
         """Real Python logic from redis_db.check_rate_limit, with mockable Lua."""

--- a/backend/utils/action_item_cleanup.py
+++ b/backend/utils/action_item_cleanup.py
@@ -77,6 +77,7 @@ def _fetch_conversation_contexts(uid: str, conversation_ids: set[str]) -> dict[s
 # Strategy: age-based staleness
 # ---------------------------------------------------------------------------
 
+
 def candidates_stale_age(uid: str, age_days: int = 30) -> list[dict]:
     """
     Return open tasks with no due date whose source conversation is older than
@@ -106,11 +107,13 @@ def candidates_stale_age(uid: str, age_days: int = 30) -> list[dict]:
             continue
 
         if (now - ref).days >= age_days:
-            candidates.append({
-                'id': item['id'],
-                'description': item.get('description', ''),
-                'strategy': 'stale_age',
-            })
+            candidates.append(
+                {
+                    'id': item['id'],
+                    'description': item.get('description', ''),
+                    'strategy': 'stale_age',
+                }
+            )
 
     return candidates
 
@@ -118,6 +121,7 @@ def candidates_stale_age(uid: str, age_days: int = 30) -> list[dict]:
 # ---------------------------------------------------------------------------
 # Strategy: overdue due dates
 # ---------------------------------------------------------------------------
+
 
 def candidates_overdue(uid: str, overdue_days: int = 7) -> list[dict]:
     """
@@ -141,6 +145,7 @@ def candidates_overdue(uid: str, overdue_days: int = 7) -> list[dict]:
 # ---------------------------------------------------------------------------
 # Strategy: semantic deduplication
 # ---------------------------------------------------------------------------
+
 
 def candidates_semantic_dedup(uid: str, similarity_threshold: float = 0.92) -> list[dict]:
     """
@@ -176,8 +181,7 @@ def candidates_semantic_dedup(uid: str, similarity_threshold: float = 0.92) -> l
     similarity = matrix @ matrix.T  # (n × n) cosine similarity
 
     # Parse creation dates for tie-breaking (newer wins)
-    dates = [_parse_dt(i.get('created_at')) or datetime.min.replace(tzinfo=timezone.utc)
-             for i in items_with_vec]
+    dates = [_parse_dt(i.get('created_at')) or datetime.min.replace(tzinfo=timezone.utc) for i in items_with_vec]
     id_to_item = {i['id']: i for i in items_with_vec}
 
     candidate_ids: set[str] = set()
@@ -199,11 +203,13 @@ def candidates_semantic_dedup(uid: str, similarity_threshold: float = 0.92) -> l
                 break  # current item is the older duplicate; outer loop will skip it
             if dup_id not in candidate_ids:
                 candidate_ids.add(dup_id)
-                candidates.append({
-                    'id': dup_id,
-                    'description': id_to_item[dup_id].get('description', ''),
-                    'strategy': 'semantic_dedup',
-                })
+                candidates.append(
+                    {
+                        'id': dup_id,
+                        'description': id_to_item[dup_id].get('description', ''),
+                        'strategy': 'semantic_dedup',
+                    }
+                )
 
     logger.info(f'semantic_dedup uid={uid} checked={len(items_with_vec)} duplicates={len(candidates)}')
     return candidates
@@ -212,6 +218,7 @@ def candidates_semantic_dedup(uid: str, similarity_threshold: float = 0.92) -> l
 # ---------------------------------------------------------------------------
 # Strategy: LLM relevance scoring
 # ---------------------------------------------------------------------------
+
 
 class _TaskVerdict(BaseModel):
     id: str = PydanticField(description="The task ID exactly as given")
@@ -223,10 +230,11 @@ class _BatchVerdicts(BaseModel):
     verdicts: list[_TaskVerdict] = PydanticField(description="One verdict per task")
 
 
-_RELEVANCE_PROMPT = ChatPromptTemplate.from_messages([
-    (
-        "system",
-        """You are reviewing open to-do items to identify ones that are likely no longer relevant.
+_RELEVANCE_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        (
+            "system",
+            """You are reviewing open to-do items to identify ones that are likely no longer relevant.
 
 For each task assess whether it is still actionable given how long ago it was created.
 
@@ -236,12 +244,13 @@ Rules:
 - Event-specific tasks (prepare for X meeting, get ready for Y event) from long ago are likely stale.
 - Vague or already-obvious tasks ("go to bed", "brush teeth") that recur daily are likely stale duplicates.
 - Return confidence >= 0.85 only when you are quite sure.""",
-    ),
-    (
-        "human",
-        "Today's date: {today}\n\nTasks to review:\n{tasks}",
-    ),
-])
+        ),
+        (
+            "human",
+            "Today's date: {today}\n\nTasks to review:\n{tasks}",
+        ),
+    ]
+)
 
 _BATCH_SIZE = 50
 
@@ -278,7 +287,7 @@ def candidates_llm_relevance(uid: str, confidence_threshold: float = 0.85) -> li
             logger.warning(f'LLM relevance batch failed: {e}')
             return []
 
-    batches = [all_items[i:i + _BATCH_SIZE] for i in range(0, len(all_items), _BATCH_SIZE)]
+    batches = [all_items[i : i + _BATCH_SIZE] for i in range(0, len(all_items), _BATCH_SIZE)]
     candidates = []
     with ThreadPoolExecutor(max_workers=5) as pool:
         for result in as_completed([pool.submit(_score_batch, b) for b in batches]):
@@ -292,10 +301,11 @@ def candidates_llm_relevance(uid: str, confidence_threshold: float = 0.85) -> li
 # Strategy: conversation context
 # ---------------------------------------------------------------------------
 
-_CONV_CONTEXT_PROMPT = ChatPromptTemplate.from_messages([
-    (
-        "system",
-        """You are reviewing open to-do items. Each task came from a specific conversation.
+_CONV_CONTEXT_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        (
+            "system",
+            """You are reviewing open to-do items. Each task came from a specific conversation.
 You will be given the conversation's title, a brief overview, and how long ago it happened,
 along with the tasks that were extracted from it.
 
@@ -308,10 +318,10 @@ Rules:
 - If the conversation topic is ongoing (a relationship, a project, a recurring role),
   tasks are more likely still relevant.
 - Return confidence >= 0.85 only when you are quite sure.""",
-    ),
-    (
-        "human",
-        """Today: {today}
+        ),
+        (
+            "human",
+            """Today: {today}
 
 Conversation: "{title}"
 Summary: {overview}
@@ -319,8 +329,9 @@ Happened: {age}
 
 Tasks from this conversation:
 {tasks}""",
-    ),
-])
+        ),
+    ]
+)
 
 
 def candidates_conversation_context(uid: str, confidence_threshold: float = 0.85) -> list[dict]:
@@ -361,13 +372,18 @@ def candidates_conversation_context(uid: str, confidence_threshold: float = 0.85
         age = f"{(now - started_at).days} days ago" if started_at else "unknown"
         task_lines = [f"- id:{i['id']} | {i.get('description', '')}" for i in batch]
         try:
-            result = cast(_BatchVerdicts, chain.invoke({
-                "today": today,
-                "title": ctx['title'] or '(untitled)',
-                "overview": ctx['overview'] or '(no summary)',
-                "age": age,
-                "tasks": "\n".join(task_lines),
-            }))
+            result = cast(
+                _BatchVerdicts,
+                chain.invoke(
+                    {
+                        "today": today,
+                        "title": ctx['title'] or '(untitled)',
+                        "overview": ctx['overview'] or '(no summary)',
+                        "age": age,
+                        "tasks": "\n".join(task_lines),
+                    }
+                ),
+            )
             return [
                 {'id': v.id, 'description': id_to_item[v.id].get('description', ''), 'strategy': 'conversation_context'}
                 for v in result.verdicts
@@ -378,9 +394,7 @@ def candidates_conversation_context(uid: str, confidence_threshold: float = 0.85
             return []
 
     all_batches = [
-        (cid, items[i:i + _BATCH_SIZE])
-        for cid, items in by_conv.items()
-        for i in range(0, len(items), _BATCH_SIZE)
+        (cid, items[i : i + _BATCH_SIZE]) for cid, items in by_conv.items() for i in range(0, len(items), _BATCH_SIZE)
     ]
     candidates = []
     with ThreadPoolExecutor(max_workers=5) as pool:
@@ -457,6 +471,7 @@ def candidates_vague(uid: str) -> list[dict]:
 # ---------------------------------------------------------------------------
 # Merge helpers
 # ---------------------------------------------------------------------------
+
 
 def merge_candidates(lists: list[list[dict]]) -> list[dict]:
     """Merge candidate lists from multiple strategies, deduplicating by ID."""

--- a/backend/utils/action_item_cleanup.py
+++ b/backend/utils/action_item_cleanup.py
@@ -4,13 +4,14 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional, cast
 
 import numpy as np
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import as_completed
 from langchain_core.prompts import ChatPromptTemplate
 from pydantic import BaseModel, Field as PydanticField
 
 import database.action_items as action_items_db
 import database.conversations as conversations_db
 from database.vector_db import fetch_action_item_vectors
+from utils.executors import llm_executor
 from utils.llm.clients import get_llm
 
 logger = logging.getLogger(__name__)
@@ -27,6 +28,24 @@ def _parse_dt(value) -> Optional[datetime]:
     if hasattr(value, 'timestamp'):
         return datetime.fromtimestamp(value.timestamp(), tz=timezone.utc)
     return None
+
+
+def _item_visible_for_cleanup(item: dict) -> bool:
+    return not item.get('is_locked', False)
+
+
+def _open_items_for_cleanup(uid: str, scan_cursor: Optional[str] = None) -> tuple[list[dict], Optional[str]]:
+    items, next_cursor, _ = action_items_db.list_open_action_items_for_cleanup(uid, cursor=scan_cursor)
+    visible = [item for item in items if _item_visible_for_cleanup(item)]
+    return visible, next_cursor
+
+
+def _candidate_from_item(item: dict, strategy: str) -> dict:
+    return {
+        'id': item['id'],
+        'description': item.get('description', ''),
+        'strategy': strategy,
+    }
 
 
 def _conversation_dates(uid: str, conversation_ids: set[str]) -> dict[str, datetime]:
@@ -78,16 +97,17 @@ def _fetch_conversation_contexts(uid: str, conversation_ids: set[str]) -> dict[s
 # ---------------------------------------------------------------------------
 
 
-def candidates_stale_age(uid: str, age_days: int = 30) -> list[dict]:
+def candidates_stale_age(
+    uid: str, age_days: int = 30, *, scan_cursor: Optional[str] = None
+) -> tuple[list[dict], Optional[str]]:
     """
     Return open tasks with no due date whose source conversation is older than
     age_days. Falls back to the task's own created_at for standalone tasks.
     Each result dict has 'id', 'description', 'strategy'.
     """
     now = datetime.now(timezone.utc)
-    all_items = action_items_db.get_action_items(uid, completed=False)
+    all_items, next_cursor = _open_items_for_cleanup(uid, scan_cursor)
 
-    # Batch-fetch conversation dates for all linked tasks in one pass
     conv_ids = {i['conversation_id'] for i in all_items if i.get('conversation_id')}
     conv_dates = _conversation_dates(uid, conv_ids)
 
@@ -98,7 +118,6 @@ def candidates_stale_age(uid: str, age_days: int = 30) -> list[dict]:
 
         cid = item.get('conversation_id')
         if cid:
-            # Use conversation start date; fall back to created_at if conversation not found
             ref = conv_dates.get(cid) or _parse_dt(item.get('created_at'))
         else:
             ref = _parse_dt(item.get('created_at'))
@@ -107,15 +126,9 @@ def candidates_stale_age(uid: str, age_days: int = 30) -> list[dict]:
             continue
 
         if (now - ref).days >= age_days:
-            candidates.append(
-                {
-                    'id': item['id'],
-                    'description': item.get('description', ''),
-                    'strategy': 'stale_age',
-                }
-            )
+            candidates.append(_candidate_from_item(item, 'stale_age'))
 
-    return candidates
+    return candidates, next_cursor
 
 
 # ---------------------------------------------------------------------------
@@ -123,23 +136,21 @@ def candidates_stale_age(uid: str, age_days: int = 30) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-def candidates_overdue(uid: str, overdue_days: int = 7) -> list[dict]:
+def candidates_overdue(
+    uid: str, overdue_days: int = 7, *, scan_cursor: Optional[str] = None
+) -> tuple[list[dict], Optional[str]]:
     """
     Return open tasks whose due_at is more than overdue_days in the past.
     These are either done-and-not-marked or permanently missed.
-    Each result dict has 'id', 'description', 'strategy'.
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=overdue_days)
-    items = action_items_db.get_action_items(uid, completed=False, due_end_date=cutoff)
-    return [
-        {
-            'id': item['id'],
-            'description': item.get('description', ''),
-            'strategy': 'overdue',
-        }
-        for item in items
-        if item.get('due_at')  # guard: due_end_date filter should handle this but be explicit
-    ]
+    all_items, next_cursor = _open_items_for_cleanup(uid, scan_cursor)
+    candidates = []
+    for item in all_items:
+        due_at = _parse_dt(item.get('due_at'))
+        if due_at and due_at <= cutoff:
+            candidates.append(_candidate_from_item(item, 'overdue'))
+    return candidates, next_cursor
 
 
 # ---------------------------------------------------------------------------
@@ -147,40 +158,35 @@ def candidates_overdue(uid: str, overdue_days: int = 7) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-def candidates_semantic_dedup(uid: str, similarity_threshold: float = 0.92) -> list[dict]:
+def candidates_semantic_dedup(
+    uid: str, similarity_threshold: float = 0.92, *, scan_cursor: Optional[str] = None
+) -> tuple[list[dict], Optional[str]]:
     """
     Find open tasks that are near-duplicates of a newer task using local cosine
     similarity. Fetches all vectors in one Pinecone call, then computes an
     in-memory similarity matrix — O(1) Pinecone calls regardless of task count.
-
-    For each group of similar tasks, the newest is kept and older duplicates
-    are returned as candidates.
     """
-    all_items = action_items_db.get_action_items(uid, completed=False)
+    all_items, next_cursor = _open_items_for_cleanup(uid, scan_cursor)
     if not all_items:
-        return []
+        return [], next_cursor
 
-    # Fetch all vectors in one batch
     ids = [item['id'] for item in all_items]
     vectors = fetch_action_item_vectors(uid, ids)
     if not vectors:
         logger.warning('semantic_dedup: no vectors found, skipping')
-        return []
+        return [], next_cursor
 
-    # Keep only items that have a vector
     items_with_vec = [i for i in all_items if i['id'] in vectors]
     if len(items_with_vec) < 2:
-        return []
+        return [], next_cursor
 
-    # Build matrix (n × d), normalise rows for cosine similarity via dot product
     item_ids = [i['id'] for i in items_with_vec]
     matrix = np.array([vectors[iid] for iid in item_ids], dtype=np.float32)
     norms = np.linalg.norm(matrix, axis=1, keepdims=True)
     norms = np.where(norms == 0, 1, norms)
     matrix /= norms
-    similarity = matrix @ matrix.T  # (n × n) cosine similarity
+    similarity = matrix @ matrix.T
 
-    # Parse creation dates for tie-breaking (newer wins)
     dates = [_parse_dt(i.get('created_at')) or datetime.min.replace(tzinfo=timezone.utc) for i in items_with_vec]
     id_to_item = {i['id']: i for i in items_with_vec}
 
@@ -195,24 +201,17 @@ def candidates_semantic_dedup(uid: str, similarity_threshold: float = 0.92) -> l
                 continue
             if float(similarity[i, j]) < similarity_threshold:
                 continue
-            # Duplicate pair found — drop the older one
             if dates[i] >= dates[j]:
                 dup_id = item_ids[j]
             else:
                 dup_id = item_id
-                break  # current item is the older duplicate; outer loop will skip it
+                break
             if dup_id not in candidate_ids:
                 candidate_ids.add(dup_id)
-                candidates.append(
-                    {
-                        'id': dup_id,
-                        'description': id_to_item[dup_id].get('description', ''),
-                        'strategy': 'semantic_dedup',
-                    }
-                )
+                candidates.append(_candidate_from_item(id_to_item[dup_id], 'semantic_dedup'))
 
     logger.info(f'semantic_dedup uid={uid} checked={len(items_with_vec)} duplicates={len(candidates)}')
-    return candidates
+    return candidates, next_cursor
 
 
 # ---------------------------------------------------------------------------
@@ -255,15 +254,29 @@ Rules:
 _BATCH_SIZE = 50
 
 
-def candidates_llm_relevance(uid: str, confidence_threshold: float = 0.85) -> list[dict]:
+def _run_llm_batches(uid: str, batches: list[list[dict]], score_fn) -> list[dict]:
+    if not batches:
+        return []
+    futures = [llm_executor.submit(score_fn, batch) for batch in batches]
+    candidates: list[dict] = []
+    for future in as_completed(futures):
+        try:
+            candidates.extend(future.result())
+        except Exception as e:
+            logger.warning(f'LLM cleanup batch failed uid={uid}: {e}')
+    return candidates
+
+
+def candidates_llm_relevance(
+    uid: str, confidence_threshold: float = 0.85, *, scan_cursor: Optional[str] = None
+) -> tuple[list[dict], Optional[str]]:
     """
     Use an LLM to score open tasks for relevance. Tasks the LLM considers stale
     with confidence >= confidence_threshold become candidates.
-    Processes tasks in batches of 50 to keep prompts manageable.
     """
-    all_items = action_items_db.get_action_items(uid, completed=False)
+    all_items, next_cursor = _open_items_for_cleanup(uid, scan_cursor)
     if not all_items:
-        return []
+        return [], next_cursor
 
     llm = get_llm('conv_discard').with_structured_output(_BatchVerdicts)
     chain = _RELEVANCE_PROMPT | llm
@@ -276,25 +289,17 @@ def candidates_llm_relevance(uid: str, confidence_threshold: float = 0.85) -> li
             created = _parse_dt(item.get('created_at'))
             age = f"{(datetime.now(timezone.utc) - created).days}d ago" if created else "unknown age"
             task_lines.append(f"- id:{item['id']} | {item.get('description', '')} [{age}]")
-        try:
-            result = cast(_BatchVerdicts, chain.invoke({"today": today, "tasks": "\n".join(task_lines)}))
-            return [
-                {'id': v.id, 'description': id_to_item[v.id].get('description', ''), 'strategy': 'llm_relevance'}
-                for v in result.verdicts
-                if v.is_stale and v.confidence >= confidence_threshold and v.id in id_to_item
-            ]
-        except Exception as e:
-            logger.warning(f'LLM relevance batch failed: {e}')
-            return []
+        result = cast(_BatchVerdicts, chain.invoke({"today": today, "tasks": "\n".join(task_lines)}))
+        return [
+            _candidate_from_item(id_to_item[v.id], 'llm_relevance')
+            for v in result.verdicts
+            if v.is_stale and v.confidence >= confidence_threshold and v.id in id_to_item
+        ]
 
     batches = [all_items[i : i + _BATCH_SIZE] for i in range(0, len(all_items), _BATCH_SIZE)]
-    candidates = []
-    with ThreadPoolExecutor(max_workers=5) as pool:
-        for result in as_completed([pool.submit(_score_batch, b) for b in batches]):
-            candidates.extend(result.result())
-
+    candidates = _run_llm_batches(uid, batches, _score_batch)
     logger.info(f'llm_relevance uid={uid} checked={len(all_items)} candidates={len(candidates)}')
-    return candidates
+    return candidates, next_cursor
 
 
 # ---------------------------------------------------------------------------
@@ -334,25 +339,25 @@ Tasks from this conversation:
 )
 
 
-def candidates_conversation_context(uid: str, confidence_threshold: float = 0.85) -> list[dict]:
+def candidates_conversation_context(
+    uid: str, confidence_threshold: float = 0.85, *, scan_cursor: Optional[str] = None
+) -> tuple[list[dict], Optional[str]]:
     """
     Use conversation title/overview as context to assess task relevance.
-    Only operates on tasks with a conversation_id. Groups tasks by conversation
-    so each conversation's context is fetched and sent to the LLM once.
+    Only operates on tasks with a conversation_id.
     """
-    all_items = action_items_db.get_action_items(uid, completed=False)
+    all_items, next_cursor = _open_items_for_cleanup(uid, scan_cursor)
     linked = [i for i in all_items if i.get('conversation_id')]
     if not linked:
         logger.info('conversation_context: no tasks with conversation_id, skipping')
-        return []
+        return [], next_cursor
 
     conv_ids = {i['conversation_id'] for i in linked}
     contexts = _fetch_conversation_contexts(uid, conv_ids)
     if not contexts:
         logger.info('conversation_context: no conversations found locally, skipping')
-        return []
+        return [], next_cursor
 
-    # Group tasks by conversation
     by_conv: dict[str, list[dict]] = {}
     for item in linked:
         cid = item['conversation_id']
@@ -363,62 +368,54 @@ def candidates_conversation_context(uid: str, confidence_threshold: float = 0.85
     chain = _CONV_CONTEXT_PROMPT | llm
     today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
     now = datetime.now(timezone.utc)
-
     id_to_item = {item['id']: item for item in linked}
 
-    def _score_conv_batch(cid: str, batch: list[dict]) -> list[dict]:
+    def _score_conv_batch(batch: list[dict], cid: str) -> list[dict]:
         ctx = contexts[cid]
         started_at = ctx['started_at']
         age = f"{(now - started_at).days} days ago" if started_at else "unknown"
         task_lines = [f"- id:{i['id']} | {i.get('description', '')}" for i in batch]
-        try:
-            result = cast(
-                _BatchVerdicts,
-                chain.invoke(
-                    {
-                        "today": today,
-                        "title": ctx['title'] or '(untitled)',
-                        "overview": ctx['overview'] or '(no summary)',
-                        "age": age,
-                        "tasks": "\n".join(task_lines),
-                    }
-                ),
-            )
-            return [
-                {'id': v.id, 'description': id_to_item[v.id].get('description', ''), 'strategy': 'conversation_context'}
-                for v in result.verdicts
-                if v.is_stale and v.confidence >= confidence_threshold and v.id in id_to_item
-            ]
-        except Exception as e:
-            logger.warning(f'conversation_context batch failed for conv {cid}: {e}')
-            return []
+        result = cast(
+            _BatchVerdicts,
+            chain.invoke(
+                {
+                    "today": today,
+                    "title": ctx['title'] or '(untitled)',
+                    "overview": ctx['overview'] or '(no summary)',
+                    "age": age,
+                    "tasks": "\n".join(task_lines),
+                }
+            ),
+        )
+        return [
+            _candidate_from_item(id_to_item[v.id], 'conversation_context')
+            for v in result.verdicts
+            if v.is_stale and v.confidence >= confidence_threshold and v.id in id_to_item
+        ]
 
     all_batches = [
         (cid, items[i : i + _BATCH_SIZE]) for cid, items in by_conv.items() for i in range(0, len(items), _BATCH_SIZE)
     ]
-    candidates = []
-    with ThreadPoolExecutor(max_workers=5) as pool:
-        for result in as_completed([pool.submit(_score_conv_batch, cid, batch) for cid, batch in all_batches]):
-            candidates.extend(result.result())
 
+    def _score_batch_wrapper(args: tuple[str, list[dict]]) -> list[dict]:
+        cid, batch = args
+        return _score_conv_batch(batch, cid)
+
+    candidates = _run_llm_batches(uid, all_batches, _score_batch_wrapper)
     logger.info(f'conversation_context uid={uid} conversations={len(by_conv)} candidates={len(candidates)}')
-    return candidates
+    return candidates, next_cursor
 
 
 # ---------------------------------------------------------------------------
 # Strategy: vagueness / context-loss detection
 # ---------------------------------------------------------------------------
 
-# Unresolved demonstratives and pronouns as objects
 _PRONOUN_PATTERN = re.compile(
     r'\b(it|them|those|these|that|this|the other|the same|the two|the ones?|'
     r'the things?|the stuff|the other one|the rest)\b',
     re.IGNORECASE,
 )
 
-# Common imperative verb + dangling reference combos. Only pronouns/demonstratives
-# count as "dangling" — "the <noun>" (e.g. "the sink", "the kitchen") is a concrete,
-# resolvable object, not a lost reference, so it's excluded here.
 _DANGLING_PATTERN = re.compile(
     r'^(put|take|send|get|fix|check|do|move|bring|pick up|drop off|return|'
     r'give back|hand|pass|grab|swap|switch|change|clean|clear|sort|set)\s+'
@@ -426,7 +423,6 @@ _DANGLING_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-# Speaker placeholders that were never resolved
 _SPEAKER_PATTERN = re.compile(r'\bspeaker\s+\d+\b', re.IGNORECASE)
 
 
@@ -434,40 +430,24 @@ def _is_vague(description: str) -> bool:
     desc = description.strip()
     words = desc.split()
 
-    # Unresolved speaker label
     if _SPEAKER_PATTERN.search(desc):
         return True
 
-    # Short description (≤ 5 words) containing a pronoun/demonstrative
     if len(words) <= 5 and _PRONOUN_PATTERN.search(desc):
         return True
 
-    # Imperative + dangling pronoun regardless of length
     if _DANGLING_PATTERN.match(desc):
         return True
 
     return False
 
 
-def candidates_vague(uid: str) -> list[dict]:
-    """
-    Find open tasks whose descriptions contain unresolved pronouns or references
-    that make them meaningless without the original conversational context.
-    Examples: "Put those away", "Swap between the two cars", "Attend ultrasound with Speaker 0"
-    Rule-based — no LLM calls needed.
-    """
-    all_items = action_items_db.get_action_items(uid, completed=False)
-    candidates = [
-        {
-            'id': item['id'],
-            'description': item.get('description', ''),
-            'strategy': 'vague',
-        }
-        for item in all_items
-        if _is_vague(item.get('description', ''))
-    ]
+def candidates_vague(uid: str, *, scan_cursor: Optional[str] = None) -> tuple[list[dict], Optional[str]]:
+    """Find open tasks whose descriptions contain unresolved pronouns or references."""
+    all_items, next_cursor = _open_items_for_cleanup(uid, scan_cursor)
+    candidates = [_candidate_from_item(item, 'vague') for item in all_items if _is_vague(item.get('description', ''))]
     logger.info(f'vague uid={uid} checked={len(all_items)} candidates={len(candidates)}')
-    return candidates
+    return candidates, next_cursor
 
 
 # ---------------------------------------------------------------------------

--- a/backend/utils/action_item_cleanup.py
+++ b/backend/utils/action_item_cleanup.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Optional, cast
 
 import numpy as np
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -268,7 +268,7 @@ def candidates_llm_relevance(uid: str, confidence_threshold: float = 0.85) -> li
             age = f"{(datetime.now(timezone.utc) - created).days}d ago" if created else "unknown age"
             task_lines.append(f"- id:{item['id']} | {item.get('description', '')} [{age}]")
         try:
-            result: _BatchVerdicts = chain.invoke({"today": today, "tasks": "\n".join(task_lines)})
+            result = cast(_BatchVerdicts, chain.invoke({"today": today, "tasks": "\n".join(task_lines)}))
             return [
                 {'id': v.id, 'description': id_to_item[v.id].get('description', ''), 'strategy': 'llm_relevance'}
                 for v in result.verdicts
@@ -361,13 +361,13 @@ def candidates_conversation_context(uid: str, confidence_threshold: float = 0.85
         age = f"{(now - started_at).days} days ago" if started_at else "unknown"
         task_lines = [f"- id:{i['id']} | {i.get('description', '')}" for i in batch]
         try:
-            result: _BatchVerdicts = chain.invoke({
+            result = cast(_BatchVerdicts, chain.invoke({
                 "today": today,
                 "title": ctx['title'] or '(untitled)',
                 "overview": ctx['overview'] or '(no summary)',
                 "age": age,
                 "tasks": "\n".join(task_lines),
-            })
+            }))
             return [
                 {'id': v.id, 'description': id_to_item[v.id].get('description', ''), 'strategy': 'conversation_context'}
                 for v in result.verdicts

--- a/backend/utils/action_item_cleanup.py
+++ b/backend/utils/action_item_cleanup.py
@@ -1,0 +1,470 @@
+import logging
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import numpy as np
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from langchain_core.prompts import ChatPromptTemplate
+from pydantic import BaseModel, Field as PydanticField
+
+import database.action_items as action_items_db
+import database.conversations as conversations_db
+from database.vector_db import fetch_action_item_vectors
+from utils.llm.clients import get_llm
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_dt(value) -> Optional[datetime]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str):
+        return datetime.fromisoformat(value.rstrip('Z')).replace(tzinfo=timezone.utc)
+    # Firestore DatetimeWithNanoseconds
+    if hasattr(value, 'timestamp'):
+        return datetime.fromtimestamp(value.timestamp(), tz=timezone.utc)
+    return None
+
+
+def _conversation_dates(uid: str, conversation_ids: set[str]) -> dict[str, datetime]:
+    """Return a map of conversation_id → started_at (or created_at) for a set of IDs."""
+    dates = {}
+    for cid in conversation_ids:
+        try:
+            conv = conversations_db.get_conversation(uid, cid)
+            if not conv:
+                continue
+            ref = _parse_dt(conv.get('started_at')) or _parse_dt(conv.get('created_at'))
+            if ref:
+                dates[cid] = ref
+        except Exception as e:
+            logger.warning(f'Failed to fetch conversation {cid}: {e}')
+    return dates
+
+
+def _fetch_conversation_contexts(uid: str, conversation_ids: set[str]) -> dict[str, dict]:
+    """
+    Return a map of conversation_id → {started_at, title, overview} for a set of IDs.
+    Missing or errored conversations are silently omitted.
+    """
+    contexts = {}
+    for cid in conversation_ids:
+        try:
+            conv = conversations_db.get_conversation(uid, cid)
+            if not conv:
+                continue
+            started_at = _parse_dt(conv.get('started_at')) or _parse_dt(conv.get('created_at'))
+            structured = conv.get('structured') or {}
+            if isinstance(structured, dict):
+                title = structured.get('title', '')
+                overview = structured.get('overview', '')
+            else:
+                title, overview = '', ''
+            contexts[cid] = {
+                'started_at': started_at,
+                'title': title,
+                'overview': overview[:300] if overview else '',
+            }
+        except Exception as e:
+            logger.warning(f'Failed to fetch conversation context {cid}: {e}')
+    return contexts
+
+
+# ---------------------------------------------------------------------------
+# Strategy: age-based staleness
+# ---------------------------------------------------------------------------
+
+def candidates_stale_age(uid: str, age_days: int = 30) -> list[dict]:
+    """
+    Return open tasks with no due date whose source conversation is older than
+    age_days. Falls back to the task's own created_at for standalone tasks.
+    Each result dict has 'id', 'description', 'strategy'.
+    """
+    now = datetime.now(timezone.utc)
+    all_items = action_items_db.get_action_items(uid, completed=False)
+
+    # Batch-fetch conversation dates for all linked tasks in one pass
+    conv_ids = {i['conversation_id'] for i in all_items if i.get('conversation_id')}
+    conv_dates = _conversation_dates(uid, conv_ids)
+
+    candidates = []
+    for item in all_items:
+        if item.get('due_at'):
+            continue
+
+        cid = item.get('conversation_id')
+        if cid:
+            # Use conversation start date; fall back to created_at if conversation not found
+            ref = conv_dates.get(cid) or _parse_dt(item.get('created_at'))
+        else:
+            ref = _parse_dt(item.get('created_at'))
+
+        if ref is None:
+            continue
+
+        if (now - ref).days >= age_days:
+            candidates.append({
+                'id': item['id'],
+                'description': item.get('description', ''),
+                'strategy': 'stale_age',
+            })
+
+    return candidates
+
+
+# ---------------------------------------------------------------------------
+# Strategy: overdue due dates
+# ---------------------------------------------------------------------------
+
+def candidates_overdue(uid: str, overdue_days: int = 7) -> list[dict]:
+    """
+    Return open tasks whose due_at is more than overdue_days in the past.
+    These are either done-and-not-marked or permanently missed.
+    Each result dict has 'id', 'description', 'strategy'.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(days=overdue_days)
+    items = action_items_db.get_action_items(uid, completed=False, due_end_date=cutoff)
+    return [
+        {
+            'id': item['id'],
+            'description': item.get('description', ''),
+            'strategy': 'overdue',
+        }
+        for item in items
+        if item.get('due_at')  # guard: due_end_date filter should handle this but be explicit
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Strategy: semantic deduplication
+# ---------------------------------------------------------------------------
+
+def candidates_semantic_dedup(uid: str, similarity_threshold: float = 0.92) -> list[dict]:
+    """
+    Find open tasks that are near-duplicates of a newer task using local cosine
+    similarity. Fetches all vectors in one Pinecone call, then computes an
+    in-memory similarity matrix — O(1) Pinecone calls regardless of task count.
+
+    For each group of similar tasks, the newest is kept and older duplicates
+    are returned as candidates.
+    """
+    all_items = action_items_db.get_action_items(uid, completed=False)
+    if not all_items:
+        return []
+
+    # Fetch all vectors in one batch
+    ids = [item['id'] for item in all_items]
+    vectors = fetch_action_item_vectors(uid, ids)
+    if not vectors:
+        logger.warning('semantic_dedup: no vectors found, skipping')
+        return []
+
+    # Keep only items that have a vector
+    items_with_vec = [i for i in all_items if i['id'] in vectors]
+    if len(items_with_vec) < 2:
+        return []
+
+    # Build matrix (n × d), normalise rows for cosine similarity via dot product
+    item_ids = [i['id'] for i in items_with_vec]
+    matrix = np.array([vectors[iid] for iid in item_ids], dtype=np.float32)
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    norms = np.where(norms == 0, 1, norms)
+    matrix /= norms
+    similarity = matrix @ matrix.T  # (n × n) cosine similarity
+
+    # Parse creation dates for tie-breaking (newer wins)
+    dates = [_parse_dt(i.get('created_at')) or datetime.min.replace(tzinfo=timezone.utc)
+             for i in items_with_vec]
+    id_to_item = {i['id']: i for i in items_with_vec}
+
+    candidate_ids: set[str] = set()
+    candidates: list[dict] = []
+
+    for i, item_id in enumerate(item_ids):
+        if item_id in candidate_ids:
+            continue
+        for j in range(i + 1, len(item_ids)):
+            if item_ids[j] in candidate_ids:
+                continue
+            if float(similarity[i, j]) < similarity_threshold:
+                continue
+            # Duplicate pair found — drop the older one
+            if dates[i] >= dates[j]:
+                dup_id = item_ids[j]
+            else:
+                dup_id = item_id
+                break  # current item is the older duplicate; outer loop will skip it
+            if dup_id not in candidate_ids:
+                candidate_ids.add(dup_id)
+                candidates.append({
+                    'id': dup_id,
+                    'description': id_to_item[dup_id].get('description', ''),
+                    'strategy': 'semantic_dedup',
+                })
+
+    logger.info(f'semantic_dedup uid={uid} checked={len(items_with_vec)} duplicates={len(candidates)}')
+    return candidates
+
+
+# ---------------------------------------------------------------------------
+# Strategy: LLM relevance scoring
+# ---------------------------------------------------------------------------
+
+class _TaskVerdict(BaseModel):
+    id: str = PydanticField(description="The task ID exactly as given")
+    is_stale: bool = PydanticField(description="True if this task is likely no longer relevant or actionable")
+    confidence: float = PydanticField(description="Confidence in the verdict, 0.0 to 1.0")
+
+
+class _BatchVerdicts(BaseModel):
+    verdicts: list[_TaskVerdict] = PydanticField(description="One verdict per task")
+
+
+_RELEVANCE_PROMPT = ChatPromptTemplate.from_messages([
+    (
+        "system",
+        """You are reviewing open to-do items to identify ones that are likely no longer relevant.
+
+For each task assess whether it is still actionable given how long ago it was created.
+
+Rules:
+- Be CONSERVATIVE. Only mark a task stale if you are highly confident it no longer matters.
+- Routine personal reminders (call someone, buy something) are likely still relevant regardless of age.
+- Event-specific tasks (prepare for X meeting, get ready for Y event) from long ago are likely stale.
+- Vague or already-obvious tasks ("go to bed", "brush teeth") that recur daily are likely stale duplicates.
+- Return confidence >= 0.85 only when you are quite sure.""",
+    ),
+    (
+        "human",
+        "Today's date: {today}\n\nTasks to review:\n{tasks}",
+    ),
+])
+
+_BATCH_SIZE = 50
+
+
+def candidates_llm_relevance(uid: str, confidence_threshold: float = 0.85) -> list[dict]:
+    """
+    Use an LLM to score open tasks for relevance. Tasks the LLM considers stale
+    with confidence >= confidence_threshold become candidates.
+    Processes tasks in batches of 50 to keep prompts manageable.
+    """
+    all_items = action_items_db.get_action_items(uid, completed=False)
+    if not all_items:
+        return []
+
+    llm = get_llm('conv_discard').with_structured_output(_BatchVerdicts)
+    chain = _RELEVANCE_PROMPT | llm
+    today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+    id_to_item = {item['id']: item for item in all_items}
+
+    def _score_batch(batch: list[dict]) -> list[dict]:
+        task_lines = []
+        for item in batch:
+            created = _parse_dt(item.get('created_at'))
+            age = f"{(datetime.now(timezone.utc) - created).days}d ago" if created else "unknown age"
+            task_lines.append(f"- id:{item['id']} | {item.get('description', '')} [{age}]")
+        try:
+            result: _BatchVerdicts = chain.invoke({"today": today, "tasks": "\n".join(task_lines)})
+            return [
+                {'id': v.id, 'description': id_to_item[v.id].get('description', ''), 'strategy': 'llm_relevance'}
+                for v in result.verdicts
+                if v.is_stale and v.confidence >= confidence_threshold and v.id in id_to_item
+            ]
+        except Exception as e:
+            logger.warning(f'LLM relevance batch failed: {e}')
+            return []
+
+    batches = [all_items[i:i + _BATCH_SIZE] for i in range(0, len(all_items), _BATCH_SIZE)]
+    candidates = []
+    with ThreadPoolExecutor(max_workers=5) as pool:
+        for result in as_completed([pool.submit(_score_batch, b) for b in batches]):
+            candidates.extend(result.result())
+
+    logger.info(f'llm_relevance uid={uid} checked={len(all_items)} candidates={len(candidates)}')
+    return candidates
+
+
+# ---------------------------------------------------------------------------
+# Strategy: conversation context
+# ---------------------------------------------------------------------------
+
+_CONV_CONTEXT_PROMPT = ChatPromptTemplate.from_messages([
+    (
+        "system",
+        """You are reviewing open to-do items. Each task came from a specific conversation.
+You will be given the conversation's title, a brief overview, and how long ago it happened,
+along with the tasks that were extracted from it.
+
+Assess whether each task is still relevant given the conversation context and how much time has passed.
+
+Rules:
+- Be CONSERVATIVE. Only mark a task stale if you are highly confident it is no longer relevant.
+- If the conversation was about a specific past event (a meeting, a trip, a service, a deadline),
+  tasks about preparing for it are almost certainly stale.
+- If the conversation topic is ongoing (a relationship, a project, a recurring role),
+  tasks are more likely still relevant.
+- Return confidence >= 0.85 only when you are quite sure.""",
+    ),
+    (
+        "human",
+        """Today: {today}
+
+Conversation: "{title}"
+Summary: {overview}
+Happened: {age}
+
+Tasks from this conversation:
+{tasks}""",
+    ),
+])
+
+
+def candidates_conversation_context(uid: str, confidence_threshold: float = 0.85) -> list[dict]:
+    """
+    Use conversation title/overview as context to assess task relevance.
+    Only operates on tasks with a conversation_id. Groups tasks by conversation
+    so each conversation's context is fetched and sent to the LLM once.
+    """
+    all_items = action_items_db.get_action_items(uid, completed=False)
+    linked = [i for i in all_items if i.get('conversation_id')]
+    if not linked:
+        logger.info('conversation_context: no tasks with conversation_id, skipping')
+        return []
+
+    conv_ids = {i['conversation_id'] for i in linked}
+    contexts = _fetch_conversation_contexts(uid, conv_ids)
+    if not contexts:
+        logger.info('conversation_context: no conversations found locally, skipping')
+        return []
+
+    # Group tasks by conversation
+    by_conv: dict[str, list[dict]] = {}
+    for item in linked:
+        cid = item['conversation_id']
+        if cid in contexts:
+            by_conv.setdefault(cid, []).append(item)
+
+    llm = get_llm('conv_discard').with_structured_output(_BatchVerdicts)
+    chain = _CONV_CONTEXT_PROMPT | llm
+    today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+    now = datetime.now(timezone.utc)
+
+    id_to_item = {item['id']: item for item in linked}
+
+    def _score_conv_batch(cid: str, batch: list[dict]) -> list[dict]:
+        ctx = contexts[cid]
+        started_at = ctx['started_at']
+        age = f"{(now - started_at).days} days ago" if started_at else "unknown"
+        task_lines = [f"- id:{i['id']} | {i.get('description', '')}" for i in batch]
+        try:
+            result: _BatchVerdicts = chain.invoke({
+                "today": today,
+                "title": ctx['title'] or '(untitled)',
+                "overview": ctx['overview'] or '(no summary)',
+                "age": age,
+                "tasks": "\n".join(task_lines),
+            })
+            return [
+                {'id': v.id, 'description': id_to_item[v.id].get('description', ''), 'strategy': 'conversation_context'}
+                for v in result.verdicts
+                if v.is_stale and v.confidence >= confidence_threshold and v.id in id_to_item
+            ]
+        except Exception as e:
+            logger.warning(f'conversation_context batch failed for conv {cid}: {e}')
+            return []
+
+    all_batches = [
+        (cid, items[i:i + _BATCH_SIZE])
+        for cid, items in by_conv.items()
+        for i in range(0, len(items), _BATCH_SIZE)
+    ]
+    candidates = []
+    with ThreadPoolExecutor(max_workers=5) as pool:
+        for result in as_completed([pool.submit(_score_conv_batch, cid, batch) for cid, batch in all_batches]):
+            candidates.extend(result.result())
+
+    logger.info(f'conversation_context uid={uid} conversations={len(by_conv)} candidates={len(candidates)}')
+    return candidates
+
+
+# ---------------------------------------------------------------------------
+# Strategy: vagueness / context-loss detection
+# ---------------------------------------------------------------------------
+
+# Unresolved demonstratives and pronouns as objects
+_PRONOUN_PATTERN = re.compile(
+    r'\b(it|them|those|these|that|this|the other|the same|the two|the ones?|'
+    r'the things?|the stuff|the other one|the rest)\b',
+    re.IGNORECASE,
+)
+
+# Common imperative verb + dangling reference combos
+_DANGLING_PATTERN = re.compile(
+    r'^(put|take|send|get|fix|check|do|move|bring|pick up|drop off|return|'
+    r'give back|hand|pass|grab|swap|switch|change|clean|clear|sort|set)\s+'
+    r'(it|them|those|these|that|this|the\s+\w+)\b',
+    re.IGNORECASE,
+)
+
+# Speaker placeholders that were never resolved
+_SPEAKER_PATTERN = re.compile(r'\bspeaker\s+\d+\b', re.IGNORECASE)
+
+
+def _is_vague(description: str) -> bool:
+    desc = description.strip()
+    words = desc.split()
+
+    # Unresolved speaker label
+    if _SPEAKER_PATTERN.search(desc):
+        return True
+
+    # Short description (≤ 5 words) containing a pronoun/demonstrative
+    if len(words) <= 5 and _PRONOUN_PATTERN.search(desc):
+        return True
+
+    # Imperative + dangling pronoun regardless of length
+    if _DANGLING_PATTERN.match(desc):
+        return True
+
+    return False
+
+
+def candidates_vague(uid: str) -> list[dict]:
+    """
+    Find open tasks whose descriptions contain unresolved pronouns or references
+    that make them meaningless without the original conversational context.
+    Examples: "Put those away", "Swap between the two cars", "Attend ultrasound with Speaker 0"
+    Rule-based — no LLM calls needed.
+    """
+    all_items = action_items_db.get_action_items(uid, completed=False)
+    candidates = [
+        {
+            'id': item['id'],
+            'description': item.get('description', ''),
+            'strategy': 'vague',
+        }
+        for item in all_items
+        if _is_vague(item.get('description', ''))
+    ]
+    logger.info(f'vague uid={uid} checked={len(all_items)} candidates={len(candidates)}')
+    return candidates
+
+
+# ---------------------------------------------------------------------------
+# Merge helpers
+# ---------------------------------------------------------------------------
+
+def merge_candidates(lists: list[list[dict]]) -> list[dict]:
+    """Merge candidate lists from multiple strategies, deduplicating by ID."""
+    seen = set()
+    merged = []
+    for lst in lists:
+        for c in lst:
+            if c['id'] not in seen:
+                seen.add(c['id'])
+                merged.append(c)
+    return merged

--- a/backend/utils/action_item_cleanup.py
+++ b/backend/utils/action_item_cleanup.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from datetime import datetime, timedelta, timezone
-from typing import Optional, cast
+from typing import Callable, Optional, TypeVar, cast
 
 import numpy as np
 from concurrent.futures import as_completed
@@ -253,8 +253,10 @@ Rules:
 
 _BATCH_SIZE = 50
 
+TBatch = TypeVar('TBatch')
 
-def _run_llm_batches(uid: str, batches: list[list[dict]], score_fn) -> list[dict]:
+
+def _run_llm_batches(uid: str, batches: list[TBatch], score_fn: Callable[[TBatch], list[dict]]) -> list[dict]:
     if not batches:
         return []
     futures = [llm_executor.submit(score_fn, batch) for batch in batches]

--- a/backend/utils/action_item_cleanup.py
+++ b/backend/utils/action_item_cleanup.py
@@ -416,11 +416,13 @@ _PRONOUN_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-# Common imperative verb + dangling reference combos
+# Common imperative verb + dangling reference combos. Only pronouns/demonstratives
+# count as "dangling" — "the <noun>" (e.g. "the sink", "the kitchen") is a concrete,
+# resolvable object, not a lost reference, so it's excluded here.
 _DANGLING_PATTERN = re.compile(
     r'^(put|take|send|get|fix|check|do|move|bring|pick up|drop off|return|'
     r'give back|hand|pass|grab|swap|switch|change|clean|clear|sort|set)\s+'
-    r'(it|them|those|these|that|this|the\s+\w+)\b',
+    r'(it|them|those|these|that|this)\b',
     re.IGNORECASE,
 )
 

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -140,6 +140,14 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     # reason as its parent policy.
     "action_items:list_hot_client": (ACTION_ITEMS_LIST_HOT_CLIENT_MAX, 60),
     "action_items:write": (120, 3600),
+    # Cleanup preview fans strategies=[llm_relevance, conversation_context] out to
+    # two ThreadPoolExecutor(max_workers=5) pools of conv_discard LLM calls per
+    # click, over up to 2000 tasks — one click is already ~10 concurrent LLM
+    # calls. Capped well below action_items:write to bound repeated clicks.
+    "action_items:cleanup_preview": (15, 3600),
+    # Execute is destructive (irreversible batch delete of staged candidates),
+    # so it gets the same order-of-magnitude cap as memories:delete_batch.
+    "action_items:cleanup_execute": (10, 3600),
     # Memories — single LLM call each
     "memories:create": (60, 3600),
     # Memory batch writes — each request can create up to 100 memories, so the

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -16752,5 +16752,5 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  // Total: 435 Swift client methods generated.
+  // Total: 437 Swift client methods generated.
 }

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -5566,6 +5566,58 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
+  public static func cleanupExecuteV1ActionItemsCleanupExecutePost(client: OmiApiClient, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, body: OmiAnyCodable) async throws -> OmiAnyCodable {
+    let _path = "/v1/action-items/cleanup/execute"
+    guard let components = URLComponents(string: client.baseURL + _path) else {
+      throw OmiApiError.invalidURL
+    }
+    guard let url = components.url else { throw OmiApiError.invalidURL }
+    var req = URLRequest(url: url)
+    req.httpMethod = "POST"
+    for (name, value) in client.headers { req.setValue(value, forHTTPHeaderField: name) }
+    if let token = client.token {
+      req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    }
+    if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
+    if let xAppPlatform { req.setValue(String(xAppPlatform), forHTTPHeaderField: "X-App-Platform") }
+    if let xDeviceIdHash { req.setValue(String(xDeviceIdHash), forHTTPHeaderField: "X-Device-Id-Hash") }
+    if let xAppVersion { req.setValue(String(xAppVersion), forHTTPHeaderField: "X-App-Version") }
+    req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    req.httpBody = try JSONEncoder().encode(body)
+    let (data, resp) = try await URLSession.shared.data(for: req)
+    guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }
+    guard (200..<300).contains(http.statusCode) else {
+      throw OmiApiError.httpError(status: http.statusCode, data: data)
+    }
+    return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
+  }
+
+  public static func cleanupPreviewV1ActionItemsCleanupPreviewPost(client: OmiApiClient, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, body: OmiAnyCodable) async throws -> OmiAnyCodable {
+    let _path = "/v1/action-items/cleanup/preview"
+    guard let components = URLComponents(string: client.baseURL + _path) else {
+      throw OmiApiError.invalidURL
+    }
+    guard let url = components.url else { throw OmiApiError.invalidURL }
+    var req = URLRequest(url: url)
+    req.httpMethod = "POST"
+    for (name, value) in client.headers { req.setValue(value, forHTTPHeaderField: name) }
+    if let token = client.token {
+      req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    }
+    if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
+    if let xAppPlatform { req.setValue(String(xAppPlatform), forHTTPHeaderField: "X-App-Platform") }
+    if let xDeviceIdHash { req.setValue(String(xDeviceIdHash), forHTTPHeaderField: "X-Device-Id-Hash") }
+    if let xAppVersion { req.setValue(String(xAppVersion), forHTTPHeaderField: "X-App-Version") }
+    req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    req.httpBody = try JSONEncoder().encode(body)
+    let (data, resp) = try await URLSession.shared.data(for: req)
+    guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }
+    guard (200..<300).contains(http.statusCode) else {
+      throw OmiApiError.httpError(status: http.statusCode, data: data)
+    }
+    return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
+  }
+
   public static func listActionItemIdsV1ActionItemsIdsGet(client: OmiApiClient, completed: Bool? = nil, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil) async throws -> OmiAnyCodable {
     let _path = "/v1/action-items/ids"
     guard var components = URLComponents(string: client.baseURL + _path) else {

--- a/desktop/windows/src/renderer/src/components/settings/TaskCleanupModal.test.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/TaskCleanupModal.test.tsx
@@ -22,7 +22,10 @@ const PREVIEW_RESULT = {
     { id: 't1', strategy: 'stale_age', description: 'Renew passport' },
     { id: 't2', strategy: 'stale_age', description: 'Book dentist' }
   ],
-  expires_in_seconds: 300
+  expires_in_seconds: 300,
+  total_open_action_items: 2,
+  scan_cap: 2000,
+  scan_truncated: false
 }
 
 beforeEach(() => {
@@ -70,5 +73,32 @@ describe('TaskCleanupModal review list', () => {
     const deleteButton = screen.getByText('Delete 0 tasks').closest('button') as HTMLButtonElement
     expect(deleteButton.disabled).toBe(true)
     expect(taskCleanupExecute).not.toHaveBeenCalled()
+  })
+})
+
+// Scan-cap truncation: get_action_items caps at 2000 open tasks, so accounts
+// with more than that get a silently partial scan unless the UI says so.
+describe('TaskCleanupModal scan truncation notice', () => {
+  it('shows a truncation notice when scan_truncated is true', async () => {
+    vi.mocked(taskCleanupPreview).mockResolvedValue({
+      ...PREVIEW_RESULT,
+      total_open_action_items: 45000,
+      scan_cap: 2000,
+      scan_truncated: true
+    })
+
+    render(<TaskCleanupModal open onOpenChange={vi.fn()} />)
+    fireEvent.click(screen.getByText('Analyze'))
+
+    await screen.findByText(/2,000 oldest open tasks/)
+    expect(screen.getByText(/43,000 weren't checked/)).toBeTruthy()
+  })
+
+  it('shows no truncation notice when scan_truncated is false', async () => {
+    render(<TaskCleanupModal open onOpenChange={vi.fn()} />)
+    fireEvent.click(screen.getByText('Analyze'))
+
+    await screen.findByText('Renew passport')
+    expect(screen.queryByText(/weren't checked/)).toBeNull()
   })
 })

--- a/desktop/windows/src/renderer/src/components/settings/TaskCleanupModal.test.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/TaskCleanupModal.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
+import { TaskCleanupModal } from './TaskCleanupModal'
+import { taskCleanupPreview, taskCleanupExecute } from '../../lib/taskCleanup'
+
+vi.mock('../../lib/taskCleanup', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../lib/taskCleanup')>('../../lib/taskCleanup')
+  return { ...actual, taskCleanupPreview: vi.fn(), taskCleanupExecute: vi.fn() }
+})
+
+const tasksReconcile = vi.fn()
+
+const PREVIEW_RESULT = {
+  session_id: 'sess-1',
+  total_candidates: 2,
+  breakdown: { stale_age: 2 },
+  sample: [],
+  candidate_ids: ['t1', 't2'],
+  candidate_meta: [
+    { id: 't1', strategy: 'stale_age', description: 'Renew passport' },
+    { id: 't2', strategy: 'stale_age', description: 'Book dentist' }
+  ],
+  expires_in_seconds: 300
+}
+
+beforeEach(() => {
+  vi.mocked(taskCleanupPreview).mockReset().mockResolvedValue(PREVIEW_RESULT)
+  vi.mocked(taskCleanupExecute).mockReset().mockResolvedValue({ deleted_count: 1 })
+  tasksReconcile.mockReset().mockResolvedValue(undefined)
+  ;(globalThis as unknown as { window: { omi: unknown } }).window.omi = { tasksReconcile }
+})
+
+afterEach(() => cleanup())
+
+// Per-item exclusion: the preview shows every candidate (not just a capped
+// sample), unchecking one keeps it out of the delete count and out of the
+// execute call's excluded_ids.
+describe('TaskCleanupModal review list', () => {
+  it('unchecking a candidate excludes it from the delete count and the execute call', async () => {
+    render(<TaskCleanupModal open onOpenChange={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('Analyze'))
+
+    await screen.findByText('Renew passport')
+    expect(screen.getByText('Book dentist')).toBeTruthy()
+    expect(screen.getByText('Delete 2 tasks')).toBeTruthy()
+
+    const [passportCheckbox] = screen
+      .getAllByRole('checkbox')
+      .filter((cb) => cb.closest('li')?.textContent?.includes('Renew passport'))
+    fireEvent.click(passportCheckbox)
+
+    expect(screen.getByText('Delete 1 task')).toBeTruthy()
+
+    fireEvent.click(screen.getByText('Delete 1 task'))
+
+    await waitFor(() => expect(taskCleanupExecute).toHaveBeenCalledWith('sess-1', ['t1']))
+  })
+
+  it('deselecting every candidate disables the delete button', async () => {
+    render(<TaskCleanupModal open onOpenChange={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('Analyze'))
+    await screen.findByText('Renew passport')
+
+    fireEvent.click(screen.getByText('Deselect all'))
+
+    const deleteButton = screen.getByText('Delete 0 tasks').closest('button') as HTMLButtonElement
+    expect(deleteButton.disabled).toBe(true)
+    expect(taskCleanupExecute).not.toHaveBeenCalled()
+  })
+})

--- a/desktop/windows/src/renderer/src/components/settings/TaskCleanupModal.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/TaskCleanupModal.tsx
@@ -295,6 +295,16 @@ export function TaskCleanupModal({ open, onOpenChange }: Props): React.JSX.Eleme
             </p>
           )}
 
+          {preview.scan_truncated && (
+            <div className="flex items-start gap-2 rounded-lg bg-amber-400/10 px-3 py-2 text-xs text-amber-300">
+              <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              Scanned your {preview.scan_cap.toLocaleString()} oldest open tasks — you have{' '}
+              {preview.total_open_action_items.toLocaleString()} total, so{' '}
+              {(preview.total_open_action_items - preview.scan_cap).toLocaleString()} weren&apos;t
+              checked. Run cleanup again after this batch to reach the rest.
+            </div>
+          )}
+
           {/* Breakdown */}
           {Object.values(preview.breakdown).some((n) => n > 0) && (
             <div className="glass-subtle rounded-lg px-4 py-3 text-sm">

--- a/desktop/windows/src/renderer/src/components/settings/TaskCleanupModal.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/TaskCleanupModal.tsx
@@ -1,0 +1,332 @@
+import { useState } from 'react'
+import { Loader2, AlertCircle } from 'lucide-react'
+import { Modal } from '../ui/Modal'
+import { toast } from '../../lib/toast'
+import {
+  taskCleanupPreview,
+  taskCleanupExecute,
+  type CleanupPreviewResult,
+  type CleanupStrategy
+} from '../../lib/taskCleanup'
+
+type Phase = 'config' | 'loading' | 'preview' | 'deleting'
+
+const STRATEGIES: {
+  id: CleanupStrategy
+  label: string
+  detail: string
+  slow?: true
+}[] = [
+  {
+    id: 'stale_age',
+    label: 'Stale tasks',
+    detail: 'Open tasks older than 90 days with no due date'
+  },
+  {
+    id: 'overdue',
+    label: 'Long overdue',
+    detail: 'Tasks with a due date more than 30 days in the past'
+  },
+  {
+    id: 'vague',
+    label: 'Vague / context-lost',
+    detail: 'Tasks with unresolved pronouns ("put it away", "fix those", "Speaker 1")'
+  },
+  {
+    id: 'semantic_dedup',
+    label: 'Near-duplicates',
+    detail: 'Older of any two tasks with nearly identical descriptions',
+    slow: true
+  },
+  {
+    id: 'llm_relevance',
+    label: 'AI relevance check',
+    detail: 'LLM judges whether each task is still actionable',
+    slow: true
+  },
+  {
+    id: 'conversation_context',
+    label: 'Conversation context',
+    detail: 'Uses the source conversation title/summary to judge staleness',
+    slow: true
+  }
+]
+
+const DEFAULT_STRATEGIES: CleanupStrategy[] = ['stale_age', 'overdue', 'vague']
+
+const STRATEGY_LABEL: Record<string, string> = {
+  stale_age: 'Stale',
+  overdue: 'Overdue',
+  vague: 'Vague',
+  semantic_dedup: 'Duplicate',
+  llm_relevance: 'AI-flagged',
+  conversation_context: 'Context-stale'
+}
+
+function apiDetail(e: unknown): string {
+  return (
+    (e as { response?: { data?: { detail?: string } } }).response?.data?.detail ??
+    (e as Error).message
+  )
+}
+
+type Props = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function TaskCleanupModal({ open, onOpenChange }: Props): React.JSX.Element {
+  const [phase, setPhase] = useState<Phase>('config')
+  const [selected, setSelected] = useState<Set<CleanupStrategy>>(new Set(DEFAULT_STRATEGIES))
+  const [preview, setPreview] = useState<CleanupPreviewResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const toggleStrategy = (s: CleanupStrategy): void => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(s)) next.delete(s)
+      else next.add(s)
+      return next
+    })
+  }
+
+  const hasSlow = [...selected].some((s) => STRATEGIES.find((x) => x.id === s)?.slow)
+
+  const analyze = async (): Promise<void> => {
+    if (selected.size === 0) return
+    setPhase('loading')
+    setError(null)
+    try {
+      const result = await taskCleanupPreview({
+        strategies: [...selected],
+        age_days: 90,
+        overdue_days: 30
+      })
+      setPreview(result)
+      setPhase('preview')
+    } catch (e) {
+      setError(apiDetail(e))
+      setPhase('config')
+    }
+  }
+
+  const execute = async (): Promise<void> => {
+    if (!preview) return
+    setPhase('deleting')
+    try {
+      const result = await taskCleanupExecute(preview.session_id)
+      const n = result.deleted_count
+      toast(`Deleted ${n.toLocaleString()} task${n === 1 ? '' : 's'}`, { tone: 'success' })
+      void window.omi.tasksReconcile()
+      resetAndClose()
+    } catch (e) {
+      const status = (e as { response?: { status?: number } }).response?.status
+      if (status === 410) {
+        toast('Session expired — please analyze again', { tone: 'warn' })
+        setPhase('config')
+        setPreview(null)
+      } else {
+        toast('Delete failed', { tone: 'error', body: apiDetail(e) })
+        setPhase('preview')
+      }
+    }
+  }
+
+  const resetAndClose = (): void => {
+    onOpenChange(false)
+    // Defer reset so the closing animation doesn't flash config state.
+    setTimeout(() => {
+      setPhase('config')
+      setPreview(null)
+      setError(null)
+    }, 300)
+  }
+
+  const isDeleting = phase === 'deleting'
+
+  const footer =
+    phase === 'config' ? (
+      <>
+        <button onClick={resetAndClose} className="btn-ghost">
+          Cancel
+        </button>
+        <button
+          onClick={analyze}
+          disabled={selected.size === 0}
+          className="btn-primary px-4 py-2 disabled:opacity-40"
+        >
+          Analyze
+        </button>
+      </>
+    ) : phase === 'preview' && preview ? (
+      <>
+        <button
+          onClick={() => {
+            setPhase('config')
+            setPreview(null)
+          }}
+          className="btn-ghost"
+        >
+          Back
+        </button>
+        <button
+          onClick={execute}
+          disabled={preview.total_candidates === 0}
+          className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-40"
+        >
+          Delete {preview.total_candidates.toLocaleString()} task
+          {preview.total_candidates === 1 ? '' : 's'}
+        </button>
+      </>
+    ) : phase === 'deleting' ? (
+      <span className="flex items-center gap-2 text-sm text-white/50">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Deleting…
+      </span>
+    ) : null
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={(v) => {
+        if (isDeleting) return
+        if (!v) resetAndClose()
+        else onOpenChange(true)
+      }}
+      title="Clean up tasks"
+      dismissible={!isDeleting}
+      size="md"
+      footer={footer}
+    >
+      {/* ── Config ─────────────────────────────────────────────── */}
+      {phase === 'config' && (
+        <div className="space-y-4">
+          <p className="text-white/60">
+            Choose which strategies to run. Fast ones finish in seconds; slow ones use AI and may
+            take 1–3 minutes on large accounts.
+          </p>
+
+          <div className="space-y-1">
+            {STRATEGIES.map((s) => (
+              <label
+                key={s.id}
+                className="flex cursor-pointer items-start gap-3 rounded-lg px-2 py-2 hover:bg-white/5"
+              >
+                <input
+                  type="checkbox"
+                  checked={selected.has(s.id)}
+                  onChange={() => toggleStrategy(s.id)}
+                  className="mt-0.5 accent-[color:var(--accent)]"
+                />
+                <div className="min-w-0">
+                  <span className="text-sm text-white/90">{s.label}</span>
+                  {s.slow && (
+                    <span className="ml-2 rounded bg-amber-400/20 px-1.5 py-0.5 text-xs text-amber-300">
+                      slow
+                    </span>
+                  )}
+                  <p className="text-xs text-white/45">{s.detail}</p>
+                </div>
+              </label>
+            ))}
+          </div>
+
+          {hasSlow && (
+            <div className="flex items-start gap-2 rounded-lg bg-amber-400/10 px-3 py-2 text-xs text-amber-300">
+              <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              AI strategies process tasks in batches — expect 1–3 minutes for accounts with
+              thousands of tasks.
+            </div>
+          )}
+
+          {error && (
+            <div className="flex items-start gap-2 rounded-lg bg-red-500/10 px-3 py-2 text-xs text-red-400">
+              <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              {error}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── Loading ─────────────────────────────────────────────── */}
+      {phase === 'loading' && (
+        <div className="flex flex-col items-center gap-4 py-8">
+          <Loader2 className="h-8 w-8 animate-spin text-white/40" />
+          <div className="text-center">
+            <p className="text-white/80">Analyzing your tasks…</p>
+            {hasSlow && (
+              <p className="mt-1 text-xs text-white/40">AI strategies may take a minute or two</p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* ── Preview ─────────────────────────────────────────────── */}
+      {phase === 'preview' && preview && (
+        <div className="space-y-4">
+          {preview.total_candidates > 0 ? (
+            <p className="text-white/80">
+              Found{' '}
+              <span className="font-semibold text-white">
+                {preview.total_candidates.toLocaleString()}
+              </span>{' '}
+              task{preview.total_candidates === 1 ? '' : 's'} to remove.
+            </p>
+          ) : (
+            <p className="text-white/60">
+              Nothing to clean up — your tasks look good with the selected strategies.
+            </p>
+          )}
+
+          {/* Breakdown */}
+          {Object.values(preview.breakdown).some((n) => n > 0) && (
+            <div className="glass-subtle rounded-lg px-4 py-3 text-sm">
+              {Object.entries(preview.breakdown)
+                .filter(([, n]) => n > 0)
+                .map(([strategy, count]) => (
+                  <div key={strategy} className="flex items-center justify-between py-0.5">
+                    <span className="text-white/55">
+                      {STRATEGY_LABEL[strategy] ?? strategy}
+                    </span>
+                    <span className="tabular-nums text-white/90">{count.toLocaleString()}</span>
+                  </div>
+                ))}
+            </div>
+          )}
+
+          {/* Sample */}
+          {preview.sample.length > 0 && (
+            <div>
+              <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-white/35">
+                Samples
+              </p>
+              <ul className="glass-subtle max-h-40 space-y-0.5 overflow-y-auto rounded-lg px-4 py-3 text-sm text-white/55">
+                {preview.sample.map((item, i) => (
+                  <li key={i} className="flex items-baseline gap-2">
+                    <span className="shrink-0 rounded bg-white/10 px-1 py-px text-xs text-white/35">
+                      {STRATEGY_LABEL[item.strategy] ?? item.strategy}
+                    </span>
+                    <span className="truncate">{item.description}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <p className="text-xs text-white/30">
+            Deletion is permanent. Session expires in{' '}
+            {Math.round(preview.expires_in_seconds / 60)} min — confirm before then.
+          </p>
+        </div>
+      )}
+
+      {/* ── Deleting ─────────────────────────────────────────────── */}
+      {phase === 'deleting' && (
+        <div className="flex flex-col items-center gap-4 py-8">
+          <Loader2 className="h-8 w-8 animate-spin text-white/40" />
+          <p className="text-white/80">Deleting tasks…</p>
+        </div>
+      )}
+    </Modal>
+  )
+}

--- a/desktop/windows/src/renderer/src/components/settings/TaskCleanupModal.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/TaskCleanupModal.tsx
@@ -80,6 +80,17 @@ export function TaskCleanupModal({ open, onOpenChange }: Props): React.JSX.Eleme
   const [selected, setSelected] = useState<Set<CleanupStrategy>>(new Set(DEFAULT_STRATEGIES))
   const [preview, setPreview] = useState<CleanupPreviewResult | null>(null)
   const [error, setError] = useState<string | null>(null)
+  // Candidate IDs the user has unchecked in the review list — kept out of deletion.
+  const [excludedIds, setExcludedIds] = useState<Set<string>>(new Set())
+
+  const toggleCandidate = (id: string): void => {
+    setExcludedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
 
   const toggleStrategy = (s: CleanupStrategy): void => {
     setSelected((prev) => {
@@ -103,6 +114,7 @@ export function TaskCleanupModal({ open, onOpenChange }: Props): React.JSX.Eleme
         overdue_days: 30
       })
       setPreview(result)
+      setExcludedIds(new Set())
       setPhase('preview')
     } catch (e) {
       setError(apiDetail(e))
@@ -114,7 +126,7 @@ export function TaskCleanupModal({ open, onOpenChange }: Props): React.JSX.Eleme
     if (!preview) return
     setPhase('deleting')
     try {
-      const result = await taskCleanupExecute(preview.session_id)
+      const result = await taskCleanupExecute(preview.session_id, [...excludedIds])
       const n = result.deleted_count
       toast(`Deleted ${n.toLocaleString()} task${n === 1 ? '' : 's'}`, { tone: 'success' })
       void window.omi.tasksReconcile()
@@ -125,6 +137,7 @@ export function TaskCleanupModal({ open, onOpenChange }: Props): React.JSX.Eleme
         toast('Session expired — please analyze again', { tone: 'warn' })
         setPhase('config')
         setPreview(null)
+        setExcludedIds(new Set())
       } else {
         toast('Delete failed', { tone: 'error', body: apiDetail(e) })
         setPhase('preview')
@@ -139,10 +152,12 @@ export function TaskCleanupModal({ open, onOpenChange }: Props): React.JSX.Eleme
       setPhase('config')
       setPreview(null)
       setError(null)
+      setExcludedIds(new Set())
     }, 300)
   }
 
   const isDeleting = phase === 'deleting'
+  const remainingCount = preview ? preview.total_candidates - excludedIds.size : 0
 
   const footer =
     phase === 'config' ? (
@@ -164,6 +179,7 @@ export function TaskCleanupModal({ open, onOpenChange }: Props): React.JSX.Eleme
           onClick={() => {
             setPhase('config')
             setPreview(null)
+            setExcludedIds(new Set())
           }}
           className="btn-ghost"
         >
@@ -171,11 +187,11 @@ export function TaskCleanupModal({ open, onOpenChange }: Props): React.JSX.Eleme
         </button>
         <button
           onClick={execute}
-          disabled={preview.total_candidates === 0}
+          disabled={remainingCount === 0}
           className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-40"
         >
-          Delete {preview.total_candidates.toLocaleString()} task
-          {preview.total_candidates === 1 ? '' : 's'}
+          Delete {remainingCount.toLocaleString()} task
+          {remainingCount === 1 ? '' : 's'}
         </button>
       </>
     ) : phase === 'deleting' ? (
@@ -270,7 +286,8 @@ export function TaskCleanupModal({ open, onOpenChange }: Props): React.JSX.Eleme
               <span className="font-semibold text-white">
                 {preview.total_candidates.toLocaleString()}
               </span>{' '}
-              task{preview.total_candidates === 1 ? '' : 's'} to remove.
+              task{preview.total_candidates === 1 ? '' : 's'} matching your criteria. Review the
+              list below and uncheck anything you want to keep.
             </p>
           ) : (
             <p className="text-white/60">
@@ -285,28 +302,51 @@ export function TaskCleanupModal({ open, onOpenChange }: Props): React.JSX.Eleme
                 .filter(([, n]) => n > 0)
                 .map(([strategy, count]) => (
                   <div key={strategy} className="flex items-center justify-between py-0.5">
-                    <span className="text-white/55">
-                      {STRATEGY_LABEL[strategy] ?? strategy}
-                    </span>
+                    <span className="text-white/55">{STRATEGY_LABEL[strategy] ?? strategy}</span>
                     <span className="tabular-nums text-white/90">{count.toLocaleString()}</span>
                   </div>
                 ))}
             </div>
           )}
 
-          {/* Sample */}
-          {preview.sample.length > 0 && (
+          {/* Review candidates — uncheck any task to keep it */}
+          {preview.candidate_meta.length > 0 && (
             <div>
-              <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-white/35">
-                Samples
-              </p>
-              <ul className="glass-subtle max-h-40 space-y-0.5 overflow-y-auto rounded-lg px-4 py-3 text-sm text-white/55">
-                {preview.sample.map((item, i) => (
-                  <li key={i} className="flex items-baseline gap-2">
+              <div className="mb-1.5 flex items-center justify-between">
+                <p className="text-xs font-medium uppercase tracking-wide text-white/35">
+                  Review ({remainingCount.toLocaleString()} of{' '}
+                  {preview.candidate_meta.length.toLocaleString()} selected)
+                </p>
+                <div className="flex gap-2 text-xs text-white/45">
+                  <button onClick={() => setExcludedIds(new Set())} className="hover:text-white/80">
+                    Select all
+                  </button>
+                  <span className="text-white/20">·</span>
+                  <button
+                    onClick={() => setExcludedIds(new Set(preview.candidate_meta.map((c) => c.id)))}
+                    className="hover:text-white/80"
+                  >
+                    Deselect all
+                  </button>
+                </div>
+              </div>
+              <ul className="glass-subtle max-h-64 space-y-0.5 overflow-y-auto rounded-lg px-4 py-3 text-sm text-white/55">
+                {preview.candidate_meta.map((item) => (
+                  <li key={item.id} className="flex items-baseline gap-2">
+                    <input
+                      type="checkbox"
+                      checked={!excludedIds.has(item.id)}
+                      onChange={() => toggleCandidate(item.id)}
+                      className="mt-0.5 shrink-0 accent-[color:var(--accent)]"
+                    />
                     <span className="shrink-0 rounded bg-white/10 px-1 py-px text-xs text-white/35">
                       {STRATEGY_LABEL[item.strategy] ?? item.strategy}
                     </span>
-                    <span className="truncate">{item.description}</span>
+                    <span
+                      className={`truncate ${excludedIds.has(item.id) ? 'text-white/30 line-through' : ''}`}
+                    >
+                      {item.description}
+                    </span>
                   </li>
                 ))}
               </ul>
@@ -314,8 +354,8 @@ export function TaskCleanupModal({ open, onOpenChange }: Props): React.JSX.Eleme
           )}
 
           <p className="text-xs text-white/30">
-            Deletion is permanent. Session expires in{' '}
-            {Math.round(preview.expires_in_seconds / 60)} min — confirm before then.
+            Deletion is permanent. Session expires in {Math.round(preview.expires_in_seconds / 60)}{' '}
+            min — confirm before then.
           </p>
         </div>
       )}

--- a/desktop/windows/src/renderer/src/components/settings/TaskCleanupModal.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/TaskCleanupModal.tsx
@@ -79,6 +79,7 @@ export function TaskCleanupModal({ open, onOpenChange }: Props): React.JSX.Eleme
   const [phase, setPhase] = useState<Phase>('config')
   const [selected, setSelected] = useState<Set<CleanupStrategy>>(new Set(DEFAULT_STRATEGIES))
   const [preview, setPreview] = useState<CleanupPreviewResult | null>(null)
+  const [nextScanCursor, setNextScanCursor] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   // Candidate IDs the user has unchecked in the review list — kept out of deletion.
   const [excludedIds, setExcludedIds] = useState<Set<string>>(new Set())
@@ -111,9 +112,11 @@ export function TaskCleanupModal({ open, onOpenChange }: Props): React.JSX.Eleme
       const result = await taskCleanupPreview({
         strategies: [...selected],
         age_days: 90,
-        overdue_days: 30
+        overdue_days: 30,
+        scan_cursor: nextScanCursor
       })
       setPreview(result)
+      setNextScanCursor(result.next_scan_cursor ?? null)
       setExcludedIds(new Set())
       setPhase('preview')
     } catch (e) {
@@ -151,6 +154,7 @@ export function TaskCleanupModal({ open, onOpenChange }: Props): React.JSX.Eleme
     setTimeout(() => {
       setPhase('config')
       setPreview(null)
+      setNextScanCursor(null)
       setError(null)
       setExcludedIds(new Set())
     }, 300)

--- a/desktop/windows/src/renderer/src/components/settings/tabs/AdvancedTab.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/AdvancedTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Download, Upload, Wrench, FolderSearch, Network, RotateCcw } from 'lucide-react'
+import { Download, Upload, Wrench, FolderSearch, Network, RotateCcw, Trash2 } from 'lucide-react'
 import { auth } from '../../../lib/firebase'
 import { toast } from '../../../lib/toast'
 import { type MemorySource } from '../../../lib/memoryExtract'
@@ -20,6 +20,7 @@ import { runMemoryExport } from '../../../lib/memoryExport'
 import { useMemories, type Memory } from '../../../hooks/useMemories'
 import { resetOnboarding } from '../../../lib/preferences'
 import { SettingRow } from '../SettingRow'
+import { TaskCleanupModal } from '../TaskCleanupModal'
 import { IntegrationsTab } from './IntegrationsTab'
 import { DeveloperKeysSection } from './DeveloperKeysSection'
 import { AiProfileCard } from './AiProfileCard'
@@ -223,6 +224,9 @@ export function AdvancedTab(): React.JSX.Element {
     window.location.reload()
   }
 
+  // --- Task cleanup ---
+  const [taskCleanupOpen, setTaskCleanupOpen] = useState(false)
+
   return (
     <>
       <SettingRow
@@ -400,6 +404,19 @@ export function AdvancedTab(): React.JSX.Element {
           )}
         </div>
       </SettingRow>
+
+      <SettingRow
+        icon={Trash2}
+        title="Task maintenance"
+        subtitle="Find and remove stale, overdue, vague, or duplicate tasks from your account."
+        keywords="task cleanup stale overdue duplicate vague delete remove"
+        control={
+          <button onClick={() => setTaskCleanupOpen(true)} className="btn-ghost">
+            Clean up tasks…
+          </button>
+        }
+      />
+      <TaskCleanupModal open={taskCleanupOpen} onOpenChange={setTaskCleanupOpen} />
 
       {/* Integrations (Sticky Notes, Google) live under Advanced. */}
       <IntegrationsTab />

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -18615,4 +18615,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 435 client methods generated.
+// Total: 437 client methods generated.

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -1046,6 +1046,49 @@ export interface CleanerMemory {
   reviewed_source?: string | null;
 }
 
+export interface CleanupCandidateMeta {
+  description: string;
+  id: string;
+  strategy: string;
+}
+
+export interface CleanupExecuteRequest {
+  excluded_ids?: Array<string>;
+  session_id: string;
+}
+
+export interface CleanupExecuteResponse {
+  deleted_count: number;
+}
+
+export interface CleanupPreviewRequest {
+  age_days?: number;
+  llm_confidence_threshold?: number;
+  overdue_days?: number;
+  scan_cursor?: string | null;
+  similarity_threshold?: number;
+  strategies?: Array<string>;
+}
+
+export interface CleanupPreviewResponse {
+  breakdown: Record<string, unknown>;
+  candidate_ids: Array<string>;
+  candidate_meta: Array<CleanupCandidateMeta>;
+  expires_in_seconds: number;
+  next_scan_cursor?: string | null;
+  sample: Array<CleanupSampleItem>;
+  scan_cap: number;
+  scan_truncated: boolean;
+  session_id: string;
+  total_candidates: number;
+  total_open_action_items: number;
+}
+
+export interface CleanupSampleItem {
+  description: string;
+  strategy: string;
+}
+
 export interface ClickUpListsResponse {
   lists?: Array<Record<string, unknown>>;
 }
@@ -4968,6 +5011,12 @@ export interface OmiApiSchemas {
   "CheckVerificationRequest": CheckVerificationRequest;
   "CheckVerificationResponse": CheckVerificationResponse;
   "CleanerMemory": CleanerMemory;
+  "CleanupCandidateMeta": CleanupCandidateMeta;
+  "CleanupExecuteRequest": CleanupExecuteRequest;
+  "CleanupExecuteResponse": CleanupExecuteResponse;
+  "CleanupPreviewRequest": CleanupPreviewRequest;
+  "CleanupPreviewResponse": CleanupPreviewResponse;
+  "CleanupSampleItem": CleanupSampleItem;
   "ClickUpListsResponse": ClickUpListsResponse;
   "ClickUpSpacesResponse": ClickUpSpacesResponse;
   "ClickUpTeamsResponse": ClickUpTeamsResponse;
@@ -5547,6 +5596,26 @@ export interface OmiApiPaths {
       operationId: "batch_delete_action_items_v1_action_items_batch_delete_post";
       responses: {
         "200": BatchDeleteActionItemsResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/action-items/cleanup/execute": {
+    post: {
+      operationId: "cleanup_execute_v1_action_items_cleanup_execute_post";
+      responses: {
+        "200": CleanupExecuteResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/action-items/cleanup/preview": {
+    post: {
+      operationId: "cleanup_preview_v1_action_items_cleanup_preview_post";
+      responses: {
+        "200": CleanupPreviewResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -10011,6 +10080,48 @@ export async function batch_update_action_items_v1_action_items_batch_patch(head
 export async function batch_delete_action_items_v1_action_items_batch_delete_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: BatchDeleteActionItemsRequest, init?: OmiApiClientInit): Promise<BatchDeleteActionItemsResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/action-items/batch-delete`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function cleanup_execute_v1_action_items_cleanup_execute_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: CleanupExecuteRequest, init?: OmiApiClientInit): Promise<CleanupExecuteResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/action-items/cleanup/execute`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function cleanup_preview_v1_action_items_cleanup_preview_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: CleanupPreviewRequest, init?: OmiApiClientInit): Promise<CleanupPreviewResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/action-items/cleanup/preview`;
   const _search = "";
   const _res = await fetch(`${_base}${_path}${_search}`, {
     method: "POST",

--- a/desktop/windows/src/renderer/src/lib/taskCleanup.test.ts
+++ b/desktop/windows/src/renderer/src/lib/taskCleanup.test.ts
@@ -68,7 +68,7 @@ describe('taskCleanupPreview', () => {
 })
 
 describe('taskCleanupExecute', () => {
-  it('posts the session_id to the execute endpoint and returns response data', async () => {
+  it('posts the session_id and an empty exclusion list by default', async () => {
     postSpy.mockResolvedValue({ data: { deleted_count: 42 } })
 
     const result = await taskCleanupExecute('my-session-id')
@@ -77,7 +77,16 @@ describe('taskCleanupExecute', () => {
     expect(postSpy).toHaveBeenCalledTimes(1)
     const [url, body] = postSpy.mock.calls[0] as [string, unknown]
     expect(url).toBe('/v1/action-items/cleanup/execute')
-    expect(body).toEqual({ session_id: 'my-session-id' })
+    expect(body).toEqual({ session_id: 'my-session-id', excluded_ids: [] })
+  })
+
+  it('forwards excluded_ids so unchecked candidates survive deletion', async () => {
+    postSpy.mockResolvedValue({ data: { deleted_count: 1 } })
+
+    await taskCleanupExecute('my-session-id', ['t1', 't2'])
+
+    const [, body] = postSpy.mock.calls[0] as [string, unknown]
+    expect(body).toEqual({ session_id: 'my-session-id', excluded_ids: ['t1', 't2'] })
   })
 
   it('does not pass a custom timeout (fast operation)', async () => {

--- a/desktop/windows/src/renderer/src/lib/taskCleanup.test.ts
+++ b/desktop/windows/src/renderer/src/lib/taskCleanup.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Wire: taskCleanupPreview posts to /preview with the user's params and a
+// 180-second timeout override (LLM strategies can take up to 2 minutes on
+// large accounts). taskCleanupExecute posts the session_id to /execute —
+// no timeout override since deletion is fast.
+
+const postSpy = vi.fn()
+vi.mock('./apiClient', () => ({
+  omiApi: { post: (url: string, body: unknown, config?: unknown) => postSpy(url, body, config) }
+}))
+
+import { taskCleanupPreview, taskCleanupExecute } from './taskCleanup'
+
+const PREVIEW_TIMEOUT_MS = 180_000
+
+beforeEach(() => postSpy.mockReset())
+
+describe('taskCleanupPreview', () => {
+  it('posts to the preview endpoint and returns response data', async () => {
+    const response = {
+      session_id: 'sess-abc',
+      total_candidates: 5,
+      breakdown: { stale_age: 5 },
+      sample: [],
+      expires_in_seconds: 300
+    }
+    postSpy.mockResolvedValue({ data: response })
+
+    const result = await taskCleanupPreview({ strategies: ['stale_age'], age_days: 90 })
+
+    expect(result).toEqual(response)
+    expect(postSpy).toHaveBeenCalledTimes(1)
+    const [url, body] = postSpy.mock.calls[0] as [string, unknown, unknown]
+    expect(url).toBe('/v1/action-items/cleanup/preview')
+    expect(body).toEqual({ strategies: ['stale_age'], age_days: 90 })
+  })
+
+  it('passes a 180-second timeout override', async () => {
+    postSpy.mockResolvedValue({ data: {} })
+
+    await taskCleanupPreview({ strategies: [] })
+
+    const [, , config] = postSpy.mock.calls[0] as [string, unknown, { timeout: number }]
+    expect(config).toMatchObject({ timeout: PREVIEW_TIMEOUT_MS })
+  })
+
+  it('forwards all optional params to the backend', async () => {
+    postSpy.mockResolvedValue({ data: {} })
+
+    await taskCleanupPreview({
+      strategies: ['semantic_dedup', 'llm_relevance'],
+      age_days: 30,
+      overdue_days: 14,
+      similarity_threshold: 0.95,
+      llm_confidence_threshold: 0.85
+    })
+
+    const [, body] = postSpy.mock.calls[0] as [string, unknown]
+    expect(body).toEqual({
+      strategies: ['semantic_dedup', 'llm_relevance'],
+      age_days: 30,
+      overdue_days: 14,
+      similarity_threshold: 0.95,
+      llm_confidence_threshold: 0.85
+    })
+  })
+})
+
+describe('taskCleanupExecute', () => {
+  it('posts the session_id to the execute endpoint and returns response data', async () => {
+    postSpy.mockResolvedValue({ data: { deleted_count: 42 } })
+
+    const result = await taskCleanupExecute('my-session-id')
+
+    expect(result).toEqual({ deleted_count: 42 })
+    expect(postSpy).toHaveBeenCalledTimes(1)
+    const [url, body] = postSpy.mock.calls[0] as [string, unknown]
+    expect(url).toBe('/v1/action-items/cleanup/execute')
+    expect(body).toEqual({ session_id: 'my-session-id' })
+  })
+
+  it('does not pass a custom timeout (fast operation)', async () => {
+    postSpy.mockResolvedValue({ data: { deleted_count: 0 } })
+
+    await taskCleanupExecute('sess-x')
+
+    const call = postSpy.mock.calls[0] as [string, unknown, unknown?]
+    // Third arg (config) should be absent or undefined — no timeout override
+    expect(call[2]).toBeUndefined()
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/taskCleanup.ts
+++ b/desktop/windows/src/renderer/src/lib/taskCleanup.ts
@@ -1,0 +1,55 @@
+import { omiApi } from './apiClient'
+
+export type CleanupStrategy =
+  | 'stale_age'
+  | 'overdue'
+  | 'semantic_dedup'
+  | 'llm_relevance'
+  | 'conversation_context'
+  | 'vague'
+
+export interface CleanupPreviewParams {
+  strategies: CleanupStrategy[]
+  age_days?: number
+  overdue_days?: number
+  similarity_threshold?: number
+  llm_confidence_threshold?: number
+}
+
+export interface CleanupSampleItem {
+  description: string
+  strategy: string
+}
+
+export interface CleanupPreviewResult {
+  session_id: string
+  total_candidates: number
+  breakdown: Record<string, number>
+  sample: CleanupSampleItem[]
+  expires_in_seconds: number
+}
+
+export interface CleanupExecuteResult {
+  deleted_count: number
+}
+
+// LLM strategies over a large task set can take 60–120 seconds server-side.
+const PREVIEW_TIMEOUT_MS = 180_000
+
+export async function taskCleanupPreview(
+  params: CleanupPreviewParams
+): Promise<CleanupPreviewResult> {
+  const r = await omiApi.post<CleanupPreviewResult>(
+    '/v1/action-items/cleanup/preview',
+    params,
+    { timeout: PREVIEW_TIMEOUT_MS }
+  )
+  return r.data
+}
+
+export async function taskCleanupExecute(sessionId: string): Promise<CleanupExecuteResult> {
+  const r = await omiApi.post<CleanupExecuteResult>('/v1/action-items/cleanup/execute', {
+    session_id: sessionId
+  })
+  return r.data
+}

--- a/desktop/windows/src/renderer/src/lib/taskCleanup.ts
+++ b/desktop/windows/src/renderer/src/lib/taskCleanup.ts
@@ -14,6 +14,7 @@ export interface CleanupPreviewParams {
   overdue_days?: number
   similarity_threshold?: number
   llm_confidence_threshold?: number
+  scan_cursor?: string | null
 }
 
 export interface CleanupSampleItem {
@@ -38,6 +39,7 @@ export interface CleanupPreviewResult {
   total_open_action_items: number
   scan_cap: number
   scan_truncated: boolean
+  next_scan_cursor?: string | null
 }
 
 export interface CleanupExecuteResult {

--- a/desktop/windows/src/renderer/src/lib/taskCleanup.ts
+++ b/desktop/windows/src/renderer/src/lib/taskCleanup.ts
@@ -21,11 +21,19 @@ export interface CleanupSampleItem {
   strategy: string
 }
 
+export interface CleanupCandidateMeta {
+  id: string
+  strategy: string
+  description: string
+}
+
 export interface CleanupPreviewResult {
   session_id: string
   total_candidates: number
   breakdown: Record<string, number>
   sample: CleanupSampleItem[]
+  candidate_ids: string[]
+  candidate_meta: CleanupCandidateMeta[]
   expires_in_seconds: number
 }
 
@@ -39,17 +47,19 @@ const PREVIEW_TIMEOUT_MS = 180_000
 export async function taskCleanupPreview(
   params: CleanupPreviewParams
 ): Promise<CleanupPreviewResult> {
-  const r = await omiApi.post<CleanupPreviewResult>(
-    '/v1/action-items/cleanup/preview',
-    params,
-    { timeout: PREVIEW_TIMEOUT_MS }
-  )
+  const r = await omiApi.post<CleanupPreviewResult>('/v1/action-items/cleanup/preview', params, {
+    timeout: PREVIEW_TIMEOUT_MS
+  })
   return r.data
 }
 
-export async function taskCleanupExecute(sessionId: string): Promise<CleanupExecuteResult> {
+export async function taskCleanupExecute(
+  sessionId: string,
+  excludedIds: string[] = []
+): Promise<CleanupExecuteResult> {
   const r = await omiApi.post<CleanupExecuteResult>('/v1/action-items/cleanup/execute', {
-    session_id: sessionId
+    session_id: sessionId,
+    excluded_ids: excludedIds
   })
   return r.data
 }

--- a/desktop/windows/src/renderer/src/lib/taskCleanup.ts
+++ b/desktop/windows/src/renderer/src/lib/taskCleanup.ts
@@ -35,6 +35,9 @@ export interface CleanupPreviewResult {
   candidate_ids: string[]
   candidate_meta: CleanupCandidateMeta[]
   expires_in_seconds: number
+  total_open_action_items: number
+  scan_cap: number
+  scan_truncated: boolean
 }
 
 export interface CleanupExecuteResult {

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -6826,6 +6826,18 @@
             "title": "Overdue Days",
             "type": "integer"
           },
+          "scan_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Resume token from a prior cleanup preview to scan the next oldest open tasks",
+            "title": "Scan Cursor"
+          },
           "similarity_threshold": {
             "default": 0.92,
             "description": "Similarity threshold for semantic_dedup",
@@ -6874,6 +6886,18 @@
             "title": "Expires In Seconds",
             "type": "integer"
           },
+          "next_scan_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Pass on the next preview to continue scanning from the oldest remaining open tasks",
+            "title": "Next Scan Cursor"
+          },
           "sample": {
             "items": {
               "$ref": "#/components/schemas/CleanupSampleItem"
@@ -6887,7 +6911,7 @@
             "type": "integer"
           },
           "scan_truncated": {
-            "description": "True if total_open_action_items exceeds scan_cap, so strategies may not have considered every open task as a candidate",
+            "description": "True when more open tasks remain beyond this preview's oldest-first scan window",
             "title": "Scan Truncated",
             "type": "boolean"
           },
@@ -30455,7 +30479,7 @@
     },
     "/v1/action-items/cleanup/execute": {
       "post": {
-        "description": "Delete the candidates staged by a prior preview call.\nFalls back to recomputing if the session has expired.",
+        "description": "Delete the candidates staged by a prior preview call.",
         "operationId": "cleanup_execute_v1_action_items_cleanup_execute_post",
         "parameters": [
           {

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -6881,12 +6881,27 @@
             "title": "Sample",
             "type": "array"
           },
+          "scan_cap": {
+            "description": "Per-strategy Firestore scan cap (see _ACTION_ITEMS_LIST_HARD_MAX)",
+            "title": "Scan Cap",
+            "type": "integer"
+          },
+          "scan_truncated": {
+            "description": "True if total_open_action_items exceeds scan_cap, so strategies may not have considered every open task as a candidate",
+            "title": "Scan Truncated",
+            "type": "boolean"
+          },
           "session_id": {
             "title": "Session Id",
             "type": "string"
           },
           "total_candidates": {
             "title": "Total Candidates",
+            "type": "integer"
+          },
+          "total_open_action_items": {
+            "description": "True count of the user's open action items, independent of any scan cap",
+            "title": "Total Open Action Items",
             "type": "integer"
           }
         },
@@ -6897,7 +6912,10 @@
           "sample",
           "candidate_ids",
           "candidate_meta",
-          "expires_in_seconds"
+          "expires_in_seconds",
+          "total_open_action_items",
+          "scan_cap",
+          "scan_truncated"
         ],
         "title": "CleanupPreviewResponse",
         "type": "object"

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -6745,6 +6745,10 @@
       },
       "CleanupCandidateMeta": {
         "properties": {
+          "description": {
+            "title": "Description",
+            "type": "string"
+          },
           "id": {
             "title": "Id",
             "type": "string"
@@ -6756,13 +6760,22 @@
         },
         "required": [
           "id",
-          "strategy"
+          "strategy",
+          "description"
         ],
         "title": "CleanupCandidateMeta",
         "type": "object"
       },
       "CleanupExecuteRequest": {
         "properties": {
+          "excluded_ids": {
+            "description": "Candidate IDs from the preview to keep (not delete)",
+            "items": {
+              "type": "string"
+            },
+            "title": "Excluded Ids",
+            "type": "array"
+          },
           "session_id": {
             "title": "Session Id",
             "type": "string"

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -6743,6 +6743,170 @@
         "title": "CleanerMemory",
         "type": "object"
       },
+      "CleanupCandidateMeta": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "strategy": {
+            "title": "Strategy",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "strategy"
+        ],
+        "title": "CleanupCandidateMeta",
+        "type": "object"
+      },
+      "CleanupExecuteRequest": {
+        "properties": {
+          "session_id": {
+            "title": "Session Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_id"
+        ],
+        "title": "CleanupExecuteRequest",
+        "type": "object"
+      },
+      "CleanupExecuteResponse": {
+        "properties": {
+          "deleted_count": {
+            "title": "Deleted Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "deleted_count"
+        ],
+        "title": "CleanupExecuteResponse",
+        "type": "object"
+      },
+      "CleanupPreviewRequest": {
+        "properties": {
+          "age_days": {
+            "default": 30,
+            "description": "Threshold for stale_age strategy",
+            "maximum": 365.0,
+            "minimum": 1.0,
+            "title": "Age Days",
+            "type": "integer"
+          },
+          "llm_confidence_threshold": {
+            "default": 0.92,
+            "description": "Confidence threshold for llm_relevance",
+            "maximum": 1.0,
+            "minimum": 0.5,
+            "title": "Llm Confidence Threshold",
+            "type": "number"
+          },
+          "overdue_days": {
+            "default": 7,
+            "description": "Threshold for overdue strategy",
+            "maximum": 365.0,
+            "minimum": 1.0,
+            "title": "Overdue Days",
+            "type": "integer"
+          },
+          "similarity_threshold": {
+            "default": 0.92,
+            "description": "Similarity threshold for semantic_dedup",
+            "maximum": 1.0,
+            "minimum": 0.5,
+            "title": "Similarity Threshold",
+            "type": "number"
+          },
+          "strategies": {
+            "default": [
+              "stale_age"
+            ],
+            "description": "Strategies to apply: stale_age, overdue, semantic_dedup, llm_relevance, conversation_context, vague",
+            "items": {
+              "type": "string"
+            },
+            "title": "Strategies",
+            "type": "array"
+          }
+        },
+        "title": "CleanupPreviewRequest",
+        "type": "object"
+      },
+      "CleanupPreviewResponse": {
+        "properties": {
+          "breakdown": {
+            "additionalProperties": true,
+            "title": "Breakdown",
+            "type": "object"
+          },
+          "candidate_ids": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Candidate Ids",
+            "type": "array"
+          },
+          "candidate_meta": {
+            "items": {
+              "$ref": "#/components/schemas/CleanupCandidateMeta"
+            },
+            "title": "Candidate Meta",
+            "type": "array"
+          },
+          "expires_in_seconds": {
+            "title": "Expires In Seconds",
+            "type": "integer"
+          },
+          "sample": {
+            "items": {
+              "$ref": "#/components/schemas/CleanupSampleItem"
+            },
+            "title": "Sample",
+            "type": "array"
+          },
+          "session_id": {
+            "title": "Session Id",
+            "type": "string"
+          },
+          "total_candidates": {
+            "title": "Total Candidates",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "session_id",
+          "total_candidates",
+          "breakdown",
+          "sample",
+          "candidate_ids",
+          "candidate_meta",
+          "expires_in_seconds"
+        ],
+        "title": "CleanupPreviewResponse",
+        "type": "object"
+      },
+      "CleanupSampleItem": {
+        "properties": {
+          "description": {
+            "title": "Description",
+            "type": "string"
+          },
+          "strategy": {
+            "title": "Strategy",
+            "type": "string"
+          }
+        },
+        "required": [
+          "description",
+          "strategy"
+        ],
+        "title": "CleanupSampleItem",
+        "type": "object"
+      },
       "ClickUpListsResponse": {
         "properties": {
           "lists": {
@@ -30253,6 +30417,182 @@
           }
         ],
         "summary": "Batch Delete Action Items",
+        "tags": [
+          "action-items"
+        ]
+      }
+    },
+    "/v1/action-items/cleanup/execute": {
+      "post": {
+        "description": "Delete the candidates staged by a prior preview call.\nFalls back to recomputing if the session has expired.",
+        "operationId": "cleanup_execute_v1_action_items_cleanup_execute_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Platform",
+            "required": false,
+            "schema": {
+              "title": "X-App-Platform",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Device-Id-Hash",
+            "required": false,
+            "schema": {
+              "title": "X-Device-Id-Hash",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Version",
+            "required": false,
+            "schema": {
+              "title": "X-App-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CleanupExecuteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CleanupExecuteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Cleanup Execute",
+        "tags": [
+          "action-items"
+        ]
+      }
+    },
+    "/v1/action-items/cleanup/preview": {
+      "post": {
+        "description": "Compute cleanup candidates and stage them server-side.\nReturns a session_id, summary counts, and a small sample for user review.\nDoes not delete anything.",
+        "operationId": "cleanup_preview_v1_action_items_cleanup_preview_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Platform",
+            "required": false,
+            "schema": {
+              "title": "X-App-Platform",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Device-Id-Hash",
+            "required": false,
+            "schema": {
+              "title": "X-Device-Id-Hash",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Version",
+            "required": false,
+            "schema": {
+              "title": "X-App-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CleanupPreviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CleanupPreviewResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Cleanup Preview",
         "tags": [
           "action-items"
         ]

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -18615,4 +18615,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 435 client methods generated.
+// Total: 437 client methods generated.

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -1046,6 +1046,49 @@ export interface CleanerMemory {
   reviewed_source?: string | null;
 }
 
+export interface CleanupCandidateMeta {
+  description: string;
+  id: string;
+  strategy: string;
+}
+
+export interface CleanupExecuteRequest {
+  excluded_ids?: Array<string>;
+  session_id: string;
+}
+
+export interface CleanupExecuteResponse {
+  deleted_count: number;
+}
+
+export interface CleanupPreviewRequest {
+  age_days?: number;
+  llm_confidence_threshold?: number;
+  overdue_days?: number;
+  scan_cursor?: string | null;
+  similarity_threshold?: number;
+  strategies?: Array<string>;
+}
+
+export interface CleanupPreviewResponse {
+  breakdown: Record<string, unknown>;
+  candidate_ids: Array<string>;
+  candidate_meta: Array<CleanupCandidateMeta>;
+  expires_in_seconds: number;
+  next_scan_cursor?: string | null;
+  sample: Array<CleanupSampleItem>;
+  scan_cap: number;
+  scan_truncated: boolean;
+  session_id: string;
+  total_candidates: number;
+  total_open_action_items: number;
+}
+
+export interface CleanupSampleItem {
+  description: string;
+  strategy: string;
+}
+
 export interface ClickUpListsResponse {
   lists?: Array<Record<string, unknown>>;
 }
@@ -4968,6 +5011,12 @@ export interface OmiApiSchemas {
   "CheckVerificationRequest": CheckVerificationRequest;
   "CheckVerificationResponse": CheckVerificationResponse;
   "CleanerMemory": CleanerMemory;
+  "CleanupCandidateMeta": CleanupCandidateMeta;
+  "CleanupExecuteRequest": CleanupExecuteRequest;
+  "CleanupExecuteResponse": CleanupExecuteResponse;
+  "CleanupPreviewRequest": CleanupPreviewRequest;
+  "CleanupPreviewResponse": CleanupPreviewResponse;
+  "CleanupSampleItem": CleanupSampleItem;
   "ClickUpListsResponse": ClickUpListsResponse;
   "ClickUpSpacesResponse": ClickUpSpacesResponse;
   "ClickUpTeamsResponse": ClickUpTeamsResponse;
@@ -5547,6 +5596,26 @@ export interface OmiApiPaths {
       operationId: "batch_delete_action_items_v1_action_items_batch_delete_post";
       responses: {
         "200": BatchDeleteActionItemsResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/action-items/cleanup/execute": {
+    post: {
+      operationId: "cleanup_execute_v1_action_items_cleanup_execute_post";
+      responses: {
+        "200": CleanupExecuteResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/action-items/cleanup/preview": {
+    post: {
+      operationId: "cleanup_preview_v1_action_items_cleanup_preview_post";
+      responses: {
+        "200": CleanupPreviewResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -10011,6 +10080,48 @@ export async function batch_update_action_items_v1_action_items_batch_patch(head
 export async function batch_delete_action_items_v1_action_items_batch_delete_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: BatchDeleteActionItemsRequest, init?: OmiApiClientInit): Promise<BatchDeleteActionItemsResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/action-items/batch-delete`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function cleanup_execute_v1_action_items_cleanup_execute_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: CleanupExecuteRequest, init?: OmiApiClientInit): Promise<CleanupExecuteResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/action-items/cleanup/execute`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function cleanup_preview_v1_action_items_cleanup_preview_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: CleanupPreviewRequest, init?: OmiApiClientInit): Promise<CleanupPreviewResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/action-items/cleanup/preview`;
   const _search = "";
   const _res = await fetch(`${_base}${_path}${_search}`, {
     method: "POST",

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -18615,4 +18615,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 435 client methods generated.
+// Total: 437 client methods generated.

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -1046,6 +1046,49 @@ export interface CleanerMemory {
   reviewed_source?: string | null;
 }
 
+export interface CleanupCandidateMeta {
+  description: string;
+  id: string;
+  strategy: string;
+}
+
+export interface CleanupExecuteRequest {
+  excluded_ids?: Array<string>;
+  session_id: string;
+}
+
+export interface CleanupExecuteResponse {
+  deleted_count: number;
+}
+
+export interface CleanupPreviewRequest {
+  age_days?: number;
+  llm_confidence_threshold?: number;
+  overdue_days?: number;
+  scan_cursor?: string | null;
+  similarity_threshold?: number;
+  strategies?: Array<string>;
+}
+
+export interface CleanupPreviewResponse {
+  breakdown: Record<string, unknown>;
+  candidate_ids: Array<string>;
+  candidate_meta: Array<CleanupCandidateMeta>;
+  expires_in_seconds: number;
+  next_scan_cursor?: string | null;
+  sample: Array<CleanupSampleItem>;
+  scan_cap: number;
+  scan_truncated: boolean;
+  session_id: string;
+  total_candidates: number;
+  total_open_action_items: number;
+}
+
+export interface CleanupSampleItem {
+  description: string;
+  strategy: string;
+}
+
 export interface ClickUpListsResponse {
   lists?: Array<Record<string, unknown>>;
 }
@@ -4968,6 +5011,12 @@ export interface OmiApiSchemas {
   "CheckVerificationRequest": CheckVerificationRequest;
   "CheckVerificationResponse": CheckVerificationResponse;
   "CleanerMemory": CleanerMemory;
+  "CleanupCandidateMeta": CleanupCandidateMeta;
+  "CleanupExecuteRequest": CleanupExecuteRequest;
+  "CleanupExecuteResponse": CleanupExecuteResponse;
+  "CleanupPreviewRequest": CleanupPreviewRequest;
+  "CleanupPreviewResponse": CleanupPreviewResponse;
+  "CleanupSampleItem": CleanupSampleItem;
   "ClickUpListsResponse": ClickUpListsResponse;
   "ClickUpSpacesResponse": ClickUpSpacesResponse;
   "ClickUpTeamsResponse": ClickUpTeamsResponse;
@@ -5547,6 +5596,26 @@ export interface OmiApiPaths {
       operationId: "batch_delete_action_items_v1_action_items_batch_delete_post";
       responses: {
         "200": BatchDeleteActionItemsResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/action-items/cleanup/execute": {
+    post: {
+      operationId: "cleanup_execute_v1_action_items_cleanup_execute_post";
+      responses: {
+        "200": CleanupExecuteResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/action-items/cleanup/preview": {
+    post: {
+      operationId: "cleanup_preview_v1_action_items_cleanup_preview_post";
+      responses: {
+        "200": CleanupPreviewResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -10011,6 +10080,48 @@ export async function batch_update_action_items_v1_action_items_batch_patch(head
 export async function batch_delete_action_items_v1_action_items_batch_delete_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: BatchDeleteActionItemsRequest, init?: OmiApiClientInit): Promise<BatchDeleteActionItemsResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/action-items/batch-delete`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function cleanup_execute_v1_action_items_cleanup_execute_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: CleanupExecuteRequest, init?: OmiApiClientInit): Promise<CleanupExecuteResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/action-items/cleanup/execute`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function cleanup_preview_v1_action_items_cleanup_preview_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: CleanupPreviewRequest, init?: OmiApiClientInit): Promise<CleanupPreviewResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/action-items/cleanup/preview`;
   const _search = "";
   const _res = await fetch(`${_base}${_path}${_search}`, {
     method: "POST",

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -18615,4 +18615,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 435 client methods generated.
+// Total: 437 client methods generated.

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -1046,6 +1046,49 @@ export interface CleanerMemory {
   reviewed_source?: string | null;
 }
 
+export interface CleanupCandidateMeta {
+  description: string;
+  id: string;
+  strategy: string;
+}
+
+export interface CleanupExecuteRequest {
+  excluded_ids?: Array<string>;
+  session_id: string;
+}
+
+export interface CleanupExecuteResponse {
+  deleted_count: number;
+}
+
+export interface CleanupPreviewRequest {
+  age_days?: number;
+  llm_confidence_threshold?: number;
+  overdue_days?: number;
+  scan_cursor?: string | null;
+  similarity_threshold?: number;
+  strategies?: Array<string>;
+}
+
+export interface CleanupPreviewResponse {
+  breakdown: Record<string, unknown>;
+  candidate_ids: Array<string>;
+  candidate_meta: Array<CleanupCandidateMeta>;
+  expires_in_seconds: number;
+  next_scan_cursor?: string | null;
+  sample: Array<CleanupSampleItem>;
+  scan_cap: number;
+  scan_truncated: boolean;
+  session_id: string;
+  total_candidates: number;
+  total_open_action_items: number;
+}
+
+export interface CleanupSampleItem {
+  description: string;
+  strategy: string;
+}
+
 export interface ClickUpListsResponse {
   lists?: Array<Record<string, unknown>>;
 }
@@ -4968,6 +5011,12 @@ export interface OmiApiSchemas {
   "CheckVerificationRequest": CheckVerificationRequest;
   "CheckVerificationResponse": CheckVerificationResponse;
   "CleanerMemory": CleanerMemory;
+  "CleanupCandidateMeta": CleanupCandidateMeta;
+  "CleanupExecuteRequest": CleanupExecuteRequest;
+  "CleanupExecuteResponse": CleanupExecuteResponse;
+  "CleanupPreviewRequest": CleanupPreviewRequest;
+  "CleanupPreviewResponse": CleanupPreviewResponse;
+  "CleanupSampleItem": CleanupSampleItem;
   "ClickUpListsResponse": ClickUpListsResponse;
   "ClickUpSpacesResponse": ClickUpSpacesResponse;
   "ClickUpTeamsResponse": ClickUpTeamsResponse;
@@ -5547,6 +5596,26 @@ export interface OmiApiPaths {
       operationId: "batch_delete_action_items_v1_action_items_batch_delete_post";
       responses: {
         "200": BatchDeleteActionItemsResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/action-items/cleanup/execute": {
+    post: {
+      operationId: "cleanup_execute_v1_action_items_cleanup_execute_post";
+      responses: {
+        "200": CleanupExecuteResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/action-items/cleanup/preview": {
+    post: {
+      operationId: "cleanup_preview_v1_action_items_cleanup_preview_post";
+      responses: {
+        "200": CleanupPreviewResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -10011,6 +10080,48 @@ export async function batch_update_action_items_v1_action_items_batch_patch(head
 export async function batch_delete_action_items_v1_action_items_batch_delete_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: BatchDeleteActionItemsRequest, init?: OmiApiClientInit): Promise<BatchDeleteActionItemsResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/action-items/batch-delete`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function cleanup_execute_v1_action_items_cleanup_execute_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: CleanupExecuteRequest, init?: OmiApiClientInit): Promise<CleanupExecuteResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/action-items/cleanup/execute`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function cleanup_preview_v1_action_items_cleanup_preview_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: CleanupPreviewRequest, init?: OmiApiClientInit): Promise<CleanupPreviewResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/action-items/cleanup/preview`;
   const _search = "";
   const _res = await fetch(`${_base}${_path}${_search}`, {
     method: "POST",


### PR DESCRIPTION
## Summary

Adds a two-phase task cleanup system — a backend that runs up to six cleanup strategies server-side, and a Windows desktop modal that lets users review candidates before deleting anything.

### Background

Large accounts accumulate tens of thousands of stale tasks. This surfaces the problem with six targeted strategies while keeping all expensive work server-side — the client makes exactly two HTTP calls regardless of task count.

---

## Backend (`backend/`)

### New router: `backend/routers/action_items_cleanup.py`

**`POST /v1/action-items/cleanup/preview`**
- Runs selected strategies in parallel via `ThreadPoolExecutor`
- Stages candidate IDs in Redis under `cleanup_session:{uid}:{session_id}` with a 5-minute TTL
- Returns: session_id, total count, per-strategy breakdown, a 5-item sample per strategy

**`POST /v1/action-items/cleanup/execute`**
- Loads the staged session and calls `delete_action_items_batch` + `delete_action_item_vectors_batch` + push notification
- Returns: `deleted_count`
- Returns HTTP 410 if the session has expired (client prompts user to re-analyze)

**Bug fix:** added early-return guard when `strategies=[]` to prevent `ThreadPoolExecutor(max_workers=0)` crash.

### New utilities: `backend/utils/action_item_cleanup.py`

Six cleanup strategies:

| Strategy | Type | Description |
|---|---|---|
| `stale_age` | fast / rule-based | Open tasks older than N days with no due date |
| `overdue` | fast / rule-based | Tasks with a due date more than N days in the past |
| `vague` | fast / regex | Tasks with unresolved pronouns ("put it away", "fix those", "Speaker 1:") |
| `semantic_dedup` | slow / Pinecone | Cosine-similarity dedup (≥0.92); keeps newest, marks older as candidate |
| `llm_relevance` | slow / LLM | Batch LLM scoring for staleness/actionability (batches of 50) |
| `conversation_context` | slow / LLM | LLM uses source conversation title/overview to judge staleness |

`merge_candidates(lists)` deduplicates across strategies by ID, preserving first-appearance order.

### New database helper: `backend/database/vector_db.py`

`fetch_action_item_vectors(uid, action_item_ids)` — batched Pinecone fetch (100 IDs/call) needed by semantic dedup.

### Router wired in `backend/main.py`

Added `action_items_cleanup` import and `app.include_router(action_items_cleanup.router)` after `action_items.router`.

---

## Windows Desktop (`desktop/windows/`)

### New: `src/renderer/src/lib/taskCleanup.ts`

Thin `omiApi` wrapper with typed params/results:
- `taskCleanupPreview(params)` — 180 s timeout (LLM strategies over large accounts)
- `taskCleanupExecute(sessionId)` — standard timeout

### New: `src/renderer/src/components/settings/TaskCleanupModal.tsx`

Four-phase modal (`config → loading → preview → deleting`):
- **Config**: checkboxes for each strategy; fast strategies checked by default; "slow" badge + amber warning when any AI strategy is selected
- **Loading**: spinner; copy varies when slow strategies are running
- **Preview**: count, per-strategy breakdown, scrollable sample list with strategy badges, session expiry notice, red "Delete N tasks" CTA
- **Deleting**: spinner; modal non-dismissible (`dismissible={!isDeleting}`) while in flight
- 410 handling: toast "Session expired — please analyze again" → back to config
- On success: `window.omi.tasksReconcile()` to sync task list + success toast

### Modified: `src/renderer/src/components/settings/tabs/AdvancedTab.tsx`

Added "Task maintenance" `SettingRow` (icon: Trash2) in the Advanced settings tab that opens the cleanup modal.

---

## Tests (41 added)

### Backend unit — `backend/tests/unit/test_action_item_cleanup_strategies.py` (26 tests)

Uses `load_module_fresh` + `stub_modules` + `AutoMockModule` to isolate the module from Pinecone/Firebase/LangChain import-time bindings:
- `TestIsVague` (7): pronoun-short, imperative+dangling, speaker label, normal long desc, etc.
- `TestCandidatesStaleAge` (6): old/young, has-due-at, conversation-date priority, young-conv suppresses, None-created_at skip
- `TestCandidatesOverdue` (4)
- `TestCandidatesVague` (4)
- `TestMergeCandidates` (5): dedup, order preservation, empty input

### Backend unit — `backend/tests/unit/test_action_items_cleanup_router.py` (10 tests)

- Preview: session staging, breakdown shape, sample cap, two-strategy breakdown, failed-strategy zero-out
- Execute: count returned, 410 on expired session, empty-list short-circuit

### Frontend — `src/renderer/src/lib/taskCleanup.test.ts` (5 tests)

vitest + `vi.hoisted` + `vi.mock`:
- Correct endpoint URLs, request body forwarding, 180 s timeout on preview, no timeout on execute

---

Failure-Class: none

## Product invariants affected

- INV-CUTOVER-1 — regenerated app-client files include cutover-gated paths; no cutover logic changed
- INV-AGENT-* — regenerated clients include agent control-plane types; no agent behavior changed
- INV-AUTH-1 — regenerated desktop auth session surfaces; no auth logic changed
- INV-CHAT-1 — regenerated clients include chat types; no chat continuity path changed
- INV-BETA-1 — regenerated desktop beta identity surfaces; no beta identity logic changed
- INV-NAV-1 — regenerated macOS shell parity surfaces; no navigation logic changed
- INV-VOICE-1 — regenerated clients include voice types; no voice-turn path changed
- INV-INT-1 — regenerated clients include integration types; no integration path changed
- INV-MEM-4 — regenerated clients include memory types; no memory promotion path changed
- INV-MEM-1 — regenerated clients include memory-tier types; no memory tier logic changed
- INV-TASK-2 — `backend/config/task_intelligence_sources_v1.json` updated to register the cleanup router as a known action-item writer; no automatic task capture path touched
- INV-TASK-1 — Windows settings TaskCleanupModal reads and deletes existing tasks; no dated-bucket completeness logic changed

## Test plan

- [ ] `cd backend && python -m pytest tests/unit/test_action_item_cleanup_strategies.py tests/unit/test_action_items_cleanup_router.py -v` — all 36 pass
- [ ] `cd desktop/windows && pnpm test src/renderer/src/lib/taskCleanup.test.ts` — all 5 pass
- [ ] Settings → Advanced → "Clean up tasks…" opens the modal; fast strategies pre-checked
- [ ] Select only fast strategies → "Analyze" → preview shows count, breakdown, sample in ~2 s
- [ ] "Delete N tasks" → tasks removed, task list syncs, toast confirms
- [ ] Let session expire (5 min) → "Delete" returns 410 → toast "Session expired — please analyze again"
- [ ] Select a slow strategy → amber warning appears → analysis completes within 180 s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCp5LUrL4FLcaLUkdDg49p

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

Line-Count-Exception: backend/database/action_items.py | 1543 -> 1575 | Re-exports added to fix pyright reportPrivateUsage for callers of action_items_cleanup_scan