### PR TITLE
fix(app): recover live-listen expired tokens

### DIFF
--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -33,6 +33,30 @@ class AuthTokenUnavailableException implements Exception {
   String toString() => 'AuthTokenUnavailableException(${result.runtimeType})';
 }
 
+/// Returns the expiry carried by the JWT itself, falling back to the persisted
+/// Firebase metadata for legacy or malformed cached values.
+///
+/// The token is the credential sent on the wire, so its `exp` claim must win if
+/// it disagrees with the separately persisted expiration timestamp.
+@visibleForTesting
+DateTime resolveAuthTokenExpiration({required String token, required int cachedExpirationTime}) {
+  final segments = token.split('.');
+  if (segments.length == 3) {
+    try {
+      final payload = jsonDecode(utf8.decode(base64Url.decode(base64Url.normalize(segments[1]))));
+      final expirationSeconds = payload is Map<String, dynamic> ? payload['exp'] : null;
+      if (expirationSeconds is num && expirationSeconds.isFinite) {
+        return DateTime.fromMillisecondsSinceEpoch(expirationSeconds.toInt() * 1000, isUtc: true);
+      }
+    } on FormatException {
+      // Fall back to Firebase's persisted metadata below.
+    } on RangeError {
+      // Fall back to Firebase's persisted metadata below.
+    }
+  }
+  return DateTime.fromMillisecondsSinceEpoch(cachedExpirationTime);
+}
+
 // Normal-mode connectivity failures on mobile (no network, DNS failure,
 // connection reset, TLS handshake during reconnect, request timeout, OS abort
 // when the app backgrounds mid-upload). Reporting these to Crashlytics drowns
@@ -62,8 +86,12 @@ Future<String> getAuthHeader({bool expireTerminalSession = true}) async {
     throw AuthTokenUnavailableException(const AuthTokenMissingUser());
   }
 
-  final expiry = DateTime.fromMillisecondsSinceEpoch(SharedPreferencesUtil().tokenExpirationTime);
-  bool hasAuthToken = SharedPreferencesUtil().authToken.isNotEmpty;
+  final cachedToken = SharedPreferencesUtil().authToken;
+  final expiry = resolveAuthTokenExpiration(
+    token: cachedToken,
+    cachedExpirationTime: SharedPreferencesUtil().tokenExpirationTime,
+  );
+  bool hasAuthToken = cachedToken.isNotEmpty;
 
   bool isExpirationDateValid = !(expiry.isBefore(DateTime.now()) ||
       expiry.isAtSameMomentAs(DateTime.fromMillisecondsSinceEpoch(0)) ||

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -34,6 +34,7 @@ import 'package:omi/services/connectivity_service.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/services/voice_playback/omi_voice_playback_service.dart';
 import 'package:omi/services/sockets/transcription_service.dart';
+import 'package:omi/services/sockets/live_listen_auth_recovery.dart';
 import 'package:omi/services/audio_sources/audio_source.dart';
 import 'package:omi/services/audio_sources/ble_device_source.dart';
 import 'package:omi/services/devices/connectors/limitless_connection.dart';
@@ -82,6 +83,7 @@ class CaptureController extends ChangeNotifier
 
   TranscriptSegmentSocketService? _socket;
   Timer? _keepAliveTimer;
+  Future<void>? _liveListenAuthRecoveryInFlight;
   DateTime? _keepAliveLastExecutedAt;
   Timer? _inProgressConversationRefreshTimer;
   int _inProgressConversationRefreshAttempts = 0;
@@ -1739,7 +1741,55 @@ class CaptureController extends ChangeNotifier
     }
 
     notifyListeners();
+
+    if (closeCode == 4001 || closeCode == 4004) {
+      _scheduleLiveListenAuthRecovery(closeCode!);
+      return;
+    }
+
     _startKeepAliveServices();
+  }
+
+  void _scheduleLiveListenAuthRecovery(int closeCode) {
+    if (_liveListenAuthRecoveryInFlight != null) return;
+
+    final recovery = _recoverLiveListenAuthClose(closeCode);
+    _liveListenAuthRecoveryInFlight = recovery;
+    unawaited(
+      recovery.whenComplete(() {
+        if (identical(_liveListenAuthRecoveryInFlight, recovery)) {
+          _liveListenAuthRecoveryInFlight = null;
+        }
+      }),
+    );
+  }
+
+  Future<void> _recoverLiveListenAuthClose(int closeCode) async {
+    try {
+      final disposition = await recoverLiveListenAuthClose(
+        closeCode: closeCode,
+        refreshToken: AuthService.instance.refreshIdToken,
+        expireSession: AuthService.instance.expireSession,
+      );
+
+      if (!_shouldReconnectTranscriptionSocket) return;
+
+      switch (disposition) {
+        case LiveListenAuthDisposition.reconnectNow:
+          await _reconnectActiveCapture();
+        case LiveListenAuthDisposition.retryLater:
+        case LiveListenAuthDisposition.notAuthRelated:
+          _startKeepAliveServices();
+        case LiveListenAuthDisposition.sessionExpired:
+          _keepAliveTimer?.cancel();
+          _keepAliveTimer = null;
+      }
+    } catch (error, stackTrace) {
+      Logger.handle(error, stackTrace, message: 'Live-listen auth recovery failed');
+      if (_shouldReconnectTranscriptionSocket) {
+        _startKeepAliveServices();
+      }
+    }
   }
 
   bool get _shouldReconnectTranscriptionSocket {

--- a/app/lib/services/sockets/live_listen_auth_recovery.dart
+++ b/app/lib/services/sockets/live_listen_auth_recovery.dart
@@ -1,0 +1,38 @@
+import 'package:omi/services/auth/auth_token_result.dart';
+
+enum LiveListenAuthDisposition { reconnectNow, retryLater, sessionExpired, notAuthRelated }
+
+Future<LiveListenAuthDisposition> recoverLiveListenAuthClose({
+  required int? closeCode,
+  required Future<AuthTokenResult> Function() refreshToken,
+  required Future<void> Function(AuthSessionExpiredEvent event) expireSession,
+}) async {
+  if (closeCode == 4004) {
+    await expireSession(
+      const AuthSessionExpiredEvent(reason: AuthSessionExpirationReason.backendRejectedRefreshedToken),
+    );
+    return LiveListenAuthDisposition.sessionExpired;
+  }
+
+  if (closeCode != 4001) return LiveListenAuthDisposition.notAuthRelated;
+
+  final result = await refreshToken();
+  return switch (result) {
+    AuthTokenSuccess() => LiveListenAuthDisposition.reconnectNow,
+    AuthTokenTransientFailure() => LiveListenAuthDisposition.retryLater,
+    AuthTokenMissingUser() => await _expireSession(AuthSessionExpirationReason.missingUser, expireSession),
+    AuthTokenMissingToken() => await _expireSession(AuthSessionExpirationReason.missingToken, expireSession),
+    AuthTokenTerminalFailure(:final code) => await _expireSession(
+        AuthSessionExpirationReason.terminalTokenFailure,
+        expireSession,
+        code: code,
+      ),
+  };
+}
+
+Future<LiveListenAuthDisposition> _expireSession(
+    AuthSessionExpirationReason reason, Future<void> Function(AuthSessionExpiredEvent event) expireSession,
+    {String? code}) async {
+  await expireSession(AuthSessionExpiredEvent(reason: reason, code: code));
+  return LiveListenAuthDisposition.sessionExpired;
+}

--- a/app/test/unit/auth_token_expiration_test.dart
+++ b/app/test/unit/auth_token_expiration_test.dart
@@ -1,0 +1,25 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/http/shared.dart';
+
+String _tokenWithExpiration(DateTime expiration) {
+  final payload =
+      base64Url.encode(utf8.encode(jsonEncode({'exp': expiration.millisecondsSinceEpoch ~/ 1000}))).replaceAll('=', '');
+  return 'header.$payload.signature';
+}
+
+void main() {
+  test('JWT expiry overrides a stale future cached expiry', () {
+    final expiredAt = DateTime.utc(2026, 8, 24);
+    final staleCachedExpiry = DateTime.utc(2026, 9, 1).millisecondsSinceEpoch;
+
+    final expiry = resolveAuthTokenExpiration(
+      token: _tokenWithExpiration(expiredAt),
+      cachedExpirationTime: staleCachedExpiry,
+    );
+
+    expect(expiry, expiredAt);
+  });
+}

--- a/app/test/unit/live_listen_auth_recovery_test.dart
+++ b/app/test/unit/live_listen_auth_recovery_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/services/auth/auth_token_result.dart';
+import 'package:omi/services/sockets/live_listen_auth_recovery.dart';
+
+void main() {
+  test('4001 refresh success requests an immediate reconnect', () async {
+    final expired = <AuthSessionExpiredEvent>[];
+
+    final disposition = await recoverLiveListenAuthClose(
+      closeCode: 4001,
+      refreshToken: () async => AuthTokenSuccess(token: 'fresh', expirationTime: DateTime.utc(2027)),
+      expireSession: (event) async => expired.add(event),
+    );
+
+    expect(disposition, LiveListenAuthDisposition.reconnectNow);
+    expect(expired, isEmpty);
+  });
+
+  test('4001 transient refresh failure leaves bounded retry armed', () async {
+    final disposition = await recoverLiveListenAuthClose(
+      closeCode: 4001,
+      refreshToken: () async => const AuthTokenTransientFailure(failureClass: 'offline'),
+      expireSession: (_) async {},
+    );
+
+    expect(disposition, LiveListenAuthDisposition.retryLater);
+  });
+
+  test('4001 terminal refresh expires the session instead of looping', () async {
+    final expired = <AuthSessionExpiredEvent>[];
+
+    final disposition = await recoverLiveListenAuthClose(
+      closeCode: 4001,
+      refreshToken: () async => const AuthTokenTerminalFailure(code: 'user-token-expired'),
+      expireSession: (event) async => expired.add(event),
+    );
+
+    expect(disposition, LiveListenAuthDisposition.sessionExpired);
+    expect(expired.single.reason, AuthSessionExpirationReason.terminalTokenFailure);
+    expect(expired.single.code, 'user-token-expired');
+  });
+
+  test('4001 missing user expires the session instead of retrying', () async {
+    final expired = <AuthSessionExpiredEvent>[];
+
+    final disposition = await recoverLiveListenAuthClose(
+      closeCode: 4001,
+      refreshToken: () async => const AuthTokenMissingUser(),
+      expireSession: (event) async => expired.add(event),
+    );
+
+    expect(disposition, LiveListenAuthDisposition.sessionExpired);
+    expect(expired.single.reason, AuthSessionExpirationReason.missingUser);
+  });
+
+  test('4004 expires immediately without attempting refresh', () async {
+    var refreshCalls = 0;
+    final expired = <AuthSessionExpiredEvent>[];
+
+    final disposition = await recoverLiveListenAuthClose(
+      closeCode: 4004,
+      refreshToken: () async {
+        refreshCalls++;
+        return const AuthTokenTransientFailure(failureClass: 'unexpected');
+      },
+      expireSession: (event) async => expired.add(event),
+    );
+
+    expect(disposition, LiveListenAuthDisposition.sessionExpired);
+    expect(refreshCalls, 0);
+    expect(expired.single.reason, AuthSessionExpirationReason.backendRejectedRefreshedToken);
+  });
+
+  test('ordinary closes stay on the transport reconnect path', () async {
+    final disposition = await recoverLiveListenAuthClose(
+      closeCode: 1006,
+      refreshToken: () async => const AuthTokenTransientFailure(failureClass: 'unused'),
+      expireSession: (_) async {},
+    );
+
+    expect(disposition, LiveListenAuthDisposition.notAuthRelated);
+  });
+}


### PR DESCRIPTION
## What changed and why

Fix both sides of the live-listen expired-token loop:

- `getAuthHeader()` now derives expiry from the cached Firebase JWT it is about to send. The token's `exp` claim wins over the separately persisted timestamp, so a dead token paired with stale future metadata is refreshed before the WebSocket upgrade instead of being rejected as HTTP 403 forever.
- If a server transport does deliver auth close codes, recovery remains bounded and single-flight: refresh and reconnect on 4001 success, retain the existing keepalive retry for transient failures, and expire the session for terminal/missing credentials or 4004 rejection.

Malformed or legacy non-JWT cached values retain the existing persisted-expiry fallback.

Closes #11694

## Product invariants affected

none

## How it was verified

- `flutter test test/unit/auth_token_expiration_test.dart test/unit/live_listen_auth_recovery_test.dart test/unit/backend/http/shared_test.dart test/unit/auth_service_token_result_test.dart test/unit/token_refresh_loop_test.dart` — all 58 auth/header/recovery tests passed.
- Targeted `flutter analyze` over the changed auth, capture, and test files — no issues.
- The original capture-controller suite verification remains 89/89 passing.
- A production token-expiry session was not forced against the live service; the stale-metadata failure and close-code/result matrix are covered hermetically.

## Tests

- [x] Added regression coverage proving an expired JWT overrides stale future expiry metadata.
- [x] Added coverage for refresh success, transient failure, terminal failure, missing user, 4004 rejection, and ordinary transport closes.
- [x] Ran the existing capture-controller provider suite.
- [ ] Live backend token-expiry exercise (would require disrupting a real account session).

Failure-Class: none
