### PR TITLE
fix: history seed merges with, never rolls back, the live question count

### DIFF
--- a/desktop/macos/Desktop/Sources/RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/RatingPrompt.swift
@@ -177,6 +177,8 @@ final class RatingPromptManager: ObservableObject {
   /// messages, owner-asserted end to end (expectedOwnerId). Assigned in init
   /// (APIClient is actor-isolated, so it cannot be a property default).
   var historyFetch: ((String) async throws -> [ChatMessageDB])!
+  /// Injectable for tests; production reads the real auth state.
+  var isSignedInCheck: () -> Bool = { AuthState.shared.isSignedIn }
 
   func seedFromHistoryIfNeeded() async {
     // Owner-fenced: the seed reads and WRITES the account that started it.
@@ -197,7 +199,7 @@ final class RatingPromptManager: ObservableObject {
     var fetched = false
     for attempt in 1...5 {
       guard ownerProvider() == owner, !Task.isCancelled else { return }
-      if AuthState.shared.isSignedIn,
+      if isSignedInCheck(),
         let result = try? await historyFetch(owner)
       {
         history = result
@@ -211,7 +213,12 @@ final class RatingPromptManager: ObservableObject {
     let asked = history.filter { $0.sender == "human" }.count
     log("RatingPrompt: history seed fetched \(history.count) messages, \(asked) questions")
     if asked >= RatingPromptPolicy.questionThreshold {
-      defaults.set(RatingPromptPolicy.questionThreshold, forKey: scopedKey("questionCount"))
+      // Merge, never decrease: questions asked live while the history fetch
+      // was in flight already advanced the persisted count past the seed
+      // value, and the seed must not roll that back.
+      defaults.set(
+        max(questionCount, RatingPromptPolicy.questionThreshold),
+        forKey: scopedKey("questionCount"))
     }
     defaults.set(true, forKey: scopedKey("historySeeded"))
     refresh()

--- a/desktop/macos/Desktop/Tests/PromptStateAccountScopingTests.swift
+++ b/desktop/macos/Desktop/Tests/PromptStateAccountScopingTests.swift
@@ -11,6 +11,7 @@ final class PromptStateAccountScopingTests: XCTestCase {
 
   override func setUp() async throws {
     RatingPromptManager.shared.remoteDisableCheck = { false }
+    RatingPromptManager.shared.isSignedInCheck = { true }
     RatingPromptManager.shared.ownerProvider = { self.owner }
     RemotePromptEngine.shared.ownerProvider = { self.owner }
     for account in ["user-a", "user-b"] {
@@ -29,6 +30,7 @@ final class PromptStateAccountScopingTests: XCTestCase {
     }
     RatingPromptManager.shared.ownerProvider = { RuntimeOwnerIdentity.currentOwnerId() ?? "anonymous" }
     RemotePromptEngine.shared.ownerProvider = { RuntimeOwnerIdentity.currentOwnerId() ?? "anonymous" }
+    RatingPromptManager.shared.isSignedInCheck = { AuthState.shared.isSignedIn }
     RatingPromptManager.shared.remoteDisableCheck = {
       PostHogManager.shared.isFeatureEnabled(RatingPromptPolicy.killSwitchFlag)
     }
@@ -233,6 +235,37 @@ final class PromptStateAccountScopingTests: XCTestCase {
       UserDefaults.standard.object(
         forKey: ScopedDefaultsKey.ratingPrompt("historySeeded", ownerID: "user-a")) != nil)
 
+    RatingPromptManager.shared.historyFetch = { _ in [] }
+  }
+
+  func testSeedNeverDecreasesACountAdvancedDuringItsFetch() async {
+    actor Gate {
+      private var waiter: CheckedContinuation<Void, Never>?
+      func wait() async { await withCheckedContinuation { waiter = $0 } }
+      func open() {
+        waiter?.resume()
+        waiter = nil
+      }
+    }
+    let gate = Gate()
+    RatingPromptManager.shared.historyFetch = { _ in
+      await gate.wait()
+      let json = (1...5).map { "{\"id\":\"m\($0)\",\"sender\":\"human\",\"text\":\"q\"}" }
+      return try JSONDecoder().decode([ChatMessageDB].self, from: Data("[\(json.joined(separator: ","))]".utf8))
+    }
+    owner = "user-a"
+    let inFlight = Task { await RatingPromptManager.shared.seedFromHistoryIfNeeded() }
+    await Task.yield()
+
+    // The user keeps asking questions while the fetch is parked.
+    for _ in 1...5 { RatingPromptManager.shared.recordQuestionAsked() }
+    XCTAssertEqual(RatingPromptManager.shared.questionCount, 5)
+
+    await gate.open()
+    await inFlight.value
+
+    // The seed merged with, and did not roll back, the live count.
+    XCTAssertEqual(RatingPromptManager.shared.questionCount, 5)
     RatingPromptManager.shared.historyFetch = { _ in [] }
   }
 


### PR DESCRIPTION
Cross-review finding: questions asked during the awaited history fetch advanced the persisted count; the seed then wrote the bare threshold (3), rolling it back. The seed write is now `max(currentCount, threshold)`.

Also hardens the tests themselves: an `isSignedInCheck` seam replaces the direct AuthState read inside the seed loop — the signed-out test process previously skipped the fetch entirely, so the two earlier seed race tests passed vacuously (exposed by their 90-second retry-sleep runtime). With the seam set, all gates genuinely exercise the fetch path.

## Verification
New regression test parks the fetch on an actor gate, records 5 live questions for the same owner, opens the gate — final count is 5, not 3. All prompt suites 28/28 in 0.2s (was 90s of vacuous retries). swift build clean.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

