### PR TITLE
fix(app): allow Limitless offload during uploads

### DIFF
--- a/app/lib/pages/capture/widgets/limitless_sync_presentation.dart
+++ b/app/lib/pages/capture/widgets/limitless_sync_presentation.dart
@@ -1,0 +1,26 @@
+final class LimitlessSyncPresentation {
+  const LimitlessSyncPresentation._({
+    required this.isVisible,
+    required this.canOffloadDevice,
+    required this.showsCloudProgress,
+    required this.showsFlashDrainProgress,
+  });
+
+  final bool isVisible;
+  final bool canOffloadDevice;
+  final bool showsCloudProgress;
+  final bool showsFlashDrainProgress;
+
+  factory LimitlessSyncPresentation.resolve({
+    required bool hasPendingFlashPages,
+    required bool isCloudUploading,
+    required bool isFlashDraining,
+  }) {
+    return LimitlessSyncPresentation._(
+      isVisible: hasPendingFlashPages || isCloudUploading || isFlashDraining,
+      canOffloadDevice: hasPendingFlashPages && !isFlashDraining,
+      showsCloudProgress: isCloudUploading,
+      showsFlashDrainProgress: isFlashDraining,
+    );
+  }
+}

--- a/app/lib/pages/capture/widgets/limitless_sync_widget.dart
+++ b/app/lib/pages/capture/widgets/limitless_sync_widget.dart
@@ -3,11 +3,11 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/pages/capture/widgets/limitless_sync_presentation.dart';
 import 'package:omi/providers/device_provider.dart';
 import 'package:omi/providers/sync_provider.dart';
 import 'package:omi/services/wals.dart';
 import 'package:omi/utils/l10n_extensions.dart';
-import 'package:omi/utils/sync_confirmation.dart';
 
 class LimitlessSyncCardWidget extends StatelessWidget {
   const LimitlessSyncCardWidget({super.key});
@@ -26,11 +26,16 @@ class LimitlessSyncCardWidget extends StatelessWidget {
         final pendingFlashPages =
             syncProvider.allWals.where((w) => w.storage == WalStorage.flashPage && w.status == WalStatus.miss).toList();
 
-        if (pendingFlashPages.isEmpty && !syncProvider.isSyncing) {
+        final presentation = LimitlessSyncPresentation.resolve(
+          hasPendingFlashPages: pendingFlashPages.isNotEmpty,
+          isCloudUploading: syncProvider.isSyncing,
+          isFlashDraining: syncProvider.isFlashPageSyncing,
+        );
+
+        if (!presentation.isVisible) {
           return const SizedBox();
         }
 
-        final isSyncing = syncProvider.isSyncing;
         final progress = syncProvider.walsSyncedProgress;
 
         return Container(
@@ -49,32 +54,41 @@ class LimitlessSyncCardWidget extends StatelessWidget {
                   const SizedBox(width: 12),
                   Expanded(
                     child: Text(
-                      isSyncing ? context.l10n.syncingYourRecordings : context.l10n.syncYourRecordings,
+                      presentation.showsCloudProgress
+                          ? context.l10n.syncingYourRecordings
+                          : context.l10n.syncYourRecordings,
                       style: const TextStyle(color: Colors.white, fontSize: 16),
                     ),
                   ),
-                  if (!isSyncing)
+                  if (presentation.showsCloudProgress)
+                    Text(
+                      '${(progress * 100).toInt()}%',
+                      style: const TextStyle(color: Colors.white70, fontSize: 14, fontWeight: FontWeight.w600),
+                    ),
+                  if (presentation.showsCloudProgress &&
+                      (presentation.showsFlashDrainProgress || presentation.canOffloadDevice))
+                    const SizedBox(width: 12),
+                  if (presentation.showsFlashDrainProgress)
+                    const SizedBox(
+                      width: 22,
+                      height: 22,
+                      child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white70),
+                    )
+                  else if (presentation.canOffloadDevice)
                     ElevatedButton(
-                      onPressed: () async {
-                        if (await confirmSyncForCustomStt(context) && context.mounted) syncProvider.syncWals();
-                      },
+                      onPressed: syncProvider.offloadLimitlessFlash,
                       style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.deepPurple,
+                        backgroundColor: const Color(0xFF16A34A),
                         foregroundColor: Colors.white,
                         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
                       ),
                       child: Text(context.l10n.syncNow),
-                    )
-                  else
-                    Text(
-                      '${(progress * 100).toInt()}%',
-                      style: const TextStyle(color: Colors.white70, fontSize: 14, fontWeight: FontWeight.w600),
                     ),
                 ],
               ),
               // Progress bar when syncing
-              if (isSyncing) ...[
+              if (presentation.showsCloudProgress) ...[
                 const SizedBox(height: 12),
                 ClipRRect(
                   borderRadius: BorderRadius.circular(4),

--- a/app/lib/pages/capture/widgets/limitless_sync_widget.dart
+++ b/app/lib/pages/capture/widgets/limitless_sync_widget.dart
@@ -8,6 +8,7 @@ import 'package:omi/providers/device_provider.dart';
 import 'package:omi/providers/sync_provider.dart';
 import 'package:omi/services/wals.dart';
 import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/utils/sync_confirmation.dart';
 
 class LimitlessSyncCardWidget extends StatelessWidget {
   const LimitlessSyncCardWidget({super.key});
@@ -76,9 +77,15 @@ class LimitlessSyncCardWidget extends StatelessWidget {
                     )
                   else if (presentation.canOffloadDevice)
                     ElevatedButton(
-                      onPressed: syncProvider.offloadLimitlessFlash,
+                      onPressed: () async {
+                        if (presentation.showsCloudProgress) {
+                          await syncProvider.offloadLimitlessFlash();
+                        } else if (await confirmSyncForCustomStt(context) && context.mounted) {
+                          await syncProvider.syncWals();
+                        }
+                      },
                       style: ElevatedButton.styleFrom(
-                        backgroundColor: const Color(0xFF16A34A),
+                        backgroundColor: Colors.deepPurple,
                         foregroundColor: Colors.white,
                         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -437,7 +437,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
 
   Future<RecordingTransferDrainResult> _drainEligibleWals() async {
     if (_isDisposed || _syncState.isProcessing) return const RecordingTransferDrainResult.contended();
-    if (_walService.getSyncs().isStorageSyncing || _walService.getSyncs().isSdCardSyncing) {
+    if (_walService.getSyncs().isStorageSyncing || _walService.getSyncs().isSdCardSyncing || isFlashPageSyncing) {
       return const RecordingTransferDrainResult.contended();
     }
 
@@ -600,8 +600,11 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   bool _isTransferSeamBusy() {
     if (_syncState.isProcessing) return true;
     final syncs = _walService.getSyncs();
-    return syncs.isStorageSyncing == true || syncs.isSdCardSyncing == true;
+    return syncs.isStorageSyncing == true || syncs.isSdCardSyncing == true || isFlashPageSyncing;
   }
+
+  @visibleForTesting
+  Future<RecordingTransferDrainResult> drainEligibleWalsForTesting() => _drainEligibleWals();
 
   Future<SyncLocalFilesResponse?> _performSync({
     required Future<SyncLocalFilesResponse?> Function() operation,

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -291,6 +291,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   int _totalWalsToProcess = 0;
   int _walsProcessedCount = 0;
   bool _isDisposed = false;
+  bool _isOffloadingLimitlessFlash = false;
   late bool _rateLimitWasActive;
 
   // Computed properties for backward compatibility
@@ -319,7 +320,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
   SyncMethod? get currentSyncMethod => _syncState.syncMethod;
 
   // Flash page (Limitless) sync state
-  bool get isFlashPageSyncing => _walService.getSyncs().isFlashPageSyncing;
+  bool get isFlashPageSyncing => _isOffloadingLimitlessFlash || _walService.getSyncs().isFlashPageSyncing;
 
   /// Get a WAL by ID from the current list
   Wal? getWalById(String walId) {
@@ -547,6 +548,26 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
       context: 'sync all WALs',
       checkFlashStall: true,
     );
+  }
+
+  /// Copies Limitless flash pages to the phone without waiting for, or
+  /// interfering with, the cloud-upload lane.
+  Future<void> offloadLimitlessFlash() async {
+    if (_isDisposed || isFlashPageSyncing) return;
+    _isOffloadingLimitlessFlash = true;
+    notifyListeners();
+    try {
+      await _walService.getSyncs().offloadFlashPages();
+    } finally {
+      _isOffloadingLimitlessFlash = false;
+      if (!_isDisposed) {
+        try {
+          await refreshWals();
+        } finally {
+          if (!_isDisposed) notifyListeners();
+        }
+      }
+    }
   }
 
   Future<void> syncWal(Wal wal) async {

--- a/app/lib/services/wals/wal_syncs.dart
+++ b/app/lib/services/wals/wal_syncs.dart
@@ -138,6 +138,16 @@ class WalSyncs implements IWalSync {
     await _flashPageSync.refreshWalsFromDevice();
   }
 
+  /// Drains Limitless flash pages to the phone without entering the cloud
+  /// upload phase. This remains independent from [syncAll], so device storage
+  /// can be freed while an earlier recording uploads.
+  Future<void> offloadFlashPages() async {
+    if (_flashPageSync.isSyncing) return;
+    await _flashPageSync.refreshWalsFromDevice();
+    final missing = (await _flashPageSync.getMissingWals()).where((wal) => wal.status == WalStatus.miss);
+    if (missing.isNotEmpty) await _flashPageSync.syncAll();
+  }
+
   Future<WalStats> getWalStats() async {
     final allWals = await getAllWals();
     int phoneFiles = 0;

--- a/app/test/providers/sync_provider_flash_stall_test.dart
+++ b/app/test/providers/sync_provider_flash_stall_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'dart:async';
-import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/providers/sync_provider.dart';
@@ -15,13 +14,19 @@ import 'package:shared_preferences/shared_preferences.dart';
 class _FakeSyncs {
   FlashSyncStallReason flashStallReason = FlashSyncStallReason.none;
   SyncLocalFilesResponse? syncAllResult;
+  bool isStorageSyncing = false;
+  bool isSdCardSyncing = false;
   bool isFlashPageSyncing = false;
+  int syncAllCalls = 0;
   int offloadFlashPagesCalls = 0;
   Completer<void>? offloadCompleter;
 
   Future<List<Wal>> getAllWals() async => [];
 
-  Future<SyncLocalFilesResponse?> syncAll({IWalSyncProgressListener? progress}) async => syncAllResult;
+  Future<SyncLocalFilesResponse?> syncAll({IWalSyncProgressListener? progress}) async {
+    syncAllCalls++;
+    return syncAllResult;
+  }
 
   Future<void> offloadFlashPages() async {
     offloadFlashPagesCalls++;
@@ -151,6 +156,22 @@ void main() {
     walService.syncs.offloadCompleter!.complete();
     await Future.wait([first, second]);
     expect(provider.isFlashPageSyncing, isFalse);
+    provider.dispose();
+  });
+
+  test('coordinator drain stays contended for the full device-only offload', () async {
+    final walService = _FakeWalService();
+    walService.syncs.offloadCompleter = Completer<void>();
+    final provider = SyncProvider(walService: walService, uploadGate: _hermeticGate(), startBackgroundSync: false);
+    await provider.initialized;
+
+    final offload = provider.offloadLimitlessFlash();
+    final drain = await provider.drainEligibleWalsForTesting();
+
+    expect(drain.contended, isTrue);
+    expect(walService.syncs.syncAllCalls, 0);
+    walService.syncs.offloadCompleter!.complete();
+    await offload;
     provider.dispose();
   });
 }

--- a/app/test/providers/sync_provider_flash_stall_test.dart
+++ b/app/test/providers/sync_provider_flash_stall_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'dart:async';
 import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
@@ -14,10 +15,18 @@ import 'package:shared_preferences/shared_preferences.dart';
 class _FakeSyncs {
   FlashSyncStallReason flashStallReason = FlashSyncStallReason.none;
   SyncLocalFilesResponse? syncAllResult;
+  bool isFlashPageSyncing = false;
+  int offloadFlashPagesCalls = 0;
+  Completer<void>? offloadCompleter;
 
   Future<List<Wal>> getAllWals() async => [];
 
   Future<SyncLocalFilesResponse?> syncAll({IWalSyncProgressListener? progress}) async => syncAllResult;
+
+  Future<void> offloadFlashPages() async {
+    offloadFlashPagesCalls++;
+    await offloadCompleter?.future;
+  }
 }
 
 class _FakeWalService implements IWalService {
@@ -113,6 +122,35 @@ void main() {
 
     expect(provider.syncState.isCompleted, isTrue);
     expect(provider.syncState.hasError, isFalse);
+    provider.dispose();
+  });
+
+  test('device-only offload does not enter the cloud sync state machine', () async {
+    final walService = _FakeWalService();
+    final provider = SyncProvider(walService: walService, uploadGate: _hermeticGate(), startBackgroundSync: false);
+    await provider.initialized;
+
+    await provider.offloadLimitlessFlash();
+
+    expect(walService.syncs.offloadFlashPagesCalls, 1);
+    expect(provider.syncState.isSyncing, isFalse);
+    provider.dispose();
+  });
+
+  test('device-only offload is single-flight before the WAL service reports syncing', () async {
+    final walService = _FakeWalService();
+    walService.syncs.offloadCompleter = Completer<void>();
+    final provider = SyncProvider(walService: walService, uploadGate: _hermeticGate(), startBackgroundSync: false);
+    await provider.initialized;
+
+    final first = provider.offloadLimitlessFlash();
+    final second = provider.offloadLimitlessFlash();
+
+    expect(provider.isFlashPageSyncing, isTrue);
+    expect(walService.syncs.offloadFlashPagesCalls, 1);
+    walService.syncs.offloadCompleter!.complete();
+    await Future.wait([first, second]);
+    expect(provider.isFlashPageSyncing, isFalse);
     provider.dispose();
   });
 }

--- a/app/test/providers/sync_provider_sync_wal_wake_test.dart
+++ b/app/test/providers/sync_provider_sync_wal_wake_test.dart
@@ -28,6 +28,7 @@ class _FakeSyncs {
 
   bool get isStorageSyncing => false;
   bool get isSdCardSyncing => false;
+  bool get isFlashPageSyncing => false;
 
   SyncLocalFilesResponse? get accumulatedResponse => null;
 

--- a/app/test/unit/limitless_sync_presentation_test.dart
+++ b/app/test/unit/limitless_sync_presentation_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/pages/capture/widgets/limitless_sync_presentation.dart';
+
+void main() {
+  test('cloud upload does not hide or disable device offload', () {
+    final state = LimitlessSyncPresentation.resolve(
+      hasPendingFlashPages: true,
+      isCloudUploading: true,
+      isFlashDraining: false,
+    );
+
+    expect(state.isVisible, isTrue);
+    expect(state.canOffloadDevice, isTrue);
+    expect(state.showsCloudProgress, isTrue);
+  });
+
+  test('only an active flash drain disables the offload action', () {
+    final state = LimitlessSyncPresentation.resolve(
+      hasPendingFlashPages: true,
+      isCloudUploading: true,
+      isFlashDraining: true,
+    );
+
+    expect(state.canOffloadDevice, isFalse);
+    expect(state.showsFlashDrainProgress, isTrue);
+  });
+
+  test('card hides when neither device work nor upload work exists', () {
+    final state = LimitlessSyncPresentation.resolve(
+      hasPendingFlashPages: false,
+      isCloudUploading: false,
+      isFlashDraining: false,
+    );
+
+    expect(state.isVisible, isFalse);
+  });
+}


### PR DESCRIPTION
## What changed and why

Separate Limitless flash draining from the cloud-upload state machine so users can free device storage while an earlier recording uploads. The card now presents cloud progress and device offload concurrently, and the device lane is immediately single-flight to prevent duplicate BLE drains.

Closes #12265

## Product invariants affected

none

## How it was verified

- `flutter test test/providers/sync_provider_flash_stall_test.dart test/unit/limitless_sync_presentation_test.dart` — all 9 UI-state, stall, cloud-state isolation, and single-flight tests passed.
- `bash scripts/analyze_ratchet.sh` — analyzer ratchet passed.
- The BLE drain was not exercised on physical Limitless hardware in this environment.

## Tests

- [x] Added presentation coverage for simultaneous cloud upload and device offload.
- [x] Added provider coverage proving the offload never enters cloud sync state and rejects a second concurrent request.
- [x] Preserved existing flash-stall regression coverage.
- [ ] Physical Limitless flash drain during an upload (hardware unavailable).

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

