### PR TITLE
fix(ci): retry Windows atomic status replacement

### DIFF
--- a/.github/failure-classes/FC-atomic-replace-ignores-host-file-sharing.json
+++ b/.github/failure-classes/FC-atomic-replace-ignores-host-file-sharing.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "id": "FC-atomic-replace-ignores-host-file-sharing",
+  "violated_contract": "An atomic status writer must tolerate the file-sharing rules of every supported host. On Windows, a reader that has the destination open without delete sharing can briefly make os.replace fail with PermissionError; treating that transient sharing violation as a permanent write failure aborts the single-flight owner while another process is only polling its status.",
+  "canonical_prevention": "Keep the write-to-temp-and-replace primitive, but retry only Windows PermissionError failures for a short bounded interval so an active reader can release the destination. Preserve immediate failure for other platforms and errors, and run a native Windows regression that holds the destination open while the writer attempts the swap.",
+  "canonical_prevention_artifact": [
+    ".github/scripts/test_preflight_runner.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    ".github/scripts/preflight_runner.py",
+    ".github/scripts/test_preflight_runner.py"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/preflight_runner.py
+++ b/.github/scripts/preflight_runner.py
@@ -19,6 +19,8 @@ from typing import TextIO
 
 POLL_SECONDS = 0.2
 STATUS_INTERVAL_SECONDS = 5.0
+WINDOWS_ATOMIC_REPLACE_RETRY_SECONDS = 0.01
+WINDOWS_ATOMIC_REPLACE_TIMEOUT_SECONDS = 2.0
 MAX_PR_BODY_FINGERPRINT_BYTES = 1024 * 1024
 FORWARDED_SIGNAL_NAMES = ("SIGINT", "SIGTERM", "SIGHUP", "SIGBREAK")
 FINGERPRINT_ENV_NAMES = (
@@ -239,7 +241,15 @@ def signal_child(
 def atomic_json(path: Path, value: dict) -> None:
     temporary = path.with_suffix(path.suffix + f".{os.getpid()}.tmp")
     temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    os.replace(temporary, path)
+    deadline = time.monotonic() + WINDOWS_ATOMIC_REPLACE_TIMEOUT_SECONDS
+    while True:
+        try:
+            os.replace(temporary, path)
+            return
+        except PermissionError:
+            if not IS_WINDOWS or time.monotonic() >= deadline:
+                raise
+            time.sleep(WINDOWS_ATOMIC_REPLACE_RETRY_SECONDS)
 
 
 def read_json(path: Path) -> dict:

--- a/.github/scripts/test_preflight_runner.py
+++ b/.github/scripts/test_preflight_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import ctypes
 import importlib.util
+import json
 import os
 from pathlib import Path
 import shutil
@@ -12,6 +13,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import types
 import unittest
 from unittest import mock
@@ -150,6 +152,91 @@ class OutputFlushTests(unittest.TestCase):
 
         self.assertEqual(stream.flush.call_count, 2)
         wait.assert_not_called()
+
+
+class AtomicJsonTests(unittest.TestCase):
+    def test_windows_retries_a_transient_replace_sharing_violation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "status.json"
+            original_replace = runner.os.replace
+            calls = 0
+
+            def replace_after_transient_failure(source: Path, destination: Path) -> None:
+                nonlocal calls
+                calls += 1
+                if calls == 1:
+                    raise PermissionError("destination is open")
+                original_replace(source, destination)
+
+            with (
+                mock.patch.object(runner, "IS_WINDOWS", True),
+                mock.patch.object(
+                    runner.os,
+                    "replace",
+                    side_effect=replace_after_transient_failure,
+                ),
+                mock.patch.object(runner.time, "sleep") as sleep,
+            ):
+                runner.atomic_json(path, {"phase": "passed"})
+
+        self.assertEqual(calls, 2)
+        sleep.assert_called_once_with(runner.WINDOWS_ATOMIC_REPLACE_RETRY_SECONDS)
+
+    def test_non_windows_permission_error_is_not_retried(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "status.json"
+            with (
+                mock.patch.object(runner, "IS_WINDOWS", False),
+                mock.patch.object(
+                    runner.os,
+                    "replace",
+                    side_effect=PermissionError("denied"),
+                ) as replace,
+                mock.patch.object(runner.time, "sleep") as sleep,
+            ):
+                with self.assertRaises(PermissionError):
+                    runner.atomic_json(path, {"phase": "failed"})
+
+        replace.assert_called_once()
+        sleep.assert_not_called()
+
+    @unittest.skipUnless(os.name == "nt", "native Windows file-sharing contract")
+    def test_windows_waits_for_a_reader_to_release_the_destination(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "status.json"
+            path.write_text('{"phase": "running"}\n', encoding="utf-8")
+            reader_ready = threading.Event()
+            release_reader = threading.Event()
+
+            def hold_reader() -> None:
+                with path.open(encoding="utf-8"):
+                    reader_ready.set()
+                    release_reader.wait(timeout=0.2)
+
+            reader = threading.Thread(target=hold_reader)
+            reader.start()
+            self.assertTrue(
+                reader_ready.wait(timeout=5),
+                "reader did not open the status file",
+            )
+            original_sleep = runner.time.sleep
+            try:
+                with mock.patch.object(
+                    runner.time,
+                    "sleep",
+                    wraps=original_sleep,
+                ) as sleep:
+                    runner.atomic_json(path, {"phase": "passed"})
+            finally:
+                release_reader.set()
+                reader.join(timeout=5)
+
+            self.assertFalse(reader.is_alive(), "reader did not release the status file")
+            self.assertGreaterEqual(sleep.call_count, 1)
+            self.assertEqual(
+                json.loads(path.read_text(encoding="utf-8")),
+                {"phase": "passed"},
+            )
 
 
 class SignalChildTests(unittest.TestCase):


### PR DESCRIPTION
## What changed and why

Retry preflight-runner status-file replacement for a short bounded interval when Windows reports a transient PermissionError. A joining runner polls status.json while the owner rewrites it; Windows readers do not share delete access by default, so the otherwise-atomic os.replace randomly aborted the owner.

The retry remains Windows-only, catches only PermissionError, waits 10 ms between attempts, and stops after 2 seconds. Other platforms and error classes keep their existing fail-fast behavior.

## Product invariants affected

none

## How it was verified

- Reproduced SingleFlightTests.test_identical_processes_join_and_execute_once on an unmodified main-derived worktree: 4 failures in 5 runs, all WinError 5 at os.replace.
- Ran the same join regression after the fix: 5/5 passed.
- Ran .github/scripts/test_preflight_runner.py on native Windows: 28/28 passed.
- The new native test holds status.json open for reading and proves the writer retries and completes after release.
- Ruff, py_compile, failure-class validation, and git diff --check passed.
- Full diff-scoped Windows preflight passed its first six checks, including the 28-test portability suite, then stopped in the broader current-main contract suite only on missing local make, the exit-259 defect addressed independently by #12347, and the remaining Unicode checkout output defect.

## Tests

AtomicJsonTests covers the transient Windows retry, immediate non-Windows failure, and the real Windows file-sharing boundary with an open destination reader.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative (only when needed)

Violated contract: an atomic writer cannot assume POSIX rename sharing semantics on every supported host.

Canonical guard: keep write-to-temp-and-replace, but bound retries for Windows sharing violations and execute the open-reader boundary on native Windows CI.

Supporting evidence: the existing join-once regression failed 4/5 times on current main under native Windows with WinError 5, then passed 5/5 with this guard.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

