### PR TITLE
fix(desktop): download JIT trigger snapshot when effective=enabled

### DIFF
--- a/.github/failure-classes/FC-client-rederives-authority-verdict.json
+++ b/.github/failure-classes/FC-client-rederives-authority-verdict.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-client-rederives-authority-verdict",
+  "violated_contract": "A client that consumes an authority's decision response must act on the authority's own verdict field, never re-derive a stricter verdict from the raw inputs the authority also returns. The re-derivation diverges silently the day the authority's computation changes: the client keeps issuing the decision read, receives a 200, and gates off anyway — no decode error, no failing test, and the server log looks healthy. #12369 collapsed backend JIT admission onto one exposure flag plus a two-UID allowlist and returns effective=enabled for admitted owners; the macOS client kept requiring rollout == enabled && kill_switch == .disabled, so Omi Beta 12237 repeatedly read /v1/jit/rollout-decision with a 200, never issued GET /v1/jit/trigger-snapshot, and persisted zero jit_trigger_snapshot_receipts rows. The Windows client parses and uses effective and was not affected.",
+  "canonical_prevention": "Point the admission predicate at the same value the authority computes: JITProactivityFlags.permitsNewLane admits on effective == .enabled and fails closed on .disabled, keeping the raw rollout + kill-switch pair only as an older-server fallback that distinguishes an absent kill_switch (wire compatibility) from a present unknown (fail closed). Exercise the full truth table through URLProtocol-level wire tests against the response shape the router actually emits, plus a runtime test that an effective-enabled authority reads the trigger snapshot and persists its receipt even for a complete empty watchlist. A downstream projection failure (ledger mirror sync) must fail that projection closed, not the authoritative receipt the client already holds.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITProactivityPolicy.swift",
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift",
+    "desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift",
+    "desktop/macos/Desktop/Tests/JITProactivityRuntimeTests.swift"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/**",
+    "desktop/windows/src/main/jit/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITProactivityPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITProactivityPolicy.swift
@@ -23,10 +23,36 @@ enum JITAmbientNanoTriage: Equatable, Sendable {
 struct JITProactivityFlags: Equatable, Sendable {
   let rollout: JITProactivityRolloutState
   let killSwitch: JITProactivityRolloutState
+  /// The backend's own admission verdict from `/v1/jit/rollout-decision`.
+  /// Servers that predate the field leave it absent; the rollout +
+  /// kill-switch pair remains the fallback derivation.
+  let effective: JITProactivityRolloutState
+  /// Whether the decision response carried `kill_switch` at all. An absent
+  /// field is wire compatibility, not an unknown-off veto; a present
+  /// `unknown` still fails closed.
+  let killSwitchPresent: Bool
 
-  /// Only a complete, known-good pair activates the additive lane.
+  init(
+    rollout: JITProactivityRolloutState,
+    killSwitch: JITProactivityRolloutState,
+    effective: JITProactivityRolloutState = .unknown,
+    killSwitchPresent: Bool = true
+  ) {
+    self.rollout = rollout
+    self.killSwitch = killSwitch
+    self.effective = effective
+    self.killSwitchPresent = killSwitchPresent
+  }
+
+  /// The server-computed `effective` verdict owns admission: the client must
+  /// not re-derive a stricter verdict from the raw flags. The complete,
+  /// known-good rollout + kill-switch pair remains the fallback for servers
+  /// that predate `effective`, and unknown still fails closed.
   var permitsNewLane: Bool {
-    rollout == .enabled && killSwitch == .disabled
+    if effective == .enabled { return true }
+    if effective == .disabled { return false }
+    guard rollout == .enabled else { return false }
+    return killSwitch == .disabled || !killSwitchPresent
   }
 }
 
@@ -86,10 +112,14 @@ enum JITProactivityPolicy {
   ) -> JITProactivityDecision {
     guard flags.permitsNewLane else {
       let reason: String
-      switch (flags.rollout, flags.killSwitch) {
-      case (_, .enabled): reason = "kill_switch"
-      case (.unknown, _), (_, .unknown): reason = "rollout_unknown"
-      default: reason = "rollout_disabled"
+      if flags.killSwitch == .enabled {
+        reason = "kill_switch"
+      } else if flags.rollout == .unknown || (flags.killSwitch == .unknown && flags.killSwitchPresent) {
+        // Only a `kill_switch` the server actually sent can report as
+        // unknown; an absent field is compatibility, not an unknown state.
+        reason = "rollout_unknown"
+      } else {
+        reason = "rollout_disabled"
       }
       return .legacyContextBucketFallback(reason: reason)
     }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
@@ -129,6 +129,15 @@ actor ProactiveLaneClient {
   private let session: URLSession
   private let baseURL: () -> String
   private let authorization: () async throws -> String
+  /// Owner-bound header for the read-only JIT authority routes; stricter
+  /// than `authorization` because the decision must never be evaluated for
+  /// another owner's credentials.
+  private let jitAuthorization: @Sendable (_ ownerID: String) async throws -> String
+  /// Downstream ledger-mirror sync attempted after a complete trigger
+  /// snapshot; injectable so tests can prove its failure is non-blocking.
+  private let ledgerMirrorSync:
+    @Sendable (_ authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot, _ snapshot: JITTriggerSnapshot) async throws
+      -> Void
   private let now: @Sendable () -> Date
   private var quotaCooldownUntil: [String: Date] = [:]
   private var loggedQuotaSkip: Set<String> = []
@@ -146,8 +155,7 @@ actor ProactiveLaneClient {
     guard let url = URL(string: root + "v1/jit/trigger-snapshot") else {
       throw ProactiveLaneClientError.invalidResponse
     }
-    let authService = await MainActor.run { AuthService.shared }
-    let header = try await authService.getAuthHeader(expectedUserId: authorizationSnapshot.ownerID)
+    let header = try await jitAuthorization(authorizationSnapshot.ownerID)
     guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else {
       throw ProactiveLaneClientError.ownerChanged
     }
@@ -168,12 +176,20 @@ actor ProactiveLaneClient {
       snapshot.ownerID == authorizationSnapshot.ownerID
     else { throw ProactiveLaneClientError.invalidResponse }
     guard snapshot.complete, snapshot.failureReason == nil else { return snapshot }
-    // The trigger snapshot is a cheap authoritative head read. A matching
-    // local mirror receipt takes the fast path; otherwise the coordinator
-    // resumes its durable cursor chain before exposing planned authority.
-    _ = try await KnowledgeLedgerMirrorCoordinator.shared.sync(
-      authorizationSnapshot: authorizationSnapshot,
-      knownAuthority: snapshot)
+    // The trigger snapshot is a cheap authoritative head read and the receipt
+    // authority for this lane. A matching local mirror receipt takes the fast
+    // path; otherwise the coordinator resumes its durable cursor chain. The
+    // mirror is a downstream projection: when its sync fails, fail the mirror
+    // closed and still return the complete snapshot so the trigger receipt is
+    // never blocked by ledger catch-up. The mirror retries on its own schedule.
+    do {
+      try await ledgerMirrorSync(authorizationSnapshot, snapshot)
+    } catch {
+      // Bounded and content-free: classification only, never error text.
+      NSLog(
+        "JIT trigger snapshot: ledger mirror sync failed error_type=%@",
+        ProactiveLaneFailureClassification.boundedNetworkErrorType(error))
+    }
     return snapshot
   }
 
@@ -181,15 +197,35 @@ actor ProactiveLaneClient {
     session: URLSession = .shared,
     baseURL: @escaping () -> String = { ProactiveLaneClient.backendBaseURL },
     authorization: (() async throws -> String)? = nil,
-    now: @escaping @Sendable () -> Date = { Date() }
+    now: @escaping @Sendable () -> Date = { Date() },
+    jitAuthorization: (@Sendable (_ ownerID: String) async throws -> String)? = nil,
+    ledgerMirrorSync:
+      (
+        @Sendable (_ authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot, _ snapshot: JITTriggerSnapshot)
+          async throws -> Void
+      )? = nil
   ) {
     self.session = session
     self.baseURL = baseURL
     self.now = now
     self.authorization =
-      authorization ?? {
+      authorization
+      ?? {
         let authService = await MainActor.run { AuthService.shared }
         return try await authService.getAuthHeader()
+      }
+    self.jitAuthorization =
+      jitAuthorization
+      ?? { ownerID in
+        let authService = await MainActor.run { AuthService.shared }
+        return try await authService.getAuthHeader(expectedUserId: ownerID)
+      }
+    self.ledgerMirrorSync =
+      ledgerMirrorSync
+      ?? { authorizationSnapshot, snapshot in
+        _ = try await KnowledgeLedgerMirrorCoordinator.shared.sync(
+          authorizationSnapshot: authorizationSnapshot,
+          knownAuthority: snapshot)
       }
   }
 
@@ -215,8 +251,7 @@ actor ProactiveLaneClient {
       return JITProactivityFlags(rollout: .unknown, killSwitch: .unknown)
     }
     do {
-      let authService = await MainActor.run { AuthService.shared }
-      let header = try await authService.getAuthHeader(expectedUserId: authorizationSnapshot.ownerID)
+      let header = try await jitAuthorization(authorizationSnapshot.ownerID)
       guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else {
         return JITProactivityFlags(rollout: .unknown, killSwitch: .unknown)
       }
@@ -231,9 +266,14 @@ actor ProactiveLaneClient {
       else {
         return cacheUnknownJITFlags(ownerID: authorizationSnapshot.ownerID)
       }
+      // The server-computed `effective` verdict owns admission; the raw
+      // rollout + kill-switch pair stays as the older-server fallback. An
+      // absent `kill_switch` is compatibility, not an unknown-off veto.
       let flags = JITProactivityFlags(
         rollout: Self.jitState(object["rollout"]),
-        killSwitch: Self.jitState(object["kill_switch"]))
+        killSwitch: Self.jitState(object["kill_switch"]),
+        effective: Self.jitState(object["effective"]),
+        killSwitchPresent: object["kill_switch"] != nil)
       let rawTTL = object["cache_ttl_seconds"] as? Int ?? 60
       let ttl = min(max(rawTTL, 15), 15 * 60)
       jitFlagsCache = (

--- a/desktop/macos/Desktop/Tests/JITProactivityPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/JITProactivityPolicyTests.swift
@@ -104,6 +104,67 @@ final class JITProactivityPolicyTests: XCTestCase {
     }
   }
 
+  /// The backend computes admission itself (`effective`); the client must not
+  /// re-derive a stricter verdict from the raw flags it also happens to carry.
+  func testEffectiveEnabledAdmitsEvenWhenRawFlagsAreNotAKnownGoodPair() {
+    let candidates = [ambient(id: "ambient", key: "ambient")]
+    for flags in [
+      JITProactivityFlags(
+        rollout: .unknown, killSwitch: .unknown, effective: .enabled),
+      JITProactivityFlags(
+        rollout: .enabled, killSwitch: .unknown, effective: .enabled),
+      // Older servers omit `kill_switch` entirely; absence is not unknown-off.
+      JITProactivityFlags(
+        rollout: .unknown, killSwitch: .unknown, effective: .enabled, killSwitchPresent: false),
+      JITProactivityFlags(
+        rollout: .enabled, killSwitch: .unknown, effective: .enabled, killSwitchPresent: false),
+      // The legacy pair still admits when `effective` is absent.
+      JITProactivityFlags(
+        rollout: .enabled, killSwitch: .disabled, effective: .unknown, killSwitchPresent: false),
+    ] {
+      XCTAssertEqual(
+        JITProactivityPolicy.decide(flags: flags, planned: [], ambient: candidates),
+        .deliver(lane: .ambient, id: "ambient", continuityKey: "ambient"),
+        "effective authority must admit: \(flags)")
+    }
+  }
+
+  func testEffectiveDisabledBlocksEvenWhenTheRawPairWouldAdmit() {
+    let flags = JITProactivityFlags(
+      rollout: .enabled, killSwitch: .disabled, effective: .disabled)
+
+    guard
+      case .legacyContextBucketFallback(let reason) = JITProactivityPolicy.decide(
+        flags: flags, planned: [], ambient: [ambient(id: "ambient", key: "ambient")])
+    else {
+      return XCTFail("server-disabled effective must fail closed")
+    }
+    XCTAssertEqual(reason, "rollout_disabled")
+  }
+
+  /// A `kill_switch` the server actually sent as `unknown` still fails closed;
+  /// only a missing field stops being an unknown-off veto.
+  func testPresentUnknownKillSwitchStillFailsClosedWithoutEffective() {
+    let flags = JITProactivityFlags(
+      rollout: .enabled, killSwitch: .unknown, effective: .unknown, killSwitchPresent: true)
+
+    XCTAssertFalse(flags.permitsNewLane)
+    guard
+      case .legacyContextBucketFallback(let reason) = JITProactivityPolicy.decide(
+        flags: flags, planned: [], ambient: [])
+    else {
+      return XCTFail("present unknown must fail closed")
+    }
+    XCTAssertEqual(reason, "rollout_unknown")
+  }
+
+  func testAbsentKillSwitchWithEnabledRolloutAdmitsViaLegacyFallback() {
+    let flags = JITProactivityFlags(
+      rollout: .enabled, killSwitch: .unknown, effective: .unknown, killSwitchPresent: false)
+
+    XCTAssertTrue(flags.permitsNewLane)
+  }
+
   func testPlannedAndAmbientContinuityKeysShareDeliveryDedup() {
     let decision = JITProactivityPolicy.decide(
       flags: enabledFlags,

--- a/desktop/macos/Desktop/Tests/JITProactivityRuntimeTests.swift
+++ b/desktop/macos/Desktop/Tests/JITProactivityRuntimeTests.swift
@@ -109,6 +109,41 @@ final class JITProactivityRuntimeTests: XCTestCase {
       .suppressed(reason: "authoritative_snapshot_unavailable"))
   }
 
+  /// The live gap: the server's `effective` verdict said enabled, but the client
+  /// re-derived admission from the raw flags and never read the snapshot. An
+  /// `effective`-enabled authority must reach the snapshot read even when the
+  /// raw pair is unknown, and a complete empty watchlist must still persist the
+  /// local trigger-snapshot receipt.
+  func testEffectiveEnabledAuthorityReadsSnapshotAndPersistsEmptyWatchlistReceipt() async throws {
+    let queue = try migratedQueue()
+    let emptyWatchlist = serverSnapshot(sequence: 4, revision: "revision-4", rows: [])
+    let sequence = SnapshotSequence([emptyWatchlist])
+    let runtime = JITProactivityRuntime(
+      flags: { _ in
+        JITProactivityFlags(rollout: .unknown, killSwitch: .unknown, effective: .enabled)
+      },
+      snapshots: { _ in try await sequence.next() },
+      reconcileSnapshot: { snapshot, _ in
+        try queue.write { db in try JITTriggerMirror.reconcile(snapshot, in: db, now: Date()) }
+      },
+      compileSnapshot: { _, _ in [] },
+      readWakeupCounts: { _, _, _ in [:] },
+      authorizationCurrent: { _ in true })
+
+    let decision = await runtime.admission(
+      authorizationSnapshot: try snapshot(), observation: KnowledgeLedgerTriggerObservation())
+
+    XCTAssertEqual(decision, .suppressed(reason: "ambient_local_gate"))
+
+    let remaining = await sequence.remaining
+    XCTAssertEqual(remaining, 0, "effective-enabled authority must read the trigger snapshot")
+    let receipts = try await queue.read { db in
+      try String.fetchAll(
+        db, sql: "SELECT ownerID FROM jit_trigger_snapshot_receipts")
+    }
+    XCTAssertEqual(receipts, ["owner"])
+  }
+
   func testAuthorityMismatchAndStaleLeaseSuppressWithoutAmbientFallback() async throws {
     let trigger = try compiledTrigger(id: "planned", condition: ["keywords": ["release"]])
     for (receiptOwner, receiptRevision, authorizationCurrent) in [
@@ -585,6 +620,10 @@ private actor SnapshotSequence {
   func next() throws -> JITTriggerSnapshot {
     guard !snapshots.isEmpty else { throw ProactiveLaneClientError.invalidResponse }
     return snapshots.removeFirst()
+  }
+
+  var remaining: Int {
+    snapshots.count
   }
 }
 

--- a/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
@@ -3,6 +3,29 @@ import XCTest
 @testable import Omi_Computer
 
 final class ProactiveLaneClientTests: XCTestCase {
+  private var priorAuthUserID: String?
+
+  override func setUp() {
+    super.setUp()
+    priorAuthUserID = UserDefaults.standard.string(forKey: .authUserId)
+  }
+
+  override func tearDown() {
+    // The JIT authority routes re-validate the runtime owner against the
+    // shared authorization authority; restore the durable auth user and the
+    // authority owner the rest of the suite expects.
+    let authority = RuntimeOwnerAuthorizationAuthority.shared
+    authority.beginTransition()
+    if let priorAuthUserID {
+      UserDefaults.standard.set(priorAuthUserID, forKey: .authUserId)
+      authority.endTransition(ownerID: priorAuthUserID)
+    } else {
+      UserDefaults.standard.removeObject(forKey: .authUserId)
+      authority.endTransition(ownerID: nil)
+    }
+    super.tearDown()
+  }
+
   func testEnvelopeParsingPreservesGatewayAccounting() throws {
     let data = try JSONSerialization.data(withJSONObject: [
       "operation": "proactive_reasoning",
@@ -353,6 +376,222 @@ final class ProactiveLaneClientTests: XCTestCase {
     XCTAssertEqual(ProactiveLaneURLStub.requestCount, 3)
   }
 
+  // MARK: - JIT authority wire contract
+
+  func testRolloutDecisionEffectiveEnabledAdmitsEvenWhenRawFlagsAreNotAKnownGoodPair() async throws {
+    ProactiveLaneURLStub.reset()
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 200,
+      body: try rolloutDecisionBody(rollout: "unknown", killSwitch: "disabled", effective: "enabled"))
+    let client = makeJITAuthorityClient()
+
+    let flags = await client.jitProactivityFlags(
+      authorizationSnapshot: try jitAuthorizationSnapshot())
+
+    XCTAssertEqual(flags.effective, .enabled)
+    XCTAssertTrue(flags.permitsNewLane)
+  }
+
+  func testRolloutDecisionToleratesMissingKillSwitchWhenEffectiveEnabled() async throws {
+    ProactiveLaneURLStub.reset()
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 200,
+      body: try rolloutDecisionBody(rollout: "enabled", killSwitch: nil, effective: "enabled"))
+    let client = makeJITAuthorityClient()
+
+    let flags = await client.jitProactivityFlags(
+      authorizationSnapshot: try jitAuthorizationSnapshot())
+
+    XCTAssertFalse(flags.killSwitchPresent)
+    XCTAssertEqual(flags.killSwitch, .unknown)
+    XCTAssertTrue(flags.permitsNewLane)
+  }
+
+  func testRolloutDecisionUnknownStatesStillFailClosed() async throws {
+    ProactiveLaneURLStub.reset()
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 200,
+      body: try rolloutDecisionBody(rollout: "unknown", killSwitch: "unknown", effective: "unknown"))
+    let client = makeJITAuthorityClient()
+
+    let flags = await client.jitProactivityFlags(
+      authorizationSnapshot: try jitAuthorizationSnapshot())
+
+    XCTAssertFalse(flags.permitsNewLane)
+  }
+
+  func testRolloutDecisionPresentUnknownKillSwitchWithoutEffectiveFailsClosed() async throws {
+    ProactiveLaneURLStub.reset()
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 200,
+      body: try rolloutDecisionBody(rollout: "enabled", killSwitch: "unknown", effective: nil))
+    let client = makeJITAuthorityClient()
+
+    let flags = await client.jitProactivityFlags(
+      authorizationSnapshot: try jitAuthorizationSnapshot())
+
+    XCTAssertTrue(flags.killSwitchPresent)
+    XCTAssertFalse(flags.permitsNewLane)
+  }
+
+  /// The live gap: a complete, empty, snake_case watchlist had to decode, and a
+  /// failing ledger-mirror sync had to stop blocking the trigger snapshot the
+  /// client already holds.
+  func testTriggerSnapshotDecodesEmptyWatchlistAndReturnsDespiteMirrorSyncFailure() async throws {
+    ProactiveLaneURLStub.reset()
+    ProactiveLaneURLStub.enqueue(statusCode: 200, body: try triggerSnapshotBody(ownerID: "owner"))
+    let mirror = MirrorSyncProbe()
+    let client = makeJITAuthorityClient(
+      mirrorSync: { _, _ in
+        await mirror.record()
+        throw URLError(.notConnectedToInternet)
+      })
+
+    let snapshot = try await client.fetchJITTriggerSnapshot(
+      authorizationSnapshot: try jitAuthorizationSnapshot())
+
+    XCTAssertTrue(snapshot.complete)
+    XCTAssertEqual(snapshot.rows, [])
+    XCTAssertNil(snapshot.failureReason)
+    XCTAssertEqual(snapshot.ownerID, "owner")
+    let attempts = await mirror.attempts
+    XCTAssertEqual(attempts, 1, "the ledger mirror must still be attempted exactly once")
+  }
+
+  func testDisabledTriggerSnapshotReturnsContentFreeReceiptWithoutTouchingTheMirror() async throws {
+    ProactiveLaneURLStub.reset()
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 200,
+      body: try triggerSnapshotBody(ownerID: "owner", complete: false, failureReason: "rollout_not_enabled"))
+    let mirror = MirrorSyncProbe()
+    let client = makeJITAuthorityClient(
+      mirrorSync: { _, _ in
+        await mirror.record()
+      })
+
+    let snapshot = try await client.fetchJITTriggerSnapshot(
+      authorizationSnapshot: try jitAuthorizationSnapshot())
+
+    XCTAssertFalse(snapshot.complete)
+    XCTAssertEqual(snapshot.failureReason, "rollout_not_enabled")
+    let attempts = await mirror.attempts
+    XCTAssertEqual(attempts, 0, "a stub snapshot must not attempt the ledger mirror")
+  }
+
+  func testTriggerSnapshotForAnotherOwnerFailsClosed() async throws {
+    ProactiveLaneURLStub.reset()
+    ProactiveLaneURLStub.enqueue(statusCode: 200, body: try triggerSnapshotBody(ownerID: "other-owner"))
+    let client = makeJITAuthorityClient()
+
+    do {
+      _ = try await client.fetchJITTriggerSnapshot(
+        authorizationSnapshot: try jitAuthorizationSnapshot())
+      XCTFail("a snapshot for another owner must fail closed")
+    } catch let error as ProactiveLaneClientError {
+      guard case .invalidResponse = error else {
+        return XCTFail("expected invalidResponse, got \(error)")
+      }
+    } catch {
+      XCTFail("expected ProactiveLaneClientError, got \(error)")
+    }
+  }
+
+  func testGarbageTriggerSnapshotThrowsInvalidResponse() async throws {
+    ProactiveLaneURLStub.reset()
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 200, body: try JSONSerialization.data(withJSONObject: ["unexpected": true]))
+    let client = makeJITAuthorityClient()
+
+    do {
+      _ = try await client.fetchJITTriggerSnapshot(
+        authorizationSnapshot: try jitAuthorizationSnapshot())
+      XCTFail("an undecodable snapshot body must fail closed")
+    } catch let error as ProactiveLaneClientError {
+      guard case .invalidResponse = error else {
+        return XCTFail("expected invalidResponse, got \(error)")
+      }
+    } catch {
+      XCTFail("expected ProactiveLaneClientError, got \(error)")
+    }
+  }
+
+  /// The JIT authority routes re-validate the runtime owner against
+  /// `RuntimeOwnerAuthorizationAuthority.shared` and the durable auth user, so
+  /// the shared authority has to hold this test owner at a known generation.
+  private func jitAuthorizationSnapshot(ownerID: String = "owner") throws
+    -> RuntimeOwnerAuthorizationSnapshot
+  {
+    UserDefaults.standard.set(ownerID, forKey: .authUserId)
+    let authority = RuntimeOwnerAuthorizationAuthority.shared
+    authority.beginTransition()
+    authority.endTransition(ownerID: ownerID)
+    return try XCTUnwrap(authority.capture(ownerID: ownerID, expectedOwnerID: ownerID))
+  }
+
+  private func makeJITAuthorityClient(
+    mirrorSync:
+      @escaping @Sendable (
+        RuntimeOwnerAuthorizationSnapshot, JITTriggerSnapshot
+      ) async throws -> Void = { _, _ in }
+  ) -> ProactiveLaneClient {
+    ProactiveLaneClient(
+      session: makeStubSession(),
+      baseURL: { "https://jit-authority.test" },
+      jitAuthorization: { ownerID in "Bearer test-\(ownerID)" },
+      ledgerMirrorSync: mirrorSync)
+  }
+
+  private func rolloutDecisionBody(
+    rollout: String?, killSwitch: String?, effective: String?
+  ) throws -> Data {
+    var object: [String: Any] = [
+      "reason": "rollout_enabled",
+      "error_class": "none",
+      "cache_hit": false,
+      "cache_ttl_seconds": 30,
+    ]
+    object["rollout"] = rollout
+    object["kill_switch"] = killSwitch
+    object["effective"] = effective
+    return try JSONSerialization.data(withJSONObject: object)
+  }
+
+  private func triggerSnapshotBody(
+    ownerID: String, complete: Bool = true, failureReason: String? = nil
+  ) throws -> Data {
+    try JSONSerialization.data(withJSONObject: [
+      "owner_id": ownerID,
+      "snapshot_revision": "revision-4",
+      "account_generation": 3,
+      "head_commit_id": "head-4",
+      "commit_sequence": 4,
+      "complete": complete,
+      "rows": [] as [[String: Any]],
+      "policy": ratifiedPolicyWireJSON(),
+      "failure_reason": (failureReason as Any?) ?? NSNull(),
+    ])
+  }
+  private func ratifiedPolicyWireJSON() -> [String: Any] {
+    [
+      "schema_version": "jit_trigger_policy.v1",
+      "planned_notifications_per_trigger_per_day": 1,
+      "total_proactive_notifications_per_day": 3,
+      "ambiguous_nano_triages_per_day": 8,
+      "full_agent_turns_per_candidate": 1,
+      "max_calendar_events": 32,
+      "valid_for_seconds": 30,
+      "paid_boundary_refresh_required": true,
+      "embedding": [
+        "enabled": false,
+        "match_similarity": 0.82,
+        "triage_similarity": 0.74,
+        "model_id": NSNull(),
+        "model_version": NSNull(),
+        "language": NSNull(),
+      ] as [String: Any],
+    ]
+  }
+
   private func completeExtraction(on client: ProactiveLaneClient) async throws -> ProactiveLaneResult {
     try await complete(operation: ModelQoS.Proactivity.extractionOperation, prompt: "extract", on: client)
   }
@@ -467,6 +706,13 @@ final class ProactiveLaneClientTests: XCTestCase {
   }
 }
 
+private actor MirrorSyncProbe {
+  private(set) var attempts = 0
+
+  func record() {
+    attempts += 1
+  }
+}
 private final class ManualDateClock: @unchecked Sendable {
   private let lock = NSLock()
   private var date: Date

--- a/desktop/macos/changelog/unreleased/20260829-jit-snapshot-admission.json
+++ b/desktop/macos/changelog/unreleased/20260829-jit-snapshot-admission.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed just-in-time proactive triggers never activating for admitted accounts because the app ignored the server's rollout verdict and blocked its snapshot download on an unrelated sync step"
+}


### PR DESCRIPTION
## What changed and why

The macOS desktop client never downloaded the JIT trigger snapshot for admitted owners: `GET /v1/jit/trigger-snapshot` was gated on the client **re-deriving admission** from the raw `rollout` + `kill_switch` pair instead of consuming the server's own `effective` verdict from the same `/v1/jit/rollout-decision` response. Live evidence (2026-08-29): Omi Beta 12237 issued rollout-decision 200s against dev desktop-backend `ecec0c281011` (contains the #12369 allowlist) with **zero** trigger-snapshot reads in the same window, and the local DB for the allowlisted owner had zero `jit_trigger_snapshot_receipts` rows.

- `JITProactivityFlags.permitsNewLane` now admits on `effective == .enabled` and fails closed on `.disabled`; the known-good rollout + kill-switch pair remains the older-server fallback. A missing `kill_switch` is wire compatibility, not an unknown-off veto; a present `unknown` still fails closed.
- `fetchJITTriggerSnapshot` no longer lets the downstream `KnowledgeLedgerMirrorCoordinator.sync` failure block the snapshot: **mirror sync must not prevent the local trigger receipt**. A failing mirror now fails itself closed (bounded, content-free error-class log) and the complete snapshot still returns, so `JITTriggerMirror.reconcile` (still `complete == true`-gated) writes the receipt. A complete empty watchlist decodes via the snake_case keys and persists its receipt.
- Server allowlist untouched; no standing triggers created; no PostHog/Firestore mutation. Owner comparison still binds to `owner_id`; foreign-owner and undecodable bodies still fail closed.

## Product invariants affected

none

## How it was verified

- `xcrun swift test --package-path Desktop --filter "JITProactivityPolicyTests|JITProactivityRuntimeTests|ProactiveLaneClientTests|JITTriggerMirrorTests|JITProactivityDeliveryTests"` — 86 tests, 0 failures. This includes new wire-level URLProtocol tests that drive the real `jitProactivityFlags` / `fetchJITTriggerSnapshot` against the router's actual response shapes, and a runtime test proving an effective-enabled authority reads the snapshot and persists the empty-watchlist receipt.
- `./scripts/swift-format-wrapper.sh lint` clean on all changed files; `./scripts/swiftlint-wrapper.sh lint` — 0 violations across 1444 files; `python3 scripts/check_desktop_test_quality.py` — at baseline.
- Not verified locally: a live Beta rebuild against the dev backend (no signed artifact rebuild in this task); the wire tests exercise the same contract the dev desktop-backend emits.

## Tests

- `ProactiveLaneClientTests`: effective=enabled admits with unknown raw flags; missing `kill_switch` + effective enabled admits; all-unknown and present-unknown fail closed; complete empty snake_case watchlist decodes and returns despite a throwing mirror sync (attempted exactly once); disabled stub returns its content-free receipt without touching the mirror; foreign-owner and garbage bodies fail closed.
- `JITProactivityPolicyTests`: effective-enabled admits over non-admitting raw pairs; effective-disabled blocks an otherwise-admitting pair; present-unknown kill switch without effective still fails closed; absent kill switch with enabled rollout admits via the fallback.
- `JITProactivityRuntimeTests`: effective-enabled authority with unknown raw flags reads the trigger snapshot and persists the receipt into `jit_trigger_snapshot_receipts`.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative

New class `FC-client-rederives-authority-verdict` (`.github/failure-classes/FC-client-rederives-authority-verdict.json`, added here with `evidence_prs: []` — this PR is the evidence). Violated contract: a client consuming an authority's decision response must act on the authority's verdict field, never re-derive a stricter verdict from the raw inputs beside it — the divergence is silent (200s on the decision read, no decode error, no failing test). Canonical guard: the admission predicate points at `effective` (fail-closed on `.disabled`), the raw pair is only an older-server fallback that distinguishes absent from present-unknown `kill_switch`, and the truth table is covered by wire-level tests plus a runtime receipt-persistence test. The Windows client already parses and uses `effective` and was not affected.

## Scoped cleanups (optional)

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

