### PR TITLE
test(byok): keep unique enrolled-provider asserts from #12302

### DIFF
--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -337,14 +337,16 @@ class TestChatQuotaBYOKBypass:
     @patch('utils.subscription.get_byok_key', side_effect=lambda provider: 'sk-user' if provider == 'openai' else None)
     @patch('utils.subscription.users_db')
     @patch('utils.subscription.is_trial_paywalled', return_value=False)
+    @patch('utils.subscription.get_chat_quota_snapshot')
     def test_enforce_chat_quota_bypasses_for_validated_openai_key(
-        self, _mock_paywalled, mock_users_db, _mock_key, _mock_state, _mock_uid, _mock_validated
+        self, mock_quota_snapshot, _mock_paywalled, mock_users_db, _mock_key, _mock_state, _mock_uid, _mock_validated
     ):
         mock_users_db.is_byok_active.return_value = True
         from utils.subscription import enforce_chat_quota
 
         enforce_chat_quota('byok-user-uid')
         mock_users_db.is_byok_active.assert_called_once_with('byok-user-uid', firestore_client=None)
+        mock_quota_snapshot.assert_not_called()
 
     @patch('utils.byok.get_byok_key', return_value=None)
     @patch('utils.subscription.users_db')
@@ -849,10 +851,15 @@ class TestRequestHasLLMByokKey:
     def test_requires_validated_context(self, monkeypatch):
         from utils import subscription
 
+        cached_state = MagicMock(return_value={'fingerprints': {'openai': 'openai-fp'}})
+        get_key = MagicMock(return_value='sk')
         monkeypatch.setattr(subscription, 'has_validated_byok_keys', lambda: False)
         monkeypatch.setattr(subscription, 'get_byok_uid', lambda: 'uid-1')
-        monkeypatch.setattr(subscription, 'get_byok_key', lambda _provider: 'sk')
+        monkeypatch.setattr(subscription, 'get_cached_byok_state', cached_state)
+        monkeypatch.setattr(subscription, 'get_byok_key', get_key)
         assert subscription.request_has_llm_byok_key() is False
+        cached_state.assert_not_called()
+        get_key.assert_not_called()
 
     def test_quota_snapshot_accepts_required_llm_provider(self, monkeypatch):
         from models.users import PlanType
@@ -1291,6 +1298,22 @@ class TestBYOKFingerprintValidation:
         token = _byok_ctx.set(self._valid_request_keys)
         try:
             validate_byok_request('byok-uid')  # Should not raise
+        finally:
+            _byok_ctx.reset(token)
+
+    @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
+    @patch('database.users.get_byok_state')
+    def test_single_provider_enrollment_accepts_its_only_header(self, mock_get_state):
+        """A capability-scoped enrollment only requires the provider it enrolled."""
+        from utils.byok import _byok_ctx, get_byok_keys, validate_byok_request
+
+        mock_get_state.return_value = self._mock_byok_state(
+            fingerprints={'openai': self._enrolled_fingerprints['openai']}
+        )
+        token = _byok_ctx.set({'openai': self._FAKE_KEY_OPENAI})
+        try:
+            validate_byok_request('single-provider-uid')
+            assert get_byok_keys() == {'openai': self._FAKE_KEY_OPENAI}
         finally:
             _byok_ctx.reset(token)
 


### PR DESCRIPTION
## What changed and why

#12302 rewrote `backend/tests/unit/test_byok_security.py` against an older `main`. Current `main` already has the 104-test fail-closed suite (`1da8880175`) and the CI restore from #12339, so that rewrite is stale. This PR keeps only the leftover asserts that current `main` does not already cover and that still match the enrolled-provider contract.

Supersedes #12302. #12289 is already fixed on `main` (the suite no longer patches `utils.subscription.get_byok_keys`).

## Product invariants affected

none

## How it was verified

```text
cd backend && python -m pytest tests/unit/test_byok_security.py -q
105 passed
```

Pre-push also ran the same file: 105 passed. Local `scripts/pr-preflight` passed 25 selected checks.

## Tests

- `test_single_provider_enrollment_accepts_its_only_header`: OpenAI-only enrollment accepts that one header (fail-closed still requires every enrolled provider).
- `test_enforce_chat_quota_bypasses_for_validated_openai_key`: bypass must not call `get_chat_quota_snapshot`.
- `test_requires_validated_context`: unvalidated context returns False without reading cached state or keys.

Discarded from #12302: monkeypatch-vs-`@patch` rewrites, exact 403 string tweaks already covered by `'missing'` / `'mismatch'` contains-checks, and replacing `test_missing_enrolled_provider_header_raises_403` (that fail-closed case stays on `main`).

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in the BYOK security unit suite; no runtime behavior is modified.
> 
> **Overview**
> This PR only extends **`test_byok_security.py`** with assertions that **`main`** did not already cover after the fail-closed BYOK suite landed.
> 
> **Chat quota bypass** — `test_enforce_chat_quota_bypasses_for_validated_openai_key` now mocks `get_chat_quota_snapshot` and asserts it is **never** called when a validated OpenAI BYOK path bypasses enforcement.
> 
> **`request_has_llm_byok_key`** — `test_requires_validated_context` checks that when `has_validated_byok_keys()` is false, the helper returns false **without** touching `get_cached_byok_state` or `get_byok_key`.
> 
> **Enrollment contract** — new `test_single_provider_enrollment_accepts_its_only_header` documents that OpenAI-only enrollment passes `validate_byok_request` when only the OpenAI header is sent, and exposes just that key downstream.
> 
> No production code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 130345b122d7315375aad33aa696079a67abd1c7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->