### PR TITLE
fix(macos): restore shell clicks after reopening

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/ShellClickThrough.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellClickThrough.swift
@@ -49,6 +49,7 @@ enum ShellClickThroughPolicy {
 @MainActor
 final class ShellMouseInterceptionSync {
   private nonisolated(unsafe) var monitors: [Any] = []
+  private var visibilityObservation: NSKeyValueObservation?
   private var pollingCancellable: AnyCancellable?
   private weak var window: NSWindow?
 
@@ -72,6 +73,9 @@ final class ShellMouseInterceptionSync {
     {
       monitors.append(local)
     }
+    visibilityObservation = window.observe(\.isVisible, options: [.new]) { [weak self] _, _ in
+      MainActor.assumeIsolated { self?.sync() }
+    }
     sync()
   }
 
@@ -86,6 +90,7 @@ final class ShellMouseInterceptionSync {
     window?.ignoresMouseEvents = false
     window = nil
     pollingCancellable = nil
+    visibilityObservation = nil
   }
 
   func sync() {

--- a/desktop/macos/Desktop/Tests/ShellClickThroughPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellClickThroughPolicyTests.swift
@@ -7,6 +7,7 @@ import XCTest
 /// frame — the reserved title-bar band, lane margins, and gaps between panels swallowed clicks
 /// aimed at other apps, which never activated (the shell-window dead zone). The policy passes the
 /// pointer through everywhere except visible content, the modal barrier's host, and the resize rim.
+@MainActor
 final class ShellClickThroughPolicyTests: XCTestCase {
   private let windowSize = NSSize(width: 960, height: 712)
 
@@ -59,5 +60,34 @@ final class ShellClickThroughPolicyTests: XCTestCase {
         isResizable: false,
         contentContains: { _ in false }),
       "a fixed-size window has no resize affordance to preserve")
+  }
+
+  /// The shell reuses one window across dismiss/summon. Reconciliation while that window is ordered
+  /// out must not leave it ignoring mouse events when AppKit puts it back on screen: while ignored,
+  /// neither its visible controls nor its local mouse monitor can recover the window.
+  func testOrderingShellBackOnScreenRestoresMouseInterception() {
+    let mouse = NSEvent.mouseLocation
+    let window = NSWindow(
+      contentRect: NSRect(x: mouse.x + 5_000, y: mouse.y + 5_000, width: 320, height: 240),
+      styleMask: [.borderless],
+      backing: .buffered,
+      defer: false)
+    window.orderFront(nil)
+    let sync = ShellMouseInterceptionSync(window: window)
+    defer {
+      sync.detach()
+      window.orderOut(nil)
+    }
+
+    XCTAssertFalse(window.ignoresMouseEvents)
+    window.orderOut(nil)
+    sync.sync()
+    XCTAssertTrue(window.ignoresMouseEvents, "the hidden shell previously entered pass-through mode")
+
+    window.orderFront(nil)
+
+    XCTAssertFalse(
+      window.ignoresMouseEvents,
+      "a visible shell must recover before the first click, without waiting for pointer movement")
   }
 }

--- a/desktop/macos/changelog/unreleased/20260826-shell-click-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260826-shell-click-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the main window occasionally ignoring clicks after reopening"
+}


### PR DESCRIPTION
## What changed and why

Fixes #12249.

The macOS shell reuses the same `NSWindow` when it is dismissed and summoned again. While the window was hidden, mouse-interception reconciliation correctly switched `ignoresMouseEvents` on, but the synchronizer then stopped polling because the window was no longer visible. Ordering that same window back on screen did not trigger another reconciliation, so the visible shell could remain click-through until an unrelated pointer event repaired it. That made visible controls intermittently ignore the first click—or every click if no local event could reach the window.

This change observes AppKit's authoritative `NSWindow.isVisible` transition and immediately reruns the existing interception policy whenever visibility changes. It also releases that observation with the synchronizer's other lifecycle resources.

The regression test mounts a real AppKit window and exercises the production sequence directly: visible → ordered out → reconciliation enables pass-through → ordered front. It proves the shell restores mouse interception before the first user click, without depending on pointer movement or test-only state.

## Product invariants affected

none

## How it was verified

- Reproduced test-first: the new AppKit lifecycle test failed against the previous implementation because the reopened window still ignored mouse events.
- Passed the exact regression after the fix.
- Passed 52 focused shell/window tests across `ShellClickThroughPolicyTests`, `GlassPanelHitRegionTests`, `ShellSummonTests`, and `ShellWindowChromeTests`.
- Repeated the visibility-transition regression 30 times: 30/30 passed.
- Passed the cross-surface agent contract smoke harness.
- Built and launched an isolated signed-in bundle (`com.omi.omi-12249-clicks`), dismissed and summoned the production shell, then used a real native pointer click on **Brain**; the selected route changed from Chat to Brain on the first click.
- Ran the complete macOS component suite: all launcher checks, 214 backend tests, and all shell suites passed. Three unrelated Swift cases failed or timed out under concurrent machine load; each exact case then passed serially (`ChatTranscriptGestureHarnessTests`, `MemoryAtlasPerformanceHarnessTests`, and `RewindArtifactGauntletTests`).

## Tests

```text
xcrun swift test --jobs 2 --package-path Desktop --filter ShellClickThroughPolicyTests/testOrderingShellBackOnScreenRestoresMouseInterception
xcrun swift test --jobs 2 --package-path Desktop --filter 'ShellClickThroughPolicyTests|GlassPanelHitRegionTests|ShellSummonTests|ShellWindowChromeTests'
./scripts/agent-logic-harness.sh --cross-surface-smoke
./test.sh
```

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

