### PR TITLE
fix(desktop): ground legacy sidebars and keep them clickable

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1324,26 +1324,24 @@ struct DesktopHomeView: View {
   @ViewBuilder
   private var sidebarSlot: some View {
     if showsPrimarySidebar {
-      ZStack {
-        SidebarView(
-          selectedIndex: $selectedIndex,
-          isCollapsed: $isSidebarCollapsed,
-          memoryDestinationRawValue: $memoryDestinationRawValue,
-          appState: appState,
-          ownsShellHitRegion: !isInSettings
-        )
-        .opacity(isInSettings ? 0 : 1)
-        .allowsHitTesting(!isInSettings)
-        if isInSettings { settingsSidebar }
+      LegacySidebarSurface {
+        ZStack {
+          SidebarView(
+            selectedIndex: $selectedIndex,
+            isCollapsed: $isSidebarCollapsed,
+            memoryDestinationRawValue: $memoryDestinationRawValue,
+            appState: appState
+          )
+          .opacity(isInSettings ? 0 : 1)
+          .allowsHitTesting(!isInSettings)
+          if isInSettings { settingsSidebar }
+        }
       }
-      .fixedSize(horizontal: true, vertical: false)
-      .clipped()
     }
   }
 
-  /// The settings section list. Modern settings hosts it inside the page panel; legacy Home keeps it
-  /// in the old sidebar slot beside that panel. The latter has no glass underneath it, so the sidebar
-  /// must register its own shell hit region or the transparent window passes its clicks through.
+  /// The settings section list. Modern settings hosts it inside the page panel; legacy Home hosts the
+  /// whole sidebar slot on `LegacySidebarSurface`, so this view always inherits a glass ground.
   private var settingsSidebar: some View {
     SettingsSidebar(
       selectedSection: $selectedSettingsSection,
@@ -1355,8 +1353,7 @@ struct DesktopHomeView: View {
             ? SidebarNavItem.dashboard.rawValue
             : previousIndexBeforeSettings
         }
-      }, appState: appState,
-      ownsShellHitRegion: showsPrimarySidebar)
+      }, appState: appState)
   }
 
   // Main content area. It paints **no background**: the window has no ground at all

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1329,7 +1329,8 @@ struct DesktopHomeView: View {
           selectedIndex: $selectedIndex,
           isCollapsed: $isSidebarCollapsed,
           memoryDestinationRawValue: $memoryDestinationRawValue,
-          appState: appState
+          appState: appState,
+          ownsShellHitRegion: !isInSettings
         )
         .opacity(isInSettings ? 0 : 1)
         .allowsHitTesting(!isInSettings)
@@ -1340,10 +1341,9 @@ struct DesktopHomeView: View {
     }
   }
 
-  /// The settings section list. In the glass shell it belongs *inside* the Settings panel rather than
-  /// beside the whole window: the window has no ground, so a nav column left outside the panel is a
-  /// list of controls floating on the user's wallpaper. It needs no surface of its own — its
-  /// `Ink.rowFill` is already a wash meant to read as a shaded part of the glass it sits on.
+  /// The settings section list. Modern settings hosts it inside the page panel; legacy Home keeps it
+  /// in the old sidebar slot beside that panel. The latter has no glass underneath it, so the sidebar
+  /// must register its own shell hit region or the transparent window passes its clicks through.
   private var settingsSidebar: some View {
     SettingsSidebar(
       selectedSection: $selectedSettingsSection,
@@ -1355,7 +1355,8 @@ struct DesktopHomeView: View {
             ? SidebarNavItem.dashboard.rawValue
             : previousIndexBeforeSettings
         }
-      }, appState: appState)
+      }, appState: appState,
+      ownsShellHitRegion: showsPrimarySidebar)
   }
 
   // Main content area. It paints **no background**: the window has no ground at all

--- a/desktop/macos/Desktop/Sources/MainWindow/LegacySidebarSurface.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/LegacySidebarSurface.swift
@@ -1,0 +1,26 @@
+//
+//  LegacySidebarSurface.swift — the one ground under the old Home sidebar slot.
+//
+
+import OmiTheme
+import SwiftUI
+
+/// Hosts the old Home navigation slot on its own piece of glass.
+///
+/// `ShellWindowChrome` leaves the top-level window transparent and `PageGlassLane` grounds only the
+/// destination beside this slot. Keeping the surface here means the primary navigation and the
+/// Settings menu share one owner for both their visible glass and their mouse-hit region.
+struct LegacySidebarSurface<Content: View>: View {
+  private let content: Content
+
+  init(@ViewBuilder content: () -> Content) {
+    self.content = content()
+  }
+
+  var body: some View {
+    content
+      .fixedSize(horizontal: true, vertical: false)
+      .clipped()
+      .inkGlassPanel(cornerRadius: 0, shadow: nil)
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -412,6 +412,9 @@ struct SettingsSidebar: View {
   @Binding var highlightedSettingId: String?
   let onBack: () -> Void
   @ObservedObject var appState: AppState
+  /// Standalone legacy Settings has no page glass underneath it, so it must own mouse input itself.
+  /// Panel-hosted Settings leaves this false to preserve the panel's rounded corner cut-outs.
+  var ownsShellHitRegion = false
 
   @State private var isBackHovered = false
   @State private var searchQuery = ""
@@ -490,6 +493,11 @@ struct SettingsSidebar: View {
     // glass, and a `.regularMaterial` here would be a *within-window* blur stacked on it — two
     // materials in one window, which on light glass reads as a grey slab down the side.
     .background(Ink.rowFill)
+    .background {
+      if ownsShellHitRegion {
+        InkGlassHitRegionReporter()
+      }
+    }
   }
 
   private var searchField: some View {

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -412,9 +412,6 @@ struct SettingsSidebar: View {
   @Binding var highlightedSettingId: String?
   let onBack: () -> Void
   @ObservedObject var appState: AppState
-  /// Standalone legacy Settings has no page glass underneath it, so it must own mouse input itself.
-  /// Panel-hosted Settings leaves this false to preserve the panel's rounded corner cut-outs.
-  var ownsShellHitRegion = false
 
   @State private var isBackHovered = false
   @State private var searchQuery = ""
@@ -489,15 +486,10 @@ struct SettingsSidebar: View {
       Spacer()
     }
     .frame(width: SettingsSidebarMetrics.expandedWidth)
-    // A half-step of shading, and deliberately not a second material: the window already wears the
-    // glass, and a `.regularMaterial` here would be a *within-window* blur stacked on it — two
-    // materials in one window, which on light glass reads as a grey slab down the side.
+    // A half-step of shading, and deliberately not a second material: the host already wears the
+    // glass (`PageGlassLane` in modern Settings, `LegacySidebarSurface` in old Home), and a
+    // `.regularMaterial` here would be a within-window blur stacked on it.
     .background(Ink.rowFill)
-    .background {
-      if ownsShellHitRegion {
-        InkGlassHitRegionReporter()
-      }
-    }
   }
 
   private var searchField: some View {

--- a/desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift
@@ -8,6 +8,8 @@ struct SidebarView: View {
   @Binding var isCollapsed: Bool
   @Binding var memoryDestinationRawValue: Int
   @ObservedObject var appState: AppState
+  /// False only while legacy Settings covers this kept-alive view in the shared sidebar slot.
+  var ownsShellHitRegion = true
   @ObservedObject private var authState = AuthState.shared
   @ObservedObject private var updaterViewModel = UpdaterViewModel.shared
 
@@ -250,6 +252,14 @@ struct SidebarView: View {
         }
     }
     .frame(width: currentWidth)
+    // The legacy shell floats this menu beside `PageGlassLane` on a transparent top-level window.
+    // Without its own registered surface the shell passes clicks on these visible controls through
+    // to Finder. Settings disables this kept-alive view's marker and owns the slot itself.
+    .background {
+      if ownsShellHitRegion {
+        InkGlassHitRegionReporter()
+      }
+    }
     .onAppear {
       syncMonitoringState()
       appState.checkAllPermissions()

--- a/desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift
@@ -8,8 +8,6 @@ struct SidebarView: View {
   @Binding var isCollapsed: Bool
   @Binding var memoryDestinationRawValue: Int
   @ObservedObject var appState: AppState
-  /// False only while legacy Settings covers this kept-alive view in the shared sidebar slot.
-  var ownsShellHitRegion = true
   @ObservedObject private var authState = AuthState.shared
   @ObservedObject private var updaterViewModel = UpdaterViewModel.shared
 
@@ -252,14 +250,6 @@ struct SidebarView: View {
         }
     }
     .frame(width: currentWidth)
-    // The legacy shell floats this menu beside `PageGlassLane` on a transparent top-level window.
-    // Without its own registered surface the shell passes clicks on these visible controls through
-    // to Finder. Settings disables this kept-alive view's marker and owns the slot itself.
-    .background {
-      if ownsShellHitRegion {
-        InkGlassHitRegionReporter()
-      }
-    }
     .onAppear {
       syncMonitoringState()
       appState.checkAllPermissions()

--- a/desktop/macos/Desktop/Tests/GlassPanelHitRegionTests.swift
+++ b/desktop/macos/Desktop/Tests/GlassPanelHitRegionTests.swift
@@ -94,6 +94,39 @@ final class GlassPanelHitRegionTests: XCTestCase {
       "the band above the panel is air and must not swallow a click aimed at another app")
   }
 
+  /// Legacy Home hosts both its primary navigation and Settings menu beside `PageGlassLane`. The
+  /// slot must keep either visible menu interactive, while the modern panel-hosted Settings menu
+  /// must not add a rectangular region that would reclaim the panel's rounded corner cut-outs.
+  func testLegacySidebarSlotOwnsHitsForBothMenus() throws {
+    defer { teardownWindow() }
+
+    for host in SidebarHost.allCases {
+      let sidebar = mountSidebar(host)
+      let window = try XCTUnwrap(self.window)
+      let inside = NSPoint(x: sidebar.midX, y: sidebar.midY)
+      let beside = NSPoint(x: sidebar.maxX + 40, y: sidebar.midY)
+
+      XCTAssertEqual(
+        InkGlassHitRegions.shared.hasSurfaces(in: window), host.expectsSurface,
+        "\(host): standalone ownership must match the host")
+      XCTAssertEqual(
+        InkGlassHitRegions.shared.containsPoint(inside, in: window), host.expectsSurface,
+        "\(host): every visible legacy menu must keep mouse input")
+      XCTAssertFalse(
+        InkGlassHitRegions.shared.containsPoint(beside, in: window),
+        "the sidebar must not make the transparent space beside it interactive")
+      XCTAssertEqual(
+        ShellClickThroughPolicy.acceptsMouseHit(
+          localPoint: inside,
+          windowSize: window.frame.size,
+          isResizable: false,
+          contentContains: { InkGlassHitRegions.shared.containsPoint($0, in: window) }),
+        host.expectsSurface)
+
+      teardownWindow()
+    }
+  }
+
   /// Mounts one glass panel inset inside a larger transparent window and returns the panel's frame
   /// in window coordinates.
   private func mountPanel(reduceTransparency: Bool) -> NSRect {
@@ -126,6 +159,70 @@ final class GlassPanelHitRegionTests: XCTestCase {
       y: (windowSize.height - panelSize.height) / 2,
       width: panelSize.width,
       height: panelSize.height)
+  }
+
+  private enum SidebarHost: CaseIterable {
+    case panelSettings
+    case legacySettings
+    case legacyNavigation
+
+    var expectsSurface: Bool { self != .panelSettings }
+    var width: CGFloat {
+      self == .legacyNavigation ? 64 : SettingsSidebarMetrics.expandedWidth
+    }
+  }
+
+  private func mountSidebar(_ host: SidebarHost) -> NSRect {
+    let windowSize = NSSize(width: 500, height: 500)
+    let sidebarSize = NSSize(width: host.width, height: windowSize.height)
+    let window = NSWindow(
+      contentRect: NSRect(origin: .zero, size: windowSize),
+      styleMask: [.borderless],
+      backing: .buffered,
+      defer: false)
+    window.isOpaque = false
+    window.backgroundColor = .clear
+
+    let sidebar: AnyView
+    switch host {
+    case .panelSettings:
+      sidebar = AnyView(settingsSidebar(ownsShellHitRegion: false))
+    case .legacySettings:
+      sidebar = AnyView(settingsSidebar(ownsShellHitRegion: true))
+    case .legacyNavigation:
+      sidebar = AnyView(
+        SidebarView(
+          selectedIndex: .constant(SidebarNavItem.dashboard.rawValue),
+          isCollapsed: .constant(true),
+          memoryDestinationRawValue: .constant(MemoryHubDestination.memories.rawValue),
+          appState: AppState()
+        ))
+    }
+
+    let root = HStack(spacing: 0) {
+      sidebar
+      Spacer(minLength: 0)
+    }
+    .frame(width: windowSize.width, height: windowSize.height)
+
+    let hosting = NSHostingView(rootView: root)
+    hosting.frame = NSRect(origin: .zero, size: windowSize)
+    window.contentView = hosting
+    NonintrusiveTestWindow.orderIn(window)
+    hosting.layoutSubtreeIfNeeded()
+    self.window = window
+
+    return NSRect(origin: .zero, size: sidebarSize)
+  }
+
+  private func settingsSidebar(ownsShellHitRegion: Bool) -> some View {
+    SettingsSidebar(
+      selectedSection: .constant(.general),
+      highlightedSettingId: .constant(nil),
+      onBack: {},
+      appState: AppState(),
+      ownsShellHitRegion: ownsShellHitRegion
+    )
   }
 
   private func teardownWindow() {

--- a/desktop/macos/Desktop/Tests/GlassPanelHitRegionTests.swift
+++ b/desktop/macos/Desktop/Tests/GlassPanelHitRegionTests.swift
@@ -95,9 +95,9 @@ final class GlassPanelHitRegionTests: XCTestCase {
   }
 
   /// Legacy Home hosts both its primary navigation and Settings menu beside `PageGlassLane`. The
-  /// slot must keep either visible menu interactive, while the modern panel-hosted Settings menu
-  /// must not add a rectangular region that would reclaim the panel's rounded corner cut-outs.
-  func testLegacySidebarSlotOwnsHitsForBothMenus() throws {
+  /// slot must give either menu the real shared glass and its matching hit region, while the modern
+  /// panel-hosted Settings menu must inherit the page panel instead of adding a second material.
+  func testLegacySidebarSlotOwnsGlassAndHitsForBothMenus() throws {
     defer { teardownWindow() }
 
     for host in SidebarHost.allCases {
@@ -109,6 +109,9 @@ final class GlassPanelHitRegionTests: XCTestCase {
       XCTAssertEqual(
         InkGlassHitRegions.shared.hasSurfaces(in: window), host.expectsSurface,
         "\(host): standalone ownership must match the host")
+      XCTAssertEqual(
+        hasBehindWindowGlass(in: window), host.expectsSurface,
+        "\(host): a standalone menu needs actual glass, not only an invisible hit marker")
       XCTAssertEqual(
         InkGlassHitRegions.shared.containsPoint(inside, in: window), host.expectsSurface,
         "\(host): every visible legacy menu must keep mouse input")
@@ -186,17 +189,19 @@ final class GlassPanelHitRegionTests: XCTestCase {
     let sidebar: AnyView
     switch host {
     case .panelSettings:
-      sidebar = AnyView(settingsSidebar(ownsShellHitRegion: false))
+      sidebar = AnyView(settingsSidebar)
     case .legacySettings:
-      sidebar = AnyView(settingsSidebar(ownsShellHitRegion: true))
+      sidebar = AnyView(LegacySidebarSurface { settingsSidebar })
     case .legacyNavigation:
       sidebar = AnyView(
-        SidebarView(
-          selectedIndex: .constant(SidebarNavItem.dashboard.rawValue),
-          isCollapsed: .constant(true),
-          memoryDestinationRawValue: .constant(MemoryHubDestination.memories.rawValue),
-          appState: AppState()
-        ))
+        LegacySidebarSurface {
+          SidebarView(
+            selectedIndex: .constant(SidebarNavItem.dashboard.rawValue),
+            isCollapsed: .constant(true),
+            memoryDestinationRawValue: .constant(MemoryHubDestination.memories.rawValue),
+            appState: AppState()
+          )
+        })
     }
 
     let root = HStack(spacing: 0) {
@@ -215,14 +220,25 @@ final class GlassPanelHitRegionTests: XCTestCase {
     return NSRect(origin: .zero, size: sidebarSize)
   }
 
-  private func settingsSidebar(ownsShellHitRegion: Bool) -> some View {
+  private var settingsSidebar: some View {
     SettingsSidebar(
       selectedSection: .constant(.general),
       highlightedSettingId: .constant(nil),
       onBack: {},
-      appState: AppState(),
-      ownsShellHitRegion: ownsShellHitRegion
+      appState: AppState()
     )
+  }
+
+  private func hasBehindWindowGlass(in window: NSWindow) -> Bool {
+    guard let contentView = window.contentView else { return false }
+    return viewTree(rootedAt: contentView).contains { view in
+      guard let material = view as? NSVisualEffectView else { return false }
+      return material.blendingMode == .behindWindow
+    }
+  }
+
+  private func viewTree(rootedAt root: NSView) -> [NSView] {
+    [root] + root.subviews.flatMap { viewTree(rootedAt: $0) }
   }
 
   private func teardownWindow() {

--- a/desktop/macos/changelog/unreleased/20260827-legacy-settings-sidebar-clicks.json
+++ b/desktop/macos/changelog/unreleased/20260827-legacy-settings-sidebar-clicks.json
@@ -1,3 +1,3 @@
 {
-  "change": "Fixed clicks passing through both left menus in the old Home design"
+  "change": "Fixed transparent and unresponsive left menus in the old Home design"
 }

--- a/desktop/macos/changelog/unreleased/20260827-legacy-settings-sidebar-clicks.json
+++ b/desktop/macos/changelog/unreleased/20260827-legacy-settings-sidebar-clicks.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed clicks passing through both left menus in the old Home design"
+}

--- a/desktop/macos/e2e/flows/navigation.yaml
+++ b/desktop/macos/e2e/flows/navigation.yaml
@@ -8,6 +8,7 @@ covers:
   - desktop/macos/Desktop/Sources/OmiApp.swift
   - desktop/macos/Desktop/Sources/Sound/OmiUISound.swift
   - desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift
+  - desktop/macos/Desktop/Sources/MainWindow/LegacySidebarSurface.swift
   - desktop/macos/Desktop/Sources/MainWindow/SidebarNavItem.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
   - desktop/macos/Desktop/Sources/MainWindow/PageGlassLane.swift
@@ -129,10 +130,18 @@ steps:
         - Home
 
   - id: S9
-    name: Verify legacy Home Conversations tab
-    do: "In Settings > Advanced, enable Use old Home design, return to Home, and verify the left sidebar shows Conversations as a separate destination from Memories. Click Conversations."
+    name: Verify the legacy Home and Settings sidebars
+    do: >-
+      In Settings > Advanced, enable Use old Home design and return to Home. Verify the left
+      sidebar is a visibly frosted lane and shows Conversations as a separate destination from
+      Memories, then click Conversations. Open Settings from the gear, verify its left section list
+      keeps the same grounded lane instead of showing the desktop directly underneath it, and click
+      General followed by Account & Plan. Each click must change the destination inside Omi rather
+      than reaching the app behind its transparent top-level window.
     expect:
       text_visible:
+        - Settings
+        - Account & Plan
         - Conversations
 
   - id: S10


### PR DESCRIPTION
## What changed and why

Give the old Home sidebar slot one real `InkGlass` surface. The primary navigation and the Settings menu now share that surface, so the area has both a visible frosted ground and the same registered mouse-hit ownership.

Previously the legacy slot sat directly on the transparent top-level window. Its menu rows added only a faint tint, while the shell knew only about the adjacent page glass; the sidebar therefore looked almost transparent and clicks could be passed through to Finder or another app behind Omi.

Modern Settings remains inside its existing `PageGlassLane`, so it does not gain a second material or a rectangular hit region over the panel's rounded corner cut-outs.

## Product invariants affected

INV-NAV-1

## How it was verified

- Mounted the real `SidebarView` and `SettingsSidebar` in a transparent `NSWindow`. The regression test verifies that both legacy menus have an actual `NSVisualEffectView` using behind-window glass, a registered surface, and an accepted shell hit; modern Settings inherits its page panel and adds neither.
- Built and launched the separately identified `/Applications/omi-legacy-sidebar-clicks.app` against the isolated local Omi harness with the old Home design enabled. The sidebar rendered as its own frosted lane.
- Exercised the live UI: Settings `About` → `General` → `Account & Plan`, Back to the primary sidebar, then `Memories`. Every selection changed the visible destination while Omi remained active.
- Probed screen points inside both live legacy menus through `debug_hit_probe`; each reported `shellAccepts=true` with `glassSurfaces=2`.
- `GlassPanelHitRegionTests`: 4 passed.
- `ShellClickThroughPolicyTests`, `PageGlassLaneTests`, `SettingsGlassChromeTests`, and `GlassSurfaceReviewRegressionTests`: 21 passed.
- Pinned Swift formatting lint and `scripts/check_desktop_test_quality.py` passed.
- Full `desktop/macos/test.sh` from the first commit: launcher/contract checks passed and backend tests passed (214/214). The overall local run remained non-zero on four unrelated existing suites: three assert English-formatted byte/count strings while this Mac's `Locale.current` is `ru_KZ`, and `ProactiveListenEventTests` crashes inside `UNUserNotificationCenter` when XCTest is launched from Xcode's command-line bundle. The impacted hit-region and shell-policy suites passed both inside that run and in focused runs.

## Tests

`GlassPanelHitRegionTests.testLegacySidebarSlotOwnsGlassAndHitsForBothMenus` is the behavioral regression test. It fails if a legacy menu loses either its actual behind-window glass or the registered surface used by shell click-through policy, and it protects modern Settings from nested material.

## Failure class (fixes)

Failure-Class: none
