### PR TITLE
fix(desktop): prevent double-localized SQL timestamps

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/ChatPrompts.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatPrompts.swift
@@ -87,25 +87,25 @@ struct ChatPrompts {
     -- Daily totals only (for counts/time breakdowns; use get_work_context for "what was I doing" — use -1 day for yesterday, -7 day for past week):
     -- Q1: App usage
     SELECT appName, COUNT(*) as count, ROUND(COUNT(*) * 10.0 / 60, 1) as minutes,
-    MIN(time(timestamp, 'localtime')) as first_seen, MAX(time(timestamp, 'localtime')) as last_seen
-    FROM screenshots WHERE timestamp >= datetime('now', 'start of day', '-1 day', 'localtime')
-    AND timestamp < datetime('now', 'start of day', 'localtime')
+    MIN(timestamp) AS firstSeenAt, MAX(timestamp) AS lastSeenAt
+    FROM screenshots WHERE timestamp >= datetime('now', 'localtime', 'start of day', '-1 day', 'utc')
+    AND timestamp < datetime('now', 'localtime', 'start of day', 'utc')
     AND appName IS NOT NULL AND appName != '' GROUP BY appName ORDER BY count DESC
     -- Q2: Conversations
     SELECT title, overview, emoji, startedAt, finishedAt,
     ROUND((julianday(finishedAt) - julianday(startedAt)) * 1440, 1) as duration_min
-    FROM transcription_sessions WHERE startedAt >= datetime('now', 'start of day', '-1 day', 'localtime')
-    AND startedAt < datetime('now', 'start of day', 'localtime') AND deleted = 0 AND discarded = 0
+    FROM transcription_sessions WHERE startedAt >= datetime('now', 'localtime', 'start of day', '-1 day', 'utc')
+    AND startedAt < datetime('now', 'localtime', 'start of day', 'utc') AND deleted = 0 AND discarded = 0
     ORDER BY startedAt DESC
     -- Q3: Tasks
     SELECT description, completed, priority FROM action_items
-    WHERE createdAt >= datetime('now', 'start of day', '-1 day', 'localtime')
-    AND createdAt < datetime('now', 'start of day', 'localtime') AND deleted = 0
+    WHERE createdAt >= datetime('now', 'localtime', 'start of day', '-1 day', 'utc')
+    AND createdAt < datetime('now', 'localtime', 'start of day', 'utc') AND deleted = 0
     ORDER BY createdAt DESC
 
     -- Bounded OCR preview for explicit low-level inspection only; recent-work retrieval belongs to get_work_context:
     SELECT timestamp, appName, windowTitle, substr(ocrText, 1, 200) as preview
-    FROM screenshots WHERE timestamp >= datetime('now', '-1 day', 'localtime')
+    FROM screenshots WHERE timestamp >= datetime('now', '-1 day')
     ORDER BY timestamp DESC LIMIT 20
 
     -- Active tasks:
@@ -130,12 +130,14 @@ struct ChatPrompts {
     WHERE s.deleted = 0 AND seg.text LIKE '%keyword%'
     GROUP BY s.id ORDER BY s.startedAt DESC LIMIT 10
 
-    -- Time in user's timezone: use datetime('now', 'localtime') or datetime('now', '-N hours', 'localtime')
-    -- "yesterday": datetime('now', 'start of day', '-1 day', 'localtime') to datetime('now', 'start of day', 'localtime')
+    -- Local calendar bounds expressed as UTC instants (UTC column versus UTC bound):
+    -- "today" start: datetime('now', 'localtime', 'start of day', 'utc')
+    -- "yesterday": datetime('now', 'localtime', 'start of day', '-1 day', 'utc') to datetime('now', 'localtime', 'start of day', 'utc')
+    -- last N hours: datetime('now', '-N hours')
     -- FTS search: SELECT * FROM screenshots WHERE id IN (SELECT rowid FROM screenshots_fts WHERE screenshots_fts MATCH 'keyword')
 
     **Timezone handling:**
-    All timestamps in the database are stored in UTC. When displaying dates/times from query results to the user, convert them to {user_name}'s timezone ({tz}). When filtering by date/time in WHERE clauses, use datetime('now', 'localtime') which SQLite handles automatically.
+    All timestamps in the database are stored in UTC. Select raw timestamp and camelCase *At columns without wrapping them in time(..., 'localtime') or datetime(..., 'localtime'); execute_sql converts those result cells once to {user_name}'s timezone ({tz}) and includes an explicit zone. Quote the converted tool output as-is. When filtering a local calendar day, compute local midnight first and convert that boundary back to UTC with datetime('now', 'localtime', 'start of day', ..., 'utc').
     </tools>
 
     <initiative>
@@ -755,6 +757,22 @@ struct ChatPrompts {
     Full DDL for any table: SELECT sql FROM sqlite_master WHERE name='table_name'
     """
 
+}
+
+enum DesktopChatSQLTime {
+  /// SQLite stores chat-visible DATETIME columns as UTC-naive text. Build local
+  /// calendar boundaries, then convert them back to UTC before comparison.
+  static func localDayStartAsUTC(daysAgo: Int) -> String {
+    let clampedDaysAgo = max(0, daysAgo)
+    guard clampedDaysAgo > 0 else {
+      return "datetime('now', 'localtime', 'start of day', 'utc')"
+    }
+    return "datetime('now', 'localtime', 'start of day', '-\(clampedDaysAgo) day', 'utc')"
+  }
+
+  static func exclusiveEndAsUTC(daysAgo: Int) -> String {
+    max(0, daysAgo) == 0 ? "datetime('now')" : localDayStartAsUTC(daysAgo: 0)
+  }
 }
 
 // MARK: - Prompt Builder

--- a/desktop/macos/Desktop/Sources/Chat/SQLQueryResultProjection.swift
+++ b/desktop/macos/Desktop/Sources/Chat/SQLQueryResultProjection.swift
@@ -6,7 +6,19 @@ enum SQLQueryResultProjection {
   private static let maxCellCharacters = 500
   private static let maxOutputCharacters = 12_000
 
-  nonisolated static func format(rows: [Row], query: String) -> (text: String, count: Int) {
+  nonisolated static func format(
+    rows: [Row],
+    query: String,
+    timeZone: TimeZone = .current
+  ) -> (text: String, count: Int) {
+    if projectsSQLiteLocalTime(query) {
+      return (
+        "Error: keep timestamp result expressions in UTC. "
+          + "Select raw timestamp/*At columns so execute_sql can localize them once with an explicit zone. "
+          + "Use localtime only when computing UTC WHERE bounds.",
+        rows.count
+      )
+    }
     guard let firstRow = rows.first else {
       let hint =
         referencesScreenshots(query)
@@ -30,8 +42,10 @@ enum SQLQueryResultProjection {
     var truncated = false
 
     for row in rows.prefix(maxRows) {
-      let line = row.map { (columnName, value) in renderedValue(value, columnName: columnName) }
-        .joined(separator: " | ")
+      let line = row.map { (columnName, value) in
+        renderedValue(value, columnName: columnName, timeZone: timeZone)
+      }
+      .joined(separator: " | ")
       guard characterCount + line.count + 1 <= maxOutputCharacters else {
         truncated = true
         break
@@ -53,6 +67,32 @@ enum SQLQueryResultProjection {
 
   private nonisolated static func referencesScreenshots(_ query: String) -> Bool {
     query.range(of: #"\bscreenshots\b"#, options: [.regularExpression, .caseInsensitive]) != nil
+  }
+
+  /// #12349 localizes timestamp-shaped result columns. Query-layer localization
+  /// in a SELECT projection would make that formatter apply the offset twice (#12350).
+  private nonisolated static func projectsSQLiteLocalTime(_ query: String) -> Bool {
+    let options: NSRegularExpression.Options = [.caseInsensitive, .dotMatchesLineSeparators]
+    guard
+      let selectRegex = try? NSRegularExpression(
+        pattern: #"\bselect\b(.*?)(?=\bfrom\b|$)"#,
+        options: options
+      ),
+      let localTimeFunctionRegex = try? NSRegularExpression(
+        pattern: #"\b(?:date|time|datetime|julianday|unixepoch|strftime)\s*\([^;]*?['\"]localtime['\"]"#,
+        options: options
+      )
+    else {
+      return false
+    }
+
+    let queryRange = NSRange(query.startIndex..<query.endIndex, in: query)
+    return selectRegex.matches(in: query, range: queryRange).contains { match in
+      guard let projectionRange = Range(match.range(at: 1), in: query) else { return false }
+      let projection = String(query[projectionRange])
+      let range = NSRange(projection.startIndex..<projection.endIndex, in: projection)
+      return localTimeFunctionRegex.firstMatch(in: projection, range: range) != nil
+    }
   }
 
   private nonisolated static func projectsUnboundedOCR(_ query: String, columns: [String]) -> Bool {
@@ -98,7 +138,11 @@ enum SQLQueryResultProjection {
     }
   }
 
-  private nonisolated static func renderedValue(_ databaseValue: DatabaseValue, columnName: String) -> String {
+  private nonisolated static func renderedValue(
+    _ databaseValue: DatabaseValue,
+    columnName: String,
+    timeZone: TimeZone
+  ) -> String {
     let value: String
     switch databaseValue.storage {
     case .null:
@@ -108,7 +152,7 @@ enum SQLQueryResultProjection {
     case .double(let double):
       value = String(double)
     case .string(let string):
-      value = localTimeString(forUTCDatetime: string, columnName: columnName) ?? string
+      value = localTimeString(forUTCDatetime: string, columnName: columnName, timeZone: timeZone) ?? string
     case .blob(let data):
       value = "<\(data.count) bytes>"
     }
@@ -121,19 +165,25 @@ enum SQLQueryResultProjection {
   /// local time (see #12321: "7:59:51 PM" shown for a 3:59:51 PM EDT event). Convert
   /// datetime-shaped columns to the user's local zone with an explicit abbreviation here,
   /// mechanically, rather than relying on the model to apply the offset itself.
-  private nonisolated static func localTimeString(forUTCDatetime raw: String, columnName: String) -> String? {
+  private nonisolated static func localTimeString(
+    forUTCDatetime raw: String,
+    columnName: String,
+    timeZone: TimeZone
+  ) -> String? {
     guard looksLikeDatetimeColumn(columnName) else { return nil }
     let utcFormatter = DateFormatter()
     utcFormatter.locale = Locale(identifier: "en_US_POSIX")
+    utcFormatter.calendar = Calendar(identifier: .gregorian)
     utcFormatter.timeZone = TimeZone(identifier: "UTC")
     utcFormatter.dateFormat = raw.contains(".") ? "yyyy-MM-dd HH:mm:ss.SSS" : "yyyy-MM-dd HH:mm:ss"
     guard let date = utcFormatter.date(from: raw) else { return nil }
 
     let localFormatter = DateFormatter()
     localFormatter.locale = Locale(identifier: "en_US_POSIX")
-    localFormatter.timeZone = .current
+    localFormatter.calendar = Calendar(identifier: .gregorian)
+    localFormatter.timeZone = timeZone
     localFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss zzz"
-    return localFormatter.string(from: date)
+    return "\(localFormatter.string(from: date)) (\(timeZone.identifier))"
   }
 
   /// Matches `timestamp` and camelCase `*At` columns (`createdAt`, `startedAt`, `completedAt`)

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -1023,7 +1023,8 @@ class ChatToolExecutor {
   static func executeSQL(
     _ args: [String: Any],
     dbQueue: DatabasePool?,
-    expectedOwnerID: String?
+    expectedOwnerID: String?,
+    timeZone: TimeZone = .current
   ) async -> String {
     guard isExpectedOwnerCurrent(expectedOwnerID) else { return authorizedOwnerChangedResult() }
     guard let query = args["query"] as? String, !query.isEmpty else {
@@ -1090,7 +1091,8 @@ class ChatToolExecutor {
           upper: upper,
           parameters: parameters,
           dbQueue: databaseQueue,
-          expectedOwnerID: expectedOwnerID)
+          expectedOwnerID: expectedOwnerID,
+          timeZone: timeZone)
       } else if isInsert || isUpdate || isDelete {
         return try await executeWriteQuery(
           trimmed,
@@ -1196,7 +1198,8 @@ class ChatToolExecutor {
     upper: String,
     parameters: [String],
     dbQueue: DatabasePool,
-    expectedOwnerID: String?
+    expectedOwnerID: String?,
+    timeZone: TimeZone
   )
     async throws -> String
   {
@@ -1214,7 +1217,7 @@ class ChatToolExecutor {
     let query = finalQuery
     let formatted = try await dbQueue.read { db -> (text: String, count: Int) in
       let rows = try Row.fetchAll(db, sql: query, arguments: StatementArguments(parameters))
-      return SQLQueryResultProjection.format(rows: rows, query: query)
+      return SQLQueryResultProjection.format(rows: rows, query: query, timeZone: timeZone)
     }
     guard isExpectedOwnerCurrent(expectedOwnerID) else { return authorizedOwnerChangedResult() }
 
@@ -1419,12 +1422,8 @@ class ChatToolExecutor {
       return "Error: database not available"
     }
     guard isExpectedOwnerCurrent(expectedOwnerID) else { return authorizedOwnerChangedResult() }
-
-    // For today (daysAgo=0), upper bound is now; for past days, upper bound is start of today
-    let upperBound =
-      daysAgo == 0
-      ? "datetime('now', 'localtime')"
-      : "datetime('now', 'start of day', 'localtime')"
+    let lowerBound = DesktopChatSQLTime.localDayStartAsUTC(daysAgo: daysAgo)
+    let upperBound = DesktopChatSQLTime.exclusiveEndAsUTC(daysAgo: daysAgo)
 
     do {
       let result = try await dbQueue.read { db in
@@ -1435,7 +1434,7 @@ class ChatToolExecutor {
             SELECT appName, COUNT(*) as screenshots, ROUND(COUNT(*) * 10.0 / 60, 1) as minutes,
                 MIN(time(timestamp, 'localtime')) as first_seen, MAX(time(timestamp, 'localtime')) as last_seen
             FROM screenshots
-            WHERE timestamp >= datetime('now', 'start of day', '-\(daysAgo) day', 'localtime')
+            WHERE timestamp >= \(lowerBound)
                 AND timestamp < \(upperBound)
                 AND appName IS NOT NULL AND appName != ''
             GROUP BY appName ORDER BY screenshots DESC
@@ -1448,7 +1447,7 @@ class ChatToolExecutor {
             SELECT backendId, title, overview, emoji, category, startedAt, finishedAt,
                 ROUND((julianday(finishedAt) - julianday(startedAt)) * 1440, 1) as duration_min
             FROM transcription_sessions
-            WHERE startedAt >= datetime('now', 'start of day', '-\(daysAgo) day', 'localtime')
+            WHERE startedAt >= \(lowerBound)
                 AND startedAt < \(upperBound)
                 AND deleted = 0 AND discarded = 0
             ORDER BY startedAt DESC
@@ -1459,7 +1458,7 @@ class ChatToolExecutor {
           db,
           sql: """
             SELECT backendId, description, completed, priority, createdAt FROM action_items
-            WHERE createdAt >= datetime('now', 'start of day', '-\(daysAgo) day', 'localtime')
+            WHERE createdAt >= \(lowerBound)
                 AND createdAt < \(upperBound)
                 AND deleted = 0
             ORDER BY createdAt DESC
@@ -1470,7 +1469,7 @@ class ChatToolExecutor {
           db,
           sql: """
             SELECT status, appOrSite, description, durationSeconds FROM focus_sessions
-            WHERE createdAt >= datetime('now', 'start of day', '-\(daysAgo) day', 'localtime')
+            WHERE createdAt >= \(lowerBound)
                 AND createdAt < \(upperBound)
             ORDER BY createdAt DESC
             """)
@@ -1480,7 +1479,7 @@ class ChatToolExecutor {
           db,
           sql: """
             SELECT backendId, content, category, source FROM memories
-            WHERE createdAt >= datetime('now', 'start of day', '-\(daysAgo) day', 'localtime')
+            WHERE createdAt >= \(lowerBound)
                 AND createdAt < \(upperBound)
                 AND deleted = 0
             ORDER BY createdAt DESC
@@ -1491,7 +1490,7 @@ class ChatToolExecutor {
           db,
           sql: """
             SELECT appName, currentActivity, contextSummary FROM observations
-            WHERE createdAt >= datetime('now', 'start of day', '-\(daysAgo) day', 'localtime')
+            WHERE createdAt >= \(lowerBound)
                 AND createdAt < \(upperBound)
             ORDER BY createdAt DESC
             LIMIT 20
@@ -1531,8 +1530,9 @@ class ChatToolExecutor {
             let screenshots = Self.rowInt(app["screenshots"]) ?? 0
             let firstSeen = app["first_seen"] as? String ?? ""
             let lastSeen = app["last_seen"] as? String ?? ""
+            let timeZone = TimeZone.current.identifier
             out +=
-              "- **\(name)**: \(minutes) min (\(screenshots) captures, \(firstSeen)–\(lastSeen))\n"
+              "- **\(name)**: \(minutes) min (\(screenshots) captures, \(firstSeen)–\(lastSeen) \(timeZone))\n"
           }
           if apps.count > 20 { out += "- ...and \(apps.count - 20) more apps\n" }
         }

--- a/desktop/macos/Desktop/Tests/ChatPromptsTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatPromptsTests.swift
@@ -13,6 +13,47 @@ final class ChatPromptsTests: XCTestCase {
     )
   }
 
+  func testDesktopChatSQLGuidanceLocalizesTimestampResultsExactlyOnce() {
+    let prompt = ChatPrompts.desktopChat
+
+    XCTAssertTrue(prompt.contains("MIN(timestamp) AS firstSeenAt, MAX(timestamp) AS lastSeenAt"))
+    XCTAssertTrue(prompt.contains("Select raw timestamp and camelCase *At columns"))
+    XCTAssertTrue(prompt.contains("execute_sql converts those result cells once"))
+    XCTAssertFalse(prompt.contains("MIN(time(timestamp, 'localtime'))"))
+    XCTAssertFalse(prompt.contains("When displaying dates/times from query results to the user, convert them"))
+  }
+
+  func testDesktopChatSQLGuidanceComparesUTCColumnsToUTCBounds() {
+    let prompt = ChatPrompts.desktopChat
+
+    XCTAssertTrue(prompt.contains("datetime('now', 'localtime', 'start of day', '-1 day', 'utc')"))
+    XCTAssertTrue(prompt.contains("datetime('now', 'localtime', 'start of day', 'utc')"))
+    XCTAssertTrue(prompt.contains("timestamp >= datetime('now', '-1 day')"))
+    XCTAssertFalse(prompt.contains("datetime('now', 'start of day', '-1 day', 'localtime')"))
+    XCTAssertFalse(prompt.contains("datetime('now', 'start of day', 'localtime')"))
+    XCTAssertFalse(prompt.contains("timestamp >= datetime('now', '-1 day', 'localtime')"))
+  }
+
+  func testDesktopChatSQLDayBoundsKeepLocalCalendarWindowsInUTC() {
+    XCTAssertEqual(
+      DesktopChatSQLTime.localDayStartAsUTC(daysAgo: 1),
+      "datetime('now', 'localtime', 'start of day', '-1 day', 'utc')"
+    )
+    XCTAssertEqual(
+      DesktopChatSQLTime.exclusiveEndAsUTC(daysAgo: 1),
+      "datetime('now', 'localtime', 'start of day', 'utc')"
+    )
+    XCTAssertEqual(
+      DesktopChatSQLTime.localDayStartAsUTC(daysAgo: 0),
+      "datetime('now', 'localtime', 'start of day', 'utc')"
+    )
+    XCTAssertEqual(DesktopChatSQLTime.exclusiveEndAsUTC(daysAgo: 0), "datetime('now')")
+    XCTAssertEqual(
+      DesktopChatSQLTime.localDayStartAsUTC(daysAgo: -1),
+      DesktopChatSQLTime.localDayStartAsUTC(daysAgo: 0)
+    )
+  }
+
   func testExplicitScreenShareRequestUsesCanonicalScreenRecordingPermissionTool() {
     let desktopPrompt = ChatPromptBuilder.buildDesktopChat(userName: "Taylor")
 

--- a/desktop/macos/Desktop/Tests/ChatToolExecutorSQLTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatToolExecutorSQLTests.swift
@@ -284,8 +284,8 @@ final class ChatToolExecutorSQLTests: XCTestCase {
     defer { try? FileManager.default.removeItem(at: directory) }
 
     let pool = try DatabasePool(path: directory.appendingPathComponent("test.sqlite").path)
-    // 2026-08-27T19:59:51Z — the exact UTC instant from #12321's repro.
-    let utcInstant = Date(timeIntervalSince1970: 1_787_082_791)
+    // The exact UTC instant from #12321's repro.
+    let utcInstant = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-27T19:59:51Z"))
     try await pool.write { db in
       try db.execute(sql: "CREATE TABLE screenshots (appName TEXT, timestamp DATETIME NOT NULL)")
       try db.execute(
@@ -294,26 +294,56 @@ final class ChatToolExecutorSQLTests: XCTestCase {
       )
     }
 
+    let timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
     let result = await ChatToolExecutor.executeSQL(
       ["query": "SELECT appName, timestamp FROM screenshots"],
       dbQueue: pool,
-      expectedOwnerID: nil
+      expectedOwnerID: nil,
+      timeZone: timeZone
     )
-
-    let expectedLocalFormatter = DateFormatter()
-    expectedLocalFormatter.locale = Locale(identifier: "en_US_POSIX")
-    expectedLocalFormatter.timeZone = .current
-    expectedLocalFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss zzz"
-    let expectedLocal = expectedLocalFormatter.string(from: utcInstant)
 
     XCTAssertTrue(
-      result.contains(expectedLocal),
-      "expected local+zone rendering '\(expectedLocal)' in result:\n\(result)"
+      result.contains("2026-08-27 15:59:51"),
+      "expected pinned local+zone rendering in result:\n\(result)"
     )
-    // Only meaningful off UTC, but guards against silently falling back to the raw UTC cell.
-    if TimeZone.current.secondsFromGMT(for: utcInstant) != 0 {
-      XCTAssertFalse(result.contains("2026-08-27 19:59:51.000"))
+    XCTAssertTrue(result.contains("(America/New_York)"))
+    XCTAssertFalse(result.contains("2026-08-27 19:59:51"))
+  }
+
+  func testExecuteSQLRejectsProjectedLocaltimeButAllowsUTCBoundaryConversion() async throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("execute-sql-localtime-projection-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let pool = try DatabasePool(path: directory.appendingPathComponent("test.sqlite").path)
+    try await pool.write { db in
+      try db.execute(sql: "CREATE TABLE screenshots (timestamp DATETIME NOT NULL)")
+      try db.execute(sql: "INSERT INTO screenshots VALUES (datetime('now'))")
     }
+
+    let utc = try XCTUnwrap(TimeZone(secondsFromGMT: 0))
+    let boundaryResult = await ChatToolExecutor.executeSQL(
+      [
+        "query": """
+        SELECT timestamp FROM screenshots
+        WHERE timestamp >= datetime('now', 'localtime', 'start of day', 'utc')
+        """
+      ],
+      dbQueue: pool,
+      expectedOwnerID: nil,
+      timeZone: utc
+    )
+    XCTAssertFalse(boundaryResult.contains("keep timestamp result expressions in UTC"))
+    XCTAssertTrue(boundaryResult.contains("timestamp"))
+
+    let projectedResult = await ChatToolExecutor.executeSQL(
+      ["query": "SELECT datetime(timestamp, 'localtime') AS timestamp FROM screenshots"],
+      dbQueue: pool,
+      expectedOwnerID: nil,
+      timeZone: utc
+    )
+    XCTAssertTrue(projectedResult.contains("keep timestamp result expressions in UTC"))
   }
 
   func testSQLAuthorizationIsOutsideSwiftPhysicalPreconditions() {

--- a/desktop/macos/changelog/unreleased/20260828-chat-sql-timezone-boundaries.json
+++ b/desktop/macos/changelog/unreleased/20260828-chat-sql-timezone-boundaries.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Desktop Chat SQL times being shifted twice and local-day queries starting at the wrong hour"
+}


### PR DESCRIPTION
## What changed and why

Fixes #12350. After #12349, Desktop Chat could apply the local offset twice when a SQL projection used SQLite `localtime`, while the prompt and daily recap still built local-day bounds in UTC-first order. This focused follow-up to the still-open macOS work in #12326 keeps projected timestamps raw until the result formatter, rejects query-layer `localtime` in `SELECT` expressions, and converts local-midnight boundaries back to UTC before comparing stored UTC values.

## Product invariants affected

- INV-CHAT-1

## How it was verified

- Reproduced the failure with SQLite on Windows in `Asia/Shanghai`: the old boundary resolves to 08:00 local, while `localtime -> start of day -> utc` resolves to 16:00 UTC (local midnight).
- `git diff --check`
- Validated the changelog JSON with jq 1.8.2.
- Ran local prompt and projection-guard contract assertions, including acceptance of `localtime` in UTC boundary predicates and rejection in projected timestamp expressions.
- Full macOS Swift tests cannot run on this Windows host; `Desktop Swift Static & Test Contracts` is the authoritative compile/test gate.

## Tests

- `ChatPromptsTests.testDesktopChatSQLGuidanceLocalizesTimestampResultsExactlyOnce`
- `ChatPromptsTests.testDesktopChatSQLGuidanceComparesUTCColumnsToUTCBounds`
- `ChatPromptsTests.testDesktopChatSQLDayBoundsKeepLocalCalendarWindowsInUTC`
- `ChatToolExecutorSQLTests.testExecuteSQLRendersDatetimeColumnsInLocalTimeWithZoneLabel`
- `ChatToolExecutorSQLTests.testExecuteSQLRejectsProjectedLocaltimeButAllowsUTCBoundaryConversion`

## Failure class (fixes)

Failure-Class: FC-naive-utc-timestamp-in-llm-surface


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

