### PR TITLE
chore(charts): sync SONIOX_API_KEY into backend secrets

### DIFF
--- a/backend/charts/backend-secrets/dev_omi_backend_secrets_values.yaml
+++ b/backend/charts/backend-secrets/dev_omi_backend_secrets_values.yaml
@@ -22,6 +22,8 @@ externalSecret:
       remoteKey: DEEPGRAM_API_KEY
     - secretKey: MODULATE_API_KEY
       remoteKey: MODULATE_API_KEY
+    - secretKey: SONIOX_API_KEY
+      remoteKey: SONIOX_API_KEY
     - secretKey: FAL_KEY
       remoteKey: FAL_KEY
     - secretKey: OPENAI_API_KEY

--- a/backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
+++ b/backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
@@ -42,6 +42,8 @@ externalSecret:
       remoteKey: DEEPGRAM_API_KEY
     - secretKey: MODULATE_API_KEY
       remoteKey: MODULATE_API_KEY
+    - secretKey: SONIOX_API_KEY
+      remoteKey: SONIOX_API_KEY
     - secretKey: GOOGLE_MAPS_API_KEY
       remoteKey: GOOGLE_MAPS_API_KEY
     - secretKey: GOOGLE_CLIENT_SECRET


### PR DESCRIPTION
## Why

`SONIOX_API_KEY` exists in Secret Manager (org-level key, created 2025-05-17) and
#12295 wired backend-listen to consume it, but the ExternalSecret enumerates its keys
explicitly and Soniox was not among the 34 listed. The key therefore never reaches the
cluster secret, so the binding resolves to nothing and Soniox can never be selected.

## What changed

Adds the `SONIOX_API_KEY` → `SONIOX_API_KEY` mapping to the prod and dev backend
secret charts, next to `MODULATE_API_KEY` and `DEEPGRAM_API_KEY`.

## Verification

The org-level key was tested against the live Soniox service before this change:
authenticated, transcribed, and returned two distinct speakers on a two-speaker
sample. It is current, not stale.

The backend-listen binding is `optional: true`, so pods start fine whether or not the
key is present; this change is what makes the provider actually usable.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

