### PR TITLE
fix: prompt activate toggle verifies the PATCH and rolls back on failure

### DIFF
--- a/web/admin/app/(protected)/dashboard/prompts/page.tsx
+++ b/web/admin/app/(protected)/dashboard/prompts/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { useAuthFetch } from "@/hooks/useAuthToken";
+import { patchPromptActive } from "@/lib/desktop-prompts-toggle";
 
 // Remote in-app prompts for Omi Desktop. Create/toggle here; every client
 // picks the change up within ~5 minutes — no app release. Responses arrive
@@ -152,14 +153,21 @@ export default function PromptsPage() {
   }
 
   async function setActive(prompt: Prompt, active: boolean) {
+    // Optimistic flip, but the switch is the kill switch: verify the PATCH
+    // and roll back on failure so the UI never claims a state change that
+    // did not reach Firestore.
     setPrompts((current) =>
       current.map((p) => (p.id === prompt.id ? { ...p, active } : p)),
     );
-    await fetchWithAuth(`/api/omi/desktop-prompts/${prompt.id}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ active }),
-    });
+    const result = await patchPromptActive(fetchWithAuth, prompt.id, active);
+    if (!result.ok) {
+      setPrompts((current) =>
+        current.map((p) =>
+          p.id === prompt.id ? { ...p, active: prompt.active } : p,
+        ),
+      );
+      setError(result.error ?? "toggle failed");
+    }
   }
 
   async function remove(prompt: Prompt) {

--- a/web/admin/lib/__tests__/desktop-prompts-toggle.test.ts
+++ b/web/admin/lib/__tests__/desktop-prompts-toggle.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { patchPromptActive } from "@/lib/desktop-prompts-toggle";
+
+describe("patchPromptActive (kill-switch honesty)", () => {
+  it("reports success only when the PATCH succeeded", async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: true }) as Response);
+    await expect(patchPromptActive(fetchImpl, "p1", false)).resolves.toEqual({
+      ok: true,
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "/api/omi/desktop-prompts/p1",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ active: false }),
+      }),
+    );
+  });
+
+  it("reports a failed kill-switch request instead of pretending it landed", async () => {
+    const fetchImpl = vi.fn(
+      async () => ({ ok: false, status: 502 }) as Response,
+    );
+    await expect(patchPromptActive(fetchImpl, "p1", false)).resolves.toEqual({
+      ok: false,
+      error: "toggle failed (502)",
+    });
+  });
+
+  it("reports network failures the same way", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("offline");
+    });
+    await expect(patchPromptActive(fetchImpl, "p1", true)).resolves.toEqual({
+      ok: false,
+      error: "offline",
+    });
+  });
+});

--- a/web/admin/lib/desktop-prompts-toggle.ts
+++ b/web/admin/lib/desktop-prompts-toggle.ts
@@ -1,0 +1,24 @@
+// The activate switch is the prompts kill switch — a failed PATCH must never
+// leave the UI claiming a prompt was enabled or disabled when it was not.
+export async function patchPromptActive(
+  fetchImpl: (url: string, init?: RequestInit) => Promise<Response>,
+  promptId: string,
+  active: boolean,
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const response = await fetchImpl(`/api/omi/desktop-prompts/${promptId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ active }),
+    });
+    if (!response.ok) {
+      return { ok: false, error: `toggle failed (${response.status})` };
+    }
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "toggle failed",
+    };
+  }
+}


### PR DESCRIPTION
Cross-review finding on the new Prompts page: `setActive` flipped the switch optimistically without checking `response.ok` — a failed PATCH falsely showed a prompt as activated or (worse, it is the kill switch) deactivated. The PATCH now goes through `patchPromptActive`, which reports HTTP and network failures; the page rolls the optimistic flip back and surfaces the error inline.

## Verification
`desktop-prompts-toggle` vitest 3/3: success passes through; failed HTTP status returns `toggle failed (502)`; a network throw returns its message. `tsc` clean. The happy path (activate/deactivate against prod Firestore) was exercised live in the browser earlier today.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

