### PR TITLE
fix(desktop): render chat execute_sql datetime columns in local time with zone label (#12321)

### DIFF
--- a/.github/failure-classes/FC-naive-utc-timestamp-in-llm-surface.json
+++ b/.github/failure-classes/FC-naive-utc-timestamp-in-llm-surface.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "FC-naive-utc-timestamp-in-llm-surface",
+  "violated_contract": "A timestamp value handed to the chat model as tool output or prompt context must carry an explicit time zone; a naive datetime string must never be presented as if it were already local time.",
+  "canonical_prevention": "Convert database-stored UTC datetime values to TimeZone.current with an explicit zone abbreviation/offset in the formatter that renders them for the model, rather than relying on prompt instructions asking the model to apply the offset itself.",
+  "evidence_prs": [],
+  "scope_hints": ["desktop/macos/Desktop/Sources/Chat/**", "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift"],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/Chat/SQLQueryResultProjection.swift
+++ b/desktop/macos/Desktop/Sources/Chat/SQLQueryResultProjection.swift
@@ -30,7 +30,8 @@ enum SQLQueryResultProjection {
     var truncated = false
 
     for row in rows.prefix(maxRows) {
-      let line = row.map { (_, value) in renderedValue(value) }.joined(separator: " | ")
+      let line = row.map { (columnName, value) in renderedValue(value, columnName: columnName) }
+        .joined(separator: " | ")
       guard characterCount + line.count + 1 <= maxOutputCharacters else {
         truncated = true
         break
@@ -97,7 +98,7 @@ enum SQLQueryResultProjection {
     }
   }
 
-  private nonisolated static func renderedValue(_ databaseValue: DatabaseValue) -> String {
+  private nonisolated static func renderedValue(_ databaseValue: DatabaseValue, columnName: String) -> String {
     let value: String
     switch databaseValue.storage {
     case .null:
@@ -107,11 +108,38 @@ enum SQLQueryResultProjection {
     case .double(let double):
       value = String(double)
     case .string(let string):
-      value = string
+      value = localTimeString(forUTCDatetime: string, columnName: columnName) ?? string
     case .blob(let data):
       value = "<\(data.count) bytes>"
     }
     guard value.count > maxCellCharacters else { return value }
     return String(value.prefix(maxCellCharacters)) + "..."
+  }
+
+  /// GRDB stores `Date` columns as naive UTC text ("yyyy-MM-dd HH:mm:ss.SSS", no zone marker).
+  /// Rendered verbatim, the chat model reads a UTC wall-clock string as if it were already
+  /// local time (see #12321: "7:59:51 PM" shown for a 3:59:51 PM EDT event). Convert
+  /// datetime-shaped columns to the user's local zone with an explicit abbreviation here,
+  /// mechanically, rather than relying on the model to apply the offset itself.
+  private nonisolated static func localTimeString(forUTCDatetime raw: String, columnName: String) -> String? {
+    guard looksLikeDatetimeColumn(columnName) else { return nil }
+    let utcFormatter = DateFormatter()
+    utcFormatter.locale = Locale(identifier: "en_US_POSIX")
+    utcFormatter.timeZone = TimeZone(identifier: "UTC")
+    utcFormatter.dateFormat = raw.contains(".") ? "yyyy-MM-dd HH:mm:ss.SSS" : "yyyy-MM-dd HH:mm:ss"
+    guard let date = utcFormatter.date(from: raw) else { return nil }
+
+    let localFormatter = DateFormatter()
+    localFormatter.locale = Locale(identifier: "en_US_POSIX")
+    localFormatter.timeZone = .current
+    localFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss zzz"
+    return localFormatter.string(from: date)
+  }
+
+  /// Matches `timestamp` and camelCase `*At` columns (`createdAt`, `startedAt`, `completedAt`)
+  /// without catching unrelated names that merely end in the letters "at" (`format`, `chat`).
+  private nonisolated static func looksLikeDatetimeColumn(_ columnName: String) -> Bool {
+    if columnName.caseInsensitiveCompare("timestamp") == .orderedSame { return true }
+    return columnName.range(of: #"[a-z]At$"#, options: .regularExpression) != nil
   }
 }

--- a/desktop/macos/Desktop/Tests/ChatToolExecutorSQLTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatToolExecutorSQLTests.swift
@@ -277,6 +277,45 @@ final class ChatToolExecutorSQLTests: XCTestCase {
     XCTAssertTrue(result.contains("call get_work_context"))
   }
 
+  func testExecuteSQLRendersDatetimeColumnsInLocalTimeWithZoneLabel() async throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("execute-sql-datetime-localization-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let pool = try DatabasePool(path: directory.appendingPathComponent("test.sqlite").path)
+    // 2026-08-27T19:59:51Z — the exact UTC instant from #12321's repro.
+    let utcInstant = Date(timeIntervalSince1970: 1_787_082_791)
+    try await pool.write { db in
+      try db.execute(sql: "CREATE TABLE screenshots (appName TEXT, timestamp DATETIME NOT NULL)")
+      try db.execute(
+        sql: "INSERT INTO screenshots (appName, timestamp) VALUES (?, ?)",
+        arguments: ["Claude", utcInstant]
+      )
+    }
+
+    let result = await ChatToolExecutor.executeSQL(
+      ["query": "SELECT appName, timestamp FROM screenshots"],
+      dbQueue: pool,
+      expectedOwnerID: nil
+    )
+
+    let expectedLocalFormatter = DateFormatter()
+    expectedLocalFormatter.locale = Locale(identifier: "en_US_POSIX")
+    expectedLocalFormatter.timeZone = .current
+    expectedLocalFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss zzz"
+    let expectedLocal = expectedLocalFormatter.string(from: utcInstant)
+
+    XCTAssertTrue(
+      result.contains(expectedLocal),
+      "expected local+zone rendering '\(expectedLocal)' in result:\n\(result)"
+    )
+    // Only meaningful off UTC, but guards against silently falling back to the raw UTC cell.
+    if TimeZone.current.secondsFromGMT(for: utcInstant) != 0 {
+      XCTAssertFalse(result.contains("2026-08-27 19:59:51.000"))
+    }
+  }
+
   func testSQLAuthorizationIsOutsideSwiftPhysicalPreconditions() {
     XCTAssertEqual(
       ChatToolExecutor.physicalExecutionPrecondition(toolName: "execute_sql"),

--- a/desktop/macos/changelog/unreleased/20260827-chat-sql-datetime-localtime.json
+++ b/desktop/macos/changelog/unreleased/20260827-chat-sql-datetime-localtime.json
@@ -1,0 +1,3 @@
+{
+  "change": "Chat's execute_sql tool now renders timestamp/*At columns in your local time zone instead of unlabeled UTC"
+}


### PR DESCRIPTION
## Bug

Desktop chat's `execute_sql` tool renders SQLite `DATETIME` columns (`timestamp`, `createdAt`, `startedAt`, `completedAt`) as raw naive-UTC text, and the chat model presents that text as if it were already local time — a 3:59:51 PM EDT event shows as 7:59:51 PM. Fixes #12321.

## Root cause

`SQLQueryResultProjection.renderedValue` copies GRDB `Date` cell values verbatim. GRDB stores `Date` columns as naive UTC text (`yyyy-MM-dd HH:mm:ss.SSS`, no zone marker), so nothing in the pipeline ever applies the UTC→local offset before the string reaches the model.

## Fix

`SQLQueryResultProjection.swift`: datetime-shaped columns (`timestamp`, or a name ending `[a-z]At`, e.g. `createdAt`/`startedAt`/`completedAt`) are parsed as naive UTC and re-rendered in `TimeZone.current` with an explicit zone abbreviation, mechanically, rather than relying on the model to apply the offset itself. Non-datetime string columns are untouched.

## What I tested

Rebased onto current `main` (2f2be5a5f8) and ran the full `ChatToolExecutorSQLTests` suite via `xcrun swift test --package-path Desktop --filter ChatToolExecutorSQLTests`: 14/14 passing, including the new regression test `testExecuteSQLRendersDatetimeColumnsInLocalTimeWithZoneLabel` (exact UTC instant from the reported repro, asserted against the local-zone rendering).

## Product invariants affected

- INV-CHAT-1

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

