### PR TITLE
feat(stt): route explicit-English sessions to Velma-2 English Fast v2

### DIFF
--- a/backend/tests/unit/test_modulate_english_fast_routing.py
+++ b/backend/tests/unit/test_modulate_english_fast_routing.py
@@ -38,9 +38,13 @@ async def test_english_sessions_use_english_fast_model(language):
     uri = await _connect(language)
     assert streaming.MODULATE_ENGLISH_FAST_PATH in uri
     params = _params(uri)
+    assert params['endpointing'] == ['true']
+    # The model rejects a language parameter; it is English-only by construction.
     assert 'language' not in params
-    assert 'speaker_diarization' not in params
-    assert 'partial_results' not in params
+    # Undocumented for this model but ignored rather than rejected, so we ask for
+    # diarization in case it is honoured.
+    assert params['speaker_diarization'] == ['true']
+    assert params['partial_results'] == ['true']
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_modulate_english_fast_routing.py
+++ b/backend/tests/unit/test_modulate_english_fast_routing.py
@@ -1,0 +1,61 @@
+"""Only explicit-English sessions may reach the English-only Velma-2 model.
+
+The ``velma-2-stt-streaming-english-v2`` endpoint rejects a ``language`` parameter and
+accepts neither ``speaker_diarization`` nor ``partial_results``. Routing a ``multi``
+session there would send auto-detect traffic -- which resolves to any language -- to a
+model that can only transcribe English, so those users would get wrong transcripts
+rather than an error. Every non-English and every auto-detect session must stay on the
+multilingual endpoint with its diarization parameters intact.
+"""
+
+import urllib.parse
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from utils.stt import streaming
+
+
+def _connect_uri(mock_connect):
+    return mock_connect.await_args.args[0]
+
+
+def _params(uri):
+    return urllib.parse.parse_qs(urllib.parse.urlparse(uri).query)
+
+
+async def _connect(language):
+    with patch.object(streaming.websockets, 'connect', new=AsyncMock()) as mock_connect, patch.object(
+        streaming, 'SafeModulateSocket'
+    ), patch.dict('os.environ', {'MODULATE_API_KEY': 'test-key'}):
+        await streaming.process_audio_modulate(lambda _segments: None, 16000, language)
+        return _connect_uri(mock_connect)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('language', ['en', 'en-US', 'EN', 'en_GB'])
+async def test_english_sessions_use_english_fast_model(language):
+    uri = await _connect(language)
+    assert streaming.MODULATE_ENGLISH_FAST_PATH in uri
+    params = _params(uri)
+    assert 'language' not in params
+    assert 'speaker_diarization' not in params
+    assert 'partial_results' not in params
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('language', ['multi', 'ja', 'es-ES', 'pl', ''])
+async def test_non_english_sessions_stay_on_multilingual_model(language):
+    uri = await _connect(language)
+    assert f'/{streaming.MODULATE_MULTILINGUAL_PATH}?' in uri
+    params = _params(uri)
+    assert params['speaker_diarization'] == ['true']
+    assert params['partial_results'] == ['true']
+
+
+@pytest.mark.asyncio
+async def test_english_fast_can_be_disabled_without_a_deploy():
+    with patch.object(streaming, 'MODULATE_ENGLISH_FAST_ENABLED', False):
+        uri = await _connect('en')
+    assert f'/{streaming.MODULATE_MULTILINGUAL_PATH}?' in uri
+    assert _params(uri)['language'] == ['en']

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -1181,6 +1181,21 @@ class SafeModulateSocket(STTSocket):
         self._stream_transcript(segments)
 
 
+MODULATE_STREAMING_HOST: Final = os.getenv('MODULATE_STREAMING_HOST', 'modulate-developer-apis.com')
+MODULATE_MULTILINGUAL_PATH: Final = 'velma-2-stt-streaming'
+MODULATE_ENGLISH_FAST_PATH: Final = 'velma-2-stt-streaming-english-v2'
+MODULATE_ENGLISH_FAST_ENABLED: Final = os.getenv('MODULATE_ENGLISH_FAST_ENABLED', 'true').lower() == 'true'
+
+
+def _modulate_english_fast_selected(language: str) -> bool:
+    """Return whether a session should use the English-only Velma-2 model.
+
+    The multilingual model must serve every other language, and 'multi' cannot be
+    routed here because auto-detection may resolve to a non-English speaker.
+    """
+    return MODULATE_ENGLISH_FAST_ENABLED and normalized_stt_language(language) == 'en'
+
+
 async def process_audio_modulate(
     stream_transcript: Callable[[List[Dict[str, Any]]], None],
     sample_rate: int,
@@ -1191,23 +1206,33 @@ async def process_audio_modulate(
     if not api_key:
         raise ValueError('MODULATE_API_KEY environment variable is not set')
 
+    english_fast = _modulate_english_fast_selected(language)
     params = {
         'api_key': api_key,
-        'speaker_diarization': 'true',
-        'partial_results': 'true',
         'sample_rate': str(sample_rate),
         'audio_format': 's16le',
         'num_channels': '1',
     }
-    if language and language != 'multi':
-        params['language'] = language
-    uri = f'wss://modulate-developer-apis.com/api/velma-2-stt-streaming?{urllib.parse.urlencode(params)}'
+    if english_fast:
+        # This model accepts neither speaker_diarization nor partial_results, and
+        # rejects a language parameter. It emits partial_utterance by default and
+        # omits the speaker field, which _handle_utterance already maps to SPEAKER_00.
+        path = MODULATE_ENGLISH_FAST_PATH
+        params['endpointing'] = 'true'
+    else:
+        path = MODULATE_MULTILINGUAL_PATH
+        params['speaker_diarization'] = 'true'
+        params['partial_results'] = 'true'
+        if language and language != 'multi':
+            params['language'] = language
+    uri = f'wss://{MODULATE_STREAMING_HOST}/api/{path}?{urllib.parse.urlencode(params)}'
 
-    logger.info(f'Connecting to Modulate Velma-2 streaming sample_rate={sample_rate} language={language}')
+    model = 'english-fast-v2' if english_fast else 'multilingual'
+    logger.info(f'Connecting to Modulate Velma-2 streaming model={model} sample_rate={sample_rate} language={language}')
     ws = await websockets.connect(uri, ping_timeout=10, ping_interval=10)
     loop = asyncio.get_running_loop()
     sock = SafeModulateSocket(ws, stream_transcript, loop, preseconds=preseconds)
-    logger.info('Modulate Velma-2 streaming connection established')
+    logger.info(f'Modulate Velma-2 streaming connection established model={model}')
     return sock
 
 

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -1214,11 +1214,15 @@ async def process_audio_modulate(
         'num_channels': '1',
     }
     if english_fast:
-        # This model accepts neither speaker_diarization nor partial_results, and
-        # rejects a language parameter. It emits partial_utterance by default and
-        # omits the speaker field, which _handle_utterance already maps to SPEAKER_00.
+        # The documented table for this model lists only api_key/audio_format/
+        # sample_rate/num_channels/endpointing, and its utterance payload carries no
+        # speaker field -- so diarization may be lost here and segments collapse to
+        # SPEAKER_00. The endpoint ignores the extra parameters rather than rejecting
+        # them, so they are still sent in case it honours them undocumented.
         path = MODULATE_ENGLISH_FAST_PATH
         params['endpointing'] = 'true'
+        params['speaker_diarization'] = 'true'
+        params['partial_results'] = 'true'
     else:
         path = MODULATE_MULTILINGUAL_PATH
         params['speaker_diarization'] = 'true'


### PR DESCRIPTION
## Why

The multilingual Velma-2 streaming endpoint is failing for our account. A direct
WebSocket probe with our production key, outside our infrastructure, reproduces it:

```
wss://.../api/velma-2-stt-streaming            → ConnectionClosedError 1011 (internal error)
wss://.../api/velma-2-stt-streaming-english-v2 → connects, returns partial_utterance
```

That matches production, where Modulate has been rejecting ~90% of streams for days
while Deepgram carries the load on rate-capped accounts.

The English-only model answers normally with the same credentials, so sessions that
declare English can be served today instead of waiting for the multilingual endpoint.

## What changed

`process_audio_modulate` picks the endpoint from the session language:

- `en` (incl. `en-US`, `en_GB`) → `velma-2-stt-streaming-english-v2`
- everything else, including `multi` → `velma-2-stt-streaming`, unchanged

`multi` stays on the multilingual model. Auto-detect resolves to any language and this
model is English-only, so routing auto-detect there would produce wrong transcripts
rather than an error.

## Known tradeoff: diarization

The documented parameter table for `velma-2-stt-streaming-english-v2` is only
`api_key`, `audio_format`, `sample_rate`, `num_channels`, `endpointing`, and its
documented utterance payload has no `speaker` field. `_handle_utterance` maps a
missing speaker to `SPEAKER_00`, so **English sessions may lose speaker separation**
and return single-speaker transcripts.

Probing showed the endpoint ignores undocumented parameters rather than rejecting
them, so `speaker_diarization=true` and `partial_results=true` are sent anyway in case
they are honoured. Whether diarization actually works there is unverified — it needs a
real two-speaker sample, which I have not run.

If diarization is lost, that is a quality regression for English users traded against
a currently ~90% failure rate. `MODULATE_ENGLISH_FAST_ENABLED=false` reverts routing
without a deploy.

## Expected impact

Measured over 20 minutes of production traffic:

```
multi   1,784   82%   unchanged
en        240   11%   → English Fast v2
other     151    7%   unchanged
```

Roughly a ninth of Modulate traffic. Useful while the multilingual endpoint is broken;
not a fix for the outage.

## Testing

- `test_modulate_english_fast_routing.py`: 10 cases covering English variants, the
  `multi`/non-English guard, parameters sent per endpoint, and the disable flag.
- Existing Modulate and STT policy suites pass (41 tests).
- Both endpoints probed live against the production key, including parameter
  acceptance and first-text-frame config.
