### PR TITLE
fix(ci): isolate candidate probe deadlines on Windows

### DIFF
--- a/.github/failure-classes/FC-orthogonal-fixture-enters-platform-boundary.json
+++ b/.github/failure-classes/FC-orthogonal-fixture-enters-platform-boundary.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-orthogonal-fixture-enters-platform-boundary",
+  "violated_contract": "A hermetic fixture for behavior inside a platform-specific security or deadline boundary must not execute that unrelated boundary; otherwise supported hosts that intentionally reject the primitive fail before the fixture reaches its assertion.",
+  "canonical_prevention": "Isolate the platform-specific primitive behind a suite-wide test seam for orthogonal cases, and keep the real boundary contract in a dedicated platform-gated test so newly added behavior cases inherit portability automatically.",
+  "canonical_prevention_artifact": [
+    ".github/scripts/test_desktop_backend_candidate_probe.py"
+  ],
+  "evidence_prs": [
+    10845
+  ],
+  "scope_hints": [
+    ".github/scripts/*candidate_probe*.py"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/test_desktop_backend_candidate_probe.py
+++ b/.github/scripts/test_desktop_backend_candidate_probe.py
@@ -9,6 +9,7 @@ import signal
 import sys
 import tempfile
 import unittest
+from contextlib import nullcontext
 from unittest import mock
 from pathlib import Path
 
@@ -26,29 +27,7 @@ def sse_event(payload: object) -> bytes:
     return f"data: {json.dumps(payload)}\n".encode()
 
 
-class CandidateProbeTests(unittest.TestCase):
-    def test_gemini_request_uses_unique_uuid_request_id(self) -> None:
-        class Response:
-            headers = {"x-omi-provider": "vertex_ai", "x-omi-request-id": "server-request-id"}
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *_args):
-                return False
-
-            def read(self) -> bytes:
-                return b'{"candidates":[{"content":{"parts":[{"text":"OK"}]}}]}'
-
-        request_id = "12345678-1234-5678-1234-567812345678"
-        with mock.patch.object(PROBE.uuid, "uuid4", return_value=request_id), mock.patch.object(
-            PROBE.urllib.request, "urlopen", return_value=Response()
-        ) as urlopen:
-            PROBE._gemini_request("https://candidate.example", token="token")
-
-        request = urlopen.call_args.args[0]
-        self.assertEqual(request.get_header("X-omi-request-id"), f"candidate-probe-{request_id}")
-
+class CandidateProbeDeadlineTests(unittest.TestCase):
     @unittest.skipUnless(hasattr(signal, "SIGALRM"), "requires POSIX interval timers")
     def test_gemini_response_read_is_interrupted_at_total_budget(self) -> None:
         class DripFeedResponse:
@@ -72,6 +51,40 @@ class CandidateProbeTests(unittest.TestCase):
         ):
             with self.assertRaisesRegex(PROBE.ProbeError, "exceeded 70s response budget"):
                 PROBE._gemini_request("https://candidate.example", token="token")
+
+
+class CandidateProbeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        response_budget = mock.patch.object(
+            PROBE,
+            "_total_response_budget",
+            autospec=True,
+            side_effect=lambda **_kwargs: nullcontext(),
+        )
+        response_budget.start()
+        self.addCleanup(response_budget.stop)
+
+    def test_gemini_request_uses_unique_uuid_request_id(self) -> None:
+        class Response:
+            headers = {"x-omi-provider": "vertex_ai", "x-omi-request-id": "server-request-id"}
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self) -> bytes:
+                return b'{"candidates":[{"content":{"parts":[{"text":"OK"}]}}]}'
+
+        request_id = "12345678-1234-5678-1234-567812345678"
+        with mock.patch.object(PROBE.uuid, "uuid4", return_value=request_id), mock.patch.object(
+            PROBE.urllib.request, "urlopen", return_value=Response()
+        ) as urlopen:
+            PROBE._gemini_request("https://candidate.example", token="token")
+
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.get_header("X-omi-request-id"), f"candidate-probe-{request_id}")
 
     def test_gemini_probe_rejects_stub_or_unknown_provider_routes(self) -> None:
         for provider in ("offline_stub", "unknown", ""):


### PR DESCRIPTION
## Summary

- isolate ordinary desktop-backend candidate-probe fixtures from the POSIX-only total-response deadline with one autospecced class-level seam
- keep the real `SIGALRM` interruption contract in a dedicated platform-gated test class, so Linux CI continues to exercise production deadline behavior
- register the recurring class where an orthogonal fixture enters an unrelated platform-specific boundary, with #10845 as prior evidence

## Why

The local manifest intentionally runs candidate-probe fixtures for broad backend changes. On native Windows, two newly added Gemini request tests fail before reaching their assertions because `_total_response_budget()` rejects hosts without `SIGALRM` and `setitimer`.

Before this change on Windows: **1 failure, 1 error, 15 passed, 1 skipped**. After this change: **17 passed, 1 POSIX-only skipped**. Production probe behavior is unchanged.

## Validation

- `python .github/scripts/test_desktop_backend_candidate_probe.py` (`17 passed, 1 skipped` on Windows)
- `ruff check .github/scripts/test_desktop_backend_candidate_probe.py`
- `black --check --line-length 120 --skip-string-normalization .github/scripts/test_desktop_backend_candidate_probe.py`
- `python -m py_compile .github/scripts/test_desktop_backend_candidate_probe.py .github/scripts/desktop_backend_candidate_probe.py`
- `python .github/scripts/pr_preflight.py --lane local --base origin/main --pr-body-file .pr-body-windows-candidate-probe-sigalrm.md`

Product invariants: none.

Changelog: not required; this changes hermetic CI fixtures only.

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

