### PR TITLE
feat(v5): native capture origin + shared Hono/Elysia HTTP core

### DIFF
--- a/apps/backend-worker/RELEASE.md
+++ b/apps/backend-worker/RELEASE.md
@@ -9,7 +9,7 @@ This runbook applies the D1-authoritative Tasks, Chat, and Attachments migration
 - `CLOUDFLARE_API_TOKEN`: the API token that owns the Worker and D1 database.
 - `CLOUDFLARE_ACCOUNT_ID`: the account that owns the Worker, D1 database, R2 bucket, and Queue.
 - Worker secrets set out-of-band: `API_TOKEN`, `R2_ACCESS_KEY_ID`, and `R2_SECRET_ACCESS_KEY`. The attachment route fails closed without all three; never place their values in repository files.
-- `STAGING_WORKER_URL`: the public URL used by `verify:release` after the deploy.
+- `STAGING_WORKER_URL`: the public URL used by `verify:release` after the deploy. Native capture (`/v1/device-sessions`) reads this origin from `OMI_V5_BACKEND_URL` (https only; loopback, `api.omi.me`, or `*.workers.dev`). The repository does not record a `workers.dev` default. Settings and connector reads stay on `https://api.omi.me` unless a loopback `OMI_LOCAL_BACKEND_URL` is selected.
 - `STAGING_OBSERVABILITY_SINK_MODE`: `cloudflare_only` or `better_stack`.
 - `STAGING_BETTER_STACK_EVIDENCE_ID`: an opaque operator evidence identifier required only for `better_stack`.
 

--- a/apps/backend-worker/package.json
+++ b/apps/backend-worker/package.json
@@ -22,6 +22,7 @@
     "@omi-core/contracts": "workspace:*",
     "@omi-core/kernel": "workspace:*",
     "@omi-core/ratified-contracts": "workspace:*",
+    "@sinclair/typebox": "0.34.41",
     "elysia": "1.4.30",
     "hono": "4.12.26"
   },

--- a/apps/backend-worker/package.json
+++ b/apps/backend-worker/package.json
@@ -8,8 +8,9 @@
     "format:check": "prettier --check .",
     "lint": "eslint --config .eslintrc.cjs --max-warnings 0 'src/**/*.ts' 'test/**/*.ts' 'scripts/**/*.ts' 'migrations/**/*.ts'",
     "typecheck": "tsc --noEmit && WRANGLER_SEND_METRICS=false wrangler types --check",
-    "test": "bun x tsc -b ../../packages/adapters-platform --force && bun test test/worker.contract.test.ts test/ready.verify.test.ts test/openrouter.gateway.test.ts test/observability.policy.test.ts test/release.gate.test.ts test/retrieval.test.ts test/migrations.verify.test.ts test/attachments.contract.test.ts test/device-sessions.contract.test.ts test/generation-prompt.test.ts && bun x vitest run test/account.integration.test.ts test/d1-tasks.integration.test.ts test/d1-chat.integration.test.ts test/attachments.integration.test.ts",
+    "test": "bun x tsc -b ../../packages/adapters-platform --force && bun test test/worker.contract.test.ts test/ready.verify.test.ts test/openrouter.gateway.test.ts test/observability.policy.test.ts test/release.gate.test.ts test/retrieval.test.ts test/migrations.verify.test.ts test/attachments.contract.test.ts test/device-sessions.contract.test.ts test/generation-prompt.test.ts test/http-adapters.contract.test.ts && bun x vitest run test/account.integration.test.ts test/d1-tasks.integration.test.ts test/d1-chat.integration.test.ts test/attachments.integration.test.ts",
     "dev": "WRANGLER_SEND_METRICS=false wrangler dev",
+    "dev:elysia": "bun scripts/dev-elysia.ts",
     "deploy:dry-run": "WRANGLER_SEND_METRICS=false wrangler deploy --dry-run --strict",
     "deploy:staging": "WRANGLER_SEND_METRICS=false wrangler deploy --strict",
     "migrate:staging": "WRANGLER_SEND_METRICS=false WRANGLER_WRITE_LOGS=false wrangler d1 migrations apply omi-v5-backend-staging-tasks --remote --config wrangler.jsonc",
@@ -21,6 +22,7 @@
     "@omi-core/contracts": "workspace:*",
     "@omi-core/kernel": "workspace:*",
     "@omi-core/ratified-contracts": "workspace:*",
+    "elysia": "1.4.30",
     "hono": "4.12.26"
   },
   "devDependencies": {

--- a/apps/backend-worker/scripts/dev-elysia.ts
+++ b/apps/backend-worker/scripts/dev-elysia.ts
@@ -3,9 +3,9 @@ import type { CoreEnv } from "../src/http-core";
 import { createD1Mock } from "../test/d1-mock";
 
 const objects = new Map<string, Uint8Array>();
-const env: CoreEnv = {
+const env = {
   ENVIRONMENT: "local",
-  API_TOKEN: process.env.API_TOKEN || "local-token",
+  API_TOKEN: process.env["API_TOKEN"] || "local-token",
   STAGING_ACCOUNT_ID: "local-account",
   STAGING_DISPLAY_NAME: "Omi Local",
   STAGING_EMAIL: "local@omi.invalid",
@@ -17,7 +17,7 @@ const env: CoreEnv = {
   OPENROUTER_MODEL: "",
   OPENROUTER_GATEWAY_URL: "",
   OPENROUTER_API_KEY: "",
-  AI: { run: async () => ({ response: "" }) } as CoreEnv["AI"],
+  AI: { run: async () => ({ response: "" }) },
   DB: createD1Mock(),
   ATTACHMENTS: {
     async put(key: string, value: unknown) {
@@ -61,8 +61,8 @@ const env: CoreEnv = {
       fetch: async () => new Response(null, { status: 404 }),
     }),
   },
-};
+} as CoreEnv;
 
-const port = Number(process.env.PORT ?? "8787");
+const port = Number(process.env["PORT"] ?? "8787");
 createElysiaApp(env).listen(port);
 console.log(`elysia listening on http://127.0.0.1:${port}`);

--- a/apps/backend-worker/scripts/dev-elysia.ts
+++ b/apps/backend-worker/scripts/dev-elysia.ts
@@ -1,0 +1,68 @@
+import { createElysiaApp } from "../src/elysia";
+import type { CoreEnv } from "../src/http-core";
+import { createD1Mock } from "../test/d1-mock";
+
+const objects = new Map<string, Uint8Array>();
+const env: CoreEnv = {
+  ENVIRONMENT: "local",
+  API_TOKEN: process.env.API_TOKEN || "local-token",
+  STAGING_ACCOUNT_ID: "local-account",
+  STAGING_DISPLAY_NAME: "Omi Local",
+  STAGING_EMAIL: "local@omi.invalid",
+  STAGING_PLAN_LABEL: "Local",
+  STAGING_CHAT_LIMIT: 1000,
+  AI_MODEL: "local-model",
+  OBSERVABILITY_SINK_MODE: "cloudflare_only",
+  OPENROUTER_GATEWAY_ENABLED: "false",
+  OPENROUTER_MODEL: "",
+  OPENROUTER_GATEWAY_URL: "",
+  OPENROUTER_API_KEY: "",
+  AI: { run: async () => ({ response: "" }) } as CoreEnv["AI"],
+  DB: createD1Mock(),
+  ATTACHMENTS: {
+    async put(key: string, value: unknown) {
+      const bytes =
+        value instanceof Uint8Array
+          ? value
+          : typeof value === "string"
+          ? new TextEncoder().encode(value)
+          : new Uint8Array();
+      objects.set(key, bytes);
+      return { key, size: bytes.byteLength } as never;
+    },
+    async get(key: string) {
+      const bytes = objects.get(key);
+      if (bytes === undefined) return null;
+      return {
+        key,
+        size: bytes.byteLength,
+        arrayBuffer: async () =>
+          bytes.buffer.slice(
+            bytes.byteOffset,
+            bytes.byteOffset + bytes.byteLength
+          ),
+      } as never;
+    },
+    async head(key: string) {
+      const bytes = objects.get(key);
+      return bytes === undefined
+        ? null
+        : ({ key, size: bytes.byteLength } as never);
+    },
+    async delete() {},
+    async list() {
+      return { objects: [], truncated: false } as never;
+    },
+  } as never,
+  ACCOUNTS: {
+    getByName: () => ({
+      admit: async () => "entitlement" as const,
+      cancel: async () => "not_found" as const,
+      fetch: async () => new Response(null, { status: 404 }),
+    }),
+  },
+};
+
+const port = Number(process.env.PORT ?? "8787");
+createElysiaApp(env).listen(port);
+console.log(`elysia listening on http://127.0.0.1:${port}`);

--- a/apps/backend-worker/src/elysia.ts
+++ b/apps/backend-worker/src/elysia.ts
@@ -1,0 +1,95 @@
+import { Elysia } from "elysia";
+
+import {
+  authorizeV1,
+  coreContext,
+  publicRoutes,
+  safeRoute,
+  v1Routes,
+  type CoreContext,
+  type CoreEnv,
+  type CoreRoute,
+} from "./http-core";
+import { requestCompletedEvent, requestFailedEvent } from "./observability";
+import { backendError } from "./wire";
+
+export function createElysiaApp(env: CoreEnv): Elysia {
+  const app = new Elysia({ name: "omi-v5-backend" });
+  for (const route of publicRoutes) {
+    mount(app, env, route, false);
+  }
+  for (const route of v1Routes) {
+    mount(app, env, route, true);
+  }
+  app.onError(({ error, request }) => {
+    console.error(
+      JSON.stringify(
+        requestFailedEvent({
+          requestId: request.headers.get("x-omi-request-id") ?? "unavailable",
+          name: error instanceof Error ? error.name : "Error",
+          route: safeRoute(new URL(request.url).pathname),
+        })
+      )
+    );
+    return backendError("internal_server_error", "retry", 500, true);
+  });
+  return app.notFound(() => backendError("not_found", "edit_request", 404));
+}
+
+function mount(
+  app: Elysia,
+  env: CoreEnv,
+  route: CoreRoute,
+  authed: boolean
+): void {
+  const handler = async ({
+    request,
+    params,
+  }: {
+    request: Request;
+    params: Record<string, string>;
+  }) => {
+    const requestId = crypto.randomUUID();
+    const startedAt = Date.now();
+    const context = coreContext({
+      env,
+      request,
+      routePath: route.path,
+      params,
+      values: { requestId },
+    });
+    if (authed) {
+      const refusal = authorizeV1(context);
+      if (refusal !== null) return observed(context, refusal, startedAt);
+    }
+    return observed(context, await route.handle(context), startedAt);
+  };
+  if (route.method === "GET") app.get(route.path, handler);
+  else if (route.method === "POST") app.post(route.path, handler);
+  else app.delete(route.path, handler);
+}
+
+function observed(
+  context: CoreContext,
+  response: Response,
+  startedAt: number
+): Response {
+  const headers = new Headers(response.headers);
+  headers.set("x-omi-request-id", context.get("requestId"));
+  console.log(
+    JSON.stringify(
+      requestCompletedEvent({
+        requestId: context.get("requestId") || "unavailable",
+        method: context.req.method,
+        route: safeRoute(context.req.routePath),
+        status: response.status,
+        durationMs: Math.max(0, Date.now() - startedAt),
+      })
+    )
+  );
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/apps/backend-worker/src/elysia.ts
+++ b/apps/backend-worker/src/elysia.ts
@@ -21,7 +21,10 @@ export function createElysiaApp(env: CoreEnv): Elysia {
   for (const route of v1Routes) {
     mount(app, env, route, true);
   }
-  app.onError(({ error, request }) => {
+  app.onError(({ error, request, code }) => {
+    if (code === "NOT_FOUND") {
+      return backendError("not_found", "edit_request", 404);
+    }
     console.error(
       JSON.stringify(
         requestFailedEvent({
@@ -33,7 +36,7 @@ export function createElysiaApp(env: CoreEnv): Elysia {
     );
     return backendError("internal_server_error", "retry", 500, true);
   });
-  return app.notFound(() => backendError("not_found", "edit_request", 404));
+  return app;
 }
 
 function mount(

--- a/apps/backend-worker/src/http-core.ts
+++ b/apps/backend-worker/src/http-core.ts
@@ -1,0 +1,783 @@
+import { SYNTHESIZED_READ_CONTRACT_VERSION } from "@omi-core/ratified-contracts/projections/synthesized";
+
+import { readHistory, readSettings, type Admission } from "./chat";
+import {
+  conversationPage,
+  paginateConversations,
+  readConversations,
+  toLegacyConversation,
+} from "./conversations";
+import {
+  gatewayConfig,
+  gatewayModeEnabled,
+  type GatewaySecretEnv,
+} from "./openrouter";
+import {
+  configurationNotReadyEvent,
+  generationAdmittedEvent,
+  observabilityConfigured,
+  parseObservabilitySinkMode,
+  type ObservabilityEnv,
+} from "./observability";
+import {
+  ATTACHMENT_CAPABILITIES,
+  completeAttachment,
+  makeR2UploadUrlSigner,
+  parseAttachmentStageRequest,
+  parseSignedUploadConfig,
+  resolveAttachmentsForAdmit,
+  stageAttachment,
+  type AttachmentIngestMessage,
+  type SignedUploadEnv,
+} from "./attachments";
+import {
+  appendDeviceSessionAudio,
+  completeDeviceSession,
+  listDeviceSessions,
+  openDeviceSession,
+  parseDeviceSessionAudio,
+  parseDeviceSessionCreate,
+} from "./device-sessions";
+import {
+  createVectorizeRetrievalBoundary,
+  noCanonicalMemoryStore,
+  type RetrievalEnv,
+} from "./retrieval";
+import { parseTaskLimit, readTasks } from "./tasks";
+import {
+  backendError,
+  isChatCreate,
+  isClientId,
+  json,
+  type ChatCreate,
+} from "./wire";
+
+export type AccountPort = {
+  admit(
+    accountId: string,
+    input: ChatCreate,
+    chatLimit: number
+  ): Promise<Admission | "conflict" | "entitlement" | "attachment_rejected">;
+  cancel(
+    accountId: string,
+    generationId: string
+  ): Promise<"not_found" | "accepted" | "terminal">;
+  fetch(request: Request): Promise<Response>;
+};
+
+export type AccountLocator = {
+  getByName(name: string): AccountPort;
+};
+
+export type CoreEnv = SignedUploadEnv &
+  GatewaySecretEnv &
+  ObservabilityEnv & {
+    ENVIRONMENT: string;
+    API_TOKEN: string;
+    STAGING_ACCOUNT_ID: string;
+    STAGING_DISPLAY_NAME: string;
+    STAGING_EMAIL: string;
+    STAGING_PLAN_LABEL: string;
+    STAGING_CHAT_LIMIT: number;
+    AI_MODEL: string;
+    OPENROUTER_GATEWAY_ENABLED?: string;
+    OPENROUTER_MODEL?: string;
+    DB?: D1Database;
+    ATTACHMENTS?: R2Bucket;
+    ATTACHMENT_INGEST?: Queue<AttachmentIngestMessage>;
+    ACCOUNTS?: AccountLocator;
+    AI?: RetrievalEnv["AI"];
+    VECTORIZE?: RetrievalEnv["VECTORIZE"];
+  };
+
+export type CoreContext = {
+  env: CoreEnv;
+  req: {
+    method: string;
+    url: string;
+    raw: Request;
+    routePath: string;
+    header(name: string): string | undefined;
+    param(name: string): string;
+  };
+  get(key: "accountId" | "requestId"): string;
+  set(key: "accountId" | "requestId", value: string): void;
+};
+
+export type RouteMethod = "GET" | "POST" | "DELETE";
+
+export type CoreRoute = {
+  method: RouteMethod;
+  path: string;
+  handle: (context: CoreContext) => Response | Promise<Response>;
+};
+
+export function coreContext(input: {
+  env: CoreEnv;
+  request: Request;
+  routePath: string;
+  params: Record<string, string>;
+  values: { accountId?: string; requestId: string };
+}): CoreContext {
+  const values = { ...input.values };
+  return {
+    env: input.env,
+    req: {
+      method: input.request.method,
+      url: input.request.url,
+      raw: input.request,
+      routePath: input.routePath,
+      header: (name) => input.request.headers.get(name) ?? undefined,
+      param: (name) => input.params[name] ?? "",
+    },
+    get: (key) => values[key] ?? "",
+    set: (key, value) => {
+      values[key] = value;
+    },
+  };
+}
+
+export function safeRoute(routePath: string): string {
+  return routePath.startsWith("/") && routePath.length <= 200
+    ? routePath
+    : "unmatched";
+}
+
+export function constantTimeEqual(
+  supplied: Uint8Array,
+  expected: Uint8Array
+): boolean {
+  const length = Math.max(supplied.byteLength, expected.byteLength);
+  let difference = supplied.byteLength ^ expected.byteLength;
+  for (let index = 0; index < length; index += 1) {
+    difference |= (supplied[index] ?? 0) ^ (expected[index] ?? 0);
+  }
+  return difference === 0;
+}
+
+export function configurationReady(env: CoreEnv): boolean {
+  const base =
+    typeof env.API_TOKEN === "string" &&
+    env.API_TOKEN.length > 0 &&
+    typeof env.STAGING_ACCOUNT_ID === "string" &&
+    env.STAGING_ACCOUNT_ID.length > 0 &&
+    typeof env.AI_MODEL === "string" &&
+    env.AI_MODEL.length > 0 &&
+    Number.isSafeInteger(env.STAGING_CHAT_LIMIT) &&
+    env.STAGING_CHAT_LIMIT >= 0 &&
+    env.ACCOUNTS !== undefined &&
+    env.AI !== undefined &&
+    env.DB !== undefined &&
+    observabilityConfigured(env);
+  if (!base) return false;
+  if (gatewayModeEnabled(env)) return gatewayConfig(env) !== null;
+  return true;
+}
+
+export function parseLimit(value: string | undefined): number | null {
+  if (value === undefined) return 50;
+  if (!/^(?:[1-9]|[1-9][0-9]|100)$/.test(value)) return null;
+  return Number(value);
+}
+
+export function parseOffset(value: string | undefined): number | null {
+  if (value === undefined) return 0;
+  if (!/^(?:0|[1-9][0-9]{0,8})$/.test(value)) return null;
+  return Number(value);
+}
+
+export async function readBoundedJson(
+  request: Request,
+  maxBytes: number
+): Promise<
+  { kind: "ok"; value: unknown } | { kind: "invalid" } | { kind: "too_large" }
+> {
+  const declaredLength = request.headers.get("content-length");
+  if (
+    declaredLength !== null &&
+    (!/^\d+$/.test(declaredLength) || Number(declaredLength) > maxBytes)
+  ) {
+    return { kind: "too_large" };
+  }
+  if (request.body === null) return { kind: "invalid" };
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    length += value.byteLength;
+    if (length > maxBytes) {
+      await reader.cancel();
+      return { kind: "too_large" };
+    }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return {
+      kind: "ok",
+      value: JSON.parse(
+        new TextDecoder("utf-8", { fatal: true }).decode(bytes)
+      ) as unknown,
+    };
+  } catch {
+    return { kind: "invalid" };
+  }
+}
+
+export function emptyPage(
+  completenessVersion: "recall-completeness-v1" | "tasks-completeness-v1"
+) {
+  return {
+    contractVersion: SYNTHESIZED_READ_CONTRACT_VERSION,
+    items: [],
+    window: {
+      status: "complete",
+      complete: true,
+      hasMore: false,
+      nextCursor: null,
+    },
+    completeness: {
+      version: completenessVersion,
+      status: "complete",
+      reasons: [],
+      frontiers:
+        completenessVersion === "tasks-completeness-v1"
+          ? {
+              declaredFrontier: "frontier-v1:tasks-declared",
+              newestAppliedFrontier: "frontier-v1:tasks-declared",
+              missingAppliedFrontierReason: null,
+            }
+          : {
+              declaredFrontier: "frontier-v1:declared",
+              newestSearchedAcceptedFrontier: null,
+              missingAcceptedFrontierReason: "no_accepted_work",
+              newestSearchedStmFrontier: null,
+              missingStmFrontierReason: "no_eligible_stm",
+            },
+    },
+    absence: { kind: "query_gap" },
+  };
+}
+
+export function authorizeV1(context: CoreContext): Response | null {
+  // Authorization is gated on the SAME readiness predicate `/ready` reports,
+  // because a readiness signal is not an enforcement point: Cloudflare routes
+  // request traffic regardless of what `/ready` returns, so a deployment whose
+  // API_TOKEN secret is unset still serves `/v1/*`. That matters here and not
+  // merely in principle: TextEncoder yields an EMPTY expectation for an absent
+  // or empty secret, and an empty bearer credential ("Authorization: Bearer ")
+  // encodes to the same empty value, so the constant-time comparison below
+  // returns true and authenticates an anonymous caller. Wrangler does not fail
+  // a deploy when a secret referenced solely in code is unset, so this is a
+  // reachable configuration, not a hypothetical one. Refuse before comparing.
+  if (!configurationReady(context.env)) {
+    // Operator-visible, client-opaque: the caller still gets the ordinary
+    // refusal, so a misconfigured deployment is not advertised over the wire.
+    console.error(
+      JSON.stringify(
+        configurationNotReadyEvent({
+          requestId: context.get("requestId") || "unavailable",
+          route: safeRoute(context.req.routePath),
+        })
+      )
+    );
+    return backendError("unauthorized", "reauthenticate", 401);
+  }
+  const authorization = context.req.header("authorization");
+  if (authorization === undefined || !authorization.startsWith("Bearer ")) {
+    return backendError("unauthorized", "reauthenticate", 401);
+  }
+  const supplied = new TextEncoder().encode(
+    authorization.slice("Bearer ".length)
+  );
+  const expected = new TextEncoder().encode(context.env.API_TOKEN);
+  if (!constantTimeEqual(supplied, expected)) {
+    return backendError("unauthorized", "reauthenticate", 401);
+  }
+  const clientId = context.req.header("x-omi-client-id");
+  // Staging isolation by client id, not production multi-tenant auth.
+  // After Bearer auth, each validated x-omi-client-id is its own data
+  // partition for chat, tasks, attachments, conversations, and device
+  // sessions. Settings display name/email/plan stay staging labels.
+  if (clientId === undefined || !isClientId(clientId)) {
+    return backendError("bad_request", "edit_request", 400);
+  }
+  context.set("accountId", clientId);
+  return null;
+}
+
+export function handleHealth(context: CoreContext): Response {
+  return json({ status: "ok", environment: context.env.ENVIRONMENT });
+}
+
+export function handleReady(context: CoreContext): Response {
+  return configurationReady(context.env) &&
+    parseObservabilitySinkMode(context.env.OBSERVABILITY_SINK_MODE) !== null
+    ? json({
+        status: "ready",
+        environment: context.env.ENVIRONMENT,
+        observability_sink_mode: context.env.OBSERVABILITY_SINK_MODE,
+      })
+    : backendError("service_unavailable", "retry", 503, true);
+}
+
+export async function handleSettings(context: CoreContext): Promise<Response> {
+  const db = context.env.DB;
+  if (db === undefined)
+    return backendError("service_unavailable", "retry", 503, true);
+  return json(
+    await readSettings(
+      db,
+      context.get("accountId"),
+      {
+        displayName: context.env.STAGING_DISPLAY_NAME,
+        email: context.env.STAGING_EMAIL,
+      },
+      context.env.STAGING_PLAN_LABEL,
+      context.env.STAGING_CHAT_LIMIT
+    )
+  );
+}
+
+export async function handleChatHistory(
+  context: CoreContext
+): Promise<Response> {
+  const query = new URL(context.req.url).searchParams;
+  if (
+    [...query.keys()].some((key) => key !== "limit" && key !== "olderCursor") ||
+    query.getAll("limit").length > 1 ||
+    query.getAll("olderCursor").length > 1
+  ) {
+    return backendError("bad_request", "edit_request", 400);
+  }
+  const limit = parseLimit(query.get("limit") ?? undefined);
+  const olderCursor = query.get("olderCursor") ?? undefined;
+  if (limit === null || olderCursor === "")
+    return backendError("bad_request", "edit_request", 400);
+  const db = context.env.DB;
+  if (db === undefined)
+    return backendError("service_unavailable", "retry", 503, true);
+  const history = await readHistory(
+    db,
+    context.get("accountId"),
+    limit,
+    olderCursor
+  );
+  return history === "invalid_cursor"
+    ? backendError("bad_request", "edit_request", 400)
+    : json(history);
+}
+
+export async function handleChatCreate(
+  context: CoreContext
+): Promise<Response> {
+  const parsed = await readBoundedJson(context.req.raw, 65_536);
+  if (parsed.kind === "too_large")
+    return backendError("attachment_too_large", "edit_request", 413);
+  if (parsed.kind === "invalid")
+    return backendError("bad_request", "edit_request", 400);
+  const body = parsed.value;
+  if (!isChatCreate(body))
+    return backendError("validation", "edit_request", 422);
+  const db = context.env.DB;
+  if (db === undefined)
+    return backendError("service_unavailable", "retry", 503, true);
+  const resolved = await resolveAttachmentsForAdmit(
+    db,
+    context.get("accountId"),
+    body.attachmentIds,
+    body.id
+  );
+  if (resolved.kind === "rejected")
+    return backendError("attachment_rejected", "edit_request", 422);
+  const stub = account(context);
+  const admission = await stub.admit(
+    context.get("accountId"),
+    body,
+    context.env.STAGING_CHAT_LIMIT
+  );
+  if (admission === "conflict") {
+    return backendError("client_message_id_conflict", "edit_request", 409);
+  }
+  if (admission === "entitlement") {
+    return backendError("entitlement", "upgrade", 402);
+  }
+  if (admission === "attachment_rejected") {
+    return backendError("attachment_rejected", "edit_request", 422);
+  }
+  console.log(
+    JSON.stringify(
+      generationAdmittedEvent({
+        requestId: context.get("requestId") || "unavailable",
+        generationId: admission.generation.id,
+      })
+    )
+  );
+  return json(
+    { message: admission.message, generation: admission.generation },
+    admission.created ? 201 : 200
+  );
+}
+
+export async function handleGenerationEvents(
+  context: CoreContext
+): Promise<Response> {
+  const generationId = context.req.param("id");
+  const target = new URL("https://account.internal/events");
+  target.searchParams.set("generationId", generationId);
+  const response = await account(context).fetch(
+    new Request(target, { headers: context.req.raw.headers })
+  );
+  return response.status === 404
+    ? backendError("not_found", "refresh_history", 404)
+    : response;
+}
+
+export async function handleGenerationCancel(
+  context: CoreContext
+): Promise<Response> {
+  const cancellation = await account(context).cancel(
+    context.get("accountId"),
+    context.req.param("id")
+  );
+  if (cancellation === "not_found")
+    return backendError("not_found", "refresh_history", 404);
+  return cancellation === "terminal"
+    ? new Response(null, {
+        status: 204,
+        headers: { "cache-control": "no-store" },
+      })
+    : json({ cancellation: { state: "accepted" } }, 202);
+}
+
+export async function handleAttachmentStage(
+  context: CoreContext
+): Promise<Response> {
+  const r2 = context.env.ATTACHMENTS;
+  if (r2 === undefined)
+    return backendError("service_unavailable", "retry", 503, true);
+  const parsed = await readBoundedJson(context.req.raw, 65_536);
+  if (parsed.kind === "too_large")
+    return backendError("attachment_too_large", "edit_request", 413);
+  if (parsed.kind === "invalid")
+    return backendError("bad_request", "edit_request", 400);
+  const request = parseAttachmentStageRequest(parsed.value);
+  if (request === null)
+    return backendError("attachment_rejected", "edit_request", 422);
+  const db = context.env.DB;
+  if (db === undefined)
+    return backendError("service_unavailable", "retry", 503, true);
+  const signedConfig = parseSignedUploadConfig(context.env);
+  if (signedConfig === null)
+    return backendError("service_unavailable", "retry", 503, true);
+  const signer = makeR2UploadUrlSigner(signedConfig);
+  const result = await stageAttachment(
+    db,
+    context.get("accountId"),
+    request,
+    ATTACHMENT_CAPABILITIES,
+    "attachments",
+    signer
+  );
+  if (result.kind === "conflict")
+    return backendError("attachment_rejected", "edit_request", 409);
+  return json(result.response, result.created ? 201 : 200);
+}
+
+export async function handleAttachmentComplete(
+  context: CoreContext
+): Promise<Response> {
+  const r2 = context.env.ATTACHMENTS;
+  const ingest = context.env.ATTACHMENT_INGEST;
+  const db = context.env.DB;
+  if (r2 === undefined || ingest === undefined || db === undefined)
+    return backendError("service_unavailable", "retry", 503, true);
+  const attachmentId = context.req.param("id");
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(
+      attachmentId
+    )
+  )
+    return backendError("bad_request", "edit_request", 400);
+  const outcome = await completeAttachment(
+    db,
+    r2,
+    ingest,
+    context.get("accountId"),
+    attachmentId,
+    Date.now()
+  );
+  switch (outcome.kind) {
+    case "accepted":
+      return json({ attachment: outcome.attachment }, 202);
+    case "queued":
+      return json({ attachment: outcome.attachment }, 202);
+    case "ingested":
+      return json({ attachment: outcome.attachment }, 200);
+    case "not_found":
+      return backendError("not_found", "refresh_history", 404);
+    case "expired":
+      return backendError("attachment_expired", "edit_request", 410);
+    case "absent":
+      return backendError("attachment_not_uploaded", "retry", 422, true);
+    case "mismatch":
+      return backendError("attachment_metadata_mismatch", "edit_request", 422);
+    case "conflict":
+      return backendError("attachment_rejected", "edit_request", 409);
+  }
+}
+
+export async function handleDeviceSessionOpen(
+  context: CoreContext
+): Promise<Response> {
+  const r2 = context.env.ATTACHMENTS;
+  const db = context.env.DB;
+  if (r2 === undefined || db === undefined)
+    return backendError("service_unavailable", "retry", 503, true);
+  const parsed = await readBoundedJson(context.req.raw, 65_536);
+  if (parsed.kind === "too_large")
+    return backendError("attachment_too_large", "edit_request", 413);
+  if (parsed.kind === "invalid")
+    return backendError("bad_request", "edit_request", 400);
+  const request = parseDeviceSessionCreate(parsed.value);
+  if (request === null) return backendError("validation", "edit_request", 422);
+  return json(
+    {
+      session: await openDeviceSession(
+        db,
+        context.get("accountId"),
+        request,
+        Date.now()
+      ),
+    },
+    201
+  );
+}
+
+export async function handleDeviceSessionAudio(
+  context: CoreContext
+): Promise<Response> {
+  const r2 = context.env.ATTACHMENTS;
+  const db = context.env.DB;
+  if (r2 === undefined || db === undefined)
+    return backendError("service_unavailable", "retry", 503, true);
+  const parsed = await readBoundedJson(context.req.raw, 1_572_864);
+  if (parsed.kind === "too_large")
+    return backendError("attachment_too_large", "edit_request", 413);
+  if (parsed.kind === "invalid")
+    return backendError("bad_request", "edit_request", 400);
+  const request = parseDeviceSessionAudio(parsed.value);
+  if (request === null) return backendError("validation", "edit_request", 422);
+  const outcome = await appendDeviceSessionAudio(
+    db,
+    r2,
+    context.get("accountId"),
+    context.req.param("id"),
+    request.bytes,
+    Date.now()
+  );
+  switch (outcome.kind) {
+    case "ok":
+      return json({ session: outcome.session });
+    case "not_found":
+      return backendError("not_found", "refresh_history", 404);
+    case "conflict":
+      return backendError("conflict", "edit_request", 409);
+    case "too_large":
+      return backendError("attachment_too_large", "edit_request", 413);
+  }
+}
+
+export async function handleDeviceSessionComplete(
+  context: CoreContext
+): Promise<Response> {
+  const r2 = context.env.ATTACHMENTS;
+  const db = context.env.DB;
+  if (r2 === undefined || db === undefined)
+    return backendError("service_unavailable", "retry", 503, true);
+  const outcome = await completeDeviceSession(
+    db,
+    context.get("accountId"),
+    context.req.param("id"),
+    Date.now()
+  );
+  return outcome.kind === "not_found"
+    ? backendError("not_found", "refresh_history", 404)
+    : json({ session: outcome.session });
+}
+
+export async function handleDeviceSessionList(
+  context: CoreContext
+): Promise<Response> {
+  const r2 = context.env.ATTACHMENTS;
+  const db = context.env.DB;
+  if (r2 === undefined || db === undefined)
+    return backendError("service_unavailable", "retry", 503, true);
+  return json({
+    sessions: await listDeviceSessions(db, context.get("accountId")),
+  });
+}
+
+export async function handleConversations(
+  context: CoreContext
+): Promise<Response> {
+  const query = new URL(context.req.url).searchParams;
+  const keys = [...query.keys()];
+  const hasOffset = query.has("offset");
+  if (hasOffset) {
+    if (
+      keys.some((key) => key !== "limit" && key !== "offset") ||
+      query.getAll("limit").length > 1 ||
+      query.getAll("offset").length > 1
+    ) {
+      return backendError("bad_request", "edit_request", 400);
+    }
+    const limit = parseLimit(query.get("limit") ?? undefined);
+    const offset = parseOffset(query.get("offset") ?? undefined);
+    if (limit === null || offset === null)
+      return backendError("bad_request", "edit_request", 400);
+    const db = context.env.DB;
+    if (db === undefined) return json([]);
+    const items = await readConversations(db, context.get("accountId"));
+    return json(
+      items
+        .slice(offset, offset + limit)
+        .map((item) => toLegacyConversation(item))
+    );
+  }
+  if (
+    keys.some((key) => key !== "limit" && key !== "cursor") ||
+    query.getAll("limit").length > 1 ||
+    query.getAll("cursor").length > 1
+  ) {
+    return backendError("bad_request", "edit_request", 400);
+  }
+  const limit = parseLimit(query.get("limit") ?? undefined);
+  const cursor = query.get("cursor") ?? undefined;
+  if (limit === null || cursor === "")
+    return backendError("bad_request", "edit_request", 400);
+  const db = context.env.DB;
+  if (db === undefined) return json(conversationPage([], false, null));
+  const page = paginateConversations(
+    await readConversations(db, context.get("accountId")),
+    limit,
+    cursor
+  );
+  return page === "invalid_cursor"
+    ? backendError("bad_request", "edit_request", 400)
+    : json(page);
+}
+
+export async function handleMemories(context: CoreContext): Promise<Response> {
+  const query = new URL(context.req.url).searchParams;
+  if (
+    [...query.keys()].some((key) => key !== "limit" && key !== "cursor") ||
+    query.getAll("limit").length > 1 ||
+    query.getAll("cursor").length > 1
+  ) {
+    return backendError("bad_request", "edit_request", 400);
+  }
+  const limit = parseTaskLimit(query.get("limit"));
+  const cursor = query.get("cursor") ?? undefined;
+  if (cursor === "") return backendError("bad_request", "edit_request", 400);
+  if (context.env.AI !== undefined) {
+    const recalled = await createVectorizeRetrievalBoundary(
+      context.env.VECTORIZE === undefined
+        ? { AI: context.env.AI }
+        : { AI: context.env.AI, VECTORIZE: context.env.VECTORIZE },
+      noCanonicalMemoryStore
+    ).query({
+      accountId: context.get("accountId"),
+      queryText: "",
+      topK: limit,
+    });
+    // No D1 memory table: ids cannot be revalidated, so hits stay empty.
+    void recalled;
+  }
+  return json(emptyPage("recall-completeness-v1"));
+}
+
+export async function handleTasks(context: CoreContext): Promise<Response> {
+  const query = new URL(context.req.url).searchParams;
+  if (
+    [...query.keys()].some((key) => key !== "limit" && key !== "cursor") ||
+    query.getAll("limit").length > 1 ||
+    query.getAll("cursor").length > 1
+  ) {
+    return backendError("bad_request", "edit_request", 400);
+  }
+  const db = context.env.DB;
+  if (db === undefined) return json(emptyPage("tasks-completeness-v1"));
+  const limit = parseTaskLimit(query.get("limit"));
+  const cursor = query.get("cursor") ?? undefined;
+  return json(await readTasks(db, context.get("accountId"), limit, cursor));
+}
+
+export const publicRoutes: readonly CoreRoute[] = [
+  { method: "GET", path: "/health", handle: handleHealth },
+  { method: "GET", path: "/ready", handle: handleReady },
+];
+
+export const v1Routes: readonly CoreRoute[] = [
+  { method: "GET", path: "/v1/settings", handle: handleSettings },
+  { method: "GET", path: "/v1/chat-messages", handle: handleChatHistory },
+  { method: "POST", path: "/v1/chat-messages", handle: handleChatCreate },
+  {
+    method: "GET",
+    path: "/v1/chat-generations/:id/events",
+    handle: handleGenerationEvents,
+  },
+  {
+    method: "DELETE",
+    path: "/v1/chat-generations/:id",
+    handle: handleGenerationCancel,
+  },
+  {
+    method: "POST",
+    path: "/v1/chat-attachments",
+    handle: handleAttachmentStage,
+  },
+  {
+    method: "POST",
+    path: "/v1/chat-attachments/:id/complete",
+    handle: handleAttachmentComplete,
+  },
+  {
+    method: "POST",
+    path: "/v1/device-sessions",
+    handle: handleDeviceSessionOpen,
+  },
+  {
+    method: "POST",
+    path: "/v1/device-sessions/:id/audio",
+    handle: handleDeviceSessionAudio,
+  },
+  {
+    method: "POST",
+    path: "/v1/device-sessions/:id/complete",
+    handle: handleDeviceSessionComplete,
+  },
+  {
+    method: "GET",
+    path: "/v1/device-sessions",
+    handle: handleDeviceSessionList,
+  },
+  { method: "GET", path: "/v1/conversations", handle: handleConversations },
+  { method: "GET", path: "/v1/memories", handle: handleMemories },
+  { method: "GET", path: "/v1/tasks", handle: handleTasks },
+];
+
+function account(context: CoreContext): AccountPort {
+  const accounts = context.env.ACCOUNTS;
+  if (accounts === undefined) {
+    throw new Error("accounts");
+  }
+  return accounts.getByName(context.get("accountId"));
+}

--- a/apps/backend-worker/src/http-core.ts
+++ b/apps/backend-worker/src/http-core.ts
@@ -10,7 +10,7 @@ import {
 import {
   gatewayConfig,
   gatewayModeEnabled,
-  type GatewaySecretEnv,
+  type GatewayEnv,
 } from "./openrouter";
 import {
   configurationNotReadyEvent,
@@ -70,7 +70,7 @@ export type AccountLocator = {
 };
 
 export type CoreEnv = SignedUploadEnv &
-  GatewaySecretEnv &
+  GatewayEnv &
   ObservabilityEnv & {
     ENVIRONMENT: string;
     API_TOKEN: string;
@@ -80,13 +80,11 @@ export type CoreEnv = SignedUploadEnv &
     STAGING_PLAN_LABEL: string;
     STAGING_CHAT_LIMIT: number;
     AI_MODEL: string;
-    OPENROUTER_GATEWAY_ENABLED?: string;
-    OPENROUTER_MODEL?: string;
     DB?: D1Database;
     ATTACHMENTS?: R2Bucket;
     ATTACHMENT_INGEST?: Queue<AttachmentIngestMessage>;
     ACCOUNTS?: AccountLocator;
-    AI?: RetrievalEnv["AI"];
+    AI?: RetrievalEnv["AI"] | { run: (...args: never[]) => Promise<unknown> };
     VECTORIZE?: RetrievalEnv["VECTORIZE"];
   };
 
@@ -688,10 +686,15 @@ export async function handleMemories(context: CoreContext): Promise<Response> {
   const cursor = query.get("cursor") ?? undefined;
   if (cursor === "") return backendError("bad_request", "edit_request", 400);
   if (context.env.AI !== undefined) {
-    const recalled = await createVectorizeRetrievalBoundary(
+    const retrievalEnv =
       context.env.VECTORIZE === undefined
-        ? { AI: context.env.AI }
-        : { AI: context.env.AI, VECTORIZE: context.env.VECTORIZE },
+        ? { AI: context.env.AI as RetrievalEnv["AI"] }
+        : {
+            AI: context.env.AI as RetrievalEnv["AI"],
+            VECTORIZE: context.env.VECTORIZE,
+          };
+    const recalled = await createVectorizeRetrievalBoundary(
+      retrievalEnv,
       noCanonicalMemoryStore
     ).query({
       accountId: context.get("accountId"),

--- a/apps/backend-worker/src/index.ts
+++ b/apps/backend-worker/src/index.ts
@@ -1,53 +1,25 @@
 import { Hono } from "hono";
-import { SYNTHESIZED_READ_CONTRACT_VERSION } from "@omi-core/ratified-contracts/projections/synthesized";
 
 import { AccountBackend } from "./account";
-import { readHistory, readSettings } from "./chat";
 import {
-  conversationPage,
-  paginateConversations,
-  readConversations,
-  toLegacyConversation,
-} from "./conversations";
+  consumeAttachmentIngest,
+  type AttachmentIngestMessage,
+} from "./attachments";
 import {
-  gatewayConfig,
-  gatewayModeEnabled,
-  type GatewaySecretEnv,
-} from "./openrouter";
+  authorizeV1,
+  publicRoutes,
+  safeRoute,
+  v1Routes,
+  type CoreContext,
+  type CoreEnv,
+} from "./http-core";
+import { type GatewaySecretEnv } from "./openrouter";
 import {
-  configurationNotReadyEvent,
-  generationAdmittedEvent,
-  observabilityConfigured,
-  parseObservabilitySinkMode,
   requestCompletedEvent,
   requestFailedEvent,
   type ObservabilityEnv,
 } from "./observability";
-import {
-  ATTACHMENT_CAPABILITIES,
-  completeAttachment,
-  consumeAttachmentIngest,
-  makeR2UploadUrlSigner,
-  parseAttachmentStageRequest,
-  parseSignedUploadConfig,
-  resolveAttachmentsForAdmit,
-  stageAttachment,
-  type AttachmentIngestMessage,
-} from "./attachments";
-import {
-  appendDeviceSessionAudio,
-  completeDeviceSession,
-  listDeviceSessions,
-  openDeviceSession,
-  parseDeviceSessionAudio,
-  parseDeviceSessionCreate,
-} from "./device-sessions";
-import {
-  createVectorizeRetrievalBoundary,
-  noCanonicalMemoryStore,
-} from "./retrieval";
-import { parseTaskLimit, readTasks } from "./tasks";
-import { backendError, isChatCreate, isClientId, json } from "./wire";
+import { backendError } from "./wire";
 
 type WorkerEnv = Omit<
   Env,
@@ -67,14 +39,6 @@ type WorkerEnv = Omit<
     R2_SIGNED_URL_TTL_SECONDS?: string | number;
   };
 type Variables = { accountId: string; requestId: string };
-
-type ObservableContext = {
-  req: { method: string; routePath: string };
-  res: { status: number };
-  set(key: "requestId", value: string): void;
-  get(key: "requestId"): string | undefined;
-  header(name: string, value: string): void;
-};
 
 const app = new Hono<{ Bindings: WorkerEnv; Variables: Variables }>({
   strict: true,
@@ -96,7 +60,7 @@ app.use("*", async (context, next) => {
       requestCompletedEvent({
         requestId,
         method: context.req.method,
-        route: safeRoute(context),
+        route: safeRoute(context.req.routePath),
         status: context.res.status,
         durationMs: Math.max(0, Date.now() - startedAt),
       })
@@ -104,434 +68,23 @@ app.use("*", async (context, next) => {
   );
 });
 
-app.get("/health", (context) =>
-  json({ status: "ok", environment: context.env.ENVIRONMENT })
-);
-app.get("/ready", (context) =>
-  configurationReady(context.env) &&
-  parseObservabilitySinkMode(context.env.OBSERVABILITY_SINK_MODE) !== null
-    ? json({
-        status: "ready",
-        environment: context.env.ENVIRONMENT,
-        observability_sink_mode: context.env.OBSERVABILITY_SINK_MODE,
-      })
-    : backendError("service_unavailable", "retry", 503, true)
-);
+for (const route of publicRoutes) {
+  app.on(route.method, route.path, (context) =>
+    route.handle(fromHono(context))
+  );
+}
 
 app.use("/v1/*", async (context, next) => {
-  // Authorization is gated on the SAME readiness predicate `/ready` reports,
-  // because a readiness signal is not an enforcement point: Cloudflare routes
-  // request traffic regardless of what `/ready` returns, so a deployment whose
-  // API_TOKEN secret is unset still serves `/v1/*`. That matters here and not
-  // merely in principle: TextEncoder yields an EMPTY expectation for an absent
-  // or empty secret, and an empty bearer credential ("Authorization: Bearer ")
-  // encodes to the same empty value, so the constant-time comparison below
-  // returns true and authenticates an anonymous caller. Wrangler does not fail
-  // a deploy when a secret referenced solely in code is unset, so this is a
-  // reachable configuration, not a hypothetical one. Refuse before comparing.
-  if (!configurationReady(context.env)) {
-    // Operator-visible, client-opaque: the caller still gets the ordinary
-    // refusal, so a misconfigured deployment is not advertised over the wire.
-    console.error(
-      JSON.stringify(
-        configurationNotReadyEvent({
-          requestId: context.get("requestId") ?? "unavailable",
-          route: safeRoute(context),
-        })
-      )
-    );
-    return backendError("unauthorized", "reauthenticate", 401);
-  }
-  const authorization = context.req.header("authorization");
-  if (authorization === undefined || !authorization.startsWith("Bearer ")) {
-    return backendError("unauthorized", "reauthenticate", 401);
-  }
-  const supplied = new TextEncoder().encode(
-    authorization.slice("Bearer ".length)
-  );
-  const expected = new TextEncoder().encode(context.env.API_TOKEN);
-  if (!constantTimeEqual(supplied, expected)) {
-    return backendError("unauthorized", "reauthenticate", 401);
-  }
-  const clientId = context.req.header("x-omi-client-id");
-  // Staging isolation by client id, not production multi-tenant auth.
-  // After Bearer auth, each validated x-omi-client-id is its own data
-  // partition for chat, tasks, attachments, conversations, and device
-  // sessions. Settings display name/email/plan stay staging labels.
-  if (clientId === undefined || !isClientId(clientId)) {
-    return backendError("bad_request", "edit_request", 400);
-  }
-  context.set("accountId", clientId);
+  const refusal = authorizeV1(fromHono(context));
+  if (refusal !== null) return refusal;
   await next();
 });
 
-app.get("/v1/settings", async (context) => {
-  const db = context.env.DB;
-  if (db === undefined)
-    return backendError("service_unavailable", "retry", 503, true);
-  return json(
-    await readSettings(
-      db,
-      context.get("accountId"),
-      {
-        displayName: context.env.STAGING_DISPLAY_NAME,
-        email: context.env.STAGING_EMAIL,
-      },
-      context.env.STAGING_PLAN_LABEL,
-      context.env.STAGING_CHAT_LIMIT
-    )
+for (const route of v1Routes) {
+  app.on(route.method, route.path, (context) =>
+    route.handle(fromHono(context))
   );
-});
-
-app.get("/v1/chat-messages", async (context) => {
-  const query = new URL(context.req.url).searchParams;
-  if (
-    [...query.keys()].some((key) => key !== "limit" && key !== "olderCursor") ||
-    query.getAll("limit").length > 1 ||
-    query.getAll("olderCursor").length > 1
-  ) {
-    return backendError("bad_request", "edit_request", 400);
-  }
-  const limit = parseLimit(query.get("limit") ?? undefined);
-  const olderCursor = query.get("olderCursor") ?? undefined;
-  if (limit === null || olderCursor === "")
-    return backendError("bad_request", "edit_request", 400);
-  const db = context.env.DB;
-  if (db === undefined)
-    return backendError("service_unavailable", "retry", 503, true);
-  const history = await readHistory(
-    db,
-    context.get("accountId"),
-    limit,
-    olderCursor
-  );
-  return history === "invalid_cursor"
-    ? backendError("bad_request", "edit_request", 400)
-    : json(history);
-});
-
-app.post("/v1/chat-messages", async (context) => {
-  const parsed = await readBoundedJson(context.req.raw, 65_536);
-  if (parsed.kind === "too_large")
-    return backendError("attachment_too_large", "edit_request", 413);
-  if (parsed.kind === "invalid")
-    return backendError("bad_request", "edit_request", 400);
-  const body = parsed.value;
-  if (!isChatCreate(body))
-    return backendError("validation", "edit_request", 422);
-  const db = context.env.DB;
-  if (db === undefined)
-    return backendError("service_unavailable", "retry", 503, true);
-  const resolved = await resolveAttachmentsForAdmit(
-    db,
-    context.get("accountId"),
-    body.attachmentIds,
-    body.id
-  );
-  if (resolved.kind === "rejected")
-    return backendError("attachment_rejected", "edit_request", 422);
-  const stub = account(context);
-  const admission = await stub.admit(
-    context.get("accountId"),
-    body,
-    context.env.STAGING_CHAT_LIMIT
-  );
-  if (admission === "conflict") {
-    return backendError("client_message_id_conflict", "edit_request", 409);
-  }
-  if (admission === "entitlement") {
-    return backendError("entitlement", "upgrade", 402);
-  }
-  if (admission === "attachment_rejected") {
-    return backendError("attachment_rejected", "edit_request", 422);
-  }
-  console.log(
-    JSON.stringify(
-      generationAdmittedEvent({
-        requestId: context.get("requestId") ?? "unavailable",
-        generationId: admission.generation.id,
-      })
-    )
-  );
-  return json(
-    { message: admission.message, generation: admission.generation },
-    admission.created ? 201 : 200
-  );
-});
-
-app.get("/v1/chat-generations/:id/events", async (context) => {
-  const generationId = context.req.param("id");
-  const target = new URL("https://account.internal/events");
-  target.searchParams.set("generationId", generationId);
-  const response = await account(context).fetch(
-    new Request(target, { headers: context.req.raw.headers })
-  );
-  return response.status === 404
-    ? backendError("not_found", "refresh_history", 404)
-    : response;
-});
-
-app.delete("/v1/chat-generations/:id", async (context) => {
-  const cancellation = await account(context).cancel(
-    context.get("accountId"),
-    context.req.param("id")
-  );
-  if (cancellation === "not_found")
-    return backendError("not_found", "refresh_history", 404);
-  return cancellation === "terminal"
-    ? new Response(null, {
-        status: 204,
-        headers: { "cache-control": "no-store" },
-      })
-    : json({ cancellation: { state: "accepted" } }, 202);
-});
-
-app.post("/v1/chat-attachments", async (context) => {
-  const r2 = context.env.ATTACHMENTS;
-  if (r2 === undefined)
-    return backendError("service_unavailable", "retry", 503, true);
-  const parsed = await readBoundedJson(context.req.raw, 65_536);
-  if (parsed.kind === "too_large")
-    return backendError("attachment_too_large", "edit_request", 413);
-  if (parsed.kind === "invalid")
-    return backendError("bad_request", "edit_request", 400);
-  const request = parseAttachmentStageRequest(parsed.value);
-  if (request === null)
-    return backendError("attachment_rejected", "edit_request", 422);
-  const db = context.env.DB;
-  if (db === undefined)
-    return backendError("service_unavailable", "retry", 503, true);
-  const signedConfig = parseSignedUploadConfig(context.env);
-  if (signedConfig === null)
-    return backendError("service_unavailable", "retry", 503, true);
-  const signer = makeR2UploadUrlSigner(signedConfig);
-  const result = await stageAttachment(
-    db,
-    context.get("accountId"),
-    request,
-    ATTACHMENT_CAPABILITIES,
-    "attachments",
-    signer
-  );
-  if (result.kind === "conflict")
-    return backendError("attachment_rejected", "edit_request", 409);
-  return json(result.response, result.created ? 201 : 200);
-});
-
-app.post("/v1/chat-attachments/:id/complete", async (context) => {
-  const r2 = context.env.ATTACHMENTS;
-  const ingest = context.env.ATTACHMENT_INGEST;
-  const db = context.env.DB;
-  if (r2 === undefined || ingest === undefined || db === undefined)
-    return backendError("service_unavailable", "retry", 503, true);
-  const attachmentId = context.req.param("id");
-  if (
-    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(
-      attachmentId
-    )
-  )
-    return backendError("bad_request", "edit_request", 400);
-  const outcome = await completeAttachment(
-    db,
-    r2,
-    ingest,
-    context.get("accountId"),
-    attachmentId,
-    Date.now()
-  );
-  switch (outcome.kind) {
-    case "accepted":
-      return json({ attachment: outcome.attachment }, 202);
-    case "queued":
-      return json({ attachment: outcome.attachment }, 202);
-    case "ingested":
-      return json({ attachment: outcome.attachment }, 200);
-    case "not_found":
-      return backendError("not_found", "refresh_history", 404);
-    case "expired":
-      return backendError("attachment_expired", "edit_request", 410);
-    case "absent":
-      return backendError("attachment_not_uploaded", "retry", 422, true);
-    case "mismatch":
-      return backendError("attachment_metadata_mismatch", "edit_request", 422);
-    case "conflict":
-      return backendError("attachment_rejected", "edit_request", 409);
-  }
-});
-
-app.post("/v1/device-sessions", async (context) => {
-  const r2 = context.env.ATTACHMENTS;
-  const db = context.env.DB;
-  if (r2 === undefined || db === undefined)
-    return backendError("service_unavailable", "retry", 503, true);
-  const parsed = await readBoundedJson(context.req.raw, 65_536);
-  if (parsed.kind === "too_large")
-    return backendError("attachment_too_large", "edit_request", 413);
-  if (parsed.kind === "invalid")
-    return backendError("bad_request", "edit_request", 400);
-  const request = parseDeviceSessionCreate(parsed.value);
-  if (request === null) return backendError("validation", "edit_request", 422);
-  return json(
-    {
-      session: await openDeviceSession(
-        db,
-        context.get("accountId"),
-        request,
-        Date.now()
-      ),
-    },
-    201
-  );
-});
-
-app.post("/v1/device-sessions/:id/audio", async (context) => {
-  const r2 = context.env.ATTACHMENTS;
-  const db = context.env.DB;
-  if (r2 === undefined || db === undefined)
-    return backendError("service_unavailable", "retry", 503, true);
-  const parsed = await readBoundedJson(context.req.raw, 1_572_864);
-  if (parsed.kind === "too_large")
-    return backendError("attachment_too_large", "edit_request", 413);
-  if (parsed.kind === "invalid")
-    return backendError("bad_request", "edit_request", 400);
-  const request = parseDeviceSessionAudio(parsed.value);
-  if (request === null) return backendError("validation", "edit_request", 422);
-  const outcome = await appendDeviceSessionAudio(
-    db,
-    r2,
-    context.get("accountId"),
-    context.req.param("id"),
-    request.bytes,
-    Date.now()
-  );
-  switch (outcome.kind) {
-    case "ok":
-      return json({ session: outcome.session });
-    case "not_found":
-      return backendError("not_found", "refresh_history", 404);
-    case "conflict":
-      return backendError("conflict", "edit_request", 409);
-    case "too_large":
-      return backendError("attachment_too_large", "edit_request", 413);
-  }
-});
-
-app.post("/v1/device-sessions/:id/complete", async (context) => {
-  const r2 = context.env.ATTACHMENTS;
-  const db = context.env.DB;
-  if (r2 === undefined || db === undefined)
-    return backendError("service_unavailable", "retry", 503, true);
-  const outcome = await completeDeviceSession(
-    db,
-    context.get("accountId"),
-    context.req.param("id"),
-    Date.now()
-  );
-  return outcome.kind === "not_found"
-    ? backendError("not_found", "refresh_history", 404)
-    : json({ session: outcome.session });
-});
-
-app.get("/v1/device-sessions", async (context) => {
-  const r2 = context.env.ATTACHMENTS;
-  const db = context.env.DB;
-  if (r2 === undefined || db === undefined)
-    return backendError("service_unavailable", "retry", 503, true);
-  return json({
-    sessions: await listDeviceSessions(db, context.get("accountId")),
-  });
-});
-
-app.get("/v1/conversations", async (context) => {
-  const query = new URL(context.req.url).searchParams;
-  const keys = [...query.keys()];
-  const hasOffset = query.has("offset");
-  if (hasOffset) {
-    if (
-      keys.some((key) => key !== "limit" && key !== "offset") ||
-      query.getAll("limit").length > 1 ||
-      query.getAll("offset").length > 1
-    ) {
-      return backendError("bad_request", "edit_request", 400);
-    }
-    const limit = parseLimit(query.get("limit") ?? undefined);
-    const offset = parseOffset(query.get("offset") ?? undefined);
-    if (limit === null || offset === null)
-      return backendError("bad_request", "edit_request", 400);
-    const db = context.env.DB;
-    if (db === undefined) return json([]);
-    const items = await readConversations(db, context.get("accountId"));
-    return json(
-      items
-        .slice(offset, offset + limit)
-        .map((item) => toLegacyConversation(item))
-    );
-  }
-  if (
-    keys.some((key) => key !== "limit" && key !== "cursor") ||
-    query.getAll("limit").length > 1 ||
-    query.getAll("cursor").length > 1
-  ) {
-    return backendError("bad_request", "edit_request", 400);
-  }
-  const limit = parseLimit(query.get("limit") ?? undefined);
-  const cursor = query.get("cursor") ?? undefined;
-  if (limit === null || cursor === "")
-    return backendError("bad_request", "edit_request", 400);
-  const db = context.env.DB;
-  if (db === undefined) return json(conversationPage([], false, null));
-  const page = paginateConversations(
-    await readConversations(db, context.get("accountId")),
-    limit,
-    cursor
-  );
-  return page === "invalid_cursor"
-    ? backendError("bad_request", "edit_request", 400)
-    : json(page);
-});
-app.get("/v1/memories", async (context) => {
-  const query = new URL(context.req.url).searchParams;
-  if (
-    [...query.keys()].some((key) => key !== "limit" && key !== "cursor") ||
-    query.getAll("limit").length > 1 ||
-    query.getAll("cursor").length > 1
-  ) {
-    return backendError("bad_request", "edit_request", 400);
-  }
-  const limit = parseTaskLimit(query.get("limit"));
-  const cursor = query.get("cursor") ?? undefined;
-  if (cursor === "") return backendError("bad_request", "edit_request", 400);
-  if (context.env.AI !== undefined) {
-    const recalled = await createVectorizeRetrievalBoundary(
-      context.env.VECTORIZE === undefined
-        ? { AI: context.env.AI }
-        : { AI: context.env.AI, VECTORIZE: context.env.VECTORIZE },
-      noCanonicalMemoryStore
-    ).query({
-      accountId: context.get("accountId"),
-      queryText: "",
-      topK: limit,
-    });
-    // No D1 memory table: ids cannot be revalidated, so hits stay empty.
-    void recalled;
-  }
-  return json(emptyPage("recall-completeness-v1"));
-});
-app.get("/v1/tasks", async (context) => {
-  const query = new URL(context.req.url).searchParams;
-  if (
-    [...query.keys()].some((key) => key !== "limit" && key !== "cursor") ||
-    query.getAll("limit").length > 1 ||
-    query.getAll("cursor").length > 1
-  ) {
-    return backendError("bad_request", "edit_request", 400);
-  }
-  const db = context.env.DB;
-  if (db === undefined) return json(emptyPage("tasks-completeness-v1"));
-  const limit = parseTaskLimit(query.get("limit"));
-  const cursor = query.get("cursor") ?? undefined;
-  return json(await readTasks(db, context.get("accountId"), limit, cursor));
-});
+}
 
 app.notFound(() => backendError("not_found", "edit_request", 404));
 app.onError((error, context) => {
@@ -540,7 +93,7 @@ app.onError((error, context) => {
       requestFailedEvent({
         requestId: context.get("requestId") ?? "unavailable",
         name: error.name,
-        route: safeRoute(context),
+        route: safeRoute(context.req.routePath),
       })
     )
   );
@@ -590,134 +143,30 @@ export {
 } from "./retrieval";
 export default handler;
 
-function safeRoute(context: Pick<ObservableContext, "req">): string {
-  const route = context.req.routePath;
-  return route.startsWith("/") && route.length <= 200 ? route : "unmatched";
-}
-
-function account(context: { env: WorkerEnv; get(key: "accountId"): string }) {
-  return context.env.ACCOUNTS.getByName(context.get("accountId"));
-}
-
-function constantTimeEqual(
-  supplied: Uint8Array,
-  expected: Uint8Array
-): boolean {
-  const length = Math.max(supplied.byteLength, expected.byteLength);
-  let difference = supplied.byteLength ^ expected.byteLength;
-  for (let index = 0; index < length; index += 1) {
-    difference |= (supplied[index] ?? 0) ^ (expected[index] ?? 0);
-  }
-  return difference === 0;
-}
-
-function configurationReady(env: WorkerEnv): boolean {
-  const base =
-    typeof env.API_TOKEN === "string" &&
-    env.API_TOKEN.length > 0 &&
-    typeof env.STAGING_ACCOUNT_ID === "string" &&
-    env.STAGING_ACCOUNT_ID.length > 0 &&
-    typeof env.AI_MODEL === "string" &&
-    env.AI_MODEL.length > 0 &&
-    Number.isSafeInteger(env.STAGING_CHAT_LIMIT) &&
-    env.STAGING_CHAT_LIMIT >= 0 &&
-    env.ACCOUNTS !== undefined &&
-    env.AI !== undefined &&
-    env.DB !== undefined &&
-    observabilityConfigured(env);
-  if (!base) return false;
-  if (gatewayModeEnabled(env)) return gatewayConfig(env) !== null;
-  return true;
-}
-
-function parseLimit(value: string | undefined): number | null {
-  if (value === undefined) return 50;
-  if (!/^(?:[1-9]|[1-9][0-9]|100)$/.test(value)) return null;
-  return Number(value);
-}
-
-function parseOffset(value: string | undefined): number | null {
-  if (value === undefined) return 0;
-  if (!/^(?:0|[1-9][0-9]{0,8})$/.test(value)) return null;
-  return Number(value);
-}
-
-async function readBoundedJson(
-  request: Request,
-  maxBytes: number
-): Promise<
-  { kind: "ok"; value: unknown } | { kind: "invalid" } | { kind: "too_large" }
-> {
-  const declaredLength = request.headers.get("content-length");
-  if (
-    declaredLength !== null &&
-    (!/^\d+$/.test(declaredLength) || Number(declaredLength) > maxBytes)
-  ) {
-    return { kind: "too_large" };
-  }
-  if (request.body === null) return { kind: "invalid" };
-  const reader = request.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let length = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    length += value.byteLength;
-    if (length > maxBytes) {
-      await reader.cancel();
-      return { kind: "too_large" };
-    }
-    chunks.push(value);
-  }
-  const bytes = new Uint8Array(length);
-  let offset = 0;
-  for (const chunk of chunks) {
-    bytes.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  try {
-    return {
-      kind: "ok",
-      value: JSON.parse(
-        new TextDecoder("utf-8", { fatal: true }).decode(bytes)
-      ) as unknown,
-    };
-  } catch {
-    return { kind: "invalid" };
-  }
-}
-
-function emptyPage(
-  completenessVersion: "recall-completeness-v1" | "tasks-completeness-v1"
-) {
+function fromHono(context: {
+  env: WorkerEnv;
+  req: {
+    method: string;
+    url: string;
+    raw: Request;
+    routePath: string;
+    header(name: string): string | undefined;
+    param(name: string): string;
+  };
+  get(key: "accountId" | "requestId"): string;
+  set(key: "accountId" | "requestId", value: string): void;
+}): CoreContext {
   return {
-    contractVersion: SYNTHESIZED_READ_CONTRACT_VERSION,
-    items: [],
-    window: {
-      status: "complete",
-      complete: true,
-      hasMore: false,
-      nextCursor: null,
+    env: context.env as CoreEnv,
+    req: {
+      method: context.req.method,
+      url: context.req.url,
+      raw: context.req.raw,
+      routePath: context.req.routePath,
+      header: (name) => context.req.header(name),
+      param: (name) => context.req.param(name),
     },
-    completeness: {
-      version: completenessVersion,
-      status: "complete",
-      reasons: [],
-      frontiers:
-        completenessVersion === "tasks-completeness-v1"
-          ? {
-              declaredFrontier: "frontier-v1:tasks-declared",
-              newestAppliedFrontier: "frontier-v1:tasks-declared",
-              missingAppliedFrontierReason: null,
-            }
-          : {
-              declaredFrontier: "frontier-v1:declared",
-              newestSearchedAcceptedFrontier: null,
-              missingAcceptedFrontierReason: "no_accepted_work",
-              newestSearchedStmFrontier: null,
-              missingStmFrontierReason: "no_eligible_stm",
-            },
-    },
-    absence: { kind: "query_gap" },
+    get: (key) => context.get(key),
+    set: (key, value) => context.set(key, value),
   };
 }

--- a/apps/backend-worker/test/http-adapters.contract.test.ts
+++ b/apps/backend-worker/test/http-adapters.contract.test.ts
@@ -5,9 +5,9 @@ import { createD1Mock } from "./d1-mock";
 
 let honoFetch: (
   request: Request,
-  env: unknown,
+  env: CoreEnv,
   ctx: unknown
-) => Promise<Response>;
+) => Response | Promise<Response>;
 let createElysiaApp: typeof import("../src/elysia")["createElysiaApp"];
 
 beforeAll(async () => {
@@ -15,7 +15,7 @@ beforeAll(async () => {
     DurableObject: class {},
   }));
   const worker = await import("../src/index");
-  honoFetch = worker.default.fetch.bind(worker.default);
+  honoFetch = worker.default.fetch.bind(worker.default) as typeof honoFetch;
   ({ createElysiaApp } = await import("../src/elysia"));
 });
 
@@ -89,7 +89,7 @@ function testEnv(): CoreEnv {
       }),
     },
     AI_MODEL: "test-model",
-    AI: { run: async () => ({ response: "test" }) } as CoreEnv["AI"],
+    AI: { run: async () => ({ response: "test" }) },
     STAGING_DISPLAY_NAME: "Test",
     STAGING_EMAIL: "test@example.invalid",
     STAGING_PLAN_LABEL: "Test",
@@ -101,7 +101,7 @@ function testEnv(): CoreEnv {
     OPENROUTER_API_KEY: "",
     ATTACHMENTS: r2Mock,
     DB: d1Mock,
-  };
+  } as CoreEnv;
 }
 
 const adapters = [
@@ -133,7 +133,9 @@ for (const adapter of adapters) {
     test("/health matches the worker contract", async () => {
       const response = await adapter.fetch("/health");
       expect(response.status).toBe(200);
-      expect(await response.json()).toEqual({
+      expect(
+        (await response.json()) as { status: string; environment: string }
+      ).toEqual({
         status: "ok",
         environment: "test",
       });
@@ -142,7 +144,13 @@ for (const adapter of adapters) {
     test("/ready matches the worker contract", async () => {
       const response = await adapter.fetch("/ready");
       expect(response.status).toBe(200);
-      expect(await response.json()).toEqual({
+      expect(
+        (await response.json()) as {
+          status: string;
+          environment: string;
+          observability_sink_mode: string;
+        }
+      ).toEqual({
         status: "ready",
         environment: "test",
         observability_sink_mode: "cloudflare_only",

--- a/apps/backend-worker/test/http-adapters.contract.test.ts
+++ b/apps/backend-worker/test/http-adapters.contract.test.ts
@@ -1,0 +1,168 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { CoreEnv } from "../src/http-core";
+import { createD1Mock } from "./d1-mock";
+
+let honoFetch: (
+  request: Request,
+  env: unknown,
+  ctx: unknown
+) => Promise<Response>;
+let createElysiaApp: typeof import("../src/elysia")["createElysiaApp"];
+
+beforeAll(async () => {
+  void mock.module("cloudflare:workers", () => ({
+    DurableObject: class {},
+  }));
+  const worker = await import("../src/index");
+  honoFetch = worker.default.fetch.bind(worker.default);
+  ({ createElysiaApp } = await import("../src/elysia"));
+});
+
+type StoredObject = { bytes: Uint8Array; contentType: string | undefined };
+
+function createR2Mock(): R2Bucket {
+  const objects = new Map<string, StoredObject>();
+  return {
+    async put(
+      key: string,
+      value: unknown,
+      options?: { httpMetadata?: { contentType?: string } }
+    ) {
+      const bytes =
+        value instanceof Uint8Array
+          ? value
+          : value instanceof ArrayBuffer
+          ? new Uint8Array(value)
+          : typeof value === "string"
+          ? new TextEncoder().encode(value)
+          : new Uint8Array();
+      objects.set(key, {
+        bytes,
+        contentType: options?.httpMetadata?.contentType,
+      });
+      return { key, size: bytes.byteLength } as never;
+    },
+    async get() {
+      return null;
+    },
+    async head() {
+      return null;
+    },
+    async delete() {},
+    async list() {
+      return { objects: [], truncated: false } as never;
+    },
+  } as never;
+}
+
+const executionContext = {
+  waitUntil: (_promise: Promise<unknown>) => undefined,
+  passThroughOnException: () => undefined,
+  props: {},
+};
+
+const authenticatedHeaders = {
+  authorization: "Bearer test-token",
+  "x-omi-client-id": "test-account",
+};
+
+const openBody = {
+  deviceId: "AA:BB:CC:DD:EE:FF",
+  deviceName: "Omi",
+  codec: 21,
+};
+
+let d1Mock: D1Database;
+let r2Mock: R2Bucket;
+
+function testEnv(): CoreEnv {
+  return {
+    ENVIRONMENT: "test",
+    API_TOKEN: "test-token",
+    STAGING_ACCOUNT_ID: "test-account",
+    ACCOUNTS: {
+      getByName: () => ({
+        admit: async () => "conflict" as const,
+        cancel: async () => "not_found" as const,
+        fetch: async () => new Response(""),
+      }),
+    },
+    AI_MODEL: "test-model",
+    AI: { run: async () => ({ response: "test" }) } as CoreEnv["AI"],
+    STAGING_DISPLAY_NAME: "Test",
+    STAGING_EMAIL: "test@example.invalid",
+    STAGING_PLAN_LABEL: "Test",
+    STAGING_CHAT_LIMIT: 10,
+    OBSERVABILITY_SINK_MODE: "cloudflare_only",
+    OPENROUTER_GATEWAY_ENABLED: "false",
+    OPENROUTER_MODEL: "",
+    OPENROUTER_GATEWAY_URL: "",
+    OPENROUTER_API_KEY: "",
+    ATTACHMENTS: r2Mock,
+    DB: d1Mock,
+  };
+}
+
+const adapters = [
+  {
+    name: "hono",
+    fetch: (path: string, init?: RequestInit) =>
+      honoFetch(
+        new Request(`https://worker.test${path}`, init),
+        testEnv(),
+        executionContext
+      ),
+  },
+  {
+    name: "elysia",
+    fetch: (path: string, init?: RequestInit) =>
+      createElysiaApp(testEnv()).fetch(
+        new Request(`https://worker.test${path}`, init)
+      ),
+  },
+] as const;
+
+beforeEach(() => {
+  d1Mock = createD1Mock();
+  r2Mock = createR2Mock();
+});
+
+for (const adapter of adapters) {
+  describe(`${adapter.name} shared HTTP core`, () => {
+    test("/health matches the worker contract", async () => {
+      const response = await adapter.fetch("/health");
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        status: "ok",
+        environment: "test",
+      });
+    });
+
+    test("/ready matches the worker contract", async () => {
+      const response = await adapter.fetch("/ready");
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        status: "ready",
+        environment: "test",
+        observability_sink_mode: "cloudflare_only",
+      });
+    });
+
+    test("device-session open uses the shared handler", async () => {
+      const response = await adapter.fetch("/v1/device-sessions", {
+        method: "POST",
+        headers: authenticatedHeaders,
+        body: JSON.stringify(openBody),
+      });
+      expect(response.status).toBe(201);
+      const body = (await response.json()) as {
+        session: { deviceId: string; codec: number; state: string };
+      };
+      expect(body.session.deviceId).toBe("AA:BB:CC:DD:EE:FF");
+      expect(body.session.codec).toBe(21);
+      expect(body.session.state).toBe("open");
+      expect(body.session).not.toHaveProperty("transcript");
+    });
+  });
+}

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "@omi-core/contracts": "workspace:*",
         "@omi-core/kernel": "workspace:*",
         "@omi-core/ratified-contracts": "workspace:*",
+        "elysia": "^1.4.30",
         "hono": "4.12.26",
       },
       "devDependencies": {
@@ -405,6 +406,8 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="],
 
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
+
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
 
     "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
@@ -741,6 +744,10 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
@@ -1067,6 +1074,8 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.407", "", {}, "sha512-4R8XgQOdfxexCd/u63lRm6wCHjECwI45MV9wxAs2ggtfWe2hwlo1ql97jKsju2IcJ+jFSTwBssyYoiWhh7mauQ=="],
 
+    "elysia": ["elysia@1.4.30", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-S2qqV0CbM4faB1hQQ5IYoeYnAUinjHlzRduxaBc4OoNqh0GjOc8k6tt3hv5ozWcG6Svr6hugw6JL4zNke4jwfA=="],
+
     "emittery": ["emittery@0.13.1", "", {}, "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -1157,6 +1166,8 @@
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
+    "exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
+
     "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
     "exit": ["exit@0.1.2", "", {}, "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ=="],
@@ -1166,6 +1177,8 @@
     "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
+
+    "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -1188,6 +1201,8 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "file-entry-cache": ["file-entry-cache@6.0.1", "", { "dependencies": { "flat-cache": "^3.0.4" } }, "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg=="],
+
+    "file-type": ["file-type@22.0.2", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.5", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0" } }, "sha512-0H8TsCUGBLx+V5adH3EY52hTAcyLKbV1D4gq5cIOJ6DnQAHeV9Z2Hhuc5CoBX4YmvB2oL+JIC84z0qO7JsCoNw=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
@@ -1557,6 +1572,8 @@
 
     "mem": ["mem@4.3.0", "", { "dependencies": { "map-age-cleaner": "^0.1.1", "mimic-fn": "^2.0.0", "p-is-promise": "^2.0.0" } }, "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w=="],
 
+    "memoirist": ["memoirist@0.4.0", "", {}, "sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg=="],
+
     "memoize-one": ["memoize-one@5.2.1", "", {}, "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
@@ -1668,6 +1685,8 @@
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
     "open": ["open@6.4.0", "", { "dependencies": { "is-wsl": "^1.1.0" } }, "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg=="],
+
+    "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -1931,6 +1950,8 @@
 
     "strnum": ["strnum@1.1.2", "", {}, "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA=="],
 
+    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
+
     "styleq": ["styleq@0.1.3", "", {}, "sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA=="],
 
     "sudo-prompt": ["sudo-prompt@9.2.1", "", {}, "sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw=="],
@@ -1961,6 +1982,8 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "ts-api-utils": ["ts-api-utils@1.4.3", "", { "peerDependencies": { "typescript": ">=4.2.0" } }, "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw=="],
@@ -1988,6 +2011,8 @@
     "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
 
     "ua-parser-js": ["ua-parser-js@1.0.41", "", { "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,8 @@
         "@omi-core/contracts": "workspace:*",
         "@omi-core/kernel": "workspace:*",
         "@omi-core/ratified-contracts": "workspace:*",
-        "elysia": "^1.4.30",
+        "@sinclair/typebox": "0.34.41",
+        "elysia": "1.4.30",
         "hono": "4.12.26",
       },
       "devDependencies": {
@@ -732,7 +733,7 @@
 
     "@sideway/pinpoint": ["@sideway/pinpoint@2.0.0", "", {}, "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="],
 
-    "@sinclair/typebox": ["@sinclair/typebox@0.27.12", "", {}, "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g=="],
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.41", "", {}, "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
 
@@ -2157,6 +2158,8 @@
     "@istanbuljs/load-nyc-config/js-yaml": ["js-yaml@3.15.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag=="],
 
     "@istanbuljs/load-nyc-config/resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.27.12", "", {}, "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g=="],
 
     "@nicolo-ribaudo/eslint-scope-5-internals/eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
 

--- a/react-native/__tests__/macOSNativeBoundary.test.ts
+++ b/react-native/__tests__/macOSNativeBoundary.test.ts
@@ -98,6 +98,11 @@ test('pairs the macOS backend origin and credentials in one validated policy', (
   expect(source).toContain('firebase-rest-tokens');
   expect(source).toContain('kSecUseAuthenticationUIFail');
   expect(source).toContain('environment[@"OMI_LOCAL_BACKEND_URL"]');
+  expect(source).toContain('environment[@"OMI_V5_BACKEND_URL"]');
+  expect(source).toContain('OmiValidatedV5URL');
+  expect(source).toContain('OmiIsCaptureBackendPath');
+  expect(source).toContain('OmiRequestBaseURL');
+  expect(source).toContain('.workers.dev');
   expect(source).toContain('environment[@"OMI_DEV_BACKEND"]');
   expect(source).toContain('http://127.0.0.1:8787');
   expect(source).toContain('NSURL URLWithString:@"http://127.0.0.1:4851"');

--- a/react-native/__tests__/omiNative.test.ts
+++ b/react-native/__tests__/omiNative.test.ts
@@ -46,9 +46,12 @@ test('android registers a credential-bearing OmiBackend transport', () => {
   expect(backend).toContain('https://api.omi.me');
   expect(backend).toContain('OMI_LOCAL_API_TOKEN');
   expect(backend).toContain('OMI_LOCAL_API_CLIENT_ID');
+  expect(backend).toContain('OMI_V5_BACKEND_URL');
+  expect(backend).toContain('validatedV5URL');
+  expect(backend).toContain('isCaptureBackendPath');
   expect(backend).toContain('x-omi-client-id');
   expect(backend).toContain('Bearer ');
-  expect(backend).not.toContain('workers.dev');
+  expect(backend).toContain('.workers.dev');
   expect(backend).toContain('Android generation streaming is unavailable');
   expect(pack).toContain('OmiBackendModule(reactContext)');
 });

--- a/react-native/__tests__/v5BackendOrigin.test.ts
+++ b/react-native/__tests__/v5BackendOrigin.test.ts
@@ -1,0 +1,98 @@
+import {
+  CLOUD_BACKEND_ORIGIN,
+  LOCAL_BACKEND_ORIGIN,
+  V5_BACKEND_URL_ENV,
+  isCaptureBackendPath,
+  resolveNativeRequestOrigin,
+  validateLoopbackBackendUrl,
+  validateV5BackendUrl,
+} from '../src/v5BackendOrigin';
+
+const workerOrigin = 'https://omi-v5-backend-staging.example.workers.dev';
+
+test('allowlisted worker URL is used for device-session capture', () => {
+  expect(validateV5BackendUrl(workerOrigin)?.origin).toBe(workerOrigin);
+  expect(
+    resolveNativeRequestOrigin({
+      path: '/v1/device-sessions',
+      v5BackendUrl: workerOrigin,
+    }),
+  ).toEqual({ok: true, origin: workerOrigin});
+  expect(
+    resolveNativeRequestOrigin({
+      path: '/v1/device-sessions/11111111-2222-3333-4444-555555555555/audio',
+      v5BackendUrl: workerOrigin,
+    }),
+  ).toEqual({ok: true, origin: workerOrigin});
+  expect(V5_BACKEND_URL_ENV).toBe('OMI_V5_BACKEND_URL');
+});
+
+test('http and credentialed V5 URLs are rejected', () => {
+  expect(
+    validateV5BackendUrl('http://omi-v5-backend-staging.example.workers.dev'),
+  ).toBeNull();
+  expect(validateV5BackendUrl('http://127.0.0.1:8787')).toBeNull();
+  expect(
+    validateV5BackendUrl(
+      'https://user:secret@omi-v5-backend-staging.example.workers.dev',
+    ),
+  ).toBeNull();
+  expect(
+    resolveNativeRequestOrigin({
+      path: '/v1/device-sessions',
+      v5BackendUrl: 'http://omi-v5-backend-staging.example.workers.dev',
+    }),
+  ).toEqual({ok: false, reason: 'rejected'});
+});
+
+test('random hosts are rejected', () => {
+  expect(validateV5BackendUrl('https://evil.example')).toBeNull();
+  expect(validateV5BackendUrl('https://example.com')).toBeNull();
+  expect(validateV5BackendUrl('https://workers.dev')).toBeNull();
+  expect(
+    resolveNativeRequestOrigin({
+      path: '/v1/device-sessions',
+      v5BackendUrl: 'https://evil.example',
+    }),
+  ).toEqual({ok: false, reason: 'rejected'});
+});
+
+test('loopback still works for local backend and https V5', () => {
+  expect(validateLoopbackBackendUrl(LOCAL_BACKEND_ORIGIN)?.origin).toBe(
+    LOCAL_BACKEND_ORIGIN,
+  );
+  expect(
+    resolveNativeRequestOrigin({
+      path: '/v1/device-sessions',
+      localSelected: true,
+      localBackendUrl: LOCAL_BACKEND_ORIGIN,
+    }),
+  ).toEqual({ok: true, origin: LOCAL_BACKEND_ORIGIN});
+  expect(validateV5BackendUrl('https://127.0.0.1')?.origin).toBe(
+    'https://127.0.0.1',
+  );
+  expect(
+    resolveNativeRequestOrigin({
+      path: '/v1/device-sessions',
+      v5BackendUrl: 'https://localhost',
+    }),
+  ).toEqual({ok: true, origin: 'https://localhost'});
+});
+
+test('old-cloud reads stay on api.omi.me when V5 is configured', () => {
+  expect(
+    resolveNativeRequestOrigin({
+      path: '/v1/settings',
+      v5BackendUrl: workerOrigin,
+    }),
+  ).toEqual({ok: true, origin: CLOUD_BACKEND_ORIGIN});
+  expect(
+    resolveNativeRequestOrigin({
+      path: '/v1/conversations',
+      v5BackendUrl: workerOrigin,
+    }),
+  ).toEqual({ok: true, origin: CLOUD_BACKEND_ORIGIN});
+  expect(isCaptureBackendPath('/v1/device-sessions')).toBe(true);
+  expect(isCaptureBackendPath('/v1/device-sessions-extra')).toBe(false);
+  expect(isCaptureBackendPath('/v1/settings')).toBe(false);
+});

--- a/react-native/android/app/src/main/java/com/rnruntime/OmiBackendModule.kt
+++ b/react-native/android/app/src/main/java/com/rnruntime/OmiBackendModule.kt
@@ -27,6 +27,8 @@ private data class BackendPolicy(
   val token: String,
   val clientId: String,
   val kind: CredentialKind,
+  val captureUrl: URI? = null,
+  val captureOriginRequired: Boolean = false,
 )
 
 class OmiBackendModule(context: ReactApplicationContext) : ReactContextBaseJavaModule(context) {
@@ -78,8 +80,10 @@ class OmiBackendModule(context: ReactApplicationContext) : ReactContextBaseJavaM
         putNull("retryAfterSeconds")
       }
     }
-    val url = URL(policy.url.toURL(), path)
-    if (!sameOrigin(url, policy.url.toURL())) {
+    val base = requestBaseURL(policy, path)
+      ?: throw TransportException("OMI_HTTP_UNCONFIGURED", "Native HTTP configuration is unavailable")
+    val url = URL(base.toURL(), path)
+    if (!sameOrigin(url, base.toURL())) {
       throw TransportException("OMI_HTTP_INVALID_REQUEST", "Native HTTP request is unavailable or invalid")
     }
     val connection = (url.openConnection() as HttpURLConnection).apply {
@@ -89,7 +93,7 @@ class OmiBackendModule(context: ReactApplicationContext) : ReactContextBaseJavaM
       doInput = true
       setRequestProperty("authorization", "Bearer ${policy.token}")
       setRequestProperty("x-omi-contract-version", CONTRACT_VERSION)
-      if (policy.kind != CredentialKind.Cloud) {
+      if (policy.kind != CredentialKind.Cloud || !isCloudHost(url.host)) {
         setRequestProperty("x-omi-client-id", policy.clientId)
       }
       if (body != null) {
@@ -138,12 +142,50 @@ class OmiBackendModule(context: ReactApplicationContext) : ReactContextBaseJavaM
     }
     val cloud = environment["OMI_CLOUD_API_TOKEN"].orEmpty().ifEmpty { environment["OMI_API_TOKEN"].orEmpty() }
     if (cloud.isEmpty()) return null
+    val v5URL = environment["OMI_V5_BACKEND_URL"].orEmpty()
     return BackendPolicy(
       url = URI(CLOUD_ORIGIN),
       token = cloud,
       clientId = "omi-android",
       kind = CredentialKind.Cloud,
+      captureOriginRequired = v5URL.isNotEmpty(),
+      captureUrl = if (v5URL.isNotEmpty()) validatedV5URL(v5URL) else null,
     )
+  }
+
+  private fun isCloudHost(host: String?): Boolean {
+    return host?.lowercase(Locale.US) == "api.omi.me"
+  }
+
+  private fun isAllowedV5Host(host: String): Boolean {
+    val normalized = host.lowercase(Locale.US)
+    val loopback = normalized == "localhost" || normalized == "127.0.0.1" || normalized == "::1"
+    if (loopback || isCloudHost(normalized)) return true
+    return normalized.endsWith(".workers.dev") && normalized.length > ".workers.dev".length
+  }
+
+  private fun isCaptureBackendPath(path: String): Boolean {
+    val route = runCatching { URI(path).path }.getOrNull() ?: path
+    return route == "/v1/device-sessions" || route.startsWith("/v1/device-sessions/")
+  }
+
+  private fun requestBaseURL(policy: BackendPolicy, path: String): URI? {
+    if (isCaptureBackendPath(path) && policy.captureOriginRequired) {
+      return policy.captureUrl
+    }
+    return policy.url
+  }
+
+  private fun validatedV5URL(value: String): URI? {
+    val url = runCatching { URI(value) }.getOrNull() ?: return null
+    if (url.scheme?.lowercase(Locale.US) != "https") return null
+    val host = url.host?.lowercase(Locale.US) ?: return null
+    if (url.userInfo != null || !url.query.isNullOrEmpty() || !url.fragment.isNullOrEmpty()) return null
+    if (url.path.isNotEmpty() && url.path != "/") return null
+    if (!isAllowedV5Host(host)) return null
+    val loopback = host == "localhost" || host == "127.0.0.1" || host == "::1"
+    if (!loopback && url.port != -1 && url.port != 443) return null
+    return url
   }
 
   private fun localBaseURL(value: String, developmentBackend: String): URI? {

--- a/react-native/macos/RnRuntime-macOS/OmiBackendModule.mm
+++ b/react-native/macos/RnRuntime-macOS/OmiBackendModule.mm
@@ -15,6 +15,8 @@ typedef NS_ENUM(NSInteger, OmiBackendCredentialKind) {
 
 @interface OmiBackendPolicy : NSObject
 @property(nonatomic, strong) NSURL *url;
+@property(nonatomic, strong) NSURL *captureURL;
+@property(nonatomic) BOOL captureOriginRequired;
 @property(nonatomic, copy) NSString *token;
 @property(nonatomic, copy) NSString *clientId;
 @property(nonatomic) OmiBackendCredentialKind kind;
@@ -32,6 +34,43 @@ static BOOL OmiIsLoopbackHost(NSString *host) {
 
 static BOOL OmiIsCloudHost(NSString *host) {
   return [host.lowercaseString isEqualToString:@"api.omi.me"];
+}
+
+static BOOL OmiIsAllowedV5Host(NSString *host) {
+  NSString *normalized = host.lowercaseString;
+  if (OmiIsLoopbackHost(normalized) || OmiIsCloudHost(normalized)) return YES;
+  return [normalized hasSuffix:@".workers.dev"] &&
+      normalized.length > [@".workers.dev" length];
+}
+
+static BOOL OmiIsCaptureBackendPath(NSString *path) {
+  NSURLComponents *components = [NSURLComponents componentsWithString:path];
+  NSString *route = components.path;
+  return [route isEqualToString:@"/v1/device-sessions"] ||
+      [route hasPrefix:@"/v1/device-sessions/"];
+}
+
+static NSURL *OmiValidatedV5URL(NSString *value) {
+  NSURL *url = value.length > 0 ? [NSURL URLWithString:value] : nil;
+  BOOL validPath = url.path.length == 0 || [url.path isEqualToString:@"/"];
+  if (url == nil || ![url.scheme.lowercaseString isEqualToString:@"https"] ||
+      url.host.length == 0 || url.user.length > 0 || url.password.length > 0 ||
+      !validPath || url.query.length > 0 || url.fragment.length > 0 ||
+      !OmiIsAllowedV5Host(url.host)) {
+    return nil;
+  }
+  if (!OmiIsLoopbackHost(url.host)) {
+    NSInteger port = url.port != nil ? url.port.integerValue : 443;
+    if (port != 443) return nil;
+  }
+  return url;
+}
+
+static NSURL *OmiRequestBaseURL(OmiBackendPolicy *policy, NSString *path) {
+  if (OmiIsCaptureBackendPath(path) && policy.captureOriginRequired) {
+    return policy.captureURL;
+  }
+  return policy.url;
 }
 
 static NSURL *OmiValidatedURL(NSString *value, BOOL requireLoopback) {
@@ -257,6 +296,11 @@ static OmiBackendPolicy *OmiResolvedBackendPolicy(NSDictionary<NSString *, NSStr
   policy.token = [cloud copy];
   policy.clientId = @"omi-macos";
   policy.kind = OmiBackendCredentialKindCloud;
+  NSString *v5URL = environment[@"OMI_V5_BACKEND_URL"];
+  if (v5URL.length > 0) {
+    policy.captureOriginRequired = YES;
+    policy.captureURL = OmiValidatedV5URL(v5URL);
+  }
   return policy;
 }
 
@@ -275,7 +319,8 @@ static BOOL OmiApplyAuthorization(NSMutableURLRequest *request, OmiBackendPolicy
   if (!OmiBackendPolicyIsValid(policy)) return NO;
   [request setValue:[NSString stringWithFormat:@"Bearer %@", policy.token]
       forHTTPHeaderField:@"authorization"];
-  if (policy.kind != OmiBackendCredentialKindCloud) {
+  if (policy.kind != OmiBackendCredentialKindCloud ||
+      !OmiIsCloudHost(request.URL.host)) {
     [request setValue:policy.clientId forHTTPHeaderField:@"x-omi-client-id"];
   }
   return YES;
@@ -540,8 +585,9 @@ RCT_REMAP_METHOD(request,
     reject(@"OMI_HTTP_INVALID_REQUEST", @"Native HTTP request is invalid", nil);
     return;
   }
-  if (!OmiBackendPolicyIsValid(policy) ||
-      ![schemes containsObject:policy.url.scheme.lowercaseString]) {
+  NSURL *baseURL = OmiRequestBaseURL(policy, path);
+  if (!OmiBackendPolicyIsValid(policy) || baseURL == nil ||
+      ![schemes containsObject:baseURL.scheme.lowercaseString]) {
     reject(@"OMI_HTTP_UNCONFIGURED", @"Native HTTP configuration is unavailable", nil);
     return;
   }
@@ -549,15 +595,15 @@ RCT_REMAP_METHOD(request,
     resolve(OmiDevelopmentBackendUnsupportedResponse(requestId));
     return;
   }
-  NSURL *url = [NSURL URLWithString:path relativeToURL:policy.url].absoluteURL;
-  NSInteger basePort = policy.url.port != nil
-      ? policy.url.port.integerValue
-      : ([policy.url.scheme.lowercaseString isEqualToString:@"https"] ? 443 : 80);
+  NSURL *url = [NSURL URLWithString:path relativeToURL:baseURL].absoluteURL;
+  NSInteger basePort = baseURL.port != nil
+      ? baseURL.port.integerValue
+      : ([baseURL.scheme.lowercaseString isEqualToString:@"https"] ? 443 : 80);
   NSInteger requestPort = url.port != nil
       ? url.port.integerValue
       : ([url.scheme.lowercaseString isEqualToString:@"https"] ? 443 : 80);
-  BOOL schemeMatches = url != nil && [url.scheme caseInsensitiveCompare:policy.url.scheme] == NSOrderedSame;
-  BOOL hostMatches = url != nil && [url.host caseInsensitiveCompare:policy.url.host] == NSOrderedSame;
+  BOOL schemeMatches = url != nil && [url.scheme caseInsensitiveCompare:baseURL.scheme] == NSOrderedSame;
+  BOOL hostMatches = url != nil && [url.host caseInsensitiveCompare:baseURL.host] == NSOrderedSame;
   BOOL portMatches = url != nil && requestPort == basePort;
   if (!schemeMatches || !hostMatches || !portMatches) {
     reject(@"OMI_HTTP_INVALID_REQUEST", @"Native HTTP request is unavailable or invalid", nil);

--- a/react-native/src/v5BackendOrigin.ts
+++ b/react-native/src/v5BackendOrigin.ts
@@ -1,0 +1,117 @@
+export const CLOUD_BACKEND_ORIGIN = 'https://api.omi.me';
+export const LOCAL_BACKEND_ORIGIN = 'http://127.0.0.1:8787';
+export const V5_BACKEND_URL_ENV = 'OMI_V5_BACKEND_URL';
+
+export function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.replace(/^\[|\]$/g, '').toLocaleLowerCase();
+  return (
+    normalized === 'localhost' ||
+    normalized === '127.0.0.1' ||
+    normalized === '::1'
+  );
+}
+
+export function isCloudHostname(hostname: string): boolean {
+  return hostname.toLocaleLowerCase() === 'api.omi.me';
+}
+
+export function isAllowedV5Hostname(hostname: string): boolean {
+  const normalized = hostname.replace(/^\[|\]$/g, '').toLocaleLowerCase();
+  if (isLoopbackHostname(normalized) || isCloudHostname(normalized)) {
+    return true;
+  }
+  return (
+    normalized.endsWith('.workers.dev') &&
+    normalized.length > '.workers.dev'.length
+  );
+}
+
+export function isCaptureBackendPath(path: string): boolean {
+  if (!path.startsWith('/') || path.startsWith('//') || path.includes('://')) {
+    return false;
+  }
+  const route = new URL(path, 'https://omi.invalid').pathname;
+  return (
+    route === '/v1/device-sessions' || route.startsWith('/v1/device-sessions/')
+  );
+}
+
+export function validateV5BackendUrl(value: string): URL | null {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  if (
+    url.protocol !== 'https:' ||
+    url.username !== '' ||
+    url.password !== '' ||
+    (url.pathname !== '' && url.pathname !== '/') ||
+    url.search !== '' ||
+    url.hash !== '' ||
+    url.hostname.length === 0 ||
+    !isAllowedV5Hostname(url.hostname)
+  ) {
+    return null;
+  }
+  if (
+    !isLoopbackHostname(url.hostname) &&
+    url.port !== '' &&
+    url.port !== '443'
+  ) {
+    return null;
+  }
+  return url;
+}
+
+export function validateLoopbackBackendUrl(value: string): URL | null {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  if (
+    (url.protocol !== 'http:' && url.protocol !== 'https:') ||
+    url.username !== '' ||
+    url.password !== '' ||
+    (url.pathname !== '' && url.pathname !== '/') ||
+    url.search !== '' ||
+    url.hash !== '' ||
+    !isLoopbackHostname(url.hostname)
+  ) {
+    return null;
+  }
+  return url;
+}
+
+export type NativeOriginResolution =
+  | {ok: true; origin: string}
+  | {ok: false; reason: 'rejected' | 'unconfigured'};
+
+export function resolveNativeRequestOrigin(input: {
+  path: string;
+  v5BackendUrl?: string;
+  localBackendUrl?: string;
+  localSelected?: boolean;
+}): NativeOriginResolution {
+  if (input.localSelected) {
+    const local = validateLoopbackBackendUrl(
+      input.localBackendUrl ?? LOCAL_BACKEND_ORIGIN,
+    );
+    return local === null
+      ? {ok: false, reason: 'rejected'}
+      : {ok: true, origin: local.origin};
+  }
+  if (isCaptureBackendPath(input.path) && input.v5BackendUrl !== undefined) {
+    if (input.v5BackendUrl.length === 0) {
+      return {ok: false, reason: 'unconfigured'};
+    }
+    const v5 = validateV5BackendUrl(input.v5BackendUrl);
+    return v5 === null
+      ? {ok: false, reason: 'rejected'}
+      : {ok: true, origin: v5.origin};
+  }
+  return {ok: true, origin: CLOUD_BACKEND_ORIGIN};
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Point RN/macOS/Android device-session traffic at a validated V5 worker origin, and serve the same `/health` `/ready` `/v1/*` handlers from Hono (Workers) and Elysia (Bun).

## Native transport
- New env: `OMI_V5_BACKEND_URL` (https only, no credentials, origin path only).
- Allowed hosts: loopback, `api.omi.me`, or `*.workers.dev`.
- Device-session paths use that origin when the env is set; Settings/connector old-cloud reads stay on `https://api.omi.me`.
- Loopback `OMI_LOCAL_BACKEND_URL` is unchanged.
- No `workers.dev` default is recorded. None exists in wrangler state or in-repo docs; operators set `OMI_V5_BACKEND_URL` to the real `STAGING_WORKER_URL`.

## HTTP core
- Route/handler logic lives in `apps/backend-worker/src/http-core.ts` as Request/Response functions plus D1/R2-like ports.
- `src/index.ts` remains the Hono Workers app (`fetch` + queue). Existing D1 `028f665e-87df-4329-b794-b0811a6e24a4`, R2 `omi-v5-backend-staging-attachments`, and queue `omi-v5-attachment-ingest` are untouched. `OPENROUTER_GATEWAY_ENABLED` stays `false`. VECTORIZE stays unbound.
- `src/elysia.ts` + `bun run --cwd apps/backend-worker dev:elysia` mount the same routes for local Bun.

## Verification
- `react-native` Jest: `v5BackendOrigin`, `omiNative`, `macOSNativeBoundary`, `deviceSessionClient` — 33 passed.
- `apps/backend-worker`: lint, typecheck, and full package test script — 195 bun tests + 32 vitest passed, including shared Hono/Elysia `/health` `/ready` device-session contract.
- Pre-push `native:test` failed in this VM (`ld` cannot find `-lstdc++`); unrelated to this diff.

Parent can fast-forward `v5` from this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f01c267-06c4-440c-9943-fa6dc6d93419?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f01c267-06c4-440c-9943-fa6dc6d93419&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

