### PR TITLE
fix(preflight): keep Windows subprocess text UTF-8

### DIFF
--- a/.github/failure-classes/FC-subprocess-output-inherits-host-locale.json
+++ b/.github/failure-classes/FC-subprocess-output-inherits-host-locale.json
@@ -2,9 +2,10 @@
   "schema_version": 1,
   "id": "FC-subprocess-output-inherits-host-locale",
   "violated_contract": "Captured text from a repository or developer CLI must be decoded with the producer's encoding, not the host locale; otherwise valid UTF-8 paths, history, or structured metadata can terminate the subprocess reader on Windows and leave policy checks without output.",
-  "canonical_prevention": "Declare strict UTF-8 decoding at every captured CLI text boundary and keep a regression contract that feeds non-ASCII output while asserting the subprocess invocation's encoding.",
+  "canonical_prevention": "Declare strict UTF-8 decoding at every captured CLI text boundary and keep a regression contract that feeds non-ASCII output while asserting the subprocess invocation's encoding. For an owned process tree, configure the runner's streams and child Python stdio as UTF-8 before decoding the captured pipe as UTF-8.",
   "canonical_prevention_artifact": [
-    ".github/scripts/test_pr_preflight.py"
+    ".github/scripts/test_pr_preflight.py",
+    ".github/scripts/test_preflight_runner.py"
   ],
   "evidence_prs": [
     10595,

--- a/.github/failure-classes/FC-subprocess-output-inherits-host-locale.json
+++ b/.github/failure-classes/FC-subprocess-output-inherits-host-locale.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "id": "FC-subprocess-output-inherits-host-locale",
+  "violated_contract": "Captured text from a repository or developer CLI must be decoded with the producer's encoding, not the host locale; otherwise valid UTF-8 paths, history, or structured metadata can terminate the subprocess reader on Windows and leave policy checks without output.",
+  "canonical_prevention": "Declare strict UTF-8 decoding at every captured CLI text boundary and keep a regression contract that feeds non-ASCII output while asserting the subprocess invocation's encoding.",
+  "canonical_prevention_artifact": [
+    ".github/scripts/test_pr_preflight.py"
+  ],
+  "evidence_prs": [
+    10595,
+    10844
+  ],
+  "scope_hints": [
+    ".github/scripts/pr_*.py",
+    ".github/scripts/*preflight*.py",
+    ".github/scripts/*failure_class*.py"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/pr_metadata.py
+++ b/.github/scripts/pr_metadata.py
@@ -127,6 +127,7 @@ def load_from_gh(root: Path) -> PullRequestMetadata:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            encoding="utf-8",
         )
     except FileNotFoundError as exc:
         raise RuntimeError("gh is not installed; pass --pr-body-file before the first push") from exc

--- a/.github/scripts/pr_preflight.py
+++ b/.github/scripts/pr_preflight.py
@@ -74,6 +74,18 @@ def current_branch(root: Path) -> str:
     ).stdout.strip()
 
 
+def configure_output_streams() -> None:
+    """Keep direct Windows preflight output UTF-8 and non-fatal."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if not callable(reconfigure):
+            continue
+        options = {"errors": "backslashreplace"}
+        if os.name == "nt":
+            options["encoding"] = "utf-8"
+        reconfigure(**options)
+
+
 def changed_files(root: Path, base: str, head: str) -> list[str]:
     output = run_git(
         root,
@@ -213,6 +225,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
+    configure_output_streams()
     args = parse_args()
     if bool(args.repository) != bool(args.pr_number):
         print("FAIL: --repository and --pr-number must be supplied together", file=sys.stderr)

--- a/.github/scripts/pr_preflight.py
+++ b/.github/scripts/pr_preflight.py
@@ -44,6 +44,36 @@ def run_git(root: Path, *args: str) -> str:
     return result.stdout.strip()
 
 
+def run_python_capture(root: Path, *args: str, errors: str = "strict") -> subprocess.CompletedProcess[str]:
+    """Run an owned Python check with a UTF-8 pipe contract on every host."""
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8:backslashreplace"
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=root,
+        env=env,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors=errors,
+    )
+
+
+def current_branch(root: Path) -> str:
+    """Return the current branch without inheriting the Windows host locale."""
+    return subprocess.run(
+        ["git", "symbolic-ref", "--short", "-q", "HEAD"],
+        cwd=root,
+        check=False,
+        stdout=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="backslashreplace",
+    ).stdout.strip()
+
+
 def changed_files(root: Path, base: str, head: str) -> list[str]:
     output = run_git(
         root,
@@ -208,19 +238,13 @@ def main() -> int:
         files_path = temp / "changed-files.txt"
         files_path.write_text("".join(f"{path}\n" for path in files), encoding="utf-8")
         if args.suggest:
-            invariants = subprocess.run(
-                [
-                    sys.executable,
-                    ".github/scripts/check_product_invariants.py",
-                    "--changed-files",
-                    str(files_path),
-                    "--suggest",
-                ],
-                cwd=root,
-                check=False,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
+            invariants = run_python_capture(
+                root,
+                ".github/scripts/check_product_invariants.py",
+                "--changed-files",
+                str(files_path),
+                "--suggest",
+                errors="backslashreplace",
             )
             if invariants.stdout:
                 print(invariants.stdout, end="")
@@ -229,25 +253,18 @@ def main() -> int:
 
             suggestion_body = temp / "suggest-pr-body.md"
             suggestion_body.write_text("", encoding="utf-8")
-            failure_classes = subprocess.run(
-                [
-                    sys.executable,
-                    "scripts/failure-class",
-                    "prepare",
-                    "--base",
-                    args.base,
-                    "--head",
-                    args.head,
-                    "--pr-body-file",
-                    str(suggestion_body),
-                    "--format",
-                    "json",
-                ],
-                cwd=root,
-                check=False,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
+            failure_classes = run_python_capture(
+                root,
+                "scripts/failure-class",
+                "prepare",
+                "--base",
+                args.base,
+                "--head",
+                args.head,
+                "--pr-body-file",
+                str(suggestion_body),
+                "--format",
+                "json",
             )
             if failure_classes.returncode:
                 print("FAIL: failure-class preparation failed.", file=sys.stderr)
@@ -274,13 +291,7 @@ def main() -> int:
             return 1
         head_branch = args.head_branch or os.getenv("GITHUB_HEAD_REF", "")
         if not head_branch:
-            head_branch = subprocess.run(
-                ["git", "symbolic-ref", "--short", "-q", "HEAD"],
-                cwd=root,
-                check=False,
-                stdout=subprocess.PIPE,
-                text=True,
-            ).stdout.strip()
+            head_branch = current_branch(root)
         skip_changelog = head_branch.startswith("changelog/v") or os.getenv("PRE_PUSH_SKIP_DESKTOP_CHANGELOG") == "1"
         if metadata:
             print(f"PR metadata: {metadata.source}, updated_at={metadata.updated_at}")

--- a/.github/scripts/preflight_runner.py
+++ b/.github/scripts/preflight_runner.py
@@ -242,6 +242,18 @@ def atomic_json(path: Path, value: dict) -> None:
     os.replace(temporary, path)
 
 
+def configure_output_streams() -> None:
+    """Keep captured runner output UTF-8 and non-fatal on Windows."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if not callable(reconfigure):
+            continue
+        options = {"errors": "backslashreplace"}
+        if IS_WINDOWS:
+            options["encoding"] = "utf-8"
+        reconfigure(**options)
+
+
 def read_json(path: Path) -> dict:
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
@@ -503,9 +515,12 @@ def run_owned(
         log_path.write_text("", encoding="utf-8")
         os.chmod(log_path, 0o600)
         write_status()
+        child_env = os.environ.copy()
+        child_env["PYTHONIOENCODING"] = "utf-8:backslashreplace"
         child = subprocess.Popen(
             child_launch_command(command),
             cwd=root,
+            env=child_env,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -607,6 +622,7 @@ def resolve_repo_root() -> Path:
 
 
 def main() -> int:
+    configure_output_streams()
     if sys.argv[1:2] == [WINDOWS_CHILD_BOOTSTRAP_FLAG]:
         return run_windows_child_bootstrap(sys.argv[2:])
 

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -26,7 +26,15 @@ from pr_metadata import (
     load_from_gh,
     resolve_main_push_body,
 )
-from pr_preflight import changed_files, format_failure_class_suggest, resolve_pr_metadata, run_git, select_checks
+from pr_preflight import (
+    changed_files,
+    current_branch,
+    format_failure_class_suggest,
+    resolve_pr_metadata,
+    run_git,
+    run_python_capture,
+    select_checks,
+)
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 RUNNER = SCRIPT_DIR / "preflight_runner.py"
@@ -266,6 +274,37 @@ class MetadataTests(unittest.TestCase):
 
 
 class SelectionTests(unittest.TestCase):
+    def test_captured_python_output_is_utf8_when_host_utf8_mode_is_disabled(self) -> None:
+        env = os.environ.copy()
+        env["PYTHONUTF8"] = "0"
+        env.pop("PYTHONIOENCODING", None)
+
+        with patch.dict(os.environ, env, clear=True):
+            completed = run_python_capture(
+                REPO_ROOT,
+                "-c",
+                "print('\\u8def\\u5f84\\U0001f680')",
+            )
+
+        self.assertEqual(completed.returncode, 0, completed.stdout)
+        self.assertEqual(completed.stdout, "路径🚀\n")
+
+    def test_current_branch_decodes_utf8_when_host_utf8_mode_is_disabled(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            env = os.environ.copy()
+            env["PYTHONUTF8"] = "0"
+            env.pop("PYTHONIOENCODING", None)
+            for key in tuple(env):
+                if key.startswith("GIT_"):
+                    del env[key]
+            subprocess.run(["git", "init", "-q", "-b", "分支-🚀", str(root)], check=True, env=env)
+
+            with patch.dict(os.environ, env, clear=True):
+                branch = current_branch(root)
+
+        self.assertEqual(branch, "分支-🚀")
+
     def test_run_git_decodes_unicode_checkout_path_as_utf8(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "路径 checkout"

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -351,11 +351,23 @@ class SelectionTests(unittest.TestCase):
         git_isolation = ["-c", "core.hooksPath=/dev/null", "-c", "commit.gpgsign=false"]
 
         def run(*args: str, cwd: Path) -> None:
-            subprocess.run(["git", *git_isolation, *args], cwd=cwd, check=True, capture_output=True, text=True)
+            subprocess.run(
+                ["git", *git_isolation, *args],
+                cwd=cwd,
+                check=True,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+            )
 
         def rev_parse(cwd: Path, ref: str = "HEAD") -> str:
             result = subprocess.run(
-                ["git", *git_isolation, "rev-parse", ref], cwd=cwd, check=True, capture_output=True, text=True
+                ["git", *git_isolation, "rev-parse", ref],
+                cwd=cwd,
+                check=True,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
             )
             return result.stdout.strip()
 
@@ -410,6 +422,7 @@ class SelectionTests(unittest.TestCase):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
+            encoding="utf-8",
         )
         self.assertEqual(result.returncode, 0, result.stdout)
         self.assertIn("scripts/dev-harness/run-python.sh", result.stdout)
@@ -475,6 +488,7 @@ class SelectionTests(unittest.TestCase):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
+                encoding="utf-8",
             )
             coverage = subprocess.run(
                 [
@@ -488,6 +502,7 @@ class SelectionTests(unittest.TestCase):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
+                encoding="utf-8",
             )
             self.assertEqual(invariant.returncode, 1, invariant.stdout)
             self.assertIn("INV-AUTH-1", invariant.stdout)
@@ -542,6 +557,7 @@ class SelectionTests(unittest.TestCase):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
+                encoding="utf-8",
             )
 
         self.assertEqual(coverage.returncode, 1, coverage.stdout)
@@ -563,6 +579,7 @@ class SelectionTests(unittest.TestCase):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
+            encoding="utf-8",
         )
         self.assertEqual(result.returncode, 0, result.stdout)
         self.assertIn("## Product invariants affected", result.stdout)
@@ -609,6 +626,7 @@ class SelectionTests(unittest.TestCase):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
+                encoding="utf-8",
             )
             # This test isolates metadata-file selection. Other manifest-selected
             # repository guardrails may legitimately fail as global state evolves;

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -23,6 +23,7 @@ from pr_metadata import (
     extract_merged_pr_number,
     load_from_api,
     load_from_event_file,
+    load_from_gh,
     resolve_main_push_body,
 )
 from pr_preflight import changed_files, format_failure_class_suggest, resolve_pr_metadata, run_git, select_checks
@@ -41,6 +42,26 @@ class FakeResponse(io.BytesIO):
 
 
 class MetadataTests(unittest.TestCase):
+    def test_gh_loader_decodes_current_metadata_as_utf8(self) -> None:
+        payload = json.dumps(
+            {
+                "number": 10823,
+                "body": "packaged entry → debug → ms",
+                "updatedAt": "2026-08-28T07:45:46Z",
+                "labels": [{"name": "workflow-review"}],
+            },
+            ensure_ascii=False,
+        )
+        completed = subprocess.CompletedProcess(args=["gh"], returncode=0, stdout=payload, stderr="")
+
+        with patch("pr_metadata.subprocess.run", return_value=completed) as run:
+            metadata = load_from_gh(REPO_ROOT)
+
+        self.assertEqual(metadata.body, "packaged entry → debug → ms")
+        self.assertEqual(metadata.labels, ("workflow-review",))
+        _, kwargs = run.call_args
+        self.assertEqual(kwargs.get("encoding"), "utf-8")
+
     def test_api_loader_uses_current_body_and_records_provenance(self) -> None:
         captured = {}
 

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -676,6 +676,7 @@ class SingleFlightTests(unittest.TestCase):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
+            encoding="utf-8",
         )
 
     def wait_for_lock(self, state_root: Path) -> None:
@@ -684,44 +685,6 @@ class SingleFlightTests(unittest.TestCase):
         while not lock.exists() and time.monotonic() < deadline:
             time.sleep(0.02)
         self.assertTrue(lock.exists(), "runner did not acquire its lock")
-
-    def test_runner_starts_from_unicode_checkout(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp) / "路径 checkout"
-            root.mkdir()
-            state_root = root / "state"
-            env = os.environ.copy()
-            env["OMI_PREFLIGHT_STATE_DIR"] = str(state_root)
-            for key in tuple(env):
-                if key.startswith("GIT_"):
-                    del env[key]
-            subprocess.run(["git", "init", "-q", str(root)], check=True, env=env)
-
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    str(RUNNER),
-                    "--name",
-                    "unicode-checkout",
-                    "--",
-                    sys.executable,
-                    "-c",
-                    "print('\\u8def\\u5f84\\U0001f680')",
-                ],
-                cwd=root,
-                env=env,
-                input="",
-                check=False,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                encoding="utf-8",
-            )
-            log = (state_root / "unicode-checkout" / "preflight.log").read_text(encoding="utf-8")
-
-        self.assertEqual(result.returncode, 0, result.stdout)
-        self.assertIn("路径🚀", result.stdout)
-        self.assertEqual(log, "路径🚀\n")
 
     @unittest.skipUnless(os.name == "nt", "Windows-only")
     def test_process_liveness_check_does_not_send_windows_ctrl_c(self) -> None:

--- a/.github/scripts/test_preflight_runner.py
+++ b/.github/scripts/test_preflight_runner.py
@@ -486,7 +486,7 @@ class LaunchContractTests(unittest.TestCase):
         self.assertIn(r"bad:\xa1", completed.stdout)
 
     @unittest.skipUnless(os.name == "nt", "native Windows Git encoding contract")
-    def test_runner_handles_utf8_git_worktree_path_without_utf8_mode(self) -> None:
+    def test_runner_emits_utf8_from_unicode_checkout_without_utf8_mode(self) -> None:
         git = shutil.which("git")
         self.assertIsNotNone(git)
 
@@ -501,7 +501,7 @@ class LaunchContractTests(unittest.TestCase):
             )
             env = os.environ.copy()
             env["PYTHONUTF8"] = "0"
-            env["PYTHONIOENCODING"] = "utf-8"
+            env.pop("PYTHONIOENCODING", None)
             completed = subprocess.run(
                 [
                     sys.executable,
@@ -511,7 +511,7 @@ class LaunchContractTests(unittest.TestCase):
                     "--",
                     sys.executable,
                     "-c",
-                    "print('unicode-path-ok')",
+                    "print('\\u8def\\u5f84\\U0001f680')",
                 ],
                 cwd=root,
                 env=env,
@@ -520,9 +520,11 @@ class LaunchContractTests(unittest.TestCase):
                 encoding="utf-8",
                 check=False,
             )
+            log = (root / ".git/omi-preflight/unicode-path/preflight.log").read_text(encoding="utf-8")
 
         self.assertEqual(completed.returncode, 0, completed.stdout)
-        self.assertIn("unicode-path-ok", completed.stdout)
+        self.assertIn("路径🚀", completed.stdout)
+        self.assertEqual(log, "路径🚀\n")
 
     @unittest.skipUnless(os.name == "nt", "native Windows Git encoding contract")
     def test_pr_preflight_handles_utf8_git_worktree_path_without_utf8_mode(self) -> None:

--- a/.github/scripts/test_preflight_runner.py
+++ b/.github/scripts/test_preflight_runner.py
@@ -527,12 +527,13 @@ class LaunchContractTests(unittest.TestCase):
         self.assertEqual(log, "路径🚀\n")
 
     @unittest.skipUnless(os.name == "nt", "native Windows Git encoding contract")
-    def test_pr_preflight_handles_utf8_git_worktree_path_without_utf8_mode(self) -> None:
+    def test_pr_preflight_emits_utf8_from_unicode_branch_without_utf8_mode(self) -> None:
         git = shutil.which("git")
         self.assertIsNotNone(git)
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "repo-\u96ea"
+            unicode_branch = "分支-🚀"
             root.mkdir()
             subprocess.run(
                 [git, "init", "--quiet"],
@@ -557,9 +558,10 @@ class LaunchContractTests(unittest.TestCase):
                 check=True,
                 capture_output=True,
             )
+            subprocess.run([git, "branch", unicode_branch], cwd=root, check=True, capture_output=True)
             env = os.environ.copy()
             env["PYTHONUTF8"] = "0"
-            env["PYTHONIOENCODING"] = "utf-8"
+            env.pop("PYTHONIOENCODING", None)
             completed = subprocess.run(
                 [
                     sys.executable,
@@ -567,7 +569,7 @@ class LaunchContractTests(unittest.TestCase):
                     "--base",
                     "HEAD",
                     "--head",
-                    "HEAD",
+                    unicode_branch,
                     "--list",
                 ],
                 cwd=root,
@@ -580,6 +582,7 @@ class LaunchContractTests(unittest.TestCase):
 
         self.assertEqual(completed.returncode, 0, completed.stdout)
         self.assertIn("PR preflight:", completed.stdout)
+        self.assertIn(f"head={unicode_branch}", completed.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed and why

Make the Windows preflight text pipeline an explicit UTF-8 contract end to end:

- decode captured `gh pr view` JSON as UTF-8 instead of the host code page;
- configure the single-flight runner and direct `pr-preflight` output streams as UTF-8 on Windows;
- propagate UTF-8 Python stdio through owned child process trees;
- decode `pr-preflight --suggest` child output and the current Git branch as UTF-8;
- pin every nested captured subprocess in the preflight contract tests to UTF-8;
- keep the native Unicode regressions in the manifest-owned portability suite that runs on `windows-latest`.

On a Chinese Windows host where Python prefers CP936, the live PR metadata reader raised `UnicodeDecodeError` on valid UTF-8 JSON. Once the runner correctly forced owned children to emit UTF-8, nested test harnesses still decoded those pipes as GBK, and direct `--suggest` output could replace valid Unicode characters. This closes all three layers rather than fixing only the first crash.

## Product invariants affected

none

## How it was verified

- `MetadataTests`: 14/14 passed; a real `load_from_gh` call loaded #12346 with `PYTHONUTF8=0` and no `PYTHONIOENCODING` on a CP936 host.
- `test_preflight_runner.py`: 25/25 passed on this head in native Windows CP936 mode.
- The new production-helper regressions launch a Python child containing Chinese plus emoji and read a Unicode Git branch with UTF-8 mode disabled.
- The direct `pr_preflight.py --suggest` path passed in CP936 mode and emitted its Unicode separator intact.
- All seven affected nested subprocess tests passed with the runner's UTF-8 child environment.
- Combined Windows audit with #12347 and #12348: 42/42 runnable `test_pr_preflight` cases passed (2 expected platform skips; only the GNU `make` prerequisite case was omitted), and the merged portability suite passed 29/29.
- Product invariants, failure-class validation and guard ratchet, 24 failure-class CLI tests, changelog data, deferred markers, plan catalog, lifecycle headers, and version-prefixed filenames all passed explicitly.
- Ruff, Black with repository options, `py_compile`, security specialist review, and `git diff --check` passed.

The diff-scoped local preflight passed through its first six checks. Its remaining full-suite blockers are external to this PR: GNU `make` is unavailable on this host, while the exit-259 liveness and atomic status replacement baselines are independently fixed by #12347 and #12348 and pass in the combined audit above.

## Tests

- `MetadataTests.test_gh_loader_decodes_current_metadata_as_utf8`
- `SelectionTests.test_captured_python_output_is_utf8_when_host_utf8_mode_is_disabled`
- `SelectionTests.test_current_branch_decodes_utf8_when_host_utf8_mode_is_disabled`
- `LaunchContractTests.test_runner_emits_utf8_from_unicode_checkout_without_utf8_mode`
- `LaunchContractTests.test_pr_preflight_emits_utf8_from_unicode_branch_without_utf8_mode`

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative (only when needed)

Violated contract: captured subprocess text must use the producer's encoding, not an implicit host locale.

Canonical guard: declare UTF-8 at captured CLI decoders, configure direct Windows output, and propagate the same contract through owned process trees; exercise non-ASCII metadata, branch names, and child output under native Windows with UTF-8 mode disabled.

Supporting evidence: merged fixes #10595 and #10844 corrected the same locale inheritance at adjacent Git and failure-class boundaries; this PR closes the remaining PR metadata, preflight suggestion, nested-test, and single-flight runner surfaces.
