### PR TITLE
fix(desktop): keep the notch island on screen after hovering

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -2469,6 +2469,33 @@ final class DesktopAutomationActionRegistry {
       }
     }
 
+    // Cursor-free notch hover driver: enter/exit run the same pointer update
+    // the tracking view calls from mouse events; state reads the island's
+    // visibility inputs so a stuck reveal or menu can be caught mechanically.
+    register(
+      name: "notch_hover",
+      summary: "Simulate notch pointer enter/exit or read island state (non-prod). action=enter|exit|state",
+      params: ["action"]
+    ) { params in
+      guard AppBuild.isNonProduction else {
+        return ["error": "notch_hover is disabled on production bundles"]
+      }
+      guard let bar = FloatingControlBarManager.shared.window else {
+        return ["error": "no floating bar window"]
+      }
+      switch params["action"] ?? "state" {
+      case "enter":
+        bar.automationSimulateNotchPointer(inside: true)
+      case "exit":
+        bar.automationSimulateNotchPointer(inside: false)
+      case "state":
+        break
+      default:
+        throw DesktopAutomationActionError.invalidParams("action must be enter, exit, or state")
+      }
+      return bar.automationNotchStateSnapshot
+    }
+
     register(
       name: "seed_subagents",
       summary: "Seed synthetic floating-bar subagents for deterministic UI benchmarks",

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift
@@ -93,6 +93,34 @@ enum FloatingControlBarGeometry {
   /// state transitions. Window owns which transition is active and supplies
   /// its already-adjusted target size; geometry owns whether that transition
   /// may inherit the current midpoint or must return to a canonical anchor.
+  /// A notch island hangs from the display's top edge by definition. Auto
+  /// layout can grow the panel to fit content that has not finished
+  /// collapsing (the hosting view forwards SwiftUI's min size as a window
+  /// constraint), and AppKit grows windows from their pinned bottom-left
+  /// origin — which pushes the top-anchored chrome above the screen where
+  /// nothing ever brings it back (the "island disappeared after hovering"
+  /// bug). Whenever a resize leaves the top edge somewhere other than the
+  /// screen top while the island is in its non-interactive chrome state,
+  /// the frame is re-anchored instead of trusted.
+  static func notchTopReanchoredFrame(
+    frame: NSRect,
+    screenFrame: NSRect,
+    isResizable: Bool,
+    isUserDragging: Bool,
+    epsilon: CGFloat = 0.5
+  ) -> NSRect? {
+    guard !isResizable, !isUserDragging else { return nil }
+    guard screenFrame.width > 0, screenFrame.height > 0 else { return nil }
+    let desiredTop = screenFrame.maxY
+    guard abs(frame.maxY - desiredTop) > epsilon else { return nil }
+    return NSRect(
+      x: screenFrame.midX - frame.width / 2,
+      y: desiredTop - frame.height,
+      width: frame.width,
+      height: frame.height
+    )
+  }
+
   static func surfaceTransitionFrame(
     currentFrame: NSRect,
     targetSize: NSSize,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -178,6 +178,9 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   static let notchHoverMenuCollapseAnimation: Animation = .spring(response: 0.3, dampingFraction: 1.0)
   static let notchHoverMenuExpandDuration: TimeInterval = 0.16
   static let notchHoverMenuCollapseDuration: TimeInterval = 0.10
+  /// How long after the collapse spring's logical completion its visual tail
+  /// can still hold the content's min size above the idle island height.
+  static let notchHoverMenuCollapseSettleTail: TimeInterval = 0.45
   private static let frameNoopEpsilon: CGFloat = 0.5
   private static let startupDisplayRevalidationDelays: [TimeInterval] = [0.2, 0.8, 2.0]
   private static let topInset: CGFloat = 40
@@ -1016,6 +1019,33 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     scheduleNotchRevealCompletion(generation: revealGeneration, after: duration)
   }
 
+  // MARK: - Automation hover seam (non-production)
+  //
+  // Drives the same pointer entry point the tracking view calls from real
+  // mouse events, so hover open/close can be exercised without a cursor.
+  func automationSimulateNotchPointer(inside: Bool) {
+    let point: NSPoint =
+      inside
+      ? NSPoint(x: frame.width / 2 - Self.notchHiddenCenterWidth / 2 - 12, y: frame.height - 4)
+      : NSPoint(x: -400, y: -400)
+    updateNotchPointer(localPoint: point)
+  }
+
+  var automationNotchStateSnapshot: [String: String] {
+    [
+      "isVisible": isVisible ? "true" : "false",
+      "alpha": String(format: "%.3f", alphaValue),
+      "frame": NSStringFromRect(frame),
+      "usesNotchIsland": state.usesNotchIsland ? "true" : "false",
+      "notchRevealProgress": String(format: "%.3f", state.notchRevealProgress),
+      "hoverMenuOpen": state.notchHoverMenuOpen ? "true" : "false",
+      "showingAIConversation": state.showingAIConversation ? "true" : "false",
+      "isVoicePresentationActive": state.isVoicePresentationActive ? "true" : "false",
+      "currentNotification": state.currentNotification == nil ? "none" : "present",
+      "screen": screen.map { NSStringFromRect($0.frame) } ?? "nil",
+    ]
+  }
+
   private enum NotchPointerMode {
     case activationOnly
     case openMenuRetention
@@ -1082,6 +1112,8 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     // unrelated controls in windows underneath it.
     state.setNotchHoverMenuOpen(allowed)
     if allowed {
+      notchCollapseReassertTask?.cancel()
+      notchCollapseReassertTask = nil
       resizeForAgentSwitcher(visible: true)
     }
   }
@@ -2030,9 +2062,26 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     }
   }
 
+  private var notchCollapseReassertTask: Task<Void, Never>?
+
   func settleNotchAgentSwitcherCollapse() {
     guard notchModeEnabled, !state.isNotchHoverMenuVisible else { return }
     resizeForAgentSwitcher(visible: false)
+    // The collapse spring is still shrinking the content when the resize
+    // above lands, and the hosting view's min-size constraint grows the
+    // panel right back (the growth itself is top-re-anchored by
+    // `reanchorNotchTopEdgeIfNeeded`, so the island stays visible). One
+    // re-assert after the spring's visual tail returns the panel to the
+    // idle island size instead of leaving a stale menu-sized frame.
+    notchCollapseReassertTask?.cancel()
+    notchCollapseReassertTask = Task { @MainActor [weak self] in
+      try? await Task.sleep(
+        nanoseconds: UInt64(Self.notchHoverMenuCollapseSettleTail * 1_000_000_000))
+      guard !Task.isCancelled, let self, self.notchModeEnabled,
+        !self.state.isNotchHoverMenuVisible
+      else { return }
+      self.resizeForAgentSwitcher(visible: false)
+    }
   }
 
   /// Window size for the pill-mode agent list. No chrome band and no glow
@@ -2566,11 +2615,37 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
   func windowDidResize(_ notification: Notification) {
     syncMouseInterception()
+    reanchorNotchTopEdgeIfNeeded()
     // Response size persistence is committed when the user finishes dragging
     // the resize grip. Persisting ordinary resize notifications here records
     // programmatic min-height transitions as user preferences because AppKit
     // can deliver the final resize notification after our animation flag is
     // cleared.
+  }
+
+  /// Keeps the island hanging from the screen top no matter who resized the
+  /// window. The buggy resizes come from auto layout (SwiftUI content that has
+  /// not finished collapsing pushes the panel back up from a pinned bottom-left
+  /// origin), which bypasses every programmatic resize path — so the anchor is
+  /// enforced at the notification, not at the call sites.
+  private var isReanchoringNotchTop = false
+  private func reanchorNotchTopEdgeIfNeeded() {
+    guard notchModeEnabled, !isReanchoringNotchTop else { return }
+    guard let screenFrame = (screen ?? screenForPlacement)?.frame else { return }
+    guard
+      let anchored = FloatingControlBarGeometry.notchTopReanchoredFrame(
+        frame: frame,
+        screenFrame: screenFrame,
+        isResizable: styleMask.contains(.resizable),
+        isUserDragging: isUserDragging
+      )
+    else { return }
+    log(
+      "FloatingControlBar: re-anchoring notch top edge from \(frame) to \(anchored)"
+    )
+    isReanchoringNotchTop = true
+    setFrame(anchored, display: true, animate: false)
+    isReanchoringNotchTop = false
   }
 
   func finishUserResponseResize() {

--- a/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
@@ -604,3 +604,57 @@ final class FloatingBarGeometryTests: XCTestCase {
       "an ordered-out panel must never retain event ownership")
   }
 }
+
+// MARK: - Notch top re-anchoring
+
+/// The island hangs from the display top by definition. Auto layout grows the
+/// panel from a pinned bottom-left origin when SwiftUI content has not
+/// finished collapsing, which pushed the chrome above the screen and made the
+/// island "disappear after hovering" until Push-to-Talk resized it back.
+final class NotchTopReanchorTests: XCTestCase {
+  private let screen = NSRect(x: 0, y: 0, width: 2048, height: 1330)
+
+  func testGrowthFromPinnedOriginIsReanchoredToScreenTop() {
+    // The reproduced bug frame: collapse origin kept, menu height restored by
+    // the hosting view's min-size constraint — top edge 240pt offscreen.
+    let grown = NSRect(x: 816, y: 1263, width: 430, height: 307)
+    let anchored = FloatingControlBarGeometry.notchTopReanchoredFrame(
+      frame: grown, screenFrame: screen, isResizable: false, isUserDragging: false)
+    XCTAssertEqual(anchored, NSRect(x: 809, y: 1023, width: 430, height: 307))
+    XCTAssertEqual(anchored?.maxY, screen.maxY)
+  }
+
+  func testCorrectlyAnchoredFrameIsLeftAlone() {
+    let idle = NSRect(x: 828, y: 1263, width: 392, height: 67)
+    XCTAssertNil(
+      FloatingControlBarGeometry.notchTopReanchoredFrame(
+        frame: idle, screenFrame: screen, isResizable: false, isUserDragging: false))
+  }
+
+  func testUserControlledWindowsAreNeverFought() {
+    let grown = NSRect(x: 816, y: 900, width: 430, height: 307)
+    XCTAssertNil(
+      FloatingControlBarGeometry.notchTopReanchoredFrame(
+        frame: grown, screenFrame: screen, isResizable: true, isUserDragging: false),
+      "a resizable conversation panel is the user's to size")
+    XCTAssertNil(
+      FloatingControlBarGeometry.notchTopReanchoredFrame(
+        frame: grown, screenFrame: screen, isResizable: false, isUserDragging: true),
+      "a drag in progress must not be yanked back")
+  }
+
+  func testDegenerateScreenIsIgnored() {
+    let grown = NSRect(x: 0, y: 0, width: 430, height: 307)
+    XCTAssertNil(
+      FloatingControlBarGeometry.notchTopReanchoredFrame(
+        frame: grown, screenFrame: .zero, isResizable: false, isUserDragging: false))
+  }
+
+  func testSubPointDriftIsNotChurned() {
+    let nearlyAnchored = NSRect(x: 828, y: 1262.7, width: 392, height: 67)
+    XCTAssertNil(
+      FloatingControlBarGeometry.notchTopReanchoredFrame(
+        frame: nearlyAnchored, screenFrame: screen, isResizable: false, isUserDragging: false),
+      "epsilon keeps AppKit rounding from causing a setFrame loop")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260827-notch-hover-disappear.json
+++ b/desktop/macos/changelog/unreleased/20260827-notch-hover-disappear.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the notch island disappearing after you hover over it — it stays put now instead of needing a Push-to-Talk press to bring it back"
+}


### PR DESCRIPTION
## Summary

On the macOS Beta, hovering over the notch island and then moving the cursor away sometimes made the island vanish entirely — it stayed gone until a Push-to-Talk press happened to bring it back.

**Root cause, reproduced deterministically.** Hover opens the agent menu; on pointer exit the collapse resize (416×67, logged) lands while the menu's collapse spring is still shrinking the SwiftUI content. The hosting view forwards the content's min size as a window constraint (`sizingOptions = [.minSize, .maxSize]`), so auto layout immediately grows the panel back to menu height — **from its pinned bottom-left origin**. The island chrome is top-anchored inside the window, so it ends up to 240pt *above* the screen edge: invisible. Nothing re-anchors it; PTT "fixed" it only because its resize recomputes the frame. Reproduced on a dev bundle with a cursor-free bridge seam driving the same `updateNotchPointer` entry the tracking view calls — every hover cycle ended at `{{816,1263},{430,307}}` (top edge 1570 on a 1330-high screen).

**Fix, two mechanical guards:**
1. `windowDidResize` re-anchors any notch-mode resize whose top edge left the screen top (`FloatingControlBarGeometry.notchTopReanchoredFrame`). The buggy growth comes from auto layout, which bypasses every programmatic resize path — so the invariant is enforced at the notification, not at call sites. Resizable (user-sized conversation) and mid-drag windows are never fought; an epsilon prevents setFrame churn on AppKit rounding.
2. The menu collapse re-asserts the idle island frame once after the spring's visual tail (0.45s), so the panel returns to size instead of keeping a stale menu-height frame. A re-hover cancels the re-assert.

Also adds the `notch_hover` bridge action (non-prod) used to reproduce and verify without a cursor.

## Verification

- **Before:** every hover cycle across 20 timing patterns left the window at `{{816,1263},{430,307}}` — chrome 240pt offscreen (the user-reported disappearance, on demand).
- **After:** the same 20 patterns — five enter-hold durations × four exit delays, rapid ×15, and re-enter-mid-collapse ×10 — all settle back to the exact idle frame `{{828,1263},{392,67}}` with `notchRevealProgress=1`, alpha 1. Menu-open and post-hover idle states captured from the running bundle (`.cross-review-verify.png`).
- `swift test --filter NotchTopReanchorTests` — 5 passed, including a case built from the reproduced bug frame.
- `swift build -c debug` — Build complete.

## Product invariants affected

- **INV-CHAT-1** — unchanged. The touched files carry chat-adjacent surfaces, but this diff only re-anchors the notch window frame and re-asserts its collapse size; no chat journaling or routing changes.

Failure-Class: none

Line-Count-Exception: desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift | 4764 -> 4791 | one cursor-free notch_hover QA action, following the file's established registry pattern
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift | 5309 -> 5384 | the top-edge re-anchor and collapse re-assert live in the notch panel's owner beside the resize paths they guard; extracting the window is out of scope


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

