### PR TITLE
feat(desktop): rename the Brain tab to Memories

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ActivityBackButton.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ActivityBackButton.swift
@@ -26,7 +26,7 @@ struct ActivityBackButton: View {
       HStack(spacing: 5) {
         Image(systemName: "chevron.left")
           .scaledFont(size: OmiType.micro, weight: .semibold)
-        Text("Brain")
+        Text("Memories")
           .scaledFont(size: OmiType.caption, weight: .semibold)
       }
       .foregroundStyle(GlassShell.controlLabel(isProminent: isHovering))
@@ -36,8 +36,8 @@ struct ActivityBackButton: View {
     }
     .buttonStyle(.plain)
     .onHover { isHovering = $0 }
-    .help("Back to Brain")
-    .accessibilityLabel("Back to Brain")
+    .help("Back to Memories")
+    .accessibilityLabel("Back to Memories")
     .accessibilityIdentifier("activity-back-button")
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
@@ -99,7 +99,7 @@ enum ShellDestination: Int, CaseIterable, Identifiable {
     case .rewind: return "Rewind"
     case .apps: return "Apps"
     case .permissions: return "Permissions"
-    case .activity: return "Brain"
+    case .activity: return "Memories"
     }
   }
 
@@ -222,8 +222,8 @@ enum TopNavigationRoutes {
     // page's own chip row, which is the mechanism `ShellDestination.reach` records for them.
     // The glyph is deliberately not `clock.arrow.circlepath`: that belongs to Rewind inside Brain.
     TopNavigationItem(
-      index: SidebarNavItem.conversations.rawValue, title: "Brain", icon: "brain",
-      tooltip: "Brain — everything Omi captured, newest first"),
+      index: SidebarNavItem.conversations.rawValue, title: "Memories", icon: "brain",
+      tooltip: "Memories — everything Omi captured, newest first"),
     TopNavigationItem(
       index: SidebarNavItem.tasks.rawValue, title: "Tasks", icon: "checklist",
       tooltip: "Tasks — everything Omi heard you commit to"),

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -200,7 +200,7 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     let hubPill = TopNavigationRoutes.primaryItems.first {
       $0.index == SidebarNavItem.conversations.rawValue
     }
-    XCTAssertEqual(hubPill?.title, "Brain")
+    XCTAssertEqual(hubPill?.title, "Memories")
     XCTAssertNotEqual(
       hubPill?.icon, "clock.arrow.circlepath",
       "the Brain pill must not wear Rewind's section glyph")

--- a/desktop/macos/changelog/unreleased/20260828-brain-tab-renamed-memories.json
+++ b/desktop/macos/changelog/unreleased/20260828-brain-tab-renamed-memories.json
@@ -1,0 +1,3 @@
+{
+  "change": "Renamed the Brain tab to Memories across the top navigation and back controls"
+}


### PR DESCRIPTION
Renames the desktop app's "Brain" navigation tab to "Memories".

Source: live community feedback in the Omi Discord meetup (2026-08-28) — "'Memories' makes more sense than 'brain' to me. Brain is not very specific" (Schlemosel), "yes Memories > Brain" (state_port.GenTek); requested by Nik.

Scope — every user-visible surface of the label, nothing else:
- Top nav pill title + tooltip (`TopNavigationDestinations.swift`)
- Back chip from drill-in pages: text, `.help`, `.accessibilityLabel` (`ActivityBackButton.swift`)
- Nav layout test assert follows the label; internal identifiers (`BrainSection*`, `.brainMap`) and the distinct "Brain Map" feature are unchanged.

## Product invariants affected

- INV-NAV-1

## Verification

- Local build + run (named dev bundle): top nav pill reads "Memories", back chip reads "Memories" — screenshot exercised via the automation bridge on the rebuilt binary.
- `swift test --filter "TopNavigationBarLayoutTests|ChatFirstDestinationParityTests|MemoryGraphRevisitTests"`: 33 tests, 0 failures.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

