### PR TITLE
fix(backend): pass a Firestore key to the sweep cursor

### DIFF
--- a/backend/tests/unit/test_daily_memory_sweep_inventory.py
+++ b/backend/tests/unit/test_daily_memory_sweep_inventory.py
@@ -20,6 +20,11 @@ class _Snapshot:
         return self._payload
 
 
+class _DocumentReference:
+    def __init__(self, uid):
+        self.id = uid
+
+
 class _Ref:
     def __init__(self, store, path):
         self.store = store
@@ -63,7 +68,8 @@ class _Query:
     def stream(self):
         rows = list(self.rows)
         if self.field and self.field[0] in ("__name__", "uid") and self.field[1] == ">":
-            rows = [row for row in rows if row.id > self.field[2]]
+            boundary = getattr(self.field[2], "id", self.field[2])
+            rows = [row for row in rows if row.id > boundary]
         rows.sort(key=lambda row: row.id)
         return rows[: self.page_size]
 
@@ -71,9 +77,17 @@ class _Query:
 class _Users:
     def __init__(self, rows):
         self.rows = rows
+        self.queries = []
+        self.requested_documents = []
 
     def where(self, *args, **kwargs):
-        return _Query(self.rows).where(*args, **kwargs)
+        query = _Query(self.rows).where(*args, **kwargs)
+        self.queries.append(query)
+        return query
+
+    def document(self, uid):
+        self.requested_documents.append(uid)
+        return _DocumentReference(uid)
 
 
 class _Db:
@@ -142,6 +156,8 @@ def test_independent_inventory_executes_registered_onboarding_cursor_query(monke
     page = independent.bounded_daily_memory_sweep_uid_inventory(db, limit=2, return_page=True)
     assert isinstance(page, independent.DailySweepUIDInventoryPage)
     assert page.onboarding_uids == ("a",)
+    assert db.users.requested_documents == []
+    assert all(query.field[0] != "__name__" for query in db.users.queries)
 
 
 def test_independent_onboarding_cursor_is_server_side_before_page_limit(monkeypatch):
@@ -163,6 +179,8 @@ def test_independent_onboarding_cursor_is_server_side_before_page_limit(monkeypa
     page = independent.bounded_daily_memory_sweep_uid_inventory(db, limit=2, return_page=True)
 
     assert page.onboarding_uids == ("z-user",)
+    assert db.users.requested_documents == ["m-user", "m-user"]
+    assert all(not isinstance(query.field[2], str) for query in db.users.queries)
 
 
 def test_independent_inventory_commits_only_its_own_fair_cursor_namespace():

--- a/backend/utils/memory/daily_memory_sweep_inventory.py
+++ b/backend/utils/memory/daily_memory_sweep_inventory.py
@@ -310,19 +310,33 @@ def bounded_daily_memory_sweep_uid_inventory(
             ),
         ):
             try:
-                query: Any = query_spec.build(
-                    users,
-                    {"completed": True, "after_uid": onboarding_cursor},
-                    field_filter_factory=FieldFilter,
-                )
+                if onboarding_cursor:
+                    # Firestore's __name__ operand is a Key, not the document ID
+                    # string. A bare UID is rejected with InvalidArgument before
+                    # any onboarding row can be inventoried.
+                    document_factory = getattr(users, "document", None)
+                    after_uid = document_factory(onboarding_cursor) if callable(document_factory) else onboarding_cursor
+                    query: Any = query_spec.build(
+                        users,
+                        {"completed": True, "after_uid": after_uid},
+                        field_filter_factory=FieldFilter,
+                    )
+                else:
+                    # There is no valid empty document reference. The first page
+                    # needs only the onboarding predicate; later pages add the
+                    # server-side document-ID cursor above.
+                    query = cast(Any, where)(filter=FieldFilter(field_name, "==", True))
             except (TypeError, ValueError):
                 # Keep compatibility with small Firestore fakes and older
                 # client releases that do not accept FieldFilter as a kwarg.
                 query = cast(Any, where)(field_name, "==", True)
-                try:
-                    query = query.where(FieldPath.document_id(), ">", onboarding_cursor)
-                except TypeError:
-                    query = query.where(filter=FieldFilter(FieldPath.document_id(), ">", onboarding_cursor))
+                if onboarding_cursor:
+                    document_factory = getattr(users, "document", None)
+                    after_uid = document_factory(onboarding_cursor) if callable(document_factory) else onboarding_cursor
+                    try:
+                        query = query.where(FieldPath.document_id(), ">", after_uid)
+                    except TypeError:
+                        query = query.where(filter=FieldFilter(FieldPath.document_id(), ">", after_uid))
             try:
                 query = query.order_by("__name__")
             except (AttributeError, TypeError):


### PR DESCRIPTION
## What changed and why

Daily-memory-sweep onboarding inventory passed a bare UID string to a Firestore `__name__` range filter. Firestore requires a document key, so every scheduled run failed before inventory with `400 __key__ filter value must be a Key`.

Cursor-relative pages now resolve the UID through the `users` collection to a DocumentReference. The initial page omits the document-ID range because Firestore has no valid empty document reference.

## Product invariants affected

- INV-MEM-4
- INV-MEM-1

This changes only bounded UID discovery. It does not alter memory tiers, promotion authority, sweep decisions, writes, or rollout gates.

## How it was verified

- `cd backend && .venv/bin/pytest -q tests/unit/test_daily_memory_sweep_inventory.py tests/unit/test_daily_memory_sweep_job.py` — 16 passed.
- The regression test proves the first page emits no invalid empty `__name__` bound and cursor pages resolve `m-user` through `users.document(...)` before filtering.
- `make preflight` was run; the initial metadata-free run stopped only because invariant IDs must come from this PR body. `scripts/pr-preflight --pr-body-file /tmp/omi-daily-sweep-key-pr.md` supplies those citations and is the authoritative rerun.
- The deployed Cloud Run path was not exercised from this branch because this PR does not deploy or mutate dev data.

## Tests

`backend/tests/unit/test_daily_memory_sweep_inventory.py` now fails if the onboarding query regresses to a bare string key or adds an empty document-ID cursor to the first page.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

