### PR TITLE
fix(ci): keep Desktop Swift main health current

### DIFF
--- a/.github/failure-classes/FC-path-filter-masks-default-branch-health.json
+++ b/.github/failure-classes/FC-path-filter-masks-default-branch-health.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-path-filter-masks-default-branch-health",
+  "violated_contract": "A path-filtered workflow answers whether one diff requires a component check; it does not establish that the component still compiles at the current default-branch SHA. Treating a later unrelated commit's skipped component jobs or overall green workflow as refreshed health evidence lets an older compiler failure remain on main behind a newer green run (#12275).",
+  "canonical_prevention": "Keep ordinary push and pull-request path filtering for cost control, but give the component an authoritative recurring health event and an operator recovery event that force its real compile/test phases against the current SHA regardless of changed paths. Guard both sides: authoritative events must select the full phases, while unrelated ordinary pushes must remain filtered.",
+  "canonical_prevention_artifact": [
+    ".github/scripts/test_pre_push_ci_prediction.py",
+    ".github/scripts/test_desktop_swift_ci_contract.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    ".github/workflows/",
+    "scripts/pre_push_ci_prediction.py"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/test_desktop_swift_ci_contract.py
+++ b/.github/scripts/test_desktop_swift_ci_contract.py
@@ -154,6 +154,20 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
         self.assertNotIn("closed", workflow)
         self.assertNotIn("pull_request.merged", workflow)
 
+    def test_current_main_health_is_independent_of_the_last_commit_paths(self):
+        """#12275: unrelated pushes must not keep the last Desktop Swift verdict alive."""
+        triggers = _workflow_text().split("concurrency:", 1)[0]
+
+        self.assertIn("schedule:", triggers)
+        self.assertRegex(triggers, r'cron:\s*["\']17 5 \* \* \*["\']')
+        self.assertIn("workflow_dispatch:", triggers)
+        for event in ("schedule", "workflow_dispatch"):
+            with self.subTest(event=event):
+                plan = resolve_impact(["backend/database/users.py"], event=event)
+                self.assertTrue(plan.includes("desktop-ci-only"))
+                self.assertTrue(plan.includes("desktop-swift-tests"))
+                self.assertTrue(plan.includes("desktop-swift-release-compile"))
+
     def test_required_release_check_names_are_literals(self):
         """GitHub does not evaluate `name:` for a skipped job.
 

--- a/.github/scripts/test_pre_push_ci_prediction.py
+++ b/.github/scripts/test_pre_push_ci_prediction.py
@@ -313,13 +313,23 @@ class PrePushCiPredictionTests(unittest.TestCase):
         """`scripts/pre-push` relies on the default; dropping it would break the hook."""
         self.assertIn("local", ACCEPTED_EVENTS)
 
-    def test_event_does_not_change_the_resolved_plan(self) -> None:
-        """Widening `--event` is safe precisely because no routing decision reads it."""
-        paths = ["desktop/macos/Desktop/Package.swift", "backend/database/users.py", "app/lib/main.dart"]
-        baseline = self.plan(paths, event="push").ordered()
-        for event in ACCEPTED_EVENTS:
+    def test_path_filtered_events_keep_unrelated_changes_off_macos(self) -> None:
+        """Ordinary local, PR, and push routing must retain the hosted-macOS saving."""
+        for event in ("local", "pull_request", "push"):
             with self.subTest(event=event):
-                self.assertEqual(self.plan(paths, event=event).ordered(), baseline)
+                plan = self.plan(["backend/database/users.py"], event=event)
+                self.assertFalse(plan.includes("desktop-ci-only"))
+                self.assertFalse(plan.includes("desktop-swift-tests"))
+                self.assertFalse(plan.includes("desktop-swift-release-compile"))
+
+    def test_authoritative_main_health_events_ignore_changed_paths(self) -> None:
+        """#12275: recovery/health runs must compile the current main SHA itself."""
+        for event in ("workflow_dispatch", "schedule"):
+            with self.subTest(event=event):
+                plan = self.plan(["backend/database/users.py"], event=event)
+                self.assertTrue(plan.includes("desktop-ci-only"))
+                self.assertTrue(plan.includes("desktop-swift-tests"))
+                self.assertTrue(plan.includes("desktop-swift-release-compile"))
 
 
 if __name__ == "__main__":

--- a/.github/workflows/desktop-swift-ci.yml
+++ b/.github/workflows/desktop-swift-ci.yml
@@ -5,12 +5,18 @@ on:
     branches: main
   pull_request:
     branches: main
+  # A later backend/docs commit must not make the last path-selected Desktop
+  # Swift verdict look current. Run against default-branch HEAD every day at an
+  # off-round UTC minute; the selector treats this as a full health event.
+  schedule:
+    - cron: "17 5 * * *"
   # Recovery hatch. `plan-desktop-release.py` requires this workflow's checks on the
   # exact source SHA, so any interruption — the workflow being disabled, a run cancelled
   # by concurrency, an infrastructure blip — leaves that SHA permanently unreleasable:
   # push events do not replay, and neither a force-push nor a PR close/reopen produces a
   # run for a commit already on main. Manual dispatch is the only way to re-mint the
-  # evidence without an unrelated commit.
+  # evidence without an unrelated commit. Manual dispatch is path-independent so
+  # it still compiles a HEAD whose final commit only touched another component.
   workflow_dispatch:
 
 concurrency:

--- a/scripts/pre_push_ci_prediction.py
+++ b/scripts/pre_push_ci_prediction.py
@@ -84,8 +84,15 @@ ACCEPTED_EVENTS = (
     "local",
     "pull_request",
     "push",
+    "schedule",
     "workflow_dispatch",
 )
+
+# These events ask whether the current default-branch SHA is healthy, not whether its
+# final commit happened to touch a Desktop Swift path.  A path-filtered main push can
+# only establish evidence for its own diff; it cannot keep an older compiler verdict
+# current after unrelated commits land (#12275).
+FULL_DESKTOP_HEALTH_EVENTS = frozenset({"schedule", "workflow_dispatch"})
 
 ROUTING_INPUTS = {
     ".github/checks-manifest.yaml",
@@ -378,6 +385,18 @@ def resolve_impact(
                 "desktop-ci-only",
                 "desktop-flow-lint",
                 "desktop-swift-tests",
+            }
+        )
+
+    if event in FULL_DESKTOP_HEALTH_EVENTS:
+        # Manual dispatch is the exact-SHA recovery hatch and the scheduled run
+        # is the default-branch health pulse. Both must exercise debug tests and
+        # release compilation even when HEAD's final diff is backend/docs only.
+        selected.update(
+            {
+                "desktop-ci-only",
+                "desktop-swift-tests",
+                "desktop-swift-release-compile",
             }
         )
 


### PR DESCRIPTION
## Summary

- make `workflow_dispatch` a real path-independent recovery hatch for Desktop Swift
- run the existing Desktop Swift workflow daily against the current default-branch SHA
- preserve diff-based runner allocation for ordinary pushes and pull requests

Fixes #12275.

## Problem

Desktop Swift CI was only authoritative for commits whose own diff selected the desktop lanes. A later backend/docs-only push could leave every Desktop Swift compile job skipped while the workflow still appeared green, so the last visible result on `main` did not prove that the current tree compiled.

This happened after the Xcode 16.4 SILGen regression: [run 33031674675](https://github.com/BasedHardware/omi/actions/runs/33031674675) completed successfully while `Desktop Swift Static & Test Contracts`, `Desktop Swift Release Compile`, and the stable `Desktop Swift Build & Tests` aggregate were all skipped.

The documented manual recovery path had the same blind spot. It accepted `workflow_dispatch`, but resolved exactly the same final-commit diff as a push, so dispatching a backend-only HEAD could not re-mint Desktop Swift evidence for that SHA.

## What changed

`pre_push_ci_prediction.py` now distinguishes two authoritative health events from normal diff-scoped events:

- `schedule` and `workflow_dispatch` always select the Desktop Swift debug test and release-compile phases.
- `push`, `pull_request`, and the local hook remain path-filtered, so an ordinary backend-only change still selects no macOS jobs.

The existing workflow now runs at `05:17 UTC` daily. It reuses the same pinned Xcode runner, caches, timeouts, stable check names, and aggregate verdict already used for selected desktop changes; no parallel workflow or duplicate implementation was added.

## Regression proof

The tests were added first. On the old selector, the new authoritative-event regression failed for both `workflow_dispatch` and `schedule` because `desktop-ci-only` was absent.

After the fix:

- `OMI_PR_BODY_FILE=/tmp/omi-12275-pr-body.md make preflight` — all 21 selected repository checks passed
- `python3 .github/scripts/test_pre_push_ci_prediction.py` — 26 passed
- `python3 .github/scripts/test_desktop_swift_ci_contract.py` — 27 passed
- `python3 .github/scripts/test_desktop_manifest_routes.py` — 4 passed
- `bash scripts/run-workflow-apt-network-bounds.sh` — 6 passed
- `python3 .github/scripts/check_runner_cost_policy.py` — passed
- `python3 .github/scripts/check_deployment_secret_boundary.py --base origin/main` — passed
- `actionlint -shellcheck "" .github/workflows/desktop-swift-ci.yml` — passed, matching the repository workflow lint configuration

Direct production-selector probes with an empty changed-file list produced:

| Event | Build & tests | Release compile |
|---|---:|---:|
| `workflow_dispatch` | selected | selected |
| `schedule` | selected | selected |
| ordinary `push` | skipped | skipped |

## Runner impact

Normal PR and push cost is unchanged. The only new recurring allocation is one daily run of the two existing bounded `macos-15` jobs (90-minute verify ceiling, 60-minute release ceiling); the release lane restores the default-branch build cache. Manual dispatch only allocates those jobs when an operator invokes it.

## Failure class

Failure-Class: new

This adds `FC-path-filter-masks-default-branch-health`. Its reusable guard artifacts assert both halves of the boundary: authoritative health events cannot be path-filtered, and unrelated ordinary pushes remain cheap.

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

