### PR TITLE
fix(backend): use locked LC3 runtime artifact

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,30 +9,13 @@ RUN python -m venv /opt/venv
 RUN python3 -m pip install --no-cache-dir "uv==${UV_VERSION}"
 ENV PATH="/opt/venv/bin:$PATH"
 
-# Install build dependencies for liblc3
+# Build locked source distributions such as webrtcvad.
 RUN apt-get update && apt-get install -y \
     git \
     gcc \
     g++ \
-    meson \
-    ninja-build \
     python3-dev \
     && rm -rf /var/lib/apt/lists/*
-
-# Build liblc3 and create wheel
-WORKDIR /tmp
-RUN git clone https://github.com/google/liblc3.git && \
-    cd liblc3 && \
-    meson setup build && \
-    cd build && \
-    meson install && \
-    ldconfig && \
-    # Stage shared libs to a fixed path (meson install path varies by arch)
-    mkdir -p /opt/liblc3 && \
-    cp /usr/local/lib/*/liblc3.so* /opt/liblc3/ 2>/dev/null || \
-    cp /usr/local/lib/liblc3.so* /opt/liblc3/ && \
-    cd /tmp/liblc3 && \
-    python3 -m pip wheel --no-cache-dir --wheel-dir /tmp/wheels .
 
 # Install Python requirements from the checked-in runtime lock.
 WORKDIR /opt/venv
@@ -43,7 +26,6 @@ FROM ${PYTHON_BASE_IMAGE}
 
 WORKDIR /app
 ENV PATH="/opt/venv/bin:$PATH"
-ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 # Patch OS packages in this layer before installing runtime deps (#7136).
 RUN apt-get update && apt-get -y dist-upgrade \
@@ -54,15 +36,6 @@ RUN apt-get update && apt-get -y dist-upgrade \
 # under high-churn bytearray allocations from WebSocket audio streams (#6938)
 # Use soname-only form so ld.so resolves via standard search paths (arch-portable)
 ENV LD_PRELOAD=libjemalloc.so.2
-
-# Copy compiled liblc3 library from builder staging dir
-COPY --from=builder /opt/liblc3/ /usr/local/lib/
-COPY --from=builder /tmp/wheels /tmp/wheels
-
-# Install liblc3 Python package and set library path
-RUN ldconfig && \
-    pip install --no-cache-dir /tmp/wheels/*.whl && \
-    rm -rf /tmp/wheels
 
 COPY --from=builder /opt/venv /opt/venv
 COPY .github/scripts/desktop_release_manifest.py /app/desktop_release_manifest_contract.py

--- a/backend/pusher/Dockerfile
+++ b/backend/pusher/Dockerfile
@@ -4,39 +4,17 @@ ARG UV_VERSION=0.11.13
 FROM ${PYTHON_BASE_IMAGE} AS builder
 
 ARG UV_VERSION
-ENV LIBLC3_COMMIT=ce2e41faf8c06d038df9f32504c61109a14130be
 
 RUN python -m venv /opt/venv
 RUN python3 -m pip install --no-cache-dir "uv==${UV_VERSION}"
 ENV PATH="/opt/venv/bin:$PATH"
 
-# Install build dependencies for liblc3
+# Build locked source distributions such as webrtcvad.
 RUN apt-get update && apt-get install -y \
-    git \
     gcc \
     g++ \
-    meson \
-    ninja-build \
     python3-dev \
     && rm -rf /var/lib/apt/lists/*
-
-# Build liblc3 and create wheel
-WORKDIR /tmp
-RUN git init liblc3 && \
-    git -C liblc3 remote add origin https://github.com/google/liblc3.git && \
-    git -C liblc3 fetch --depth=1 origin "${LIBLC3_COMMIT}" && \
-    git -C liblc3 checkout --detach FETCH_HEAD && \
-    cd liblc3 && \
-    meson setup build && \
-    cd build && \
-    meson install && \
-    ldconfig && \
-    # Stage shared libs to a fixed path (meson install path varies by arch)
-    mkdir -p /opt/liblc3 && \
-    cp /usr/local/lib/*/liblc3.so* /opt/liblc3/ 2>/dev/null || \
-    cp /usr/local/lib/liblc3.so* /opt/liblc3/ && \
-    cd /tmp/liblc3 && \
-    python3 -m pip wheel --no-cache-dir --wheel-dir /tmp/wheels .
 
 # Install Python requirements from the pusher-specific checked-in lock.
 WORKDIR /opt/venv
@@ -47,7 +25,6 @@ FROM ${PYTHON_BASE_IMAGE}
 
 WORKDIR /app
 ENV PATH="/opt/venv/bin:$PATH"
-ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 # Patch OS packages in this layer before installing runtime deps (#7136).
 RUN apt-get update && apt-get -y dist-upgrade \
@@ -62,15 +39,6 @@ RUN apt-get update && apt-get -y dist-upgrade \
 # under high-churn bytearray allocations from WebSocket audio streams (#6938)
 # Use soname-only form so ld.so resolves via standard search paths (arch-portable)
 ENV LD_PRELOAD=libjemalloc.so.2
-
-# Copy compiled liblc3 library from builder staging dir
-COPY --from=builder /opt/liblc3/ /usr/local/lib/
-COPY --from=builder /tmp/wheels /tmp/wheels
-
-# Install liblc3 Python package and set library path
-RUN ldconfig && \
-    pip install --no-cache-dir /tmp/wheels/*.whl && \
-    rm -rf /tmp/wheels
 
 COPY --from=builder /opt/venv /opt/venv
 

--- a/backend/scripts/runtime_image_contracts.py
+++ b/backend/scripts/runtime_image_contracts.py
@@ -210,7 +210,7 @@ def _logical_docker_lines(path: Path) -> list[str]:
     return logical_lines
 
 
-def final_stage_copy_instructions(dockerfile: Path) -> list[CopyInstruction]:
+def docker_stages(dockerfile: Path) -> list[list[str]]:
     stages: list[list[str]] = []
     current_stage: list[str] | None = None
     for line in _logical_docker_lines(dockerfile):
@@ -222,6 +222,11 @@ def final_stage_copy_instructions(dockerfile: Path) -> list[CopyInstruction]:
             current_stage.append(line)
     if not stages:
         raise ContractError(f"{_repository_relative(dockerfile)} has no Docker stage")
+    return stages
+
+
+def final_stage_copy_instructions(dockerfile: Path) -> list[CopyInstruction]:
+    stages = docker_stages(dockerfile)
 
     copies: list[CopyInstruction] = []
     for line in stages[-1]:
@@ -235,6 +240,58 @@ def final_stage_copy_instructions(dockerfile: Path) -> list[CopyInstruction]:
             raise ContractError(f"cannot parse COPY instruction in {_repository_relative(dockerfile)}: {line}")
         copies.append(CopyInstruction(sources=tuple(tokens[:-1]), destination=tokens[-1]))
     return copies
+
+
+def _copy_destination(line: str) -> str | None:
+    if not line.upper().startswith("COPY "):
+        return None
+    tokens = [token for token in shlex.split(line[5:]) if not token.startswith("--")]
+    return tokens[-1] if len(tokens) >= 2 else None
+
+
+def final_stage_layer_errors(contract: ImageContract) -> list[str]:
+    """Reject bytes hidden by later layers and installs shadowed by a late venv copy."""
+    instructions = docker_stages(contract.dockerfile)[-1]
+    errors: list[str] = []
+
+    copied_destinations: dict[str, int] = {}
+    path_venvs: dict[str, int] = {}
+    for index, line in enumerate(instructions):
+        if line.upper().startswith("COPY "):
+            destination = _copy_destination(line)
+            if destination:
+                copied_destinations[destination.rstrip("/")] = index
+            continue
+        if line.upper().startswith("ENV PATH="):
+            path_value = line.split("=", 1)[1].strip('"\'')
+            first_entry = path_value.split(":", 1)[0]
+            if first_entry.endswith("/bin"):
+                path_venvs[first_entry[: -len("/bin")].rstrip("/")] = index
+
+    for destination, copy_index in copied_destinations.items():
+        for line in instructions[copy_index + 1 :]:
+            if line.upper().startswith("RUN ") and any(
+                marker in line for marker in (f"rm -rf {destination}", f"rm -r {destination}")
+            ):
+                errors.append(
+                    f"{contract.name}: final-stage COPY to {destination!r} is removed in a later RUN layer; "
+                    "the copied bytes remain in the image manifest"
+                )
+                break
+
+    for venv, path_index in path_venvs.items():
+        copy_index = copied_destinations.get(venv)
+        if copy_index is None or copy_index <= path_index:
+            continue
+        for line in instructions[path_index + 1 : copy_index]:
+            if line.upper().startswith("RUN ") and "pip install" in line:
+                errors.append(
+                    f"{contract.name}: {venv!r} leads PATH but pip runs before that environment is copied into "
+                    "the final stage; the install is shadowed at runtime"
+                )
+                break
+
+    return errors
 
 
 def _ignore_source_directory(_: str, names: list[str]) -> set[str]:
@@ -436,6 +493,7 @@ def import_smoke_environment_errors(contracts: Iterable[ImageContract]) -> list[
 def check_source_closures(contracts: Iterable[ImageContract]) -> list[str]:
     errors: list[str] = []
     for contract in contracts:
+        errors.extend(final_stage_layer_errors(contract))
         errors.extend(source_closure_errors(contract))
     return errors
 

--- a/backend/tests/unit/test_runtime_image_contracts.py
+++ b/backend/tests/unit/test_runtime_image_contracts.py
@@ -40,6 +40,47 @@ def test_registered_runtime_image_sources_are_closed(contracts_module):
     assert contracts_module.check_source_closures(contracts_module.load_contracts()) == []
 
 
+def _contract_with_dockerfile(contracts_module, tmp_path, dockerfile_text):
+    dockerfile = tmp_path / 'Dockerfile'
+    dockerfile.write_text(dockerfile_text, encoding='utf-8')
+    return replace(_contract(contracts_module, 'pusher'), dockerfile=dockerfile)
+
+
+def test_final_stage_rejects_copy_removed_in_a_later_layer(contracts_module, tmp_path):
+    contract = _contract_with_dockerfile(
+        contracts_module,
+        tmp_path,
+        'FROM python AS builder\n'
+        'RUN mkdir -p /tmp/wheels\n'
+        'FROM python\n'
+        'COPY --from=builder /tmp/wheels /tmp/wheels\n'
+        'RUN pip install /tmp/wheels/*.whl && rm -rf /tmp/wheels\n',
+    )
+
+    errors = contracts_module.final_stage_layer_errors(contract)
+
+    assert len(errors) == 1
+    assert 'remain in the image manifest' in errors[0]
+
+
+def test_final_stage_rejects_install_shadowed_by_late_venv_copy(contracts_module, tmp_path):
+    contract = _contract_with_dockerfile(
+        contracts_module,
+        tmp_path,
+        'FROM python AS builder\n'
+        'RUN python -m venv /opt/venv\n'
+        'FROM python\n'
+        'ENV PATH="/opt/venv/bin:$PATH"\n'
+        'RUN pip install /tmp/package.whl\n'
+        'COPY --from=builder /opt/venv /opt/venv\n',
+    )
+
+    errors = contracts_module.final_stage_layer_errors(contract)
+
+    assert len(errors) == 1
+    assert 'install is shadowed at runtime' in errors[0]
+
+
 def test_registered_runtime_image_workflows_smoke_their_declared_dockerfile(contracts_module):
     assert contracts_module.workflow_contract_errors(contracts_module.load_contracts()) == []
 

--- a/backend/tests/unit/test_verify_pusher_source_closure.py
+++ b/backend/tests/unit/test_verify_pusher_source_closure.py
@@ -93,13 +93,6 @@ def test_source_closure_excludes_builder_stage_copies() -> None:
     assert "backend/pusher/pylock.toml" not in sources
 
 
-def test_liblc3_source_is_pinned() -> None:
-    dockerfile = (REPO / "backend/pusher/Dockerfile").read_text(encoding="utf-8")
-    assert "ENV LIBLC3_COMMIT=ce2e41faf8c06d038df9f32504c61109a14130be" in dockerfile
-    assert "ARG LIBLC3_COMMIT" not in dockerfile
-    assert 'git -C liblc3 fetch --depth=1 origin "${LIBLC3_COMMIT}"' in dockerfile
-
-
 def test_runtime_uses_a_non_root_user_with_writable_working_directories() -> None:
     dockerfile = (REPO / "backend/pusher/Dockerfile").read_text(encoding="utf-8")
     assert "mkdir -p _temp _samples _segments _speech_profiles" in dockerfile


### PR DESCRIPTION
## What changed and why

Fixes #12345.

The backend and pusher images now install LC3 exactly once, from their checked-in `uv` locks into `/opt/venv`. This removes the redundant `google/liblc3` source checkout/build, the system-interpreter wheel install that was later shadowed by `/opt/venv`, the copied-and-whiteouted `/tmp/wheels` layer, and the unused `/usr/local/lib` staging path.

This is behavior-preserving on the deployed Linux x86_64 target: both locks already resolve `lc3py==1.1.3` to the same SHA-256-pinned manylinux wheel, and that wheel contains both the Python binding and its native `liblc3.so.1`. The binding loads that colocated library before consulting the system library search path.

## Product invariants affected

none

## How it was verified

- `python3 -m pytest -q --noconftest backend/tests/unit/test_runtime_image_contracts.py backend/tests/unit/test_verify_pusher_source_closure.py` — 21 passed.
- `make runtime-image-source-closure` — all 12 registered runtime-image contracts passed.
- `python3 -m black --check backend/scripts/runtime_image_contracts.py backend/tests/unit/test_runtime_image_contracts.py backend/tests/unit/test_verify_pusher_source_closure.py` — clean.
- Inspected the exact wheel pinned by both lockfiles (`sha256:601a9a2ea3135547f2d22a10475b5fec8f784f716f4b22a61acc3908c827694e`): its archive contains `.lc3py.mesonpy.libs/liblc3.so.1`, and `lc3.py` prefers that colocated library.
- Built both final images locally for the deployed `linux/amd64` platform. The fork-only private GCR base was replaced through the existing `PYTHON_BASE_IMAGE` build argument with public `python:3.11-slim`; every remaining Dockerfile instruction and locked dependency was unchanged.
- Ran the registered offline smoke contract against both built images: the backend resolved all 302 reachable third-party modules, while the pusher resolved all 192 and imported its `routers.pusher` entrypoint.
- Instantiated a real `lc3.Decoder(10000, 16000)` inside both network-isolated final images. Both loaded `lc3py==1.1.3` and `/opt/venv/lib/python3.11/site-packages/.lc3py.mesonpy.libs/liblc3.so.1`; no system LC3 installation was present or needed.
- The GitHub image-smoke job is intentionally skipped for fork PRs because the workflow's production base-image credentials are private. The equivalent local final-image proof above covers this branch; the static source-closure job still runs on the fork.

## Tests

`backend/tests/unit/test_runtime_image_contracts.py` now proves the shared runtime-image checker rejects both defect shapes from #12345:

- a path copied into one final-stage layer and removed in a later `RUN`, which still ships the bytes;
- a `pip install` executed while `PATH` points at a venv that is only copied into the stage afterward, which shadows the install.

The existing registry-wide contract test also verifies every registered image is free of both patterns.

## Failure class (fixes)

Failure-Class: none

## New guards (only when adding a check or ratchet)

This shared guard would have caught #12345. It lives in the existing runtime-image contract primitive rather than a Dockerfile-specific layout test, so every registered deployable Python image inherits the protection.
