### PR TITLE
fix: fence remote-prompt fetches by owner generation

### DIFF
--- a/desktop/macos/Desktop/Sources/RemotePrompts.swift
+++ b/desktop/macos/Desktop/Sources/RemotePrompts.swift
@@ -43,6 +43,10 @@ final class RemotePromptEngine: ObservableObject {
 
   private(set) var specs: [RemotePromptSpec] = []
   private var pollTask: Task<Void, Never>?
+  /// Owner-fetch fence: bumped on every owner transition so an in-flight
+  /// fetch started for the previous account can never land its
+  /// audience-filtered payload after the switch.
+  private var fetchGeneration = 0
   private let defaults = UserDefaults.standard
   static let pollInterval: TimeInterval = 300
 
@@ -78,8 +82,13 @@ final class RemotePromptEngine: ObservableObject {
 
   func refreshFromServer() async {
     guard isSignedInCheck() else { return }
+    let generation = fetchGeneration
     do {
-      specs = try await fetch()
+      let fetched = try await fetch()
+      // A switch happened while this fetch was in flight — the result was
+      // filtered for the PREVIOUS owner's audience and must be discarded.
+      guard generation == fetchGeneration else { return }
+      specs = fetched
     } catch {
       // Fail closed to "no new prompts"; an already-visible prompt stays so a
       // transient network error does not flicker the bar away mid-answer.
@@ -114,6 +123,7 @@ final class RemotePromptEngine: ObservableObject {
   /// indefinitely). Nothing renders until an authenticated fetch for the new
   /// owner succeeds.
   func ownerDidChange() {
+    fetchGeneration += 1
     current = nil
     specs = []
     Task { await self.refreshFromServer() }

--- a/desktop/macos/Desktop/Tests/PromptStateAccountScopingTests.swift
+++ b/desktop/macos/Desktop/Tests/PromptStateAccountScopingTests.swift
@@ -143,6 +143,55 @@ final class PromptStateAccountScopingTests: XCTestCase {
     await RemotePromptEngine.shared.refreshFromServer()
   }
 
+  func testDelayedFetchFromPreviousOwnerNeverLandsAfterSwitch() async {
+    let specA = RemotePromptSpec(
+      id: "a-delayed-banner", type: "banner", question: "Hey A", options: [],
+      ctaLabel: "Open", ctaURL: "https://omi.me", triggerKind: "app_launch", triggerCount: 0)
+    RemotePromptEngine.shared.isSignedInCheck = { true }
+    RatingPromptManager.shared.dismiss()
+    owner = "user-b"
+    RatingPromptManager.shared.dismiss()
+    owner = "user-a"
+
+    // A's fetch suspends until released; B's fetch returns nothing.
+    // An actor holds the gate so the fetch closure stays Sendable-clean.
+    actor Gate {
+      private var waiter: CheckedContinuation<Void, Never>?
+      func wait() async {
+        await withCheckedContinuation { waiter = $0 }
+      }
+      func open() {
+        waiter?.resume()
+        waiter = nil
+      }
+    }
+    let gate = Gate()
+    RemotePromptEngine.shared.fetch = {
+      if self.owner == "user-a" {
+        await gate.wait()
+        return [specA]
+      }
+      return []
+    }
+
+    // Start A's refresh; it parks awaiting the gate.
+    let inFlight = Task { await RemotePromptEngine.shared.refreshFromServer() }
+    await Task.yield()
+
+    // Switch to B while A's fetch is still in flight, then release it.
+    owner = "user-b"
+    RemotePromptEngine.shared.ownerDidChange()
+    await gate.open()
+    await inFlight.value
+
+    // A's stale audience-filtered payload must have been DISCARDED.
+    XCTAssertNil(RemotePromptEngine.shared.current)
+    XCTAssertFalse(RemotePromptEngine.shared.specs.contains(where: { $0.id == "a-delayed-banner" }))
+
+    RemotePromptEngine.shared.fetch = { [] }
+    await RemotePromptEngine.shared.refreshFromServer()
+  }
+
   func testLegacyGlobalStateMigratesToTheFirstAccountOnly() {
     UserDefaults.standard.set(4, forKey: DefaultsKey.ratingPromptQuestionCount.rawValue)
     UserDefaults.standard.set(true, forKey: DefaultsKey.ratingPromptDismissed.rawValue)


### PR DESCRIPTION
Cross-review race: an in-flight `fetch()` started for account A could complete AFTER an owner switch and land A's audience-filtered payload for B. `refreshFromServer()` now captures `fetchGeneration` before awaiting and discards the result unless the generation is unchanged; `ownerDidChange()` bumps it.

## Verification
New test parks A's fetch on an actor gate, switches the owner to B mid-flight, opens the gate, and proves the stale payload is discarded (`current` nil, `specs` free of A's prompt). All prompt suites 26/26; swift build clean.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

