### PR TITLE
SCA-363: macOS in-app CSAT + admin copy/stats

### DIFF
--- a/backend/database/csat.py
+++ b/backend/database/csat.py
@@ -1,0 +1,162 @@
+"""Server-driven config + storage for the in-app product CSAT ask.
+
+Firestore layout:
+
+  Collection: csat_config — Document ID: product (singleton)
+
+    enabled: bool             default true when the doc is missing
+    title: str                default "How would you rate Omi Desktop?"
+    body: str                 optional subtitle, default ""
+    thank_you_text: str       default "Thank you!"
+    refer_cta_text: str       default "Enjoying Omi? Give a friend a free month."
+    question_threshold: int   1..50, default 3
+    comment_max_score: int    1..5, default 3
+    revision: int             incremented on every admin save
+    updated_at: number        unix seconds
+    updated_by: str           admin uid
+
+  Collection: csat_ratings — Document ID: "{platform}_{uid}"
+
+    uid, platform, app_version, score, comment, revision, created_at
+
+Ratings are create-only (Firestore `create` is an atomic exists=false
+compare-and-create): a user gets exactly one rating per platform and a
+resubmit never overwrites the first answer.
+
+The config singleton is admin-authored on admin.omi.me; the backend GET is
+the only client read path. The doc is cached 60s like app_review_config so
+admin copy edits reach clients within one poll (~5 min) plus the cache.
+"""
+
+import time
+from typing import Any, Dict, Tuple, cast
+
+from google.api_core.exceptions import AlreadyExists, Conflict
+
+from database._client import get_firestore_client
+from database.cache import get_memory_cache
+
+CONFIG_COLLECTION = 'csat_config'
+CONFIG_DOC = 'product'
+RATINGS_COLLECTION = 'csat_ratings'
+
+PLATFORMS = {'macos', 'windows', 'ios', 'android'}
+
+_CACHE_KEY = 'csat_config:product'
+_CACHE_TTL_SECONDS = 60
+
+MAX_APP_VERSION_LENGTH = 32
+MAX_COMMENT_LENGTH = 500
+
+DEFAULT_TITLE = 'How would you rate Omi Desktop?'
+DEFAULT_THANK_YOU_TEXT = 'Thank you!'
+DEFAULT_REFER_CTA_TEXT = 'Enjoying Omi? Give a friend a free month.'
+
+# What a missing/empty doc means; also the shape returned to clients.
+DEFAULT_CONFIG: Dict[str, Any] = {
+    'enabled': True,
+    'title': DEFAULT_TITLE,
+    'body': '',
+    'thank_you_text': DEFAULT_THANK_YOU_TEXT,
+    'refer_cta_text': DEFAULT_REFER_CTA_TEXT,
+    'question_threshold': 3,
+    'comment_max_score': 3,
+    'revision': 0,
+}
+
+
+def _clamped_int(raw: Any, default: int, low: int, high: int) -> int:
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return max(low, min(high, value))
+
+
+def normalize_config(raw: Dict[str, Any] | None) -> Dict[str, Any]:
+    """Coerce a stored (possibly admin-mangled) config doc to the client shape.
+
+    Pure so both the backend GET and tests can pin the contract: unknown or
+    out-of-range fields fall back to defaults / clamps, never 500.
+    """
+    raw = raw if isinstance(raw, dict) else {}
+
+    def text(field: str, fallback: str) -> str:
+        value = raw.get(field)
+        return value.strip() if isinstance(value, str) and value.strip() else fallback
+
+    return {
+        'enabled': raw.get('enabled') is not False,
+        'title': text('title', DEFAULT_TITLE),
+        'body': raw.get('body').strip() if isinstance(raw.get('body'), str) else '',
+        'thank_you_text': text('thank_you_text', DEFAULT_THANK_YOU_TEXT),
+        'refer_cta_text': text('refer_cta_text', DEFAULT_REFER_CTA_TEXT),
+        'question_threshold': _clamped_int(raw.get('question_threshold'), 3, 1, 50),
+        'comment_max_score': _clamped_int(raw.get('comment_max_score'), 3, 1, 5),
+        'revision': max(0, _clamped_int(raw.get('revision'), 0, 0, 1_000_000_000)),
+    }
+
+
+def _fetch_config() -> Dict[str, Any]:
+    doc = get_firestore_client().collection(CONFIG_COLLECTION).document(CONFIG_DOC).get()
+    if not getattr(doc, 'exists', False):
+        return dict(DEFAULT_CONFIG)
+    raw: object = doc.to_dict()
+    return cast(Dict[str, Any], raw) if isinstance(raw, dict) else dict(DEFAULT_CONFIG)
+
+
+def get_product_config() -> Dict[str, Any]:
+    """Return the product CSAT config, normalized, cached for 60s."""
+    fetched = get_memory_cache().get_or_fetch(_CACHE_KEY, _fetch_config, ttl=_CACHE_TTL_SECONDS)
+    raw = cast(Dict[str, Any], fetched) if isinstance(fetched, dict) else dict(DEFAULT_CONFIG)
+    return normalize_config(raw)
+
+
+def submit_rating(
+    *,
+    uid: str,
+    platform: str,
+    app_version: str,
+    score: int,
+    comment: str,
+    revision: int,
+) -> Tuple[str, bool]:
+    """Create the user's one rating doc for the platform.
+
+    The comment is dropped server-side when the score is above the current
+    `comment_max_score` (the client may still send one — the server wins).
+    Returns `(doc_id, created)`; `created=False` means a rating already
+    existed and was left untouched.
+    """
+    config = get_product_config()
+    effective_comment = comment if score <= config['comment_max_score'] else ''
+    doc_id = f'{platform}_{uid}'
+    payload: Dict[str, Any] = {
+        'uid': uid,
+        'platform': platform,
+        'app_version': app_version[:MAX_APP_VERSION_LENGTH],
+        'score': score,
+        'comment': effective_comment,
+        'revision': max(0, revision),
+        'created_at': int(time.time()),
+    }
+    ref = get_firestore_client().collection(RATINGS_COLLECTION).document(doc_id)
+    try:
+        ref.create(payload)
+    except (AlreadyExists, Conflict):
+        return doc_id, False
+    return doc_id, True
+
+
+__all__ = [
+    'CONFIG_COLLECTION',
+    'CONFIG_DOC',
+    'DEFAULT_CONFIG',
+    'MAX_APP_VERSION_LENGTH',
+    'MAX_COMMENT_LENGTH',
+    'PLATFORMS',
+    'RATINGS_COLLECTION',
+    'get_product_config',
+    'normalize_config',
+    'submit_rating',
+]

--- a/backend/database/csat.py
+++ b/backend/database/csat.py
@@ -88,7 +88,7 @@ def normalize_config(raw: Dict[str, Any] | None) -> Dict[str, Any]:
     return {
         'enabled': raw.get('enabled') is not False,
         'title': text('title', DEFAULT_TITLE),
-        'body': raw.get('body').strip() if isinstance(raw.get('body'), str) else '',
+        'body': text('body', ''),
         'thank_you_text': text('thank_you_text', DEFAULT_THANK_YOU_TEXT),
         'refer_cta_text': text('refer_cta_text', DEFAULT_REFER_CTA_TEXT),
         'question_threshold': _clamped_int(raw.get('question_threshold'), 3, 1, 50),

--- a/backend/main.py
+++ b/backend/main.py
@@ -100,6 +100,7 @@ from routers import (
     public_shared_conversation_chat,
     screen_frames,
     jit_ledger_snapshot,
+    csat,
     jit_rollout,
 )
 from routers.listen.registry import proactive_message_dispatcher
@@ -199,6 +200,7 @@ app.include_router(integration.router)
 app.include_router(agents.router)
 app.include_router(users.router)
 app.include_router(referrals.router)
+app.include_router(csat.router)
 app.include_router(desktop_prompts.router)
 app.include_router(conversation_finalization.router)
 app.include_router(trends.router)

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -430,6 +430,54 @@ routes:
         state: active
       owner: backend
   - route_type: http
+    method: GET
+    path: /v1/csat/config
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - firebase_id_token
+          - admin_key_uid_prefix
+        placement: dependency
+        scopes: []
+      byok: validated_when_headers_present
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: first_party
+      data_domain: user_profile
+      deprecation:
+        state: active
+      owner: backend
+  - route_type: http
+    method: POST
+    path: /v1/csat/ratings
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - firebase_id_token
+          - admin_key_uid_prefix
+        placement: dependency
+        scopes: []
+      byok: validated_when_headers_present
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: first_party
+      data_domain: user_profile
+      deprecation:
+        state: active
+      owner: backend
+  - route_type: http
     method: POST
     path: /v1/users/me/referral/claim
     policy:

--- a/backend/routers/csat.py
+++ b/backend/routers/csat.py
@@ -1,0 +1,68 @@
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from database import csat
+from utils.other import endpoints as auth
+
+router = APIRouter(tags=['csat'])
+
+
+class CsatConfigResponse(BaseModel):
+    enabled: bool
+    title: str
+    body: str
+    thank_you_text: str
+    refer_cta_text: str
+    question_threshold: int
+    comment_max_score: int
+    revision: int
+
+
+class CsatRatingRequest(BaseModel):
+    platform: str
+    app_version: str = ''
+    score: int
+    comment: Optional[str] = None
+    revision: int = 0
+
+
+@router.get('/v1/csat/config', response_model=CsatConfigResponse)
+def get_csat_config(
+    platform: str = 'macos',
+    uid: str = Depends(auth.get_current_user_uid),
+) -> CsatConfigResponse:
+    # `platform` is accepted and reserved so Windows/iOS/Android callers can
+    # attach later without a contract change; v1 serves the same product-wide
+    # singleton for every platform. A missing doc returns defaults — never 404.
+    return CsatConfigResponse(**csat.get_product_config())
+
+
+@router.post('/v1/csat/ratings', status_code=201)
+def submit_csat_rating(
+    payload: CsatRatingRequest,
+    uid: str = Depends(auth.get_current_user_uid),
+) -> JSONResponse:
+    if payload.platform not in csat.PLATFORMS:
+        raise HTTPException(status_code=400, detail=f'platform must be one of {sorted(csat.PLATFORMS)}')
+    if not 1 <= payload.score <= 5:
+        raise HTTPException(status_code=400, detail='score must be between 1 and 5')
+    if payload.revision < 0:
+        raise HTTPException(status_code=400, detail='revision must be >= 0')
+    app_version = payload.app_version.strip()[: csat.MAX_APP_VERSION_LENGTH]
+    comment = (payload.comment or '').strip()[: csat.MAX_COMMENT_LENGTH]
+    # The comment is never logged; only the clamped fields above travel on.
+    doc_id, created = csat.submit_rating(
+        uid=uid,
+        platform=payload.platform,
+        app_version=app_version,
+        score=payload.score,
+        comment=comment,
+        revision=payload.revision,
+    )
+    if not created:
+        # One rating per user per platform; the existing answer stands.
+        return JSONResponse(status_code=409, content={'id': doc_id, 'created': False})
+    return JSONResponse(status_code=201, content={'id': doc_id, 'created': True})

--- a/backend/routers/csat.py
+++ b/backend/routers/csat.py
@@ -21,6 +21,11 @@ class CsatConfigResponse(BaseModel):
     revision: int
 
 
+class CsatRatingReceipt(BaseModel):
+    id: str
+    created: bool
+
+
 class CsatRatingRequest(BaseModel):
     platform: str
     app_version: str = ''
@@ -40,11 +45,11 @@ def get_csat_config(
     return CsatConfigResponse(**csat.get_product_config())
 
 
-@router.post('/v1/csat/ratings', status_code=201)
+@router.post('/v1/csat/ratings', response_model=CsatRatingReceipt, status_code=201)
 def submit_csat_rating(
     payload: CsatRatingRequest,
     uid: str = Depends(auth.get_current_user_uid),
-) -> JSONResponse:
+):
     if payload.platform not in csat.PLATFORMS:
         raise HTTPException(status_code=400, detail=f'platform must be one of {sorted(csat.PLATFORMS)}')
     if not 1 <= payload.score <= 5:
@@ -65,4 +70,4 @@ def submit_csat_rating(
     if not created:
         # One rating per user per platform; the existing answer stands.
         return JSONResponse(status_code=409, content={'id': doc_id, 'created': False})
-    return JSONResponse(status_code=201, content={'id': doc_id, 'created': True})
+    return CsatRatingReceipt(id=doc_id, created=True)

--- a/backend/scripts/export_openapi.py
+++ b/backend/scripts/export_openapi.py
@@ -65,6 +65,7 @@ APP_CLIENT_PREFIXES = (
     '/v1/chat',
     '/v1/connectors',
     '/v1/conversations',
+    '/v1/csat',
     '/v1/dev',
     '/v1/fair-use',
     '/v1/frame-requests',

--- a/backend/scripts/select_backend_unit_tests.py
+++ b/backend/scripts/select_backend_unit_tests.py
@@ -68,14 +68,18 @@ FULL_RUN_GLOBS = (
     'backend/utils/encryption.py',
 )
 
-# These paths participate in the location-context contract below. They are
-# intentionally narrow exceptions to the generic model/database full-suite
-# fallback so local pre-push feedback remains focused; CI still owns --all.
-NARROW_LOCATION_CONTEXT_PATHS = frozenset(
+# Intentionally narrow exceptions to the generic model/database full-suite
+# fallback so local pre-push feedback stays focused; CI still owns --all.
+# Every entry must be mapped to a narrow area in AREA_TESTS below, so the
+# exception still selects that area's contracts instead of nothing.
+NARROW_FULL_RUN_EXCEPTIONS = frozenset(
     {
+        # location-context consent area
         'backend/database/users.py',
         'backend/models/geolocation.py',
         'backend/models/users.py',
+        # in-app CSAT surface
+        'backend/database/csat.py',
     }
 )
 
@@ -148,6 +152,14 @@ AREA_TESTS = (
         ),
         (),
         ('tests/unit/test_location_context_consent.py', 'tests/unit/test_chat_async_offload.py'),
+    ),
+    (
+        (
+            'backend/database/csat.py',
+            'backend/routers/csat.py',
+        ),
+        (),
+        ('tests/unit/test_csat.py', 'tests/unit/test_desktop_rest_inventory.py'),
     ),
     (
         ('backend/llm_gateway/',),
@@ -326,7 +338,7 @@ def normalize_changed_path(path: str) -> str:
 
 
 def is_full_run_path(path: str) -> bool:
-    if path in NARROW_LOCATION_CONTEXT_PATHS:
+    if path in NARROW_FULL_RUN_EXCEPTIONS:
         return False
     if path in FULL_RUN_PATHS:
         return True

--- a/backend/tests/unit/test_csat.py
+++ b/backend/tests/unit/test_csat.py
@@ -1,0 +1,169 @@
+"""CSAT contract: config defaults on a missing doc, create-only ratings."""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from google.api_core.exceptions import AlreadyExists
+
+from database import csat as csat_db
+from routers import csat as csat_router
+
+UID = 'uid-csat-1'
+
+
+class _Snapshot:
+    def __init__(self, doc_id, data):
+        self.id = doc_id
+        self._data = data
+        self.exists = data is not None
+
+    def to_dict(self):
+        return None if self._data is None else dict(self._data)
+
+
+class _DocRef:
+    def __init__(self, docs, doc_id):
+        self._docs = docs
+        self._doc_id = doc_id
+
+    def get(self):
+        return _Snapshot(self._doc_id, self._docs.get(self._doc_id))
+
+    def create(self, data):
+        # Same atomicity contract as Firestore: create never overwrites.
+        if self._doc_id in self._docs:
+            raise AlreadyExists(self._doc_id)
+        self._docs[self._doc_id] = dict(data)
+
+
+class _Collection:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def document(self, doc_id):
+        return _DocRef(self._docs, doc_id)
+
+
+class _FakeFirestore:
+    def __init__(self):
+        self._collections = {}
+
+    def collection(self, name):
+        return _Collection(self._collections.setdefault(name, {}))
+
+
+class _MemoryCache:
+    def __init__(self):
+        self._store = {}
+
+    def get_or_fetch(self, key, fetch, ttl=None):
+        if key not in self._store:
+            self._store[key] = fetch()
+        return self._store[key]
+
+
+def _install_fake_backend(monkeypatch):
+    firestore = _FakeFirestore()
+    monkeypatch.setattr(csat_db, 'get_firestore_client', lambda: firestore)
+    monkeypatch.setattr(csat_db, 'get_memory_cache', lambda: _MemoryCache())
+    return firestore
+
+
+def _client(monkeypatch) -> TestClient:
+    _install_fake_backend(monkeypatch)
+    app = FastAPI()
+    app.include_router(csat_router.router)
+    app.dependency_overrides[csat_router.auth.get_current_user_uid] = lambda: UID
+    return TestClient(app)
+
+
+def test_get_returns_defaults_when_config_doc_is_missing(monkeypatch):
+    client = _client(monkeypatch)
+    response = client.get('/v1/csat/config', params={'platform': 'macos'})
+    assert response.status_code == 200
+    assert response.json() == {
+        'enabled': True,
+        'title': 'How would you rate Omi Desktop?',
+        'body': '',
+        'thank_you_text': 'Thank you!',
+        'refer_cta_text': 'Enjoying Omi? Give a friend a free month.',
+        'question_threshold': 3,
+        'comment_max_score': 3,
+        'revision': 0,
+    }
+
+
+def test_post_persists_platform_scoped_rating_and_second_post_conflicts(monkeypatch):
+    firestore = _install_fake_backend(monkeypatch)
+    app = FastAPI()
+    app.include_router(csat_router.router)
+    app.dependency_overrides[csat_router.auth.get_current_user_uid] = lambda: UID
+    client = TestClient(app)
+
+    payload = {
+        'platform': 'macos',
+        'app_version': '1.2.3',
+        'score': 2,
+        'comment': 'too slow',
+        'revision': 1,
+    }
+    response = client.post('/v1/csat/ratings', json=payload)
+    assert response.status_code == 201
+    assert response.json() == {'id': f'macos_{UID}', 'created': True}
+
+    stored = firestore._collections[csat_db.RATINGS_COLLECTION][f'macos_{UID}']
+    assert stored['uid'] == UID
+    assert stored['platform'] == 'macos'
+    assert stored['score'] == 2
+    assert stored['comment'] == 'too slow'
+    assert stored['revision'] == 1
+    assert stored['created_at'] > 0
+
+    # Resubmit (client retry, double-tap): 409, and the first answer stands.
+    again = client.post('/v1/csat/ratings', json={**payload, 'score': 5, 'comment': 'changed my mind'})
+    assert again.status_code == 409
+    assert again.json() == {'id': f'macos_{UID}', 'created': False}
+    unchanged = firestore._collections[csat_db.RATINGS_COLLECTION][f'macos_{UID}']
+    assert unchanged['score'] == 2
+    assert unchanged['comment'] == 'too slow'
+
+
+def test_post_drops_comment_above_comment_max_score(monkeypatch):
+    firestore = _install_fake_backend(monkeypatch)
+    app = FastAPI()
+    app.include_router(csat_router.router)
+    app.dependency_overrides[csat_router.auth.get_current_user_uid] = lambda: UID
+    client = TestClient(app)
+
+    response = client.post(
+        '/v1/csat/ratings',
+        json={'platform': 'macos', 'score': 5, 'comment': 'love it', 'revision': 0},
+    )
+    assert response.status_code == 201
+    stored = firestore._collections[csat_db.RATINGS_COLLECTION][f'macos_{UID}']
+    # Server wins over whatever the client sends for a high score.
+    assert stored['comment'] == ''
+
+
+def test_post_rejects_invalid_platform_and_score(monkeypatch):
+    client = _client(monkeypatch)
+    assert client.post('/v1/csat/ratings', json={'platform': 'web', 'score': 3}).status_code == 400
+    assert client.post('/v1/csat/ratings', json={'platform': 'macos', 'score': 0}).status_code == 400
+    assert client.post('/v1/csat/ratings', json={'platform': 'macos', 'score': 6}).status_code == 400
+
+
+def test_normalize_config_clamps_stored_doc(monkeypatch):
+    normalized = csat_db.normalize_config(
+        {
+            'enabled': False,
+            'title': '  ',
+            'question_threshold': 500,
+            'comment_max_score': 9,
+            'revision': -3,
+        }
+    )
+    assert normalized['enabled'] is False
+    # Blank copy falls back to the default, never an empty bar.
+    assert normalized['title'] == csat_db.DEFAULT_TITLE
+    assert normalized['question_threshold'] == 50
+    assert normalized['comment_max_score'] == 5
+    assert normalized['revision'] == 0

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -198,6 +198,17 @@ def test_location_context_paths_select_their_focused_privacy_regressions(selecto
         assert reason == "selected backend unit tests from changed paths and workflow contracts"
 
 
+def test_csat_surface_paths_select_their_focused_contracts(selector_and_all_tests):
+    selector, all_tests = selector_and_all_tests
+
+    for source_path in ("backend/database/csat.py", "backend/routers/csat.py"):
+        selected, reason = selector.tests_for_changed_paths([source_path], all_tests)
+        assert "tests/unit/test_csat.py" in selected, source_path
+        assert "tests/unit/test_desktop_rest_inventory.py" in selected, source_path
+        assert selected != all_tests, source_path
+        assert reason == "selected backend unit tests from changed paths and workflow contracts"
+
+
 def test_removed_test_forces_full_discovered_suite(selector_and_all_tests):
     selector, all_tests = selector_and_all_tests
 

--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -735,8 +735,8 @@ class AnalyticsManager {
     }
   }
 
-  func desktopRatingSubmitted(rating: Int) {
-    PostHogManager.shared.desktopRatingSubmitted(rating: rating)
+  func desktopRatingSubmitted(rating: Int, revision: Int? = nil) {
+    PostHogManager.shared.desktopRatingSubmitted(rating: rating, revision: revision)
   }
 
   func desktopPromptShown(promptId: String, promptType: String) {

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -65,6 +65,9 @@ enum DefaultsKey: String {
   /// One-shot marker: the question counter was seeded from server chat
   /// history so long-time users see the rating ask without three NEW questions.
   case ratingPromptHistorySeeded = "ratingPromptHistorySeeded"
+  /// Last-good server CSAT config (JSON), so a cold start renders the right
+  /// copy before the first config poll lands. Product-wide, not owner-scoped.
+  case csatConfigLastGood = "csatConfigLastGood"
   case screenAnalysisAutoStartFixedV2 = "screenAnalysisAutoStartFixed_v2"
   case screenAnalysisAutoStartFixedV3 = "screenAnalysisAutoStartFixed_v3"
   case homeOmiDeviceAccountHistory = "home-omi-device-account-history"

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RatingPrompt.swift
@@ -20,6 +20,11 @@ extension DesktopAutomationActionRegistry {
           "dismissed": manager.isDismissed ? "true" : "false",
           "thank_you": "\(manager.thankYouRating ?? 0)",
           "remotely_disabled": manager.isRemotelyDisabled ? "true" : "false",
+          "comment_pending": "\(manager.commentPendingScore ?? 0)",
+          "config_enabled": manager.config.enabled ? "true" : "false",
+          "config_threshold": "\(manager.config.questionThreshold)",
+          "config_comment_max_score": "\(manager.config.commentMaxScore)",
+          "config_revision": "\(manager.config.revision)",
         ]
       }
     }
@@ -36,7 +41,27 @@ extension DesktopAutomationActionRegistry {
           return ["submitted": "false", "reason": "prompt not visible"]
         }
         manager.submit(rating: rating)
+        if let pending = manager.commentPendingScore {
+          // Low score: nothing is submitted yet — the comment step is next.
+          return ["submitted": "false", "comment_pending": "\(pending)"]
+        }
         return ["submitted": "true", "rating": "\(manager.submittedRating)"]
+      }
+    }
+
+    register(
+      name: "rating_prompt_submit_comment",
+      summary: "Send the pending low-score comment through the same path as the Send button (empty comment = Skip)",
+      params: ["comment"]
+    ) { params in
+      let comment = params["comment"] ?? ""
+      return await MainActor.run {
+        let manager = RatingPromptManager.shared
+        guard let score = manager.commentPendingScore else {
+          return ["submitted": "false", "reason": "no comment pending"]
+        }
+        manager.submitPendingComment(comment)
+        return ["submitted": "true", "rating": "\(score)", "comment": comment]
       }
     }
 

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -8700,6 +8700,61 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
+  public static func getCsatConfigV1CsatConfigGet(client: OmiApiClient, platform: String? = nil, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil) async throws -> OmiAnyCodable {
+    let _path = "/v1/csat/config"
+    guard var components = URLComponents(string: client.baseURL + _path) else {
+      throw OmiApiError.invalidURL
+    }
+    var queryItems: [URLQueryItem] = []
+    if let platform {
+      queryItems.append(URLQueryItem(name: "platform", value: String(platform)))
+    }
+    if !queryItems.isEmpty { components.queryItems = queryItems }
+    guard let url = components.url else { throw OmiApiError.invalidURL }
+    var req = URLRequest(url: url)
+    req.httpMethod = "GET"
+    for (name, value) in client.headers { req.setValue(value, forHTTPHeaderField: name) }
+    if let token = client.token {
+      req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    }
+    if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
+    if let xAppPlatform { req.setValue(String(xAppPlatform), forHTTPHeaderField: "X-App-Platform") }
+    if let xDeviceIdHash { req.setValue(String(xDeviceIdHash), forHTTPHeaderField: "X-Device-Id-Hash") }
+    if let xAppVersion { req.setValue(String(xAppVersion), forHTTPHeaderField: "X-App-Version") }
+    let (data, resp) = try await URLSession.shared.data(for: req)
+    guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }
+    guard (200..<300).contains(http.statusCode) else {
+      throw OmiApiError.httpError(status: http.statusCode, data: data)
+    }
+    return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
+  }
+
+  public static func submitCsatRatingV1CsatRatingsPost(client: OmiApiClient, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, body: OmiAnyCodable) async throws -> OmiAnyCodable {
+    let _path = "/v1/csat/ratings"
+    guard let components = URLComponents(string: client.baseURL + _path) else {
+      throw OmiApiError.invalidURL
+    }
+    guard let url = components.url else { throw OmiApiError.invalidURL }
+    var req = URLRequest(url: url)
+    req.httpMethod = "POST"
+    for (name, value) in client.headers { req.setValue(value, forHTTPHeaderField: name) }
+    if let token = client.token {
+      req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    }
+    if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
+    if let xAppPlatform { req.setValue(String(xAppPlatform), forHTTPHeaderField: "X-App-Platform") }
+    if let xDeviceIdHash { req.setValue(String(xDeviceIdHash), forHTTPHeaderField: "X-Device-Id-Hash") }
+    if let xAppVersion { req.setValue(String(xAppVersion), forHTTPHeaderField: "X-App-Version") }
+    req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    req.httpBody = try JSONEncoder().encode(body)
+    let (data, resp) = try await URLSession.shared.data(for: req)
+    guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }
+    guard (200..<300).contains(http.statusCode) else {
+      throw OmiApiError.httpError(status: http.statusCode, data: data)
+    }
+    return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
+  }
+
   public static func listApiKeys(client: OmiApiClient) async throws -> [OmiAnyCodable] {
     let _path = "/v1/dev/keys"
     guard let components = URLComponents(string: client.baseURL + _path) else {
@@ -16337,5 +16392,5 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  // Total: 430 Swift client methods generated.
+  // Total: 432 Swift client methods generated.
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1162,6 +1162,7 @@ struct DesktopHomeView: View {
         RatingPromptManager.shared.ownerDidChange()
         RemotePromptEngine.shared.ownerDidChange()
         RemotePromptEngine.shared.start()
+        RatingPromptManager.shared.startConfigPolling()
         await RatingPromptManager.shared.seedFromHistoryIfNeeded()
       }
       .overlay {

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1162,7 +1162,6 @@ struct DesktopHomeView: View {
         RatingPromptManager.shared.ownerDidChange()
         RemotePromptEngine.shared.ownerDidChange()
         RemotePromptEngine.shared.start()
-        RatingPromptManager.shared.startConfigPolling()
         await RatingPromptManager.shared.seedFromHistoryIfNeeded()
       }
       .overlay {

--- a/desktop/macos/Desktop/Sources/PostHogManager.swift
+++ b/desktop/macos/Desktop/Sources/PostHogManager.swift
@@ -690,13 +690,19 @@ extension PostHogManager {
       ])
   }
 
-  func desktopRatingSubmitted(rating: Int) {
+  func desktopRatingSubmitted(rating: Int, revision: Int? = nil) {
+    var properties: [String: Any] = [
+      "rating": rating,
+      "trigger": "third_question",
+    ]
+    // The prompt revision the client saw, so copy experiments are separable.
+    // The comment NEVER travels to PostHog — Firestore only, admin-only read.
+    if let revision {
+      properties["revision"] = revision
+    }
     track(
       "Desktop Rating Submitted",
-      properties: [
-        "rating": rating,
-        "trigger": "third_question",
-      ])
+      properties: properties)
   }
 
   // MARK: - Rewind Events (Desktop-specific)

--- a/desktop/macos/Desktop/Sources/RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/RatingPrompt.swift
@@ -516,8 +516,15 @@ struct RatingPromptBar: View {
         .foregroundColor(.primary)
 
       TextField("What can we improve?", text: $commentDraft)
-        .textFieldStyle(.roundedBorder)
-        .frame(width: 320)
+        .textFieldStyle(.plain)
+        .font(.system(size: 13))
+        .foregroundColor(Ink.primary)
+        .padding(.horizontal, OmiSpacing.md)
+        .frame(width: 320, alignment: .leading)
+        .frame(minHeight: 30)
+        // Same quiet field surface as OmiSearchField, at the bar's radius so
+        // the row reads as one chrome — no system blue focus ring.
+        .glassField(cornerRadius: 10)
         .onSubmit { manager.submitPendingComment(commentDraft) }
         .onChange(of: commentDraft) { _, newValue in
           if newValue.count > 500 {
@@ -529,15 +536,15 @@ struct RatingPromptBar: View {
       Button("Send") {
         manager.submitPendingComment(commentDraft)
       }
-      .buttonStyle(.borderedProminent)
-      .controlSize(.small)
-      .tint(.primary)
+      .buttonStyle(
+        OmiButtonStyle(
+          RatingPromptButtonStyle.referralKind,
+          size: RatingPromptButtonStyle.referralSize))
 
       Button("Skip") {
         manager.skipPendingComment()
       }
-      .buttonStyle(.bordered)
-      .controlSize(.small)
+      .buttonStyle(OmiButtonStyle(.secondary, size: .compact))
 
       closeButton { manager.dismiss() }
     }

--- a/desktop/macos/Desktop/Sources/RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/RatingPrompt.swift
@@ -5,7 +5,8 @@ import SwiftUI
 
 /// Decides when the one-time "rate Omi Desktop" ask is due. Pure so the
 /// trigger contract stays unit-testable: the prompt appears once the user has
-/// asked their 3rd question, and never again after a submit or a dismiss.
+/// asked their 3rd question (or the server-configured threshold), and never
+/// again after a submit or a dismiss.
 enum RatingPromptPolicy {
   static let questionThreshold = 3
   /// Remote kill switch (PostHog feature flag, preloaded at analytics init).
@@ -14,9 +15,20 @@ enum RatingPromptPolicy {
   static let killSwitchFlag = "desktop-rating-prompt-disabled"
 
   static func shouldShow(
-    questionCount: Int, submittedRating: Int, dismissed: Bool, remotelyDisabled: Bool = false
+    questionCount: Int,
+    submittedRating: Int,
+    dismissed: Bool,
+    remotelyDisabled: Bool = false,
+    enabled: Bool = true,
+    questionThreshold: Int = RatingPromptPolicy.questionThreshold
   ) -> Bool {
-    !remotelyDisabled && questionCount >= questionThreshold && submittedRating == 0 && !dismissed
+    enabled && !remotelyDisabled && questionCount >= questionThreshold && submittedRating == 0 && !dismissed
+  }
+
+  /// Pure comment gate: only a low score (≤ commentMaxScore, from the
+  /// server config) is asked for an optional comment before completing.
+  static func shouldAskForComment(score: Int, commentMaxScore: Int) -> Bool {
+    score <= commentMaxScore
   }
 }
 
@@ -30,6 +42,25 @@ enum RatingPromptPolicy {
 final class RatingPromptManager: ObservableObject {
   static let shared = RatingPromptManager()
 
+  /// Server-driven copy/trigger/threshold config. Starts from the last-good
+  /// cached value (or hardcoded defaults) so a cold start needs no network;
+  /// `startConfigPolling()` refreshes it while signed in.
+  @Published private(set) var config: CsatConfig = RatingPromptManager.cachedConfig() ?? .fallback
+
+  /// Set between the star tap and Send/Skip on a low score: the bar stays
+  /// up and shows the comment field instead of the stars. Nothing is
+  /// persisted while a comment is pending.
+  @Published private(set) var commentPendingScore: Int?
+
+  /// Seam for tests and the automation bridge; assigned in init (a default
+  /// value cannot reference the MainActor-isolated APIClient).
+  var configFetch: () async throws -> CsatConfig
+  /// Same cadence as RemotePromptEngine: admin copy edits reach the bar
+  /// within one poll (~5 minutes) plus the backend's 60s config cache.
+  static let configPollInterval: TimeInterval = 300
+
+  private var configPollTask: Task<Void, Never>?
+  private var lastConfigFetchFailed = false
   @Published private(set) var isVisible = false
 
   private let defaults = UserDefaults.standard
@@ -81,6 +112,9 @@ final class RatingPromptManager: ObservableObject {
     historyFetch = { owner in
       try await APIClient.shared.getMessages(
         limit: 100, expectedOwnerId: owner == "anonymous" ? nil : owner)
+    }
+    configFetch = {
+      try await APIClient.shared.getCsatConfig()
     }
     refresh()
     // Sign-out is an owner transition too: hide immediately, not at the next
@@ -141,14 +175,65 @@ final class RatingPromptManager: ObservableObject {
 
   func submit(rating: Int) {
     let clamped = min(max(rating, 1), 5)
+    if RatingPromptPolicy.shouldAskForComment(score: clamped, commentMaxScore: config.commentMaxScore) {
+      // Low score: keep the bar up (stars stay replaced by the comment
+      // field) and persist nothing until Send or Skip.
+      commentPendingScore = clamped
+      return
+    }
+    finalizeSubmission(rating: clamped, comment: "")
+  }
+
+  /// Send button: complete the pending low score with the typed comment.
+  func submitPendingComment(_ comment: String) {
+    guard let score = commentPendingScore else { return }
+    finalizeSubmission(rating: score, comment: comment)
+  }
+
+  /// Skip button: complete the pending low score with an empty comment.
+  func skipPendingComment() {
+    guard let score = commentPendingScore else { return }
+    finalizeSubmission(rating: score, comment: "")
+  }
+
+  private func finalizeSubmission(rating: Int, comment: String) {
+    let clamped = min(max(rating, 1), 5)
+    commentPendingScore = nil
     defaults.set(clamped, forKey: scopedKey("submittedRating"))
-    AnalyticsManager.shared.desktopRatingSubmitted(rating: clamped)
+    AnalyticsManager.shared.desktopRatingSubmitted(rating: clamped, revision: config.revision)
     thankYouRating = clamped
     refresh()
+    submitToBackend(rating: clamped, comment: comment)
     if clamped < 4 {
       Task { @MainActor in
         try? await Task.sleep(nanoseconds: 6_000_000_000)
         if self.thankYouRating == clamped { self.closeThankYou() }
+      }
+    }
+  }
+
+  /// Best-effort backend persist (`POST /v1/csat/ratings`): the local record
+  /// and the PostHog event already happened, so a failure degrades telemetry,
+  /// never the thank-you UX. The comment text itself is never logged.
+  private func submitToBackend(rating: Int, comment: String) {
+    let revision = config.revision
+    Task { @MainActor in
+      do {
+        _ = try await APIClient.shared.submitCsatRating(
+          score: rating, comment: comment, revision: revision)
+      } catch {
+        if case APIError.httpError(let statusCode, _) = error, statusCode == 409 {
+          // Already submitted (retry / double-tap): success locally, and the
+          // ask must never resurface.
+        } else {
+          DesktopDiagnosticsManager.shared.recordFallback(
+            area: "other",
+            from: "remote_config",
+            to: "local_defaults",
+            reason: "other",
+            outcome: .degraded)
+          log("RatingPrompt: CSAT submit failed (kept locally): \(error.localizedDescription)")
+        }
       }
     }
   }
@@ -165,6 +250,9 @@ final class RatingPromptManager: ObservableObject {
   }
 
   func dismiss() {
+    // A dismiss during comment entry abandons the pending rating too —
+    // the bar must not outlive the X that closed it.
+    commentPendingScore = nil
     defaults.set(true, forKey: scopedKey("dismissed"))
     refresh()
   }
@@ -186,9 +274,11 @@ final class RatingPromptManager: ObservableObject {
     // while the request was in flight the result is discarded — account B
     // must never be seeded from account A's history.
     let owner = ownerProvider()
+    // The fetched threshold if the config poll has landed, else the default.
+    let threshold = config.questionThreshold
     guard !(defaults.object(forKey: scopedKey("historySeeded")) as? Bool ?? false) else { return }
     guard submittedRating == 0, !isDismissed,
-      questionCount < RatingPromptPolicy.questionThreshold
+      questionCount < threshold
     else {
       defaults.set(true, forKey: scopedKey("historySeeded"))
       return
@@ -212,12 +302,12 @@ final class RatingPromptManager: ObservableObject {
     guard fetched, ownerProvider() == owner, !Task.isCancelled else { return }
     let asked = history.filter { $0.sender == "human" }.count
     log("RatingPrompt: history seed fetched \(history.count) messages, \(asked) questions")
-    if asked >= RatingPromptPolicy.questionThreshold {
+    if asked >= threshold {
       // Merge, never decrease: questions asked live while the history fetch
       // was in flight already advanced the persisted count past the seed
       // value, and the seed must not roll that back.
       defaults.set(
-        max(questionCount, RatingPromptPolicy.questionThreshold),
+        max(questionCount, threshold),
         forKey: scopedKey("questionCount"))
     }
     defaults.set(true, forKey: scopedKey("historySeeded"))
@@ -228,6 +318,7 @@ final class RatingPromptManager: ObservableObject {
   /// path can be exercised repeatedly on a dev bundle.
   func resetForTesting() {
     thankYouRating = nil
+    commentPendingScore = nil
     for field in ["historySeeded", "questionCount", "submittedRating", "dismissed"] {
       defaults.removeObject(forKey: scopedKey(field))
     }
@@ -240,12 +331,70 @@ final class RatingPromptManager: ObservableObject {
     remoteDisableCheck()
   }
 
+  // MARK: Server config
+
+  /// Fetch the CSAT config now, then every `configPollInterval` while signed
+  /// in — same cadence as RemotePromptEngine, called from the same launch
+  /// `.task` next to `seedFromHistoryIfNeeded()`.
+  func startConfigPolling() {
+    guard configPollTask == nil else { return }
+    configPollTask = Task { @MainActor [weak self] in
+      while !Task.isCancelled {
+        if let self, self.isSignedInCheck() {
+          await self.refreshConfigFromServer()
+        }
+        try? await Task.sleep(nanoseconds: UInt64(Self.configPollInterval * 1_000_000_000))
+      }
+    }
+  }
+
+  func refreshConfigFromServer() async {
+    do {
+      let fetched = try await configFetch()
+      config = fetched
+      persistConfig(fetched)
+      lastConfigFetchFailed = false
+      // enabled / threshold may have changed whether the ask is due.
+      refresh()
+    } catch {
+      // Fail-open: keep last-good (or hardcoded defaults). An `enabled=false`
+      // only ever applies after a successful fetch; the PostHog kill switch
+      // still applies on this branch.
+      if !lastConfigFetchFailed {
+        // One diagnostics event per outage, not one per 5-minute poll.
+        DesktopDiagnosticsManager.shared.recordFallback(
+          area: "other",
+          from: "remote_config",
+          to: "local_defaults",
+          reason: "other",
+          outcome: .degraded)
+      }
+      lastConfigFetchFailed = true
+      log("RatingPrompt: CSAT config fetch failed, keeping last-good: \(error.localizedDescription)")
+    }
+  }
+
+  private func persistConfig(_ value: CsatConfig) {
+    if let data = try? JSONEncoder().encode(value) {
+      defaults.set(data, forKey: DefaultsKey.csatConfigLastGood.rawValue)
+    }
+  }
+
+  private static func cachedConfig() -> CsatConfig? {
+    guard
+      let data = UserDefaults.standard.data(forKey: DefaultsKey.csatConfigLastGood.rawValue)
+    else { return nil }
+    return try? JSONDecoder().decode(CsatConfig.self, from: data)
+  }
+
   private func refresh() {
     isVisible = RatingPromptPolicy.shouldShow(
       questionCount: questionCount,
       submittedRating: submittedRating,
       dismissed: isDismissed,
-      remotelyDisabled: isRemotelyDisabled)
+      remotelyDisabled: isRemotelyDisabled,
+      enabled: config.enabled,
+      questionThreshold: config.questionThreshold)
     // Deferred: refresh() runs inside this singleton's own `static let`
     // initialization, and RemotePromptEngine.builtInAskChanged() reads
     // RatingPromptManager.shared back — a synchronous call would re-enter the
@@ -281,10 +430,15 @@ enum RatingPromptButtonStyle {
 struct RatingPromptBar: View {
   @ObservedObject private var manager = RatingPromptManager.shared
   @State private var hoveredStar = 0
+  @State private var commentDraft = ""
 
   var body: some View {
     if let rating = manager.thankYouRating {
       thankYouContent(rating: rating)
+    } else if manager.commentPendingScore != nil {
+      // Low score awaiting an optional comment: the bar stays up so the
+      // built-in ask keeps right of way in RemotePromptEngine.
+      commentContent
     } else if manager.isVisible {
       starsContent
     }
@@ -292,10 +446,16 @@ struct RatingPromptBar: View {
 
   private var starsContent: some View {
     barChrome {
-      Text("How would you rate Omi Desktop?")
-        .font(.system(size: 13, weight: .medium))
-        .foregroundColor(.primary)
-
+      VStack(alignment: .leading, spacing: 2) {
+        Text(manager.config.title)
+          .font(.system(size: 13, weight: .medium))
+          .foregroundColor(.primary)
+        if !manager.config.body.isEmpty {
+          Text(manager.config.body)
+            .font(.system(size: 12))
+            .foregroundColor(.secondary)
+        }
+      }
       HStack(spacing: OmiSpacing.xs) {
         ForEach(1...5, id: \.self) { star in
           Button {
@@ -323,12 +483,12 @@ struct RatingPromptBar: View {
 
   private func thankYouContent(rating: Int) -> some View {
     barChrome {
-      Text("Thank you!")
+      Text(manager.config.thankYouText)
         .font(.system(size: 13, weight: .semibold))
         .foregroundColor(.primary)
 
       if rating >= 4 {
-        Text("Enjoying Omi? Give a friend a free month.")
+        Text(manager.config.referCtaText)
           .font(.system(size: 13))
           .foregroundColor(.secondary)
         Button("Refer a friend") {
@@ -341,6 +501,43 @@ struct RatingPromptBar: View {
       }
 
       closeButton { manager.closeThankYou() }
+    }
+  }
+
+  /// Low-score follow-up: one-line optional comment (≤ 500 chars) plus Send
+  /// and Skip — both complete the submission through the manager; the X
+  /// still dismisses forever. No rating is persisted while this is showing.
+  private var commentContent: some View {
+    barChrome {
+      Text("Tell us more (optional)")
+        .font(.system(size: 13, weight: .medium))
+        .foregroundColor(.primary)
+
+      TextField("What can we improve?", text: $commentDraft)
+        .textFieldStyle(.roundedBorder)
+        .frame(width: 320)
+        .onSubmit { manager.submitPendingComment(commentDraft) }
+        .onChange(of: commentDraft) { _, newValue in
+          if newValue.count > 500 {
+            commentDraft = String(newValue.prefix(500))
+          }
+        }
+        .accessibilityLabel("Rating comment")
+
+      Button("Send") {
+        manager.submitPendingComment(commentDraft)
+      }
+      .buttonStyle(.borderedProminent)
+      .controlSize(.small)
+      .tint(.primary)
+
+      Button("Skip") {
+        manager.skipPendingComment()
+      }
+      .buttonStyle(.bordered)
+      .controlSize(.small)
+
+      closeButton { manager.dismiss() }
     }
   }
 

--- a/desktop/macos/Desktop/Sources/RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/RatingPrompt.swift
@@ -269,6 +269,8 @@ final class RatingPromptManager: ObservableObject {
   var isSignedInCheck: () -> Bool = { AuthState.shared.isSignedIn }
 
   func seedFromHistoryIfNeeded() async {
+    // Same launch seam: every caller that seeds also starts the config poll.
+    startConfigPolling()
     // Owner-fenced: the seed reads and WRITES the account that started it.
     // The fetch carries expectedOwnerId, and if the signed-in owner changed
     // while the request was in flight the result is discarded — account B

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+CSAT.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+CSAT.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Server-driven config for the built-in product CSAT ask
+/// (`csat_config/product` in Firestore, served by `GET /v1/csat/config`).
+/// Admin.omi.me edits the copy; clients pick changes up within one poll.
+struct CsatConfig: Codable, Equatable {
+  let enabled: Bool
+  let title: String
+  let body: String
+  let thankYouText: String
+  let referCtaText: String
+  let questionThreshold: Int
+  let commentMaxScore: Int
+  let revision: Int
+
+  enum CodingKeys: String, CodingKey {
+    case enabled, title, body, revision
+    case thankYouText = "thank_you_text"
+    case referCtaText = "refer_cta_text"
+    case questionThreshold = "question_threshold"
+    case commentMaxScore = "comment_max_score"
+  }
+
+  /// Hardcoded copy of the server defaults (`backend/database/csat.py`).
+  /// This is the fail-open branch when no fetch has ever succeeded; the
+  /// PostHog kill switch still applies on top of it.
+  static let fallback = CsatConfig(
+    enabled: true,
+    title: "How would you rate Omi Desktop?",
+    body: "",
+    thankYouText: "Thank you!",
+    referCtaText: "Enjoying Omi? Give a friend a free month.",
+    questionThreshold: 3,
+    commentMaxScore: 3,
+    revision: 0
+  )
+}
+
+struct CsatRatingReceipt: Decodable {
+  let id: String
+  let created: Bool
+}
+
+private struct CsatRatingBody: Encodable {
+  let platform: String
+  let appVersion: String
+  let score: Int
+  let comment: String
+  let revision: Int
+
+  enum CodingKeys: String, CodingKey {
+    case platform, score, comment, revision
+    case appVersion = "app_version"
+  }
+}
+
+extension APIClient {
+  func getCsatConfig(platform: String = "macos") async throws -> CsatConfig {
+    try await get(
+      "v1/csat/config?platform=\(platform)",
+      customBaseURL: DesktopBackendEnvironment.authBaseURL())
+  }
+
+  func submitCsatRating(
+    score: Int,
+    comment: String,
+    revision: Int,
+    platform: String = "macos"
+  ) async throws -> CsatRatingReceipt {
+    try await post(
+      "v1/csat/ratings",
+      body: CsatRatingBody(
+        platform: platform,
+        appVersion: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "",
+        score: score,
+        comment: comment,
+        revision: revision),
+      customBaseURL: DesktopBackendEnvironment.authBaseURL())
+  }
+}

--- a/desktop/macos/Desktop/Tests/RatingPromptPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/RatingPromptPolicyTests.swift
@@ -37,4 +37,28 @@ final class RatingPromptPolicyTests: XCTestCase {
     XCTAssertEqual(OmiButtonStyle.fill(.primary, pressed: false), Ink.primary)
     XCTAssertEqual(OmiButtonStyle.label(.primary), Ink.surface)
   }
+
+  func testRemoteQuestionThresholdDefersUntilTheConfiguredQuestion() {
+    // Threshold 5: three questions are not due anymore…
+    XCTAssertFalse(
+      RatingPromptPolicy.shouldShow(
+        questionCount: 3, submittedRating: 0, dismissed: false, questionThreshold: 5))
+    // …and the fifth is.
+    XCTAssertTrue(
+      RatingPromptPolicy.shouldShow(
+        questionCount: 5, submittedRating: 0, dismissed: false, questionThreshold: 5))
+  }
+
+  func testRemoteDisableConfigHidesADuePrompt() {
+    XCTAssertFalse(
+      RatingPromptPolicy.shouldShow(
+        questionCount: 3, submittedRating: 0, dismissed: false, enabled: false))
+  }
+
+  func testCommentGateIsThePureLowScoreRule() {
+    XCTAssertTrue(RatingPromptPolicy.shouldAskForComment(score: 1, commentMaxScore: 3))
+    XCTAssertTrue(RatingPromptPolicy.shouldAskForComment(score: 3, commentMaxScore: 3))
+    XCTAssertFalse(RatingPromptPolicy.shouldAskForComment(score: 4, commentMaxScore: 3))
+    XCTAssertFalse(RatingPromptPolicy.shouldAskForComment(score: 5, commentMaxScore: 3))
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260828-in-app-rating-comment.json
+++ b/desktop/macos/changelog/unreleased/20260828-in-app-rating-comment.json
@@ -1,0 +1,3 @@
+{
+  "change": "After a low in-app rating, you can leave an optional comment"
+}

--- a/desktop/macos/e2e/flows/rating-prompt.yaml
+++ b/desktop/macos/e2e/flows/rating-prompt.yaml
@@ -5,6 +5,7 @@ description: One-time desktop rating ask — due exactly at the 3rd question, st
 app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/RatingPrompt.swift
+  - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+CSAT.swift
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge+RatingPrompt.swift
 preconditions:
   - automation_bridge_ready

--- a/desktop/macos/e2e/flows/rating-prompt.yaml
+++ b/desktop/macos/e2e/flows/rating-prompt.yaml
@@ -79,7 +79,6 @@ steps:
     expect:
       ok: true
       result.detail.visible: "false"
-
   - id: S7
     name: A second submit is refused
     bridge.action:
@@ -89,6 +88,85 @@ steps:
     expect:
       ok: true
       result.detail.submitted: "false"
+
+  - id: S7a
+    name: Reset again for the low-score comment path
+    bridge.action:
+      name: rating_prompt_reset
+    expect:
+      ok: true
+      result.detail.reset: "true"
+
+  - id: S7b
+    name: First question of the second pass
+    bridge.action:
+      name: rating_prompt_record_question
+    expect:
+      ok: true
+      result.detail.question_count: "1"
+      result.detail.visible: "false"
+
+  - id: S7c
+    name: Second question of the second pass
+    bridge.action:
+      name: rating_prompt_record_question
+    expect:
+      ok: true
+      result.detail.question_count: "2"
+      result.detail.visible: "false"
+
+  - id: S7d
+    name: Third question arms the prompt again
+    bridge.action:
+      name: rating_prompt_record_question
+    expect:
+      ok: true
+      result.detail.question_count: "3"
+      result.detail.visible: "true"
+
+  - id: S7e
+    name: A 2-star rating holds the bar for an optional comment
+    bridge.action:
+      name: rating_prompt_submit
+      params:
+        rating: "2"
+    expect:
+      ok: true
+      result.detail.submitted: "false"
+      result.detail.comment_pending: "2"
+
+  - id: S7f
+    name: The bar stays up while the comment is pending
+    bridge.action:
+      name: rating_prompt_state
+    expect:
+      ok: true
+      result.detail.visible: "true"
+      result.detail.comment_pending: "2"
+      result.detail.submitted_rating: "0"
+
+  - id: S7g
+    name: Sending the comment completes the submission
+    bridge.action:
+      name: rating_prompt_submit_comment
+      params:
+        comment: "too slow"
+    expect:
+      ok: true
+      result.detail.submitted: "true"
+      result.detail.rating: "2"
+
+  - id: S7h
+    name: A low score thanks without the refer proposal
+    bridge.action:
+      name: rating_prompt_state
+    expect:
+      ok: true
+      result.detail.thank_you: "2"
+      result.detail.visible: "false"
+      result.detail.submitted_rating: "2"
+
+
 
   - id: S8
     name: Leave no persisted QA state behind

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -1465,6 +1465,30 @@ export interface CreateTaskResponse {
   success: boolean;
 }
 
+export interface CsatConfigResponse {
+  body: string;
+  comment_max_score: number;
+  enabled: boolean;
+  question_threshold: number;
+  refer_cta_text: string;
+  revision: number;
+  thank_you_text: string;
+  title: string;
+}
+
+export interface CsatRatingReceipt {
+  created: boolean;
+  id: string;
+}
+
+export interface CsatRatingRequest {
+  app_version?: string;
+  comment?: string | null;
+  platform: string;
+  revision?: number;
+  score: number;
+}
+
 export interface CustomerPortalSessionResponse {
   url: string;
 }
@@ -4818,6 +4842,9 @@ export interface OmiApiSchemas {
   "CreatePerson": CreatePerson;
   "CreateTaskRequest": CreateTaskRequest;
   "CreateTaskResponse": CreateTaskResponse;
+  "CsatConfigResponse": CsatConfigResponse;
+  "CsatRatingReceipt": CsatRatingReceipt;
+  "CsatRatingRequest": CsatRatingRequest;
   "CustomerPortalSessionResponse": CustomerPortalSessionResponse;
   "DailySummariesResponse": DailySummariesResponse;
   "DailySummaryActionItem": DailySummaryActionItem;
@@ -6633,6 +6660,26 @@ export interface OmiApiPaths {
         "200": ConversationStatusResponse;
         "401": void;
         "404": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/csat/config": {
+    get: {
+      operationId: "get_csat_config_v1_csat_config_get";
+      responses: {
+        "200": CsatConfigResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/csat/ratings": {
+    post: {
+      operationId: "submit_csat_rating_v1_csat_ratings_post";
+      responses: {
+        "201": CsatRatingReceipt;
+        "401": void;
         "422": HTTPValidationError;
       };
     };
@@ -12317,6 +12364,49 @@ export async function set_conversation_visibility_v1_conversations__conversation
       ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
       ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
     },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function get_csat_config_v1_csat_config_get(query: { platform?: string }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<CsatConfigResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/csat/config`;
+  const _params = query ? Object.entries(query)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&') : '';
+  const _search = _params ? `?${_params}` : "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function submit_csat_rating_v1_csat_ratings_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: CsatRatingRequest, init?: OmiApiClientInit): Promise<CsatRatingReceipt> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/csat/ratings`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
   });
   if (!_res.ok) throw new OmiApiError(_res.status, _res);
   return _res.status === 204 ? (undefined as any) : await _res.json();
@@ -18118,4 +18208,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 430 client methods generated.
+// Total: 432 client methods generated.

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -9428,6 +9428,111 @@
         "title": "CreateTaskResponse",
         "type": "object"
       },
+      "CsatConfigResponse": {
+        "properties": {
+          "body": {
+            "title": "Body",
+            "type": "string"
+          },
+          "comment_max_score": {
+            "title": "Comment Max Score",
+            "type": "integer"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "question_threshold": {
+            "title": "Question Threshold",
+            "type": "integer"
+          },
+          "refer_cta_text": {
+            "title": "Refer Cta Text",
+            "type": "string"
+          },
+          "revision": {
+            "title": "Revision",
+            "type": "integer"
+          },
+          "thank_you_text": {
+            "title": "Thank You Text",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "enabled",
+          "title",
+          "body",
+          "thank_you_text",
+          "refer_cta_text",
+          "question_threshold",
+          "comment_max_score",
+          "revision"
+        ],
+        "title": "CsatConfigResponse",
+        "type": "object"
+      },
+      "CsatRatingReceipt": {
+        "properties": {
+          "created": {
+            "title": "Created",
+            "type": "boolean"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "created"
+        ],
+        "title": "CsatRatingReceipt",
+        "type": "object"
+      },
+      "CsatRatingRequest": {
+        "properties": {
+          "app_version": {
+            "default": "",
+            "title": "App Version",
+            "type": "string"
+          },
+          "comment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Comment"
+          },
+          "platform": {
+            "title": "Platform",
+            "type": "string"
+          },
+          "revision": {
+            "default": 0,
+            "title": "Revision",
+            "type": "integer"
+          },
+          "score": {
+            "title": "Score",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "platform",
+          "score"
+        ],
+        "title": "CsatRatingRequest",
+        "type": "object"
+      },
       "CustomerPortalSessionResponse": {
         "properties": {
           "url": {
@@ -40816,6 +40921,180 @@
         "summary": "Set Conversation Visibility",
         "tags": [
           "conversations"
+        ]
+      }
+    },
+    "/v1/csat/config": {
+      "get": {
+        "operationId": "get_csat_config_v1_csat_config_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "platform",
+            "required": false,
+            "schema": {
+              "default": "macos",
+              "title": "Platform",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Platform",
+            "required": false,
+            "schema": {
+              "title": "X-App-Platform",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Device-Id-Hash",
+            "required": false,
+            "schema": {
+              "title": "X-Device-Id-Hash",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Version",
+            "required": false,
+            "schema": {
+              "title": "X-App-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CsatConfigResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Get Csat Config",
+        "tags": [
+          "csat"
+        ]
+      }
+    },
+    "/v1/csat/ratings": {
+      "post": {
+        "operationId": "submit_csat_rating_v1_csat_ratings_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Platform",
+            "required": false,
+            "schema": {
+              "title": "X-App-Platform",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Device-Id-Hash",
+            "required": false,
+            "schema": {
+              "title": "X-Device-Id-Hash",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Version",
+            "required": false,
+            "schema": {
+              "title": "X-App-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CsatRatingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CsatRatingReceipt"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Submit Csat Rating",
+        "tags": [
+          "csat"
         ]
       }
     },

--- a/web/admin/app/(protected)/dashboard/csat/page.tsx
+++ b/web/admin/app/(protected)/dashboard/csat/page.tsx
@@ -1,0 +1,379 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { useAuthFetch } from "@/hooks/useAuthToken";
+
+// Copy + trigger editor and stats for the built-in Desktop rating bar
+// (Firestore `csat_config/product` + `csat_ratings`) — NOT the Prompts
+// survey builder; ad-hoc surveys live under /dashboard/prompts.
+
+type CsatConfig = {
+  enabled: boolean;
+  title: string;
+  body: string;
+  thank_you_text: string;
+  refer_cta_text: string;
+  question_threshold: number;
+  comment_max_score: number;
+  revision: number;
+  updated_at?: number;
+  updated_by?: string;
+};
+
+type CsatComment = {
+  uid: string;
+  platform: string;
+  score: number;
+  comment: string;
+  app_version: string;
+  created_at: number;
+  revision: number;
+};
+
+type CsatStats = {
+  available: boolean;
+  total: number;
+  histogram: Record<string, number>;
+  avg: number | null;
+  comments: CsatComment[];
+};
+
+const EMPTY_STATS: CsatStats = {
+  available: false,
+  total: 0,
+  histogram: {},
+  avg: null,
+  comments: [],
+};
+
+function formatTime(unixSeconds: number): string {
+  if (!unixSeconds) return "—";
+  return new Date(unixSeconds * 1000).toLocaleString();
+}
+
+export default function CsatPage() {
+  const { fetchWithAuth, token } = useAuthFetch();
+  const [config, setConfig] = useState<CsatConfig | null>(null);
+  const [stats, setStats] = useState<CsatStats>(EMPTY_STATS);
+  const [loading, setLoading] = useState(true);
+  const [partial, setPartial] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [savedRevision, setSavedRevision] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      // Both fetches are independent — one failing must not hide the other.
+      const [configRes, statsRes] = await Promise.allSettled([
+        fetchWithAuth("/api/omi/csat"),
+        fetchWithAuth("/api/omi/csat/stats?limit=500"),
+      ]);
+      let failed = 0;
+      if (configRes.status === "fulfilled" && configRes.value.ok) {
+        setConfig((await configRes.value.json()).config ?? null);
+      } else {
+        failed += 1;
+      }
+      if (statsRes.status === "fulfilled" && statsRes.value.ok) {
+        setStats((await statsRes.value.json()) ?? EMPTY_STATS);
+      } else {
+        failed += 1;
+      }
+      setPartial(failed === 1);
+      setError(failed === 2 ? "load failed" : null);
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchWithAuth]);
+
+  useEffect(() => {
+    if (token) void load();
+  }, [token, load]);
+
+  async function save() {
+    if (!config) return;
+    setSaving(true);
+    try {
+      const response = await fetchWithAuth("/api/omi/csat", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          enabled: config.enabled,
+          title: config.title,
+          body: config.body,
+          thank_you_text: config.thank_you_text,
+          refer_cta_text: config.refer_cta_text,
+          question_threshold: config.question_threshold,
+          comment_max_score: config.comment_max_score,
+        }),
+      });
+      const body = await response.json();
+      if (!response.ok)
+        throw new Error(body.error ?? `save failed (${response.status})`);
+      setConfig(body.config ?? config);
+      setSavedRevision(body.config?.revision ?? null);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const maxBar = Math.max(1, ...Object.values(stats.histogram));
+
+  return (
+    <div className="max-w-4xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">CSAT</h1>
+        <p className="text-sm text-muted-foreground">
+          Built-in Desktop rating bar — not the Prompts survey builder. Copy
+          edits reach clients within ~5 minutes.
+        </p>
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : (
+        <>
+          {partial && (
+            <p className="text-sm text-amber-600">
+              Partially loaded — one source failed; refresh to retry.
+            </p>
+          )}
+          {error && <p className="text-sm text-red-500">{error}</p>}
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Copy &amp; trigger</CardTitle>
+              <CardDescription>
+                One product-wide config; every save bumps the revision clients
+                report back with their rating.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {config && (
+                <>
+                  <div className="flex items-center gap-3">
+                    <Switch
+                      checked={config.enabled}
+                      onCheckedChange={(enabled) =>
+                        setConfig({ ...config, enabled })
+                      }
+                    />
+                    <span className="text-sm">
+                      Prompt enabled
+                      {savedRevision !== null && (
+                        <Badge variant="secondary" className="ml-2">
+                          revision {savedRevision}
+                        </Badge>
+                      )}
+                    </span>
+                  </div>
+                  <div className="space-y-1">
+                    <Label htmlFor="csat-title">Title</Label>
+                    <Input
+                      id="csat-title"
+                      value={config.title}
+                      onChange={(e) =>
+                        setConfig({ ...config, title: e.target.value })
+                      }
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label htmlFor="csat-body">Subtitle (optional)</Label>
+                    <Input
+                      id="csat-body"
+                      value={config.body}
+                      onChange={(e) =>
+                        setConfig({ ...config, body: e.target.value })
+                      }
+                    />
+                  </div>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1">
+                      <Label htmlFor="csat-thanks">Thank-you text</Label>
+                      <Input
+                        id="csat-thanks"
+                        value={config.thank_you_text}
+                        onChange={(e) =>
+                          setConfig({
+                            ...config,
+                            thank_you_text: e.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label htmlFor="csat-refer">Refer CTA text</Label>
+                      <Input
+                        id="csat-refer"
+                        value={config.refer_cta_text}
+                        onChange={(e) =>
+                          setConfig({
+                            ...config,
+                            refer_cta_text: e.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div className="flex items-end gap-3">
+                    <div className="space-y-1">
+                      <Label htmlFor="csat-threshold">
+                        Ask after Nth question (1–50)
+                      </Label>
+                      <Input
+                        id="csat-threshold"
+                        type="number"
+                        className="w-28"
+                        min={1}
+                        max={50}
+                        value={config.question_threshold}
+                        onChange={(e) =>
+                          setConfig({
+                            ...config,
+                            question_threshold: parseInt(e.target.value) || 3,
+                          })
+                        }
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label htmlFor="csat-comment-max">
+                        Ask comment at score ≤ (1–5)
+                      </Label>
+                      <Input
+                        id="csat-comment-max"
+                        type="number"
+                        className="w-28"
+                        min={1}
+                        max={5}
+                        value={config.comment_max_score}
+                        onChange={(e) =>
+                          setConfig({
+                            ...config,
+                            comment_max_score: parseInt(e.target.value) || 3,
+                          })
+                        }
+                      />
+                    </div>
+                    <Button
+                      onClick={save}
+                      disabled={saving || !config.title.trim()}
+                    >
+                      Save
+                    </Button>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Saved config: revision {config.revision}
+                    {config.updated_at
+                      ? ` · last saved ${formatTime(config.updated_at)}`
+                      : ""}
+                    . Clients refresh within ~5 minutes (5-minute poll + 60s
+                    server cache).
+                  </p>
+                </>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Stats</CardTitle>
+              <CardDescription>
+                One rating per user per platform, from Firestore. The PostHog
+                daily chart stays on the Desktop ratings dashboard.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {!stats.available ? (
+                <p className="text-sm text-amber-600">
+                  Stats unavailable (N/A) — Firestore read failed. No zeros are
+                  shown for a failed read.
+                </p>
+              ) : (
+                <>
+                  <div className="flex items-center gap-6 text-sm">
+                    <span>
+                      <strong>{stats.total}</strong> ratings
+                    </span>
+                    <span>
+                      avg{" "}
+                      <strong>
+                        {stats.avg === null ? "—" : stats.avg.toFixed(2)}
+                      </strong>
+                    </span>
+                  </div>
+                  <div className="space-y-1">
+                    {[5, 4, 3, 2, 1].map((score) => {
+                      const count = stats.histogram[String(score)] ?? 0;
+                      return (
+                        <div
+                          key={score}
+                          className="flex items-center gap-3 text-sm"
+                        >
+                          <span className="w-6 text-right">{score}★</span>
+                          <div className="h-3 flex-1 overflow-hidden rounded bg-muted">
+                            <div
+                              className="h-full bg-primary"
+                              style={{
+                                width: `${(count / maxBar) * 100}%`,
+                              }}
+                            />
+                          </div>
+                          <span className="w-8 text-right tabular-nums">
+                            {count}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                  <div className="space-y-2">
+                    <p className="text-sm font-medium">
+                      Latest comments ({stats.comments.length} of last{" "}
+                      {stats.total})
+                    </p>
+                    {stats.comments.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">
+                        No comments yet.
+                      </p>
+                    ) : (
+                      stats.comments.map((c) => (
+                        <div
+                          key={`${c.platform}_${c.uid}`}
+                          className="rounded-md border p-2 text-sm"
+                        >
+                          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                            <span>{c.score}★</span>
+                            <span>{c.platform}</span>
+                            <span>v{c.app_version || "?"}</span>
+                            <span>{formatTime(c.created_at)}</span>
+                            <span className="truncate">uid {c.uid}</span>
+                          </div>
+                          <p className="mt-1 break-words">{c.comment}</p>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </>
+              )}
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/admin/app/api/omi/csat/route.ts
+++ b/web/admin/app/api/omi/csat/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyAdmin } from "@/lib/auth";
+import { getDb } from "@/lib/firebase/admin";
+export const dynamic = "force-dynamic";
+
+// Admin editor for the built-in Desktop CSAT ask (`csat_config/product` in
+// Firestore — a single product-wide doc). The backend serves it to every
+// client via GET /v1/csat/config; a save here reaches clients within one
+// client poll (~5 minutes) plus the backend's 60s cache. The backend GET is
+// the only client read path — this BFF never serves app clients.
+const CONFIG_COLLECTION = "csat_config";
+const CONFIG_DOC = "product";
+
+type CsatConfigDoc = {
+  enabled: boolean;
+  title: string;
+  body: string;
+  thank_you_text: string;
+  refer_cta_text: string;
+  question_threshold: number;
+  comment_max_score: number;
+};
+
+// Mirrors `DEFAULT_CONFIG` in backend/database/csat.py: what a missing doc
+// means, and the fail-open copy clients render before any fetch succeeds.
+export const CSAT_DEFAULT_CONFIG: CsatConfigDoc & { revision: number } = {
+  enabled: true,
+  title: "How would you rate Omi Desktop?",
+  body: "",
+  thank_you_text: "Thank you!",
+  refer_cta_text: "Enjoying Omi? Give a friend a free month.",
+  question_threshold: 3,
+  comment_max_score: 3,
+  revision: 0,
+};
+
+function field(source: unknown, key: string): unknown {
+  return source && typeof source === "object" && key in source
+    ? (source as Record<string, unknown>)[key]
+    : undefined;
+}
+
+function clamp(value: unknown, low: number, high: number, fallback: number) {
+  const n = Math.round(Number(value));
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(Math.max(n, low), high);
+}
+
+export function normalizeCsatConfig(body: unknown): {
+  error?: string;
+  doc?: CsatConfigDoc;
+} {
+  const title = String(field(body, "title") ?? "").trim();
+  if (!title) return { error: "title is required" };
+  const doc: CsatConfigDoc = {
+    enabled: Boolean(field(body, "enabled") ?? true),
+    title,
+    body: String(field(body, "body") ?? "").trim(),
+    thank_you_text: String(field(body, "thank_you_text") ?? "").trim(),
+    refer_cta_text: String(field(body, "refer_cta_text") ?? "").trim(),
+    question_threshold: clamp(field(body, "question_threshold"), 1, 50, 3),
+    comment_max_score: clamp(field(body, "comment_max_score"), 1, 5, 3),
+  };
+  return { doc };
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const snapshot = await getDb()
+    .collection(CONFIG_COLLECTION)
+    .doc(CONFIG_DOC)
+    .get();
+  const config = snapshot.exists
+    ? { ...CSAT_DEFAULT_CONFIG, ...snapshot.data() }
+    : { ...CSAT_DEFAULT_CONFIG };
+  return NextResponse.json({ config });
+}
+
+export async function PUT(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const { error, doc } = normalizeCsatConfig(await request.json());
+  if (error) return NextResponse.json({ error }, { status: 400 });
+  const ref = getDb().collection(CONFIG_COLLECTION).doc(CONFIG_DOC);
+  const current = await ref.get();
+  const revision = (Number(current.data()?.revision) || 0) + 1;
+  const config = {
+    ...doc,
+    revision,
+    updated_at: Date.now() / 1000,
+    updated_by: authResult.uid,
+  };
+  await ref.set(config);
+  return NextResponse.json({ config });
+}

--- a/web/admin/app/api/omi/csat/stats/route.ts
+++ b/web/admin/app/api/omi/csat/stats/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyAdmin } from "@/lib/auth";
+import { getDb } from "@/lib/firebase/admin";
+export const dynamic = "force-dynamic";
+
+// Firestore-backed CSAT stats (`csat_ratings`): overall count, 1–5 histogram,
+// average, and the most recent comments. The PostHog `Desktop Rating
+// Submitted` chart stays as the daily trend feed — PostHog has no comments,
+// so this is the read path for them. One rating doc per `{platform}_{uid}`,
+// newest-first, computed in memory (no composite index needed at this scale).
+
+type CsatRatingRow = {
+  uid: string;
+  platform: string;
+  app_version: string;
+  score: number;
+  comment: string;
+  created_at: number;
+  revision: number;
+};
+
+type CsatStats = {
+  available: boolean;
+  total: number;
+  histogram: Record<string, number>;
+  avg: number | null;
+  comments: CsatRatingRow[];
+};
+
+function row(data: Record<string, unknown>): CsatRatingRow {
+  return {
+    uid: String(data.uid ?? ""),
+    platform: String(data.platform ?? ""),
+    app_version: String(data.app_version ?? ""),
+    score: Number(data.score) || 0,
+    comment: String(data.comment ?? ""),
+    created_at: Number(data.created_at) || 0,
+    revision: Number(data.revision) || 0,
+  };
+}
+
+export function summarizeCsatRatings(
+  rawRows: CsatRatingRow[]
+): Omit<CsatStats, "available"> {
+  const histogram: Record<string, number> = {};
+  let sum = 0;
+  let counted = 0;
+  for (const entry of rawRows) {
+    if (entry.score < 1 || entry.score > 5) continue;
+    const key = String(entry.score);
+    histogram[key] = (histogram[key] ?? 0) + 1;
+    sum += entry.score;
+    counted += 1;
+  }
+  return {
+    total: counted,
+    histogram,
+    avg: counted > 0 ? Math.round((sum / counted) * 100) / 100 : null,
+    // Newest first already (query order); only rows that carry a comment.
+    comments: rawRows.filter((entry) => entry.comment.trim()).slice(0, 50),
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const requested = parseInt(
+    request.nextUrl.searchParams.get("limit") || "500",
+    10
+  );
+  const limit = Number.isFinite(requested)
+    ? Math.min(Math.max(requested, 1), 500)
+    : 500;
+  try {
+    const snapshot = await getDb()
+      .collection("csat_ratings")
+      .orderBy("created_at", "desc")
+      .limit(limit)
+      .get();
+    const rows = snapshot.docs.map((d) => row(d.data()));
+    return NextResponse.json({
+      available: true,
+      ...summarizeCsatRatings(rows),
+    });
+  } catch (error) {
+    console.error("CSAT stats error:", error);
+    // Never invent zeros while claiming success.
+    return NextResponse.json({
+      available: false,
+      total: 0,
+      histogram: {},
+      avg: null,
+      comments: [],
+    });
+  }
+}

--- a/web/admin/components/dashboard/sidebar.tsx
+++ b/web/admin/components/dashboard/sidebar.tsx
@@ -22,6 +22,7 @@ import {
   FlaskConical,
   Rocket,
   Handshake,
+  Star,
   MessageSquarePlus,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -110,6 +111,11 @@ export function DashboardSidebar() {
       icon: MessageSquarePlus,
     },
     {
+      title: "CSAT",
+      href: "/dashboard/csat",
+      icon: Star,
+    },
+    {
       title: "Releases",
       href: "/dashboard/releases",
       icon: Rocket,
@@ -138,28 +144,28 @@ export function DashboardSidebar() {
   return (
     <aside
       className={cn(
-        "border-r bg-card h-screen flex-shrink-0 sticky top-0 flex flex-col z-20 transition-all duration-300",
-        isCollapsed ? "w-16" : "w-64",
+        "sticky top-0 z-20 flex h-screen flex-shrink-0 flex-col border-r bg-card transition-all duration-300",
+        isCollapsed ? "w-16" : "w-64"
       )}
     >
       <div
         className={cn(
-          "border-b h-14 flex items-center transition-all duration-300 relative",
-          isCollapsed ? "px-2 justify-center" : "px-4 justify-between",
+          "relative flex h-14 items-center border-b transition-all duration-300",
+          isCollapsed ? "justify-center px-2" : "justify-between px-4"
         )}
       >
         <Link
           href="/dashboard"
           className={cn(
             "flex items-center space-x-2 font-semibold transition-all duration-200",
-            isCollapsed ? "justify-center" : "justify-start",
+            isCollapsed ? "justify-center" : "justify-start"
           )}
         >
           <Package2 className="h-6 w-6 flex-shrink-0" />
           <span
             className={cn(
-              "transition-opacity duration-200 whitespace-nowrap",
-              isCollapsed ? "opacity-0 w-0 overflow-hidden" : "opacity-100",
+              "whitespace-nowrap transition-opacity duration-200",
+              isCollapsed ? "w-0 overflow-hidden opacity-0" : "opacity-100"
             )}
           >
             OMI Admin
@@ -171,7 +177,7 @@ export function DashboardSidebar() {
           className={cn(
             "h-8 w-8 flex-shrink-0",
             isCollapsed &&
-              "absolute top-1/2 -right-3 translate-y-[-50%] bg-background border border-border rounded-full shadow-sm z-10",
+              "absolute -right-3 top-1/2 z-10 translate-y-[-50%] rounded-full border border-border bg-background shadow-sm"
           )}
           onClick={toggleCollapse}
           aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
@@ -183,18 +189,18 @@ export function DashboardSidebar() {
           )}
         </Button>
       </div>
-      <div className="flex-1 py-6 flex flex-col justify-between">
-        <nav className="px-2 space-y-1">
+      <div className="flex flex-1 flex-col justify-between py-6">
+        <nav className="space-y-1 px-2">
           {navItems.map((item) => (
             <Link
               key={item.href}
               href={item.href}
               className={cn(
-                "flex items-center px-2 py-2 rounded-md text-sm font-medium transition-colors",
+                "flex items-center rounded-md px-2 py-2 text-sm font-medium transition-colors",
                 isCollapsed ? "justify-center" : "justify-start",
                 pathname === item.href
                   ? "bg-primary/10 text-primary"
-                  : "text-foreground hover:bg-accent hover:text-accent-foreground",
+                  : "text-foreground hover:bg-accent hover:text-accent-foreground"
               )}
               title={isCollapsed ? item.title : undefined}
             >
@@ -203,8 +209,8 @@ export function DashboardSidebar() {
                 className={cn(
                   "transition-opacity duration-200",
                   isCollapsed
-                    ? "opacity-0 w-0 overflow-hidden ml-0"
-                    : "opacity-100 ml-3",
+                    ? "ml-0 w-0 overflow-hidden opacity-0"
+                    : "ml-3 opacity-100"
                 )}
               >
                 {item.title}
@@ -212,12 +218,12 @@ export function DashboardSidebar() {
             </Link>
           ))}
         </nav>
-        <div className="px-2 space-y-1">
+        <div className="space-y-1 px-2">
           <Button
             variant="ghost"
             className={cn(
               "w-full text-muted-foreground transition-colors",
-              isCollapsed ? "justify-center" : "justify-start",
+              isCollapsed ? "justify-center" : "justify-start"
             )}
             onClick={handleLogout}
             title={isCollapsed ? "Log out" : undefined}
@@ -227,8 +233,8 @@ export function DashboardSidebar() {
               className={cn(
                 "transition-opacity duration-200",
                 isCollapsed
-                  ? "opacity-0 w-0 overflow-hidden ml-0"
-                  : "opacity-100 ml-3",
+                  ? "ml-0 w-0 overflow-hidden opacity-0"
+                  : "ml-3 opacity-100"
               )}
             >
               Log out

--- a/web/admin/lib/__tests__/csat-admin.test.ts
+++ b/web/admin/lib/__tests__/csat-admin.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  verifyAdmin: vi.fn(async () => ({ uid: "t" })),
+}));
+vi.mock("@/lib/firebase/admin", () => ({ getDb: () => ({}) }));
+
+import { normalizeCsatConfig } from "@/app/api/omi/csat/route";
+
+describe("normalizeCsatConfig", () => {
+  it("clamps question_threshold to 1..50 and comment_max_score to 1..5", () => {
+    const high = normalizeCsatConfig({
+      title: "How would you rate Omi Desktop?",
+      question_threshold: 500,
+      comment_max_score: 9,
+    });
+    expect(high.error).toBeUndefined();
+    expect(high.doc?.question_threshold).toBe(50);
+    expect(high.doc?.comment_max_score).toBe(5);
+
+    const low = normalizeCsatConfig({
+      title: "How would you rate Omi Desktop?",
+      question_threshold: 0,
+      comment_max_score: -2,
+    });
+    expect(low.doc?.question_threshold).toBe(1);
+    expect(low.doc?.comment_max_score).toBe(1);
+  });
+
+  it("trims the title and rejects an empty one", () => {
+    const { doc, error } = normalizeCsatConfig({
+      title: "  How would you rate Omi Desktop?  ",
+    });
+    expect(error).toBeUndefined();
+    expect(doc?.title).toBe("How would you rate Omi Desktop?");
+    expect(normalizeCsatConfig({ title: "   " }).error).toContain("title");
+    expect(normalizeCsatConfig({}).error).toContain("title");
+  });
+
+  it("keeps defaults for omitted optional fields", () => {
+    const { doc, error } = normalizeCsatConfig({ title: "Rate us" });
+    expect(error).toBeUndefined();
+    expect(doc?.enabled).toBe(true);
+    expect(doc?.body).toBe("");
+    expect(doc?.question_threshold).toBe(3);
+    expect(doc?.comment_max_score).toBe(3);
+  });
+});

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -1465,6 +1465,30 @@ export interface CreateTaskResponse {
   success: boolean;
 }
 
+export interface CsatConfigResponse {
+  body: string;
+  comment_max_score: number;
+  enabled: boolean;
+  question_threshold: number;
+  refer_cta_text: string;
+  revision: number;
+  thank_you_text: string;
+  title: string;
+}
+
+export interface CsatRatingReceipt {
+  created: boolean;
+  id: string;
+}
+
+export interface CsatRatingRequest {
+  app_version?: string;
+  comment?: string | null;
+  platform: string;
+  revision?: number;
+  score: number;
+}
+
 export interface CustomerPortalSessionResponse {
   url: string;
 }
@@ -4818,6 +4842,9 @@ export interface OmiApiSchemas {
   "CreatePerson": CreatePerson;
   "CreateTaskRequest": CreateTaskRequest;
   "CreateTaskResponse": CreateTaskResponse;
+  "CsatConfigResponse": CsatConfigResponse;
+  "CsatRatingReceipt": CsatRatingReceipt;
+  "CsatRatingRequest": CsatRatingRequest;
   "CustomerPortalSessionResponse": CustomerPortalSessionResponse;
   "DailySummariesResponse": DailySummariesResponse;
   "DailySummaryActionItem": DailySummaryActionItem;
@@ -6633,6 +6660,26 @@ export interface OmiApiPaths {
         "200": ConversationStatusResponse;
         "401": void;
         "404": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/csat/config": {
+    get: {
+      operationId: "get_csat_config_v1_csat_config_get";
+      responses: {
+        "200": CsatConfigResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/csat/ratings": {
+    post: {
+      operationId: "submit_csat_rating_v1_csat_ratings_post";
+      responses: {
+        "201": CsatRatingReceipt;
+        "401": void;
         "422": HTTPValidationError;
       };
     };
@@ -12317,6 +12364,49 @@ export async function set_conversation_visibility_v1_conversations__conversation
       ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
       ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
     },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function get_csat_config_v1_csat_config_get(query: { platform?: string }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<CsatConfigResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/csat/config`;
+  const _params = query ? Object.entries(query)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&') : '';
+  const _search = _params ? `?${_params}` : "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function submit_csat_rating_v1_csat_ratings_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: CsatRatingRequest, init?: OmiApiClientInit): Promise<CsatRatingReceipt> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/csat/ratings`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
   });
   if (!_res.ok) throw new OmiApiError(_res.status, _res);
   return _res.status === 204 ? (undefined as any) : await _res.json();
@@ -18118,4 +18208,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 430 client methods generated.
+// Total: 432 client methods generated.

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -1465,6 +1465,30 @@ export interface CreateTaskResponse {
   success: boolean;
 }
 
+export interface CsatConfigResponse {
+  body: string;
+  comment_max_score: number;
+  enabled: boolean;
+  question_threshold: number;
+  refer_cta_text: string;
+  revision: number;
+  thank_you_text: string;
+  title: string;
+}
+
+export interface CsatRatingReceipt {
+  created: boolean;
+  id: string;
+}
+
+export interface CsatRatingRequest {
+  app_version?: string;
+  comment?: string | null;
+  platform: string;
+  revision?: number;
+  score: number;
+}
+
 export interface CustomerPortalSessionResponse {
   url: string;
 }
@@ -4818,6 +4842,9 @@ export interface OmiApiSchemas {
   "CreatePerson": CreatePerson;
   "CreateTaskRequest": CreateTaskRequest;
   "CreateTaskResponse": CreateTaskResponse;
+  "CsatConfigResponse": CsatConfigResponse;
+  "CsatRatingReceipt": CsatRatingReceipt;
+  "CsatRatingRequest": CsatRatingRequest;
   "CustomerPortalSessionResponse": CustomerPortalSessionResponse;
   "DailySummariesResponse": DailySummariesResponse;
   "DailySummaryActionItem": DailySummaryActionItem;
@@ -6633,6 +6660,26 @@ export interface OmiApiPaths {
         "200": ConversationStatusResponse;
         "401": void;
         "404": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/csat/config": {
+    get: {
+      operationId: "get_csat_config_v1_csat_config_get";
+      responses: {
+        "200": CsatConfigResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/csat/ratings": {
+    post: {
+      operationId: "submit_csat_rating_v1_csat_ratings_post";
+      responses: {
+        "201": CsatRatingReceipt;
+        "401": void;
         "422": HTTPValidationError;
       };
     };
@@ -12317,6 +12364,49 @@ export async function set_conversation_visibility_v1_conversations__conversation
       ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
       ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
     },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function get_csat_config_v1_csat_config_get(query: { platform?: string }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<CsatConfigResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/csat/config`;
+  const _params = query ? Object.entries(query)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&') : '';
+  const _search = _params ? `?${_params}` : "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function submit_csat_rating_v1_csat_ratings_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: CsatRatingRequest, init?: OmiApiClientInit): Promise<CsatRatingReceipt> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/csat/ratings`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
   });
   if (!_res.ok) throw new OmiApiError(_res.status, _res);
   return _res.status === 204 ? (undefined as any) : await _res.json();
@@ -18118,4 +18208,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 430 client methods generated.
+// Total: 432 client methods generated.

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -1465,6 +1465,30 @@ export interface CreateTaskResponse {
   success: boolean;
 }
 
+export interface CsatConfigResponse {
+  body: string;
+  comment_max_score: number;
+  enabled: boolean;
+  question_threshold: number;
+  refer_cta_text: string;
+  revision: number;
+  thank_you_text: string;
+  title: string;
+}
+
+export interface CsatRatingReceipt {
+  created: boolean;
+  id: string;
+}
+
+export interface CsatRatingRequest {
+  app_version?: string;
+  comment?: string | null;
+  platform: string;
+  revision?: number;
+  score: number;
+}
+
 export interface CustomerPortalSessionResponse {
   url: string;
 }
@@ -4818,6 +4842,9 @@ export interface OmiApiSchemas {
   "CreatePerson": CreatePerson;
   "CreateTaskRequest": CreateTaskRequest;
   "CreateTaskResponse": CreateTaskResponse;
+  "CsatConfigResponse": CsatConfigResponse;
+  "CsatRatingReceipt": CsatRatingReceipt;
+  "CsatRatingRequest": CsatRatingRequest;
   "CustomerPortalSessionResponse": CustomerPortalSessionResponse;
   "DailySummariesResponse": DailySummariesResponse;
   "DailySummaryActionItem": DailySummaryActionItem;
@@ -6633,6 +6660,26 @@ export interface OmiApiPaths {
         "200": ConversationStatusResponse;
         "401": void;
         "404": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/csat/config": {
+    get: {
+      operationId: "get_csat_config_v1_csat_config_get";
+      responses: {
+        "200": CsatConfigResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/csat/ratings": {
+    post: {
+      operationId: "submit_csat_rating_v1_csat_ratings_post";
+      responses: {
+        "201": CsatRatingReceipt;
+        "401": void;
         "422": HTTPValidationError;
       };
     };
@@ -12317,6 +12364,49 @@ export async function set_conversation_visibility_v1_conversations__conversation
       ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
       ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
     },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function get_csat_config_v1_csat_config_get(query: { platform?: string }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<CsatConfigResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/csat/config`;
+  const _params = query ? Object.entries(query)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&') : '';
+  const _search = _params ? `?${_params}` : "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function submit_csat_rating_v1_csat_ratings_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: CsatRatingRequest, init?: OmiApiClientInit): Promise<CsatRatingReceipt> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/csat/ratings`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
   });
   if (!_res.ok) throw new OmiApiError(_res.status, _res);
   return _res.status === 204 ? (undefined as any) : await _res.json();
@@ -18118,4 +18208,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 430 client methods generated.
+// Total: 432 client methods generated.


### PR DESCRIPTION
Closes SCA-363
Failure-Class: none

## What

In-app product CSAT for Omi Desktop, extending the existing one-time native `RatingPromptBar` (not a second survey stack; `/dashboard/prompts` / `desktop_prompts` / `app_review_config` untouched).

### Backend
- `GET /v1/csat/config?platform=…` — serves the Firestore `csat_config/product` singleton (60s memory cache, like `app_review_config`); missing doc returns defaults, never 404. `platform` accepted and reserved (v1 = same product-wide config).
- `POST /v1/csat/ratings` — Firebase user JWT (`get_current_user_uid`); writes one create-only doc per `{platform}_{uid}` (Firestore `create` = atomic no-overwrite); resubmit → `409` with the existing answer untouched. Comment dropped server-side when `score > comment_max_score`; comment is never logged.
- Route-policy manifest entries for both routes.

### macOS
- Bar renders server copy (title/body/thank-you/refer CTA), question threshold, and enable flag; polls every 5 min while signed in; fails open to last-good config (UserDefaults) then hardcoded defaults matching today's bar. Fail-open branch records a degraded `recordFallback` diagnostics event (one per outage). `enabled=false` hides the bar even with the PostHog kill off; the PostHog kill (`desktop-rating-prompt-disabled`, existing polarity) still applies when config fetch is down.
- Low scores (≤ `comment_max_score`, default 3) keep the bar up with a one-line ≤500-char comment field + Send/Skip (Skip = empty comment); nothing persists until Send/Skip. POST is best-effort: local record + PostHog happen regardless; 409 treated as success; thank-you never gated on network.
- PostHog `Desktop Rating Submitted` gains optional `revision` — the comment never travels to PostHog.
- Bridge action `rating_prompt_submit_comment` goes through the same manager method as Send.

### admin.omi.me
- `/dashboard/csat` (sidebar "CSAT"): copy & trigger card (enable switch, title, body, thank-you, refer CTA, threshold, comment-max-score, revision display) + Firestore-backed stats (count, avg, 1–5 histogram, last 50 comments; `available: false` shown honestly on Firestore failure).
- BFF `GET/PUT /api/omi/csat` (verifyAdmin; server clamps + bumps revision + stamps updated_at/updated_by) and `GET /api/omi/csat/stats` (newest-first, in-memory histogram, no composite index).

## Verification
- Backend: `tests/unit/test_csat.py` — 5 passed (defaults on missing doc, persist + 409 no-overwrite, comment gate, 400s, clamp normalize).
- Desktop: `RatingPromptPolicyTests` 7 passed; `RatingPromptCountingTests`, `RatingPromptKillSwitchTests`, `RemotePromptLedgerTests` all green.
- Named bundle `OMI_APP_NAME=omi-csat`: `e2e/flows/rating-prompt.yaml` PASS on bridge lane (18 steps, including the new reset → 3 questions → 2 stars → comment "too slow" → thank-you-without-refer path) and visual lane; signed-out POST fail-open observed live (rating kept locally, no UX block).
- Admin: `csat-admin.test.ts` 3 passed; lint 0 errors; `tsc --noEmit` clean; `next build` green.
- `make preflight`: 11 checks passed; full pre-push gate passed.

No new dependencies. No Postgres. Firestore only.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

