### PR TITLE
fix: owner-fence the rating history seed

### DIFF
--- a/desktop/macos/Desktop/Sources/RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/RatingPrompt.swift
@@ -78,6 +78,10 @@ final class RatingPromptManager: ObservableObject {
   }
 
   private init() {
+    historyFetch = { owner in
+      try await APIClient.shared.getMessages(
+        limit: 100, expectedOwnerId: owner == "anonymous" ? nil : owner)
+    }
     refresh()
     // Sign-out is an owner transition too: hide immediately, not at the next
     // question. Sign-IN transitions arrive via the owner-keyed task in
@@ -169,7 +173,17 @@ final class RatingPromptManager: ObservableObject {
   /// the ask on their NEXT LAUNCH, not after three more questions: a one-shot
   /// seed of the counter from server chat history. Fetch failure leaves the
   /// marker unset so the next launch retries.
+  /// Injectable for tests; production asks the backend for the owner's own
+  /// messages, owner-asserted end to end (expectedOwnerId). Assigned in init
+  /// (APIClient is actor-isolated, so it cannot be a property default).
+  var historyFetch: ((String) async throws -> [ChatMessageDB])!
+
   func seedFromHistoryIfNeeded() async {
+    // Owner-fenced: the seed reads and WRITES the account that started it.
+    // The fetch carries expectedOwnerId, and if the signed-in owner changed
+    // while the request was in flight the result is discarded — account B
+    // must never be seeded from account A's history.
+    let owner = ownerProvider()
     guard !(defaults.object(forKey: scopedKey("historySeeded")) as? Bool ?? false) else { return }
     guard submittedRating == 0, !isDismissed,
       questionCount < RatingPromptPolicy.questionThreshold
@@ -182,8 +196,9 @@ final class RatingPromptManager: ObservableObject {
     var history: [ChatMessageDB] = []
     var fetched = false
     for attempt in 1...5 {
+      guard ownerProvider() == owner, !Task.isCancelled else { return }
       if AuthState.shared.isSignedIn,
-        let result = try? await APIClient.shared.getMessages(limit: 100)
+        let result = try? await historyFetch(owner)
       {
         history = result
         fetched = true
@@ -192,7 +207,7 @@ final class RatingPromptManager: ObservableObject {
       log("RatingPrompt: history seed attempt \(attempt) not ready, retrying")
       try? await Task.sleep(nanoseconds: 15_000_000_000)
     }
-    guard fetched else { return }
+    guard fetched, ownerProvider() == owner, !Task.isCancelled else { return }
     let asked = history.filter { $0.sender == "human" }.count
     log("RatingPrompt: history seed fetched \(history.count) messages, \(asked) questions")
     if asked >= RatingPromptPolicy.questionThreshold {

--- a/desktop/macos/Desktop/Tests/PromptStateAccountScopingTests.swift
+++ b/desktop/macos/Desktop/Tests/PromptStateAccountScopingTests.swift
@@ -192,6 +192,50 @@ final class PromptStateAccountScopingTests: XCTestCase {
     await RemotePromptEngine.shared.refreshFromServer()
   }
 
+  func testDelayedHistorySeedFromPreviousOwnerNeverTouchesTheNextAccount() async {
+    // Account A's history fetch parks on a gate; the owner switches to B
+    // before it completes. B's seed state must remain untouched, and the
+    // stale result must be discarded entirely.
+    actor Gate {
+      private var waiter: CheckedContinuation<Void, Never>?
+      func wait() async { await withCheckedContinuation { waiter = $0 } }
+      func open() {
+        waiter?.resume()
+        waiter = nil
+      }
+    }
+    let gate = Gate()
+    RatingPromptManager.shared.historyFetch = { owner in
+      await gate.wait()
+      let json = (1...5).map { "{\"id\":\"m\($0)\",\"sender\":\"human\",\"text\":\"q\"}" }
+      let data = Data("[\(json.joined(separator: ","))]".utf8)
+      return try JSONDecoder().decode([ChatMessageDB].self, from: data)
+    }
+
+    owner = "user-a"
+    let inFlight = Task { await RatingPromptManager.shared.seedFromHistoryIfNeeded() }
+    await Task.yield()
+
+    owner = "user-b"
+    RatingPromptManager.shared.ownerDidChange()
+    await gate.open()
+    await inFlight.value
+
+    // B: untouched — no seeded marker, zero count, prompt not armed.
+    XCTAssertEqual(RatingPromptManager.shared.questionCount, 0)
+    XCTAssertFalse(
+      UserDefaults.standard.object(
+        forKey: ScopedDefaultsKey.ratingPrompt("historySeeded", ownerID: "user-b")) != nil)
+    XCTAssertFalse(RatingPromptManager.shared.isVisible)
+    // A: the stale result was discarded (owner changed mid-flight), so A's
+    // marker is also unset and the NEXT launch under A retries cleanly.
+    XCTAssertFalse(
+      UserDefaults.standard.object(
+        forKey: ScopedDefaultsKey.ratingPrompt("historySeeded", ownerID: "user-a")) != nil)
+
+    RatingPromptManager.shared.historyFetch = { _ in [] }
+  }
+
   func testLegacyGlobalStateMigratesToTheFirstAccountOnly() {
     UserDefaults.standard.set(4, forKey: DefaultsKey.ratingPromptQuestionCount.rawValue)
     UserDefaults.standard.set(true, forKey: DefaultsKey.ratingPromptDismissed.rawValue)


### PR DESCRIPTION
Cross-review finding: the history seed fetched without `expectedOwnerId` and wrote through `scopedKey()` for whichever account was current at completion — an account switch mid-flight could seed account B from account A's history.

The seed now captures the owner at start, passes `getMessages(expectedOwnerId:)` (transport-level owner assertion), and discards the result if the owner changed or the task was cancelled before persistence — the marker stays unset so that owner's next launch retries cleanly.

## Verification
New regression test parks A's history fetch on an actor gate, switches the owner to B, opens the gate: B's count and seed marker remain untouched and the stale result is fully discarded (A's marker also unset for a clean retry). All prompt suites 27/27; swift build clean.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

