### PR TITLE
fix(desktop): speaker naming works from every surface and for unsynced conversations

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
@@ -243,6 +243,16 @@ extension AppState {
   }
 
   /// Assigns segments to a person or user via bulk API
+  /// When a backend bulk-assign fails, only "the conversation does not exist
+  /// there yet" may fall back to a local-first assignment — any other failure
+  /// (auth, validation, server error) must surface to the user, because the
+  /// backend HAS the conversation and rejected the change.
+  enum SpeakerAssignmentFallbackPolicy {
+    static func keepsAssignmentLocally(statusCode: Int) -> Bool {
+      statusCode == 404
+    }
+  }
+
   func assignSpeakerToSegments(
     conversationId: String,
     segmentIds: [String],
@@ -257,36 +267,72 @@ extension AppState {
         personId: personId
       )
       log("People: Assigned \(segmentIds.count) segments in conversation \(conversationId)")
-      // Update in-memory conversations list so the prop is fresh on next open
-      let idSet = Set(segmentIds)
-      if let idx = conversations.firstIndex(where: { $0.id == conversationId }) {
-        for segIdx in conversations[idx].transcriptSegments.indices
-        where idSet.contains(conversations[idx].transcriptSegments[segIdx].id) {
-          let old = conversations[idx].transcriptSegments[segIdx]
-          conversations[idx].transcriptSegments[segIdx] = TranscriptSegment(
-            id: old.id,
-            backendId: old.backendId,
-            text: old.text,
-            speaker: old.speaker,
-            isUser: isUser,
-            personId: isUser ? nil : personId,
-            start: old.start,
-            end: old.end,
-            translations: old.translations
-          )
-        }
+    } catch let APIError.httpError(statusCode, _)
+      where SpeakerAssignmentFallbackPolicy.keepsAssignmentLocally(statusCode: statusCode)
+    {
+      // The conversation has not reached the backend yet (a pending local session,
+      // or one recovering from local fallback data). The assignment is still the
+      // user's decision: keep it locally — the finalization sync uploads every
+      // segment's person_id/is_user with the conversation itself, so the backend
+      // converges once the session syncs. Failing here surfaced as the
+      // "Couldn't assign this speaker" report on Beta.
+      log("People: Conversation \(conversationId) not on backend yet; keeping speaker assignment local")
+      DesktopDiagnosticsManager.shared.recordFallback(
+        area: "speaker_assignment",
+        from: "backend_bulk_assign",
+        to: "local_store",
+        reason: "conversation_not_synced",
+        outcome: .degraded
+      )
+      applySpeakerAssignmentLocally(
+        conversationId: conversationId, segmentIds: segmentIds, personId: personId, isUser: isUser)
+      return true
+    } catch {
+      logError("People: Failed to assign segments", error: error)
+      return false
+    }
+    applySpeakerAssignmentLocally(
+      conversationId: conversationId, segmentIds: segmentIds, personId: personId, isUser: isUser)
+    return true
+  }
+
+  /// The client-side half of a speaker assignment: the in-memory conversation list
+  /// (so the label is fresh on next open) and the local SQLite cache (so it
+  /// survives restarts, and so a not-yet-synced session carries the assignment to
+  /// the backend when it finalizes).
+  private func applySpeakerAssignmentLocally(
+    conversationId: String,
+    segmentIds: [String],
+    personId: String?,
+    isUser: Bool
+  ) {
+    // Update in-memory conversations list so the prop is fresh on next open
+    let idSet = Set(segmentIds)
+    if let idx = conversations.firstIndex(where: { $0.id == conversationId }) {
+      for segIdx in conversations[idx].transcriptSegments.indices
+      where idSet.contains(conversations[idx].transcriptSegments[segIdx].id) {
+        let old = conversations[idx].transcriptSegments[segIdx]
+        conversations[idx].transcriptSegments[segIdx] = TranscriptSegment(
+          id: old.id,
+          backendId: old.backendId,
+          text: old.text,
+          speaker: old.speaker,
+          isUser: isUser,
+          personId: isUser ? nil : personId,
+          start: old.start,
+          end: old.end,
+          translations: old.translations
+        )
       }
-      // Also update local SQLite cache so changes persist across app restarts
+    }
+    // Also update local SQLite cache so changes persist across app restarts
+    Task {
       try? await TranscriptionStorage.shared.updateSegmentSpeakerAssignment(
         backendConversationId: conversationId,
         segmentIds: segmentIds,
         personId: personId,
         isUser: isUser
       )
-      return true
-    } catch {
-      logError("People: Failed to assign segments", error: error)
-      return false
     }
   }
 

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -3731,6 +3731,31 @@ final class DesktopAutomationActionRegistry {
         ?? "[[MARKER:speaker-naming]] Harness Speaker"
       let segmentIndex = max(0, Int(params["segmentIndex"] ?? "") ?? 0)
 
+      // Raw mode: drive assignSpeakerToSegments with the ids exactly as given,
+      // without resolving the conversation first — the seam that exercises the
+      // local-first fallback for conversations the backend does not have yet.
+      if let rawConversationId = params["rawConversationId"]?.trimmingCharacters(
+        in: .whitespacesAndNewlines), !rawConversationId.isEmpty
+      {
+        let rawSegmentIds = (params["rawSegmentIds"] ?? "").split(separator: ",").map(String.init)
+        guard !rawSegmentIds.isEmpty else { return ["error": "rawSegmentIds required in raw mode"] }
+        guard let person = await appState.createPerson(name: personName) else {
+          return ["error": "failed to create person"]
+        }
+        let assigned = await appState.assignSpeakerToSegments(
+          conversationId: rawConversationId,
+          segmentIds: rawSegmentIds,
+          personId: person.id,
+          isUser: false
+        )
+        return [
+          "raw_mode": "true",
+          "assigned": assigned ? "true" : "false",
+          "conversation_id": rawConversationId,
+          "person_id": person.id,
+        ]
+      }
+
       var conversationId = params["conversationId"]?.trimmingCharacters(in: .whitespacesAndNewlines)
       if conversationId == "latest" || conversationId?.isEmpty != false {
         if appState.conversations.isEmpty {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -42,11 +42,12 @@ struct ConversationDetailView: View {
   var onDelete: (() -> Void)?
   var onTitleUpdated: ((String) -> Void)?
 
-  // People (speaker naming)
-  var people: [Person] = []
-  var onFetchPeople: (() async -> Void)?
-  var onCreatePerson: ((String) async -> Person?)?
-  var onAssignSpeaker: ((String, [String], String?, Bool) async -> Bool)?
+  // People (speaker naming). Owned here, not injected: every surface that can
+  // present a conversation detail — Conversations, Memories, Dashboard citations —
+  // must offer the same speaker assignment. Requiring callers to thread closures
+  // left two of the three entry points with dead, un-tappable speaker labels
+  // ("impossible to assign speakers" reports).
+  private var people: [Person] { AppState.current?.people ?? [] }
   @ObservedObject private var automation = ConversationDetailAutomationState.shared
 
   @StateObject private var appProvider = AppProvider()
@@ -237,7 +238,7 @@ struct ConversationDetailView: View {
       preferredSummaryAppId =
         UserDefaults.standard.string(forKey: .preferredSummarizationAppId).flatMap { $0.isEmpty ? nil : $0 }
       await appProvider.fetchApps()
-      await onFetchPeople?()
+      await AppState.current?.fetchPeople()
       AnalyticsManager.shared.conversationDetailOpened(conversationId: conversation.id)
 
       // All detail reads go through the repository. It can paint a complete
@@ -302,17 +303,17 @@ struct ConversationDetailView: View {
         allSegments: displayConversation.transcriptSegments,
         people: people,
         onSave: { personId, isUser, segmentIndices in
-          guard let onAssignSpeaker else { return false }
+          guard let appState = AppState.current else { return false }
 
           let assignment = Self.assignmentMetadata(
             for: segmentIndices,
             in: displayConversation.transcriptSegments
           )
-          let success = await onAssignSpeaker(
-            conversation.id,
-            assignment.targets,
-            personId,
-            isUser
+          let success = await appState.assignSpeakerToSegments(
+            conversationId: conversation.id,
+            segmentIds: assignment.targets,
+            personId: personId,
+            isUser: isUser
           )
           guard success else { return false }
 
@@ -326,7 +327,7 @@ struct ConversationDetailView: View {
           updateDisplayedConversation(segmentIndices: segmentIndices, isUser: isUser, personId: personId)
           return true
         },
-        onCreatePerson: onCreatePerson,
+        onCreatePerson: { name in await AppState.current?.createPerson(name: name) },
         onDismiss: {
           selectedSegmentForNaming = nil
         }
@@ -833,7 +834,7 @@ struct ConversationDetailView: View {
         segment: segment,
         isUser: segment.isUser,
         personName: segment.personId.flatMap { peopleDict[$0]?.name },
-        onSpeakerTapped: segment.isUser || onAssignSpeaker == nil
+        onSpeakerTapped: segment.isUser
           ? nil
           : {
             selectedSegmentForNaming = segment

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -76,21 +76,6 @@ struct ConversationsPage: View {
               }
             }
           },
-          people: appState.people,
-          onFetchPeople: {
-            await appState.fetchPeople()
-          },
-          onCreatePerson: { name in
-            await appState.createPerson(name: name)
-          },
-          onAssignSpeaker: { conversationId, segmentIds, personId, isUser in
-            await appState.assignSpeakerToSegments(
-              conversationId: conversationId,
-              segmentIds: segmentIds,
-              personId: personId,
-              isUser: isUser
-            )
-          }
         )
       } else {
         // Main view with recording header and conversation list

--- a/desktop/macos/Desktop/Tests/SpeakerAssignmentTests.swift
+++ b/desktop/macos/Desktop/Tests/SpeakerAssignmentTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Speaker assignment regressions from the Beta "Couldn't assign this speaker"
+/// report: the backend bulk-assign 404s for conversations that have not synced
+/// yet (pending local sessions), and the client treated that as a hard failure
+/// even though the finalization sync uploads every segment's person_id anyway.
+final class SpeakerAssignmentTests: XCTestCase {
+
+  /// 404 — the conversation is not on the backend yet — is the ONLY status that
+  /// may keep the assignment local and report success.
+  @MainActor
+  func testOnlyMissingConversationFallsBackToLocalAssignment() {
+    XCTAssertTrue(AppState.SpeakerAssignmentFallbackPolicy.keepsAssignmentLocally(statusCode: 404))
+    for status in [400, 401, 403, 409, 422, 500, 502, 503] {
+      XCTAssertFalse(
+        AppState.SpeakerAssignmentFallbackPolicy.keepsAssignmentLocally(statusCode: status),
+        "\(status) means the backend HAS the conversation and rejected the change — it must surface")
+    }
+  }
+
+  /// The wire targets the detail sheet sends: backend ids when known, positional
+  /// #index: fallbacks otherwise — the contract the backend's
+  /// _resolve_bulk_segment_indices accepts for completed conversations.
+  @MainActor
+  func testAssignmentMetadataPrefersBackendIdsAndFallsBackToIndices() {
+    let segments = [
+      TranscriptSegment(
+        id: "local-a", backendId: "backend-a", text: "a", speaker: "SPEAKER_01", isUser: false,
+        personId: nil, start: 0, end: 1, translations: []),
+      TranscriptSegment(
+        id: "local-b", backendId: nil, text: "b", speaker: "SPEAKER_01", isUser: false,
+        personId: nil, start: 1, end: 2, translations: []),
+    ]
+    let meta = ConversationDetailView.assignmentMetadata(for: [0, 1], in: segments)
+    XCTAssertEqual(meta.targets, ["backend-a", "#index:1"])
+    XCTAssertEqual(meta.backendIds, ["backend-a"])
+    XCTAssertEqual(meta.fallbackOrders, [1])
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260828-speaker-assignment.json
+++ b/desktop/macos/changelog/unreleased/20260828-speaker-assignment.json
@@ -1,0 +1,3 @@
+{
+  "change": "Tagging a speaker with a name now works everywhere: conversations opened from Memories or the Dashboard were missing the tap-to-name control, and recent recordings that hadn't finished syncing failed with \"Couldn't assign this speaker\""
+}


### PR DESCRIPTION
## What

Users report it's impossible to tag speakers by name on macOS (mobile can). Two real defects behind the one report:

**1. Dead labels on two of three entry points.** `ConversationDetailView` required callers to thread `people`/`onFetchPeople`/`onCreatePerson`/`onAssignSpeaker` closures. Only ConversationsPage did — conversations opened from **Memories** or **Dashboard citations** rendered speaker labels as plain, un-tappable text. The detail view now owns the operations (AppState directly); the closure plumbing is deleted, so every entry point runs the identical path.

**2. "Couldn't assign this speaker. Try again." on Beta.** Real log from Nik's Beta: `People: Failed to assign segments: HTTP error: 404`. The bulk-assign endpoint 404s when the conversation hasn't reached the backend yet (pending local sessions, local-fallback recoveries — his log shows `Recovering 1 pending sessions` right before the failure). Assignment now falls back to **local-first** for exactly that case: `SpeakerAssignmentFallbackPolicy` pins 404-only, the in-memory list + local SQLite keep the decision, `record_fallback(area: speaker_assignment, reason: conversation_not_synced)` reports it, and `ConversationFinalizationService` already uploads each segment's `person_id`/`is_user` when the session syncs — the backend converges. Any other status (400/401/409/500…) still surfaces as a failure.

`assign_speaker_fixture` gains a raw mode that drives `assignSpeakerToSegments` with unresolved ids — the seam that exercises the 404 fallback live.

## Verification

Dev bundle (dev backend, signed in), all through production paths:
- Created a 3-speaker conversation via the hermetic capture seam; tagged **"Lika"**, then **"Marcus"** post-refactor — transcript renders both by name, untagged speakers keep the pencil, assignment **survives app restart** (captured).
- Bogus-conversation probe (raw mode): `assigned=true` with `People: Conversation … not on backend yet; keeping speaker assignment local` in the log.
- `swift test --filter SpeakerAssignmentTests` — fallback policy (404-only, 8 negative statuses) + wire-target metadata (backend ids preferred, `#index:` fallback matching the backend's `_resolve_bulk_segment_indices` contract) — 0 failures.

## Product invariants affected

- INV-NAV-1 — touched paths match its globs (ConversationsPage/ConversationDetailView); navigation structure is unchanged — the diff removes closure plumbing and adds speaker-assignment behavior inside the existing detail view — so its guard test needs no update.

Line-Count-Exception: desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift | 4823 -> 4848 | assign_speaker_fixture raw mode — the seam that exercises the 404 local-first fallback live

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

