### PR TITLE
fix: prompt state is per-account (rating, history seed, remote resolutions)

### DIFF
--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -173,10 +173,18 @@ struct ScopedDefaultsKey {
     Self(rawValue: "appsImportConnectorSourceCount.\(connectorID)")
   }
 
-  /// Per-prompt resolution of a remote (admin-authored) prompt: "answered" or
-  /// "dismissed". Absent = still eligible.
-  static func remotePromptResolution(promptId: String) -> Self {
-    Self(rawValue: "remotePrompt.resolution.v1.\(promptId)")
+  /// Per-prompt, per-account resolution of a remote (admin-authored) prompt:
+  /// "answered" or "dismissed". Absent = still eligible. Owner-scoped so one
+  /// account's answer never suppresses prompts for another account on the
+  /// same Mac (the #9821 account-switch-bleed class).
+  static func remotePromptResolution(promptId: String, ownerID: String) -> Self {
+    Self(rawValue: "remotePrompt.resolution.v2.\(ownerID).\(promptId)")
+  }
+
+  /// Owner-scoped rating-prompt state (count / submitted / dismissed /
+  /// historySeeded) — same bleed class as above.
+  static func ratingPrompt(_ field: String, ownerID: String) -> Self {
+    Self(rawValue: "ratingPrompt.v2.\(field).\(ownerID)")
   }
 
   static func taskInterruptionLedger(ownerID: String) -> Self {

--- a/desktop/macos/Desktop/Sources/RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/RatingPrompt.swift
@@ -35,6 +35,42 @@ final class RatingPromptManager: ObservableObject {
   private let defaults = UserDefaults.standard
   private var flagObserver: NSObjectProtocol?
   private var flagPollTask: Task<Void, Never>?
+  private var migratedOwners = Set<String>()
+
+  /// Injectable for tests; production scopes all prompt state to the signed-in
+  /// account so a switch never inherits another account's answers (#9821 class).
+  var ownerProvider: () -> String = { RuntimeOwnerIdentity.currentOwnerId() ?? "anonymous" }
+
+  private func scopedKey(_ field: String) -> ScopedDefaultsKey {
+    let owner = ownerProvider()
+    if !migratedOwners.contains(owner) {
+      migratedOwners.insert(owner)
+      migrateLegacyGlobalState(to: owner)
+    }
+    return .ratingPrompt(field, ownerID: owner)
+  }
+
+  /// The first shipped build stored this state device-globally; the account
+  /// signed in when the scoped build first runs inherits it (correct for the
+  /// overwhelmingly common single-account Mac, and prevents re-prompting
+  /// users who already answered), then the global keys are removed.
+  private func migrateLegacyGlobalState(to owner: String) {
+    let legacy: [(DefaultsKey, String)] = [
+      (.ratingPromptQuestionCount, "questionCount"),
+      (.ratingPromptSubmittedRating, "submittedRating"),
+      (.ratingPromptDismissed, "dismissed"),
+      (.ratingPromptHistorySeeded, "historySeeded"),
+    ]
+    for (globalKey, field) in legacy {
+      if let value = defaults.object(forKey: globalKey.rawValue) {
+        let scoped = ScopedDefaultsKey.ratingPrompt(field, ownerID: owner)
+        if defaults.object(forKey: scoped) == nil {
+          defaults.set(value, forKey: scoped)
+        }
+        defaults.removeObject(forKey: globalKey.rawValue)
+      }
+    }
+  }
 
   /// Injectable for tests; production reads the preloaded PostHog flag.
   var remoteDisableCheck: () -> Bool = {
@@ -59,19 +95,19 @@ final class RatingPromptManager: ObservableObject {
   }
 
   var questionCount: Int {
-    defaults.integer(forKey: DefaultsKey.ratingPromptQuestionCount.rawValue)
+    defaults.object(forKey: scopedKey("questionCount")) as? Int ?? 0
   }
 
   var submittedRating: Int {
-    defaults.integer(forKey: DefaultsKey.ratingPromptSubmittedRating.rawValue)
+    defaults.object(forKey: scopedKey("submittedRating")) as? Int ?? 0
   }
 
   var isDismissed: Bool {
-    defaults.bool(forKey: DefaultsKey.ratingPromptDismissed.rawValue)
+    defaults.object(forKey: scopedKey("dismissed")) as? Bool ?? false
   }
 
   func recordQuestionAsked() {
-    defaults.set(questionCount + 1, forKey: DefaultsKey.ratingPromptQuestionCount.rawValue)
+    defaults.set(questionCount + 1, forKey: scopedKey("questionCount"))
     refresh()
     // Remote prompts share the same accepted-question seam: only sends the
     // chat provider accepted reach here, so both counters agree by
@@ -85,7 +121,7 @@ final class RatingPromptManager: ObservableObject {
 
   func submit(rating: Int) {
     let clamped = min(max(rating, 1), 5)
-    defaults.set(clamped, forKey: DefaultsKey.ratingPromptSubmittedRating.rawValue)
+    defaults.set(clamped, forKey: scopedKey("submittedRating"))
     AnalyticsManager.shared.desktopRatingSubmitted(rating: clamped)
     thankYouRating = clamped
     refresh()
@@ -109,7 +145,7 @@ final class RatingPromptManager: ObservableObject {
   }
 
   func dismiss() {
-    defaults.set(true, forKey: DefaultsKey.ratingPromptDismissed.rawValue)
+    defaults.set(true, forKey: scopedKey("dismissed"))
     refresh()
   }
 
@@ -118,11 +154,11 @@ final class RatingPromptManager: ObservableObject {
   /// seed of the counter from server chat history. Fetch failure leaves the
   /// marker unset so the next launch retries.
   func seedFromHistoryIfNeeded() async {
-    guard !defaults.bool(forKey: DefaultsKey.ratingPromptHistorySeeded.rawValue) else { return }
+    guard !(defaults.object(forKey: scopedKey("historySeeded")) as? Bool ?? false) else { return }
     guard submittedRating == 0, !isDismissed,
       questionCount < RatingPromptPolicy.questionThreshold
     else {
-      defaults.set(true, forKey: DefaultsKey.ratingPromptHistorySeeded.rawValue)
+      defaults.set(true, forKey: scopedKey("historySeeded"))
       return
     }
     // Launch timing: auth/session may not be ready at first .task — retry a
@@ -144,11 +180,9 @@ final class RatingPromptManager: ObservableObject {
     let asked = history.filter { $0.sender == "human" }.count
     log("RatingPrompt: history seed fetched \(history.count) messages, \(asked) questions")
     if asked >= RatingPromptPolicy.questionThreshold {
-      defaults.set(
-        RatingPromptPolicy.questionThreshold,
-        forKey: DefaultsKey.ratingPromptQuestionCount.rawValue)
+      defaults.set(RatingPromptPolicy.questionThreshold, forKey: scopedKey("questionCount"))
     }
-    defaults.set(true, forKey: DefaultsKey.ratingPromptHistorySeeded.rawValue)
+    defaults.set(true, forKey: scopedKey("historySeeded"))
     refresh()
   }
 
@@ -156,11 +190,12 @@ final class RatingPromptManager: ObservableObject {
   /// path can be exercised repeatedly on a dev bundle.
   func resetForTesting() {
     thankYouRating = nil
-    defaults.removeObject(forKey: DefaultsKey.ratingPromptHistorySeeded.rawValue)
-    defaults.removeObject(forKey: DefaultsKey.ratingPromptQuestionCount.rawValue)
-    defaults.removeObject(forKey: DefaultsKey.ratingPromptSubmittedRating.rawValue)
-    defaults.removeObject(forKey: DefaultsKey.ratingPromptDismissed.rawValue)
+    for field in ["historySeeded", "questionCount", "submittedRating", "dismissed"] {
+      defaults.removeObject(forKey: scopedKey(field))
+    }
     refresh()
+    // Allow migration to be exercised again after a test reset.
+    migratedOwners.removeAll()
   }
 
   var isRemotelyDisabled: Bool {

--- a/desktop/macos/Desktop/Sources/RemotePrompts.swift
+++ b/desktop/macos/Desktop/Sources/RemotePrompts.swift
@@ -50,6 +50,12 @@ final class RemotePromptEngine: ObservableObject {
   var fetch: () async throws -> [RemotePromptSpec]
   /// Injectable for tests; production reads the real auth state.
   var isSignedInCheck: () -> Bool = { AuthState.shared.isSignedIn }
+  /// Same account scoping as RatingPromptManager (#9821 bleed class).
+  var ownerProvider: () -> String = { RuntimeOwnerIdentity.currentOwnerId() ?? "anonymous" }
+
+  private func resolutionKey(_ promptId: String) -> ScopedDefaultsKey {
+    .remotePromptResolution(promptId: promptId, ownerID: ownerProvider())
+  }
 
   private init() {
     fetch = {
@@ -88,11 +94,11 @@ final class RemotePromptEngine: ObservableObject {
     evaluate()
   }
 
-  /// The accepted-question ledger IS the persisted rating-prompt counter —
-  /// one source of truth, so relaunches and the history seed carry over to
-  /// "after Nth question" remote prompts instead of restarting at zero.
+  /// The accepted-question ledger IS the rating manager's persisted,
+  /// owner-scoped counter — one accessor, so relaunches, the history seed,
+  /// and account switches all carry over consistently.
   private var questionCount: Int {
-    defaults.integer(forKey: DefaultsKey.ratingPromptQuestionCount.rawValue)
+    RatingPromptManager.shared.questionCount
   }
 
   /// Notification from the accepted-question seam (the manager increments the
@@ -149,7 +155,7 @@ final class RemotePromptEngine: ObservableObject {
   /// real trigger path can be exercised repeatedly on a dev bundle.
   func resetForTesting() {
     for spec in specs {
-      defaults.removeObject(forKey: ScopedDefaultsKey.remotePromptResolution(promptId: spec.id))
+      defaults.removeObject(forKey: resolutionKey(spec.id))
     }
     current = nil
     evaluate()
@@ -163,7 +169,7 @@ final class RemotePromptEngine: ObservableObject {
     guard current == nil else { return }
     let resolved = Set(
       specs.map(\.id).filter {
-        defaults.object(forKey: ScopedDefaultsKey.remotePromptResolution(promptId: $0)) != nil
+        defaults.object(forKey: resolutionKey($0)) != nil
       })
     if let due = RemotePromptPolicy.duePrompt(
       specs: specs, resolvedIds: resolved, questionCount: questionCount)
@@ -174,7 +180,7 @@ final class RemotePromptEngine: ObservableObject {
   }
 
   private func markResolved(_ id: String, outcome: String) {
-    defaults.set(outcome, forKey: ScopedDefaultsKey.remotePromptResolution(promptId: id))
+    defaults.set(outcome, forKey: resolutionKey(id))
   }
 }
 

--- a/desktop/macos/Desktop/Tests/PromptStateAccountScopingTests.swift
+++ b/desktop/macos/Desktop/Tests/PromptStateAccountScopingTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Prompt state must be per-account: one account's answers, dismissals, and
+/// question counts on a shared Mac must not change another account's
+/// eligibility (#9821 account-switch-bleed class).
+@MainActor
+final class PromptStateAccountScopingTests: XCTestCase {
+  private var owner = "user-a"
+
+  override func setUp() async throws {
+    RatingPromptManager.shared.remoteDisableCheck = { false }
+    RatingPromptManager.shared.ownerProvider = { self.owner }
+    RemotePromptEngine.shared.ownerProvider = { self.owner }
+    for account in ["user-a", "user-b"] {
+      owner = account
+      RatingPromptManager.shared.resetForTesting()
+      RemotePromptEngine.shared.resetForTesting()
+    }
+    owner = "user-a"
+  }
+
+  override func tearDown() async throws {
+    for account in ["user-a", "user-b"] {
+      owner = account
+      RatingPromptManager.shared.resetForTesting()
+      RemotePromptEngine.shared.resetForTesting()
+    }
+    RatingPromptManager.shared.ownerProvider = { RuntimeOwnerIdentity.currentOwnerId() ?? "anonymous" }
+    RemotePromptEngine.shared.ownerProvider = { RuntimeOwnerIdentity.currentOwnerId() ?? "anonymous" }
+    RatingPromptManager.shared.remoteDisableCheck = {
+      PostHogManager.shared.isFeatureEnabled(RatingPromptPolicy.killSwitchFlag)
+    }
+  }
+
+  func testRatingSubmissionDoesNotSuppressTheNextAccount() {
+    for _ in 1...3 { RatingPromptManager.shared.recordQuestionAsked() }
+    RatingPromptManager.shared.submit(rating: 5)
+    XCTAssertEqual(RatingPromptManager.shared.submittedRating, 5)
+
+    // Switch accounts: a fresh user must start from zero, still eligible.
+    owner = "user-b"
+    XCTAssertEqual(RatingPromptManager.shared.questionCount, 0)
+    XCTAssertEqual(RatingPromptManager.shared.submittedRating, 0)
+    for _ in 1...3 { RatingPromptManager.shared.recordQuestionAsked() }
+    RatingPromptManager.shared.flagsDidUpdate()
+    XCTAssertTrue(RatingPromptManager.shared.isVisible)
+
+    // And switching back preserves the first account's submission.
+    owner = "user-a"
+    XCTAssertEqual(RatingPromptManager.shared.submittedRating, 5)
+  }
+
+  func testRemotePromptResolutionIsPerAccount() async {
+    let spec = RemotePromptSpec(
+      id: "launch-note", type: "banner", question: "Hi", options: [],
+      ctaLabel: "Open", ctaURL: "https://omi.me", triggerKind: "app_launch", triggerCount: 0)
+    RemotePromptEngine.shared.isSignedInCheck = { true }
+    RemotePromptEngine.shared.fetch = { [spec] }
+    await RemotePromptEngine.shared.refreshFromServer()
+    // Now that the spec is loaded, clear any resolution persisted by a
+    // previous test-runner process, and free the slot for both accounts.
+    for account in ["user-a", "user-b"] {
+      owner = account
+      RemotePromptEngine.shared.resetForTesting()
+      RatingPromptManager.shared.dismiss()
+    }
+    owner = "user-a"
+
+    await RemotePromptEngine.shared.refreshFromServer()
+    XCTAssertEqual(RemotePromptEngine.shared.current?.id, "launch-note")
+    RemotePromptEngine.shared.dismissCurrent()
+    await RemotePromptEngine.shared.refreshFromServer()
+    XCTAssertNil(RemotePromptEngine.shared.current)
+
+    // The other account is still eligible for the same prompt.
+    owner = "user-b"
+    await RemotePromptEngine.shared.refreshFromServer()
+    XCTAssertEqual(RemotePromptEngine.shared.current?.id, "launch-note")
+
+    RemotePromptEngine.shared.fetch = { [] }
+    await RemotePromptEngine.shared.refreshFromServer()
+  }
+
+  func testLegacyGlobalStateMigratesToTheFirstAccountOnly() {
+    UserDefaults.standard.set(4, forKey: DefaultsKey.ratingPromptQuestionCount.rawValue)
+    UserDefaults.standard.set(true, forKey: DefaultsKey.ratingPromptDismissed.rawValue)
+
+    // First scoped read migrates the pre-scoping global keys to user-a…
+    XCTAssertEqual(RatingPromptManager.shared.questionCount, 4)
+    XCTAssertTrue(RatingPromptManager.shared.isDismissed)
+    XCTAssertNil(UserDefaults.standard.object(forKey: DefaultsKey.ratingPromptQuestionCount.rawValue))
+
+    // …and user-b starts clean.
+    owner = "user-b"
+    XCTAssertEqual(RatingPromptManager.shared.questionCount, 0)
+    XCTAssertFalse(RatingPromptManager.shared.isDismissed)
+  }
+}

--- a/desktop/macos/Desktop/Tests/RemotePromptLedgerTests.swift
+++ b/desktop/macos/Desktop/Tests/RemotePromptLedgerTests.swift
@@ -14,9 +14,11 @@ final class RemotePromptLedgerTests: XCTestCase {
 
   override func setUp() async throws {
     RatingPromptManager.shared.remoteDisableCheck = { false }
+    RatingPromptManager.shared.ownerProvider = { "ledger-user" }
+    RemotePromptEngine.shared.ownerProvider = { "ledger-user" }
     RatingPromptManager.shared.resetForTesting()
     // The built-in ask must not own the slot in this test.
-    UserDefaults.standard.set(true, forKey: DefaultsKey.ratingPromptDismissed.rawValue)
+    RatingPromptManager.shared.dismiss()
     RemotePromptEngine.shared.isSignedInCheck = { true }
     RemotePromptEngine.shared.fetch = { [self.spec] }
     RemotePromptEngine.shared.resetForTesting()
@@ -30,6 +32,8 @@ final class RemotePromptLedgerTests: XCTestCase {
     await RemotePromptEngine.shared.refreshFromServer()
     RemotePromptEngine.shared.resetForTesting()
     RatingPromptManager.shared.resetForTesting()
+    RatingPromptManager.shared.ownerProvider = { RuntimeOwnerIdentity.currentOwnerId() ?? "anonymous" }
+    RemotePromptEngine.shared.ownerProvider = { RuntimeOwnerIdentity.currentOwnerId() ?? "anonymous" }
     RatingPromptManager.shared.remoteDisableCheck = {
       PostHogManager.shared.isFeatureEnabled(RatingPromptPolicy.killSwitchFlag)
     }
@@ -39,13 +43,15 @@ final class RemotePromptLedgerTests: XCTestCase {
     XCTAssertNil(RemotePromptEngine.shared.current)
     // Questions persisted by a PREVIOUS session (or the history seed) — write
     // the ledger key directly, then simulate the relaunch-time fetch.
-    UserDefaults.standard.set(3, forKey: DefaultsKey.ratingPromptQuestionCount.rawValue)
+    UserDefaults.standard.set(
+      3, forKey: ScopedDefaultsKey.ratingPrompt("questionCount", ownerID: "ledger-user"))
     await RemotePromptEngine.shared.refreshFromServer()
     XCTAssertEqual(RemotePromptEngine.shared.current?.id, "q3-survey")
   }
 
   func testLedgerBelowThresholdStaysHidden() async {
-    UserDefaults.standard.set(2, forKey: DefaultsKey.ratingPromptQuestionCount.rawValue)
+    UserDefaults.standard.set(
+      2, forKey: ScopedDefaultsKey.ratingPrompt("questionCount", ownerID: "ledger-user"))
     await RemotePromptEngine.shared.refreshFromServer()
     XCTAssertNil(RemotePromptEngine.shared.current)
   }

--- a/desktop/macos/changelog/unreleased/20260827-prompt-state-per-account.json
+++ b/desktop/macos/changelog/unreleased/20260827-prompt-state-per-account.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Rating and in-app prompt history is now tracked per account, so switching accounts on one Mac never hides or repeats prompts incorrectly."
+  ]
+}


### PR DESCRIPTION
## Why

Cross-review caught the #9821 account-switch-bleed class in the new prompt surfaces: all rating/remote-prompt state was device-global, so one account's answer or dismissal suppressed prompts for every later account on the same Mac.

## What

Every key (question count, submitted rating, dismissed, history-seed marker, per-prompt remote resolutions) is now owner-scoped via ScopedDefaultsKey. First scoped access migrates the pre-scoping global keys to the currently signed-in account (single-account Macs keep their state — nobody who already answered gets re-prompted) and deletes the globals. The remote engine's question count is now literally `RatingPromptManager.questionCount` — one owner-scoped ledger.

## Verification

`PromptStateAccountScopingTests` (3): submit on account A → account B starts clean, asks 3 questions, sees the prompt; switching back preserves A's submission; remote prompt dismissed by A is still offered to B; legacy global state migrates to the first account only, second account starts clean. All prompt suites 23/23. swift build clean.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

