### PR TITLE
fix(app): distinguish cutover outages from migration

### DIFF
--- a/app/lib/services/account_cutover/account_cutover_blocking_gate.dart
+++ b/app/lib/services/account_cutover/account_cutover_blocking_gate.dart
@@ -15,11 +15,8 @@ import 'package:omi/services/account_cutover/account_cutover_runtime.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 class AccountCutoverBlockingGate extends StatefulWidget {
-  const AccountCutoverBlockingGate({
-    super.key,
-    this.productBuilder,
-    this.child,
-  }) : assert(productBuilder != null || child != null, 'productBuilder or child is required');
+  const AccountCutoverBlockingGate({super.key, this.productBuilder, this.child})
+      : assert(productBuilder != null || child != null, 'productBuilder or child is required');
 
   /// Preferred: built only while product traffic is allowed.
   final WidgetBuilder? productBuilder;
@@ -45,17 +42,19 @@ class _AccountCutoverBlockingGateState extends State<AccountCutoverBlockingGate>
 
   static const _fenceRefreshInterval = Duration(seconds: 30);
 
+  Future<void> _refreshFence() async {
+    if (_refreshInFlight) return;
+    _refreshInFlight = true;
+    try {
+      await AccountCutoverRuntime.instance.refresh();
+    } finally {
+      _refreshInFlight = false;
+    }
+  }
+
   void _syncFenceRefreshTimer(bool fenceVisible) {
     if (fenceVisible && _fenceRefreshTimer == null) {
-      _fenceRefreshTimer = Timer.periodic(_fenceRefreshInterval, (_) async {
-        if (_refreshInFlight) return;
-        _refreshInFlight = true;
-        try {
-          await AccountCutoverRuntime.instance.refresh();
-        } finally {
-          _refreshInFlight = false;
-        }
-      });
+      _fenceRefreshTimer = Timer.periodic(_fenceRefreshInterval, (_) => unawaited(_refreshFence()));
     } else if (!fenceVisible && _fenceRefreshTimer != null) {
       _fenceRefreshTimer!.cancel();
       _fenceRefreshTimer = null;
@@ -82,15 +81,15 @@ class _AccountCutoverBlockingGateState extends State<AccountCutoverBlockingGate>
         }
 
         return AccountCutoverBlockingView(
-          decision: decision,
+          blockingReason: runtime.blockingReason,
           strandedNewData: runtime.control.strandedNewData,
           appStoreUrl: AccountCutoverBlockingGate._appStoreUrl,
           playStoreUrl: AccountCutoverBlockingGate._playStoreUrl,
-          // A fence this client synthesized after the server had allowed the
-          // owner (unreachable control plane, a blown refresh) keeps a manual
-          // way back to that last authoritative projection. A fence the server
-          // itself decided — or one with no server allow to return to — does
-          // not.
+          onRetry: () => unawaited(_refreshFence()),
+          // An unconfirmed fence after the server had allowed the owner keeps
+          // a manual way back to that last authoritative projection. A fence
+          // the server itself decided — or one with no server allow to return
+          // to — does not.
           onSkipUnresolvedFence: runtime.canSkipUnresolvedFence ? runtime.skipUnresolvedFence : null,
         );
       },
@@ -101,17 +100,19 @@ class _AccountCutoverBlockingGateState extends State<AccountCutoverBlockingGate>
 class AccountCutoverBlockingView extends StatelessWidget {
   const AccountCutoverBlockingView({
     super.key,
-    required this.decision,
+    required this.blockingReason,
     required this.strandedNewData,
     required this.appStoreUrl,
     required this.playStoreUrl,
+    this.onRetry,
     this.onSkipUnresolvedFence,
   });
 
-  final AccountCutoverGateDecision decision;
+  final AccountCutoverBlockingReason blockingReason;
   final bool strandedNewData;
   final Uri appStoreUrl;
   final Uri playStoreUrl;
+  final VoidCallback? onRetry;
 
   /// Non-null only while this client synthesized the fence and the server had
   /// authoritatively allowed the owner. Pressing it returns to that last
@@ -121,13 +122,32 @@ class AccountCutoverBlockingView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
-    final forceUpgrade = decision == AccountCutoverGateDecision.forceUpgrade;
-    final title = forceUpgrade ? l10n.accountCutoverUpdateRequiredTitle : l10n.accountCutoverMigrationInProgressTitle;
-    final message = forceUpgrade
-        ? l10n.accountCutoverUpdateRequiredMessage
-        : (strandedNewData
-            ? l10n.accountCutoverMigrationRollbackMessage
-            : l10n.accountCutoverMigrationInProgressMessage);
+    final forceUpgrade = blockingReason == AccountCutoverBlockingReason.forceUpgrade;
+    final retryable = blockingReason == AccountCutoverBlockingReason.connectionUnavailable ||
+        blockingReason == AccountCutoverBlockingReason.controlUnavailable;
+    final (title, message, icon) = switch (blockingReason) {
+      AccountCutoverBlockingReason.forceUpgrade => (
+          l10n.accountCutoverUpdateRequiredTitle,
+          l10n.accountCutoverUpdateRequiredMessage,
+          Icons.system_update,
+        ),
+      AccountCutoverBlockingReason.confirmedMigration => (
+          l10n.accountCutoverMigrationInProgressTitle,
+          strandedNewData ? l10n.accountCutoverMigrationRollbackMessage : l10n.accountCutoverMigrationInProgressMessage,
+          Icons.hourglass_top,
+        ),
+      AccountCutoverBlockingReason.checkingStatus => (l10n.loading, l10n.pleaseWait, Icons.sync),
+      AccountCutoverBlockingReason.connectionUnavailable => (
+          l10n.noInternetConnection,
+          l10n.pleaseCheckInternetConnectionAndTryAgain,
+          Icons.cloud_off_outlined,
+        ),
+      AccountCutoverBlockingReason.controlUnavailable || AccountCutoverBlockingReason.none => (
+          l10n.connectionError,
+          l10n.somethingWentWrong,
+          Icons.sync_problem_outlined,
+        ),
+    };
 
     return Semantics(
       container: true,
@@ -144,20 +164,12 @@ class AccountCutoverBlockingView extends StatelessWidget {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    Icon(
-                      forceUpgrade ? Icons.system_update : Icons.hourglass_top,
-                      color: Colors.white,
-                      size: 36,
-                    ),
+                    Icon(icon, color: Colors.white, size: 36),
                     const SizedBox(height: 16),
                     Text(
                       title,
                       textAlign: TextAlign.center,
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 22,
-                        fontWeight: FontWeight.w600,
-                      ),
+                      style: const TextStyle(color: Colors.white, fontSize: 22, fontWeight: FontWeight.w600),
                     ),
                     const SizedBox(height: 12),
                     Text(
@@ -174,11 +186,15 @@ class AccountCutoverBlockingView extends StatelessWidget {
                         },
                         child: Text(l10n.accountCutoverOpenStore),
                       ),
-                    ] else if (onSkipUnresolvedFence != null) ...[
+                    ] else if (retryable) ...[
+                      const SizedBox(height: 20),
+                      FilledButton(onPressed: onRetry, child: Text(l10n.retry)),
+                    ],
+                    if (!forceUpgrade && onSkipUnresolvedFence != null) ...[
                       const SizedBox(height: 20),
                       TextButton(
                         onPressed: onSkipUnresolvedFence,
-                        child: Text(l10n.skip, style: const TextStyle(color: Colors.white70)),
+                        child: Text(l10n.continueAction, style: const TextStyle(color: Colors.white70)),
                       ),
                     ],
                   ],

--- a/app/lib/services/account_cutover/account_cutover_control.dart
+++ b/app/lib/services/account_cutover/account_cutover_control.dart
@@ -77,6 +77,12 @@ bool _requireBool(Map<String, dynamic> json, String key) {
   throw AccountCutoverControlParseException('expected boolean for $key, got ${value.runtimeType}');
 }
 
+String _requireString(Map<String, dynamic> json, String key) {
+  final value = json[key];
+  if (value is String) return value;
+  throw AccountCutoverControlParseException('expected string for $key, got ${value.runtimeType}');
+}
+
 int _requireNonNegativeInt(Map<String, dynamic> json, String key) {
   final value = json[key];
   if (value is num && value == value.roundToDouble() && value >= 0) {
@@ -154,12 +160,12 @@ class AccountCutoverControl {
     }
 
     return AccountCutoverControl(
-      state: parseAccountCutoverState(json['state'] as String?),
+      state: parseAccountCutoverState(_requireString(json, 'state')),
       accountGeneration: _requireNonNegativeInt(json, 'account_generation'),
       uiGeneration: json.containsKey('ui_generation') ? _requireNonNegativeInt(json, 'ui_generation') : 0,
       apiGeneration: json.containsKey('api_generation') ? _requireNonNegativeInt(json, 'api_generation') : 0,
-      clientAction: parseAccountCutoverClientAction(json['client_action'] as String?),
-      offlineQueueInstruction: parseOfflineQueueInstruction(json['offline_queue_instruction'] as String?),
+      clientAction: parseAccountCutoverClientAction(_requireString(json, 'client_action')),
+      offlineQueueInstruction: parseOfflineQueueInstruction(_requireString(json, 'offline_queue_instruction')),
       strandedNewData: json.containsKey('stranded_new_data') ? _requireBool(json, 'stranded_new_data') : false,
       legacyWritesAllowed: _requireBool(json, 'legacy_writes_allowed'),
       productTrafficAllowed: _requireBool(json, 'product_traffic_allowed'),

--- a/app/lib/services/account_cutover/account_cutover_runtime.dart
+++ b/app/lib/services/account_cutover/account_cutover_runtime.dart
@@ -9,6 +9,21 @@ import 'package:omi/services/account_cutover/account_cutover_control.dart';
 import 'package:omi/services/account_cutover/account_cutover_control_client.dart';
 import 'package:omi/services/account_cutover/account_cutover_gate.dart';
 
+/// Why product traffic is currently fenced.
+///
+/// This is deliberately separate from [AccountCutoverGateDecision]. The gate
+/// decision owns access policy; this reason owns what the client may truthfully
+/// tell the user. A failed or pending control fetch is not evidence that an
+/// account is migrating, even when both conditions must fail closed.
+enum AccountCutoverBlockingReason {
+  none,
+  forceUpgrade,
+  confirmedMigration,
+  checkingStatus,
+  connectionUnavailable,
+  controlUnavailable,
+}
+
 class AccountCutoverRuntime extends ChangeNotifier {
   AccountCutoverRuntime._();
   static final AccountCutoverRuntime instance = AccountCutoverRuntime._();
@@ -25,11 +40,24 @@ class AccountCutoverRuntime extends ChangeNotifier {
   String? _ownerUid;
   int _refreshEpoch = 0;
   bool _resolvedForOwner = true;
+  AccountCutoverBlockingReason _blockingReason = AccountCutoverBlockingReason.none;
 
   AccountCutoverControl get control => _control;
   bool get hasAuthoritativeControl => _hasAuthoritative;
   String? get ownerUid => _ownerUid;
   bool get isResolvedForOwner => _resolvedForOwner;
+  AccountCutoverBlockingReason get blockingReason => _blockingReason;
+
+  AccountCutoverBlockingReason _reasonForAuthoritativeControl(AccountCutoverControl control) {
+    switch (_gate.decide(control)) {
+      case AccountCutoverGateDecision.allowProductTraffic:
+        return AccountCutoverBlockingReason.none;
+      case AccountCutoverGateDecision.forceUpgrade:
+        return AccountCutoverBlockingReason.forceUpgrade;
+      case AccountCutoverGateDecision.migrationMaintenance:
+        return AccountCutoverBlockingReason.confirmedMigration;
+    }
+  }
 
   /// The only projection [skipUnresolvedFence] may return to: the last
   /// AUTHORITATIVE projection for this owner, and only while that projection
@@ -47,8 +75,8 @@ class AccountCutoverRuntime extends ChangeNotifier {
   }
 
   /// True while the fence currently on screen was synthesized by this client
-  /// (503, timeouts, an in-flight owner refresh) after the server had
-  /// authoritatively allowed this owner. Only such a fence is skippable.
+  /// after an unavailable or malformed control response, and the server had
+  /// previously allowed this owner. Only such a fence is skippable.
   ///
   /// This is the distinction the `hasAuthoritativeControl` gate got wrong:
   /// after one successful "legacy/allow" fetch, a single blown refresh
@@ -72,6 +100,11 @@ class AccountCutoverRuntime extends ChangeNotifier {
     _hasAuthoritative = authoritative;
     if (authoritative) {
       _lastAuthoritativeControl = control;
+      _blockingReason = _reasonForAuthoritativeControl(control);
+    } else {
+      _blockingReason = _gate.decide(control) == AccountCutoverGateDecision.allowProductTraffic
+          ? AccountCutoverBlockingReason.none
+          : AccountCutoverBlockingReason.controlUnavailable;
     }
     _resolvedForOwner = true;
     notifyListeners();
@@ -84,6 +117,7 @@ class AccountCutoverRuntime extends ChangeNotifier {
     _ownerUid = null;
     _refreshEpoch = 0;
     _resolvedForOwner = true;
+    _blockingReason = AccountCutoverBlockingReason.none;
     controlClientOverrideForTesting = null;
   }
 
@@ -92,10 +126,7 @@ class AccountCutoverRuntime extends ChangeNotifier {
   /// A null/empty [uid] clears to legacy defaults. Owner changes immediately
   /// clear prior-account state and block product traffic until the in-flight
   /// refresh for that owner completes. Stale in-flight results are discarded.
-  Future<void> bindAuthenticatedOwner(
-    String? uid, {
-    AccountCutoverControlClient? client,
-  }) async {
+  Future<void> bindAuthenticatedOwner(String? uid, {AccountCutoverControlClient? client}) async {
     final epoch = ++_refreshEpoch;
     final normalized = (uid == null || uid.isEmpty) ? null : uid;
 
@@ -105,6 +136,7 @@ class AccountCutoverRuntime extends ChangeNotifier {
       _hasAuthoritative = false;
       _lastAuthoritativeControl = null;
       _resolvedForOwner = true;
+      _blockingReason = AccountCutoverBlockingReason.none;
       notifyListeners();
       return;
     }
@@ -125,6 +157,7 @@ class AccountCutoverRuntime extends ChangeNotifier {
       // form — including as the "last known good" a skip could restore.
       _lastAuthoritativeControl = null;
       _resolvedForOwner = false;
+      _blockingReason = AccountCutoverBlockingReason.checkingStatus;
       if (isGenuineOwnerSwitch) {
         _control = AccountCutoverControl.unavailable();
       }
@@ -157,15 +190,19 @@ class AccountCutoverRuntime extends ChangeNotifier {
         _control = result.control!;
         _hasAuthoritative = true;
         _lastAuthoritativeControl = result.control;
+        _blockingReason = _reasonForAuthoritativeControl(result.control!);
         break;
       case AccountCutoverFetchKind.unavailable:
         // The server explicitly failed closed — respect it and fence. When the
         // last authoritative word was "allow", this fence is the client's own:
         // the blocking screen offers skip and keeps retrying (see
         // canSkipUnresolvedFence).
-        _control = AccountCutoverControl.unavailable(
-          retaining: _hasAuthoritative ? _control : null,
-        );
+        _control = AccountCutoverControl.unavailable(retaining: _hasAuthoritative ? _control : null);
+        final lastAuthoritative = _lastAuthoritativeControl;
+        _blockingReason = lastAuthoritative != null &&
+                _gate.decide(lastAuthoritative) != AccountCutoverGateDecision.allowProductTraffic
+            ? _reasonForAuthoritativeControl(lastAuthoritative)
+            : AccountCutoverBlockingReason.controlUnavailable;
         break;
       case AccountCutoverFetchKind.transportFailure:
         if (lastAuthAllow != null) {
@@ -176,13 +213,18 @@ class AccountCutoverRuntime extends ChangeNotifier {
           // single timed-out refresh on a flaky connection could block the
           // whole app while the server kept answering legacy/none.
           _control = lastAuthAllow;
+          _blockingReason = AccountCutoverBlockingReason.none;
         } else if (_hasAuthoritative) {
           // Last authoritative state was itself a fence (migrating/new/...):
           // keep failing closed across the outage.
           _control = AccountCutoverControl.unavailable(retaining: _control);
+          _blockingReason = _reasonForAuthoritativeControl(_lastAuthoritativeControl!);
         } else if (_gate.decide(_control) == AccountCutoverGateDecision.allowProductTraffic) {
           // No authoritative projection yet (bridge rollout): stay legacy-compatible.
           _control = AccountCutoverControl.legacyDefault();
+          _blockingReason = AccountCutoverBlockingReason.none;
+        } else {
+          _blockingReason = AccountCutoverBlockingReason.connectionUnavailable;
         }
         // If already blocked (e.g. owner-change unavailable), keep that fence.
         break;
@@ -202,6 +244,7 @@ class AccountCutoverRuntime extends ChangeNotifier {
     if (lastGood == null) return false;
     _control = lastGood;
     _resolvedForOwner = true;
+    _blockingReason = AccountCutoverBlockingReason.none;
     notifyListeners();
     return true;
   }

--- a/app/test/unit/account_cutover_gate_test.dart
+++ b/app/test/unit/account_cutover_gate_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -168,6 +169,10 @@ void main() {
       () => AccountCutoverControl.fromJson({..._validControlJson()..remove('product_traffic_allowed')}),
       throwsA(isA<AccountCutoverControlParseException>()),
     );
+    expect(
+      () => AccountCutoverControl.fromJson({..._validControlJson(), 'state': 7}),
+      throwsA(isA<AccountCutoverControlParseException>()),
+    );
   });
 
   test('503 and malformed control responses classify as unavailable', () {
@@ -178,6 +183,12 @@ void main() {
     expect(
       AccountCutoverControlClient.interpretControlResponse(
         http.Response('{"state":"legacy","client_action":"none"}', 200),
+      ).kind,
+      AccountCutoverFetchKind.unavailable,
+    );
+    expect(
+      AccountCutoverControlClient.interpretControlResponse(
+        http.Response(jsonEncode({..._validControlJson(), 'client_action': 7}), 200),
       ).kind,
       AccountCutoverFetchKind.unavailable,
     );
@@ -227,6 +238,7 @@ void main() {
     expect(runtime.isResolvedForOwner, isTrue);
     expect(runtime.hasAuthoritativeControl, isFalse);
     expect(runtime.decision, AccountCutoverGateDecision.allowProductTraffic);
+    expect(runtime.blockingReason, AccountCutoverBlockingReason.none);
   });
 
   test('a genuine owner switch stays fenced across a transport failure (no leaked prior allow)', () async {
@@ -246,6 +258,7 @@ void main() {
     expect(runtime.isResolvedForOwner, isTrue);
     expect(runtime.hasAuthoritativeControl, isFalse);
     expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+    expect(runtime.blockingReason, AccountCutoverBlockingReason.connectionUnavailable);
 
     // The owner change discarded owner-a's projection, so there is nothing the
     // server ever allowed for owner-b to fall back to: no escape hatch, and
@@ -253,6 +266,7 @@ void main() {
     expect(runtime.canSkipUnresolvedFence, isFalse);
     expect(runtime.skipUnresolvedFence(), isFalse);
     expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+    expect(runtime.blockingReason, AccountCutoverBlockingReason.connectionUnavailable);
   });
 
   test('the escape hatch never invents an allow the server has not given', () async {
@@ -265,6 +279,7 @@ void main() {
     // The owner's first fetch has not landed, so the fence has no
     // server-allowed projection to fall back to: it must hold.
     expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+    expect(runtime.blockingReason, AccountCutoverBlockingReason.checkingStatus);
     expect(runtime.canSkipUnresolvedFence, isFalse);
     expect(runtime.skipUnresolvedFence(), isFalse);
     expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
@@ -276,9 +291,13 @@ void main() {
     pending.complete(AccountCutoverFetchResult.success(fenced));
     await Future<void>.delayed(Duration.zero);
     expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+    expect(runtime.blockingReason, AccountCutoverBlockingReason.confirmedMigration);
     expect(runtime.canSkipUnresolvedFence, isFalse);
     expect(runtime.skipUnresolvedFence(), isFalse);
     expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+
+    runtime.applyFetchResult(const AccountCutoverFetchResult.unavailable());
+    expect(runtime.blockingReason, AccountCutoverBlockingReason.confirmedMigration);
   });
 
   test('a transport blip after an authoritative allow does NOT fence (stays on last-known-good)', () async {
@@ -303,6 +322,7 @@ void main() {
     expect(runtime.decision, AccountCutoverGateDecision.allowProductTraffic);
     expect(runtime.control.accountGeneration, 5);
     expect(runtime.canSkipUnresolvedFence, isTrue);
+    expect(runtime.blockingReason, AccountCutoverBlockingReason.none);
   });
 
   test('an explicit 503 after an authoritative allow fences but keeps the escape hatch', () async {
@@ -322,6 +342,7 @@ void main() {
 
     // The server explicitly failed closed — respect the fence...
     expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+    expect(runtime.blockingReason, AccountCutoverBlockingReason.controlUnavailable);
     // ...but it never authoritatively said "migrating", so the fence is
     // unconfirmed and the user can skip back to the last-known-good state.
     expect(runtime.canSkipUnresolvedFence, isTrue);
@@ -355,6 +376,7 @@ void main() {
     await runtime.refresh(client: client);
 
     expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+    expect(runtime.blockingReason, AccountCutoverBlockingReason.confirmedMigration);
     expect(runtime.canSkipUnresolvedFence, isFalse);
     expect(runtime.skipUnresolvedFence(), isFalse);
     expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);

--- a/app/test/widgets/account_cutover_fence_test.dart
+++ b/app/test/widgets/account_cutover_fence_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -65,8 +67,12 @@ void main() {
     await _pumpGate(tester);
 
     // The fence is correct — it fails closed — but the server never asked for
-    // a migration, so this screen must not be a dead end.
+    // a migration, so say that control is unavailable instead of claiming one.
     expect(find.text('product'), findsNothing);
+    expect(find.text('Connection Error'), findsOneWidget);
+    expect(find.text('Migration in Progress'), findsNothing);
+    expect(find.text('Retry'), findsOneWidget);
+    expect(find.text('Continue'), findsOneWidget);
     expect(find.byType(TextButton), findsOneWidget);
 
     await tester.tap(find.byType(TextButton));
@@ -97,6 +103,8 @@ void main() {
     await _pumpGate(tester);
 
     expect(find.text('product'), findsNothing);
+    expect(find.text('Migration in Progress'), findsOneWidget);
+    expect(find.text('Connection Error'), findsNothing);
     expect(find.byType(TextButton), findsNothing);
 
     // Same widget, same screen, different cause: the server answers "allow"
@@ -119,6 +127,10 @@ void main() {
     await tester.pump();
 
     expect(find.text('product'), findsNothing);
+    expect(find.text('Connection Error'), findsOneWidget);
+    expect(find.text('Migration in Progress'), findsNothing);
+    expect(find.text('Retry'), findsOneWidget);
+    expect(find.text('Continue'), findsOneWidget);
     expect(find.byType(TextButton), findsOneWidget);
 
     await tester.pumpWidget(const SizedBox.shrink());
@@ -142,28 +154,86 @@ void main() {
     await runtime.bindAuthenticatedOwner('owner-a');
     expect(fetches, 1);
     expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+    expect(runtime.blockingReason, AccountCutoverBlockingReason.controlUnavailable);
 
     await _pumpGate(tester);
     expect(find.text('product'), findsNothing);
+    expect(find.text('Connection Error'), findsOneWidget);
+    expect(find.text('Migration in Progress'), findsNothing);
     // The server has never allowed this owner, so there is no escape hatch to
     // fall back on: retrying is the only way this screen can ever clear.
     expect(find.byType(TextButton), findsNothing);
 
-    // Nothing else in the app re-fetches control while product traffic is
-    // blocked, so the fence can only lift if the gate retries by itself.
-    await tester.pump(const Duration(seconds: 29));
-    expect(fetches, 1);
-    expect(find.text('product'), findsNothing);
-
-    await tester.pump(const Duration(seconds: 1));
+    await tester.tap(find.text('Retry'));
     await tester.pump();
     expect(fetches, 2);
     expect(find.text('product'), findsNothing);
 
-    await tester.pump(const Duration(seconds: 30));
+    // Nothing else in the app re-fetches control while product traffic is
+    // blocked, so the fence can only lift if the gate retries by itself.
+    await tester.pump(const Duration(seconds: 29));
+    expect(fetches, 2);
+    expect(find.text('product'), findsNothing);
+
+    await tester.pump(const Duration(seconds: 1));
     await tester.pump();
     expect(fetches, 3);
     expect(find.text('product'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('retry and the periodic refresh never overlap control requests', (tester) async {
+    final runtime = AccountCutoverRuntime.instance;
+    final pendingRetry = Completer<AccountCutoverFetchResult>();
+    var fetches = 0;
+    final client = AccountCutoverControlClient(
+      fetch: () {
+        fetches++;
+        if (fetches == 1) return Future.value(const AccountCutoverFetchResult.unavailable());
+        return pendingRetry.future;
+      },
+    );
+    AccountCutoverRuntime.controlClientOverrideForTesting = client;
+
+    await runtime.bindAuthenticatedOwner('owner-a');
+    await _pumpGate(tester);
+
+    await tester.tap(find.text('Retry'));
+    await tester.pump();
+    expect(fetches, 2);
+
+    await tester.tap(find.text('Retry'));
+    await tester.pump(const Duration(seconds: 30));
+    expect(fetches, 2);
+
+    pendingRetry.complete(AccountCutoverFetchResult.success(_control()));
+    await tester.pump();
+    expect(find.text('product'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('an offline owner switch shows a connection fence, never a migration claim', (tester) async {
+    final runtime = AccountCutoverRuntime.instance;
+    await runtime.bindAuthenticatedOwner(
+      'owner-a',
+      client: AccountCutoverControlClient(fetch: () async => AccountCutoverFetchResult.success(_control())),
+    );
+    await runtime.bindAuthenticatedOwner(
+      'owner-b',
+      client: AccountCutoverControlClient(fetch: () async => const AccountCutoverFetchResult.transportFailure()),
+    );
+
+    expect(runtime.decision, AccountCutoverGateDecision.migrationMaintenance);
+    expect(runtime.blockingReason, AccountCutoverBlockingReason.connectionUnavailable);
+
+    await _pumpGate(tester);
+
+    expect(find.text('product'), findsNothing);
+    expect(find.text('No internet connection'), findsOneWidget);
+    expect(find.text('Migration in Progress'), findsNothing);
+    expect(find.text('Retry'), findsOneWidget);
 
     await tester.pumpWidget(const SizedBox.shrink());
   });


### PR DESCRIPTION
## What changed and why

The mobile account-cutover gate previously rendered every non-upgrade fence as "Migration", including pending control checks, transport failures, and malformed/unavailable control responses. This change keeps the existing fail-closed access policy while giving each state truthful copy: only an authoritative migration response says "Migration"; offline and control failures get connection-specific messaging, Retry, and the existing Continue escape hatch where allowed.

The control parser now also rejects wrong-typed enum fields as unavailable, and manual/timer refreshes share one in-flight request so retries cannot overlap.

## Product invariants affected

- INV-CUTOVER-1

## How it was verified

- `flutter test test/unit/account_cutover_gate_test.dart test/widgets/account_cutover_fence_test.dart` — 24/24 passed after rebasing onto current `origin/main`.
- `bash test.sh` — 1,582 tests passed with 5 expected skips.
- `scripts/analyze_ratchet.sh` — passed.
- `flutter gen-l10n` — generated successfully; current main still reports the pre-existing `memoryHistoryPartial` untranslated key in 48 non-English locales. This PR adds no localization keys.
- `git diff --check` — passed.
- Independent Luna review — approved after adding malformed-field and overlapping-refresh regressions.
- Physical-device reproduction was not run because it requires manipulating account-control state; widget tests exercise the production fence view, retry action, and periodic refresh path.

## Tests

- `test/unit/account_cutover_gate_test.dart` covers the typed runtime reasons, fresh/owner-switch transport failures, authoritative migration retention, unavailable responses, and wrong-typed control fields.
- `test/widgets/account_cutover_fence_test.dart` proves unconfirmed failures never render "Migration", confirmed migration still does, Retry recovers, and timer/manual refreshes do not overlap.

## Failure class (fixes)

Failure-Class: FC-unestablished-capability-default


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

