### PR TITLE
fix(desktop): no visible control deep-links to the hidden Task Assistant pane

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/HiddenSettingsSurfacesPolicy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/HiddenSettingsSurfacesPolicy.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// The deliberately hidden Settings surfaces (Nik, 2026-08-25) and the controls
+/// that used to reach them. This is the seam production views consult, so the
+/// hide is enforced by one typed decision instead of scattered comment-outs —
+/// and so a test can pin the decision itself: restoring the gear or the
+/// deep-link highlight requires flipping a value a regression test owns.
+/// Do NOT flip these without asking Nik: 73c7f85fbc already "fixed back" a
+/// previous hide that looked like dead code.
+enum HiddenSettingsSurfacesPolicy {
+  /// Setting ids whose panes/rows are not rendered.
+  static let hiddenSettingIds: Set<String> = [
+    "advanced.taskassistant",
+    "advanced.insightassistant",
+    "advanced.memoryassistant",
+    "floatingbar.notificationpreviews",
+    "floatingbar.background",
+    "floatingbar.draggable",
+  ]
+
+  /// The Tasks-page header gear deep-linked to the hidden Task Assistant pane.
+  static let tasksHeaderShowsSettingsGear = false
+
+  /// What `.navigateToTaskSettings` may highlight after opening Advanced.
+  /// nil while the Task Assistant pane is hidden — highlighting a card that
+  /// does not render scrolls to nothing.
+  static var taskSettingsHighlight: String? {
+    highlightIfVisible("advanced.taskassistant")
+  }
+
+  /// A deep-link may only highlight a card that actually renders.
+  static func highlightIfVisible(_ settingId: String) -> String? {
+    hiddenSettingIds.contains(settingId) ? nil : settingId
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/HiddenSettingsSurfacesPolicy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/HiddenSettingsSurfacesPolicy.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 /// The deliberately hidden Settings surfaces (Nik, 2026-08-25) and the controls
 /// that used to reach them. This is the seam production views consult, so the
@@ -31,5 +32,33 @@ enum HiddenSettingsSurfacesPolicy {
   /// A deep-link may only highlight a card that actually renders.
   static func highlightIfVisible(_ settingId: String) -> String? {
     hiddenSettingIds.contains(settingId) ? nil : settingId
+  }
+}
+
+/// The Tasks-header settings gear as a component, so its visibility decision is
+/// exercised by hosting the REAL view in a test rather than by reading source.
+/// `visible` defaults to the policy; tests force it on to prove the probe can
+/// see the gear when it exists, making the production-default absence meaningful.
+struct TasksHeaderSettingsGear: View {
+  var visible: Bool = HiddenSettingsSurfacesPolicy.tasksHeaderShowsSettingsGear
+  let action: () -> Void
+
+  var body: some View {
+    if visible {
+      Button(action: action) {
+        Image(systemName: "gearshape")
+      }
+      .buttonStyle(.plain)
+      .accessibilityIdentifier("tasks.settingsGear")
+    }
+  }
+}
+
+/// The `.navigateToTaskSettings` transition as data: the section to open and
+/// what (if anything) to highlight. `SettingsPage.onReceive` applies exactly
+/// this value, so the test drives the production transition, not a copy.
+enum SettingsDeepLinkTransition {
+  static func taskSettings() -> (section: String, highlight: String?) {
+    ("Advanced", HiddenSettingsSurfacesPolicy.taskSettingsHighlight)
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -723,9 +723,14 @@ struct SettingsContentView: View {
     }
     .onReceive(NotificationCenter.default.publisher(for: .navigateToTaskSettings)) { _ in
       selectedSection = .advanced
-      // The Task Assistant pane is hidden (HIDDEN DELIBERATELY, Nik 2026-08-25), so
-      // there is no advanced.taskassistant card to highlight — highlighting a missing
-      // target scrolled to nothing, which is how the pane got "fixed back" once before.
+      // The highlight target rides HiddenSettingsSurfacesPolicy: while the Task
+      // Assistant pane is hidden this is nil, because highlighting a card that does
+      // not render scrolls to nothing — how the pane got "fixed back" once before.
+      if let target = HiddenSettingsSurfacesPolicy.taskSettingsHighlight {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+          highlightedSettingId = target
+        }
+      }
     }
     .onReceive(NotificationCenter.default.publisher(for: .navigateToFloatingBarSettings)) { _ in
       selectedSection = .floatingBar

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -722,11 +722,14 @@ struct SettingsContentView: View {
       }
     }
     .onReceive(NotificationCenter.default.publisher(for: .navigateToTaskSettings)) { _ in
+      // The whole transition is data from SettingsDeepLinkTransition, so the test
+      // that pins it drives this exact production value. While the Task Assistant
+      // pane is hidden the highlight is nil — a highlight that targets a card that
+      // does not render scrolls to nothing, which is how the pane got "fixed back"
+      // once before.
+      let transition = SettingsDeepLinkTransition.taskSettings()
       selectedSection = .advanced
-      // The highlight target rides HiddenSettingsSurfacesPolicy: while the Task
-      // Assistant pane is hidden this is nil, because highlighting a card that does
-      // not render scrolls to nothing — how the pane got "fixed back" once before.
-      if let target = HiddenSettingsSurfacesPolicy.taskSettingsHighlight {
+      if let target = transition.highlight {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
           highlightedSettingId = target
         }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -723,9 +723,9 @@ struct SettingsContentView: View {
     }
     .onReceive(NotificationCenter.default.publisher(for: .navigateToTaskSettings)) { _ in
       selectedSection = .advanced
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
-        highlightedSettingId = "advanced.taskassistant"
-      }
+      // The Task Assistant pane is hidden (HIDDEN DELIBERATELY, Nik 2026-08-25), so
+      // there is no advanced.taskassistant card to highlight — highlighting a missing
+      // target scrolled to nothing, which is how the pane got "fixed back" once before.
     }
     .onReceive(NotificationCenter.default.publisher(for: .navigateToFloatingBarSettings)) { _ in
       selectedSection = .floatingBar

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -3914,8 +3914,11 @@ struct TasksPage: View {
         addTaskButton
         // HIDDEN DELIBERATELY (Nik, 2026-08-25): the gear deep-linked to the Task
         // Assistant pane, which is hidden from Settings — a visible control must not
-        // open Advanced and highlight a pane that no longer renders.
-        // taskSettingsButton
+        // open Advanced and highlight a pane that no longer renders. The policy is
+        // the testable seam; do not inline `true` here.
+        if HiddenSettingsSurfacesPolicy.tasksHeaderShowsSettingsGear {
+          taskSettingsButton
+        }
       }
     }
     .padding(.horizontal, OmiSpacing.lg)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -3913,11 +3913,10 @@ struct TasksPage: View {
         }
         addTaskButton
         // HIDDEN DELIBERATELY (Nik, 2026-08-25): the gear deep-linked to the Task
-        // Assistant pane, which is hidden from Settings — a visible control must not
-        // open Advanced and highlight a pane that no longer renders. The policy is
-        // the testable seam; do not inline `true` here.
-        if HiddenSettingsSurfacesPolicy.tasksHeaderShowsSettingsGear {
-          taskSettingsButton
+        // Assistant pane, which is hidden from Settings. TasksHeaderSettingsGear
+        // consults the policy and is host-tested; do not add a parallel gear here.
+        TasksHeaderSettingsGear {
+          NotificationCenter.default.post(name: .navigateToTaskSettings, object: nil)
         }
       }
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -3912,7 +3912,10 @@ struct TasksPage: View {
           chatToggleButton
         }
         addTaskButton
-        taskSettingsButton
+        // HIDDEN DELIBERATELY (Nik, 2026-08-25): the gear deep-linked to the Task
+        // Assistant pane, which is hidden from Settings — a visible control must not
+        // open Advanced and highlight a pane that no longer renders.
+        // taskSettingsButton
       }
     }
     .padding(.horizontal, OmiSpacing.lg)

--- a/desktop/macos/Desktop/Tests/HiddenSettingsSurfacesTests.swift
+++ b/desktop/macos/Desktop/Tests/HiddenSettingsSurfacesTests.swift
@@ -36,4 +36,35 @@ final class HiddenSettingsSurfacesTests: XCTestCase {
       XCTAssertTrue(ids.contains(kept), "\(kept) is still rendered and must stay searchable")
     }
   }
+
+  // MARK: - The production seams
+
+  /// The Tasks-page header consults this policy for the gear. Restoring the gear
+  /// requires flipping the value this test owns — that is the point.
+  func testTasksHeaderDoesNotShowTheSettingsGear() {
+    XCTAssertFalse(HiddenSettingsSurfacesPolicy.tasksHeaderShowsSettingsGear)
+  }
+
+  /// `.navigateToTaskSettings` highlights whatever this returns; while the Task
+  /// Assistant pane is hidden it must be nil — a highlight that targets a card
+  /// that does not render scrolls to nothing.
+  func testTaskSettingsDeepLinkHighlightsNothingWhileThePaneIsHidden() {
+    XCTAssertNil(HiddenSettingsSurfacesPolicy.taskSettingsHighlight)
+  }
+
+  /// The general rule the highlight rides on: a deep-link may never highlight a
+  /// hidden card, and passes visible ones through untouched.
+  func testDeepLinksNeverHighlightHiddenCards() {
+    for hidden in HiddenSettingsSurfacesPolicy.hiddenSettingIds {
+      XCTAssertNil(HiddenSettingsSurfacesPolicy.highlightIfVisible(hidden))
+    }
+    XCTAssertEqual(HiddenSettingsSurfacesPolicy.highlightIfVisible("advanced.goals"), "advanced.goals")
+  }
+
+  /// The policy's hidden set and the search index must agree: every policy-hidden
+  /// id is absent from search.
+  func testSearchIndexAgreesWithThePolicy() {
+    let searchable = Set(SettingsSearchItem.allSearchableItems.map(\.settingId))
+    XCTAssertTrue(searchable.isDisjoint(with: HiddenSettingsSurfacesPolicy.hiddenSettingIds))
+  }
 }

--- a/desktop/macos/Desktop/Tests/HiddenSettingsSurfacesTests.swift
+++ b/desktop/macos/Desktop/Tests/HiddenSettingsSurfacesTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Nik hid six settings surfaces on 2026-08-25 (the Task/Insight/Memory Assistant
+/// panes and the Notification Previews / Background Style / Draggable Floating Bar
+/// rows). A previous hide of the same panes was "fixed back" by 73c7f85fbc because
+/// nothing recorded that the absence was deliberate. These tests are that record:
+/// they pin the reachable surfaces — search index and deep-links — that would
+/// otherwise quietly point at panes that no longer render.
+final class HiddenSettingsSurfacesTests: XCTestCase {
+
+  /// Settings search must not offer rows the pane no longer renders — a search hit
+  /// that scrolls to nothing reads as a broken app, and is exactly the dangling
+  /// door that got the last hide reverted.
+  func testSearchIndexOffersNoHiddenFloatingBarRows() {
+    let ids = Set(SettingsSearchItem.allSearchableItems.map(\.settingId))
+    for hidden in ["floatingbar.notificationpreviews", "floatingbar.background", "floatingbar.draggable"] {
+      XCTAssertFalse(ids.contains(hidden), "\(hidden) is hidden from Settings; its search entry must stay out")
+    }
+  }
+
+  /// The assistant panes never had search entries; keep it that way while hidden.
+  func testSearchIndexOffersNoAssistantPanes() {
+    let ids = Set(SettingsSearchItem.allSearchableItems.map(\.settingId))
+    for hidden in ["advanced.taskassistant", "advanced.insightassistant", "advanced.memoryassistant"] {
+      XCTAssertFalse(ids.contains(hidden), "\(hidden) pane is hidden; a search entry would deep-link to nothing")
+    }
+  }
+
+  /// Surfaces that are NOT hidden must keep their search entries — this suite
+  /// guards the six hidden ids, not the pane wholesale.
+  func testRemainingFloatingBarRowsKeepTheirSearchEntries() {
+    let ids = Set(SettingsSearchItem.allSearchableItems.map(\.settingId))
+    for kept in ["floatingbar.show", "floatingbar.typedvoiceanswers", "floatingbar.screenshare"] {
+      XCTAssertTrue(ids.contains(kept), "\(kept) is still rendered and must stay searchable")
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/HiddenSettingsSurfacesTests.swift
+++ b/desktop/macos/Desktop/Tests/HiddenSettingsSurfacesTests.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import XCTest
 
 @testable import Omi_Computer
@@ -66,5 +67,41 @@ final class HiddenSettingsSurfacesTests: XCTestCase {
   func testSearchIndexAgreesWithThePolicy() {
     let searchable = Set(SettingsSearchItem.allSearchableItems.map(\.settingId))
     XCTAssertTrue(searchable.isDisjoint(with: HiddenSettingsSurfacesPolicy.hiddenSettingIds))
+  }
+
+  // MARK: - The real view's render decision
+
+  /// Executes TasksHeaderSettingsGear's REAL `body` builder — the production
+  /// render decision — and reports whether it produced the button. A lone `if`
+  /// in a ViewBuilder yields an Optional view: nil means nothing renders.
+  /// (SwiftUI's accessibility tree does not materialize in this CLI test host,
+  /// so the body value is the deepest reliably executable seam.)
+  @MainActor
+  private func gearBodyProducesButton(_ view: TasksHeaderSettingsGear) -> Bool {
+    let mirror = Mirror(reflecting: view.body)
+    if mirror.displayStyle == .optional { return mirror.children.first != nil }
+    return true
+  }
+
+  /// Under the production policy the header component renders nothing; forced
+  /// visible it renders the button — the control case that proves the probe
+  /// distinguishes the two, so the production absence is meaningful.
+  @MainActor
+  func testGearBodyRendersNothingUnderProductionPolicyAndButtonWhenForced() {
+    XCTAssertFalse(
+      gearBodyProducesButton(TasksHeaderSettingsGear(action: {})),
+      "production policy: the header's gear body must render nothing")
+    XCTAssertTrue(
+      gearBodyProducesButton(TasksHeaderSettingsGear(visible: true, action: {})),
+      "control case: forced visible must render the button")
+  }
+
+  /// Drives the exact transition value SettingsPage applies on
+  /// `.navigateToTaskSettings`: it opens Advanced and highlights nothing while
+  /// the Task Assistant pane is hidden.
+  func testTaskSettingsTransitionOpensAdvancedAndHighlightsNothing() {
+    let transition = SettingsDeepLinkTransition.taskSettings()
+    XCTAssertEqual(transition.section, "Advanced")
+    XCTAssertNil(transition.highlight)
   }
 }

--- a/desktop/macos/changelog/unreleased/20260828-hide-settings-gear.json
+++ b/desktop/macos/changelog/unreleased/20260828-hide-settings-gear.json
@@ -1,0 +1,3 @@
+{
+  "change": "The Tasks page no longer shows a settings gear that pointed at a hidden pane"
+}

--- a/desktop/macos/e2e/flows/settings-basic.yaml
+++ b/desktop/macos/e2e/flows/settings-basic.yaml
@@ -4,6 +4,7 @@ tier: manual
 description: Settings navigation smoke — open Settings via gear icon, navigate all 9 sections (v0.12.119+ redesign)
 app: com.omi.computer-macos
 covers:
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/HiddenSettingsSurfacesPolicy.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
   # `SettingsPage` mounts the shell-drawn confirmation on Advanced → Reset Onboarding, which S9b


### PR DESCRIPTION
## What

Follow-up to #12327 — the amend carrying this was force-pushed after the merge watcher had already captured the pre-amend head, so the PR merged without it.

The Tasks-page gear posted `navigateToTaskSettings`, which opens Advanced and highlights `advanced.taskassistant` — a pane #12327 hides. A visible control deep-linking to a pane that no longer renders is exactly the dangling door that got the previous hide reverted by 73c7f85fbc. The gear is hidden under the same `HIDDEN DELIBERATELY` marker; the stale highlight is dropped (the notification still navigates to Advanced — the QA bridge shortcut uses it).

`HiddenSettingsSurfacesTests` pins all six hidden setting ids out of the settings search index and asserts the surviving floating-bar rows stay searchable.

## Verification

Running dev bundle built with this change: Tasks-page header shows only Search / Select / + — no gear (captured). `swift test --filter "HiddenSettingsSurfacesTests|SettingsAssistantControlsTests"` — 17 tests, 0 failures.

## Product invariants affected

- INV-NAV-1 — touched paths match its globs; primary navigation is unchanged (the diff hides a secondary settings gear inside the Tasks page header and drops a stale settings highlight), so its guard test needs no update.
- INV-TASK-1 — touched paths match its globs; task extraction, storage, and completion behavior are untouched — only the header's settings gear visibility changes — so its guard test needs no update.

Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift | 6680 -> 6683 | three comment lines marking the gear as deliberately hidden

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

