### PR TITLE
fix(app): correct recording size estimates

### DIFF
--- a/app/lib/backend/schema/bt_device/bt_device.dart
+++ b/app/lib/backend/schema/bt_device/bt_device.dart
@@ -86,6 +86,29 @@ enum BleAudioCodec {
     return this == BleAudioCodec.opusFS320 ? 320 : 160;
   }
 
+  /// Encoded bytes produced per second for the fixed-rate Opus wire formats.
+  int get encodedBytesPerSecond {
+    return switch (this) {
+      BleAudioCodec.opus => 8000,
+      BleAudioCodec.opusFS320 => 16000,
+      _ => 8000,
+    };
+  }
+
+  /// Best-effort encoded size rate used by recording/storage UI.
+  int estimatedBytesPerSecond({required int sampleRate, required int channels}) {
+    return switch (this) {
+      BleAudioCodec.opus || BleAudioCodec.opusFS320 => encodedBytesPerSecond,
+      BleAudioCodec.pcm16 => sampleRate * 2 * channels,
+      BleAudioCodec.pcm8 || BleAudioCodec.mulaw16 || BleAudioCodec.mulaw8 => sampleRate * channels,
+      _ => 8000,
+    };
+  }
+
+  int estimatedRecordingBytes({required int seconds, required int sampleRate, required int channels}) {
+    return estimatedBytesPerSecond(sampleRate: sampleRate, channels: channels) * seconds;
+  }
+
   /// Check if this codec is supported for custom STT providers
   bool get isCustomSttSupported {
     return this == BleAudioCodec.pcm8 ||

--- a/app/lib/pages/conversations/wal_item_detail/wal_item_detail_page.dart
+++ b/app/lib/pages/conversations/wal_item_detail/wal_item_detail_page.dart
@@ -6,7 +6,6 @@ import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:provider/provider.dart';
-import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/models/playback_state.dart';
 import 'package:omi/providers/sync_provider.dart';
 import 'package:omi/services/wals.dart';
@@ -678,28 +677,11 @@ class _WalItemDetailPageState extends State<WalItemDetailPage> {
   }
 
   String _estimateFileSize() {
-    // Estimate size based on codec, sample rate, channels, and duration
-    int bytesPerSecond;
-    switch (widget.wal.codec) {
-      case BleAudioCodec.opus:
-      case BleAudioCodec.opusFS320:
-        bytesPerSecond = widget.wal.codec == BleAudioCodec.opusFS320 ? 40000 : 8000; // ~320kbps vs ~64kbps
-        break;
-      case BleAudioCodec.pcm16:
-        bytesPerSecond = widget.wal.sampleRate * 2 * widget.wal.channel; // 16-bit samples
-        break;
-      case BleAudioCodec.pcm8:
-        bytesPerSecond = widget.wal.sampleRate * 1 * widget.wal.channel; // 8-bit samples
-        break;
-      case BleAudioCodec.mulaw16:
-      case BleAudioCodec.mulaw8:
-        bytesPerSecond = widget.wal.sampleRate * 1 * widget.wal.channel; // μ-law is 8-bit encoded
-        break;
-      default:
-        bytesPerSecond = 8000;
-    }
-
-    final totalBytes = bytesPerSecond * widget.wal.seconds;
+    final totalBytes = widget.wal.codec.estimatedRecordingBytes(
+      seconds: widget.wal.seconds,
+      sampleRate: widget.wal.sampleRate,
+      channels: widget.wal.channel,
+    );
     return _formatBytes(totalBytes);
   }
 

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -189,23 +189,11 @@ class WalSyncs implements IWalSync {
   }
 
   int _estimateWalSize(Wal wal) {
-    int bytesPerSecond;
-    switch (wal.codec) {
-      case BleAudioCodec.opusFS320:
-        bytesPerSecond = 16000;
-      case BleAudioCodec.opus:
-        bytesPerSecond = 8000;
-        break;
-      case BleAudioCodec.pcm16:
-        bytesPerSecond = wal.sampleRate * 2 * wal.channel;
-        break;
-      case BleAudioCodec.pcm8:
-        bytesPerSecond = wal.sampleRate * 1 * wal.channel;
-        break;
-      default:
-        bytesPerSecond = 8000;
-    }
-    return bytesPerSecond * wal.seconds;
+    return wal.codec.estimatedRecordingBytes(
+      seconds: wal.seconds,
+      sampleRate: wal.sampleRate,
+      channels: wal.channel,
+    );
   }
 
   Future<void> deleteAllSyncedWals() async {

--- a/app/test/unit/recording_size_estimate_test.dart
+++ b/app/test/unit/recording_size_estimate_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+
+void main() {
+  group('BleAudioCodec.encodedBytesPerSecond', () {
+    test('uses the canonical encoded rates for both Opus codecs', () {
+      expect(BleAudioCodec.opus.encodedBytesPerSecond, 8000);
+      expect(BleAudioCodec.opusFS320.encodedBytesPerSecond, 16000);
+    });
+
+    test('derives PCM and mu-law rates from stream metadata', () {
+      expect(BleAudioCodec.pcm16.estimatedBytesPerSecond(sampleRate: 16000, channels: 2), 64000);
+      expect(BleAudioCodec.pcm8.estimatedBytesPerSecond(sampleRate: 16000, channels: 1), 16000);
+      expect(BleAudioCodec.mulaw16.estimatedBytesPerSecond(sampleRate: 16000, channels: 1), 16000);
+    });
+
+    test('uses the established Opus fallback for variable or unknown codecs', () {
+      expect(BleAudioCodec.aac.estimatedBytesPerSecond(sampleRate: 48000, channels: 2), 8000);
+      expect(BleAudioCodec.unknown.estimatedBytesPerSecond(sampleRate: 0, channels: 0), 8000);
+    });
+
+    test('estimates FS320 recordings at 16000 bytes per second', () {
+      expect(
+        BleAudioCodec.opusFS320.estimatedRecordingBytes(seconds: 60, sampleRate: 16000, channels: 1),
+        960000,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What changed and why

Centralize recording-size estimation on `BleAudioCodec` and use the same encoded-rate model in WAL sync and the recording detail UI. This removes the conflicting 320 kbps UI estimate for Opus FS320 and keeps displayed size aligned with transfer planning.

Closes #3579

## Product invariants affected

none

## How it was verified

- `flutter test test/unit/recording_size_estimate_test.dart` — all 4 codec/rate regression tests passed.
- `bash test.sh` — 1,521 tests passed and 5 skipped; the only 3 failures were missing backend fixture paths in the initial sparse checkout. After adding `backend/`, the 5 fixture-contract tests passed.
- `bash scripts/analyze_ratchet.sh` — analyzer ratchet passed.
- The real recording detail screen was not exercised on hardware locally; both UI and sync now call the regression-tested shared estimator.

## Tests

- [x] Added regression coverage for both Opus rates, PCM/mu-law derivation, fallback codecs, and one-minute FS320 recordings.
- [x] Ran the app-wide Flutter suite plus the affected fixture-contract tests.
- [ ] Physical-device recording flow (no paired Omi hardware in this environment).

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

