### PR TITLE
fix(ci): point the dev deploy smoke at development's real API host

### DIFF
--- a/.github/actions/deploy-backend-stack/action.yml
+++ b/.github/actions/deploy-backend-stack/action.yml
@@ -972,7 +972,10 @@ runs:
         ADMIN_KEY="$(gcloud secrets versions access latest --secret=ADMIN_KEY --project="$PROJECT_ID")"
         export ADMIN_KEY
         trap 'unset ADMIN_KEY' EXIT
-        python3 "$DEPLOY_CONTROL_SCRIPTS/smoke_what_matters_now.py" --base-url https://api.omi.dev
+        # api.omi.dev has never resolved (NXDOMAIN), so this smoke could not reach
+        # anything; api.omiapi.com is development's real public API host, matching
+        # the rest of the dev domain family (parakeet/nllb/pusher.omiapi.com).
+        python3 "$DEPLOY_CONTROL_SCRIPTS/smoke_what_matters_now.py" --base-url https://api.omiapi.com
 
     - name: Restore Cloud Run traffic snapshot after failed promotion
       if: >-

--- a/backend/.env.dev.template
+++ b/backend/.env.dev.template
@@ -23,8 +23,8 @@ GOOGLE_APPLICATION_CREDENTIALS=google-credentials-dev.json
 FIRESTORE_DATABASE_ID=(default)
 
 # --- API URLs (dev cloud) ---
-BASE_API_URL=https://api.omi.dev
-API_BASE_URL=https://api.omi.dev
+BASE_API_URL=https://api.omiapi.com
+API_BASE_URL=https://api.omiapi.com
 OPENAI_BASE_URL=https://api.openai.com/v1
 
 # --- LangSmith (non-secret defaults) ---

--- a/backend/tests/unit/test_smoke_what_matters_now.py
+++ b/backend/tests/unit/test_smoke_what_matters_now.py
@@ -128,7 +128,7 @@ def test_auto_dev_smoke_uses_the_tagged_candidate_output_with_existing_auth():
         'Shift Cloud Run traffic to validated revisions'
     )
     assert '--audience backend=${{ steps.candidate-urls.outputs.backend_audience }}' in workflow
-    assert 'smoke_what_matters_now.py --base-url https://api.omi.dev' not in workflow
+    assert 'smoke_what_matters_now.py --base-url https://api.omiapi.com' not in workflow
 
 
 def test_manual_development_smoke_keeps_its_existing_external_hostname_path():
@@ -139,7 +139,7 @@ def test_manual_development_smoke_keeps_its_existing_external_hostname_path():
     # The SCA-33 workflow refactor invokes the smoke via the deploy-control scripts
     # root: `"$DEPLOY_CONTROL_SCRIPTS/smoke_what_matters_now.py" --base-url ...`, so
     # the quote from that path prefix sits between the script name and the flag.
-    assert 'smoke_what_matters_now.py" --base-url https://api.omi.dev' in workflow
+    assert 'smoke_what_matters_now.py" --base-url https://api.omiapi.com' in workflow
     assert 'id: smoke-what-matters-now-datastore-query' in workflow
     assert "steps.smoke-what-matters-now-datastore-query.outcome == 'failure'" in workflow
     restore = workflow.index('Restore Cloud Run traffic snapshot after failed promotion')


### PR DESCRIPTION
Failure-Class: none

The reachable-host defect here is a plain wrong-constant bug, not a recurrence of a
registered class. FC-release-probe-signer-identity (declared on #12264) is about signer
identity for Firebase probe tokens and does not describe a smoke target hostname.

## What is broken

The manual **development** backend deploy runs its post-promotion smoke as:

```
python3 "$DEPLOY_CONTROL_SCRIPTS/smoke_what_matters_now.py" --base-url https://api.omi.dev
```

`api.omi.dev` **has never resolved**. The `omi.dev` zone exists (Route53 nameservers
answer) but the `api` record is `NXDOMAIN`:

```
$ dig @8.8.8.8 api.omi.dev
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN
```

So the smoke fails with `ERROR: What Matters Now smoke could not reach the deployed
backend`. Because this step runs *after* the traffic shift, it fails the deploy and
trips `Restore Cloud Run traffic snapshot after failed promotion`, rolling the
promotion back.

This was introduced by `933fdf7d62` — the same day as the probe-signer defect fixed in
#12264 — and stayed invisible for six weeks because the probe failed first and the lane
never got this far. Run
[33008079463](https://github.com/BasedHardware/omi/actions/runs/33008079463) is the
first development deploy to reach this step.

## The fix

Point the smoke at development's real public API host, `api.omiapi.com`.

That is development's host by the same convention production uses. `backend/deploy/runtime_env/dev.overlay.yaml`
puts the whole development domain family on `omiapi.com` — `api.omiapi.com`,
`parakeet.omiapi.com`, `nllb.omiapi.com`, `pusher.omiapi.com` — exactly mirroring
`prod.overlay.yaml`'s `omi.me` family. It is also `mobileBeta.defaultApiBaseUrl` in
`app/lib/env/environment_profile.dart`. It serves `/ready` 200 today:

```
$ curl https://api.omiapi.com/ready
{"status":"ready","service":"omi-desktop-backend","redis":{"status":"ready"}}
```

**Making `api.omi.dev` real was rejected.** The codebase already uses it as the
canonical *fake* hostname in mobile production-routing fixtures
(`.github/scripts/test_check_mobile_production_routing.py`, `app/test/unit/env_test.dart`),
where it stands in for a URL that must be refused. Giving it a live record would
undermine those tests.

## Scope

- The smoke step is guarded `deploy_profile == 'manual' && environment == 'development'`.
- The **production** smoke keeps its own `https://api.omi.me` path, untouched.
- `backend/tests/unit/test_smoke_what_matters_now.py` exists to pin this exact constant,
  so the two workflow-pinning assertions move to the corrected host. The script's own
  unit-test fixtures deliberately keep `api.omi.dev` as a fake input.
- `backend/.env.dev.template` carried the same dead host on `BASE_API_URL`/`API_BASE_URL`;
  corrected for consistency. Nothing reads that file programmatically.

## Proof

All 32 selected preflight checks pass locally. The real proof is the next manual
development deploy reaching a green smoke and keeping its promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

