### PR TITLE
fix(macos): finish Google sign-in after the loopback success page

### DIFF
--- a/react-native/__tests__/macOSNativeBoundary.test.ts
+++ b/react-native/__tests__/macOSNativeBoundary.test.ts
@@ -273,6 +273,10 @@ test('refreshes expiring macOS cloud sessions without using stale tokens', () =>
 
 test('validates loopback callbacks before success and keeps listening past probes', () => {
   const auth = readNativeSource('OmiAuthModule.mm');
+  const validated = auth.slice(
+    auth.indexOf('static NSURL *OmiAuthValidatedCallbackURL'),
+    auth.indexOf('static NSURL *OmiAuthAcceptCallback'),
+  );
 
   expect(auth).toContain('struct sockaddr_storage');
   expect(auth).toContain('getpeername');
@@ -292,6 +296,40 @@ test('validates loopback callbacks before success and keeps listening past probe
     /callback\.scheme[^]*callback\.host[^]*callback\.port[^]*callback\.path/,
   );
   expect(auth).toMatch(/values\[@"state"\][^]*values\[@"code"\]/);
+  expect(validated).toMatch(/uint16_t port/);
+  expect(validated).not.toContain(
+    '@"http://127.0.0.1" stringByAppendingString:target',
+  );
+  expect(validated).toMatch(/http:\/\/127\.0\.0\.1:%u%@/);
+  expect(auth).toMatch(
+    /static NSURL \*OmiAuthAcceptCallback\(int listener,\s*uint16_t port,/,
+  );
+  expect(auth).toContain(
+    'OmiAuthValidatedCallbackURL(request ?: @"", expectedState, port)',
+  );
+  expect(auth).toContain('OmiAuthAcceptCallback(listener, port, 180, state)');
+});
+
+test('does not reject sign-in when ASWebAuth cancels while loopback waits', () => {
+  const auth = readNativeSource('OmiAuthModule.mm');
+  const sessionStart = auth.indexOf(
+    'initWithURL:authorize.URL callbackURLScheme:@"http"',
+  );
+  expect(sessionStart).toBeGreaterThan(-1);
+  const handler = auth.slice(
+    sessionStart,
+    auth.indexOf(
+      'self.authenticationSession.presentationContextProvider',
+      sessionStart,
+    ),
+  );
+
+  expect(handler).toContain('completeSignInWithCallback:callbackURL');
+  expect(handler).not.toContain('completeSignInWithCallback:nil');
+  expect(handler).toMatch(/if \(callbackURL == nil\) \{\s*return;/);
+  expect(auth).toContain(
+    '[self completeSignInWithCallback:callbackURL\n                                   state:state',
+  );
 });
 
 test('serves a branded auto-closing success page and returns the user to the app', () => {

--- a/react-native/macos/RnRuntime-macOS/OmiAuthModule.mm
+++ b/react-native/macos/RnRuntime-macOS/OmiAuthModule.mm
@@ -176,7 +176,7 @@ static NSString *OmiAuthSuccessPageHTML(void) {
       @"</html>";
 }
 
-static NSURL *OmiAuthValidatedCallbackURL(NSString *request, NSString *expectedState) {
+static NSURL *OmiAuthValidatedCallbackURL(NSString *request, NSString *expectedState, uint16_t port) {
   NSString *requestLine = [[request componentsSeparatedByString:@"\r\n"] firstObject];
   NSArray<NSString *> *rawParts = [requestLine componentsSeparatedByCharactersInSet:
       NSCharacterSet.whitespaceCharacterSet];
@@ -189,7 +189,7 @@ static NSURL *OmiAuthValidatedCallbackURL(NSString *request, NSString *expectedS
   NSString *target = parts[1];
   if (![target hasPrefix:@"/"] || [target hasPrefix:@"//"] || [target containsString:@"#"]) return nil;
   NSURLComponents *components = [NSURLComponents componentsWithString:
-      [@"http://127.0.0.1" stringByAppendingString:target]];
+      [NSString stringWithFormat:@"http://127.0.0.1:%u%@", port, target]];
   if (components == nil || ![components.path isEqualToString:@"/callback"] ||
       ![components.percentEncodedPath isEqualToString:@"/callback"] ||
       components.fragment.length > 0) {
@@ -201,7 +201,7 @@ static NSURL *OmiAuthValidatedCallbackURL(NSString *request, NSString *expectedS
   return components.URL;
 }
 
-static NSURL *OmiAuthAcceptCallback(int listener, NSTimeInterval timeout, NSString *expectedState) {
+static NSURL *OmiAuthAcceptCallback(int listener, uint16_t port, NSTimeInterval timeout, NSString *expectedState) {
   if (listener < 0) return nil;
   NSTimeInterval deadline = NSDate.date.timeIntervalSince1970 + timeout;
   while (NSDate.date.timeIntervalSince1970 < deadline) {
@@ -233,7 +233,7 @@ static NSURL *OmiAuthAcceptCallback(int listener, NSTimeInterval timeout, NSStri
                                          length:(NSUInteger)count
                                        encoding:NSUTF8StringEncoding];
     }
-    NSURL *callbackURL = OmiAuthValidatedCallbackURL(request ?: @"", expectedState);
+    NSURL *callbackURL = OmiAuthValidatedCallbackURL(request ?: @"", expectedState, port);
     if (callbackURL == nil) {
       const char *invalid =
           "HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain; charset=utf-8\r\n"
@@ -768,7 +768,7 @@ RCT_REMAP_METHOD(signIn,
       [NSURLQueryItem queryItemWithName:@"code_challenge_method" value:@"S256"],
     ];
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-      NSURL *callbackURL = OmiAuthAcceptCallback(listener, 180, state);
+      NSURL *callbackURL = OmiAuthAcceptCallback(listener, port, 180, state);
       dispatch_async(dispatch_get_main_queue(), ^{
         if (attempt != self.signInAttempt) return;
         [self completeSignInWithCallback:callbackURL
@@ -782,18 +782,8 @@ RCT_REMAP_METHOD(signIn,
     });
     self.authenticationSession = [[ASWebAuthenticationSession alloc]
         initWithURL:authorize.URL callbackURLScheme:@"http"
-        completionHandler:^(NSURL *callbackURL, NSError *error) {
-      if (error != nil && callbackURL == nil) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-          if (attempt != self.signInAttempt) return;
-          [self completeSignInWithCallback:nil
-                                     state:state
-                                  verifier:verifier
-                               redirectURI:redirectURI
-                                   attempt:attempt
-                                   resolve:resolve
-                                    reject:reject];
-        });
+        completionHandler:^(NSURL *callbackURL, NSError *__unused error) {
+      if (callbackURL == nil) {
         return;
       }
       dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Google sign-in in the macOS RN Omi app showed the loopback success page ("Signed in to Omi" / close this window) and then never became signed-in. JS `omiAuth.signIn()` never received `{signedIn: true}`.

## Root cause (confirmed in source)

In `react-native/macos/RnRuntime-macOS/OmiAuthModule.mm`:

1. `OmiAuthListenLoopback` binds an ephemeral port and `redirectURI` is `http://127.0.0.1:<port>/callback`.
2. `OmiAuthValidatedCallbackURL` rebuilt the bounce-back as `http://127.0.0.1` + the request target — **no listen port**.
3. `completeSignInWithCallback` requires `[callback.port isEqualToNumber:redirect.port]`. `nil isEqualToNumber:@(port)` is `NO`, so the loopback path returned **without resolve or reject**. The branded success HTML had already been served (the auth code landed). Token exchange never ran.
4. `ASWebAuthenticationSession` uses `callbackURLScheme:@"http"` and usually does not complete with the loopback URL. Closing the sheet later called `completeSignInWithCallback:nil` and rejected as cancelled, even while the loopback listener was still the bounce-back.

## Fix

- Pass the actual listen port into `OmiAuthAcceptCallback` / `OmiAuthValidatedCallbackURL` so constructed callbacks are `http://127.0.0.1:<port>/callback?...`.
- Keep the port check for real ASWebAuth URLs.
- Do not treat ASWebAuth cancel/error as fatal while the loopback listener is still waiting. Settlement happens on loopback success (token exchange) or loopback timeout / a real failed exchange.
- Unchanged: branded success page, cancel the auth sheet after a successful code, persist the keychain session, `bringOmiToFront`, resolve `{signedIn:YES}`. No custom URL scheme, no `api.omi.me` auth change, no workers.dev, no OpenRouter, no `/Applications/Omi.app`.

## Tests

`react-native/__tests__/macOSNativeBoundary.test.ts` now fails if the loopback callback is still built as `http://127.0.0.1` without the listen port, and if the ASWebAuth completion handler immediately rejects on cancel.

```
cd react-native && bun run test -- --runInBand __tests__/macOSNativeBoundary.test.ts
# 20 passed, 20 total
```

Could not exercise the live Google sheet on this Linux VM (needs the macOS RN host).

## Files

- `react-native/macos/RnRuntime-macOS/OmiAuthModule.mm`
- `react-native/__tests__/macOSNativeBoundary.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33dd306b-bd11-440e-ad23-ff8e6c936ad0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33dd306b-bd11-440e-ad23-ff8e6c936ad0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

