### PR TITLE
fix(desktop): pin the OpenAI realtime voice to cedar, Charon's counterpart

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -2496,6 +2496,28 @@ final class DesktopAutomationActionRegistry {
       return bar.automationNotchStateSnapshot
     }
 
+    // Drives the REAL provider failover the quota/auth close handlers call
+    // (failoverToAlternateProvider), then re-warms, so the cross-provider path
+    // can be exercised without waiting for the shared key to actually throttle.
+    register(
+      name: "realtime_failover",
+      summary: "Fail the realtime hub over to the alternate provider via the production path (non-prod).",
+      params: []
+    ) { _ in
+      guard AppBuild.isNonProduction else {
+        return ["error": "realtime_failover is disabled on production bundles"]
+      }
+      let controller = RealtimeHubController.shared
+      let from = controller.effectiveProvider.rawValue
+      let started = controller.failoverToAlternateProvider(reason: "quota")
+      controller.ensureWarm()
+      return [
+        "failover_started": started ? "true" : "false",
+        "from": from,
+        "to": controller.effectiveProvider.rawValue,
+      ]
+    }
+
     register(
       name: "seed_subagents",
       summary: "Seed synthetic floating-bar subagents for deterministic UI benchmarks",

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
@@ -1017,7 +1017,10 @@ final class RealtimeHubSession: NSObject, @unchecked Sendable {
             "turn_detection": NSNull(),  // PTT controls turns
             "transcription": transcription,
           ],
-          "output": ["format": ["type": "audio/pcm", "rate": 24000], "voice": "marin"],
+          // cedar: the deep, calm male voice of the gpt-realtime family — the closest
+          // match to the Gemini hub voice (Charon), so a provider failover does not
+          // change who Omi sounds like mid-conversation.
+          "output": ["format": ["type": "audio/pcm", "rate": 24000], "voice": "cedar"],
         ],
         "tools": RealtimeHubTools.openAITools(availableDirectedProviders: availableDirectedProviders),
         "tool_choice": "auto",
@@ -1044,7 +1047,7 @@ final class RealtimeHubSession: NSObject, @unchecked Sendable {
             "responseModalities": ["AUDIO"], "temperature": 0.3,
             "mediaResolution": "MEDIA_RESOLUTION_HIGH",
             // Pin the spoken voice — with no speechConfig Gemini picks its own default,
-            // which differs from the OpenAI hub voice (marin) and can change across
+            // which differs from the OpenAI hub voice (cedar) and can change across
             // model revisions. Charon: deep, calm, "informative" — closest match to marin.
             "speechConfig": [
               "voiceConfig": ["prebuiltVoiceConfig": ["voiceName": "Charon"]]

--- a/desktop/macos/changelog/unreleased/20260827-openai-voice-cedar.json
+++ b/desktop/macos/changelog/unreleased/20260827-openai-voice-cedar.json
@@ -1,0 +1,3 @@
+{
+  "change": "Voice replies keep the same deep male voice even when the assistant fails over between providers"
+}


### PR DESCRIPTION
## Summary

PTT's Gemini lane speaks as **Charon** (deep, calm male). The OpenAI lane pinned **marin** — a female voice — so when the shared Gemini key hits its Tier-3 spend throttle ($200 / rolling 10 min, project-wide) and the hub fails over to `gpt-realtime-2`, Omi's voice audibly changed to a woman mid-day. One line: pin the OpenAI voice to **cedar**, the gpt-realtime family's deep male voice and the closest match to Charon, so a provider failover no longer changes who Omi sounds like.

## Verification

- `cedar` accepted by `gpt-realtime-2` via a real `/v1/realtime/client_secrets` mint (also probed `ash`/`echo`; cedar is marin's male counterpart per OpenAI's voice family).
- Dev bundle forced to the OpenAI provider connects and reports `RealtimeHub[openai:gpt-realtime-2]: ready` running this diff — a rejected voice fails session configuration, so `ready` is acceptance through the app's own path.
- Voice-identity closeness is per OpenAI's published descriptions; the audio itself was not human-audited.

## Product invariants affected

- **INV-CHAT-1** — unchanged; audio session config only, no chat journaling or routing changes.

Failure-Class: none

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift | 1658 -> 1661 | three comment lines documenting why cedar is pinned, beside the session config they explain

Line-Count-Exception: desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift | 4791 -> 4814 | one non-prod realtime_failover QA action, following the file's established registry pattern


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

