### PR TITLE
Fix/web app duplicate task title

### DIFF
--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -287,9 +287,9 @@ def create_action_item(
             retry on flaky networks or duplicate event delivery — the previous
             behaviour silently allocated a fresh Firestore id on every call,
             producing user-visible duplicates. The key is stored on the
-            document so future calls can find it. Callers that want
-            content-based idempotency typically pass
-            ``hashlib.sha256(f"{uid}:{normalized_description}".encode()).hexdigest()``.
+            document so future calls can find it. Pass a per-attempt client
+            key (for example an ``Idempotency-Key`` header), not a hash of
+            the description: task titles are not unique.
         document_id: Optional caller-reserved Firestore document id. Reusing
             the id returns the existing document without rewriting it, making
             a crash-retried create deterministic.

--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -1,12 +1,11 @@
 import asyncio
-import hashlib
 import logging
 import uuid
 
 from utils.executors import postprocess_executor, submit_with_context
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
-from typing import Optional, List
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response
+from typing import Annotated, Optional, List
 from datetime import datetime, timezone
 
 import database.action_items as action_items_db
@@ -276,30 +275,30 @@ def sync_batch_update(request: SyncBatchRequest, uid: str = Depends(auth.get_cur
 # *****************************
 
 
-def _content_idempotency_key(uid: str, description: str) -> str:
-    """Stable idempotency key from (uid, normalized description).
+def _client_idempotency_key(raw: Optional[str]) -> Optional[str]:
+    """Return a caller-supplied retry key, or None to always insert.
 
-    Two POSTs from the same user with the same description (modulo case +
-    surrounding whitespace) collapse to the same key, so a flaky-network
-    retry no longer creates a duplicate Firestore document.
-
-    Uses a length-prefixed encoding so the boundary between ``uid`` and
-    ``description`` is unambiguous: ``f"{len(uid)}:{uid}:{description}"``.
-    Without this, a uid containing ``:`` (federated identities, future
-    multi-tenant ids) could collide with a different ``(uid, description)``
-    pair after concatenation.
+    Task titles are not unique: hashing the description treated a second
+    "Buy milk" as a retry of the first and returned the existing document
+    (same due date, gone after reload). Real retries must send their own
+    ``Idempotency-Key``.
     """
-    normalized = (description or '').strip().lower()
-    payload = f"{len(uid)}:{uid}:{normalized}"
-    return hashlib.sha256(payload.encode('utf-8')).hexdigest()
+    if raw is None:
+        return None
+    key = raw.strip()
+    return key or None
 
 
 @router.post("/v1/action-items", response_model=ActionItemResponse, tags=['action-items'])
-def create_action_item(request: ActionItemCreateRequest, uid: str = Depends(auth.get_current_user_uid)):
+def create_action_item(
+    request: ActionItemCreateRequest,
+    uid: str = Depends(auth.get_current_user_uid),
+    idempotency_key: Annotated[Optional[str], Header(alias='Idempotency-Key', max_length=256)] = None,
+):
     """Create a new action item.
 
-    Content-idempotent on (uid, normalized description): a retry of the same
-    request returns the original action_item rather than creating a duplicate.
+    Idempotent only when the client sends ``Idempotency-Key``. Two creates
+    with the same description (and different keys, or no key) are two tasks.
     """
     try:
         task_links.validate_task_links(uid, goal_id=request.goal_id, workstream_id=request.workstream_id)
@@ -307,9 +306,10 @@ def create_action_item(request: ActionItemCreateRequest, uid: str = Depends(auth
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     action_item_data = request.storage_payload()
 
-    idempotency_key = _content_idempotency_key(uid, request.description)
     try:
-        action_item_id = action_items_db.create_action_item(uid, action_item_data, idempotency_key=idempotency_key)
+        action_item_id = action_items_db.create_action_item(
+            uid, action_item_data, idempotency_key=_client_idempotency_key(idempotency_key)
+        )
     except FirestoreContentionExhausted as exc:
         raise HTTPException(status_code=503, detail="Service temporarily unavailable") from exc
     except action_items_db.TaskRelationshipConflictError as exc:

--- a/backend/tests/unit/test_action_item_idempotency.py
+++ b/backend/tests/unit/test_action_item_idempotency.py
@@ -1,4 +1,4 @@
-"""Tests for content-hash idempotency on create_action_item.
+"""Tests for optional-key idempotency on create_action_item.
 
 `database.action_items.create_action_item` historically allocated a fresh
 Firestore id on every call. A flaky-network retry from the desktop client
@@ -9,12 +9,13 @@ would happily produce a duplicate document. The fix:
   its id without creating a new one. The key is stored on the document so
   later calls can find it.
 
-- ``routers/action_items.create_action_item`` (the FastAPI handler) computes
-  a stable key from ``sha256(f"{uid}:{normalized_description}")`` so a
-  retried POST of the same task collapses to the original.
+- ``routers/action_items.create_action_item`` honors an optional
+  ``Idempotency-Key`` header. It must not hash the description: two tasks
+  named "123" are two tasks, and hashing the title returned the first
+  document (wrong due date, gone after reload).
 
 These tests exercise the db-layer contract (idempotency hit / miss / no-key
-backwards compat) and the router-layer key derivation.
+backwards compat) and the router-layer key handling.
 """
 
 from unittest.mock import MagicMock
@@ -243,41 +244,65 @@ def test_create_retries_precommit_contention_without_duplicate_write(monkeypatch
 
 
 # ---------------------------------------------------------------------------
-# router-layer content key
+# router-layer Idempotency-Key
 # ---------------------------------------------------------------------------
 
 
-def test_content_key_is_stable_for_same_input():
-    a = action_items_router._content_idempotency_key('uid-1', 'Buy milk')
-    b = action_items_router._content_idempotency_key('uid-1', 'Buy milk')
-    assert a == b
+def test_client_idempotency_key_strips_and_drops_blank():
+    assert action_items_router._client_idempotency_key(None) is None
+    assert action_items_router._client_idempotency_key('') is None
+    assert action_items_router._client_idempotency_key('   ') is None
+    assert action_items_router._client_idempotency_key(' retry-1 ') == 'retry-1'
 
 
-def test_content_key_normalizes_case_and_whitespace():
-    a = action_items_router._content_idempotency_key('uid-1', 'Buy Milk')
-    b = action_items_router._content_idempotency_key('uid-1', '  buy milk  ')
-    assert a == b
+def _stub_router_create(monkeypatch, *, capture):
+    monkeypatch.setattr(action_items_router.task_links, 'validate_task_links', lambda *args, **kwargs: None)
+    monkeypatch.setattr(action_items_router, 'upsert_action_item_vector', lambda *args, **kwargs: None)
+    monkeypatch.setattr(action_items_router, 'submit_with_context', lambda *args, **kwargs: None)
+    monkeypatch.setattr(action_items_router, 'send_action_item_data_message', lambda **kwargs: None)
+    monkeypatch.setattr(action_items_router, '_wake_task_changes', lambda *args, **kwargs: None)
+
+    def _create(uid, data, idempotency_key=None, **kwargs):
+        capture.append({'data': data, 'idempotency_key': idempotency_key})
+        return f'task-{len(capture)}'
+
+    monkeypatch.setattr(action_items_db, 'create_action_item', _create)
+    monkeypatch.setattr(
+        action_items_db,
+        'get_action_item',
+        lambda uid, task_id: {'id': task_id, 'description': '123', 'completed': False, 'due_at': None},
+    )
 
 
-def test_content_key_separates_users():
-    a = action_items_router._content_idempotency_key('uid-1', 'Buy milk')
-    b = action_items_router._content_idempotency_key('uid-2', 'Buy milk')
-    assert a != b
+def test_router_does_not_hash_description_as_idempotency_key(monkeypatch):
+    """Two POSTs with the same title and no header must both insert.
+
+    Hashing (uid, description) made the second create return the first
+    document, so the UI showed a clone with the old due date that vanished
+    on reload.
+    """
+    capture = []
+    _stub_router_create(monkeypatch, capture=capture)
+    request = action_items_router.CreateActionItemRequest(description='123')
+
+    first = action_items_router.create_action_item(request, uid='user-1')
+    second = action_items_router.create_action_item(request, uid='user-1')
+
+    assert first.id != second.id
+    assert [row['idempotency_key'] for row in capture] == [None, None]
 
 
-def test_content_key_separates_descriptions():
-    a = action_items_router._content_idempotency_key('uid-1', 'Buy milk')
-    b = action_items_router._content_idempotency_key('uid-1', 'Buy bread')
-    assert a != b
+def test_router_honors_client_idempotency_key(monkeypatch):
+    capture = []
+    _stub_router_create(monkeypatch, capture=capture)
 
+    action_items_router.create_action_item(
+        action_items_router.CreateActionItemRequest(description='123'),
+        uid='user-1',
+        idempotency_key='retry-1',
+    )
 
-def test_content_key_avoids_separator_collision():
-    """Length-prefixed encoding must distinguish (uid='org', desc='user:task')
-    from (uid='org:user', desc='task'). A naive ``f"{uid}:{desc}"`` encoding
-    would collapse both to the same hash; the length prefix prevents this."""
-    a = action_items_router._content_idempotency_key('org', 'user:task')
-    b = action_items_router._content_idempotency_key('org:user', 'task')
-    assert a != b
+    assert capture[0]['idempotency_key'] == 'retry-1'
 
 
 def test_create_dispatches_auto_sync_outside_the_database_pool(monkeypatch):
@@ -296,6 +321,7 @@ def test_create_dispatches_auto_sync_outside_the_database_pool(monkeypatch):
     monkeypatch.setattr(legacy_db_executor, 'submit', lambda function: database_submissions.append(function))
     monkeypatch.setattr(action_items_router, 'db_executor', legacy_db_executor, raising=False)
     monkeypatch.setattr(action_items_router.task_links, 'validate_task_links', lambda *args, **kwargs: None)
+    monkeypatch.setattr(action_items_router, '_wake_task_changes', lambda *args, **kwargs: None)
     monkeypatch.setattr(action_items_db, 'create_action_item', lambda *args, **kwargs: 'task-1')
     monkeypatch.setattr(
         action_items_db,

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -4650,7 +4650,7 @@ public enum OmiAPI {
     return try JSONDecoder().decode(ActionItemsResponse.self, from: data)
   }
 
-  public static func createActionItemV1ActionItemsPost(client: OmiApiClient, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, body: ActionItemCreateRequest) async throws -> ActionItemResponse {
+  public static func createActionItemV1ActionItemsPost(client: OmiApiClient, idempotencyKey: String? = nil, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, body: ActionItemCreateRequest) async throws -> ActionItemResponse {
     let _path = "/v1/action-items"
     guard let components = URLComponents(string: client.baseURL + _path) else {
       throw OmiApiError.invalidURL
@@ -4662,6 +4662,7 @@ public enum OmiAPI {
     if let token = client.token {
       req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
     }
+    if let idempotencyKey { req.setValue(String(idempotencyKey), forHTTPHeaderField: "Idempotency-Key") }
     if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
     if let xAppPlatform { req.setValue(String(xAppPlatform), forHTTPHeaderField: "X-App-Platform") }
     if let xDeviceIdHash { req.setValue(String(xDeviceIdHash), forHTTPHeaderField: "X-Device-Id-Hash") }

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -8882,7 +8882,7 @@ export async function get_action_items_v1_action_items_get(query: { limit?: numb
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function create_action_item_v1_action_items_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ActionItemCreateRequest, init?: OmiApiClientInit): Promise<ActionItemResponse> {
+export async function create_action_item_v1_action_items_post(header: { Idempotency_Key?: string | null, authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ActionItemCreateRequest, init?: OmiApiClientInit): Promise<ActionItemResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/action-items`;
   const _search = "";
@@ -8892,6 +8892,7 @@ export async function create_action_item_v1_action_items_post(header: { authoriz
       ...(body ? { 'Content-Type': 'application/json' } : {}),
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
       ...init?.headers,
+      ...(header.Idempotency_Key !== undefined ? { "Idempotency-Key": String(header.Idempotency_Key) } : {}),
       ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
       ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
       ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -25678,9 +25678,26 @@
         ]
       },
       "post": {
-        "description": "Create a new action item.\n\nContent-idempotent on (uid, normalized description): a retry of the same\nrequest returns the original action_item rather than creating a duplicate.",
+        "description": "Create a new action item.\n\nIdempotent only when the client sends ``Idempotency-Key``. Two creates\nwith the same description (and different keys, or no key) are two tasks.",
         "operationId": "create_action_item_v1_action_items_post",
         "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 256,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          },
           {
             "in": "header",
             "name": "authorization",

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -8882,7 +8882,7 @@ export async function get_action_items_v1_action_items_get(query: { limit?: numb
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function create_action_item_v1_action_items_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ActionItemCreateRequest, init?: OmiApiClientInit): Promise<ActionItemResponse> {
+export async function create_action_item_v1_action_items_post(header: { Idempotency_Key?: string | null, authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ActionItemCreateRequest, init?: OmiApiClientInit): Promise<ActionItemResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/action-items`;
   const _search = "";
@@ -8892,6 +8892,7 @@ export async function create_action_item_v1_action_items_post(header: { authoriz
       ...(body ? { 'Content-Type': 'application/json' } : {}),
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
       ...init?.headers,
+      ...(header.Idempotency_Key !== undefined ? { "Idempotency-Key": String(header.Idempotency_Key) } : {}),
       ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
       ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
       ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),

--- a/web/app/src/app/api/proxy/[...path]/route.ts
+++ b/web/app/src/app/api/proxy/[...path]/route.ts
@@ -45,14 +45,18 @@ async function handleRequest(request: Request) {
       Authorization: authHeader,
     };
 
-    // Forward custom headers for FCM token registration
+    // Forward custom headers for FCM token registration and create retries
     const appPlatform = request.headers.get('X-App-Platform');
     const deviceIdHash = request.headers.get('X-Device-Id-Hash');
+    const idempotencyKey = request.headers.get('Idempotency-Key');
     if (appPlatform) {
       headers['X-App-Platform'] = appPlatform;
     }
     if (deviceIdHash) {
       headers['X-Device-Id-Hash'] = deviceIdHash;
+    }
+    if (idempotencyKey) {
+      headers['Idempotency-Key'] = idempotencyKey;
     }
 
     if (!isMultipart && request.method !== 'GET') {

--- a/web/app/src/hooks/useActionItems.ts
+++ b/web/app/src/hooks/useActionItems.ts
@@ -10,6 +10,7 @@ import {
   deleteActionItem,
   type CreateActionItemParams,
 } from '@/lib/api';
+import { prependOrReplaceById } from '@/lib/actionItemList';
 import { onCacheInvalidation, invalidationPatterns } from '@/lib/cache';
 import type { ActionItem, GroupedActionItems } from '@/types/conversation';
 
@@ -153,7 +154,10 @@ function groupActionItems(items: ActionItem[]): GroupedActionItems {
 /**
  * Calculate task counts for a specific date
  */
-function getTaskCountsForDate(items: ActionItem[], date: Date): { pending: number; completed: number } {
+function getTaskCountsForDate(
+  items: ActionItem[],
+  date: Date,
+): { pending: number; completed: number } {
   if (!Array.isArray(items)) {
     return { pending: 0, completed: 0 };
   }
@@ -270,12 +274,12 @@ export function useActionItems(): UseActionItemsReturn {
 
   // Calculate stats
   const stats = useMemo(() => {
-    const completed = items.filter(i => i.completed).length;
-    const pending = items.filter(i => !i.completed).length;
+    const completed = items.filter((i) => i.completed).length;
+    const pending = items.filter((i) => !i.completed).length;
     const overdue = groupedItems.overdue.length;
     const noDueDateCount = groupedItems.noDueDate.length;
-    const todayItems = items.filter(i => i.due_at && isToday(new Date(i.due_at)));
-    const todayCompleted = todayItems.filter(i => i.completed).length;
+    const todayItems = items.filter((i) => i.due_at && isToday(new Date(i.due_at)));
+    const todayCompleted = todayItems.filter((i) => i.completed).length;
 
     // Calculate weekly stats (last 7 days)
     const today = new Date();
@@ -283,21 +287,21 @@ export function useActionItems(): UseActionItemsReturn {
     const weekAgo = new Date(today);
     weekAgo.setDate(weekAgo.getDate() - 7);
 
-    const weekItems = items.filter(i => {
+    const weekItems = items.filter((i) => {
       if (!i.due_at) return false;
       const dueDate = new Date(i.due_at);
       dueDate.setHours(0, 0, 0, 0);
       return dueDate >= weekAgo && dueDate <= today;
     });
-    const weekCompleted = weekItems.filter(i => i.completed).length;
-    const weekPending = weekItems.filter(i => !i.completed).length;
+    const weekCompleted = weekItems.filter((i) => i.completed).length;
+    const weekPending = weekItems.filter((i) => !i.completed).length;
 
     // Calculate streak (consecutive days with at least one completion)
     let streak = 0;
     const checkDate = new Date(today);
 
     // Check if we completed anything today first
-    const todayHasCompletion = items.some(i => {
+    const todayHasCompletion = items.some((i) => {
       if (!i.completed || !i.completed_at) return false;
       const completedDate = new Date(i.completed_at);
       return completedDate.toDateString() === today.toDateString();
@@ -310,7 +314,7 @@ export function useActionItems(): UseActionItemsReturn {
       // Count backwards from yesterday
       while (true) {
         const dateStr = checkDate.toDateString();
-        const hasCompletion = items.some(i => {
+        const hasCompletion = items.some((i) => {
           if (!i.completed || !i.completed_at) return false;
           const completedDate = new Date(i.completed_at);
           return completedDate.toDateString() === dateStr;
@@ -356,7 +360,10 @@ export function useActionItems(): UseActionItemsReturn {
 
       days.push({
         date,
-        dayName: i === 0 ? 'TODAY' : date.toLocaleDateString('en-US', { weekday: 'short' }).toUpperCase(),
+        dayName:
+          i === 0
+            ? 'TODAY'
+            : date.toLocaleDateString('en-US', { weekday: 'short' }).toUpperCase(),
         dayNumber: date.getDate(),
         isToday: i === 0,
         pending: counts.pending,
@@ -369,8 +376,8 @@ export function useActionItems(): UseActionItemsReturn {
 
   // Sorted flat list for list view (pending sorted by due date, no-date items last)
   const sortedFlatList = useMemo(() => {
-    const pending = items.filter(i => !i.completed);
-    const completed = items.filter(i => i.completed);
+    const pending = items.filter((i) => !i.completed);
+    const completed = items.filter((i) => i.completed);
 
     // Sort pending: by due date (soonest first), items without due date go last
     pending.sort((a, b) => {
@@ -398,27 +405,34 @@ export function useActionItems(): UseActionItemsReturn {
   }, [items]);
 
   // Add new item
-  const addItem = useCallback(async (params: CreateActionItemParams): Promise<ActionItem | null> => {
-    try {
-      const newItem = await createActionItem(params);
-      setItems(prev => [newItem, ...prev]);
-      return newItem;
-    } catch (err) {
-      console.error('Failed to create action item:', err);
-      setError(err instanceof Error ? err.message : 'Failed to create task');
-      return null;
-    }
-  }, []);
+  const addItem = useCallback(
+    async (params: CreateActionItemParams): Promise<ActionItem | null> => {
+      try {
+        const newItem = await createActionItem(params);
+        setItems((prev) => prependOrReplaceById(prev, newItem));
+        return newItem;
+      } catch (err) {
+        console.error('Failed to create action item:', err);
+        setError(err instanceof Error ? err.message : 'Failed to create task');
+        return null;
+      }
+    },
+    [],
+  );
 
   // Toggle completion
   const toggleComplete = useCallback(async (id: string, completed: boolean) => {
     // Optimistic update
-    setItems(prev =>
-      prev.map(item =>
+    setItems((prev) =>
+      prev.map((item) =>
         item.id === id
-          ? { ...item, completed, completed_at: completed ? new Date().toISOString() : null }
-          : item
-      )
+          ? {
+              ...item,
+              completed,
+              completed_at: completed ? new Date().toISOString() : null,
+            }
+          : item,
+      ),
     );
 
     try {
@@ -426,199 +440,217 @@ export function useActionItems(): UseActionItemsReturn {
     } catch (err) {
       console.error('Failed to toggle completion:', err);
       // Revert on error
-      setItems(prev =>
-        prev.map(item =>
-          item.id === id ? { ...item, completed: !completed, completed_at: null } : item
-        )
+      setItems((prev) =>
+        prev.map((item) =>
+          item.id === id ? { ...item, completed: !completed, completed_at: null } : item,
+        ),
       );
       setError(err instanceof Error ? err.message : 'Failed to update task');
     }
   }, []);
 
   // Snooze (add days to due date)
-  const snooze = useCallback(async (id: string, days: number) => {
-    const item = items.find(i => i.id === id);
-    if (!item) return;
+  const snooze = useCallback(
+    async (id: string, days: number) => {
+      const item = items.find((i) => i.id === id);
+      if (!item) return;
 
-    const newDate = new Date();
-    if (item.due_at) {
-      const currentDate = new Date(item.due_at);
-      // If current date is in the past, start from today
-      if (currentDate < newDate) {
-        newDate.setDate(newDate.getDate() + days);
+      const newDate = new Date();
+      if (item.due_at) {
+        const currentDate = new Date(item.due_at);
+        // If current date is in the past, start from today
+        if (currentDate < newDate) {
+          newDate.setDate(newDate.getDate() + days);
+        } else {
+          newDate.setTime(currentDate.getTime());
+          newDate.setDate(newDate.getDate() + days);
+        }
       } else {
-        newDate.setTime(currentDate.getTime());
         newDate.setDate(newDate.getDate() + days);
       }
-    } else {
-      newDate.setDate(newDate.getDate() + days);
-    }
 
-    // Optimistic update
-    const newDueAt = newDate.toISOString();
-    setItems(prev =>
-      prev.map(i => (i.id === id ? { ...i, due_at: newDueAt } : i))
-    );
+      // Optimistic update
+      const newDueAt = newDate.toISOString();
+      setItems((prev) => prev.map((i) => (i.id === id ? { ...i, due_at: newDueAt } : i)));
 
-    try {
-      await updateActionItemDueDate(id, newDueAt);
-    } catch (err) {
-      console.error('Failed to snooze task:', err);
-      // Revert on error
-      setItems(prev =>
-        prev.map(i => (i.id === id ? { ...i, due_at: item.due_at } : i))
-      );
-      setError(err instanceof Error ? err.message : 'Failed to snooze task');
-    }
-  }, [items]);
+      try {
+        await updateActionItemDueDate(id, newDueAt);
+      } catch (err) {
+        console.error('Failed to snooze task:', err);
+        // Revert on error
+        setItems((prev) =>
+          prev.map((i) => (i.id === id ? { ...i, due_at: item.due_at } : i)),
+        );
+        setError(err instanceof Error ? err.message : 'Failed to snooze task');
+      }
+    },
+    [items],
+  );
 
   // Set specific due date
-  const setDueDate = useCallback(async (id: string, date: Date | null) => {
-    const item = items.find(i => i.id === id);
-    if (!item) return;
+  const setDueDate = useCallback(
+    async (id: string, date: Date | null) => {
+      const item = items.find((i) => i.id === id);
+      if (!item) return;
 
-    const newDueAt = date ? date.toISOString() : null;
+      const newDueAt = date ? date.toISOString() : null;
 
-    // Optimistic update
-    setItems(prev =>
-      prev.map(i => (i.id === id ? { ...i, due_at: newDueAt } : i))
-    );
+      // Optimistic update
+      setItems((prev) => prev.map((i) => (i.id === id ? { ...i, due_at: newDueAt } : i)));
 
-    try {
-      await updateActionItemDueDate(id, newDueAt);
-    } catch (err) {
-      console.error('Failed to update due date:', err);
-      // Revert on error
-      setItems(prev =>
-        prev.map(i => (i.id === id ? { ...i, due_at: item.due_at } : i))
-      );
-      setError(err instanceof Error ? err.message : 'Failed to update due date');
-    }
-  }, [items]);
+      try {
+        await updateActionItemDueDate(id, newDueAt);
+      } catch (err) {
+        console.error('Failed to update due date:', err);
+        // Revert on error
+        setItems((prev) =>
+          prev.map((i) => (i.id === id ? { ...i, due_at: item.due_at } : i)),
+        );
+        setError(err instanceof Error ? err.message : 'Failed to update due date');
+      }
+    },
+    [items],
+  );
 
   // Update description
-  const updateDescription = useCallback(async (id: string, description: string) => {
-    const item = items.find(i => i.id === id);
-    if (!item) return;
+  const updateDescription = useCallback(
+    async (id: string, description: string) => {
+      const item = items.find((i) => i.id === id);
+      if (!item) return;
 
-    const oldDescription = item.description;
+      const oldDescription = item.description;
 
-    // Optimistic update
-    setItems(prev =>
-      prev.map(i => (i.id === id ? { ...i, description } : i))
-    );
+      // Optimistic update
+      setItems((prev) => prev.map((i) => (i.id === id ? { ...i, description } : i)));
 
-    try {
-      await updateActionItemDescription(id, description);
-    } catch (err) {
-      console.error('Failed to update description:', err);
-      // Revert on error
-      setItems(prev =>
-        prev.map(i => (i.id === id ? { ...i, description: oldDescription } : i))
-      );
-      setError(err instanceof Error ? err.message : 'Failed to update task');
-    }
-  }, [items]);
+      try {
+        await updateActionItemDescription(id, description);
+      } catch (err) {
+        console.error('Failed to update description:', err);
+        // Revert on error
+        setItems((prev) =>
+          prev.map((i) => (i.id === id ? { ...i, description: oldDescription } : i)),
+        );
+        setError(err instanceof Error ? err.message : 'Failed to update task');
+      }
+    },
+    [items],
+  );
 
   // Remove item
-  const removeItem = useCallback(async (id: string) => {
-    const item = items.find(i => i.id === id);
-    if (!item) return;
+  const removeItem = useCallback(
+    async (id: string) => {
+      const item = items.find((i) => i.id === id);
+      if (!item) return;
 
-    // Optimistic update
-    setItems(prev => prev.filter(i => i.id !== id));
+      // Optimistic update
+      setItems((prev) => prev.filter((i) => i.id !== id));
 
-    try {
-      await deleteActionItem(id);
-    } catch (err) {
-      console.error('Failed to delete task:', err);
-      // Revert on error
-      setItems(prev => [...prev, item]);
-      setError(err instanceof Error ? err.message : 'Failed to delete task');
-    }
-  }, [items]);
+      try {
+        await deleteActionItem(id);
+      } catch (err) {
+        console.error('Failed to delete task:', err);
+        // Revert on error
+        setItems((prev) => [...prev, item]);
+        setError(err instanceof Error ? err.message : 'Failed to delete task');
+      }
+    },
+    [items],
+  );
 
   // Bulk complete
-  const bulkComplete = useCallback(async (ids: string[]) => {
-    // Optimistic update
-    setItems(prev =>
-      prev.map(item =>
-        ids.includes(item.id)
-          ? { ...item, completed: true, completed_at: new Date().toISOString() }
-          : item
-      )
-    );
+  const bulkComplete = useCallback(
+    async (ids: string[]) => {
+      // Optimistic update
+      setItems((prev) =>
+        prev.map((item) =>
+          ids.includes(item.id)
+            ? { ...item, completed: true, completed_at: new Date().toISOString() }
+            : item,
+        ),
+      );
 
-    try {
-      await Promise.all(ids.map(id => toggleActionItemCompleted(id, true)));
-    } catch (err) {
-      console.error('Failed to bulk complete:', err);
-      // Refresh to get correct state
-      fetchItems();
-      setError(err instanceof Error ? err.message : 'Failed to complete tasks');
-    }
-  }, [fetchItems]);
+      try {
+        await Promise.all(ids.map((id) => toggleActionItemCompleted(id, true)));
+      } catch (err) {
+        console.error('Failed to bulk complete:', err);
+        // Refresh to get correct state
+        fetchItems();
+        setError(err instanceof Error ? err.message : 'Failed to complete tasks');
+      }
+    },
+    [fetchItems],
+  );
 
   // Bulk delete
-  const bulkDelete = useCallback(async (ids: string[]) => {
-    const deletedItems = items.filter(i => ids.includes(i.id));
+  const bulkDelete = useCallback(
+    async (ids: string[]) => {
+      const deletedItems = items.filter((i) => ids.includes(i.id));
 
-    // Optimistic update
-    setItems(prev => prev.filter(i => !ids.includes(i.id)));
+      // Optimistic update
+      setItems((prev) => prev.filter((i) => !ids.includes(i.id)));
 
-    try {
-      await Promise.all(ids.map(id => deleteActionItem(id)));
-    } catch (err) {
-      console.error('Failed to bulk delete:', err);
-      // Revert on error
-      setItems(prev => [...prev, ...deletedItems]);
-      setError(err instanceof Error ? err.message : 'Failed to delete tasks');
-    }
-  }, [items]);
+      try {
+        await Promise.all(ids.map((id) => deleteActionItem(id)));
+      } catch (err) {
+        console.error('Failed to bulk delete:', err);
+        // Revert on error
+        setItems((prev) => [...prev, ...deletedItems]);
+        setError(err instanceof Error ? err.message : 'Failed to delete tasks');
+      }
+    },
+    [items],
+  );
 
   // Bulk snooze
-  const bulkSnooze = useCallback(async (ids: string[], days: number) => {
-    const newDate = new Date();
-    newDate.setDate(newDate.getDate() + days);
-    const newDueAt = newDate.toISOString();
+  const bulkSnooze = useCallback(
+    async (ids: string[], days: number) => {
+      const newDate = new Date();
+      newDate.setDate(newDate.getDate() + days);
+      const newDueAt = newDate.toISOString();
 
-    // Optimistic update
-    setItems(prev =>
-      prev.map(item =>
-        ids.includes(item.id) ? { ...item, due_at: newDueAt } : item
-      )
-    );
+      // Optimistic update
+      setItems((prev) =>
+        prev.map((item) =>
+          ids.includes(item.id) ? { ...item, due_at: newDueAt } : item,
+        ),
+      );
 
-    try {
-      await Promise.all(ids.map(id => updateActionItemDueDate(id, newDueAt)));
-    } catch (err) {
-      console.error('Failed to bulk snooze:', err);
-      // Refresh to get correct state
-      fetchItems();
-      setError(err instanceof Error ? err.message : 'Failed to snooze tasks');
-    }
-  }, [fetchItems]);
+      try {
+        await Promise.all(ids.map((id) => updateActionItemDueDate(id, newDueAt)));
+      } catch (err) {
+        console.error('Failed to bulk snooze:', err);
+        // Refresh to get correct state
+        fetchItems();
+        setError(err instanceof Error ? err.message : 'Failed to snooze tasks');
+      }
+    },
+    [fetchItems],
+  );
 
   // Bulk set due date (for no-due-date items)
-  const bulkSetDueDate = useCallback(async (ids: string[], date: Date | null) => {
-    const newDueAt = date ? date.toISOString() : null;
+  const bulkSetDueDate = useCallback(
+    async (ids: string[], date: Date | null) => {
+      const newDueAt = date ? date.toISOString() : null;
 
-    // Optimistic update
-    setItems(prev =>
-      prev.map(item =>
-        ids.includes(item.id) ? { ...item, due_at: newDueAt } : item
-      )
-    );
+      // Optimistic update
+      setItems((prev) =>
+        prev.map((item) =>
+          ids.includes(item.id) ? { ...item, due_at: newDueAt } : item,
+        ),
+      );
 
-    try {
-      await Promise.all(ids.map(id => updateActionItemDueDate(id, newDueAt)));
-    } catch (err) {
-      console.error('Failed to bulk set due date:', err);
-      // Refresh to get correct state
-      fetchItems();
-      setError(err instanceof Error ? err.message : 'Failed to set due dates');
-    }
-  }, [fetchItems]);
+      try {
+        await Promise.all(ids.map((id) => updateActionItemDueDate(id, newDueAt)));
+      } catch (err) {
+        console.error('Failed to bulk set due date:', err);
+        // Refresh to get correct state
+        fetchItems();
+        setError(err instanceof Error ? err.message : 'Failed to set due dates');
+      }
+    },
+    [fetchItems],
+  );
 
   return {
     items,

--- a/web/app/src/lib/__tests__/actionItemList.test.ts
+++ b/web/app/src/lib/__tests__/actionItemList.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { prependOrReplaceById } from '../actionItemList';
+
+describe('prependOrReplaceById', () => {
+  it('prepends a new id', () => {
+    const existing = { id: 'old', description: '123' };
+    const created = { id: 'new', description: '123' };
+    expect(prependOrReplaceById([existing], created)).toEqual([created, existing]);
+  });
+
+  it('replaces an existing id instead of cloning the row', () => {
+    const first = { id: 'same', description: '123', due_at: '2026-01-01' };
+    const replay = { id: 'same', description: '123', due_at: '2026-01-02' };
+    expect(prependOrReplaceById([first], replay)).toEqual([replay]);
+  });
+});

--- a/web/app/src/lib/actionItemList.ts
+++ b/web/app/src/lib/actionItemList.ts
@@ -1,0 +1,16 @@
+/**
+ * Insert a newly created action item at the front of the list.
+ *
+ * If the API replayed an existing id (legacy description-hash idempotency),
+ * replace that row instead of prepending a ghost duplicate that vanishes on
+ * reload.
+ */
+export function prependOrReplaceById<T extends { id: string }>(items: T[], item: T): T[] {
+  const index = items.findIndex((existing) => existing.id === item.id);
+  if (index === -1) {
+    return [item, ...items];
+  }
+  const next = items.slice();
+  next[index] = item;
+  return next;
+}

--- a/web/app/src/lib/api.ts
+++ b/web/app/src/lib/api.ts
@@ -349,6 +349,7 @@ export async function createActionItem(
 ): Promise<ActionItem> {
   return fetchWithAuth<ActionItem>('/v1/action-items', {
     method: 'POST',
+    headers: { 'Idempotency-Key': crypto.randomUUID() },
     body: JSON.stringify(params),
   });
 }

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -8882,7 +8882,7 @@ export async function get_action_items_v1_action_items_get(query: { limit?: numb
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function create_action_item_v1_action_items_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ActionItemCreateRequest, init?: OmiApiClientInit): Promise<ActionItemResponse> {
+export async function create_action_item_v1_action_items_post(header: { Idempotency_Key?: string | null, authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ActionItemCreateRequest, init?: OmiApiClientInit): Promise<ActionItemResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/action-items`;
   const _search = "";
@@ -8892,6 +8892,7 @@ export async function create_action_item_v1_action_items_post(header: { authoriz
       ...(body ? { 'Content-Type': 'application/json' } : {}),
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
       ...init?.headers,
+      ...(header.Idempotency_Key !== undefined ? { "Idempotency-Key": String(header.Idempotency_Key) } : {}),
       ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
       ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
       ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -8882,7 +8882,7 @@ export async function get_action_items_v1_action_items_get(query: { limit?: numb
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function create_action_item_v1_action_items_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ActionItemCreateRequest, init?: OmiApiClientInit): Promise<ActionItemResponse> {
+export async function create_action_item_v1_action_items_post(header: { Idempotency_Key?: string | null, authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ActionItemCreateRequest, init?: OmiApiClientInit): Promise<ActionItemResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/action-items`;
   const _search = "";
@@ -8892,6 +8892,7 @@ export async function create_action_item_v1_action_items_post(header: { authoriz
       ...(body ? { 'Content-Type': 'application/json' } : {}),
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
       ...init?.headers,
+      ...(header.Idempotency_Key !== undefined ? { "Idempotency-Key": String(header.Idempotency_Key) } : {}),
       ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
       ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
       ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),


### PR DESCRIPTION
<!-- Keep this short and honest. Reviewers read the Verification section first. -->

## What changed and why

`POST /v1/action-items` hashed the task title as an idempotency key, so creating a second task named like an existing one (`123`) returned the original document (same due date, gone after reload). Create is now idempotent only when the client sends `Idempotency-Key`; the web app sends a per-submit UUID, and the proxy forwards it.

## Product invariants affected

none

## How it was verified

- `BACKEND_UNIT_TEST_FILE_LIST=tests/unit/test_action_item_idempotency.py BACKEND_PYTEST_XDIST=0 ./test.sh` → 11 passed
- `NODE_OPTIONS=--no-experimental-webstorage bunx vitest run --config vitest.config.mts src/lib/__tests__/actionItemList.test.ts` → 2 passed
- Did **not** exercise live `/tasks` against this backend: production still hashes titles until this change is deployed. Could not confirm two same-title tasks persist after reload on a real account.

## Tests

Regression: `backend/tests/unit/test_action_item_idempotency.py::test_router_does_not_hash_description_as_idempotency_key` — two POSTs with the same description and no header must both insert.

Web defensive list merge: `web/app/src/lib/__tests__/actionItemList.test.ts` — if the API still returns an existing id, the list replaces that row instead of prepending a ghost duplicate.

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

