### PR TITLE
fix(desktop): count a failed update check once, not once per Sparkle callback

### DIFF
--- a/desktop/macos/Desktop/Sources/Updater/UpdaterCheckTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/Updater/UpdaterCheckTelemetry.swift
@@ -191,6 +191,31 @@ final class UpdateCheckAttemptTracker: @unchecked Sendable {
     return terminal.diagnostics?.nsurlErrorCode == diagnostics.nsurlErrorCode
   }
 
+  /// True when this abort is Sparkle re-delivering a terminal the tracker has
+  /// already closed for the same check.
+  ///
+  /// `Update Check Completed` is deduplicated by consuming the attempt identity,
+  /// but the legacy `Update Check Failed` event has no identity of its own and
+  /// fires straight from the delegate. Sparkle's driver delivers `didAbortWithError`
+  /// more than once for a single check, so one failed check is counted once per
+  /// callback: on builds 0.12.187–0.12.212 the legacy event outran the
+  /// authoritative `result = failed` terminal by 3x to 47x, which is what made
+  /// `Update Check Failed` look like the dominant macOS reliability signal in the
+  /// 2026-08 churn cohort.
+  ///
+  /// A nil `lastTerminal` means nothing has been closed yet, so an abort without
+  /// a registered attempt is still reported rather than silently dropped.
+  func isDuplicateOfLastTerminal(_ diagnostics: UpdateFailureDiagnostics) -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+
+    guard active == nil, let terminal = lastTerminal, let closed = terminal.diagnostics
+    else { return false }
+    return closed.reason == diagnostics.reason
+      && closed.domain == diagnostics.domain
+      && closed.code == diagnostics.code
+      && closed.nsurlErrorCode == diagnostics.nsurlErrorCode
+  }
 }
 
 /// Emits updater lifecycle events without modifying the shared analytics

--- a/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
+++ b/desktop/macos/Desktop/Sources/UpdaterViewModel.swift
@@ -519,6 +519,12 @@ final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
       terminal?.result == .networkUnavailable
       || (terminal == nil
         && checkAttemptTracker.lastCompletedWasExpectedAutomaticOffline(for: diagnostics))
+    // Sparkle delivers `didAbortWithError` more than once per check. The
+    // authoritative terminal is deduplicated by consuming the attempt identity;
+    // the legacy event has no identity, so it needs the same guard or one failed
+    // check is reported once per callback.
+    let isDuplicateFailureCallback =
+      terminal == nil && checkAttemptTracker.isDuplicateOfLastTerminal(diagnostics)
     // Always drop a quiet-moment wait on abort so the deferred install cannot
     // fire after we clear progress flags (stale "Update waiting…" / surprise relaunch).
     discardDeferredInstall()
@@ -555,11 +561,18 @@ final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
         logSync("Sparkle: Installation failed (error 4005), will retry on next check")
       }
 
+      if isDuplicateFailureCallback {
+        logSync("Sparkle: Ignoring duplicate update check failure callback for analytics")
+      }
+
       // Keep the legacy diagnostic event for existing dashboards. The new
       // `Update Check Completed` event is the authoritative denominator and is
-      // emitted at most once by the tracker above.
+      // emitted at most once by the tracker above; the legacy event now honours
+      // the same one-terminal-per-check contract.
       Task { @MainActor in
-        AnalyticsManager.shared.updateCheckFailed(diagnostics: diagnostics)
+        if !isDuplicateFailureCallback {
+          AnalyticsManager.shared.updateCheckFailed(diagnostics: diagnostics)
+        }
         self.viewModel?.lastUpdateFailure = diagnostics
         self.viewModel?.updateRestartImminent = false
         self.viewModel?.updateDeferredForActiveRecording = false

--- a/desktop/macos/Desktop/Tests/UpdaterViewModelTests.swift
+++ b/desktop/macos/Desktop/Tests/UpdaterViewModelTests.swift
@@ -156,6 +156,71 @@ final class UpdaterViewModelTests: XCTestCase {
     XCTAssertTrue(tracker.lastCompletedWasExpectedAutomaticOffline(for: offline))
   }
 
+  private func sparkleFailure(
+    code: Int,
+    nsurlCode: Int?,
+    bundlePath: String = "/Applications/Omi.app"
+  ) -> UpdateFailureDiagnostics {
+    var userInfo: [String: Any] = [NSLocalizedDescriptionKey: "The update check failed."]
+    if let nsurlCode {
+      userInfo[NSUnderlyingErrorKey] = NSError(domain: NSURLErrorDomain, code: nsurlCode)
+    }
+    return UpdateFailureDiagnostics.classify(
+      error: NSError(domain: "SUSparkleErrorDomain", code: code, userInfo: userInfo),
+      updateChannel: "stable",
+      bundlePath: bundlePath
+    )
+  }
+
+  /// Sparkle re-delivers `didAbortWithError` for a single check. `Update Check
+  /// Completed` is protected by consuming the attempt identity, but the legacy
+  /// `Update Check Failed` event fires straight from the delegate and had no
+  /// such guard, so one failed check was counted once per callback — 3x to 47x
+  /// inflation on shipped builds, which is why it dominated macOS reliability
+  /// reporting in the 2026-08 churn cohort.
+  func testRepeatedAbortForOneCheckIsRecognizedAsADuplicate() {
+    let failure = sparkleFailure(code: 2001, nsurlCode: NSURLErrorNetworkConnectionLost)
+    let tracker = UpdateCheckAttemptTracker(makeID: { "check-duplicate-failure" })
+    _ = tracker.begin(trigger: .automatic, context: analyticsContext())
+
+    XCTAssertEqual(tracker.finishFailure(diagnostics: failure)?.result, .failed)
+    XCTAssertTrue(
+      tracker.isDuplicateOfLastTerminal(failure),
+      "the second abort for the same closed check must not be reported again")
+  }
+
+  /// The guard keys on the closed terminal, not on "no active attempt", so a
+  /// genuinely different failure and a first-ever abort are both still reported.
+  func testDistinctAndUntrackedFailuresAreStillReported() {
+    let network = sparkleFailure(code: 2001, nsurlCode: NSURLErrorTimedOut)
+    let installer = sparkleFailure(code: 4005, nsurlCode: nil)
+
+    let tracker = UpdateCheckAttemptTracker(makeID: { "check-distinct-failure" })
+    _ = tracker.begin(trigger: .automatic, context: analyticsContext())
+    XCTAssertEqual(tracker.finishFailure(diagnostics: network)?.result, .failed)
+    XCTAssertFalse(
+      tracker.isDuplicateOfLastTerminal(installer),
+      "a different failure after a closed check is a new occurrence")
+
+    let untracked = UpdateCheckAttemptTracker(makeID: { "check-never-started" })
+    XCTAssertFalse(
+      untracked.isDuplicateOfLastTerminal(network),
+      "an abort with nothing closed yet must still be reported, not swallowed")
+  }
+
+  /// The guard must never suppress a live check's first terminal.
+  func testActiveCheckIsNeverTreatedAsADuplicate() {
+    let failure = sparkleFailure(code: 3000, nsurlCode: nil)
+    let tracker = UpdateCheckAttemptTracker(makeID: { "check-active" })
+    _ = tracker.begin(trigger: .automatic, context: analyticsContext())
+    XCTAssertEqual(tracker.finishFailure(diagnostics: failure)?.result, .failed)
+
+    _ = tracker.begin(trigger: .automatic, context: analyticsContext())
+    XCTAssertFalse(
+      tracker.isDuplicateOfLastTerminal(failure),
+      "a new admitted check owns its own terminal even when the failure repeats")
+  }
+
   func testManualCheckIsUnavailableWhileBackgroundUpdateSessionIsInProgress() {
     XCTAssertFalse(
       UpdaterViewModel.allowsManualCheck(

--- a/desktop/macos/changelog/unreleased/20260826-update-check-failed-dedupe.json
+++ b/desktop/macos/changelog/unreleased/20260826-update-check-failed-dedupe.json
@@ -1,0 +1,3 @@
+{
+  "change": "A single failed update check is now reported once instead of once per Sparkle callback"
+}

--- a/desktop/macos/docs/release-health-metrics.md
+++ b/desktop/macos/docs/release-health-metrics.md
@@ -187,7 +187,12 @@ the release-evidence layer (`#9523`) will consume.
   a real update-service outage is not masked. A manual check while offline remains
   `failed` so the user receives feedback. The legacy
   `Update Check Failed` event remains diagnostic-only and MUST NOT be used as a
-  denominator or user-impact rate.
+  denominator or user-impact rate. It now honours the same one-terminal-per-check
+  contract: Sparkle re-delivers `didAbortWithError` for a single check, and until
+  2026-08 the legacy event fired once per callback (3x–47x the authoritative
+  `result = failed` count on builds 0.12.187–0.12.212). Historical `Update Check
+  Failed` volume before that fix is inflated and must not be compared against
+  post-fix builds.
 - **Denominator:** distinct started attempts. Missing terminals are a separate
   instrumentation-health defect (`callback_missing` when the next Sparkle-admitted
   check closes a stale identity). Starts are recorded only at Sparkle's serialized


### PR DESCRIPTION
## Defect

The 2026-08 macOS churn cohort analysis (`omi-knowledge-base/projects/macos-churn-analysis/evidence/2026-08-26-macos-churn-cohort-analysis.md`, "Methodology guardrails") records:

> `Update Check Failed` code **2001 is ambient noise** (Sparkle "no update" mis-logged; ~42% of cohort, ~17.5 events/user) — exclude it.

**The recorded cause is wrong, and correcting it changes what the fix should be.**

Sparkle code 2001 is `SUDownloadError`, not "no update available" — that is `SUNoUpdateError` (1001), which `UpdateFailureDiagnostics.reason` already maps to `.noUpdate` and which `didAbortWithError` already suppresses. In PostHog (project 302298, production namespace) the 2001 corpus is dominated by an `NSURLErrorDomain` chain: `-1009` not-connected (28,802 events / 1,295 users, Aug 1–25), then `-1005`, `-1001`, `-1003`, `-1004`. Those are genuine "the check never reached the appcast" events, and the `-1009` half of them was already fixed on current builds by `98f1ee7c7f` / `f34be3b3c1` (2026-08-11): `Update Check Completed` reports them as `result = network_unavailable` and the legacy event is suppressed.

What is still broken is the volume itself. Sparkle re-delivers `didAbortWithError` for a single check — the tracker's own doc comment says so — and only the authoritative event is protected. `UpdateCheckAttemptTracker.finishFailure` consumes the attempt identity, so a second callback returns nil and emits nothing. `AnalyticsManager.shared.updateCheckFailed(diagnostics:)` fires straight from the delegate with no identity of its own, so **one failed check is counted once per callback**.

PostHog, `$app_namespace = com.omi.computer-macos`, 2026-08-18 → 2026-08-25:

| build | `Update Check Failed` | `Update Check Completed` `result=failed` | ratio |
| --- | --- | --- | --- |
| 0.12.187 | 1,590 events / 307 users | 506 / 160 | 3.1x |
| 0.12.208 | 141 / 36 | 3 / 2 | 47x |
| 0.12.212 | 233 / 62 | 11 / 6 | 21x |
| 0.12.213 | 52 / 27 | 52 / 27 | 1.0x |

## Fix

`UpdateCheckAttemptTracker.isDuplicateOfLastTerminal(_:)` reports whether an abort is Sparkle re-delivering a terminal already closed for the same check: no active attempt, and the closed terminal's `reason`, `domain`, `code` and `nsurlErrorCode` all match. `didAbortWithError` then skips **only** the legacy analytics call; the local diagnostic log and the view-model state are untouched.

The guard keys on the closed terminal rather than on "no active attempt", so an abort with nothing closed yet is still reported instead of being swallowed.

**No failure code is reclassified.** 1003, 2001, 3000, 4005, 4007 and everything else still emit exactly as before — once. `Update Check Completed`, the authoritative metric defined in `docs/release-health-metrics.md`, is unchanged.

## Proof

`UpdaterViewModelTests` — 12 tests pass locally (`xcrun swift test --filter UpdaterViewModelTests`):

- `testRepeatedAbortForOneCheckIsRecognizedAsADuplicate` — the second abort for one closed check is a duplicate. This is the automatic-or-dead check: remove the guard and it fails.
- `testDistinctAndUntrackedFailuresAreStillReported` — a *different* failure after a closed check, and a first-ever abort with nothing tracked, are both still reported. This is the check that stops the fix from over-suppressing.
- `testActiveCheckIsNeverTreatedAsADuplicate` — a new admitted check owns its own terminal even when the failure repeats.

`docs/release-health-metrics.md` now records that pre-fix `Update Check Failed` volume is inflated and must not be compared across the boundary.

Local `make preflight` passes. Full Swift contract CI (~42 min) runs after push; not claimed green here.

## Deliberately not in this PR

The remaining `Update Check Failed` volume on current builds is transient network (`-1005`, `-1001`, `-1003`, `-1004`: 1,824 of 2,016 events on 0.12.187+ over 7 days). Reclassifying those as `network_unavailable` would be a change to the *metric definition* — `docs/release-health-metrics.md` deliberately keeps "timeouts, DNS, and server reachability errors" as failures so a real update-service outage is not masked. That is a decision for the metric owner, not a drive-by change, so it is written up as a separate shaped issue rather than folded in here.

## Invariants

- INV-BETA-1 — touched by path only (`desktop/macos/Desktop/Sources/UpdaterViewModel.swift` is in the updater/beta-identity glob). This PR changes only whether a duplicate Sparkle abort callback re-emits a legacy analytics event. Channel selection, `allowedChannels(for:)`, bundle identity, and the Omi Beta side-by-side app are untouched.

Failure-Class: FC-same-subject-counted-once-per-evidence-source

---

*First commit is unrelated housekeeping needed to get any desktop PR past the local pre-push gate on Xcode 26.x (also in #12267): a swift-format drift already on `main` and one implicit `self` capture that Swift 6.2 rejects and Xcode 16.4 accepts. It drops out on rebase once either PR lands.*


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

