### PR TITLE
Feat/macos chat voice controls

### DIFF
--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -103,6 +103,8 @@ actor APIClient {
   /// - Parameter requestTimeout: overrides the shared 30s transport timeout. Managed LLM
   ///   endpoints need a longer budget than a normal API call; without it a slow synthesis
   ///   is cancelled client-side while the backend is still producing the answer.
+  /// - Parameter idempotencyKey: when set, sent as `Idempotency-Key` so retries of the
+  ///   same logical create do not mint duplicate action items.
   func post<T: Decodable, B: Encodable>(
     _ endpoint: String,
     body: B,
@@ -112,7 +114,8 @@ actor APIClient {
     expectedOwnerId: String? = nil,
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil,
     allowsAuthRetry: Bool = true,
-    requestTimeout: TimeInterval? = nil
+    requestTimeout: TimeInterval? = nil,
+    idempotencyKey: String? = nil
   ) async throws -> T {
     var authPolicy = try resolvedRequestAuthPolicy(
       expectedOwnerId: expectedOwnerId,
@@ -134,6 +137,9 @@ actor APIClient {
       requireAuth: requireAuth,
       includeBYOK: includeBYOK,
       expectedAuthOwnerId: authOwnerId)
+    if let idempotencyKey {
+      request.setValue(idempotencyKey, forHTTPHeaderField: "Idempotency-Key")
+    }
     try validateExpectedOwner(authPolicy)
     request.httpBody = try transport.encoder.encode(body)
 

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1429,7 +1429,8 @@ final class DesktopAutomationActionRegistry {
     }
 
     // Drive the real push-to-talk state machine headlessly (MIC-01). ptt_start begins
-    // capture like the shortcut key-down; ptt_stop finalizes like a long-hold release.
+    // capture like the shortcut key-down; ptt_stop finalizes like a long-hold release;
+    // ptt_cancel discards without sending (composer Cancel control).
     // Releasing with no mic audio exercises the empty-batch release path — it must end
     // the turn with a hint, not hang. Both hit the exact private startListening/finalize
     // the shortcut handler calls, so no synthetic key events or cursor are involved.
@@ -1445,6 +1446,13 @@ final class DesktopAutomationActionRegistry {
       summary: "Finalize the in-progress push-to-talk capture (mirrors a long-hold release)"
     ) { _ in
       PushToTalkManager.shared.endPushToTalkForAutomation()
+    }
+
+    register(
+      name: "ptt_cancel",
+      summary: "Cancel the in-progress push-to-talk capture without sending"
+    ) { _ in
+      PushToTalkManager.shared.cancelPushToTalkForAutomation()
     }
 
     // Manager-level PTT harness: this crosses the real shortcut lifecycle,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AskAIInputView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AskAIInputView.swift
@@ -11,6 +11,7 @@ struct AskAIInputView: View {
   @State private var hasMarkedText = false
   @State private var attachments: [ChatAttachment] = []
   @State private var isDropTargeted = false
+  @ObservedObject private var voicePlayback = VoiceResponsePlaybackMonitor.shared
 
   var canClearVisibleConversation: Bool = false
   var onSend: ((String) -> Void)?
@@ -93,18 +94,30 @@ struct AskAIInputView: View {
         // pill's black glass, so the ladder here is white-on-black whatever the app's appearance is.
         PushToTalkMicButton(idleTint: NotchGlass.secondary)
 
-        Button(action: {
-          guard canSend else { return }
-          sendMessage()
-        }) {
-          Image(systemName: "arrow.up.circle.fill")
-            .scaledFont(size: 24)
-            .foregroundColor(
-              canSend ? NotchGlass.primary : NotchGlass.disabled
-            )
+        if voicePlayback.isActive {
+          Button(action: { VoiceResponsePlayback.interrupt() }) {
+            Image(systemName: "speaker.slash.circle.fill")
+              .scaledFont(size: 24)
+              .foregroundColor(NotchGlass.primary)
+          }
+          .buttonStyle(.plain)
+          .help("Stop speaking")
+          .accessibilityLabel("Stop speaking")
+          .accessibilityIdentifier("floating_ask_stop_speaking")
+        } else {
+          Button(action: {
+            guard canSend else { return }
+            sendMessage()
+          }) {
+            Image(systemName: "arrow.up.circle.fill")
+              .scaledFont(size: 24)
+              .foregroundColor(
+                canSend ? NotchGlass.primary : NotchGlass.disabled
+              )
+          }
+          .disabled(!canSend)
+          .buttonStyle(.plain)
         }
-        .disabled(!canSend)
-        .buttonStyle(.plain)
       }
       .padding(.horizontal, OmiSpacing.lg)
       .padding(.vertical, OmiSpacing.md)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -523,6 +523,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
     }
     resetPlaybackPipeline(clearMode: false)
     clearFloatingPillResponseGlowIfIdle()
+    VoiceResponsePlaybackMonitor.shared.refresh()
     return true
   }
 
@@ -555,6 +556,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
       audioPlayer = player
       activePlayerFallbackText = fallbackText
       tracer?.end("tts_start")
+      VoiceResponsePlaybackMonitor.shared.refresh()
     } catch {
       // Don't drop the reply silently — speak this chunk with the system voice instead.
       log(
@@ -755,9 +757,10 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
     if let lease = activePTTLease {
       VoiceTurnCoordinator.shared.publish(
         .responseActiveChanged(turnID: lease.turnID, active: active))
-      return
+    } else {
+      VoiceTurnCoordinator.shared.setUnscopedResponseActive(active)
     }
-    VoiceTurnCoordinator.shared.setUnscopedResponseActive(active)
+    VoiceResponsePlaybackMonitor.shared.refresh()
   }
 
   private func clearFloatingPillResponseGlowIfIdle() {
@@ -765,6 +768,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
       finishActivePTTLeaseIfIdle()
       setFloatingPillResponseGlow(false)
     }
+    VoiceResponsePlaybackMonitor.shared.refresh()
   }
 
   private func acquirePTTLeaseIfNeeded(_ lane: VoiceOutputLane) -> VoiceOutputLease? {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -403,19 +403,32 @@ struct FloatingControlBarView: View {
         // `conversationView` replaces the normal notch waveform while
         // chat is open. Keep the recording/hint projection visible at
         // the bottom of that same surface instead of hiding PTT state.
-        voiceListeningView
-          .padding(.horizontal, OmiSpacing.md)
-          .frame(height: 42)
-          .background(Capsule().fill(Color.white.opacity(0.12)))
-          .overlay(Capsule().stroke(Color.white.opacity(0.15), lineWidth: 1))
-          .padding(.horizontal, notchSurfaceHorizontalInset + OmiSpacing.md)
-          .padding(.bottom, notchSurfaceBottomInset + 8)
-          .accessibilityIdentifier("floating_chat_ptt_recording")
-          .accessibilityLabel(
-            state.pttHintText.isEmpty ? "Recording voice message" : state.pttHintText
-          )
-          .allowsHitTesting(false)
-          .transition(.move(edge: .bottom).combined(with: .opacity))
+        HStack(spacing: OmiSpacing.sm) {
+          voiceListeningView
+          Button(action: { PushToTalkManager.shared.cancelListening() }) {
+            Image(systemName: "xmark")
+              .scaledFont(size: 11, weight: .bold)
+              .foregroundColor(.white.opacity(0.9))
+              .frame(width: 22, height: 22)
+              .background(Circle().fill(Color.white.opacity(0.18)))
+          }
+          .buttonStyle(.plain)
+          .help("Cancel recording")
+          .accessibilityLabel("Cancel voice recording")
+          .accessibilityIdentifier("floating_chat_ptt_cancel")
+        }
+        .padding(.horizontal, OmiSpacing.md)
+        .frame(height: 42)
+        .background(Capsule().fill(Color.white.opacity(0.12)))
+        .overlay(Capsule().stroke(Color.white.opacity(0.15), lineWidth: 1))
+        .padding(.horizontal, notchSurfaceHorizontalInset + OmiSpacing.md)
+        .padding(.bottom, notchSurfaceBottomInset + 8)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("floating_chat_ptt_recording")
+        .accessibilityLabel(
+          state.pttHintText.isEmpty ? "Recording voice message" : state.pttHintText
+        )
+        .transition(.move(edge: .bottom).combined(with: .opacity))
       }
     }
     .scaleEffect(
@@ -1274,11 +1287,24 @@ struct FloatingControlBarView: View {
         .padding(.vertical, 5)
         .transition(.opacity)
       } else if state.isVoiceListening {
-        voiceListeningView
-          .padding(.horizontal, 10)
-          .padding(.vertical, 5)
-          .frame(height: 42)
-          .transition(.opacity)
+        HStack(spacing: OmiSpacing.sm) {
+          voiceListeningView
+          Button(action: { PushToTalkManager.shared.cancelListening() }) {
+            Image(systemName: "xmark")
+              .scaledFont(size: 11, weight: .bold)
+              .foregroundColor(.white.opacity(0.9))
+              .frame(width: 22, height: 22)
+              .background(Circle().fill(Color.white.opacity(0.18)))
+          }
+          .buttonStyle(.plain)
+          .help("Cancel recording")
+          .accessibilityLabel("Cancel voice recording")
+          .accessibilityIdentifier("floating_pill_ptt_cancel")
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .frame(height: 42)
+        .transition(.opacity)
       } else if allowsHoverExpansion {
         VStack(spacing: 1) {
           compactButton(title: "Open Omi", keys: shortcutSettings.askOmiShortcut.displayTokens) {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -716,8 +716,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   }
 
   func handleEscapeKey() {
-    if FloatingBarVoicePlaybackService.shared.isSpeaking {
-      FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
+    if VoiceResponsePlayback.interrupt() {
       return
     }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkButtonTrigger.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkButtonTrigger.swift
@@ -87,6 +87,18 @@ extension PushToTalkManager {
     }
   }
 
+  /// Discard control is offered only while audio is still being captured —
+  /// never while the turn is committing or idle. Mic click stays "send".
+  nonisolated static func showsCancelRecordingControl(phase: VoiceTurnPhase?) -> Bool {
+    switch phase {
+    case .recording, .lockedRecording, .pendingLockDecision:
+      return true
+    case .idle, .finalizing, .awaitingResponse, .awaitingTools, .awaitingJournal, .playing,
+      .terminal, .none:
+      return false
+    }
+  }
+
   // MARK: - Button surface
 
   /// Read-only projection of the same rule `isBlockedByUsageLimit()` enforces,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -914,6 +914,20 @@ class PushToTalkManager: ObservableObject {
     return ["state": VoiceTurnCoordinator.phaseLabel(phase ?? .idle), "finalized": wasActive ? "true" : "false"]
   }
 
+  /// Discard an in-progress capture without sending — the same path the Cancel
+  /// control in the composer and floating overlay takes.
+  @discardableResult
+  func cancelPushToTalkForAutomation() -> [String: String] {
+    let wasActive = voiceTurnCoordinator.activeTurn?.phase.isRecording == true
+    if wasActive { cancelListening() }
+    automationCaptureBypass = false
+    return [
+      "state": VoiceTurnCoordinator.phaseLabel(phase ?? .idle),
+      "cancelled": wasActive ? "true" : "false",
+      "listening": voiceTurnCoordinator.activeTurn?.phase.isRecording == true ? "true" : "false",
+    ]
+  }
+
   private var finalizedMode: String = "hold"
 
   private func currentPTTMode() -> String {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkMicButton.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkMicButton.swift
@@ -11,6 +11,11 @@ import SwiftUI
 /// no "hold", so it takes the hands-free lane the double-tap shortcut already
 /// uses: click to start locked listening, click again to send.
 ///
+/// While listening, a separate cancel control discards the capture without
+/// sending so the user can re-record. Cancel sits *after* the mic so the mic's
+/// hit target does not jump when cancel appears — otherwise the second click
+/// lands on cancel and discards instead of sending.
+///
 /// **It renders on two grounds that are not the same colour**, and that is what its palette is built
 /// around. The main window's composer is light-pinned glass; the floating ask bar is the notch pill's
 /// black glass. Its first version was drawn in the legacy dark palette — a hardcoded `#FFFFFF`
@@ -28,38 +33,73 @@ struct PushToTalkMicButton: View {
   @ObservedObject private var usageLimiter = FloatingBarUsageLimiter.shared
   @ObservedObject private var shortcutSettings = ShortcutSettings.shared
 
-  @State private var isHovering = false
+  @State private var isHoveringMic = false
+  @State private var isHoveringCancel = false
 
   private var state: PushToTalkButtonState { manager.pushToTalkButtonState }
+  private var showsCancel: Bool {
+    PushToTalkManager.showsCancelRecordingControl(phase: manager.phase)
+  }
 
   var body: some View {
+    // Mic first, cancel trailing: the mic's leading edge stays fixed when cancel
+    // mounts, so "click again to send" still hits the mic.
+    HStack(spacing: OmiSpacing.xs) {
+      micButton
+      if showsCancel {
+        cancelButton
+      }
+    }
+  }
+
+  private var micButton: some View {
     Button(action: { manager.togglePushToTalkFromButton() }) {
       ZStack {
         // Green rather than the palette's accent: "on" has to read as on without a label, and this is
         // the one job `Ink.listeningGreen` exists for. The old white ring said nothing on a dark
         // surface and nothing at all on a light one.
-        Circle().fill(state == .listening ? Ink.listeningGreen.opacity(0.16) : hoverFill)
+        Circle().fill(state == .listening ? Ink.listeningGreen.opacity(0.16) : micHoverFill)
         glyph
       }
       .frame(width: diameter, height: diameter)
       .contentShape(Circle())
     }
     .buttonStyle(.plain)
-    .onHover { isHovering = $0 }
+    .onHover { isHoveringMic = $0 }
     // Colour only, never scale — a control this size bouncing reads as a toy, and on a translucent
     // panel a scaling shape drags its own wash across the desktop behind it.
-    .animation(InkReduceMotion.animation(.easeOut(duration: InkMotion.press)), value: isHovering)
+    .animation(InkReduceMotion.animation(.easeOut(duration: InkMotion.press)), value: isHoveringMic)
     .animation(InkReduceMotion.animation(.easeOut(duration: InkMotion.press)), value: state)
     .help(helpText)
     .accessibilityLabel(Text(accessibilityLabel))
+    .accessibilityIdentifier("push_to_talk_mic")
     // Deliberately never `.disabled` while blocked: a disabled button swallows
     // the click, and a blocked click must surface the usage-limit popup.
     .accessibilityAddTraits(state == .listening ? .isSelected : [])
   }
 
+  private var cancelButton: some View {
+    Button(action: { manager.cancelListening() }) {
+      Image(systemName: "xmark")
+        .scaledFont(size: glyphSize * 0.7, weight: .semibold)
+        .foregroundColor(idleTint)
+        .frame(width: diameter, height: diameter)
+        .contentShape(Circle())
+        .background(Circle().fill(isHoveringCancel ? Ink.rowFill : .clear))
+    }
+    .buttonStyle(.plain)
+    .onHover { isHoveringCancel = $0 }
+    .animation(
+      InkReduceMotion.animation(.easeOut(duration: InkMotion.press)), value: isHoveringCancel
+    )
+    .help("Cancel recording")
+    .accessibilityLabel("Cancel voice recording")
+    .accessibilityIdentifier("push_to_talk_cancel")
+  }
+
   /// Nothing at rest. A wash on `labelColor`, so it darkens the light composer and lightens the pill
   /// from one value.
-  private var hoverFill: Color { isHovering ? Ink.rowFill : .clear }
+  private var micHoverFill: Color { isHoveringMic ? Ink.rowFill : .clear }
 
   @ViewBuilder
   private var glyph: some View {
@@ -92,7 +132,7 @@ struct PushToTalkMicButton: View {
     case .idle:
       return "Ask by voice — click to start, click again to send (or hold \(shortcutLabel))"
     case .listening:
-      return "Stop and send (or press \(shortcutLabel))"
+      return "Stop and send (or press \(shortcutLabel)). Cancel discards without sending."
     case .committing:
       return "Sending your voice message…"
     case .blocked:

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+VoiceOutput.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+VoiceOutput.swift
@@ -93,6 +93,7 @@ extension RealtimeHubController {
     realtimePlaybackEpoch += 1
     pcmPlayer?.stop()
     responseGlowGate.clearImmediately()
+    VoiceResponsePlaybackMonitor.shared.refresh()
     return true
   }
 }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceResponsePlayback.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceResponsePlayback.swift
@@ -1,0 +1,48 @@
+import Combine
+import Foundation
+import VoiceTurnDomain
+
+/// Single entry point for "stop the AI voice answer" across app TTS and native
+/// realtime PCM. Escape, composer Stop-speaking, and agent Stop all share this
+/// so one surface never leaves another lane talking.
+@MainActor
+enum VoiceResponsePlayback {
+  /// True while either the selected-voice / system TTS pipeline or the hub's
+  /// native realtime player is producing audible response audio.
+  static var isActive: Bool {
+    FloatingBarVoicePlaybackService.shared.isSpeaking
+      || RealtimeHubController.shared.reducerNativePlaybackActive
+  }
+
+  /// Stops every response-audio lane. Returns whether any lane was active.
+  @discardableResult
+  static func interrupt() -> Bool {
+    let wasActive = isActive
+    if let lease = VoiceTurnCoordinator.shared.outputSnapshot.activeLease,
+      lease.lane == .nativeRealtime
+    {
+      _ = RealtimeHubController.shared.stopNativePlayback(lease: lease)
+    }
+    FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
+    VoiceResponsePlaybackMonitor.shared.refresh()
+    return wasActive
+  }
+}
+
+/// Publishes whether response audio is playing so composers can show a stop
+/// control without polling `isSpeaking`.
+@MainActor
+final class VoiceResponsePlaybackMonitor: ObservableObject {
+  static let shared = VoiceResponsePlaybackMonitor()
+
+  @Published private(set) var isActive = false
+
+  private init() {}
+
+  func refresh() {
+    let next = VoiceResponsePlayback.isActive
+    if next != isActive {
+      isActive = next
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
@@ -87,6 +87,7 @@ struct ChatInputView: View {
 
   @AppStorage("askModeEnabled") private var askModeEnabled = false
   @Environment(\.fontScale) private var fontScale
+  @ObservedObject private var voicePlayback = VoiceResponsePlaybackMonitor.shared
   @State private var isDropTargeted = false
   @State private var hasMarkedText = false
 
@@ -192,7 +193,19 @@ struct ChatInputView: View {
                 .foregroundColor(.red.opacity(0.8))
             }
             .buttonStyle(.plain)
+            .help("Stop response")
+            .accessibilityLabel("Stop response")
           }
+        } else if voicePlayback.isActive {
+          Button(action: { VoiceResponsePlayback.interrupt() }) {
+            Image(systemName: "speaker.slash.circle.fill")
+              .scaledFont(size: 24)
+              .foregroundColor(.red.opacity(0.8))
+          }
+          .buttonStyle(.plain)
+          .help("Stop speaking")
+          .accessibilityLabel("Stop speaking")
+          .accessibilityIdentifier("chat_input_stop_speaking")
         } else {
           Button(action: handleSubmit) {
             Image(systemName: "arrow.up.circle.fill")

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -2249,6 +2249,7 @@ struct HomeAskBar: View {
   let onConnect: () -> Void
   let onActivate: () -> Void
 
+  @ObservedObject private var voicePlayback = VoiceResponsePlaybackMonitor.shared
   @State private var isHovering = false
   @State private var isDropTargeted = false
 
@@ -2318,10 +2319,15 @@ struct HomeAskBar: View {
 
         HomeAskBarTrailingControls(
           controls: HomeAskBarControls.resolve(
-            isSending: isSending, isStopping: isStopping, hasText: hasText, isFocused: isFocused),
+            isSending: isSending,
+            isStopping: isStopping,
+            hasText: hasText,
+            isFocused: isFocused,
+            isSpeaking: voicePlayback.isActive),
           isConnectActive: isConnectActive,
           onSend: handleSubmit,
           onStop: onStop,
+          onStopSpeaking: { VoiceResponsePlayback.interrupt() },
           onConnect: onConnect
         )
       }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/HomeAskBarControls.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/HomeAskBarControls.swift
@@ -22,6 +22,8 @@ enum HomeAskBarPrimaryAction: Equatable {
   /// primary that thins out the moment it becomes the only control is a button
   /// that disappears exactly when it starts to matter.
   case stop(isStopping: Bool)
+  /// Stop spoken playback after the text answer is already on screen.
+  case stopSpeaking
 }
 
 /// The Home ask bar's trailing cluster, resolved from composer state.
@@ -37,10 +39,14 @@ struct HomeAskBarControls: Equatable {
     isSending: Bool,
     isStopping: Bool,
     hasText: Bool,
-    isFocused: Bool
+    isFocused: Bool,
+    isSpeaking: Bool = false
   ) -> HomeAskBarControls {
     if isSending {
       return HomeAskBarControls(primary: .stop(isStopping: isStopping), showsConnect: false)
+    }
+    if isSpeaking {
+      return HomeAskBarControls(primary: .stopSpeaking, showsConnect: false)
     }
     return HomeAskBarControls(primary: .send(isArmed: hasText), showsConnect: !hasText && !isFocused)
   }
@@ -58,6 +64,7 @@ struct HomeAskBarTrailingControls: View {
   let isConnectActive: Bool
   let onSend: () -> Void
   let onStop: () -> Void
+  var onStopSpeaking: (() -> Void)? = nil
   let onConnect: () -> Void
 
   var body: some View {
@@ -71,6 +78,8 @@ struct HomeAskBarTrailingControls: View {
         sendButton(isArmed: isArmed)
       case .stop(let isStopping):
         stopButton(isStopping: isStopping)
+      case .stopSpeaking:
+        stopSpeakingButton
       }
     }
   }
@@ -120,6 +129,24 @@ struct HomeAskBarTrailingControls: View {
     .disabled(isStopping)
     .help("Stop")
     .accessibilityLabel("Stop response")
+  }
+
+  private var stopSpeakingButton: some View {
+    Button(action: { (onStopSpeaking ?? onStop)() }) {
+      ZStack {
+        Circle()
+          .fill(HomeAskBarPalette.primaryFill)
+        Image(systemName: "speaker.slash.fill")
+          .scaledFont(size: OmiType.caption, weight: .bold)
+          .foregroundStyle(HomeAskBarPalette.primaryLabel)
+      }
+      .frame(width: 34, height: 34)
+      .contentShape(Circle())
+    }
+    .buttonStyle(.plain)
+    .help("Stop speaking")
+    .accessibilityLabel("Stop speaking")
+    .accessibilityIdentifier("home_ask_bar_stop_speaking")
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryHeroBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryHeroBar.swift
@@ -89,6 +89,7 @@ struct QueryHeroBar: View {
   var onAttachmentsAdded: ([URL]) -> Void = { _ in }
   var onAttachmentRemoved: (String) -> Void = { _ in }
 
+  @ObservedObject private var voicePlayback = VoiceResponsePlaybackMonitor.shared
   @State private var isDropTargeted = false
   /// True while an input method has uncommitted marked text, which is the one moment the placeholder
   /// must stay hidden over an apparently empty field.
@@ -220,6 +221,14 @@ struct QueryHeroBar: View {
           .accessibilityIdentifier("query-shell-stop")
           .accessibilityLabel("Stop response")
           .help("Stop this response")
+      } else if voicePlayback.isActive {
+        heroPrimary(
+          systemImage: "speaker.slash.fill", isProminent: true,
+          action: { VoiceResponsePlayback.interrupt() }
+        )
+        .accessibilityIdentifier("query-shell-stop-speaking")
+        .accessibilityLabel("Stop speaking")
+        .help("Stop speaking")
       } else {
         heroPrimary(systemImage: "arrow.up", isProminent: canSend, action: onAsk)
           .keyboardShortcut(.return, modifiers: .command)
@@ -275,6 +284,14 @@ struct QueryHeroBar: View {
           .accessibilityIdentifier("query-shell-stop")
           .accessibilityLabel("Stop response")
           .help("Stop this response")
+      } else if voicePlayback.isActive {
+        panelPrimary(
+          systemImage: "speaker.slash.fill", isProminent: true,
+          action: { VoiceResponsePlayback.interrupt() }
+        )
+        .accessibilityIdentifier("query-shell-stop-speaking")
+        .accessibilityLabel("Stop speaking")
+        .help("Stop speaking")
       } else {
         panelPrimary(systemImage: "arrow.up", isProminent: canSend, action: onAsk)
           .keyboardShortcut(.return, modifiers: .command)

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -3258,6 +3258,8 @@ class ChatProvider: ObservableObject {
       log("ChatProvider: ignoring stop from non-owner turn")
       return false
     }
+    // Stop spoken audio with the agent turn so Stop never leaves TTS talking.
+    VoiceResponsePlayback.interrupt()
     return revokeActiveTurn(reason: reason)
   }
 

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+TaskCatalog.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+TaskCatalog.swift
@@ -148,6 +148,7 @@ extension APIClient {
     status: String? = nil,
     sortOrder: Int? = nil,
     indentLevel: Int? = nil,
+    idempotencyKey: String? = nil,
     expectedOwnerId: String? = nil,
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
   ) async throws -> TaskActionItem {
@@ -193,11 +194,15 @@ extension APIClient {
       relevanceScore: relevanceScore
     )
 
+    // Always send a key (web parity). Callers with a durable local row pass a
+    // stable key so launch retries dedupe; everyone else gets a fresh UUID.
+    let key = idempotencyKey ?? UUID().uuidString
     return try await post(
       "v1/action-items",
       body: request,
       expectedOwnerId: expectedOwnerId,
-      authorizationSnapshot: authorizationSnapshot)
+      authorizationSnapshot: authorizationSnapshot,
+      idempotencyKey: key)
   }
 
   private func taskMutationBody<Wire: Encodable>(

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -20,6 +20,12 @@ struct ActionItemMetadataBox: @unchecked Sendable {
 class TasksStore: ObservableObject {
   static let shared = TasksStore()
 
+  /// Stable create key for a local SQLite row so launch retries of the same
+  /// unsynced insert do not mint duplicate backend tasks.
+  nonisolated static func actionItemCreateIdempotencyKey(localRowID: Int64) -> String {
+    "desktop-action-item:\(localRowID)"
+  }
+
   struct DashboardTaskSnapshot {
     let overdue: [TaskActionItem]
     let today: [TaskActionItem]
@@ -2444,6 +2450,7 @@ class TasksStore: ObservableObject {
           category: item.category,
           metadataBox: ActionItemMetadataBox(metadata),
           relevanceScore: item.relevanceScore,
+          idempotencyKey: Self.actionItemCreateIdempotencyKey(localRowID: localId),
           expectedOwnerId: ownerID,
           authorizationSnapshot: lease.authorizationSnapshot
         )
@@ -3113,6 +3120,7 @@ class TasksStore: ObservableObject {
             category: tags?.first,
             metadata: metadata,
             recurrenceRule: recurrenceRule,
+            idempotencyKey: Self.actionItemCreateIdempotencyKey(localRowID: localId),
             expectedOwnerId: lease.ownerID,
             authorizationSnapshot: lease.authorizationSnapshot
           )

--- a/desktop/macos/Desktop/Tests/ActionItemCreateIdempotencyTests.swift
+++ b/desktop/macos/Desktop/Tests/ActionItemCreateIdempotencyTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+
+@testable import Omi_Computer
+
+private struct CapturedCreateRequest {
+  let url: URL
+  let method: String
+  let headers: [String: String]
+}
+
+private final class ActionItemCreateURLCapture: URLProtocol, @unchecked Sendable {
+  private static let lock = NSLock()
+  private nonisolated(unsafe) static var request: CapturedCreateRequest?
+
+  static func reset() {
+    lock.lock()
+    request = nil
+    lock.unlock()
+  }
+
+  static func captured() -> CapturedCreateRequest? {
+    lock.lock()
+    defer { lock.unlock() }
+    return request
+  }
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    Self.lock.lock()
+    Self.request = CapturedCreateRequest(
+      url: request.url!,
+      method: request.httpMethod ?? "GET",
+      headers: request.allHTTPHeaderFields ?? [:]
+    )
+    Self.lock.unlock()
+
+    let body = Data(
+      #"{"id":"task-1","description":"Buy milk","completed":false,"created_at":"2026-01-01T00:00:00.000Z","updated_at":"2026-01-01T00:00:00.000Z"}"#
+        .utf8)
+    let response = HTTPURLResponse(
+      url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: body)
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+}
+
+final class ActionItemCreateIdempotencyTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    ActionItemCreateURLCapture.reset()
+    setenv("OMI_PYTHON_API_URL", "http://python-test:9001", 1)
+  }
+
+  override func tearDown() {
+    unsetenv("OMI_PYTHON_API_URL")
+    ActionItemCreateURLCapture.reset()
+    super.tearDown()
+  }
+
+  func testCreateActionItemAlwaysSendsIdempotencyKey() async throws {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [ActionItemCreateURLCapture.self]
+    let client = APIClient(session: URLSession(configuration: config))
+    await client.setTestAuthHeader("Bearer test-token")
+
+    _ = try await client.createActionItem(description: "Buy milk")
+
+    let request = try XCTUnwrap(ActionItemCreateURLCapture.captured())
+    XCTAssertEqual(request.method, "POST")
+    XCTAssertTrue(request.url.path.hasSuffix("/v1/action-items"))
+    let key = try XCTUnwrap(request.headers["Idempotency-Key"])
+    XCTAssertFalse(key.isEmpty)
+  }
+
+  func testCreateActionItemReusesCallerProvidedKey() async throws {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [ActionItemCreateURLCapture.self]
+    let client = APIClient(session: URLSession(configuration: config))
+    await client.setTestAuthHeader("Bearer test-token")
+
+    _ = try await client.createActionItem(
+      description: "Buy milk",
+      idempotencyKey: "desktop-action-item:42"
+    )
+
+    let request = try XCTUnwrap(ActionItemCreateURLCapture.captured())
+    XCTAssertEqual(request.headers["Idempotency-Key"], "desktop-action-item:42")
+  }
+
+  func testLocalRowIdempotencyKeyIsStableAcrossRetries() {
+    let first = TasksStore.actionItemCreateIdempotencyKey(localRowID: 17)
+    let second = TasksStore.actionItemCreateIdempotencyKey(localRowID: 17)
+    XCTAssertEqual(first, second)
+    XCTAssertEqual(first, "desktop-action-item:17")
+    XCTAssertNotEqual(
+      TasksStore.actionItemCreateIdempotencyKey(localRowID: 17),
+      TasksStore.actionItemCreateIdempotencyKey(localRowID: 18))
+  }
+}

--- a/desktop/macos/Desktop/Tests/ActionItemCreateIdempotencyTests.swift
+++ b/desktop/macos/Desktop/Tests/ActionItemCreateIdempotencyTests.swift
@@ -28,9 +28,13 @@ private final class ActionItemCreateURLCapture: URLProtocol, @unchecked Sendable
   override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
   override func startLoading() {
+    guard let url = request.url else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+      return
+    }
     Self.lock.lock()
     Self.request = CapturedCreateRequest(
-      url: request.url!,
+      url: url,
       method: request.httpMethod ?? "GET",
       headers: request.allHTTPHeaderFields ?? [:]
     )
@@ -39,8 +43,13 @@ private final class ActionItemCreateURLCapture: URLProtocol, @unchecked Sendable
     let body = Data(
       #"{"id":"task-1","description":"Buy milk","completed":false,"created_at":"2026-01-01T00:00:00.000Z","updated_at":"2026-01-01T00:00:00.000Z"}"#
         .utf8)
-    let response = HTTPURLResponse(
-      url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+    guard
+      let response = HTTPURLResponse(
+        url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+    else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+      return
+    }
     client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
     client?.urlProtocol(self, didLoad: body)
     client?.urlProtocolDidFinishLoading(self)

--- a/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
@@ -680,6 +680,20 @@ final class HomeAskBarControlsTests: XCTestCase {
     XCTAssertEqual(primary(isSending: true, hasText: true), .stop(isStopping: false))
   }
 
+  func testSpokenPlaybackReplacesSendWithStopSpeaking() {
+    XCTAssertEqual(
+      HomeAskBarControls.resolve(
+        isSending: false, isStopping: false, hasText: false, isFocused: false, isSpeaking: true
+      ).primary,
+      .stopSpeaking)
+    // An in-flight agent turn still owns Stop over stop-speaking.
+    XCTAssertEqual(
+      HomeAskBarControls.resolve(
+        isSending: true, isStopping: false, hasText: false, isFocused: false, isSpeaking: true
+      ).primary,
+      .stop(isStopping: false))
+  }
+
   func testConnectOnlyHoldsTheSlotWhileTheBarIsAtRest() {
     let resting = HomeAskBarControls.resolve(
       isSending: false, isStopping: false, hasText: false, isFocused: false)

--- a/desktop/macos/Desktop/Tests/PushToTalkButtonTriggerTests.swift
+++ b/desktop/macos/Desktop/Tests/PushToTalkButtonTriggerTests.swift
@@ -143,12 +143,11 @@ final class PushToTalkButtonTriggerTests: XCTestCase {
   /// Cancel must trail the mic in the control cluster. Leading cancel shifts the
   /// mic's hit target when it mounts, so the second click lands on cancel.
   func testCancelRecordingControlTrailsTheMicInSourceLayout() throws {
-    // omi-test-quality: source-inspection -- static contract: cancel must trail
-    // mic in PushToTalkMicButton body so the mic hit target does not jump.
     let sourceURL = URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()
       .deletingLastPathComponent()
       .appendingPathComponent("Sources/FloatingControlBar/PushToTalkMicButton.swift")
+    // omi-test-quality: source-inspection -- static contract: cancel must trail mic in PushToTalkMicButton body so the mic hit target does not jump on mount
     let source = try String(contentsOf: sourceURL, encoding: .utf8)
     guard let bodyRange = source.range(of: "var body: some View") else {
       return XCTFail("PushToTalkMicButton body missing")

--- a/desktop/macos/Desktop/Tests/PushToTalkButtonTriggerTests.swift
+++ b/desktop/macos/Desktop/Tests/PushToTalkButtonTriggerTests.swift
@@ -110,6 +110,60 @@ final class PushToTalkButtonTriggerTests: XCTestCase {
     }
   }
 
+  func testCancelRecordingControlIsOfferedOnlyWhileCapturing() {
+    XCTAssertTrue(PushToTalkManager.showsCancelRecordingControl(phase: .recording))
+    XCTAssertTrue(PushToTalkManager.showsCancelRecordingControl(phase: .lockedRecording))
+    XCTAssertTrue(PushToTalkManager.showsCancelRecordingControl(phase: .pendingLockDecision))
+    let hidden: [VoiceTurnPhase?] = [
+      .idle, .finalizing, .awaitingResponse, .awaitingTools, .awaitingJournal,
+      .playing(.nativeRealtime), .terminal(.cancelled), nil,
+    ]
+    for phase in hidden {
+      XCTAssertFalse(
+        PushToTalkManager.showsCancelRecordingControl(phase: phase),
+        "\(String(describing: phase)) must not show cancel.")
+    }
+  }
+
+  func testCancelWhileListeningEndsTheTurnWithoutFinalizing() {
+    let coordinator = VoiceTurnCoordinator(scheduler: ManualPushToTalkButtonScheduler())
+    let turnID = coordinator.begin(intent: .locked)
+    XCTAssertEqual(coordinator.activeTurn?.phase, .lockedRecording)
+
+    coordinator.publish(.cancel(turnID: turnID, reason: .cancelled))
+    XCTAssertNil(coordinator.activeTurn)
+    XCTAssertEqual(coordinator.model.lastTerminal?.turnID, turnID)
+    XCTAssertEqual(coordinator.model.lastTerminal?.reason, .cancelled)
+    XCTAssertEqual(
+      PushToTalkManager.clickAction(phase: coordinator.activeTurn?.phase),
+      .beginHandsFree,
+      "After cancel the mic must be ready to start a fresh recording.")
+  }
+
+  /// Cancel must trail the mic in the control cluster. Leading cancel shifts the
+  /// mic's hit target when it mounts, so the second click lands on cancel.
+  func testCancelRecordingControlTrailsTheMicInSourceLayout() throws {
+    // omi-test-quality: source-inspection -- static contract: cancel must trail
+    // mic in PushToTalkMicButton body so the mic hit target does not jump.
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/FloatingControlBar/PushToTalkMicButton.swift")
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+    guard let bodyRange = source.range(of: "var body: some View") else {
+      return XCTFail("PushToTalkMicButton body missing")
+    }
+    let body = String(source[bodyRange.lowerBound...])
+    guard let micRange = body.range(of: "micButton"),
+      let cancelRange = body.range(of: "cancelButton")
+    else {
+      return XCTFail("micButton/cancelButton missing from body")
+    }
+    XCTAssertLessThan(
+      micRange.lowerBound, cancelRange.lowerBound,
+      "micButton must appear before cancelButton so the mic does not shift when cancel mounts.")
+  }
+
   // MARK: - Error path
 
   /// A blocked click must take the same usage-limit popup path the hotkey does.

--- a/desktop/macos/Desktop/Tests/VoiceResponsePlaybackTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceResponsePlaybackTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class VoiceResponsePlaybackTests: XCTestCase {
+  func testInterruptWhenIdleReturnsFalse() {
+    VoiceResponsePlaybackMonitor.shared.refresh()
+    XCTAssertFalse(VoiceResponsePlayback.isActive)
+    XCTAssertFalse(VoiceResponsePlayback.interrupt())
+    XCTAssertFalse(VoiceResponsePlaybackMonitor.shared.isActive)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260827-chat-voice-cancel-stop.json
+++ b/desktop/macos/changelog/unreleased/20260827-chat-voice-cancel-stop.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added cancel while recording voice in chat and a stop control for spoken AI answers"
+}

--- a/desktop/macos/e2e/flows/floating-bar-functional.yaml
+++ b/desktop/macos/e2e/flows/floating-bar-functional.yaml
@@ -17,6 +17,7 @@ covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarLaunchPolicy.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceResponsePlayback.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarMouseInterception.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift


### PR DESCRIPTION
<!-- Keep this short and honest. Reviewers read the Verification section first. -->

## What changed and why

Add cancel-while-recording for chat PTT (mic still sends; cancel trails so the hit target does not jump), a stop-speaking control for spoken AI answers (composers, Escape, agent Stop), and a stable `Idempotency-Key` on action-item create keyed to the local SQLite row so sync retries do not duplicate tasks. Backend dedupe for that key lands with the web duplicate-task fix branch and is not in this PR.

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1
- INV-VOICE-1
- INV-TASK-1

## How it was verified

- Focused Swift tests: `PushToTalkButtonTriggerTests`, `VoiceResponsePlaybackTests`, `ActionItemCreateIdempotencyTests` (and Home ask-bar stop control coverage) — **14/14 PASS**.
- Named bundle `/Applications/omi-voice-controls.app`: bridge `ptt_start` → `ptt_cancel` → `cancelled=true`, `terminal_reason=cancelled`.
- Pre-push / local PR preflight passed with this body (line-count exceptions + invariant citations).
- Not re-verified in this session: mid-TTS Stop in the live UI (spoken playback was already silent on this machine and on the site download build — treated as environmental, not introduced here). Manual cancel → re-record and live task create with Idempotency-Key still worth a quick pass on reviewer’s machine.

## Tests

- Core cancel path + post-cancel restart: `PushToTalkButtonTriggerTests` (including cancel-trails-mic layout tripwire).
- Stop-speaking helper: `VoiceResponsePlaybackTests`.
- Idempotency-Key always sent / caller key reused / stable local-row key: `ActionItemCreateIdempotencyTests`.
- `VoiceResponsePlayback.swift` covered in `floating-bar-functional.yaml` for e2e flow coverage.

## Failure class (fixes)

Failure-Class: none

## Scoped cleanups (optional)

- Pre-push unblock commits: e2e `covers` for `VoiceResponsePlayback`, SwiftLint force-unwrap fix in the idempotency URL stub, source-inspection escape placement for the layout tripwire.

Line-Count-Exception: desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift | 4679 -> 4687 | Register ptt_cancel automation action next to existing PTT bridge actions
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift | 3012 -> 3038 | Add interactive cancel on floating/notch PTT recording overlays
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift | 2807 -> 2821 | Expose cancelPushToTalkForAutomation for the bridge cancel path
Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift | 4297 -> 4303 | Wire Home ask bar stop-speaking through existing trailing controls
Line-Count-Exception: desktop/macos/Desktop/Sources/Providers/ChatProvider.swift | 6858 -> 6860 | Interrupt spoken playback when the user stops an in-flight agent turn
Line-Count-Exception: desktop/macos/Desktop/Sources/Stores/TasksStore.swift | 3676 -> 3684 | Pass stable Idempotency-Key when syncing local-first task creates

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

