### PR TITLE
fix(desktop): sync JIT trigger snapshot on signed-in startup without Rewind

### DIFF
--- a/.github/failure-classes/FC-sync-gated-on-consumer-trigger.json
+++ b/.github/failure-classes/FC-sync-gated-on-consumer-trigger.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-sync-gated-on-consumer-trigger",
+  "violated_contract": "A durable state sync whose authority is cheap to read (a snapshot plus its receipt) must be driven by the lifecycle event of the scope that owns it — signed-in admitted startup, owner change — never only by the opportunistic consumer path that happens to need it next. Binding the sync to the consumer's trigger silently couples availability to an unrelated subsystem: the JIT trigger snapshot download only ran inside JITProactivityRuntime.admission, reached solely after a notify-worthy screen-capture context visit, so an allowlisted owner whose TCC Screen Recording grant dropped (Sparkle replaced the signed binary) held a valid authority, kept the routes it did hit green, and stayed at zero jit_trigger_snapshot_receipts forever — the client fix in #12381 shipped in Beta 12240 but could never execute. No decode error, no failing test, and the server log looks healthy because the gating read simply never happens.",
+  "canonical_prevention": "Hook the same flag → fetch → reconcile chain the consumer uses onto the owner-ready startup path: DesktopHomeSignedInStartup.runProductServicesIfAdmitted fires JITProactivityRuntime.syncTriggerSnapshot once after isProductShellAdmitted, and the .task(id: productShellAdmissionToken) restart supplies the owner-change retry. Fire-and-forget so a slow authority route never gates startup; keep the consumer's fail-closed gate (permitsNewLane) and the complete-empty-snapshot receipt contract. Behavioral coverage: a runtime test that fetches and persists a receipt with zero context visits, fail-closed tests that every non-permitting authority performs no snapshot read, and URLProtocol-level wire tests asserting the GET sequence rollout-decision → trigger-snapshot.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Sources/AccountCutover/DesktopHomeSignedInStartup.swift",
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITProactivityRuntime.swift",
+    "desktop/macos/Desktop/Tests/JITProactivityRuntimeTests.swift",
+    "desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/**",
+    "desktop/windows/src/main/jit/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/AccountCutover/DesktopHomeSignedInStartup.swift
+++ b/desktop/macos/Desktop/Sources/AccountCutover/DesktopHomeSignedInStartup.swift
@@ -17,6 +17,20 @@ enum DesktopHomeSignedInStartup {
       return
     }
 
+    // The JIT trigger snapshot is the receipt authority for the proactive
+    // lane and must not depend on screen capture ever having produced a
+    // context visit: reconcile it once per signed-in admitted startup. The
+    // `.task(id: productShellAdmissionToken)` restart re-runs this cheaply
+    // on owner change. Fire-and-forget so a slow authority route never gates
+    // product startup; the fetch is owner-bound and reconciliation is
+    // idempotent.
+    if let authorizationSnapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot() {
+      Task {
+        await JITProactivityRuntime.shared.syncTriggerSnapshot(
+          authorizationSnapshot: authorizationSnapshot)
+      }
+    }
+
     if !AppBuild.usesLazyDevPermissions
       && !UserDefaults.standard.bool(forKey: .hasCompletedFileIndexing)
     {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITProactivityRuntime.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITProactivityRuntime.swift
@@ -298,6 +298,28 @@ actor JITProactivityRuntime {
     }
   }
 
+  /// Signed-in startup mirror sync: fetch and reconcile the authoritative
+  /// trigger snapshot before any context visit exists, so the snapshot (and
+  /// its receipt) never depends on screen capture being live, a
+  /// notify-worthy visit, or calendar access. Shares admission's
+  /// flag → fetch → reconcile chain and its fail-closed gate; a non-permitting
+  /// authority performs no snapshot read. No evaluation, no delivery — the
+  /// next context visit still owns those. One shot per signed-in startup:
+  /// a transport failure is logged (bounded, content-free) and retried only
+  /// by the next owner change or launch.
+  func syncTriggerSnapshot(authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot) async {
+    let resolved = await flags(authorizationSnapshot)
+    guard resolved.permitsNewLane else { return }
+    do {
+      let snapshot = try await snapshots(authorizationSnapshot)
+      _ = try await reconcile(snapshot, authorizationSnapshot: authorizationSnapshot)
+    } catch {
+      NSLog(
+        "JIT trigger snapshot: startup sync failed error_type=%@",
+        ProactiveLaneFailureClassification.boundedNetworkErrorType(error))
+    }
+  }
+
   private func approvePlannedAmbiguity(
     _ ambiguous: KnowledgeLedgerTriggerRuntimeEntryResult,
     observation: KnowledgeLedgerTriggerObservation,

--- a/desktop/macos/Desktop/Tests/JITProactivityRuntimeTests.swift
+++ b/desktop/macos/Desktop/Tests/JITProactivityRuntimeTests.swift
@@ -144,6 +144,94 @@ final class JITProactivityRuntimeTests: XCTestCase {
     XCTAssertEqual(receipts, ["owner"])
   }
 
+  // MARK: - Signed-in startup snapshot sync
+
+  /// Snapshot sync on signed-in startup must not wait for a context visit: an
+  /// effective-enabled owner fetches the authoritative snapshot and persists
+  /// the receipt even when the watchlist is empty and no visit ever settles.
+  func testStartupSyncFetchesSnapshotAndPersistsEmptyWatchlistReceiptWithoutAContextVisit() async throws {
+    let queue = try migratedQueue()
+    let emptyWatchlist = serverSnapshot(sequence: 4, revision: "revision-4", rows: [])
+    let sequence = SnapshotSequence([emptyWatchlist])
+    let runtime = JITProactivityRuntime(
+      flags: { _ in
+        JITProactivityFlags(rollout: .unknown, killSwitch: .unknown, effective: .enabled)
+      },
+      snapshots: { _ in try await sequence.next() },
+      reconcileSnapshot: { snapshot, _ in
+        try queue.write { db in try JITTriggerMirror.reconcile(snapshot, in: db, now: Date()) }
+      },
+      authorizationCurrent: { _ in true })
+
+    await runtime.syncTriggerSnapshot(authorizationSnapshot: try snapshot())
+
+    let remaining = await sequence.remaining
+    XCTAssertEqual(remaining, 0, "startup sync must read the trigger snapshot with zero context visits")
+    let receipts = try await queue.read { db in
+      try Row.fetchAll(
+        db, sql: "SELECT ownerID, rowCount FROM jit_trigger_snapshot_receipts")
+    }
+    XCTAssertEqual(receipts.count, 1)
+    let receipt = try XCTUnwrap(receipts.first)
+    let ownerID: String = receipt["ownerID"]
+    let rowCount: Int = receipt["rowCount"]
+    XCTAssertEqual(ownerID, "owner")
+    XCTAssertEqual(rowCount, 0, "an empty watchlist still persists its receipt")
+  }
+
+  /// Fail-closed startup: every non-permitting authority — unknown, rollout
+  /// disabled, kill switch, and an explicit `effective=disabled` — skips the
+  /// snapshot read and writes no receipt.
+  func testStartupSyncFailsClosedWhenAuthorityDoesNotPermitNewLane() async throws {
+    let nonPermitting: [JITProactivityFlags] = [
+      JITProactivityFlags(rollout: .unknown, killSwitch: .unknown),
+      JITProactivityFlags(rollout: .disabled, killSwitch: .disabled),
+      JITProactivityFlags(rollout: .enabled, killSwitch: .enabled),
+      JITProactivityFlags(rollout: .enabled, killSwitch: .disabled, effective: .disabled),
+    ]
+    for flags in nonPermitting {
+      let queue = try migratedQueue()
+      let runtime = JITProactivityRuntime(
+        flags: { _ in flags },
+        snapshots: { _ in
+          XCTFail("a non-permitting authority must not fetch the trigger snapshot")
+          throw ProactiveLaneClientError.invalidResponse
+        },
+        reconcileSnapshot: { snapshot, _ in
+          try queue.write { db in try JITTriggerMirror.reconcile(snapshot, in: db, now: Date()) }
+        })
+
+      await runtime.syncTriggerSnapshot(authorizationSnapshot: try snapshot())
+
+      let receipts = try await queue.read { db in
+        try String.fetchAll(db, sql: "SELECT ownerID FROM jit_trigger_snapshot_receipts")
+      }
+      XCTAssertTrue(receipts.isEmpty, "flags \(flags) must leave no receipt")
+    }
+  }
+
+  /// One shot, no loop: an unavailable snapshot at startup must swallow the
+  /// failure without crashing and leave the mirror untouched — the next
+  /// context visit's admission still owns recovery.
+  func testStartupSyncSwallowsSnapshotFailureWithoutPersistingAReceipt() async throws {
+    let queue = try migratedQueue()
+    let runtime = JITProactivityRuntime(
+      flags: { _ in
+        JITProactivityFlags(rollout: .unknown, killSwitch: .unknown, effective: .enabled)
+      },
+      snapshots: { _ in throw ProactiveLaneClientError.invalidResponse },
+      reconcileSnapshot: { snapshot, _ in
+        try queue.write { db in try JITTriggerMirror.reconcile(snapshot, in: db, now: Date()) }
+      })
+
+    await runtime.syncTriggerSnapshot(authorizationSnapshot: try snapshot())
+
+    let receipts = try await queue.read { db in
+      try String.fetchAll(db, sql: "SELECT ownerID FROM jit_trigger_snapshot_receipts")
+    }
+    XCTAssertTrue(receipts.isEmpty)
+  }
+
   func testAuthorityMismatchAndStaleLeaseSuppressWithoutAmbientFallback() async throws {
     let trigger = try compiledTrigger(id: "planned", condition: ["keywords": ["release"]])
     for (receiptOwner, receiptRevision, authorizationCurrent) in [

--- a/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
@@ -1,3 +1,4 @@
+@preconcurrency import GRDB
 import XCTest
 
 @testable import Omi_Computer
@@ -515,6 +516,67 @@ final class ProactiveLaneClientTests: XCTestCase {
     }
   }
 
+  // MARK: - Signed-in startup snapshot sync (wire)
+
+  /// Signed-in startup must fetch the trigger snapshot without any context
+  /// visit: the runtime's startup sync drives the real client routes in
+  /// order — rollout-decision, then trigger-snapshot — and a complete empty
+  /// watchlist still persists the local receipt.
+  func testStartupSnapshotSyncIssuesRolloutThenSnapshotGETAndWritesReceipt() async throws {
+    ProactiveLaneURLStub.reset()
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 200,
+      body: try rolloutDecisionBody(rollout: "unknown", killSwitch: "disabled", effective: "enabled"))
+    ProactiveLaneURLStub.enqueue(statusCode: 200, body: try triggerSnapshotBody(ownerID: "owner"))
+    let client = makeJITAuthorityClient()
+    let queue = try migratedMirrorQueue()
+    let runtime = JITProactivityRuntime(
+      flags: { await client.jitProactivityFlags(authorizationSnapshot: $0) },
+      snapshots: { try await client.fetchJITTriggerSnapshot(authorizationSnapshot: $0) },
+      reconcileSnapshot: { snapshot, _ in
+        try queue.write { db in try JITTriggerMirror.reconcile(snapshot, in: db, now: Date()) }
+      })
+
+    await runtime.syncTriggerSnapshot(authorizationSnapshot: try jitAuthorizationSnapshot())
+
+    XCTAssertEqual(
+      ProactiveLaneURLStub.requestedPaths, ["/v1/jit/rollout-decision", "/v1/jit/trigger-snapshot"])
+    let receipts = try await queue.read { db in
+      try Row.fetchAll(db, sql: "SELECT ownerID, rowCount FROM jit_trigger_snapshot_receipts")
+    }
+    XCTAssertEqual(receipts.count, 1)
+    let receipt = try XCTUnwrap(receipts.first)
+    let ownerID: String = receipt["ownerID"]
+    let rowCount: Int = receipt["rowCount"]
+    XCTAssertEqual(ownerID, "owner")
+    XCTAssertEqual(rowCount, 0, "an empty watchlist still persists its receipt")
+  }
+
+  /// Fail-closed startup: an `effective=disabled` authority reads only the
+  /// rollout decision and never issues the trigger-snapshot GET.
+  func testStartupSnapshotSyncWithEffectiveDisabledNeverIssuesSnapshotGET() async throws {
+    ProactiveLaneURLStub.reset()
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 200,
+      body: try rolloutDecisionBody(rollout: "unknown", killSwitch: "unknown", effective: "disabled"))
+    let client = makeJITAuthorityClient()
+    let queue = try migratedMirrorQueue()
+    let runtime = JITProactivityRuntime(
+      flags: { await client.jitProactivityFlags(authorizationSnapshot: $0) },
+      snapshots: { try await client.fetchJITTriggerSnapshot(authorizationSnapshot: $0) },
+      reconcileSnapshot: { snapshot, _ in
+        try queue.write { db in try JITTriggerMirror.reconcile(snapshot, in: db, now: Date()) }
+      })
+
+    await runtime.syncTriggerSnapshot(authorizationSnapshot: try jitAuthorizationSnapshot())
+
+    XCTAssertEqual(ProactiveLaneURLStub.requestedPaths, ["/v1/jit/rollout-decision"])
+    let receipts = try await queue.read { db in
+      try String.fetchAll(db, sql: "SELECT ownerID FROM jit_trigger_snapshot_receipts")
+    }
+    XCTAssertTrue(receipts.isEmpty)
+  }
+
   /// The JIT authority routes re-validate the runtime owner against
   /// `RuntimeOwnerAuthorizationAuthority.shared` and the durable auth user, so
   /// the shared authority has to hold this test owner at a known generation.
@@ -539,6 +601,14 @@ final class ProactiveLaneClientTests: XCTestCase {
       baseURL: { "https://jit-authority.test" },
       jitAuthorization: { ownerID in "Bearer test-\(ownerID)" },
       ledgerMirrorSync: mirrorSync)
+  }
+
+  private func migratedMirrorQueue() throws -> DatabaseQueue {
+    let queue = try DatabaseQueue()
+    var migrator = DatabaseMigrator()
+    JITTriggerMirrorSchema.registerMigration(on: &migrator)
+    try migrator.migrate(queue)
+    return queue
   }
 
   private func rolloutDecisionBody(
@@ -745,6 +815,7 @@ private final class ProactiveLaneURLStub: URLProtocol, @unchecked Sendable {
   private nonisolated(unsafe) static var responses: [StubResponse] = []
   private nonisolated(unsafe) static var served = 0
   private nonisolated(unsafe) static var operations: [String] = []
+  private nonisolated(unsafe) static var paths: [String] = []
   /// How many requests must be in flight before any of them is answered, if the caller asked for
   /// that. Nil is the ordinary case: answer each request as it arrives.
   private nonisolated(unsafe) static var holdThreshold: Int?
@@ -763,11 +834,20 @@ private final class ProactiveLaneURLStub: URLProtocol, @unchecked Sendable {
     return operations
   }
 
+  /// Request URL paths in issue order, for asserting which authority routes a
+  /// caller actually reached.
+  static var requestedPaths: [String] {
+    lock.lock()
+    defer { lock.unlock() }
+    return paths
+  }
+
   static func reset() {
     lock.lock()
     responses = []
     served = 0
     operations = []
+    paths = []
     holdThreshold = nil
     holdReached = nil
     held = []
@@ -813,6 +893,7 @@ private final class ProactiveLaneURLStub: URLProtocol, @unchecked Sendable {
     let operation = Self.operation(from: request)
     Self.lock.lock()
     Self.operations.append(operation)
+    Self.paths.append(url.path)
     let stub = Self.responses.isEmpty ? nil : Self.responses.removeFirst()
     Self.served += 1
     let deliver = { self.deliver(stub, for: url) }

--- a/desktop/macos/changelog/unreleased/20260829-jit-startup-snapshot-sync.json
+++ b/desktop/macos/changelog/unreleased/20260829-jit-startup-snapshot-sync.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed just-in-time proactive triggers never syncing on launch because the trigger snapshot download waited for a screen-capture context visit; signed-in startups now reconcile the snapshot directly"
+}


### PR DESCRIPTION
Failure-Class: new

## What changed and why

The macOS client only downloaded the JIT trigger snapshot inside
`JITProactivityRuntime.admission`, which is reached exclusively through
`JITProactivityCoordinator.handle` after a **notify-worthy context visit**
from `ContextProactivityEngine`. Live evidence on the allowlisted account
after #12381 shipped in Omi Beta 0.12.240 / 12240:
`jit_trigger_snapshot_receipts` = 0, UA `Omi Beta/12240` still hits
`GET /v1/jit/knowledge-ledger/prompt-snapshot` but never `rollout-decision`
or `trigger-snapshot` — because Sparkle replaced the signed binary and the
TCC Screen Recording grant likely dropped, so the director never evaluated
and the client fix could never run. Snapshot sync must not depend on screen
capture.

- `JITProactivityRuntime.syncTriggerSnapshot(authorizationSnapshot:)` runs
  the exact admission chain — `jitProactivityFlags` → guard
  `permitsNewLane` → `fetchJITTriggerSnapshot` → `JITTriggerMirror.reconcile`
  — with no observation, no evaluation, no delivery. The fail-closed gate is
  unchanged: unknown/disabled still performs no snapshot read.
- `DesktopHomeSignedInStartup.runProductServicesIfAdmitted` fires it once
  after `isProductShellAdmitted`, as a detached task so a slow authority
  route never gates product startup. The `.task(id:
  productShellAdmissionToken)` restart supplies the cheap owner-change
  retry (the token includes `boundOwnerID`). No new timers or loops.
- A complete **empty** snapshot still persists its receipt (`rowCount` 0),
  and the #12381 contract is preserved: the downstream ledger-mirror sync
  inside `fetchJITTriggerSnapshot` stays non-blocking for the receipt.

## Product invariants affected

- INV-CUTOVER-1

The hook stays strictly behind the existing `isProductShellAdmitted` fence
and invents no parallel cohort/generation primitive; it is a read-only,
owner-bound snapshot reconcile on the already-admitted path.

## Testing

- `JITProactivityRuntimeTests.testStartupSyncFetchesSnapshotAndPersistsEmptyWatchlistReceiptWithoutAContextVisit`
  — effective=enabled startup fetches the snapshot and writes a receipt with
  zero context visits and an empty watchlist.
- `JITProactivityRuntimeTests.testStartupSyncFailsClosedWhenAuthorityDoesNotPermitNewLane`
  — unknown, rollout-disabled, kill-switch, and `effective=disabled` skip
  the snapshot read and write no receipt.
- `JITProactivityRuntimeTests.testStartupSyncSwallowsSnapshotFailureWithoutPersistingAReceipt`
  — one shot, no loop: an unavailable snapshot is swallowed content-free.
- `ProactiveLaneClientTests.testStartupSnapshotSyncIssuesRolloutThenSnapshotGETAndWritesReceipt`
  — wire-level: the runtime startup sync drives the real client routes in
  order (`/v1/jit/rollout-decision` then `/v1/jit/trigger-snapshot`) and
  persists the empty-watchlist receipt.
- `ProactiveLaneClientTests.testStartupSnapshotSyncWithEffectiveDisabledNeverIssuesSnapshotGET`
  — wire-level: `effective=disabled` reads only the rollout decision.
- Existing #12381 wire/runtime suites (`ProactiveLaneClientTests`,
  `JITProactivityRuntimeTests`, `JITTriggerMirrorTests`,
  `JITProactivityPolicyTests`, `JITProactivityDeliveryTests`,
  `FloatingBarLaunchPolicyTests`) all pass unchanged.

Ambient proactive work still needs screen capture; this change only removes
that dependency from the snapshot/receipt sync.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

