### PR TITLE
test(windows): make insight date assertion timezone-safe

### DIFF
--- a/desktop/windows/src/main/assistants/insight/prompt.test.ts
+++ b/desktop/windows/src/main/assistants/insight/prompt.test.ts
@@ -89,9 +89,10 @@ describe('insight phase-1 date grounding', () => {
 
     const prompt = buildPhase1Prompt(data)
 
-    // The runner's local zone decides the wall clock, but the rendered line always
-    // names the year and the zone — the two anchors the model was missing.
-    expect(prompt).toMatch(/Date\/Time: \w+, August 2[45], 2026 at \d+:\d{2} [AP]M \(.+\)\./)
+    // The runner's local zone decides the wall clock. Pin the exact host-local
+    // rendering so every IANA timezone exercises the same contract.
+    const expectedDateTime = formatDateTime(data.now)
+    expect(prompt).toContain(`Date/Time: ${expectedDateTime}.`)
     expect(prompt).toContain('CURRENT APP: Calendar.')
     expect(prompt).toContain('Window: "October".')
   })


### PR DESCRIPTION
## What changed and why

Make the Windows insight prompt test compare against the exact host-local `Date/Time` rendering instead of hard-coding August 24/25. The previous assertion fails on clean `main` in valid positive-offset IANA timezones; this is a test-only follow-up to #12236.

## Product invariants affected

none

## How it was verified

- `TZ=UTC|Asia/Shanghai|Pacific/Kiritimati|America/Adak pnpm exec vitest run src/main/assistants/insight/prompt.test.ts` - 5/5 passed in each timezone.
- `TZ=Asia/Shanghai pnpm exec vitest run` - 559 files passed, 6 skipped; 5,544 tests passed, 27 skipped.
- `pnpm run typecheck` - passed for Node and Web.
- `pnpm exec eslint src/main/assistants/insight/prompt.test.ts` - passed.
- `pnpm exec prettier --check src/main/assistants/insight/prompt.test.ts` - passed.

## Tests

The existing `states the full date and timezone in the user-turn head` regression test fails on the old code under `Asia/Shanghai` and `Pacific/Kiritimati`, then passes in all four verified timezones with this change.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

