### PR TITLE
fix(app): align Firebase plugins for SwiftPM

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -541,10 +541,10 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_crashlytics
-      sha256: "6273ed71bcd8a6fb4d0ca13d3abddbb3301796807efaad8782b5f90156f26f03"
+      sha256: f3fa4a17c2f061b16b2e3ac7aaed889ae954b8952d0fd3e0009a9870cde7bbd2
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.2"
+    version: "4.3.5"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   firebase_core: 3.13.0
   firebase_auth: 5.5.3
   firebase_messaging: 15.2.5
-  firebase_crashlytics: 4.3.2
+  firebase_crashlytics: 4.3.5
 
   # Auth
   google_sign_in: 6.2.2
@@ -182,14 +182,6 @@ flutter_launcher_icons:
   image_path: "assets/images/app_launcher_icon.png"
 
 flutter:
-  # Flutter 3.44 turned Swift Package Manager on by default for iOS/macOS.
-  # firebase_crashlytics 4.3.2 is built against firebase_core 3.11.0 while
-  # firebase_messaging 15.2.5 is built against 3.13.0, so SPM cannot resolve a
-  # single `flutterfire` package version and every iOS archive fails. CocoaPods
-  # tolerates the skew. Re-enable once the Firebase plugin versions are aligned;
-  # Flutter will eventually stop honouring this. https://github.com/BasedHardware/omi/issues/11676
-  config:
-    enable-swift-package-manager: false
   generate: true
   uses-material-design: true
   assets:

--- a/app/test/unit/flutterfire_spm_contract_test.dart
+++ b/app/test/unit/flutterfire_spm_contract_test.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('FlutterFire pins share firebase_core 3.13 and SPM is enabled', () {
+    final source = File('pubspec.yaml').readAsStringSync();
+
+    expect(source, contains('firebase_core: 3.13.0'));
+    expect(source, contains('firebase_messaging: 15.2.5'));
+    expect(source, contains('firebase_crashlytics: 4.3.5'));
+    expect(
+      source,
+      isNot(contains('enable-swift-package-manager')),
+      reason: 'the temporary SPM opt-out must be removed',
+    );
+  });
+}


### PR DESCRIPTION
## What changed and why

Align `firebase_crashlytics` with the repository's `firebase_core` 3.13 family and remove the temporary Flutter Swift Package Manager opt-out. A contract test locks the compatible plugin set so the skew cannot silently return.

Closes #11676

## Product invariants affected

none

## How it was verified

- `flutter pub get --enforce-lockfile` — resolved the checked-in lockfile without changes.
- `flutter test test/unit/flutterfire_spm_contract_test.dart` — the aligned Firebase versions and enabled SPM contract passed.
- Inspected the resolved `firebase_auth`, `firebase_messaging`, and `firebase_crashlytics` plugin manifests — each now requires the `firebase_core` 3.13 family.
- `bash scripts/analyze_ratchet.sh` — analyzer ratchet passed.
- `pod install`, then `flutter build ipa --release --flavor dev --no-codesign` — Flutter added SwiftPM integration and resolved the native graph successfully, including Firebase iOS SDK 11.15.0 plus aligned `firebase_core` 3.13.0, `firebase_auth` 5.5.3, `firebase_crashlytics` 4.3.5, and `firebase_messaging` 15.2.5. No Firebase/SwiftPM version conflict occurred.
- Xcode reached the archive action but this machine lacks the watchOS 26.2 platform required by the scheme's embedded Watch app. The remaining failure is `watchOS 26.2 must be installed in order to archive the scheme`, not package resolution or compilation skew. A signed maintainer/Codemagic archive is still the final acceptance gate.

## Tests

- [x] Added a regression contract for the Firebase version family and SPM opt-out removal.
- [x] Resolved dependencies from the committed lockfile and checked the native plugin compatibility family.
- [x] Generated the CocoaPods workspace and resolved Flutter's hybrid SwiftPM/CocoaPods dependency graph.
- [ ] Completed signed iOS + Watch archive (blocked locally by missing watchOS 26.2 platform and signing credentials).

Failure-Class: none
