### PR TITLE
Fix unreadable post-rating referral button

### DIFF
--- a/desktop/macos/Desktop/Sources/RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/RatingPrompt.swift
@@ -271,6 +271,11 @@ final class RatingPromptManager: ObservableObject {
 
 // MARK: - View
 
+enum RatingPromptButtonStyle {
+  static let referralKind: OmiButtonStyle.Kind = .primary
+  static let referralSize: OmiButtonStyle.Size = .compact
+}
+
 /// Closable sticky bar pinned to the bottom of the main window asking
 /// "How would you rate Omi Desktop?" with 1–5 stars.
 struct RatingPromptBar: View {
@@ -329,9 +334,10 @@ struct RatingPromptBar: View {
         Button("Refer a friend") {
           manager.referFriend()
         }
-        .buttonStyle(.borderedProminent)
-        .controlSize(.small)
-        .tint(.primary)
+        .buttonStyle(
+          OmiButtonStyle(
+            RatingPromptButtonStyle.referralKind,
+            size: RatingPromptButtonStyle.referralSize))
       }
 
       closeButton { manager.closeThankYou() }

--- a/desktop/macos/Desktop/Tests/RatingPromptPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/RatingPromptPolicyTests.swift
@@ -1,3 +1,4 @@
+import OmiTheme
 import XCTest
 
 @testable import Omi_Computer
@@ -28,5 +29,12 @@ final class RatingPromptPolicyTests: XCTestCase {
     XCTAssertFalse(
       RatingPromptPolicy.shouldShow(
         questionCount: 3, submittedRating: 0, dismissed: false, remotelyDisabled: true))
+  }
+
+  func testReferralButtonUsesReadableSharedPrimaryStyle() {
+    XCTAssertEqual(RatingPromptButtonStyle.referralKind, .primary)
+    XCTAssertEqual(RatingPromptButtonStyle.referralSize, .compact)
+    XCTAssertEqual(OmiButtonStyle.fill(.primary, pressed: false), Ink.primary)
+    XCTAssertEqual(OmiButtonStyle.label(.primary), Ink.surface)
   }
 }

--- a/desktop/macos/changelog/unreleased/20260828-referral-button-contrast.json
+++ b/desktop/macos/changelog/unreleased/20260828-referral-button-contrast.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the post-rating referral button so its label remains readable"
+}


### PR DESCRIPTION
## Summary

- Replaced the post-rating referral CTA's system prominent button and tint override with Omi's shared compact primary button style.
- Added regression coverage for the referral CTA style and a desktop changelog entry.

## Root cause

The CTA used SwiftUI's `.borderedProminent` style with `.tint(.primary)`. On macOS this resolved the button to the primary color without Omi's inverse label treatment, producing the unreadable black appearance shown in the report.

## Verification

- `xcrun swift test -c debug --package-path Desktop --filter RatingPromptPolicyTests`
- `./scripts/swift-format-wrapper.sh lint -r Desktop/Sources/RatingPrompt.swift Desktop/Tests/RatingPromptPolicyTests.swift`
- `python3 scripts/check_desktop_test_quality.py`
- `./scripts/omi-macos-dev doctor`
- `make preflight`
- Exercised the named bundle `com.omi.omi-fix-referral-button`: reset the rating prompt, recorded three questions, submitted a 5-star rating, and verified the thank-you state exposed a `Refer a friend` button in the macOS accessibility tree.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

