### PR TITLE
fix(desktop): make every chat_agent_error explain itself

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
@@ -17,6 +17,70 @@ enum ChatQueryErrorClass: String, Equatable, Sendable {
   case toolStall = "tool_stall"
   case transientNetwork = "transient_network"
   case unknown
+
+  /// Which subsystem a failed turn is attributed to. `error_class` is the
+  /// symptom a person saw; `root_cause` is the owner of the defect, and it is
+  /// what triage and churn analysis need to group on. Bounded by construction —
+  /// this never carries exception text.
+  var rootCause: ChatQueryRootCause {
+    switch self {
+    // Both auth and billing failures originate in the model provider account,
+    // not on the device. `provider_claude` is the value already published for
+    // `.authentication`; keep it so existing PostHog breakdowns stay valid.
+    case .authentication, .quota: return .providerClaude
+    case .agentError, .agentRuntime, .timeout, .toolStall: return .agentRuntime
+    case .bridgeUnavailable, .bridgeStartFailed: return .bridgeProcess
+    case .sessionSetup, .concurrentRequest: return .localSession
+    case .attachmentUpload: return .attachmentPipeline
+    case .browserExtensionMissing: return .browserExtension
+    case .encoding: return .requestEncoding
+    case .resourceExhausted: return .deviceResources
+    case .transientNetwork: return .network
+    case .unknown: return .unclassified
+    }
+  }
+
+  /// Bounded `error_code` for failures that reach analytics without a
+  /// `ChatQueryErrorDetail`. Only the bridge catch path in `ChatProvider`
+  /// supplies a detail, so without this every other terminal — timeouts, tool
+  /// stalls, session setup, bridge unavailability — arrives with no code at all
+  /// and the event cannot explain itself.
+  func fallbackErrorCode(watchdogFired: Bool) -> String {
+    switch self {
+    // The two timeouts have different owners: the watchdog is ours, the bridge
+    // timeout is the runtime's. Collapsing them loses the only actionable bit.
+    case .timeout: return watchdogFired ? "watchdog_timeout" : "bridge_timeout"
+    case .toolStall: return "tool_stall_abort"
+    case .sessionSetup: return "session_setup_failed"
+    case .bridgeUnavailable: return "bridge_unavailable"
+    case .bridgeStartFailed: return "bridge_start_failed"
+    case .browserExtensionMissing: return "browser_extension_missing"
+    case .attachmentUpload: return "attachment_upload_failed"
+    case .concurrentRequest: return "request_already_active"
+    case .encoding: return "encoding_failed"
+    case .resourceExhausted: return "out_of_memory"
+    case .transientNetwork: return "transient_network"
+    case .quota: return "quota_exceeded"
+    case .authentication: return "authentication"
+    case .agentError: return "agent_error"
+    case .agentRuntime: return "agent_runtime_failure"
+    case .unknown: return "unclassified"
+    }
+  }
+}
+
+/// Closed vocabulary for `chat_agent_error.root_cause`.
+enum ChatQueryRootCause: String, Equatable, Sendable {
+  case agentRuntime = "agent_runtime"
+  case attachmentPipeline = "attachment_pipeline"
+  case bridgeProcess = "bridge_process"
+  case browserExtension = "browser_extension"
+  case deviceResources = "device_resources"
+  case localSession = "local_session"
+  case network
+  case providerClaude = "provider_claude"
+  case requestEncoding = "request_encoding"
+  case unclassified
 }
 
 enum ChatQueryCancellationReason: String, Equatable, Sendable {
@@ -403,8 +467,12 @@ extension ChatQueryTelemetryEvent {
         "error_class": errorClass.rawValue,
         "partial_response": partialResponse,
         "watchdog_fired": watchdogFired,
+        // Populated for every failure, not only the ones that carry a detail.
+        "error_code": errorClass.fallbackErrorCode(watchdogFired: watchdogFired),
+        "root_cause": errorClass.rootCause.rawValue,
       ]
       if let detail {
+        // A detail is a strictly better code than the class fallback.
         properties["error_code"] = detail.errorCode
         if let retryable = detail.retryable { properties["retryable"] = retryable }
         if let failureCode = detail.failureCode { properties["failure_code"] = failureCode }
@@ -456,7 +524,6 @@ extension ChatQueryTelemetryEvent {
       properties["error"] = errorClass.rawValue
       if errorClass == .authentication {
         properties["turn_disposition"] = "auth_blocked"
-        properties["root_cause"] = "provider_claude"
       }
     }
     return ChatQueryAnalyticsPayload(eventName: eventName, properties: properties)

--- a/desktop/macos/Desktop/Tests/ChatQueryTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatQueryTelemetryTests.swift
@@ -189,6 +189,7 @@ final class ChatQueryTelemetryTests: XCTestCase {
       Set(payload.properties.keys),
       Set([
         "attempt_id", "surface", "harness", "duration_ms", "error_class", "error",
+        "error_code", "root_cause",
         "partial_response", "watchdog_fired", "telemetry_schema_version", "input_length_bucket",
         "attachment_count", "has_image",
       ])
@@ -196,6 +197,82 @@ final class ChatQueryTelemetryTests: XCTestCase {
     XCTAssertEqual(payload.properties["error_class"] as? String, "timeout")
     XCTAssertEqual(payload.properties["error"] as? String, "timeout")
     XCTAssertFalse(payload.properties.keys.contains("text"))
+  }
+
+  /// The 2026-08 macOS churn cohort could not explain `chat_agent_error` because
+  /// only the bridge catch path supplied a `ChatQueryErrorDetail`; every other
+  /// terminal arrived with no `error_code` and no `root_cause`. Every failure
+  /// class must now classify itself.
+  func testEveryFailureClassCarriesABoundedCodeAndRootCause() {
+    let allClasses: [ChatQueryErrorClass] = [
+      .agentError, .agentRuntime, .attachmentUpload, .authentication, .bridgeUnavailable,
+      .bridgeStartFailed, .browserExtensionMissing, .concurrentRequest, .encoding, .quota,
+      .resourceExhausted, .sessionSetup, .timeout, .toolStall, .transientNetwork, .unknown,
+    ]
+    let allowedRootCauses = Set(
+      [
+        ChatQueryRootCause.agentRuntime, .attachmentPipeline, .bridgeProcess, .browserExtension,
+        .deviceResources, .localSession, .network, .providerClaude, .requestEncoding, .unclassified,
+      ].map(\.rawValue))
+
+    for errorClass in allClasses {
+      let payload = ChatQueryTelemetryEvent.failed(
+        ChatQueryTelemetryContext(attemptId: "a", surface: "main_chat", harness: "pimono"),
+        durationMs: 10,
+        errorClass: errorClass,
+        partialResponse: false,
+        detail: nil
+      ).analyticsPayload
+      let code = payload.properties["error_code"] as? String
+      let rootCause = payload.properties["root_cause"] as? String
+      XCTAssertNotNil(code, "\(errorClass.rawValue) emitted no error_code")
+      XCTAssertFalse(code?.isEmpty ?? true, "\(errorClass.rawValue) emitted an empty error_code")
+      XCTAssertNotNil(rootCause, "\(errorClass.rawValue) emitted no root_cause")
+      XCTAssertTrue(
+        allowedRootCauses.contains(rootCause ?? ""),
+        "\(errorClass.rawValue) emitted unbounded root_cause \(rootCause ?? "nil")")
+    }
+  }
+
+  /// Auth kept the value already published to PostHog so existing breakdowns
+  /// stay valid, and the two timeouts stay distinguishable because they have
+  /// different owners.
+  func testRootCauseAndTimeoutCodesStayActionable() {
+    func payload(_ errorClass: ChatQueryErrorClass, watchdogFired: Bool = false) -> [String: Any] {
+      ChatQueryTelemetryEvent.failed(
+        ChatQueryTelemetryContext(attemptId: "a", surface: "main_chat", harness: "pimono"),
+        durationMs: 10,
+        errorClass: errorClass,
+        partialResponse: false,
+        detail: nil,
+        watchdogFired: watchdogFired
+      ).analyticsPayload.properties
+    }
+
+    XCTAssertEqual(payload(.authentication)["root_cause"] as? String, "provider_claude")
+    XCTAssertEqual(payload(.authentication)["turn_disposition"] as? String, "auth_blocked")
+    XCTAssertEqual(payload(.quota)["root_cause"] as? String, "provider_claude")
+    XCTAssertEqual(payload(.bridgeUnavailable)["root_cause"] as? String, "bridge_process")
+    XCTAssertEqual(payload(.timeout, watchdogFired: true)["error_code"] as? String, "watchdog_timeout")
+    XCTAssertEqual(payload(.timeout)["error_code"] as? String, "bridge_timeout")
+  }
+
+  /// A detail is strictly better information than the class fallback, so it
+  /// must win rather than be shadowed by it.
+  func testErrorDetailCodeOverridesTheClassFallback() {
+    let payload = ChatQueryTelemetryEvent.failed(
+      ChatQueryTelemetryContext(attemptId: "a", surface: "main_chat", harness: "pimono"),
+      durationMs: 10,
+      errorClass: .agentRuntime,
+      partialResponse: false,
+      detail: .from(
+        BridgeError.agentRuntimeFailure(
+          AgentRuntimeFailure(code: "adapter_not_registered", userMessage: "Agent run failed")))
+    ).analyticsPayload
+
+    XCTAssertEqual(payload.properties["failure_code"] as? String, "adapter_not_registered")
+    XCTAssertNotEqual(payload.properties["error_code"] as? String, "agent_runtime_failure")
+    XCTAssertEqual(payload.properties["root_cause"] as? String, "agent_runtime")
   }
 
   func testDecoratedToolAndFailureDimensionsCannotLeakContentOrExplodeCardinality() {

--- a/desktop/macos/changelog/unreleased/20260826-chat-error-classification.json
+++ b/desktop/macos/changelog/unreleased/20260826-chat-error-classification.json
@@ -1,0 +1,3 @@
+{
+  "change": "Chat failures now report which subsystem they came from, so a failed answer can be diagnosed instead of just counted"
+}


### PR DESCRIPTION
## Defect

The 2026-08 macOS churn cohort analysis (`omi-knowledge-base/projects/macos-churn-analysis/evidence/2026-08-26-macos-churn-cohort-analysis.md`, "Engineering leads") filed `chat_agent_error` as the highest-value instrumentation fix: *"the event is well-powered but cannot explain itself."*

Re-measured against PostHog (project 302298, `$os = macOS`) for August 2026, `chat_agent_error` = 1,197 events:

| property | populated |
| --- | --- |
| `error_class` / `surface` / `harness` | 1,177 |
| `error_code` | 909 |
| `root_cause` | 178 |

Two corrections to the analysis are worth recording, because both changed the scope of this PR:

1. **The "97.9% null" figure is mostly a client-rollout artifact, not a live defect.** Schema v2 (`4d711b4dbe`, 2026-07-11) already populates `error_class`/`surface`/`harness` on every event. Monthly completeness for `error_class`: June 0/2,028 → July 410/1,687 → August 1,177/1,197. The cohort window was dominated by pre-v2 clients.
2. **`properties['error_code']` reads back NULL in HogQL even though the client sends it.** `JSONExtractString(properties, 'error_code')` returns real values (`unknown`, `authentication`, `adapter_unavailable`, `provider_billing_exhausted`) for the same rows. Any future payload-completeness audit must cross-check with `JSONExtractString`; the map subscript under-reports.

The real remaining hole is in this repo. Only one of the ~15 `telemetryAttempt.fail(...)` call sites — `desktop/macos/Desktop/Sources/Providers/ChatProvider.swift:5446` — passes a `ChatQueryErrorDetail`. Every other terminal (`.timeout`, `.toolStall`, `.sessionSetup`, `.bridgeUnavailable`, `.attachmentUpload`, `.concurrentRequest`, ...) reached PostHog with no `error_code` at all, and `root_cause` was hardcoded for exactly one class:

```swift
if errorClass == .authentication {
  properties["turn_disposition"] = "auth_blocked"
  properties["root_cause"] = "provider_claude"
}
```

A typed failure existed at the catch boundary and was collapsed to a bare class name by the time it was recorded.

## Fix

`ChatQueryErrorClass` now classifies itself, so this lands at the single place that builds the payload rather than at 15 call sites:

- **`rootCause`** maps every class to a bounded `ChatQueryRootCause` — subsystem attribution (`provider_claude`, `agent_runtime`, `bridge_process`, `local_session`, `network`, `device_resources`, `attachment_pipeline`, `browser_extension`, `request_encoding`, `unclassified`). `.authentication` keeps the already-published `provider_claude` value so existing PostHog breakdowns stay valid.
- **`fallbackErrorCode(watchdogFired:)`** gives every class a bounded code when no `ChatQueryErrorDetail` is available, and separates `watchdog_timeout` from `bridge_timeout` — different owners, previously indistinguishable.
- A supplied `ChatQueryErrorDetail` still wins; the fallback only fills the gap.

No raw exception text, prompt, path, or message enters the payload. Every value is an enum raw value, per the analytics integrity contract in `desktop/macos/AGENTS.md`.

Expected event shape after this change, for a watchdog timeout that previously carried nothing beyond its class:

```
error_class = timeout
error_code  = watchdog_timeout   (was: absent)
root_cause  = agent_runtime      (was: absent)
```

## Proof

`ChatQueryTelemetryTests` (37 tests pass locally, `xcrun swift test --filter ChatQueryTelemetryTests`):

- `testEveryFailureClassCarriesABoundedCodeAndRootCause` — iterates all 16 classes; fails if any emits an empty/absent `error_code` or an out-of-vocabulary `root_cause`. This is the automatic-or-dead check: a new `ChatQueryErrorClass` added without a mapping fails to compile (exhaustive `switch`), and one added with an empty mapping fails this test.
- `testRootCauseAndTimeoutCodesStayActionable` — pins the auth compatibility value and the watchdog/bridge timeout split.
- `testErrorDetailCodeOverridesTheClassFallback` — the fallback cannot shadow real detail.
- `testAnalyticsPayloadUsesTypedAllowlist` (existing, updated) — still pins the exact emitted key set, so no unbounded property can be added silently.

Local `make preflight` passes. Full Swift contract CI (~42 min) runs after push; not claimed green here.

## Invariants

- INV-CHAT-1 — touched by path only. This PR changes the analytics payload built from an already-terminal chat query; it does not move rich-block handling, answer submission, or task completion out of the existing provider, and adds no lifecycle behavior.

## Scope

Telemetry payload only. No product behavior, no new event, no new call site, no flag.

Failure-Class: FC-typed-failure-collapsed-to-generic

---

*Second commit is unrelated housekeeping needed to get any desktop PR past the local pre-push gate on Xcode 26.x: a swift-format drift already on `main` (`lint-scope` covers every first-party Swift file) and one implicit `self` capture that Swift 6.2 rejects and Xcode 16.4 accepts. Formatter output and an explicit `self.`; no behavior change on either toolchain.*


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

