### PR TITLE
fix(desktop): notch re-anchor guard leaves open conversation frames alone

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift
@@ -102,14 +102,20 @@ enum FloatingControlBarGeometry {
   /// bug). Whenever a resize leaves the top edge somewhere other than the
   /// screen top while the island is in its non-interactive chrome state,
   /// the frame is re-anchored instead of trusted.
+  /// `isConversationOpen` is the chrome/content boundary: an open conversation
+  /// surface (input, response, agent chat) is user content whose frame the user
+  /// may have moved or resized — Spaces transitions and content growth on it
+  /// must never be snapped back to the screen-top chrome anchor. Only the
+  /// closed-surface island (idle pill, hover menu) is chrome this guard owns.
   static func notchTopReanchoredFrame(
     frame: NSRect,
     screenFrame: NSRect,
     isResizable: Bool,
     isUserDragging: Bool,
+    isConversationOpen: Bool,
     epsilon: CGFloat = 0.5
   ) -> NSRect? {
-    guard !isResizable, !isUserDragging else { return nil }
+    guard !isResizable, !isUserDragging, !isConversationOpen else { return nil }
     guard screenFrame.width > 0, screenFrame.height > 0 else { return nil }
     let desiredTop = screenFrame.maxY
     guard abs(frame.maxY - desiredTop) > epsilon else { return nil }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -2637,7 +2637,8 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         frame: frame,
         screenFrame: screenFrame,
         isResizable: styleMask.contains(.resizable),
-        isUserDragging: isUserDragging
+        isUserDragging: isUserDragging,
+        isConversationOpen: state.conversationSurface.isOpen
       )
     else { return }
     log(

--- a/desktop/macos/Desktop/Sources/RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/RatingPrompt.swift
@@ -176,7 +176,7 @@ final class RatingPromptManager: ObservableObject {
   /// Injectable for tests; production asks the backend for the owner's own
   /// messages, owner-asserted end to end (expectedOwnerId). Assigned in init
   /// (APIClient is actor-isolated, so it cannot be a property default).
-  var historyFetch: ((String) async throws -> [ChatMessageDB])!
+  var historyFetch: (String) async throws -> [ChatMessageDB]
   /// Injectable for tests; production reads the real auth state.
   var isSignedInCheck: () -> Bool = { AuthState.shared.isSignedIn }
 

--- a/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
@@ -619,7 +619,7 @@ final class NotchTopReanchorTests: XCTestCase {
     // the hosting view's min-size constraint — top edge 240pt offscreen.
     let grown = NSRect(x: 816, y: 1263, width: 430, height: 307)
     let anchored = FloatingControlBarGeometry.notchTopReanchoredFrame(
-      frame: grown, screenFrame: screen, isResizable: false, isUserDragging: false)
+      frame: grown, screenFrame: screen, isResizable: false, isUserDragging: false, isConversationOpen: false)
     XCTAssertEqual(anchored, NSRect(x: 809, y: 1023, width: 430, height: 307))
     XCTAssertEqual(anchored?.maxY, screen.maxY)
   }
@@ -628,18 +628,18 @@ final class NotchTopReanchorTests: XCTestCase {
     let idle = NSRect(x: 828, y: 1263, width: 392, height: 67)
     XCTAssertNil(
       FloatingControlBarGeometry.notchTopReanchoredFrame(
-        frame: idle, screenFrame: screen, isResizable: false, isUserDragging: false))
+        frame: idle, screenFrame: screen, isResizable: false, isUserDragging: false, isConversationOpen: false))
   }
 
   func testUserControlledWindowsAreNeverFought() {
     let grown = NSRect(x: 816, y: 900, width: 430, height: 307)
     XCTAssertNil(
       FloatingControlBarGeometry.notchTopReanchoredFrame(
-        frame: grown, screenFrame: screen, isResizable: true, isUserDragging: false),
+        frame: grown, screenFrame: screen, isResizable: true, isUserDragging: false, isConversationOpen: false),
       "a resizable conversation panel is the user's to size")
     XCTAssertNil(
       FloatingControlBarGeometry.notchTopReanchoredFrame(
-        frame: grown, screenFrame: screen, isResizable: false, isUserDragging: true),
+        frame: grown, screenFrame: screen, isResizable: false, isUserDragging: true, isConversationOpen: false),
       "a drag in progress must not be yanked back")
   }
 
@@ -647,14 +647,26 @@ final class NotchTopReanchorTests: XCTestCase {
     let grown = NSRect(x: 0, y: 0, width: 430, height: 307)
     XCTAssertNil(
       FloatingControlBarGeometry.notchTopReanchoredFrame(
-        frame: grown, screenFrame: .zero, isResizable: false, isUserDragging: false))
+        frame: grown, screenFrame: .zero, isResizable: false, isUserDragging: false, isConversationOpen: false))
   }
 
   func testSubPointDriftIsNotChurned() {
     let nearlyAnchored = NSRect(x: 828, y: 1262.7, width: 392, height: 67)
     XCTAssertNil(
       FloatingControlBarGeometry.notchTopReanchoredFrame(
-        frame: nearlyAnchored, screenFrame: screen, isResizable: false, isUserDragging: false),
+        frame: nearlyAnchored, screenFrame: screen, isResizable: false, isUserDragging: false, isConversationOpen: false
+      ),
       "epsilon keeps AppKit rounding from causing a setFrame loop")
+  }
+
+  func testOpenConversationSurfaceIsNeverFought() {
+    // The Spaces-transition regression: a user-resized chat frame is content,
+    // not chrome — re-anchoring it snaps the user's window to the screen top.
+    let userChatFrame = NSRect(x: 240, y: 420, width: 640, height: 520)
+    XCTAssertNil(
+      FloatingControlBarGeometry.notchTopReanchoredFrame(
+        frame: userChatFrame, screenFrame: screen, isResizable: false, isUserDragging: false,
+        isConversationOpen: true),
+      "an open conversation surface owns its frame")
   }
 }

--- a/desktop/macos/changelog/unreleased/20260827-notch-reanchor-respect-chat.json
+++ b/desktop/macos/changelog/unreleased/20260827-notch-reanchor-respect-chat.json
@@ -1,0 +1,3 @@
+{
+  "change": "A chat window you moved or resized no longer snaps back to the top of the screen when switching Spaces"
+}


### PR DESCRIPTION
## What

Main is red: `AgentPillLifecycleTests.testSpacesTransitionPreservesUserResizedNotchChatFrame` fails since #12311 merged. The failure is real, not stale: the re-anchor guard's comment promises it only owns the island's **chrome** state, but the code never checked the surface — so a Spaces transition on a chat window the user had moved or resized snaps that window back to the screen-top center. The regression ships in **v0.12.228+**.

`notchTopReanchoredFrame` now takes the chrome/content boundary explicitly (`isConversationOpen`, no default — every caller must decide): an open conversation surface (input, response, agent chat) is never fought. The closed-surface island — where the original hover-disappearance bug lives — is still re-anchored exactly as #12311 intended, and its geometry tests pass unchanged.

## Verification

- `swift test --filter FloatingBarGeometryTests` — **29 tests, 0 failures**, including the new `testOpenConversationSurfaceIsNeverFought` (the exact regression frame) and the untouched chrome-path tests (bug frame still re-anchored).
- `swift test --filter AgentPillLifecycleTests` — **113 tests, 0 failures**; the previously failing Spaces test passes.

## Product invariants affected

- INV-CHAT-1 — touched paths match its globs; chat behavior itself is unchanged (the fix stops a window-geometry guard from moving the chat window; no message flow, persistence, or send path is altered), so its guard test needs no update.

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift | 5386 -> 5387 | one line: pass the conversation-surface flag into the re-anchor guard

Also removes the `historyFetch` implicitly-unwrapped optional in `RatingPrompt.swift` (2 lines): f4cd38a2f7 introduced it without a baseline entry, so main has failed the desktop-swiftlint gate on every push since; the baseline forbids net-new suppressions, so removing the IUO is the only clean fix. The property is assigned unconditionally in init; `PromptStateAccountScopingTests` (8 tests, the suite that injects it) passes.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

