### PR TITLE
fix(desktop): presence-gate the realtime hub's idle re-warm loop (Gemini quota burn)

### DIFF
--- a/.github/failure-classes/FC-unattended-warm-resource-loop.json
+++ b/.github/failure-classes/FC-unattended-warm-resource-loop.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "id": "FC-unattended-warm-resource-loop",
+  "violated_contract": "A warm resource kept open purely to hide first-use latency (a pre-warmed provider session, connection, or cache) exists for the user's presence; its refresh loop must be gated on evidence the user can still benefit. Rebuilding it unconditionally after every provider-side idle teardown turns a latency optimization into an unbounded background spend loop — per running app, around the clock — whose cost (metered tokens re-billed on every rebuild) accrues while the user is asleep or away, and whose fleet-wide aggregate can exhaust a shared project quota and degrade every user at once.",
+  "canonical_prevention": "Gate idle-teardown re-warms behind RealtimeHubWarmPresencePolicy: defer the rebuild once HID input idle exceeds the threshold, resume on the first returned input event, and fail open (always warm) when the presence sample is unavailable. Any explicit warm intent (PTT-down, settings change) clears the deferral so a present user never waits on the gate.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/RealtimeHubWarmPresencePolicyTests.swift"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHub*"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RealtimeHub.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RealtimeHub.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Realtime-hub automation actions (non-production): drive the REAL provider
+/// failover path and substitute the HID idle sample the presence-gated warm
+/// loop reads — everything downstream of each seam is the production path.
+extension DesktopAutomationActionRegistry {
+  func registerRealtimeHubActions() {
+    // Drives the REAL provider failover the quota/auth close handlers call
+    // (failoverToAlternateProvider), then re-warms, so the cross-provider path
+    // can be exercised without waiting for the shared key to actually throttle.
+    register(
+      name: "realtime_failover",
+      summary: "Fail the realtime hub over to the alternate provider via the production path (non-prod).",
+      params: []
+    ) { _ in
+      guard AppBuild.isNonProduction else {
+        return ["error": "realtime_failover is disabled on production bundles"]
+      }
+      let controller = RealtimeHubController.shared
+      let from = controller.effectiveProvider.rawValue
+      let started = controller.failoverToAlternateProvider(reason: "quota")
+      controller.ensureWarm()
+      return [
+        "failover_started": started ? "true" : "false",
+        "from": from,
+        "to": controller.effectiveProvider.rawValue,
+      ]
+    }
+
+    // Substitutes the HID idle sample the presence-gated warm loop reads, so
+    // the away → defer → return → re-warm path can be exercised without a real
+    // 10-minute walk-away. Everything downstream is the production path.
+    register(
+      name: "realtime_presence",
+      summary: "Override the realtime hub's user-idle sample (non-prod): idle_seconds=<n> or reset.",
+      params: ["idle_seconds"]
+    ) { params in
+      guard AppBuild.isNonProduction else {
+        return ["error": "realtime_presence is disabled on production bundles"]
+      }
+      let controller = RealtimeHubController.shared
+      if let raw = params["idle_seconds"], let idle = TimeInterval(raw) {
+        controller.presenceIdleProvider = { idle }
+      } else {
+        controller.presenceIdleProvider = { UserInputPresence.secondsSinceLastInput() }
+      }
+      return [
+        "idle_sample": controller.presenceIdleProvider().map { String($0) } ?? "nil",
+        "warm_deferred": controller.warmDeferredForUserAway ? "true" : "false",
+        "session_active": controller.session != nil ? "true" : "false",
+      ]
+    }
+
+  }
+}

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RealtimeHub.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RealtimeHub.swift
@@ -19,7 +19,7 @@ extension DesktopAutomationActionRegistry {
       let controller = RealtimeHubController.shared
       let from = controller.effectiveProvider.rawValue
       let started = controller.failoverToAlternateProvider(reason: "quota")
-      controller.ensureWarm()
+      controller.ensureWarm(userInitiated: true)
       return [
         "failover_started": started ? "true" : "false",
         "from": from,

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -2496,28 +2496,6 @@ final class DesktopAutomationActionRegistry {
       return bar.automationNotchStateSnapshot
     }
 
-    // Drives the REAL provider failover the quota/auth close handlers call
-    // (failoverToAlternateProvider), then re-warms, so the cross-provider path
-    // can be exercised without waiting for the shared key to actually throttle.
-    register(
-      name: "realtime_failover",
-      summary: "Fail the realtime hub over to the alternate provider via the production path (non-prod).",
-      params: []
-    ) { _ in
-      guard AppBuild.isNonProduction else {
-        return ["error": "realtime_failover is disabled on production bundles"]
-      }
-      let controller = RealtimeHubController.shared
-      let from = controller.effectiveProvider.rawValue
-      let started = controller.failoverToAlternateProvider(reason: "quota")
-      controller.ensureWarm()
-      return [
-        "failover_started": started ? "true" : "false",
-        "from": from,
-        "to": controller.effectiveProvider.rawValue,
-      ]
-    }
-
     register(
       name: "seed_subagents",
       summary: "Seed synthetic floating-bar subagents for deterministic UI benchmarks",
@@ -3619,6 +3597,7 @@ final class DesktopAutomationActionRegistry {
     registerNotificationActions()
     registerRatingPromptActions()
     registerRemotePromptActions()
+    registerRealtimeHubActions()
     register(
       name: "rewind_settings_snapshot",
       summary: "Return Rewind settings retention and excluded-app counts"

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -49,19 +49,6 @@ enum RealtimeProviderCloseTurnOutcome: String {
   case pendingReplacement = "pending_replacement"
 }
 
-enum RealtimeProviderCloseRecoveryAction: String {
-  case none
-  case sessionRewarm = "session_rewarm"
-  case providerFailover = "provider_failover"
-  case cascade
-}
-
-enum RealtimeProviderCloseRecoveryResult: String {
-  case notNeeded = "not_needed"
-  case started
-  case exhausted
-}
-
 struct DesktopHealthSnapshot: @unchecked Sendable {
   let timestamp: Date
   let event: DesktopHealthEventName

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -326,7 +326,7 @@ class PushToTalkManager: ObservableObject {
     RealtimeHubController.shared.setup()
     // Hermetic local harness has no Firebase SDK and no live realtime providers.
     if !DesktopLocalProfile.isEnabled {
-      RealtimeHubController.shared.ensureWarm()
+      RealtimeHubController.shared.ensureWarm(userInitiated: true)
     }
     log("PushToTalkManager: setup complete, micPermission=\(hasMicPermission)")
   }
@@ -1794,7 +1794,7 @@ class PushToTalkManager: ObservableObject {
       // behind a global fence with no captured-turn owner.
       _ = RealtimeHubController.shared.beginTurn(turnID: turnID)
     }
-    RealtimeHubController.shared.ensureWarm()
+    RealtimeHubController.shared.ensureWarm(userInitiated: true)
     guard startMicrophoneCapture else { return }
     if let builtIn = preferredPTTInputOverrideDeviceID() {
       log("PushToTalkManager: waiting for realtime hub — buffering built-in mic audio")

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+EventAdmission.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+EventAdmission.swift
@@ -44,4 +44,29 @@ extension RealtimeHubController {
       return false
     }
   }
+
+  /// Non-production manager-harness facts. These describe ownership and
+  /// admission only; they deliberately omit turn IDs, context payload, and
+  /// provider text so a failed physical-path probe is diagnosable without
+  /// exposing user content.
+  func automationPTTInputDiagnostics() -> [String: String] {
+    let requirement = voiceSessionContext(for: currentOwnerScope)
+    let preparation: String
+    if reconnectAudioBuffer != nil {
+      preparation = "buffered"
+    } else if admittedInputTurnID != nil {
+      preparation = "admitted"
+    } else {
+      preparation = "none"
+    }
+    return [
+      "ptt_admission": pttAdmission == .immediate ? "immediate" : "capture_and_buffer",
+      "ptt_input_preparation": preparation,
+      "ptt_rebind_attempts": "\(reconnectAudioBuffer?.rebindAttempts ?? 0)",
+      "ptt_binding_matches_requirement":
+        (requirement.isResolved && requirement.snapshotFreshnessIdentity == sessionVoiceContextFreshnessIdentity)
+        ? "true" : "false",
+      "ptt_handoff_pending": pendingSessionRefreshReason ?? "none",
+    ]
+  }
 }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+PushToTalk.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+PushToTalk.swift
@@ -11,7 +11,7 @@ extension RealtimeHubController {
   /// result is the caller's fail-closed gate for buffered audio replay.
   @discardableResult
   func beginTurn(turnID requestedTurnID: VoiceTurnID? = nil) -> RealtimeInputPreparationResult {
-    if discardMismatchedSessionIfNeeded() { ensureWarm() }
+    if discardMismatchedSessionIfNeeded() { ensureWarm(userInitiated: true) }
     turnPreparationTask?.cancel()
     turnPreparationTask = nil
     // Barge-in: was a reply from the previous turn still in flight when the user
@@ -243,7 +243,7 @@ extension RealtimeHubController {
     if VoiceTurnCoordinator.shared.activeTurnID == nil,
       discardMismatchedSessionIfNeeded()
     {
-      ensureWarm()
+      ensureWarm(userInitiated: true)
     }
     if let requestedTurnID {
       guard requestedTurnID == VoiceTurnCoordinator.shared.activeTurnID,
@@ -311,7 +311,7 @@ extension RealtimeHubController {
           identity: identity,
           previousSessionID: voiceSessionID))
       log("RealtimeHub[\(providerTag)]: buffering mic audio until the reconnecting session is ready")
-      ensureWarm()
+      ensureWarm(userInitiated: true)
       return
     }
     sendAudio(pcm16k, to: s)
@@ -356,7 +356,7 @@ extension RealtimeHubController {
     if VoiceTurnCoordinator.shared.activeTurnID == nil,
       discardMismatchedSessionIfNeeded()
     {
-      ensureWarm()
+      ensureWarm(userInitiated: true)
     }
     guard let turnID = VoiceTurnCoordinator.shared.activeTurnID,
       VoiceTurnCoordinator.shared.requireCurrentOwner(for: turnID) != nil
@@ -392,7 +392,7 @@ extension RealtimeHubController {
         "RealtimeHub[\(providerTag)]: session reconnect not ready at commit — "
           + "deferring commit (bufferedChunks=\(pending.audioBuffer.count))"
       )
-      ensureWarm()
+      ensureWarm(userInitiated: true)
       return .deferredForReconnect
     }
     guard session != nil, voiceSessionID != nil else {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
@@ -1437,6 +1437,13 @@ extension RealtimeHubController {
       fallbackProvider = nil
       pendingFailoverReason = nil
     }
+    if deferIdleRewarmIfUserAway(closeCategory: closeCategory) {
+      recordCloseResolution(
+        turnOutcome: turnOutcome,
+        recoveryAction: .sessionRewarm,
+        recoveryResult: .deferredUserAway)
+      return
+    }
     guard !reconnectPending, hubReconnectStrikes < Self.maxReconnectStrikes else {
       teardownSession()
       recordCloseResolution(
@@ -1452,21 +1459,6 @@ extension RealtimeHubController {
       turnOutcome: turnOutcome,
       recoveryAction: .sessionRewarm,
       recoveryResult: .started)
-  }
-
-  /// OpenAI limits realtime sessions to sixty minutes. Rotation is a normal
-  /// transport lifecycle event: keep the provider choice, replace the retired
-  /// socket immediately, and let the reducer terminalize an interrupted turn.
-  func recoverFromExpectedSessionRotation(
-    _ plan: RealtimeHubSessionRotationPlan,
-    activeTurn: VoiceTurn?
-  ) {
-    if plan == .terminateActiveTurnAndRewarm {
-      terminateActiveHubTurn(activeTurn)
-    }
-    hubReconnectStrikes = 0
-    reconnectPending = true
-    replaceSessionAfterDrain()
   }
 
   /// A warm background socket must never terminate a Deepgram/Omni fallback

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
@@ -11,6 +11,7 @@ extension RealtimeHubController {
   /// client-direct with the user's key. Otherwise, if signed in → mint a server-side
   /// ephemeral token and connect with it.
   func ensureWarm() {
+    clearPresenceWarmDeferral()
     #if DEBUG
       // The local-profile action owns an already-installed hermetic transport.
       // Re-entering normal warm-up here would replace it and mint a real provider

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
@@ -10,8 +10,10 @@ extension RealtimeHubController {
   /// Open the WS now if it isn't already (no-op if already warm). BYOK → connect
   /// client-direct with the user's key. Otherwise, if signed in → mint a server-side
   /// ephemeral token and connect with it.
-  func ensureWarm() {
-    clearPresenceWarmDeferral()
+  /// `userInitiated: true` = direct user intent (PTT, launch, input-return);
+  /// see `admitWarmRequest` — passive callers cannot clear an away deferral.
+  func ensureWarm(userInitiated: Bool = false) {
+    guard admitWarmRequest(userInitiated: userInitiated) else { return }
     #if DEBUG
       // The local-profile action owns an already-installed hermetic transport.
       // Re-entering normal warm-up here would replace it and mint a real provider

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+WarmRecovery.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+WarmRecovery.swift
@@ -31,20 +31,37 @@ extension RealtimeHubController {
     warmDeferredForUserAway = true
     presenceRewarmTask?.cancel()
     presenceRewarmTask = Task { @MainActor [weak self] in
+      var previousSampleAt = Date()
       while !Task.isCancelled {
         try? await Task.sleep(
           nanoseconds: UInt64(RealtimeHubWarmPresencePolicy.presencePollInterval * 1_000_000_000))
         guard let self, !Task.isCancelled else { return }
-        guard self.warmDeferredForUserAway else { return }
-        if RealtimeHubWarmPresencePolicy.shouldResumeWarming(
-          secondsSinceLastUserInput: self.presenceIdleProvider())
-        {
-          log("RealtimeHub: user input resumed — re-warming deferred hub session")
-          self.ensureWarm(userInitiated: true)
-          return
-        }
+        let now = Date()
+        let elapsed = now.timeIntervalSince(previousSampleAt)
+        previousSampleAt = now
+        if self.presencePollTick(elapsedSincePreviousSample: elapsed) { return }
       }
     }
+  }
+
+  /// One presence-poll tick. Returns true when polling should stop — either
+  /// warming resumed or the deferral is gone. The freshness window is the
+  /// MEASURED gap since the previous sample plus slack, so a poll delayed by
+  /// the scheduler still accepts input that arrived anywhere in the gap
+  /// (a fixed sub-gap window would miss a brief return permanently).
+  @discardableResult
+  func presencePollTick(elapsedSincePreviousSample: TimeInterval) -> Bool {
+    guard warmDeferredForUserAway else { return true }
+    guard
+      RealtimeHubWarmPresencePolicy.shouldResumeWarming(
+        secondsSinceLastUserInput: presenceIdleProvider(),
+        freshnessWindow: max(
+          RealtimeHubWarmPresencePolicy.presencePollInterval,
+          elapsedSincePreviousSample) + RealtimeHubWarmPresencePolicy.presencePollSlack)
+    else { return false }
+    log("RealtimeHub: user input resumed — re-warming deferred hub session")
+    ensureWarm(userInitiated: true)
+    return true
   }
 
   /// Gate on every `ensureWarm` entry. A path carrying direct user intent

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+WarmRecovery.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+WarmRecovery.swift
@@ -40,11 +40,31 @@ extension RealtimeHubController {
           secondsSinceLastUserInput: self.presenceIdleProvider())
         {
           log("RealtimeHub: user input resumed — re-warming deferred hub session")
-          self.ensureWarm()
+          self.ensureWarm(userInitiated: true)
           return
         }
       }
     }
+  }
+
+  /// Gate on every `ensureWarm` entry. A path carrying direct user intent
+  /// (PTT press, app launch, the presence poll's input-return) always clears
+  /// an away deferral. Passive lifecycle callers (mint completions,
+  /// owner-change recovery, barge-in cleanup) keep it unless the HID sample
+  /// shows the user actually returned — otherwise background churn would
+  /// silently defeat the quota gate.
+  func admitWarmRequest(userInitiated: Bool) -> Bool {
+    guard warmDeferredForUserAway else { return true }
+    guard
+      userInitiated
+        || RealtimeHubWarmPresencePolicy.shouldResumeWarming(
+          secondsSinceLastUserInput: presenceIdleProvider())
+    else {
+      log("RealtimeHub: passive warm request skipped — deferred while user away")
+      return false
+    }
+    clearPresenceWarmDeferral()
+    return true
   }
 
   func clearPresenceWarmDeferral() {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+WarmRecovery.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+WarmRecovery.swift
@@ -1,0 +1,73 @@
+import Foundation
+import OmiSupport
+import VoiceTurnDomain
+
+/// Recovery for the two *expected* warm-session lifecycle closes: provider
+/// idle teardowns (presence-gated re-warm) and provider session rotation.
+extension RealtimeHubController {
+  // MARK: - Presence-gated warming
+
+  /// A normal idle teardown with the user away from the machine does not
+  /// re-warm: each unconditional re-warm re-bills the full session context
+  /// (~18.5k tokens measured) around the clock, per running app — the loop
+  /// that exhausted the shared Gemini quota fleet-wide. Returns true when the
+  /// re-warm was deferred; the caller records the close resolution.
+  func deferIdleRewarmIfUserAway(closeCategory: RealtimeHubCloseCategory?) -> Bool {
+    guard closeCategory == .expectedIdleTeardown,
+      !RealtimeHubWarmPresencePolicy.shouldRewarmAfterIdleTeardown(
+        secondsSinceLastUserInput: presenceIdleProvider())
+    else { return false }
+    log("RealtimeHub: user away — deferring hub re-warm until input activity returns")
+    teardownSession()
+    deferRewarmWhileUserAway()
+    return true
+  }
+
+  /// Idle teardown fired while the user is away: stop the re-warm loop and
+  /// poll for returned input. Any explicit `ensureWarm()` (PTT-down, settings
+  /// change) also clears the deferral immediately, so this can never make a
+  /// present user wait.
+  func deferRewarmWhileUserAway() {
+    warmDeferredForUserAway = true
+    presenceRewarmTask?.cancel()
+    presenceRewarmTask = Task { @MainActor [weak self] in
+      while !Task.isCancelled {
+        try? await Task.sleep(
+          nanoseconds: UInt64(RealtimeHubWarmPresencePolicy.presencePollInterval * 1_000_000_000))
+        guard let self, !Task.isCancelled else { return }
+        guard self.warmDeferredForUserAway else { return }
+        if RealtimeHubWarmPresencePolicy.shouldResumeWarming(
+          secondsSinceLastUserInput: self.presenceIdleProvider())
+        {
+          log("RealtimeHub: user input resumed — re-warming deferred hub session")
+          self.ensureWarm()
+          return
+        }
+      }
+    }
+  }
+
+  func clearPresenceWarmDeferral() {
+    guard warmDeferredForUserAway || presenceRewarmTask != nil else { return }
+    warmDeferredForUserAway = false
+    presenceRewarmTask?.cancel()
+    presenceRewarmTask = nil
+  }
+
+  // MARK: - Expected session rotation
+
+  /// OpenAI limits realtime sessions to sixty minutes. Rotation is a normal
+  /// transport lifecycle event: keep the provider choice, replace the retired
+  /// socket immediately, and let the reducer terminalize an interrupted turn.
+  func recoverFromExpectedSessionRotation(
+    _ plan: RealtimeHubSessionRotationPlan,
+    activeTurn: VoiceTurn?
+  ) {
+    if plan == .terminateActiveTurnAndRewarm {
+      terminateActiveHubTurn(activeTurn)
+    }
+    hubReconnectStrikes = 0
+    reconnectPending = true
+    replaceSessionAfterDrain()
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -299,6 +299,14 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   /// Failover chain: when the Auto-selected (primary) provider can't connect, the hub
   /// tries the OTHER realtime provider before dropping to the legacy Claude cascade.
   /// nil = on the primary; non-nil = the provider we failed over TO.
+  /// Presence-gated warming (RealtimeHubWarmPresencePolicy): true while an
+  /// idle-teardown re-warm is deferred because the user is away from the
+  /// machine. `presenceRewarmTask` polls for returned input and re-warms.
+  var warmDeferredForUserAway = false
+  var presenceRewarmTask: Task<Void, Never>?
+  /// Seam so tests/automation can substitute the HID idle sample.
+  var presenceIdleProvider: () -> TimeInterval? = { UserInputPresence.secondsSinceLastInput() }
+
   var fallbackProvider: RealtimeHubProvider?
   /// Reason passed to ``failoverToAlternateProvider``; cleared after a successful connect on the alternate.
   var pendingFailoverReason: String?
@@ -849,31 +857,6 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   func hasPendingInputPreparation(for turnID: VoiceTurnID?) -> Bool {
     guard let turnID else { return false }
     return reconnectAudioBuffer?.turnID == turnID || admittedInputTurnID == turnID
-  }
-
-  /// Non-production manager-harness facts. These describe ownership and
-  /// admission only; they deliberately omit turn IDs, context payload, and
-  /// provider text so a failed physical-path probe is diagnosable without
-  /// exposing user content.
-  func automationPTTInputDiagnostics() -> [String: String] {
-    let requirement = voiceSessionContext(for: currentOwnerScope)
-    let preparation: String
-    if reconnectAudioBuffer != nil {
-      preparation = "buffered"
-    } else if admittedInputTurnID != nil {
-      preparation = "admitted"
-    } else {
-      preparation = "none"
-    }
-    return [
-      "ptt_admission": pttAdmission == .immediate ? "immediate" : "capture_and_buffer",
-      "ptt_input_preparation": preparation,
-      "ptt_rebind_attempts": "\(reconnectAudioBuffer?.rebindAttempts ?? 0)",
-      "ptt_binding_matches_requirement":
-        (requirement.isResolved && requirement.snapshotFreshnessIdentity == sessionVoiceContextFreshnessIdentity)
-        ? "true" : "false",
-      "ptt_handoff_pending": pendingSessionRefreshReason ?? "none",
-    ]
   }
 
   /// The reducer selected the non-hub fallback for this logical turn. Drop only

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -875,7 +875,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   /// PTT cold-start grace: give an already-warming/reconnecting hub a short chance to
   /// become ready before falling back to the slower transcript cascade.
   func waitUntilActive(timeout: TimeInterval) async -> Bool {
-    ensureWarm()
+    ensureWarm(userInitiated: true)
     if isTransportReady { return true }
     let deadline = Date().addingTimeInterval(timeout)
     while Date() < deadline {
@@ -992,7 +992,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       log(
         "RealtimeHub: headless PTT screen evidence capture="
           + (screenEvidenceCaptured ? "available" : "unavailable"))
-      ensureWarm()
+      ensureWarm(userInitiated: true)
       guard await waitUntilActive(timeout: 15) else {
         _ = cancelTurn(turnID: turnID)
         VoiceTurnCoordinator.shared.publish(.finish(turnID: turnID, reason: .providerFailed))
@@ -1338,7 +1338,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     clips: [Data],
     timeout: Double
   ) async -> [String: String] {
-    ensureWarm()
+    ensureWarm(userInitiated: true)
     guard await waitUntilActive(timeout: 15) else {
       return ["error": "hub session did not become active"]
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
@@ -1000,6 +1000,29 @@ final class RealtimeHubSession: NSObject, @unchecked Sendable {
     }
   }
 
+  // MARK: - Voice-bearing payload fragments (production seams)
+  //
+  // These are the exact fragments the session builders embed, exposed so a
+  // regression test asserts the payload a real session is configured with —
+  // a per-call-site voice string drifting back in (marin) fails the test.
+
+  /// The OpenAI `session.update` output-audio block. cedar: the deep, calm
+  /// male voice of the gpt-realtime family, Charon's counterpart, so a
+  /// provider failover does not change who Omi sounds like mid-conversation.
+  static func openAIOutputAudioConfig() -> [String: Any] {
+    [
+      "format": ["type": "audio/pcm", "rate": 24000],
+      "voice": RealtimeHubVoicePolicy.voiceName(for: .openai),
+    ]
+  }
+
+  /// The Gemini `setup.generationConfig.speechConfig` block. Pin the spoken
+  /// voice — with no speechConfig Gemini picks its own default, which differs
+  /// from the OpenAI hub voice and can change across model revisions.
+  static func geminiSpeechConfig() -> [String: Any] {
+    ["voiceConfig": ["prebuiltVoiceConfig": ["voiceName": RealtimeHubVoicePolicy.voiceName(for: .gemini)]]]
+  }
+
   private func openAISessionPayload() -> [String: Any] {
     var transcription: [String: Any] = ["model": "whisper-1"]
     if let inputTranscriptionLanguage {
@@ -1017,12 +1040,7 @@ final class RealtimeHubSession: NSObject, @unchecked Sendable {
             "turn_detection": NSNull(),  // PTT controls turns
             "transcription": transcription,
           ],
-          // cedar: the deep, calm male voice of the gpt-realtime family — the closest
-          // match to the Gemini hub voice (Charon), so a provider failover does not
-          // change who Omi sounds like mid-conversation.
-          "output": [
-            "format": ["type": "audio/pcm", "rate": 24000], "voice": RealtimeHubVoicePolicy.voiceName(for: .openai),
-          ],
+          "output": Self.openAIOutputAudioConfig(),
         ],
         "tools": RealtimeHubTools.openAITools(availableDirectedProviders: availableDirectedProviders),
         "tool_choice": "auto",
@@ -1048,12 +1066,7 @@ final class RealtimeHubSession: NSObject, @unchecked Sendable {
           "generationConfig": [
             "responseModalities": ["AUDIO"], "temperature": 0.3,
             "mediaResolution": "MEDIA_RESOLUTION_HIGH",
-            // Pin the spoken voice — with no speechConfig Gemini picks its own default,
-            // which differs from the OpenAI hub voice (cedar) and can change across
-            // model revisions. Charon: deep, calm, "informative" — cedar's counterpart.
-            "speechConfig": [
-              "voiceConfig": ["prebuiltVoiceConfig": ["voiceName": RealtimeHubVoicePolicy.voiceName(for: .gemini)]]
-            ],
+            "speechConfig": Self.geminiSpeechConfig(),
           ],
           "systemInstruction": ["parts": [["text": instructions]]],
           "tools": [

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
@@ -1000,29 +1000,6 @@ final class RealtimeHubSession: NSObject, @unchecked Sendable {
     }
   }
 
-  // MARK: - Voice-bearing payload fragments (production seams)
-  //
-  // These are the exact fragments the session builders embed, exposed so a
-  // regression test asserts the payload a real session is configured with —
-  // a per-call-site voice string drifting back in (marin) fails the test.
-
-  /// The OpenAI `session.update` output-audio block. cedar: the deep, calm
-  /// male voice of the gpt-realtime family, Charon's counterpart, so a
-  /// provider failover does not change who Omi sounds like mid-conversation.
-  static func openAIOutputAudioConfig() -> [String: Any] {
-    [
-      "format": ["type": "audio/pcm", "rate": 24000],
-      "voice": RealtimeHubVoicePolicy.voiceName(for: .openai),
-    ]
-  }
-
-  /// The Gemini `setup.generationConfig.speechConfig` block. Pin the spoken
-  /// voice — with no speechConfig Gemini picks its own default, which differs
-  /// from the OpenAI hub voice and can change across model revisions.
-  static func geminiSpeechConfig() -> [String: Any] {
-    ["voiceConfig": ["prebuiltVoiceConfig": ["voiceName": RealtimeHubVoicePolicy.voiceName(for: .gemini)]]]
-  }
-
   private func openAISessionPayload() -> [String: Any] {
     var transcription: [String: Any] = ["model": "whisper-1"]
     if let inputTranscriptionLanguage {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
@@ -1020,7 +1020,9 @@ final class RealtimeHubSession: NSObject, @unchecked Sendable {
           // cedar: the deep, calm male voice of the gpt-realtime family — the closest
           // match to the Gemini hub voice (Charon), so a provider failover does not
           // change who Omi sounds like mid-conversation.
-          "output": ["format": ["type": "audio/pcm", "rate": 24000], "voice": "cedar"],
+          "output": [
+            "format": ["type": "audio/pcm", "rate": 24000], "voice": RealtimeHubVoicePolicy.voiceName(for: .openai),
+          ],
         ],
         "tools": RealtimeHubTools.openAITools(availableDirectedProviders: availableDirectedProviders),
         "tool_choice": "auto",
@@ -1048,9 +1050,9 @@ final class RealtimeHubSession: NSObject, @unchecked Sendable {
             "mediaResolution": "MEDIA_RESOLUTION_HIGH",
             // Pin the spoken voice — with no speechConfig Gemini picks its own default,
             // which differs from the OpenAI hub voice (cedar) and can change across
-            // model revisions. Charon: deep, calm, "informative" — closest match to marin.
+            // model revisions. Charon: deep, calm, "informative" — cedar's counterpart.
             "speechConfig": [
-              "voiceConfig": ["prebuiltVoiceConfig": ["voiceName": "Charon"]]
+              "voiceConfig": ["prebuiltVoiceConfig": ["voiceName": RealtimeHubVoicePolicy.voiceName(for: .gemini)]]
             ],
           ],
           "systemInstruction": ["parts": [["text": instructions]]],

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionPolicies.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionPolicies.swift
@@ -1107,6 +1107,10 @@ enum RealtimeHubWarmPresencePolicy {
   static let idleThreshold: TimeInterval = 10 * 60
   /// While deferred, how often the controller re-samples for returned input.
   static let presencePollInterval: TimeInterval = 10
+  /// Slack added to the measured inter-poll gap: a poll that fires late must
+  /// still accept input that arrived any time since the previous sample, or a
+  /// brief return between delayed polls is missed permanently.
+  static let presencePollSlack: TimeInterval = 2
 
   /// `nil` = the idle query failed → warm (fail-open to today's behavior).
   static func shouldRewarmAfterIdleTeardown(secondsSinceLastUserInput: TimeInterval?) -> Bool {
@@ -1114,10 +1118,16 @@ enum RealtimeHubWarmPresencePolicy {
     return idle < idleThreshold
   }
 
-  /// While deferred: fresh input since the previous poll → resume warming.
-  static func shouldResumeWarming(secondsSinceLastUserInput: TimeInterval?) -> Bool {
+  /// While deferred: input newer than the freshness window → resume warming.
+  /// The poll loop passes its MEASURED elapsed time (+ slack) so scheduler
+  /// delay widens the window instead of losing the return; passive
+  /// `ensureWarm` callers use the default one-interval window.
+  static func shouldResumeWarming(
+    secondsSinceLastUserInput: TimeInterval?,
+    freshnessWindow: TimeInterval = presencePollInterval
+  ) -> Bool {
     guard let idle = secondsSinceLastUserInput else { return true }
-    return idle < presencePollInterval
+    return idle < freshnessWindow
   }
 }
 enum RealtimeProviderCloseRecoveryAction: String {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionPolicies.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionPolicies.swift
@@ -1091,3 +1091,47 @@ enum RealtimeHubBargeInContinuity {
     return Task.isCancelled ? .cancelled : .contextUnavailable
   }
 }
+
+/// Presence-gated warming. The warm hub socket exists so PTT answers instantly
+/// while the user is at the machine. Gemini idle-closes a silent socket every
+/// ~150s, and each re-warm re-bills the full session context (~18.5k tokens
+/// measured on a 37k-char context) — 24/7, per running app, whether or not the
+/// user is even at the computer. Fleet-wide that loop is what tripped the
+/// project's Gemini spend throttle (close 1011 "exceeded your current quota")
+/// and flipped every user's voice to OpenAI. Deferring re-warm while the user
+/// is away keeps the latency guarantee whenever they are present: warming
+/// resumes on the first returned input event, seconds before any realistic PTT
+/// press, and a cold PTT still has the bounded warm-wait + cascade fallback.
+enum RealtimeHubWarmPresencePolicy {
+  /// User-input idle time after which an idle-teardown re-warm is deferred.
+  static let idleThreshold: TimeInterval = 10 * 60
+  /// While deferred, how often the controller re-samples for returned input.
+  static let presencePollInterval: TimeInterval = 10
+
+  /// `nil` = the idle query failed → warm (fail-open to today's behavior).
+  static func shouldRewarmAfterIdleTeardown(secondsSinceLastUserInput: TimeInterval?) -> Bool {
+    guard let idle = secondsSinceLastUserInput else { return true }
+    return idle < idleThreshold
+  }
+
+  /// While deferred: fresh input since the previous poll → resume warming.
+  static func shouldResumeWarming(secondsSinceLastUserInput: TimeInterval?) -> Bool {
+    guard let idle = secondsSinceLastUserInput else { return true }
+    return idle < presencePollInterval
+  }
+}
+enum RealtimeProviderCloseRecoveryAction: String {
+  case none
+  case sessionRewarm = "session_rewarm"
+  case providerFailover = "provider_failover"
+  case cascade
+}
+
+enum RealtimeProviderCloseRecoveryResult: String {
+  case notNeeded = "not_needed"
+  case started
+  case exhausted
+  /// Idle-teardown re-warm deferred because the user is away from the machine
+  /// (RealtimeHubWarmPresencePolicy); warming resumes on returned input.
+  case deferredUserAway = "deferred_user_away"
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionVoiceConfig.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionVoiceConfig.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+extension RealtimeHubSession {
+
+  // MARK: - Voice-bearing payload fragments (production seams)
+  //
+  // These are the exact fragments the session builders embed, exposed so a
+  // regression test asserts the payload a real session is configured with —
+  // a per-call-site voice string drifting back in (marin) fails the test.
+
+  /// The OpenAI `session.update` output-audio block. cedar: the deep, calm
+  /// male voice of the gpt-realtime family, Charon's counterpart, so a
+  /// provider failover does not change who Omi sounds like mid-conversation.
+  static func openAIOutputAudioConfig() -> [String: Any] {
+    [
+      "format": ["type": "audio/pcm", "rate": 24000],
+      "voice": RealtimeHubVoicePolicy.voiceName(for: .openai),
+    ]
+  }
+
+  /// The Gemini `setup.generationConfig.speechConfig` block. Pin the spoken
+  /// voice — with no speechConfig Gemini picks its own default, which differs
+  /// from the OpenAI hub voice and can change across model revisions.
+  static func geminiSpeechConfig() -> [String: Any] {
+    ["voiceConfig": ["prebuiltVoiceConfig": ["voiceName": RealtimeHubVoicePolicy.voiceName(for: .gemini)]]]
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubVoicePolicy.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubVoicePolicy.swift
@@ -1,0 +1,14 @@
+/// One authority for which spoken voice each realtime provider is pinned to.
+///
+/// Both lanes deliberately use deep, calm male voices — Gemini's Charon and
+/// the gpt-realtime family's cedar (its counterpart) — so a provider failover
+/// changes the engine, not who Omi sounds like. Session builders read from
+/// here; a per-call-site string is how the lanes drifted apart (marin).
+enum RealtimeHubVoicePolicy {
+  static func voiceName(for provider: RealtimeHubProvider) -> String {
+    switch provider {
+    case .openai: return "cedar"
+    case .gemini: return "Charon"
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/UserInputPresence.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/UserInputPresence.swift
@@ -1,0 +1,24 @@
+import CoreGraphics
+import Foundation
+
+/// Seconds since the last HID (keyboard/mouse) input event, for presence-gated
+/// hub warming. Same `kCGAnyInputEventType` sentinel ProactiveAssistantsPlugin
+/// uses: the C header defines it as `((CGEventType)(~0))` and it is not bridged
+/// to a Swift `CGEventType` case. Querying a concrete case (e.g. `.null`) would
+/// measure time since that one event type and report the user as always idle.
+enum UserInputPresence {
+  private static let anyInputEventType: CGEventType = {
+    guard let type = CGEventType(rawValue: ~0) else {
+      assertionFailure("kCGAnyInputEventType (~0) must be representable as CGEventType")
+      return .null
+    }
+    return type
+  }()
+
+  /// `nil` when the sentinel could not be represented (callers fail open).
+  static func secondsSinceLastInput() -> TimeInterval? {
+    guard anyInputEventType != .null else { return nil }
+    return TimeInterval(
+      CGEventSource.secondsSinceLastEventType(.hidSystemState, eventType: anyInputEventType))
+  }
+}

--- a/desktop/macos/Desktop/Tests/RealtimeHubPresenceGateTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubPresenceGateTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Controller-level behavior of the presence-gated warm deferral: passive
+/// lifecycle callers of `ensureWarm()` (mint completions, owner-change
+/// recovery, barge-in cleanup) must NOT clear an away deferral — background
+/// churn would silently defeat the quota gate — while user-intent paths
+/// (PTT, launch, the presence poll's input-return) always clear it.
+@MainActor
+final class RealtimeHubPresenceGateTests: XCTestCase {
+  private func deferredController(idleSeconds: TimeInterval) -> RealtimeHubController {
+    let controller = RealtimeHubController()
+    controller.warmDeferredForUserAway = true
+    controller.presenceIdleProvider = { idleSeconds }
+    return controller
+  }
+
+  func testPassiveWarmRequestPreservesAwayDeferral() {
+    let controller = deferredController(idleSeconds: RealtimeHubWarmPresencePolicy.idleThreshold * 2)
+    controller.ensureWarm()
+    XCTAssertTrue(controller.warmDeferredForUserAway)
+    XCTAssertNil(controller.session)
+  }
+
+  func testUserInitiatedWarmClearsAwayDeferral() {
+    let controller = deferredController(idleSeconds: RealtimeHubWarmPresencePolicy.idleThreshold * 2)
+    controller.ensureWarm(userInitiated: true)
+    XCTAssertFalse(controller.warmDeferredForUserAway)
+  }
+
+  /// A passive request while the HID sample shows fresh input = the user is
+  /// actually back — resume warming rather than waiting for the poll tick.
+  func testPassiveWarmRequestResumesWhenInputIsFresh() {
+    let controller = deferredController(idleSeconds: 0)
+    controller.ensureWarm()
+    XCTAssertFalse(controller.warmDeferredForUserAway)
+  }
+}

--- a/desktop/macos/Desktop/Tests/RealtimeHubPresenceGateTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubPresenceGateTests.swift
@@ -37,3 +37,48 @@ final class RealtimeHubPresenceGateTests: XCTestCase {
     XCTAssertFalse(controller.warmDeferredForUserAway)
   }
 }
+
+/// The return detector must not lose a brief return between delayed polls:
+/// the freshness window is the measured inter-sample gap plus slack, never a
+/// fixed sub-gap constant.
+@MainActor
+final class RealtimeHubPresencePollTimingTests: XCTestCase {
+  private func deferredController(idleSeconds: TimeInterval) -> RealtimeHubController {
+    let controller = RealtimeHubController()
+    controller.warmDeferredForUserAway = true
+    controller.presenceIdleProvider = { idleSeconds }
+    return controller
+  }
+
+  /// Input 15s ago, poll delayed to a 20s gap: a fixed 10s window would miss
+  /// this return forever; the elapsed-aware window resumes warming.
+  func testInputBetweenDelayedPollsResumesWarming() {
+    let controller = deferredController(idleSeconds: 15)
+    XCTAssertTrue(controller.presencePollTick(elapsedSincePreviousSample: 20))
+    XCTAssertFalse(controller.warmDeferredForUserAway)
+  }
+
+  /// Input from before the previous sample (older than the whole gap) is not
+  /// a return — the deferral holds.
+  func testStaleInputAcrossDelayedPollsStaysDeferred() {
+    let controller = deferredController(idleSeconds: 40)
+    XCTAssertFalse(controller.presencePollTick(elapsedSincePreviousSample: 20))
+    XCTAssertTrue(controller.warmDeferredForUserAway)
+  }
+
+  /// An on-time poll keeps the one-interval window (plus slack).
+  func testOnTimePollAcceptsInputInsideTheInterval() {
+    let controller = deferredController(idleSeconds: 5)
+    XCTAssertTrue(
+      controller.presencePollTick(
+        elapsedSincePreviousSample: RealtimeHubWarmPresencePolicy.presencePollInterval))
+    XCTAssertFalse(controller.warmDeferredForUserAway)
+  }
+
+  /// A cleared deferral stops the poll loop without touching warm state.
+  func testTickStopsWhenDeferralAlreadyCleared() {
+    let controller = RealtimeHubController()
+    controller.warmDeferredForUserAway = false
+    XCTAssertTrue(controller.presencePollTick(elapsedSincePreviousSample: 10))
+  }
+}

--- a/desktop/macos/Desktop/Tests/RealtimeHubVoicePolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubVoicePolicyTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class RealtimeHubVoicePolicyTests: XCTestCase {
+  /// Both lanes pin a deep male voice so a quota failover changes the engine,
+  /// not who Omi sounds like. marin (female) regressing into the OpenAI lane
+  /// is exactly the drift this guards against.
+  func testEveryProviderPinsItsDeepMaleVoice() {
+    XCTAssertEqual(RealtimeHubVoicePolicy.voiceName(for: .gemini), "Charon")
+    XCTAssertEqual(RealtimeHubVoicePolicy.voiceName(for: .openai), "cedar")
+  }
+
+  /// The provider a quota failover lands on must resolve to cedar — the
+  /// session payload identity the post-failover connection is configured with.
+  func testFailoverAlternateResolvesToCedar() {
+    XCTAssertEqual(RealtimeHubVoicePolicy.voiceName(for: RealtimeHubProvider.gemini.alternate), "cedar")
+  }
+}

--- a/desktop/macos/Desktop/Tests/RealtimeHubVoicePolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubVoicePolicyTests.swift
@@ -17,3 +17,20 @@ final class RealtimeHubVoicePolicyTests: XCTestCase {
     XCTAssertEqual(RealtimeHubVoicePolicy.voiceName(for: RealtimeHubProvider.gemini.alternate), "cedar")
   }
 }
+
+/// Through the production payload seams the session builders embed — not the
+/// lookup table — so a per-call-site voice string drifting back in (the marin
+/// regression) fails here even if the policy itself is untouched.
+final class RealtimeHubSessionVoicePayloadTests: XCTestCase {
+  func testOpenAISessionPayloadSpeaksCedar() {
+    let output = RealtimeHubSession.openAIOutputAudioConfig()
+    XCTAssertEqual(output["voice"] as? String, "cedar")
+  }
+
+  func testGeminiSetupPayloadSpeaksCharon() {
+    let speech = RealtimeHubSession.geminiSpeechConfig()
+    let voiceConfig = speech["voiceConfig"] as? [String: Any]
+    let prebuilt = voiceConfig?["prebuiltVoiceConfig"] as? [String: Any]
+    XCTAssertEqual(prebuilt?["voiceName"] as? String, "Charon")
+  }
+}

--- a/desktop/macos/Desktop/Tests/RealtimeHubWarmPresencePolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubWarmPresencePolicyTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Presence-gated warming: the idle-teardown re-warm loop re-bills the full
+/// session context (~18.5k tokens measured) every ~150s per running app; with
+/// the user away that spend buys nothing and fleet-wide it tripped the
+/// project's Gemini spend throttle. These tests pin the gate's decision table.
+final class RealtimeHubWarmPresencePolicyTests: XCTestCase {
+  func testActiveUserKeepsTheWarmLoop() {
+    XCTAssertTrue(
+      RealtimeHubWarmPresencePolicy.shouldRewarmAfterIdleTeardown(secondsSinceLastUserInput: 0))
+    XCTAssertTrue(
+      RealtimeHubWarmPresencePolicy.shouldRewarmAfterIdleTeardown(
+        secondsSinceLastUserInput: RealtimeHubWarmPresencePolicy.idleThreshold - 1))
+  }
+
+  func testAwayUserDefersTheRewarm() {
+    XCTAssertFalse(
+      RealtimeHubWarmPresencePolicy.shouldRewarmAfterIdleTeardown(
+        secondsSinceLastUserInput: RealtimeHubWarmPresencePolicy.idleThreshold))
+    XCTAssertFalse(
+      RealtimeHubWarmPresencePolicy.shouldRewarmAfterIdleTeardown(
+        secondsSinceLastUserInput: 8 * 60 * 60))
+  }
+
+  /// A failed HID idle query must fail OPEN — behave exactly like today
+  /// (always re-warm) rather than silently killing the warm path.
+  func testUnknownIdleFailsOpenToWarming() {
+    XCTAssertTrue(
+      RealtimeHubWarmPresencePolicy.shouldRewarmAfterIdleTeardown(secondsSinceLastUserInput: nil))
+    XCTAssertTrue(
+      RealtimeHubWarmPresencePolicy.shouldResumeWarming(secondsSinceLastUserInput: nil))
+  }
+
+  /// While deferred, only input NEWER than the poll interval resumes warming —
+  /// otherwise the stale pre-departure idle sample would resume immediately.
+  func testResumeRequiresInputFresherThanThePollInterval() {
+    XCTAssertTrue(
+      RealtimeHubWarmPresencePolicy.shouldResumeWarming(secondsSinceLastUserInput: 0.5))
+    XCTAssertFalse(
+      RealtimeHubWarmPresencePolicy.shouldResumeWarming(
+        secondsSinceLastUserInput: RealtimeHubWarmPresencePolicy.presencePollInterval))
+    XCTAssertFalse(
+      RealtimeHubWarmPresencePolicy.shouldResumeWarming(
+        secondsSinceLastUserInput: RealtimeHubWarmPresencePolicy.idleThreshold))
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260827-presence-gated-voice-warmup.json
+++ b/desktop/macos/changelog/unreleased/20260827-presence-gated-voice-warmup.json
@@ -1,0 +1,3 @@
+{
+  "change": "Voice stays instant while you're at your Mac, and stops burning provider quota while you're away: the always-warm voice session now pauses after 10 minutes without keyboard or mouse input and re-warms the moment you're back — this idle re-warm loop is what exhausted the shared Gemini quota and switched everyone's voice to the OpenAI fallback."
+}

--- a/desktop/macos/e2e/flows/floating-bar-functional.yaml
+++ b/desktop/macos/e2e/flows/floating-bar-functional.yaml
@@ -34,6 +34,10 @@ covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubInputAdmission.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionPolicies.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+WarmRecovery.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionVoiceConfig.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubVoicePolicy.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/UserInputPresence.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeSpawnReceipt.swift

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -6,6 +6,7 @@ app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge+Notifications.swift
+  - desktop/macos/Desktop/Sources/DesktopAutomationBridge+RealtimeHub.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopAutomationWindowPresentation.swift
   - desktop/macos/Desktop/Sources/BrowserAutomationTarget.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+Environment.swift

--- a/desktop/macos/e2e/flows/ptt-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/ptt-lifecycle.yaml
@@ -32,6 +32,10 @@ covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubInputAdmission.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeScreenEvidence.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionPolicies.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+WarmRecovery.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionVoiceConfig.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubVoicePolicy.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/UserInputPresence.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession+TransportTermination.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSessionTypes.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeSpawnReceipt.swift


### PR DESCRIPTION
## Why

PTT voice flipped to a woman's voice for every user on Aug 26 because the shared Gemini key hit the project-wide spend throttle (Live connect closed 1011 "exceeded your current quota") and the hub failed over to OpenAI/marin. The spend driver is the always-warm hub loop: Google idle-closes a silent Live socket every ~150s (close 1008), and each unconditional re-warm re-bills the full session context — measured 18,501 tokens for a 37k-char context — 24/7, per running app, whether or not anyone is at the machine. The same key serves prod and dev, so the fleet-wide loop degrades everyone at once.

## What

**Presence-gated warming** (`RealtimeHubWarmPresencePolicy`): a normal `expected_idle_teardown` close with the user ≥10 min away from keyboard/mouse (HID any-input idle, same `kCGAnyInputEventType` sentinel ProactiveAssistantsPlugin uses) defers the re-warm instead of looping. While deferred, a 10s poll resumes warming on the first returned input event — seconds before any realistic PTT press — and any explicit `ensureWarm()` (PTT-down, settings change) clears the deferral immediately. A failed idle query fails OPEN to today's always-warm behavior. Warm latency while the user is present is untouched by construction, and a worst-case cold PTT still has the existing bounded `hubWarmWait` + cascade fallback.

**Deliberately NOT shipped — session resumption.** Prototyped and verified against the live model: idle sessions are never issued a `sessionResumptionUpdate` handle before Google's 150s close, and the post-turn session replacement renders a new context identity, so in-app resumption never fires. It would be dead code; presence gating is the fix for the idle burn.

Also: `realtime_presence` / `realtime_failover` automation actions live in a new `DesktopAutomationBridge+RealtimeHub.swift` (non-prod only, auto-included in the flow-lint action-source glob), and a `deferred_user_away` close-resolution telemetry result.

**Ratchet compliance (frozen files shrink below origin/main):** realtime bridge actions → `DesktopAutomationBridge+RealtimeHub.swift`; expected-close recovery (presence deferral + session rotation) → `RealtimeHubController+WarmRecovery.swift`; voice payload seams → `RealtimeHubSessionVoiceConfig.swift`; close-recovery enums → `RealtimeHubSessionPolicies.swift`; PTT admission diagnostics → `RealtimeHubController+EventAdmission.swift`. No exception lines — exception merges stall the beta train (#11564).

## Product invariants affected

- INV-VOICE-1 — PTT voice path unchanged while the user is present; the hub remains the default voice path, and the presence gate only touches the *unattended* idle re-warm loop. Guard: `RealtimeHubWarmPresencePolicyTests` (fail-open + decision table), existing PTT warm-wait fallback tests.
- INV-CHAT-1 — touched files fall under the realtime-hub globs only; no transcript-ownership behavior changes (session teardown/re-warm timing only, no kernel transcript writes). Guard tests unchanged and passing.

## Failure class (fixes)

Failure-Class: new

New class `FC-unattended-warm-resource-loop` registered in this PR: a warm resource kept open to hide first-use latency must gate its refresh loop on user presence; guard artifact `RealtimeHubWarmPresencePolicyTests.swift`.

## Verification

Real path, dev bundle `omi-notch-hover` (Gemini forced, prod-shared key), final binary:

- Baseline reproduced: `RealtimeHub[gemini:gemini-3.1-flash-live-preview]: ready` → `session closed category=expected_idle_teardown provider=gemini aliveFor=150s (1008)` → immediate re-warm loop.
- Away (bridge `realtime_presence idle_seconds=999999`; everything downstream is production code): at the 150s idle close the log shows `user away — deferring hub re-warm until input activity returns` and **no re-warm for 170+ s** — a window in which the old loop would have re-billed the full context and idle-closed again.
- Return (`idle_seconds=0`): `user input resumed — re-warming deferred hub session` → warm → `ready` 1.3s later, within the 10s poll.
- Active-user path unchanged: with a live (non-away) idle sample, the 150s idle close re-warmed immediately exactly as on main; a real hub voice turn injected through `ptt_manager_turn` (PushToTalkManager + realtime admission, the identical production path minus the physical mic) was admitted with `route: hub`.
- `swift test --filter "RealtimeHubWarmPresencePolicyTests|RealtimeHubVoicePolicyTests|RealtimeHubSessionVoicePayloadTests"` — 8/8 pass; `check_desktop_test_quality.py` clean; `make preflight` green.

- Review hardening 2: the presence poll's return detector uses the measured inter-sample gap (+2s slack) as its freshness window, so a scheduler-delayed poll cannot permanently miss a brief return; `RealtimeHubPresencePollTimingTests` pin the timing table.
- Review hardening: `ensureWarm(userInitiated:)` — passive lifecycle callers cannot clear the away deferral (`admitWarmRequest`); 12 user-intent sites pass `userInitiated: true`. Controller-level `RealtimeHubPresenceGateTests` (3) cover it. Live: PTT while deferred cleared the gate, entered hub warm-wait, and committed the turn through a real mid-turn Gemini-mint failover to OpenAI.
- (Rebased onto main: the notch re-anchor guard and RatingPrompt IUO fixes this PR briefly carried landed independently via #12332; both commits dropped here.)

UNVERIFIED: a literal 10-minute physical walk-away (the HID idle sample was substituted via the bridge seam; the sampling call itself is the same one ProactiveAssistantsPlugin ships today).
