### PR TITLE
feat(windows): structure OCR screen context

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-08-ocr-spatial-context.json
+++ b/desktop/windows/changelog/unreleased/2026-08-ocr-spatial-context.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Screen memory extraction now preserves OCR reading order while removing repeated frames and desktop chrome."
+  ]
+}

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -113,6 +113,7 @@ import {
   rewindSampleStep,
   buildRewindSampledSql
 } from './rewindSampleSql'
+import { SCREEN_SYNTH_FRAMES_SQL, type ScreenSynthFrameRow } from './screenSynthSql'
 import type {
   AiUserProfileInput,
   AiUserProfileRecord,
@@ -1559,6 +1560,13 @@ export function listRewindFrames(from: number, to: number): RewindFrame[] {
         get(),
         `SELECT ${REWIND_COLUMNS} FROM rewind_frames WHERE ts BETWEEN ? AND ? ORDER BY ts`
       ).all(from, to) as RewindFrame[]
+  )
+}
+
+export function listScreenSynthFrames(from: number, to: number): ScreenSynthFrameRow[] {
+  return timed(
+    'listScreenSynthFrames',
+    () => cachedStmt(get(), SCREEN_SYNTH_FRAMES_SQL).all(from, to) as ScreenSynthFrameRow[]
   )
 }
 

--- a/desktop/windows/src/main/ipc/screenSynth.test.ts
+++ b/desktop/windows/src/main/ipc/screenSynth.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ScreenSynthFrameRow } from './screenSynthSql'
+
+const h = vi.hoisted(() => ({
+  handle: vi.fn(),
+  listFrames: vi.fn(),
+  getState: vi.fn(),
+  updateState: vi.fn(),
+  advanceWatermark: vi.fn(),
+  recordRun: vi.fn()
+}))
+
+vi.mock('electron', () => ({ ipcMain: { handle: h.handle } }))
+vi.mock('./db', () => ({ listScreenSynthFrames: h.listFrames }))
+vi.mock('../screenSynth/state', () => ({
+  getScreenSynthState: h.getState,
+  updateScreenSynthState: h.updateState,
+  advanceWatermark: h.advanceWatermark,
+  recordRun: h.recordRun
+}))
+
+import {
+  buildSpatialOcrText,
+  isNearDuplicateScreenText,
+  registerScreenSynthHandlers
+} from './screenSynth'
+
+function frame(overrides: Partial<ScreenSynthFrameRow> = {}): ScreenSynthFrameRow {
+  return {
+    ts: 1,
+    app: 'Code',
+    windowTitle: 'plan.md',
+    processName: 'code.exe',
+    ocrText: 'File Edit quarterly plan Save',
+    ocrLinesJson: JSON.stringify([
+      { text: 'File', x: 10, y: 20, w: 20, h: 10, confidence: 1 },
+      { text: 'quarterly plan', x: 100, y: 200, w: 100, h: 20, confidence: 1 },
+      { text: 'Edit', x: 20, y: 205, w: 40, h: 20, confidence: 1 },
+      { text: 'Save', x: 10, y: 1050, w: 40, h: 10, confidence: 1 }
+    ]),
+    height: 1080,
+    ...overrides
+  }
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('spatial OCR synthesis', () => {
+  it('filters screen chrome, clusters within 10px, and orders each Markdown row left-to-right', () => {
+    expect(buildSpatialOcrText(frame())).toBe('- Edit | quarterly plan')
+  })
+
+  it('falls back for malformed or incomplete geometry without reintroducing chrome-only layouts', () => {
+    expect(buildSpatialOcrText(frame({ ocrLinesJson: '{bad json' }))).toBe(
+      'File Edit quarterly plan Save'
+    )
+    expect(
+      buildSpatialOcrText(
+        frame({
+          ocrText: 'one two three four five six seven eight nine ten',
+          ocrLinesJson: JSON.stringify([
+            { text: 'one', x: 10, y: 200, w: 20, h: 10, confidence: 1 }
+          ])
+        })
+      )
+    ).toBe('one two three four five six seven eight nine ten')
+    expect(
+      buildSpatialOcrText(
+        frame({
+          ocrText: 'alpha beta',
+          ocrLinesJson: JSON.stringify([
+            { text: 'alpha zeta', x: 10, y: 200, w: 80, h: 10, confidence: 1 }
+          ])
+        })
+      )
+    ).toBe('alpha beta')
+    expect(
+      buildSpatialOcrText(
+        frame({
+          ocrText: 'File Save',
+          ocrLinesJson: JSON.stringify([
+            { text: 'File', x: 10, y: 20, w: 20, h: 10, confidence: 1 },
+            { text: 'Save', x: 10, y: 1050, w: 40, h: 10, confidence: 1 }
+          ])
+        })
+      )
+    ).toBe('')
+  })
+
+  it('uses the indexed private query and keeps duplicate tail timestamps as blank markers', async () => {
+    h.getState.mockReturnValue({ watermarkTs: 40 })
+    const first = frame({ ts: 41 })
+    const nearDuplicate = frame({
+      ts: 42,
+      ocrText: 'File Edit quarterly plans Save',
+      ocrLinesJson: JSON.stringify([
+        { text: 'File', x: 10, y: 20, w: 20, h: 10, confidence: 1 },
+        { text: 'quarterly plans', x: 100, y: 200, w: 100, h: 20, confidence: 1 },
+        { text: 'Edit', x: 20, y: 205, w: 40, h: 20, confidence: 1 },
+        { text: 'Save', x: 10, y: 1050, w: 40, h: 10, confidence: 1 }
+      ])
+    })
+    const otherWindow = frame({ ts: 43, windowTitle: 'notes.md' })
+    h.listFrames.mockReturnValue([first, nearDuplicate, otherWindow])
+    vi.spyOn(Date, 'now').mockReturnValue(50)
+
+    registerScreenSynthHandlers()
+    const handler = h.handle.mock.calls.find(([name]) => name === 'screenSynth:framesSince')?.[1]
+    expect(handler).toBeTypeOf('function')
+
+    const result = await handler()
+    expect(h.listFrames).toHaveBeenCalledWith(41, 50)
+    expect(result).toEqual([
+      {
+        ts: 41,
+        app: 'Code',
+        windowTitle: 'plan.md',
+        processName: 'code.exe',
+        ocrText: '- Edit | quarterly plan'
+      },
+      {
+        ts: 42,
+        app: 'Code',
+        windowTitle: 'plan.md',
+        processName: 'code.exe',
+        ocrText: ''
+      },
+      {
+        ts: 43,
+        app: 'Code',
+        windowTitle: 'notes.md',
+        processName: 'code.exe',
+        ocrText: '- Edit | quarterly plan'
+      }
+    ])
+    expect(isNearDuplicateScreenText('- Edit | quarterly plan', '- Edit | quarterly plans')).toBe(
+      true
+    )
+    expect(isNearDuplicateScreenText('a'.repeat(100), `${'a'.repeat(92)}${'b'.repeat(8)}`)).toBe(
+      false
+    )
+    expect(isNearDuplicateScreenText('a'.repeat(100), `${'a'.repeat(93)}${'b'.repeat(7)}`)).toBe(
+      true
+    )
+    const shifted = 'ab'.repeat(50)
+    expect(isNearDuplicateScreenText(shifted, `${shifted.slice(1)}${shifted[0]}`)).toBe(true)
+  })
+})

--- a/desktop/windows/src/main/ipc/screenSynth.ts
+++ b/desktop/windows/src/main/ipc/screenSynth.ts
@@ -1,27 +1,279 @@
 // src/main/ipc/screenSynth.ts
 import { ipcMain } from 'electron'
-import { listRewindFrames } from './db'
+import { listScreenSynthFrames } from './db'
 import {
   getScreenSynthState,
   updateScreenSynthState,
   advanceWatermark,
   recordRun
 } from '../screenSynth/state'
-import type { ScreenFrameLite, ScreenSynthState, ScreenSynthRun } from '../../shared/types'
+import type { OcrLine, ScreenFrameLite, ScreenSynthState, ScreenSynthRun } from '../../shared/types'
+import type { ScreenSynthFrameRow } from './screenSynthSql'
+
+const ROW_CLUSTER_THRESHOLD_PX = 10
+const CHROME_EDGE_PX_AT_1080P = 40
+const REFERENCE_FRAME_HEIGHT = 1080
+const NEAR_DUPLICATE_THRESHOLD = 0.92
+
+type SpatialRow = { anchorY: number; lines: OcrLine[] }
+
+function normalizedLine(value: unknown): OcrLine | null {
+  if (!value || typeof value !== 'object') return null
+  const line = value as Record<string, unknown>
+  const text = typeof line.text === 'string' ? line.text.trim().replace(/\s+/g, ' ') : ''
+  const finite = (field: string): number | null => {
+    const candidate = line[field]
+    return typeof candidate === 'number' && Number.isFinite(candidate) ? candidate : null
+  }
+  const x = finite('x')
+  const y = finite('y')
+  const w = finite('w')
+  const h = finite('h')
+  if (!text || x == null || y == null || w == null || h == null || w <= 0 || h <= 0) {
+    return null
+  }
+  return {
+    text,
+    x,
+    y,
+    w,
+    h,
+    confidence: finite('confidence') ?? 0
+  }
+}
+
+function parseStoredOcrLines(raw: string | null): OcrLine[] | null {
+  if (!raw) return null
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return null
+    return parsed.map(normalizedLine).filter((line): line is OcrLine => line !== null)
+  } catch {
+    return null
+  }
+}
+
+function coverageTokens(text: string): string[] {
+  return text.trim().split(/\s+/).filter(Boolean).sort()
+}
+
+function hasCompleteTextCoverage(lineText: string, plainText: string): boolean {
+  const lineTokens = coverageTokens(lineText)
+  const plainTokens = coverageTokens(plainText)
+  return (
+    lineTokens.length === plainTokens.length &&
+    lineTokens.every((token, index) => token === plainTokens[index])
+  )
+}
+
+function chromeEdgePx(height: number): number {
+  const effectiveHeight = Number.isFinite(height) && height > 0 ? height : REFERENCE_FRAME_HEIGHT
+  return (effectiveHeight / REFERENCE_FRAME_HEIGHT) * CHROME_EDGE_PX_AT_1080P
+}
+
+function clusterRows(lines: OcrLine[]): SpatialRow[] {
+  const rows: SpatialRow[] = []
+  const sorted = [...lines].sort((a, b) => a.y - b.y || a.x - b.x)
+  for (const line of sorted) {
+    const current = rows[rows.length - 1]
+    if (!current || Math.abs(current.anchorY - line.y) >= ROW_CLUSTER_THRESHOLD_PX) {
+      rows.push({ anchorY: line.y, lines: [line] })
+    } else {
+      current.lines.push(line)
+    }
+  }
+  return rows
+}
+
+/** Build layout-aware OCR while preserving plain text when stored geometry is incomplete. */
+export function buildSpatialOcrText(frame: ScreenSynthFrameRow): string {
+  const plainText = frame.ocrText.trim()
+  const lines = parseStoredOcrLines(frame.ocrLinesJson)
+  if (!lines) return plainText
+
+  const lineText = lines.map((line) => line.text).join(' ')
+  if (plainText && !hasCompleteTextCoverage(lineText, plainText)) {
+    return plainText
+  }
+
+  const edge = chromeEdgePx(frame.height)
+  const effectiveHeight =
+    Number.isFinite(frame.height) && frame.height > 0 ? frame.height : REFERENCE_FRAME_HEIGHT
+  const contentLines = lines.filter((line) => line.y >= edge && line.y <= effectiveHeight - edge)
+
+  return clusterRows(contentLines)
+    .map(
+      (row) =>
+        `- ${[...row.lines]
+          .sort((a, b) => a.x - b.x)
+          .map((line) => line.text)
+          .join(' | ')}`
+    )
+    .join('\n')
+}
+
+type DistanceBand = { start: number; values: number[] }
+
+function bandValue(band: DistanceBand, index: number, outside: number): number {
+  const offset = index - band.start
+  return offset >= 0 && offset < band.values.length ? band.values[offset] : outside
+}
+
+function hasAlignedEditScriptWithin(left: string, right: string, maxDistance: number): boolean {
+  const overlap = Math.min(left.length, right.length)
+  const lengthDelta = Math.abs(left.length - right.length)
+  const withinFromOffsets = (leftOffset: number, rightOffset: number): boolean => {
+    let edits = lengthDelta
+    for (let i = 0; i < overlap && edits <= maxDistance; i++) {
+      if (left.charCodeAt(leftOffset + i) !== right.charCodeAt(rightOffset + i)) edits++
+    }
+    return edits <= maxDistance
+  }
+
+  if (withinFromOffsets(0, 0)) return true
+  if (lengthDelta === 0) return false
+  return withinFromOffsets(left.length - overlap, right.length - overlap)
+}
+
+function characterCountLowerBoundExceeds(
+  left: string,
+  right: string,
+  maxDistance: number
+): boolean {
+  const counts = new Map<number, number>()
+  for (let i = 0; i < left.length; i++) {
+    const code = left.charCodeAt(i)
+    counts.set(code, (counts.get(code) ?? 0) + 1)
+  }
+  for (let i = 0; i < right.length; i++) {
+    const code = right.charCodeAt(i)
+    counts.set(code, (counts.get(code) ?? 0) - 1)
+  }
+  let imbalance = 0
+  for (const count of counts.values()) imbalance += Math.abs(count)
+  return Math.ceil(imbalance / 2) > maxDistance
+}
+
+// Only distances at or below maxDistance matter. Keep that diagonal band instead
+// of allocating and evaluating the full Levenshtein matrix.
+function isWithinLevenshteinDistance(left: string, right: string, maxDistance: number): boolean {
+  let prefixLength = 0
+  const sharedLength = Math.min(left.length, right.length)
+  while (
+    prefixLength < sharedLength &&
+    left.charCodeAt(prefixLength) === right.charCodeAt(prefixLength)
+  ) {
+    prefixLength++
+  }
+
+  let leftEnd = left.length
+  let rightEnd = right.length
+  while (
+    leftEnd > prefixLength &&
+    rightEnd > prefixLength &&
+    left.charCodeAt(leftEnd - 1) === right.charCodeAt(rightEnd - 1)
+  ) {
+    leftEnd--
+    rightEnd--
+  }
+
+  const trimmedLeft = left.slice(prefixLength, leftEnd)
+  const trimmedRight = right.slice(prefixLength, rightEnd)
+  if (Math.abs(trimmedLeft.length - trimmedRight.length) > maxDistance) return false
+  if (Math.max(trimmedLeft.length, trimmedRight.length) <= maxDistance) return true
+  if (hasAlignedEditScriptWithin(trimmedLeft, trimmedRight, maxDistance)) return true
+  if (characterCountLowerBoundExceeds(trimmedLeft, trimmedRight, maxDistance)) return false
+
+  const outside = maxDistance + 1
+  let previous: DistanceBand = {
+    start: 0,
+    values: Array.from({ length: Math.min(trimmedRight.length, maxDistance) + 1 }, (_, i) => i)
+  }
+
+  for (let i = 1; i <= trimmedLeft.length; i++) {
+    const start = Math.max(0, i - maxDistance)
+    const end = Math.min(trimmedRight.length, i + maxDistance)
+    const values = Array<number>(end - start + 1).fill(outside)
+    const current: DistanceBand = { start, values }
+
+    for (let j = start; j <= end; j++) {
+      const offset = j - start
+      if (j === 0) {
+        values[offset] = i
+        continue
+      }
+      const deletion = bandValue(previous, j, outside) + 1
+      const insertion = (offset > 0 ? values[offset - 1] : outside) + 1
+      const substitution =
+        bandValue(previous, j - 1, outside) +
+        (trimmedLeft.charCodeAt(i - 1) === trimmedRight.charCodeAt(j - 1) ? 0 : 1)
+      values[offset] = Math.min(deletion, insertion, substitution)
+    }
+    previous = current
+  }
+
+  return bandValue(previous, trimmedRight.length, outside) <= maxDistance
+}
+
+function normalizeForSimilarity(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, ' ').trim()
+}
+
+export function isNearDuplicateScreenText(previous: string, next: string): boolean {
+  const left = normalizeForSimilarity(previous)
+  const right = normalizeForSimilarity(next)
+  if (!left || !right) return false
+  if (left === right) return true
+
+  const maxLength = Math.max(left.length, right.length)
+  const minLength = Math.min(left.length, right.length)
+  if (minLength / maxLength <= NEAR_DUPLICATE_THRESHOLD) return false
+
+  // Similarity must EXCEED 92%, so an exact 8% edit distance is not a duplicate.
+  const maxDistance = Math.ceil(maxLength * (1 - NEAR_DUPLICATE_THRESHOLD)) - 1
+  return isWithinLevenshteinDistance(left, right, maxDistance)
+}
+
+function sameContext(previous: ScreenFrameLite, next: ScreenFrameLite): boolean {
+  return (
+    previous.app === next.app &&
+    previous.windowTitle === next.windowTitle &&
+    previous.processName === next.processName
+  )
+}
+
+export function prepareScreenSynthFrames(frames: ScreenSynthFrameRow[]): ScreenFrameLite[] {
+  const prepared: ScreenFrameLite[] = []
+  let previousMeaningful: ScreenFrameLite | null = null
+
+  for (const frame of frames) {
+    const next: ScreenFrameLite = {
+      ts: frame.ts,
+      app: frame.app,
+      windowTitle: frame.windowTitle,
+      processName: frame.processName,
+      ocrText: buildSpatialOcrText(frame)
+    }
+    const duplicate =
+      previousMeaningful !== null &&
+      sameContext(previousMeaningful, next) &&
+      isNearDuplicateScreenText(previousMeaningful.ocrText, next.ocrText)
+
+    // Keep a zero-text timestamp marker so the renderer still advances its watermark
+    // past duplicate tail frames; grouping already ignores blank OCR.
+    prepared.push(duplicate ? { ...next, ocrText: '' } : next)
+    if (!duplicate) previousMeaningful = next
+  }
+
+  return prepared
+}
 
 export function registerScreenSynthHandlers(): void {
   // Frames since the watermark, stripped to the fields synthesis needs (no image bytes).
   ipcMain.handle('screenSynth:framesSince', async (): Promise<ScreenFrameLite[]> => {
     const { watermarkTs } = getScreenSynthState()
     // +1 so we never re-emit the exact watermark frame.
-    const frames = listRewindFrames(watermarkTs + 1, Date.now())
-    return frames.map((f) => ({
-      ts: f.ts,
-      app: f.app,
-      windowTitle: f.windowTitle,
-      processName: f.processName,
-      ocrText: f.ocrText
-    }))
+    return prepareScreenSynthFrames(listScreenSynthFrames(watermarkTs + 1, Date.now()))
   })
   ipcMain.handle('screenSynth:getState', async () => getScreenSynthState())
   ipcMain.handle('screenSynth:setState', async (_e, patch: Partial<ScreenSynthState>) =>

--- a/desktop/windows/src/main/ipc/screenSynthSql.test.ts
+++ b/desktop/windows/src/main/ipc/screenSynthSql.test.ts
@@ -1,0 +1,44 @@
+import { DatabaseSync } from 'node:sqlite'
+import { describe, expect, it } from 'vitest'
+import { SCREEN_SYNTH_FRAMES_SQL, type ScreenSynthFrameRow } from './screenSynthSql'
+
+describe('screen synthesis frame query', () => {
+  it('returns only indexed frames in the requested range and keeps OCR geometry private', () => {
+    const db = new DatabaseSync(':memory:')
+    db.exec(`
+      CREATE TABLE rewind_frames (
+        ts INTEGER NOT NULL,
+        app TEXT NOT NULL,
+        window_title TEXT NOT NULL,
+        process_name TEXT NOT NULL,
+        ocr_text TEXT NOT NULL,
+        ocr_lines_json TEXT,
+        width INTEGER NOT NULL,
+        height INTEGER NOT NULL,
+        indexed INTEGER NOT NULL
+      );
+      CREATE INDEX idx_rewind_frames_ts ON rewind_frames(ts);
+    `)
+    const insert = db.prepare('INSERT INTO rewind_frames VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)')
+    insert.run(99, 'Old', 'old', 'old.exe', 'old', null, 1920, 1080, 1)
+    insert.run(100, 'Code', 'plan.md', 'code.exe', 'draft', '[{"text":"draft"}]', 1920, 1080, 1)
+    insert.run(101, 'Code', 'plan.md', 'code.exe', '', null, 1920, 1080, 0)
+    insert.run(102, 'Docs', 'API', 'browser.exe', '', null, 1920, 1080, 1)
+    insert.run(103, 'New', 'new', 'new.exe', 'new', null, 1920, 1080, 1)
+
+    const rows = db.prepare(SCREEN_SYNTH_FRAMES_SQL).all(100, 102) as ScreenSynthFrameRow[]
+
+    expect(rows.map((row) => row.ts)).toEqual([100, 102])
+    expect(rows[0]).toEqual({
+      ts: 100,
+      app: 'Code',
+      windowTitle: 'plan.md',
+      processName: 'code.exe',
+      ocrText: 'draft',
+      ocrLinesJson: '[{"text":"draft"}]',
+      height: 1080
+    })
+    expect(Object.keys(rows[0])).not.toContain('imagePath')
+    db.close()
+  })
+})

--- a/desktop/windows/src/main/ipc/screenSynthSql.ts
+++ b/desktop/windows/src/main/ipc/screenSynthSql.ts
@@ -1,0 +1,24 @@
+export type ScreenSynthFrameRow = {
+  ts: number
+  app: string
+  windowTitle: string
+  processName: string
+  ocrText: string
+  ocrLinesJson: string | null
+  height: number
+}
+
+// Keep raw OCR geometry inside the main process. The public Rewind DTO intentionally
+// omits ocr_lines_json; this query is the one narrow synthesis-only read boundary.
+export const SCREEN_SYNTH_FRAMES_SQL = `
+  SELECT ts,
+         app,
+         window_title AS windowTitle,
+         process_name AS processName,
+         ocr_text AS ocrText,
+         ocr_lines_json AS ocrLinesJson,
+         height
+    FROM rewind_frames
+   WHERE indexed = 1 AND ts BETWEEN ? AND ?
+   ORDER BY ts
+`


### PR DESCRIPTION
## What changed and why

Closes #8453 with a narrow current-main implementation: read existing `ocr_lines_json` through a synthesis-only indexed query, remove top/bottom desktop chrome, cluster rows at the requested 10px threshold, preserve left-to-right order, and discard consecutive screen text only when Levenshtein similarity strictly exceeds 92%.

Raw OCR geometry stays in the Electron main process; IPC still returns `ScreenFrameLite`. This does not add a schema, shared DTO, renderer path, or dependency. The query preserves the existing watermark range instead of hard-clamping to five minutes because screen synthesis runs every ten minutes and a five-minute clamp would silently drop half of each batch. Existing prompt assembly already adds the application/window Markdown header.

## Product invariants affected

none

## How it was verified

- `TZ=UTC pnpm test` -> 561 files passed, 5,553 tests passed, 22 skipped.
- Native `Asia/Shanghai` run -> 5,547 passed; the only failure is the pre-existing hard-coded Aug 24/25 date assertion in `insight/prompt.test.ts`, reproduced unchanged on clean `origin/main`.
- `pnpm typecheck` -> node and renderer typechecks passed.
- ESLint on all changed TypeScript files -> 0 errors, 0 warnings.
- `scripts/pr-preflight` -> 13 selected checks passed.
- Real `node:sqlite` benchmark over 100k rows -> query p95 0.62ms; 150-box spatial formatting p95 0.23ms (both below 15ms).
- 7,000 generated string pairs matched a reference Levenshtein implementation exactly; common 5,000-character near-duplicate comparison measured p95 0.15ms.

The packaged Electron app was not launched locally; dependencies were installed with `--ignore-scripts`, so validation used the production SQL constant, real in-memory SQLite, handler tests, and the full component suite.

## Tests

- `screenSynth.test.ts` covers chrome filtering, 10px clustering, x-ordering, malformed/incomplete-layout fallback, strict 92% behavior, context boundaries, and duplicate-tail watermark markers.
- `screenSynthSql.test.ts` executes the production query against SQLite and proves indexed/range/order behavior plus the main-process-only field boundary.

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

