### PR TITLE
fix: prompt state swaps accounts instantly on owner transition

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1156,7 +1156,11 @@ struct DesktopHomeView: View {
         RatingPromptBar()
         RemotePromptBar()
       }
-      .task {
+      .task(id: RuntimeOwnerIdentity.currentOwnerId() ?? "signed-out") {
+        // Re-runs on every owner transition (same pattern as the chat-first
+        // capability task): cached prompt state must swap accounts instantly.
+        RatingPromptManager.shared.ownerDidChange()
+        RemotePromptEngine.shared.ownerDidChange()
         RemotePromptEngine.shared.start()
         await RatingPromptManager.shared.seedFromHistoryIfNeeded()
       }

--- a/desktop/macos/Desktop/Sources/RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/RatingPrompt.swift
@@ -79,6 +79,14 @@ final class RatingPromptManager: ObservableObject {
 
   private init() {
     refresh()
+    // Sign-out is an owner transition too: hide immediately, not at the next
+    // question. Sign-IN transitions arrive via the owner-keyed task in
+    // DesktopHomeView calling ownerDidChange().
+    NotificationCenter.default.addObserver(
+      forName: .userDidSignOut, object: nil, queue: nil
+    ) { _ in
+      Task { @MainActor in RatingPromptManager.shared.ownerDidChange() }
+    }
     // The kill switch must not wait for the next question: recompute whenever
     // PostHog delivers a flag payload (initial preload can finish AFTER this
     // singleton initializes, and reloads deliver mid-session flips).
@@ -91,6 +99,14 @@ final class RatingPromptManager: ObservableObject {
   }
 
   func flagsDidUpdate() {
+    refresh()
+  }
+
+  /// The signed-in owner changed (switch, sign-in, sign-out): recompute all
+  /// cached state for the NEW owner's keys immediately — cached isVisible /
+  /// thank-you from the previous account must never survive a switch.
+  func ownerDidChange() {
+    thankYouRating = nil
     refresh()
   }
 

--- a/desktop/macos/Desktop/Sources/RemotePrompts.swift
+++ b/desktop/macos/Desktop/Sources/RemotePrompts.swift
@@ -107,6 +107,15 @@ final class RemotePromptEngine: ObservableObject {
     evaluate()
   }
 
+  /// Owner transition: drop the previous account's prompt from the slot
+  /// (its resolution keys no longer apply) and re-evaluate/refetch for the
+  /// new owner.
+  func ownerDidChange() {
+    current = nil
+    evaluate()
+    Task { await self.refreshFromServer() }
+  }
+
   /// The built-in rating ask owns the bottom slot whenever it is visible.
   /// A remote prompt that was already on screen is SUSPENDED (cleared without
   /// a resolution) and re-offered by evaluate() once the ask resolves — the

--- a/desktop/macos/Desktop/Tests/PromptStateAccountScopingTests.swift
+++ b/desktop/macos/Desktop/Tests/PromptStateAccountScopingTests.swift
@@ -83,6 +83,56 @@ final class PromptStateAccountScopingTests: XCTestCase {
     await RemotePromptEngine.shared.refreshFromServer()
   }
 
+  func testOwnerTransitionSwapsCachedStateImmediately() async {
+    // Account A has an armed, VISIBLE rating prompt.
+    for _ in 1...3 { RatingPromptManager.shared.recordQuestionAsked() }
+    XCTAssertTrue(RatingPromptManager.shared.isVisible)
+
+    // Switch to account B: the owner-keyed task calls ownerDidChange() —
+    // no question, no flag reload. Cached visibility must drop at once.
+    owner = "user-b"
+    RatingPromptManager.shared.ownerDidChange()
+    XCTAssertFalse(RatingPromptManager.shared.isVisible)
+
+    // And switching back restores A's armed prompt the same way.
+    owner = "user-a"
+    RatingPromptManager.shared.ownerDidChange()
+    XCTAssertTrue(RatingPromptManager.shared.isVisible)
+  }
+
+  func testOwnerTransitionClearsRemotePromptFromTheSlot() async {
+    let spec = RemotePromptSpec(
+      id: "switch-banner", type: "banner", question: "Hey", options: [],
+      ctaLabel: "Open", ctaURL: "https://omi.me", triggerKind: "app_launch", triggerCount: 0)
+    RemotePromptEngine.shared.isSignedInCheck = { true }
+    RemotePromptEngine.shared.fetch = { [spec] }
+    await RemotePromptEngine.shared.refreshFromServer()
+    for account in ["user-a", "user-b"] {
+      owner = account
+      RemotePromptEngine.shared.resetForTesting()
+      RatingPromptManager.shared.dismiss()
+    }
+    owner = "user-a"
+    await RemotePromptEngine.shared.refreshFromServer()
+    XCTAssertEqual(RemotePromptEngine.shared.current?.id, "switch-banner")
+
+    // Owner switch drops the previous account's prompt synchronously and
+    // re-evaluates for the new owner (also eligible here -> re-offered).
+    owner = "user-b"
+    RemotePromptEngine.shared.ownerDidChange()
+    XCTAssertEqual(RemotePromptEngine.shared.current?.id, "switch-banner")
+    RemotePromptEngine.shared.dismissCurrent()
+    XCTAssertNil(RemotePromptEngine.shared.current)
+
+    // Back to A: B's dismissal must not stick to A.
+    owner = "user-a"
+    RemotePromptEngine.shared.ownerDidChange()
+    XCTAssertEqual(RemotePromptEngine.shared.current?.id, "switch-banner")
+
+    RemotePromptEngine.shared.fetch = { [] }
+    await RemotePromptEngine.shared.refreshFromServer()
+  }
+
   func testLegacyGlobalStateMigratesToTheFirstAccountOnly() {
     UserDefaults.standard.set(4, forKey: DefaultsKey.ratingPromptQuestionCount.rawValue)
     UserDefaults.standard.set(true, forKey: DefaultsKey.ratingPromptDismissed.rawValue)


### PR DESCRIPTION
## Why

Follow-up to #12312 (per-account prompt state): storage was owner-scoped, but the cached `isVisible`/`current` published state persisted across an account switch until the next question or flag reload.

## What

`RatingPromptManager.ownerDidChange()` (clears thank-you, recomputes from the new owner's keys) and `RemotePromptEngine.ownerDidChange()` (drops the slot without writing a resolution, re-evaluates, refetches). DesktopHomeView's owner-keyed `.task(id: currentOwnerId)` — the app's established owner-transition seam (same pattern as the chat-first capability task) — invokes both on every transition; the rating manager additionally observes `.userDidSignOut` for the sign-out leg.

## Verification

Two new `PromptStateAccountScopingTests` exercise the transition with a VISIBLE prompt and no manual flag reload or extra question: the armed rating bar disappears the moment the owner flips to B and returns when it flips back to A; a visible remote banner survives the switch unresolved, B's dismissal doesn't stick to A. All prompt suites 25/25; swift build clean.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

