### PR TITLE
Enforce the action-items rate limit: exempt action_items:list from RATE_LIMIT_BOOST

### DIFF
--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -14,7 +14,12 @@ import pytest
 from fastapi import HTTPException
 
 from testing.import_isolation import stub_modules
-from utils.rate_limit_config import RATE_LIMIT_BOOST, RATE_POLICIES, get_effective_limit
+from utils.rate_limit_config import (
+    BOOST_EXEMPT_POLICIES,
+    RATE_LIMIT_BOOST,
+    RATE_POLICIES,
+    get_effective_limit,
+)
 
 
 class _RedisError(Exception):
@@ -162,6 +167,71 @@ class TestBoostFactor(unittest.TestCase):
         self.assertEqual(window, base_window)
 
 
+class TestBoostExemption(unittest.TestCase):
+    """A boost-exempt policy serves its base limit; everything else still boosts.
+
+    Prod ran RATE_LIMIT_BOOST=100, which turned the 12/60s action_items:list cap
+    into 1,200/60s — so the cap never fired while ~82 stale Windows clients
+    hot-looped GET /v1/action-items at ~97 req/min (48.8% of all billable
+    Firestore reads). The exemption is what makes that cap real, and lowering the
+    global boost instead would silently retune ~40 unrelated policies.
+    """
+
+    def test_action_items_list_is_exempt_by_default(self):
+        self.assertIn("action_items:list", BOOST_EXEMPT_POLICIES)
+
+    def test_exempt_policy_ignores_the_boost(self):
+        """(b) The exempt policy enforces its base limit under any boost."""
+        base = RATE_POLICIES["action_items:list"]
+        for boost in (2.0, 100.0, 1000.0):
+            self.assertEqual(get_effective_limit("action_items:list", boost=boost), base)
+
+    def test_exempt_policy_still_honours_a_tightening_boost_is_not_required(self):
+        """The exemption is absolute in both directions — base limit, always."""
+        base = RATE_POLICIES["action_items:list"]
+        self.assertEqual(get_effective_limit("action_items:list", boost=0.1), base)
+
+    def test_non_exempt_policies_still_boost(self):
+        """(a) Every other policy keeps the existing boost behaviour."""
+        for name in RATE_POLICIES:
+            if name in BOOST_EXEMPT_POLICIES:
+                continue
+            base, window = RATE_POLICIES[name]
+            max_req, eff_window = get_effective_limit(name, boost=100.0)
+            self.assertEqual(max_req, max(1, int(base * 100.0)), f"{name} must still boost")
+            self.assertEqual(eff_window, window)
+
+    def test_exempt_set_is_env_overridable(self):
+        """Operator escape hatch: the exemption list is env-driven, no code change."""
+        import utils.rate_limit_config as rlc
+
+        with patch.dict(os.environ, {"RATE_LIMIT_BOOST_EXEMPT": ""}):
+            importlib.reload(rlc)
+            self.assertEqual(rlc.BOOST_EXEMPT_POLICIES, frozenset())
+            base, _ = rlc.RATE_POLICIES["action_items:list"]
+            self.assertEqual(rlc.get_effective_limit("action_items:list", boost=100.0)[0], base * 100)
+
+        with patch.dict(os.environ, {"RATE_LIMIT_BOOST_EXEMPT": "action_items:list, chat:send_message"}):
+            importlib.reload(rlc)
+            self.assertEqual(rlc.BOOST_EXEMPT_POLICIES, frozenset({"action_items:list", "chat:send_message"}))
+
+        importlib.reload(rlc)
+
+    def test_unknown_exempt_names_are_dropped_not_enforced(self):
+        """A typo in the env var must not take the process down or exempt nothing real."""
+        import utils.rate_limit_config as rlc
+
+        with patch.dict(os.environ, {"RATE_LIMIT_BOOST_EXEMPT": "action_items:lst,action_items:list"}):
+            importlib.reload(rlc)
+            self.assertEqual(rlc.BOOST_EXEMPT_POLICIES, frozenset({"action_items:list"}))
+        importlib.reload(rlc)
+
+    def test_default_boost_leaves_every_limit_unchanged(self):
+        """With the default boost of 1.0 the exemption is a no-op for everyone."""
+        for name, (base, window) in RATE_POLICIES.items():
+            self.assertEqual(get_effective_limit(name, boost=1.0), (base, window))
+
+
 class TestShadowMode(unittest.TestCase):
     """Test shadow mode env var parsing."""
 
@@ -275,6 +345,53 @@ class TestEnforceRateLimit(unittest.TestCase):
     def test_fail_open_on_redis_error(self, mock_check):
         # Should not raise — fail open
         self.ep._enforce_rate_limit("uid123", "chat:send_message")
+
+    @patch('utils.rate_limit_config.RATE_LIMIT_BOOST', 100.0)
+    @patch('utils.other.endpoints.check_rate_limit')
+    @patch('utils.other.endpoints.RATE_LIMIT_SHADOW', False)
+    def test_action_items_list_checks_base_limit_under_a_boost(self, mock_check):
+        """The Redis check for the exempt policy uses 12/60s even at boost=100."""
+        mock_check.return_value = (True, 11, 0)
+        self.ep._enforce_rate_limit("uid123", "action_items:list")
+        _key, policy, max_requests, window = mock_check.call_args[0]
+        self.assertEqual(policy, "action_items:list")
+        self.assertEqual((max_requests, window), RATE_POLICIES["action_items:list"])
+
+    @patch('utils.rate_limit_config.RATE_LIMIT_BOOST', 100.0)
+    @patch('utils.other.endpoints.check_rate_limit', return_value=(False, 0, 37))
+    @patch('utils.other.endpoints.RATE_LIMIT_SHADOW', False)
+    def test_action_items_list_429_carries_the_degraded_mode_contract(self, mock_check):
+        """(c) The 429 the Windows client's degraded-mode handling keys on.
+
+        ``53d5b9e54a`` (desktop/windows/src/main/observability/) classifies a
+        response purely by status: ``classifyForRateLimit(429) == 'hit'``. A storm
+        (banner) additionally needs >= 5 hits across >= 2 distinct request paths
+        within 60s, so a client looping GET /v1/action-items alone gets 429s and a
+        stalled sync but NOT the banner — that rule lives in the client and is
+        covered by ``backendDegraded.test.ts``. What the server owes it is a real
+        429 with an honest Retry-After and a limit header that reports the cap
+        actually enforced (12), not the boosted one (1200).
+        """
+        with self.assertRaises(HTTPException) as ctx:
+            self.ep._enforce_rate_limit("uid123", "action_items:list")
+
+        exc = ctx.exception
+        self.assertEqual(exc.status_code, 429)
+        self.assertEqual(exc.headers["Retry-After"], "37")
+        self.assertEqual(exc.headers["X-RateLimit-Remaining"], "0")
+        base_max, _ = RATE_POLICIES["action_items:list"]
+        self.assertEqual(exc.headers["X-RateLimit-Limit"], str(base_max))
+
+    @patch('utils.rate_limit_config.RATE_LIMIT_BOOST', 100.0)
+    @patch('utils.other.endpoints.check_rate_limit')
+    @patch('utils.other.endpoints.RATE_LIMIT_SHADOW', False)
+    def test_boosted_policies_still_check_the_boosted_limit(self, mock_check):
+        """The exemption is scoped to one policy; the boost still relaxes the rest."""
+        mock_check.return_value = (True, 1, 0)
+        self.ep._enforce_rate_limit("uid123", "chat:send_message")
+        _key, _policy, max_requests, _window = mock_check.call_args[0]
+        base_max, _ = RATE_POLICIES["chat:send_message"]
+        self.assertEqual(max_requests, base_max * 100)
 
 
 class TestCheckRateLimitBoundary(unittest.TestCase):

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -13,6 +13,18 @@ Tuning knobs:
     RATE_LIMIT_SHADOW: defaults OFF (enforcement/429 rejections). Set env var
         RATE_LIMIT_SHADOW_MODE=true to revert to shadow/log-only mode.
 
+    RATE_LIMIT_BOOST_EXEMPT: comma-separated policy names that RATE_LIMIT_BOOST
+        must NOT multiply. A boost sized for "relax everything during an event"
+        also relaxes the few policies whose base limit is the whole point of the
+        policy — a cap chosen to stop a client hot loop is not something an
+        event boost should widen 100x. Those policies are listed here and always
+        serve their base limit.
+
+        Default: "action_items:list". Read from env at startup, so the exemption
+        is operator-escapable without a code change: set
+        RATE_LIMIT_BOOST_EXEMPT="" to put every policy back under the boost.
+        Unknown names are ignored (a typo must not take the process down).
+
 Redis efficiency:
     Each check = 1 Lua script call (atomic INCR + TTL check).
     Multi-instance safe — all state in Redis, no in-process caching.
@@ -27,11 +39,17 @@ import os
 RATE_LIMIT_BOOST: float = float(os.getenv("RATE_LIMIT_BOOST", "1.0"))
 RATE_LIMIT_SHADOW: bool = os.getenv("RATE_LIMIT_SHADOW_MODE", "false").lower() == "true"
 
+# Policies the boost must not touch. Env-overridable (see module docstring);
+# resolved against RATE_POLICIES below so a typo is dropped, not enforced.
+_BOOST_EXEMPT_DEFAULT = "action_items:list"
+_RATE_LIMIT_BOOST_EXEMPT_RAW: str = os.getenv("RATE_LIMIT_BOOST_EXEMPT", _BOOST_EXEMPT_DEFAULT)
+
 # ---------------------------------------------------------------------------
 # Policies: "name" -> (max_requests, window_seconds)
 #
 # max_requests is the BASE limit before boost is applied.
-# Effective limit = int(max_requests * boost).
+# Effective limit = int(max_requests * boost), except for the policies in
+# BOOST_EXEMPT_POLICIES, which always serve max_requests.
 # ---------------------------------------------------------------------------
 
 RATE_POLICIES: dict[str, tuple[int, int]] = {
@@ -71,6 +89,9 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     # stormed this route (~120 qps fleet) with no platform/version header.
     # 12/min/uid covers Mac/Flutter hydrate plus a few pagination pages and
     # stops a tight loop. Enforced in Depends() before Firestore.
+    # Boost-exempt (see BOOST_EXEMPT_POLICIES): with RATE_LIMIT_BOOST=100 in
+    # prod this cap resolved to 1,200/60s and never fired once, while the loop
+    # ran at ~97/min — 48.8% of all billable Firestore document reads.
     "action_items:list": (12, 60),
     "action_items:write": (120, 3600),
     # Memories — single LLM call each
@@ -159,8 +180,22 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
 }
 
 
+# Resolved after RATE_POLICIES so unknown names (typos, policies deleted since the
+# env var was set) are dropped rather than silently "exempting" nothing that exists.
+BOOST_EXEMPT_POLICIES: frozenset[str] = frozenset(
+    name for name in (n.strip() for n in _RATE_LIMIT_BOOST_EXEMPT_RAW.split(",")) if name in RATE_POLICIES
+)
+
+
 def get_effective_limit(policy_name: str, boost: float | None = None) -> tuple[int, int]:
-    """Return (effective_max_requests, window_seconds) with boost applied."""
+    """Return (effective_max_requests, window_seconds) with boost applied.
+
+    Policies in BOOST_EXEMPT_POLICIES ignore the boost entirely — including an
+    explicitly passed ``boost`` — and always return their base limit. The point
+    of exempting a policy is that its number is a decision, not a default.
+    """
     base_max, window = RATE_POLICIES[policy_name]
+    if policy_name in BOOST_EXEMPT_POLICIES:
+        return base_max, window
     b = boost if boost is not None else RATE_LIMIT_BOOST
     return max(1, int(base_max * b)), window


### PR DESCRIPTION
## The measured problem

`GET /v1/action-items` is **48.8% of every billable Firestore document read in the project** — ~6,600 docs/sec sustained.

The source is ~82 stale `omi-windows/1.0.0` clients, each hot-looping the endpoint with a `completed=false` / `completed=true` pair roughly every 1.2s (~97 req/min/uid). At the billing-measured marginal price of **$0.05395 per 100k reads** — a SKU with zero credits applied — that traffic costs **~$328/day**.

Evidence, including the derivation of the price and the per-client cadence: `omi-knowledge/projects/gcp-cost-efficiency/evidence/2026-08-26-c006-falsification.md` (lever L1).

## Why this lever

The correct cap already exists. #11965 shipped a `(12, 60)` per-uid policy for `action_items:list`.

It has never fired once. The serving revision carries `RATE_LIMIT_BOOST=100`, so `get_effective_limit()` resolves the policy to **1,200 requests / 60s** — well above the observed ~97/min. Zero 429s in a 7,932-request observation window, and shadow mode is off, so this is not a shadow-mode artifact: the cap is deployed and inert.

This PR restores an **already-approved** number rather than choosing a new one. It needs no client release, touches no client code, and captures **~$290/day** (~88% of the loop).

## Mechanism

- New module-level `BOOST_EXEMPT_POLICIES: frozenset[str]` in `backend/utils/rate_limit_config.py`, honored inside `get_effective_limit()`. An exempt policy returns its base `(max_requests, window)` and ignores the boost entirely — including an explicitly passed `boost=` argument.
- Seeded with **`action_items:list` and only that**. The other ~40 policies keep the boost, and a test asserts it for every one of them.
- `RATE_POLICIES` keeps its `dict[str, tuple[int, int]]` shape. A third tuple element would have broken ~15 call sites across six test files that unpack it as a 2-tuple, so the exemption is a sibling set — matching the module's existing "flat module-level knobs" style.

**Rollback is an env change, not a deploy of code.** The exemption list is read from `RATE_LIMIT_BOOST_EXEMPT` at import time, in the same style as the module's only two other knobs:

```
RATE_LIMIT_BOOST_EXEMPT=""      # every policy back under the boost
```

That returns prod byte-for-byte to today's behaviour via a Cloud Run env-var change on a new revision — no build, no image push, no revert, no merge. Unknown names are resolved against `RATE_POLICIES` and dropped, so a typo neither crashes the process at import nor silently exempts nothing. `RATE_LIMIT_SHADOW_MODE=true` remains the blunter kill switch for all enforcement.

Do **not** roll back by lowering `RATE_LIMIT_BOOST` — that silently retunes ~40 unrelated policies.

## The tradeoff, stated honestly

**Stale Windows clients will start receiving 429s on `/v1/action-items`, and most likely will not be told.**

The degraded-mode banner from `53d5b9e54a` requires ≥5 rate-limit hits across **≥2 distinct request paths** within 60s (`minDistinctKeys: 2`), specifically so one endpoint's retry loop cannot trip it. This change 429s exactly one path. Users on stale builds therefore see a **silently stalled task sync** — the failure mode that banner exists to make visible — rather than the amber banner. That is the main thing to weigh here, and it is worse than the evidence file's blast-radius wording assumed.

Mitigating facts:

- **Data stays correct.** 12 refreshes/minute is still ~**150x more often** than the app's own post-fix design (`65249902cb`: one sync per 5 minutes at `limit=100`). Nothing is dropped; the client just cannot poll at 97/min.
- Enforcement runs in `Depends()` **before** the handler, so a 429 costs one Cloud Run request and **zero Firestore reads** — which is the entire saving.
- Writes (`action_items:write`) and every other route are untouched and keep the boost.
- Legit first-party clients (Mac/Flutter hydrate plus pagination) fit inside 12/min — the #11965 sizing rationale, unchanged. Multiple devices on one uid share the per-uid budget.

This is a server-side backstop, not the structural fix. Getting `65249902cb` into users' hands is still the real answer; this PR is what does not depend on that shipping.

## Post-ship falsification bar

Measure **7 complete days** after the change is confirmed *serving* (check the revision's release SHA and that `RATE_LIMIT_BOOST_EXEMPT` is as expected on it — merged is not serving).

**Primary (money, decides it):** `App Engine | Cloud Firestore Read Ops` net $/day, 7-day post-ship mean vs. the 7-day pre-ship baseline of **$542/day** (08-18…08-24).

- **≥ $480/day → the cut is NOT supported** (<12%, inside the $460–629 day-to-day range).
- $350–480/day → partial; name which lever under-delivered.
- ≤ $300/day → validated.

**Secondary (mechanism — must also hold, or the money moved for some other reason):**

1. `/v1/action-items` **429 share jumps above zero**. Today it is exactly zero, so any nonzero count is the proof the cap went live.
2. `action_items_list` share of billed reads falls to **≤ ~15%** (from 48.8%), and its docs/sec 24h median falls below 1,200 (from 6,600).
3. Distinct `remoteIp` on `/v1/action-items` in a 60s window stays **≥ 60** — the drop must come from each client polling less, not from clients disappearing. If IP count collapses, the result is void.

Note: this lever stops the *Firestore reads*; it does not stop the clients from *asking*. Whether total request rate to `/v1/action-items` falls depends on how the pre-fix binary reacts to a 429, which is not determinable from the code alone. Worst case this converts an expensive Firestore bill into a much cheaper Cloud Run request bill — still the right trade, but it is not a request-rate claim.

**Void conditions:** serving revision changed mid-window; `RATE_LIMIT_BOOST` changed for an unrelated reason; any partial day in the billing export; a `/v1/action-items` availability incident (non-200 > 1%).

## Test coverage

+10 unit tests in `backend/tests/unit/test_rate_limiting.py` (84 passed, 1 skipped locally; baseline without this change is 74 passed, 1 skipped).

- **Boosted policies still boost** — `TestBoostExemption.test_non_exempt_policies_still_boost` covers every non-exempt policy at `boost=100`, and `TestEnforceRateLimit.test_boosted_policies_still_check_the_boosted_limit` pins the value actually handed to `check_rate_limit`.
- **The exempt policy binds at its base limit** — `test_exempt_policy_ignores_the_boost` (boosts of 2, 100, 1000) and `test_action_items_list_checks_base_limit_under_a_boost`, which asserts `check_rate_limit` is called with `(12, 60)` while `RATE_LIMIT_BOOST=100`. Plus env-override and typo-handling tests.
- **The 429 carries the enforced limit** — `test_action_items_list_429_carries_the_degraded_mode_contract`: status 429, `Retry-After`, `X-RateLimit-Remaining: 0`, and `X-RateLimit-Limit: 12` — the cap actually enforced, not the boosted 1,200.

`black --line-length 120 --skip-string-normalization --check` is clean on both files.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

