### PR TITLE
feat(desktop): polish unified navigation and search surfaces

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -3599,7 +3599,8 @@ final class DesktopAutomationActionRegistry {
       NotificationCenter.default.post(name: .navigateToRewindNotes, object: nil)
       return [
         "posted": "navigateToRewindNotes",
-        "expected_tab_index": "\(SidebarNavItem.rewind.rawValue)",
+        "expected_tab_index": "\(SidebarNavItem.conversations.rawValue)",
+        "expected_memory_destination": "\(MemoryHubDestination.rewind.rawValue)",
       ]
     }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift
@@ -52,10 +52,7 @@ struct ChatFirstShell: View {
         appState: appState,
         memoriesViewModel: viewModelContainer.memoriesViewModel,
         tasksStore: viewModelContainer.tasksStore,
-        sinceDate: topBarSinceDate,
-        onRewind: {
-          navigation.selectMore(.rewind)
-        }
+        sinceDate: topBarSinceDate
       )
       // Route-specific identity guarantees every semantic navigation change
       // mounts a fresh destination root and runs its visibility acknowledgement.
@@ -210,9 +207,6 @@ struct ChatFirstShell: View {
         memoriesViewModel: viewModelContainer.memoriesViewModel,
         destinationRawValue: $memoryDestinationRawValue,
         onSelectDestination: selectHubDestination,
-        // The Activity spine's screenshot rows leave for Rewind through the
-        // shell that owns the route — without this the rows are inert here.
-        onOpenRewind: { navigation.selectMore(.rewind) },
         // The typed deep link, so a conversation opened from Activity arrives at the Conversations
         // host as a record rather than as an id the host has to find again. `selectPrimary` — what
         // the spine used to call — is the tab-selection primitive and drops pending records by
@@ -295,6 +289,10 @@ struct ChatFirstShell: View {
   }
 
   private func syncMemoryDestination(for route: ChatFirstRoute) {
+    if route == .more(.rewind) {
+      selectHubDestination(.rewind)
+      return
+    }
     if route == .memories, case .memory = navigation.pendingFocus {
       memoryDestinationRawValue = MemoryHubDestination.memories.rawValue
       return
@@ -391,19 +389,22 @@ struct ChatFirstShell: View {
   }
 }
 
-/// Chat-first keeps Home and Rewind as self-contained surfaces. All other mounted destinations
-/// receive the existing shared lane exactly once at the shell boundary.
+/// Chat-first passes through every destination that owns search/content panels. Older single-panel
+/// destinations receive the shared lane exactly once at the shell boundary.
 enum ChatFirstPageGlassLanePolicy {
   static func shouldWrap(_ route: ChatFirstRoute, memoryDestinationRawValue: Int? = nil) -> Bool {
     switch route {
     case .chat, .more(.dashboard), .more(.rewind):
       return false
     case .memories:
-      // The memory route mounts the hub, and Activity is the one hub page that builds Home's own
-      // two panels. Wrapping it puts glass inside glass and doubles the scrim.
-      return MemoryHubDestination(rawValue: memoryDestinationRawValue ?? -1) != .activity
-    case .conversations, .tasks, .goals,
-      .more(.apps), .more(.permissions), .more(.settings):
+      // Every Brain destination builds the shared search panel and navigation-first content panel.
+      guard let destination = MemoryHubDestination(rawValue: memoryDestinationRawValue ?? -1) else {
+        return true
+      }
+      return !MemoryHubDestination.allCases.contains(destination)
+    case .tasks, .more(.apps):
+      return false
+    case .conversations, .goals, .more(.permissions), .more(.settings):
       return true
     }
   }
@@ -416,7 +417,7 @@ enum ChatFirstPageGlassLanePolicy {
     case .conversations: return SidebarNavItem.conversations.rawValue
     case .tasks, .goals: return SidebarNavItem.tasks.rawValue
     case .memories: return SidebarNavItem.memories.rawValue
-    case .more(.rewind): return SidebarNavItem.rewind.rawValue
+    case .more(.rewind): return SidebarNavItem.conversations.rawValue
     case .more(.apps): return SidebarNavItem.apps.rawValue
     case .more(.permissions): return SidebarNavItem.permissions.rawValue
     case .more(.settings): return SidebarNavItem.settings.rawValue
@@ -682,7 +683,7 @@ enum ChatFirstModernNavigationPolicy {
       switch page {
       case .apps: return SidebarNavItem.apps.rawValue
       case .settings: return SidebarNavItem.settings.rawValue
-      case .rewind: return SidebarNavItem.rewind.rawValue
+      case .rewind: return SidebarNavItem.conversations.rawValue
       default: return SidebarNavItem.dashboard.rawValue
       }
     }
@@ -695,7 +696,7 @@ enum ChatFirstModernNavigationPolicy {
     case .tasks: return .tasks
     case .apps: return .more(.apps)
     case .settings: return .more(.settings)
-    case .rewind: return .more(.rewind)
+    case .rewind: return .memories
     default: return nil
     }
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationListView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationListView.swift
@@ -192,8 +192,9 @@ struct ConversationListView: View {
         }
       }
     }
-    .padding(.horizontal, OmiSpacing.xxl)
-    .padding(.vertical, OmiSpacing.xl)
+    .padding(.horizontal, PagePanelVerticalRhythm.horizontalPadding)
+    .padding(.top, PagePanelVerticalRhythm.contentGap)
+    .padding(.bottom, PagePanelVerticalRhythm.contentBottomPadding)
   }
 
   private var conversationList: some View {

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
@@ -210,63 +210,55 @@ struct ConversationRowView: View {
     isUpdatingTitle = false
   }
 
-  // MARK: - Inline Action Buttons
+  // MARK: - Row Actions
 
-  private var inlineActionButtons: some View {
-    HStack(spacing: OmiSpacing.xxs) {
-      // Reprocess (only when the LLM never produced a title for a non-empty
-      // transcript). Surface inline so the user can fix the bad row in one tap
-      // instead of digging into the context menu.
+  private var inlineActionMenu: some View {
+    Menu {
       if conversation.canReprocess {
-        Button(action: { Task { await reprocessConversation() } }) {
-          Image(systemName: isReprocessing ? "arrow.triangle.2.circlepath" : "wand.and.stars")
-            .scaledFont(size: OmiType.caption)
-            .foregroundColor(Ink.accent)
-            .frame(width: 22, height: 22)
-            .background(Circle().fill(Ink.rowFill))
+        Button {
+          Task { await reprocessConversation() }
+        } label: {
+          Label(
+            isReprocessing ? "Reprocessing…" : "Reprocess title & summary",
+            systemImage: isReprocessing ? "arrow.triangle.2.circlepath" : "wand.and.stars")
         }
-        .buttonStyle(.plain)
         .disabled(isReprocessing)
-        .help(isReprocessing ? "Reprocessing…" : "Reprocess title & summary")
       }
 
-      // Edit title
-      Button(action: {
+      Button {
         editedTitle = conversation.title
         showEditDialog = true
-      }) {
-        Image(systemName: "pencil")
-          .scaledFont(size: OmiType.caption)
-          .foregroundColor(Ink.secondary)
-          .frame(width: 22, height: 22)
-          .background(Circle().fill(Ink.rowFill))
+      } label: {
+        Label("Edit title…", systemImage: "pencil")
       }
-      .buttonStyle(.plain)
-      .help("Edit title")
 
-      // Copy link
-      Button(action: { Task { await copyLink() } }) {
-        Image(systemName: isCopyingLink ? "arrow.triangle.2.circlepath" : "link")
-          .scaledFont(size: OmiType.caption)
-          .foregroundColor(Ink.secondary)
-          .frame(width: 22, height: 22)
-          .background(Circle().fill(Ink.rowFill))
+      Button(action: copyTranscript) {
+        Label("Copy transcript", systemImage: "doc.on.doc")
       }
-      .buttonStyle(.plain)
+
+      Button {
+        Task { await copyLink() }
+      } label: {
+        Label(
+          isCopyingLink ? "Generating link…" : "Copy share link",
+          systemImage: isCopyingLink ? "arrow.triangle.2.circlepath" : "link")
+      }
       .disabled(isCopyingLink)
-      .help("Copy share link — anyone with the link can view")
 
-      // Move to folder (if folders exist)
       if !folders.isEmpty {
         Menu {
           if conversation.folderId != nil {
-            Button(action: { Task { await onMoveToFolder(conversation.id, nil) } }) {
+            Button {
+              Task { await onMoveToFolder(conversation.id, nil) }
+            } label: {
               Label("Remove from Folder", systemImage: "folder.badge.minus")
             }
             Divider()
           }
           ForEach(folders) { folder in
-            Button(action: { Task { await onMoveToFolder(conversation.id, folder.id) } }) {
+            Button {
+              Task { await onMoveToFolder(conversation.id, folder.id) }
+            } label: {
               HStack {
                 Text(folder.name)
                 if conversation.folderId == folder.id {
@@ -277,29 +269,46 @@ struct ConversationRowView: View {
             .disabled(conversation.folderId == folder.id)
           }
         } label: {
-          Image(systemName: conversation.folderId != nil ? "folder.fill" : "folder")
-            .scaledFont(size: OmiType.caption)
-            .foregroundColor(conversation.folderId != nil ? Ink.primary : Ink.secondary)
-            .frame(width: 22, height: 22)
-            .background(Circle().fill(Ink.rowFill))
+          Label("Move to folder", systemImage: "folder")
         }
-        .tint(Ink.primary)
-        .menuStyle(.borderlessButton)
-        .frame(width: 22)
-        .help("Move to folder")
       }
 
-      // Delete
-      Button(action: { showDeleteConfirmation = true }) {
-        Image(systemName: "trash")
-          .scaledFont(size: OmiType.caption)
-          .foregroundColor(Ink.errorRed)
-          .frame(width: 22, height: 22)
-          .background(Circle().fill(Ink.rowFill))
+      Divider()
+
+      Button(role: .destructive) {
+        showDeleteConfirmation = true
+      } label: {
+        Label("Delete conversation…", systemImage: "trash")
       }
-      .buttonStyle(.plain)
-      .help("Delete")
+    } label: {
+      Image(systemName: "ellipsis")
+        .scaledFont(size: OmiType.caption, weight: .semibold)
+        .foregroundColor(Ink.secondary)
+        .frame(width: 26, height: 26)
+        .background(Circle().fill(Ink.rowFill))
     }
+    .menuStyle(.borderlessButton)
+    .menuIndicator(.hidden)
+    .fixedSize()
+    .help("Conversation actions")
+    .accessibilityLabel("Actions for \(conversation.displayTitle)")
+    .accessibilityIdentifier("conversation-row-actions-\(conversation.id)")
+  }
+
+  private var starButton: some View {
+    Button {
+      Task { await toggleStar() }
+    } label: {
+      Image(systemName: conversation.starred ? "star.fill" : "star")
+        .scaledFont(size: isCompactView ? OmiType.caption : OmiType.body)
+        .foregroundColor(conversation.starred ? PageGlass.starred : Ink.secondary)
+        .opacity(isStarring ? 0.5 : 1.0)
+        .frame(width: 26, height: 26)
+    }
+    .buttonStyle(.plain)
+    .disabled(isStarring)
+    .help(conversation.starred ? "Remove from Starred" : "Add to Starred")
+    .accessibilityLabel(conversation.starred ? "Remove from Starred" : "Add to Starred")
   }
 
   // MARK: - Compact Row (single line)
@@ -335,11 +344,6 @@ struct ConversationRowView: View {
             NewBadge()
           }
 
-          // Inline action buttons (show on hover)
-          if isHovering && !isMultiSelectMode {
-            inlineActionButtons
-              .transition(.opacity)
-          }
         }
 
         HStack(spacing: OmiSpacing.xs) {
@@ -358,17 +362,7 @@ struct ConversationRowView: View {
       }
 
       Spacer()
-
-      // Star button
-      Button(action: {
-        Task { await toggleStar() }
-      }) {
-        Image(systemName: conversation.starred ? "star.fill" : "star")
-          .scaledFont(size: OmiType.caption)
-          .foregroundColor(conversation.starred ? PageGlass.starred : Ink.secondary)
-          .opacity(isStarring ? 0.5 : 1.0)
-      }
-      .buttonStyle(.plain)
+      Color.clear.frame(width: 58, height: 26)
     }
     .padding(.horizontal, OmiSpacing.md)
     .padding(.vertical, OmiSpacing.md)
@@ -412,11 +406,6 @@ struct ConversationRowView: View {
             NewBadge()
           }
 
-          // Inline action buttons (show on hover)
-          if isHovering && !isMultiSelectMode {
-            inlineActionButtons
-              .transition(.opacity)
-          }
         }
 
         HStack(spacing: OmiSpacing.xs) {
@@ -435,17 +424,7 @@ struct ConversationRowView: View {
       }
 
       Spacer()
-
-      // Star button
-      Button(action: {
-        Task { await toggleStar() }
-      }) {
-        Image(systemName: conversation.starred ? "star.fill" : "star")
-          .scaledFont(size: OmiType.body)
-          .foregroundColor(conversation.starred ? PageGlass.starred : Ink.secondary)
-          .opacity(isStarring ? 0.5 : 1.0)
-      }
-      .buttonStyle(.plain)
+      Color.clear.frame(width: 58, height: 26)
     }
     .padding(OmiSpacing.lg)
     // The shared row states: nothing at rest, a wash under the pointer, the heavier
@@ -457,26 +436,39 @@ struct ConversationRowView: View {
   }
 
   var body: some View {
-    Button(action: {
-      if isMultiSelectMode {
-        onToggleSelection?()
-      } else {
-        onTap()
-      }
-    }) {
-      Group {
-        if isCompactView {
-          // Compact mode: single line with all info
-          compactRowContent
+    ZStack(alignment: .trailing) {
+      Button(action: {
+        if isMultiSelectMode {
+          onToggleSelection?()
         } else {
-          // Expanded mode: title + overview with metadata below
-          expandedRowContent
+          onTap()
         }
+      }) {
+        Group {
+          if isCompactView {
+            // Compact mode: single line with all info
+            compactRowContent
+          } else {
+            // Expanded mode: title + overview with metadata below
+            expandedRowContent
+          }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
       }
-      .frame(maxWidth: .infinity, alignment: .leading)
-      .contentShape(Rectangle())
+      .buttonStyle(.plain)
+
+      if !isMultiSelectMode {
+        HStack(spacing: OmiSpacing.xxs) {
+          if isHovering {
+            inlineActionMenu
+              .transition(.opacity)
+          }
+          starButton
+        }
+        .padding(.trailing, isCompactView ? OmiSpacing.md : OmiSpacing.lg)
+      }
     }
-    .buttonStyle(.plain)
     .onHover { hovering in
       isHovering = hovering
       if hovering {

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/GlassContentChrome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/GlassContentChrome.swift
@@ -47,9 +47,10 @@ enum PageGlass {
   /// A text field or search field.
   static let fieldRadius: CGFloat = 13
 
-  /// The default top fade on a scrolling column: enough to say "there is more above" and not so much
-  /// that a pinned first row looks half-erased.
-  static let topFade: CGFloat = 18
+  /// Page content starts fully opaque. A permanent top-edge mask fades the first visible row before
+  /// the user has scrolled, which makes correctly positioned controls and headings look clipped.
+  /// The bottom edge still signals overflow without compromising the page's resting state.
+  static let topFade: CGFloat = 0
   /// Deeper than the top, because the bottom of a page is where floating bars sit and the content has
   /// to pass under one legibly.
   static let bottomFade: CGFloat = 30

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/PageQueryToolbar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/PageQueryToolbar.swift
@@ -1,16 +1,25 @@
 import OmiTheme
 import SwiftUI
 
-/// The first interactive row inside a destination panel.
+/// The compact vertical rhythm shared by every destination panel.
 ///
-/// Activity established the visual rhythm for the compact shell: ten points of
-/// breathing room above its navigation, then six points before the content it
-/// controls. List and catalog pages use the same contract so their first pills
-/// do not appear pinned to the panel's rounded top edge.
-enum PagePanelFirstRowMetrics {
+/// Each gap has exactly one owner: the destination owns the navigation-to-
+/// surface gap, the panel owns its top inset, the preceding control row owns
+/// the row gap, and content owns the final eight points before its first item.
+/// This prevents adjacent views from stacking otherwise reasonable padding.
+enum PagePanelVerticalRhythm {
   static let horizontalPadding = QueryShellLayout.panelPaddingHorizontal
-  static let topPadding = QueryShellLayout.panelPaddingTop
-  static let bottomPadding = QueryShellLayout.panelHeaderSpacing
+  static let panelTopPadding = QueryShellLayout.panelPaddingTop
+  static let rowGap = QueryShellLayout.panelHeaderSpacing
+  static let contentGap = OmiSpacing.sm
+  static let sectionGap = OmiSpacing.lg
+  static let contentBottomPadding = OmiSpacing.lg
+}
+
+enum PagePanelFirstRowMetrics {
+  static let horizontalPadding = PagePanelVerticalRhythm.horizontalPadding
+  static let topPadding = PagePanelVerticalRhythm.panelTopPadding
+  static let bottomPadding: CGFloat = 0
 }
 
 extension View {
@@ -18,6 +27,21 @@ extension View {
     padding(.horizontal, PagePanelFirstRowMetrics.horizontalPadding)
       .padding(.top, PagePanelFirstRowMetrics.topPadding)
       .padding(.bottom, PagePanelFirstRowMetrics.bottomPadding)
+  }
+
+  /// A refinement row below Brain navigation. Navigation already owns the six
+  /// points between rows, so this row only owns horizontal alignment.
+  func pagePanelSubsequentRowInsets() -> some View {
+    padding(.horizontal, PagePanelVerticalRhythm.horizontalPadding)
+  }
+
+  @ViewBuilder
+  func pagePanelToolbarInsets(isBelowNavigation: Bool) -> some View {
+    if isBelowNavigation {
+      pagePanelSubsequentRowInsets()
+    } else {
+      pagePanelFirstRowInsets()
+    }
   }
 }
 
@@ -42,20 +66,29 @@ struct PageQueryToolbar<Refinement: View, ActiveFilters: View, Actions: View>: V
   }
 
   var body: some View {
+    ViewThatFits(in: .horizontal) {
+      toolbarRow(showsActiveFilters: true)
+      toolbarRow(showsActiveFilters: false)
+    }
+    .frame(minHeight: QueryShellLayout.chipHeight)
+    .accessibilityElement(children: .contain)
+  }
+
+  private func toolbarRow(showsActiveFilters: Bool) -> some View {
     HStack(alignment: .center, spacing: OmiSpacing.sm) {
       refinement
         .fixedSize(horizontal: true, vertical: false)
 
-      activeFilters
-        .layoutPriority(1)
+      if showsActiveFilters {
+        activeFilters
+          .layoutPriority(-1)
+      }
 
       Spacer(minLength: OmiSpacing.xs)
 
       actions
         .fixedSize(horizontal: true, vertical: false)
     }
-    .frame(minHeight: QueryShellLayout.chipHeight)
-    .accessibilityElement(children: .contain)
   }
 }
 
@@ -77,6 +110,7 @@ struct PageQueryControlLabel: View {
   let value: String
   var isActive = false
   var showsDisclosure = true
+  var dimensionSeparator = ":"
 
   var body: some View {
     HStack(spacing: OmiSpacing.xs) {
@@ -84,7 +118,7 @@ struct PageQueryControlLabel: View {
         .scaledFont(size: OmiType.caption, weight: .medium)
 
       if let dimension, !dimension.isEmpty {
-        Text("\(dimension):")
+        Text("\(dimension)\(dimensionSeparator)")
           .scaledFont(size: OmiType.caption, weight: .medium)
           .foregroundStyle(Ink.secondary)
       }
@@ -117,6 +151,7 @@ struct PageQueryActionLabel: View {
   let icon: String
   let title: String
   var isPrimary = false
+  @State private var isHovering = false
 
   var body: some View {
     ViewThatFits(in: .horizontal) {
@@ -132,6 +167,7 @@ struct PageQueryActionLabel: View {
         .scaledFont(size: OmiType.caption, weight: .semibold)
     }
     .foregroundStyle(isPrimary ? Ink.surface : Ink.primary)
+    .tint(isPrimary ? Ink.surface : Ink.primary)
     .padding(.horizontal, OmiSpacing.sm)
     .frame(minWidth: QueryShellLayout.chipHeight)
     .frame(height: QueryShellLayout.chipHeight)
@@ -141,13 +177,15 @@ struct PageQueryActionLabel: View {
           .fill(Ink.primary)
       } else {
         Capsule(style: .continuous)
-          .fill(Ink.rowFill)
+          .fill(isHovering ? Ink.rowFillHover : Ink.rowFill)
           .overlay {
             Capsule(style: .continuous)
               .stroke(Ink.separator, lineWidth: 1)
           }
       }
     }
+    .contentShape(Capsule(style: .continuous))
+    .onHover { isHovering = $0 }
     .accessibilityElement(children: .combine)
     .accessibilityLabel(title)
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/PageQueryToolbar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/PageQueryToolbar.swift
@@ -1,0 +1,252 @@
+import OmiTheme
+import SwiftUI
+
+/// The first interactive row inside a destination panel.
+///
+/// Activity established the visual rhythm for the compact shell: ten points of
+/// breathing room above its navigation, then six points before the content it
+/// controls. List and catalog pages use the same contract so their first pills
+/// do not appear pinned to the panel's rounded top edge.
+enum PagePanelFirstRowMetrics {
+  static let horizontalPadding = QueryShellLayout.panelPaddingHorizontal
+  static let topPadding = QueryShellLayout.panelPaddingTop
+  static let bottomPadding = QueryShellLayout.panelHeaderSpacing
+}
+
+extension View {
+  func pagePanelFirstRowInsets() -> some View {
+    padding(.horizontal, PagePanelFirstRowMetrics.horizontalPadding)
+      .padding(.top, PagePanelFirstRowMetrics.topPadding)
+      .padding(.bottom, PagePanelFirstRowMetrics.bottomPadding)
+  }
+}
+
+/// Shared chrome for the controls that refine a page's search results.
+///
+/// Search remains in the product-wide search panel. This row belongs to the
+/// content it changes and gives filters, sorting, modes, and actions distinct
+/// positions instead of rendering all of them as an undifferentiated chip row.
+struct PageQueryToolbar<Refinement: View, ActiveFilters: View, Actions: View>: View {
+  let refinement: Refinement
+  let activeFilters: ActiveFilters
+  let actions: Actions
+
+  init(
+    @ViewBuilder refinement: () -> Refinement,
+    @ViewBuilder activeFilters: () -> ActiveFilters,
+    @ViewBuilder actions: () -> Actions = { EmptyView() }
+  ) {
+    self.refinement = refinement()
+    self.activeFilters = activeFilters()
+    self.actions = actions()
+  }
+
+  var body: some View {
+    HStack(alignment: .center, spacing: OmiSpacing.sm) {
+      refinement
+        .fixedSize(horizontal: true, vertical: false)
+
+      activeFilters
+        .layoutPriority(1)
+
+      Spacer(minLength: OmiSpacing.xs)
+
+      actions
+        .fixedSize(horizontal: true, vertical: false)
+    }
+    .frame(minHeight: QueryShellLayout.chipHeight)
+    .accessibilityElement(children: .contain)
+  }
+}
+
+extension PageQueryToolbar where ActiveFilters == EmptyView {
+  init(
+    @ViewBuilder refinement: () -> Refinement,
+    @ViewBuilder actions: () -> Actions = { EmptyView() }
+  ) {
+    self.init(refinement: refinement, activeFilters: { EmptyView() }, actions: actions)
+  }
+}
+
+/// A labelled value used as a Menu or Button label in `PageQueryToolbar`.
+/// The dimension is always visible so values such as "All" and "Default" do
+/// not force users to infer what they control.
+struct PageQueryControlLabel: View {
+  let icon: String
+  let dimension: String?
+  let value: String
+  var isActive = false
+  var showsDisclosure = true
+
+  var body: some View {
+    HStack(spacing: OmiSpacing.xs) {
+      Image(systemName: icon)
+        .scaledFont(size: OmiType.caption, weight: .medium)
+
+      if let dimension, !dimension.isEmpty {
+        Text("\(dimension):")
+          .scaledFont(size: OmiType.caption, weight: .medium)
+          .foregroundStyle(Ink.secondary)
+      }
+
+      Text(value)
+        .scaledFont(size: OmiType.caption, weight: isActive ? .semibold : .medium)
+        .foregroundStyle(Ink.primary)
+        .lineLimit(1)
+
+      if showsDisclosure {
+        Image(systemName: "chevron.down")
+          .scaledFont(size: 10, weight: .semibold)
+          .foregroundStyle(Ink.secondary)
+      }
+    }
+    .padding(.horizontal, OmiSpacing.md)
+    .frame(height: QueryShellLayout.chipHeight)
+    .glassChip(isActive: isActive)
+    .fixedSize(horizontal: true, vertical: false)
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(
+      dimension.map { "\($0), \(value)" } ?? value
+    )
+  }
+}
+
+/// Textual action chrome for page-level operations. Primary actions invert the
+/// shared ink; secondary actions retain the neutral chip treatment.
+struct PageQueryActionLabel: View {
+  let icon: String
+  let title: String
+  var isPrimary = false
+
+  var body: some View {
+    ViewThatFits(in: .horizontal) {
+      HStack(spacing: OmiSpacing.xs) {
+        Image(systemName: icon)
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+        Text(title)
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+          .lineLimit(1)
+      }
+
+      Image(systemName: icon)
+        .scaledFont(size: OmiType.caption, weight: .semibold)
+    }
+    .foregroundStyle(isPrimary ? Ink.surface : Ink.primary)
+    .padding(.horizontal, OmiSpacing.sm)
+    .frame(minWidth: QueryShellLayout.chipHeight)
+    .frame(height: QueryShellLayout.chipHeight)
+    .background {
+      if isPrimary {
+        Capsule(style: .continuous)
+          .fill(Ink.primary)
+      } else {
+        Capsule(style: .continuous)
+          .fill(Ink.rowFill)
+          .overlay {
+            Capsule(style: .continuous)
+              .stroke(Ink.separator, lineWidth: 1)
+          }
+      }
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(title)
+  }
+}
+
+/// A filter value and the action that removes it. Keeping these as data lets
+/// the strip progressively collapse values into one `+N` menu instead of
+/// wrapping the page header or clipping the selected value.
+struct PageActiveFilter: Identifiable {
+  let id: String
+  let title: String
+  let onRemove: () -> Void
+
+  init(id: String, title: String, onRemove: @escaping () -> Void) {
+    self.id = id
+    self.title = title
+    self.onRemove = onRemove
+  }
+}
+
+struct ActivePageFilterStrip: View {
+  let filters: [PageActiveFilter]
+  var onClearAll: (() -> Void)?
+
+  var body: some View {
+    if !filters.isEmpty {
+      ViewThatFits(in: .horizontal) {
+        filterRow(visibleCount: filters.count)
+        filterRow(visibleCount: min(2, filters.count))
+        filterRow(visibleCount: min(1, filters.count))
+        filterRow(visibleCount: 0)
+      }
+      .accessibilityIdentifier("active-page-filters")
+    }
+  }
+
+  private func filterRow(visibleCount: Int) -> some View {
+    let visible = Array(filters.prefix(visibleCount))
+    let hidden = Array(filters.dropFirst(visibleCount))
+
+    return HStack(spacing: OmiSpacing.xs) {
+      ForEach(visible) { filter in
+        ActivePageFilterChip(label: filter.title, onRemove: filter.onRemove)
+      }
+
+      if !hidden.isEmpty {
+        Menu {
+          Section("Active filters") {
+            ForEach(hidden) { filter in
+              Button("Remove \(filter.title)", action: filter.onRemove)
+            }
+          }
+
+          if filters.count > 1, let onClearAll {
+            Divider()
+            Button("Clear all filters", action: onClearAll)
+          }
+        } label: {
+          Text("+\(hidden.count)")
+            .scaledFont(size: OmiType.caption, weight: .semibold)
+            .foregroundStyle(Ink.primary)
+            .padding(.horizontal, OmiSpacing.sm)
+            .frame(height: QueryShellLayout.chipHeight)
+            .glassChip(isActive: true)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Show \(hidden.count) more active filters")
+        .accessibilityLabel("\(hidden.count) more active filters")
+      }
+    }
+    .fixedSize(horizontal: true, vertical: false)
+  }
+}
+
+/// One removable value in the single active-filter row shared by list pages.
+struct ActivePageFilterChip: View {
+  let label: String
+  let onRemove: () -> Void
+
+  var body: some View {
+    Button(action: onRemove) {
+      HStack(spacing: OmiSpacing.xs) {
+        Text(label)
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+          .lineLimit(1)
+          .truncationMode(.tail)
+        Image(systemName: "xmark")
+          .scaledFont(size: 9, weight: .bold)
+      }
+      .foregroundStyle(Ink.primary)
+      .padding(.horizontal, OmiSpacing.sm)
+      .frame(maxWidth: 150)
+      .frame(height: QueryShellLayout.chipHeight)
+      .glassChip(isActive: true)
+    }
+    .buttonStyle(.plain)
+    .help("Remove \(label) filter")
+    .accessibilityLabel("Remove \(label) filter")
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -768,6 +768,12 @@ struct DesktopHomeView: View {
     }
     highlightedSettingId = settingId
 
+    if target.lowercased().replacingOccurrences(of: "-", with: "_") == "rewind" {
+      navigateToLegacyDestination(.rewind)
+      reportAutomationState()
+      return
+    }
+
     if usesChatFirstShell, let route = ChatFirstRoute.automationVisibilityDestination(named: target) {
       switch route {
       case .more(let page):
@@ -1125,6 +1131,15 @@ struct DesktopHomeView: View {
   /// names. This is the sole root adapter between those callers and typed
   /// Chat-first navigation.
   private func navigateToLegacyDestination(_ item: SidebarNavItem) {
+    if item == .rewind, OMIApp.launchMode != .rewind {
+      memoryDestinationRawValue = MemoryHubDestination.rewind.rawValue
+      if usesChatFirstShell {
+        chatFirstNavigation.selectPrimary(.memories)
+      } else {
+        selectedIndex = SidebarNavItem.conversations.rawValue
+      }
+      return
+    }
     if usesChatFirstShell {
       chatFirstNavigation.selectLegacyDestination(item)
     } else {
@@ -1385,12 +1400,7 @@ struct DesktopHomeView: View {
           appState: appState,
           memoriesViewModel: viewModelContainer.memoriesViewModel,
           tasksStore: viewModelContainer.tasksStore,
-          sinceDate: topBarSinceDate,
-          onRewind: {
-            OmiMotion.withGated(Self.pageNavigationAnimation) {
-              selectedIndex = SidebarNavItem.rewind.rawValue
-            }
-          }
+          sinceDate: topBarSinceDate
         )
         .zIndex(1)
       }
@@ -1545,8 +1555,7 @@ private struct PageContentView: View {
         ConversationsDestinationView(
           appState: appState,
           viewModelContainer: viewModelContainer,
-          memoryDestinationRawValue: $memoryDestinationRawValue,
-          onOpenRewind: { selectedTabIndex = SidebarNavItem.rewind.rawValue }
+          memoryDestinationRawValue: $memoryDestinationRawValue
         )
       case 3:
         // Same rule as the hub's Memories destination: the readable-width
@@ -1606,6 +1615,8 @@ private struct PageContentView: View {
 /// so tapping a row navigates to the detail view.
 struct ConversationsPageHost: View {
   let appState: AppState
+  var brainDestination: MemoryHubDestination? = nil
+  var onSelectBrainDestination: ((MemoryHubDestination) -> Void)? = nil
   /// Optional exact record supplied by a Chat-first conversation deep-link.
   /// The normal Conversations page still owns list loading and row selection;
   /// this value only seeds selection when a link fetched a record that is not
@@ -1623,26 +1634,32 @@ struct ConversationsPageHost: View {
   }
 
   var body: some View {
-    ConversationsPage(appState: appState, selectedConversation: $selectedConversation)
-      .frame(
-        maxWidth: usesAvailableWidth ? .infinity : MemoryHubLayoutPolicy.readableContentWidth,
-        maxHeight: .infinity
-      )
-      .frame(maxWidth: .infinity, maxHeight: .infinity)
-      .animation(.easeInOut(duration: 0.22), value: usesAvailableWidth)
-      // Owner fencing: an open detail view must not keep showing the previous
-      // account's conversation after an in-place account switch.
-      .onReceive(NotificationCenter.default.publisher(for: .runtimeOwnerDidChange)) { _ in
-        selectedConversation = nil
-      }
-      .onAppear {
-        if let initialConversation {
-          selectedConversation = initialConversation
-        }
-      }
-      .onChange(of: initialConversation?.id) { _, _ in
+    ConversationsPage(
+      appState: appState,
+      selectedConversation: $selectedConversation,
+      brainDestination: brainDestination,
+      onSelectBrainDestination: onSelectBrainDestination
+    )
+    .frame(
+      maxWidth: brainDestination != nil || usesAvailableWidth
+        ? .infinity : MemoryHubLayoutPolicy.readableContentWidth,
+      maxHeight: .infinity
+    )
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .animation(.easeInOut(duration: 0.22), value: usesAvailableWidth)
+    // Owner fencing: an open detail view must not keep showing the previous
+    // account's conversation after an in-place account switch.
+    .onReceive(NotificationCenter.default.publisher(for: .runtimeOwnerDidChange)) { _ in
+      selectedConversation = nil
+    }
+    .onAppear {
+      if let initialConversation {
         selectedConversation = initialConversation
       }
+    }
+    .onChange(of: initialConversation?.id) { _, _ in
+      selectedConversation = initialConversation
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -4,8 +4,9 @@ import SwiftUI
 /// The constant floating top bar.
 ///
 /// **It carries the destinations flat, and nothing opens.** On the left, one pill per destination:
-/// `Home`, `Activity`, `Tasks`, `Rewind`, `Apps`. On the right, the referral action sits immediately
-/// before the microphone, followed by screen capture and settings.
+/// `Chat`, `Brain`, `Tasks`, `Apps`. On the right, operational status and Settings
+/// stay persistent; referral remains available from Settings without competing
+/// with the product's primary destinations.
 ///
 /// The bar used to spell out `Home · Memory · Tasks · Apps` beside `Listening` and `Capture`, and both
 /// halves were wrong once Home became a search surface. A **`Memory` destination sitting next to a
@@ -26,7 +27,7 @@ import SwiftUI
 ///
 /// **Nothing became unreachable.** INV-NAV-1 is about the destination a shell routes to, not about how
 /// many pills the bar has: every established destination — Home, Conversations, Memories, Brain Map,
-/// Tasks, Rewind — still lands on its own feature-complete page. `Insights` is not in that list
+/// Tasks — still lands on its own feature-complete page. `Insights` is not in that list
 /// because its page was deleted rather than rehoused: the invariant forbids *stranding* a destination
 /// behind a reduced copy, not retiring one. What the assistant produces still arrives, as memories and
 /// notifications, and Home's knows-list still reads its history (`InsightStorage`).
@@ -47,7 +48,6 @@ struct DesktopTopBar: View {
   /// Items created after this instant count as "new" — updated whenever Omi
   /// last resigned front (see DesktopHomeView).
   let sinceDate: Date
-  let onRewind: () -> Void
   @State private var showingReferral = false
 
   private var newConversations: Int {
@@ -79,7 +79,6 @@ struct DesktopTopBar: View {
           persistentControls: {
             TopNavigationTrailingControlsLayout(
               updateStatus: { DesktopUpdateStatusChip() },
-              referral: { ReferralTopBarButton { showingReferral = true } },
               statusControls: { ShellStatusIcons(appState: appState) }
             )
           },
@@ -163,13 +162,7 @@ struct DesktopTopBar: View {
   /// Every nav press on this bar: the brand, the pills and the settings gear. Keeping the transition
   /// in one place prevents those entry points from drifting apart.
   ///
-  /// `Rewind` is the one destination the shell does not reach by index — each shell hands the bar its
-  /// own way in (an overlay here, a `More` route in chat-first), so the pill calls that.
   private func navigate(to index: Int) {
-    guard index != SidebarNavItem.rewind.rawValue else {
-      onRewind()
-      return
-    }
     OmiMotion.withGated(.easeOut(duration: 0.08)) {
       // The pill says `Activity`, so it opens Activity rather than whichever hub page was persisted
       // last. `memoryDestinationRawValue` was declared here and never written — which is why this
@@ -183,27 +176,23 @@ struct DesktopTopBar: View {
   }
 }
 
-/// The right-side controls in their visual order. Keeping Refer in this cluster makes its placement
-/// independent of navigation width and keeps it directly beside the microphone at every window size.
-struct TopNavigationTrailingControlsLayout<UpdateStatus: View, Referral: View, StatusControls: View>: View {
+/// The right-side controls in their visual order. These are persistent because
+/// they report live app state; promotional actions live in Settings instead.
+struct TopNavigationTrailingControlsLayout<UpdateStatus: View, StatusControls: View>: View {
   let updateStatus: UpdateStatus
-  let referral: Referral
   let statusControls: StatusControls
 
   init(
     @ViewBuilder updateStatus: () -> UpdateStatus,
-    @ViewBuilder referral: () -> Referral,
     @ViewBuilder statusControls: () -> StatusControls
   ) {
     self.updateStatus = updateStatus()
-    self.referral = referral()
     self.statusControls = statusControls()
   }
 
   var body: some View {
     HStack(spacing: OmiSpacing.sm) {
       updateStatus
-      referral
       statusControls
     }
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -99,8 +99,8 @@ struct DesktopTopBar: View {
       .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
     .frame(height: TopNavigationLayoutMetrics.barHeight)
-    // Gap below the bar only: padding above it would put the top resize handle on empty air.
-    .padding(.bottom, OmiSpacing.sm)
+    // The destination owns the single 8 pt gap below navigation. Keeping that
+    // ownership there prevents the bar and the page from silently doubling it.
     // The compact fallback's menu is the one surface here that draws outside the bar. Elevation
     // belongs to the shared top-bar component so every shell and exported preview paints it above the
     // destination sibling rather than relying on each call site to remember (INV-NAV-1).

--- a/desktop/macos/Desktop/Sources/MainWindow/MemoryHubDestination.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/MemoryHubDestination.swift
@@ -6,7 +6,7 @@ enum MemoryHubDestination: Int, CaseIterable, Identifiable {
 
   /// `allCases` is storage identity, not reading order: the raw values are persisted, so this list
   /// starts at `memories` — where the stored default lands — rather than where the user's row
-  /// starts. The order the four pages are *presented* in belongs to the control that presents them,
+  /// starts. The order the five pages are *presented* in belongs to the control that presents them,
   /// `ActivityDestinationChip`.
   case memories
   case conversations
@@ -14,6 +14,8 @@ enum MemoryHubDestination: Int, CaseIterable, Identifiable {
   /// The chronological spine that used to be Home's landing surface — everything captured, in the
   /// order it happened. Home now lands in the chat; the timeline lives here.
   case activity
+  /// The visual screen-history player. Appended to preserve every persisted raw value above.
+  case rewind
 
   enum Presentation: Equatable {
     case standaloneConversations
@@ -27,7 +29,8 @@ enum MemoryHubDestination: Int, CaseIterable, Identifiable {
     case .memories: return "Memories"
     case .conversations: return "Conversations"
     case .brainMap: return "Brain Map"
-    case .activity: return "Brain"
+    case .activity: return "Activity"
+    case .rewind: return "Rewind"
     }
   }
 
@@ -37,6 +40,7 @@ enum MemoryHubDestination: Int, CaseIterable, Identifiable {
     case .conversations: return "text.bubble"
     case .brainMap: return "point.3.connected.trianglepath.dotted"
     case .activity: return "clock.arrow.circlepath"
+    case .rewind: return "clock.arrow.circlepath"
     }
   }
 
@@ -108,9 +112,9 @@ enum MemoryHubLayoutPolicy {
 enum MemoryHubSelectionPolicy {
   /// The chat-first route that must be selected for a hub destination.
   ///
-  /// `Conversations` has its own route (it carries capture-archive focus); the other two are the
-  /// Memory route, which is where `MemoryHubPage` lives.
+  /// Direct capture deep links still use the dedicated Conversations route, but selecting any
+  /// Brain section uses the Memory route so the persistent section navigation remains mounted.
   static func chatFirstRoute(for destination: MemoryHubDestination) -> ChatFirstRoute {
-    destination == .conversations ? .conversations : .memories
+    .memories
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/MemoryHubPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/MemoryHubPage.swift
@@ -31,12 +31,10 @@ struct MemoryHubPage: View {
   @ObservedObject var memoriesViewModel: MemoriesViewModel
   @ObservedObject private var conversationDetailState = ConversationDetailAutomationState.shared
   @Binding var destinationRawValue: Int
+  @State private var brainMapSearchText = ""
   /// How this shell applies a hub selection. The modern shell only has to write the persisted
   /// destination; the chat-first shell also moves its own typed route, so it passes its own.
   var onSelectDestination: ((MemoryHubDestination) -> Void)? = nil
-  /// Rewind lives on the shell rail, not in this hub, so the Activity spine's way into it has to be
-  /// supplied by the host that owns the rail index. Hosts without one leave the card inert.
-  var onOpenRewind: (() -> Void)? = nil
   /// How the host opens one exact conversation.
   ///
   /// The chat-first shell supplies its typed deep link (`navigation.open(conversation:)`), which
@@ -59,32 +57,11 @@ struct MemoryHubPage: View {
     )
   }
 
-  /// **The hub wears no switcher.** It used to carry one directly above Activity's own filter row —
-  /// two chip rows a few points apart, sharing three of their words, doing different things. The
-  /// row that survived is Activity's, and every chip in it navigates (`ActivityDestinationChip`),
-  /// so the hub's four pages are reached from one place with one rule. Landing on any of them and
-  /// pressing `Activity` in the top bar comes back to that row (INV-NAV-1).
+  /// Brain is a stable parent with one persistent peer-navigation row. Switching sections never
+  /// becomes a drill-in, so Conversations, Memories, Rewind, and Brain Map do not replace the row
+  /// with a back button.
   var body: some View {
     hubContent
-  }
-
-  /// Puts the way back to Activity on the page itself.
-  ///
-  /// Activity's chip row is what opened this page, and the row stayed behind on Activity's panel.
-  /// The top-bar pill does return, but that is window chrome answering for a control the page
-  /// offered — the page has to carry its own way back (INV-NAV-1).
-  @ViewBuilder
-  private func backToActivity<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
-    VStack(alignment: .leading, spacing: 0) {
-      HStack {
-        ActivityBackButton { select(.activity) }
-        Spacer(minLength: 0)
-      }
-      .padding(.top, 18)
-      .padding(.horizontal, 28)
-      .padding(.bottom, 6)
-      content()
-    }
   }
 
   private func select(_ next: MemoryHubDestination) {
@@ -127,27 +104,46 @@ struct MemoryHubPage: View {
           }
         },
         onOpenBrainMap: { select(.brainMap) },
-        onOpenRewind: { onOpenRewind?() },
-        onOpenHubDestination: select
+        onOpenRewind: { select(.rewind) },
+        selectedDestination: destination,
+        onSelectDestination: select
       )
       .frame(maxWidth: .infinity, maxHeight: .infinity)
     case .memories:
-      backToActivity {
-        adaptiveContent(
-          MemoriesPage(viewModel: viewModelContainer.memoriesViewModel),
-          conversationID: viewModelContainer.memoriesViewModel.linkedConversation?.id
-        )
-      }
+      MemoriesPage(
+        viewModel: viewModelContainer.memoriesViewModel,
+        brainDestination: destination,
+        onSelectBrainDestination: select
+      )
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
     case .conversations:
-      backToActivity {
-        ConversationsPageHost(appState: appState)
-          .frame(maxWidth: .infinity, maxHeight: .infinity)
-      }
+      ConversationsPageHost(
+        appState: appState,
+        brainDestination: destination,
+        onSelectBrainDestination: select
+      )
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+    case .rewind:
+      RewindPage(
+        appState: appState,
+        brainDestination: destination,
+        onSelectBrainDestination: select
+      )
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
     case .brainMap:
-      backToActivity {
-        brainMapDestination
-          .frame(maxWidth: .infinity, maxHeight: .infinity)
-      }
+      BrainSectionPageLayout(
+        selected: destination,
+        onSelect: select,
+        search: {
+          QuerySearchBar(
+            text: $brainMapSearchText,
+            accessibilityID: "brain-map-search-field",
+            placeholder: "Search your entities…"
+          )
+        },
+        content: { brainMapDestination }
+      )
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
       // The lifecycle capability is established by the first authoritative
       // memory response. Without this, opening straight into a persisted
       // Brain Map destination would resolve the compatibility graph before
@@ -167,11 +163,14 @@ struct MemoryHubPage: View {
       CanonicalBrainMapDestination(
         graphViewModel: viewModelContainer.memoryGraphViewModel,
         memoriesViewModel: memoriesViewModel,
+        searchText: $brainMapSearchText,
         onLeave: { destinationRawValue = MemoryHubDestination.memories.rawValue }
       )
-      .equatable()
     case .legacyBrainMap:
-      MemoryGraphPage(viewModel: viewModelContainer.memoryGraphViewModel)
+      MemoryGraphPage(
+        viewModel: viewModelContainer.memoryGraphViewModel,
+        searchText: brainMapSearchText
+      )
     case .undetermined:
       // Neither surface may mount before the server capability is known. The compatibility graph
       // in particular latches the shared view model's in-flight guard and runs
@@ -193,14 +192,11 @@ struct MemoryHubPage: View {
   /// and open actions use the current model at invocation time, while the map
   /// itself observes `MemoryGraphViewModel` for the only state that changes its
   /// projection.
-  private struct CanonicalBrainMapDestination: View, Equatable {
+  private struct CanonicalBrainMapDestination: View {
     let graphViewModel: MemoryGraphViewModel
     let memoriesViewModel: MemoriesViewModel
+    @Binding var searchText: String
     let onLeave: () -> Void
-
-    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
-      lhs.graphViewModel === rhs.graphViewModel && lhs.memoriesViewModel === rhs.memoriesViewModel
-    }
 
     var body: some View {
       CanonicalMemoryAtlasTabView(
@@ -214,6 +210,8 @@ struct MemoryHubPage: View {
               id: memoryID, in: memoriesViewModel, leave: onLeave)
           }
         },
+        searchText: $searchText,
+        showsSearchField: false,
         onLeave: onLeave
       )
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/PageGlassLane.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/PageGlassLane.swift
@@ -6,8 +6,8 @@
 //  wallpaper. That is the whole point — panels sit *on* the desktop rather than on a full-bleed slab
 //  of glass the window painted for them.
 //
-//  QueryShell Home and Rewind were already built that way: each is a set of glass objects with real air
-//  between them (`QueryShellHome`, `RewindSearchLayout`). The two older Home surfaces are the exception:
+//  Search-first pages and Rewind are built that way: each is a set of glass objects with real air
+//  between them. The older single-surface pages are the exception:
 //  `DashboardPage` is laned when it mounts either one, so without this file they render straight onto
 //  the wallpaper. **Every other destination was drawn assuming the window's ground was underneath it**,
 //  so this file is where they get a surface, and it is one surface for all of them: a page that invents
@@ -40,8 +40,8 @@ import SwiftUI
 
 /// Which destinations already carry their own glass, and therefore must not be wrapped in more.
 ///
-/// A pure function of the route rather than a condition inside the router, so "Home and Rewind own
-/// their panels and everything else is given one" is a claim a hermetic test can hold. Nesting a
+/// A pure function of the route rather than a condition inside the router, so panel ownership is a
+/// claim a hermetic test can hold. Nesting a
 /// second `.behindWindow` surface inside a panel does not stack two materials, it takes a second copy
 /// of the desktop and doubles the scrim — see `InkGlassBackdrop` — so a page wrapped twice reads
 /// visibly muddier than the pages around it.
@@ -63,19 +63,23 @@ enum PageGlassLanePolicy {
       return homeOwnsItsPanels
     case .rewind:
       return true
+    case .tasks, .apps:
+      return true
     case .conversations:
       // **Only this index is the Memory hub.** It is one rail slot wearing four different pages, and
-      // only one of them builds its own glass: Activity is Home's column — a search bar and a
-      // results panel, each already an `inkGlassPanel` — so wrapping the hub wholesale nested those
-      // two inside a third and double-scrimmed both, the muddier-than-its-neighbours failure this
-      // policy exists to prevent. The hub's list pages paint no ground and still need the lane.
+      // every Brain destination now builds the same two-panel shape: search above, then navigation
+      // and destination content together below. Wrapping the hub wholesale would nest both inside a
+      // third panel.
       //
       // `SidebarNavItem.memories` is deliberately NOT here. In this shell that index is the
       // *standalone* `MemoriesPage`, not the hub, and it paints no ground of its own — answering
       // for it off a persisted hub destination stripped its panel and drew its rows onto the
       // wallpaper. The chat-first shell reaches the hub through `ChatFirstPageGlassLanePolicy`,
       // which never constructs this view for Activity at all.
-      return MemoryHubDestination(rawValue: memoryDestinationRawValue ?? -1) == .activity
+      guard MemoryHubDestination(rawValue: memoryDestinationRawValue ?? -1) != nil else {
+        return false
+      }
+      return true
     default:
       return false
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -114,6 +114,27 @@ enum AppsCatalogInitialSection {
   case exports
 }
 
+/// The Apps surface contains three different catalog kinds. Keeping the kind
+/// explicit prevents marketplace filters from looking like they also refine
+/// local imports and memory exports.
+enum AppsCatalogKind: String, CaseIterable, Identifiable {
+  case all = "All"
+  case apps = "Apps"
+  case imports = "Imports"
+  case exports = "Exports"
+
+  var id: String { rawValue }
+
+  var icon: String {
+    switch self {
+    case .all: return "square.grid.2x2"
+    case .apps: return "app.badge"
+    case .imports: return "arrow.down.circle"
+    case .exports: return "arrow.up.circle"
+    }
+  }
+}
+
 enum AppsPageCategoryFilter {
   static let allCategoriesOptionId = ""
   static let allCategoriesTitle = "All Categories"
@@ -178,104 +199,55 @@ struct AppsPage: View {
   @State private var visibleAutomationPresentationTarget: DesktopAutomationPresentationTarget?
   @State private var exportStatuses: [MemoryExportDestination: MemoryExportStatus] = [:]
   @State private var viewAllSection: String? = nil  // "featured", "integrations", "notifications"
+  @State private var selectedKind: AppsCatalogKind = .all
 
   var body: some View {
-    VStack(spacing: 0) {
-      // Search bar
-      searchBar
-        .padding()
+    GeometryReader { proxy in
+      let lane = QueryShellLayout.laneWidth(for: proxy.size.width)
 
-      Ink.separator
-        .frame(height: 1)
+      VStack(spacing: QueryShellLayout.panelGap) {
+        QuerySearchBar(
+          text: $searchText,
+          accessibilityID: "apps-search-field",
+          placeholder: searchPlaceholder
+        )
 
-      // Content
-      if appProvider.isLoading {
-        loadingShimmerView
-      } else {
-        // Always render the page (Imports/Exports are local connectors
-        // and must show even when the marketplace API returned no apps).
-        // The marketplace sections inside the else branch are each
-        // self-gated and skip when empty.
-        ScrollView {
-          LazyVStack(alignment: .leading, spacing: OmiSpacing.xxl) {
-            if hasActiveFilters {
-              filteredAppsContent
-            } else {
-              switch initialSection {
-              case .imports:
-                ImportsSection(statusStore: connectorStatusStore) { connector in
-                  selectConnector(connector)
-                }
+        VStack(spacing: 0) {
+          appsControlsBar
+            .pagePanelFirstRowInsets()
 
-                ExportsSection(statuses: exportStatuses) { destination in
-                  selectDestination(destination)
-                }
-              case .exports:
-                ExportsSection(statuses: exportStatuses) { destination in
-                  selectDestination(destination)
-                }
-
-                ImportsSection(statusStore: connectorStatusStore) { connector in
-                  selectConnector(connector)
-                }
+          // Content is scoped by Kind. Marketplace-only filters never replace
+          // the local Imports/Exports catalog with an empty app result.
+          if appProvider.isLoading {
+            loadingShimmerView
+          } else {
+            ScrollView {
+              LazyVStack(alignment: .leading, spacing: OmiSpacing.xxl) {
+                catalogContent
               }
-
-              // Featured section (apps marked as is_popular in backend)
-              if !appProvider.popularApps.isEmpty {
-                AppGridSection(
-                  title: "Other",
-                  apps: Array(appProvider.popularApps.prefix(6)),
-                  appProvider: appProvider,
-                  onSelectApp: selectApp,
-                  showSeeMore: appProvider.popularApps.count > 6,
-                  onSeeMore: { viewAllSection = "featured" }
-                )
-              }
-
-              // Integrations section (external_integration capability)
-              if !appProvider.integrationApps.isEmpty {
-                AppGridSection(
-                  title: "Integrations",
-                  apps: Array(appProvider.integrationApps.prefix(6)),
-                  appProvider: appProvider,
-                  onSelectApp: selectApp,
-                  showSeeMore: appProvider.integrationApps.count > 6,
-                  onSeeMore: { viewAllSection = "integrations" }
-                )
-              }
-
-              // Realtime Notifications section (proactive_notification capability)
-              if !appProvider.notificationApps.isEmpty {
-                AppGridSection(
-                  title: "Realtime Notifications",
-                  apps: Array(appProvider.notificationApps.prefix(6)),
-                  appProvider: appProvider,
-                  onSelectApp: selectApp,
-                  showSeeMore: appProvider.notificationApps.count > 6,
-                  onSeeMore: { viewAllSection = "notifications" }
-                )
-              }
+              .padding()
             }
           }
-          .padding()
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .inkGlassPanel(cornerRadius: QueryShellLayout.panelCornerRadius, shadow: .ambient)
       }
+      .frame(width: lane)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+      .padding(.top, QueryShellLayout.surfaceTopInset)
     }
     .background(Color.clear)
     .onChange(of: searchText) { _, newValue in
+      // Search never changes scope on the user's behalf. In All, the same
+      // query is applied to apps, imports, and exports; a narrower Kind keeps
+      // the query local to that catalog.
+      guard selectedKind == .apps || selectedKind == .all else { return }
       appProvider.searchQuery = newValue
-      // Clear filters when searching
       if !newValue.isEmpty {
         viewAllSection = nil
         appProvider.clearCategoryFilter()
       }
-      Task {
-        // Debounce search
-        try? await Task.sleep(for: .milliseconds(300))
-        if appProvider.searchQuery == newValue {
-          await appProvider.searchApps()
-        }
-      }
+      scheduleAppSearch(for: newValue)
     }
     .dismissableSheet(item: $selectedApp) { app in
       AppDetailSheet(app: app, appProvider: appProvider, onDismiss: { selectedApp = nil })
@@ -447,99 +419,196 @@ struct AppsPage: View {
     activeAutomationCommand = nil
   }
 
-  private var searchBar: some View {
-    AppsHeaderRow(
-      search: { searchField },
-      filters: { filterControls },
-      create: { createAppButton },
-      dismiss: { dismissControl }
-    )
-  }
-
-  private var searchField: some View {
-    HStack(spacing: OmiSpacing.sm) {
-      Image(systemName: "magnifyingglass")
-        .scaledFont(size: OmiType.body, weight: .medium)
-        .frame(width: AppsHeaderMetrics.controlIconSize, height: AppsHeaderMetrics.controlIconSize)
-        .foregroundColor(Ink.secondary)
-
-      TextField("Search apps...", text: $searchText)
-        .textFieldStyle(.plain)
-        .scaledFont(size: OmiType.body)
-        .foregroundColor(Ink.primary)
-        .accessibilityLabel("Search apps")
-
-      if !searchText.isEmpty {
-        Button(action: { searchText = "" }) {
-          Image(systemName: "xmark.circle.fill")
-            .scaledFont(size: OmiType.body)
-            .foregroundColor(Ink.secondary)
+  private var appsControlsBar: some View {
+    PageQueryToolbar(
+      refinement: {
+        kindMenu
+        if selectedKind == .apps {
+          appsFiltersMenu
         }
-        .buttonStyle(.plain)
-        .help("Clear search")
-        .accessibilityLabel("Clear search")
+      },
+      activeFilters: {
+        ActivePageFilterStrip(filters: activeAppFilters, onClearAll: clearAppFilters)
+      },
+      actions: {
+        appsMoreMenu
+        dismissControl
       }
-    }
-    .padding(.horizontal, OmiSpacing.md)
-    .frame(height: AppsHeaderMetrics.controlHeight)
-    .background(
-      Capsule(style: .continuous)
-        .fill(Ink.rowFill)
-        .overlay(
-          Capsule(style: .continuous)
-            .stroke(Ink.separator, lineWidth: 1)
-        )
     )
   }
 
-  private var filterControls: some View {
-    HStack(spacing: OmiSpacing.sm) {
-      FilterToggle(
-        icon: "arrow.down.circle",
-        label: "Installed",
-        isActive: appProvider.showInstalledOnly
-      ) {
-        viewAllSection = nil
-        appProvider.showInstalledOnly.toggle()
-        Task { await appProvider.searchApps() }
-      }
-
-      categoryMenu
+  private var searchPlaceholder: String {
+    switch selectedKind {
+    case .all: return "Search apps, imports, and exports…"
+    case .apps: return "Search apps…"
+    case .imports: return "Search imports…"
+    case .exports: return "Search exports…"
     }
   }
 
-  private var categoryMenu: some View {
-    SearchableDropdown(
-      title: "Category",
-      label: "Category",
-      options: AppsPageCategoryFilter.categoryDropdownOptions(categories: appProvider.categories),
-      selectedId: AppsPageCategoryFilter.selectedCategoryDropdownId(appProvider.selectedCategory),
-      minWidth: 180,
-      controlHeight: AppsHeaderMetrics.controlHeight,
-      usesHeaderChrome: true
-    ) { option in
-      viewAllSection = nil
-      switch AppsPageCategoryFilter.categorySelection(forOptionId: option.id) {
-      case .allCategories:
-        appProvider.clearCategoryFilter()
-      case .category(let categoryId):
-        appProvider.selectedCategory = categoryId
-      }
-      Task { await appProvider.searchApps() }
+  private var activeAppFilters: [PageActiveFilter] {
+    guard selectedKind == .apps else { return [] }
+    var filters: [PageActiveFilter] = []
+
+    if appProvider.showInstalledOnly {
+      filters.append(
+        PageActiveFilter(id: "installed", title: "Installed") {
+          setConnectionFilter(installedOnly: false)
+        })
     }
+
+    if appProvider.selectedCategory != nil {
+      filters.append(
+        PageActiveFilter(id: "category", title: selectedCategoryTitle) {
+          appProvider.clearCategoryFilter()
+          scheduleAppSearch(for: searchText)
+        })
+    }
+
+    return filters
+  }
+
+  private var kindMenu: some View {
+    Menu {
+      ForEach(AppsCatalogKind.allCases) { kind in
+        Button {
+          selectKind(kind)
+        } label: {
+          Label(kind.rawValue, systemImage: kind.icon)
+        }
+      }
+    } label: {
+      PageQueryControlLabel(
+        icon: selectedKind.icon,
+        dimension: "Kind",
+        value: selectedKind.rawValue,
+        isActive: selectedKind != .all
+      )
+    }
+    .menuStyle(.button)
+    .buttonStyle(.plain)
+    .accessibilityIdentifier("apps-kind-filter")
+    .help("Choose which app catalog to show")
+  }
+
+  private var appsFiltersMenu: some View {
+    Menu {
+      Section("Connection") {
+        Button {
+          setConnectionFilter(installedOnly: false)
+        } label: {
+          Label("All apps", systemImage: "square.grid.2x2")
+        }
+        Button {
+          setConnectionFilter(installedOnly: true)
+        } label: {
+          Label("Installed", systemImage: "checkmark.circle")
+        }
+      }
+
+      Section("Category") {
+        ForEach(AppsPageCategoryFilter.categoryDropdownOptions(categories: appProvider.categories)) { option in
+          Button(option.title) {
+            viewAllSection = nil
+            switch AppsPageCategoryFilter.categorySelection(forOptionId: option.id) {
+            case .allCategories:
+              appProvider.clearCategoryFilter()
+            case .category(let categoryId):
+              appProvider.selectedCategory = categoryId
+            }
+            scheduleAppSearch(for: searchText)
+          }
+        }
+      }
+
+      if !activeAppFilters.isEmpty {
+        Divider()
+        Button("Clear all filters", action: clearAppFilters)
+      }
+    } label: {
+      PageQueryControlLabel(
+        icon: "line.3.horizontal.decrease",
+        dimension: "Filter",
+        value: activeAppFilters.isEmpty ? "None" : "\(activeAppFilters.count)",
+        isActive: !activeAppFilters.isEmpty
+      )
+    }
+    .menuStyle(.button)
+    .buttonStyle(.plain)
+    .accessibilityIdentifier("apps-filter-menu")
+    .help("Filter apps by connection or category")
+  }
+
+  private var selectedCategoryTitle: String {
+    guard let selectedCategory = appProvider.selectedCategory,
+      let category = appProvider.categories.first(where: { $0.id == selectedCategory })
+    else {
+      return "All"
+    }
+    return category.title
+  }
+
+  private func selectKind(_ kind: AppsCatalogKind) {
+    guard selectedKind != kind else { return }
+    viewAllSection = nil
+    selectedKind = kind
+
+    // Connection and Category are marketplace dimensions. Clear their query
+    // projection when leaving Apps so a later local-catalog view cannot appear
+    // filtered by stale marketplace state.
+    if kind != .apps {
+      appProvider.clearFilters()
+      searchText = ""
+    }
+
+    if kind == .apps {
+      appProvider.searchQuery = searchText
+      scheduleAppSearch(for: searchText)
+    }
+  }
+
+  private func setConnectionFilter(installedOnly: Bool) {
+    guard selectedKind == .apps else { return }
+    viewAllSection = nil
+    appProvider.showInstalledOnly = installedOnly
+    scheduleAppSearch(for: searchText)
+  }
+
+  private func clearAppFilters() {
+    viewAllSection = nil
+    appProvider.clearFilters()
+    searchText = ""
+  }
+
+  private func scheduleAppSearch(for query: String) {
+    Task {
+      // Debounce search and keep the provider's current query authoritative.
+      try? await Task.sleep(for: .milliseconds(300))
+      guard selectedKind == .apps || selectedKind == .all,
+        appProvider.searchQuery == query
+      else { return }
+      await appProvider.searchApps()
+    }
+  }
+
+  private var appsMoreMenu: some View {
+    Menu {
+      Button {
+        if let url = URL(string: "https://docs.omi.me/docs/developer/apps/Introduction") {
+          NSWorkspace.shared.open(url)
+        }
+      } label: {
+        Label("Build an app…", systemImage: "app.badge.fill")
+      }
+    } label: {
+      PageQueryActionLabel(icon: "ellipsis", title: "More")
+    }
+    .menuStyle(.borderlessButton)
+    .menuIndicator(.hidden)
     .fixedSize()
-  }
-
-  private var createAppButton: some View {
-    SmallHeaderButton(
-      icon: "app.badge.fill",
-      label: "Create App",
-      color: Ink.secondary
-    ) {
-      if let url = URL(string: "https://docs.omi.me/docs/developer/apps/Introduction") {
-        NSWorkspace.shared.open(url)
-      }
-    }
+    .help("More app actions")
+    .accessibilityLabel("More app actions")
+    .accessibilityIdentifier("apps-more-actions")
   }
 
   @ViewBuilder
@@ -549,8 +618,140 @@ struct AppsPage: View {
     }
   }
 
-  private var hasActiveFilters: Bool {
+  @ViewBuilder
+  private var catalogContent: some View {
+    switch selectedKind {
+    case .imports:
+      ImportsSection(
+        statusStore: connectorStatusStore,
+        onSelectConnector: { connector in
+          selectConnector(connector)
+        },
+        connectors: visibleImportConnectors,
+        searchText: searchText,
+        onClearSearch: { searchText = "" }
+      )
+    case .exports:
+      ExportsSection(statuses: exportStatuses, searchText: searchText) { destination in
+        selectDestination(destination)
+      }
+    case .apps:
+      marketplaceContent
+    case .all:
+      if hasSearchQuery {
+        allCatalogSearchContent
+      } else {
+        localAndMarketplaceContent
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var allCatalogSearchContent: some View {
+    ImportsSection(
+      statusStore: connectorStatusStore,
+      onSelectConnector: { connector in selectConnector(connector) },
+      connectors: visibleImportConnectors,
+      searchText: searchText,
+      onClearSearch: { searchText = "" }
+    )
+    ExportsSection(statuses: exportStatuses, searchText: searchText) { destination in
+      selectDestination(destination)
+    }
+    filteredAppsContent
+  }
+
+  @ViewBuilder
+  private var localAndMarketplaceContent: some View {
+    switch initialSection {
+    case .imports:
+      ImportsSection(statusStore: connectorStatusStore) { connector in
+        selectConnector(connector)
+      }
+      ExportsSection(statuses: exportStatuses) { destination in
+        selectDestination(destination)
+      }
+    case .exports:
+      ExportsSection(statuses: exportStatuses) { destination in
+        selectDestination(destination)
+      }
+      ImportsSection(statusStore: connectorStatusStore) { connector in
+        selectConnector(connector)
+      }
+    }
+
+    marketplaceSections
+  }
+
+  @ViewBuilder
+  private var marketplaceContent: some View {
+    if hasMarketplaceQuery {
+      filteredAppsContent
+    } else {
+      marketplaceSections
+    }
+  }
+
+  @ViewBuilder
+  private var marketplaceSections: some View {
+    if !appProvider.popularApps.isEmpty {
+      AppGridSection(
+        title: "Other",
+        apps: Array(appProvider.popularApps.prefix(6)),
+        appProvider: appProvider,
+        onSelectApp: selectApp,
+        showSeeMore: appProvider.popularApps.count > 6,
+        onSeeMore: {
+          selectedKind = .apps
+          viewAllSection = "featured"
+        }
+      )
+    }
+
+    if !appProvider.integrationApps.isEmpty {
+      AppGridSection(
+        title: "Integrations",
+        apps: Array(appProvider.integrationApps.prefix(6)),
+        appProvider: appProvider,
+        onSelectApp: selectApp,
+        showSeeMore: appProvider.integrationApps.count > 6,
+        onSeeMore: {
+          selectedKind = .apps
+          viewAllSection = "integrations"
+        }
+      )
+    }
+
+    if !appProvider.notificationApps.isEmpty {
+      AppGridSection(
+        title: "Realtime Notifications",
+        apps: Array(appProvider.notificationApps.prefix(6)),
+        appProvider: appProvider,
+        onSelectApp: selectApp,
+        showSeeMore: appProvider.notificationApps.count > 6,
+        onSeeMore: {
+          selectedKind = .apps
+          viewAllSection = "notifications"
+        }
+      )
+    }
+  }
+
+  private var hasMarketplaceQuery: Bool {
     appProvider.hasActiveFilters || viewAllSection != nil
+  }
+
+  private var hasSearchQuery: Bool {
+    !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
+
+  private var visibleImportConnectors: [ImportConnector] {
+    let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !query.isEmpty else { return ImportConnector.all }
+    return ImportConnector.all.filter { connector in
+      [connector.title, connector.subtitle, connector.description]
+        .contains { $0.localizedCaseInsensitiveContains(query) }
+    }
   }
 
   /// Apps for the selected filter/search result set or "See more" section.
@@ -1274,27 +1475,53 @@ final class ImportConnectorStatusStore: ObservableObject {
 }
 
 struct ImportsSection: View {
-  private let connectors = ImportConnector.all
   @ObservedObject var statusStore: ImportConnectorStatusStore
   let onSelectConnector: (ImportConnector) -> Void
+  var connectors: [ImportConnector] = ImportConnector.all
+  var searchText: String = ""
+  var onClearSearch: (() -> Void)? = nil
+
+  private var normalizedSearchText: String {
+    searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: OmiSpacing.md) {
+    VStack(alignment: .leading, spacing: OmiSpacing.sm) {
       Text("Imports")
-        .scaledFont(size: OmiType.heading, weight: .semibold)
+        .scaledFont(size: OmiType.subheading, weight: .semibold)
         .foregroundColor(Ink.primary)
 
-      LazyVGrid(
-        columns: [GridItem(.adaptive(minimum: 260), spacing: OmiSpacing.md)],
-        alignment: .leading,
-        spacing: OmiSpacing.md
-      ) {
-        ForEach(connectors) { connector in
-          ImportConnectorCard(
-            connector: connector,
-            snapshot: statusStore.snapshot(for: connector)
-          ) {
-            onSelectConnector(connector)
+      if connectors.isEmpty && !normalizedSearchText.isEmpty {
+        VStack(spacing: OmiSpacing.md) {
+          Image(systemName: "magnifyingglass")
+            .scaledFont(size: 32)
+            .foregroundColor(Ink.secondary)
+
+          Text("No imports match “\(normalizedSearchText)”")
+            .scaledFont(size: OmiType.subheading, weight: .medium)
+            .foregroundColor(Ink.primary)
+            .multilineTextAlignment(.center)
+
+          if let onClearSearch {
+            Button("Clear Search", action: onClearSearch)
+              .buttonStyle(.bordered)
+              .tint(Ink.secondary)
+          }
+        }
+        .frame(maxWidth: .infinity, minHeight: 200)
+      } else {
+        LazyVGrid(
+          columns: [GridItem(.adaptive(minimum: 260), spacing: OmiSpacing.md)],
+          alignment: .leading,
+          spacing: OmiSpacing.md
+        ) {
+          ForEach(connectors) { connector in
+            ImportConnectorCard(
+              connector: connector,
+              snapshot: statusStore.snapshot(for: connector)
+            ) {
+              onSelectConnector(connector)
+            }
           }
         }
       }
@@ -1350,9 +1577,9 @@ struct ImportConnectorCard: View {
 
   var body: some View {
     Button(action: action) {
-      VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+      VStack(alignment: .leading, spacing: OmiSpacing.xs) {
         HStack(spacing: OmiSpacing.md) {
-          ConnectorBrandIcon(brand: connector.brand, size: 50, cornerRadius: OmiChrome.smallControlRadius)
+          ConnectorBrandIcon(brand: connector.brand, size: 38, cornerRadius: OmiChrome.smallControlRadius)
 
           VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
             Text(connector.title)
@@ -1372,7 +1599,7 @@ struct ImportConnectorCard: View {
         Text(connector.description)
           .scaledFont(size: OmiType.caption)
           .foregroundColor(Ink.secondary)
-          .lineLimit(2)
+          .lineLimit(1)
           .multilineTextAlignment(.leading)
 
         HStack {
@@ -1394,7 +1621,7 @@ struct ImportConnectorCard: View {
           ImportConnectorActionButton(title: snapshot.actionTitle, isConnected: snapshot.isConnected)
         }
       }
-      .padding(OmiSpacing.md)
+      .padding(OmiSpacing.sm)
       .background(isHovering ? Ink.rowFillHover : Ink.rowFill)
       .cornerRadius(OmiChrome.smallControlRadius)
       .overlay(
@@ -1417,7 +1644,7 @@ struct ImportConnectorActionButton: View {
     Text(title)
       .scaledFont(size: OmiType.caption, weight: .medium)
       .foregroundColor(isConnected ? Ink.primary : Ink.surface)
-      .frame(width: isConnected ? 84 : 72, height: 28)
+      .frame(width: isConnected ? 78 : 68, height: 26)
       .background(isConnected ? Ink.wash : Ink.primary)
       .cornerRadius(OmiChrome.chipRadius)
       .overlay(
@@ -2140,7 +2367,7 @@ struct AppCard: View {
 
   var body: some View {
     Button(action: onSelect) {
-      VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+      VStack(alignment: .leading, spacing: OmiSpacing.xs) {
         HStack(spacing: OmiSpacing.md) {
           // App icon
           AsyncImage(url: URL(string: app.image)) { phase in
@@ -2153,7 +2380,7 @@ struct AppCard: View {
               appIconPlaceholder
             }
           }
-          .frame(width: 50, height: 50)
+          .frame(width: 38, height: 38)
           .clipShape(RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius))
 
           VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
@@ -2174,7 +2401,7 @@ struct AppCard: View {
         Text(app.description)
           .scaledFont(size: OmiType.caption)
           .foregroundColor(Ink.secondary)
-          .lineLimit(2)
+          .lineLimit(1)
           .multilineTextAlignment(.leading)
 
         HStack {
@@ -2208,7 +2435,7 @@ struct AppCard: View {
           AppActionButton(app: app, appProvider: appProvider, onOpen: onSelect)
         }
       }
-      .padding(OmiSpacing.md)
+      .padding(OmiSpacing.sm)
       .background(isHovering ? Ink.rowFill : Ink.wash)
       .cornerRadius(OmiChrome.smallControlRadius)
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -179,6 +179,31 @@ enum AppsFilteredResultsPresentation: Equatable {
   }
 }
 
+enum AppsAllSearchPresentation: Equatable {
+  case loading
+  case empty
+  case results(total: Int)
+  case failure
+
+  static func resolve(
+    importsCount: Int,
+    exportsCount: Int,
+    appsCount: Int,
+    marketplace: AppsFilteredResultsPresentation
+  ) -> AppsAllSearchPresentation {
+    let localCount = importsCount + exportsCount
+    let visibleAppsCount = marketplace == .results ? appsCount : 0
+    let total = localCount + visibleAppsCount
+
+    if total > 0 { return .results(total: total) }
+    switch marketplace {
+    case .loading: return .loading
+    case .failure: return .failure
+    case .empty, .results: return .empty
+    }
+  }
+}
+
 struct AppsPage: View {
   @ObservedObject var appProvider: AppProvider
   var appState: AppState? = nil
@@ -222,10 +247,12 @@ struct AppsPage: View {
             loadingShimmerView
           } else {
             ScrollView {
-              LazyVStack(alignment: .leading, spacing: OmiSpacing.xxl) {
+              LazyVStack(alignment: .leading, spacing: PagePanelVerticalRhythm.sectionGap) {
                 catalogContent
               }
-              .padding()
+              .padding(.horizontal, PagePanelVerticalRhythm.horizontalPadding)
+              .padding(.top, PagePanelVerticalRhythm.contentGap)
+              .padding(.bottom, PagePanelVerticalRhythm.contentBottomPadding)
             }
           }
         }
@@ -528,9 +555,10 @@ struct AppsPage: View {
     } label: {
       PageQueryControlLabel(
         icon: "line.3.horizontal.decrease",
-        dimension: "Filter",
-        value: activeAppFilters.isEmpty ? "None" : "\(activeAppFilters.count)",
-        isActive: !activeAppFilters.isEmpty
+        dimension: activeAppFilters.isEmpty ? nil : "Filter",
+        value: activeAppFilters.isEmpty ? "Filter" : "\(activeAppFilters.count)",
+        isActive: !activeAppFilters.isEmpty,
+        dimensionSeparator: " ·"
       )
     }
     .menuStyle(.button)
@@ -553,15 +581,13 @@ struct AppsPage: View {
     viewAllSection = nil
     selectedKind = kind
 
-    // Connection and Category are marketplace dimensions. Clear their query
-    // projection when leaving Apps so a later local-catalog view cannot appear
-    // filtered by stale marketplace state.
+    // Connection and Category are marketplace dimensions. Search is a page-
+    // wide intent, so changing scope never discards what the user typed.
     if kind != .apps {
-      appProvider.clearFilters()
-      searchText = ""
+      clearMarketplaceFiltersPreservingSearch()
     }
 
-    if kind == .apps {
+    if kind == .apps || kind == .all {
       appProvider.searchQuery = searchText
       scheduleAppSearch(for: searchText)
     }
@@ -576,8 +602,14 @@ struct AppsPage: View {
 
   private func clearAppFilters() {
     viewAllSection = nil
+    clearMarketplaceFiltersPreservingSearch()
+    scheduleAppSearch(for: searchText)
+  }
+
+  private func clearMarketplaceFiltersPreservingSearch() {
+    let query = searchText
     appProvider.clearFilters()
-    searchText = ""
+    appProvider.searchQuery = query
   }
 
   private func scheduleAppSearch(for query: String) {
@@ -648,17 +680,53 @@ struct AppsPage: View {
 
   @ViewBuilder
   private var allCatalogSearchContent: some View {
-    ImportsSection(
-      statusStore: connectorStatusStore,
-      onSelectConnector: { connector in selectConnector(connector) },
-      connectors: visibleImportConnectors,
-      searchText: searchText,
-      onClearSearch: { searchText = "" }
-    )
-    ExportsSection(statuses: exportStatuses, searchText: searchText) { destination in
-      selectDestination(destination)
+    switch allSearchPresentation {
+    case .loading:
+      searchLoadingState
+    case .failure:
+      searchFailureState
+    case .empty:
+      globalSearchEmptyState
+    case .results(let total):
+      Text("Search Results (\(total))")
+        .scaledFont(size: OmiType.heading, weight: .semibold)
+        .foregroundStyle(Ink.primary)
+
+      if !visibleImportConnectors.isEmpty {
+        ImportsSection(
+          statusStore: connectorStatusStore,
+          onSelectConnector: { connector in selectConnector(connector) },
+          connectors: visibleImportConnectors,
+          title: "Imports (\(visibleImportConnectors.count))"
+        )
+      }
+
+      if !visibleExportEntries.isEmpty {
+        ExportsSection(
+          statuses: exportStatuses,
+          title: "Exports (\(visibleExportEntries.count))",
+          entriesOverride: visibleExportEntries
+        ) { destination in
+          selectDestination(destination)
+        }
+      }
+
+      if !visibleMarketplaceSearchApps.isEmpty {
+        AppGridSection(
+          title: "Apps (\(visibleMarketplaceSearchApps.count))",
+          apps: visibleMarketplaceSearchApps,
+          appProvider: appProvider,
+          onSelectApp: selectApp,
+          titleSize: OmiType.subheading
+        )
+      }
+
+      if filteredAppsPresentation == .loading {
+        marketplaceSearchProgress
+      } else if filteredAppsPresentation == .failure {
+        marketplaceSearchFailure
+      }
     }
-    filteredAppsContent
   }
 
   @ViewBuilder
@@ -748,9 +816,97 @@ struct AppsPage: View {
   private var visibleImportConnectors: [ImportConnector] {
     let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !query.isEmpty else { return ImportConnector.all }
-    return ImportConnector.all.filter { connector in
-      [connector.title, connector.subtitle, connector.description]
-        .contains { $0.localizedCaseInsensitiveContains(query) }
+    return ImportConnector.all
+      .filter { connector in
+        [connector.title, connector.subtitle, connector.description]
+          .contains { $0.localizedCaseInsensitiveContains(query) }
+      }
+      .sorted { catalogMatchRank($0.title, query: query) < catalogMatchRank($1.title, query: query) }
+  }
+
+  private var visibleExportEntries: [MemoryExportCatalogEntry] {
+    MemoryExportCatalog.matching(searchText)
+  }
+
+  private var visibleMarketplaceSearchApps: [OmiApp] {
+    guard filteredAppsPresentation == .results else { return [] }
+    let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    return filteredApps.sorted {
+      catalogMatchRank($0.name, query: query) < catalogMatchRank($1.name, query: query)
+    }
+  }
+
+  private var allSearchPresentation: AppsAllSearchPresentation {
+    AppsAllSearchPresentation.resolve(
+      importsCount: visibleImportConnectors.count,
+      exportsCount: visibleExportEntries.count,
+      appsCount: filteredApps.count,
+      marketplace: filteredAppsPresentation
+    )
+  }
+
+  private func catalogMatchRank(_ title: String, query: String) -> Int {
+    if title.localizedCaseInsensitiveCompare(query) == .orderedSame { return 0 }
+    if title.range(of: query, options: [.anchored, .caseInsensitive, .diacriticInsensitive]) != nil {
+      return 1
+    }
+    return 2
+  }
+
+  private var searchLoadingState: some View {
+    VStack(spacing: OmiSpacing.md) {
+      ProgressView()
+      Text("Searching apps, imports, and exports…")
+        .scaledFont(size: OmiType.body)
+        .foregroundStyle(Ink.secondary)
+    }
+    .frame(maxWidth: .infinity, minHeight: QueryShellLayout.minimumBodyHeight)
+  }
+
+  private var searchFailureState: some View {
+    VStack(spacing: OmiSpacing.md) {
+      Image(systemName: "exclamationmark.circle")
+        .scaledFont(size: 28)
+        .foregroundStyle(Ink.secondary)
+      Text("Couldn't finish searching apps")
+        .scaledFont(size: OmiType.subheading, weight: .medium)
+      Button("Try Again") { Task { await appProvider.searchApps() } }
+        .buttonStyle(.bordered)
+    }
+    .frame(maxWidth: .infinity, minHeight: QueryShellLayout.minimumBodyHeight)
+  }
+
+  private var globalSearchEmptyState: some View {
+    VStack(spacing: OmiSpacing.md) {
+      Image(systemName: "magnifyingglass")
+        .scaledFont(size: 28)
+        .foregroundStyle(Ink.secondary)
+      Text("No results for “\(searchText.trimmingCharacters(in: .whitespacesAndNewlines))”")
+        .scaledFont(size: OmiType.subheading, weight: .medium)
+        .foregroundStyle(Ink.primary)
+      Button("Clear Search") { searchText = "" }
+        .buttonStyle(.bordered)
+    }
+    .frame(maxWidth: .infinity, minHeight: QueryShellLayout.minimumBodyHeight)
+  }
+
+  private var marketplaceSearchProgress: some View {
+    HStack(spacing: OmiSpacing.sm) {
+      ProgressView().controlSize(.small)
+      Text("Searching marketplace apps…")
+        .scaledFont(size: OmiType.caption)
+        .foregroundStyle(Ink.secondary)
+    }
+  }
+
+  private var marketplaceSearchFailure: some View {
+    HStack(spacing: OmiSpacing.sm) {
+      Text("Marketplace apps couldn't be loaded.")
+        .scaledFont(size: OmiType.caption)
+        .foregroundStyle(Ink.secondary)
+      Button("Try Again") { Task { await appProvider.searchApps() } }
+        .buttonStyle(.plain)
+        .foregroundStyle(Ink.primary)
     }
   }
 
@@ -814,7 +970,7 @@ struct AppsPage: View {
           .scaledFont(size: OmiType.body)
           .foregroundColor(Ink.secondary)
       }
-      .frame(maxWidth: .infinity, minHeight: 200)
+      .frame(maxWidth: .infinity, minHeight: QueryShellLayout.minimumBodyHeight)
     case .empty:
       VStack(spacing: OmiSpacing.md) {
         Image(systemName: "magnifyingglass")
@@ -824,7 +980,7 @@ struct AppsPage: View {
           .scaledFont(size: OmiType.subheading, weight: .medium)
           .foregroundColor(Ink.secondary)
       }
-      .frame(maxWidth: .infinity, minHeight: 200)
+      .frame(maxWidth: .infinity, minHeight: QueryShellLayout.minimumBodyHeight)
     case .failure:
       VStack(spacing: OmiSpacing.md) {
         Image(systemName: "exclamationmark.circle")
@@ -838,7 +994,7 @@ struct AppsPage: View {
         }
         .buttonStyle(.bordered)
       }
-      .frame(maxWidth: .infinity, minHeight: 200)
+      .frame(maxWidth: .infinity, minHeight: QueryShellLayout.minimumBodyHeight)
     case .results:
       filteredAppsGrid
     }
@@ -894,7 +1050,7 @@ struct AppsPage: View {
 
   private var loadingShimmerView: some View {
     ScrollView {
-      VStack(alignment: .leading, spacing: OmiSpacing.xxl) {
+      VStack(alignment: .leading, spacing: PagePanelVerticalRhythm.sectionGap) {
         // Shimmer sections
         ForEach(0..<3, id: \.self) { _ in
           VStack(alignment: .leading, spacing: OmiSpacing.md) {
@@ -912,7 +1068,9 @@ struct AppsPage: View {
           }
         }
       }
-      .padding()
+      .padding(.horizontal, PagePanelVerticalRhythm.horizontalPadding)
+      .padding(.top, PagePanelVerticalRhythm.contentGap)
+      .padding(.bottom, PagePanelVerticalRhythm.contentBottomPadding)
     }
   }
 
@@ -1480,6 +1638,7 @@ struct ImportsSection: View {
   var connectors: [ImportConnector] = ImportConnector.all
   var searchText: String = ""
   var onClearSearch: (() -> Void)? = nil
+  var title = "Imports"
 
   private var normalizedSearchText: String {
     searchText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1487,7 +1646,7 @@ struct ImportsSection: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: OmiSpacing.sm) {
-      Text("Imports")
+      Text(title)
         .scaledFont(size: OmiType.subheading, weight: .semibold)
         .foregroundColor(Ink.primary)
 
@@ -1508,7 +1667,7 @@ struct ImportsSection: View {
               .tint(Ink.secondary)
           }
         }
-        .frame(maxWidth: .infinity, minHeight: 200)
+        .frame(maxWidth: .infinity, minHeight: QueryShellLayout.minimumBodyHeight)
       } else {
         LazyVGrid(
           columns: [GridItem(.adaptive(minimum: 260), spacing: OmiSpacing.md)],
@@ -2200,6 +2359,7 @@ struct AppGridSection: View {
   let apps: [OmiApp]
   let appProvider: AppProvider
   let onSelectApp: (OmiApp) -> Void
+  var titleSize = OmiType.heading
   var showSeeMore: Bool = false
   var onSeeMore: (() -> Void)? = nil
 
@@ -2207,7 +2367,7 @@ struct AppGridSection: View {
     VStack(alignment: .leading, spacing: OmiSpacing.md) {
       HStack {
         Text(title)
-          .scaledFont(size: OmiType.heading, weight: .semibold)
+          .scaledFont(size: titleSize, weight: .semibold)
           .foregroundColor(Ink.primary)
 
         Spacer()

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsDestinationView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsDestinationView.swift
@@ -4,8 +4,6 @@ struct ConversationsDestinationView: View {
   let appState: AppState
   let viewModelContainer: ViewModelContainer
   @Binding var memoryDestinationRawValue: Int
-  /// The Activity spine's way out to Rewind — the rail index belongs to the page host above.
-  var onOpenRewind: (() -> Void)? = nil
   @AppStorage("useLegacyHomeDesign") private var useLegacyHomeDesign = false
 
   var body: some View {
@@ -20,8 +18,7 @@ struct ConversationsDestinationView: View {
         appState: appState,
         viewModelContainer: viewModelContainer,
         memoriesViewModel: viewModelContainer.memoriesViewModel,
-        destinationRawValue: $memoryDestinationRawValue,
-        onOpenRewind: onOpenRewind
+        destinationRawValue: $memoryDestinationRawValue
       )
     }
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -1,11 +1,47 @@
 import OmiTheme
 import SwiftUI
 
+/// Applies the list query's refinements to remote text-search results.
+///
+/// The search endpoint only accepts text, so search results must pass through
+/// this same local predicate as the list's cached/server rows. Keeping the
+/// predicate pure also means a filter change immediately updates an already
+/// visible search without starting a second request.
+enum ConversationSearchResultFilter {
+  static func apply(
+    _ conversations: [ServerConversation],
+    starredOnly: Bool,
+    date: Date?,
+    folderId: String?,
+    calendar: Calendar = .current
+  ) -> [ServerConversation] {
+    let dateRange: (start: Date, end: Date)? = date.flatMap { selectedDate in
+      let start = calendar.startOfDay(for: selectedDate)
+      guard let end = calendar.date(byAdding: .day, value: 1, to: start) else { return nil }
+      return (start: start, end: end)
+    }
+
+    return conversations.filter { conversation in
+      if starredOnly && !conversation.starred { return false }
+      if let folderId, conversation.folderId != folderId { return false }
+      if let dateRange {
+        let conversationDate = conversation.startedAt ?? conversation.createdAt
+        guard conversationDate >= dateRange.start && conversationDate < dateRange.end else {
+          return false
+        }
+      }
+      return true
+    }
+  }
+}
+
 // MARK: - Conversations Page
 
 struct ConversationsPage: View {
   @ObservedObject var appState: AppState
   @Binding var selectedConversation: ServerConversation?
+  var brainDestination: MemoryHubDestination? = nil
+  var onSelectBrainDestination: ((MemoryHubDestination) -> Void)? = nil
   @ObservedObject private var automation = ConversationDetailAutomationState.shared
 
   /// When true, renders without internal ScrollViews (for embedding in an outer ScrollView)
@@ -15,7 +51,7 @@ struct ConversationsPage: View {
   @AppStorage("conversationsCompactView") private var isCompactView = true
 
   // Listening mode — used only to decide whether the manual "Start Recording"
-  // affordance is meaningful (see startRecordingButton gating).
+  // action is meaningful in the page's overflow menu.
   @AppStorage(AssistantSettings.audioRecordingModeDefaultsKey) private var audioRecordingModeRaw =
     AssistantSettings.AudioRecordingMode.onlyMeetings.rawValue
   private var audioRecordingMode: AssistantSettings.AudioRecordingMode {
@@ -52,104 +88,131 @@ struct ConversationsPage: View {
   @State private var isLiveTranscriptExpanded: Bool = false
 
   var body: some View {
-    Group {
-      if let selected = selectedConversation {
-        // Detail view for selected conversation
-        ConversationDetailView(
-          conversation: selected,
-          onBack: { selectedConversation = nil },
-          folders: appState.folders,
-          onMoveToFolder: { conversationId, folderId in
-            await appState.moveConversationToFolder(conversationId, folderId: folderId)
-          },
-          onDelete: {
-            // Cascade is owned by ConversationDetailView; refresh list after dismiss.
+    pageSurface
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .glassContent()
+      .onAppear {
+        // Load conversations when view appears
+        if appState.conversations.isEmpty {
+          Task {
+            await appState.loadConversations()
+          }
+        } else {
+          // Already loaded, notify sidebar to clear loading indicator
+          NotificationCenter.default.post(name: .conversationsPageDidLoad, object: nil)
+        }
+        // Load folders
+        if appState.folders.isEmpty {
+          Task {
+            await appState.loadFolders()
+          }
+        }
+        consumePendingAutomationOpenConversation()
+      }
+      .onReceive(automation.$pendingOpenRequest.compactMap { $0 }) { _ in
+        consumePendingAutomationOpenConversation()
+      }
+      .onReceive(NotificationCenter.default.publisher(for: .desktopAutomationOpenConversationRequested)) {
+        _ in
+        consumePendingAutomationOpenConversation()
+      }
+      .onReceive(
+        NotificationCenter.default.publisher(for: .desktopAutomationSetConversationsSearchRequested)
+      ) { notification in
+        searchQuery = (notification.userInfo?["query"] as? String) ?? ""
+      }
+      // Owner fencing: an in-place account switch posts only .runtimeOwnerDidChange;
+      // this page's local state (active search results, multi-select/merge state,
+      // folder sheets) otherwise keeps rendering the previous account's rows even
+      // after AppState and the repository reset.
+      .onReceive(NotificationCenter.default.publisher(for: .runtimeOwnerDidChange)) { _ in
+        searchQuery = ""
+        searchResults = []
+        isSearching = false
+        searchError = nil
+        showDatePicker = false
+        showCreateFolderSheet = false
+        editingFolder = nil
+        deletingFolder = nil
+        isFilteringStarred = false
+        isFilteringDate = false
+        isMultiSelectMode = false
+        selectedConversationIds = []
+        showMergeConfirmation = false
+        isMerging = false
+        mergeError = nil
+        isLiveTranscriptExpanded = false
+      }
+      .dismissableSheet(isPresented: $showCreateFolderSheet) {
+        FolderFormSheet(folder: nil, onDismiss: { showCreateFolderSheet = false })
+          .environmentObject(appState)
+          .frame(width: 380)
+      }
+      .dismissableSheet(item: $editingFolder) { folder in
+        FolderFormSheet(folder: folder, onDismiss: { editingFolder = nil })
+          .environmentObject(appState)
+          .frame(width: 380)
+      }
+      .dismissableSheet(item: $deletingFolder) { folder in
+        DeleteFolderSheet(folder: folder, onDismiss: { deletingFolder = nil })
+          .environmentObject(appState)
+          .frame(width: 380)
+      }
+  }
+
+  @ViewBuilder
+  private var pageSurface: some View {
+    if let brainDestination, let onSelectBrainDestination {
+      BrainSectionPageLayout(
+        selected: brainDestination,
+        onSelect: onSelectBrainDestination,
+        search: {
+          QuerySearchBar(
+            text: $searchQuery,
+            accessibilityID: "conversations-search-field",
+            placeholder: "Search conversations…"
+          )
+          .onChange(of: searchQuery) { _, newValue in
+            if !newValue.isEmpty { selectedConversation = nil }
+            submitSearch(newValue)
+          }
+        },
+        content: { pageContent }
+      )
+    } else {
+      pageContent
+    }
+  }
+
+  @ViewBuilder
+  private var pageContent: some View {
+    if let selected = selectedConversation {
+      // Detail view for selected conversation
+      ConversationDetailView(
+        conversation: selected,
+        onBack: { selectedConversation = nil },
+        folders: appState.folders,
+        onMoveToFolder: { conversationId, folderId in
+          await appState.moveConversationToFolder(conversationId, folderId: folderId)
+        },
+        onDelete: {
+          // Cascade is owned by ConversationDetailView; refresh list after dismiss.
+          Task {
+            await appState.refreshConversations()
+          }
+        },
+        onTitleUpdated: { _ in
+          // Refresh to get updated data if conversation still exists
+          if appState.conversations.contains(where: { $0.id == selected.id }) {
             Task {
               await appState.refreshConversations()
             }
-          },
-          onTitleUpdated: { _ in
-            // Refresh to get updated data if conversation still exists
-            if appState.conversations.contains(where: { $0.id == selected.id }) {
-              Task {
-                await appState.refreshConversations()
-              }
-            }
-          },
-        )
-      } else {
-        // Main view with recording header and conversation list
-        mainConversationsView
-      }
-    }
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .glassContent()
-    .onAppear {
-      // Load conversations when view appears
-      if appState.conversations.isEmpty {
-        Task {
-          await appState.loadConversations()
+          }
         }
-      } else {
-        // Already loaded, notify sidebar to clear loading indicator
-        NotificationCenter.default.post(name: .conversationsPageDidLoad, object: nil)
-      }
-      // Load folders
-      if appState.folders.isEmpty {
-        Task {
-          await appState.loadFolders()
-        }
-      }
-      consumePendingAutomationOpenConversation()
-    }
-    .onReceive(automation.$pendingOpenRequest.compactMap { $0 }) { _ in
-      consumePendingAutomationOpenConversation()
-    }
-    .onReceive(NotificationCenter.default.publisher(for: .desktopAutomationOpenConversationRequested)) {
-      _ in
-      consumePendingAutomationOpenConversation()
-    }
-    .onReceive(
-      NotificationCenter.default.publisher(for: .desktopAutomationSetConversationsSearchRequested)
-    ) { notification in
-      searchQuery = (notification.userInfo?["query"] as? String) ?? ""
-    }
-    // Owner fencing: an in-place account switch posts only .runtimeOwnerDidChange;
-    // this page's local state (active search results, multi-select/merge state,
-    // folder sheets) otherwise keeps rendering the previous account's rows even
-    // after AppState and the repository reset.
-    .onReceive(NotificationCenter.default.publisher(for: .runtimeOwnerDidChange)) { _ in
-      searchQuery = ""
-      searchResults = []
-      isSearching = false
-      searchError = nil
-      showDatePicker = false
-      showCreateFolderSheet = false
-      editingFolder = nil
-      deletingFolder = nil
-      isFilteringStarred = false
-      isFilteringDate = false
-      isMultiSelectMode = false
-      selectedConversationIds = []
-      showMergeConfirmation = false
-      isMerging = false
-      mergeError = nil
-      isLiveTranscriptExpanded = false
-    }
-    .dismissableSheet(isPresented: $showCreateFolderSheet) {
-      FolderFormSheet(folder: nil, onDismiss: { showCreateFolderSheet = false })
-        .environmentObject(appState)
-        .frame(width: 380)
-    }
-    .dismissableSheet(item: $editingFolder) { folder in
-      FolderFormSheet(folder: folder, onDismiss: { editingFolder = nil })
-        .environmentObject(appState)
-        .frame(width: 380)
-    }
-    .dismissableSheet(item: $deletingFolder) { folder in
-      DeleteFolderSheet(folder: folder, onDismiss: { deletingFolder = nil })
-        .environmentObject(appState)
-        .frame(width: 380)
+      )
+    } else {
+      // Main view with recording header and conversation list
+      mainConversationsView
     }
   }
 
@@ -210,42 +273,18 @@ struct ConversationsPage: View {
     }
   }
 
-  /// The Conversations list chrome: pinned title row, then the scrolling live card + list.
+  /// Compact workspace chrome followed by the scrolling live card + list.
+  ///
+  /// Brain navigation already names this destination, so repeating a large
+  /// Conversations title and subtitle only pushes the first useful row down.
+  /// Keep the page's refinements and actions pinned in one Activity-density
+  /// command row instead.
   private var conversationsListLayout: some View {
     VStack(spacing: 0) {
-      // Fixed page header — title + actions stay pinned; everything below it
-      // (live transcript, search, filters, list) scrolls together as one.
-      HStack {
-        VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-          Text("Conversations")
-            .inkStyle(InkType.firstTitle, color: Ink.primary)
-          Text("Recordings, notes, and transcripts from your day")
-            .inkStyle(InkType.statusLabel, color: Ink.secondary)
-        }
+      conversationQueryToolbar
+        .pagePanelFirstRowInsets()
 
-        Spacer()
-
-        if !appState.conversations.isEmpty {
-          selectModeButton
-        }
-
-        quickNoteButton
-
-        // Only offer the manual "Start Recording" affordance when listening is
-        // set to Always. In Meetings-only (the default) or Off, showing it while
-        // nothing is transcribing misleads the user into thinking capture is
-        // active — during an actual meeting isTranscribing is already true and
-        // the live transcript replaces this button.
-        if !appState.isTranscribing && audioRecordingMode == .always {
-          startRecordingButton
-        }
-      }
-      .padding(.horizontal, OmiSpacing.xxl)
-      .padding(.top, OmiSpacing.lg)
-      .padding(.bottom, OmiSpacing.md)
-      .background(Color.clear)
-
-      // The whole page below the header scrolls together. Floating action bars
+      // The whole page below the command row scrolls together. Floating action bars
       // (load-more, merge) stay pinned to the bottom via the ZStack overlay.
       ZStack(alignment: .bottom) {
         scrollingBody
@@ -331,7 +370,19 @@ struct ConversationsPage: View {
   /// IDs of the conversations currently shown to the user — search results while
   /// a search is active, otherwise the full list. Used to scope "Select All".
   private var displayedConversationIds: [String] {
-    searchQuery.isEmpty ? appState.conversations.map { $0.id } : searchResults.map { $0.id }
+    searchQuery.isEmpty ? appState.conversations.map { $0.id } : visibleSearchResults.map { $0.id }
+  }
+
+  /// Search is text-only at the API boundary. Apply the same local refinements
+  /// to the returned rows so search and list queries have identical AND
+  /// semantics without inventing a second backend endpoint.
+  private var visibleSearchResults: [ServerConversation] {
+    ConversationSearchResultFilter.apply(
+      searchResults,
+      starredOnly: appState.showStarredOnly,
+      date: appState.selectedDateFilter,
+      folderId: appState.selectedFolderId
+    )
   }
 
   /// Entry point for the multi-select / merge feature. Without this the whole
@@ -363,56 +414,22 @@ struct ConversationsPage: View {
     .accessibilityIdentifier("conversations-select-toggle")
   }
 
-  private var quickNoteButton: some View {
-    Button {
-      NotificationCenter.default.post(name: .navigateToRewindNotes, object: nil)
-    } label: {
-      HStack(spacing: OmiSpacing.xs) {
-        Image(systemName: "note.text")
-          .scaledFont(size: OmiType.caption)
-        Text("Quick Note")
-          .scaledFont(size: OmiType.body, weight: .medium)
-      }
-      .foregroundColor(Ink.secondary)
-      .padding(.horizontal, OmiSpacing.md)
-      .padding(.vertical, OmiSpacing.sm)
-      .glassChip()
-    }
-    .buttonStyle(.plain)
-  }
-
   // MARK: - Conversation List Section
 
   private var conversationListSection: some View {
     VStack(spacing: 0) {
-      // Section header with search bar and filters
-      HStack(spacing: OmiSpacing.sm) {
+      // Search stays in the shared top search surface on Brain pages. The
+      // local search is retained for the standalone conversations surface.
+      if brainDestination == nil {
         OmiSearchField(
           placeholder: "Search conversations",
           text: $searchQuery,
           isLoading: isSearching
         )
-        .onChange(of: searchQuery) { _, newValue in
-          searchCoordinator.submit(newValue) { query in
-            performSearch(query: query)
-          }
-        }
-
-        // Filter buttons
-        filterButtonsRow
+        .onChange(of: searchQuery) { _, newValue in submitSearch(newValue) }
+        .padding(.horizontal, QueryShellLayout.panelPaddingHorizontal)
+        .padding(.bottom, OmiSpacing.sm)
       }
-      .padding(.horizontal, OmiSpacing.xxl)
-      .padding(.vertical, OmiSpacing.md)
-
-      // Folder tabs strip
-      FolderTabsStrip(
-        appState: appState,
-        onCreateFolder: { showCreateFolderSheet = true },
-        onEditFolder: { folder in editingFolder = folder },
-        onDeleteFolder: { folder in deletingFolder = folder }
-      )
-      .padding(.horizontal, OmiSpacing.xxl)
-      .padding(.bottom, OmiSpacing.md)
 
       // List - show search results or regular conversations. Both render
       // embedded (no inner ScrollView); the page's outer ScrollView (see
@@ -422,37 +439,45 @@ struct ConversationsPage: View {
         // Search results view
         searchResultsView
       } else {
-        // Regular conversation list
-        ConversationListView(
-          conversations: appState.conversations,
-          isLoading: appState.isLoadingConversations,
-          error: appState.conversationsError,
-          folders: appState.folders,
-          isCompactView: isCompactView,
-          onSelect: { conversation in
-            AnalyticsManager.shared.memoryListItemClicked(conversationId: conversation.id)
-            selectedConversation = conversation
-          },
-          onRefresh: {
-            Task {
-              await appState.refreshConversations()
-            }
-          },
-          onMoveToFolder: { conversationId, folderId in
-            await appState.moveConversationToFolder(conversationId, folderId: folderId)
-          },
-          isMultiSelectMode: isMultiSelectMode,
-          selectedIds: selectedConversationIds,
-          onToggleSelection: { conversationId in
-            if selectedConversationIds.contains(conversationId) {
-              selectedConversationIds.remove(conversationId)
-            } else {
-              selectedConversationIds.insert(conversationId)
-            }
-          },
-          embedded: true,
-          appState: appState
-        )
+        // A successful filtered request with no rows is different from an
+        // account with no conversations. Keep the recovery action beside the
+        // state that caused the empty result instead of suggesting recording.
+        if appState.hasActiveConversationFilters && !appState.isLoadingConversations
+          && appState.conversationsError == nil && appState.conversations.isEmpty
+        {
+          filteredConversationsEmptyView
+        } else {
+          ConversationListView(
+            conversations: appState.conversations,
+            isLoading: appState.isLoadingConversations,
+            error: appState.conversationsError,
+            folders: appState.folders,
+            isCompactView: isCompactView,
+            onSelect: { conversation in
+              AnalyticsManager.shared.memoryListItemClicked(conversationId: conversation.id)
+              selectedConversation = conversation
+            },
+            onRefresh: {
+              Task {
+                await appState.refreshConversations()
+              }
+            },
+            onMoveToFolder: { conversationId, folderId in
+              await appState.moveConversationToFolder(conversationId, folderId: folderId)
+            },
+            isMultiSelectMode: isMultiSelectMode,
+            selectedIds: selectedConversationIds,
+            onToggleSelection: { conversationId in
+              if selectedConversationIds.contains(conversationId) {
+                selectedConversationIds.remove(conversationId)
+              } else {
+                selectedConversationIds.insert(conversationId)
+              }
+            },
+            embedded: true,
+            appState: appState
+          )
+        }
       }
     }
   }
@@ -481,17 +506,22 @@ struct ConversationsPage: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding()
-      } else if searchResults.isEmpty {
+      } else if visibleSearchResults.isEmpty {
         VStack(spacing: OmiSpacing.md) {
           Image(systemName: "magnifyingglass")
             .scaledFont(size: 32)
             .foregroundColor(Ink.secondary)
-          Text("No conversations found")
-            .scaledFont(size: OmiType.body)
+          Text("No search results")
+            .scaledFont(size: OmiType.heading, weight: .semibold)
             .foregroundColor(Ink.secondary)
-          Text("Try a different search term")
-            .scaledFont(size: OmiType.caption)
-            .foregroundColor(Ink.secondary)
+          Text(
+            appState.hasActiveConversationFilters
+              ? "Nothing matches \(quotedSearchQuery) with your active filters."
+              : "Nothing matches \(quotedSearchQuery). Try a different term."
+          )
+          .scaledFont(size: OmiType.body)
+          .foregroundColor(Ink.secondary)
+          .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
       } else {
@@ -505,7 +535,7 @@ struct ConversationsPage: View {
   @ViewBuilder
   private var searchResultsContent: some View {
     LazyVStack(spacing: OmiSpacing.sm) {
-      ForEach(searchResults) { conversation in
+      ForEach(visibleSearchResults) { conversation in
         ConversationRowView(
           conversation: conversation,
           onTap: {
@@ -535,6 +565,12 @@ struct ConversationsPage: View {
   }
 
   // MARK: - Search
+
+  private func submitSearch(_ query: String) {
+    searchCoordinator.submit(query) { submittedQuery in
+      performSearch(query: submittedQuery)
+    }
+  }
 
   private func performSearch(query: String) {
     guard !query.isEmpty else {
@@ -567,98 +603,231 @@ struct ConversationsPage: View {
     }
   }
 
-  // MARK: - Filter Buttons
+  // MARK: - Query Toolbar
 
-  private var filterButtonsRow: some View {
-    HStack(spacing: OmiSpacing.sm) {
-      // Starred filter button
-      Button(action: {
-        Task {
-          isFilteringStarred = true
-          await appState.toggleStarredFilter()
-          isFilteringStarred = false
+  /// The toolbar makes collection scope and refinements explicit. A folder is
+  /// a single Collection dimension; Starred is only a refinement, so it cannot
+  /// appear as a second, competing tab.
+  private var conversationQueryToolbar: some View {
+    PageQueryToolbar(
+      refinement: {
+        conversationFiltersMenu
+      },
+      activeFilters: {
+        ActivePageFilterStrip(
+          filters: activeConversationFilters,
+          onClearAll: { Task { await appState.clearFilters() } }
+        )
+      },
+      actions: {
+        if isMultiSelectMode {
+          selectModeButton
+        } else if !appState.conversations.isEmpty
+          || (!appState.isTranscribing && audioRecordingMode == .always)
+        {
+          conversationMoreMenu
         }
-      }) {
-        HStack(spacing: OmiSpacing.xs) {
-          if isFilteringStarred {
-            ProgressView()
-              .scaleEffect(0.5)
-              .frame(width: 12, height: 12)
-          } else {
-            Image(systemName: appState.showStarredOnly ? "star.fill" : "star")
-              .scaledFont(size: OmiType.caption)
-          }
-          Text("Starred")
-            .scaledFont(size: OmiType.caption, weight: .medium)
-        }
-        .foregroundColor(appState.showStarredOnly ? PageGlass.starred : Ink.secondary)
-        .padding(.horizontal, OmiSpacing.md)
-        .padding(.vertical, OmiSpacing.sm)
-        .glassChip(isActive: appState.showStarredOnly)
       }
-      .buttonStyle(.plain)
-      .disabled(isFilteringStarred)
+    )
+  }
 
-      // Date filter button
-      Button(action: {
-        showDatePicker.toggle()
-      }) {
-        HStack(spacing: OmiSpacing.xs) {
-          if isFilteringDate {
-            ProgressView()
-              .scaleEffect(0.5)
-              .frame(width: 12, height: 12)
-          } else {
-            Image(systemName: "calendar")
-              .scaledFont(size: OmiType.caption)
-          }
-          if let date = appState.selectedDateFilter {
-            Text(formatFilterDate(date))
-              .scaledFont(size: OmiType.caption, weight: .medium)
-            // Clear button
-            Button(action: {
-              Task {
-                isFilteringDate = true
-                await appState.setDateFilter(nil)
-                isFilteringDate = false
-              }
-            }) {
-              Image(systemName: "xmark.circle.fill")
-                .scaledFont(size: OmiType.micro)
+  private var conversationFiltersMenu: some View {
+    Menu {
+      Section("Collection") {
+        Button {
+          Task { await appState.setFolderFilter(nil) }
+        } label: {
+          HStack {
+            Label("All collections", systemImage: "tray.2")
+            Spacer()
+            if appState.selectedFolderId == nil {
+              Image(systemName: "checkmark")
             }
-            .buttonStyle(.plain)
-          } else {
-            Text("Date")
-              .scaledFont(size: OmiType.caption, weight: .medium)
           }
         }
-        .foregroundColor(appState.selectedDateFilter != nil ? Ink.primary : Ink.secondary)
-        .padding(.horizontal, OmiSpacing.md)
-        .padding(.vertical, OmiSpacing.sm)
-        .glassChip(isActive: appState.selectedDateFilter != nil)
-      }
-      .buttonStyle(.plain)
-      .disabled(isFilteringDate)
-      .popover(isPresented: $showDatePicker) {
-        datePickerPopover
+
+        ForEach(appState.folders) { folder in
+          Button {
+            Task {
+              await appState.setFolderFilter(
+                appState.selectedFolderId == folder.id ? nil : folder.id
+              )
+            }
+          } label: {
+            HStack {
+              Text(folder.name)
+              Spacer()
+              if appState.selectedFolderId == folder.id {
+                Image(systemName: "checkmark")
+              }
+            }
+          }
+        }
       }
 
-      // Clear all filters button (only show if any filter is active)
-      if appState.showStarredOnly || appState.selectedDateFilter != nil
-        || appState.selectedFolderId != nil
-      {
-        Button(action: {
+      Section("Refine") {
+        Button {
           Task {
-            await appState.clearFilters()
+            isFilteringStarred = true
+            await appState.toggleStarredFilter()
+            isFilteringStarred = false
           }
-        }) {
-          Image(systemName: "xmark.circle.fill")
-            .scaledFont(size: OmiType.caption)
-            .foregroundColor(Ink.secondary)
+        } label: {
+          Label(
+            appState.showStarredOnly ? "Remove Starred filter" : "Starred",
+            systemImage: appState.showStarredOnly ? "star.fill" : "star")
         }
-        .buttonStyle(.plain)
+        .disabled(isFilteringStarred)
+
+        Button {
+          showDatePicker = true
+        } label: {
+          Label(appState.selectedDateFilter == nil ? "Date…" : "Change date…", systemImage: "calendar")
+        }
       }
+
+      Section("Collections") {
+        Button {
+          showCreateFolderSheet = true
+        } label: {
+          Label("New collection…", systemImage: "plus")
+        }
+
+        if !appState.folders.isEmpty {
+          Menu("Manage collections") {
+            ForEach(appState.folders) { folder in
+              Menu(folder.name) {
+                Button("Edit…") { editingFolder = folder }
+                Button("Delete…", role: .destructive) { deletingFolder = folder }
+              }
+            }
+          }
+        }
+      }
+    } label: {
+      PageQueryControlLabel(
+        icon: "line.3.horizontal.decrease",
+        dimension: "Filter",
+        value: activeConversationFilterCount == 0
+          ? "None" : "\(activeConversationFilterCount)",
+        isActive: activeConversationFilterCount > 0
+      )
     }
+    .menuStyle(.button)
+    .buttonStyle(.plain)
+    .popover(isPresented: $showDatePicker) {
+      datePickerPopover
+    }
+    .help("Filter conversations by collection, starred status, or date")
+    .accessibilityIdentifier("conversations-filter-menu")
+  }
+
+  private var conversationMoreMenu: some View {
+    Menu {
+      if !appState.conversations.isEmpty {
+        Button {
+          OmiMotion.withGated(.easeInOut(duration: 0.2)) {
+            isMultiSelectMode = true
+          }
+        } label: {
+          Label("Select conversations…", systemImage: "checkmark.circle")
+        }
+      }
+
+      if !appState.isTranscribing && audioRecordingMode == .always {
+        Button {
+          appState.startTranscription()
+        } label: {
+          Label("Start recording", systemImage: "mic.fill")
+        }
+      }
+    } label: {
+      PageQueryActionLabel(icon: "ellipsis", title: "More")
+    }
+    .menuStyle(.borderlessButton)
+    .menuIndicator(.hidden)
+    .fixedSize()
+    .help("More conversation actions")
+    .accessibilityLabel("More conversation actions")
+    .accessibilityIdentifier("conversations-more-actions")
+  }
+
+  private var activeConversationFilters: [PageActiveFilter] {
+    var filters: [PageActiveFilter] = []
+
+    if appState.showStarredOnly {
+      filters.append(
+        PageActiveFilter(id: "starred", title: "Starred") {
+          Task { await appState.toggleStarredFilter() }
+        })
+    }
+
+    if let date = appState.selectedDateFilter {
+      filters.append(
+        PageActiveFilter(id: "date", title: formatFilterDate(date)) {
+          Task { await appState.setDateFilter(nil) }
+        })
+    }
+
+    if appState.selectedFolderId != nil {
+      filters.append(
+        PageActiveFilter(id: "collection", title: selectedCollectionName) {
+          Task { await appState.setFolderFilter(nil) }
+        })
+    }
+
+    return filters
+  }
+
+  private var activeConversationFilterCount: Int {
+    (appState.showStarredOnly ? 1 : 0)
+      + (appState.selectedDateFilter == nil ? 0 : 1)
+      + (appState.selectedFolderId == nil ? 0 : 1)
+  }
+
+  private var selectedCollectionName: String {
+    guard let selectedFolderId = appState.selectedFolderId else { return "All" }
+    return appState.folders.first(where: { $0.id == selectedFolderId })?.name ?? "Selected"
+  }
+
+  private var filteredConversationsEmptyView: some View {
+    VStack(spacing: OmiSpacing.md) {
+      Image(systemName: "line.3.horizontal.decrease.circle")
+        .scaledFont(size: 42)
+        .foregroundColor(Ink.secondary)
+
+      Text("No matching conversations")
+        .scaledFont(size: OmiType.heading, weight: .semibold)
+        .foregroundColor(Ink.primary)
+
+      Text("Nothing matches \(activeConversationFilterDescription).")
+        .scaledFont(size: OmiType.body)
+        .foregroundColor(Ink.secondary)
+        .multilineTextAlignment(.center)
+
+      Button {
+        Task { await appState.clearFilters() }
+      } label: {
+        PageQueryActionLabel(icon: "xmark.circle", title: "Clear filters", isPrimary: true)
+      }
+      .buttonStyle(.plain)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .padding(OmiSpacing.section)
+    .accessibilityIdentifier("conversations-filtered-empty")
+  }
+
+  private var activeConversationFilterDescription: String {
+    var filters: [String] = []
+    if appState.showStarredOnly { filters.append("Starred") }
+    if let date = appState.selectedDateFilter { filters.append("Date: \(formatFilterDate(date))") }
+    if appState.selectedFolderId != nil { filters.append("Collection: \(selectedCollectionName)") }
+    return filters.joined(separator: " and ")
+  }
+
+  private var quotedSearchQuery: String {
+    let query = DebouncedSearchCoordinator.normalized(searchQuery)
+    return "\u{201c}\(query)\u{201d}"
   }
 
   private var datePickerPopover: some View {
@@ -820,26 +989,6 @@ struct ConversationsPage: View {
     }
 
     isMerging = false
-  }
-
-  // MARK: - Buttons
-
-  private var startRecordingButton: some View {
-    Button(action: {
-      appState.startTranscription()
-    }) {
-      HStack(spacing: OmiSpacing.xs) {
-        Image(systemName: "mic.fill")
-          .scaledFont(size: OmiType.caption)
-        Text("Start Recording")
-          .scaledFont(size: OmiType.body, weight: .medium)
-      }
-      .foregroundColor(Ink.surface)
-      .padding(.horizontal, OmiSpacing.md)
-      .padding(.vertical, OmiSpacing.sm)
-      .background(Capsule(style: .continuous).fill(Ink.primary))
-    }
-    .buttonStyle(.plain)
   }
 
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -282,7 +282,7 @@ struct ConversationsPage: View {
   private var conversationsListLayout: some View {
     VStack(spacing: 0) {
       conversationQueryToolbar
-        .pagePanelFirstRowInsets()
+        .pagePanelToolbarInsets(isBelowNavigation: brainDestination != nil)
 
       // The whole page below the command row scrolls together. Floating action bars
       // (load-more, merge) stay pinned to the bottom via the ZStack overlay.
@@ -560,7 +560,8 @@ struct ConversationsPage: View {
         )
       }
     }
-    .padding(.horizontal, OmiSpacing.lg)
+    .padding(.horizontal, PagePanelVerticalRhythm.horizontalPadding)
+    .padding(.top, PagePanelVerticalRhythm.contentGap)
     .padding(.bottom, isMultiSelectMode && !selectedConversationIds.isEmpty ? 80 : OmiSpacing.lg)
   }
 
@@ -707,10 +708,11 @@ struct ConversationsPage: View {
     } label: {
       PageQueryControlLabel(
         icon: "line.3.horizontal.decrease",
-        dimension: "Filter",
+        dimension: activeConversationFilterCount == 0 ? nil : "Filter",
         value: activeConversationFilterCount == 0
-          ? "None" : "\(activeConversationFilterCount)",
-        isActive: activeConversationFilterCount > 0
+          ? "Filter" : "\(activeConversationFilterCount)",
+        isActive: activeConversationFilterCount > 0,
+        dimensionSeparator: " ·"
       )
     }
     .menuStyle(.button)
@@ -813,7 +815,9 @@ struct ConversationsPage: View {
       .buttonStyle(.plain)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .padding(OmiSpacing.section)
+    .padding(.horizontal, OmiSpacing.section)
+    .padding(.top, PagePanelVerticalRhythm.contentGap)
+    .padding(.bottom, PagePanelVerticalRhythm.contentBottomPadding)
     .accessibilityIdentifier("conversations-filtered-empty")
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -2102,7 +2102,7 @@ struct MemoriesPage: View {
     VStack(alignment: .leading, spacing: OmiSpacing.xs) {
       if brainDestination != nil {
         memoriesQueryToolbar
-          .pagePanelFirstRowInsets()
+          .pagePanelSubsequentRowInsets()
       } else {
         // A pill row and a text field cannot share one line in a narrow column.
         // The pills hold their intrinsic width so their own labels stay readable,
@@ -2234,9 +2234,10 @@ struct MemoriesPage: View {
     } label: {
       PageQueryControlLabel(
         icon: "line.3.horizontal.decrease",
-        dimension: "Filter",
-        value: memoryActiveFilterCount == 0 ? "None" : "\(memoryActiveFilterCount)",
-        isActive: memoryActiveFilterCount > 0)
+        dimension: memoryActiveFilterCount == 0 ? nil : "Filter",
+        value: memoryActiveFilterCount == 0 ? "Filter" : "\(memoryActiveFilterCount)",
+        isActive: memoryActiveFilterCount > 0,
+        dimensionSeparator: " ·")
     }
     .menuStyle(.button)
     .buttonStyle(.plain)
@@ -2682,8 +2683,9 @@ struct MemoriesPage: View {
           }
         }
       }
-      .padding(.horizontal, OmiSpacing.xxl)
-      .padding(.bottom, OmiSpacing.xxl)
+      .padding(.horizontal, PagePanelVerticalRhythm.horizontalPadding)
+      .padding(.top, PagePanelVerticalRhythm.contentGap)
+      .padding(.bottom, PagePanelVerticalRhythm.contentBottomPadding)
     }
     .glassScrollFade()
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -1894,30 +1894,55 @@ class MemoriesViewModel: ObservableObject {
 
 struct MemoriesPage: View {
   @ObservedObject var viewModel: MemoriesViewModel
+  var brainDestination: MemoryHubDestination? = nil
+  var onSelectBrainDestination: ((MemoryHubDestination) -> Void)? = nil
   @State private var showCategoryFilter = false
   @State private var categorySearchText = ""
   @State private var pendingSelectedTags: Set<MemoryTag> = []
   @State private var showManagementMenu = false
 
   var body: some View {
-    Group {
-      if let conversation = viewModel.linkedConversation {
-        // Show conversation detail view
-        ConversationDetailView(
-          conversation: conversation,
-          onBack: { viewModel.dismissConversation() }
-        )
-      } else {
-        // Main memories view
-        mainMemoriesView
-      }
+    pageSurface
+      .glassContent()
+  }
+
+  @ViewBuilder
+  private var pageSurface: some View {
+    if let brainDestination, let onSelectBrainDestination {
+      BrainSectionPageLayout(
+        selected: brainDestination,
+        onSelect: onSelectBrainDestination,
+        search: {
+          QuerySearchBar(
+            text: $viewModel.searchText,
+            accessibilityID: "memories-search-field",
+            placeholder: "Search memories…"
+          )
+        },
+        content: { pageContent }
+      )
+    } else {
+      pageContent
     }
-    .glassContent()
+  }
+
+  @ViewBuilder
+  private var pageContent: some View {
+    if let conversation = viewModel.linkedConversation {
+      // Show conversation detail view
+      ConversationDetailView(
+        conversation: conversation,
+        onBack: { viewModel.dismissConversation() }
+      )
+    } else {
+      // Main memories view
+      mainMemoriesView
+    }
   }
 
   private var memoriesColumn: some View {
     VStack(spacing: 0) {
-      // Header (includes search, filters, and action buttons)
+      // Compact query/actions row. Brain navigation already identifies the page.
       header
 
       // Content
@@ -1925,6 +1950,8 @@ struct MemoriesPage: View {
         loadingView
       } else if let error = viewModel.errorMessage {
         errorView(error)
+      } else if hasActiveMemoryQueryScope && viewModel.filteredMemories.isEmpty {
+        noResultsView
       } else if viewModel.memories.isEmpty {
         emptyState
       } else if viewModel.filteredMemories.isEmpty {
@@ -2072,42 +2099,31 @@ struct MemoriesPage: View {
 
   // MARK: - Header
   private var header: some View {
-    VStack(alignment: .leading, spacing: OmiSpacing.md) {
-      HStack(alignment: .firstTextBaseline) {
-        VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-          Text("Memories")
-            .scaledFont(size: OmiType.heading, weight: .semibold)
-            .foregroundStyle(Ink.primary)
-          Text("What Omi has learned and saved for you")
-            .scaledFont(size: OmiType.caption)
-            .foregroundStyle(Ink.secondary)
-        }
-        Spacer()
-      }
-
-      // A pill row and a text field cannot share one line in a narrow column.
-      // The pills hold their intrinsic width so their own labels stay readable,
-      // which used to leave the search field squeezed to "Sea" whenever the
-      // detail panel was open. Below the width where both fit, the search field
-      // takes its own line instead of being the thing that loses.
-      ViewThatFits(in: .horizontal) {
-        HStack(spacing: OmiSpacing.sm) {
-          searchField.frame(minWidth: 200)
-          filterControls
-        }
-
-        VStack(alignment: .leading, spacing: OmiSpacing.sm) {
-          searchField
+    VStack(alignment: .leading, spacing: OmiSpacing.xs) {
+      if brainDestination != nil {
+        memoriesQueryToolbar
+          .pagePanelFirstRowInsets()
+      } else {
+        // A pill row and a text field cannot share one line in a narrow column.
+        // The pills hold their intrinsic width so their own labels stay readable,
+        // which used to leave the search field squeezed to "Sea" whenever the
+        // detail panel was open. Below the width where both fit, the search field
+        // takes its own line instead of being the thing that loses.
+        ViewThatFits(in: .horizontal) {
           HStack(spacing: OmiSpacing.sm) {
-            filterControls
-            Spacer(minLength: 0)
+            searchField.frame(minWidth: 200)
+            memoriesQueryToolbar
+          }
+
+          VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+            searchField
+            memoriesQueryToolbar
           }
         }
+        .padding(.horizontal, QueryShellLayout.panelPaddingHorizontal)
+        .padding(.vertical, OmiSpacing.xs)
       }
     }
-    .padding(.horizontal, OmiSpacing.xxl)
-    .padding(.top, OmiSpacing.lg)
-    .padding(.bottom, OmiSpacing.md)
     .alert("Delete Default Memories?", isPresented: $viewModel.showingDeleteAllConfirmation) {
       Button("Cancel", role: .cancel) {}
       Button("Delete Default Memories", role: .destructive) {
@@ -2130,137 +2146,163 @@ struct MemoriesPage: View {
     )
   }
 
+  private var memoriesQueryToolbar: some View {
+    PageQueryToolbar(
+      refinement: {
+        filterControls
+      },
+      activeFilters: {
+        ActivePageFilterStrip(filters: activeMemoryFilters, onClearAll: clearMemoryFilters)
+      },
+      actions: {
+        HStack(spacing: OmiSpacing.sm) {
+          Button {
+            viewModel.showingAddMemory = true
+          } label: {
+            PageQueryActionLabel(icon: "plus", title: "Add Memory", isPrimary: true)
+          }
+          .buttonStyle(.plain)
+          .help("Add a memory")
+          .accessibilityIdentifier("memories-add-memory")
+
+          Button {
+            showManagementMenu = true
+          } label: {
+            PageQueryActionLabel(icon: "ellipsis", title: "More")
+          }
+          .buttonStyle(.plain)
+          .popover(isPresented: $showManagementMenu, arrowEdge: .bottom) {
+            managementMenuPopover
+          }
+          .help("More memory actions")
+          .accessibilityIdentifier("memories-more-actions")
+        }
+      }
+    )
+  }
+
   @ViewBuilder
   private var filterControls: some View {
-    if viewModel.canonicalLifecycleExposed {
-      // Layer filter dropdown. Default is product default access: Short-term + Long-term.
-      Menu {
-        ForEach(MemoryLayerFilter.allCases) { filter in
-          Button {
-            viewModel.selectedLayerFilter = filter
-          } label: {
-            HStack {
-              Text(filter.displayName)
-              if viewModel.selectedLayerFilter == filter {
-                Image(systemName: "checkmark")
+    Menu {
+      if viewModel.canonicalLifecycleExposed {
+        Section("Lifecycle") {
+          ForEach(MemoryLayerFilter.allCases) { filter in
+            Button {
+              viewModel.selectedLayerFilter = filter
+            } label: {
+              HStack {
+                Text(filter.displayName)
+                if viewModel.selectedLayerFilter == filter {
+                  Image(systemName: "checkmark")
+                }
               }
             }
+            .help(filter.description)
           }
-          .help(filter.description)
         }
-      } label: {
-        HStack(spacing: OmiSpacing.xs) {
-          Image(
-            systemName: viewModel.selectedLayerFilter == .archive
-              ? "archivebox" : "clock.badge.checkmark"
-          )
-          .scaledFont(size: OmiType.caption)
-          // Pills keep their intrinsic width so the search field absorbs
-          // the squeeze. Without this the detail panel narrows the column
-          // and "Default" wraps to "Defa / ult" inside its own pill.
-          Text(viewModel.selectedLayerFilter.displayName)
-            .scaledFont(
-              size: OmiType.body,
-              weight: viewModel.selectedLayerFilter == .defaultAccess ? .regular : .medium
-            )
-            .lineLimit(1)
-            .fixedSize(horizontal: true, vertical: false)
-          Image(systemName: "chevron.down")
-            .scaledFont(size: OmiType.micro)
+      }
+
+      Section("Source") {
+        Button {
+          viewModel.filterThisDeviceOnly.toggle()
+        } label: {
+          Label(
+            viewModel.filterThisDeviceOnly ? "All devices" : "This device",
+            systemImage: "desktopcomputer")
         }
-        .foregroundColor(
-          viewModel.selectedLayerFilter == .defaultAccess
-            ? Ink.secondary : Ink.primary
-        )
-        .padding(.horizontal, OmiSpacing.md)
-        .frame(minHeight: 44)
-        .glassChip(isActive: viewModel.selectedLayerFilter != .defaultAccess)
       }
-      .menuStyle(.button)
-      .buttonStyle(.plain)
-      .help("Default shows Short-term + Long-term. Archive is explicit.")
-    }
 
-    Button {
-      viewModel.filterThisDeviceOnly.toggle()
-    } label: {
-      HStack(spacing: OmiSpacing.xs) {
-        Image(systemName: "desktopcomputer")
-          .scaledFont(size: OmiType.caption)
-        Text("This device")
-          .scaledFont(
-            size: OmiType.body, weight: viewModel.filterThisDeviceOnly ? .medium : .regular
-          )
-          .lineLimit(1)
-          .fixedSize(horizontal: true, vertical: false)
+      Section("Type") {
+        Button {
+          pendingSelectedTags = viewModel.selectedTags
+          categorySearchText = ""
+          // Let the menu dismiss before presenting its anchored popover.
+          DispatchQueue.main.async {
+            showCategoryFilter = true
+          }
+        } label: {
+          Label(
+            viewModel.selectedTags.isEmpty ? "Choose types…" : "Change types…",
+            systemImage: "tag")
+        }
       }
-      .foregroundColor(
-        viewModel.filterThisDeviceOnly ? Ink.primary : Ink.secondary
-      )
-      .padding(.horizontal, OmiSpacing.md)
-      .frame(minHeight: 44)
-      .glassChip(isActive: viewModel.filterThisDeviceOnly)
-    }
-    .buttonStyle(.plain)
-    .help("Show memories captured on this Mac")
 
-    // Category filter dropdown
-    Button {
-      pendingSelectedTags = viewModel.selectedTags
-      categorySearchText = ""
-      showCategoryFilter = true
-    } label: {
-      HStack(spacing: OmiSpacing.xs) {
-        Image(systemName: "line.3.horizontal.decrease")
-          .scaledFont(size: OmiType.caption)
-        Text(categoryFilterLabel)
-          .scaledFont(
-            size: OmiType.body, weight: viewModel.selectedTags.isEmpty ? .regular : .medium
-          )
-          .lineLimit(1)
-          .fixedSize(horizontal: true, vertical: false)
-        Image(systemName: "chevron.down")
-          .scaledFont(size: OmiType.micro)
+      if memoryActiveFilterCount > 0 {
+        Divider()
+        Button("Clear all filters", action: clearMemoryFilters)
       }
-      .foregroundColor(
-        viewModel.selectedTags.isEmpty ? Ink.secondary : Ink.primary
-      )
-      .padding(.horizontal, OmiSpacing.md)
-      .frame(minHeight: 44)
-      .glassChip(isActive: !viewModel.selectedTags.isEmpty)
+    } label: {
+      PageQueryControlLabel(
+        icon: "line.3.horizontal.decrease",
+        dimension: "Filter",
+        value: memoryActiveFilterCount == 0 ? "None" : "\(memoryActiveFilterCount)",
+        isActive: memoryActiveFilterCount > 0)
     }
+    .menuStyle(.button)
     .buttonStyle(.plain)
     .popover(isPresented: $showCategoryFilter, arrowEdge: .bottom) {
       categoryFilterPopover
     }
+    .help("Filter memories by lifecycle, source, or type")
+    .accessibilityIdentifier("memories-filter-menu")
+  }
 
-    // Add Memory button (icon only)
-    Button {
-      viewModel.showingAddMemory = true
-    } label: {
-      Image(systemName: "plus")
-        .scaledFont(size: OmiType.body)
-        .foregroundColor(Ink.surface)
-        .frame(width: 44, height: 44)
-        .background(Capsule(style: .continuous).fill(Ink.primary))
-    }
-    .buttonStyle(.plain)
-    .help("Add Memory")
+  private var memoryActiveFilterCount: Int {
+    let lifecycle =
+      viewModel.canonicalLifecycleExposed && viewModel.selectedLayerFilter != .defaultAccess ? 1 : 0
+    return lifecycle + (viewModel.filterThisDeviceOnly ? 1 : 0) + viewModel.selectedTags.count
+  }
 
-    // Management menu
-    Button {
-      showManagementMenu = true
-    } label: {
-      Image(systemName: "ellipsis")
-        .scaledFont(size: OmiType.caption, weight: .semibold)
-        .foregroundColor(Ink.secondary)
-        .frame(width: 44, height: 44)
-        .glassChip()
+  private var activeMemoryFilters: [PageActiveFilter] {
+    let hasLifecycleFilter =
+      viewModel.canonicalLifecycleExposed
+      && viewModel.selectedLayerFilter != .defaultAccess
+    var filters: [PageActiveFilter] = []
+
+    if hasLifecycleFilter {
+      filters.append(
+        PageActiveFilter(
+          id: "lifecycle", title: viewModel.selectedLayerFilter.displayName,
+          onRemove: { viewModel.selectedLayerFilter = .defaultAccess }))
     }
-    .buttonStyle(.plain)
-    .popover(isPresented: $showManagementMenu, arrowEdge: .bottom) {
-      managementMenuPopover
+
+    if viewModel.filterThisDeviceOnly {
+      filters.append(
+        PageActiveFilter(
+          id: "device", title: "This device",
+          onRemove: { viewModel.filterThisDeviceOnly = false }))
     }
+
+    filters.append(
+      contentsOf: viewModel.selectedTags.sorted { $0.displayName < $1.displayName }.map { tag in
+        PageActiveFilter(id: "tag-\(tag.id)", title: tag.displayName) {
+          viewModel.selectedTags.remove(tag)
+        }
+      })
+
+    return filters
+  }
+
+  private func clearMemoryFilters() {
+    if viewModel.canonicalLifecycleExposed {
+      viewModel.selectedLayerFilter = .defaultAccess
+    }
+    if viewModel.filterThisDeviceOnly {
+      viewModel.filterThisDeviceOnly = false
+    }
+    if !viewModel.selectedTags.isEmpty {
+      viewModel.selectedTags = []
+    }
+  }
+
+  /// A scoped request is not an empty account. This intentionally includes
+  /// lifecycle and device scope even though `MemoriesViewModel.isInFilteredMode`
+  /// excludes them for pagination routing.
+  private var hasActiveMemoryQueryScope: Bool {
+    !viewModel.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      || viewModel.selectedLayerFilter != .defaultAccess
+      || viewModel.filterThisDeviceOnly
+      || !viewModel.selectedTags.isEmpty
   }
 
   // MARK: - Filter Bar
@@ -2564,7 +2606,7 @@ struct MemoriesPage: View {
         // previously embedded at the top of the memory list too; a second entry
         // point to the same surface only competed with the memories the page
         // exists to show.
-        LazyVStack(spacing: OmiSpacing.sm) {
+        LazyVStack(spacing: 0) {
           ForEach(viewModel.filteredMemories) { memory in
             MemoryCardView(
               memory: memory,
@@ -2724,26 +2766,55 @@ struct MemoriesPage: View {
         .scaledFont(size: 36)
         .foregroundColor(Ink.secondary)
 
-      Text("No Results")
+      Text("No matching memories")
         .scaledFont(size: OmiType.heading, weight: .semibold)
         .foregroundColor(Ink.primary)
 
-      Text("Try a different search or filter")
+      Text(memoryNoResultsDescription)
         .scaledFont(size: OmiType.body)
         .foregroundColor(Ink.secondary)
+        .multilineTextAlignment(.center)
 
-      if !viewModel.selectedTags.isEmpty {
-        Button {
-          viewModel.selectedTags.removeAll()
-        } label: {
-          Text("Clear Filters")
-            .scaledFont(size: OmiType.body, weight: .medium)
-            .foregroundColor(Ink.secondary)
+      HStack(spacing: OmiSpacing.sm) {
+        if !viewModel.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+          Button {
+            viewModel.searchText = ""
+          } label: {
+            PageQueryActionLabel(icon: "xmark.circle", title: "Clear search", isPrimary: true)
+          }
+          .buttonStyle(.plain)
         }
-        .buttonStyle(.plain)
+
+        if hasActiveMemoryFilterScope {
+          Button {
+            clearMemoryFilters()
+          } label: {
+            PageQueryActionLabel(icon: "line.3.horizontal.decrease.circle", title: "Clear filters")
+          }
+          .buttonStyle(.plain)
+        }
       }
+      .fixedSize(horizontal: false, vertical: true)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .accessibilityIdentifier("memories-filtered-empty")
+  }
+
+  private var hasActiveMemoryFilterScope: Bool {
+    viewModel.selectedLayerFilter != .defaultAccess
+      || viewModel.filterThisDeviceOnly
+      || !viewModel.selectedTags.isEmpty
+  }
+
+  private var memoryNoResultsDescription: String {
+    let hasSearch = !viewModel.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    if hasSearch && hasActiveMemoryFilterScope {
+      return "Nothing matches your search and active filters."
+    }
+    if hasSearch {
+      return "Nothing matches your search. Try a different term."
+    }
+    return "Nothing matches the selected filters."
   }
 
   private var loadingView: some View {
@@ -2859,7 +2930,7 @@ private struct MemoryCardView: View {
 
   var body: some View {
     Button(action: onTap) {
-      VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+      VStack(alignment: .leading, spacing: OmiSpacing.xs) {
         HStack(alignment: .top, spacing: OmiSpacing.sm) {
           Group {
             if memory.content.hasPrefix("[Protected") || memory.content.hasPrefix("[Encrypted") {
@@ -2928,12 +2999,16 @@ private struct MemoryCardView: View {
           }
         }
       }
-      .padding(.horizontal, OmiSpacing.lg)
-      .padding(.vertical, OmiSpacing.md)
-      .glassCard(
-        cornerRadius: OmiChrome.controlRadius,
-        emphasized: isHovered || isNewlyCreated
+      .padding(.horizontal, OmiSpacing.md)
+      .padding(.vertical, OmiSpacing.xs)
+      .background(
+        RoundedRectangle(cornerRadius: OmiChrome.elementRadius, style: .continuous)
+          .fill(isHovered || isNewlyCreated ? Ink.rowFillHover : Color.clear)
       )
+      .overlay(alignment: .bottom) {
+        GlassSeparator()
+          .padding(.leading, OmiSpacing.md)
+      }
       .clipShape(RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous))
     }
     .buttonStyle(.plain)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
@@ -3,45 +3,77 @@ import Combine
 import OmiTheme
 import SwiftUI
 
+struct MemoryExportCatalogEntry: Identifiable {
+  let destination: MemoryExportDestination
+  let title: String?
+  let subtitle: String?
+  let description: String?
+
+  var id: String { destination.id }
+  var resolvedTitle: String { title ?? destination.title }
+  var resolvedSubtitle: String { subtitle ?? destination.subtitle }
+  var resolvedDescription: String { description ?? destination.description }
+}
+
+enum MemoryExportCatalog {
+  static let entries: [MemoryExportCatalogEntry] =
+    MemoryExportDestination.allCases.compactMap { destination in
+      switch destination {
+      case .claudeCode, .codex:
+        return nil
+      case .claude:
+        return MemoryExportCatalogEntry(
+          destination: .claude,
+          title: "Claude / Claude Code",
+          subtitle: nil,
+          description: "Claude Code (CLI) or Claude cloud — choose in setup."
+        )
+      case .chatgpt:
+        return MemoryExportCatalogEntry(
+          destination: .chatgpt,
+          title: "ChatGPT / Codex",
+          subtitle: "ChatGPT app or Codex CLI",
+          description: "Add Omi in ChatGPT or connect Codex locally — choose in setup."
+        )
+      default:
+        return MemoryExportCatalogEntry(
+          destination: destination, title: nil, subtitle: nil, description: nil)
+      }
+    }
+
+  static func matching(_ searchText: String) -> [MemoryExportCatalogEntry] {
+    let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !query.isEmpty else { return entries }
+
+    return
+      entries
+      .filter { entry in
+        [entry.resolvedTitle, entry.resolvedSubtitle, entry.resolvedDescription]
+          .contains { $0.localizedCaseInsensitiveContains(query) }
+      }
+      .sorted { matchRank($0, query: query) < matchRank($1, query: query) }
+  }
+
+  private static func matchRank(_ entry: MemoryExportCatalogEntry, query: String) -> Int {
+    if entry.resolvedTitle.localizedCaseInsensitiveCompare(query) == .orderedSame { return 0 }
+    if entry.resolvedTitle.range(
+      of: query, options: [.anchored, .caseInsensitive, .diacriticInsensitive]) != nil
+    {
+      return 1
+    }
+    return 2
+  }
+}
+
 struct ExportsSection: View {
   let statuses: [MemoryExportDestination: MemoryExportStatus]
   var searchText = ""
+  var title = "Exports"
+  var entriesOverride: [MemoryExportCatalogEntry]? = nil
   let onSelectDestination: (MemoryExportDestination) -> Void
 
-  // Claude/Claude Code and ChatGPT/Codex each share one choice. Their setup
-  // sheets keep the cloud and CLI paths distinct without making this list uneven.
-  private var entries: [(destination: MemoryExportDestination, title: String?, subtitle: String?, description: String?)]
-  {
-    let allEntries: [(destination: MemoryExportDestination, title: String?, subtitle: String?, description: String?)] =
-      MemoryExportDestination.allCases.compactMap { d in
-        switch d {
-        case .claudeCode, .codex:
-          return nil
-        case .claude:
-          return (
-            .claude, "Claude / Claude Code", nil,
-            "Claude Code (CLI) or Claude cloud — choose in setup."
-          )
-        case .chatgpt:
-          return (
-            .chatgpt, "ChatGPT / Codex", "ChatGPT app or Codex CLI",
-            "Add Omi in ChatGPT or connect Codex locally — choose in setup."
-          )
-        default:
-          return (d, nil, nil, nil)
-        }
-      }
-
-    let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !query.isEmpty else { return allEntries }
-    return allEntries.filter { entry in
-      let destination = entry.destination
-      return [
-        entry.title ?? destination.title,
-        entry.subtitle ?? destination.subtitle,
-        entry.description ?? destination.description,
-      ].contains { $0.localizedCaseInsensitiveContains(query) }
-    }
+  private var entries: [MemoryExportCatalogEntry] {
+    entriesOverride ?? MemoryExportCatalog.matching(searchText)
   }
 
   private func status(for destination: MemoryExportDestination) -> MemoryExportStatus {
@@ -78,8 +110,8 @@ struct ExportsSection: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: OmiSpacing.md) {
-      Text("Exports")
-        .scaledFont(size: OmiType.heading, weight: .semibold)
+      Text(title)
+        .scaledFont(size: OmiType.subheading, weight: .semibold)
         .foregroundColor(Ink.primary)
 
       if entries.isEmpty {
@@ -93,7 +125,7 @@ struct ExportsSection: View {
           alignment: .leading,
           spacing: OmiSpacing.md
         ) {
-          ForEach(entries, id: \.destination.id) { entry in
+          ForEach(entries) { entry in
             MemoryExportRow(
               destination: entry.destination,
               titleOverride: entry.title,
@@ -131,7 +163,7 @@ private struct MemoryExportRow: View {
     case .obsidian:
       return status.isConfigured ? "Sync" : "Connect"
     case .notion, .chatgpt, .claude, .gemini, .agents, .claudeCode, .codex, .openclaw, .hermes:
-      return "Open"
+      return status.hasConnection ? "Open" : "Connect"
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
@@ -5,29 +5,42 @@ import SwiftUI
 
 struct ExportsSection: View {
   let statuses: [MemoryExportDestination: MemoryExportStatus]
+  var searchText = ""
   let onSelectDestination: (MemoryExportDestination) -> Void
 
   // Claude/Claude Code and ChatGPT/Codex each share one choice. Their setup
   // sheets keep the cloud and CLI paths distinct without making this list uneven.
   private var entries: [(destination: MemoryExportDestination, title: String?, subtitle: String?, description: String?)]
   {
-    MemoryExportDestination.allCases.compactMap { d in
-      switch d {
-      case .claudeCode, .codex:
-        return nil
-      case .claude:
-        return (
-          .claude, "Claude / Claude Code", nil,
-          "Claude Code (CLI) or Claude cloud — choose in setup."
-        )
-      case .chatgpt:
-        return (
-          .chatgpt, "ChatGPT / Codex", "ChatGPT app or Codex CLI",
-          "Add Omi in ChatGPT or connect Codex locally — choose in setup."
-        )
-      default:
-        return (d, nil, nil, nil)
+    let allEntries: [(destination: MemoryExportDestination, title: String?, subtitle: String?, description: String?)] =
+      MemoryExportDestination.allCases.compactMap { d in
+        switch d {
+        case .claudeCode, .codex:
+          return nil
+        case .claude:
+          return (
+            .claude, "Claude / Claude Code", nil,
+            "Claude Code (CLI) or Claude cloud — choose in setup."
+          )
+        case .chatgpt:
+          return (
+            .chatgpt, "ChatGPT / Codex", "ChatGPT app or Codex CLI",
+            "Add Omi in ChatGPT or connect Codex locally — choose in setup."
+          )
+        default:
+          return (d, nil, nil, nil)
+        }
       }
+
+    let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !query.isEmpty else { return allEntries }
+    return allEntries.filter { entry in
+      let destination = entry.destination
+      return [
+        entry.title ?? destination.title,
+        entry.subtitle ?? destination.subtitle,
+        entry.description ?? destination.description,
+      ].contains { $0.localizedCaseInsensitiveContains(query) }
     }
   }
 
@@ -69,20 +82,27 @@ struct ExportsSection: View {
         .scaledFont(size: OmiType.heading, weight: .semibold)
         .foregroundColor(Ink.primary)
 
-      LazyVGrid(
-        columns: [GridItem(.adaptive(minimum: 260), spacing: OmiSpacing.md)],
-        alignment: .leading,
-        spacing: OmiSpacing.md
-      ) {
-        ForEach(entries, id: \.destination.id) { entry in
-          MemoryExportRow(
-            destination: entry.destination,
-            titleOverride: entry.title,
-            subtitleOverride: entry.subtitle,
-            descriptionOverride: entry.description,
-            status: status(for: entry.destination)
-          ) {
-            onSelectDestination(entry.destination)
+      if entries.isEmpty {
+        Text("No exports match “\(searchText.trimmingCharacters(in: .whitespacesAndNewlines))”.")
+          .scaledFont(size: OmiType.body)
+          .foregroundStyle(Ink.secondary)
+          .padding(.vertical, OmiSpacing.md)
+      } else {
+        LazyVGrid(
+          columns: [GridItem(.adaptive(minimum: 260), spacing: OmiSpacing.md)],
+          alignment: .leading,
+          spacing: OmiSpacing.md
+        ) {
+          ForEach(entries, id: \.destination.id) { entry in
+            MemoryExportRow(
+              destination: entry.destination,
+              titleOverride: entry.title,
+              subtitleOverride: entry.subtitle,
+              descriptionOverride: entry.description,
+              status: status(for: entry.destination)
+            ) {
+              onSelectDestination(entry.destination)
+            }
           }
         }
       }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift
@@ -1891,6 +1891,8 @@ struct CanonicalMemoryAtlasTabView: View {
   let evidenceProvider: ([String]) async -> [MemoryAtlasEvidence]
   /// Opens a cited memory on the hub's Memories destination.
   let onOpenMemory: (String) -> Void
+  @Binding var searchText: String
+  var showsSearchField = true
   /// Where Escape goes once the map has nothing of its own left to undo.
   var onLeave: (() -> Void)?
 
@@ -1904,6 +1906,8 @@ struct CanonicalMemoryAtlasTabView: View {
         onOpenMemory: onOpenMemory,
         onRebuild: { Task { await viewModel.rebuildCanonicalAtlas() } },
         isRebuilding: viewModel.isRebuilding,
+        externalSearchText: $searchText,
+        showsSearchField: showsSearchField,
         onLeave: onLeave
       )
     }
@@ -1941,6 +1945,8 @@ private struct CanonicalMemoryAtlasSurface: View {
   /// view model to drive it (the inline preview, offscreen export renders).
   let onRebuild: (() -> Void)?
   let isRebuilding: Bool
+  var externalSearchText: Binding<String>? = nil
+  var showsSearchField = true
   /// Where Escape goes once the map itself has nothing left to undo. Absent on
   /// surfaces with nowhere to go, which is how those keep passing the key on.
   let onLeave: (() -> Void)?
@@ -1954,7 +1960,7 @@ private struct CanonicalMemoryAtlasSurface: View {
   private let previewTimeCursor: Double?
   private let previewEvidence: [MemoryAtlasEvidence]
 
-  @State private var searchText = ""
+  @State private var localSearchText = ""
   @State private var selectedNodeID: String?
   /// Set when the user clicked a painted connection rather than an entity.
   /// `selectedNodeID` still holds one endpoint so the map keeps its existing
@@ -2009,6 +2015,8 @@ private struct CanonicalMemoryAtlasSurface: View {
     onOpenMemory: ((String) -> Void)? = nil,
     onRebuild: (() -> Void)? = nil,
     isRebuilding: Bool = false,
+    externalSearchText: Binding<String>? = nil,
+    showsSearchField: Bool = true,
     onLeave: (() -> Void)? = nil,
     previewTimeCursor: Double? = nil,
     /// Deterministic offscreen renders open the inspector, which is otherwise
@@ -2029,6 +2037,8 @@ private struct CanonicalMemoryAtlasSurface: View {
     self.onOpenMemory = onOpenMemory
     self.onRebuild = onRebuild
     self.isRebuilding = isRebuilding
+    self.externalSearchText = externalSearchText
+    self.showsSearchField = showsSearchField
     self.onLeave = onLeave
     self.previewTimeCursor = previewTimeCursor
     self.previewEvidence = previewEvidence
@@ -2159,6 +2169,14 @@ private struct CanonicalMemoryAtlasSurface: View {
     recentConnectionCount > 99 ? "99+ new connections" : "\(recentConnectionCount) new connections"
   }
 
+  private var searchBinding: Binding<String> {
+    externalSearchText ?? $localSearchText
+  }
+
+  private var searchText: String {
+    searchBinding.wrappedValue
+  }
+
   var body: some View {
     // The inspector is a sibling of the whole map, not an overlay on it: the
     // canvas keeps its full height and the map simply narrows, so opening an
@@ -2172,6 +2190,9 @@ private struct CanonicalMemoryAtlasSurface: View {
       }
     }
     .animation(OmiMotion.gated(.easeOut(duration: 0.18)), value: selectedNodeID)
+    .onChange(of: searchText) { _, query in
+      updateSearchMatches(query)
+    }
     .task(id: evidenceSelectionKey) { await loadEvidence() }
     .onEscapeKey(priority: .content) {
       guard !compact else { return false }
@@ -2267,6 +2288,11 @@ private struct CanonicalMemoryAtlasSurface: View {
             // could cover would be the one label on the map with nothing
             // underneath it to explain itself.
             neighbourhoodCaptions(regions: regions)
+          }
+
+          if hasNoSearchMatches {
+            searchEmptyState
+              .allowsHitTesting(false)
           }
 
           zoomControls
@@ -2439,39 +2465,38 @@ private struct CanonicalMemoryAtlasSurface: View {
 
   private var atlasToolbar: some View {
     HStack(spacing: 12) {
-      HStack(spacing: 8) {
-        Image(systemName: "magnifyingglass")
-          .scaledFont(size: 12)
-          .foregroundColor(Ink.secondary)
+      if showsSearchField {
+        HStack(spacing: 8) {
+          Image(systemName: "magnifyingglass")
+            .scaledFont(size: 12)
+            .foregroundColor(Ink.secondary)
 
-        TextField("Search your entities", text: $searchText)
-          .textFieldStyle(.plain)
-          .focused($searchIsFocused)
-          .scaledFont(size: 12)
-          .foregroundColor(Ink.primary)
-          .onSubmit { selectFirstSearchResult() }
-          .onChange(of: searchText) { _, newValue in
-            updateSearchMatches(newValue)
-          }
-          .accessibilityLabel("Search entities")
-          .accessibilityIdentifier("memory_atlas_search")
+          TextField("Search your entities", text: searchBinding)
+            .textFieldStyle(.plain)
+            .focused($searchIsFocused)
+            .scaledFont(size: 12)
+            .foregroundColor(Ink.primary)
+            .onSubmit { selectFirstSearchResult() }
+            .accessibilityLabel("Search entities")
+            .accessibilityIdentifier("memory_atlas_search")
 
-        if !searchText.isEmpty {
-          Button {
-            searchText = ""
-          } label: {
-            Image(systemName: "xmark.circle.fill")
-              .scaledFont(size: 11)
-              .foregroundColor(Ink.secondary)
+          if !searchText.isEmpty {
+            Button {
+              searchBinding.wrappedValue = ""
+            } label: {
+              Image(systemName: "xmark.circle.fill")
+                .scaledFont(size: 11)
+                .foregroundColor(Ink.secondary)
+            }
+            .buttonStyle(.plain)
+            .help("Clear search (Esc)")
+            .accessibilityLabel("Clear search")
           }
-          .buttonStyle(.plain)
-          .help("Clear search (Esc)")
-          .accessibilityLabel("Clear search")
         }
+        .padding(.horizontal, 12)
+        .frame(width: compact ? 250 : 320, height: 30)
+        .glassChip()
       }
-      .padding(.horizontal, 12)
-      .frame(width: compact ? 250 : 320, height: 30)
-      .glassChip()
 
       Spacer()
 
@@ -2493,24 +2518,58 @@ private struct CanonicalMemoryAtlasSurface: View {
       // The legacy Brain Map carried a rebuild control; without it a thin or
       // stale server graph has no recovery path from inside the atlas.
       if let onRebuild {
-        Button(action: onRebuild) {
-          Image(systemName: "arrow.clockwise")
-            .scaledFont(size: 11, weight: .medium)
-            .foregroundColor(Ink.secondary.opacity(isRebuilding ? 0.35 : 1))
-            .frame(width: 26, height: 26)
-            .glassChip()
+        Menu {
+          Button(action: onRebuild) {
+            Label(
+              isRebuilding ? "Rebuilding Brain Map…" : "Rebuild Brain Map…",
+              systemImage: "arrow.clockwise")
+          }
+          .disabled(isRebuilding)
+        } label: {
+          PageQueryActionLabel(icon: "ellipsis", title: "More")
         }
-        .buttonStyle(.plain)
-        .disabled(isRebuilding)
-        .help(isRebuilding ? "Rebuilding your Brain Map…" : "Rebuild the Brain Map from your memories")
-        .accessibilityLabel("Rebuild Brain Map")
-        .accessibilityIdentifier("memory_atlas_rebuild")
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("More Brain Map actions")
+        .accessibilityLabel("More Brain Map actions")
+        .accessibilityIdentifier("memory_atlas_more_actions")
       }
     }
     .padding(.horizontal, compact ? 12 : 18)
     .frame(height: compact ? 40 : 44)
     .background(Color.clear)
     .accessibilityHint("Press Command-F to search. Press Return to select the first visible result.")
+  }
+
+  private var hasNoSearchMatches: Bool {
+    !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      && matchingNodeIDs?.isEmpty == true
+      && !snapshot.nodes.isEmpty
+  }
+
+  private var searchEmptyState: some View {
+    VStack(spacing: OmiSpacing.sm) {
+      Image(systemName: "magnifyingglass")
+        .scaledFont(size: OmiType.heading)
+        .foregroundStyle(Ink.surface)
+      Text(
+        "No entities match \u{201c}\(searchText.trimmingCharacters(in: .whitespacesAndNewlines))\u{201d}"
+      )
+      .scaledFont(size: OmiType.body, weight: .semibold)
+      .foregroundStyle(Ink.surface)
+      .multilineTextAlignment(.center)
+      Text("Try a different search or clear the search above.")
+        .scaledFont(size: OmiType.caption)
+        .foregroundStyle(Ink.surface.opacity(0.78))
+        .multilineTextAlignment(.center)
+    }
+    .padding(.horizontal, OmiSpacing.lg)
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(
+      "No entities match \(searchText.trimmingCharacters(in: .whitespacesAndNewlines))"
+    )
+    .accessibilityHint("Try a different search or clear the search above.")
   }
 
   /// Which colour means which kind of entity.
@@ -2523,6 +2582,10 @@ private struct CanonicalMemoryAtlasSurface: View {
   /// without claiming a location for it.
   private var typeKey: some View {
     HStack(spacing: 11) {
+      Text("Legend")
+        .scaledFont(size: 10, weight: .semibold)
+        .foregroundColor(Ink.primary)
+
       ForEach(snapshot.activeClusters) { cluster in
         HStack(spacing: 5) {
           Circle().fill(cluster.color).frame(width: 5, height: 5)
@@ -2532,6 +2595,14 @@ private struct CanonicalMemoryAtlasSurface: View {
         }
       }
     }
+    // The key identifies the map's colors; it is intentionally not a filter. Naming that contract
+    // keeps the dots from presenting a false affordance to pointer-free users.
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Brain Map legend")
+    .accessibilityValue(
+      snapshot.activeClusters.map { "\($0.title), color coded" }.joined(separator: "; ")
+    )
+    .accessibilityHint("Legend only; these items are not interactive filters.")
     .accessibilityIdentifier("memory_atlas_type_key")
   }
 
@@ -3930,7 +4001,7 @@ private struct CanonicalMemoryAtlasSurface: View {
     {
     case .search:
       searchIsFocused = false
-      searchText = ""
+      searchBinding.wrappedValue = ""
       matchingNodeIDs = nil
       matchingEdges = nil
     case .selectionStep:

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
@@ -37,6 +37,7 @@ enum MemoryGraphPresentationMode: Equatable {
 
 struct MemoryGraphPage: View {
   @ObservedObject var viewModel: MemoryGraphViewModel
+  var searchText = ""
 
   var body: some View {
     ZStack {
@@ -48,6 +49,10 @@ struct MemoryGraphPage: View {
       // a Memory tab now, not a modal, so there's no close button.)
       VStack {
         HStack {
+          if !viewModel.isEmpty {
+            legacyGraphLegend
+          }
+
           Spacer()
 
           // Rebuild control: while rebuilding it just dims and disables — the
@@ -56,19 +61,38 @@ struct MemoryGraphPage: View {
           Button {
             Task { await viewModel.rebuildGraph() }
           } label: {
-            Image(systemName: "arrow.clockwise")
-              .scaledFont(size: OmiType.body)
-              .foregroundColor(Ink.secondary.opacity(viewModel.isRebuilding ? 0.4 : 1))
-              .frame(width: 28, height: 28)
+            PageQueryActionLabel(
+              icon: "arrow.clockwise",
+              title: viewModel.isRebuilding ? "Rebuilding…" : "Rebuild"
+            )
           }
           .buttonStyle(.plain)
           .disabled(viewModel.isRebuilding)
           .help("Rebuild graph")
         }
-        .padding(.horizontal, OmiSpacing.lg)
-        .padding(.top, OmiSpacing.md)
+        .padding(.horizontal, OmiSpacing.sm)
+        .padding(.top, OmiSpacing.sm)
 
         Spacer()
+      }
+
+      if shouldShowSearchEmptyState {
+        VStack(spacing: OmiSpacing.sm) {
+          Image(systemName: "magnifyingglass")
+            .scaledFont(size: OmiType.heading)
+            .foregroundStyle(Ink.surface)
+          Text("No entities match \u{201c}\(trimmedSearchText)\u{201d}")
+            .scaledFont(size: OmiType.body, weight: .semibold)
+            .foregroundStyle(Ink.surface)
+          Text("Try a different search or clear the search above.")
+            .scaledFont(size: OmiType.caption)
+            .foregroundStyle(Ink.surface.opacity(0.78))
+        }
+        .multilineTextAlignment(.center)
+        .allowsHitTesting(false)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("No entities match \(trimmedSearchText)")
+        .accessibilityHint("Try a different search or clear the search above.")
       }
 
       // Exactly one status view: a single centered spinner while loading or
@@ -92,12 +116,57 @@ struct MemoryGraphPage: View {
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .padding(OmiSpacing.md)
+    .padding(OmiSpacing.xs)
     .glassMediaMat(cornerRadius: PageGlass.cardRadius)
-    .padding(OmiSpacing.md)
+    .padding(OmiSpacing.xs)
     .task {
       await viewModel.prepareGraph()
+      viewModel.applySearch(query: searchText)
     }
+    .onChange(of: searchText) { _, query in
+      viewModel.applySearch(query: query)
+    }
+  }
+
+  private var trimmedSearchText: String {
+    searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private var shouldShowSearchEmptyState: Bool {
+    !trimmedSearchText.isEmpty
+      && viewModel.searchMatchCount == 0
+      && !viewModel.isLoading
+      && !viewModel.isRebuilding
+      && !viewModel.isEmpty
+  }
+
+  private var legacyGraphLegend: some View {
+    let activeTypes = KnowledgeGraphNodeType.allCases.filter { type in
+      viewModel.graphResponse.nodes.contains { $0.nodeType == type }
+    }
+
+    return HStack(spacing: OmiSpacing.sm) {
+      Text("Legend")
+        .scaledFont(size: OmiType.caption, weight: .semibold)
+        .foregroundStyle(Ink.surface)
+
+      ForEach(activeTypes, id: \.self) { type in
+        HStack(spacing: OmiSpacing.xs) {
+          Circle()
+            .fill(type.color)
+            .frame(width: 6, height: 6)
+          Text(type.displayName)
+            .scaledFont(size: OmiType.caption)
+            .foregroundStyle(Ink.surface.opacity(0.84))
+        }
+      }
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Brain Map legend")
+    .accessibilityValue(
+      activeTypes.map { "\($0.displayName), color coded" }.joined(separator: "; ")
+    )
+    .accessibilityHint("Legend only; these items are not interactive filters.")
   }
 }
 
@@ -161,6 +230,7 @@ class MemoryGraphViewModel: ObservableObject {
   @Published var isRebuilding = false
   @Published var isEmpty = true
   @Published var selectedNodeId: String?
+  @Published private(set) var searchMatchCount: Int?
   @Published private(set) var graphResponse = KnowledgeGraphResponse(nodes: [], edges: [])
   /// Prepared off the main actor and retained for the complete lifetime of a
   /// canonical graph revision. The SwiftUI Brain Map can re-render freely
@@ -187,6 +257,7 @@ class MemoryGraphViewModel: ObservableObject {
   private var hasLoadedCanonicalAtlas = false
   private var hasRunEmptyBootstrap = false
   private var loadedGraphSignature: Int?
+  private var activeSearchQuery = ""
   private var sessionGeneration = 0
   private let canonicalGraphFetcher: CanonicalGraphFetcher
 
@@ -717,6 +788,7 @@ class MemoryGraphViewModel: ObservableObject {
 
     // Create scene nodes for new entries, animate them in
     addNewSceneNodes()
+    applySearch(query: activeSearchQuery)
     autoFitCamera(animated: true)
 
     // Re-enable animation for settling
@@ -735,6 +807,8 @@ class MemoryGraphViewModel: ObservableObject {
     isRebuilding = false
     isEmpty = true
     selectedNodeId = nil
+    searchMatchCount = nil
+    activeSearchQuery = ""
     graphResponse = KnowledgeGraphResponse(nodes: [], edges: [])
     canonicalAtlasProjection = nil
     isAnimating = false
@@ -752,6 +826,27 @@ class MemoryGraphViewModel: ObservableObject {
     for (_, node) in edgeSceneNodes { node.removeFromParentNode() }
     nodeSceneNodes.removeAll()
     edgeSceneNodes.removeAll()
+  }
+
+  /// The compatibility graph keeps its SceneKit renderer, but participates in the same Brain search
+  /// contract by dimming non-matching entities and their connections in place.
+  func applySearch(query: String) {
+    let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
+    activeSearchQuery = needle
+    let matchingIDs = Set(
+      simulation.nodes.compactMap { node in
+        needle.isEmpty || node.label.localizedCaseInsensitiveContains(needle) ? node.id : nil
+      })
+    searchMatchCount = needle.isEmpty ? nil : matchingIDs.count
+
+    for (id, node) in nodeSceneNodes {
+      node.isHidden = !needle.isEmpty && !matchingIDs.contains(id)
+    }
+    for edge in simulation.edges {
+      edgeSceneNodes[edge.id]?.isHidden =
+        !needle.isEmpty
+        && (!matchingIDs.contains(edge.sourceId) && !matchingIDs.contains(edge.targetId))
+    }
   }
 
   /// Create scene nodes only for simulation nodes/edges not yet in the scene
@@ -841,6 +936,10 @@ class MemoryGraphViewModel: ObservableObject {
       containerNode.scale = SCNVector3(1, 1, 1)
       SCNTransaction.commit()
     }
+
+    // Search can be entered before the first scene build completes. Re-apply the query after the
+    // nodes exist so a matching query never leaves an unfiltered graph behind on its first render.
+    applySearch(query: activeSearchQuery)
   }
 
   // MARK: - Scene Nodes
@@ -982,6 +1081,10 @@ class MemoryGraphViewModel: ObservableObject {
 
     // Auto-fit camera to graph bounds
     autoFitCamera()
+
+    // Search may have been entered while the graph was loading. Re-apply it after the SceneKit
+    // nodes exist so the initial render cannot briefly expose non-matching entities.
+    applySearch(query: activeSearchQuery)
   }
 
   /// Create a text label below a node

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+Controls.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+Controls.swift
@@ -871,7 +871,7 @@ extension SettingsContentView {
   ) -> some View {
     let card = content()
       .frame(maxWidth: .infinity, alignment: .leading)
-      .padding(OmiSpacing.lg)
+      .padding(OmiSpacing.md)
       .settingsGlassCard()
     return Group {
       if let settingId = settingId {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsGlassKit.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsGlassKit.swift
@@ -34,19 +34,19 @@ import SwiftUI
 enum SettingsGlassMetrics {
   /// Pane gutters. The horizontal value is the one rows are inset by; the vertical pair is
   /// deliberately asymmetric — a pane scrolls, so the foot needs more room than the head.
-  static let paneHorizontalPadding: CGFloat = 22
-  static let paneTopPadding: CGFloat = 18
-  static let paneBottomPadding: CGFloat = 26
+  static let paneHorizontalPadding: CGFloat = 16
+  static let paneTopPadding: CGFloat = 12
+  static let paneBottomPadding: CGFloat = 18
 
   /// Between two sections. The one vertical gap on a pane that is allowed to be large.
-  static let sectionSpacing: CGFloat = 22
+  static let sectionSpacing: CGFloat = 14
   /// Between a section's title and its card.
   static let sectionTitleSpacing: CGFloat = 6
   /// Between two rows *inside* a card. Nearly nothing: the hairline separates them, not the gap.
   static let rowSpacing: CGFloat = 2
 
-  static let rowVerticalPadding: CGFloat = 9
-  static let rowHorizontalPadding: CGFloat = 12
+  static let rowVerticalPadding: CGFloat = 7
+  static let rowHorizontalPadding: CGFloat = 10
   /// Between the icon tile and the copy beside it.
   static let rowContentSpacing: CGFloat = 11
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Advanced.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Advanced.swift
@@ -35,25 +35,45 @@ extension SettingsContentView {
       // memoryAssistantSubsection
       advancedCategoryHeader(title: "Analysis Throttle", icon: "clock.arrow.2.circlepath")
       analysisThrottleSubsection
-      advancedCategoryHeader(title: "Profile & Stats", icon: "brain")
-      profileAndStatsSubsection
-      advancedCategoryHeader(title: "Reset Onboarding", icon: "arrow.counterclockwise")
-      resetOnboardingSubsection
-      advancedCategoryHeader(title: "Goals", icon: "target")
-      goalsSubsection
-      advancedCategoryHeader(title: "Preferences", icon: "slider.horizontal.3")
-      preferencesSubsection
-      advancedCategoryHeader(title: "Troubleshooting", icon: "wrench.and.screwdriver")
-      troubleshootingSubsection
-      if AppBuild.isBetaProductionBundle {
-        advancedCategoryHeader(title: "Beta Diagnostics", icon: "waveform.path.ecg")
-        betaDiagnosticsSubsection
-      }
-      advancedCategoryHeader(title: "Developer API Keys", icon: "key")
-      developerKeysSubsection
 
-      advancedCategoryHeader(title: "Dev Tools", icon: "hammer")
-      devToolsSubsection
+      DisclosureGroup(isExpanded: $advancedDetailsExpanded) {
+        VStack(spacing: OmiSpacing.xxl) {
+          advancedCategoryHeader(title: "Profile & Stats", icon: "brain")
+          profileAndStatsSubsection
+          advancedCategoryHeader(title: "Reset Onboarding", icon: "arrow.counterclockwise")
+          resetOnboardingSubsection
+          advancedCategoryHeader(title: "Goals", icon: "target")
+          goalsSubsection
+          advancedCategoryHeader(title: "Preferences", icon: "slider.horizontal.3")
+          preferencesSubsection
+          advancedCategoryHeader(title: "Troubleshooting", icon: "wrench.and.screwdriver")
+          troubleshootingSubsection
+          if AppBuild.isBetaProductionBundle {
+            advancedCategoryHeader(title: "Beta Diagnostics", icon: "waveform.path.ecg")
+            betaDiagnosticsSubsection
+          }
+          advancedCategoryHeader(title: "Developer API Keys", icon: "key")
+          developerKeysSubsection
+
+          if devModeEnabled {
+            advancedCategoryHeader(title: "Dev Tools", icon: "hammer")
+            devToolsSubsection
+          }
+        }
+        .padding(.top, OmiSpacing.md)
+      } label: {
+        HStack(spacing: OmiSpacing.sm) {
+          Image(systemName: "wrench.and.screwdriver")
+            .scaledFont(size: OmiType.subheading)
+            .foregroundStyle(Ink.secondary)
+          Text("Advanced")
+            .scaledFont(size: OmiType.heading, weight: .semibold)
+            .foregroundStyle(Ink.primary)
+        }
+      }
+      .tint(Ink.secondary)
+      .padding(.top, OmiSpacing.lg)
+      .accessibilityIdentifier("settings-ai-automation-advanced-disclosure")
     }
     // The assistant cards above are seeded from their singletons when the pane is constructed, but
     // `loadBackendSettings()` then runs `SettingsSyncManager.syncFromServer()`, which is
@@ -63,6 +83,14 @@ extension SettingsContentView {
     // this is the pane agreeing to listen. Same shape as the Notifications pane.
     .onReceive(NotificationCenter.default.publisher(for: .assistantSettingsDidSyncFromServer)) { _ in
       syncAssistantControlsFromSettings()
+    }
+    .onChange(of: highlightedSettingId) { _, settingId in
+      // Search and deep links must still reveal cards tucked into the collapsed
+      // secondary section. The default presentation stays compact until a
+      // specific result asks for that content.
+      if settingId != nil {
+        advancedDetailsExpanded = true
+      }
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
@@ -20,7 +20,7 @@ import WebKit
 // tint is `Ink.primary`, which is what the rest of the pane is set in.
 extension SettingsContentView {
   var generalSection: some View {
-    VStack(spacing: OmiSpacing.xl) {
+    VStack(spacing: OmiSpacing.sm) {
       // Screen Capture toggle
       settingsCard(settingId: "general.screencapture") {
         HStack(spacing: OmiSpacing.lg) {
@@ -69,7 +69,7 @@ extension SettingsContentView {
 
       // One recording policy; no independent enable switch or system-audio mode.
       settingsCard(settingId: "general.audiorecording") {
-        VStack(alignment: .leading, spacing: OmiSpacing.md) {
+        VStack(alignment: .leading, spacing: OmiSpacing.xs) {
           HStack(spacing: OmiSpacing.lg) {
             SettingsIconTile(symbol: "mic.fill")
 
@@ -93,7 +93,7 @@ extension SettingsContentView {
 
       // Notifications toggle
       settingsCard(settingId: "general.notifications") {
-        VStack(spacing: OmiSpacing.md) {
+        VStack(spacing: OmiSpacing.xs) {
           HStack(spacing: OmiSpacing.lg) {
             SettingsIconTile(symbol: "bell.fill")
 
@@ -177,7 +177,7 @@ extension SettingsContentView {
 
       // Font Size
       settingsCard(settingId: "general.fontsize") {
-        VStack(spacing: OmiSpacing.md) {
+        VStack(spacing: OmiSpacing.sm) {
           HStack(spacing: OmiSpacing.lg) {
             SettingsIconTile(symbol: "textformat.size")
 
@@ -286,8 +286,8 @@ private struct AudioRecordingModeSwitcher: View {
   var body: some View {
     HStack(spacing: 2) {
       segment(.off, label: "Off")
-      segment(.always, label: "Always On")
-      segment(.onlyMeetings, label: "Only Meetings")
+      segment(.always, label: "Always")
+      segment(.onlyMeetings, label: "Meetings")
     }
     .padding(3)
     .background(
@@ -298,7 +298,7 @@ private struct AudioRecordingModeSwitcher: View {
       RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous)
         .strokeBorder(Ink.hairline, lineWidth: 1)
     )
-    .frame(width: 310)
+    .frame(width: 230)
     .accessibilityElement(children: .contain)
     .accessibilityLabel("Audio Recording")
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -76,22 +76,8 @@ struct SettingsPage: View {
     ScrollViewReader { proxy in
       ScrollView {
         VStack(spacing: 0) {
-          // The pane's own heading. Open Runde at display size — the one run on this surface above
-          // `Font.inkDisplayThreshold`, which is what decides the face; everything below it stays SF
-          // Pro, because that is what a native macOS app sets a settings pane in.
-          HStack {
-            Text(selectedSection.displayTitle)
-              .inkStyle(.stepHeadline, color: Ink.primary)
-              .id(selectedSection)
-              .transition(.opacity)
-              .omiAnimation(.easeInOut(duration: 0.15), value: selectedSection)
-
-            Spacer()
-          }
-          .padding(.horizontal, SettingsGlassMetrics.paneHorizontalPadding)
-          .padding(.top, SettingsGlassMetrics.paneTopPadding)
-          .padding(.bottom, SettingsGlassMetrics.sectionSpacing)
-
+          // The selected sidebar row already names the destination. Repeating
+          // it as a large page title consumed a row without adding context.
           SettingsContentView(
             appState: appState,
             selectedSection: $selectedSection,
@@ -100,6 +86,7 @@ struct SettingsPage: View {
             showResetOnboardingConfirm: $showResetOnboardingConfirm
           )
           .padding(.horizontal, SettingsGlassMetrics.paneHorizontalPadding)
+          .padding(.top, SettingsGlassMetrics.paneTopPadding)
           .padding(.bottom, SettingsGlassMetrics.paneBottomPadding)
 
           Spacer()
@@ -400,6 +387,7 @@ struct SettingsContentView: View {
   // Dev Mode setting
   @AppStorage("devModeEnabled") var devModeEnabled = false
   @AppStorage(BetaEnhancedDiagnosticsConfiguration.defaultsKey) var betaEnhancedDiagnosticsEnabled = true
+  @State var advancedDetailsExpanded = false
 
   // Browser Extension settings
   @AppStorage("playwrightUseExtension") var playwrightUseExtension = true
@@ -453,7 +441,8 @@ struct SettingsContentView: View {
     var displayTitle: String {
       switch self {
       case .account, .planUsage: return "Account & Plan"
-      case .notifications, .privacy: return "Notifications & Privacy"
+      case .notifications, .privacy: return "Alerts & Privacy"
+      case .advanced: return "AI & Automation"
       default: return rawValue
       }
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -2445,7 +2445,11 @@ class TasksViewModel: ObservableObject {
     let filterContext = TaskFilterTag.FilterContext()
     var filteredTasks: [TaskActionItem]
     if !normalizedSearchQuery.isEmpty {
-      filteredTasks = applyNonStatusTagFilters(sourceTasks, context: filterContext)
+      // Search returns every matching status from SQLite. Keep the visible
+      // Status control authoritative so a To Do search cannot surface Done
+      // rows (and vice versa).
+      filteredTasks = applyStatusFilters(sourceTasks)
+      filteredTasks = applyNonStatusTagFilters(filteredTasks, context: filterContext)
     } else if hasSQLiteFilters || hasDateFilters {
       // SQLite already filtered by category/source/priority/date when filteredFromDatabase is populated.
       // When using in-memory source (filteredFromDatabase empty — e.g. async query not yet complete),
@@ -2485,7 +2489,8 @@ class TasksViewModel: ObservableObject {
     for task in displayTasks {
       // Mobile-parity gate (Flutter _categorizeItems): the categorized list
       // shows only the active view's tasks — To Do shows incomplete, Done
-      // shows completed. Search bypasses the gate like mobile's flat search.
+      // shows completed. Search has already applied the same status filter
+      // above, so this gate remains a defensive invariant for cached rows.
       if normalizedSearchQuery.isEmpty && task.completed != showCompleted {
         continue
       }
@@ -2522,7 +2527,8 @@ class TasksViewModel: ObservableObject {
     for task in displayTasks {
       // Mobile-parity gate (Flutter _categorizeItems): the categorized list
       // shows only the active view's tasks — To Do shows incomplete, Done
-      // shows completed. Search bypasses the gate like mobile's flat search.
+      // shows completed. Search has already applied the same status filter
+      // above, so this gate remains a defensive invariant for cached rows.
       if normalizedSearchQuery.isEmpty && task.completed != showCompleted {
         continue
       }
@@ -3433,14 +3439,102 @@ struct TasksPage: View {
   }
 
   var body: some View {
-    let isChatVisible = showChatPanel
+    GeometryReader { proxy in
+      let lane = QueryShellLayout.laneWidth(for: proxy.size.width)
 
+      VStack(spacing: QueryShellLayout.panelGap) {
+        QuerySearchBar(
+          text: $viewModel.searchText,
+          accessibilityID: "tasks-search-field",
+          placeholder: "Search tasks…"
+        )
+
+        taskWorkspace
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+          .inkGlassPanel(cornerRadius: QueryShellLayout.panelCornerRadius, shadow: .ambient)
+      }
+      .frame(width: lane)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+      .padding(.top, QueryShellLayout.surfaceTopInset)
+    }
+    .alert(
+      "Task action failed",
+      isPresented: Binding(
+        get: { viewModel.bulkTaskErrorMessage != nil },
+        set: { isPresented in
+          if !isPresented {
+            viewModel.bulkTaskErrorMessage = nil
+          }
+        }
+      )
+    ) {
+      Button("OK", role: .cancel) {
+        viewModel.bulkTaskErrorMessage = nil
+      }
+    } message: {
+      Text(viewModel.bulkTaskErrorMessage ?? "Please try again.")
+    }
+    .onEscapeKey(priority: .content) { handleEscapeKey() }
+    .onAppear {
+      Task { @MainActor in
+        await viewModel.loadTasksForFirstUse()
+        await suggestedStore.load()
+        hydratePendingDashboardNavigationTarget()
+        chatCoordinator.ingestTaskMappings(viewModel.displayTasks)
+        if !viewModel.isLoading {
+          NotificationCenter.default.post(name: .tasksPageDidLoad, object: nil)
+        }
+      }
+      suggestedStore.registerAutomationActions()
+      if chatCoordinator.isPanelOpen, chatCoordinator.activeTaskId != nil {
+        showChatPanel = true
+        adjustWindowWidth(expand: true)
+      }
+      Task { await TaskPrioritizationService.shared.start() }
+      if !showChatPanel {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+          shrinkWindowIfNeeded()
+        }
+      }
+    }
+    .onDisappear {
+      if showChatPanel {
+        adjustWindowWidth(expand: false)
+        showChatPanel = false
+      }
+    }
+    .onReceive(chatCoordinator.$activeTaskId) { taskId in
+      activeChatTaskId = taskId
+    }
+    .onReceive(viewModel.$displayTasks) { tasks in
+      chatCoordinator.ingestTaskMappings(tasks)
+    }
+    .onReceive(chatCoordinator.$isPanelOpen.removeDuplicates()) { isOpen in
+      guard isOpen != showChatPanel else { return }
+      if isOpen {
+        viewModel.detailPanelTaskID = nil
+        adjustWindowWidth(expand: true)
+        OmiMotion.withGated(.easeInOut(duration: 0.25)) {
+          showChatPanel = true
+        }
+      } else {
+        OmiMotion.withGated(.easeInOut(duration: 0.25)) {
+          showChatPanel = false
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+          adjustWindowWidth(expand: false)
+        }
+      }
+    }
+  }
+
+  private var taskWorkspace: some View {
     HStack(spacing: 0) {
       // Left panel: Tasks content (always full width)
       tasksContent
         .frame(maxWidth: .infinity)
 
-      if isChatVisible {
+      if showChatPanel {
         // Draggable divider with handle
         ZStack {
           Rectangle()
@@ -3532,86 +3626,6 @@ struct TasksPage: View {
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .glassContent()
-    .alert(
-      "Task action failed",
-      isPresented: Binding(
-        get: { viewModel.bulkTaskErrorMessage != nil },
-        set: { isPresented in
-          if !isPresented {
-            viewModel.bulkTaskErrorMessage = nil
-          }
-        }
-      )
-    ) {
-      Button("OK", role: .cancel) {
-        viewModel.bulkTaskErrorMessage = nil
-      }
-    } message: {
-      Text(viewModel.bulkTaskErrorMessage ?? "Please try again.")
-    }
-    .onEscapeKey(priority: .content) { handleEscapeKey() }
-    // Modal creation sheet removed — Cmd+N now creates inline at top
-    .onAppear {
-      Task { @MainActor in
-        await viewModel.loadTasksForFirstUse()
-        await suggestedStore.load()
-        hydratePendingDashboardNavigationTarget()
-        chatCoordinator.ingestTaskMappings(viewModel.displayTasks)
-        // If tasks are already loaded, notify sidebar to clear loading indicator
-        if !viewModel.isLoading {
-          NotificationCenter.default.post(name: .tasksPageDidLoad, object: nil)
-        }
-      }
-      suggestedStore.registerAutomationActions()
-      // Restore panel UI if coordinator was open when we navigated away
-      if chatCoordinator.isPanelOpen, chatCoordinator.activeTaskId != nil {
-        showChatPanel = true
-        adjustWindowWidth(expand: true)
-      }
-      // Ensure prioritization service is running (no-op if already started)
-      Task { await TaskPrioritizationService.shared.start() }
-
-      // Shrink window if it was left expanded from a previous session with chat open.
-      // Delay slightly so the window is fully visible before resizing.
-      if !showChatPanel {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-          shrinkWindowIfNeeded()
-        }
-      }
-    }
-    .onDisappear {
-      // Shrink window when navigating away, but keep coordinator alive
-      // so streaming state and unread dots persist across tab switches.
-      if showChatPanel {
-        adjustWindowWidth(expand: false)
-        showChatPanel = false
-        // Do NOT call chatCoordinator.closeChat() — coordinator state persists at app level
-      }
-    }
-    .onReceive(chatCoordinator.$activeTaskId) { taskId in
-      activeChatTaskId = taskId
-    }
-    .onReceive(viewModel.$displayTasks) { tasks in
-      chatCoordinator.ingestTaskMappings(tasks)
-    }
-    .onReceive(chatCoordinator.$isPanelOpen.removeDuplicates()) { isOpen in
-      guard isOpen != showChatPanel else { return }
-      if isOpen {
-        viewModel.detailPanelTaskID = nil
-        adjustWindowWidth(expand: true)
-        OmiMotion.withGated(.easeInOut(duration: 0.25)) {
-          showChatPanel = true
-        }
-      } else {
-        OmiMotion.withGated(.easeInOut(duration: 0.25)) {
-          showChatPanel = false
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
-          adjustWindowWidth(expand: false)
-        }
-      }
-    }
   }
 
   /// Start a background AI investigation for a task (no panel opens)
@@ -3736,7 +3750,7 @@ struct TasksPage: View {
 
   private var tasksContent: some View {
     VStack(spacing: 0) {
-      // Header with filter toggle and sort
+      // Compact query/actions row; the selected top navigation already names the page.
       headerView
 
       if let failure = viewModel.sortOrderSyncFailure {
@@ -3746,10 +3760,13 @@ struct TasksPage: View {
       // Content
       if viewModel.isActiveViewLoading && viewModel.activeTasks.isEmpty {
         loadingView
+      } else if viewModel.isSearching && viewModel.displayTasks.isEmpty {
+        loadingView
       } else if let error = viewModel.activeViewError, viewModel.activeTasks.isEmpty {
         errorView(error)
       } else if viewModel.displayTasks.isEmpty && !viewModel.isInlineCreating
-        && suggestedStore.candidates.isEmpty && !suggestedStore.isLoading
+        && (!viewModel.normalizedSearchQuery.isEmpty
+          || (suggestedStore.candidates.isEmpty && !suggestedStore.isLoading))
       {
         emptyView
       } else {
@@ -3759,32 +3776,39 @@ struct TasksPage: View {
         tasksListView
       }
     }
-    .overlay(alignment: .bottom) {
-      VStack(spacing: OmiSpacing.sm) {
-        Spacer()
-        // Keyboard hint bar
-        if !viewModel.displayTasks.isEmpty {
-          KeyboardHintBar(
-            isAnyTaskEditing: viewModel.isAnyTaskEditing,
-            isInlineCreating: viewModel.isInlineCreating,
-            hasSelection: viewModel.keyboardSelectedTaskId != nil
-          )
-          .transition(.opacity)
-          .omiAnimation(.easeInOut(duration: 0.15), value: viewModel.keyboardSelectedTaskId)
-          .omiAnimation(.easeInOut(duration: 0.15), value: viewModel.isInlineCreating)
-        }
-        // Undo toast
-        if viewModel.showUndoToast, let lastAction = viewModel.undoStack.last {
-          UndoToastView(
-            taskDescription: lastAction.task.description,
-            undoCount: viewModel.undoStack.count,
-            onUndo: { Task { await viewModel.undoLastDelete() } }
-          )
-          .transition(.move(edge: .bottom).combined(with: .opacity))
-        }
+    // Reserve space for the keyboard hints instead of floating them over the
+    // last row. The list already keeps a small bottom inset for the bar; the
+    // safe-area inset makes that clearance part of the scrollable viewport.
+    .safeAreaInset(edge: .bottom, spacing: 0) {
+      if !viewModel.displayTasks.isEmpty
+        && (viewModel.isAnyTaskEditing
+          || viewModel.isInlineCreating
+          || viewModel.keyboardSelectedTaskId != nil)
+      {
+        KeyboardHintBar(
+          isAnyTaskEditing: viewModel.isAnyTaskEditing,
+          isInlineCreating: viewModel.isInlineCreating,
+          hasSelection: viewModel.keyboardSelectedTaskId != nil
+        )
+        .padding(.bottom, OmiSpacing.sm)
+        .transition(.opacity)
+        .omiAnimation(.easeInOut(duration: 0.15), value: viewModel.keyboardSelectedTaskId)
+        .omiAnimation(.easeInOut(duration: 0.15), value: viewModel.isInlineCreating)
       }
-      .padding(.bottom, OmiSpacing.lg)
-      .omiAnimation(.easeInOut(duration: 0.25), value: viewModel.showUndoToast)
+    }
+    .overlay(alignment: .bottom) {
+      // Undo is transient feedback, not navigation. It remains over the panel
+      // while the keyboard hint bar has its own reserved space above it.
+      if viewModel.showUndoToast, let lastAction = viewModel.undoStack.last {
+        UndoToastView(
+          taskDescription: lastAction.task.description,
+          undoCount: viewModel.undoStack.count,
+          onUndo: { Task { await viewModel.undoLastDelete() } }
+        )
+        .padding(.bottom, OmiSpacing.lg)
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+        .omiAnimation(.easeInOut(duration: 0.25), value: viewModel.showUndoToast)
+      }
     }
     .onAppear {
       installKeyboardMonitor()
@@ -3859,70 +3883,27 @@ struct TasksPage: View {
   // MARK: - Header View
 
   private var headerView: some View {
-    HStack(spacing: OmiSpacing.sm) {
-      Text("Tasks")
-        .inkStyle(InkType.firstTitle, color: Ink.primary)
-        .fixedSize()
-
-      // Search field
-      HStack(spacing: OmiSpacing.sm) {
-        if viewModel.isSearching || viewModel.isLoadingFiltered {
-          ProgressView()
-            .scaleEffect(0.7)
-            .frame(width: 14, height: 14)
+    PageQueryToolbar(
+      refinement: {
+        if viewModel.isMultiSelectMode {
+          multiSelectControls
         } else {
-          Image(systemName: "magnifyingglass")
-            .scaledFont(size: OmiType.body)
-            .foregroundColor(Ink.secondary)
+          taskStatusMenu
         }
-
-        TextField("Search tasks...", text: $viewModel.searchText)
-          .textFieldStyle(.plain)
-          .foregroundColor(Ink.primary)
-
-        if !viewModel.normalizedSearchQuery.isEmpty {
-          Button {
-            viewModel.searchText = ""
-          } label: {
-            Image(systemName: "xmark.circle.fill")
-              .foregroundColor(Ink.secondary)
+      },
+      actions: {
+        if viewModel.isMultiSelectMode {
+          if viewModel.multiSelection.selectionCount > 0 {
+            deleteSelectedButton
           }
-          .buttonStyle(.plain)
+          cancelMultiSelectButton
+        } else {
+          tasksMoreMenu
+          addTaskButton
         }
       }
-      .padding(.horizontal, OmiSpacing.md)
-      .padding(.vertical, OmiSpacing.sm)
-      .glassField()
-
-      if !viewModel.isMultiSelectMode {
-        completedToggleButton
-      } else {
-        multiSelectControls
-      }
-
-      selectModeButton
-
-      if viewModel.isMultiSelectMode {
-        if viewModel.multiSelection.selectionCount > 0 {
-          deleteSelectedButton
-        }
-        cancelMultiSelectButton
-      } else {
-        if chatProvider != nil && TaskAgentSettings.shared.isChatEnabled {
-          chatToggleButton
-        }
-        addTaskButton
-        // HIDDEN DELIBERATELY (Nik, 2026-08-25): the gear deep-linked to the Task
-        // Assistant pane, which is hidden from Settings. TasksHeaderSettingsGear
-        // consults the policy and is host-tested; do not add a parallel gear here.
-        TasksHeaderSettingsGear {
-          NotificationCenter.default.post(name: .navigateToTaskSettings, object: nil)
-        }
-      }
-    }
-    .padding(.horizontal, OmiSpacing.lg)
-    .padding(.top, OmiSpacing.lg)
-    .padding(.bottom, OmiSpacing.md)
+    )
+    .pagePanelFirstRowInsets()
   }
 
   // MARK: - Board / List view toggle
@@ -4017,37 +3998,40 @@ struct TasksPage: View {
       viewModel.inlineCreateAfterTaskId = nil
       viewModel.isInlineCreating = true
     } label: {
-      Image(systemName: "plus")
-        .scaledFont(size: OmiType.body)
-        .foregroundColor(Ink.surface)
-        .padding(.horizontal, OmiSpacing.sm)
-        .padding(.vertical, OmiSpacing.sm)
-        .background(Capsule(style: .continuous).fill(Ink.primary))
+      PageQueryActionLabel(icon: "plus", title: "New Task", isPrimary: true)
     }
     .buttonStyle(.plain)
-    .help("Add task (⌘N)")
+    .help("New task (⌘N)")
+    .accessibilityIdentifier("tasks-new-task")
   }
 
-  // MARK: - Completed Toggle (mobile parity)
+  // MARK: - Status refinement (mobile parity)
 
-  private var completedToggleButton: some View {
-    Button {
-      viewModel.toggleShowCompletedView()
+  private var taskStatusMenu: some View {
+    Menu {
+      Button {
+        viewModel.selectedTags = [.todo]
+      } label: {
+        Label("To Do", systemImage: "circle")
+      }
+
+      Button {
+        viewModel.selectedTags = [.done]
+      } label: {
+        Label("Completed", systemImage: "checkmark.circle.fill")
+      }
     } label: {
-      Image(systemName: viewModel.showCompleted ? "checkmark.circle.fill" : "checkmark.circle")
-        .scaledFont(size: OmiType.caption)
-        .foregroundColor(viewModel.showCompleted ? Ink.primary : Ink.secondary)
-        .padding(.horizontal, OmiSpacing.sm)
-        .padding(.vertical, OmiSpacing.sm)
-        .background(Ink.rowFill)
-        .cornerRadius(OmiChrome.elementRadius)
-        .overlay(
-          RoundedRectangle(cornerRadius: OmiChrome.elementRadius)
-            .stroke(viewModel.showCompleted ? Ink.separator : Color.clear, lineWidth: 1)
-        )
+      PageQueryControlLabel(
+        icon: "checkmark.circle",
+        dimension: nil,
+        value: viewModel.showCompleted ? "Completed" : "To Do",
+        isActive: viewModel.showCompleted
+      )
     }
+    .menuStyle(.button)
     .buttonStyle(.plain)
-    .help(viewModel.showCompleted ? "Hide completed tasks" : "Show completed tasks")
+    .accessibilityIdentifier("tasks-status-filter")
+    .help("Filter tasks by status")
   }
 
   private var selectModeButton: some View {
@@ -4152,24 +4136,45 @@ struct TasksPage: View {
     .buttonStyle(.plain)
   }
 
-  private var taskSettingsButton: some View {
-    Button {
-      NotificationCenter.default.post(
-        name: .navigateToTaskSettings,
-        object: nil
-      )
+  private var tasksMoreMenu: some View {
+    Menu {
+      if !viewModel.displayTasks.isEmpty {
+        Button {
+          OmiMotion.withGated(.easeInOut(duration: 0.2)) {
+            viewModel.toggleMultiSelectMode()
+          }
+        } label: {
+          Label("Select tasks…", systemImage: "checkmark.circle")
+        }
+      }
+
+      if chatProvider != nil && TaskAgentSettings.shared.isChatEnabled {
+        Button {
+          if showChatPanel {
+            closeChatPanel()
+          } else if let selectedId = viewModel.keyboardSelectedTaskId,
+            let task = viewModel.displayTasks.first(where: { $0.id == selectedId })
+          {
+            openChatForTask(task)
+          } else {
+            adjustWindowWidth(expand: true)
+            OmiMotion.withGated(.easeInOut(duration: 0.25)) {
+              showChatPanel = true
+            }
+          }
+        } label: {
+          Label(showChatPanel ? "Close task assistant" : "Open task assistant", systemImage: "bubble.left")
+        }
+      }
     } label: {
-      Image(systemName: "gearshape")
-        .scaledFont(size: OmiType.caption)
-        .foregroundColor(Ink.secondary)
-        .padding(OmiSpacing.sm)
-        .background(
-          RoundedRectangle(cornerRadius: OmiChrome.elementRadius)
-            .fill(Ink.rowFill)
-        )
+      PageQueryActionLabel(icon: "ellipsis", title: "More")
     }
-    .buttonStyle(.plain)
-    .help("Task Settings")
+    .menuStyle(.borderlessButton)
+    .menuIndicator(.hidden)
+    .fixedSize()
+    .help("More task actions")
+    .accessibilityLabel("More task actions")
+    .accessibilityIdentifier("tasks-more-actions")
   }
 
   private var chatToggleButton: some View {
@@ -4200,6 +4205,7 @@ struct TasksPage: View {
     }
     .buttonStyle(.plain)
     .help(showChatPanel ? "Close chat panel" : "Open task chat")
+    .accessibilityLabel(showChatPanel ? "Close task chat" : "Open task chat")
   }
 
   // MARK: - Loading View
@@ -4293,18 +4299,26 @@ struct TasksPage: View {
         .scaledFont(size: 48)
         .foregroundColor(Ink.secondary)
 
-      Text(isSearchEmpty ? "No Results Found" : (viewModel.showCompleted ? "No Completed Tasks" : "All Caught Up"))
+      Text(isSearchEmpty ? "No Matching Tasks" : (viewModel.showCompleted ? "No Completed Tasks" : "All Caught Up"))
         .scaledFont(size: 24, weight: .semibold)
         .foregroundColor(Ink.primary)
 
       Text(
         isSearchEmpty
-          ? "Try a different search"
+          ? "No \(viewModel.showCompleted ? "completed" : "to-do") tasks match “\(viewModel.normalizedSearchQuery)”"
           : (viewModel.showCompleted ? "Tasks you complete will appear here" : "You have no tasks yet")
       )
       .scaledFont(size: OmiType.body)
       .foregroundColor(Ink.secondary)
       .multilineTextAlignment(.center)
+
+      if isSearchEmpty {
+        Button("Clear Search") {
+          viewModel.searchText = ""
+        }
+        .buttonStyle(.bordered)
+        .tint(Ink.secondary)
+      }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
@@ -4319,7 +4333,7 @@ struct TasksPage: View {
           // Multi-select keeps this grouping: selecting tasks must not reshuffle the
           // list out from under the user. Only the row's selection control changes.
           if !viewModel.showCompleted {
-            if !viewModel.isMultiSelectMode {
+            if viewModel.normalizedSearchQuery.isEmpty && !viewModel.isMultiSelectMode {
               SuggestedTasksSection(
                 store: suggestedStore,
                 isExpanded: $suggestionsSectionExpanded,
@@ -4735,18 +4749,26 @@ struct TaskCategorySection: View {
 
         Spacer()
 
-        if category == .today {
-          Button {
-            confirmClearTodayDeadlines()
+        if category == .today, onClearTodayDeadlines != nil {
+          Menu {
+            Button(role: .destructive) {
+              confirmClearTodayDeadlines()
+            } label: {
+              Label("Remove today from all…", systemImage: "calendar.badge.minus")
+            }
           } label: {
-            Image(systemName: "xmark")
-              .scaledFont(size: OmiType.micro, weight: .semibold)
-              .foregroundColor(Ink.secondary)
-              .frame(width: 18, height: 18)
+            Image(systemName: "ellipsis")
+              .scaledFont(size: OmiType.caption, weight: .semibold)
+              .foregroundStyle(Ink.secondary)
+              .frame(width: 28, height: 28)
+              .contentShape(Rectangle())
           }
-          .buttonStyle(.plain)
-          .contentShape(Rectangle())
-          .help("Clean today's tasks")
+          .menuStyle(.borderlessButton)
+          .menuIndicator(.hidden)
+          .fixedSize()
+          .help("More Today actions")
+          .accessibilityLabel("More Today actions")
+          .accessibilityIdentifier("tasks-today-actions")
         }
 
       }
@@ -4755,7 +4777,7 @@ struct TaskCategorySection: View {
       .onTapGesture {
         onToggleCollapse?()
       }
-      .accessibilityElement(children: .combine)
+      .accessibilityElement(children: .contain)
       .accessibilityAddTraits(onToggleCollapse != nil ? .isButton : [])
       .accessibilityAction {
         onToggleCollapse?()
@@ -5761,83 +5783,71 @@ struct TaskRow: View {
       // Hover actions overlaid on trailing edge (no layout shift)
       if TaskDetailPanelPresentationPolicy.showsHoverActions(
         isRowHovering: isHovering,
+        isKeyboardSelected: isKeyboardSelected,
         isMultiSelectMode: isMultiSelectMode,
         isDeletedTask: isDeletedTask,
         isTextFieldFocused: isTextFieldFocused,
         isDetailPanelPresented: isTaskDetailPanelActive
       ) {
-        HStack(spacing: OmiSpacing.xxs) {
-          // Add date button (shown on hover when no due date)
+        Menu {
           if task.dueAt == nil && !task.completed {
             Button {
               editDueDate = Date()
               showDatePicker = true
             } label: {
-              Image(systemName: "calendar.badge.plus")
-                .scaledFont(size: OmiType.caption)
-                .foregroundColor(Ink.secondary)
-                .frame(width: 24, height: 24)
+              Label("Add due date…", systemImage: "calendar.badge.plus")
             }
-            .buttonStyle(.plain)
-            .help("Add due date")
           }
 
-          // Outdent button (decrease indent)
           if indentLevel > 0 {
             Button {
               OmiMotion.withGated(.easeInOut(duration: 0.2)) {
                 onDecrementIndent?(task.id)
               }
             } label: {
-              Image(systemName: "arrow.left.to.line")
-                .scaledFont(size: OmiType.caption)
-                .foregroundColor(Ink.secondary)
-                .frame(width: 24, height: 24)
+              Label("Decrease indent", systemImage: "arrow.left.to.line")
             }
-            .buttonStyle(.plain)
-            .help("Decrease indent")
           }
 
-          // Indent button (increase indent)
           if indentLevel < 3 {
             Button {
               OmiMotion.withGated(.easeInOut(duration: 0.2)) {
                 onIncrementIndent?(task.id)
               }
             } label: {
-              Image(systemName: "arrow.right.to.line")
-                .scaledFont(size: OmiType.caption)
-                .foregroundColor(Ink.secondary)
-                .frame(width: 24, height: 24)
+              Label("Increase indent", systemImage: "arrow.right.to.line")
             }
-            .buttonStyle(.plain)
-            .help("Increase indent")
           }
 
-          // Share link button
           Button {
             Task { await copyShareLink() }
           } label: {
-            Image(systemName: isCopyingLink ? "arrow.triangle.2.circlepath" : "arrowshape.turn.up.right.fill")
-              .scaledFont(size: OmiType.body)
-              .foregroundColor(Ink.secondary)
-              .frame(width: 24, height: 24)
+            Label(
+              isCopyingLink ? "Copying share link…" : "Copy share link",
+              systemImage: isCopyingLink ? "arrow.triangle.2.circlepath" : "link")
           }
-          .buttonStyle(.plain)
           .disabled(isCopyingLink)
-          .help("Copy share link")
 
-          // Delete button
-          Button {
+          Divider()
+
+          Button(role: .destructive) {
             Task { await onDelete?(task) }
           } label: {
-            Image(systemName: "trash")
-              .scaledFont(size: OmiType.body)
-              .foregroundColor(Ink.secondary)
-              .frame(width: 24, height: 24)
+            Label("Delete task", systemImage: "trash")
           }
-          .buttonStyle(.plain)
+        } label: {
+          Image(systemName: "ellipsis")
+            .scaledFont(size: OmiType.caption, weight: .semibold)
+            .foregroundStyle(Ink.secondary)
+            .frame(width: 28, height: 28)
+            .contentShape(Rectangle())
         }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("More actions for this task")
+        .accessibilityLabel("More actions for \(task.description)")
+        .accessibilityIdentifier("task-row-actions-\(task.id)")
         .padding(.trailing, OmiSpacing.xxs)
         .padding(.leading, OmiSpacing.sm)
         .padding(.vertical, OmiSpacing.xxs)

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityDestinationChip.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityDestinationChip.swift
@@ -170,7 +170,7 @@ struct BrainSectionPageLayout<Search: View, Content: View>: View {
 
 enum BrainSectionPageMetrics {
   static let navigationTopPadding = PagePanelFirstRowMetrics.topPadding
-  static let navigationBottomPadding = PagePanelFirstRowMetrics.bottomPadding
+  static let navigationBottomPadding = PagePanelVerticalRhythm.rowGap
   static let navigationHeight: CGFloat =
     QueryShellLayout.chipHeight + navigationTopPadding + navigationBottomPadding
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityDestinationChip.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityDestinationChip.swift
@@ -18,29 +18,31 @@
 //  test failure rather than a page someone discovers is stranded.
 //
 
-import Foundation
+import OmiTheme
+import SwiftUI
 
 /// One chip in Activity's row. Every case is a destination; none is a filter.
 enum ActivityDestinationChip: String, CaseIterable, Identifiable {
   case activity
   case conversations
   case memories
+  case rewind
   case brainMap
 
   var id: String { rawValue }
 
   var title: String {
     switch self {
-    case .activity: return "Brain"
+    case .activity: return "Activity"
     case .conversations: return "Conversations"
     case .memories: return "Memories"
+    case .rewind: return "Rewind"
     case .brainMap: return "Brain Map"
     }
   }
 
-  /// The Memory hub page this chip opens. Every chip in this row is one of the hub's four pages:
-  /// `Tasks` and `Rewind` were here too and were removed, because each already has its own pill in
-  /// the bar directly above — a second control to the same place, two inches apart.
+  /// The Brain page this chip opens. Tasks stays global because it has its own primary pill. Rewind
+  /// belongs here because it is another way to inspect captured history.
   ///
   /// **Not optional, and that is the reachability claim's teeth.** A chip that opens no hub page
   /// would be a chip that reaches nothing while `reachableHubDestinations` quietly dropped it; the
@@ -50,6 +52,7 @@ enum ActivityDestinationChip: String, CaseIterable, Identifiable {
     case .activity: return .activity
     case .conversations: return .conversations
     case .memories: return .memories
+    case .rewind: return .rewind
     case .brainMap: return .brainMap
     }
   }
@@ -58,4 +61,116 @@ enum ActivityDestinationChip: String, CaseIterable, Identifiable {
   static var reachableHubDestinations: [MemoryHubDestination] {
     allCases.map(\.hubDestination)
   }
+}
+
+/// Stable peer navigation for every Brain surface. A section selection is not a drill-in, so this
+/// row stays visible instead of making each page manufacture a way back to Activity.
+struct BrainSectionNavigation: View {
+  let selected: MemoryHubDestination
+  let onSelect: (MemoryHubDestination) -> Void
+
+  var body: some View {
+    ViewThatFits(in: .horizontal) {
+      navigationRow
+      ScrollView(.horizontal, showsIndicators: false) {
+        navigationRow
+          .padding(.trailing, QueryShellLayout.chipSpacing)
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("brain-section-navigation")
+  }
+
+  @ViewBuilder
+  private var navigationRow: some View {
+    HStack(spacing: QueryShellLayout.chipSpacing) {
+      ForEach(ActivityDestinationChip.allCases) { chip in
+        BrainSectionButton(
+          title: chip.title,
+          isActive: chip.hubDestination == selected,
+          action: { onSelect(chip.hubDestination) }
+        )
+        .accessibilityIdentifier("brain-section-\(chip.rawValue)")
+      }
+    }
+  }
+}
+
+private struct BrainSectionButton: View {
+  let title: String
+  let isActive: Bool
+  let action: () -> Void
+
+  @State private var isHovering = false
+
+  var body: some View {
+    Button(action: action) {
+      Text(title)
+        .scaledFont(size: OmiType.caption, weight: isActive ? .semibold : .regular)
+        .foregroundStyle(GlassShell.controlLabel(isProminent: isActive || isHovering))
+        .padding(.horizontal, 12)
+        .frame(height: QueryShellLayout.chipHeight)
+        .glassChip(isActive: isActive)
+    }
+    .buttonStyle(.plain)
+    .contentShape(Capsule(style: .continuous))
+    .onHover { isHovering = $0 }
+    .animation(InkReduceMotion.animation(.easeOut(duration: InkMotion.press)), value: isActive)
+    .accessibilityAddTraits(isActive ? .isSelected : [])
+  }
+}
+
+/// The shared Brain page shape: the product-wide search surface above a content panel whose first
+/// row is Brain navigation. Search stays visually and behaviorally identical to Chat, Tasks, and
+/// Apps; section switching belongs to the thing it changes rather than decorating the query field.
+struct BrainSectionPageLayout<Search: View, Content: View>: View {
+  let selected: MemoryHubDestination
+  let onSelect: (MemoryHubDestination) -> Void
+  let search: Search
+  let content: Content
+
+  init(
+    selected: MemoryHubDestination,
+    onSelect: @escaping (MemoryHubDestination) -> Void,
+    @ViewBuilder search: () -> Search,
+    @ViewBuilder content: () -> Content
+  ) {
+    self.selected = selected
+    self.onSelect = onSelect
+    self.search = search()
+    self.content = content()
+  }
+
+  var body: some View {
+    GeometryReader { proxy in
+      let lane = QueryShellLayout.laneWidth(for: proxy.size.width)
+
+      VStack(spacing: QueryShellLayout.panelGap) {
+        search
+
+        VStack(alignment: .leading, spacing: 0) {
+          BrainSectionNavigation(selected: selected, onSelect: onSelect)
+            .padding(.horizontal, QueryShellLayout.panelPaddingHorizontal)
+            .padding(.top, BrainSectionPageMetrics.navigationTopPadding)
+            .padding(.bottom, BrainSectionPageMetrics.navigationBottomPadding)
+
+          content
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .inkGlassPanel(cornerRadius: QueryShellLayout.panelCornerRadius, shadow: .ambient)
+      }
+      .frame(width: lane)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+      .padding(.top, QueryShellLayout.surfaceTopInset)
+    }
+  }
+}
+
+enum BrainSectionPageMetrics {
+  static let navigationTopPadding = PagePanelFirstRowMetrics.topPadding
+  static let navigationBottomPadding = PagePanelFirstRowMetrics.bottomPadding
+  static let navigationHeight: CGFloat =
+    QueryShellLayout.chipHeight + navigationTopPadding + navigationBottomPadding
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityHubTab.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityHubTab.swift
@@ -16,9 +16,8 @@ struct ActivityHubTab: View {
   let onOpenMemory: (SpineMemory) -> Void
   let onOpenBrainMap: () -> Void
   let onOpenRewind: () -> Void
-  /// Opens one of the Memory hub's sibling pages. The chip row is the only door to them now that
-  /// the hub's switcher is gone, so a host that cannot supply this would strand three pages.
-  let onOpenHubDestination: (MemoryHubDestination) -> Void
+  let selectedDestination: MemoryHubDestination
+  let onSelectDestination: (MemoryHubDestination) -> Void
 
   @ObservedObject private var tasksStore = TasksStore.shared
   @State private var filters = QueryShellFilters()
@@ -30,8 +29,10 @@ struct ActivityHubTab: View {
       let lane = QueryShellLayout.laneWidth(for: proxy.size.width)
       // The panel arithmetic with the search bar in the hero slot but no composer inside the panel.
       let room =
-        proxy.size.height - QueryShellLayout.surfaceTopInset - QueryShellLayout.barMinHeight
+        proxy.size.height - QueryShellLayout.surfaceTopInset
+        - QueryShellLayout.barMinHeight
         - QueryShellLayout.panelGap
+        - BrainSectionPageMetrics.navigationHeight
         - QueryShellLayout.panelChromeHeight(mode: .results, composerHeight: 0)
       let bodyHeight = min(
         QueryShellLayout.maximumBodyHeight, max(QueryShellLayout.minimumBodyHeight, room))
@@ -43,7 +44,13 @@ struct ActivityHubTab: View {
           total: total,
           onExitAnswer: nil,
           bodyHeight: bodyHeight,
-          chipBehavior: .openDestinations(selected: .activity, open: openChip),
+          chipBehavior: .none,
+          topAccessory: {
+            BrainSectionNavigation(
+              selected: selectedDestination,
+              onSelect: onSelectDestination
+            )
+          },
           headerAccessory: { EmptyView() },
           footer: { EmptyView() }
         ) {
@@ -68,18 +75,12 @@ struct ActivityHubTab: View {
   }
 
   private var searchBar: some View {
-    QuerySearchBar(text: $searchText, accessibilityID: "activity-search-field")
-  }
-
-  /// Every chip in this row navigates — see `ActivityDestinationChip`. `Activity` is the page we
-  /// are already on, so it is the row's selected state rather than a fifth way to reload it.
-  private func openChip(_ chip: ActivityDestinationChip) {
-    switch chip {
-    case .activity:
-      return
-    case .conversations, .memories, .brainMap:
-      onOpenHubDestination(chip.hubDestination)
-    }
+    QuerySearchBar(
+      text: $searchText,
+      accessibilityID: "activity-search-field",
+      placeholder: "Search activity…",
+      focus: nil
+    )
   }
 
   private var requestBinding: Binding<QueryShellRequest> {

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryResultsPanel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryResultsPanel.swift
@@ -53,7 +53,7 @@ extension View {
   }
 }
 
-struct QueryResultsPanel<Content: View, Accessory: View, Footer: View>: View {
+struct QueryResultsPanel<Content: View, TopAccessory: View, Accessory: View, Footer: View>: View {
   @Binding var request: QueryShellRequest
   let mode: QueryShellMode
   /// The whole corpus, for the resting sentence. Nil while it is still being counted, which reads as
@@ -72,6 +72,9 @@ struct QueryResultsPanel<Content: View, Accessory: View, Footer: View>: View {
   /// What the chip row does on this surface. Home narrows its search results in place; Activity's
   /// row is navigation — see `ActivityDestinationChip`.
   var chipBehavior: QueryPanelChipBehavior = .filterKinds
+  /// A full-width row above the filter/count header. Brain uses it for peer navigation so the
+  /// switcher belongs to the results panel rather than to the search field.
+  @ViewBuilder var topAccessory: () -> TopAccessory
 
   /// One slot in the header's leading cluster, next to `Filter ›` / `‹ Results`.
   ///
@@ -95,8 +98,9 @@ struct QueryResultsPanel<Content: View, Accessory: View, Footer: View>: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: QueryShellLayout.panelHeaderSpacing) {
+      topAccessory()
       header
-      if mode == .results {
+      if mode == .results, chipBehavior.showsChipRow {
         chips
       }
       content()
@@ -169,8 +173,15 @@ struct QueryResultsPanel<Content: View, Accessory: View, Footer: View>: View {
     // own content — so without this the `Filter` control renders in the accent, which on a surface
     // that spends its single accent on `⌘⏎ Ask` reads as two primary actions.
     .tint(Ink.primary)
-    .help("Narrow the panel to a time window")
+    .help(filterHelp)
     .accessibilityIdentifier("query-shell-filter")
+  }
+
+  private var filterHelp: String {
+    if case .none = chipBehavior {
+      return "Choose a time range. The timeline rail below navigates within that range."
+    }
+    return "Narrow the panel to a time window"
   }
 
   /// In answer mode the same corner carries the way back, because asking is a mode of this query and
@@ -210,6 +221,8 @@ struct QueryResultsPanel<Content: View, Accessory: View, Footer: View>: View {
   private var chips: some View {
     HStack(spacing: QueryShellLayout.chipSpacing) {
       switch chipBehavior {
+      case .none:
+        EmptyView()
       case .filterKinds:
         ForEach(QueryShellKind.allCases) { kind in
           QueryTypeChip(
@@ -239,14 +252,21 @@ struct QueryResultsPanel<Content: View, Accessory: View, Footer: View>: View {
 /// cannot quietly become the other: a row where some chips filter and some navigate teaches a rule
 /// and then breaks it.
 enum QueryPanelChipBehavior {
+  case none
   case filterKinds
   case openDestinations(selected: ActivityDestinationChip, open: (ActivityDestinationChip) -> Void)
+
+  var showsChipRow: Bool {
+    if case .none = self { return false }
+    return true
+  }
 
   /// What the row's own header calls it. The word has to follow the behaviour: on Home the chips
   /// narrow the results in place and `Filter` is the truth; on Activity they open pages, and a row
   /// of destinations under the word `Filter` describes something the row does not do.
   var disclosureLabel: String {
     switch self {
+    case .none: return "Time range"
     case .filterKinds: return "Filter"
     case .openDestinations: return "View"
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QuerySearchBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QuerySearchBar.swift
@@ -8,17 +8,21 @@ import SwiftUI
 struct QuerySearchBar: View {
   @Binding var text: String
   var accessibilityID: String = "query-search-field"
+  var placeholder: String = RewindSearchMetrics.placeholder
+  var focus: FocusState<Bool>.Binding? = nil
 
   var body: some View {
+    searchRow
+      .frame(minHeight: QueryShellLayout.barMinHeight)
+      .inkGlassPanel(cornerRadius: QueryShellLayout.panelCornerRadius, shadow: .ambient)
+  }
+
+  private var searchRow: some View {
     HStack(spacing: QueryShellLayout.heroRowSpacing) {
       Image(systemName: "magnifyingglass")
         .scaledFont(size: QueryShellLayout.heroGlyphSize, weight: .regular)
         .foregroundStyle(Ink.secondary)
-      TextField(RewindSearchMetrics.placeholder, text: $text)
-        .textFieldStyle(.plain)
-        .scaledFont(size: QueryShellLayout.queryFontSize, weight: .regular)
-        .foregroundStyle(Ink.primary)
-        .accessibilityIdentifier(accessibilityID)
+      searchField
       if !text.isEmpty {
         Button {
           text = ""
@@ -28,11 +32,28 @@ struct QuerySearchBar: View {
             .foregroundStyle(Ink.secondary)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("Clear search")
         .help("Clear the search")
       }
     }
     .padding(.horizontal, QueryShellLayout.barPaddingHorizontal)
-    .frame(minHeight: QueryShellLayout.barMinHeight)
-    .inkGlassPanel(cornerRadius: QueryShellLayout.panelCornerRadius, shadow: .ambient)
+  }
+
+  @ViewBuilder
+  private var searchField: some View {
+    if let focus {
+      TextField(placeholder, text: $text)
+        .textFieldStyle(.plain)
+        .scaledFont(size: QueryShellLayout.queryFontSize, weight: .regular)
+        .foregroundStyle(Ink.primary)
+        .focused(focus)
+        .accessibilityIdentifier(accessibilityID)
+    } else {
+      TextField(placeholder, text: $text)
+        .textFieldStyle(.plain)
+        .scaledFont(size: QueryShellLayout.queryFontSize, weight: .regular)
+        .foregroundStyle(Ink.primary)
+        .accessibilityIdentifier(accessibilityID)
+    }
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QuerySearchBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QuerySearchBar.swift
@@ -10,11 +10,22 @@ struct QuerySearchBar: View {
   var accessibilityID: String = "query-search-field"
   var placeholder: String = RewindSearchMetrics.placeholder
   var focus: FocusState<Bool>.Binding? = nil
+  @FocusState private var internalFocus: Bool
+  @State private var isClearHovered = false
+
+  private var isFocused: Bool {
+    focus?.wrappedValue ?? internalFocus
+  }
 
   var body: some View {
     searchRow
       .frame(minHeight: QueryShellLayout.barMinHeight)
       .inkGlassPanel(cornerRadius: QueryShellLayout.panelCornerRadius, shadow: .ambient)
+      .overlay {
+        RoundedRectangle(cornerRadius: QueryShellLayout.panelCornerRadius, style: .continuous)
+          .stroke(isFocused ? Ink.primary.opacity(0.28) : Color.clear, lineWidth: 1)
+          .allowsHitTesting(false)
+      }
   }
 
   private var searchRow: some View {
@@ -28,10 +39,15 @@ struct QuerySearchBar: View {
           text = ""
         } label: {
           Image(systemName: "xmark.circle.fill")
-            .scaledFont(size: QueryShellLayout.heroGlyphSize, weight: .regular)
+            .scaledFont(size: OmiType.body, weight: .semibold)
             .foregroundStyle(Ink.secondary)
+            .frame(width: 28, height: 28)
+            .background(isClearHovered ? Ink.rowFillHover : Color.clear)
+            .clipShape(Circle())
+            .contentShape(Circle())
         }
         .buttonStyle(.plain)
+        .onHover { isClearHovered = $0 }
         .accessibilityLabel("Clear search")
         .help("Clear the search")
       }
@@ -53,6 +69,7 @@ struct QuerySearchBar: View {
         .textFieldStyle(.plain)
         .scaledFont(size: QueryShellLayout.queryFontSize, weight: .regular)
         .foregroundStyle(Ink.primary)
+        .focused($internalFocus)
         .accessibilityIdentifier(accessibilityID)
     }
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
@@ -148,6 +148,7 @@ struct QueryShellHome: View {
             total: total,
             onExitAnswer: nil,
             bodyHeight: bodyHeight,
+            topAccessory: { EmptyView() },
             headerAccessory: { headerAccessory },
             footer: {
               if mode == .answer {
@@ -341,25 +342,14 @@ struct QueryShellHome: View {
       isClearing: chatProvider.isClearing)
   }
 
-  /// Clear, copy and the jump to AI settings — the deleted chat page's last three controls, which
-  /// have had nowhere to live since it went. An overflow rather than three icons in the header,
-  /// because none of them is something you reach for during a conversation.
+  /// Conversation-local actions only. Global AI configuration belongs to the
+  /// Settings gear that is already present on every page.
   private var chatMenu: some View {
     Menu {
       Button(didCopyTranscript ? "Copied" : "Copy conversation", action: copyTranscript)
         .disabled(!menu.canCopy)
       Button("Clear conversation", role: .destructive, action: clearTranscript)
         .disabled(!menu.canClear)
-      Divider()
-      // The deleted page's gear, with its own words ("Advanced AI settings"). It posts the shared
-      // notification rather than routing itself, so it lands wherever `DesktopHomeView` already
-      // sends that jump — today `.advanced`, which is the *visible* section holding AI Provider, the
-      // Claude connection and the chat workspace directory. `SettingsSection.aiChat` is deliberately
-      // absent from the sidebar and bounces to `.advanced` on production bundles; pointing a chat
-      // control straight at it would be a menu item that silently lands somewhere else.
-      Button("Advanced AI settings…") {
-        NotificationCenter.default.post(name: .navigateToAIChatSettings, object: nil)
-      }
     } label: {
       QueryPanelChipLabel(
         systemImage: didCopyTranscript ? "checkmark" : "ellipsis",

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
@@ -323,19 +323,17 @@ enum QueryShellRoute: Equatable, CaseIterable, Sendable {
   /// The established page that owns this destination. Never a shell-local surface (INV-NAV-1).
   var navItem: SidebarNavItem {
     switch self {
-    case .conversation, .memories, .brainMap: return .conversations
-    case .rewind: return .rewind
+    case .conversation, .memories, .brainMap, .rewind: return .conversations
     }
   }
 
-  /// Which of the Memory hub's own three views to select on arrival, for the three that share its
-  /// page. `nil` means the destination is a page of its own.
+  /// Which Brain view to select on arrival.
   var memoryDestination: MemoryHubDestination? {
     switch self {
     case .conversation: return .conversations
     case .memories: return .memories
     case .brainMap: return .brainMap
-    case .rewind: return nil
+    case .rewind: return .rewind
     }
   }
 }
@@ -413,18 +411,19 @@ enum QueryShellLayout {
 
   // The hero bar.
 
-  /// Roomy: this is a place to type, not a control strip.
-  static let barMinHeight: CGFloat = 64
-  static let barPaddingHorizontal: CGFloat = 18
-  static let barPaddingVertical: CGFloat = 12
+  /// Search is a persistent utility, not a hero. Keep it large enough to scan
+  /// and focus while returning the vertical space to the page it filters.
+  static let barMinHeight: CGFloat = 48
+  static let barPaddingHorizontal: CGFloat = 14
+  static let barPaddingVertical: CGFloat = 6
   /// The animated mark at the leading edge.
-  static let markDiameter: CGFloat = 26
-  /// The push-to-talk disc. Larger than the composer's 32 because it is the bar's only round target.
-  static let micDiameter: CGFloat = 38
+  static let markDiameter: CGFloat = 22
+  /// The push-to-talk disc. Larger than the compact in-panel controls because it is the bar's only round target.
+  static let micDiameter: CGFloat = 32
 
   /// Between the hero row's controls. It is set at the query face, so it can afford more air than
   /// the chat row inside the panel, which uses `OmiSpacing.sm`.
-  static let heroRowSpacing: CGFloat = 14
+  static let heroRowSpacing: CGFloat = 10
 
   /// The glyph the hero's two quiet controls share — the paperclip and the mic, which are the same
   /// kind of thing and must not be two sizes.
@@ -438,7 +437,7 @@ enum QueryShellLayout {
   /// The query's point size. Visibly larger than every other run on the surface, and deliberately
   /// under `Font.inkDisplayThreshold` (22) so it resolves to the reading face rather than the display
   /// one — a search field is type you read, not a headline.
-  static let queryFontSize: CGFloat = 21
+  static let queryFontSize: CGFloat = 17
 
   // The composer inside the bar.
   //
@@ -449,16 +448,16 @@ enum QueryShellLayout {
   // one line is and where it stops.
 
   /// One laid-out line of the query face — `NSLayoutManager.defaultLineHeight` for
-  /// `NSFont.systemFont(ofSize: 21)`, measured rather than estimated. `QueryComposerTests` checks it
+  /// `NSFont.systemFont(ofSize: 17)`, measured rather than estimated. `QueryComposerTests` checks it
   /// against the platform every run, because the ceiling below is a whole number of these and an
   /// approximate line height shows as a sixth line half-drawn at the bottom edge of the glass.
-  static let composerLineHeight: CGFloat = 24
+  static let composerLineHeight: CGFloat = 20
 
   /// The text container's breathing room, top and bottom.
   static let composerInsetVertical: CGFloat = 6
 
   /// **The resting height is the height it always was.** One line plus its insets is 37, which the
-  /// 38 pt push-to-talk disc beside it already sets — so an empty bar is exactly as tall as before
+  /// 32 pt push-to-talk disc beside it already sets — so an empty bar is exactly as tall as before
   /// (`barMinHeight`) and nothing on the surface moves until there is a second line to show.
   static var composerMinHeight: CGFloat { composerLineHeight + composerInsetVertical * 2 }
 
@@ -491,7 +490,7 @@ enum QueryShellLayout {
   /// paperclip frame, a 28 pt text pill and a 38 pt mic disc, each drawn in a different visual
   /// language. Three loud controls at three sizes is not a cluster, it is a queue — and the loudest
   /// of them was the least important. One diameter, and only one of them filled.
-  static let panelComposerControlDiameter: CGFloat = 32
+  static let panelComposerControlDiameter: CGFloat = 28
 
   /// The one glyph size the quiet controls share, so the paperclip and the mic read as the same
   /// kind of thing rather than as two unrelated icons that happened to land beside each other.
@@ -499,7 +498,7 @@ enum QueryShellLayout {
 
   /// **The text's breathing room, chosen so one line is exactly a control tall.**
   ///
-  /// `(32 − 17) / 2`. It is derived rather than picked because when one laid-out line of the chat
+  /// `(28 − 17) / 2`. It is derived rather than picked because when one laid-out line of the chat
   /// face is the same height as the disc beside it, the row's baseline and the glyphs' centres
   /// coincide — at rest and at the ceiling, whichever way the row aligns. A round number here buys a
   /// permanent point or two of vertical drift between the reader's own words and the button that
@@ -512,7 +511,7 @@ enum QueryShellLayout {
   /// than from a declared row height, which is what keeps the padding symmetric: the placeholder
   /// starts this far in from the fill's leading edge, the send disc ends this far from its trailing
   /// one, and there is the same air above and below.
-  static let panelComposerShellInset: CGFloat = 10
+  static let panelComposerShellInset: CGFloat = 7
 
   static var panelComposerMinEditorHeight: CGFloat {
     panelComposerLineHeight + panelComposerInsetVertical * 2
@@ -542,7 +541,7 @@ enum QueryShellLayout {
 
   /// **The air between the pill and the panel holding it**, so the composer reads as an object
   /// *inside* the panel rather than as the panel's own bottom edge. On top of the panel's padding
-  /// this leaves 22 pt at the sides and 16 pt underneath.
+  /// this leaves 20 pt at the sides and 14 pt underneath.
   static let panelComposerEdgeInset: CGFloat = OmiSpacing.xs
   static let panelComposerBottomInset: CGFloat = OmiSpacing.xxs
 
@@ -565,12 +564,12 @@ enum QueryShellLayout {
   // The results panel.
 
   static let panelPaddingHorizontal: CGFloat = 16
-  static let panelPaddingTop: CGFloat = 14
-  static let panelPaddingBottom: CGFloat = 12
+  static let panelPaddingTop: CGFloat = 10
+  static let panelPaddingBottom: CGFloat = 10
   /// Between the `Filter ›` row and the chips under it.
-  static let panelHeaderSpacing: CGFloat = 10
+  static let panelHeaderSpacing: CGFloat = 6
   static let chipSpacing: CGFloat = 6
-  static let chipHeight: CGFloat = 26
+  static let chipHeight: CGFloat = 28
 
   /// The floor under the panel body, so an empty result set is still a panel and not a sliver.
   static let minimumBodyHeight: CGFloat = 120

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -13,7 +13,7 @@ struct SettingsSearchItem: Identifiable {
   let settingId: String
 
   var breadcrumb: String {
-    return section.rawValue
+    section.displayTitle
   }
 
   static let allSearchableItems: [SettingsSearchItem] = [
@@ -354,22 +354,9 @@ enum SettingsSidebarMetrics {
   ///
   /// The value is **derived from the longest label rather than chosen**, because this row truncates
   /// (`lineLimit(1)`, `.tail`) and a truncated item in a table of contents is worse than a wide one.
-  /// "Notifications & Privacy" needs 196 pt including its fixtures — the icon column, the gap after
-  /// it and the row's two side paddings — measured through the real font by
-  /// `SettingsSidebarItemLayoutTests`, at the *selected* weight, which is the wider of the two.
-  ///
-  /// The two numbers below the floor were both tried on a build and both truncated:
-  ///
-  /// - **196**, the settings kit's nominal width, renders "Notifications & P…".
-  /// - **216**, which clears the 196 pt requirement by 4 pt on paper, still renders
-  ///   "Notifications & Priva…" — a bare fit is not a fit once the scroll container and subpixel
-  ///   rounding have taken their share.
-  ///
-  /// So the width carries **`labelSlack`** rather than trusting the arithmetic to the last point,
-  /// and the guard test asserts the slack rather than the fit. 232 is still 28 pt narrower than the
-  /// 260 this started at, which was the app's *main* sidebar width — that one carries conversation
-  /// titles and has something to do with the room; nine section names do not.
-  static let expandedWidth: CGFloat = 232
+  /// The longest merged label is deliberately concise, so the table of contents
+  /// can stay narrow without truncating or stealing room from the settings pane.
+  static let expandedWidth: CGFloat = 208
 
   /// Headroom over the measured label requirement. See `expandedWidth`: a zero-slack fit truncated
   /// on a real build, so the fit is held open by this rather than by luck.
@@ -608,7 +595,7 @@ struct SettingsSidebarItem: View {
     case .aiChat: return "cpu"
     case .floatingBar: return "sparkles"
     case .shortcuts: return "keyboard"
-    case .advanced: return "chart.bar"
+    case .advanced: return "cpu"
     case .referral: return "gift"
     case .about: return "info.circle"
     case .permissions: return PermissionNavSymbol.outline

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellSummon.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellSummon.swift
@@ -40,6 +40,7 @@
 
 import AppKit
 import Foundation
+import OmiTheme
 
 /// The geometry half, with no window and no defaults in it, so every placement decision is a claim a
 /// hermetic test can hold. Multi-display placement is the part that breaks in the field and the part
@@ -53,8 +54,7 @@ enum ShellSummonPlacement {
   /// hugged glass (readable lane + page margins), so a 5K display still gets a panel, not a sheet.
   /// It stays above `DesktopWindowLayoutPolicy.minimumContentSize`, which is the floor the
   /// destinations lay out to.
-  static let defaultSize = NSSize(
-    width: ChatComposerLayout.contentLaneMaxWidth, height: 700)
+  static let defaultSize = WindowSizeResetPolicy.defaultSize
 
   /// Where the shell lands on a given display.
   ///

--- a/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineModel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineModel.swift
@@ -375,8 +375,8 @@ enum SpineComposer {
   /// Recomposing on every keystroke would make the query bar feel like the list is thinking; this
   /// way the store composes when the *data* changes and filters when the *question* does.
   ///
-  /// It also keeps the day header honest: `filter(_:kind:query:)` never touches the counts, so a
-  /// filtered spine still says how big the day really was.
+  /// It also keeps the day header honest: `filter(_:kind:query:)` recomputes the counts from the
+  /// rows it leaves on screen, so a filtered spine does not claim that hidden records are visible.
   ///
   /// - Parameters:
   ///   - conversations: the loaded page(s) of the real conversation list, any order.
@@ -502,12 +502,28 @@ enum SpineComposer {
         }
       }
 
+      // The day header describes the rows currently on screen. Carrying the composed day's totals
+      // through a query made an empty-looking kind filter still say "1 conversation · 1 memory";
+      // recompute each unit count after narrowing while keeping the timeline's row ordering intact.
+      let momentCount = rows.reduce(0) { total, row in
+        guard case .moments(_, let count) = row.content else { return total }
+        return total + count
+      }
+      let conversationCount = rows.reduce(0) { total, row in
+        guard case .conversation = row.content else { return total }
+        return total + 1
+      }
+      let taskCount = rows.reduce(0) { total, row in
+        guard case .tasks(let tasks) = row.content else { return total }
+        return total + tasks.count
+      }
+
       return SpineDay(
         id: day.id,
         title: day.title,
-        momentCount: day.momentCount,
-        conversationCount: day.conversationCount,
-        taskCount: day.taskCount,
+        momentCount: momentCount,
+        conversationCount: conversationCount,
+        taskCount: taskCount,
         rows: rows
       )
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineStream.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineStream.swift
@@ -236,7 +236,7 @@ struct SpineStream: View {
       guard let anchor else { return }
       Task { @MainActor in viewport.report(dayID: anchor.dayID, hour: anchor.hour) }
     }
-    .glassScrollFade(top: 6, bottom: 18)
+    .glassScrollFade(bottom: 18)
   }
 
   /// A layout-neutral reporter behind each row. A `GeometryReader` in a `background` never affects

--- a/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineStream.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineStream.swift
@@ -115,7 +115,8 @@ struct SpineStream: View {
     GeometryReader { proxy in
       HStack(spacing: 0) {
         if proxy.size.width >= SpineLayout.railBreakpoint {
-          SpineRailColumn(store: store, viewport: viewport, collapse: collapse)
+          SpineRailColumn(
+            store: store, viewport: viewport, collapse: collapse, request: request)
           Rectangle().fill(Ink.separator).frame(width: 1)
         }
         Group {
@@ -392,6 +393,7 @@ private struct SpineRailColumn: View {
   @ObservedObject var store: SpineStore
   @ObservedObject var viewport: SpineViewport
   let collapse: SpineDayCollapse
+  let request: QueryShellRequest
 
   /// The day the rail describes.
   ///
@@ -414,13 +416,26 @@ private struct SpineRailColumn: View {
     return viewport.hour
   }
 
+  /// The rail remains a timeline navigator while the list narrows. Its capture histogram and
+  /// screen-moment total therefore describe the complete day, not just the matching rows. Say so in
+  /// the scope line; otherwise a search for a memory can make "1,204 screen moments" look like a
+  /// result count for the memory search.
+  private var railDayTitle: String {
+    guard request.isFiltering, let title = day?.title, !title.isEmpty else {
+      return day?.title ?? ""
+    }
+    return "\(title) · full day"
+  }
+
   var body: some View {
     SpineHourRail(
       density: dayID.map(store.density(for:)) ?? Array(repeating: 0, count: 24),
       currentHour: currentHour,
       momentCount: dayID.flatMap(store.momentCount(for:)),
-      dayTitle: day?.title ?? "",
-      conversationCount: day?.conversationCount ?? 0
+      dayTitle: railDayTitle,
+      // Filtered results no longer carry the complete day's conversation count. The footer is
+      // supplementary context, so omit it rather than pairing a full-day rail with a filtered noun.
+      conversationCount: request.isFiltering ? 0 : (day?.conversationCount ?? 0)
     )
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Tasks/TaskDetailPanelPolicy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Tasks/TaskDetailPanelPolicy.swift
@@ -79,13 +79,14 @@ struct TaskDetailPanelState: Equatable {
 enum TaskDetailPanelPresentationPolicy {
   static func showsHoverActions(
     isRowHovering: Bool,
+    isKeyboardSelected: Bool = false,
     isMultiSelectMode: Bool,
     isDeletedTask: Bool,
     isTextFieldFocused: Bool,
     isDetailPanelPresented: Bool
   ) -> Bool {
     guard !isDetailPanelPresented else { return false }
-    return isRowHovering
+    return (isRowHovering || isKeyboardSelected)
       && !isMultiSelectMode
       && !isDeletedTask
       && !isTextFieldFocused

--- a/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
@@ -7,15 +7,12 @@
 //  did not ask and cancels when you did. Replacing hover with a click only changes *when* the wrong
 //  thing happens; the destinations were still hidden behind a disclosure the rest of the time.
 //
-//  So the disclosure is gone and the seven destinations were re-sorted by what they actually are:
+//  So the disclosure is gone and the destinations were re-sorted by what they actually are:
 //
-//  - **Three of them are one page.** Conversations, Memories and Brain Map are three of the Memory
-//    hub's four views (`MemoryHubDestination`). The bar was carrying a page's internal tabs, which is
-//    why it needed a menu to hold them. The bar keeps one pill, `Brain`, which opens the hub's
-//    fourth view — the chronological spine — and the other three are chips in that page's own
-//    navigating row (`ActivityDestinationChip`), with a `‹ Brain` control on each of them for the
-//    way back (`ActivityBackButton`).
-//  - **The rest are genuinely separate views**, so they are flat pills: `Tasks`, `Rewind`, `Apps`.
+//  - **Five of them are one section.** Activity, Conversations, Memories, Rewind and Brain Map are
+//    peer views in Brain (`MemoryHubDestination`). The bar keeps one `Brain` pill; a persistent row
+//    inside the section keeps every peer visible, instead of pretending peer navigation is Back.
+//  - **The rest are genuinely separate views**, so they are flat pills: `Tasks` and `Apps`.
 //    Always visible, one click, no disclosure, no hover.
 //
 //  `Home` is a peer of those, with a magnifying glass for a glyph. It used to be the eight-dot Omi
@@ -24,7 +21,7 @@
 //  mark means "this is Omi answering", and a nav button that spends it on "you are on Home" dilutes
 //  that to decoration. The bar's row is uniform now — every item is a glyph and a word.
 //
-//  What is left is a row of five words. That fits the lane at the narrowest window
+//  What is left is a row of four words. That fits the lane at the narrowest window
 //  the shell allows without falling back to the compact menu —
 //  `TopNavigationBarLayoutTests.testTheFlatDestinationRowFitsTheNarrowestWindow…` measures the real
 //  pills with both badges at their widest and asserts it.
@@ -110,22 +107,22 @@ enum ShellDestination: Int, CaseIterable, Identifiable {
   var navItem: SidebarNavItem {
     switch self {
     case .home: return .dashboard
-    case .conversations, .memories, .brainMap, .activity: return .conversations
+    case .conversations, .memories, .brainMap, .rewind, .activity: return .conversations
     case .tasks: return .tasks
-    case .rewind: return .rewind
     case .apps: return .apps
     case .permissions: return .permissions
     }
   }
 
-  /// The Memory hub sub-destination this selects, for the three that share the hub's page.
+  /// The Brain sub-destination this selects.
   var memoryDestination: MemoryHubDestination? {
     switch self {
     case .conversations: return .conversations
     case .memories: return .memories
     case .brainMap: return .brainMap
     case .activity: return .activity
-    case .home, .tasks, .rewind, .apps, .permissions: return nil
+    case .rewind: return .rewind
+    case .home, .tasks, .apps, .permissions: return nil
     }
   }
 
@@ -139,11 +136,11 @@ enum ShellDestination: Int, CaseIterable, Identifiable {
 
   var reach: Reach {
     switch self {
-    /// `Activity` is what the hub's pill opens, so its door is the bar itself — the other three
+    /// `Activity` is what the hub's pill opens, so its door is the bar itself — the other four
     /// hub views are reached from Activity's chip row once you are there.
-    case .conversations, .memories, .brainMap: return .activityChipRow
+    case .conversations, .memories, .brainMap, .rewind: return .activityChipRow
     case .permissions: return .settingsSidebar
-    case .home, .tasks, .rewind, .apps, .activity: return .topBar
+    case .home, .tasks, .apps, .activity: return .topBar
     }
   }
 
@@ -212,9 +209,8 @@ struct TopNavigationItem: Identifiable, Equatable {
 }
 
 enum TopNavigationRoutes {
-  /// **The whole navigation, flat.** `Activity` is the Memory hub — the one destination that owns
-  /// more than one view, and it offers the other three from a chip row on its own page. The other
-  /// four are single pages, so they are single pills. Nothing here opens a menu.
+  /// **The whole primary navigation, flat.** `Brain` owns five peer views and exposes them from a
+  /// persistent section row. Chat, Tasks and Apps are single pages, so they are single pills.
   static let primaryItems = [
     TopNavigationItem(
       index: SidebarNavItem.dashboard.rawValue, title: "Chat", icon: "bubble.left.and.text.bubble.right",
@@ -222,18 +218,15 @@ enum TopNavigationRoutes {
     // The hub's pill names the view it opens. It used to say `Memories` while opening whichever hub
     // view was last persisted, so the word on the bar and the page you landed on were only
     // sometimes the same thing. It opens `Brain` — the chronological spine over everything
-    // captured — and says so; Conversations, Memories and Brain Map stay one click away in that
+    // captured — and says so; Conversations, Memories, Rewind and Brain Map stay one click away in that
     // page's own chip row, which is the mechanism `ShellDestination.reach` records for them.
-    // The glyph is deliberately not `clock.arrow.circlepath`: that is Rewind's, two pills away.
+    // The glyph is deliberately not `clock.arrow.circlepath`: that belongs to Rewind inside Brain.
     TopNavigationItem(
       index: SidebarNavItem.conversations.rawValue, title: "Brain", icon: "brain",
       tooltip: "Brain — everything Omi captured, newest first"),
     TopNavigationItem(
       index: SidebarNavItem.tasks.rawValue, title: "Tasks", icon: "checklist",
       tooltip: "Tasks — everything Omi heard you commit to"),
-    TopNavigationItem(
-      index: SidebarNavItem.rewind.rawValue, title: "Rewind", icon: "clock.arrow.circlepath",
-      tooltip: "Rewind — replay what was on your screen"),
     TopNavigationItem(
       index: SidebarNavItem.apps.rawValue, title: "Apps", icon: "puzzlepiece.fill",
       tooltip: "Apps — connectors, imports and exports"),

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage+CaptureHealth.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage+CaptureHealth.swift
@@ -3,38 +3,39 @@ import SwiftUI
 
 extension RewindPage {
   var rewindToggle: some View {
-    ZStack {
-      Capsule()
-        // Green for on. `Ink.listeningGreen` is the palette's "this is live" colour and the one
-        // that reads as on without a label; the accent was doing that job in blue while every
-        // other live indicator in the app was green.
-        .fill(
-          screenCaptureHealth == .active
-            ? Ink.listeningGreen
-            : (screenCaptureHealth == .stopped ? Ink.errorRed : PageGlass.warning)
-        )
-        .frame(width: 36, height: 20)
+    Button {
+      toggleMonitoring(enabled: !isMonitoring)
+    } label: {
+      ZStack {
+        Capsule()
+          // The adjacent text supplies the state; colour is a redundant signal.
+          .fill(
+            screenCaptureHealth == .active
+              ? Ink.listeningGreen
+              : (screenCaptureHealth == .stopped ? Ink.errorRed : PageGlass.warning)
+          )
+          .frame(width: 36, height: 20)
 
-      Circle()
-        .fill(Ink.surface)
-        .frame(width: 16, height: 16)
-        .shadow(color: .black.opacity(0.08), radius: 1, x: 0, y: 1)
-        .offset(x: isMonitoring ? 8 : -8)
-        .omiAnimation(.easeInOut(duration: 0.15), value: isMonitoring)
+        Circle()
+          .fill(Ink.surface)
+          .frame(width: 16, height: 16)
+          .shadow(color: .black.opacity(0.08), radius: 1, x: 0, y: 1)
+          .offset(x: isMonitoring ? 8 : -8)
+          .omiAnimation(.easeInOut(duration: 0.15), value: isMonitoring)
+
+        if isTogglingMonitoring {
+          ProgressView()
+            .scaleEffect(0.5)
+        }
+      }
     }
+    .buttonStyle(.plain)
+    .disabled(isTogglingMonitoring)
     .opacity(isTogglingMonitoring ? 0.5 : 1.0)
-    .overlay {
-      if isTogglingMonitoring {
-        ProgressView()
-          .scaleEffect(0.5)
-      }
-    }
-    .onTapGesture {
-      if !isTogglingMonitoring {
-        toggleMonitoring(enabled: !isMonitoring)
-      }
-    }
     .help(screenCaptureHealth.rewindToggleHelp)
+    .accessibilityLabel("Screen capture")
+    .accessibilityValue(screenCaptureHealth.statusText)
+    .accessibilityHint(isMonitoring ? "Turn screen capture off" : "Turn screen capture on")
   }
 
   private func toggleMonitoring(enabled: Bool) {

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -7,6 +7,8 @@ import SwiftUI
 /// The timeline is the primary interface, with search results highlighted inline
 struct RewindPage: View {
   var appState: AppState? = nil
+  var brainDestination: MemoryHubDestination? = nil
+  var onSelectBrainDestination: ((MemoryHubDestination) -> Void)? = nil
 
   @StateObject private var viewModel = RewindViewModel()
 
@@ -112,22 +114,27 @@ struct RewindPage: View {
           VStack(spacing: 0) {
             if isTranscriptExpanded {
               // Expanded transcript + notes view replaces timeline
-              expandedTranscriptView.rewindPlayerPanel(width: player)
+              rewindContentPanel(expandedTranscriptView, width: player)
             } else {
               // Recovery banner (if database was recovered from corruption)
               if viewModel.showRecoveryBanner {
                 recoveryBanner.rewindHeaderPanel(width: header)
               }
 
-              // Unified top bar - search field is always here
-              unifiedTopBar.rewindHeaderPanel(width: header)
+              // Brain uses the same standalone search panel as every primary page. Standalone
+              // Rewind keeps its historical compact header panel.
+              if brainDestination != nil {
+                unifiedTopBar.frame(width: header)
+              } else {
+                unifiedTopBar.rewindHeaderPanel(width: header)
+              }
 
               // Content area changes based on mode
               if isInSearchMode {
                 if viewModel.screenshots.isEmpty {
-                  noSearchResultsView.rewindPlayerPanel(width: player)
+                  rewindContentPanel(noSearchResultsView, width: player)
                 } else if searchViewMode == .timeline {
-                  timelineWithSearch.rewindPlayerPanel(width: player)
+                  rewindContentPanel(timelineWithSearch, width: player)
                 } else {
                   // Already two panels of its own, with its own gap under the bar.
                   fullScreenResultsView(width: header)
@@ -136,10 +143,10 @@ struct RewindPage: View {
                 screenshotCount: viewModel.screenshots.count,
                 historyRange: viewModel.historyRange
               ) {
-                emptyState.rewindPlayerPanel(width: player)
+                rewindContentPanel(emptyState, width: player)
               } else {
                 // Normal timeline view (without top bar, since we have unified one)
-                timelineContentBody.rewindPlayerPanel(width: player)
+                rewindContentPanel(timelineContentBody, width: player)
               }
             }
           }
@@ -471,6 +478,151 @@ struct RewindPage: View {
   // MARK: - Unified Top Bar (persistent search field)
 
   private var unifiedTopBar: some View {
+    Group {
+      if brainDestination != nil {
+        QuerySearchBar(
+          text: $viewModel.searchQuery,
+          accessibilityID: "rewind-search-field",
+          placeholder: "Search screen history…",
+          focus: $isSearchFocused
+        )
+        .onChange(of: viewModel.searchQuery) { _, query in
+          if query.isEmpty { searchViewMode = nil }
+        }
+      } else {
+        unifiedTopBarControls
+          .padding(.horizontal, OmiSpacing.xxl)
+          .padding(.vertical, OmiSpacing.md)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func rewindContentPanel<Content: View>(_ content: Content, width: CGFloat) -> some View {
+    if brainDestination != nil {
+      VStack(alignment: .leading, spacing: 0) {
+        brainNavigationRow
+        content.frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+      .rewindPlayerPanel(width: width)
+    } else {
+      content.rewindPlayerPanel(width: width)
+    }
+  }
+
+  @ViewBuilder
+  private var brainNavigationRow: some View {
+    if let brainDestination, let onSelectBrainDestination {
+      HStack(spacing: OmiSpacing.md) {
+        BrainSectionNavigation(
+          selected: brainDestination,
+          onSelect: onSelectBrainDestination
+        )
+        Spacer(minLength: OmiSpacing.sm)
+        rewindBrainActions
+      }
+      .padding(.horizontal, QueryShellLayout.panelPaddingHorizontal)
+      .padding(.top, BrainSectionPageMetrics.navigationTopPadding)
+      .padding(.bottom, BrainSectionPageMetrics.navigationBottomPadding)
+    }
+  }
+
+  private var rewindBrainActions: some View {
+    HStack(spacing: OmiSpacing.sm) {
+      if isInSearchMode {
+        searchViewModeButton(
+          title: "Results", icon: "list.bullet", mode: .results)
+        searchViewModeButton(
+          title: "Timeline", icon: "timeline.selection", mode: .timeline)
+      }
+
+      if isInSearchMode {
+        Rectangle()
+          .fill(Ink.separator)
+          .frame(width: 1, height: 18)
+          .accessibilityHidden(true)
+      }
+
+      rewindMoreMenu
+
+      captureStateControl
+    }
+  }
+
+  private func searchViewModeButton(title: String, icon: String, mode: SearchViewMode) -> some View {
+    let isActive = searchViewMode == mode
+    return Button {
+      if mode == .timeline {
+        if searchViewMode != .timeline && !viewModel.screenshots.isEmpty { currentIndex = 0 }
+        searchViewMode = .timeline
+        scheduleLoadCurrentFrame()
+      } else {
+        searchViewMode = .results
+      }
+    } label: {
+      PageQueryActionLabel(icon: icon, title: title, isPrimary: isActive)
+    }
+    .buttonStyle(.plain)
+    .help("Show search \(title.lowercased())")
+    .accessibilityLabel("Search \(title.lowercased())")
+    .accessibilityAddTraits(isActive ? .isSelected : [])
+  }
+
+  private var rewindMoreMenu: some View {
+    Menu {
+      Button {
+        NotificationCenter.default.post(name: .navigateToRewindSettings, object: nil)
+      } label: {
+        Label("Rewind settings…", systemImage: "gearshape")
+      }
+    } label: {
+      PageQueryActionLabel(icon: "ellipsis", title: "More")
+    }
+    .menuStyle(.borderlessButton)
+    .menuIndicator(.hidden)
+    .fixedSize()
+    .help("More Rewind actions")
+    .accessibilityLabel("More Rewind actions")
+    .accessibilityIdentifier("rewind-more-actions")
+  }
+
+  /// The switch still owns the capture action, but the surrounding control names its state so it
+  /// cannot be mistaken for an unlabeled status light. The health-specific help preserves the
+  /// reason when capture is paused or recovering.
+  private var captureStateControl: some View {
+    HStack(spacing: OmiSpacing.xs) {
+      Text(captureStateLabel)
+        .scaledFont(size: OmiType.caption, weight: .semibold)
+        .foregroundStyle(Ink.primary)
+        .lineLimit(1)
+        .accessibilityHidden(true)
+      rewindToggle
+    }
+    .padding(.horizontal, OmiSpacing.sm)
+    .frame(height: QueryShellLayout.chipHeight)
+    .background {
+      Capsule(style: .continuous)
+        .fill(Ink.rowFill)
+        .overlay { Capsule(style: .continuous).stroke(Ink.separator, lineWidth: 1) }
+    }
+    .contentShape(Capsule(style: .continuous))
+    .help(captureStateHelp)
+  }
+
+  private var captureStateLabel: String {
+    switch screenCaptureHealth {
+    case .active: return "Capture On"
+    case .temporarilyUnavailable: return "Capture Paused"
+    case .recovering: return "Capture Recovering"
+    case .stopped: return "Capture Off"
+    }
+  }
+
+  private var captureStateHelp: String {
+    "\(screenCaptureHealth.statusText). Click to turn screen capture \(isMonitoring ? "off" : "on")."
+  }
+
+  private var unifiedTopBarControls: some View {
     HStack(spacing: OmiSpacing.md) {
       // Left side: Back button (search timeline mode) or Rewind logo (other modes)
       if isInSearchMode && searchViewMode == .timeline {
@@ -558,35 +710,10 @@ struct RewindPage: View {
 
       Spacer()
 
-      // Settings
-      Button {
-        NotificationCenter.default.post(
-          name: .navigateToRewindSettings,
-          object: nil
-        )
-      } label: {
-        Image(systemName: "gearshape")
-          .scaledFont(size: OmiType.caption)
-          .foregroundColor(Ink.secondary)
-      }
-      .buttonStyle(.plain)
-      .help("Rewind Settings")
+      rewindMoreMenu
 
-      // Rewind on/off toggle (screen capture only)
-      if let badgeText = screenCaptureHealth.rewindBadgeText {
-        Text(badgeText)
-          .scaledFont(size: OmiType.micro, weight: .medium)
-          .foregroundColor(PageGlass.warning)
-          .padding(.horizontal, OmiSpacing.xs)
-          .padding(.vertical, OmiSpacing.hairline)
-          .background(PageGlass.warning.opacity(0.15))
-          .cornerRadius(OmiChrome.stripRadius)
-          .help(screenCaptureHealth.statusText)
-      }
-      rewindToggle
+      captureStateControl
     }
-    .padding(.horizontal, OmiSpacing.xxl)
-    .padding(.vertical, OmiSpacing.md)
   }
 
   // MARK: - Timeline Content Body (without top bar)
@@ -610,35 +737,74 @@ struct RewindPage: View {
   /// The panel owns its own grid, filter block, height clamp and scrolling
   /// (`RewindSearchResultsPanel`); the page keeps only what is genuinely the page's — which group is
   /// selected, and what opening one does.
+  @ViewBuilder
   private func fullScreenResultsView(width: CGFloat) -> some View {
-    RewindSearchResultsSurface(
+    if brainDestination != nil {
+      GeometryReader { proxy in
+        VStack(alignment: .leading, spacing: 0) {
+          brainNavigationRow
+          rewindSearchResultsPanel(
+            width: width,
+            availableBodyHeight: max(
+              0,
+              proxy.size.height - BrainSectionPageMetrics.navigationHeight
+                - RewindSearchLayout.panelHeaderHeight - RewindSearchLayout.panelGap
+                - RewindSearchLayout.shadowMargin
+            )
+          )
+        }
+        .frame(width: width, alignment: .top)
+        .inkGlassPanel(cornerRadius: RewindSearchLayout.panelCornerRadius, shadow: .ambient)
+        .padding(.top, RewindSearchLayout.panelGap)
+        .frame(maxWidth: .infinity, alignment: .top)
+      }
+    } else {
+      RewindSearchResultsSurface(
+        groups: viewModel.groupedSearchResults,
+        query: viewModel.activeSearchQuery ?? "",
+        totalScreenshots: viewModel.totalScreenshotCount,
+        selectedIndex: $selectedGroupIndex,
+        panelWidth: width,
+        onOpen: openSearchResult
+      )
+      .onChange(of: selectedGroupIndex) { _, _ in
+        invalidatePendingFrameLoad()
+      }
+    }
+  }
+
+  private func rewindSearchResultsPanel(
+    width: CGFloat,
+    availableBodyHeight: CGFloat
+  ) -> some View {
+    RewindSearchResultsPanel(
       groups: viewModel.groupedSearchResults,
       query: viewModel.activeSearchQuery ?? "",
       totalScreenshots: viewModel.totalScreenshotCount,
       selectedIndex: $selectedGroupIndex,
-      panelWidth: width
-    ) { groupIndex in
-      // Set the screenshots to this group's screenshots for timeline navigation
-      selectedGroupIndex = groupIndex
-      currentIndex = 0
-      searchViewMode = .timeline
-      // Search now spans the whole history, so the opened group is frequently not from the day the
-      // page was showing. Move the day control onto it rather than leaving it asserting "today"
-      // over a frame from weeks ago — and so that clearing the search lands on that day.
-      let groups = viewModel.groupedSearchResults
-      if groups.indices.contains(groupIndex) {
-        viewModel.alignSelectedDay(to: groups[groupIndex].startTime)
-        trackWindow.center(on: groups[groupIndex].startTime.timeIntervalSince1970)
-        viewModel.rememberTimelineWindow(
-          from: trackWindow.start,
-          to: trackWindow.start + trackWindow.span
-        )
-      }
-      scheduleLoadCurrentFrame()
-    }
+      panelWidth: width,
+      availableBodyHeight: availableBodyHeight,
+      onOpen: openSearchResult
+    )
     .onChange(of: selectedGroupIndex) { _, _ in
       invalidatePendingFrameLoad()
     }
+  }
+
+  private func openSearchResult(_ groupIndex: Int) {
+    selectedGroupIndex = groupIndex
+    currentIndex = 0
+    searchViewMode = .timeline
+    let groups = viewModel.groupedSearchResults
+    if groups.indices.contains(groupIndex) {
+      viewModel.alignSelectedDay(to: groups[groupIndex].startTime)
+      trackWindow.center(on: groups[groupIndex].startTime.timeIntervalSince1970)
+      viewModel.rememberTimelineWindow(
+        from: trackWindow.start,
+        to: trackWindow.start + trackWindow.span
+      )
+    }
+    scheduleLoadCurrentFrame()
   }
 
   /// Screenshots for the currently selected group (used in timeline view)
@@ -696,6 +862,8 @@ struct RewindPage: View {
   private func searchField(showResultsCount: Bool = false) -> some View {
     RewindSearchBar(
       query: $viewModel.searchQuery,
+      placeholder: brainDestination == nil
+        ? RewindSearchMetrics.placeholder : "Search screen history…",
       isSearching: viewModel.isSearching,
       countLabel: showResultsCount && viewModel.activeSearchQuery != nil
         ? RewindSearchResultsPanel.countLabel(

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindSearchBar.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindSearchBar.swift
@@ -28,6 +28,7 @@ import SwiftUI
 /// the results. The bar's furniture is the same either way; only the ground under it changes.
 struct RewindSearchBar: View {
   @Binding var query: String
+  var placeholder: String = RewindSearchMetrics.placeholder
   /// Whether a search is in flight, so the bar can say so where the count would otherwise sit.
   var isSearching: Bool = false
   /// What the search found, already phrased. `nil` when nothing has been asked and there is no
@@ -110,7 +111,7 @@ struct RewindSearchBar: View {
             .foregroundStyle(RewindSearchInk.queryChipGlyph)
             .accessibilityHidden(true)
         }
-        TextField(RewindSearchMetrics.placeholder, text: $query)
+        TextField(placeholder, text: $query)
           .textFieldStyle(.plain)
           .font(.system(size: RewindSearchMetrics.queryFontSize, weight: .semibold))
           .foregroundStyle(Ink.primary)

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindSearchLayout.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindSearchLayout.swift
@@ -32,18 +32,16 @@ enum RewindSearchLayout {
 
   /// **The gap.** The single most important number in this file.
   ///
-  /// Two panels 12 pt apart read as two objects; the same two at 0 read as one slab with a rule
-  /// through it. It is a hair under the 14 pt rung of `InkLayout.rhythm` on purpose: the panels have
-  /// their own shadows, and a shadow already reads as a few points of separation, so a rhythm gap on
-  /// top of one measures as too much air.
-  static let panelGap: CGFloat = 12
+  /// Eight points keeps the objects distinct without turning the shared search
+  /// shell into a large empty band above every destination.
+  static let panelGap: CGFloat = 8
 
   /// The corner is the shared one. Not restated as a number: a search panel and a settings card cut
   /// to two different radii read as two products, which is exactly why `InkGlass` owns it.
   static var panelCornerRadius: CGFloat { InkGlass.cornerRadius }
 
-  /// The query bar's height. Roomy — this is a place to type, not a control strip.
-  static let barHeight: CGFloat = 60
+  /// Matches the product-wide query bar so search does not change size by page.
+  static let barHeight: CGFloat = 48
 
   /// The results panel is **as tall as what is in it**, between these two bounds.
   ///
@@ -105,10 +103,10 @@ enum RewindSearchLayout {
   }
 
   /// The results panel's own header — the `Filter` row and the rule under it.
-  static let panelHeaderHeight: CGFloat = 44
+  static let panelHeaderHeight: CGFloat = 36
 
-  static let panelPaddingHorizontal: CGFloat = 20
-  static let panelPaddingVertical: CGFloat = 16
+  static let panelPaddingHorizontal: CGFloat = 14
+  static let panelPaddingVertical: CGFloat = 10
 
   /// Clear margin kept around the panels so the ambient shadow has room to fall off instead of being
   /// clipped at the surface's edge. Taken from the shadow itself, never guessed — a margin that stops
@@ -167,7 +165,7 @@ enum RewindSearchLayout {
   // The bar's own furniture.
 
   /// The glyph at the leading edge.
-  static let glyphSize: CGFloat = 22
+  static let glyphSize: CGFloat = 18
 
   /// Room the query chip may grow into before it stops. The bar's content width, less the glyph and
   /// the space the keyboard hint needs on the other side.
@@ -188,10 +186,9 @@ enum RewindSearchMetrics {
 
   /// The size the query is set at.
   ///
-  /// 19 is visibly larger than every other run of type on the surface (the next is `rowCopy` at 15),
-  /// which is the hierarchy the bar needs, and it stays under `Font.inkDisplayThreshold` (22) so it
-  /// resolves to SF Pro rather than the display face — a search field is reading type.
-  static let queryFontSize: CGFloat = 19
+  /// The shared search face: prominent enough to find immediately, compact
+  /// enough to remain utility chrome rather than a page title.
+  static let queryFontSize: CGFloat = 17
 
   /// The face the query is set in, resolved to the AppKit font the field is actually made of. Both
   /// the chip's width and the field's own text use this exact value; two different faces here is a

--- a/desktop/macos/Desktop/Sources/Theme/OmiFont.swift
+++ b/desktop/macos/Desktop/Sources/Theme/OmiFont.swift
@@ -184,11 +184,18 @@ extension View {
 
 // MARK: - Window Size Reset
 
+package enum WindowSizeResetPolicy {
+  /// Reset means the same compact shell users get on first summon. Keeping a
+  /// second, legacy managed-window size here made the recovery action enlarge
+  /// the product it was supposed to normalize.
+  package static let defaultSize = NSSize(width: 900, height: 700)
+}
+
 @MainActor package func resetWindowToDefaultSize() {
   guard
     let window = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.title.contains("omi") || $0.title.contains("Omi") })
   else { return }
-  let defaultSize = NSSize(width: 1200, height: 800)
+  let defaultSize = WindowSizeResetPolicy.defaultSize
   let frame = window.frame
   let newOrigin = NSPoint(
     x: frame.midX - defaultSize.width / 2,

--- a/desktop/macos/Desktop/Sources/ViewExporter.swift
+++ b/desktop/macos/Desktop/Sources/ViewExporter.swift
@@ -358,8 +358,7 @@ enum ViewExporter {
             appState: topBarAppState,
             memoriesViewModel: topBarMemories,
             tasksStore: topBarTasks,
-            sinceDate: Date(),
-            onRewind: {}
+            sinceDate: Date()
           )
           pageContent
         }

--- a/desktop/macos/Desktop/Tests/AppsPageCategoryFilterTests.swift
+++ b/desktop/macos/Desktop/Tests/AppsPageCategoryFilterTests.swift
@@ -4,6 +4,13 @@ import XCTest
 
 @MainActor
 final class AppsPageCategoryFilterTests: XCTestCase {
+  func testCatalogKindNamesMakeTheCatalogScopeExplicit() {
+    XCTAssertEqual(
+      AppsCatalogKind.allCases.map(\.rawValue),
+      ["All", "Apps", "Imports", "Exports"]
+    )
+  }
+
   private func sampleCategories(count: Int) -> [OmiAppCategory] {
     (1...count).map { index in
       OmiAppCategory(id: "category-\(index)", title: "Category \(index)")

--- a/desktop/macos/Desktop/Tests/AppsPageSearchResultsPresentationTests.swift
+++ b/desktop/macos/Desktop/Tests/AppsPageSearchResultsPresentationTests.swift
@@ -34,6 +34,66 @@ final class AppsPageSearchResultsPresentationTests: XCTestCase {
     )
   }
 
+  func testAllCatalogSearchAggregatesOnlyVisibleGroups() {
+    XCTAssertEqual(
+      AppsAllSearchPresentation.resolve(
+        importsCount: 1,
+        exportsCount: 2,
+        appsCount: 4,
+        marketplace: .results
+      ),
+      .results(total: 7))
+
+    // Marketplace loading/failed states do not contribute cards to the All
+    // presentation. Local matches still render while that group resolves.
+    XCTAssertEqual(
+      AppsAllSearchPresentation.resolve(
+        importsCount: 1,
+        exportsCount: 0,
+        appsCount: 4,
+        marketplace: .loading
+      ),
+      .results(total: 1))
+    XCTAssertEqual(
+      AppsAllSearchPresentation.resolve(
+        importsCount: 0,
+        exportsCount: 0,
+        appsCount: 4,
+        marketplace: .failure
+      ),
+      .failure)
+  }
+
+  func testAllCatalogSearchUsesOneGlobalEmptyStateWhenEveryGroupIsEmpty() {
+    XCTAssertEqual(
+      AppsAllSearchPresentation.resolve(
+        importsCount: 0,
+        exportsCount: 0,
+        appsCount: 0,
+        marketplace: .empty
+      ),
+      .empty)
+    XCTAssertEqual(
+      AppsAllSearchPresentation.resolve(
+        importsCount: 0,
+        exportsCount: 0,
+        appsCount: 0,
+        marketplace: .results
+      ),
+      .empty)
+  }
+
+  func testExportSearchTrimsWhitespaceAndRanksExactTitlesFirst() {
+    let results = MemoryExportCatalog.matching("  notion  ")
+
+    XCTAssertEqual(results.first?.destination, .notion)
+    XCTAssertTrue(
+      results.allSatisfy { entry in
+        [entry.resolvedTitle, entry.resolvedSubtitle, entry.resolvedDescription]
+          .contains { $0.localizedCaseInsensitiveContains("notion") }
+      })
+  }
+
   func testChangingAFilterInvalidatesPreviouslyDisplayedResults() {
     let provider = AppProvider()
     provider.filteredApps = []
@@ -44,5 +104,23 @@ final class AppsPageSearchResultsPresentationTests: XCTestCase {
     XCTAssertNil(provider.filteredApps)
     XCTAssertFalse(provider.hasMoreFilteredApps)
     XCTAssertEqual(provider.filteredAppsQueryState, .unknown)
+  }
+
+  func testClearingIndividualMarketplaceRefinementsPreservesSearchText() {
+    let provider = AppProvider()
+    provider.searchQuery = "notion"
+    provider.selectedCategory = "productivity"
+    provider.selectedCapability = "chat"
+    provider.showInstalledOnly = true
+
+    provider.clearCategoryFilter()
+    provider.selectedCapability = nil
+    provider.showInstalledOnly = false
+
+    XCTAssertEqual(provider.searchQuery, "notion")
+    XCTAssertTrue(provider.hasActiveFilters, "the preserved query remains an active search")
+    XCTAssertNil(provider.selectedCategory)
+    XCTAssertNil(provider.selectedCapability)
+    XCTAssertFalse(provider.showInstalledOnly)
   }
 }

--- a/desktop/macos/Desktop/Tests/AutomationSettingsSectionTests.swift
+++ b/desktop/macos/Desktop/Tests/AutomationSettingsSectionTests.swift
@@ -56,7 +56,7 @@ final class AutomationSettingsSectionTests: XCTestCase {
     XCTAssertEqual(Section.planUsage.rawValue, "Plan and Usage")
     XCTAssertEqual(Section.privacy.rawValue, "Privacy")
     XCTAssertEqual(Section.account.displayTitle, "Account & Plan")
-    XCTAssertEqual(Section.notifications.displayTitle, "Notifications & Privacy")
+    XCTAssertEqual(Section.notifications.displayTitle, "Alerts & Privacy")
     XCTAssertEqual(Section.advanced.displayTitle, "AI & Automation")
   }
 

--- a/desktop/macos/Desktop/Tests/AutomationSettingsSectionTests.swift
+++ b/desktop/macos/Desktop/Tests/AutomationSettingsSectionTests.swift
@@ -57,6 +57,7 @@ final class AutomationSettingsSectionTests: XCTestCase {
     XCTAssertEqual(Section.privacy.rawValue, "Privacy")
     XCTAssertEqual(Section.account.displayTitle, "Account & Plan")
     XCTAssertEqual(Section.notifications.displayTitle, "Notifications & Privacy")
+    XCTAssertEqual(Section.advanced.displayTitle, "AI & Automation")
   }
 
   func testUnknownAndEmptyReturnNil() {

--- a/desktop/macos/Desktop/Tests/ChatFirstDestinationParityTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatFirstDestinationParityTests.swift
@@ -10,7 +10,7 @@ final class ChatFirstDestinationParityTests: XCTestCase {
     )
     XCTAssertEqual(
       ChatFirstMemoryRoutePolicy.destination(afterSelecting: .memories, current: .conversations),
-      .memories
+      .conversations
     )
     XCTAssertEqual(
       ChatFirstMemoryRoutePolicy.destination(afterSelecting: .conversations, current: .brainMap),
@@ -42,31 +42,30 @@ final class ChatFirstDestinationParityTests: XCTestCase {
   }
 
   /// Selecting a hub view in the chat-first shell has to move its typed route as well as the
-  /// persisted destination. Conversations has its own route (it carries capture-archive focus);
-  /// Memories and Brain Map are both the Memory route, which is where `MemoryHubPage` is mounted.
+  /// persisted destination. Every peer enters through the Memory route, which owns Brain's
+  /// persistent section navigation. A typed conversation deep link may still use its own route.
   ///
   /// Without this, picking Brain Map from the Conversations route left the shell on a host that has
   /// no Brain Map in it — the state that made the map unreachable once the menu was gone.
   func testChatFirstAppliesAHubSelectionToItsOwnRoute() {
-    XCTAssertEqual(MemoryHubSelectionPolicy.chatFirstRoute(for: .conversations), .conversations)
+    XCTAssertEqual(MemoryHubSelectionPolicy.chatFirstRoute(for: .conversations), .memories)
     XCTAssertEqual(MemoryHubSelectionPolicy.chatFirstRoute(for: .memories), .memories)
     XCTAssertEqual(MemoryHubSelectionPolicy.chatFirstRoute(for: .brainMap), .memories)
     XCTAssertEqual(MemoryHubSelectionPolicy.chatFirstRoute(for: .activity), .memories)
+    XCTAssertEqual(MemoryHubSelectionPolicy.chatFirstRoute(for: .rewind), .memories)
   }
 
   /// **The chip row is the door, so its contents are a contract.**
   ///
   /// The hub's switcher was deleted and this row replaced it. `ShellDestination.Reach.activityChipRow`
-  /// claims the row reaches Conversations, Memories and Brain Map; that claim is only true while the
-  /// row actually offers every hub page. Tasks and Rewind were removed from the row deliberately —
-  /// each already has its own pill in the bar directly above it — and neither is a hub page, so
-  /// neither may come back here without the reachability model being revisited. That every chip
+  /// claims the row reaches Conversations, Memories, Rewind and Brain Map; that claim is only true
+  /// while the row actually offers every hub page. That every chip
   /// opens *some* hub page is held by the type — `hubDestination` is not optional — rather than by
   /// an assertion here.
   func testTheActivityChipRowOffersEveryHubPageAndNothingElse() {
     XCTAssertEqual(
       ActivityDestinationChip.allCases.map(\.title),
-      ["Brain", "Conversations", "Memories", "Brain Map"])
+      ["Activity", "Conversations", "Memories", "Rewind", "Brain Map"])
 
     XCTAssertEqual(
       Set(ActivityDestinationChip.reachableHubDestinations), Set(MemoryHubDestination.allCases),
@@ -80,6 +79,8 @@ final class ChatFirstDestinationParityTests: XCTestCase {
     XCTAssertEqual(
       QueryPanelChipBehavior.openDestinations(selected: .activity, open: { _ in }).disclosureLabel,
       "View")
+    XCTAssertEqual(QueryPanelChipBehavior.none.disclosureLabel, "Time range")
+    XCTAssertFalse(QueryPanelChipBehavior.none.showsChipRow)
   }
 
   /// Every flat pill the bar now shows must resolve to a chat-first route, both ways. `Focus` did

--- a/desktop/macos/Desktop/Tests/ChatFirstShellTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatFirstShellTests.swift
@@ -584,10 +584,12 @@ final class ChatFirstShellTests: XCTestCase {
 
   func testChatFirstGlassBoundaryWrapsOnlyRoutesWithoutTheirOwnPanels() {
     let wrapped: [ChatFirstRoute] = [
-      .conversations, .tasks, .goals, .memories,
-      .more(.apps), .more(.permissions), .more(.settings),
+      .conversations, .goals, .memories,
+      .more(.permissions), .more(.settings),
     ]
-    let selfContained: [ChatFirstRoute] = [.chat, .more(.dashboard), .more(.rewind)]
+    let selfContained: [ChatFirstRoute] = [
+      .chat, .tasks, .more(.dashboard), .more(.rewind), .more(.apps),
+    ]
 
     for route in wrapped {
       XCTAssertTrue(ChatFirstPageGlassLanePolicy.shouldWrap(route), route.stableName)
@@ -604,13 +606,9 @@ final class ChatFirstShellTests: XCTestCase {
       XCTAssertFalse(ChatFirstPageGlassLanePolicy.shouldWrap(route), route.stableName)
     }
 
-    // The memory route mounts the hub, whose Activity page carries Home's own two panels. Wrapping
-    // that one puts glass inside glass and doubles the scrim.
-    XCTAssertFalse(
-      ChatFirstPageGlassLanePolicy.shouldWrap(
-        .memories, memoryDestinationRawValue: MemoryHubDestination.activity.rawValue))
-    for destination in MemoryHubDestination.allCases where destination != .activity {
-      XCTAssertTrue(
+    // Every hub page carries the shared search panel and a navigation-first content panel.
+    for destination in MemoryHubDestination.allCases {
+      XCTAssertFalse(
         ChatFirstPageGlassLanePolicy.shouldWrap(
           .memories, memoryDestinationRawValue: destination.rawValue),
         destination.title)

--- a/desktop/macos/Desktop/Tests/ChatSurfaceBoundsTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatSurfaceBoundsTests.swift
@@ -169,7 +169,14 @@ final class ChatSurfaceBoundsTests: XCTestCase {
   /// strictly better off than the list it replaced. If this ever inverts, the composer is being
   /// reserved twice.
   func testOpeningChatLeavesTheTranscriptMoreRoomThanTheListHad() {
-    let page = pageHeights(windowHeights: [ShellSummonPlacement.defaultSize.height])[0]
+    // Keep the arithmetic below the shared body ceiling so the comparison observes the room
+    // returned by removing the hero bar instead of comparing two equally capped bodies.
+    let page = min(
+      pageHeights(windowHeights: [ShellSummonPlacement.defaultSize.height])[0],
+      QueryShellLayout.maximumBodyHeight + QueryShellLayout.surfaceTopInset
+        + QueryShellLayout.panelGap
+        + QueryShellLayout.panelChromeHeight(
+          mode: .results, composerHeight: restingComposerHeight(mode: .results)))
 
     let list = QueryShellLayout.panelBodyHeight(
       availableHeight: page, composerHeight: restingComposerHeight(mode: .results), mode: .results)

--- a/desktop/macos/Desktop/Tests/ConversationSearchResultFilterTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationSearchResultFilterTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import XCTest
+
+@testable import Omi_Computer
+
+final class ConversationSearchResultFilterTests: XCTestCase {
+  func testApplyUsesTheSameAndPredicateAsTheListQuery() throws {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: 0))
+    let conversations = [
+      try decodeConversation(
+        id: "keep",
+        createdAt: "2026-06-25T10:00:00Z",
+        startedAt: "2026-06-25T10:01:00Z",
+        starred: true,
+        folderId: "work"
+      ),
+      try decodeConversation(
+        id: "wrong-folder",
+        createdAt: "2026-06-25T10:00:00Z",
+        startedAt: "2026-06-25T10:01:00Z",
+        starred: true,
+        folderId: "personal"
+      ),
+      try decodeConversation(
+        id: "wrong-date",
+        createdAt: "2026-06-24T10:00:00Z",
+        startedAt: "2026-06-24T10:01:00Z",
+        starred: true,
+        folderId: "work"
+      ),
+      try decodeConversation(
+        id: "not-starred",
+        createdAt: "2026-06-25T10:00:00Z",
+        startedAt: "2026-06-25T10:01:00Z",
+        starred: false,
+        folderId: "work"
+      ),
+    ]
+
+    let selectedDate = try XCTUnwrap(
+      ISO8601DateFormatter().date(from: "2026-06-25T00:00:00Z")
+    )
+    let filtered = ConversationSearchResultFilter.apply(
+      conversations,
+      starredOnly: true,
+      date: selectedDate,
+      folderId: "work",
+      calendar: calendar
+    )
+
+    XCTAssertEqual(filtered.map(\.id), ["keep"])
+  }
+
+  func testApplyPreservesAllTextSearchHitsWhenNoRefinementsAreActive() throws {
+    let conversations = [
+      try decodeConversation(
+        id: "first",
+        createdAt: "2026-06-25T10:00:00Z",
+        startedAt: nil,
+        starred: false,
+        folderId: nil
+      ),
+      try decodeConversation(
+        id: "second",
+        createdAt: "2026-06-24T10:00:00Z",
+        startedAt: nil,
+        starred: true,
+        folderId: "work"
+      ),
+    ]
+
+    let filtered = ConversationSearchResultFilter.apply(
+      conversations,
+      starredOnly: false,
+      date: nil,
+      folderId: nil
+    )
+
+    XCTAssertEqual(filtered, conversations)
+  }
+
+  private func decodeConversation(
+    id: String,
+    createdAt: String,
+    startedAt: String?,
+    starred: Bool,
+    folderId: String?
+  ) throws -> ServerConversation {
+    let startedAtJSON = startedAt.map { "\"\($0)\"" } ?? "null"
+    let folderIdJSON = folderId.map { "\"\($0)\"" } ?? "null"
+    let json = """
+      {
+        "id": "\(id)",
+        "created_at": "\(createdAt)",
+        "started_at": \(startedAtJSON),
+        "finished_at": null,
+        "structured": {
+          "title": "Search hit",
+          "overview": "Overview",
+          "emoji": "💬",
+          "category": "other",
+          "action_items": [],
+          "events": []
+        },
+        "status": "completed",
+        "source": "desktop",
+        "discarded": false,
+        "deleted": false,
+        "starred": \(starred),
+        "folder_id": \(folderIdJSON),
+        "deferred": false
+      }
+      """
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return try decoder.decode(ServerConversation.self, from: Data(json.utf8))
+  }
+}

--- a/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
+++ b/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
@@ -347,37 +347,37 @@ final class DashboardCaptureStateTests: XCTestCase {
   }
 
   func testAppsPageSupportsPopupDismissalAndFocusedSections() throws {
-    let source = try appsSource()
+    let appsPageSource = try appsSource()
 
-    XCTAssertTrue(source.contains("enum AppsCatalogInitialSection"))
-    XCTAssertTrue(source.contains("var initialSection: AppsCatalogInitialSection = .imports"))
-    XCTAssertTrue(source.contains("var onDismiss: (() -> Void)? = nil"))
-    XCTAssertTrue(source.contains("var onSelectApp: ((OmiApp) -> Void)? = nil"))
-    XCTAssertTrue(source.contains("var onSelectConnector: ((ImportConnector) -> Void)? = nil"))
-    XCTAssertTrue(source.contains("var onSelectDestination: ((MemoryExportDestination) -> Void)? = nil"))
-    XCTAssertTrue(source.contains("private var dismissControl: some View"))
-    XCTAssertTrue(source.contains("DismissButton(action: onDismiss)"))
-    XCTAssertTrue(
-      source.contains(
-        "case .imports:\n                ImportsSection(statusStore: connectorStatusStore)"))
-    XCTAssertTrue(
-      source.contains("case .exports:\n                ExportsSection(statuses: exportStatuses)"))
-    XCTAssertTrue(source.contains("private func selectApp(_ app: OmiApp)"))
-    XCTAssertTrue(source.contains("private func selectConnector(_ connector: ImportConnector)"))
-    XCTAssertTrue(source.contains("private func selectDestination(_ destination: MemoryExportDestination)"))
-    XCTAssertTrue(source.contains("onSelectApp(app)"))
-    XCTAssertTrue(source.contains("selectedApp = app"))
-    XCTAssertTrue(source.contains("onSelectConnector(connector)"))
-    XCTAssertTrue(source.contains("selectedConnector = connector"))
-    XCTAssertTrue(source.contains("onSelectDestination(destination)"))
-    XCTAssertTrue(source.contains("selectedExportDestination = destination"))
-    XCTAssertTrue(source.contains("if appProvider.apps.isEmpty && !appProvider.isLoading"))
+    XCTAssertTrue(appsPageSource.contains("enum AppsCatalogInitialSection"))
+    XCTAssertTrue(appsPageSource.contains("var initialSection: AppsCatalogInitialSection = .imports"))
+    XCTAssertTrue(appsPageSource.contains("var onDismiss: (() -> Void)? = nil"))
+    XCTAssertTrue(appsPageSource.contains("var onSelectApp: ((OmiApp) -> Void)? = nil"))
+    XCTAssertTrue(appsPageSource.contains("var onSelectConnector: ((ImportConnector) -> Void)? = nil"))
+    XCTAssertTrue(appsPageSource.contains("var onSelectDestination: ((MemoryExportDestination) -> Void)? = nil"))
+    XCTAssertTrue(appsPageSource.contains("private var dismissControl: some View"))
+    XCTAssertTrue(appsPageSource.contains("DismissButton(action: onDismiss)"))
+    XCTAssertTrue(appsPageSource.contains("case .imports:"))
+    XCTAssertTrue(appsPageSource.contains("case .exports:"))
+    XCTAssertTrue(appsPageSource.contains("ImportsSection("))
+    XCTAssertTrue(appsPageSource.contains("ExportsSection("))
+    XCTAssertTrue(appsPageSource.contains("private func selectApp(_ app: OmiApp)"))
+    XCTAssertTrue(appsPageSource.contains("private func selectConnector(_ connector: ImportConnector)"))
+    XCTAssertTrue(appsPageSource.contains("private func selectDestination(_ destination: MemoryExportDestination)"))
+    XCTAssertTrue(appsPageSource.contains("onSelectApp(app)"))
+    XCTAssertTrue(appsPageSource.contains("selectedApp = app"))
+    XCTAssertTrue(appsPageSource.contains("onSelectConnector(connector)"))
+    XCTAssertTrue(appsPageSource.contains("selectedConnector = connector"))
+    XCTAssertTrue(appsPageSource.contains("onSelectDestination(destination)"))
+    XCTAssertTrue(appsPageSource.contains("selectedExportDestination = destination"))
+    XCTAssertTrue(appsPageSource.contains("if appProvider.apps.isEmpty && !appProvider.isLoading"))
     // Responsive layout was extracted into AppsHeaderRow (AppsPageHeaderControls.swift);
     // AppsPage now delegates to it instead of inlining ViewThatFits.
-    XCTAssertTrue(source.contains("AppsHeaderRow("))
-    XCTAssertTrue(source.contains("private var searchField: some View"))
-    XCTAssertTrue(source.contains("private var filterControls: some View"))
-    XCTAssertFalse(source.contains("struct AppsCatalogContent: View"))
+    let headerSource = try source(named: "AppsPageHeaderControls.swift")
+    XCTAssertTrue(headerSource.contains("struct AppsHeaderRow"))
+    XCTAssertTrue(headerSource.contains("let search: Search"))
+    XCTAssertTrue(headerSource.contains("let filters: Filters"))
+    XCTAssertFalse(appsPageSource.contains("struct AppsCatalogContent: View"))
   }
 
   func testConnectorSetupSurfacesDoNotUsePurpleAccents() throws {

--- a/desktop/macos/Desktop/Tests/MemoryGraphRevisitTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryGraphRevisitTests.swift
@@ -18,7 +18,7 @@ final class MemoryGraphRevisitTests: XCTestCase {
     // model at all. Both the canonical destination and legacy fallback must use
     // the persistent, container-owned instance.
     XCTAssertTrue(hub.contains("graphViewModel: viewModelContainer.memoryGraphViewModel"))
-    XCTAssertTrue(hub.contains("MemoryGraphPage(viewModel: viewModelContainer.memoryGraphViewModel)"))
+    XCTAssertTrue(hub.contains("MemoryGraphPage(\n        viewModel: viewModelContainer.memoryGraphViewModel"))
     XCTAssertTrue(hub.contains("switch destination"))
     // Static wiring tripwire: the shell owns the hub's placement, and the hub is
     // a full-bleed destination — the readable-width cap belongs to the pages
@@ -37,16 +37,18 @@ final class MemoryGraphRevisitTests: XCTestCase {
   func testMemoryHubDestinationMenuHasStableRoutes() {
     XCTAssertEqual(
       MemoryHubDestination.allCases,
-      [.memories, .conversations, .brainMap, .activity]
+      [.memories, .conversations, .brainMap, .activity, .rewind]
     )
     // Storage identity, pinned: these raw values are persisted, so the enum may not be reordered.
     // Reading order is a different list and lives with the control that presents it — see
     // `ChatFirstDestinationParityTests.testTheActivityChipRowOffersEveryHubPageAndNothingElse`.
-    XCTAssertEqual(MemoryHubDestination.activity.title, "Brain")
+    XCTAssertEqual(MemoryHubDestination.activity.title, "Activity")
     XCTAssertEqual(MemoryHubDestination.memories.title, "Memories")
     XCTAssertEqual(MemoryHubDestination.conversations.title, "Conversations")
     XCTAssertEqual(MemoryHubDestination.brainMap.title, "Brain Map")
+    XCTAssertEqual(MemoryHubDestination.rewind.title, "Rewind")
     XCTAssertEqual(MemoryHubDestination(rawValue: 1), .conversations)
+    XCTAssertEqual(MemoryHubDestination(rawValue: 4), .rewind)
     XCTAssertEqual(
       MemoryHubDestination.destination(for: .conversations),
       .conversations
@@ -63,7 +65,7 @@ final class MemoryGraphRevisitTests: XCTestCase {
 
   /// The hover menu these three tests used to cover is gone, and so is
   /// `MemoryDropdownInteractionState` — its hover-generation machinery had no other caller. The
-  /// Memory hub's four destinations are now selected by Activity's chip row; that contract is held
+  /// Memory hub's five destinations are now selected by Brain's section row; that contract is held
   /// by `ChatFirstDestinationParityTests.testTheActivityChipRowOffersEveryHubPageAndNothingElse`
   /// and `TopNavigationBarLayoutTests`.
   func testTopNavigationUsesCompactPillSpacing() {

--- a/desktop/macos/Desktop/Tests/MemoryHubBrainMapRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryHubBrainMapRoutingTests.swift
@@ -139,7 +139,7 @@ final class MemoryHubBrainMapRoutingTests: XCTestCase {
       "The legacy branch must remain reachable for users outside the cohort."
     )
     XCTAssertEqual(
-      source.components(separatedBy: "MemoryGraphPage(viewModel:").count - 1,
+      source.components(separatedBy: "MemoryGraphPage(").count - 1,
       1,
       "The legacy graph should be constructed once, inside the gated branch."
     )

--- a/desktop/macos/Desktop/Tests/PageGlassLaneTests.swift
+++ b/desktop/macos/Desktop/Tests/PageGlassLaneTests.swift
@@ -23,11 +23,11 @@ final class PageGlassLaneTests: XCTestCase {
 
   // MARK: - Which destinations already have glass
 
-  /// QueryShell Home and Rewind build their own panels when the router says they do. Wrapping them
+  /// Search-first pages and Rewind build their own panels. Wrapping them
   /// again does not stack two materials — a
   /// nested `.behindWindow` surface takes a *second* copy of the desktop and doubles the scrim — so a
   /// double-wrapped page reads visibly muddier than the pages around it.
-  func testHomeAndRewindKeepTheirOwnPanelsAndEveryOtherDestinationIsGivenOne() {
+  func testSearchFirstPagesAndRewindKeepTheirOwnPanelsAndOtherDestinationsAreGivenOne() {
     for homeOwnsItsPanels in [false, true] {
       XCTAssertEqual(
         PageGlassLanePolicy.ownsItsPanels(
@@ -39,39 +39,32 @@ final class PageGlassLaneTests: XCTestCase {
           selectedIndex: SidebarNavItem.rewind.rawValue,
           homeOwnsItsPanels: homeOwnsItsPanels))
 
-      for item in SidebarNavItem.allCases where item != .dashboard && item != .rewind {
+      let selfContained: Set<SidebarNavItem> = [.dashboard, .rewind, .tasks, .apps]
+      for item in SidebarNavItem.allCases where !selfContained.contains(item) {
         XCTAssertFalse(
           PageGlassLanePolicy.ownsItsPanels(
             selectedIndex: item.rawValue,
             homeOwnsItsPanels: homeOwnsItsPanels),
-          "\(item.title) has no glass of its own and must be given the lane's")
+          "\(item.title) has no page panels of its own and must be given the lane's")
       }
     }
   }
 
-  /// **The hub is one rail index wearing four pages, and only one of them brings its own glass.**
+  /// **The hub is one rail index wearing five pages; every page brings the same two-panel shape.**
   ///
   /// Activity is Home's column — a search bar and a results panel, each already an `inkGlassPanel`.
   /// Wrapping the hub wholesale nested both inside a third panel, which does not stack two materials
   /// but takes a second copy of the desktop and doubles the scrim, so Activity read visibly muddier
-  /// than Chat and its two panels lost their separation. The hub's list pages paint no ground of
-  /// their own and must keep the lane.
-  func testOnlyTheActivityHubPageBringsItsOwnPanels() {
+  /// than Chat and its two panels lost their separation.
+  func testEveryBrainHubPageBringsItsOwnPanels() {
     let hubIndex = SidebarNavItem.conversations.rawValue
-    XCTAssertTrue(
-      PageGlassLanePolicy.ownsItsPanels(
-        selectedIndex: hubIndex,
-        memoryDestinationRawValue: MemoryHubDestination.activity.rawValue,
-        homeOwnsItsPanels: true),
-      "Activity builds Home's own two panels and must not be wrapped in a third")
-
-    for destination in MemoryHubDestination.allCases where destination != .activity {
-      XCTAssertFalse(
+    for destination in MemoryHubDestination.allCases {
+      XCTAssertTrue(
         PageGlassLanePolicy.ownsItsPanels(
           selectedIndex: hubIndex,
           memoryDestinationRawValue: destination.rawValue,
           homeOwnsItsPanels: true),
-        "\(destination.title) paints no ground of its own and must be given the lane's")
+        "\(destination.title) builds Brain search and content panels and must not be wrapped")
     }
 
     for destination in MemoryHubDestination.allCases {
@@ -144,7 +137,7 @@ final class PageGlassLaneTests: XCTestCase {
   func testAWrappedDestinationIsPlacedInTheLaneWithTheGapAboveAndBelowIt() throws {
     let size = CGSize(width: 1_400, height: 800)
     for (index, homeOwnsItsPanels) in [
-      (SidebarNavItem.tasks.rawValue, true),
+      (SidebarNavItem.permissions.rawValue, true),
       (SidebarNavItem.dashboard.rawValue, false),
     ] {
       let recorder = PageGlassLaneFrameRecorder()
@@ -185,7 +178,7 @@ final class PageGlassLaneTests: XCTestCase {
       let recorder = PageGlassLaneFrameRecorder()
       let host = NSHostingView(
         rootView: PageGlassLane(
-          selectedIndex: SidebarNavItem.tasks.rawValue,
+          selectedIndex: SidebarNavItem.permissions.rawValue,
           homeOwnsItsPanels: true
         ) {
           PageGlassLaneProbe(recorder: recorder) { Color.clear }

--- a/desktop/macos/Desktop/Tests/PagePanelVerticalRhythmTests.swift
+++ b/desktop/macos/Desktop/Tests/PagePanelVerticalRhythmTests.swift
@@ -54,4 +54,15 @@ final class PagePanelVerticalRhythmTests: XCTestCase {
       RewindSearchLayout.panelGap,
       "all destination surfaces must use the same search-to-content gap")
   }
+
+  func testPageListsStartFullyOpaqueAndKeepOnlyTheOverflowCueBelow() {
+    XCTAssertEqual(
+      PageGlass.topFade,
+      0,
+      "the first visible row must not be faded when a page loads at its resting scroll position")
+    XCTAssertGreaterThan(
+      PageGlass.bottomFade,
+      0,
+      "the bottom edge may still signal that additional content continues below the viewport")
+  }
 }

--- a/desktop/macos/Desktop/Tests/PagePanelVerticalRhythmTests.swift
+++ b/desktop/macos/Desktop/Tests/PagePanelVerticalRhythmTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+@testable import OmiTheme
+@testable import Omi_Computer
+
+/// The compact page chrome has one owner for each vertical gap. These tests
+/// keep child pages from reintroducing the old stacked padding while they are
+/// migrated onto the shared toolbar contract.
+@MainActor
+final class PagePanelVerticalRhythmTests: XCTestCase {
+  func testFirstRowOnlyOwnsThePanelTopInset() {
+    XCTAssertEqual(
+      PagePanelFirstRowMetrics.topPadding,
+      PagePanelVerticalRhythm.panelTopPadding,
+      "the first row must align with the panel's shared top inset")
+    XCTAssertEqual(
+      PagePanelFirstRowMetrics.bottomPadding,
+      0,
+      "the first row must not add a second gap before its content")
+  }
+
+  func testSubsequentRowsUseTheSharedHorizontalLane() {
+    XCTAssertEqual(
+      PagePanelFirstRowMetrics.horizontalPadding,
+      PagePanelVerticalRhythm.horizontalPadding)
+    XCTAssertEqual(
+      PagePanelVerticalRhythm.rowGap,
+      QueryShellLayout.panelHeaderSpacing,
+      "adjacent control rows must share one compact gap")
+    XCTAssertEqual(
+      PagePanelVerticalRhythm.contentGap,
+      OmiSpacing.sm,
+      "content owns the one gap after its toolbar")
+  }
+
+  func testBrainNavigationUsesTheSameFirstRowAndSubsequentRowRhythm() {
+    XCTAssertEqual(
+      BrainSectionPageMetrics.navigationTopPadding,
+      PagePanelVerticalRhythm.panelTopPadding)
+    XCTAssertEqual(
+      BrainSectionPageMetrics.navigationBottomPadding,
+      PagePanelVerticalRhythm.rowGap)
+    XCTAssertEqual(
+      BrainSectionPageMetrics.navigationHeight,
+      QueryShellLayout.chipHeight
+        + PagePanelVerticalRhythm.panelTopPadding
+        + PagePanelVerticalRhythm.rowGap)
+  }
+
+  func testSearchAndDestinationPanelsShareTheSingleInterPanelGap() {
+    XCTAssertEqual(QueryShellLayout.panelGap, 8)
+    XCTAssertEqual(
+      QueryShellLayout.panelGap,
+      RewindSearchLayout.panelGap,
+      "all destination surfaces must use the same search-to-content gap")
+  }
+}

--- a/desktop/macos/Desktop/Tests/QueryShellTests.swift
+++ b/desktop/macos/Desktop/Tests/QueryShellTests.swift
@@ -227,14 +227,34 @@ final class QueryShellTests: XCTestCase {
 
   // MARK: - The gap
 
-  /// The single most important number on the surface: two panels 12 pt apart read as two objects,
+  /// The single most important number on the surface: two panels keep a compact real gap,
   /// the same two at 0 read as one slab with a rule through it.
   func testTheTwoPanelsKeepRealAirBetweenThemAndShareOneCorner() {
-    XCTAssertEqual(QueryShellLayout.panelGap, 12)
+    XCTAssertEqual(QueryShellLayout.panelGap, 8)
     XCTAssertEqual(
       QueryShellLayout.panelGap, RewindSearchLayout.panelGap,
       "one product, one opinion about how far apart its glass sits")
     XCTAssertEqual(QueryShellLayout.panelCornerRadius, InkGlass.cornerRadius)
+  }
+
+  func testSharedSearchAndBrainChromeUseTheCompactDensityContract() {
+    XCTAssertEqual(QueryShellLayout.barMinHeight, 48)
+    XCTAssertEqual(RewindSearchLayout.barHeight, QueryShellLayout.barMinHeight)
+    XCTAssertEqual(RewindSearchMetrics.queryFontSize, QueryShellLayout.queryFontSize)
+    XCTAssertEqual(
+      PagePanelFirstRowMetrics.topPadding,
+      QueryShellLayout.panelPaddingTop,
+      "list and catalog toolbars must start where Activity's first row starts")
+    XCTAssertEqual(
+      BrainSectionPageMetrics.navigationTopPadding,
+      PagePanelFirstRowMetrics.topPadding,
+      "Brain pills must not sit closer to the panel edge than the other page controls")
+    XCTAssertEqual(
+      BrainSectionPageMetrics.navigationBottomPadding,
+      PagePanelFirstRowMetrics.bottomPadding)
+    XCTAssertEqual(BrainSectionPageMetrics.navigationHeight, 44)
+    XCTAssertGreaterThanOrEqual(QueryShellLayout.chipHeight, 28)
+    XCTAssertLessThan(QueryShellLayout.panelHeaderSpacing, 8)
   }
 
   /// Both panels sit in the top bar's lane, or the surface reads as three objects that missed
@@ -499,20 +519,15 @@ final class QueryShellTests: XCTestCase {
     XCTAssertEqual(QueryShellRoute.conversation.navItem, .conversations)
     XCTAssertEqual(QueryShellRoute.memories.navItem, .conversations)
     XCTAssertEqual(QueryShellRoute.brainMap.navItem, .conversations)
-    XCTAssertEqual(QueryShellRoute.rewind.navItem, .rewind)
+    XCTAssertEqual(QueryShellRoute.rewind.navItem, .conversations)
   }
 
-  /// The three hub routes must each select a *different* one of the hub's own views, and Rewind must
-  /// select none — writing a Memory-hub destination on the way to Rewind is how the hub ends up on
-  /// whichever view the last unrelated navigation happened to leave behind.
-  func testTheThreeHubRoutesSelectTheHubsOwnThreeViews() {
+  /// Each route into Brain must select the peer view that owns its content.
+  func testTheBrainRoutesSelectTheirOwnViews() {
     XCTAssertEqual(
       QueryShellRoute.allCases.compactMap(\.memoryDestination),
-      [.conversations, .memories, .brainMap],
-      "Home's hub routes no longer cover the hub's three views one-for-one")
-    XCTAssertNil(
-      QueryShellRoute.rewind.memoryDestination,
-      "a page of its own must not write the Memory hub's destination on the way there")
+      [.conversations, .memories, .brainMap, .rewind],
+      "Home's Brain routes no longer select their peer views one-for-one")
 
     for route in QueryShellRoute.allCases {
       guard let hubView = route.memoryDestination else { continue }

--- a/desktop/macos/Desktop/Tests/QueryShellTests.swift
+++ b/desktop/macos/Desktop/Tests/QueryShellTests.swift
@@ -250,8 +250,13 @@ final class QueryShellTests: XCTestCase {
       PagePanelFirstRowMetrics.topPadding,
       "Brain pills must not sit closer to the panel edge than the other page controls")
     XCTAssertEqual(
+      PagePanelFirstRowMetrics.bottomPadding,
+      0,
+      "the first row must not stack a second gap before its content")
+    XCTAssertEqual(
       BrainSectionPageMetrics.navigationBottomPadding,
-      PagePanelFirstRowMetrics.bottomPadding)
+      PagePanelVerticalRhythm.rowGap,
+      "Brain navigation owns the single gap before its refinement row")
     XCTAssertEqual(BrainSectionPageMetrics.navigationHeight, 44)
     XCTAssertGreaterThanOrEqual(QueryShellLayout.chipHeight, 28)
     XCTAssertLessThan(QueryShellLayout.panelHeaderSpacing, 8)

--- a/desktop/macos/Desktop/Tests/RewindSearchLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindSearchLayoutTests.swift
@@ -13,7 +13,11 @@ final class RewindSearchLayoutTests: XCTestCase {
 
   func testThreeColumnsFitTheContentWidthExactly() {
     let content = RewindSearchLayout.contentWidth()
-    XCTAssertEqual(content, 720, accuracy: 0.001, "760 pt panel less 20 pt padding either side")
+    XCTAssertEqual(
+      content,
+      RewindSearchLayout.panelWidth - RewindSearchLayout.panelPaddingHorizontal * 2,
+      accuracy: 0.001,
+      "the content lane is the panel less its shared horizontal padding")
 
     let card = RewindSearchLayout.cardWidth()
     let gutters = RewindSearchLayout.cardGutter * CGFloat(RewindSearchLayout.resultColumns - 1)
@@ -24,11 +28,15 @@ final class RewindSearchLayoutTests: XCTestCase {
 
   func testACardIsAsTallAsTheLayoutSays() {
     let card = RewindSearchLayout.cardWidth()
-    XCTAssertEqual(card, 230.667, accuracy: 0.01)
+    let gutters = RewindSearchLayout.cardGutter * CGFloat(RewindSearchLayout.resultColumns - 1)
     XCTAssertEqual(
-      RewindSearchLayout.cardHeight(), card / RewindSearchLayout.thumbnailAspect + 46,
+      card,
+      (RewindSearchLayout.contentWidth() - gutters) / CGFloat(RewindSearchLayout.resultColumns),
       accuracy: 0.001)
-    XCTAssertEqual(RewindSearchLayout.cardHeight(), 219, accuracy: 0.01)
+    XCTAssertEqual(
+      RewindSearchLayout.cardHeight(),
+      card / RewindSearchLayout.thumbnailAspect + RewindSearchLayout.cardCaptionHeight,
+      accuracy: 0.001)
   }
 
   func testCardsStayLegibleAtThePanelWidth() {

--- a/desktop/macos/Desktop/Tests/SettingsGlassChromeTests.swift
+++ b/desktop/macos/Desktop/Tests/SettingsGlassChromeTests.swift
@@ -73,8 +73,8 @@ final class SettingsGlassChromeTests: XCTestCase {
       SettingsGlassMetrics.rowDividerInset,
       SettingsGlassMetrics.rowHorizontalPadding + SettingsGlassMetrics.iconTile
         + SettingsGlassMetrics.rowContentSpacing)
-    // The measured value from the settings kit these metrics come from: 12 + 26 + 11.
-    XCTAssertEqual(SettingsGlassMetrics.rowDividerInset, 49)
+    // The compact settings kit uses 10 + 26 + 11, keeping the divider aligned while reclaiming 2 pt.
+    XCTAssertEqual(SettingsGlassMetrics.rowDividerInset, 47)
   }
 
   /// A card drawn inside the glass must round *tighter* than the glass does.

--- a/desktop/macos/Desktop/Tests/ShellSummonTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellSummonTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import OmiTheme
 import XCTest
 
 @testable import Omi_Computer
@@ -125,6 +126,13 @@ final class ShellSummonTests: XCTestCase {
       ShellSummonPlacement.defaultSize.width, DesktopWindowLayoutPolicy.minimumContentSize.width)
     XCTAssertGreaterThanOrEqual(
       ShellSummonPlacement.defaultSize.height, DesktopWindowLayoutPolicy.minimumContentSize.height)
+  }
+
+  func testResetWindowSizeReturnsToTheActualSummonedPanelSize() {
+    XCTAssertEqual(
+      WindowSizeResetPolicy.defaultSize,
+      ShellSummonPlacement.defaultSize,
+      "reset must not revive the obsolete 1200×800 managed-window geometry")
   }
 
   /// A remembered frame already at the hug size is restored exactly. This is the payoff of

--- a/desktop/macos/Desktop/Tests/SpineCompositionTests.swift
+++ b/desktop/macos/Desktop/Tests/SpineCompositionTests.swift
@@ -173,8 +173,8 @@ final class SpineCompositionTests: XCTestCase {
 
     let matchingOneTask = SpineComposer.filter(days, kind: .everything, query: "coffee")
     XCTAssertEqual(
-      matchingOneTask[0].taskCount, 2,
-      "a filtered day header still describes every task hidden behind that day"
+      matchingOneTask[0].taskCount, 1,
+      "a filtered day header describes the task that remains visible"
     )
 
     let tasksOnly = SpineComposer.filter(days, kind: .tasks, query: "")
@@ -228,7 +228,7 @@ final class SpineCompositionTests: XCTestCase {
 
   // MARK: - Day header counts
 
-  func testTheDayHeaderCountsTheWholeDayNotTheFilteredView() {
+  func testTheDayHeaderCountsTheFilteredView() {
     let start = date(6, 20, 0)
     let screen = SpineDayScreen(total: 1204, hourCounts: [], sampled: [moment(1, at: date(6, 20, 2))])
     let composed = SpineComposer.compose(
@@ -246,8 +246,16 @@ final class SpineCompositionTests: XCTestCase {
 
     let soloed = SpineComposer.filter(composed, kind: .memories, query: "")
     XCTAssertEqual(
-      soloed[0].momentCount, 1204, "a filtered spine still says how big the day really was")
-    XCTAssertEqual(soloed[0].conversationCount, 1)
+      soloed[0].momentCount, 0, "a memory filter must not claim screen moments are visible")
+    XCTAssertEqual(soloed[0].conversationCount, 0)
+    XCTAssertEqual(soloed[0].memoryCount, 1)
+    XCTAssertEqual(soloed[0].subtitle, "1 memory")
+
+    let matchingMemory = SpineComposer.filter(composed, kind: .everything, query: "doors")
+    XCTAssertEqual(matchingMemory[0].momentCount, 0)
+    XCTAssertEqual(matchingMemory[0].conversationCount, 0)
+    XCTAssertEqual(matchingMemory[0].memoryCount, 1)
+    XCTAssertEqual(matchingMemory[0].subtitle, "1 memory")
   }
 
   // MARK: - Solo

--- a/desktop/macos/Desktop/Tests/TaskDetailPanelTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskDetailPanelTests.swift
@@ -234,6 +234,17 @@ final class TaskDetailPanelTests: XCTestCase {
         isDetailPanelPresented: false
       )
     )
+    XCTAssertTrue(
+      TaskDetailPanelPresentationPolicy.showsHoverActions(
+        isRowHovering: false,
+        isKeyboardSelected: true,
+        isMultiSelectMode: false,
+        isDeletedTask: false,
+        isTextFieldFocused: false,
+        isDetailPanelPresented: false
+      ),
+      "keyboard-selected rows need the same accessible action menu as hovered rows"
+    )
     XCTAssertFalse(
       TaskDetailPanelPresentationPolicy.showsHoverActions(
         isRowHovering: true,

--- a/desktop/macos/Desktop/Tests/TasksViewModelCompletedToggleTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksViewModelCompletedToggleTests.swift
@@ -58,6 +58,24 @@ final class TasksViewModelCompletedToggleTests: XCTestCase {
     XCTAssertEqual(vm.displayTasks.map(\.id), ["done-1"])
   }
 
+  func testSearchResultsRespectSelectedStatusView() async {
+    let todo = task(id: "todo-match", completed: false)
+    let done = task(id: "done-match", completed: true)
+    let vm = TasksViewModel(searchLoader: { _, _ in [todo, done] })
+
+    vm.searchText = "match"
+    for _ in 0..<100 {
+      await Task.yield()
+      if vm.searchResults.count == 2, !vm.isSearching { break }
+    }
+
+    XCTAssertEqual(Set(vm.displayTasks.map(\.id)), Set([todo.id]))
+
+    vm.toggleShowCompletedView()
+
+    XCTAssertEqual(Set(vm.displayTasks.map(\.id)), Set([done.id]))
+  }
+
   func testTodoPresentationDoesNotUseDoneRowsAsItsLoadingState() {
     let store = TasksStore.shared
     store.resetSessionState()

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -146,7 +146,7 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     )
   }
 
-  /// The bar carries five flat destination pills and no destination menu. The claim worth holding is not the pill count —
+  /// The bar carries four flat destination pills and no destination menu. The claim worth holding is not the pill count —
   /// it is that **nothing was stranded when the menu was deleted** (INV-NAV-1). `reach` names the one
   /// mechanism responsible for each destination, so this fails the moment a pill is removed without
   /// the destination being moved somewhere that exists.
@@ -157,12 +157,12 @@ final class TopNavigationBarLayoutTests: XCTestCase {
         SidebarNavItem.dashboard.rawValue,
         SidebarNavItem.conversations.rawValue,
         SidebarNavItem.tasks.rawValue,
-        SidebarNavItem.rewind.rawValue,
         SidebarNavItem.apps.rawValue,
       ]
     )
     XCTAssertEqual(
-      TopNavigationRoutes.memoryDestinations, [.memories, .conversations, .brainMap, .activity])
+      TopNavigationRoutes.memoryDestinations,
+      [.memories, .conversations, .brainMap, .activity, .rewind])
 
     // No pill may instruct the user how to operate it. The retired menu's tooltip read "hover for
     // conversations, memories, tasks, Rewind", which is chrome apologising for itself.
@@ -177,12 +177,12 @@ final class TopNavigationBarLayoutTests: XCTestCase {
       ShellDestination.unreachable(), [],
       "a destination lost the only mechanism that reached it")
 
-    // The hub's other three pages are reached from Activity's chip row, on the page the pill opens.
+    // The hub's other four pages are reached from Brain's section row, on the page the pill opens.
     // `Activity` itself is what the pill opens, so the bar is its own door.
     XCTAssertEqual(
       ShellDestination.allCases.filter { $0.reach == .activityChipRow }
         .compactMap(\.memoryDestination),
-      [.conversations, .memories, .brainMap])
+      [.conversations, .memories, .brainMap, .rewind])
     // The claim is checkable because the row and the model read one value. A page dropped from the
     // chip row is unreachable here rather than silently stranded in the app.
     for destination in ShellDestination.allCases where destination.reach == .activityChipRow {
@@ -203,7 +203,7 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     XCTAssertEqual(hubPill?.title, "Brain")
     XCTAssertNotEqual(
       hubPill?.icon, "clock.arrow.circlepath",
-      "the hub pill must not wear Rewind's glyph two pills away from Rewind")
+      "the Brain pill must not wear Rewind's section glyph")
     // Chat is a peer pill, not a brand mark: the eight-dot mark belongs to the query bar, where it
     // animates while Omi is answering. The pill wears a chat glyph because the page IS the chat.
     XCTAssertEqual(ShellDestination.home.navItem, .dashboard)
@@ -258,29 +258,24 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     )
   }
 
-  func testReferAFriendSitsImmediatelyAfterAdvancedInSettings() {
+  func testReferAFriendRemainsAvailableAfterAIAndAutomationInSettings() {
     guard
       let advanced = SettingsSidebarRoutes.visibleSections.firstIndex(of: .advanced),
       let referral = SettingsSidebarRoutes.visibleSections.firstIndex(of: .referral)
     else {
-      return XCTFail("Advanced and Refer a Friend must both be visible Settings rows")
+      return XCTFail("AI & Automation and Refer a Friend must both be visible Settings rows")
     }
 
     XCTAssertEqual(referral, advanced + 1)
   }
 
-  func testReferControlIsPinnedImmediatelyBeforeTheMicrophoneControl() {
+  func testOperationalStatusFollowsUpdateStatusWithoutPromotionalChrome() {
     let recorder = TopNavigationLayoutRecorder()
     let host = NSHostingView(
       rootView: TopNavigationTrailingControlsLayout(
         updateStatus: {
           TopNavigationLayoutProbe(recorder: recorder, slot: .updateStatus) {
             Color.clear.frame(width: 100, height: 32)
-          }
-        },
-        referral: {
-          TopNavigationLayoutProbe(recorder: recorder, slot: .referral) {
-            Color.clear.frame(width: 78, height: 30)
           }
         },
         statusControls: {
@@ -298,33 +293,24 @@ final class TopNavigationBarLayoutTests: XCTestCase {
 
     guard
       let updateStatus = recorder.frame(of: .updateStatus),
-      let referral = recorder.frame(of: .referral),
       let microphone = recorder.frame(of: .microphone)
     else {
       return XCTFail("expected every trailing control to be laid out")
     }
 
-    XCTAssertEqual(referral.minX, updateStatus.maxX + OmiSpacing.sm, accuracy: 0.5)
-    XCTAssertEqual(microphone.minX, referral.maxX + OmiSpacing.sm, accuracy: 0.5)
+    XCTAssertEqual(microphone.minX, updateStatus.maxX + OmiSpacing.sm, accuracy: 0.5)
   }
 
   /// A destination whose `reach` points at a page the bar does not have a pill for is exactly the
   /// stranding INV-NAV-1 forbids, so the checker has to *see* it rather than pass vacuously.
   func testTheReachabilityCheckerCatchesADestinationWhosePillWasRemoved() {
-    let barWithoutRewind = TopNavigationRoutes.primaryItems.filter {
-      $0.index != SidebarNavItem.rewind.rawValue
-    }
-    XCTAssertEqual(
-      ShellDestination.unreachable(fromBarItems: barWithoutRewind), [.rewind],
-      "Rewind lost its pill and nothing noticed")
-
     let barWithoutLibrary = TopNavigationRoutes.primaryItems.filter {
       $0.index != SidebarNavItem.conversations.rawValue
     }
     XCTAssertEqual(
       Set(ShellDestination.unreachable(fromBarItems: barWithoutLibrary)),
-      [.conversations, .memories, .brainMap, .activity],
-      "without the Activity pill the hub's views have no way in")
+      [.conversations, .memories, .brainMap, .rewind, .activity],
+      "without the Brain pill the section's views have no way in")
   }
 
   /// **The bridge's destination vocabulary, now that a test can reach it.** This mapping was a
@@ -439,11 +425,8 @@ final class TopNavigationBarLayoutTests: XCTestCase {
           }
         },
         persistentControls: {
-          HStack(spacing: OmiSpacing.sm) {
-            ReferralTopBarButton {}
-            Color.clear.frame(
-              width: TopNavigationLayoutMetrics.persistentControlsWidth, height: 32)
-          }
+          Color.clear.frame(
+            width: TopNavigationLayoutMetrics.persistentControlsWidth, height: 32)
         },
         settings: {
           Color.clear.frame(width: TopNavigationLayoutMetrics.settingsControlWidth, height: 32)
@@ -571,7 +554,6 @@ private enum TopNavigationLayoutSlot: Hashable {
   case persistentControls
   case settings
   case updateStatus
-  case referral
   case microphone
 }
 

--- a/desktop/macos/changelog/unreleased/20260827-brain-rewind-navigation.json
+++ b/desktop/macos/changelog/unreleased/20260827-brain-rewind-navigation.json
@@ -1,0 +1,3 @@
+{
+  "change": "Moved Rewind into Brain and unified compact search, navigation, filtering, and contextual actions across Chat, Brain, Tasks, and Apps"
+}

--- a/desktop/macos/e2e/flows/audio-recording.yaml
+++ b/desktop/macos/e2e/flows/audio-recording.yaml
@@ -45,7 +45,7 @@ preconditions:
 steps:
   - id: S1
     name: Navigate to Dashboard
-    do: "Click the Dashboard sidebar icon (identifier: sidebar_dashboard) to navigate to the Dashboard page. Verify the page loads with conversations list, Quick Note button, and Start Recording button."
+    do: "Open Brain, choose Conversations, and verify the conversation list loads. When Listening is set to Always, open the More menu and verify Start recording is available."
     expect:
       interactive_count: { min: 5 }
       text_visible:
@@ -53,7 +53,7 @@ steps:
 
   - id: S2
     name: Verify Start Recording button
-    do: "Check that the 'Start Recording' button with microphone icon is visible on the Dashboard. Note its position and state. If the app is already recording, a 'Stop Recording' button should be visible instead."
+    do: "Open the Conversations More menu and check that 'Start recording' with a microphone icon is available. If the app is already recording, verify the live recording state instead."
     expect:
       interactive_count: { min: 1 }
 
@@ -65,7 +65,7 @@ steps:
 
   - id: S3
     name: Click Start Recording
-    do: "Click the 'Start Recording' button. If microphone permission is NOT granted, the app should show a permission request dialog or navigate to permission settings. If permission IS granted, the app should begin audio capture and the button should change to show recording state (e.g., 'Stop Recording' or recording indicator)."
+    do: "Choose 'Start recording' from the Conversations More menu. If microphone permission is NOT granted, the app should show a permission request dialog or navigate to permission settings. If permission IS granted, the app should begin audio capture and show the live recording state."
     expect:
       interactive_count: { min: 1 }
 
@@ -95,7 +95,7 @@ steps:
 
   - id: S7
     name: Return to Dashboard
-    do: "Click the Back button or Dashboard sidebar icon (identifier: sidebar_dashboard) to return to the Dashboard page. Verify the Start Recording button is visible."
+    do: "Return to Brain → Conversations. When Listening is set to Always, verify Start recording remains available in the More menu."
     expect:
       interactive_count: { min: 5 }
       text_visible:

--- a/desktop/macos/e2e/flows/memories.yaml
+++ b/desktop/macos/e2e/flows/memories.yaml
@@ -92,7 +92,7 @@ steps:
 
   - id: S4
     name: Verify conversation list features
-    do: "Check for Select and Quick Note buttons at the top. Verify conversation entries show title, date, duration, and star icon. Check for 'Load older conversations' at the bottom if scrolled down."
+    do: "Open the More menu and verify Select conversations is available. Verify conversation entries show title, date, duration, and star icon. Check for 'Load older conversations' at the bottom if scrolled down."
     expect:
       interactive_count: { min: 3 }
 

--- a/desktop/macos/e2e/flows/navigation.yaml
+++ b/desktop/macos/e2e/flows/navigation.yaml
@@ -13,6 +13,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
   - desktop/macos/Desktop/Sources/MainWindow/PageGlassLane.swift
   - desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityDestinationChip.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Components/PageQueryToolbar.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsDestinationView.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
   - desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
@@ -22,6 +23,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/ActiveDisplay.swift
   - desktop/macos/Desktop/Sources/MainWindow/QueryShell/ShellStatusIcons.swift
   - desktop/macos/Desktop/Sources/MainWindow/QueryShell/OmiQueryDotMark.swift
+  - desktop/macos/Desktop/Sources/Theme/OmiFont.swift
   - desktop/macos/Desktop/Sources/MainWindow/EscapeKeyHandler.swift
   - desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
 preconditions:


### PR DESCRIPTION
## Summary

- Unify the compact search, navigation, and filter chrome across Chat, Brain, Tasks, and Apps
- Polish Brain subpage routing, spacing, empty states, and filter/search behavior
- Simplify Tasks and Settings surfaces while keeping the Activity page's compact layout rhythm

## Testing

- `./scripts/dev-feedback.py --once swift 'QueryShellTests'`
- `./scripts/dev-feedback.py --once swift 'PageGlassLaneTests'`
- `./scripts/dev-feedback.py --once swift 'AppsPageCategoryFilterTests'`
- `./scripts/agent-logic-harness.sh --cross-surface-smoke`
- Full named-bundle build and signed local QA via `OMI_APP_NAME=omi-nav-audit ./run.sh --yolo --full`
- `./scripts/omi-macos-dev doctor`

## Notes

- Production bundles were not modified.
- The named QA bundle is available at `/Applications/omi-nav-audit.app`.

## Product invariants affected

- INV-BETA-1
- INV-NAV-1
- INV-INT-1
- INV-MEM-1
- INV-TASK-1

Line-Count-Exception: desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift | 4814 -> 4815 | reason: added the destination routing needed to exercise the unified navigation surfaces
Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift | 1654 -> 1671 | reason: consolidated compact shell routing and shared page chrome
Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift | 3463 -> 3850 | reason: unified search and filter states with compact imports layout
Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift | 3606 -> 3683 | reason: unified Brain search, filters, empty states, and navigation chrome
Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift | 4254 -> 4325 | reason: retained Brain Map routing while sharing the compact Brain page shell
Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift | 6680 -> 6695 | reason: unified task search, status filtering, and compact controls
Line-Count-Exception: desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift | 1607 -> 1775 | reason: moved Rewind into Brain and kept capture/search controls accessible in the compact shell


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


