### PR TITLE
feat(desktop): hide the assistant panes and three floating-bar rows from Settings

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -3654,6 +3654,15 @@ final class DesktopAutomationActionRegistry {
       case "5", "rewind": item = .rewind
       case "6", "apps": item = .apps
       case ",", "comma", "settings": item = .settings
+      // Settings sub-sections ride the same notifications the app already posts
+      // for its own deep-links (the Tasks gear, the floating-bar context menu),
+      // so QA can land on a specific pane without any cursor input.
+      case "tasksettings", "advancedsettings":
+        NotificationCenter.default.post(name: .navigateToTaskSettings, object: nil)
+        return ["navigated": "Settings › Advanced"]
+      case "floatingbarsettings":
+        NotificationCenter.default.post(name: .navigateToFloatingBarSettings, object: nil)
+        return ["navigated": "Settings › Floating Bar"]
       default: item = nil
       }
       guard let item else {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Advanced.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Advanced.swift
@@ -22,15 +22,17 @@ extension SettingsContentView {
     VStack(spacing: OmiSpacing.xxl) {
       advancedCategoryHeader(title: "AI Setup", icon: "cpu")
       aiSetupSubsection
-      // The three assistants that read your screen, and the throttle they share. Each card carries
-      // the switch that stops its assistant — which, until this pane rendered them, no surface in the
-      // app did. `advanced.taskassistant` is also where the Tasks page's gear button deep-links.
-      advancedCategoryHeader(title: "Task Assistant", icon: "checklist")
-      taskAssistantSubsection
-      advancedCategoryHeader(title: "Insight Assistant", icon: ProactiveNotificationBadge.insightSystemImage)
-      insightAssistantSubsection
-      advancedCategoryHeader(title: "Memory Assistant", icon: "brain.head.profile")
-      memoryAssistantSubsection
+      // HIDDEN DELIBERATELY (Nik, 2026-08-25): the Task/Insight/Memory Assistant panes are
+      // intentionally not rendered. This is product direction, not dead code — do NOT re-wire
+      // them the way 73c7f85fbc ("give the three proactive assistants a pane you can reach")
+      // did after the last hide. The assistants themselves keep running with their stored
+      // settings; only the settings UI is hidden.
+      // advancedCategoryHeader(title: "Task Assistant", icon: "checklist")
+      // taskAssistantSubsection
+      // advancedCategoryHeader(title: "Insight Assistant", icon: ProactiveNotificationBadge.insightSystemImage)
+      // insightAssistantSubsection
+      // advancedCategoryHeader(title: "Memory Assistant", icon: "brain.head.profile")
+      // memoryAssistantSubsection
       advancedCategoryHeader(title: "Analysis Throttle", icon: "clock.arrow.2.circlepath")
       analysisThrottleSubsection
       advancedCategoryHeader(title: "Profile & Stats", icon: "brain")

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+FloatingBarAndChat.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+FloatingBarAndChat.swift
@@ -28,65 +28,68 @@ extension SettingsContentView {
         }
       }
 
-      settingsCard(settingId: "floatingbar.notificationpreviews") {
-        HStack(spacing: OmiSpacing.lg) {
-          VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-            Text("Notification Previews")
-              .scaledFont(size: OmiType.subheading, weight: .semibold)
-              .foregroundColor(Ink.primary)
-            Text(
-              "Show assistant notifications under the Floating Bar. When off, notifications use macOS banners instead."
-            )
-            .scaledFont(size: OmiType.body)
-            .foregroundColor(Ink.secondary)
-          }
-          Spacer()
-          Toggle("", isOn: $shortcutSettings.floatingBarNotificationPreviewsEnabled)
-            .toggleStyle(OmiToggleStyle())
-        }
-      }
+      // HIDDEN DELIBERATELY (Nik, 2026-08-25): Notification Previews, Background Style, and
+      // Draggable Floating Bar are intentionally not rendered (their stored settings still
+      // apply). Product direction, not dead code — do not re-wire without asking Nik.
+      // settingsCard(settingId: "floatingbar.notificationpreviews") {
+      // HStack(spacing: OmiSpacing.lg) {
+      // VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+      // Text("Notification Previews")
+      // .scaledFont(size: OmiType.subheading, weight: .semibold)
+      // .foregroundColor(Ink.primary)
+      // Text(
+      // "Show assistant notifications under the Floating Bar. When off, notifications use macOS banners instead."
+      // )
+      // .scaledFont(size: OmiType.body)
+      // .foregroundColor(Ink.secondary)
+      // }
+      // Spacer()
+      // Toggle("", isOn: $shortcutSettings.floatingBarNotificationPreviewsEnabled)
+      // .toggleStyle(OmiToggleStyle())
+      // }
+      // }
 
-      settingsCard(settingId: "floatingbar.background") {
-        VStack(alignment: .leading, spacing: OmiSpacing.lg) {
-          Text("Background Style")
-            .scaledFont(size: OmiType.subheading, weight: .semibold)
-            .foregroundColor(Ink.primary)
+      // settingsCard(settingId: "floatingbar.background") {
+      // VStack(alignment: .leading, spacing: OmiSpacing.lg) {
+      // Text("Background Style")
+      // .scaledFont(size: OmiType.subheading, weight: .semibold)
+      // .foregroundColor(Ink.primary)
+      //
+      // HStack(spacing: OmiSpacing.lg) {
+      // Text("Transparent")
+      // .scaledFont(size: OmiType.body, weight: shortcutSettings.solidBackground ? .regular : .semibold)
+      // .foregroundColor(
+      // shortcutSettings.solidBackground ? Ink.secondary : Ink.primary)
+      //
+      // Toggle("", isOn: $shortcutSettings.solidBackground)
+      // .toggleStyle(OmiToggleStyle())
+      // .labelsHidden()
+      //
+      // Text("Solid Dark")
+      // .scaledFont(size: OmiType.body, weight: shortcutSettings.solidBackground ? .semibold : .regular)
+      // .foregroundColor(
+      // shortcutSettings.solidBackground ? Ink.primary : Ink.secondary)
+      //
+      // Spacer()
+      // }
+      // }
+      // }
 
-          HStack(spacing: OmiSpacing.lg) {
-            Text("Transparent")
-              .scaledFont(size: OmiType.body, weight: shortcutSettings.solidBackground ? .regular : .semibold)
-              .foregroundColor(
-                shortcutSettings.solidBackground ? Ink.secondary : Ink.primary)
-
-            Toggle("", isOn: $shortcutSettings.solidBackground)
-              .toggleStyle(OmiToggleStyle())
-              .labelsHidden()
-
-            Text("Solid Dark")
-              .scaledFont(size: OmiType.body, weight: shortcutSettings.solidBackground ? .semibold : .regular)
-              .foregroundColor(
-                shortcutSettings.solidBackground ? Ink.primary : Ink.secondary)
-
-            Spacer()
-          }
-        }
-      }
-
-      settingsCard(settingId: "floatingbar.draggable") {
-        HStack(spacing: OmiSpacing.lg) {
-          VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-            Text("Draggable Floating Bar")
-              .scaledFont(size: OmiType.subheading, weight: .semibold)
-              .foregroundColor(Ink.primary)
-            Text("Allow repositioning the floating bar by dragging it.")
-              .scaledFont(size: OmiType.body)
-              .foregroundColor(Ink.secondary)
-          }
-          Spacer()
-          Toggle("", isOn: $shortcutSettings.draggableBarEnabled)
-            .toggleStyle(OmiToggleStyle())
-        }
-      }
+      // settingsCard(settingId: "floatingbar.draggable") {
+      // HStack(spacing: OmiSpacing.lg) {
+      // VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+      // Text("Draggable Floating Bar")
+      // .scaledFont(size: OmiType.subheading, weight: .semibold)
+      // .foregroundColor(Ink.primary)
+      // Text("Allow repositioning the floating bar by dragging it.")
+      // .scaledFont(size: OmiType.body)
+      // .foregroundColor(Ink.secondary)
+      // }
+      // Spacer()
+      // Toggle("", isOn: $shortcutSettings.draggableBarEnabled)
+      // .toggleStyle(OmiToggleStyle())
+      // }
+      // }
 
       settingsCard(settingId: "floatingbar.typedvoiceanswers") {
         HStack(spacing: OmiSpacing.lg) {

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -275,20 +275,21 @@ struct SettingsSearchItem: Identifiable {
       subtitle: "Configure the floating bar appearance and visibility",
       keywords: ["floating bar", "ask omi", "show bar"], section: .floatingBar, icon: "sparkles",
       settingId: "floatingbar.show"),
-    SettingsSearchItem(
-      name: "Notification Previews",
-      subtitle: "Show assistant notifications under the Floating Bar",
-      keywords: ["notification preview", "floating bar notification", "mute preview", "focus", "dnd"],
-      section: .floatingBar, icon: "sparkles", settingId: "floatingbar.notificationpreviews"),
-    SettingsSearchItem(
-      name: "Background Style", subtitle: "Toggle between solid and transparent background",
-      keywords: ["background", "solid", "transparent", "blur"], section: .floatingBar,
-      icon: "sparkles", settingId: "floatingbar.background"),
-    SettingsSearchItem(
-      name: "Draggable Floating Bar",
-      subtitle: "Allow repositioning the floating bar by dragging it",
-      keywords: ["drag", "move", "reposition", "draggable"], section: .floatingBar,
-      icon: "sparkles", settingId: "floatingbar.draggable"),
+    // HIDDEN DELIBERATELY (Nik, 2026-08-25): search entries for hidden floating-bar rows.
+    // SettingsSearchItem(
+    // name: "Notification Previews",
+    // subtitle: "Show assistant notifications under the Floating Bar",
+    // keywords: ["notification preview", "floating bar notification", "mute preview", "focus", "dnd"],
+    // section: .floatingBar, icon: "sparkles", settingId: "floatingbar.notificationpreviews"),
+    // SettingsSearchItem(
+    // name: "Background Style", subtitle: "Toggle between solid and transparent background",
+    // keywords: ["background", "solid", "transparent", "blur"], section: .floatingBar,
+    // icon: "sparkles", settingId: "floatingbar.background"),
+    // SettingsSearchItem(
+    // name: "Draggable Floating Bar",
+    // subtitle: "Allow repositioning the floating bar by dragging it",
+    // keywords: ["drag", "move", "reposition", "draggable"], section: .floatingBar,
+    // icon: "sparkles", settingId: "floatingbar.draggable"),
     SettingsSearchItem(
       name: "Typed Questions", subtitle: "Speak replies aloud for typed floating-bar questions",
       keywords: ["typed", "text", "speech", "tts", "audio answers"], section: .floatingBar,

--- a/desktop/macos/changelog/unreleased/20260827-hide-assistant-settings.json
+++ b/desktop/macos/changelog/unreleased/20260827-hide-assistant-settings.json
@@ -1,0 +1,3 @@
+{
+  "change": "Settings is lighter: the Task, Insight, and Memory Assistant panes and three floating-bar rows are hidden"
+}


### PR DESCRIPTION
## What

Hides from Settings, per Nik's screenshots: the **Task / Insight / Memory Assistant** panes in Advanced, and the **Notification Previews / Background Style / Draggable Floating Bar** rows in the Floating Bar pane.

Everything is **commented out, not deleted**, under a `HIDDEN DELIBERATELY` marker. That marker is the point: this exact surface was re-added once before (73c7f85fbc, "give the three proactive assistants a pane you can reach") because the previous hide left the code looking like dead-by-accident. Matching sidebar search-index entries are commented out with the rows so search cannot point at hidden panes.

The assistants keep running with their stored settings — only the settings UI is hidden. All stored defaults keep applying (previews, background, draggability, intervals, confidence).

`navigate_via_shortcut` gains `tasksettings` / `floatingbarsettings` cases that post the app's existing deep-link notifications (`.navigateToTaskSettings`, `.navigateToFloatingBarSettings`), so QA can land on these panes with zero cursor input — this is how the change itself was verified.

## Verification

- `swift build` clean; `swift test --filter SettingsAssistantControlsTests` — 14 tests, 0 failures.
- Running bundle (`com.omi.omi-hide-check`, built from this branch), navigated via the new bridge shortcuts, in-app window captures: **Advanced flows AI Setup → Analysis Throttle** (trio gone); **Floating Bar shows only Show / Typed Questions / Screen Sharing / Voice / Faster**.

Line-Count-Exception: desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift | 4792 -> 4801 | nine lines: two navigate_via_shortcut cases posting existing deep-link notifications, needed to verify the hidden panes cursor-free

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

