### PR TITLE
fix(openapi): keep contract tooling UTF-8 on Windows

### DIFF
--- a/.github/failure-classes/FC-repository-text-io-inherits-host-locale.json
+++ b/.github/failure-classes/FC-repository-text-io-inherits-host-locale.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-repository-text-io-inherits-host-locale",
+  "violated_contract": "Repository text artifacts must be decoded and encoded consistently on every supported host; relying on the process locale makes UTF-8 source and generated files unreadable on Windows code pages such as CP936.",
+  "canonical_prevention": "Declare UTF-8 on every pathlib text read and write in portable generator scripts and their contract tests, and enforce that property with an AST-based test covering all app-client generator surfaces.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_app_client_generator_utf8_contract.py"
+  ],
+  "evidence_prs": [
+    9759
+  ],
+  "scope_hints": [
+    "backend/scripts/generate_*",
+    "backend/tests/unit/test_app_client_*_generator.py"
+  ],
+  "status": "open"
+}

--- a/.github/failure-classes/FC-repository-text-io-inherits-host-locale.json
+++ b/.github/failure-classes/FC-repository-text-io-inherits-host-locale.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "id": "FC-repository-text-io-inherits-host-locale",
   "violated_contract": "Repository text artifacts must be decoded and encoded consistently on every supported host; relying on the process locale makes UTF-8 source and generated files unreadable on Windows code pages such as CP936.",
-  "canonical_prevention": "Declare UTF-8 on every pathlib text read and write in portable generator scripts and their contract tests, and enforce that property with an AST-based test covering all app-client generator surfaces.",
+  "canonical_prevention": "Declare UTF-8 on every pathlib text read and write in portable OpenAPI contract scripts and tests, and enforce that static property with one AST-based guard covering the generator, exporter, schema inventory, and REST inventory surfaces.",
   "canonical_prevention_artifact": [
     "backend/tests/unit/test_app_client_generator_utf8_contract.py"
   ],
@@ -10,8 +10,10 @@
     9759
   ],
   "scope_hints": [
-    "backend/scripts/generate_*",
-    "backend/tests/unit/test_app_client_*_generator.py"
+    "backend/scripts/*openapi*",
+    "backend/scripts/inventory_app_client_schemas.py",
+    "backend/tests/unit/test_*openapi*.py",
+    "backend/tests/unit/test_*_rest_inventory.py"
   ],
   "status": "open"
 }

--- a/backend/scripts/export_openapi.py
+++ b/backend/scripts/export_openapi.py
@@ -1061,7 +1061,7 @@ def stable_json(schema: dict[str, Any]) -> str:
 
 def write_spec(path: Path, generated: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(generated)
+    path.write_text(generated, encoding='utf-8', newline='\n')
 
 
 def regenerate_hint(path: Path, surface: str) -> str:
@@ -1081,7 +1081,7 @@ def check_spec(path: Path, generated: str, *, surface: str = 'public') -> None:
     hint = regenerate_hint(path, surface)
     if not path.exists():
         raise OpenAPIContractError(f'{path} does not exist; run {hint}')
-    current = path.read_text()
+    current = path.read_text(encoding='utf-8')
     if current != generated:
         raise OpenAPIContractError(f'{path} is stale; run {hint}')
 

--- a/backend/scripts/inventory_app_client_schemas.py
+++ b/backend/scripts/inventory_app_client_schemas.py
@@ -69,6 +69,11 @@ RAW_DECODE_RE = re.compile(
 WIRE_DECODE_RE = re.compile(r'wire\.Generated[A-Za-z0-9_]+\.fromJson|\.fromGenerated\s*\(|fromGeneratedWireJson')
 
 
+def repo_relative_path(path: Path) -> str:
+    """Return a stable repository path for JSON reports and diagnostics."""
+    return path.relative_to(ROOT_DIR).as_posix()
+
+
 def _collect_wire_backed_type_names() -> list[str]:
     """Collect Dart type names whose fromJson delegates to wire.Generated* parsers.
 
@@ -113,7 +118,7 @@ class DartSchemaFile:
 
     def to_report(self) -> dict[str, Any]:
         return {
-            'path': str(self.path.relative_to(ROOT_DIR)),
+            'path': repo_relative_path(self.path),
             'classes': self.classes,
             'enums': self.enums,
             'fromJson': self.from_json_count,
@@ -137,7 +142,7 @@ class AppRoute:
 
     def to_report(self) -> dict[str, Any]:
         return {
-            'path': str(self.path.relative_to(ROOT_DIR)),
+            'path': repo_relative_path(self.path),
             'route': self.route,
             'normalized_route': self.normalized_route,
             'line': self.line,
@@ -185,7 +190,7 @@ class DartDecodeSite:
 
     def to_report(self) -> dict[str, Any]:
         return {
-            'path': str(self.path.relative_to(ROOT_DIR)),
+            'path': repo_relative_path(self.path),
             'line': self.line,
             'kind': self.kind,
             'snippet': self.snippet,
@@ -220,7 +225,7 @@ class AppOperationManifestItem:
         raw_request_sites = [site for site in raw_sites if site.context == 'request_encode']
         generated_backed_sites = [site for site in self.decode_sites if site.generated_backed]
         return {
-            'path': str(self.path.relative_to(ROOT_DIR)),
+            'path': repo_relative_path(self.path),
             'route': self.route,
             'normalized_route': self.normalized_route,
             'line': self.line,
@@ -984,11 +989,11 @@ def build_report(spec_path: Path) -> dict[str, Any]:
     unmodeled_operations = [operation for operation in openapi_operations if operation.unmodeled_success_response]
     return {
         'dart_schema_dirs': [
-            str(APP_SCHEMA_DIR.relative_to(ROOT_DIR)),
-            str(APP_API_DIR.relative_to(ROOT_DIR)),
-            *(str(path.relative_to(ROOT_DIR)) for path in MODEL_REST_DTO_FILES if path.exists()),
+            repo_relative_path(APP_SCHEMA_DIR),
+            repo_relative_path(APP_API_DIR),
+            *(repo_relative_path(path) for path in MODEL_REST_DTO_FILES if path.exists()),
         ],
-        'app_client_openapi': str(spec_path.relative_to(ROOT_DIR)),
+        'app_client_openapi': repo_relative_path(spec_path),
         'openapi_schema_count': len(load_openapi_schema_names(spec_path)),
         'openapi_schemas': load_openapi_schema_names(spec_path),
         'openapi_path_count': len(openapi_paths),

--- a/backend/scripts/inventory_app_client_schemas.py
+++ b/backend/scripts/inventory_app_client_schemas.py
@@ -87,7 +87,7 @@ def _collect_wire_backed_type_names() -> list[str]:
     for path in sorted(APP_SCHEMA_DIR.rglob('*.dart')):
         if path.name.endswith('.g.dart') or path.name.endswith('.gen.dart'):
             continue
-        text = path.read_text()
+        text = path.read_text(encoding='utf-8')
         names.update(typedef_re.findall(text))
         names.update(adapter_re.findall(text))
     return sorted(names, key=len, reverse=True)  # longest first for alternation
@@ -250,7 +250,7 @@ class AppOperationManifestItem:
 
 
 def scan_dart_schema_file(path: Path) -> DartSchemaFile:
-    text = path.read_text()
+    text = path.read_text(encoding='utf-8')
     return DartSchemaFile(
         path=path,
         classes=CLASS_RE.findall(text),
@@ -316,8 +316,8 @@ def scan_dart_decode_sites() -> list[DartDecodeSite]:
     for path in paths:
         if path.name.endswith('.gen.dart') or path.name.endswith('.g.dart') or path in LOCAL_NON_REST_SCHEMA_FILES:
             continue
-        lines = path.read_text().splitlines()
-        functions = _function_ranges(path.read_text())
+        lines = path.read_text(encoding='utf-8').splitlines()
+        functions = _function_ranges(path.read_text(encoding='utf-8'))
         for index, line in enumerate(lines, start=1):
             stripped = line.strip()
             if not stripped or stripped.startswith('//') or not RAW_DECODE_RE.search(line):
@@ -746,7 +746,7 @@ def _mask_dart_comments(text: str) -> str:
 def scan_app_routes() -> list[AppRoute]:
     routes: list[AppRoute] = []
     for path in sorted(APP_API_DIR.glob('*.dart')):
-        original_text = path.read_text()
+        original_text = path.read_text(encoding='utf-8')
         text = _mask_dart_comments(original_text)
         functions = _function_ranges(original_text)
         env_routes = _scan_marker_route_occurrences(text, 'Env.apiBaseUrl', must_start_with='v')
@@ -800,14 +800,14 @@ def scan_app_routes() -> list[AppRoute]:
 def load_openapi_schema_names(path: Path) -> list[str]:
     if not path.exists():
         return []
-    spec = json.loads(path.read_text())
+    spec = json.loads(path.read_text(encoding='utf-8'))
     return sorted(spec.get('components', {}).get('schemas', {}).keys())
 
 
 def load_openapi_paths(path: Path) -> list[str]:
     if not path.exists():
         return []
-    spec = json.loads(path.read_text())
+    spec = json.loads(path.read_text(encoding='utf-8'))
     return sorted(spec.get('paths', {}).keys())
 
 
@@ -877,7 +877,7 @@ def operation_request_schema_name(operation: dict[str, Any]) -> str | None:
 def load_openapi_operations(path: Path) -> list[OpenApiOperation]:
     if not path.exists():
         return []
-    spec = json.loads(path.read_text())
+    spec = json.loads(path.read_text(encoding='utf-8'))
     operations = []
     for route, methods in spec.get('paths', {}).items():
         for method, operation in methods.items():

--- a/backend/scripts/run_dart_wire_hardening_check.py
+++ b/backend/scripts/run_dart_wire_hardening_check.py
@@ -18,7 +18,7 @@ MESSAGE_ADAPTER = ROOT_DIR / 'app' / 'lib' / 'backend' / 'schema' / 'message.dar
 
 
 def package_free_message_adapter_source() -> str:
-    source = MESSAGE_ADAPTER.read_text()
+    source = MESSAGE_ADAPTER.read_text(encoding='utf-8')
     source = source.replace("import 'package:collection/collection.dart';\n", '')
     source = source.replace(
         "import 'package:omi/backend/schema/gen/messages_wire.g.dart' as wire;\n",
@@ -174,9 +174,11 @@ void main() {
     with tempfile.TemporaryDirectory(prefix='omi-dart-wire-check-') as temp_dir:
         temp_path = Path(temp_dir)
         shutil.copyfile(MESSAGES_WIRE, temp_path / 'messages_wire.g.dart')
-        (temp_path / 'message_adapter.dart').write_text(package_free_message_adapter_source())
+        (temp_path / 'message_adapter.dart').write_text(
+            package_free_message_adapter_source(), encoding='utf-8', newline='\n'
+        )
         script = temp_path / 'wire_hardening_check.dart'
-        script.write_text(source)
+        script.write_text(source, encoding='utf-8', newline='\n')
         result = subprocess.run(
             [dart, str(script)],
             cwd=ROOT_DIR,

--- a/backend/tests/unit/test_app_client_dart_generator.py
+++ b/backend/tests/unit/test_app_client_dart_generator.py
@@ -59,10 +59,10 @@ def test_dart_generator_cli_uses_utf8_when_the_process_locale_does_not():
 
 
 def test_conversation_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'conversation')
 
-    assert GENERATED_DART_PATH.read_text() == generated
+    assert GENERATED_DART_PATH.read_text(encoding='utf-8') == generated
     for schema_name in generate_dart_models.SCHEMA_GROUPS['conversation']['schemas']:
         assert f'class Generated{schema_name}' in generated
     assert 'items: _required(_readFieldValue<List<GeneratedConversationSearchItem>>' in generated
@@ -74,10 +74,10 @@ def test_conversation_wire_dart_is_generated_from_app_client_openapi():
 
 
 def test_messages_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'messages')
 
-    assert MESSAGES_DART_PATH.read_text() == generated
+    assert MESSAGES_DART_PATH.read_text(encoding='utf-8') == generated
     assert 'class GeneratedMessage' in generated
     assert 'class GeneratedResponseMessage' in generated
     assert 'class GeneratedMessageReportResponse' in generated
@@ -92,7 +92,7 @@ def test_messages_wire_dart_is_generated_from_app_client_openapi():
 
 
 def test_message_adapter_preserves_arbitrary_chart_data_union_payloads():
-    adapter = (ROOT_DIR / 'app' / 'lib' / 'backend' / 'schema' / 'message.dart').read_text()
+    adapter = (ROOT_DIR / 'app' / 'lib' / 'backend' / 'schema' / 'message.dart').read_text(encoding='utf-8')
 
     assert 'Map<String, dynamic>? rawChartData;' in adapter
     assert "const requiredKeys = {'chart_type', 'title', 'datasets'};" in adapter
@@ -108,10 +108,10 @@ def test_message_adapter_preserves_arbitrary_chart_data_union_payloads():
 
 
 def test_action_items_folders_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'action_items_folders')
 
-    assert ACTION_ITEMS_FOLDERS_DART_PATH.read_text() == generated
+    assert ACTION_ITEMS_FOLDERS_DART_PATH.read_text(encoding='utf-8') == generated
     assert 'class GeneratedActionItemResponse' in generated
     assert 'class GeneratedActionItemsResponse' in generated
     assert 'class GeneratedActionItemsSearchResponse' in generated
@@ -131,7 +131,7 @@ def test_action_items_folders_wire_dart_is_generated_from_app_client_openapi():
 
 
 def test_action_items_adapter_uses_generated_envelope_defaults():
-    adapter = (ROOT_DIR / 'app' / 'lib' / 'backend' / 'schema' / 'action_item.dart').read_text()
+    adapter = (ROOT_DIR / 'app' / 'lib' / 'backend' / 'schema' / 'action_item.dart').read_text(encoding='utf-8')
 
     # Phase 4.1 collapsed the hand-written wrappers into typedefs over the
     # generated wire types, so JSON encode/decode is provided by GeneratedX.
@@ -141,10 +141,10 @@ def test_action_items_adapter_uses_generated_envelope_defaults():
 
 
 def test_api_keys_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'api_keys')
 
-    assert API_KEYS_DART_PATH.read_text() == generated
+    assert API_KEYS_DART_PATH.read_text(encoding='utf-8') == generated
     assert 'class GeneratedDevApiKey' in generated
     assert 'class GeneratedDevApiKeyCreated' in generated
     assert 'class GeneratedMcpApiKey' in generated
@@ -155,10 +155,10 @@ def test_api_keys_wire_dart_is_generated_from_app_client_openapi():
 
 
 def test_phone_calls_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'phone_calls')
 
-    assert PHONE_CALLS_DART_PATH.read_text() == generated
+    assert PHONE_CALLS_DART_PATH.read_text(encoding='utf-8') == generated
     assert 'class GeneratedPhoneNumberResponse' in generated
     assert 'class GeneratedPhoneNumbersResponse' in generated
     assert 'class GeneratedTokenResponse' in generated
@@ -166,26 +166,26 @@ def test_phone_calls_wire_dart_is_generated_from_app_client_openapi():
 
 
 def test_people_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'people')
 
-    assert PEOPLE_DART_PATH.read_text() == generated
+    assert PEOPLE_DART_PATH.read_text(encoding='utf-8') == generated
     assert 'class GeneratedPerson' in generated
     assert 'this.speechSamplesVersion = 3' in generated
 
 
 def test_person_adapter_preserves_required_timestamp_behavior():
-    adapter = (ROOT_DIR / 'app' / 'lib' / 'backend' / 'schema' / 'person.dart').read_text()
+    adapter = (ROOT_DIR / 'app' / 'lib' / 'backend' / 'schema' / 'person.dart').read_text(encoding='utf-8')
 
     assert "FormatException('Missing required field: created_at')" in adapter
     assert "FormatException('Missing required field: updated_at')" in adapter
 
 
 def test_imports_integrations_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'imports_integrations')
 
-    assert IMPORTS_INTEGRATIONS_DART_PATH.read_text() == generated
+    assert IMPORTS_INTEGRATIONS_DART_PATH.read_text(encoding='utf-8') == generated
     assert 'class GeneratedImportJobResponse' in generated
     assert 'class GeneratedIntegrationResponse' in generated
     assert 'class GeneratedOAuthUrlResponse' in generated
@@ -197,10 +197,10 @@ def test_imports_integrations_wire_dart_is_generated_from_app_client_openapi():
 
 
 def test_device_speech_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'device_speech')
 
-    assert DEVICE_SPEECH_DART_PATH.read_text() == generated
+    assert DEVICE_SPEECH_DART_PATH.read_text(encoding='utf-8') == generated
     assert 'class GeneratedFirmwareVersionResponse' in generated
     assert 'class GeneratedHasSpeechProfileResponse' in generated
     assert 'class GeneratedSpeechProfileResponse' in generated
@@ -213,10 +213,10 @@ def test_device_speech_wire_dart_is_generated_from_app_client_openapi():
 
 
 def test_misc_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'misc')
 
-    assert MISC_DART_PATH.read_text() == generated
+    assert MISC_DART_PATH.read_text(encoding='utf-8') == generated
     assert 'class GeneratedFcmTokenResponse' in generated
     assert 'class GeneratedDeleteKnowledgeGraphResponse' in generated
     assert 'class GeneratedKnowledgeGraphResponse' in generated
@@ -227,10 +227,10 @@ def test_misc_wire_dart_is_generated_from_app_client_openapi():
 
 
 def test_wrapped_task_integrations_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'wrapped_task_integrations')
 
-    assert WRAPPED_TASK_INTEGRATIONS_DART_PATH.read_text() == generated
+    assert WRAPPED_TASK_INTEGRATIONS_DART_PATH.read_text(encoding='utf-8') == generated
     assert 'class GeneratedWrappedStatusResponse' in generated
     assert 'class GeneratedGenerateWrappedResponse' in generated
     assert 'class GeneratedTaskIntegrationsResponse' in generated
@@ -249,10 +249,10 @@ def test_wrapped_task_integrations_wire_dart_is_generated_from_app_client_openap
 
 
 def test_apps_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'apps')
 
-    assert APPS_DART_PATH.read_text() == generated
+    assert APPS_DART_PATH.read_text(encoding='utf-8') == generated
     assert 'class GeneratedAppSelectOption' in generated
     assert 'class GeneratedAppCapabilityResponse' in generated
     assert 'class GeneratedAppThumbnailUploadResponse' in generated
@@ -282,10 +282,10 @@ def test_apps_wire_dart_is_generated_from_app_client_openapi():
 
 
 def test_users_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'users')
 
-    assert USERS_DART_PATH.read_text() == generated
+    assert USERS_DART_PATH.read_text(encoding='utf-8') == generated
     assert 'class GeneratedUserStatusResponse' in generated
     assert 'class GeneratedUserWebhooksStatusResponse' in generated
     assert 'class GeneratedStoreRecordingPermissionResponse' in generated
@@ -315,10 +315,10 @@ def test_users_wire_dart_is_generated_from_app_client_openapi():
 
 
 def test_subscription_usage_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'subscription_usage')
 
-    assert SUBSCRIPTION_USAGE_DART_PATH.read_text() == generated
+    assert SUBSCRIPTION_USAGE_DART_PATH.read_text(encoding='utf-8') == generated
     assert 'class GeneratedUserSubscriptionResponse' in generated
     assert 'class GeneratedUserUsageResponse' in generated
     assert 'final List<String> features;' in generated
@@ -328,10 +328,10 @@ def test_subscription_usage_wire_dart_is_generated_from_app_client_openapi():
 
 
 def test_privacy_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'privacy')
 
-    assert PRIVACY_DART_PATH.read_text() == generated
+    assert PRIVACY_DART_PATH.read_text(encoding='utf-8') == generated
     assert 'class GeneratedMigrationRequest' in generated
     assert 'class GeneratedBatchMigrationRequest' in generated
     assert 'class GeneratedMigrationTargetRequest' in generated
@@ -344,10 +344,10 @@ def test_privacy_wire_dart_is_generated_from_app_client_openapi():
 
 
 def test_announcements_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'announcements')
 
-    assert ANNOUNCEMENTS_DART_PATH.read_text() == generated
+    assert ANNOUNCEMENTS_DART_PATH.read_text(encoding='utf-8') == generated
     assert 'class GeneratedTargeting' in generated
     assert 'class GeneratedDisplay' in generated
     assert 'class GeneratedAnnouncement' in generated
@@ -357,10 +357,10 @@ def test_announcements_wire_dart_is_generated_from_app_client_openapi():
 
 
 def test_audio_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'audio')
 
-    assert AUDIO_DART_PATH.read_text() == generated
+    assert AUDIO_DART_PATH.read_text(encoding='utf-8') == generated
     assert 'class GeneratedAudioPrecacheResponse' in generated
     assert 'class GeneratedAudioFileUrlInfo' in generated
     assert 'class GeneratedAudioUrlsResponse' in generated
@@ -371,10 +371,10 @@ def test_audio_wire_dart_is_generated_from_app_client_openapi():
 
 
 def test_payments_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'payments')
 
-    assert PAYMENTS_DART_PATH.read_text() == generated
+    assert PAYMENTS_DART_PATH.read_text(encoding='utf-8') == generated
     assert 'class GeneratedStripeConnectAccountResponse' in generated
     assert 'class GeneratedStripeOnboardingStatusResponse' in generated
     assert 'class GeneratedStripeSupportedCountryResponse' in generated
@@ -395,10 +395,10 @@ def test_payments_wire_dart_is_generated_from_app_client_openapi():
 
 
 def test_memories_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'memories')
 
-    assert MEMORIES_DART_PATH.read_text() == generated
+    assert MEMORIES_DART_PATH.read_text(encoding='utf-8') == generated
     assert 'class GeneratedEvidence' in generated
     assert 'class GeneratedMemoryDB' in generated
     assert 'class GeneratedMemoryEditResponse' in generated
@@ -412,10 +412,10 @@ def test_memories_wire_dart_is_generated_from_app_client_openapi():
 
 
 def test_goals_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'goals')
 
-    assert GOALS_DART_PATH.read_text() == generated
+    assert GOALS_DART_PATH.read_text(encoding='utf-8') == generated
     assert 'class GeneratedGoalResponse' in generated
     assert 'class GeneratedGoalSuggestionResponse' in generated
     assert 'class GeneratedAdviceResponse' in generated
@@ -426,10 +426,10 @@ def test_goals_wire_dart_is_generated_from_app_client_openapi():
 
 
 def test_task_intelligence_wire_dart_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_dart_models.build_output(spec, 'task_intelligence')
 
-    assert TASK_INTELLIGENCE_DART_PATH.read_text() == generated
+    assert TASK_INTELLIGENCE_DART_PATH.read_text(encoding='utf-8') == generated
     for name in (
         'GeneratedCandidateRecord',
         'GeneratedGoalDetailProjection',
@@ -451,7 +451,7 @@ def test_task_intelligence_wire_dart_is_generated_from_app_client_openapi():
     assert 'static const dependency = GeneratedContextMatchSignal._("dependency");' in generated
     assert 'factory GeneratedContextMatchSignal.fromJson(dynamic value)' in generated
     assert '_readValueList(value, GeneratedContextMatchSignal.fromJson)' in generated
-    action_items_generated = ACTION_ITEMS_FOLDERS_DART_PATH.read_text()
+    action_items_generated = ACTION_ITEMS_FOLDERS_DART_PATH.read_text(encoding='utf-8')
     assert 'class GeneratedActionItemCreateRequest' in action_items_generated
     assert 'class GeneratedActionItemUpdateRequest' in action_items_generated
     assert 'final GeneratedPatchField<String> goalId;' in action_items_generated
@@ -459,7 +459,7 @@ def test_task_intelligence_wire_dart_is_generated_from_app_client_openapi():
 
 
 def test_conversation_wire_dart_preserves_known_client_aliases():
-    generated = GENERATED_DART_PATH.read_text()
+    generated = GENERATED_DART_PATH.read_text(encoding='utf-8')
 
     assert 'const ["action_items", "actionItems"]' in generated
     assert 'const ["start", "startsAt"]' in generated
@@ -516,7 +516,7 @@ def test_generator_rejects_unsupported_schema_shapes_without_string_fallback():
 
 
 def test_conversation_fixtures_validate_against_python_schema_authority():
-    fixtures = json.loads(CONVERSATION_FIXTURE_PATH.read_text())
+    fixtures = json.loads(CONVERSATION_FIXTURE_PATH.read_text(encoding='utf-8'))
 
     for name, payload in fixtures.items():
         conversation = Conversation.model_validate(payload)

--- a/backend/tests/unit/test_app_client_generator_utf8_contract.py
+++ b/backend/tests/unit/test_app_client_generator_utf8_contract.py
@@ -5,13 +5,25 @@ from pathlib import Path
 
 ROOT_DIR = Path(__file__).resolve().parents[3]
 TEXT_IO_SURFACES = (
+    'backend/scripts/check_app_client_openapi_compatibility.py',
+    'backend/scripts/export_openapi.py',
     'backend/scripts/generate_dart_models.py',
     'backend/scripts/generate_swift_openapi_types.py',
     'backend/scripts/generate_ts_openapi_types.py',
+    'backend/scripts/inventory_app_client_schemas.py',
+    'backend/scripts/run_dart_wire_hardening_check.py',
     'backend/tests/unit/test_app_client_dart_generator.py',
     'backend/tests/unit/test_app_client_generator_utf8_contract.py',
+    'backend/tests/unit/test_app_client_openapi_compatibility.py',
+    'backend/tests/unit/test_app_client_schema_inventory.py',
     'backend/tests/unit/test_app_client_swift_generator.py',
     'backend/tests/unit/test_app_client_ts_generator.py',
+    'backend/tests/unit/test_assistant_settings_response_models.py',
+    'backend/tests/unit/test_desktop_rest_inventory.py',
+    'backend/tests/unit/test_dev_ask_endpoint.py',
+    'backend/tests/unit/test_flutter_rest_inventory.py',
+    'backend/tests/unit/test_integration_public_contract.py',
+    'backend/tests/unit/test_windows_rest_inventory.py',
 )
 
 
@@ -22,7 +34,7 @@ def _declares_utf8(call: ast.Call) -> bool:
     )
 
 
-def test_app_client_generator_path_text_io_declares_utf8():
+def test_openapi_contract_path_text_io_declares_utf8():
     violations: list[str] = []
 
     for relative_path in TEXT_IO_SURFACES:

--- a/backend/tests/unit/test_app_client_generator_utf8_contract.py
+++ b/backend/tests/unit/test_app_client_generator_utf8_contract.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+TEXT_IO_SURFACES = (
+    'backend/scripts/generate_dart_models.py',
+    'backend/scripts/generate_swift_openapi_types.py',
+    'backend/scripts/generate_ts_openapi_types.py',
+    'backend/tests/unit/test_app_client_dart_generator.py',
+    'backend/tests/unit/test_app_client_generator_utf8_contract.py',
+    'backend/tests/unit/test_app_client_swift_generator.py',
+    'backend/tests/unit/test_app_client_ts_generator.py',
+)
+
+
+def _declares_utf8(call: ast.Call) -> bool:
+    return any(
+        keyword.arg == 'encoding' and isinstance(keyword.value, ast.Constant) and keyword.value.value == 'utf-8'
+        for keyword in call.keywords
+    )
+
+
+def test_app_client_generator_path_text_io_declares_utf8():
+    violations: list[str] = []
+
+    for relative_path in TEXT_IO_SURFACES:
+        source_path = ROOT_DIR / relative_path
+        tree = ast.parse(source_path.read_text(encoding='utf-8'), filename=relative_path)
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr not in {'read_text', 'write_text'} or _declares_utf8(node):
+                continue
+            violations.append(f'{relative_path}:{node.lineno} {node.func.attr}()')
+
+    assert not violations, 'Path text I/O must declare UTF-8:\n' + '\n'.join(violations)

--- a/backend/tests/unit/test_app_client_schema_inventory.py
+++ b/backend/tests/unit/test_app_client_schema_inventory.py
@@ -128,7 +128,7 @@ def test_inventory_separates_generated_backed_adapters_from_raw_manual_dtos():
     ) not in unmodeled_operations
     assert ('GET', '/v1/users/language', 'get_user_language_v1_users_language_get') not in unmodeled_operations
     assert ('GET', '/v1/users/export', 'export_all_user_data_v1_users_export_get') not in unmodeled_operations
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     export_properties = spec['components']['schemas']['UserDataExportResponse']['properties']
     assert {
         'profile',
@@ -300,12 +300,15 @@ def test_inventory_classifies_bounded_error_discriminator_as_non_rest_decode(tmp
     schema_dir = tmp_path / 'schema'
     api_dir.mkdir()
     schema_dir.mkdir()
-    (api_dir / 'conversations.dart').write_text("""
+    (api_dir / 'conversations.dart').write_text(
+        """
 bool isSyncRecoveryWindowExceededResponse(Response response) {
   final body = jsonDecode(response.body);
   return body is Map && body['code'] == 'backfill_lookback_exceeded';
 }
-""")
+""",
+        encoding='utf-8',
+    )
 
     monkeypatch.setattr(inventory_app_client_schemas, 'APP_API_DIR', api_dir)
     monkeypatch.setattr(inventory_app_client_schemas, 'APP_SCHEMA_DIR', schema_dir)

--- a/backend/tests/unit/test_app_client_schema_inventory.py
+++ b/backend/tests/unit/test_app_client_schema_inventory.py
@@ -4,12 +4,19 @@ import json
 import re
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 from scripts import inventory_app_client_schemas
 
 ROOT_DIR = Path(__file__).resolve().parents[3]
 SPEC_PATH = ROOT_DIR / 'docs' / 'api-reference' / 'app-client-openapi.json'
+
+
+def test_repo_relative_path_uses_forward_slashes_on_windows(monkeypatch):
+    windows_root = PureWindowsPath('C:/repo')
+    monkeypatch.setattr(inventory_app_client_schemas, 'ROOT_DIR', windows_root)
+
+    assert inventory_app_client_schemas.repo_relative_path(windows_root / 'app/lib/model.dart') == 'app/lib/model.dart'
 
 
 def test_inventory_separates_generated_backed_adapters_from_raw_manual_dtos():

--- a/backend/tests/unit/test_app_client_swift_generator.py
+++ b/backend/tests/unit/test_app_client_swift_generator.py
@@ -21,16 +21,16 @@ SWIFT_PATH = ROOT_DIR / 'desktop' / 'macos' / 'Desktop' / 'Sources' / 'Generated
 
 
 def test_swift_dto_file_is_generated_from_app_client_openapi():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     generated = generate_swift_openapi_types.generate(spec, 'docs/api-reference/app-client-openapi.json')
 
-    assert SWIFT_PATH.read_text() == generated
+    assert SWIFT_PATH.read_text(encoding='utf-8') == generated
     assert '// GENERATED CODE - DO NOT EDIT.' in generated
     assert 'public enum OmiAPI {' in generated
 
 
 def test_swift_dto_file_covers_desktop_high_traffic_read_schemas():
-    generated = SWIFT_PATH.read_text()
+    generated = SWIFT_PATH.read_text(encoding='utf-8')
 
     # The desktop's highest-traffic read endpoints (conversations, memories,
     # action items, goals) decode these generated DTOs through adapter inits

--- a/backend/tests/unit/test_assistant_settings_response_models.py
+++ b/backend/tests/unit/test_assistant_settings_response_models.py
@@ -30,7 +30,7 @@ def test_assistant_settings_model_schema_exposes_known_fields_and_allows_future_
 
 
 def test_app_client_openapi_assistant_settings_response_exposes_known_fields_and_allows_future_sections():
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     schema = spec['components']['schemas']['AssistantSettingsResponse']
 
     assert schema['title'] == 'AssistantSettingsResponse'

--- a/backend/tests/unit/test_desktop_rest_inventory.py
+++ b/backend/tests/unit/test_desktop_rest_inventory.py
@@ -97,14 +97,14 @@ def _in_scope(routes: Set[str]) -> Set[str]:
 def _load_spec_paths() -> Set[str]:
     import json
 
-    spec = json.loads(SPEC_PATH.read_text())
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
     return set(spec.get('paths', {}).keys())
 
 
 def _load_spec() -> dict[str, Any]:
     import json
 
-    return json.loads(SPEC_PATH.read_text())
+    return json.loads(SPEC_PATH.read_text(encoding='utf-8'))
 
 
 def _normalize_for_match(path: str) -> str:
@@ -284,7 +284,7 @@ def test_desktop_named_model_response_items_are_not_free_form_objects():
 
 
 def test_conversations_search_hydrates_index_hits_before_returning_app_client_rows():
-    source = CONVERSATIONS_ROUTER.read_text()
+    source = CONVERSATIONS_ROUTER.read_text(encoding='utf-8')
     endpoint_start = source.index('def search_conversations_endpoint(')
     endpoint_end = source.index(
         '@router.get(\n    "/v1/conversations/{conversation_id}/suggested-apps"', endpoint_start
@@ -300,7 +300,7 @@ def test_conversations_search_hydrates_index_hits_before_returning_app_client_ro
 
 
 def test_conversation_id_hydration_backfills_legacy_missing_ids():
-    source = CONVERSATIONS_DB.read_text()
+    source = CONVERSATIONS_DB.read_text(encoding='utf-8')
     helper_start = source.index('def _get_conversations_by_id(')
     helper_end = source.index('# **************************************', helper_start)
     helper_source = source[helper_start:helper_end]

--- a/backend/tests/unit/test_dev_ask_endpoint.py
+++ b/backend/tests/unit/test_dev_ask_endpoint.py
@@ -152,8 +152,8 @@ def test_ask_lives_on_public_developer_api_not_app_client_firebase():
     from pathlib import Path
 
     root = Path(__file__).resolve().parents[3]
-    public = json.loads((root / "docs/api-reference/openapi.json").read_text())
-    app_client = json.loads((root / "docs/api-reference/app-client-openapi.json").read_text())
+    public = json.loads((root / "docs/api-reference/openapi.json").read_text(encoding='utf-8'))
+    app_client = json.loads((root / "docs/api-reference/app-client-openapi.json").read_text(encoding='utf-8'))
 
     ask = public["paths"]["/v1/dev/user/ask"]["post"]
     assert ask["security"] == [{"developerApiKey": []}]

--- a/backend/tests/unit/test_integration_public_contract.py
+++ b/backend/tests/unit/test_integration_public_contract.py
@@ -42,7 +42,7 @@ EXPECTED_OPERATIONS: Set[Tuple[str, str]] = {
 def _load_spec() -> Dict:
     import json
 
-    return json.loads(SPEC_PATH.read_text())
+    return json.loads(SPEC_PATH.read_text(encoding='utf-8'))
 
 
 def _operations(spec: Dict) -> Set[Tuple[str, str]]:


### PR DESCRIPTION
## Summary

- make app-client generator tests, OpenAPI export/check tooling, schema inventory, and Dart wire hardening read and write repository text as UTF-8
- add one AST contract test that rejects locale-dependent `Path.read_text()` and `Path.write_text()` calls across the affected OpenAPI contract surfaces
- emit repository-relative schema inventory paths with forward slashes on Windows
- register the recurring host-locale failure class and its reusable guard, building on #9759

## Why

Python otherwise uses the active Windows code page for `Path.read_text()` and `Path.write_text()`. On a Chinese Windows host using CP936, UTF-8 OpenAPI contracts and source files fail before the contract checks can run. Once decoding is fixed, schema inventory JSON also differs from the checked contract because `str(Path.relative_to(...))` emits backslashes on Windows.

The guard is intentionally limited to the OpenAPI contract surfaces involved in this failure class; applying a repository-wide static rule would turn this portability fix into an unrelated migration. It would have caught both the generator failures addressed here and the same class previously repaired in #9759.

## Validation

- CP936 (`PYTHONUTF8=0`, preferred encoding `cp936`): 116 focused generator, exporter, inventory, assistant-settings, and developer API contract tests passed
- real CP936 CLI: app-client schema inventory JSON generation passed
- real CP936 exporter checks: app-client spec comparison passed and a non-CP936 test string was written as UTF-8 with LF newlines
- Dart, Swift, and TypeScript generator `--check` commands passed
- Black 26.5.1 passed on all changed Python files
- Ruff 0.4.4 passed on changed production files and tests, excluding 10 unchanged baseline findings reproduced on `origin/main`
- `git diff --check` passed
- diff-scoped local PR preflight passed all selected checks except two candidate-probe cases that require POSIX response deadlines and fail identically on clean `origin/main`; all 12 runtime-image source closures and all 30 desktop release fixture cases passed with verified `jq 1.8.2`

Product invariants: none.

Changelog: not required; this changes repository tooling and contract tests only.

Failure-Class: new

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

