### PR TITLE
fix(stt): keep Soniox sockets alive through VAD-gated silence

### DIFF
--- a/backend/tests/unit/test_soniox_streaming.py
+++ b/backend/tests/unit/test_soniox_streaming.py
@@ -183,6 +183,28 @@ async def test_a_declared_language_is_sent_as_a_hint():
     assert config['language_hints'] == ['ja']
 
 
+@pytest.mark.asyncio
+async def test_a_silent_socket_sends_keepalives_instead_of_idling_out():
+    """VAD gating starves the socket of audio; Soniox drops it after 20s without one."""
+    ws = AsyncMock()
+    ws.__aiter__ = lambda _self: _empty_stream()
+    with patch('utils.stt.soniox.SONIOX_KEEPALIVE_SECONDS', 0.01):
+        sock = SafeSonioxSocket(ws, lambda _s: None, asyncio.get_running_loop())
+        await asyncio.sleep(0.08)
+        sock.finish()
+    keepalives = [c.args[0] for c in ws.send.await_args_list if c.args and c.args[0] == '{"type": "keepalive"}']
+    assert len(keepalives) >= 2
+
+
+def _empty_stream():
+    async def gen():
+        await asyncio.sleep(10)
+        if False:
+            yield ''
+
+    return gen()
+
+
 def test_soniox_is_streaming_only_and_off_by_default():
     assert provider_is_enabled(SONIOX_PROVIDER, STTServingSurface.STREAMING)
     assert not provider_is_enabled(SONIOX_PROVIDER, STTServingSurface.PRERECORDED)

--- a/backend/utils/stt/soniox.py
+++ b/backend/utils/stt/soniox.py
@@ -23,6 +23,10 @@ logger = logging.getLogger(__name__)
 SONIOX_SERVICE_NAME: Final = 'soniox'
 SONIOX_WS_URL: Final = os.getenv('SONIOX_WS_URL', 'wss://stt-rt.soniox.com/transcribe-websocket')
 SONIOX_MODEL: Final = os.getenv('SONIOX_MODEL', 'stt-rt-v5')
+# Soniox closes any socket that receives neither audio nor a keepalive for 20s.
+# VAD gating routinely holds audio back for longer than that, so idle sockets die
+# as 408 request_timeout unless we fill the gap ourselves.
+SONIOX_KEEPALIVE_SECONDS: Final = 10.0
 
 
 class SafeSonioxSocket(STTSocket):
@@ -136,7 +140,11 @@ class SafeSonioxSocket(STTSocket):
     async def _send_loop(self) -> None:
         try:
             while not self._closed and not self._dead:
-                data = await self._send_queue.get()
+                try:
+                    data = await asyncio.wait_for(self._send_queue.get(), timeout=SONIOX_KEEPALIVE_SECONDS)
+                except asyncio.TimeoutError:
+                    await self._ws.send(json.dumps({'type': 'keepalive'}))
+                    continue
                 if data == b'':
                     # Documented end-of-audio signal: an empty text frame.
                     await self._ws.send('')


### PR DESCRIPTION
## Problem

Soniox closes any streaming socket that receives neither audio nor a keepalive
for more than 20 seconds ([docs](https://soniox.com/docs/stt/rt/connection-keepalive)).

Our VAD gates audio out during silence, and ordinary conversational pauses run
well past 20s, so we starve the socket and Soniox hangs up. In a 15-minute
production sample on the Soniox tier, 84% of established sockets died with
`408 request_timeout`, including 86% of sessions that carried real speech.
Sessions that are gated to zero bytes for their whole life fail essentially
every time.

This is our bug, not a provider fault — the connection is dropped because we go
quiet, not because transcription fails.

## Fix

The send loop now waits on the audio queue with a timeout instead of blocking
indefinitely. When no audio is queued for 10s it emits the documented
`{"type": "keepalive"}` frame and keeps waiting, which holds the socket open
through gated silence. Audio and end-of-stream handling are unchanged.

10s is half the server's 20s window, so a single dropped or delayed keepalive
still leaves room before the server gives up.

## Tests

New test drives a socket that is never fed audio, with the keepalive interval
patched down, and asserts keepalive frames are actually sent. The existing 10
Soniox tests still pass (11 total).

## Note

Until this ships, the Soniox tier's error rate measures our own VAD gating
rather than Soniox transcription quality, so the provider evaluation is not
meaningful yet.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

