### PR TITLE
fix(web): add the pinned prettier deps to web/app's lockfile

### DIFF
--- a/web/app/bun.lock
+++ b/web/app/bun.lock
@@ -64,6 +64,8 @@
         "eslint": "^9",
         "jsdom": "^29.1.1",
         "postcss": "~8.5.18",
+        "prettier": "^2.8.8",
+        "prettier-plugin-tailwindcss": "^0.3.0",
         "tailwindcss": "^3.4.1",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.7",
@@ -1252,6 +1254,10 @@
     "preact": ["preact@10.29.1", "", {}, "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
+
+    "prettier-plugin-tailwindcss": ["prettier-plugin-tailwindcss@0.3.0", "", { "peerDependencies": { "@ianvs/prettier-plugin-sort-imports": "*", "@prettier/plugin-pug": "*", "@shopify/prettier-plugin-liquid": "*", "@shufo/prettier-plugin-blade": "*", "@trivago/prettier-plugin-sort-imports": "*", "prettier": ">=2.2.0", "prettier-plugin-astro": "*", "prettier-plugin-css-order": "*", "prettier-plugin-import-sort": "*", "prettier-plugin-jsdoc": "*", "prettier-plugin-marko": "*", "prettier-plugin-organize-attributes": "*", "prettier-plugin-organize-imports": "*", "prettier-plugin-style-order": "*", "prettier-plugin-svelte": "*", "prettier-plugin-twig-melody": "*" }, "optionalPeers": ["@ianvs/prettier-plugin-sort-imports", "@prettier/plugin-pug", "@shopify/prettier-plugin-liquid", "@shufo/prettier-plugin-blade", "@trivago/prettier-plugin-sort-imports", "prettier-plugin-astro", "prettier-plugin-css-order", "prettier-plugin-import-sort", "prettier-plugin-jsdoc", "prettier-plugin-marko", "prettier-plugin-organize-attributes", "prettier-plugin-organize-imports", "prettier-plugin-style-order", "prettier-plugin-svelte", "prettier-plugin-twig-melody"] }, "sha512-009/Xqdy7UmkcTBpwlq7jsViDqXAYSOMLDrHAdTMlVZOrKfM2o9Ci7EMWTMZ7SkKBFTG04UM9F9iM2+4i6boDA=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 


### PR DESCRIPTION
## What changed and why

`64db30c791` ("fix(web): pin prettier and tighten pre-commit toolchain resolution") added two dev deps to `web/app/package.json` without regenerating `web/app/bun.lock`:

```
+    "prettier": "^2.8.8",
+    "prettier-plugin-tailwindcss": "^0.3.0",
```

`web/app/test.sh` installs with a frozen lockfile, so it fails:

```
error: lockfile had changes, but lockfile is frozen
note: try re-running without --frozen-lockfile and commit the updated lockfile
```

That is the `web-app-checks` manifest entry, which triggers on `web/app/src/**`, `web/app/package.json`, `web/app/bun.lock`, and friends. So **every PR touching `web/app/src/**` inherits a red `Hygiene` and `Build`**, regardless of what it changed.

It surfaced on #12262, whose only web-side change is a regenerated `omiApi.generated.ts` client. Other open PRs are green purely because none of them happen to trip the trigger paths — this is latent, not rare.

## Reproduction

Pristine checkout of `main`, no branch involved:

```bash
mkdir -p /tmp/mainweb
git archive origin/main web/app | tar -x -C /tmp/mainweb
cd /tmp/mainweb/web/app && bun install --frozen-lockfile
```

Reproduces on `ed5a6fc42c`.

`web/admin/package.json` took an edit in the same commit, but its lockfile already resolves — I checked it separately (790 packages installed, no error), so this is scoped to `web/app` alone.

## The fix

A plain `bun install`, committing the result. The diff is the two declared deps and their resolution entries — six lines, no transitive drift:

```
+    "prettier": "^2.8.8",
+    "prettier-plugin-tailwindcss": "^0.3.0",
+    "prettier": ["prettier@2.8.8", ...]
+    "prettier-plugin-tailwindcss": ["prettier-plugin-tailwindcss@0.3.0", ...]
```

## Verification

- `bun install --frozen-lockfile` against a cleared `node_modules` — succeeds (was the failure above).
- `bash web/app/test.sh` — **66 files, 394 tests, 0 failures.**
- Node pinned to 22.23.1 for both; on the default Node 26 the vitest suite fails unrelatedly on `localStorage`.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

