### PR TITLE
feat: remote in-app prompts authored on admin.omi.me (no releases)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -76,6 +76,7 @@ from routers import (
     desktop_agent_vm,
     desktop_chat,
     desktop_core,
+    desktop_prompts,
     desktop_proxy,
     desktop_realtime,
     desktop_screen_crisp,
@@ -184,6 +185,7 @@ app.include_router(integration.router)
 app.include_router(agents.router)
 app.include_router(users.router)
 app.include_router(referrals.router)
+app.include_router(desktop_prompts.router)
 app.include_router(conversation_finalization.router)
 app.include_router(trends.router)
 

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -165,6 +165,30 @@ routes:
         state: active
       owner: backend
   - route_type: http
+    method: GET
+    path: /v2/desktop/prompts
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - firebase_id_token
+          - admin_key_uid_prefix
+        placement: dependency
+        scopes: []
+      byok: validated_when_headers_present
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: first_party
+      data_domain: user_profile
+      deprecation:
+        state: active
+      owner: backend
+  - route_type: http
     method: POST
     path: /v1/users/me/referral/claim
     policy:

--- a/backend/routers/desktop_prompts.py
+++ b/backend/routers/desktop_prompts.py
@@ -1,0 +1,96 @@
+import hashlib
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from database._client import db
+from utils.other import endpoints as auth
+
+router = APIRouter(tags=['desktop-prompts'])
+
+# Remote in-app prompts: admin.omi.me authors documents in the
+# `desktop_prompts` Firestore collection; every desktop client polls this
+# endpoint and renders matching prompts natively — shipping a new survey,
+# rating ask, or announcement needs no app release. Documents are
+# admin-authored (never user input) and this route only ever READS them.
+PROMPTS_COLLECTION = 'desktop_prompts'
+ALLOWED_TYPES = {'stars', 'nps', 'choice', 'banner'}
+
+
+class DesktopPromptSpec(BaseModel):
+    id: str
+    type: str
+    question: str
+    options: List[str] = []
+    cta_label: Optional[str] = None
+    cta_url: Optional[str] = None
+    trigger_kind: str = 'app_launch'
+    trigger_count: int = 0
+    max_per_day: int = 1
+
+
+class DesktopPromptsResponse(BaseModel):
+    prompts: List[DesktopPromptSpec]
+
+
+def rollout_bucket(uid: str, prompt_id: str) -> int:
+    """Stable 0-99 bucket per (user, prompt): percentage rollouts hold steady
+    across polls instead of re-rolling, and a user lands in different buckets
+    for different prompts."""
+    digest = hashlib.sha256(f'{prompt_id}:{uid}'.encode()).hexdigest()
+    return int(digest[:8], 16) % 100
+
+
+def prompt_matches_audience(doc: Dict[str, Any], uid: str, channel: str, build: int) -> bool:
+    audience = doc.get('audience') or {}
+    channels = audience.get('channels') or []
+    if channels and channel not in channels:
+        return False
+    min_build = audience.get('min_build') or 0
+    if build and min_build and build < min_build:
+        return False
+    rollout_pct = audience.get('rollout_pct')
+    if rollout_pct is None:
+        rollout_pct = 100
+    return rollout_bucket(uid, str(doc.get('id'))) < int(rollout_pct)
+
+
+def spec_from_doc(doc: Dict[str, Any]) -> Optional[DesktopPromptSpec]:
+    prompt_type = doc.get('type')
+    question = doc.get('question')
+    prompt_id = doc.get('id')
+    if not prompt_id or prompt_type not in ALLOWED_TYPES or not question:
+        return None
+    trigger = doc.get('trigger') or {}
+    cta = doc.get('cta') or {}
+    return DesktopPromptSpec(
+        id=str(prompt_id),
+        type=prompt_type,
+        question=str(question),
+        options=[str(o) for o in (doc.get('options') or [])][:6],
+        cta_label=cta.get('label'),
+        cta_url=cta.get('url'),
+        trigger_kind=str(trigger.get('kind') or 'app_launch'),
+        trigger_count=int(trigger.get('count') or 0),
+        max_per_day=int(doc.get('max_per_day') or 1),
+    )
+
+
+@router.get('/v2/desktop/prompts', response_model=DesktopPromptsResponse)
+def get_desktop_prompts(
+    channel: str = 'stable',
+    build: int = 0,
+    uid: str = Depends(auth.get_current_user_uid),
+) -> DesktopPromptsResponse:
+    prompts: List[DesktopPromptSpec] = []
+    for snapshot in db.collection(PROMPTS_COLLECTION).where('active', '==', True).limit(50).stream():
+        doc = snapshot.to_dict() or {}
+        doc.setdefault('id', snapshot.id)
+        if not prompt_matches_audience(doc, uid, channel, build):
+            continue
+        spec = spec_from_doc(doc)
+        if spec is not None:
+            prompts.append(spec)
+    prompts.sort(key=lambda p: p.id)
+    return DesktopPromptsResponse(prompts=prompts)

--- a/backend/tests/unit/test_desktop_prompts.py
+++ b/backend/tests/unit/test_desktop_prompts.py
@@ -1,0 +1,66 @@
+from routers.desktop_prompts import prompt_matches_audience, rollout_bucket, spec_from_doc
+
+
+def _doc(**overrides):
+    base = {
+        'id': 'rate-2026-09',
+        'type': 'stars',
+        'question': 'How would you rate Omi Desktop?',
+        'active': True,
+        'trigger': {'kind': 'question_count', 'count': 3},
+        'audience': {'rollout_pct': 100},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_spec_carries_trigger_and_defaults():
+    spec = spec_from_doc(_doc())
+    assert spec is not None
+    assert spec.trigger_kind == 'question_count'
+    assert spec.trigger_count == 3
+    assert spec.max_per_day == 1
+    assert spec.options == []
+
+
+def test_spec_rejects_unknown_type_and_missing_question():
+    assert spec_from_doc(_doc(type='modal')) is None
+    assert spec_from_doc(_doc(question=None)) is None
+    assert spec_from_doc(_doc(id=None)) is None
+
+
+def test_banner_spec_carries_cta():
+    spec = spec_from_doc(_doc(type='banner', cta={'label': 'Try it', 'url': 'https://omi.me/x'}))
+    assert spec is not None
+    assert spec.cta_label == 'Try it'
+    assert spec.cta_url == 'https://omi.me/x'
+
+
+def test_channel_audience_excludes_other_channels():
+    doc = _doc(audience={'channels': ['beta']})
+    assert prompt_matches_audience(doc, 'uid-1', 'beta', 12218)
+    assert not prompt_matches_audience(doc, 'uid-1', 'stable', 12218)
+
+
+def test_min_build_excludes_older_builds_but_not_unknown():
+    doc = _doc(audience={'min_build': 12218})
+    assert prompt_matches_audience(doc, 'uid-1', 'stable', 12300)
+    assert not prompt_matches_audience(doc, 'uid-1', 'stable', 12100)
+    # A client that does not report its build is not silently excluded.
+    assert prompt_matches_audience(doc, 'uid-1', 'stable', 0)
+
+
+def test_rollout_bucket_is_stable_and_prompt_scoped():
+    a = rollout_bucket('uid-1', 'prompt-a')
+    assert a == rollout_bucket('uid-1', 'prompt-a')
+    assert 0 <= a < 100
+    # Different prompts re-bucket the same user independently.
+    buckets = {rollout_bucket('uid-1', f'prompt-{i}') for i in range(20)}
+    assert len(buckets) > 1
+
+
+def test_rollout_pct_gates_by_stable_bucket():
+    doc = _doc(audience={'rollout_pct': 0})
+    assert not prompt_matches_audience(doc, 'uid-1', 'stable', 0)
+    doc = _doc(audience={'rollout_pct': 100})
+    assert prompt_matches_audience(doc, 'uid-1', 'stable', 0)

--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -715,6 +715,22 @@ class AnalyticsManager {
     PostHogManager.shared.desktopRatingSubmitted(rating: rating)
   }
 
+  func desktopPromptShown(promptId: String, promptType: String) {
+    PostHogManager.shared.track(
+      "Desktop Prompt Shown", properties: ["prompt_id": promptId, "prompt_type": promptType])
+  }
+
+  func desktopPromptAnswered(promptId: String, promptType: String, value: String) {
+    PostHogManager.shared.track(
+      "Desktop Prompt Answered",
+      properties: ["prompt_id": promptId, "prompt_type": promptType, "value": value])
+  }
+
+  func desktopPromptDismissed(promptId: String, promptType: String) {
+    PostHogManager.shared.track(
+      "Desktop Prompt Dismissed", properties: ["prompt_id": promptId, "prompt_type": promptType])
+  }
+
   // MARK: - Search Events
 
   func searchQueryEntered(query: String) {

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -62,6 +62,9 @@ enum DefaultsKey: String {
   case ratingPromptQuestionCount = "ratingPromptQuestionCount"
   case ratingPromptSubmittedRating = "ratingPromptSubmittedRating"
   case ratingPromptDismissed = "ratingPromptDismissed"
+  /// One-shot marker: the question counter was seeded from server chat
+  /// history so long-time users see the rating ask without three NEW questions.
+  case ratingPromptHistorySeeded = "ratingPromptHistorySeeded"
   case screenAnalysisAutoStartFixedV2 = "screenAnalysisAutoStartFixed_v2"
   case screenAnalysisAutoStartFixedV3 = "screenAnalysisAutoStartFixed_v3"
   case homeOmiDeviceAccountHistory = "home-omi-device-account-history"

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -170,6 +170,12 @@ struct ScopedDefaultsKey {
     Self(rawValue: "appsImportConnectorSourceCount.\(connectorID)")
   }
 
+  /// Per-prompt resolution of a remote (admin-authored) prompt: "answered" or
+  /// "dismissed". Absent = still eligible.
+  static func remotePromptResolution(promptId: String) -> Self {
+    Self(rawValue: "remotePrompt.resolution.v1.\(promptId)")
+  }
+
   static func taskInterruptionLedger(ownerID: String) -> Self {
     Self(rawValue: "proactiveTaskInterruptionLedger.v1.\(ownerID)")
   }

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RatingPrompt.swift
@@ -69,6 +69,17 @@ extension DesktopAutomationActionRegistry {
     }
 
     register(
+      name: "rating_prompt_seed",
+      summary: "Run the history seed now (same call as app launch)"
+    ) { _ in
+      await RatingPromptManager.shared.seedFromHistoryIfNeeded()
+      return await MainActor.run {
+        let m = RatingPromptManager.shared
+        return ["question_count": "\(m.questionCount)", "visible": m.isVisible ? "true" : "false"]
+      }
+    }
+
+    register(
       name: "rating_prompt_reset",
       summary: "Reset persisted rating-prompt state so the trigger can be exercised again"
     ) { _ in

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RemotePrompts.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RemotePrompts.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Remote-prompt automation actions: drive the admin-authored prompt engine
+/// without cursor clicks. `remote_prompt_answer` runs the same
+/// `RemotePromptEngine.answer` the visible controls call.
+extension DesktopAutomationActionRegistry {
+  func registerRemotePromptActions() {
+    register(
+      name: "remote_prompts_state",
+      summary: "Return the remote-prompt engine's fetched specs and active prompt"
+    ) { _ in
+      await MainActor.run {
+        let engine = RemotePromptEngine.shared
+        return [
+          "schema": "current_id,current_type,spec_count,spec_ids",
+          "current_id": engine.current?.id ?? "",
+          "current_type": engine.current?.type ?? "",
+          "spec_count": "\(engine.specs.count)",
+          "spec_ids": engine.specs.map(\.id).joined(separator: ","),
+        ]
+      }
+    }
+
+    register(
+      name: "remote_prompts_refresh",
+      summary: "Fetch prompts from the backend now (same call as the 5-minute poll)"
+    ) { _ in
+      await RemotePromptEngine.shared.refreshFromServer()
+      return await MainActor.run {
+        let engine = RemotePromptEngine.shared
+        return [
+          "refreshed": "true",
+          "spec_count": "\(engine.specs.count)",
+          "current_id": engine.current?.id ?? "",
+        ]
+      }
+    }
+
+    register(
+      name: "remote_prompt_answer",
+      summary: "Answer the active remote prompt through the same path as its buttons",
+      params: ["value"]
+    ) { params in
+      let value = params["value"] ?? ""
+      return await MainActor.run {
+        let engine = RemotePromptEngine.shared
+        guard let spec = engine.current else {
+          return ["answered": "false", "reason": "no active prompt"]
+        }
+        let id = spec.id
+        engine.answer(value: value)
+        return ["answered": "true", "prompt_id": id, "value": value]
+      }
+    }
+
+    register(
+      name: "remote_prompt_dismiss",
+      summary: "Dismiss the active remote prompt through the same path as its close button"
+    ) { _ in
+      await MainActor.run {
+        let engine = RemotePromptEngine.shared
+        guard engine.current != nil else {
+          return ["dismissed": "false", "reason": "no active prompt"]
+        }
+        engine.dismissCurrent()
+        return ["dismissed": "true"]
+      }
+    }
+
+    register(
+      name: "remote_prompts_reset",
+      summary: "Forget local prompt resolutions and counters so triggers can be exercised again"
+    ) { _ in
+      await MainActor.run {
+        RemotePromptEngine.shared.resetForTesting()
+        return ["reset": "true"]
+      }
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -3569,6 +3569,7 @@ final class DesktopAutomationActionRegistry {
 
     registerNotificationActions()
     registerRatingPromptActions()
+    registerRemotePromptActions()
     register(
       name: "rewind_settings_snapshot",
       summary: "Return Rewind settings retention and excluded-app counts"

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1150,9 +1150,13 @@ struct DesktopHomeView: View {
         GoalCelebrationView()
       }
       .overlay(alignment: .bottom) {
-        // One-time rating ask, due after the user's 3rd question.
+        // One-time rating ask, due after the user's 3rd question. Remote
+        // (admin-authored) prompts render through the same slot; the built-in
+        // ask has right of way inside RemotePromptEngine.evaluate().
         RatingPromptBar()
+        RemotePromptBar()
       }
+      .task { RemotePromptEngine.shared.start() }
       .overlay {
         if !usesChatFirstShell && showTryAskingPopup {
           let suggestions = PostOnboardingPromptSuggestions.suggestions()

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1156,7 +1156,10 @@ struct DesktopHomeView: View {
         RatingPromptBar()
         RemotePromptBar()
       }
-      .task { RemotePromptEngine.shared.start() }
+      .task {
+        RemotePromptEngine.shared.start()
+        await RatingPromptManager.shared.seedFromHistoryIfNeeded()
+      }
       .overlay {
         if !usesChatFirstShell && showTryAskingPopup {
           let suggestions = PostOnboardingPromptSuggestions.suggestions()

--- a/desktop/macos/Desktop/Sources/RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/RatingPrompt.swift
@@ -113,10 +113,50 @@ final class RatingPromptManager: ObservableObject {
     refresh()
   }
 
+  /// Users who already asked 3+ questions before this build ship must see
+  /// the ask on their NEXT LAUNCH, not after three more questions: a one-shot
+  /// seed of the counter from server chat history. Fetch failure leaves the
+  /// marker unset so the next launch retries.
+  func seedFromHistoryIfNeeded() async {
+    guard !defaults.bool(forKey: DefaultsKey.ratingPromptHistorySeeded.rawValue) else { return }
+    guard submittedRating == 0, !isDismissed,
+      questionCount < RatingPromptPolicy.questionThreshold
+    else {
+      defaults.set(true, forKey: DefaultsKey.ratingPromptHistorySeeded.rawValue)
+      return
+    }
+    // Launch timing: auth/session may not be ready at first .task — retry a
+    // few times before deferring to the next launch (marker stays unset).
+    var history: [ChatMessageDB] = []
+    var fetched = false
+    for attempt in 1...5 {
+      if AuthState.shared.isSignedIn,
+        let result = try? await APIClient.shared.getMessages(limit: 100)
+      {
+        history = result
+        fetched = true
+        break
+      }
+      log("RatingPrompt: history seed attempt \(attempt) not ready, retrying")
+      try? await Task.sleep(nanoseconds: 15_000_000_000)
+    }
+    guard fetched else { return }
+    let asked = history.filter { $0.sender == "human" }.count
+    log("RatingPrompt: history seed fetched \(history.count) messages, \(asked) questions")
+    if asked >= RatingPromptPolicy.questionThreshold {
+      defaults.set(
+        RatingPromptPolicy.questionThreshold,
+        forKey: DefaultsKey.ratingPromptQuestionCount.rawValue)
+    }
+    defaults.set(true, forKey: DefaultsKey.ratingPromptHistorySeeded.rawValue)
+    refresh()
+  }
+
   /// Automation/testing hook: rewind the persisted state so the real trigger
   /// path can be exercised repeatedly on a dev bundle.
   func resetForTesting() {
     thankYouRating = nil
+    defaults.removeObject(forKey: DefaultsKey.ratingPromptHistorySeeded.rawValue)
     defaults.removeObject(forKey: DefaultsKey.ratingPromptQuestionCount.rawValue)
     defaults.removeObject(forKey: DefaultsKey.ratingPromptSubmittedRating.rawValue)
     defaults.removeObject(forKey: DefaultsKey.ratingPromptDismissed.rawValue)
@@ -133,7 +173,12 @@ final class RatingPromptManager: ObservableObject {
       submittedRating: submittedRating,
       dismissed: isDismissed,
       remotelyDisabled: isRemotelyDisabled)
-    RemotePromptEngine.shared.builtInAskChanged()
+    // Deferred: refresh() runs inside this singleton's own `static let`
+    // initialization, and RemotePromptEngine.builtInAskChanged() reads
+    // RatingPromptManager.shared back — a synchronous call would re-enter the
+    // still-initializing static let (startup deadlock). The async hop runs
+    // after init completes.
+    Task { @MainActor in RemotePromptEngine.shared.builtInAskChanged() }
     // While the prompt is on screen, poll for a remote disable so an active
     // kill switch takes effect within minutes, not at the next app launch.
     if isVisible, flagPollTask == nil {

--- a/desktop/macos/Desktop/Sources/RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/RatingPrompt.swift
@@ -99,11 +99,13 @@ final class RatingPromptManager: ObservableObject {
 
   func closeThankYou() {
     thankYouRating = nil
+    RemotePromptEngine.shared.builtInAskChanged()
   }
 
   func referFriend() {
     thankYouRating = nil
     NotificationCenter.default.post(name: .openReferralSheet, object: nil)
+    RemotePromptEngine.shared.builtInAskChanged()
   }
 
   func dismiss() {
@@ -131,6 +133,7 @@ final class RatingPromptManager: ObservableObject {
       submittedRating: submittedRating,
       dismissed: isDismissed,
       remotelyDisabled: isRemotelyDisabled)
+    RemotePromptEngine.shared.builtInAskChanged()
     // While the prompt is on screen, poll for a remote disable so an active
     // kill switch takes effect within minutes, not at the next app launch.
     if isVisible, flagPollTask == nil {

--- a/desktop/macos/Desktop/Sources/RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/RatingPrompt.swift
@@ -73,6 +73,10 @@ final class RatingPromptManager: ObservableObject {
   func recordQuestionAsked() {
     defaults.set(questionCount + 1, forKey: DefaultsKey.ratingPromptQuestionCount.rawValue)
     refresh()
+    // Remote prompts share the same accepted-question seam: only sends the
+    // chat provider accepted reach here, so both counters agree by
+    // construction.
+    RemotePromptEngine.shared.recordQuestionAsked()
   }
 
   /// Rating just submitted this session — drives the thank-you state. 4-5

--- a/desktop/macos/Desktop/Sources/RemotePrompts.swift
+++ b/desktop/macos/Desktop/Sources/RemotePrompts.swift
@@ -94,6 +94,21 @@ final class RemotePromptEngine: ObservableObject {
     evaluate()
   }
 
+  /// The built-in rating ask owns the bottom slot whenever it is visible.
+  /// A remote prompt that was already on screen is SUSPENDED (cleared without
+  /// a resolution) and re-offered by evaluate() once the ask resolves — the
+  /// same third question that arms the rating bar must never leave two bars
+  /// stacked in one overlay.
+  func builtInAskChanged() {
+    let askActive =
+      RatingPromptManager.shared.isVisible || RatingPromptManager.shared.thankYouRating != nil
+    if askActive {
+      current = nil
+    } else {
+      evaluate()
+    }
+  }
+
   func answer(value: String) {
     guard let spec = current else { return }
     markResolved(spec.id, outcome: "answered")

--- a/desktop/macos/Desktop/Sources/RemotePrompts.swift
+++ b/desktop/macos/Desktop/Sources/RemotePrompts.swift
@@ -42,13 +42,14 @@ final class RemotePromptEngine: ObservableObject {
   @Published private(set) var current: RemotePromptSpec?
 
   private(set) var specs: [RemotePromptSpec] = []
-  private var questionCount = 0
   private var pollTask: Task<Void, Never>?
   private let defaults = UserDefaults.standard
   static let pollInterval: TimeInterval = 300
 
   /// Seam for tests and the automation bridge; production uses APIClient.
   var fetch: () async throws -> [RemotePromptSpec]
+  /// Injectable for tests; production reads the real auth state.
+  var isSignedInCheck: () -> Bool = { AuthState.shared.isSignedIn }
 
   private init() {
     fetch = {
@@ -70,7 +71,7 @@ final class RemotePromptEngine: ObservableObject {
   }
 
   func refreshFromServer() async {
-    guard AuthState.shared.isSignedIn else { return }
+    guard isSignedInCheck() else { return }
     do {
       specs = try await fetch()
     } catch {
@@ -87,10 +88,16 @@ final class RemotePromptEngine: ObservableObject {
     evaluate()
   }
 
-  /// Fed from the same accepted-question seam as RatingPromptManager: only
-  /// sends the chat provider accepted advance this counter.
+  /// The accepted-question ledger IS the persisted rating-prompt counter —
+  /// one source of truth, so relaunches and the history seed carry over to
+  /// "after Nth question" remote prompts instead of restarting at zero.
+  private var questionCount: Int {
+    defaults.integer(forKey: DefaultsKey.ratingPromptQuestionCount.rawValue)
+  }
+
+  /// Notification from the accepted-question seam (the manager increments the
+  /// persisted counter before calling this).
   func recordQuestionAsked() {
-    questionCount += 1
     evaluate()
   }
 
@@ -144,7 +151,6 @@ final class RemotePromptEngine: ObservableObject {
     for spec in specs {
       defaults.removeObject(forKey: ScopedDefaultsKey.remotePromptResolution(promptId: spec.id))
     }
-    questionCount = 0
     current = nil
     evaluate()
   }

--- a/desktop/macos/Desktop/Sources/RemotePrompts.swift
+++ b/desktop/macos/Desktop/Sources/RemotePrompts.swift
@@ -1,0 +1,258 @@
+import AppKit
+import OmiTheme
+import SwiftUI
+
+// MARK: - Policy
+
+/// Which remote prompt (if any) is due. Pure so the trigger contract is
+/// unit-testable. One prompt at a time; unresolved prompts are ordered by id
+/// so the choice is deterministic across polls.
+enum RemotePromptPolicy {
+  static func duePrompt(
+    specs: [RemotePromptSpec],
+    resolvedIds: Set<String>,
+    questionCount: Int
+  ) -> RemotePromptSpec? {
+    specs
+      .filter { !resolvedIds.contains($0.id) }
+      .filter { spec in
+        switch spec.triggerKind {
+        case "question_count":
+          return questionCount >= max(spec.triggerCount, 1)
+        default:  // "app_launch" and forward-compatible unknown kinds
+          return spec.triggerKind == "app_launch"
+        }
+      }
+      .sorted { $0.id < $1.id }
+      .first
+  }
+}
+
+// MARK: - Engine
+
+/// Renders prompts authored on admin.omi.me without app releases: polls
+/// `GET /v2/desktop/prompts` (launch + every 5 minutes — deactivating a
+/// prompt on admin hides it within one poll), evaluates triggers against the
+/// same accepted-question ledger the built-in rating prompt uses, and reports
+/// answers to PostHog (`Desktop Prompt Answered` / `Dismissed`).
+@MainActor
+final class RemotePromptEngine: ObservableObject {
+  static let shared = RemotePromptEngine()
+
+  @Published private(set) var current: RemotePromptSpec?
+
+  private(set) var specs: [RemotePromptSpec] = []
+  private var questionCount = 0
+  private var pollTask: Task<Void, Never>?
+  private let defaults = UserDefaults.standard
+  static let pollInterval: TimeInterval = 300
+
+  /// Seam for tests and the automation bridge; production uses APIClient.
+  var fetch: () async throws -> [RemotePromptSpec]
+
+  private init() {
+    fetch = {
+      try await APIClient.shared.getDesktopPrompts(
+        channel: AppBuild.currentUpdateChannel,
+        build: Int(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "") ?? 0
+      ).prompts
+    }
+  }
+
+  func start() {
+    guard pollTask == nil else { return }
+    pollTask = Task { @MainActor [weak self] in
+      while !Task.isCancelled {
+        await self?.refreshFromServer()
+        try? await Task.sleep(nanoseconds: UInt64(Self.pollInterval * 1_000_000_000))
+      }
+    }
+  }
+
+  func refreshFromServer() async {
+    guard AuthState.shared.isSignedIn else { return }
+    do {
+      specs = try await fetch()
+    } catch {
+      // Fail closed to "no new prompts"; an already-visible prompt stays so a
+      // transient network error does not flicker the bar away mid-answer.
+      log("RemotePromptEngine: fetch failed: \(error.localizedDescription)")
+      return
+    }
+    // A prompt deactivated on admin disappears from the payload — drop it
+    // even if currently showing (this is the no-release kill path).
+    if let showing = current, !specs.contains(where: { $0.id == showing.id }) {
+      current = nil
+    }
+    evaluate()
+  }
+
+  /// Fed from the same accepted-question seam as RatingPromptManager: only
+  /// sends the chat provider accepted advance this counter.
+  func recordQuestionAsked() {
+    questionCount += 1
+    evaluate()
+  }
+
+  func answer(value: String) {
+    guard let spec = current else { return }
+    markResolved(spec.id, outcome: "answered")
+    AnalyticsManager.shared.desktopPromptAnswered(
+      promptId: spec.id, promptType: spec.type, value: value)
+    current = nil
+    evaluate()
+  }
+
+  func openCTA() {
+    guard let spec = current else { return }
+    if let raw = spec.ctaURL, let url = URL(string: raw) {
+      NSWorkspace.shared.open(url)
+    }
+    markResolved(spec.id, outcome: "answered")
+    AnalyticsManager.shared.desktopPromptAnswered(
+      promptId: spec.id, promptType: spec.type, value: "cta_clicked")
+    current = nil
+    evaluate()
+  }
+
+  func dismissCurrent() {
+    guard let spec = current else { return }
+    markResolved(spec.id, outcome: "dismissed")
+    AnalyticsManager.shared.desktopPromptDismissed(promptId: spec.id, promptType: spec.type)
+    current = nil
+    evaluate()
+  }
+
+  /// Automation/testing hook: forget local resolutions and counters so the
+  /// real trigger path can be exercised repeatedly on a dev bundle.
+  func resetForTesting() {
+    for spec in specs {
+      defaults.removeObject(forKey: ScopedDefaultsKey.remotePromptResolution(promptId: spec.id))
+    }
+    questionCount = 0
+    current = nil
+    evaluate()
+  }
+
+  private func evaluate() {
+    // The built-in rating ask keeps right of way; remote prompts wait.
+    guard RatingPromptManager.shared.isVisible == false,
+      RatingPromptManager.shared.thankYouRating == nil
+    else { return }
+    guard current == nil else { return }
+    let resolved = Set(
+      specs.map(\.id).filter {
+        defaults.object(forKey: ScopedDefaultsKey.remotePromptResolution(promptId: $0)) != nil
+      })
+    if let due = RemotePromptPolicy.duePrompt(
+      specs: specs, resolvedIds: resolved, questionCount: questionCount)
+    {
+      current = due
+      AnalyticsManager.shared.desktopPromptShown(promptId: due.id, promptType: due.type)
+    }
+  }
+
+  private func markResolved(_ id: String, outcome: String) {
+    defaults.set(outcome, forKey: ScopedDefaultsKey.remotePromptResolution(promptId: id))
+  }
+}
+
+// MARK: - View
+
+/// Closable sticky bar above the composer rendering the active remote prompt.
+struct RemotePromptBar: View {
+  @ObservedObject private var engine = RemotePromptEngine.shared
+  @State private var hoveredStar = 0
+
+  var body: some View {
+    if let spec = engine.current {
+      HStack(spacing: OmiSpacing.lg) {
+        Text(spec.question)
+          .font(.system(size: 13, weight: .medium))
+          .foregroundColor(.primary)
+
+        switch spec.type {
+        case "stars":
+          starsRow
+        case "nps":
+          npsRow
+        case "choice":
+          choiceRow(spec.options)
+        default:  // banner
+          if let label = spec.ctaLabel {
+            Button(label) { engine.openCTA() }
+              .buttonStyle(.borderedProminent)
+              .controlSize(.small)
+              .tint(.primary)
+          }
+        }
+
+        Button {
+          engine.dismissCurrent()
+        } label: {
+          Image(systemName: "xmark")
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundColor(.secondary)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Dismiss prompt")
+      }
+      .padding(.horizontal, OmiSpacing.xl)
+      .padding(.vertical, OmiSpacing.md)
+      .background(
+        RoundedRectangle(cornerRadius: 10)
+          .fill(.regularMaterial)
+          .overlay(
+            RoundedRectangle(cornerRadius: 10)
+              .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+          )
+      )
+      // Clears the chat composer row pinned to the window's bottom edge.
+      .padding(.bottom, 76)
+      .transition(.move(edge: .bottom).combined(with: .opacity))
+    }
+  }
+
+  private var starsRow: some View {
+    HStack(spacing: OmiSpacing.xs) {
+      ForEach(1...5, id: \.self) { star in
+        Button {
+          engine.answer(value: "\(star)")
+        } label: {
+          Image(systemName: star <= hoveredStar ? "star.fill" : "star")
+            .font(.system(size: 15))
+            .foregroundColor(star <= hoveredStar ? .yellow : .secondary)
+        }
+        .buttonStyle(.plain)
+        .onHover { inside in
+          if inside {
+            hoveredStar = star
+          } else if hoveredStar == star {
+            hoveredStar = star - 1
+          }
+        }
+        .accessibilityLabel("Answer \(star)")
+      }
+    }
+  }
+
+  private var npsRow: some View {
+    HStack(spacing: 2) {
+      ForEach(0...10, id: \.self) { n in
+        Button("\(n)") { engine.answer(value: "\(n)") }
+          .buttonStyle(.bordered)
+          .controlSize(.mini)
+      }
+    }
+  }
+
+  private func choiceRow(_ options: [String]) -> some View {
+    HStack(spacing: OmiSpacing.sm) {
+      ForEach(options, id: \.self) { option in
+        Button(option) { engine.answer(value: option) }
+          .buttonStyle(.bordered)
+          .controlSize(.small)
+      }
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+DesktopPrompts.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+DesktopPrompts.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Remote in-app prompt authored on admin.omi.me (`desktop_prompts` in
+/// Firestore) and served by `GET /v2/desktop/prompts`. Adding one needs no
+/// app release — clients poll and render natively.
+struct RemotePromptSpec: Decodable, Equatable, Identifiable {
+  let id: String
+  let type: String
+  let question: String
+  let options: [String]
+  let ctaLabel: String?
+  let ctaURL: String?
+  let triggerKind: String
+  let triggerCount: Int
+
+  enum CodingKeys: String, CodingKey {
+    case id, type, question, options
+    case ctaLabel = "cta_label"
+    case ctaURL = "cta_url"
+    case triggerKind = "trigger_kind"
+    case triggerCount = "trigger_count"
+  }
+}
+
+struct RemotePromptsResponse: Decodable, Equatable {
+  let prompts: [RemotePromptSpec]
+}
+
+extension APIClient {
+  func getDesktopPrompts(channel: String, build: Int) async throws -> RemotePromptsResponse {
+    try await get(
+      "v2/desktop/prompts?channel=\(channel)&build=\(build)",
+      customBaseURL: DesktopBackendEnvironment.authBaseURL()
+    )
+  }
+}

--- a/desktop/macos/Desktop/Tests/RemotePromptLedgerTests.swift
+++ b/desktop/macos/Desktop/Tests/RemotePromptLedgerTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Remote "after Nth question" prompts must read the PERSISTED accepted-
+/// question ledger (the same key the rating prompt and history seed write) —
+/// an engine-local counter would reset every launch and demand N fresh
+/// questions per session.
+@MainActor
+final class RemotePromptLedgerTests: XCTestCase {
+  private let spec = RemotePromptSpec(
+    id: "q3-survey", type: "stars", question: "Useful?", options: [],
+    ctaLabel: nil, ctaURL: nil, triggerKind: "question_count", triggerCount: 3)
+
+  override func setUp() async throws {
+    RatingPromptManager.shared.remoteDisableCheck = { false }
+    RatingPromptManager.shared.resetForTesting()
+    // The built-in ask must not own the slot in this test.
+    UserDefaults.standard.set(true, forKey: DefaultsKey.ratingPromptDismissed.rawValue)
+    RemotePromptEngine.shared.isSignedInCheck = { true }
+    RemotePromptEngine.shared.fetch = { [self.spec] }
+    RemotePromptEngine.shared.resetForTesting()
+    await RemotePromptEngine.shared.refreshFromServer()
+  }
+
+  override func tearDown() async throws {
+    RemotePromptEngine.shared.isSignedInCheck = { AuthState.shared.isSignedIn }
+    RemotePromptEngine.shared.fetch = { [] }
+    RemotePromptEngine.shared.isSignedInCheck = { true }
+    await RemotePromptEngine.shared.refreshFromServer()
+    RemotePromptEngine.shared.resetForTesting()
+    RatingPromptManager.shared.resetForTesting()
+    RatingPromptManager.shared.remoteDisableCheck = {
+      PostHogManager.shared.isFeatureEnabled(RatingPromptPolicy.killSwitchFlag)
+    }
+  }
+
+  func testPersistedLedgerArmsPromptWithoutNewSessionQuestions() async {
+    XCTAssertNil(RemotePromptEngine.shared.current)
+    // Questions persisted by a PREVIOUS session (or the history seed) — write
+    // the ledger key directly, then simulate the relaunch-time fetch.
+    UserDefaults.standard.set(3, forKey: DefaultsKey.ratingPromptQuestionCount.rawValue)
+    await RemotePromptEngine.shared.refreshFromServer()
+    XCTAssertEqual(RemotePromptEngine.shared.current?.id, "q3-survey")
+  }
+
+  func testLedgerBelowThresholdStaysHidden() async {
+    UserDefaults.standard.set(2, forKey: DefaultsKey.ratingPromptQuestionCount.rawValue)
+    await RemotePromptEngine.shared.refreshFromServer()
+    XCTAssertNil(RemotePromptEngine.shared.current)
+  }
+}

--- a/desktop/macos/Desktop/Tests/RemotePromptPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/RemotePromptPolicyTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class RemotePromptPolicyTests: XCTestCase {
+  private func spec(
+    _ id: String, kind: String = "app_launch", count: Int = 0, type: String = "banner"
+  ) -> RemotePromptSpec {
+    RemotePromptSpec(
+      id: id, type: type, question: "Q?", options: [], ctaLabel: nil, ctaURL: nil,
+      triggerKind: kind, triggerCount: count)
+  }
+
+  func testAppLaunchPromptIsDueImmediatelyAndOnlyOnce() {
+    let s = spec("a")
+    XCTAssertEqual(RemotePromptPolicy.duePrompt(specs: [s], resolvedIds: [], questionCount: 0)?.id, "a")
+    XCTAssertNil(RemotePromptPolicy.duePrompt(specs: [s], resolvedIds: ["a"], questionCount: 0))
+  }
+
+  func testQuestionCountPromptWaitsForItsThreshold() {
+    let s = spec("q", kind: "question_count", count: 3)
+    XCTAssertNil(RemotePromptPolicy.duePrompt(specs: [s], resolvedIds: [], questionCount: 2))
+    XCTAssertEqual(RemotePromptPolicy.duePrompt(specs: [s], resolvedIds: [], questionCount: 3)?.id, "q")
+  }
+
+  func testZeroCountQuestionTriggerStillRequiresOneQuestion() {
+    let s = spec("q", kind: "question_count", count: 0)
+    XCTAssertNil(RemotePromptPolicy.duePrompt(specs: [s], resolvedIds: [], questionCount: 0))
+    XCTAssertNotNil(RemotePromptPolicy.duePrompt(specs: [s], resolvedIds: [], questionCount: 1))
+  }
+
+  func testUnknownTriggerKindsAreIgnoredNotShownAtLaunch() {
+    let s = spec("x", kind: "on_full_moon")
+    XCTAssertNil(RemotePromptPolicy.duePrompt(specs: [s], resolvedIds: [], questionCount: 99))
+  }
+
+  func testOnePromptAtATimeDeterministicById() {
+    let due = RemotePromptPolicy.duePrompt(
+      specs: [spec("b"), spec("a")], resolvedIds: [], questionCount: 0)
+    XCTAssertEqual(due?.id, "a")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260827-remote-prompts.json
+++ b/desktop/macos/changelog/unreleased/20260827-remote-prompts.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Omi can now ask short in-app questions (stars, NPS, quick choices) configured by the team - no update needed, one prompt at a time, never twice."
+  ]
+}

--- a/desktop/macos/e2e/flows/remote-prompts.yaml
+++ b/desktop/macos/e2e/flows/remote-prompts.yaml
@@ -1,0 +1,47 @@
+version: 2
+name: remote-prompts
+tier: 2
+description: Remote prompt engine — bridge surface for admin-authored prompts (fetch, state, reset)
+app: non-prod
+covers:
+  - desktop/macos/Desktop/Sources/RemotePrompts.swift
+  - desktop/macos/Desktop/Sources/DesktopAutomationBridge+RemotePrompts.swift
+  - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+DesktopPrompts.swift
+preconditions:
+  - automation_bridge_ready
+
+steps:
+  - id: S1
+    name: Reset persisted prompt resolutions
+    bridge.action:
+      name: remote_prompts_reset
+    expect:
+      ok: true
+      result.detail.reset: "true"
+
+  - id: S2
+    name: Engine state is reachable and empty by default
+    bridge.action:
+      name: remote_prompts_state
+    expect:
+      ok: true
+      result.detail.schema: "current_id,current_type,spec_count,spec_ids"
+      result.detail.current_id: ""
+
+  - id: S3
+    name: A live fetch succeeds against the configured backend
+    bridge.action:
+      name: remote_prompts_refresh
+    expect:
+      ok: true
+      result.detail.refreshed: "true"
+
+  - id: S4
+    name: Answering with no active prompt is refused
+    bridge.action:
+      name: remote_prompt_answer
+      params:
+        value: "5"
+    expect:
+      ok: true
+      result.detail.answered: "false"

--- a/web/admin/app/(protected)/dashboard/prompts/page.tsx
+++ b/web/admin/app/(protected)/dashboard/prompts/page.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { useAuthFetch } from "@/hooks/useAuthToken";
+
+// Remote in-app prompts for Omi Desktop. Create/toggle here; every client
+// picks the change up within ~5 minutes — no app release. Responses arrive
+// as PostHog events and are tallied per prompt below.
+
+type Prompt = {
+  id: string;
+  type: string;
+  question: string;
+  active: boolean;
+  options?: string[];
+  cta?: { label: string; url: string } | null;
+  trigger?: { kind: string; count: number };
+  audience?: { rollout_pct?: number; channels?: string[] };
+};
+
+type PromptResults = Record<
+  string,
+  {
+    shown: number;
+    answered: number;
+    dismissed: number;
+    answers: Record<string, number>;
+  }
+>;
+
+const TYPE_LABELS: Record<string, string> = {
+  stars: "Stars 1-5",
+  nps: "NPS 0-10",
+  choice: "Multiple choice",
+  banner: "Banner + button",
+};
+
+function summarizeAnswers(
+  type: string,
+  answers: Record<string, number>,
+): string {
+  const entries = Object.entries(answers);
+  if (entries.length === 0) return "—";
+  if (type === "stars" || type === "nps") {
+    let total = 0;
+    let count = 0;
+    for (const [value, n] of entries) {
+      const v = parseFloat(value);
+      if (!Number.isNaN(v)) {
+        total += v * n;
+        count += n;
+      }
+    }
+    return count > 0 ? `avg ${(total / count).toFixed(2)} (${count})` : "—";
+  }
+  return entries
+    .sort((a, b) => b[1] - a[1])
+    .map(([value, n]) => `${value}: ${n}`)
+    .join(" · ");
+}
+
+export default function PromptsPage() {
+  const { fetchWithAuth, token } = useAuthFetch();
+  const [prompts, setPrompts] = useState<Prompt[]>([]);
+  const [results, setResults] = useState<PromptResults>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const [form, setForm] = useState({
+    type: "stars",
+    question: "",
+    options: "",
+    ctaLabel: "",
+    ctaUrl: "",
+    triggerKind: "question_count",
+    triggerCount: 3,
+    rolloutPct: 100,
+  });
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      const [promptsRes, resultsRes] = await Promise.all([
+        fetchWithAuth("/api/omi/desktop-prompts"),
+        fetchWithAuth("/api/omi/desktop-prompts/results"),
+      ]);
+      if (!promptsRes.ok) throw new Error(`load failed (${promptsRes.status})`);
+      setPrompts((await promptsRes.json()).prompts ?? []);
+      if (resultsRes.ok) setResults((await resultsRes.json()).results ?? {});
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "load failed");
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchWithAuth]);
+
+  useEffect(() => {
+    if (token) void load();
+  }, [token, load]);
+
+  async function create() {
+    setSaving(true);
+    try {
+      const response = await fetchWithAuth("/api/omi/desktop-prompts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: form.type,
+          question: form.question,
+          options: form.options
+            .split("\n")
+            .map((o) => o.trim())
+            .filter(Boolean),
+          cta_label: form.ctaLabel || undefined,
+          cta_url: form.ctaUrl || undefined,
+          trigger_kind: form.triggerKind,
+          trigger_count: form.triggerCount,
+          rollout_pct: form.rolloutPct,
+          active: false,
+        }),
+      });
+      const body = await response.json();
+      if (!response.ok)
+        throw new Error(body.error ?? `create failed (${response.status})`);
+      setForm({ ...form, question: "", options: "", ctaLabel: "", ctaUrl: "" });
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "create failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function setActive(prompt: Prompt, active: boolean) {
+    setPrompts((current) =>
+      current.map((p) => (p.id === prompt.id ? { ...p, active } : p)),
+    );
+    await fetchWithAuth(`/api/omi/desktop-prompts/${prompt.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ active }),
+    });
+  }
+
+  async function remove(prompt: Prompt) {
+    if (!window.confirm(`Delete prompt "${prompt.question}"?`)) return;
+    await fetchWithAuth(`/api/omi/desktop-prompts/${prompt.id}`, {
+      method: "DELETE",
+    });
+    await load();
+  }
+
+  return (
+    <div className="space-y-6 max-w-4xl">
+      <div>
+        <h1 className="text-2xl font-semibold">Desktop prompts</h1>
+        <p className="text-sm text-muted-foreground">
+          In-app surveys and banners for Omi Desktop. Toggling here reaches
+          every client within ~5 minutes — no release. One prompt shows at a
+          time, once per user.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">New prompt</CardTitle>
+          <CardDescription>
+            Created inactive — flip the switch when ready.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex gap-3">
+            <Select
+              value={form.type}
+              onValueChange={(type) => setForm({ ...form, type })}
+            >
+              <SelectTrigger className="w-44">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(TYPE_LABELS).map(([value, label]) => (
+                  <SelectItem key={value} value={value}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Input
+              placeholder="Question — e.g. How useful was today's summary?"
+              value={form.question}
+              onChange={(e) => setForm({ ...form, question: e.target.value })}
+            />
+          </div>
+          {form.type === "choice" && (
+            <textarea
+              className="w-full rounded-md border bg-transparent p-2 text-sm"
+              rows={3}
+              placeholder={"One option per line (2-6)"}
+              value={form.options}
+              onChange={(e) => setForm({ ...form, options: e.target.value })}
+            />
+          )}
+          {form.type === "banner" && (
+            <div className="flex gap-3">
+              <Input
+                placeholder="Button label"
+                value={form.ctaLabel}
+                onChange={(e) => setForm({ ...form, ctaLabel: e.target.value })}
+              />
+              <Input
+                placeholder="Button URL"
+                value={form.ctaUrl}
+                onChange={(e) => setForm({ ...form, ctaUrl: e.target.value })}
+              />
+            </div>
+          )}
+          <div className="flex items-center gap-3 text-sm">
+            <Select
+              value={form.triggerKind}
+              onValueChange={(triggerKind) => setForm({ ...form, triggerKind })}
+            >
+              <SelectTrigger className="w-52">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="question_count">
+                  After Nth question
+                </SelectItem>
+                <SelectItem value="app_launch">On app launch</SelectItem>
+              </SelectContent>
+            </Select>
+            {form.triggerKind === "question_count" && (
+              <Input
+                type="number"
+                className="w-20"
+                min={1}
+                value={form.triggerCount}
+                onChange={(e) =>
+                  setForm({
+                    ...form,
+                    triggerCount: parseInt(e.target.value) || 1,
+                  })
+                }
+              />
+            )}
+            <span className="text-muted-foreground">Rollout %</span>
+            <Input
+              type="number"
+              className="w-20"
+              min={1}
+              max={100}
+              value={form.rolloutPct}
+              onChange={(e) =>
+                setForm({
+                  ...form,
+                  rolloutPct: parseInt(e.target.value) || 100,
+                })
+              }
+            />
+            <Button onClick={create} disabled={saving || !form.question.trim()}>
+              Create
+            </Button>
+          </div>
+          {error && <p className="text-sm text-red-500">{error}</p>}
+        </CardContent>
+      </Card>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : (
+        prompts.map((prompt) => {
+          const tally = results[prompt.id];
+          return (
+            <Card key={prompt.id}>
+              <CardContent className="flex items-center justify-between gap-4 py-4">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium truncate">
+                      {prompt.question}
+                    </span>
+                    <Badge variant="outline">
+                      {TYPE_LABELS[prompt.type] ?? prompt.type}
+                    </Badge>
+                    {prompt.trigger?.kind === "question_count" && (
+                      <Badge variant="secondary">
+                        after Q{prompt.trigger.count}
+                      </Badge>
+                    )}
+                    {(prompt.audience?.rollout_pct ?? 100) < 100 && (
+                      <Badge variant="secondary">
+                        {prompt.audience?.rollout_pct}%
+                      </Badge>
+                    )}
+                  </div>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    {tally
+                      ? `${tally.shown} shown · ${tally.answered} answered · ${tally.dismissed} dismissed · ${summarizeAnswers(prompt.type, tally.answers)}`
+                      : "no responses yet"}
+                  </p>
+                </div>
+                <div className="flex items-center gap-3 shrink-0">
+                  <Switch
+                    checked={prompt.active}
+                    onCheckedChange={(active) => void setActive(prompt, active)}
+                  />
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => void remove(prompt)}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/web/admin/app/api/omi/desktop-prompts/[id]/route.ts
+++ b/web/admin/app/api/omi/desktop-prompts/[id]/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyAdmin } from "@/lib/auth";
+import { getDb } from "@/lib/firebase/admin";
+export const dynamic = "force-dynamic";
+
+// PATCH toggles/edits one remote desktop prompt; DELETE removes it. A
+// deactivated or deleted prompt disappears from every client within one
+// poll (~5 minutes) — this is the no-release kill path.
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const { id } = await params;
+  const body = await request.json();
+  const updates: Record<string, unknown> = { updated_at: Date.now() / 1000 };
+  if (typeof body?.active === "boolean") updates.active = body.active;
+  if (typeof body?.question === "string" && body.question.trim()) {
+    updates.question = body.question.trim();
+  }
+  if (body?.rollout_pct !== undefined) {
+    updates["audience.rollout_pct"] = Math.min(
+      Math.max(Number(body.rollout_pct), 0),
+      100,
+    );
+  }
+  await getDb().collection("desktop_prompts").doc(id).update(updates);
+  return NextResponse.json({ id, updated: true });
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const { id } = await params;
+  await getDb().collection("desktop_prompts").doc(id).delete();
+  return NextResponse.json({ id, deleted: true });
+}

--- a/web/admin/app/api/omi/desktop-prompts/results/route.ts
+++ b/web/admin/app/api/omi/desktop-prompts/results/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyAdmin } from "@/lib/auth";
+import { posthogResults } from "@/lib/posthog";
+export const dynamic = "force-dynamic";
+
+// Per-prompt response tallies from the client events the engine emits
+// (Desktop Prompt Shown / Answered / Dismissed), grouped by answer value so
+// stars/NPS averages and per-option counts render on the Prompts page.
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  const projectId = process.env.POSTHOG_PROJECT_ID;
+  const host = (process.env.POSTHOG_HOST || "https://us.posthog.com").replace(
+    /\/$/,
+    "",
+  );
+  if (!apiKey || !projectId) {
+    return NextResponse.json({ available: false, results: [] });
+  }
+
+  const days = parseInt(request.nextUrl.searchParams.get("days") || "90", 10);
+  try {
+    const rows = (await posthogResults(
+      host,
+      projectId,
+      apiKey,
+      `
+        SELECT
+          toString(properties.prompt_id) AS prompt_id,
+          event,
+          toString(properties.value) AS value,
+          count() AS n
+        FROM events
+        WHERE event IN ('Desktop Prompt Shown', 'Desktop Prompt Answered', 'Desktop Prompt Dismissed')
+          AND timestamp >= now() - INTERVAL ${days} DAY
+        GROUP BY prompt_id, event, value
+        ORDER BY prompt_id
+      `,
+    )) as any[];
+    const byPrompt: Record<
+      string,
+      {
+        shown: number;
+        answered: number;
+        dismissed: number;
+        answers: Record<string, number>;
+      }
+    > = {};
+    for (const [promptId, event, value, n] of rows ?? []) {
+      const entry = (byPrompt[promptId] ??= {
+        shown: 0,
+        answered: 0,
+        dismissed: 0,
+        answers: {},
+      });
+      const count = Number(n) || 0;
+      if (event === "Desktop Prompt Shown") entry.shown += count;
+      else if (event === "Desktop Prompt Dismissed") entry.dismissed += count;
+      else {
+        entry.answered += count;
+        if (value) entry.answers[value] = (entry.answers[value] ?? 0) + count;
+      }
+    }
+    return NextResponse.json({ available: true, results: byPrompt });
+  } catch (error) {
+    console.error("Prompt results error:", error);
+    return NextResponse.json({ available: false, results: {} });
+  }
+}

--- a/web/admin/app/api/omi/desktop-prompts/route.ts
+++ b/web/admin/app/api/omi/desktop-prompts/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyAdmin } from "@/lib/auth";
+import { getDb } from "@/lib/firebase/admin";
+export const dynamic = "force-dynamic";
+
+// Admin CRUD for remote desktop prompts (`desktop_prompts` in Firestore).
+// The prod backend serves active documents to every desktop client via
+// GET /v2/desktop/prompts — creating or toggling one here reaches users
+// within one client poll (~5 minutes), no app release.
+const ALLOWED_TYPES = new Set(["stars", "nps", "choice", "banner"]);
+const TRIGGER_KINDS = new Set(["app_launch", "question_count"]);
+
+export function normalizePrompt(body: any): { error?: string; doc?: any } {
+  const type = String(body?.type ?? "");
+  const question = String(body?.question ?? "").trim();
+  if (!ALLOWED_TYPES.has(type))
+    return {
+      error: `type must be one of ${Array.from(ALLOWED_TYPES).join(", ")}`,
+    };
+  if (!question) return { error: "question is required" };
+  const triggerKind = String(body?.trigger_kind ?? "app_launch");
+  if (!TRIGGER_KINDS.has(triggerKind)) {
+    return {
+      error: `trigger_kind must be one of ${Array.from(TRIGGER_KINDS).join(", ")}`,
+    };
+  }
+  const rolloutPct = Math.min(
+    Math.max(Number(body?.rollout_pct ?? 100), 0),
+    100,
+  );
+  const doc: any = {
+    type,
+    question,
+    active: Boolean(body?.active ?? false),
+    options:
+      type === "choice"
+        ? (Array.isArray(body?.options) ? body.options : [])
+            .map((o: any) => String(o).trim())
+            .filter(Boolean)
+            .slice(0, 6)
+        : [],
+    cta:
+      type === "banner" && body?.cta_label && body?.cta_url
+        ? { label: String(body.cta_label), url: String(body.cta_url) }
+        : null,
+    trigger: {
+      kind: triggerKind,
+      count: Math.max(Number(body?.trigger_count ?? 0), 0),
+    },
+    audience: {
+      rollout_pct: rolloutPct,
+      channels: (Array.isArray(body?.channels) ? body.channels : [])
+        .map((c: any) => String(c))
+        .filter((c: string) => ["stable", "beta"].includes(c)),
+    },
+    updated_at: Date.now() / 1000,
+  };
+  if (type === "choice" && doc.options.length < 2) {
+    return { error: "choice prompts need at least 2 options" };
+  }
+  return { doc };
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const snapshot = await getDb()
+    .collection("desktop_prompts")
+    .orderBy("created_at", "desc")
+    .limit(100)
+    .get();
+  return NextResponse.json({
+    prompts: snapshot.docs.map((d) => ({ id: d.id, ...d.data() })),
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const { error, doc } = normalizePrompt(await request.json());
+  if (error) return NextResponse.json({ error }, { status: 400 });
+  doc.created_at = Date.now() / 1000;
+  const ref = await getDb().collection("desktop_prompts").add(doc);
+  return NextResponse.json({ id: ref.id, ...doc }, { status: 201 });
+}

--- a/web/admin/components/dashboard/sidebar.tsx
+++ b/web/admin/components/dashboard/sidebar.tsx
@@ -22,6 +22,7 @@ import {
   FlaskConical,
   Rocket,
   Handshake,
+  MessageSquarePlus,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -34,9 +35,9 @@ export function DashboardSidebar() {
 
   // Load collapsed state from localStorage on mount
   useEffect(() => {
-    const savedState = localStorage.getItem('sidebarCollapsed');
+    const savedState = localStorage.getItem("sidebarCollapsed");
     if (savedState !== null) {
-      setIsCollapsed(savedState === 'true');
+      setIsCollapsed(savedState === "true");
     }
   }, []);
 
@@ -44,9 +45,9 @@ export function DashboardSidebar() {
   const toggleCollapse = () => {
     const newState = !isCollapsed;
     setIsCollapsed(newState);
-    localStorage.setItem('sidebarCollapsed', String(newState));
+    localStorage.setItem("sidebarCollapsed", String(newState));
   };
-  
+
   const navItems = [
     {
       title: "Dashboard",
@@ -104,6 +105,11 @@ export function DashboardSidebar() {
       icon: Bell,
     },
     {
+      title: "Prompts",
+      href: "/dashboard/prompts",
+      icon: MessageSquarePlus,
+    },
+    {
       title: "Releases",
       href: "/dashboard/releases",
       icon: Rocket,
@@ -130,26 +136,32 @@ export function DashboardSidebar() {
   };
 
   return (
-    <aside className={cn(
-      "border-r bg-card h-screen flex-shrink-0 sticky top-0 flex flex-col z-20 transition-all duration-300",
-      isCollapsed ? "w-16" : "w-64"
-    )}>
-      <div className={cn(
-        "border-b h-14 flex items-center transition-all duration-300 relative",
-        isCollapsed ? "px-2 justify-center" : "px-4 justify-between"
-      )}>
-        <Link 
-          href="/dashboard" 
+    <aside
+      className={cn(
+        "border-r bg-card h-screen flex-shrink-0 sticky top-0 flex flex-col z-20 transition-all duration-300",
+        isCollapsed ? "w-16" : "w-64",
+      )}
+    >
+      <div
+        className={cn(
+          "border-b h-14 flex items-center transition-all duration-300 relative",
+          isCollapsed ? "px-2 justify-center" : "px-4 justify-between",
+        )}
+      >
+        <Link
+          href="/dashboard"
           className={cn(
             "flex items-center space-x-2 font-semibold transition-all duration-200",
-            isCollapsed ? "justify-center" : "justify-start"
+            isCollapsed ? "justify-center" : "justify-start",
           )}
         >
           <Package2 className="h-6 w-6 flex-shrink-0" />
-          <span className={cn(
-            "transition-opacity duration-200 whitespace-nowrap",
-            isCollapsed ? "opacity-0 w-0 overflow-hidden" : "opacity-100"
-          )}>
+          <span
+            className={cn(
+              "transition-opacity duration-200 whitespace-nowrap",
+              isCollapsed ? "opacity-0 w-0 overflow-hidden" : "opacity-100",
+            )}
+          >
             OMI Admin
           </span>
         </Link>
@@ -158,7 +170,8 @@ export function DashboardSidebar() {
           size="icon"
           className={cn(
             "h-8 w-8 flex-shrink-0",
-            isCollapsed && "absolute top-1/2 -right-3 translate-y-[-50%] bg-background border border-border rounded-full shadow-sm z-10"
+            isCollapsed &&
+              "absolute top-1/2 -right-3 translate-y-[-50%] bg-background border border-border rounded-full shadow-sm z-10",
           )}
           onClick={toggleCollapse}
           aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
@@ -181,35 +194,43 @@ export function DashboardSidebar() {
                 isCollapsed ? "justify-center" : "justify-start",
                 pathname === item.href
                   ? "bg-primary/10 text-primary"
-                  : "text-foreground hover:bg-accent hover:text-accent-foreground"
+                  : "text-foreground hover:bg-accent hover:text-accent-foreground",
               )}
               title={isCollapsed ? item.title : undefined}
             >
               <item.icon className="h-5 w-5 flex-shrink-0" />
-              <span className={cn(
-                "transition-opacity duration-200",
-                isCollapsed ? "opacity-0 w-0 overflow-hidden ml-0" : "opacity-100 ml-3"
-              )}>
+              <span
+                className={cn(
+                  "transition-opacity duration-200",
+                  isCollapsed
+                    ? "opacity-0 w-0 overflow-hidden ml-0"
+                    : "opacity-100 ml-3",
+                )}
+              >
                 {item.title}
               </span>
             </Link>
           ))}
         </nav>
         <div className="px-2 space-y-1">
-          <Button 
-            variant="ghost" 
+          <Button
+            variant="ghost"
             className={cn(
               "w-full text-muted-foreground transition-colors",
-              isCollapsed ? "justify-center" : "justify-start"
+              isCollapsed ? "justify-center" : "justify-start",
             )}
             onClick={handleLogout}
             title={isCollapsed ? "Log out" : undefined}
           >
             <LogOut className="h-5 w-5 flex-shrink-0" />
-            <span className={cn(
-              "transition-opacity duration-200",
-              isCollapsed ? "opacity-0 w-0 overflow-hidden ml-0" : "opacity-100 ml-3"
-            )}>
+            <span
+              className={cn(
+                "transition-opacity duration-200",
+                isCollapsed
+                  ? "opacity-0 w-0 overflow-hidden ml-0"
+                  : "opacity-100 ml-3",
+              )}
+            >
               Log out
             </span>
           </Button>

--- a/web/admin/lib/__tests__/desktop-prompts-admin.test.ts
+++ b/web/admin/lib/__tests__/desktop-prompts-admin.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  verifyAdmin: vi.fn(async () => ({ uid: "t" })),
+}));
+vi.mock("@/lib/firebase/admin", () => ({ getDb: () => ({}) }));
+
+import { normalizePrompt } from "@/app/api/omi/desktop-prompts/route";
+
+describe("normalizePrompt", () => {
+  it("builds the document the desktop delivery route expects", () => {
+    const { doc, error } = normalizePrompt({
+      type: "stars",
+      question: " How useful was today's summary? ",
+      trigger_kind: "question_count",
+      trigger_count: 3,
+      rollout_pct: 250,
+      channels: ["beta", "nightly"],
+    });
+    expect(error).toBeUndefined();
+    expect(doc.question).toBe("How useful was today's summary?");
+    expect(doc.trigger).toEqual({ kind: "question_count", count: 3 });
+    expect(doc.audience.rollout_pct).toBe(100); // clamped
+    expect(doc.audience.channels).toEqual(["beta"]); // unknown channel dropped
+    expect(doc.active).toBe(false); // prompts are born inactive
+  });
+
+  it("rejects unknown types, empty questions, and 1-option choices", () => {
+    expect(normalizePrompt({ type: "modal", question: "x" }).error).toContain(
+      "type",
+    );
+    expect(normalizePrompt({ type: "stars", question: "  " }).error).toContain(
+      "question",
+    );
+    expect(
+      normalizePrompt({
+        type: "choice",
+        question: "Pick",
+        options: ["only one"],
+      }).error,
+    ).toContain("options");
+  });
+
+  it("keeps the banner CTA only when both label and url are present", () => {
+    const withCta = normalizePrompt({
+      type: "banner",
+      question: "Try X",
+      cta_label: "Open",
+      cta_url: "https://omi.me",
+    }).doc;
+    expect(withCta.cta).toEqual({ label: "Open", url: "https://omi.me" });
+    const withoutCta = normalizePrompt({
+      type: "banner",
+      question: "Try X",
+      cta_label: "Open",
+    }).doc;
+    expect(withoutCta.cta).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

Every in-app ask (rating bar, surveys, announcements) previously needed a desktop release and days of channel rollout. This adds the remote prompt engine: prompts are authored on **admin.omi.me → Prompts** and reach every desktop client within one poll (~5 minutes) — created, targeted, killed, and measured with zero releases.

## What

- **Backend** — `GET /v2/desktop/prompts` (new `routers/desktop_prompts.py`): serves active `desktop_prompts` Firestore docs with stable per-(user,prompt) rollout buckets, channel and min-build audience filters. Read-only over admin-authored docs; standard user auth.
- **Desktop** — `RemotePromptEngine`: polls at launch + every 5 min, renders `stars` / `nps` / `choice` / `banner` natively above the composer, one prompt at a time, once per user (persisted resolution). Question-count triggers ride the same accepted-question seam as the built-in rating ask, which keeps right of way. Answers/dismissals land in PostHog (`Desktop Prompt Shown/Answered/Dismissed`). A prompt deactivated on admin disappears from live clients on the next poll — the no-release kill path.
- **Admin** — `/dashboard/prompts` page (sidebar: Prompts): create (born inactive), activate/deactivate, rollout %, delete, with live per-prompt tallies (shown / answered / dismissed, stars-NPS averages, per-option counts) from PostHog.
- Bridge actions `remote_prompts_state/refresh/reset`, `remote_prompt_answer/dismiss` drive the same engine methods the visible controls call; e2e flow `remote-prompts.yaml`.

## Verification

- Units: backend 7/7 (`test_desktop_prompts.py` — audience, rollout stability, spec validation), `RemotePromptPolicyTests` 5/5 (trigger thresholds, once-only, unknown-kind ignored, deterministic ordering), admin vitest 198/198 (incl. `normalizePrompt` contract), `tsc` clean.
- **Live end-to-end on a dev bundle** (`omi-rating-qa`, real seeded account): created a stars prompt through the real admin POST route (prod Firestore) → real-auth backend route served it → running app fetched it (`spec_count 1`) → hidden until the 3rd accepted question, and the built-in rating ask correctly took right of way first → after resolving it the remote bar rendered ("How useful was Omi today?" with stars, window capture) → bridge answer(4) resolved it via the same method the star buttons call → refresh does NOT re-show → **deactivating on admin removed it from the live client on the next fetch** → deleted (no test residue).
- UNVERIFIED (narrow): the Prompts page UI in a browser (admin login wall blocks headless); its API routes were exercised for real above. Will screenshot on prod admin after deploy.

Failure-Class: none

Line-Count-Exception: desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift | 4764 -> 4765 | one registration line for the remote-prompt action group (actions live in their own extension file)
Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift | 1643 -> 1650 | remote-prompt overlay slot, engine start, and history-seed hook; the features live in RemotePrompts.swift / RatingPrompt.swift

Product invariants affected: INV-NAV-1 — DesktopHomeView changed only by adding a bottom overlay slot and an engine-start hook for remote prompts; no navigation destination, route owner, or shell chrome changed.

## Round 3

- **Instant ask for existing users** (Nik): the question counter seeds one-shot from real chat history — users with 3+ lifetime questions see the rating bar on next launch, zero new questions needed. Live-verified: reset → seed → bar armed (capture).
- **Init-cycle fix** (review): `refresh()` inside `RatingPromptManager`'s own `static let` init reached `RemotePromptEngine` which read `.shared` back — now a deferred MainActor hop; the pre-fix trap reproduced in a test process, post-fix the live app runs clean.
- **Slot exclusivity live-verified** (review): remote banner current → 3rd question arms rating bar and remote prompt suspends (`current_id` empty) → resolving the ask restores it unresolved. Captures attached in-repo for review.
