### PR TITLE
fix(desktop): speaker assignments resolve positional targets and persist before success

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
@@ -253,6 +253,28 @@ extension AppState {
     }
   }
 
+  /// The wire targets a caller may send: backend segment ids, or `#index:N`
+  /// positional fallbacks for segments stored without ids (the same contract
+  /// the backend's `_resolve_bulk_segment_indices` accepts). The local half of
+  /// an assignment must resolve BOTH — matching only ids silently drops every
+  /// positional target on the floor.
+  enum SpeakerAssignmentTargets {
+    static let indexPrefix = "#index:"
+
+    static func parse(_ targets: [String]) -> (ids: [String], orders: [Int]) {
+      var ids: [String] = []
+      var orders: [Int] = []
+      for target in targets {
+        if target.hasPrefix(indexPrefix), let order = Int(target.dropFirst(indexPrefix.count)) {
+          orders.append(order)
+        } else {
+          ids.append(target)
+        }
+      }
+      return (ids, orders)
+    }
+  }
+
   func assignSpeakerToSegments(
     conversationId: String,
     segmentIds: [String],
@@ -284,14 +306,14 @@ extension AppState {
         reason: "conversation_not_synced",
         outcome: .degraded
       )
-      applySpeakerAssignmentLocally(
+      await applySpeakerAssignmentLocally(
         conversationId: conversationId, segmentIds: segmentIds, personId: personId, isUser: isUser)
       return true
     } catch {
       logError("People: Failed to assign segments", error: error)
       return false
     }
-    applySpeakerAssignmentLocally(
+    await applySpeakerAssignmentLocally(
       conversationId: conversationId, segmentIds: segmentIds, personId: personId, isUser: isUser)
     return true
   }
@@ -305,12 +327,20 @@ extension AppState {
     segmentIds: [String],
     personId: String?,
     isUser: Bool
-  ) {
-    // Update in-memory conversations list so the prop is fresh on next open
-    let idSet = Set(segmentIds)
+  ) async {
+    let targets = SpeakerAssignmentTargets.parse(segmentIds)
+    // Update the in-memory conversations list so the label is fresh on next open.
+    // A target may be the segment's local id, its backend id, or a positional
+    // #index:N — all three must land, or the caller's positional targets are
+    // silently dropped on the floor.
+    let idSet = Set(targets.ids)
+    let orderSet = Set(targets.orders)
     if let idx = conversations.firstIndex(where: { $0.id == conversationId }) {
       for segIdx in conversations[idx].transcriptSegments.indices
-      where idSet.contains(conversations[idx].transcriptSegments[segIdx].id) {
+      where idSet.contains(conversations[idx].transcriptSegments[segIdx].id)
+        || conversations[idx].transcriptSegments[segIdx].backendId.map(idSet.contains) == true
+        || orderSet.contains(segIdx)
+      {
         let old = conversations[idx].transcriptSegments[segIdx]
         conversations[idx].transcriptSegments[segIdx] = TranscriptSegment(
           id: old.id,
@@ -325,15 +355,17 @@ extension AppState {
         )
       }
     }
-    // Also update local SQLite cache so changes persist across app restarts
-    Task {
-      try? await TranscriptionStorage.shared.updateSegmentSpeakerAssignment(
-        backendConversationId: conversationId,
-        segmentIds: segmentIds,
-        personId: personId,
-        isUser: isUser
-      )
-    }
+    // Also update the local SQLite cache so the assignment survives restarts —
+    // and, for a conversation the backend does not have yet, so the finalization
+    // sync can carry person_id/is_user up with the session. Awaited: returning
+    // success before the write lands would let a quit drop the user's decision.
+    try? await TranscriptionStorage.shared.updateSpeakerAssignmentByBackendId(
+      conversationId,
+      segmentIds: targets.ids,
+      fallbackSegmentOrders: targets.orders,
+      isUser: isUser,
+      personId: isUser ? nil : personId
+    )
   }
 
   // MARK: - Backend Segment Handling

--- a/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
@@ -299,21 +299,32 @@ extension AppState {
       // converges once the session syncs. Failing here surfaced as the
       // "Couldn't assign this speaker" report on Beta.
       log("People: Conversation \(conversationId) not on backend yet; keeping speaker assignment local")
+      // Here the local store is the ONLY holder of the user's decision — if the
+      // write did not land (no matching session, no matching segment, or a
+      // storage error) reporting success would silently drop the assignment.
+      let persisted = await applySpeakerAssignmentLocally(
+        conversationId: conversationId, segmentIds: segmentIds, personId: personId, isUser: isUser)
       DesktopDiagnosticsManager.shared.recordFallback(
         area: "speaker_assignment",
         from: "backend_bulk_assign",
         to: "local_store",
         reason: "conversation_not_synced",
-        outcome: .degraded
+        outcome: persisted ? .degraded : .exhausted
       )
-      await applySpeakerAssignmentLocally(
-        conversationId: conversationId, segmentIds: segmentIds, personId: personId, isUser: isUser)
-      return true
+      if !persisted {
+        log(
+          "People: Conversation \(conversationId) is neither on the backend (\(statusCode)) nor in local storage — assignment failed"
+        )
+      }
+      return persisted
     } catch {
       logError("People: Failed to assign segments", error: error)
       return false
     }
-    await applySpeakerAssignmentLocally(
+    // Backend accepted the change — it owns the assignment now. The local
+    // mirror is best-effort: a conversation recorded on another device has no
+    // local session, and 0 updated rows is expected there.
+    _ = await applySpeakerAssignmentLocally(
       conversationId: conversationId, segmentIds: segmentIds, personId: personId, isUser: isUser)
     return true
   }
@@ -322,12 +333,16 @@ extension AppState {
   /// (so the label is fresh on next open) and the local SQLite cache (so it
   /// survives restarts, and so a not-yet-synced session carries the assignment to
   /// the backend when it finalizes).
+  /// - Returns: whether the SQLite write actually updated at least one segment.
+  ///   False means nothing durable holds the assignment (no local session, no
+  ///   matching segment, or a storage error).
+  @discardableResult
   private func applySpeakerAssignmentLocally(
     conversationId: String,
     segmentIds: [String],
     personId: String?,
     isUser: Bool
-  ) async {
+  ) async -> Bool {
     let targets = SpeakerAssignmentTargets.parse(segmentIds)
     // Update the in-memory conversations list so the label is fresh on next open.
     // A target may be the segment's local id, its backend id, or a positional
@@ -359,13 +374,19 @@ extension AppState {
     // and, for a conversation the backend does not have yet, so the finalization
     // sync can carry person_id/is_user up with the session. Awaited: returning
     // success before the write lands would let a quit drop the user's decision.
-    try? await TranscriptionStorage.shared.updateSpeakerAssignmentByBackendId(
-      conversationId,
-      segmentIds: targets.ids,
-      fallbackSegmentOrders: targets.orders,
-      isUser: isUser,
-      personId: isUser ? nil : personId
-    )
+    do {
+      let updatedRows = try await TranscriptionStorage.shared.updateSpeakerAssignmentByBackendId(
+        conversationId,
+        segmentIds: targets.ids,
+        fallbackSegmentOrders: targets.orders,
+        isUser: isUser,
+        personId: isUser ? nil : personId
+      )
+      return updatedRows > 0
+    } catch {
+      logError("People: Failed to persist speaker assignment locally", error: error)
+      return false
+    }
   }
 
   // MARK: - Backend Segment Handling

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -317,13 +317,8 @@ struct ConversationDetailView: View {
           )
           guard success else { return false }
 
-          await persistSpeakerAssignment(
-            conversationId: conversation.id,
-            backendSegmentIds: assignment.backendIds,
-            fallbackSegmentOrders: assignment.fallbackOrders,
-            isUser: isUser,
-            personId: personId
-          )
+          // assignSpeakerToSegments already persisted the assignment (backend
+          // and/or awaited local SQLite) — only the displayed copy needs updating.
           updateDisplayedConversation(segmentIndices: segmentIndices, isUser: isUser, personId: personId)
           return true
         },
@@ -883,26 +878,6 @@ struct ConversationDetailView: View {
       )
     }
     loadedConversation = updatedConversation
-  }
-
-  private func persistSpeakerAssignment(
-    conversationId: String,
-    backendSegmentIds: [String],
-    fallbackSegmentOrders: [Int],
-    isUser: Bool,
-    personId: String?
-  ) async {
-    do {
-      try await TranscriptionStorage.shared.updateSpeakerAssignmentByBackendId(
-        conversationId,
-        segmentIds: backendSegmentIds,
-        fallbackSegmentOrders: fallbackSegmentOrders,
-        isUser: isUser,
-        personId: isUser ? nil : personId
-      )
-    } catch {
-      logError("ConversationDetail: Failed to persist speaker assignment locally", error: error)
-    }
   }
 
   // MARK: - Deferred Processing Loader

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -552,16 +552,21 @@ actor TranscriptionStorage {
 
   /// Update speaker assignment metadata for existing segments in a synced conversation.
   /// Matches by backend segment IDs when available, then falls back to local segment order.
+  /// - Returns: the number of segment rows actually updated — 0 means the
+  ///   conversation has no local session or no segment matched, i.e. nothing was
+  ///   persisted. Callers for whom the local store is the only holder of the
+  ///   assignment (the backend-404 fallback) must treat 0 as failure.
+  @discardableResult
   func updateSpeakerAssignmentByBackendId(
     _ backendId: String,
     segmentIds: [String],
     fallbackSegmentOrders: [Int],
     isUser: Bool,
     personId: String?
-  ) async throws {
+  ) async throws -> Int {
     let db = try await ensureInitialized()
 
-    try await db.write { database in
+    return try await db.write { database -> Int in
       guard
         let sessionId = try Int64.fetchOne(
           database,
@@ -569,7 +574,7 @@ actor TranscriptionStorage {
           arguments: [backendId]
         )
       else {
-        return
+        return 0
       }
 
       let encodedSegmentIds = String(
@@ -581,6 +586,7 @@ actor TranscriptionStorage {
         as: UTF8.self
       )
 
+      var updatedRows = 0
       if !segmentIds.isEmpty {
         try database.execute(
           sql: """
@@ -592,6 +598,7 @@ actor TranscriptionStorage {
             """,
           arguments: [isUser, personId, sessionId, encodedSegmentIds]
         )
+        updatedRows += database.changesCount
       }
 
       if !fallbackSegmentOrders.isEmpty {
@@ -605,7 +612,9 @@ actor TranscriptionStorage {
             """,
           arguments: [isUser, personId, sessionId, encodedFallbackOrders]
         )
+        updatedRows += database.changesCount
       }
+      return updatedRows
     }
   }
   /// Get all segments for a session ordered by segmentOrder

--- a/desktop/macos/Desktop/Tests/SpeakerAssignmentTests.swift
+++ b/desktop/macos/Desktop/Tests/SpeakerAssignmentTests.swift
@@ -38,4 +38,15 @@ final class SpeakerAssignmentTests: XCTestCase {
     XCTAssertEqual(meta.backendIds, ["backend-a"])
     XCTAssertEqual(meta.fallbackOrders, [1])
   }
+
+  /// The local half must consume BOTH target kinds the wire carries — backend
+  /// ids and positional #index:N — because unsynced/legacy segments only have
+  /// the positional form. Dropping them was the "assignment succeeded but did
+  /// not survive reload" defect.
+  func testTargetParsingSplitsIdsAndPositionalFallbacks() {
+    let parsed = AppState.SpeakerAssignmentTargets.parse(
+      ["backend-a", "#index:1", "#index:12", "not-an-index", "#index:x"])
+    XCTAssertEqual(parsed.ids, ["backend-a", "not-an-index", "#index:x"])
+    XCTAssertEqual(parsed.orders, [1, 12])
+  }
 }

--- a/desktop/macos/Desktop/Tests/SpeakerAssignmentTests.swift
+++ b/desktop/macos/Desktop/Tests/SpeakerAssignmentTests.swift
@@ -50,3 +50,89 @@ final class SpeakerAssignmentTests: XCTestCase {
     XCTAssertEqual(parsed.orders, [1, 12])
   }
 }
+
+/// The 404 fallback's durable half, exercised through the REAL SQLite write and
+/// reload path (a per-test RewindDatabase, same seam as the finalization state
+/// machine tests). The write must report whether it landed: when it returns 0
+/// nothing durable holds the user's decision, and `assignSpeakerToSegments`
+/// must not report success — the `try?` that swallowed this was the reviewed
+/// defect.
+final class SpeakerAssignmentPersistenceTests: XCTestCase {
+  private var testUserId = ""
+  private var userDir: URL?
+
+  override func setUp() async throws {
+    try await super.setUp()
+    testUserId = "speaker-assignment-test-\(UUID().uuidString)"
+    await RewindDatabase.shared.close()
+    await TranscriptionStorage.shared.invalidateCache()
+    RewindDatabase.currentUserId = testUserId
+    await RewindDatabase.shared.configure(userId: testUserId)
+    try await RewindDatabase.shared.initialize()
+
+    let appSupport = try XCTUnwrap(
+      FileManager.default
+        .urls(for: .applicationSupportDirectory, in: .userDomainMask).first)
+    userDir =
+      appSupport
+      .appendingPathComponent("Omi", isDirectory: true)
+      .appendingPathComponent(testUserId, isDirectory: true)
+  }
+
+  override func tearDown() async throws {
+    await RewindDatabase.shared.close()
+    await TranscriptionStorage.shared.invalidateCache()
+    RewindDatabase.currentUserId = nil
+    if let userDir {
+      try? FileManager.default.removeItem(at: userDir)
+    }
+    try await super.tearDown()
+  }
+
+  func testPositionalAssignmentPersistsThroughSQLiteAndSurvivesReload() async throws {
+    let sessionId = try await TranscriptionStorage.shared.startSession(source: "desktop")
+    for i in 0..<3 {
+      try await TranscriptionStorage.shared.appendSegment(
+        sessionId: sessionId, speaker: i, text: "segment \(i)",
+        startTime: Double(i), endTime: Double(i) + 1)
+    }
+    try await TranscriptionStorage.shared.finishSession(id: sessionId)
+    _ = try await TranscriptionStorage.shared.markSessionCompleted(
+      id: sessionId, backendId: "backend-conv-speaker")
+
+    // The positional #index:N form the wire carries for segments without
+    // backend ids — parsed to fallbackSegmentOrders by the production caller.
+    let updated = try await TranscriptionStorage.shared.updateSpeakerAssignmentByBackendId(
+      "backend-conv-speaker",
+      segmentIds: [],
+      fallbackSegmentOrders: [1],
+      isUser: false,
+      personId: "person-dana"
+    )
+    XCTAssertEqual(updated, 1, "exactly the targeted segment row must report as updated")
+
+    // Reload path: close and reopen storage, then read back what a restart sees.
+    await RewindDatabase.shared.close()
+    await TranscriptionStorage.shared.invalidateCache()
+    try await RewindDatabase.shared.initialize()
+
+    let segments = try await TranscriptionStorage.shared.getSegments(sessionId: sessionId)
+    XCTAssertEqual(segments.count, 3)
+    XCTAssertNil(segments[0].personId)
+    XCTAssertEqual(segments[1].personId, "person-dana", "the assignment must survive a storage reload")
+    XCTAssertNil(segments[2].personId)
+  }
+
+  func testAssignmentAgainstUnknownConversationReportsNothingPersisted() async throws {
+    let updated = try await TranscriptionStorage.shared.updateSpeakerAssignmentByBackendId(
+      "no-such-conversation",
+      segmentIds: ["seg-a"],
+      fallbackSegmentOrders: [0],
+      isUser: false,
+      personId: "person-dana"
+    )
+    XCTAssertEqual(
+      updated, 0,
+      "no local session means nothing persisted — the caller must surface failure, not success")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260828-speaker-naming-persist.json
+++ b/desktop/macos/changelog/unreleased/20260828-speaker-naming-persist.json
@@ -1,0 +1,3 @@
+{
+  "change": "Speaker names tagged on a recording that hasn't finished syncing now reliably survive restarting the app"
+}


### PR DESCRIPTION
## What

Follow-up to #12359, fixing a real review finding: the local half of a speaker assignment matched only exact segment ids, but the detail sheet sends `#index:N` positional targets for segments stored without backend ids. So a 404-fallback (unsynced conversation) assignment could report success while neither the in-memory list nor SQLite retained it — and the SQLite write was fire-and-forget, so even id-targeted assignments could be dropped by a quick quit.

- `SpeakerAssignmentTargets.parse` splits wire targets into ids and positional orders (tested, including malformed `#index:` strings staying ids).
- `applySpeakerAssignmentLocally` matches local id, backend id, **or** positional index in memory; persists through `updateSpeakerAssignmentByBackendId` (which consumes both target kinds); and is **awaited** before `assignSpeakerToSegments` returns success.

## Verification

Dev bundle rebuilt from this change, production paths:
- Assigned **"Priya"** to `#index:5` on a real 3-speaker conversation, then `quit_and_reopen`: the name still renders, and the profile SQLite shows `segmentOrder 5 → personId set` (orders 1/2 from earlier assignments intact, 0/3/4 untouched).
- 404+positional probe on a bogus conversation id: `assigned=true` through the local-first fallback branch.
- `swift test --filter SpeakerAssignmentTests` — **22 tests, 0 failures**.

## Product invariants affected

- INV-NAV-1 — touched paths match its globs; no navigation change (data-layer fix inside the existing assignment flow), so its guard test needs no update.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

