### PR TITLE
fix(desktop-backend): admit the gateway route in the candidate probe

### DIFF
--- a/.github/scripts/desktop_backend_candidate_probe.py
+++ b/.github/scripts/desktop_backend_candidate_probe.py
@@ -36,7 +36,13 @@ MAX_CHAT_SECONDS = 70
 MAX_FIRST_EVENT_SECONDS = 20
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 CONTRACT_PATTERN = re.compile(r"^[1-9][0-9]{0,5}$")
-REAL_GEMINI_PROVIDER_ROUTES = frozenset({"vertex_ai", "ai_studio", "ai_studio_byok"})
+REAL_GEMINI_PROVIDER_ROUTES = frozenset({"vertex_ai", "ai_studio", "ai_studio_byok", "llm_gateway"})
+# `llm_gateway` is the route the desktop proxy stamps on X-Omi-Provider for
+# company-paid Gemini traffic since #12337 routed it through the LLM gateway
+# (backend/utils/llm/desktop_gemini_gateway.py proxy_company_paid_via_gateway).
+# The gateway's desktop-vertex lanes pin the Vertex provider with no fallbacks
+# (backend/llm_gateway/gateway/config_loader.py), so the hop is still real
+# Gemini-on-Vertex; stub and unknown routes stay rejected fail-closed.
 
 
 class ProbeError(RuntimeError):

--- a/.github/scripts/test_desktop_backend_candidate_probe.py
+++ b/.github/scripts/test_desktop_backend_candidate_probe.py
@@ -74,10 +74,33 @@ class CandidateProbeTests(unittest.TestCase):
                 PROBE._gemini_request("https://candidate.example", token="token")
 
     def test_gemini_probe_rejects_stub_or_unknown_provider_routes(self) -> None:
-        for provider in ("offline_stub", "unknown", ""):
+        for provider in ("offline_stub", "desktop_llm_stub", "unknown", ""):
             with self.assertRaisesRegex(PROBE.ProbeError, "admitted provider"):
                 PROBE._require_real_gemini_provider(provider)
-        self.assertEqual(PROBE._require_real_gemini_provider("vertex_ai"), "vertex_ai")
+        for admitted in ("vertex_ai", "ai_studio", "ai_studio_byok"):
+            self.assertEqual(PROBE._require_real_gemini_provider(admitted), admitted)
+
+    def test_gemini_probe_admits_post_gateway_llm_gateway_route(self) -> None:
+        # Since #12337 the desktop proxy serves company-paid Gemini traffic via
+        # the LLM gateway's Vertex-backed desktop-vertex lanes and stamps
+        # `llm_gateway` on X-Omi-Provider; the probe must admit that real route.
+        self.assertEqual(PROBE._require_real_gemini_provider("llm_gateway"), "llm_gateway")
+
+        class GatewayResponse:
+            headers = {"x-omi-provider": "llm_gateway", "x-omi-request-id": "server-request-id"}
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self) -> bytes:
+                return b'{"candidates":[{"content":{"parts":[{"text":"OK"}]}}]}'
+
+        with mock.patch.object(PROBE.urllib.request, "urlopen", return_value=GatewayResponse()):
+            summary = PROBE._gemini_request("https://candidate.example", token="token")
+        self.assertEqual(summary["provider_route"], "llm_gateway")
 
     def test_gemini_request_cannot_pass_against_offline_stub(self) -> None:
         class StubResponse:


### PR DESCRIPTION
## What

The Auto Deploy Desktop Backend to Development promotion gate fail-closed on every candidate since #12337: the probe's `REAL_GEMINI_PROVIDER_ROUTES` did not admit the `llm_gateway` provider route the desktop proxy now stamps on `X-Omi-Provider` for company-paid Gemini traffic (run [33219770852](https://github.com/BasedHardware/omi/actions/runs/33219770852), step "Prove candidate chat compatibility", `gemini_proxy: response did not come from an admitted provider route`). Dev stayed 100% on the stale revision `desktop-backend-cdca0c865fd1-33169706190-1`; the candidate was correctly held tag-only.

This PR admits the real post-gateway route in the probe allowlist. No backend behavior changes.

## Why this is a real route, not a weakened gate

The probed surface is `POST /v1/proxy/gemini/models/gemini-2.5-flash:generateContent`. Post-#12337, that request hops the gateway:

- `backend/routers/desktop_proxy.py` → `company_paid_via_gateway` → `proxy_company_paid_via_gateway` stamps `telemetry.provider = 'llm_gateway'` → `X-Omi-Provider: llm_gateway` (`backend/utils/llm/desktop_gemini_gateway.py:595`).
- `gemini-2.5-flash` maps to lane `omi:auto:desktop-vertex-flash` (`utils/llm/vertex_pt_routing.py` DESKTOP_TEXT_LANES), whose route pins primary provider `gemini` = `VertexGeminiProvider` with **no fallbacks** (`backend/llm_gateway/gateway/config_loader.py:330`) — real Gemini-on-Vertex.
- `offline_stub`, `desktop_llm_stub`, unknown, and empty header values remain rejected fail-closed; the existing offline-stub rejection test is unchanged.

## Test plan

- `python3 .github/scripts/test_desktop_backend_candidate_probe.py` — 19 tests OK locally, including:
  - updated `test_gemini_probe_rejects_stub_or_unknown_provider_routes`: rejects `offline_stub` / `desktop_llm_stub` / `unknown` / `""`, admits `vertex_ai` / `ai_studio` / `ai_studio_byok`;
  - new `test_gemini_probe_admits_post_gateway_llm_gateway_route`: a gateway-served response (`x-omi-provider: llm_gateway`) passes `_gemini_request` end to end and reports `provider_route: llm_gateway` — the exact live failure mode, now pinned as passing.
- After merge: Auto Deploy Desktop Backend to Development must build, probe, and shift 100% dev traffic to the merge-SHA revision; `gcloud run services describe desktop-backend --project=based-hardware-dev --region=us-central1` is the independent serving proof (tracked on SCA-368).

## Product invariants

none (per `scripts/pr-preflight --suggest`)

## Failure-Class

Failure-Class: FC-client-model-outside-proxy-allowlist

#12337 retargeted the desktop proxy at a new provider route without widening the gate that admits it in the same change, so the promotion gate rejected a value it did not know instead of degrading. This PR widens the admission set in data and pins both directions (real route admitted, stub class still rejected) in the probe's test file.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

