### PR TITLE
SCA-364: render Desktop Chat SQL timestamps in the user timezone

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/ChatPrompts.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatPrompts.swift
@@ -15,14 +15,14 @@ struct ChatPrompts {
 
   /// Simplified prompt for desktop client-side chat (no tool instructions)
   /// This is what we use in ChatProvider.swift
-  /// Variables: {user_name}, {tz}, {current_datetime_str}, {memories_section}
+  /// Variables: {user_name}, {tz}, {memories_section} — live clock is per-turn, not cached here.
   static let desktopChat = """
     <assistant_role>
     You are Omi, an AI assistant & mentor for {user_name}. You are a smart friend who gives honest and concise feedback and responses to user's questions in the most personalized way possible.
     </assistant_role>
 
     <user_context>
-    Current date/time in {user_name}'s timezone ({tz}): {current_datetime_str}
+    {user_name}'s timezone is {tz}. Quote tool timestamps as printed — they already include the zone. The # Current Time block on each request is the authoritative clock.
     {memories_section}
     {goal_section}{tasks_section}{ai_profile_section}
     </user_context>
@@ -87,25 +87,25 @@ struct ChatPrompts {
     -- Daily totals only (for counts/time breakdowns; use get_work_context for "what was I doing" — use -1 day for yesterday, -7 day for past week):
     -- Q1: App usage
     SELECT appName, COUNT(*) as count, ROUND(COUNT(*) * 10.0 / 60, 1) as minutes,
-    MIN(time(timestamp, 'localtime')) as first_seen, MAX(time(timestamp, 'localtime')) as last_seen
-    FROM screenshots WHERE timestamp >= datetime('now', 'start of day', '-1 day', 'localtime')
-    AND timestamp < datetime('now', 'start of day', 'localtime')
+    MIN(timestamp) AS firstSeenAt, MAX(timestamp) AS lastSeenAt
+    FROM screenshots WHERE timestamp >= datetime('now', 'localtime', 'start of day', '-1 day', 'utc')
+    AND timestamp < datetime('now', 'localtime', 'start of day', 'utc')
     AND appName IS NOT NULL AND appName != '' GROUP BY appName ORDER BY count DESC
     -- Q2: Conversations
     SELECT title, overview, emoji, startedAt, finishedAt,
     ROUND((julianday(finishedAt) - julianday(startedAt)) * 1440, 1) as duration_min
-    FROM transcription_sessions WHERE startedAt >= datetime('now', 'start of day', '-1 day', 'localtime')
-    AND startedAt < datetime('now', 'start of day', 'localtime') AND deleted = 0 AND discarded = 0
+    FROM transcription_sessions WHERE startedAt >= datetime('now', 'localtime', 'start of day', '-1 day', 'utc')
+    AND startedAt < datetime('now', 'localtime', 'start of day', 'utc') AND deleted = 0 AND discarded = 0
     ORDER BY startedAt DESC
     -- Q3: Tasks
     SELECT description, completed, priority FROM action_items
-    WHERE createdAt >= datetime('now', 'start of day', '-1 day', 'localtime')
-    AND createdAt < datetime('now', 'start of day', 'localtime') AND deleted = 0
+    WHERE createdAt >= datetime('now', 'localtime', 'start of day', '-1 day', 'utc')
+    AND createdAt < datetime('now', 'localtime', 'start of day', 'utc') AND deleted = 0
     ORDER BY createdAt DESC
 
     -- Bounded OCR preview for explicit low-level inspection only; recent-work retrieval belongs to get_work_context:
     SELECT timestamp, appName, windowTitle, substr(ocrText, 1, 200) as preview
-    FROM screenshots WHERE timestamp >= datetime('now', '-1 day', 'localtime')
+    FROM screenshots WHERE timestamp >= datetime('now', '-1 day')
     ORDER BY timestamp DESC LIMIT 20
 
     -- Active tasks:
@@ -130,12 +130,14 @@ struct ChatPrompts {
     WHERE s.deleted = 0 AND seg.text LIKE '%keyword%'
     GROUP BY s.id ORDER BY s.startedAt DESC LIMIT 10
 
-    -- Time in user's timezone: use datetime('now', 'localtime') or datetime('now', '-N hours', 'localtime')
-    -- "yesterday": datetime('now', 'start of day', '-1 day', 'localtime') to datetime('now', 'start of day', 'localtime')
+    -- Local calendar bounds as UTC instants (never compare a UTC column to datetime('now', 'localtime')):
+    -- "today" start: datetime('now', 'localtime', 'start of day', 'utc')
+    -- "yesterday": datetime('now', 'localtime', 'start of day', '-1 day', 'utc') to datetime('now', 'localtime', 'start of day', 'utc')
+    -- last 24 hours: datetime('now', '-1 day')
     -- FTS search: SELECT * FROM screenshots WHERE id IN (SELECT rowid FROM screenshots_fts WHERE screenshots_fts MATCH 'keyword')
 
     **Timezone handling:**
-    All timestamps in the database are stored in UTC. When displaying dates/times from query results to the user, convert them to {user_name}'s timezone ({tz}). When filtering by date/time in WHERE clauses, use datetime('now', 'localtime') which SQLite handles automatically.
+    All timestamps in the database are stored in UTC. Select raw timestamp and camelCase *At columns without wrapping them in time(..., 'localtime') or datetime(..., 'localtime'); execute_sql converts those result cells once to {user_name}'s timezone ({tz}) with an explicit zone label. Quote the converted tool output as-is. When filtering, compare UTC columns to UTC bounds (convert local midnight with datetime('now', 'localtime', 'start of day', 'utc')). Never compare a UTC column to datetime('now', 'localtime').
     </tools>
 
     <initiative>
@@ -151,7 +153,7 @@ struct ChatPrompts {
     - Give specific feedback/advice; never generic.
     - Always answer the question directly; no extra info, no fluff.
     - Use what you know about {user_name} to personalize your responses.
-    - Show times/dates in {user_name}'s timezone ({tz}), in a natural, friendly way.
+    - Show times/dates in {user_name}'s timezone ({tz}), including the zone, in a natural, friendly way. Quote tool timestamps as printed.
     - When searching screen history, summarize findings naturally — don't dump raw data.
     </instructions>
     """
@@ -762,22 +764,11 @@ struct ChatPrompts {
 /// Helper class to build prompts with template variables
 struct ChatPromptBuilder {
 
-  /// Shared formatter — `DateFormatter` is expensive to construct, and
-  /// `currentDatetimeString` is on the per-query hot path. Configured once and
-  /// only read afterwards (safe for concurrent formatting).
-  private static let datetimeFormatter: DateFormatter = {
-    let f = DateFormatter()
-    f.dateFormat = "yyyy-MM-dd HH:mm:ss"
-    f.timeZone = .current
-    return f
-  }()
-
-  /// Human-readable "now" in the user's timezone ("yyyy-MM-dd HH:mm:ss").
-  /// Single source for the {current_datetime_str} substitution and the
-  /// floating-bar live-context line, so the cached prefix and live tail can't
-  /// drift in datetime format.
-  static func currentDatetimeString(_ date: Date = Date()) -> String {
-    datetimeFormatter.string(from: date)
+  /// Human-readable "now" in the user's timezone, always including IANA zone.
+  /// Live clocks belong on the per-turn `# Current Time` prefix — not in a
+  /// cached system-prompt template.
+  static func currentDatetimeString(_ date: Date = Date(), timeZone: TimeZone = .current) -> String {
+    DesktopChatTimestampFormat.userFacing(date, timeZone: timeZone)
   }
 
   static func currentTimePrompt(for prompt: String, at date: Date = Date(), timeZone: TimeZone = .current) -> String {
@@ -854,7 +845,8 @@ struct ChatPromptBuilder {
     isoFormatter.timeZone = TimeZone.current
 
     let now = Date()
-    let datetime = currentDatetime ?? currentDatetimeString(now)
+    let resolvedTimeZone = TimeZone(identifier: timezone) ?? .current
+    let datetime = currentDatetime ?? currentDatetimeString(now, timeZone: resolvedTimeZone)
     let datetimeISO = currentDatetimeISO ?? isoFormatter.string(from: now)
     let utcFormatter = DateFormatter()
     utcFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"

--- a/desktop/macos/Desktop/Sources/Chat/DesktopChatTimestampFormat.swift
+++ b/desktop/macos/Desktop/Sources/Chat/DesktopChatTimestampFormat.swift
@@ -1,0 +1,110 @@
+import Foundation
+@preconcurrency import GRDB
+
+/// Single formatter for timestamps that reach the chat model.
+///
+/// SQLite DATETIME / GRDB `Date` cells are UTC-naive. Presenting that wall-clock
+/// as if it were local made Desktop Chat quote 7:59 PM for a 3:59 PM Eastern
+/// event (#12321). Format in an injected `TimeZone` and always include a zone
+/// token so the model cannot invent an unlabeled local time.
+enum DesktopChatTimestampFormat {
+  /// `2026-08-27 3:59:51 PM EDT (America/New_York)`
+  static func userFacing(_ date: Date, timeZone: TimeZone) -> String {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.timeZone = timeZone
+    formatter.dateFormat = "yyyy-MM-dd h:mm:ss a zzz"
+    return "\(formatter.string(from: date)) (\(timeZone.identifier))"
+  }
+
+  static func isTimestampColumn(_ name: String) -> Bool {
+    let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return false }
+    if trimmed.compare("timestamp", options: .caseInsensitive) == .orderedSame { return true }
+    if trimmed.compare("ts", options: .caseInsensitive) == .orderedSame { return true }
+    if trimmed.hasSuffix("At") || trimmed.hasSuffix("Date") { return true }
+    let lower = trimmed.lowercased()
+    return lower.hasSuffix("_at") || lower.hasSuffix("_date")
+  }
+
+  /// Convert a UTC-naive SQL cell when the column is a datetime field.
+  /// Returns nil to keep the raw rendering (NULL, numbers that are not dates, OCR, …).
+  static func formatSQLCell(
+    column: String,
+    value: DatabaseValue,
+    timeZone: TimeZone
+  ) -> String? {
+    guard isTimestampColumn(column) else { return nil }
+    if value.isNull { return nil }
+    if let date = Date.fromDatabaseValue(value) {
+      return userFacing(date, timeZone: timeZone)
+    }
+    switch value.storage {
+    case .string(let string):
+      guard let date = parseUTCNaiveDate(string) else { return nil }
+      return userFacing(date, timeZone: timeZone)
+    case .int64(let integer):
+      guard let date = parseEpoch(integer) else { return nil }
+      return userFacing(date, timeZone: timeZone)
+    case .double(let double):
+      guard let date = parseEpoch(double) else { return nil }
+      return userFacing(date, timeZone: timeZone)
+    default:
+      return nil
+    }
+  }
+
+  /// Local calendar-day bounds expressed as UTC instants so WHERE clauses stay UTC-vs-UTC.
+  enum SQLDayBounds {
+    static func startAsUTC(daysAgo: Int) -> String {
+      let clampedDaysAgo = max(0, daysAgo)
+      if clampedDaysAgo == 0 {
+        return "datetime('now', 'localtime', 'start of day', 'utc')"
+      }
+      return "datetime('now', 'localtime', 'start of day', '-\(clampedDaysAgo) day', 'utc')"
+    }
+
+    static func exclusiveEndAsUTC(daysAgo: Int) -> String {
+      max(0, daysAgo) == 0
+        ? "datetime('now')"
+        : "datetime('now', 'localtime', 'start of day', 'utc')"
+    }
+  }
+
+  private static func parseUTCNaiveDate(_ raw: String) -> Date? {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    let iso = ISO8601DateFormatter()
+    iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let date = iso.date(from: trimmed) { return date }
+    iso.formatOptions = [.withInternetDateTime]
+    if let date = iso.date(from: trimmed) { return date }
+
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    for pattern in [
+      "yyyy-MM-dd HH:mm:ss.SSS", "yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd'T'HH:mm:ss.SSS", "yyyy-MM-dd'T'HH:mm:ss",
+    ] {
+      formatter.dateFormat = pattern
+      if let date = formatter.date(from: trimmed) { return date }
+    }
+    return nil
+  }
+
+  private static func parseEpoch(_ value: Int64) -> Date? {
+    parseEpoch(Double(value))
+  }
+
+  private static func parseEpoch(_ value: Double) -> Date? {
+    if value >= 1_000_000_000_000 {
+      return Date(timeIntervalSince1970: value / 1000)
+    }
+    if value >= 1_000_000_000 {
+      return Date(timeIntervalSince1970: value)
+    }
+    return nil
+  }
+}

--- a/desktop/macos/Desktop/Sources/Chat/SQLQueryResultProjection.swift
+++ b/desktop/macos/Desktop/Sources/Chat/SQLQueryResultProjection.swift
@@ -6,7 +6,19 @@ enum SQLQueryResultProjection {
   private static let maxCellCharacters = 500
   private static let maxOutputCharacters = 12_000
 
-  nonisolated static func format(rows: [Row], query: String) -> (text: String, count: Int) {
+  nonisolated static func format(
+    rows: [Row],
+    query: String,
+    timeZone: TimeZone = .current
+  ) -> (text: String, count: Int) {
+    if projectsSQLiteLocalTime(query) {
+      return (
+        "Error: keep timestamp result expressions in UTC. "
+          + "Select raw timestamp/*At columns so execute_sql can localize them once with an explicit zone. "
+          + "Use localtime only when computing UTC WHERE bounds.",
+        rows.count
+      )
+    }
     guard let firstRow = rows.first else {
       let hint =
         referencesScreenshots(query)
@@ -30,8 +42,9 @@ enum SQLQueryResultProjection {
     var truncated = false
 
     for row in rows.prefix(maxRows) {
-      let line = row.map { (columnName, value) in renderedValue(value, columnName: columnName) }
-        .joined(separator: " | ")
+      let line = columns.map { name in
+        renderedValue(row[name], column: name, timeZone: timeZone)
+      }.joined(separator: " | ")
       guard characterCount + line.count + 1 <= maxOutputCharacters else {
         truncated = true
         break
@@ -53,6 +66,33 @@ enum SQLQueryResultProjection {
 
   private nonisolated static func referencesScreenshots(_ query: String) -> Bool {
     query.range(of: #"\bscreenshots\b"#, options: [.regularExpression, .caseInsensitive]) != nil
+  }
+
+  /// Timestamp-shaped result columns are localized below. Applying SQLite's
+  /// `localtime` modifier inside the SELECT projection would apply the offset
+  /// twice. WHERE-clause boundary conversion remains valid and is not rejected.
+  private nonisolated static func projectsSQLiteLocalTime(_ query: String) -> Bool {
+    let options: NSRegularExpression.Options = [.caseInsensitive, .dotMatchesLineSeparators]
+    guard
+      let selectRegex = try? NSRegularExpression(
+        pattern: #"\bselect\b(.*?)(?=\bfrom\b|$)"#,
+        options: options
+      ),
+      let localTimeFunctionRegex = try? NSRegularExpression(
+        pattern: #"\b(?:date|time|datetime|julianday|unixepoch|strftime)\s*\([^;]*?['\"]localtime['\"]"#,
+        options: options
+      )
+    else {
+      return false
+    }
+
+    let queryRange = NSRange(query.startIndex..<query.endIndex, in: query)
+    return selectRegex.matches(in: query, range: queryRange).contains { match in
+      guard let projectionRange = Range(match.range(at: 1), in: query) else { return false }
+      let projection = String(query[projectionRange])
+      let range = NSRange(projection.startIndex..<projection.endIndex, in: projection)
+      return localTimeFunctionRegex.firstMatch(in: projection, range: range) != nil
+    }
   }
 
   private nonisolated static func projectsUnboundedOCR(_ query: String, columns: [String]) -> Bool {
@@ -98,7 +138,16 @@ enum SQLQueryResultProjection {
     }
   }
 
-  private nonisolated static func renderedValue(_ databaseValue: DatabaseValue, columnName: String) -> String {
+  private nonisolated static func renderedValue(
+    _ databaseValue: DatabaseValue,
+    column: String,
+    timeZone: TimeZone
+  ) -> String {
+    if let formatted = DesktopChatTimestampFormat.formatSQLCell(
+      column: column, value: databaseValue, timeZone: timeZone)
+    {
+      return formatted
+    }
     let value: String
     switch databaseValue.storage {
     case .null:
@@ -108,7 +157,7 @@ enum SQLQueryResultProjection {
     case .double(let double):
       value = String(double)
     case .string(let string):
-      value = localTimeString(forUTCDatetime: string, columnName: columnName) ?? string
+      value = string
     case .blob(let data):
       value = "<\(data.count) bytes>"
     }
@@ -116,30 +165,4 @@ enum SQLQueryResultProjection {
     return String(value.prefix(maxCellCharacters)) + "..."
   }
 
-  /// GRDB stores `Date` columns as naive UTC text ("yyyy-MM-dd HH:mm:ss.SSS", no zone marker).
-  /// Rendered verbatim, the chat model reads a UTC wall-clock string as if it were already
-  /// local time (see #12321: "7:59:51 PM" shown for a 3:59:51 PM EDT event). Convert
-  /// datetime-shaped columns to the user's local zone with an explicit abbreviation here,
-  /// mechanically, rather than relying on the model to apply the offset itself.
-  private nonisolated static func localTimeString(forUTCDatetime raw: String, columnName: String) -> String? {
-    guard looksLikeDatetimeColumn(columnName) else { return nil }
-    let utcFormatter = DateFormatter()
-    utcFormatter.locale = Locale(identifier: "en_US_POSIX")
-    utcFormatter.timeZone = TimeZone(identifier: "UTC")
-    utcFormatter.dateFormat = raw.contains(".") ? "yyyy-MM-dd HH:mm:ss.SSS" : "yyyy-MM-dd HH:mm:ss"
-    guard let date = utcFormatter.date(from: raw) else { return nil }
-
-    let localFormatter = DateFormatter()
-    localFormatter.locale = Locale(identifier: "en_US_POSIX")
-    localFormatter.timeZone = .current
-    localFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss zzz"
-    return localFormatter.string(from: date)
-  }
-
-  /// Matches `timestamp` and camelCase `*At` columns (`createdAt`, `startedAt`, `completedAt`)
-  /// without catching unrelated names that merely end in the letters "at" (`format`, `chat`).
-  private nonisolated static func looksLikeDatetimeColumn(_ columnName: String) -> Bool {
-    if columnName.caseInsensitiveCompare("timestamp") == .orderedSame { return true }
-    return columnName.range(of: #"[a-z]At$"#, options: .regularExpression) != nil
-  }
 }

--- a/desktop/macos/Desktop/Sources/Chat/ScreenContextTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ScreenContextTelemetry.swift
@@ -438,6 +438,12 @@ enum ScreenContextWorkContextBuilder {
   static let staleCaptureThresholdSeconds = 60
   static let voiceTurnStaleCaptureThresholdSeconds = 15
 
+  static func isoFormatter(timeZone: TimeZone = .current) -> ISO8601DateFormatter {
+    let formatter = ISO8601DateFormatter()
+    formatter.timeZone = timeZone
+    return formatter
+  }
+
   /// Ambient turns without Screen Recording get this instead of silence, so the
   /// model can explain a blind answer when the question was screen-dependent —
   /// without manufacturing a permission request for generic utterances.
@@ -466,7 +472,7 @@ enum ScreenContextWorkContextBuilder {
     screenRecordingGranted: Bool,
     imageAttached: Bool,
     capturedAt: Date = Date(),
-    formatter: ISO8601DateFormatter = ISO8601DateFormatter()
+    formatter: ISO8601DateFormatter = isoFormatter()
   ) -> [String: Any] {
     guard screenRecordingGranted else {
       return permissionDeniedPayload(windowMinutes: 1)
@@ -519,7 +525,7 @@ enum ScreenContextWorkContextBuilder {
     let includeScreen = parseBool(arguments["include_screen"]) ?? false
     let now = Date()
     let start = now.addingTimeInterval(-Double(minutes) * 60)
-    let formatter = ISO8601DateFormatter()
+    let formatter = isoFormatter()
 
     // Cheap index first. A durable handle (URL / file) already names the document the
     // user means, so answering "where was that pricing doc" must not require Screen
@@ -783,9 +789,10 @@ enum ScreenContextWorkContextBuilder {
     return latestCaptureAgeSeconds > staleThresholdSeconds
   }
 
-  static func freshScreenCapturePayload(now: Date = Date(), formatter: ISO8601DateFormatter = ISO8601DateFormatter())
-    -> [String: Any]?
-  {
+  static func freshScreenCapturePayload(
+    now: Date = Date(),
+    formatter: ISO8601DateFormatter = isoFormatter()
+  ) -> [String: Any]? {
     guard ScreenCaptureManager.captureScreenData() != nil else { return nil }
     return [
       "available": true,

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryIndex.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryIndex.swift
@@ -55,7 +55,9 @@ struct WorkstreamBrief: Equatable, Sendable {
       "facts": facts,
     ]
     if let lastVisitAt {
-      object["last_visit"] = ISO8601DateFormatter().string(from: lastVisitAt)
+      let formatter = ISO8601DateFormatter()
+      formatter.timeZone = TimeZone.current
+      object["last_visit"] = formatter.string(from: lastVisitAt)
     }
     return object
   }

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -2896,10 +2896,7 @@ class ChatProvider: ObservableObject {
         line += " [priority: \(priority)]"
       }
       if let dueAt = task.dueAt {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .short
-        formatter.timeStyle = .short
-        line += " [due: \(formatter.string(from: dueAt))]"
+        line += " [due: \(DesktopChatTimestampFormat.userFacing(dueAt, timeZone: .current))]"
       }
       if let category = task.category {
         line += " [category: \(category)]"

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -1035,7 +1035,8 @@ class ChatToolExecutor {
   static func executeSQL(
     _ args: [String: Any],
     dbQueue: DatabasePool?,
-    expectedOwnerID: String?
+    expectedOwnerID: String?,
+    timeZone: TimeZone = .current
   ) async -> String {
     guard isExpectedOwnerCurrent(expectedOwnerID) else { return authorizedOwnerChangedResult() }
     guard let query = args["query"] as? String, !query.isEmpty else {
@@ -1102,7 +1103,8 @@ class ChatToolExecutor {
           upper: upper,
           parameters: parameters,
           dbQueue: databaseQueue,
-          expectedOwnerID: expectedOwnerID)
+          expectedOwnerID: expectedOwnerID,
+          timeZone: timeZone)
       } else if isInsert || isUpdate || isDelete {
         return try await executeWriteQuery(
           trimmed,
@@ -1208,7 +1210,8 @@ class ChatToolExecutor {
     upper: String,
     parameters: [String],
     dbQueue: DatabasePool,
-    expectedOwnerID: String?
+    expectedOwnerID: String?,
+    timeZone: TimeZone
   )
     async throws -> String
   {
@@ -1226,7 +1229,7 @@ class ChatToolExecutor {
     let query = finalQuery
     let formatted = try await dbQueue.read { db -> (text: String, count: Int) in
       let rows = try Row.fetchAll(db, sql: query, arguments: StatementArguments(parameters))
-      return SQLQueryResultProjection.format(rows: rows, query: query)
+      return SQLQueryResultProjection.format(rows: rows, query: query, timeZone: timeZone)
     }
     guard isExpectedOwnerCurrent(expectedOwnerID) else { return authorizedOwnerChangedResult() }
 
@@ -1432,11 +1435,9 @@ class ChatToolExecutor {
     }
     guard isExpectedOwnerCurrent(expectedOwnerID) else { return authorizedOwnerChangedResult() }
 
-    // For today (daysAgo=0), upper bound is now; for past days, upper bound is start of today
-    let upperBound =
-      daysAgo == 0
-      ? "datetime('now', 'localtime')"
-      : "datetime('now', 'start of day', 'localtime')"
+    // UTC-vs-UTC: local midnight converted back to UTC so "today" does not shift by offset.
+    let lowerBound = DesktopChatTimestampFormat.SQLDayBounds.startAsUTC(daysAgo: daysAgo)
+    let upperBound = DesktopChatTimestampFormat.SQLDayBounds.exclusiveEndAsUTC(daysAgo: daysAgo)
 
     do {
       let result = try await dbQueue.read { db in
@@ -1445,9 +1446,9 @@ class ChatToolExecutor {
           db,
           sql: """
             SELECT appName, COUNT(*) as screenshots, ROUND(COUNT(*) * 10.0 / 60, 1) as minutes,
-                MIN(time(timestamp, 'localtime')) as first_seen, MAX(time(timestamp, 'localtime')) as last_seen
+                MIN(timestamp) AS firstSeenAt, MAX(timestamp) AS lastSeenAt
             FROM screenshots
-            WHERE timestamp >= datetime('now', 'start of day', '-\(daysAgo) day', 'localtime')
+            WHERE timestamp >= \(lowerBound)
                 AND timestamp < \(upperBound)
                 AND appName IS NOT NULL AND appName != ''
             GROUP BY appName ORDER BY screenshots DESC
@@ -1460,7 +1461,7 @@ class ChatToolExecutor {
             SELECT backendId, title, overview, emoji, category, startedAt, finishedAt,
                 ROUND((julianday(finishedAt) - julianday(startedAt)) * 1440, 1) as duration_min
             FROM transcription_sessions
-            WHERE startedAt >= datetime('now', 'start of day', '-\(daysAgo) day', 'localtime')
+            WHERE startedAt >= \(lowerBound)
                 AND startedAt < \(upperBound)
                 AND deleted = 0 AND discarded = 0
             ORDER BY startedAt DESC
@@ -1471,7 +1472,7 @@ class ChatToolExecutor {
           db,
           sql: """
             SELECT backendId, description, completed, priority, createdAt FROM action_items
-            WHERE createdAt >= datetime('now', 'start of day', '-\(daysAgo) day', 'localtime')
+            WHERE createdAt >= \(lowerBound)
                 AND createdAt < \(upperBound)
                 AND deleted = 0
             ORDER BY createdAt DESC
@@ -1482,7 +1483,7 @@ class ChatToolExecutor {
           db,
           sql: """
             SELECT status, appOrSite, description, durationSeconds FROM focus_sessions
-            WHERE createdAt >= datetime('now', 'start of day', '-\(daysAgo) day', 'localtime')
+            WHERE createdAt >= \(lowerBound)
                 AND createdAt < \(upperBound)
             ORDER BY createdAt DESC
             """)
@@ -1492,7 +1493,7 @@ class ChatToolExecutor {
           db,
           sql: """
             SELECT backendId, content, category, source FROM memories
-            WHERE createdAt >= datetime('now', 'start of day', '-\(daysAgo) day', 'localtime')
+            WHERE createdAt >= \(lowerBound)
                 AND createdAt < \(upperBound)
                 AND deleted = 0
             ORDER BY createdAt DESC
@@ -1503,7 +1504,7 @@ class ChatToolExecutor {
           db,
           sql: """
             SELECT appName, currentActivity, contextSummary FROM observations
-            WHERE createdAt >= datetime('now', 'start of day', '-\(daysAgo) day', 'localtime')
+            WHERE createdAt >= \(lowerBound)
                 AND createdAt < \(upperBound)
             ORDER BY createdAt DESC
             LIMIT 20
@@ -1541,10 +1542,16 @@ class ChatToolExecutor {
             let name = app["appName"] as? String ?? "Unknown"
             let minutes = app["minutes"] as? Double ?? 0
             let screenshots = Self.rowInt(app["screenshots"]) ?? 0
-            let firstSeen = app["first_seen"] as? String ?? ""
-            let lastSeen = app["last_seen"] as? String ?? ""
+            let timeZone = TimeZone.current
+            let firstSeen =
+              DesktopChatTimestampFormat.formatSQLCell(
+                column: "firstSeenAt", value: app["firstSeenAt"], timeZone: timeZone) ?? ""
+            let lastSeen =
+              DesktopChatTimestampFormat.formatSQLCell(
+                column: "lastSeenAt", value: app["lastSeenAt"], timeZone: timeZone) ?? ""
+            let window = firstSeen.isEmpty && lastSeen.isEmpty ? "" : " \(firstSeen)–\(lastSeen)"
             out +=
-              "- **\(name)**: \(minutes) min (\(screenshots) captures, \(firstSeen)–\(lastSeen))\n"
+              "- **\(name)**: \(minutes) min (\(screenshots) captures,\(window))\n"
           }
           if apps.count > 20 { out += "- ...and \(apps.count - 20) more apps\n" }
         }
@@ -1699,9 +1706,7 @@ class ChatToolExecutor {
       log("Tool semantic_search: vector returned \(vectorResults.count) results")
 
       // Filter by similarity threshold and fetch screenshot details
-      let dateFormatter = DateFormatter()
-      dateFormatter.dateStyle = .medium
-      dateFormatter.timeStyle = .short
+      let displayTimeZone = TimeZone.current
 
       var lines: [String] = []
       var sources = [APIClient.ToolSource]()
@@ -1721,7 +1726,8 @@ class ChatToolExecutor {
         }
 
         count += 1
-        let dateStr = dateFormatter.string(from: screenshot.timestamp)
+        let dateStr = DesktopChatTimestampFormat.userFacing(
+          screenshot.timestamp, timeZone: displayTimeZone)
         let windowTitle = screenshot.windowTitle ?? ""
         let titlePart = windowTitle.isEmpty ? "" : " - \(windowTitle)"
         lines.append(

--- a/desktop/macos/Desktop/Tests/ChatPromptsTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatPromptsTests.swift
@@ -3,6 +3,61 @@ import XCTest
 @testable import Omi_Computer
 
 final class ChatPromptsTests: XCTestCase {
+  func testCurrentDatetimeStringIncludesIANAZoneAndConvertsUTCInstant() throws {
+    let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-27T19:59:51Z"))
+    let timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
+
+    let rendered = ChatPromptBuilder.currentDatetimeString(date, timeZone: timeZone)
+    XCTAssertTrue(
+      rendered.contains("3:59:51 PM") || rendered.contains("15:59:51"),
+      "expected local 3:59:51 PM, got \(rendered)")
+    XCTAssertTrue(
+      rendered.contains("America/New_York") || rendered.contains("EDT"),
+      "expected a zone token, got \(rendered)")
+    XCTAssertFalse(rendered.contains("7:59:51 PM"), "must not present UTC-as-local \(rendered)")
+  }
+
+  func testDesktopChatPromptDoesNotBakeALiveClockIntoTheCachedPrefix() {
+    XCTAssertFalse(ChatPrompts.desktopChat.contains("{current_datetime_str}"))
+    XCTAssertTrue(ChatPrompts.desktopChat.contains("# Current Time"))
+    XCTAssertTrue(ChatPrompts.desktopChat.contains("{tz}"))
+  }
+
+  func testDesktopChatSQLFiltersCompareUTCColumnsToUTCBounds() {
+    let prompt = ChatPrompts.desktopChat
+    XCTAssertTrue(prompt.contains("MIN(timestamp) AS firstSeenAt, MAX(timestamp) AS lastSeenAt"))
+    XCTAssertTrue(prompt.contains("Select raw timestamp and camelCase *At columns"))
+    XCTAssertTrue(prompt.contains("execute_sql converts those result cells once"))
+    XCTAssertFalse(prompt.contains("MIN(time(timestamp, 'localtime'))"))
+    XCTAssertTrue(prompt.contains("datetime('now', 'localtime', 'start of day', '-1 day', 'utc')"))
+    XCTAssertTrue(prompt.contains("datetime('now', 'localtime', 'start of day', 'utc')"))
+    XCTAssertFalse(
+      prompt.contains("timestamp >= datetime('now', 'start of day', '-1 day', 'localtime')"))
+    XCTAssertFalse(prompt.contains("timestamp >= datetime('now', '-1 day', 'localtime')"))
+    XCTAssertFalse(prompt.contains("startedAt >= datetime('now', 'start of day', '-1 day', 'localtime')"))
+    XCTAssertFalse(prompt.contains("createdAt >= datetime('now', 'start of day', '-1 day', 'localtime')"))
+    XCTAssertFalse(prompt.contains("which SQLite handles automatically"))
+  }
+
+  func testSQLDayBoundsStayUTCVersusUTC() {
+    XCTAssertEqual(
+      DesktopChatTimestampFormat.SQLDayBounds.startAsUTC(daysAgo: 1),
+      "datetime('now', 'localtime', 'start of day', '-1 day', 'utc')")
+    XCTAssertEqual(
+      DesktopChatTimestampFormat.SQLDayBounds.exclusiveEndAsUTC(daysAgo: 1),
+      "datetime('now', 'localtime', 'start of day', 'utc')")
+    XCTAssertEqual(
+      DesktopChatTimestampFormat.SQLDayBounds.exclusiveEndAsUTC(daysAgo: 0),
+      "datetime('now')")
+    XCTAssertTrue(DesktopChatTimestampFormat.SQLDayBounds.startAsUTC(daysAgo: 0).hasSuffix("'utc')"))
+    XCTAssertEqual(
+      DesktopChatTimestampFormat.SQLDayBounds.startAsUTC(daysAgo: -1),
+      DesktopChatTimestampFormat.SQLDayBounds.startAsUTC(daysAgo: 0))
+    XCTAssertEqual(
+      DesktopChatTimestampFormat.SQLDayBounds.exclusiveEndAsUTC(daysAgo: -1),
+      DesktopChatTimestampFormat.SQLDayBounds.exclusiveEndAsUTC(daysAgo: 0))
+  }
+
   func testCurrentTimePromptUsesOneExplicitInstantAndTimeZone() throws {
     let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-07-31T02:30:45Z"))
     let timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))

--- a/desktop/macos/Desktop/Tests/ChatToolExecutorSQLTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatToolExecutorSQLTests.swift
@@ -102,6 +102,39 @@ final class ChatToolExecutorSQLTests: XCTestCase {
     try await super.tearDown()
   }
 
+  func testExecuteSQLRendersUTCTimestampInPinnedLocalTimeZone() async throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("execute-sql-tz-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let pool = try DatabasePool(path: directory.appendingPathComponent("test.sqlite").path)
+    try await pool.write { db in
+      try db.execute(sql: "CREATE TABLE screenshots (timestamp TEXT, appName TEXT)")
+      try db.execute(
+        sql: "INSERT INTO screenshots VALUES (?, ?)",
+        arguments: ["2026-08-27 19:59:51", "Claude"]
+      )
+    }
+
+    let timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
+    let result = await ChatToolExecutor.executeSQL(
+      ["query": "SELECT timestamp, appName FROM screenshots"],
+      dbQueue: pool,
+      expectedOwnerID: nil,
+      timeZone: timeZone
+    )
+
+    XCTAssertTrue(
+      result.contains("3:59:51 PM") || result.contains("15:59:51"),
+      "expected local 3:59:51, got \(result)")
+    XCTAssertTrue(
+      result.contains("America/New_York") || result.contains("EDT"),
+      "expected a zone token, got \(result)")
+    XCTAssertFalse(result.contains("7:59:51 PM"), "must not present UTC-as-local \(result)")
+    XCTAssertTrue(result.contains("Claude"))
+  }
+
   func testReadOnlySQLAllowsSelectAndReadOnlyCTE() {
     XCTAssertTrue(ChatToolExecutor.isReadOnlySQLStatement("SELECT * FROM screenshots LIMIT 1"))
     XCTAssertTrue(
@@ -277,7 +310,7 @@ final class ChatToolExecutorSQLTests: XCTestCase {
     XCTAssertTrue(result.contains("call get_work_context"))
   }
 
-  func testExecuteSQLRendersDatetimeColumnsInLocalTimeWithZoneLabel() async throws {
+  func testExecuteSQLRendersStoredGRDBDateInPinnedLocalTimeWithZoneLabel() async throws {
     let directory = FileManager.default.temporaryDirectory
       .appendingPathComponent("execute-sql-datetime-localization-\(UUID().uuidString)", isDirectory: true)
     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -285,7 +318,7 @@ final class ChatToolExecutorSQLTests: XCTestCase {
 
     let pool = try DatabasePool(path: directory.appendingPathComponent("test.sqlite").path)
     // 2026-08-27T19:59:51Z — the exact UTC instant from #12321's repro.
-    let utcInstant = Date(timeIntervalSince1970: 1_787_082_791)
+    let utcInstant = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-27T19:59:51Z"))
     try await pool.write { db in
       try db.execute(sql: "CREATE TABLE screenshots (appName TEXT, timestamp DATETIME NOT NULL)")
       try db.execute(
@@ -294,26 +327,56 @@ final class ChatToolExecutorSQLTests: XCTestCase {
       )
     }
 
+    let timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
     let result = await ChatToolExecutor.executeSQL(
       ["query": "SELECT appName, timestamp FROM screenshots"],
       dbQueue: pool,
-      expectedOwnerID: nil
+      expectedOwnerID: nil,
+      timeZone: timeZone
     )
-
-    let expectedLocalFormatter = DateFormatter()
-    expectedLocalFormatter.locale = Locale(identifier: "en_US_POSIX")
-    expectedLocalFormatter.timeZone = .current
-    expectedLocalFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss zzz"
-    let expectedLocal = expectedLocalFormatter.string(from: utcInstant)
 
     XCTAssertTrue(
-      result.contains(expectedLocal),
-      "expected local+zone rendering '\(expectedLocal)' in result:\n\(result)"
+      result.contains("2026-08-27 3:59:51 PM"),
+      "expected pinned local+zone rendering in result:\n\(result)"
     )
-    // Only meaningful off UTC, but guards against silently falling back to the raw UTC cell.
-    if TimeZone.current.secondsFromGMT(for: utcInstant) != 0 {
-      XCTAssertFalse(result.contains("2026-08-27 19:59:51.000"))
+    XCTAssertTrue(result.contains("(America/New_York)"))
+    XCTAssertFalse(result.contains("2026-08-27 19:59:51"))
+  }
+
+  func testExecuteSQLRejectsProjectedLocaltimeButAllowsUTCBoundaryConversion() async throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("execute-sql-localtime-projection-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let pool = try DatabasePool(path: directory.appendingPathComponent("test.sqlite").path)
+    try await pool.write { db in
+      try db.execute(sql: "CREATE TABLE screenshots (timestamp DATETIME NOT NULL)")
+      try db.execute(sql: "INSERT INTO screenshots VALUES (datetime('now'))")
     }
+
+    let utc = try XCTUnwrap(TimeZone(secondsFromGMT: 0))
+    let boundaryResult = await ChatToolExecutor.executeSQL(
+      [
+        "query": """
+        SELECT timestamp FROM screenshots
+        WHERE timestamp >= datetime('now', 'localtime', 'start of day', 'utc')
+        """
+      ],
+      dbQueue: pool,
+      expectedOwnerID: nil,
+      timeZone: utc
+    )
+    XCTAssertFalse(boundaryResult.contains("keep timestamp result expressions in UTC"))
+    XCTAssertTrue(boundaryResult.contains("timestamp"))
+
+    let projectedResult = await ChatToolExecutor.executeSQL(
+      ["query": "SELECT datetime(timestamp, 'localtime') AS timestamp FROM screenshots"],
+      dbQueue: pool,
+      expectedOwnerID: nil,
+      timeZone: utc
+    )
+    XCTAssertTrue(projectedResult.contains("keep timestamp result expressions in UTC"))
   }
 
   func testSQLAuthorizationIsOutsideSwiftPhysicalPreconditions() {

--- a/desktop/macos/changelog/unreleased/20260828-chat-sql-local-timestamps.json
+++ b/desktop/macos/changelog/unreleased/20260828-chat-sql-local-timestamps.json
@@ -1,0 +1,3 @@
+{
+  "change": "Desktop Chat now shows SQL and search times in your timezone instead of unlabeled UTC"
+}

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -49,6 +49,7 @@ covers:
   - desktop/macos/Desktop/Sources/Chat/ChatComposerDraft.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatDraftScope.swift
   - desktop/macos/Desktop/Sources/Chat/SQLQueryResultProjection.swift
+  - desktop/macos/Desktop/Sources/Chat/DesktopChatTimestampFormat.swift
   # The marker query enters AgentClient.Session through the serialized context
   # admission path before the exact stub reply is asserted below.
   - desktop/macos/Desktop/Sources/Chat/AgentContextAdmissionGate.swift

--- a/desktop/windows/changelog/unreleased/2026-08-chat-sql-local-timestamps.json
+++ b/desktop/windows/changelog/unreleased/2026-08-chat-sql-local-timestamps.json
@@ -1,0 +1,3 @@
+{
+  "change": "Desktop Chat now shows SQL and task times in your timezone instead of unlabeled UTC"
+}

--- a/desktop/windows/src/main/agentKernel/desktopChatPrompt.test.ts
+++ b/desktop/windows/src/main/agentKernel/desktopChatPrompt.test.ts
@@ -151,14 +151,18 @@ describe('buildDesktopChatPersonalization', () => {
       timezone: 'America/New_York',
       tasks: [{ description: 'submit report', dueAt: Date.UTC(2026, 6, 20, 15, 30) }]
     })
-    expect(ny).toContain('- submit report [due: 2026-07-20 11:30]')
+    expect(ny).toMatch(/11:30/)
+    expect(ny).toMatch(/America\/New_York|EDT/)
+    expect(ny).not.toContain('7:59:51 PM')
+    expect(ny).toContain('submit report')
     // A fractional-offset zone (Kolkata, UTC+5:30) → 21:00 local, proving it is a
     // real tz conversion and not a fixed slice.
     const kolkata = buildDesktopChatPersonalization({
       timezone: 'Asia/Kolkata',
       tasks: [{ description: 'submit report', dueAt: Date.UTC(2026, 6, 20, 15, 30) }]
     })
-    expect(kolkata).toContain('- submit report [due: 2026-07-20 21:00]')
+    expect(kolkata).toMatch(/9:00:00 PM|21:00/)
+    expect(kolkata).toContain('Asia/Kolkata')
   })
 
   it('marks the due date as UTC when no timezone is known (never unlabeled)', () => {
@@ -168,7 +172,9 @@ describe('buildDesktopChatPersonalization', () => {
     const block = buildDesktopChatPersonalization({
       tasks: [{ description: 'submit report', dueAt: Date.UTC(2026, 6, 20, 15, 30) }]
     })
-    expect(block).toContain('- submit report [due: 2026-07-20 15:30 UTC]')
+    expect(block).toMatch(/3:30:00 PM|15:30/)
+    expect(block).toMatch(/UTC|GMT/)
+    expect(block).toContain('submit report')
   })
 
   it('falls back to marked UTC when the timezone id is invalid', () => {
@@ -176,7 +182,9 @@ describe('buildDesktopChatPersonalization', () => {
       timezone: 'Not/AZone',
       tasks: [{ description: 'submit report', dueAt: Date.UTC(2026, 6, 20, 15, 30) }]
     })
-    expect(block).toContain('- submit report [due: 2026-07-20 15:30 UTC]')
+    expect(block).toMatch(/3:30:00 PM|15:30/)
+    expect(block).toMatch(/UTC|GMT/)
+    expect(block).toContain('submit report')
   })
 
   it('falls back to "the user" in the facts header when no name is given', () => {

--- a/desktop/windows/src/main/agentKernel/desktopChatPrompt.ts
+++ b/desktop/windows/src/main/agentKernel/desktopChatPrompt.ts
@@ -29,6 +29,8 @@
 // subprocess every message (isBindingCompatible keys on the system-prompt hash).
 // The builder therefore interpolates only stable inputs — no volatile datetime.
 
+import { formatUserFacingTimestamp } from '../../shared/chatTimestamp'
+
 /** Inputs interpolated into the prompt. All optional and stable per session. */
 export interface DesktopChatPromptOptions {
   /** The signed-in user's display/given name, when available. Falls back to a
@@ -251,23 +253,12 @@ const TASKS_CAP = 20
 function formatDueAt(dueAt: number, timezone?: string): string {
   if (timezone) {
     try {
-      const parts = new Intl.DateTimeFormat('en-US', {
-        timeZone: timezone,
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit',
-        hourCycle: 'h23'
-      }).formatToParts(new Date(dueAt))
-      const at = (type: Intl.DateTimeFormatPartTypes): string =>
-        parts.find((p) => p.type === type)?.value ?? ''
-      return `${at('year')}-${at('month')}-${at('day')} ${at('hour')}:${at('minute')}`
+      return formatUserFacingTimestamp(new Date(dueAt), timezone)
     } catch {
       // Invalid timezone id → fall through to the marked-UTC path below.
     }
   }
-  return `${new Date(dueAt).toISOString().slice(0, 16).replace('T', ' ')} UTC`
+  return formatUserFacingTimestamp(new Date(dueAt), 'UTC')
 }
 
 /**

--- a/desktop/windows/src/main/assistants/insight/sql.test.ts
+++ b/desktop/windows/src/main/assistants/insight/sql.test.ts
@@ -117,6 +117,27 @@ describe('formatRows caps', () => {
     const out = formatRows(['id'], rows)
     expect(out.endsWith(`${MAX_ROWS} row(s)`)).toBe(true)
   })
+  it('renders UTC timestamp cells in the pinned local timezone', () => {
+    const out = formatRows(
+      ['timestamp', 'app'],
+      [['2026-08-27 19:59:51', 'Claude']],
+      'America/New_York'
+    )
+    expect(out).toMatch(/3:59:51 PM|15:59:51/)
+    expect(out).toMatch(/America\/New_York|EDT/)
+    expect(out).not.toContain('7:59:51 PM')
+    expect(out).toContain('Claude')
+  })
+  it('renders Windows epoch-ms timestamp columns in the pinned timezone', () => {
+    const out = formatRows(
+      ['ts', 'app'],
+      [[Date.parse('2026-08-27T19:59:51Z'), 'Claude']],
+      'America/New_York'
+    )
+    expect(out).toMatch(/3:59:51 PM|15:59:51/)
+    expect(out).toMatch(/America\/New_York|EDT/)
+    expect(out).not.toContain('7:59:51 PM')
+  })
 })
 
 describe('executeSql', () => {
@@ -130,6 +151,23 @@ describe('executeSql', () => {
     const runQuery = vi.fn()
     expect(executeSql('SELECT 1; SELECT 2', runQuery)).toMatch(/single statement/i)
     expect(runQuery).not.toHaveBeenCalled()
+  })
+
+  it('rejects projected localtime but allows local-day UTC boundary conversion', () => {
+    const runQuery = vi.fn(() => ({ columns: ['timestamp'], rows: [['2026-08-27 19:59:51']] }))
+    const projected = executeSql(
+      "SELECT datetime(ts, 'localtime') AS timestamp FROM rewind_frames",
+      runQuery
+    )
+    expect(projected).toContain('keep timestamp result expressions in UTC')
+    expect(runQuery).not.toHaveBeenCalled()
+
+    const boundary = executeSql(
+      "SELECT ts AS timestamp FROM rewind_frames WHERE ts >= datetime('now', 'localtime', 'start of day', 'utc')",
+      runQuery
+    )
+    expect(boundary).not.toContain('keep timestamp result expressions in UTC')
+    expect(runQuery).toHaveBeenCalledOnce()
   })
   it('wraps the query in an unsuppressible outer LIMIT and passes it to the runner', () => {
     const runQuery = vi.fn(() => ({ columns: ['id'], rows: [[1]] }))

--- a/desktop/windows/src/main/assistants/insight/sql.ts
+++ b/desktop/windows/src/main/assistants/insight/sql.ts
@@ -19,6 +19,7 @@
 // NEVER log a query, a result cell, or a window title from here — SQL results are
 // raw OCR/screen text.
 import type { RewindFrame } from '../../../shared/types'
+import { formatSqlTimestampCell, resolveChatTimeZone } from '../../../shared/chatTimestamp'
 
 /** Mac's auto-limit + belt-and-suspenders row cap ("Auto-limited to 200 rows"). */
 export const MAX_ROWS = 200
@@ -599,6 +600,25 @@ export function rejectDangerousShape(sql: string): string | null {
   return null
 }
 
+/** Timestamp-shaped result columns are localized by formatRows. Applying
+ * SQLite's `localtime` modifier inside the SELECT projection would apply the
+ * offset twice. Boundary conversion in a WHERE clause remains valid. */
+function rejectProjectedLocalTime(sql: string): string | null {
+  const selectProjection = /\bselect\b([\s\S]*?)(?=\bfrom\b|$)/gi
+  const localTimeFunction =
+    /\b(?:date|time|datetime|julianday|unixepoch|strftime)\s*\([^;]*?['"]localtime['"]/i
+  for (const match of sql.matchAll(selectProjection)) {
+    if (localTimeFunction.test(match[1] ?? '')) {
+      return (
+        'Error: keep timestamp result expressions in UTC. ' +
+        'Select raw timestamp/*At columns so execute_sql can localize them once with an explicit zone. ' +
+        'Use localtime only when computing UTC WHERE bounds.'
+      )
+    }
+  }
+  return null
+}
+
 function cellToString(v: unknown): string {
   const s = v == null ? '' : String(v)
   return s.length > CELL_CAP ? `${s.slice(0, CELL_CAP)}...` : s
@@ -606,12 +626,25 @@ function cellToString(v: unknown): string {
 
 /** Mac's pipe-table rendering: header, divider, one line per (capped) row, a
  *  trailing `N row(s)`. Empty set → the literal `No results`. */
-export function formatRows(columns: string[], rows: unknown[][]): string {
+export function formatRows(
+  columns: string[],
+  rows: unknown[][],
+  timeZone: string = resolveChatTimeZone()
+): string {
   if (rows.length === 0) return 'No results'
   const capped = rows.slice(0, MAX_ROWS)
   const divider = '-'.repeat(Math.min(columns.length * 20, 120))
   const lines = [columns.join(' | '), divider]
-  for (const row of capped) lines.push(row.map(cellToString).join(' | '))
+  for (const row of capped) {
+    lines.push(
+      row
+        .map((cell, index) => {
+          const formatted = formatSqlTimestampCell(columns[index] ?? '', cell, timeZone)
+          return cellToString(formatted ?? cell)
+        })
+        .join(' | ')
+    )
+  }
   lines.push(`${capped.length} row(s)`)
   return lines.join('\n')
 }
@@ -750,6 +783,9 @@ export function executeSql(
 
   if (!isReadOnlySql(single)) return 'Error: only read-only SELECT/WITH queries are allowed'
 
+  const localTimeProjection = rejectProjectedLocalTime(single)
+  if (localTimeProjection) return localTimeProjection
+
   const denyTerms = denylist.map((t) => t.trim()).filter((t) => t.length > 0)
   const denyActive = denyTerms.length > 0
 
@@ -822,6 +858,9 @@ export function executeReadOnlySql(
   if (!isReadOnlySql(single)) {
     return 'Error: this SQL surface is read-only. Use SELECT or read-only WITH queries.'
   }
+
+  const localTimeProjection = rejectProjectedLocalTime(single)
+  if (localTimeProjection) return localTimeProjection
 
   // Even a valid read-only SELECT may only touch allowlisted tables — a closed
   // allowlist so meta/embedding/credential-shaped tables can never be read.

--- a/desktop/windows/src/shared/chatTimestamp.ts
+++ b/desktop/windows/src/shared/chatTimestamp.ts
@@ -1,0 +1,99 @@
+/** Format timestamps that reach the desktop-chat model.
+ *
+ * SQLite / GRDB cells and Windows epoch-ms integers are UTC instants. Printing
+ * the UTC wall-clock without a zone made the model quote 7:59 PM for a 3:59 PM
+ * Eastern event (#12321). Always convert in an injected IANA zone and label it.
+ */
+
+const TIMESTAMP_COLUMN = /^(timestamp|ts|.*(?:At|_at|Date|_date))$/
+
+export function isTimestampColumn(name: string): boolean {
+  return TIMESTAMP_COLUMN.test(name.trim())
+}
+
+function localParts(
+  now: Date,
+  timeZone: string
+): { year: string; month: string; day: string; hour: string; minute: string; second: string } {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hourCycle: 'h23',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  }).formatToParts(now)
+  const value = (type: Intl.DateTimeFormatPartTypes): string =>
+    parts.find((part) => part.type === type)?.value ?? ''
+  return {
+    year: value('year'),
+    month: value('month'),
+    day: value('day'),
+    hour: value('hour'),
+    minute: value('minute'),
+    second: value('second')
+  }
+}
+
+function hour12(hour23: number): { hour: number; period: 'AM' | 'PM' } {
+  const period: 'AM' | 'PM' = hour23 >= 12 ? 'PM' : 'AM'
+  const hour = hour23 % 12 === 0 ? 12 : hour23 % 12
+  return { hour, period }
+}
+
+/** `2026-08-27 3:59:51 PM EDT (America/New_York)` */
+export function formatUserFacingTimestamp(date: Date, timeZone: string): string {
+  const parts = localParts(date, timeZone)
+  const { hour, period } = hour12(Number(parts.hour))
+  const short = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    timeZoneName: 'short'
+  })
+    .formatToParts(date)
+    .find((part) => part.type === 'timeZoneName')?.value
+  const zoneToken = short && short !== timeZone ? short : timeZone
+  return `${parts.year}-${parts.month}-${parts.day} ${hour}:${parts.minute}:${parts.second} ${period} ${zoneToken} (${timeZone})`
+}
+
+function parseCellDate(value: unknown): Date | null {
+  if (value == null) return null
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime()) ? value : null
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    if (value >= 1_000_000_000_000) return new Date(value)
+    if (value >= 1_000_000_000) return new Date(value * 1000)
+    return null
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    const naive = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2}(?:\.\d+)?)$/.exec(trimmed)
+    if (naive) {
+      const parsed = Date.parse(`${naive[1]}T${naive[2]}Z`)
+      if (Number.isFinite(parsed)) return new Date(parsed)
+    }
+    const iso = Date.parse(trimmed)
+    if (Number.isFinite(iso)) return new Date(iso)
+  }
+  return null
+}
+
+/** Convert a UTC-naive SQL cell when the column is a datetime field. */
+export function formatSqlTimestampCell(
+  column: string,
+  value: unknown,
+  timeZone: string
+): string | null {
+  if (!isTimestampColumn(column)) return null
+  const date = parseCellDate(value)
+  if (!date) return null
+  return formatUserFacingTimestamp(date, timeZone)
+}
+
+export function resolveChatTimeZone(timeZone?: string): string {
+  if (timeZone?.trim()) return timeZone.trim()
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+}


### PR DESCRIPTION
## Summary

Desktop Chat treated UTC-naive SQLite DATETIME cells as local wall-clock, so “when did I last open Claude?” quoted **7:59:51 PM** for a **3:59:51 PM EDT** instant.

This PR converts `timestamp` / `*At` cells in `execute_sql` (and the matching Windows renderer) into the user’s timezone with an explicit IANA/offset label, repairs SQL “today/yesterday” examples so filters stay UTC-vs-UTC, and keeps the live clock on the per-turn `# Current Time` prefix instead of the cached system prompt.

## Test plan

- [x] Pinned clock `2026-08-27T19:59:51Z` + `America/New_York`: `execute_sql` / `formatRows` contain `3:59:51 PM` and a zone token; must not present unlabeled `7:59:51 PM`
- [x] `ChatPromptsTests` — cached desktop prompt has no `{current_datetime_str}`; SQL examples compare UTC columns to UTC bounds
- [x] Windows `desktopChatPrompt.test.ts` + `sql.test.ts` (88 tests)
- [x] `make preflight` on this branch

Line-Count-Exception: desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift | 3520 -> 3526 | thread display timezone through execute_sql and keep daily-recap bounds UTC-vs-UTC

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1

Failure-Class: FC-machine-timezone-timestamp-in-prompt

Closes #12321

Related: #4643, #12236 (do not close)

SCA-364


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


