### PR TITLE
fix(web-app): keep the tasks bulk bar from overflowing at mid widths

### DIFF
--- a/web/app/src/components/tasks/BulkActionBar.tsx
+++ b/web/app/src/components/tasks/BulkActionBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Check,
@@ -15,6 +15,7 @@ import {
   FileCode,
   CheckSquare,
   Square,
+  MoreHorizontal,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { ActionItem } from '@/types/conversation';
@@ -28,15 +29,155 @@ interface BulkActionBarProps {
   onClear: () => void;
   onCopy?: () => void;
   onExport?: (format: 'csv' | 'json' | 'markdown') => void;
-  // Inline mode props
   inline?: boolean;
   onSelectAll?: () => void;
   onDone?: () => void;
   allSelected?: boolean;
   totalCount?: number;
-  // Hide task-specific actions (for use in Memories, etc.)
   hideComplete?: boolean;
   hideSnooze?: boolean;
+}
+
+type OpenMenu = 'snooze' | 'export' | 'overflow' | null;
+type ExportFormat = 'csv' | 'json' | 'markdown';
+
+const menuPanelClass =
+  'z-50 rounded-lg border border-bg-tertiary bg-bg-secondary py-1 shadow-lg shadow-black/20';
+const menuItemClass =
+  'flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-left text-sm text-text-secondary hover:bg-bg-tertiary';
+
+const SNOOZE_OPTIONS = [
+  { days: 0, label: 'Today' },
+  { days: 1, label: 'Tomorrow' },
+  { days: 7, label: 'Next week' },
+] as const;
+
+const EXPORT_OPTIONS = [
+  { format: 'csv' as const, label: 'CSV', Icon: FileText },
+  { format: 'json' as const, label: 'JSON', Icon: FileJson },
+  { format: 'markdown' as const, label: 'Markdown', Icon: FileCode },
+];
+
+function MenuPanel({
+  inline,
+  align = 'start',
+  className,
+  role,
+  children,
+}: {
+  inline: boolean;
+  align?: 'start' | 'end';
+  className?: string;
+  role?: string;
+  children: ReactNode;
+}) {
+  return (
+    <motion.div
+      role={role}
+      initial={{ opacity: 0, y: 5 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 5 }}
+      transition={{ duration: 0.15 }}
+      className={cn(
+        inline ? 'absolute top-full mt-2' : 'absolute bottom-full mb-2',
+        align === 'end' ? 'right-0' : 'left-0',
+        menuPanelClass,
+        className,
+      )}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+function MenuItem({
+  children,
+  className,
+  role,
+  onClick,
+}: {
+  children: ReactNode;
+  className?: string;
+  role?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role={role}
+      onClick={onClick}
+      className={cn(menuItemClass, className)}
+    >
+      {children}
+    </button>
+  );
+}
+
+function MenuLabel({ children }: { children: ReactNode }) {
+  return (
+    <p className="px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-text-quaternary">
+      {children}
+    </p>
+  );
+}
+
+function MenuSeparator({ className }: { className?: string }) {
+  return <div className={cn('my-1 h-px bg-bg-tertiary', className)} role="separator" />;
+}
+
+function SnoozeItems({
+  onSnooze,
+  onDone,
+  menuitem,
+}: {
+  onSnooze: (days: number) => void;
+  onDone: () => void;
+  menuitem?: boolean;
+}) {
+  return (
+    <>
+      {SNOOZE_OPTIONS.map(({ days, label }) => (
+        <MenuItem
+          key={days}
+          role={menuitem ? 'menuitem' : undefined}
+          onClick={() => {
+            onSnooze(days);
+            onDone();
+          }}
+        >
+          {label}
+        </MenuItem>
+      ))}
+    </>
+  );
+}
+
+function ExportItems({
+  onExport,
+  onDone,
+  menuitem,
+}: {
+  onExport: (format: ExportFormat) => void;
+  onDone: () => void;
+  menuitem?: boolean;
+}) {
+  return (
+    <>
+      {EXPORT_OPTIONS.map(({ format, label, Icon }) => (
+        <MenuItem
+          key={format}
+          role={menuitem ? 'menuitem' : undefined}
+          onClick={() => {
+            onExport(format);
+            onDone();
+          }}
+        >
+          <Icon className="h-3.5 w-3.5" />
+          {label}
+        </MenuItem>
+      ))}
+    </>
+  );
 }
 
 export function BulkActionBar({
@@ -56,16 +197,49 @@ export function BulkActionBar({
   hideComplete = false,
   hideSnooze = false,
 }: BulkActionBarProps) {
-  const [showSnoozeMenu, setShowSnoozeMenu] = useState(false);
-  const [showExportMenu, setShowExportMenu] = useState(false);
+  const [openMenu, setOpenMenu] = useState<OpenMenu>(null);
+  const snoozeRef = useRef<HTMLDivElement>(null);
+  const exportRef = useRef<HTMLDivElement>(null);
+  const overflowRef = useRef<HTMLDivElement>(null);
 
-  // For inline mode, always show the bar (it's part of the page layout)
-  // For floating mode, hide when nothing selected
+  const closeMenu = () => setOpenMenu(null);
+  const toggleMenu = (menu: Exclude<OpenMenu, null>) => {
+    setOpenMenu((current) => (current === menu ? null : menu));
+  };
+
+  useEffect(() => {
+    if (!openMenu) return;
+
+    const root =
+      openMenu === 'snooze'
+        ? snoozeRef.current
+        : openMenu === 'export'
+          ? exportRef.current
+          : overflowRef.current;
+
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (root?.contains(target)) return;
+      closeMenu();
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') closeMenu();
+    };
+
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [openMenu]);
+
   if (!inline && selectedCount === 0) return null;
 
   const content = (
     <>
-      {/* Select All - only in inline mode */}
       {inline && onSelectAll && (
         <>
           <button
@@ -89,7 +263,6 @@ export function BulkActionBar({
         </>
       )}
 
-      {/* Selection count */}
       <div className="flex items-center gap-2">
         <span className="text-sm font-medium text-text-primary">
           {selectedCount} selected
@@ -105,16 +278,14 @@ export function BulkActionBar({
         )}
       </div>
 
-      {/* Divider */}
       <div className="w-px h-6 bg-bg-tertiary" />
 
-      {/* Actions */}
       <div className="flex items-center gap-2">
-        {/* Snooze dropdown - hidden when hideSnooze is true */}
         {!hideSnooze && onSnooze && (
-          <div className="relative">
+          <div ref={snoozeRef} className="relative hidden min-[1200px]:block">
             <button
-              onClick={() => setShowSnoozeMenu(!showSnoozeMenu)}
+              type="button"
+              onClick={() => toggleMenu('snooze')}
               disabled={selectedCount === 0}
               className={cn(
                 'flex items-center gap-1.5 px-3 py-1.5 rounded-lg',
@@ -129,63 +300,22 @@ export function BulkActionBar({
               <ChevronDown className="w-3 h-3" />
             </button>
 
-            {/* Dropdown menu */}
             <AnimatePresence>
-              {showSnoozeMenu && (
-                <motion.div
-                  initial={{ opacity: 0, y: 5 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: 5 }}
-                  transition={{ duration: 0.15 }}
-                  className={cn(
-                    inline
-                      ? 'absolute top-full mt-2 left-0'
-                      : 'absolute bottom-full mb-2 left-0',
-                    'bg-bg-secondary border border-bg-tertiary rounded-lg',
-                    'shadow-lg shadow-black/20',
-                    'py-1 min-w-[120px] z-50',
-                  )}
-                >
-                  <button
-                    onClick={() => {
-                      onSnooze(0);
-                      setShowSnoozeMenu(false);
-                    }}
-                    className="w-full px-3 py-1.5 text-left text-sm text-text-secondary hover:bg-bg-tertiary"
-                  >
-                    Today
-                  </button>
-                  <button
-                    onClick={() => {
-                      onSnooze(1);
-                      setShowSnoozeMenu(false);
-                    }}
-                    className="w-full px-3 py-1.5 text-left text-sm text-text-secondary hover:bg-bg-tertiary"
-                  >
-                    Tomorrow
-                  </button>
-                  <button
-                    onClick={() => {
-                      onSnooze(7);
-                      setShowSnoozeMenu(false);
-                    }}
-                    className="w-full px-3 py-1.5 text-left text-sm text-text-secondary hover:bg-bg-tertiary"
-                  >
-                    Next week
-                  </button>
-                </motion.div>
+              {openMenu === 'snooze' && (
+                <MenuPanel inline={inline} className="min-w-[120px]">
+                  <SnoozeItems onSnooze={onSnooze} onDone={closeMenu} />
+                </MenuPanel>
               )}
             </AnimatePresence>
           </div>
         )}
 
-        {/* Complete button - hidden when hideComplete is true */}
         {!hideComplete && onComplete && (
           <button
             onClick={onComplete}
             disabled={selectedCount === 0}
             className={cn(
-              'flex items-center gap-1.5 px-3 py-1.5 rounded-lg',
+              'hidden min-[1430px]:flex items-center gap-1.5 px-3 py-1.5 rounded-lg',
               'bg-success/20 hover:bg-success/30',
               'text-success text-sm',
               'transition-colors',
@@ -197,12 +327,11 @@ export function BulkActionBar({
           </button>
         )}
 
-        {/* Delete button */}
         <button
           onClick={onDelete}
           disabled={selectedCount === 0}
           className={cn(
-            'flex items-center gap-1.5 px-3 py-1.5 rounded-lg',
+            'hidden min-[1430px]:flex items-center gap-1.5 px-3 py-1.5 rounded-lg',
             'bg-error/20 hover:bg-error/30',
             'text-error text-sm',
             'transition-colors',
@@ -213,16 +342,16 @@ export function BulkActionBar({
           <span>Delete</span>
         </button>
 
-        {/* Divider */}
-        {(onCopy || onExport) && <div className="w-px h-6 bg-bg-tertiary" />}
+        {(onCopy || onExport) && (
+          <div className="hidden h-6 w-px shrink-0 bg-bg-tertiary min-[1600px]:block" />
+        )}
 
-        {/* Copy button */}
         {onCopy && (
           <button
             onClick={onCopy}
             disabled={selectedCount === 0}
             className={cn(
-              'flex items-center gap-1.5 px-3 py-1.5 rounded-lg',
+              'hidden min-[1600px]:flex items-center gap-1.5 px-3 py-1.5 rounded-lg',
               'bg-bg-tertiary hover:bg-bg-quaternary',
               'text-text-secondary text-sm',
               'transition-colors',
@@ -235,11 +364,11 @@ export function BulkActionBar({
           </button>
         )}
 
-        {/* Export dropdown */}
         {onExport && (
-          <div className="relative">
+          <div ref={exportRef} className="relative hidden min-[1600px]:block">
             <button
-              onClick={() => setShowExportMenu(!showExportMenu)}
+              type="button"
+              onClick={() => toggleMenu('export')}
               disabled={selectedCount === 0}
               className={cn(
                 'flex items-center gap-1.5 px-3 py-1.5 rounded-lg',
@@ -254,61 +383,17 @@ export function BulkActionBar({
               <ChevronDown className="w-3 h-3" />
             </button>
 
-            {/* Export dropdown menu */}
             <AnimatePresence>
-              {showExportMenu && (
-                <motion.div
-                  initial={{ opacity: 0, y: 5 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: 5 }}
-                  transition={{ duration: 0.15 }}
-                  className={cn(
-                    inline
-                      ? 'absolute top-full mt-2 right-0'
-                      : 'absolute bottom-full mb-2 right-0',
-                    'bg-bg-secondary border border-bg-tertiary rounded-lg',
-                    'shadow-lg shadow-black/20',
-                    'py-1 min-w-[140px] z-50',
-                  )}
-                >
-                  <button
-                    onClick={() => {
-                      onExport('csv');
-                      setShowExportMenu(false);
-                    }}
-                    className="w-full px-3 py-1.5 text-left text-sm text-text-secondary hover:bg-bg-tertiary flex items-center gap-2"
-                  >
-                    <FileText className="w-3.5 h-3.5" />
-                    CSV
-                  </button>
-                  <button
-                    onClick={() => {
-                      onExport('json');
-                      setShowExportMenu(false);
-                    }}
-                    className="w-full px-3 py-1.5 text-left text-sm text-text-secondary hover:bg-bg-tertiary flex items-center gap-2"
-                  >
-                    <FileJson className="w-3.5 h-3.5" />
-                    JSON
-                  </button>
-                  <button
-                    onClick={() => {
-                      onExport('markdown');
-                      setShowExportMenu(false);
-                    }}
-                    className="w-full px-3 py-1.5 text-left text-sm text-text-secondary hover:bg-bg-tertiary flex items-center gap-2"
-                  >
-                    <FileCode className="w-3.5 h-3.5" />
-                    Markdown
-                  </button>
-                </motion.div>
+              {openMenu === 'export' && (
+                <MenuPanel inline={inline} align="end" className="min-w-[140px]">
+                  <ExportItems onExport={onExport} onDone={closeMenu} />
+                </MenuPanel>
               )}
             </AnimatePresence>
           </div>
         )}
       </div>
 
-      {/* Done button - only in inline mode */}
       {inline && onDone && (
         <>
           <div className="w-px h-6 bg-bg-tertiary ml-auto" />
@@ -325,10 +410,95 @@ export function BulkActionBar({
           </button>
         </>
       )}
+
+      {(onCopy || onExport) && (
+        <div ref={overflowRef} className="relative">
+          <button
+            type="button"
+            aria-label="More actions"
+            aria-haspopup="menu"
+            aria-expanded={openMenu === 'overflow'}
+            disabled={selectedCount === 0}
+            onClick={() => toggleMenu('overflow')}
+            className={cn(
+              'flex items-center justify-center rounded-lg p-1.5 min-[1600px]:hidden',
+              'bg-bg-tertiary hover:bg-bg-quaternary',
+              'text-text-secondary',
+              'transition-colors',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </button>
+          <AnimatePresence>
+            {openMenu === 'overflow' && (
+              <MenuPanel
+                inline={inline}
+                align="end"
+                role="menu"
+                className="min-w-[140px]"
+              >
+                {!hideSnooze && onSnooze && (
+                  <div className="hidden max-[1199px]:block">
+                    <MenuLabel>Snooze</MenuLabel>
+                    <SnoozeItems onSnooze={onSnooze} onDone={closeMenu} menuitem />
+                    <MenuSeparator />
+                  </div>
+                )}
+                {!hideComplete && onComplete && (
+                  <MenuItem
+                    role="menuitem"
+                    onClick={() => {
+                      onComplete();
+                      closeMenu();
+                    }}
+                    className="hidden text-success hover:bg-success/10 max-[1429px]:flex"
+                  >
+                    <Check className="h-3.5 w-3.5" />
+                    Complete
+                  </MenuItem>
+                )}
+                <MenuItem
+                  role="menuitem"
+                  onClick={() => {
+                    onDelete();
+                    closeMenu();
+                  }}
+                  className="hidden text-error hover:bg-error/10 max-[1429px]:flex"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                  Delete
+                </MenuItem>
+                {(onCopy || onExport) && (
+                  <MenuSeparator className="hidden max-[1429px]:block" />
+                )}
+                {onCopy && (
+                  <MenuItem
+                    role="menuitem"
+                    onClick={() => {
+                      onCopy();
+                      closeMenu();
+                    }}
+                  >
+                    <Copy className="h-3.5 w-3.5" />
+                    Copy
+                  </MenuItem>
+                )}
+                {onCopy && onExport && <MenuSeparator />}
+                {onExport && (
+                  <>
+                    <MenuLabel>Export</MenuLabel>
+                    <ExportItems onExport={onExport} onDone={closeMenu} menuitem />
+                  </>
+                )}
+              </MenuPanel>
+            )}
+          </AnimatePresence>
+        </div>
+      )}
     </>
   );
 
-  // Inline mode - normal flow layout
   if (inline) {
     return (
       <motion.div
@@ -346,7 +516,6 @@ export function BulkActionBar({
     );
   }
 
-  // Floating mode - fixed position at bottom
   return (
     <AnimatePresence>
       <motion.div

--- a/web/app/src/components/tasks/__tests__/BulkActionBar.test.tsx
+++ b/web/app/src/components/tasks/__tests__/BulkActionBar.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { BulkActionBar } from '@/components/tasks/BulkActionBar';
+
+function renderBar(onCopy = vi.fn()) {
+  render(
+    <BulkActionBar
+      inline
+      selectedCount={1}
+      onComplete={vi.fn()}
+      onDelete={vi.fn()}
+      onSnooze={vi.fn()}
+      onClear={vi.fn()}
+      onCopy={onCopy}
+      onExport={vi.fn()}
+      onSelectAll={vi.fn()}
+      onDone={vi.fn()}
+    />,
+  );
+  return { onCopy, user: userEvent.setup() };
+}
+
+describe('BulkActionBar', () => {
+  it('parks Copy and Export behind the more menu below 1600px', async () => {
+    const { onCopy, user } = renderBar();
+
+    const more = screen.getByRole('button', { name: 'More actions' });
+    expect(more.className).toMatch(/min-\[1600px\]:hidden/);
+    expect(screen.getByRole('button', { name: 'Copy' }).className).toMatch(
+      /min-\[1600px\]:flex/,
+    );
+
+    expect(screen.getByRole('button', { name: 'Complete' }).className).toMatch(
+      /min-\[1430px\]:flex/,
+    );
+    expect(screen.getByRole('button', { name: 'Snooze' }).parentElement).toHaveClass(
+      'min-[1200px]:block',
+    );
+
+    await user.click(more);
+    const menu = screen.getByRole('menu');
+    expect(within(menu).getByText('Export')).toBeInTheDocument();
+    expect(menu.className).toMatch(/bg-bg-secondary/);
+    expect(menu.className).toMatch(/rounded-lg/);
+    expect(screen.getByRole('menuitem', { name: 'Copy' }).className).toMatch(
+      /cursor-pointer/,
+    );
+    await user.click(screen.getByRole('menuitem', { name: 'Copy' }));
+    expect(onCopy).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the more menu on outside click', async () => {
+    const { user } = renderBar();
+
+    await user.click(screen.getByRole('button', { name: 'More actions' }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Select All' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION

## What changed and why

The tasks bulk bar overflowed at mid widths. Copy/Export now sit behind a ⋯ menu below 1600px, Complete/Delete below 1430px, and Snooze below 1200px. The custom menus close on outside click and Escape.

## Product invariants affected

none

## How it was verified

- `cd web/app && NODE_OPTIONS=--no-experimental-webstorage bun run check` — typecheck, moonshine smoke, 328 vitest tests (including the new BulkActionBar cases).
- Pre-push: 15 manifest checks passed (`Failure-Class: none`, no locked invariants, INV-UI-1 no purple increase).
- Did not re-exercise `/tasks` in the browser after the last refactor. The overflow + click-outside paths are covered by unit tests only.

## Tests

`web/app/src/components/tasks/__tests__/BulkActionBar.test.tsx`

- Copy/Export are parked behind ⋯ below 1600px; choosing Copy from the menu still fires `onCopy`.
- Clicking outside the ⋯ menu closes it.

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

