### PR TITLE
test(desktop): isolate FloatingBar notification owner authority

### DIFF
--- a/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
@@ -12,6 +12,23 @@ import XCTest
 /// enabled is the one case that falls back to a native system banner so the
 /// notification is never fully silenced.
 final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
+  /// Runtime owner authorization is process-wide and fails closed on an
+  /// out-of-band `authUserId` write, staying revoked for every later suite in
+  /// the xctest process. The two owner-seeding tests below therefore establish
+  /// their owner through the production transition boundary, and restore runs
+  /// in `tearDown` rather than a `defer` so a failed assertion cannot leave the
+  /// authority revoked for whatever runs next.
+  private var ownerFixture: RuntimeOwnerAuthorityTestFixture?
+
+  override func setUp() async throws {
+    ownerFixture = await RuntimeOwnerAuthorityTestFixture()
+  }
+
+  override func tearDown() async throws {
+    await ownerFixture?.restore()
+    ownerFixture = nil
+  }
+
   func testPreviewsAndBarEnabledShowsPreviewWithNoForcedBanner() {
     XCTAssertTrue(
       FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
@@ -166,11 +183,9 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
   /// `presentContextDirectorNotification` makes this call return `.queued` from the
   /// banner path instead of `.suppressed`, failing the test.
   @MainActor
-  func testDirectorDeliveryWithDisabledCategoryToggleIsSuppressedAtTheEntryPoint() throws {
+  func testDirectorDeliveryWithDisabledCategoryToggleIsSuppressedAtTheEntryPoint() async throws {
     let defaults = UserDefaults.standard
     let pinnedKeys = [
-      DefaultsKey.authUserId.rawValue,
-      DefaultsKey.automationOwnerOverride.rawValue,
       NotificationService.masterEnabledDefaultsKey,
       NotificationService.frequencyDefaultsKey,
       DefaultsKey.desktopIsPaywalled.rawValue,
@@ -192,8 +207,8 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
     }
 
     let owner = "owner-category-gate-\(UUID().uuidString)"
-    defaults.set(owner, forKey: DefaultsKey.authUserId.rawValue)
-    defaults.removeObject(forKey: DefaultsKey.automationOwnerOverride.rawValue)
+    let fixture = try XCTUnwrap(ownerFixture)
+    await fixture.establish(authOwnerID: owner)
     defaults.set(true, forKey: NotificationService.masterEnabledDefaultsKey)
     defaults.set(5, forKey: NotificationService.frequencyDefaultsKey)
     defaults.set(false, forKey: DefaultsKey.desktopIsPaywalled.rawValue)
@@ -228,11 +243,9 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
   /// host cannot perform, failing the test; with the gate present they return
   /// before any surface and leave the presentation ledger untouched.
   @MainActor
-  func testGoalAndMeetingProducersHonorTheirCategoryTogglesAtTheSharedBoundary() throws {
+  func testGoalAndMeetingProducersHonorTheirCategoryTogglesAtTheSharedBoundary() async throws {
     let defaults = UserDefaults.standard
     let pinnedKeys = [
-      DefaultsKey.authUserId.rawValue,
-      DefaultsKey.automationOwnerOverride.rawValue,
       NotificationService.masterEnabledDefaultsKey,
       NotificationService.frequencyDefaultsKey,
       DefaultsKey.desktopIsPaywalled.rawValue,
@@ -256,8 +269,8 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
     }
 
     let owner = "owner-producer-gate-\(UUID().uuidString)"
-    defaults.set(owner, forKey: DefaultsKey.authUserId.rawValue)
-    defaults.removeObject(forKey: DefaultsKey.automationOwnerOverride.rawValue)
+    let fixture = try XCTUnwrap(ownerFixture)
+    await fixture.establish(authOwnerID: owner)
     defaults.set(true, forKey: NotificationService.masterEnabledDefaultsKey)
     defaults.set(5, forKey: NotificationService.frequencyDefaultsKey)
     defaults.set(false, forKey: DefaultsKey.desktopIsPaywalled.rawValue)


### PR DESCRIPTION
## What changed and why

The same defect #12192 fixes in `RewindCaptureExclusionGenerationTests`, in a suite #12039 does not name. I found it while checking whether the other suites in that issue shared a root cause — three of them don't, this one does.

Both owner-seeding tests wrote `auth_userId` directly:

```swift
defaults.set(owner, forKey: DefaultsKey.authUserId.rawValue)
```

Runtime owner authorization is process-wide and deliberately fails closed on exactly that write — `RuntimeOwnerIdentity.swift:51`:

```swift
} else if self.ownerID != normalized {
  revokeUnexpectedOwnerMismatch()
  return nil
}
```

Once any earlier owner-bound suite has bootstrapped a different owner, the raw write revokes the authority and it stays revoked without a real `beginTransition`/`endTransition` pair. So the outcome depended on which suite ran first.

Both tests now establish their owner through `RuntimeOwnerAuthorityTestFixture`, crossing the same serialized transition boundary production uses. Restore happens in `tearDown` rather than a `defer` — a `defer` can't `await`, and more importantly a failed assertion must not leave the process-wide authority revoked for whatever runs next, which is the contamination this is fixing. Adopting the fixture also enrolls the suite in the runner's derived owner-isolation cluster, since `swift-test-suites.sh` greps for that symbol.

## How it was verified

I checked the guard actually does the work rather than assuming it. Identical command, same three owner-bound suites, only the fix differing:

```
before:  Executed 28 tests, with 1 failure
         FloatingBarNotificationPreviewPolicyTests.swift:218: error:
         XCTAssertEqual failed: ("rejectedOwnerChange") is not equal to ("suppressed")

after:   Executed 28 tests, with 0 failures
```

```bash
xcrun swift test --package-path Desktop \
  --filter 'CaptureScreenToolTests|FloatingBarNotificationPreviewPolicyTests|ChatToolExecutorPolicyTests'
```

In isolation the suite passes both before and after (19/19) — which is exactly why the flake read as nondeterministic and why running it alone never reproduced it.

`xcrun swift build -c debug --package-path Desktop` clean.

Worth noting the symptom is not where I first expected it. I predicted `XCTUnwrap(RuntimeOwnerIdentity.currentOwnerId())` would throw on a nil owner; it doesn't — `currentOwnerId()` returns fine and the revocation surfaces later at the delivery gate as `rejectedOwnerChange`. Same root cause, different surfacing point, and the `rejectedOwnerChange` payload is precisely the "production error payload that looks like a real defect" the failure class describes.

This is test-harness isolation only; no production code is touched and there is no user-facing path to exercise.

## Product invariants affected

none

## Relationship to the other #12039 suites

`ChatTranscriptGestureHarnessTests`, `KernelTurnRecordedProjectionTests`, and `SuggestedTasksStoreTests` have no `authUserId` writes and don't use the fixture, so they flake for some other reason. This PR does not address them and I have not diagnosed them.

Failure-Class: FC-hand-listed-test-isolation-membership


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

