### PR TITLE
fix(desktop): put the Omi mark back on every Omi reply

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/ChatOmiMark.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatOmiMark.swift
@@ -47,10 +47,6 @@ enum ChatOmiMarkPlacement {
   /// object needs, not a margin of its own.
   static let markGutter: CGFloat = markSize + OmiSpacing.sm
 
-  static func finalAssistantMessageID(in messages: [ChatMessage]) -> String? {
-    messages.last(where: { $0.sender == .ai })?.id
-  }
-
   static func rowHeight(showsMark: Bool) -> CGFloat {
     showsMark ? reservedRowHeight : 0
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -982,12 +982,13 @@ struct ChatMessagesView<WelcomeContent: View>: View {
       // re-run on every rewrite of the streaming tail.
       let visibleMessages = visibleTranscriptMessages
       let displayMessages = AgentLifecycleDisplayProjection.project(visibleMessages)
-      let finalAssistantMessageID = ChatOmiMarkPlacement.finalAssistantMessageID(in: displayMessages)
       ForEach(Array(displayMessages.enumerated()), id: \.element.id) { index, message in
         ChatBubble(
           message: message,
           app: app,
-          showsOmiMark: message.id == finalAssistantMessageID,
+          // Every Omi reply carries the identity mark — limiting it to the
+          // newest reply left older answers looking unattributed.
+          showsOmiMark: message.sender == .ai,
           onRate: { rating in
             onRate(message.id, rating)
           },

--- a/desktop/macos/Desktop/Tests/ChatWorkingIndicatorTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatWorkingIndicatorTests.swift
@@ -35,30 +35,19 @@ final class ChatWorkingIndicatorTests: XCTestCase {
     #endif
   }
 
-  func testOnlyTheFinalAssistantMessageOwnsTheOmiMark() {
+  /// Every Omi reply carries the identity mark; limiting it to the newest
+  /// reply left older answers looking unattributed (reverted by request).
+  func testEveryAssistantMessageOwnsTheOmiMark() {
     let messages = [
       ChatMessage(id: "assistant-1", text: "First answer", sender: .ai),
       ChatMessage(id: "user-2", text: "Follow-up", sender: .user),
       ChatMessage(id: "assistant-2", text: "Final answer", sender: .ai),
     ]
 
-    let markedIDs = messages.compactMap { message in
-      message.id == ChatOmiMarkPlacement.finalAssistantMessageID(in: messages)
-        ? message.id
-        : nil
-    }
+    // Mirrors the transcript's gate: the mark follows the sender, not recency.
+    let markedIDs = messages.compactMap { $0.sender == .ai ? $0.id : nil }
 
-    XCTAssertEqual(markedIDs, ["assistant-2"])
-  }
-
-  func testOmiMarkPlacementRequiresAnAssistantMessage() {
-    let messages = [
-      ChatMessage(id: "user-1", text: "Question", sender: .user),
-      ChatMessage(id: "user-2", text: "Follow-up", sender: .user),
-    ]
-
-    XCTAssertNil(ChatOmiMarkPlacement.finalAssistantMessageID(in: []))
-    XCTAssertNil(ChatOmiMarkPlacement.finalAssistantMessageID(in: messages))
+    XCTAssertEqual(markedIDs, ["assistant-1", "assistant-2"])
   }
 
   func testOmiMarkReservesAVisibleRowForAnEmptyStreamingReply() {

--- a/desktop/macos/changelog/unreleased/20260827-omi-mark-every-reply.json
+++ b/desktop/macos/changelog/unreleased/20260827-omi-mark-every-reply.json
@@ -1,0 +1,3 @@
+{
+  "change": "Every Omi reply in chat shows the Omi mark again, not just the newest one"
+}


### PR DESCRIPTION
## Summary

By request: `142a0fe44e` (Jul 27) limited the chat's Omi identity mark to only the newest assistant message, which left every older reply unattributed. The mark now follows the sender again — every Omi reply carries it, app personas keep their own avatars, user bubbles are unchanged. The last-assistant-message helper had no remaining caller and is retired together with the tests that asserted the old gating; the replacement test asserts the sender-based rule.

## Verification

- Running dev bundle, real chat: two turns ("Say only: echo" / "Say only: foxtrot") — **both** replies render the Omi mark (screenshot: `.cross-review-verify.png`).
- `swift test --filter ChatWorkingIndicatorTests` — 13 passed.
- `swift build -c debug` — Build complete.

## Product invariants affected

- **INV-CHAT-1** — unchanged; presentation-only (which rows show the identity mark), no journaling or routing changes.
- **INV-CHAT-2** — unchanged; the transcript's message ordering, sessions, and content are untouched — only the per-row avatar gate changed.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

