### PR TITLE
fix: owner switch clears audience-filtered specs until the new owner's fetch succeeds

### DIFF
--- a/desktop/macos/Desktop/Sources/RemotePrompts.swift
+++ b/desktop/macos/Desktop/Sources/RemotePrompts.swift
@@ -107,12 +107,15 @@ final class RemotePromptEngine: ObservableObject {
     evaluate()
   }
 
-  /// Owner transition: drop the previous account's prompt from the slot
-  /// (its resolution keys no longer apply) and re-evaluate/refetch for the
-  /// new owner.
+  /// Owner transition: drop the previous account's prompt AND its fetched
+  /// specs — the server filters audience (rollout %, channel) per user, so
+  /// the old payload must never be evaluated for the new owner (a failed
+  /// refetch would otherwise show account A's prompts to account B
+  /// indefinitely). Nothing renders until an authenticated fetch for the new
+  /// owner succeeds.
   func ownerDidChange() {
     current = nil
-    evaluate()
+    specs = []
     Task { await self.refreshFromServer() }
   }
 

--- a/desktop/macos/Desktop/Tests/PromptStateAccountScopingTests.swift
+++ b/desktop/macos/Desktop/Tests/PromptStateAccountScopingTests.swift
@@ -100,12 +100,15 @@ final class PromptStateAccountScopingTests: XCTestCase {
     XCTAssertTrue(RatingPromptManager.shared.isVisible)
   }
 
-  func testOwnerTransitionClearsRemotePromptFromTheSlot() async {
-    let spec = RemotePromptSpec(
-      id: "switch-banner", type: "banner", question: "Hey", options: [],
+  func testOwnerTransitionNeverLeaksAnotherAccountsAudienceFilteredSpecs() async {
+    // The server filters audience per user: A is inside the rollout, B is
+    // NOT (and B's refetch also fails — the worst case).
+    let specA = RemotePromptSpec(
+      id: "a-only-banner", type: "banner", question: "Hey A", options: [],
       ctaLabel: "Open", ctaURL: "https://omi.me", triggerKind: "app_launch", triggerCount: 0)
+    struct Offline: Error {}
     RemotePromptEngine.shared.isSignedInCheck = { true }
-    RemotePromptEngine.shared.fetch = { [spec] }
+    RemotePromptEngine.shared.fetch = { [specA] }
     await RemotePromptEngine.shared.refreshFromServer()
     for account in ["user-a", "user-b"] {
       owner = account
@@ -113,21 +116,28 @@ final class PromptStateAccountScopingTests: XCTestCase {
       RatingPromptManager.shared.dismiss()
     }
     owner = "user-a"
+    RemotePromptEngine.shared.fetch = {
+      if self.owner == "user-a" { return [specA] }
+      throw Offline()
+    }
     await RemotePromptEngine.shared.refreshFromServer()
-    XCTAssertEqual(RemotePromptEngine.shared.current?.id, "switch-banner")
+    XCTAssertEqual(RemotePromptEngine.shared.current?.id, "a-only-banner")
 
-    // Owner switch drops the previous account's prompt synchronously and
-    // re-evaluates for the new owner (also eligible here -> re-offered).
+    // Switch to B: the slot AND the stale payload clear synchronously, and
+    // because B's fetch fails, NOTHING may render — A's audience-filtered
+    // prompt must not survive the switch.
     owner = "user-b"
     RemotePromptEngine.shared.ownerDidChange()
-    XCTAssertEqual(RemotePromptEngine.shared.current?.id, "switch-banner")
-    RemotePromptEngine.shared.dismissCurrent()
+    XCTAssertNil(RemotePromptEngine.shared.current)
+    XCTAssertTrue(RemotePromptEngine.shared.specs.isEmpty)
+    await RemotePromptEngine.shared.refreshFromServer()  // B's fetch throws
     XCTAssertNil(RemotePromptEngine.shared.current)
 
-    // Back to A: B's dismissal must not stick to A.
+    // Back to A: a successful refetch restores A's prompt, unresolved.
     owner = "user-a"
     RemotePromptEngine.shared.ownerDidChange()
-    XCTAssertEqual(RemotePromptEngine.shared.current?.id, "switch-banner")
+    await RemotePromptEngine.shared.refreshFromServer()
+    XCTAssertEqual(RemotePromptEngine.shared.current?.id, "a-only-banner")
 
     RemotePromptEngine.shared.fetch = { [] }
     await RemotePromptEngine.shared.refreshFromServer()


### PR DESCRIPTION
Cross-review finding: `RemotePromptEngine.ownerDidChange()` re-evaluated the previous account's server-filtered specs before fetching for the new UID — audience filtering (rollout %, channel) is per-user, so a user outside a rollout could see another account's prompt indefinitely when their refetch failed.

`ownerDidChange()` now clears `current` AND `specs` synchronously and evaluates only after a successful authenticated fetch for the new owner; a failed fetch renders nothing.

## Verification
The account-switch test now uses per-owner fetch results (A inside the rollout; B outside with a THROWING fetch): at the switch B shows nothing and specs are empty, after B's failed refetch still nothing, and switching back restores A's prompt unresolved. All prompt suites 25/25; swift build clean.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

