### PR TITLE
fix(ci): distinguish Windows exit 259 from liveness

### DIFF
--- a/.github/failure-classes/FC-sentinel-exit-code-misclassified-as-liveness.json
+++ b/.github/failure-classes/FC-sentinel-exit-code-misclassified-as-liveness.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "id": "FC-sentinel-exit-code-misclassified-as-liveness",
+  "violated_contract": "A sentinel returned by a status API is not authoritative state when a completed operation may return the same value. On Windows, a process can terminate with exit code 259, which is also STILL_ACTIVE; treating GetExitCodeProcess alone as liveness leaves a stale single-flight owner classified as running forever.",
+  "canonical_prevention": "Determine process liveness from the process object's signaled state with a zero-timeout wait, then read creation time only for a process that is still nonsignaled. Keep a native Windows regression process that exits with the sentinel value and require the liveness probe to classify it as terminated.",
+  "canonical_prevention_artifact": [
+    ".github/scripts/test_preflight_runner.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    ".github/scripts/preflight_runner.py",
+    ".github/scripts/test_preflight_runner.py"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/preflight_runner.py
+++ b/.github/scripts/preflight_runner.py
@@ -30,8 +30,10 @@ FINGERPRINT_ENV_NAMES = (
 )
 IS_WINDOWS = os.name == "nt"
 HAS_PROCESS_GROUPS = os.name != "nt" and hasattr(os, "killpg")
-WINDOWS_STILL_ACTIVE = 259
 WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+WINDOWS_SYNCHRONIZE = 0x00100000
+WINDOWS_WAIT_OBJECT_0 = 0x00000000
+WINDOWS_WAIT_TIMEOUT = 0x00000102
 WINDOWS_PROCESS_SET_QUOTA = 0x0100
 WINDOWS_PROCESS_TERMINATE = 0x0001
 WINDOWS_ERROR_ACCESS_DENIED = 5
@@ -258,9 +260,9 @@ def windows_process_status(pid: int) -> tuple[bool, int | None]:
     open_process = kernel32.OpenProcess
     open_process.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
     open_process.restype = wintypes.HANDLE
-    get_exit_code = kernel32.GetExitCodeProcess
-    get_exit_code.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
-    get_exit_code.restype = wintypes.BOOL
+    wait_for_single_object = kernel32.WaitForSingleObject
+    wait_for_single_object.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    wait_for_single_object.restype = wintypes.DWORD
     get_process_times = kernel32.GetProcessTimes
     get_process_times.argtypes = [
         wintypes.HANDLE,
@@ -274,15 +276,19 @@ def windows_process_status(pid: int) -> tuple[bool, int | None]:
     close_handle.argtypes = [wintypes.HANDLE]
     close_handle.restype = wintypes.BOOL
 
-    handle = open_process(WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    handle = open_process(
+        WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION | WINDOWS_SYNCHRONIZE,
+        False,
+        pid,
+    )
     if not handle:
         return ctypes.get_last_error() == WINDOWS_ERROR_ACCESS_DENIED, None
     try:
-        exit_code = wintypes.DWORD()
-        if not get_exit_code(handle, ctypes.byref(exit_code)):
-            return True, None
-        if exit_code.value != WINDOWS_STILL_ACTIVE:
+        wait_result = wait_for_single_object(handle, 0)
+        if wait_result == WINDOWS_WAIT_OBJECT_0:
             return False, None
+        if wait_result != WINDOWS_WAIT_TIMEOUT:
+            return True, None
 
         creation = wintypes.FILETIME()
         exit_time = wintypes.FILETIME()

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -708,12 +708,6 @@ class SingleFlightTests(unittest.TestCase):
             self.assertTrue(preflight_runner.process_exists(os.getpid()))
             self.assertFalse(preflight_runner.process_exists(0x7FFFFFFF))
 
-    @unittest.skipUnless(os.name == "nt", "Windows-only")
-    def test_process_that_exits_with_still_active_status_is_not_alive(self) -> None:
-        child = subprocess.Popen([sys.executable, "-c", "raise SystemExit(259)"])
-        self.assertEqual(child.wait(), 259)
-        self.assertFalse(preflight_runner.process_exists(child.pid))
-
     def test_pr_body_content_participates_in_singleflight_fingerprint(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             body = Path(tmp) / "body.md"

--- a/.github/scripts/test_preflight_runner.py
+++ b/.github/scripts/test_preflight_runner.py
@@ -236,6 +236,12 @@ class ProcessExistsTests(unittest.TestCase):
         self.assertFalse(runner.process_exists(0))
 
     @unittest.skipUnless(os.name == "nt", "native Windows liveness contract")
+    def test_process_that_exits_with_still_active_status_is_not_alive(self) -> None:
+        child = subprocess.Popen([sys.executable, "-c", "raise SystemExit(259)"])
+        self.assertEqual(child.wait(), 259)
+        self.assertFalse(runner.process_exists(child.pid))
+
+    @unittest.skipUnless(os.name == "nt", "native Windows liveness contract")
     def test_windows_liveness_probe_does_not_terminate_the_target(self) -> None:
         child = subprocess.Popen(
             [sys.executable, "-c", "import sys; sys.stdin.buffer.read()"],


### PR DESCRIPTION
## What changed and why

Use the Windows process object's signaled state for preflight-runner liveness instead of interpreting GetExitCodeProcess value 259 as authoritative. Windows explicitly permits a completed process to return 259, the same value as STILL_ACTIVE; the old check therefore left that process's single-flight lock classified as live forever.

The fix uses a zero-timeout WaitForSingleObject result as the liveness source while retaining creation-time matching for PID reuse:
- https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getexitcodeprocess
- https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject

## Product invariants affected

none

## How it was verified

- Reproduced the existing native-Windows exit-259 regression three times on main: 3/3 failed.
- Ran .github/scripts/test_preflight_runner.py after the fix: 26/26 passed on native Windows.
- Re-ran the exit-259 regression three times after the fix: 3/3 passed.
- Ruff, py_compile, failure-class validation, and git diff --check passed.
- The full diff-scoped Windows preflight passed its first six checks, including the complete portability suite, then stopped in the broader current-main contract suite on three independent host failures: no local make executable, Unicode child output decoded as UTF-8, and an intermittent status.json replacement race. The replacement race also reproduced 4/5 times from an unmodified main-derived worktree.

## Tests

Moved test_process_that_exits_with_still_active_status_is_not_alive into the manifest-owned preflight-runner portability suite. The windows-latest portability job now executes this regression instead of leaving it in a suite that only skips it on Linux CI.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative (only when needed)

Violated contract: a status sentinel cannot prove liveness when a completed operation may return the same integer.

Canonical guard: use a zero-timeout wait on the Windows process handle, retain creation-time matching for PID reuse, and execute an actual process that exits 259 in native Windows CI.

Supporting evidence: the existing regression failed deterministically before this change, and the Win32 API contract explicitly warns that exit code 259 is ambiguous.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

