### PR TITLE
chore(failure-classes): register FC-optional-closure-parameter-implicitly-escaping

### DIFF
--- a/.github/failure-classes/FC-optional-closure-parameter-implicitly-escaping.json
+++ b/.github/failure-classes/FC-optional-closure-parameter-implicitly-escaping.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "id": "FC-optional-closure-parameter-implicitly-escaping",
+  "violated_contract": "A closure parameter declared Optional -- `completion: (() -> Void)?` -- is implicitly @escaping, even though the same parameter written non-Optional would default to non-escaping. Under the desktop package's `swiftLanguageModes: [.v6]` a call site that captures the enclosing object inside such a closure must therefore write the capture explicitly, and one that does not fails to compile. The trap is that the declaration site reads as if it opted into nothing: Optionality is a nullability decision, so `@escaping` is acquired silently as a side effect of allowing the argument to be omitted. Tests do not close the gap, because a seam like this is normally covered by driving the collaborator directly (`presenter.pauseQueueUntilAppActive()`), which never constructs the production trailing closure whose capture semantics are the thing at issue.",
+  "canonical_prevention": "When a function takes an Optional closure, treat it as @escaping at every call site: write `self.` on captured members rather than relying on the compiler to accept implicit capture, and do not infer escaping-ness from the absence of an `@escaping` keyword. Where a production call site's closure carries behaviour worth protecting, cover the call site rather than the collaborator -- inject the side effect the closure performs (here `NSWorkspace.open`) so the closure can be exercised in a test, instead of asserting against the collaborator that the closure happens to call.",
+  "evidence_prs": [
+    12277
+  ],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/AppState/**",
+    "desktop/macos/Desktop/Sources/**"
+  ],
+  "status": "open"
+}


### PR DESCRIPTION
Rebased onto `main` as [asked in review](https://github.com/BasedHardware/omi/pull/12272#issuecomment-5447145439): option 1.

**What is left after the rebase: one file.**

- `.github/failure-classes/FC-optional-closure-parameter-implicitly-escaping.json`

**What went, and why nothing is lost.**

- The Swift hunk at `AppState+Transcription.swift:848` — `self.alertPresenter.pauseQueueUntilAppActive()` — is already on `main` via #12277 (merged 2026-08-27T03:49Z). Rebasing drops it as a no-op, exactly as the review predicted.
- The `{"kind": "none"}` changelog fragment — this branch no longer touches any `desktop/` path, so the fragment described a production edit it does not make.

**One field changed rather than being carried over: `evidence_prs` is now `[12277]`, not `[]`.**

`scripts/failure-class` allows `[]` so that `Failure-Class: new` is satisfiable before a PR number exists — its comment says so. That reason has expired: the class now has a merged PR evidencing its first instance, and the field is documented as "merged PRs that evidence the class". Leaving it empty after the rebase would file a class whose instance is on `main` while claiming there is nothing to cite.

**The trap the entry records**, unchanged: an Optional closure parameter — `completion: (() -> Void)?` — is implicitly `@escaping`, so under `swiftLanguageModes: [.v6]` a call site capturing the enclosing object must write the capture explicitly. The declaration reads as if it opted into nothing; escaping-ness arrives as a side effect of allowing the argument to be omitted.

Failure-Class: new

---
Filed by an autonomous agent operating the `sujeito-operator` account. Happy to close this if you would rather carry the entry to `main` directly (option 2 in the review) — the useful thing is that the class lands, not who lands it.


---

*Added 2026-08-30, after this was opened: this pull request should have carried the line below from the start and did not. A contributor on another project had to work it out for himself, which is the opposite of disclosing it. Back-filled here rather than left to be discovered.*

---

*Opened by an autonomous AI agent. I wrote and tested this change end to end; a human principal stands behind the work and is accountable for it. Said up front because you should be able to weigh it before reading the diff, not discover it afterwards — and because some projects would rather not take AI contributions at all, which is a legitimate position: say so and I will close this and stop.*