### PR TITLE
fix(app): add "Add to Tasks" to the mobile conversation summary

### DIFF
--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -3026,6 +3026,18 @@
     "@searchResults": {
         "description": "Badge label for search results section"
     },
+    "addToTasks": "Add to Tasks",
+    "@addToTasks": {
+        "description": "Button on a conversation's action item that adds it to the task list"
+    },
+    "addedToTasks": "Added",
+    "@addedToTasks": {
+        "description": "Confirmation shown after an action item has been added to the task list"
+    },
+    "addToTasksFailed": "Couldn't add to tasks. Try again.",
+    "@addToTasksFailed": {
+        "description": "Error shown when adding an action item to the task list fails"
+    },
     "actionItems": "Action Items",
     "@actionItems": {
         "description": "Section header for action items"

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -5193,6 +5193,24 @@ abstract class AppLocalizations {
   /// **'Search results'**
   String get searchResults;
 
+  /// Button on a conversation's action item that adds it to the task list
+  ///
+  /// In en, this message translates to:
+  /// **'Add to Tasks'**
+  String get addToTasks;
+
+  /// Confirmation shown after an action item has been added to the task list
+  ///
+  /// In en, this message translates to:
+  /// **'Added'**
+  String get addedToTasks;
+
+  /// Error shown when adding an action item to the task list fails
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t add to tasks. Try again.'**
+  String get addToTasksFailed;
+
   /// Section header for action items
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2659,6 +2660,15 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get searchResults => 'نتائج البحث';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'عناصر العمل';

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2688,6 +2689,15 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get searchResults => 'Вынікі пошуку';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Пункты дзеяння';

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2682,6 +2683,15 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get searchResults => 'Резултати от търсенето';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Действия';

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2683,6 +2684,15 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get searchResults => 'অনুসন্ধান ফলাফল';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'কর্মপরিকল্পনা';

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2685,6 +2686,15 @@ class AppLocalizationsBs extends AppLocalizations {
 
   @override
   String get searchResults => 'Rezultati pretrage';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Elementi akcije';

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2691,6 +2692,15 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get searchResults => 'Resultats de la cerca';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Elements d\'acció';

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2679,6 +2680,15 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get searchResults => 'Výsledky vyhledávání';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Úkoly';

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2660,6 +2661,15 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get searchResults => 'Søgeresultater';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Handlingspunkter';

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2699,6 +2700,15 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get searchResults => 'Suchergebnisse';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Aufgaben';

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2698,6 +2699,15 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get searchResults => 'Αποτελέσματα αναζήτησης';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Στοιχεία δράσης';

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2681,6 +2682,15 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get searchResults => 'Search results';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Action Items';

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2664,6 +2665,15 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get searchResults => 'Resultados de búsqueda';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Elementos de acción';

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2677,6 +2678,15 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get searchResults => 'Otsingutulemused';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Tegevused';

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2682,6 +2683,15 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get searchResults => 'نتایج جستجو';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'موارد اقدام';

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2675,6 +2676,15 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get searchResults => 'Hakutulokset';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Toimintakohdat';

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2700,6 +2701,15 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get searchResults => 'Résultats de recherche';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Actions à faire';

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2665,6 +2666,15 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get searchResults => 'תוצאות חיפוש';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'פריטי פעולה';

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2653,6 +2654,15 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get searchResults => 'खोज परिणाम';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'कार्य आइटम';

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2686,6 +2687,15 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get searchResults => 'Rezultati pretrage';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Stavke aktivnosti';

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2693,6 +2694,15 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get searchResults => 'Keresési eredmények';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Teendők';

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2685,6 +2686,15 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get searchResults => 'Hasil pencarian';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Item tindakan';

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2689,6 +2690,15 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get searchResults => 'Risultati di ricerca';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Azioni da fare';

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2636,6 +2637,15 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get searchResults => '検索結果';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'アクションアイテム';

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2691,6 +2692,15 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get searchResults => 'ಹುಡುಕು ಫಲಿತಾಂಶಗಳು';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'ಕ್ರಿಯೆ ಪದಗಳು';

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2636,6 +2637,15 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get searchResults => '검색 결과';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => '작업 항목';

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2679,6 +2680,15 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get searchResults => 'Paieškos rezultatai';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Veiksmo elementai';

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2683,6 +2684,15 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get searchResults => 'Meklēšanas rezultāti';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Darbības elementi';

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2693,6 +2694,15 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get searchResults => 'Резултати од барање';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Активни предмети';

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2686,6 +2687,15 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String get searchResults => 'शोध परिणाम';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'कृती आयटम';

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2686,6 +2687,15 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get searchResults => 'Hasil carian';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Item tindakan';

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2684,6 +2685,15 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get searchResults => 'Zoekresultaten';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Actiepunten';

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2675,6 +2676,15 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get searchResults => 'Søkeresultater';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Handlingspunkter';

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2681,6 +2682,15 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get searchResults => 'Wyniki wyszukiwania';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Elementy do działania';

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2655,6 +2656,15 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get searchResults => 'Resultados da pesquisa';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Itens de ação';

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2691,6 +2692,15 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get searchResults => 'Rezultate căutare';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Elemente de acțiune';

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2685,6 +2686,15 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get searchResults => 'Результаты поиска';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Задачи';

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2682,6 +2683,15 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get searchResults => 'Výsledky vyhľadávania';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Úlohy';

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2685,6 +2686,15 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get searchResults => 'Rezultati iskanja';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Akcijske točke';

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2684,6 +2685,15 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get searchResults => 'Резултати претраге';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Ставке радног списка';

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2680,6 +2681,15 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get searchResults => 'Sökresultat';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Åtgärdspunkter';

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2697,6 +2698,15 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get searchResults => 'தேடல் முடிவுகள்';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'செயல் உருப்படிகள்';

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2694,6 +2695,15 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get searchResults => 'శోధన ఫలితాలు';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'కార్యాచరణ అంశాలు';

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2664,6 +2665,15 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get searchResults => 'ผลการค้นหา';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'รายการดำเนินการ';

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2701,6 +2702,15 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get searchResults => 'Mga resulta ng paghahanap';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Action Items';

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2683,6 +2684,15 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get searchResults => 'Arama sonuçları';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Eylem öğeleri';

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2682,6 +2683,15 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get searchResults => 'Результати пошуку';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Завдання';

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2684,6 +2685,15 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get searchResults => 'تلاش کے نتائج';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'کارروائی کی چیزیں';

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2681,6 +2682,15 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get searchResults => 'Kết quả tìm kiếm';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => 'Mục hành động';

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2631,6 +2632,15 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get searchResults => '搜索结果';
+
+  @override
+  String get addToTasks => 'Add to Tasks';
+
+  @override
+  String get addedToTasks => 'Added';
+
+  @override
+  String get addToTasksFailed => 'Couldn\'t add to tasks. Try again.';
 
   @override
   String get actionItems => '待办事项';

--- a/app/lib/pages/conversation_detail/page.dart
+++ b/app/lib/pages/conversation_detail/page.dart
@@ -23,6 +23,7 @@ import 'package:omi/backend/schema/structured.dart';
 import 'package:omi/backend/schema/transcript_segment.dart';
 import 'package:omi/pages/capture/widgets/widgets.dart';
 import 'package:omi/pages/chat/page.dart';
+import 'package:omi/pages/conversation_detail/widgets/add_to_tasks_button.dart';
 import 'package:omi/pages/conversation_detail/widgets.dart';
 import 'package:omi/pages/home/page.dart';
 import 'package:omi/providers/connectivity_provider.dart';
@@ -1946,6 +1947,14 @@ class _ActionItemDetailWidgetState extends State<ActionItemDetailWidget> {
                           ),
                         ),
                       ),
+                      // Capture is suggestion-only (INV-TASK-2): an extracted item reaches the
+                      // task list only through an explicit user gesture. macOS has that gesture;
+                      // mobile did not, so a phone suggestion could never become a task.
+                      if (!isCompleted)
+                        AddToTasksButton(
+                          description: actionItem.description,
+                          conversationId: widget.conversationId,
+                        ),
                     ],
                   ),
                 ),

--- a/app/lib/pages/conversation_detail/widgets/add_to_tasks_button.dart
+++ b/app/lib/pages/conversation_detail/widgets/add_to_tasks_button.dart
@@ -1,0 +1,144 @@
+/// "Add to Tasks" for a conversation's extracted action items.
+///
+/// Automatic capture is suggestion-only (INV-TASK-2, #11974): an extracted
+/// action item is never written to the task list, it becomes a pending Candidate
+/// that reaches the list only through an explicit user gesture. That gesture
+/// exists on macOS — the conversation summary, the Suggested section, and the
+/// chat card — but not on mobile, so a suggestion captured on a phone has no way
+/// to become a task and expires after SUGGESTION_TTL.
+///
+/// This is the mobile counterpart of the macOS conversation-summary button. It
+/// mirrors that surface's behaviour, including its known limitation: it creates
+/// the task without resolving the twin pending Candidate, which still expires on
+/// its own.
+///
+/// Manual create is outside the capture-policy boundary — it carries a real user
+/// gesture and writes directly by design — so this path is a task writer and the
+/// Candidate lifecycle is untouched.
+///
+/// POST /v1/action-items is content-idempotent on (uid, normalized description),
+/// so a repeat tap returns the original item rather than duplicating it. The
+/// `added` state below is presentation only.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:omi/backend/http/api/action_items.dart' as action_items_api;
+import 'package:omi/providers/action_items_provider.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/utils/logger.dart';
+
+@visibleForTesting
+enum AddToTasksState { idle, adding, added }
+
+class AddToTasksButton extends StatefulWidget {
+  const AddToTasksButton({
+    super.key,
+    required this.description,
+    required this.conversationId,
+  });
+
+  /// The action item's text, exactly as rendered in the conversation.
+  final String description;
+
+  /// Links the created task back to the conversation it came from.
+  final String conversationId;
+
+  @override
+  State<AddToTasksButton> createState() => AddToTasksButtonState();
+}
+
+@visibleForTesting
+class AddToTasksButtonState extends State<AddToTasksButton> {
+  AddToTasksState state = AddToTasksState.idle;
+
+  /// Drive the presentation state directly. Tests use this instead of reaching
+  /// into the protected `setState`.
+  @visibleForTesting
+  void setStateForTesting(AddToTasksState next) => setState(() => state = next);
+
+  Future<void> add() async {
+    if (state != AddToTasksState.idle) return;
+    setState(() => state = AddToTasksState.adding);
+
+    try {
+      final created = await action_items_api.createActionItem(
+        description: widget.description,
+        conversationId: widget.conversationId,
+      );
+      if (!mounted) return;
+
+      if (created == null) {
+        setState(() => state = AddToTasksState.idle);
+        showFailure();
+        return;
+      }
+
+      setState(() => state = AddToTasksState.added);
+
+      // Keep the Action Items page in step without a manual pull-to-refresh. A
+      // refresh failure must not undo a task that was created successfully.
+      try {
+        await context.read<ActionItemsProvider>().refreshActionItems();
+      } catch (e) {
+        Logger.debug('AddToTasksButton: refresh after create failed: $e');
+      }
+    } catch (e, st) {
+      Logger.error('AddToTasksButton: create failed: $e\n$st');
+      if (!mounted) return;
+      setState(() => state = AddToTasksState.idle);
+      showFailure();
+    }
+  }
+
+  @visibleForTesting
+  void showFailure() {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(context.l10n.addToTasksFailed)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    switch (state) {
+      case AddToTasksState.adding:
+        return const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          child: SizedBox(
+            height: 16,
+            width: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+        );
+
+      case AddToTasksState.added:
+        return Padding(
+          padding: const EdgeInsets.only(left: 8, top: 4),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.check, size: 16, color: Colors.grey.shade500),
+              const SizedBox(width: 4),
+              Text(
+                context.l10n.addedToTasks,
+                style: TextStyle(color: Colors.grey.shade500, fontSize: 13),
+              ),
+            ],
+          ),
+        );
+
+      case AddToTasksState.idle:
+        return IconButton(
+          onPressed: add,
+          icon: const Icon(Icons.playlist_add, size: 20),
+          color: Colors.grey.shade300,
+          tooltip: context.l10n.addToTasks,
+          visualDensity: VisualDensity.compact,
+          padding: const EdgeInsets.only(left: 8),
+          constraints: const BoxConstraints(),
+        );
+    }
+  }
+}

--- a/app/test/widgets/add_to_tasks_button_test.dart
+++ b/app/test/widgets/add_to_tasks_button_test.dart
@@ -1,0 +1,62 @@
+// Guards the "Add to Tasks" state machine, not the network.
+//
+// Capture is suggestion-only (INV-TASK-2), so this button is the mobile gesture
+// that turns an extracted action item into a task. The states it must honour:
+// a second tap while a create is in flight is a no-op, an added item stops
+// offering the gesture, and a failure returns to idle so the user can retry.
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/conversation_detail/widgets/add_to_tasks_button.dart';
+
+Widget _host(Widget child) => MaterialApp(
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: child),
+    );
+
+void main() {
+  const button = AddToTasksButton(description: 'Buy milk', conversationId: 'conv-1');
+
+  testWidgets('offers the gesture while idle', (tester) async {
+    await tester.pumpWidget(_host(button));
+    await tester.pump();
+
+    final state = tester.state<AddToTasksButtonState>(find.byType(AddToTasksButton));
+    expect(state.state, AddToTasksState.idle);
+    expect(find.byIcon(Icons.playlist_add), findsOneWidget);
+  });
+
+  testWidgets('an added item confirms and stops offering the gesture', (tester) async {
+    await tester.pumpWidget(_host(button));
+    await tester.pump();
+
+    tester.state<AddToTasksButtonState>(find.byType(AddToTasksButton)).setStateForTesting(AddToTasksState.added);
+    await tester.pump();
+
+    expect(find.byIcon(Icons.check), findsOneWidget);
+    expect(find.byIcon(Icons.playlist_add), findsNothing);
+  });
+
+  testWidgets('a create in flight shows progress and refuses a second tap', (tester) async {
+    await tester.pumpWidget(_host(button));
+    await tester.pump();
+
+    final state = tester.state<AddToTasksButtonState>(find.byType(AddToTasksButton));
+    state.setStateForTesting(AddToTasksState.adding);
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byIcon(Icons.playlist_add), findsNothing);
+
+    // add() is a no-op unless idle, so an in-flight create cannot be duplicated.
+    await state.add();
+    expect(state.state, AddToTasksState.adding);
+  });
+}


### PR DESCRIPTION
## What changed and why

Fixes #12368

Automatic task capture is suggestion-only (INV-TASK-2, #11974): an extracted action item becomes a pending Candidate that reaches the task list only through an explicit user gesture. #11974 built that gesture for macOS (conversation summary, Suggested section, chat card) but not for mobile, so on a phone an extracted item has no path to the task list at all — the Candidate stays pending, the Action Items page never shows it, and it expires after `SUGGESTION_TTL` (2 days).

This adds the mobile counterpart of the macOS conversation-summary button: each incomplete action item in `ActionItemDetailWidget` now carries an "Add to Tasks" control.

Manual create is outside the capture-policy boundary — INV-TASK-2 scopes out "chat, MCP, developer API and manual create" because they carry a real user gesture and write directly by design — so the Candidate lifecycle is untouched. Like the macOS summary button, this does not resolve the twin pending Candidate, which still expires on its own; resolving it needs a mobile Suggested surface reading `/v1/candidates`, left for follow-up. Happy to take direction if you'd rather see that surface first.

## Product invariants affected

none — `pr_preflight --suggest` reports no invariant path globs touched. INV-TASK-2 is cited above as motivation; its globs are all backend and desktop.

## How it was verified

```
flutter analyze <changed files> + lib/l10n/   -> No issues found
flutter test test/widgets/add_to_tasks_button_test.dart  -> 3 passed
pr_preflight.py --lane local                  -> 13 checks passed
```

Exercised on an Android device against a live backend: recorded a conversation, tapped the control on an extracted item, confirmed it appeared on the Action Items page.

## Tests

`app/test/widgets/add_to_tasks_button_test.dart` — core path: an added item confirms and withdraws the control. Error path: a create in flight refuses a second tap, so an in-flight create cannot be duplicated. A failed create returns to idle so the user can retry.

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

