### PR TITLE
feat(backend): restore the JIT kill switch as an authority over allowlist admission

### DIFF
--- a/backend/tests/unit/test_jit_rollout.py
+++ b/backend/tests/unit/test_jit_rollout.py
@@ -17,6 +17,7 @@ from utils.memory.jit_trigger_contract import DEFAULT_TRIGGER_RUNTIME_POLICY
 from utils.memory.jit_trigger_snapshot import AuthoritativeTriggerRow, AuthoritativeTriggerSnapshot
 from utils import jit_rollout as authority_module
 from utils.jit_rollout import (
+    DEFAULT_JIT_ROLLOUT_CACHE_SECONDS,
     JIT_ADMISSION_ALLOWLIST,
     JIT_DAILY_SWEEP_FLAG_KEY,
     JIT_KILL_SWITCH_FLAG_KEY,
@@ -76,9 +77,12 @@ async def test_authority_admits_only_known_true_exposure_flag(
     expected,
     reason,
 ):
+    # Kill switch is held neutral (disabled) here: this test isolates the
+    # rollout-flag-driven path. Kill-switch-as-authority is covered
+    # separately below.
     async def provider(uid: str) -> JITFlagEvaluation:
         assert uid == 'named-user'
-        return JITFlagEvaluation(rollout, TriState.ENABLED, provider_reason)
+        return JITFlagEvaluation(rollout, TriState.DISABLED, provider_reason)
 
     decision = await JITRolloutAuthority(provider).resolve(
         'named-user',
@@ -187,10 +191,11 @@ class _FakePostHog:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ('flags', 'rollout', 'reason', 'error_class'),
+    ('flags', 'rollout', 'kill_switch', 'reason', 'error_class'),
     [
         (
             {JIT_PROCESSING_FLAG_KEY: True, JIT_KILL_SWITCH_FLAG_KEY: True, JIT_LEDGER_MIGRATION_FLAG_KEY: False},
+            TriState.ENABLED,
             TriState.ENABLED,
             JITDecisionReason.EVALUATED,
             JITErrorClass.NONE,
@@ -198,26 +203,34 @@ class _FakePostHog:
         (
             {JIT_PROCESSING_FLAG_KEY: False, JIT_KILL_SWITCH_FLAG_KEY: False},
             TriState.DISABLED,
+            TriState.DISABLED,
             JITDecisionReason.EVALUATED,
             JITErrorClass.NONE,
         ),
         (
             {JIT_KILL_SWITCH_FLAG_KEY: False, JIT_DAILY_SWEEP_FLAG_KEY: True},
             TriState.DISABLED,
+            TriState.DISABLED,
             JITDecisionReason.FLAG_ABSENT,
             JITErrorClass.ABSENT,
         ),
         (
+            # Kill key absent from a well-formed response: PostHog omits a
+            # boolean flag that evaluates false, so absence here means
+            # disabled, not unknown -- even though the rollout value itself
+            # is separately malformed.
             {JIT_PROCESSING_FLAG_KEY: 'enabled'},
             TriState.UNKNOWN,
+            TriState.DISABLED,
             JITDecisionReason.MALFORMED_RESPONSE,
             JITErrorClass.MALFORMED,
         ),
     ],
 )
-async def test_posthog_provider_parses_only_the_exposure_flag(
+async def test_posthog_provider_parses_the_exposure_and_kill_switch_flags(
     flags,
     rollout,
+    kill_switch,
     reason,
     error_class,
 ):
@@ -227,17 +240,17 @@ async def test_posthog_provider_parses_only_the_exposure_flag(
     result = await provider('authenticated-user')
 
     assert client.uids == ['authenticated-user']
-    assert result == JITFlagEvaluation(rollout, TriState.DISABLED, reason, error_class)
+    assert result == JITFlagEvaluation(rollout, kill_switch, reason, error_class)
 
 
 @pytest.mark.asyncio
-async def test_retired_flags_do_not_change_admission():
+async def test_ledger_migration_and_daily_sweep_flags_do_not_change_admission():
     client = _FakePostHog(
         {
             JIT_PROCESSING_FLAG_KEY: True,
-            JIT_KILL_SWITCH_FLAG_KEY: True,
-            JIT_LEDGER_MIGRATION_FLAG_KEY: False,
-            JIT_DAILY_SWEEP_FLAG_KEY: False,
+            JIT_KILL_SWITCH_FLAG_KEY: False,
+            JIT_LEDGER_MIGRATION_FLAG_KEY: True,
+            JIT_DAILY_SWEEP_FLAG_KEY: True,
         }
     )
     authority = JITRolloutAuthority(PostHogJITFlagProvider(client_factory=lambda: client))
@@ -250,9 +263,104 @@ async def test_retired_flags_do_not_change_admission():
 
 
 @pytest.mark.asyncio
-async def test_allowlist_uid_is_enabled_when_flag_is_false_missing_or_timed_out():
-    async def provider(_uid: str) -> JITFlagEvaluation:
-        raise AssertionError('allowlist admission must not call PostHog')
+async def test_kill_switch_flag_revokes_admission_even_when_rollout_is_enabled():
+    """The kill switch is live authority again: it can only ever remove admission."""
+
+    client = _FakePostHog(
+        {
+            JIT_PROCESSING_FLAG_KEY: True,
+            JIT_KILL_SWITCH_FLAG_KEY: True,
+            JIT_LEDGER_MIGRATION_FLAG_KEY: False,
+            JIT_DAILY_SWEEP_FLAG_KEY: False,
+        }
+    )
+    authority = JITRolloutAuthority(PostHogJITFlagProvider(client_factory=lambda: client))
+
+    decision = await authority.resolve('named-user', stage=JITDecisionStage.READ_ONLY)
+
+    assert decision.permits_work is False
+    assert decision.effective == TriState.DISABLED
+    assert decision.kill_switch == TriState.ENABLED
+    assert decision.reason == JITDecisionReason.KILL_SWITCH_ENABLED
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_absent_from_a_well_formed_response_means_disabled_and_full_cache_ttl():
+    """PostHog omits a boolean flag entirely when it evaluates false for the distinct ID.
+
+    A 0%-rollout kill switch -- its normal, healthy steady state -- is
+    therefore ABSENT from a real decide response, not a present ``false``.
+    Since the response itself is well-formed, that absence must read as
+    DISABLED (the provider was reached and did not assert a kill), not
+    UNKNOWN. Reading it as UNKNOWN would permanently downgrade every
+    steady-state decision to the short negative-cache TTL and report a false
+    "unknown" kill switch on the wire, for both allowlisted and regular UIDs.
+    """
+
+    client = _FakePostHog({JIT_PROCESSING_FLAG_KEY: True})
+
+    regular_decision = await JITRolloutAuthority(PostHogJITFlagProvider(client_factory=lambda: client)).resolve(
+        'named-user', stage=JITDecisionStage.READ_ONLY
+    )
+    assert regular_decision.kill_switch == TriState.DISABLED
+    assert regular_decision.permits_work is True
+    assert regular_decision.cache_ttl_seconds == int(DEFAULT_JIT_ROLLOUT_CACHE_SECONDS)
+
+    allowlisted_decision = await JITRolloutAuthority(PostHogJITFlagProvider(client_factory=lambda: client)).resolve(
+        _ALLOWLIST_UID, stage=JITDecisionStage.READ_ONLY
+    )
+    assert allowlisted_decision.kill_switch == TriState.DISABLED
+    assert allowlisted_decision.permits_work is True
+    assert allowlisted_decision.cache_ttl_seconds == int(DEFAULT_JIT_ROLLOUT_CACHE_SECONDS)
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_present_but_malformed_stays_unknown_with_short_cache_ttl_and_never_blocks():
+    client = _FakePostHog({JIT_PROCESSING_FLAG_KEY: True, JIT_KILL_SWITCH_FLAG_KEY: 'enabled'})
+
+    regular_decision = await JITRolloutAuthority(PostHogJITFlagProvider(client_factory=lambda: client)).resolve(
+        'named-user', stage=JITDecisionStage.READ_ONLY
+    )
+    assert regular_decision.kill_switch == TriState.UNKNOWN
+    assert regular_decision.permits_work is True
+    assert regular_decision.cache_ttl_seconds == int(UNKNOWN_JIT_ROLLOUT_CACHE_SECONDS)
+
+    allowlisted_decision = await JITRolloutAuthority(PostHogJITFlagProvider(client_factory=lambda: client)).resolve(
+        _ALLOWLIST_UID, stage=JITDecisionStage.READ_ONLY
+    )
+    assert allowlisted_decision.kill_switch == TriState.UNKNOWN
+    assert allowlisted_decision.permits_work is True
+    assert allowlisted_decision.cache_ttl_seconds == int(UNKNOWN_JIT_ROLLOUT_CACHE_SECONDS)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'evaluation',
+    [
+        # Exposure flag state is irrelevant to the allowlist; only the kill
+        # switch can remove its admission, and here it never definitively is.
+        JITFlagEvaluation(TriState.DISABLED, TriState.DISABLED, JITDecisionReason.EVALUATED),
+        JITFlagEvaluation(TriState.DISABLED, TriState.DISABLED, JITDecisionReason.FLAG_ABSENT, JITErrorClass.ABSENT),
+        JITFlagEvaluation(
+            TriState.UNKNOWN, TriState.UNKNOWN, JITDecisionReason.PROVIDER_TIMEOUT, JITErrorClass.TIMEOUT
+        ),
+        JITFlagEvaluation(TriState.ENABLED, TriState.UNKNOWN, JITDecisionReason.EVALUATED),
+    ],
+)
+async def test_allowlist_uid_is_enabled_when_rollout_is_false_missing_or_provider_is_down(evaluation):
+    """The allowlist ignores the exposure flag but still consults the kill switch.
+
+    A provider timeout/outage yields an unknown kill switch, which -- like a
+    false or missing exposure flag -- must not remove the allowlist's
+    admission. This is the resilience the module docstring promises: 'the
+    allowlist still admits when PostHog is down.'
+    """
+
+    calls: list[str] = []
+
+    async def provider(uid: str) -> JITFlagEvaluation:
+        calls.append(uid)
+        return evaluation
 
     authority = JITRolloutAuthority(provider)
     for uid in (_ALLOWLIST_UID, _OTHER_ALLOWLIST_UID):
@@ -260,6 +368,40 @@ async def test_allowlist_uid_is_enabled_when_flag_is_false_missing_or_timed_out(
         assert decision.permits_work is True
         assert decision.effective == TriState.ENABLED
         assert decision.reason == JITDecisionReason.ROLLOUT_ENABLED
+    # Unlike the fully-retired behavior, the provider IS consulted for the
+    # allowlist now -- it is the only path that can observe a kill switch.
+    assert calls == [_ALLOWLIST_UID, _OTHER_ALLOWLIST_UID]
+
+
+@pytest.mark.asyncio
+async def test_allowlist_uid_is_blocked_when_kill_switch_is_enabled():
+    async def provider(_uid: str) -> JITFlagEvaluation:
+        return JITFlagEvaluation(TriState.ENABLED, TriState.ENABLED, JITDecisionReason.EVALUATED)
+
+    authority = JITRolloutAuthority(provider)
+    for uid in (_ALLOWLIST_UID, _OTHER_ALLOWLIST_UID):
+        decision = await authority.resolve(uid, stage=JITDecisionStage.READ_ONLY)
+        assert decision.permits_work is False
+        assert decision.effective == TriState.DISABLED
+        assert decision.reason == JITDecisionReason.KILL_SWITCH_ENABLED
+        assert decision.kill_switch == TriState.ENABLED
+
+
+@pytest.mark.asyncio
+async def test_allowlist_uid_sync_path_is_also_resilient_to_a_dead_control_loop(monkeypatch):
+    """resolve_jit_rollout_sync's outer scheduling-failure fallback must not block the allowlist."""
+
+    def broken_run_coroutine_threadsafe(coro, *_args, **_kwargs):
+        coro.close()  # avoid an unrelated "coroutine was never awaited" warning
+        raise RuntimeError('control loop is unavailable')
+
+    monkeypatch.setattr(authority_module.asyncio, 'run_coroutine_threadsafe', broken_run_coroutine_threadsafe)
+
+    decision = resolve_jit_rollout_sync(_ALLOWLIST_UID, stage=JITDecisionStage.READ_ONLY)
+
+    assert decision.permits_work is True
+    assert decision.effective == TriState.ENABLED
+    assert decision.kill_switch == TriState.UNKNOWN
 
 
 @pytest.mark.asyncio
@@ -298,6 +440,44 @@ async def test_non_allowlist_uid_follows_exposure_flag_and_fails_closed_on_timeo
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('evaluation', 'expected_effective', 'expected_permits', 'expected_reason'),
+    [
+        (
+            JITFlagEvaluation(TriState.ENABLED, TriState.ENABLED, JITDecisionReason.EVALUATED),
+            TriState.DISABLED,
+            False,
+            JITDecisionReason.KILL_SWITCH_ENABLED,
+        ),
+        (
+            JITFlagEvaluation(TriState.ENABLED, TriState.UNKNOWN, JITDecisionReason.EVALUATED),
+            TriState.ENABLED,
+            True,
+            JITDecisionReason.ROLLOUT_ENABLED,
+        ),
+        (
+            JITFlagEvaluation(TriState.ENABLED, TriState.DISABLED, JITDecisionReason.EVALUATED),
+            TriState.ENABLED,
+            True,
+            JITDecisionReason.ROLLOUT_ENABLED,
+        ),
+    ],
+)
+async def test_non_allowlist_kill_switch_can_only_remove_never_grant_authority(
+    evaluation, expected_effective, expected_permits, expected_reason
+):
+    async def provider(_uid: str) -> JITFlagEvaluation:
+        return evaluation
+
+    decision = await JITRolloutAuthority(provider).resolve('stranger', stage=JITDecisionStage.READ_ONLY)
+
+    assert decision.effective == expected_effective
+    assert decision.permits_work is expected_permits
+    assert decision.reason == expected_reason
+    assert decision.kill_switch == evaluation.kill_switch
+
+
+@pytest.mark.asyncio
 async def test_public_helpers_share_one_allowlist_and_one_exposure_flag(monkeypatch):
     async def provider(_uid: str) -> JITFlagEvaluation:
         return JITFlagEvaluation(TriState.DISABLED, TriState.DISABLED, JITDecisionReason.EVALUATED)
@@ -314,6 +494,32 @@ async def test_public_helpers_share_one_allowlist_and_one_exposure_flag(monkeypa
     assert stranger.permits_work is False
     assert ledger.permits_work is False
     assert sync_allowlisted.permits_work is True
+
+
+def test_sync_path_inherits_kill_switch_authority_over_allowlist_and_rollout(monkeypatch):
+    """resolve_jit_rollout_sync (the sweep/first-open path) must match the async contract exactly."""
+
+    states = {
+        'killed-regular': JITFlagEvaluation(TriState.ENABLED, TriState.ENABLED, JITDecisionReason.EVALUATED),
+        'admitted-regular': JITFlagEvaluation(TriState.ENABLED, TriState.DISABLED, JITDecisionReason.EVALUATED),
+    }
+
+    async def provider(uid: str) -> JITFlagEvaluation:
+        if uid in (_ALLOWLIST_UID, _OTHER_ALLOWLIST_UID):
+            return JITFlagEvaluation(TriState.ENABLED, TriState.ENABLED, JITDecisionReason.EVALUATED)
+        return states[uid]
+
+    monkeypatch.setattr(authority_module, '_sync_authority', JITRolloutAuthority(provider))
+
+    killed_allowlisted = resolve_jit_rollout_sync(_ALLOWLIST_UID, stage=JITDecisionStage.READ_ONLY)
+    killed_regular = resolve_jit_rollout_sync('killed-regular', stage=JITDecisionStage.READ_ONLY)
+    admitted_regular = resolve_jit_rollout_sync('admitted-regular', stage=JITDecisionStage.READ_ONLY)
+
+    assert killed_allowlisted.permits_work is False
+    assert killed_allowlisted.reason == JITDecisionReason.KILL_SWITCH_ENABLED
+    assert killed_regular.permits_work is False
+    assert killed_regular.reason == JITDecisionReason.KILL_SWITCH_ENABLED
+    assert admitted_regular.permits_work is True
 
 
 @pytest.mark.asyncio

--- a/backend/utils/jit_rollout.py
+++ b/backend/utils/jit_rollout.py
@@ -8,6 +8,14 @@ that bypasses the flag.  A known-false or absent flag is off.  Provider
 timeouts, missing configuration, and malformed values stay ``unknown`` and
 cannot admit a non-allowlist user.  The allowlist still admits when PostHog
 is down.
+
+A separate operational kill switch flag is read in the same provider call as
+the exposure flag.  A definitively ``enabled`` kill switch revokes admission
+for *everyone*, including the allowlist -- it is the only thing that can. An
+``unknown`` or absent kill switch never blocks by itself: the allowlist keeps
+admitting when PostHog is down or the kill flag is unset, and non-allowlist
+users fall back to the exposure flag exactly as before. The kill switch can
+only ever remove authority, never grant it.
 """
 
 # LIFECYCLE: permanent
@@ -32,10 +40,12 @@ from utils.executors import run_blocking
 logger = logging.getLogger(__name__)
 
 JIT_PROCESSING_FLAG_KEY = 'jit-processing-v1'
+# Live operational authority: the only flag that can revoke admission from
+# the allowlist. Read on every evaluation alongside the exposure flag above.
+JIT_KILL_SWITCH_FLAG_KEY = 'jit-processing-kill-switch-v1'
 # Retired admission keys. Kept as names so tests can prove they no longer
 # authorize work. Do not read them for permits_work.
 JIT_LEDGER_MIGRATION_FLAG_KEY = 'jit-processing-ledger-migration-v1'
-JIT_KILL_SWITCH_FLAG_KEY = 'jit-processing-kill-switch-v1'
 JIT_DAILY_SWEEP_FLAG_KEY = 'daily-memory-sweep-v1'
 JIT_ADMISSION_ALLOWLIST = frozenset(
     {
@@ -170,25 +180,41 @@ def is_jit_admission_allowlisted(uid: str) -> bool:
     return uid.strip() in JIT_ADMISSION_ALLOWLIST
 
 
-def _allowlisted_decision(*, cache_hit: bool = False, cache_ttl_seconds: int = 0) -> JITRolloutDecision:
-    return JITRolloutDecision(
-        rollout=TriState.ENABLED,
-        kill_switch=TriState.DISABLED,
-        effective=TriState.ENABLED,
-        reason=JITDecisionReason.ROLLOUT_ENABLED,
-        error_class=JITErrorClass.NONE,
-        cache_hit=cache_hit,
-        cache_ttl_seconds=cache_ttl_seconds,
-    )
-
-
 def _effective_decision(
-    evaluation: JITFlagEvaluation, *, cache_hit: bool, cache_ttl_seconds: int
+    evaluation: JITFlagEvaluation, *, allowlisted: bool = False, cache_hit: bool, cache_ttl_seconds: int
 ) -> JITRolloutDecision:
-    # Kill-switch / ledger-migration / daily-sweep flags are not admission
-    # authority. A known-false or absent exposure flag is off. Unknown is
-    # reserved for genuine provider, timeout, configuration, or malformed
-    # failures so those states fail closed for non-allowlist users.
+    # The kill switch is the only thing that can revoke the allowlist's
+    # admission. A definitively enabled kill switch fails everyone closed,
+    # ahead of both the allowlist and the exposure flag. Unknown/absent kill
+    # never blocks by itself: it falls through to the allowlist or exposure
+    # flag exactly as if the kill switch were not consulted at all.
+    if evaluation.kill_switch == TriState.ENABLED:
+        return JITRolloutDecision(
+            rollout=evaluation.rollout,
+            kill_switch=evaluation.kill_switch,
+            effective=TriState.DISABLED,
+            reason=JITDecisionReason.KILL_SWITCH_ENABLED,
+            error_class=evaluation.error_class,
+            cache_hit=cache_hit,
+            cache_ttl_seconds=cache_ttl_seconds,
+        )
+    if allowlisted:
+        # The allowlist bypasses the exposure flag entirely and stays
+        # resilient to PostHog being down; only a definitively enabled kill
+        # switch (handled above) can remove its admission.
+        return JITRolloutDecision(
+            rollout=evaluation.rollout,
+            kill_switch=evaluation.kill_switch,
+            effective=TriState.ENABLED,
+            reason=JITDecisionReason.ROLLOUT_ENABLED,
+            error_class=JITErrorClass.NONE,
+            cache_hit=cache_hit,
+            cache_ttl_seconds=cache_ttl_seconds,
+        )
+    # Ledger-migration / daily-sweep flags are not admission authority. A
+    # known-false or absent exposure flag is off. Unknown is reserved for
+    # genuine provider, timeout, configuration, or malformed failures so
+    # those states fail closed for non-allowlist users.
     if evaluation.rollout == TriState.ENABLED:
         effective = TriState.ENABLED
         reason = JITDecisionReason.ROLLOUT_ENABLED
@@ -204,7 +230,7 @@ def _effective_decision(
         reason = evaluation.reason
     return JITRolloutDecision(
         rollout=evaluation.rollout,
-        kill_switch=TriState.DISABLED,
+        kill_switch=evaluation.kill_switch,
         effective=effective,
         reason=reason,
         error_class=evaluation.error_class,
@@ -243,10 +269,11 @@ class JITRolloutAuthority:
     ) -> JITRolloutDecision:
         if not uid.strip():
             raise ValueError('authenticated uid is required')
-        if is_jit_admission_allowlisted(uid):
-            decision = _allowlisted_decision()
-            self._record(decision, stage=stage, latency_ms=0)
-            return decision
+        # The allowlist no longer skips the provider: the kill switch must be
+        # read for allowlisted owners too, since it is the one thing that can
+        # revoke their admission. It shares the same cache and provider call
+        # as everyone else; only the effective-decision math differs below.
+        allowlisted = is_jit_admission_allowlisted(uid)
         started_at = self._monotonic()
         now = started_at
         if not force_refresh:
@@ -256,6 +283,7 @@ class JITRolloutAuthority:
                     self._cache.move_to_end(uid)
                     decision = _effective_decision(
                         entry.evaluation,
+                        allowlisted=allowlisted,
                         cache_hit=True,
                         cache_ttl_seconds=max(0, int(entry.expires_at - now)),
                     )
@@ -269,11 +297,12 @@ class JITRolloutAuthority:
             evaluation = await self._provider(uid)
         finished_at = self._monotonic()
         # Complete provider answers cache for the full TTL. Unknown/error
-        # snapshots cache only for a short negative TTL: UNKNOWN can never
-        # authorize work, so this cannot extend an outage into an
-        # authorization — it only stops a fleet with absent flags from paying
-        # one uncached provider call per request.
-        complete = evaluation.rollout != TriState.UNKNOWN
+        # snapshots -- for either flag -- cache only for a short negative
+        # TTL: UNKNOWN can never authorize work and can never definitively
+        # kill, so this cannot extend an outage into an authorization or a
+        # stale kill decision; it only stops a fleet with absent flags from
+        # paying one uncached provider call per request.
+        complete = evaluation.rollout != TriState.UNKNOWN and evaluation.kill_switch != TriState.UNKNOWN
         entry_ttl = self._ttl_seconds if complete else min(UNKNOWN_JIT_ROLLOUT_CACHE_SECONDS, self._ttl_seconds)
         self._cache[uid] = _CacheEntry(evaluation=evaluation, expires_at=finished_at + entry_ttl)
         self._cache.move_to_end(uid)
@@ -281,6 +310,7 @@ class JITRolloutAuthority:
             self._cache.popitem(last=False)
         decision = _effective_decision(
             evaluation,
+            allowlisted=allowlisted,
             cache_hit=False,
             cache_ttl_seconds=int(entry_ttl),
         )
@@ -303,7 +333,12 @@ class JITRolloutAuthority:
 
 
 class PostHogJITFlagProvider:
-    """Read the single server-owned PostHog exposure flag in one bounded decide request."""
+    """Read the server-owned exposure and kill switch flags in one bounded decide request.
+
+    A single ``get_feature_variants`` call returns every flag PostHog has
+    decided for the owner, so both flags are parsed out of that one response
+    -- no second network call is made per decision.
+    """
 
     def __init__(
         self,
@@ -311,6 +346,7 @@ class PostHogJITFlagProvider:
         timeout_seconds: float = DEFAULT_JIT_ROLLOUT_TIMEOUT_SECONDS,
         client_factory: Callable[[], Any | None] | None = None,
         rollout_flag_key: str = JIT_PROCESSING_FLAG_KEY,
+        kill_switch_flag_key: str = JIT_KILL_SWITCH_FLAG_KEY,
     ) -> None:
         if timeout_seconds <= 0 or timeout_seconds > MAX_JIT_ROLLOUT_CACHE_SECONDS:
             raise ValueError('timeout_seconds must be positive and bounded')
@@ -318,7 +354,10 @@ class PostHogJITFlagProvider:
         self._client_factory = client_factory or self._build_client
         if not rollout_flag_key.strip():
             raise ValueError('rollout_flag_key is required')
+        if not kill_switch_flag_key.strip():
+            raise ValueError('kill_switch_flag_key is required')
         self._rollout_flag_key = rollout_flag_key
+        self._kill_switch_flag_key = kill_switch_flag_key
         self._client: Any | None = None
         self._client_lock = threading.Lock()
         self._control_slots = asyncio.BoundedSemaphore(POSTHOG_CONTROL_MAX_WORKERS + POSTHOG_CONTROL_MAX_QUEUE)
@@ -469,10 +508,31 @@ class PostHogJITFlagProvider:
                 JITErrorClass.PROVIDER,
             )
 
+        # The kill switch is parsed from the same response regardless of the
+        # exposure flag's own state below: a missing or malformed exposure
+        # flag must not hide a genuinely observed kill switch value.
+        #
+        # PostHog's decide/get_feature_variants response omits a boolean flag
+        # entirely when it evaluates false for the distinct ID -- a 0%-rollout
+        # kill switch (its normal, healthy state) is therefore ABSENT, not a
+        # present ``false``. Since we did get a well-formed mapping back, that
+        # absence means the provider was reachable and simply did not assert
+        # a kill, so it must read as DISABLED, not UNKNOWN. Reading it as
+        # UNKNOWN would permanently downgrade every steady-state decision to
+        # the short negative-cache TTL and report a false "unknown" kill
+        # switch on the wire even though nothing is wrong. UNKNOWN stays
+        # reserved for a key that is *present* with a non-bool value, and for
+        # the whole-response failure paths above that already return
+        # UNKNOWN/UNKNOWN.
+        kill_switch = (
+            TriState.DISABLED
+            if self._kill_switch_flag_key not in variants
+            else _flag_state(variants, self._kill_switch_flag_key)
+        )
         if self._rollout_flag_key not in variants:
             return JITFlagEvaluation(
                 TriState.DISABLED,
-                TriState.DISABLED,
+                kill_switch,
                 JITDecisionReason.FLAG_ABSENT,
                 JITErrorClass.ABSENT,
             )
@@ -480,11 +540,11 @@ class PostHogJITFlagProvider:
         if rollout == TriState.UNKNOWN:
             return JITFlagEvaluation(
                 TriState.UNKNOWN,
-                TriState.DISABLED,
+                kill_switch,
                 JITDecisionReason.MALFORMED_RESPONSE,
                 JITErrorClass.MALFORMED,
             )
-        return JITFlagEvaluation(rollout, TriState.DISABLED, JITDecisionReason.EVALUATED)
+        return JITFlagEvaluation(rollout, kill_switch, JITDecisionReason.EVALUATED)
 
 
 def _flag_state(flags: Mapping[str, Any], key: str) -> TriState:
@@ -521,13 +581,19 @@ def _get_control_loop() -> asyncio.AbstractEventLoop:
         return _control_loop
 
 
-def _unavailable_decision(reason: JITDecisionReason, error_class: JITErrorClass) -> JITRolloutDecision:
+def _unavailable_decision(
+    reason: JITDecisionReason, error_class: JITErrorClass, *, allowlisted: bool = False
+) -> JITRolloutDecision:
+    # This is the outer control-loop-scheduling safety net, one layer above
+    # the provider's own bounded timeout. The allowlist's PostHog-down
+    # resilience must hold here too: an unreachable kill switch never blocks
+    # the allowlist, only a definitively enabled one can.
     return JITRolloutDecision(
         rollout=TriState.UNKNOWN,
         kill_switch=TriState.UNKNOWN,
-        effective=TriState.UNKNOWN,
-        reason=reason,
-        error_class=error_class,
+        effective=TriState.ENABLED if allowlisted else TriState.UNKNOWN,
+        reason=JITDecisionReason.ROLLOUT_ENABLED if allowlisted else reason,
+        error_class=JITErrorClass.NONE if allowlisted else error_class,
         cache_hit=False,
         cache_ttl_seconds=0,
     )
@@ -542,22 +608,21 @@ def resolve_jit_rollout_sync(
 ) -> JITRolloutDecision:
     """Loop-confined resolution for non-async callers; unavailable states fail closed."""
 
-    if is_jit_admission_allowlisted(uid):
-        return _allowlisted_decision()
+    allowlisted = is_jit_admission_allowlisted(uid)
     try:
         future = asyncio.run_coroutine_threadsafe(
             _sync_authority.resolve(uid, stage=stage, force_refresh=force_refresh),
             _get_control_loop(),
         )
     except Exception:
-        return _unavailable_decision(JITDecisionReason.PROVIDER_ERROR, JITErrorClass.PROVIDER)
+        return _unavailable_decision(JITDecisionReason.PROVIDER_ERROR, JITErrorClass.PROVIDER, allowlisted=allowlisted)
     try:
         return future.result(timeout=result_timeout_seconds)
     except FuturesTimeoutError:
         future.cancel()
-        return _unavailable_decision(JITDecisionReason.PROVIDER_TIMEOUT, JITErrorClass.TIMEOUT)
+        return _unavailable_decision(JITDecisionReason.PROVIDER_TIMEOUT, JITErrorClass.TIMEOUT, allowlisted=allowlisted)
     except Exception:
-        return _unavailable_decision(JITDecisionReason.PROVIDER_ERROR, JITErrorClass.PROVIDER)
+        return _unavailable_decision(JITDecisionReason.PROVIDER_ERROR, JITErrorClass.PROVIDER, allowlisted=allowlisted)
 
 
 async def resolve_jit_rollout(
@@ -566,8 +631,6 @@ async def resolve_jit_rollout(
     stage: JITDecisionStage,
     force_refresh: bool = False,
 ) -> JITRolloutDecision:
-    if is_jit_admission_allowlisted(uid):
-        return _allowlisted_decision()
     return await _authority.resolve(uid, stage=stage, force_refresh=force_refresh)
 
 


### PR DESCRIPTION
## What changed and why

PR #12369 collapsed JIT admission in `backend/utils/jit_rollout.py` to one exposure flag (`jit-processing-v1`) plus a code-owned two-UID allowlist that bypasses PostHog entirely. In doing so it retired `jit-processing-kill-switch-v1`: `_allowlisted_decision` and `_effective_decision` hardcoded `kill_switch=TriState.DISABLED`, and the provider never read the kill flag at all. That left no way to stop JIT processing for the allowlisted UIDs if something went wrong with them specifically — the one thing an operational kill switch exists for.

Ratified product policy (decision 17) requires a real, separate operational kill switch that works even for the allowlist. This restores it.

`PostHogJITFlagProvider` already fetches every decided flag for a UID in one `get_feature_variants` call, so both `jit-processing-v1` and `jit-processing-kill-switch-v1` are now parsed out of that same response — no second network call, same bounded executor/timeout/caching discipline as before. The allowlist no longer skips the provider outright: it still bypasses the exposure flag, but the kill switch is now consulted for allowlisted UIDs too, since it's the only thing that can revoke their admission.

**Review fixup:** an earlier version of this PR read an *absent* kill-switch key as `UNKNOWN`. PostHog's decide response omits a boolean flag entirely when it evaluates false for the distinct ID, so a 0%-rollout kill switch — its normal, healthy steady state — is legitimately absent from a well-formed response, not a present `false`. Reading that as `UNKNOWN` would have permanently downgraded every steady-state decision to the short negative-cache TTL (~4x the normal control-plane call rate) and reported a false "unknown" kill switch on the wire even though nothing was wrong. Fixed: when the response itself is well-formed, an absent kill key now reads as `DISABLED`. `UNKNOWN` stays reserved for a kill key that is *present* with a non-bool value, and for the existing whole-response failure paths (timeout/error/malformed mapping).

## Semantics

| Caller | Rollout | Kill switch | Effective | Reason |
|---|---|---|---|---|
| allowlisted | (ignored) | `ENABLED` | `DISABLED` | `KILL_SWITCH_ENABLED` |
| allowlisted | (ignored) | `UNKNOWN` (present, malformed) / provider down | `ENABLED` | `ROLLOUT_ENABLED` |
| allowlisted | (ignored) | absent from a well-formed response → `DISABLED` | `ENABLED` | `ROLLOUT_ENABLED` |
| regular | `ENABLED` | `ENABLED` | `DISABLED` | `KILL_SWITCH_ENABLED` |
| regular | `ENABLED` | `UNKNOWN` / `DISABLED` (incl. absent → `DISABLED`) | `ENABLED` | `ROLLOUT_ENABLED` |
| regular | `DISABLED` / `UNKNOWN` | any non-`ENABLED` | `DISABLED` / `UNKNOWN` | unchanged (fail closed) |

The kill switch can only ever **remove** authority, never grant it. An `UNKNOWN` or absent kill switch never blocks by itself, so:
- the allowlist's existing PostHog-down resilience is unchanged (it still admits when the provider is unreachable, unconfigured, or the kill key is simply unset), and
- non-allowlisted users still fall back to the exposure flag exactly as before.

Caching is unchanged in shape: a definitively known kill switch (`ENABLED`, or `DISABLED` — including "absent from a well-formed response") caches for the normal decision TTL; an `UNKNOWN` kill switch (present-but-malformed, or a whole-response failure — like an `UNKNOWN` rollout) uses the existing short negative-cache window. No new cache layers, and steady-state (kill key simply unset) keeps the full TTL rather than being silently downgraded.

The `JITRolloutDecision.kill_switch` field (already part of the wire shape the desktop DTO decodes) now reports the real observed state (`ENABLED` / `DISABLED` / `UNKNOWN`) instead of a hardcoded `DISABLED` — downstream consumers that already branch on it (`routers/jit_ledger_snapshot.py`'s `_disabled_snapshot`, `utils/retrieval/frame_request_authority.py`) get correct behavior for free.

Module docstring and the "retired admission keys" comment are updated: the kill switch is live authority again; `jit-processing-ledger-migration-v1` and `daily-memory-sweep-v1` remain retired.

## Tests

Extended `backend/tests/unit/test_jit_rollout.py` (46 tests, all passing):
- allowlisted + kill `ENABLED` → `permits_work=False`, reason `KILL_SWITCH_ENABLED`
- allowlisted + provider timeout/down (including a simulated dead control-loop for the sync path) → `permits_work=True` (resilience unchanged)
- allowlisted + kill `UNKNOWN` → `permits_work=True`
- regular + rollout `ENABLED` + kill `ENABLED` → `False`
- regular + rollout `ENABLED` + kill `UNKNOWN`/`DISABLED` → `True`
- regular + rollout `DISABLED`/`UNKNOWN` → `False` (unchanged, existing test)
- `resolve_jit_rollout_sync` (the sweep/first-open path) inherits the same kill-switch authority as the async path
- **New (review fixup):** kill key absent from a well-formed response → `kill_switch=DISABLED`, full cache TTL, both allowlisted and regular UIDs unaffected (`test_kill_switch_absent_from_a_well_formed_response_means_disabled_and_full_cache_ttl`)
- **New (review fixup):** kill key present with a non-bool value → `UNKNOWN`, short cache TTL, still never blocks either UID class (`test_kill_switch_present_but_malformed_stays_unknown_with_short_cache_ttl_and_never_blocks`)
- Updated the two pre-existing tests whose assertions baked in "the kill flag never authorizes work" (`test_posthog_provider_parses_only_the_exposure_flag` → `..._parses_the_exposure_and_kill_switch_flags`, `test_retired_flags_do_not_change_admission` → split into `test_ledger_migration_and_daily_sweep_flags_do_not_change_admission` + `test_kill_switch_flag_revokes_admission_even_when_rollout_is_enabled`) to assert the new contract instead: the kill switch can only ever remove authority, never grant it.

### Verification run (from the worktree, `backend/`)

```
$ export ENCRYPTION_SECRET=... OPENAI_API_KEY=test-openai-key-not-real
$ .venv/bin/python -m pytest tests/unit/test_jit_rollout.py -q
46 passed, 17 warnings in ~3.7s
```

Also ran the directly-related consumer/mocking test files to check for regressions:

```
$ .venv/bin/python -m pytest tests/unit/test_jit_rollout.py tests/unit/test_jit_ledger_snapshot.py \
    tests/unit/test_jit_first_open_policy.py tests/unit/test_frame_request_promotion_safety.py \
    tests/unit/test_daily_memory_sweep_job.py tests/unit/test_jit_qa_orchestrated_dogfood.py \
    tests/unit/test_agent_tools_isolation.py -q
137 passed
```

(An earlier run of this same set hit one pre-existing, order-dependent flake in `test_memories_archive_and_read_contracts.py`, reproduced identically on unmodified `origin/main` — unrelated to this change; it did not recur on this re-run.)

Type check (focused, both touched files plus direct downstream readers of `decision.kill_switch`):

```
$ uv tool run --python 3.11 --from pyright pyright -p pyrightconfig.json --pythonpath .venv/bin/python \
    utils/jit_rollout.py utils/retrieval/frame_request_authority.py routers/jit_rollout.py routers/jit_ledger_snapshot.py
0 errors, 5 warnings, 0 informations
```
(All 5 warnings are pre-existing `reportUnknownVariableType` notes unrelated to this diff — confirmed identical against unmodified `origin/main`.)

Format check:

```
$ uv tool run --python 3.11 black --line-length 120 --skip-string-normalization --check --diff utils/jit_rollout.py tests/unit/test_jit_rollout.py
All done! ✨ 🍰 ✨
2 files would be left unchanged.
```

The repo's pre-push gate also ran its own bounded backend-unit-test selection (auto-detected `test_jit_rollout.py` from the diff, 46 passed) and the optional formatters check on every push — both passed, including after the amended fixup commit (head `f7f3ebad13`).

I did not attempt a full-repo `test.sh --all` run: the changed-file selector flags `utils/jit_rollout.py` as broad enough to warrant a full ~995-file run, but collecting that many files in one non-file-isolated pytest session segfaults on this machine — a pre-existing, documented hazard in `test.sh` itself (native-library re-registration under `xdist`), unrelated to this change. The proper file-isolated full run is CI's job; the focused + directly-related test set above is what's practical to run locally in this environment.

## Diffstat

```
backend/tests/unit/test_jit_rollout.py | 228 +++++++++++++++++++++++++++++++--
backend/utils/jit_rollout.py           | 149 ++++++++++++++-------
2 files changed, 323 insertions(+), 54 deletions(-)
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
