### PR TITLE
feat(app): add device button action switch

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -271,6 +271,12 @@ class SharedPreferencesUtil {
 
   set batchModeSuspendedForOnboarding(bool value) => saveBool('batchModeSuspendedForOnboarding', value);
 
+  // Master switch for user-configured button actions. Interactive onboarding
+  // still receives button events before this preference is applied.
+  bool get deviceButtonEnabled => getBool('deviceButtonEnabled', defaultValue: true);
+
+  set deviceButtonEnabled(bool value) => saveBool('deviceButtonEnabled', value);
+
   // Double tap behavior: 0 = end conversation (default), 1 = pause/mute, 2 = star ongoing conversation
   int get doubleTapAction => getInt('doubleTapAction');
 

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -164,6 +164,8 @@
     "modelNumber": "رقم الطراز",
     "manufacturer": "الشركة المصنعة",
     "doubleTap": "نقرة مزدوجة",
+    "deviceButtonActions": "إجراءات زر الجهاز",
+    "deviceButtonActionsDescription": "السماح لضغطات الزر بالتحكم في التسجيل والأوامر الصوتية",
     "ledBrightness": "سطوع LED",
     "micGain": "تضخيم الميكروفون",
     "disconnect": "قطع الاتصال",

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -661,6 +661,8 @@
         "description": "Label for manufacturer field"
     },
     "doubleTap": "Двайны дотык",
+    "deviceButtonActions": "Дзеянні кнопкі прылады",
+    "deviceButtonActionsDescription": "Дазволіць націсканням кнопкі кіраваць запісам і галасавымі камандамі",
     "@doubleTap": {
         "description": "Double tap action label"
     },

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Номер на модела",
     "manufacturer": "Производител",
     "doubleTap": "Двойно докосване",
+    "deviceButtonActions": "Действия на бутона на устройството",
+    "deviceButtonActionsDescription": "Разрешаване на натисканията на бутона да управляват записа и гласовите команди",
     "ledBrightness": "Яркост на LED",
     "micGain": "Усилване на микрофон",
     "disconnect": "Прекъсни",

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -661,6 +661,8 @@
         "description": "Label for manufacturer field"
     },
     "doubleTap": "দ্বিগুণ ট্যাপ",
+    "deviceButtonActions": "ডিভাইস বোতামের কার্যক্রম",
+    "deviceButtonActionsDescription": "বোতাম চাপ দিয়ে রেকর্ডিং ও ভয়েস কমান্ড নিয়ন্ত্রণের অনুমতি দিন",
     "@doubleTap": {
         "description": "Double tap action label"
     },

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -661,6 +661,8 @@
         "description": "Label for manufacturer field"
     },
     "doubleTap": "Dupli dodir",
+    "deviceButtonActions": "Radnje dugmeta uređaja",
+    "deviceButtonActionsDescription": "Dozvoli da pritisci na dugme upravljaju snimanjem i glasovnim komandama",
     "@doubleTap": {
         "description": "Double tap action label"
     },

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Número de model",
     "manufacturer": "Fabricant",
     "doubleTap": "Doble toc",
+    "deviceButtonActions": "Accions del botó del dispositiu",
+    "deviceButtonActionsDescription": "Permet que les pulsacions del botó controlin l'enregistrament i les ordres de veu",
     "ledBrightness": "Brillantor LED",
     "micGain": "Guany del micròfon",
     "disconnect": "Desconnectar",

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Číslo modelu",
     "manufacturer": "Výrobce",
     "doubleTap": "Dvojité klepnutí",
+    "deviceButtonActions": "Akce tlačítka zařízení",
+    "deviceButtonActionsDescription": "Povolit ovládání nahrávání a hlasových příkazů stisknutím tlačítka",
     "ledBrightness": "Jas LED",
     "micGain": "Zesílení mikrofonu",
     "disconnect": "Odpojit",

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Modelnummer",
     "manufacturer": "Producent",
     "doubleTap": "Dobbelttryk",
+    "deviceButtonActions": "Handlinger for enhedsknap",
+    "deviceButtonActionsDescription": "Tillad, at knaptryk styrer optagelse og stemmekommandoer",
     "ledBrightness": "LED-lysstyrke",
     "micGain": "Mikrofonforstærkning",
     "disconnect": "Afbryd",

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Modellnummer",
     "manufacturer": "Hersteller",
     "doubleTap": "Doppeltippen",
+    "deviceButtonActions": "Gerätetasten-Aktionen",
+    "deviceButtonActionsDescription": "Tastendrücke dürfen Aufnahme und Sprachbefehle steuern",
     "ledBrightness": "LED-Helligkeit",
     "micGain": "Mikrofonverstärkung",
     "disconnect": "Trennen",

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Αριθμός μοντέλου",
     "manufacturer": "Κατασκευαστής",
     "doubleTap": "Διπλό Πάτημα",
+    "deviceButtonActions": "Ενέργειες κουμπιού συσκευής",
+    "deviceButtonActionsDescription": "Να επιτρέπεται ο έλεγχος της εγγραφής και των φωνητικών εντολών με το κουμπί",
     "ledBrightness": "Φωτεινότητα LED",
     "micGain": "Ενίσχυση Μικροφώνου",
     "disconnect": "Αποσύνδεση",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -676,6 +676,14 @@
         "description": "Label for manufacturer field"
     },
     "doubleTap": "Double Tap",
+    "deviceButtonActions": "Device Button Actions",
+    "@deviceButtonActions": {
+        "description": "Title of the master toggle for hardware button actions in device settings"
+    },
+    "deviceButtonActionsDescription": "Allow button presses to control recording and voice commands",
+    "@deviceButtonActionsDescription": {
+        "description": "Explains that the master device-button toggle controls recording and voice command actions"
+    },
     "@doubleTap": {
         "description": "Double tap action label"
     },

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Número de modelo",
     "manufacturer": "Fabricante",
     "doubleTap": "Doble toque",
+    "deviceButtonActions": "Acciones del botón del dispositivo",
+    "deviceButtonActionsDescription": "Permitir que las pulsaciones controlen la grabación y los comandos de voz",
     "ledBrightness": "Brillo LED",
     "micGain": "Ganancia de micrófono",
     "disconnect": "Desconectar",

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Mudeli number",
     "manufacturer": "Tootja",
     "doubleTap": "Topeltpuudutus",
+    "deviceButtonActions": "Seadme nupu toimingud",
+    "deviceButtonActionsDescription": "Luba nupuvajutustega juhtida salvestamist ja häälkäsklusi",
     "ledBrightness": "LED heledus",
     "micGain": "Mikrofoni võimendus",
     "disconnect": "Katkesta ühendus",

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -661,6 +661,8 @@
         "description": "Label for manufacturer field"
     },
     "doubleTap": "دو ضربه",
+    "deviceButtonActions": "عملکردهای دکمه دستگاه",
+    "deviceButtonActionsDescription": "اجازه دهید فشار دادن دکمه، ضبط و فرمان‌های صوتی را کنترل کند",
     "@doubleTap": {
         "description": "Double tap action label"
     },

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Mallinumero",
     "manufacturer": "Valmistaja",
     "doubleTap": "Kaksoisnapautus",
+    "deviceButtonActions": "Laitteen painiketoiminnot",
+    "deviceButtonActionsDescription": "Salli painikkeen painallusten ohjata tallennusta ja äänikomentoja",
     "ledBrightness": "LED-kirkkaus",
     "micGain": "Mikrofonin vahvistus",
     "disconnect": "Katkaise yhteys",

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Numéro de modèle",
     "manufacturer": "Fabricant",
     "doubleTap": "Double appui",
+    "deviceButtonActions": "Actions du bouton de l’appareil",
+    "deviceButtonActionsDescription": "Autoriser le bouton à contrôler l’enregistrement et les commandes vocales",
     "ledBrightness": "Luminosité LED",
     "micGain": "Gain du micro",
     "disconnect": "Déconnecter",

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -661,6 +661,8 @@
         "description": "Label for manufacturer field"
     },
     "doubleTap": "לחץ כפול",
+    "deviceButtonActions": "פעולות לחצן המכשיר",
+    "deviceButtonActionsDescription": "לאפשר ללחיצות על הלחצן לשלוט בהקלטה ובפקודות קוליות",
     "@doubleTap": {
         "description": "Double tap action label"
     },

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -164,6 +164,8 @@
     "modelNumber": "मॉडल संख्या",
     "manufacturer": "निर्माता",
     "doubleTap": "डबल टैप",
+    "deviceButtonActions": "डिवाइस बटन की क्रियाएँ",
+    "deviceButtonActionsDescription": "बटन दबाकर रिकॉर्डिंग और वॉइस कमांड नियंत्रित करने दें",
     "ledBrightness": "LED चमक",
     "micGain": "माइक गेन",
     "disconnect": "डिस्कनेक्ट करें",

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -661,6 +661,8 @@
         "description": "Label for manufacturer field"
     },
     "doubleTap": "Dvostruki dodir",
+    "deviceButtonActions": "Radnje gumba uređaja",
+    "deviceButtonActionsDescription": "Dopusti da pritisci gumba upravljaju snimanjem i glasovnim naredbama",
     "@doubleTap": {
         "description": "Double tap action label"
     },

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Modellszám",
     "manufacturer": "Gyártó",
     "doubleTap": "Dupla érintés",
+    "deviceButtonActions": "Eszközgomb műveletei",
+    "deviceButtonActionsDescription": "A gombnyomások vezérelhetik a felvételt és a hangparancsokat",
     "ledBrightness": "LED fényerő",
     "micGain": "Mikrofon erősítés",
     "disconnect": "Leválasztás",

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Nomor Model",
     "manufacturer": "Produsen",
     "doubleTap": "Ketuk Ganda",
+    "deviceButtonActions": "Tindakan Tombol Perangkat",
+    "deviceButtonActionsDescription": "Izinkan penekanan tombol mengontrol rekaman dan perintah suara",
     "ledBrightness": "Kecerahan LED",
     "micGain": "Penguatan Mikrofon",
     "disconnect": "Putuskan",

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Numero modello",
     "manufacturer": "Produttore",
     "doubleTap": "Doppio Tocco",
+    "deviceButtonActions": "Azioni del pulsante del dispositivo",
+    "deviceButtonActionsDescription": "Consenti al pulsante di controllare la registrazione e i comandi vocali",
     "ledBrightness": "Luminosità LED",
     "micGain": "Guadagno Microfono",
     "disconnect": "Disconnetti",

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -163,6 +163,8 @@
     "modelNumber": "モデル番号",
     "manufacturer": "製造元",
     "doubleTap": "ダブルタップ",
+    "deviceButtonActions": "デバイスボタンの操作",
+    "deviceButtonActionsDescription": "ボタン操作による録音と音声コマンドの制御を許可します",
     "ledBrightness": "LED明るさ",
     "micGain": "マイクゲイン",
     "disconnect": "接続解除",

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -661,6 +661,8 @@
         "description": "Label for manufacturer field"
     },
     "doubleTap": "ಗುಣ ಟ್ಯಾಪ್",
+    "deviceButtonActions": "ಸಾಧನ ಬಟನ್ ಕ್ರಿಯೆಗಳು",
+    "deviceButtonActionsDescription": "ಬಟನ್ ಒತ್ತುವ ಮೂಲಕ ರೆಕಾರ್ಡಿಂಗ್ ಮತ್ತು ಧ್ವನಿ ಆಜ್ಞೆಗಳನ್ನು ನಿಯಂತ್ರಿಸಲು ಅನುಮತಿಸಿ",
     "@doubleTap": {
         "description": "Double tap action label"
     },

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -164,6 +164,8 @@
     "modelNumber": "모델 번호",
     "manufacturer": "제조업체",
     "doubleTap": "더블 탭",
+    "deviceButtonActions": "기기 버튼 동작",
+    "deviceButtonActionsDescription": "버튼을 눌러 녹음과 음성 명령을 제어하도록 허용합니다",
     "ledBrightness": "LED 밝기",
     "micGain": "마이크 게인",
     "disconnect": "연결 해제",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -1173,6 +1173,18 @@ abstract class AppLocalizations {
   /// **'Double Tap'**
   String get doubleTap;
 
+  /// Title of the master toggle for hardware button actions in device settings
+  ///
+  /// In en, this message translates to:
+  /// **'Device Button Actions'**
+  String get deviceButtonActions;
+
+  /// Explains that the master device-button toggle controls recording and voice command actions
+  ///
+  /// In en, this message translates to:
+  /// **'Allow button presses to control recording and voice commands'**
+  String get deviceButtonActionsDescription;
+
   /// LED brightness setting
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -514,6 +514,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get doubleTap => 'نقرة مزدوجة';
 
   @override
+  String get deviceButtonActions => 'إجراءات زر الجهاز';
+
+  @override
+  String get deviceButtonActionsDescription => 'السماح لضغطات الزر بالتحكم في التسجيل والأوامر الصوتية';
+
+  @override
   String get ledBrightness => 'سطوع LED';
 
   @override

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -518,6 +518,12 @@ class AppLocalizationsBe extends AppLocalizations {
   String get doubleTap => 'Двайны дотык';
 
   @override
+  String get deviceButtonActions => 'Дзеянні кнопкі прылады';
+
+  @override
+  String get deviceButtonActionsDescription => 'Дазволіць націсканням кнопкі кіраваць запісам і галасавымі камандамі';
+
+  @override
   String get ledBrightness => 'Яркасць LED';
 
   @override

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -520,6 +520,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get doubleTap => 'Двойно докосване';
 
   @override
+  String get deviceButtonActions => 'Действия на бутона на устройството';
+
+  @override
+  String get deviceButtonActionsDescription =>
+      'Разрешаване на натисканията на бутона да управляват записа и гласовите команди';
+
+  @override
   String get ledBrightness => 'Яркост на LED';
 
   @override

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -518,6 +518,12 @@ class AppLocalizationsBn extends AppLocalizations {
   String get doubleTap => 'দ্বিগুণ ট্যাপ';
 
   @override
+  String get deviceButtonActions => 'ডিভাইস বোতামের কার্যক্রম';
+
+  @override
+  String get deviceButtonActionsDescription => 'বোতাম চাপ দিয়ে রেকর্ডিং ও ভয়েস কমান্ড নিয়ন্ত্রণের অনুমতি দিন';
+
+  @override
   String get ledBrightness => 'LED উজ্জ্বলতা';
 
   @override

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -519,6 +519,13 @@ class AppLocalizationsBs extends AppLocalizations {
   String get doubleTap => 'Dupli dodir';
 
   @override
+  String get deviceButtonActions => 'Radnje dugmeta uređaja';
+
+  @override
+  String get deviceButtonActionsDescription =>
+      'Dozvoli da pritisci na dugme upravljaju snimanjem i glasovnim komandama';
+
+  @override
   String get ledBrightness => 'Svetlina LED-a';
 
   @override

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -521,6 +521,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get doubleTap => 'Doble toc';
 
   @override
+  String get deviceButtonActions => 'Accions del botó del dispositiu';
+
+  @override
+  String get deviceButtonActionsDescription =>
+      'Permet que les pulsacions del botó controlin l\'enregistrament i les ordres de veu';
+
+  @override
   String get ledBrightness => 'Brillantor LED';
 
   @override

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -519,6 +519,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get doubleTap => 'Dvojité klepnutí';
 
   @override
+  String get deviceButtonActions => 'Akce tlačítka zařízení';
+
+  @override
+  String get deviceButtonActionsDescription => 'Povolit ovládání nahrávání a hlasových příkazů stisknutím tlačítka';
+
+  @override
   String get ledBrightness => 'Jas LED';
 
   @override

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -519,6 +519,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get doubleTap => 'Dobbelttryk';
 
   @override
+  String get deviceButtonActions => 'Handlinger for enhedsknap';
+
+  @override
+  String get deviceButtonActionsDescription => 'Tillad, at knaptryk styrer optagelse og stemmekommandoer';
+
+  @override
   String get ledBrightness => 'LED-lysstyrke';
 
   @override

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -523,6 +523,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get doubleTap => 'Doppeltippen';
 
   @override
+  String get deviceButtonActions => 'Gerätetasten-Aktionen';
+
+  @override
+  String get deviceButtonActionsDescription => 'Tastendrücke dürfen Aufnahme und Sprachbefehle steuern';
+
+  @override
   String get ledBrightness => 'LED-Helligkeit';
 
   @override

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -522,6 +522,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get doubleTap => 'Διπλό Πάτημα';
 
   @override
+  String get deviceButtonActions => 'Ενέργειες κουμπιού συσκευής';
+
+  @override
+  String get deviceButtonActionsDescription =>
+      'Να επιτρέπεται ο έλεγχος της εγγραφής και των φωνητικών εντολών με το κουμπί';
+
+  @override
   String get ledBrightness => 'Φωτεινότητα LED';
 
   @override

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -517,6 +517,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get doubleTap => 'Double Tap';
 
   @override
+  String get deviceButtonActions => 'Device Button Actions';
+
+  @override
+  String get deviceButtonActionsDescription => 'Allow button presses to control recording and voice commands';
+
+  @override
   String get ledBrightness => 'LED Brightness';
 
   @override

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -519,6 +519,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get doubleTap => 'Doble toque';
 
   @override
+  String get deviceButtonActions => 'Acciones del botón del dispositivo';
+
+  @override
+  String get deviceButtonActionsDescription =>
+      'Permitir que las pulsaciones controlen la grabación y los comandos de voz';
+
+  @override
   String get ledBrightness => 'Brillo LED';
 
   @override

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -520,6 +520,12 @@ class AppLocalizationsEt extends AppLocalizations {
   String get doubleTap => 'Topeltpuudutus';
 
   @override
+  String get deviceButtonActions => 'Seadme nupu toimingud';
+
+  @override
+  String get deviceButtonActionsDescription => 'Luba nupuvajutustega juhtida salvestamist ja häälkäsklusi';
+
+  @override
   String get ledBrightness => 'LED heledus';
 
   @override

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -519,6 +519,12 @@ class AppLocalizationsFa extends AppLocalizations {
   String get doubleTap => 'دو ضربه';
 
   @override
+  String get deviceButtonActions => 'عملکردهای دکمه دستگاه';
+
+  @override
+  String get deviceButtonActionsDescription => 'اجازه دهید فشار دادن دکمه، ضبط و فرمان‌های صوتی را کنترل کند';
+
+  @override
   String get ledBrightness => 'روشنایی LED';
 
   @override

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -517,6 +517,12 @@ class AppLocalizationsFi extends AppLocalizations {
   String get doubleTap => 'Kaksoisnapautus';
 
   @override
+  String get deviceButtonActions => 'Laitteen painiketoiminnot';
+
+  @override
+  String get deviceButtonActionsDescription => 'Salli painikkeen painallusten ohjata tallennusta ja äänikomentoja';
+
+  @override
   String get ledBrightness => 'LED-kirkkaus';
 
   @override

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -522,6 +522,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get doubleTap => 'Double appui';
 
   @override
+  String get deviceButtonActions => 'Actions du bouton de l’appareil';
+
+  @override
+  String get deviceButtonActionsDescription =>
+      'Autoriser le bouton à contrôler l’enregistrement et les commandes vocales';
+
+  @override
   String get ledBrightness => 'Luminosité LED';
 
   @override

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -515,6 +515,12 @@ class AppLocalizationsHe extends AppLocalizations {
   String get doubleTap => 'לחץ כפול';
 
   @override
+  String get deviceButtonActions => 'פעולות לחצן המכשיר';
+
+  @override
+  String get deviceButtonActionsDescription => 'לאפשר ללחיצות על הלחצן לשלוט בהקלטה ובפקודות קוליות';
+
+  @override
   String get ledBrightness => 'בהיקות LED';
 
   @override

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -516,6 +516,12 @@ class AppLocalizationsHi extends AppLocalizations {
   String get doubleTap => 'डबल टैप';
 
   @override
+  String get deviceButtonActions => 'डिवाइस बटन की क्रियाएँ';
+
+  @override
+  String get deviceButtonActionsDescription => 'बटन दबाकर रिकॉर्डिंग और वॉइस कमांड नियंत्रित करने दें';
+
+  @override
   String get ledBrightness => 'LED चमक';
 
   @override

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -519,6 +519,12 @@ class AppLocalizationsHr extends AppLocalizations {
   String get doubleTap => 'Dvostruki dodir';
 
   @override
+  String get deviceButtonActions => 'Radnje gumba uređaja';
+
+  @override
+  String get deviceButtonActionsDescription => 'Dopusti da pritisci gumba upravljaju snimanjem i glasovnim naredbama';
+
+  @override
   String get ledBrightness => 'Svjetlina LED-a';
 
   @override

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -521,6 +521,12 @@ class AppLocalizationsHu extends AppLocalizations {
   String get doubleTap => 'Dupla érintés';
 
   @override
+  String get deviceButtonActions => 'Eszközgomb műveletei';
+
+  @override
+  String get deviceButtonActionsDescription => 'A gombnyomások vezérelhetik a felvételt és a hangparancsokat';
+
+  @override
   String get ledBrightness => 'LED fényerő';
 
   @override

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -518,6 +518,12 @@ class AppLocalizationsId extends AppLocalizations {
   String get doubleTap => 'Ketuk Ganda';
 
   @override
+  String get deviceButtonActions => 'Tindakan Tombol Perangkat';
+
+  @override
+  String get deviceButtonActionsDescription => 'Izinkan penekanan tombol mengontrol rekaman dan perintah suara';
+
+  @override
   String get ledBrightness => 'Kecerahan LED';
 
   @override

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -521,6 +521,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get doubleTap => 'Doppio Tocco';
 
   @override
+  String get deviceButtonActions => 'Azioni del pulsante del dispositivo';
+
+  @override
+  String get deviceButtonActionsDescription =>
+      'Consenti al pulsante di controllare la registrazione e i comandi vocali';
+
+  @override
   String get ledBrightness => 'Luminosità LED';
 
   @override

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -509,6 +509,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get doubleTap => 'ダブルタップ';
 
   @override
+  String get deviceButtonActions => 'デバイスボタンの操作';
+
+  @override
+  String get deviceButtonActionsDescription => 'ボタン操作による録音と音声コマンドの制御を許可します';
+
+  @override
   String get ledBrightness => 'LED明るさ';
 
   @override

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -520,6 +520,13 @@ class AppLocalizationsKn extends AppLocalizations {
   String get doubleTap => 'ಗುಣ ಟ್ಯಾಪ್';
 
   @override
+  String get deviceButtonActions => 'ಸಾಧನ ಬಟನ್ ಕ್ರಿಯೆಗಳು';
+
+  @override
+  String get deviceButtonActionsDescription =>
+      'ಬಟನ್ ಒತ್ತುವ ಮೂಲಕ ರೆಕಾರ್ಡಿಂಗ್ ಮತ್ತು ಧ್ವನಿ ಆಜ್ಞೆಗಳನ್ನು ನಿಯಂತ್ರಿಸಲು ಅನುಮತಿಸಿ';
+
+  @override
   String get ledBrightness => 'LED ಝಗಬೆಳಗುವುದು';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -509,6 +509,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get doubleTap => '더블 탭';
 
   @override
+  String get deviceButtonActions => '기기 버튼 동작';
+
+  @override
+  String get deviceButtonActionsDescription => '버튼을 눌러 녹음과 음성 명령을 제어하도록 허용합니다';
+
+  @override
   String get ledBrightness => 'LED 밝기';
 
   @override

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -520,6 +520,12 @@ class AppLocalizationsLt extends AppLocalizations {
   String get doubleTap => 'Dvigubas bakstelėjimas';
 
   @override
+  String get deviceButtonActions => 'Įrenginio mygtuko veiksmai';
+
+  @override
+  String get deviceButtonActionsDescription => 'Leisti mygtuko paspaudimais valdyti įrašymą ir balso komandas';
+
+  @override
   String get ledBrightness => 'LED ryškumas';
 
   @override

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -520,6 +520,12 @@ class AppLocalizationsLv extends AppLocalizations {
   String get doubleTap => 'Dubultklikšķis';
 
   @override
+  String get deviceButtonActions => 'Ierīces pogas darbības';
+
+  @override
+  String get deviceButtonActionsDescription => 'Atļaut ar pogas nospiešanu vadīt ierakstīšanu un balss komandas';
+
+  @override
   String get ledBrightness => 'LED spilgtums';
 
   @override

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -521,6 +521,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get doubleTap => 'Двојно допирање';
 
   @override
+  String get deviceButtonActions => 'Дејства на копчето на уредот';
+
+  @override
+  String get deviceButtonActionsDescription =>
+      'Дозволи притискањата на копчето да управуваат со снимањето и гласовните команди';
+
+  @override
   String get ledBrightness => 'Осветленост на LED';
 
   @override

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -519,6 +519,12 @@ class AppLocalizationsMr extends AppLocalizations {
   String get doubleTap => 'दुहेरी टॅप';
 
   @override
+  String get deviceButtonActions => 'डिव्हाइस बटण क्रिया';
+
+  @override
+  String get deviceButtonActionsDescription => 'बटण दाबून रेकॉर्डिंग आणि व्हॉइस कमांड नियंत्रित करण्यास अनुमती द्या';
+
+  @override
   String get ledBrightness => 'LED चमक';
 
   @override

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -519,6 +519,12 @@ class AppLocalizationsMs extends AppLocalizations {
   String get doubleTap => 'Ketik Dua Kali';
 
   @override
+  String get deviceButtonActions => 'Tindakan Butang Peranti';
+
+  @override
+  String get deviceButtonActionsDescription => 'Benarkan tekanan butang mengawal rakaman dan arahan suara';
+
+  @override
   String get ledBrightness => 'Kecerahan LED';
 
   @override

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -520,6 +520,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get doubleTap => 'Dubbel tikken';
 
   @override
+  String get deviceButtonActions => 'Acties voor apparaatknop';
+
+  @override
+  String get deviceButtonActionsDescription => 'Sta toe dat knopdrukken opnames en spraakopdrachten bedienen';
+
+  @override
   String get ledBrightness => 'LED-helderheid';
 
   @override

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -519,6 +519,12 @@ class AppLocalizationsNo extends AppLocalizations {
   String get doubleTap => 'Dobbelttrykk';
 
   @override
+  String get deviceButtonActions => 'Handlinger for enhetsknapp';
+
+  @override
+  String get deviceButtonActionsDescription => 'Tillat at knappetrykk styrer opptak og talekommandoer';
+
+  @override
   String get ledBrightness => 'LED-lysstyrke';
 
   @override

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -518,6 +518,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get doubleTap => 'Podwójne dotknięcie';
 
   @override
+  String get deviceButtonActions => 'Funkcje przycisku urządzenia';
+
+  @override
+  String get deviceButtonActionsDescription =>
+      'Zezwól, aby naciśnięcia przycisku sterowały nagrywaniem i poleceniami głosowymi';
+
+  @override
   String get ledBrightness => 'Jasność LED';
 
   @override

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -517,6 +517,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get doubleTap => 'Toque duplo';
 
   @override
+  String get deviceButtonActions => 'Ações do botão do dispositivo';
+
+  @override
+  String get deviceButtonActionsDescription =>
+      'Permitir que os toques no botão controlem a gravação e os comandos de voz';
+
+  @override
   String get ledBrightness => 'Brilho do LED';
 
   @override

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -521,6 +521,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get doubleTap => 'Dublă apăsare';
 
   @override
+  String get deviceButtonActions => 'Acțiunile butonului dispozitivului';
+
+  @override
+  String get deviceButtonActionsDescription =>
+      'Permite apăsărilor butonului să controleze înregistrarea și comenzile vocale';
+
+  @override
   String get ledBrightness => 'Luminozitate LED';
 
   @override

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -520,6 +520,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get doubleTap => 'Двойное нажатие';
 
   @override
+  String get deviceButtonActions => 'Действия кнопки устройства';
+
+  @override
+  String get deviceButtonActionsDescription => 'Разрешить управление записью и голосовыми командами с помощью кнопки';
+
+  @override
   String get ledBrightness => 'Яркость LED';
 
   @override

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -520,6 +520,12 @@ class AppLocalizationsSk extends AppLocalizations {
   String get doubleTap => 'Dvojité ťuknutie';
 
   @override
+  String get deviceButtonActions => 'Akcie tlačidla zariadenia';
+
+  @override
+  String get deviceButtonActionsDescription => 'Povoliť ovládanie nahrávania a hlasových príkazov stlačením tlačidla';
+
+  @override
   String get ledBrightness => 'Jas LED';
 
   @override

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -518,6 +518,12 @@ class AppLocalizationsSl extends AppLocalizations {
   String get doubleTap => 'Dvojni dotik';
 
   @override
+  String get deviceButtonActions => 'Dejanja gumba naprave';
+
+  @override
+  String get deviceButtonActionsDescription => 'Dovoli, da pritiski gumba upravljajo snemanje in glasovne ukaze';
+
+  @override
   String get ledBrightness => 'Svetlost LED';
 
   @override

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -518,6 +518,12 @@ class AppLocalizationsSr extends AppLocalizations {
   String get doubleTap => 'Дупло додирни';
 
   @override
+  String get deviceButtonActions => 'Радње дугмета уређаја';
+
+  @override
+  String get deviceButtonActionsDescription => 'Дозволи да притисци на дугме управљају снимањем и гласовним командама';
+
+  @override
   String get ledBrightness => 'Сјајност LED';
 
   @override

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -519,6 +519,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get doubleTap => 'Dubbeltryck';
 
   @override
+  String get deviceButtonActions => 'Åtgärder för enhetsknappen';
+
+  @override
+  String get deviceButtonActionsDescription => 'Tillåt att knapptryck styr inspelning och röstkommandon';
+
+  @override
   String get ledBrightness => 'LED-ljusstyrka';
 
   @override

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -521,6 +521,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get doubleTap => 'இரட்டை தட்டு';
 
   @override
+  String get deviceButtonActions => 'சாதன பொத்தான் செயல்கள்';
+
+  @override
+  String get deviceButtonActionsDescription =>
+      'பொத்தான் அழுத்தங்கள் பதிவையும் குரல் கட்டளைகளையும் கட்டுப்படுத்த அனுமதிக்கவும்';
+
+  @override
   String get ledBrightness => 'LED பிரகாசம்';
 
   @override

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -520,6 +520,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get doubleTap => 'డబల్ నొక్కండి';
 
   @override
+  String get deviceButtonActions => 'పరికర బటన్ చర్యలు';
+
+  @override
+  String get deviceButtonActionsDescription =>
+      'బటన్ నొక్కడం ద్వారా రికార్డింగ్ మరియు వాయిస్ ఆదేశాలను నియంత్రించడానికి అనుమతించండి';
+
+  @override
   String get ledBrightness => 'LED ప్రకాశం';
 
   @override

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -516,6 +516,12 @@ class AppLocalizationsTh extends AppLocalizations {
   String get doubleTap => 'แตะสองครั้ง';
 
   @override
+  String get deviceButtonActions => 'การทำงานของปุ่มอุปกรณ์';
+
+  @override
+  String get deviceButtonActionsDescription => 'อนุญาตให้การกดปุ่มควบคุมการบันทึกและคำสั่งเสียง';
+
+  @override
   String get ledBrightness => 'ความสว่าง LED';
 
   @override

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -521,6 +521,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get doubleTap => 'Double Tap';
 
   @override
+  String get deviceButtonActions => 'Mga Aksyon ng Button ng Device';
+
+  @override
+  String get deviceButtonActionsDescription =>
+      'Payagang kontrolin ng pagpindot sa button ang pag-record at mga voice command';
+
+  @override
   String get ledBrightness => 'LED Brightness';
 
   @override

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -520,6 +520,12 @@ class AppLocalizationsTr extends AppLocalizations {
   String get doubleTap => 'Çift Dokunma';
 
   @override
+  String get deviceButtonActions => 'Cihaz Düğmesi Eylemleri';
+
+  @override
+  String get deviceButtonActionsDescription => 'Düğmeye basarak kaydı ve sesli komutları kontrol etmeye izin ver';
+
+  @override
   String get ledBrightness => 'LED Parlaklığı';
 
   @override

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -520,6 +520,12 @@ class AppLocalizationsUk extends AppLocalizations {
   String get doubleTap => 'Подвійне натискання';
 
   @override
+  String get deviceButtonActions => 'Дії кнопки пристрою';
+
+  @override
+  String get deviceButtonActionsDescription => 'Дозволити керувати записом і голосовими командами натисканням кнопки';
+
+  @override
   String get ledBrightness => 'Яскравість світлодіода';
 
   @override

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -518,6 +518,12 @@ class AppLocalizationsUr extends AppLocalizations {
   String get doubleTap => 'دوگنا تھپتھپائیں';
 
   @override
+  String get deviceButtonActions => 'ڈیوائس بٹن کی کارروائیاں';
+
+  @override
+  String get deviceButtonActionsDescription => 'بٹن دبانے سے ریکارڈنگ اور صوتی احکامات کنٹرول کرنے کی اجازت دیں';
+
+  @override
   String get ledBrightness => 'LED روشنی';
 
   @override

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -520,6 +520,12 @@ class AppLocalizationsVi extends AppLocalizations {
   String get doubleTap => 'Nhấn đúp';
 
   @override
+  String get deviceButtonActions => 'Thao tác nút thiết bị';
+
+  @override
+  String get deviceButtonActionsDescription => 'Cho phép thao tác nút điều khiển ghi âm và lệnh thoại';
+
+  @override
   String get ledBrightness => 'Độ sáng đèn LED';
 
   @override

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -509,6 +509,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get doubleTap => '双击';
 
   @override
+  String get deviceButtonActions => '设备按钮操作';
+
+  @override
+  String get deviceButtonActionsDescription => '允许通过按键控制录音和语音命令';
+
+  @override
   String get ledBrightness => 'LED 亮度';
 
   @override

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -738,6 +738,8 @@
     "dontAskAgain": "Daugiau neklausti",
     "dontShowAgain": "Daugiau nerodyti",
     "doubleTap": "Dvigubas bakstelėjimas",
+    "deviceButtonActions": "Įrenginio mygtuko veiksmai",
+    "deviceButtonActionsDescription": "Leisti mygtuko paspaudimais valdyti įrašymą ir balso komandas",
     "doubleTapAction": "Dvigubo bakstelėjimo veiksmas",
     "download": "Atsisiųsti",
     "downloadErrorWithMessage": "Atsisiuntimo klaida: {error}",

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Modeļa numurs",
     "manufacturer": "Ražotājs",
     "doubleTap": "Dubultklikšķis",
+    "deviceButtonActions": "Ierīces pogas darbības",
+    "deviceButtonActionsDescription": "Atļaut ar pogas nospiešanu vadīt ierakstīšanu un balss komandas",
     "ledBrightness": "LED spilgtums",
     "micGain": "Mikrofona pastiprinājums",
     "disconnect": "Atvienot",

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -661,6 +661,8 @@
         "description": "Label for manufacturer field"
     },
     "doubleTap": "Двојно допирање",
+    "deviceButtonActions": "Дејства на копчето на уредот",
+    "deviceButtonActionsDescription": "Дозволи притискањата на копчето да управуваат со снимањето и гласовните команди",
     "@doubleTap": {
         "description": "Double tap action label"
     },

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -661,6 +661,8 @@
         "description": "Label for manufacturer field"
     },
     "doubleTap": "दुहेरी टॅप",
+    "deviceButtonActions": "डिव्हाइस बटण क्रिया",
+    "deviceButtonActionsDescription": "बटण दाबून रेकॉर्डिंग आणि व्हॉइस कमांड नियंत्रित करण्यास अनुमती द्या",
     "@doubleTap": {
         "description": "Double tap action label"
     },

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Nombor Model",
     "manufacturer": "Pengeluar",
     "doubleTap": "Ketik Dua Kali",
+    "deviceButtonActions": "Tindakan Butang Peranti",
+    "deviceButtonActionsDescription": "Benarkan tekanan butang mengawal rakaman dan arahan suara",
     "ledBrightness": "Kecerahan LED",
     "micGain": "Gandaan Mikrofon",
     "disconnect": "Putuskan Sambungan",

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Modelnummer",
     "manufacturer": "Fabrikant",
     "doubleTap": "Dubbel tikken",
+    "deviceButtonActions": "Acties voor apparaatknop",
+    "deviceButtonActionsDescription": "Sta toe dat knopdrukken opnames en spraakopdrachten bedienen",
     "ledBrightness": "LED-helderheid",
     "micGain": "Microfoonversterking",
     "disconnect": "Loskoppelen",

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Modellnummer",
     "manufacturer": "Produsent",
     "doubleTap": "Dobbelttrykk",
+    "deviceButtonActions": "Handlinger for enhetsknapp",
+    "deviceButtonActionsDescription": "Tillat at knappetrykk styrer opptak og talekommandoer",
     "ledBrightness": "LED-lysstyrke",
     "micGain": "Mikrofonforsterkning",
     "disconnect": "Koble fra",

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Numer modelu",
     "manufacturer": "Producent",
     "doubleTap": "Podwójne dotknięcie",
+    "deviceButtonActions": "Funkcje przycisku urządzenia",
+    "deviceButtonActionsDescription": "Zezwól, aby naciśnięcia przycisku sterowały nagrywaniem i poleceniami głosowymi",
     "ledBrightness": "Jasność LED",
     "micGain": "Wzmocnienie mikrofonu",
     "disconnect": "Rozłącz",

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Número do Modelo",
     "manufacturer": "Fabricante",
     "doubleTap": "Toque duplo",
+    "deviceButtonActions": "Ações do botão do dispositivo",
+    "deviceButtonActionsDescription": "Permitir que os toques no botão controlem a gravação e os comandos de voz",
     "ledBrightness": "Brilho do LED",
     "micGain": "Ganho do microfone",
     "disconnect": "Desconectar",

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Număr model",
     "manufacturer": "Producător",
     "doubleTap": "Dublă apăsare",
+    "deviceButtonActions": "Acțiunile butonului dispozitivului",
+    "deviceButtonActionsDescription": "Permite apăsărilor butonului să controleze înregistrarea și comenzile vocale",
     "ledBrightness": "Luminozitate LED",
     "micGain": "Câștig microfon",
     "disconnect": "Deconectează",

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Номер модели",
     "manufacturer": "Производитель",
     "doubleTap": "Двойное нажатие",
+    "deviceButtonActions": "Действия кнопки устройства",
+    "deviceButtonActionsDescription": "Разрешить управление записью и голосовыми командами с помощью кнопки",
     "ledBrightness": "Яркость LED",
     "micGain": "Усиление микрофона",
     "disconnect": "Отключить",

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Číslo modelu",
     "manufacturer": "Výrobca",
     "doubleTap": "Dvojité ťuknutie",
+    "deviceButtonActions": "Akcie tlačidla zariadenia",
+    "deviceButtonActionsDescription": "Povoliť ovládanie nahrávania a hlasových príkazov stlačením tlačidla",
     "ledBrightness": "Jas LED",
     "micGain": "Zosilnenie mikrofónu",
     "disconnect": "Odpojiť",

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -661,6 +661,8 @@
         "description": "Label for manufacturer field"
     },
     "doubleTap": "Dvojni dotik",
+    "deviceButtonActions": "Dejanja gumba naprave",
+    "deviceButtonActionsDescription": "Dovoli, da pritiski gumba upravljajo snemanje in glasovne ukaze",
     "@doubleTap": {
         "description": "Double tap action label"
     },

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -661,6 +661,8 @@
         "description": "Label for manufacturer field"
     },
     "doubleTap": "Дупло додирни",
+    "deviceButtonActions": "Радње дугмета уређаја",
+    "deviceButtonActionsDescription": "Дозволи да притисци на дугме управљају снимањем и гласовним командама",
     "@doubleTap": {
         "description": "Double tap action label"
     },

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Modellnummer",
     "manufacturer": "Tillverkare",
     "doubleTap": "Dubbeltryck",
+    "deviceButtonActions": "Åtgärder för enhetsknappen",
+    "deviceButtonActionsDescription": "Tillåt att knapptryck styr inspelning och röstkommandon",
     "ledBrightness": "LED-ljusstyrka",
     "micGain": "Mikrofonförstärkning",
     "disconnect": "Koppla från",

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -661,6 +661,8 @@
         "description": "Label for manufacturer field"
     },
     "doubleTap": "இரட்டை தட்டு",
+    "deviceButtonActions": "சாதன பொத்தான் செயல்கள்",
+    "deviceButtonActionsDescription": "பொத்தான் அழுத்தங்கள் பதிவையும் குரல் கட்டளைகளையும் கட்டுப்படுத்த அனுமதிக்கவும்",
     "@doubleTap": {
         "description": "Double tap action label"
     },

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -661,6 +661,8 @@
         "description": "Label for manufacturer field"
     },
     "doubleTap": "డబల్ నొక్కండి",
+    "deviceButtonActions": "పరికర బటన్ చర్యలు",
+    "deviceButtonActionsDescription": "బటన్ నొక్కడం ద్వారా రికార్డింగ్ మరియు వాయిస్ ఆదేశాలను నియంత్రించడానికి అనుమతించండి",
     "@doubleTap": {
         "description": "Double tap action label"
     },

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -164,6 +164,8 @@
     "modelNumber": "หมายเลขรุ่น",
     "manufacturer": "ผู้ผลิต",
     "doubleTap": "แตะสองครั้ง",
+    "deviceButtonActions": "การทำงานของปุ่มอุปกรณ์",
+    "deviceButtonActionsDescription": "อนุญาตให้การกดปุ่มควบคุมการบันทึกและคำสั่งเสียง",
     "ledBrightness": "ความสว่าง LED",
     "micGain": "ระดับไมโครโฟน",
     "disconnect": "ตัดการเชื่อมต่อ",

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -661,6 +661,8 @@
         "description": "Label for manufacturer field"
     },
     "doubleTap": "Double Tap",
+    "deviceButtonActions": "Mga Aksyon ng Button ng Device",
+    "deviceButtonActionsDescription": "Payagang kontrolin ng pagpindot sa button ang pag-record at mga voice command",
     "@doubleTap": {
         "description": "Double tap action label"
     },

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Model Numarası",
     "manufacturer": "Üretici",
     "doubleTap": "Çift Dokunma",
+    "deviceButtonActions": "Cihaz Düğmesi Eylemleri",
+    "deviceButtonActionsDescription": "Düğmeye basarak kaydı ve sesli komutları kontrol etmeye izin ver",
     "ledBrightness": "LED Parlaklığı",
     "micGain": "Mikrofon Kazancı",
     "disconnect": "Bağlantıyı Kes",

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Номер моделі",
     "manufacturer": "Виробник",
     "doubleTap": "Подвійне натискання",
+    "deviceButtonActions": "Дії кнопки пристрою",
+    "deviceButtonActionsDescription": "Дозволити керувати записом і голосовими командами натисканням кнопки",
     "ledBrightness": "Яскравість світлодіода",
     "micGain": "Підсилення мікрофона",
     "disconnect": "Відключити",

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -661,6 +661,8 @@
         "description": "Label for manufacturer field"
     },
     "doubleTap": "دوگنا تھپتھپائیں",
+    "deviceButtonActions": "ڈیوائس بٹن کی کارروائیاں",
+    "deviceButtonActionsDescription": "بٹن دبانے سے ریکارڈنگ اور صوتی احکامات کنٹرول کرنے کی اجازت دیں",
     "@doubleTap": {
         "description": "Double tap action label"
     },

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -164,6 +164,8 @@
     "modelNumber": "Số Mô Hình",
     "manufacturer": "Nhà Sản Xuất",
     "doubleTap": "Nhấn đúp",
+    "deviceButtonActions": "Thao tác nút thiết bị",
+    "deviceButtonActionsDescription": "Cho phép thao tác nút điều khiển ghi âm và lệnh thoại",
     "ledBrightness": "Độ sáng đèn LED",
     "micGain": "Độ tăng micro",
     "disconnect": "Ngắt kết nối",

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -164,6 +164,8 @@
     "modelNumber": "型号",
     "manufacturer": "制造商",
     "doubleTap": "双击",
+    "deviceButtonActions": "设备按钮操作",
+    "deviceButtonActionsDescription": "允许通过按键控制录音和语音命令",
     "ledBrightness": "LED 亮度",
     "micGain": "麦克风增益",
     "disconnect": "断开连接",

--- a/app/lib/pages/settings/device_settings.dart
+++ b/app/lib/pages/settings/device_settings.dart
@@ -734,6 +734,7 @@ class _DeviceSettingsState extends State<DeviceSettings> {
 
   Widget _buildCustomizationSection(BtDevice? device, DeviceProvider provider) {
     final doubleTapAction = SharedPreferencesUtil().doubleTapAction;
+    final deviceButtonEnabled = SharedPreferencesUtil().deviceButtonEnabled;
     final supportsFind = device?.type == DeviceType.omi && !FirmwareUpdateBuildPolicy.current.isOpenGlassDevice(device);
 
     return Container(
@@ -757,6 +758,21 @@ class _DeviceSettingsState extends State<DeviceSettings> {
             ),
             const Divider(height: 1, color: Color(0xFF3C3C43)),
           ],
+          _buildProfileStyleItem(
+            key: const Key('device_button_enabled_switch'),
+            icon: FontAwesomeIcons.circleDot,
+            title: context.l10n.deviceButtonActions,
+            subtitle: context.l10n.deviceButtonActionsDescription,
+            showChevron: false,
+            trailing: Switch.adaptive(
+              value: deviceButtonEnabled,
+              onChanged: (value) {
+                SharedPreferencesUtil().deviceButtonEnabled = value;
+                setState(() {});
+              },
+            ),
+          ),
+          const Divider(height: 1, color: Color(0xFF3C3C43)),
           // Double Tap
           _buildProfileStyleItem(
             icon: FontAwesomeIcons.handPointer,

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -26,6 +26,7 @@ import 'package:omi/models/custom_stt_config.dart';
 import 'package:omi/providers/device_onboarding_provider.dart';
 import 'package:omi/services/capture/capture_external_actions.dart';
 import 'package:omi/services/capture/capture_metrics_tracker.dart';
+import 'package:omi/services/capture/device_button_policy.dart';
 import 'package:omi/services/capture/conversation_source_for_device.dart';
 import 'package:omi/services/capture/conversation_location_capture.dart';
 import 'package:omi/utils/audio/foreground.dart';
@@ -901,6 +902,11 @@ class CaptureController extends ChangeNotifier
           } else {
             return;
           }
+        }
+
+        if (!DeviceButtonPolicy.shouldHandleAction(enabled: SharedPreferencesUtil().deviceButtonEnabled)) {
+          Logger.debug('Device button action ignored: disabled in settings');
+          return;
         }
 
         // double tap

--- a/app/lib/services/capture/device_button_policy.dart
+++ b/app/lib/services/capture/device_button_policy.dart
@@ -1,0 +1,3 @@
+abstract final class DeviceButtonPolicy {
+  static bool shouldHandleAction({required bool enabled}) => enabled;
+}

--- a/app/test/unit/device_button_policy_test.dart
+++ b/app/test/unit/device_button_policy_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/services/capture/device_button_policy.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  test('device button actions stay enabled by default for existing users', () {
+    expect(SharedPreferencesUtil().deviceButtonEnabled, isTrue);
+    expect(DeviceButtonPolicy.shouldHandleAction(enabled: SharedPreferencesUtil().deviceButtonEnabled), isTrue);
+  });
+
+  test('disabled preference survives a preferences reload', () async {
+    SharedPreferencesUtil().deviceButtonEnabled = false;
+    await SharedPreferencesUtil.reload();
+
+    expect(SharedPreferencesUtil().deviceButtonEnabled, isFalse);
+    expect(DeviceButtonPolicy.shouldHandleAction(enabled: SharedPreferencesUtil().deviceButtonEnabled), isFalse);
+  });
+
+  test('disabled preference blocks user-configured button actions', () {
+    expect(DeviceButtonPolicy.shouldHandleAction(enabled: false), isFalse);
+  });
+}

--- a/app/test/widgets/device_settings_double_tap_test.dart
+++ b/app/test/widgets/device_settings_double_tap_test.dart
@@ -79,6 +79,25 @@ void main() {
     expect(find.text('Pause/Resume Recording'), findsNothing);
   });
 
+  testWidgets('device button actions can be disabled and persist', (tester) async {
+    final provider = _StubDeviceProvider();
+    addTearDown(provider.dispose);
+
+    await tester.pumpWidget(_app(provider));
+    await tester.pump();
+
+    final toggle = find.byKey(const Key('device_button_enabled_switch'));
+    expect(toggle, findsOneWidget);
+    expect(SharedPreferencesUtil().deviceButtonEnabled, isTrue);
+
+    await tester.tap(find.descendant(of: toggle, matching: find.byType(Switch)));
+    await tester.pump();
+
+    expect(SharedPreferencesUtil().deviceButtonEnabled, isFalse);
+    await SharedPreferencesUtil.reload();
+    expect(SharedPreferencesUtil().deviceButtonEnabled, isFalse);
+  });
+
   testWidgets('Find triggers one guarded request for a connected Omi', (tester) async {
     final findCompleter = Completer<bool>();
     final provider = _StubDeviceProvider(


### PR DESCRIPTION
## What changed and why

Add a default-on, persisted master switch for Omi device button actions. Interactive onboarding still receives the button event first, while normal single-, double-, and long-press actions return before side effects when the user disables the switch.

Closes #4458

## Product invariants affected

none

## How it was verified

- `flutter test test/unit/device_button_policy_test.dart test/widgets/device_settings_double_tap_test.dart` — all 9 preference, policy, persistence, and settings-widget tests passed.
- `flutter gen-l10n` — generated all 48 supported locale implementations with zero untranslated messages.
- `bash scripts/analyze_ratchet.sh` — analyzer ratchet passed.
- The physical button path was not exercised because no paired Omi device is available locally.

## Tests

- [x] Added default-on, disabled, and persistence policy coverage.
- [x] Added widget coverage for toggling and reloading the setting.
- [x] Regenerated and validated every supported locale.
- [ ] Physical-device button presses (hardware unavailable).

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

