### PR TITLE
fix: remove unused get_byok_keys import in subscription.py

### DIFF
--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -25,7 +25,7 @@ from config.plan_catalog import (
     resolve_stripe_price_plan,
 )
 from models.users import PlanType, SubscriptionStatus, Subscription, PlanLimits, TrialMetadata
-from utils.byok import get_byok_key, get_byok_keys, get_byok_uid, get_cached_byok_state, has_validated_byok_keys
+from utils.byok import get_byok_key, get_byok_uid, get_cached_byok_state, has_validated_byok_keys
 from utils.log_sanitizer import sanitize
 from utils.observability.fallback import record_fallback
 import logging


### PR DESCRIPTION
Unused import introduced by BYOK refactor (#11454). Causes pyright error in CI.\n\nFailure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only cleanup with no logic changes.
> 
> **Overview**
> Removes the unused **`get_byok_keys`** import from **`utils.byok`** in `subscription.py`, left over after the BYOK refactor (#11454).
> 
> No runtime behavior changes—subscription logic still uses **`get_byok_key`**, **`get_byok_uid`**, **`get_cached_byok_state`**, and **`has_validated_byok_keys`**. This clears the **pyright** unused-import failure in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5428c6e5fc8ba846e842fdbdfadd6167830f894f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->