### PR TITLE
fix(ci): sign the dev backend release probe for its Firebase project

### DIFF
--- a/.github/actions/deploy-backend-stack/action.yml
+++ b/.github/actions/deploy-backend-stack/action.yml
@@ -11,6 +11,15 @@ inputs:
       roles/iam.serviceAccountTokenCreator for the deploy identity on it.
     required: false
     default: ''
+  firebase_probe_signer_credentials:
+    description: >-
+      Base64-encoded service-account key for the Firebase auth project, used to
+      sign release-probe custom tokens locally. This is how the development lane
+      signs for production Firebase without an IAM grant, matching
+      desktop_backend_auto_dev.yml. Mutually exclusive with
+      firebase_probe_signer_service_account.
+    required: false
+    default: ''
   deploy_profile:
     description: 'manual or auto-dev orchestration profile'
     required: true
@@ -753,12 +762,15 @@ runs:
         candidate_api_url: ${{ steps.transcription-candidate.outputs.url }}
         project_id: ${{ inputs.project_id }}
         firebase_auth_project_id: based-hardware
-        # A development deploy identity cannot sign a custom token for the
-        # production Firebase project this gate authenticates against, so it
+        # The development backend authenticates against production Firebase, so
+        # a development deploy identity cannot sign this gate's custom token: it
         # failed at custom_token_signing and blocked every manual development
-        # deploy. Left empty the behaviour is unchanged; set the variable to
-        # the Firebase project's signer to make this lane usable.
-        firebase_signer_service_account: ${{ inputs.firebase_probe_signer_service_account }}
+        # deploy. Sign locally with the Firebase project's own key instead --
+        # the same resolution desktop_backend_auto_dev.yml already uses. The
+        # named-signer input stays available but needs an IAM grant, so it is
+        # only consulted when a credential is not supplied.
+        firebase_signer_service_account: ${{ inputs.firebase_probe_signer_credentials == '' && inputs.firebase_probe_signer_service_account || '' }}
+        firebase_signer_credentials: ${{ inputs.firebase_probe_signer_credentials }}
 
     - name: Accept no-traffic Cloud Run candidate
       id: verify-cloud-run-candidate

--- a/.github/actions/transcription-release-candidate-probe/action.yml
+++ b/.github/actions/transcription-release-candidate-probe/action.yml
@@ -19,6 +19,18 @@ inputs:
       deploy identity needs roles/iam.serviceAccountTokenCreator on it.
     required: false
     default: ''
+  firebase_signer_credentials:
+    description: >-
+      Base64-encoded service-account key for firebase_auth_project_id, used to
+      sign the probe's custom token locally. This is the other way to resolve a
+      Firebase auth project that differs from project_id, and unlike
+      firebase_signer_service_account it needs no IAM grant on the deploy
+      identity. The key is staged in a mode-0600 runner file and deleted after
+      the probe; the token minter rejects a key whose project does not match
+      firebase_auth_project_id. Mutually exclusive with
+      firebase_signer_service_account.
+    required: false
+    default: ''
   evidence_path:
     description: Optional absolute path for the redacted probe report.
     required: false
@@ -35,11 +47,18 @@ runs:
         PROBE_SECRET_PROJECT: ${{ inputs.project_id }}
         FIREBASE_AUTH_PROJECT_ID: ${{ inputs.firebase_auth_project_id }}
         FIREBASE_SIGNER_SERVICE_ACCOUNT: ${{ inputs.firebase_signer_service_account }}
+        FIREBASE_SIGNER_CREDENTIALS: ${{ inputs.firebase_signer_credentials }}
       run: |
         set -euo pipefail
+        umask 077
         DEPLOY_CONTROL_SCRIPT_DIR="${DEPLOY_CONTROL_SCRIPTS:-backend/scripts}"
         token_file="$(mktemp "$RUNNER_TEMP/omi-transcription-probe.XXXXXX")"
-        trap 'rm -f "$token_file"' EXIT
+        signer_file=''
+        trap 'rm -f "$token_file" ${signer_file:+"$signer_file"}' EXIT
+        if [[ -n "$FIREBASE_SIGNER_SERVICE_ACCOUNT" && -n "$FIREBASE_SIGNER_CREDENTIALS" ]]; then
+          echo "::error::Set at most one of firebase_signer_service_account or firebase_signer_credentials." >&2
+          exit 1
+        fi
         token_args=(
           --secret-project "$PROBE_SECRET_PROJECT"
           --firebase-project "$FIREBASE_AUTH_PROJECT_ID"
@@ -47,8 +66,17 @@ runs:
         )
         if [[ -n "$FIREBASE_SIGNER_SERVICE_ACCOUNT" ]]; then
           token_args+=(--signer-service-account "$FIREBASE_SIGNER_SERVICE_ACCOUNT")
+        elif [[ -n "$FIREBASE_SIGNER_CREDENTIALS" ]]; then
+          signer_file="$(mktemp "$RUNNER_TEMP/omi-firebase-probe-signer.XXXXXX")"
+          chmod 600 "$signer_file"
+          printf '%s' "$FIREBASE_SIGNER_CREDENTIALS" | base64 --decode > "$signer_file"
+          token_args+=(--signer-credentials-file "$signer_file")
         fi
         python3 "$DEPLOY_CONTROL_SCRIPT_DIR/firebase_release_probe_token.py" "${token_args[@]}"
+        if [[ -n "$signer_file" ]]; then
+          rm -f "$signer_file"
+          signer_file=''
+        fi
         probe_args=(
           --candidate-api-url "$CANDIDATE_API_URL"
           --bearer-token-file "$token_file"

--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -407,6 +407,11 @@ jobs:
           runtime_gcp_project_id: ${{ vars.RUNTIME_GCP_PROJECT_ID }}
           # Unset by default, which keeps the existing signing behaviour.
           firebase_probe_signer_service_account: ${{ vars.FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT }}
+          # The known-audio gate runs only for development, where the Firebase
+          # auth project (based-hardware) is not this lane's deploy project.
+          # This environment secret is the production Firebase signer key; the
+          # token minter refuses it if its project does not match.
+          firebase_probe_signer_credentials: ${{ github.event.inputs.environment == 'development' && secrets.GCP_SERVICE_ACCOUNT || '' }}
           runtime_env: ${{ vars.ENV }}
           region: ${{ env.REGION }}
           service: ${{ env.SERVICE }}

--- a/.github/workflows/sync_ledger_fence_cutover.yml
+++ b/.github/workflows/sync_ledger_fence_cutover.yml
@@ -271,6 +271,11 @@ jobs:
           candidate_api_url: ${{ steps.prepare.outputs.candidate_probe_url }}
           project_id: ${{ vars.GCP_PROJECT_ID }}
           firebase_auth_project_id: based-hardware
+          # Development deploys into a different project than the Firebase auth
+          # project, so the deploy identity cannot sign the probe's custom token.
+          # Production already deploys into based-hardware and keeps signing with
+          # its active identity, so this stays empty there.
+          firebase_signer_credentials: ${{ github.event.inputs.environment == 'prod' && '' || secrets.GCP_SERVICE_ACCOUNT }}
           evidence_path: ${{ runner.temp }}/transcription-capability-probe.json
 
       - name: Record protected full-route probe proof

--- a/backend/tests/unit/test_firebase_release_probe_token.py
+++ b/backend/tests/unit/test_firebase_release_probe_token.py
@@ -379,3 +379,33 @@ def test_signer_service_account_must_look_like_a_service_account(monkeypatch):
         with pytest.raises(module.ProbeTokenError) as caught:
             module.mint_probe_token('based-hardware-dev', 'based-hardware', signer_service_account=bad)
         assert caught.value.stage == 'signer_service_account'
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+PROBE_ACTION = REPOSITORY_ROOT / '.github/actions/transcription-release-candidate-probe/action.yml'
+DEPLOY_BACKEND_STACK_ACTION = REPOSITORY_ROOT / '.github/actions/deploy-backend-stack/action.yml'
+GCP_BACKEND_WORKFLOW = REPOSITORY_ROOT / '.github/workflows/gcp_backend.yml'
+
+
+def test_development_backend_deploy_supplies_a_firebase_project_signer():
+    """The known-audio gate authenticates against production Firebase.
+
+    A development deploy identity cannot sign for that project, so the lane
+    failed at custom_token_signing until it named its own signer. Losing this
+    wiring silently re-blocks every development backend deploy.
+    """
+    workflow = GCP_BACKEND_WORKFLOW.read_text(encoding='utf-8')
+    assert 'firebase_probe_signer_credentials:' in workflow
+    assert 'secrets.GCP_SERVICE_ACCOUNT' in workflow
+
+    stack = DEPLOY_BACKEND_STACK_ACTION.read_text(encoding='utf-8')
+    assert 'firebase_signer_credentials: ${{ inputs.firebase_probe_signer_credentials }}' in stack
+
+
+def test_probe_action_stages_the_signer_key_as_transient_owner_only_material():
+    action = PROBE_ACTION.read_text(encoding='utf-8')
+    assert '--signer-credentials-file' in action
+    assert 'chmod 600 "$signer_file"' in action
+    # The key must not outlive the probe.
+    assert 'rm -f "$token_file" ${signer_file:+"$signer_file"}' in action
+    assert 'rm -f "$signer_file"' in action


### PR DESCRIPTION
Failure-Class: FC-release-probe-signer-identity

## Product invariants affected

- INV-DATA-1

This change does not move any Firebase or Firestore project. `firebase_auth_project_id`
stays `based-hardware` on every lane; only *how the probe signs* changes.

## What is broken

Every manual **development** backend deploy fails deterministically at the
`Gate backend candidate on known audio` step:

```
{"suite": "omi_firebase_release_probe_token", "stage": "custom_token_signing",
 "error_class": "permission_denied", "status": "FAIL"}
```

Reproduced today on runs 32992789266 and 32994463647 (both `af8a490afc`), and at
07:29:24Z on the unrelated commit `d5c6d75` — so this is not a regression from
today's merges.

The blast radius is quiet and bad: candidate revisions are deployed `--no-traffic`,
the gate fails before promotion, the tag is torn down, and dev keeps serving the old
revision. Development has been silently refusing new deploys — dev is still on
`0300eb2`, which is why PR #12258's rate-limit change never reached it.

## Root cause

`firebase_auth_project_id: based-hardware` is **correct and deliberate**: the
development backend verifies user tokens against the *production* Firebase project.
`firebase_release_probe_token.py` says so, and `_validate_firebase_id_token_claims`
enforces `aud == based-hardware`. So this is not a wrong-project string to swap.

The defect is the **signer**, introduced by 224b2c536d ("fix(dev): harden realtime
provider proof", 2026-07-14). That commit split the single `project_id` input into
`project_id` (Secret Manager + deploy identity) and `firebase_auth_project_id`
(token audience). Before the split both were `based-hardware-dev`, so the deploy
identity signed for its own project. After the split the *audience* was corrected
but the *signer* was not: the probe still calls IAM `signJwt` as the
`based-hardware-dev` deploy identity, and Identity Toolkit only accepts a custom
token whose signer is authorized for the Firebase project — hence 403
`permission_denied` at `custom_token_signing`. 404eb82b33 carried it verbatim into
the shared composite action.

#12019 diagnosed this correctly and plumbed an escape hatch,
`firebase_probe_signer_service_account` ← `vars.FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT`.
That variable has never existed (it is absent from both repo variables and the
`development` environment), and using it would also require a
`roles/iam.serviceAccountTokenCreator` grant. The hatch stayed empty and the lane
stayed dead.

## The fix

Adopt the resolution that already works for the identical split, one workflow over.
`.github/workflows/desktop_backend_auto_dev.yml` deploys into `based-hardware-dev`
with `FIREBASE_AUTH_PROJECT_ID: based-hardware` and signs **locally** with the
Firebase project's own key: it stages the environment-owned `GCP_SERVICE_ACCOUNT`
secret in a mode-0600 runner file and passes `--signer-credentials-file`. That lane
is green today (run 32999384549), and `.github/AGENTS.md:23` prescribes exactly this
shape.

`firebase_release_probe_token.py::_read_signer_credentials` already rejects a signer
whose `project_id` does not match `firebase_auth_project_id`, so the credential
cannot silently drift.

**No IAM change is required** — local signing needs no `serviceAccountTokenCreator`
grant. Secret Manager access was never the problem: `secret_access` succeeded in the
failing runs; the failure was at the later `custom_token_signing` stage.

The named-signer input is left in place and is only consulted when no credential is
supplied, so nothing that sets it changes behaviour.

`sync_ledger_fence_cutover.yml` carries the same split in its development lane and is
wired the same way. Its production lane deploys into `based-hardware` and keeps
signing with its active identity, so production is byte-identical there.

## Proof

- `backend/tests/unit/test_firebase_release_probe_token.py` — the failure class's
  existing `canonical_prevention_artifact` — gains two tests: the development deploy
  lane must supply a Firebase-project signer, and the probe action must stage that key
  as transient, owner-only material that does not outlive the probe.
- All 36 selected preflight checks pass locally.
- The real proof is the next development deploy: the gate reaching `PASS` and traffic
  actually shifting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

