### PR TITLE
docs(desktop-windows): update AGENTS.md with Node 22 pin, Wayland notes, and parity audit

### DIFF
--- a/desktop/windows/AGENTS.md
+++ b/desktop/windows/AGENTS.md
@@ -22,10 +22,10 @@ in those three files with no matching commit, this is almost certainly why;
 If your local `pnpm --version` is a different major (e.g. a system package
 manager installed 11+), `.npmrc`'s `node-linker=hoisted` may be silently
 ignored, breaking the pi-mono dependency-closure postinstall check
-(`scripts/verify-pimono-unpack.mjs`) with a confusing "closure package(s) do
+(`scripts/verify-pimono-unpack.mjs`) with "closure package(s) do
 not resolve on disk" error. Use `npx pnpm@10 <command>` if your system pnpm
 is a different major version — don't downgrade a system-managed pnpm install
-for this alone. **Node pin:** `>=22.19.0 <23` (`.nvmrc`; Node 24+ breaks vitest jsdom — `pretest` calls `scripts/check-node-version.mjs`).
+for this alone. **Node pin:** `>=22.19.0 <23` (`.nvmrc`; 24+ fails pretest).
 
 ## Development Workflow
 

--- a/desktop/windows/AGENTS.md
+++ b/desktop/windows/AGENTS.md
@@ -25,8 +25,7 @@ ignored, breaking the pi-mono dependency-closure postinstall check
 (`scripts/verify-pimono-unpack.mjs`) with a confusing "closure package(s) do
 not resolve on disk" error. Use `npx pnpm@10 <command>` if your system pnpm
 is a different major version — don't downgrade a system-managed pnpm install
-for this alone.
-**Node version pin:** `>=22.19.0 <23` — `.nvmrc` sets it for `nvm use`; Node 24+ breaks vitest (jsdom localStorage shadow) — `pretest` calls `scripts/check-node-version.mjs`.
+for this alone. **Node pin:** `>=22.19.0 <23` (`.nvmrc`; Node 24+ breaks vitest jsdom — `pretest` calls `scripts/check-node-version.mjs`).
 
 ## Development Workflow
 

--- a/desktop/windows/AGENTS.md
+++ b/desktop/windows/AGENTS.md
@@ -26,6 +26,7 @@ ignored, breaking the pi-mono dependency-closure postinstall check
 not resolve on disk" error. Use `npx pnpm@10 <command>` if your system pnpm
 is a different major version — don't downgrade a system-managed pnpm install
 for this alone.
+**Node version pin:** `>=22.19.0 <23` — `.nvmrc` sets it for `nvm use`; Node 24+ breaks vitest (jsdom localStorage shadow) — `pretest` calls `scripts/check-node-version.mjs`.
 
 ## Development Workflow
 


### PR DESCRIPTION
## Summary

Comprehensive update to the Windows/Linux desktop `AGENTS.md` documentation:

- Documents the Node 22.19+ pin in `AGENTS.md` and adds `.nvmrc`
- Documents Wayland blank-window and floating-window quirks for Linux devs
- Re-audits and updates parity-audit files 01-14 against current source
- Adds parity-audit sequencing/effort plan
- Strips trailing whitespace in mac-parity-audit files

## Test plan

- [ ] Verify `.nvmrc` pins to Node 22
- [ ] Review AGENTS.md Wayland section for accuracy on a Linux dev machine
- [ ] Check that parity audit file updates reflect current feature state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

