### PR TITLE
feat(backend): wire close_fact, write_playbook, and create_trigger to JIT-gated chat tools

### DIFF
--- a/backend/tests/unit/test_agent_tools_isolation.py
+++ b/backend/tests/unit/test_agent_tools_isolation.py
@@ -98,3 +98,72 @@ def test_jit_only_tool_execution_requires_fresh_enabled_authority():
 
     assert exc_info.value.status_code == 404
     assert resolve.await_args.kwargs["force_refresh"] is True
+
+
+# The three dormant knowledge-ledger write verbs (save_playbook,
+# create_standing_trigger, close_fact) are newly wired to chat tools and must
+# be gated identically to the existing JIT-only read tools: invisible and
+# unexecutable for a uid the JIT rollout has not admitted, visible and
+# executable once it has.
+NEW_LEDGER_WRITE_TOOL_NAMES = ("save_playbook", "create_standing_trigger", "close_fact")
+
+
+def test_new_ledger_write_tools_are_registered_as_jit_only_core_tools():
+    for name in NEW_LEDGER_WRITE_TOOL_NAMES:
+        assert name in agent_tools.JIT_ONLY_TOOL_NAMES
+        assert any(t.name == name for t in agent_tools.CORE_TOOLS)
+
+
+@pytest.mark.parametrize("tool_name", NEW_LEDGER_WRITE_TOOL_NAMES)
+def test_ledger_write_tool_schema_is_hidden_when_rollout_is_not_enabled(tool_name):
+    jit_tool = _tool(tool_name)
+    legacy_tool = _tool("legacy_tool")
+    with (
+        patch.object(agent_tools, "CORE_TOOLS", [legacy_tool, jit_tool]),
+        patch.object(agent_tools, "load_app_tools", return_value=[]),
+        patch.object(
+            agent_tools,
+            "resolve_jit_rollout_sync",
+            return_value=SimpleNamespace(permits_work=False),
+        ),
+    ):
+        result = agent_tools.list_tools(uid="u1")
+
+    assert [tool["name"] for tool in result["tools"]] == ["legacy_tool"]
+
+
+@pytest.mark.parametrize("tool_name", NEW_LEDGER_WRITE_TOOL_NAMES)
+def test_ledger_write_tool_schema_is_listed_when_rollout_is_enabled(tool_name):
+    jit_tool = _tool(tool_name)
+    legacy_tool = _tool("legacy_tool")
+    with (
+        patch.object(agent_tools, "CORE_TOOLS", [legacy_tool, jit_tool]),
+        patch.object(agent_tools, "load_app_tools", return_value=[]),
+        patch.object(
+            agent_tools,
+            "resolve_jit_rollout_sync",
+            return_value=SimpleNamespace(permits_work=True),
+        ),
+    ):
+        result = agent_tools.list_tools(uid="u1")
+
+    assert {tool["name"] for tool in result["tools"]} == {"legacy_tool", tool_name}
+
+
+@pytest.mark.parametrize("tool_name", NEW_LEDGER_WRITE_TOOL_NAMES)
+def test_ledger_write_tool_execution_requires_fresh_enabled_authority(tool_name):
+    with patch.object(
+        agent_tools,
+        "resolve_jit_rollout",
+        AsyncMock(return_value=SimpleNamespace(permits_work=False)),
+    ) as resolve:
+        with pytest.raises(agent_tools.HTTPException) as exc_info:
+            asyncio.run(
+                agent_tools.execute_tool(
+                    agent_tools.ExecuteToolRequest(tool_name=tool_name),
+                    uid="u1",
+                )
+            )
+
+    assert exc_info.value.status_code == 404
+    assert resolve.await_args.kwargs["force_refresh"] is True

--- a/backend/tests/unit/test_knowledge_ledger.py
+++ b/backend/tests/unit/test_knowledge_ledger.py
@@ -821,3 +821,90 @@ def test_ledger_migration_adapter_retry_is_a_noop(monkeypatch):
     )
 
     assert result == adapted
+
+
+def test_write_playbook_and_create_trigger_persist_their_own_kind(monkeypatch):
+    """The two dormant write verbs land the exact kind their JIT tools rely on."""
+    captured: dict = {}
+
+    def fake_write(uid, data, **kwargs):
+        captured["uid"] = uid
+        captured["data"] = data
+        return data["id"]
+
+    monkeypatch.setattr(knowledge_ledger, "write_canonical_knowledge_ledger_memory", fake_write)
+
+    playbook_provenance = LedgerProvenance(
+        source_id="turn-playbook", source_type="agent_chat", action_id="action-playbook"
+    )
+    playbook_id = knowledge_ledger.write_playbook(
+        "u1",
+        "Cut a release candidate",
+        "1. Run checks\n2. Publish",
+        provenance=playbook_provenance,
+    )
+    assert captured["uid"] == "u1"
+    assert captured["data"]["id"] == playbook_id
+    assert captured["data"]["kind"] == MemoryKind.document.value
+    assert captured["data"]["body"] == "1. Run checks\n2. Publish"
+    assert captured["data"]["write_reason"] == LedgerWriteReason.recurring_workflow.value
+    assert captured["data"]["subject_scope"] == MemorySubjectScope.primary_user.value
+
+    trigger_provenance = LedgerProvenance(
+        source_id="turn-trigger", source_type="agent_chat", action_id="action-trigger"
+    )
+    trigger_condition = {
+        "keywords": ["jane"],
+        "action": {"type": "agent_prompt", "prompt": "Tell the user Jane emailed."},
+    }
+    trigger_id = knowledge_ledger.create_trigger(
+        "u1",
+        "Watch for Jane",
+        trigger_condition,
+        provenance=trigger_provenance,
+        arguments={"wakeup_budget_per_day": 1},
+    )
+    assert captured["data"]["id"] == trigger_id
+    assert captured["data"]["kind"] == MemoryKind.trigger.value
+    assert captured["data"]["trigger_condition"] == trigger_condition
+    assert captured["data"]["arguments"] == {"wakeup_budget_per_day": 1}
+    assert captured["data"]["write_reason"] == LedgerWriteReason.standing_trigger.value
+
+    # The pre-existing verb signature omitted ``arguments`` entirely, which
+    # made it impossible for any caller to ever populate
+    # ``wakeup_budget_per_day`` — the one field the paid-work trigger snapshot
+    # (utils.memory.jit_trigger_snapshot) requires before it will admit a row.
+    # Confirm the additive default still behaves for a caller that omits it.
+    trigger_id_no_arguments = knowledge_ledger.create_trigger(
+        "u1",
+        "Watch for Jane again",
+        trigger_condition,
+        provenance=LedgerProvenance(source_id="turn-trigger-2", source_type="agent_chat", action_id="action-trigger-2"),
+    )
+    assert captured["data"]["id"] == trigger_id_no_arguments
+    assert captured["data"]["arguments"] == {}
+
+
+def test_close_fact_sets_valid_to_via_canonical_mutation(monkeypatch):
+    """A fresh (not already-closed) fact close commits a ``valid_to`` patch."""
+    open_fact = _item("open-fact", status=MemoryItemStatus.active, valid_to=None)
+    captured: dict = {}
+
+    def fake_apply_mutation(uid, memory_id, *, mutation_kind, build_patch, operation_type, db_client):
+        captured["memory_id"] = memory_id
+        captured["mutation_kind"] = mutation_kind
+        _logical, patch = build_patch(open_fact, NOW)
+        captured["patch"] = patch
+        closed = open_fact.model_copy(update={"status": MemoryItemStatus.superseded, **patch})
+        return open_fact, closed
+
+    monkeypatch.setattr(canonical_memory_adapter, "_read_canonical_memory_item_for_lineage", lambda *_a, **_k: None)
+    monkeypatch.setattr(canonical_memory_adapter, "_apply_canonical_user_mutation", fake_apply_mutation)
+
+    result = close_fact("u1", "open-fact", valid_to=NOW, db_client=object())
+
+    assert captured["memory_id"] == "open-fact"
+    assert captured["mutation_kind"] == "ledger_close"
+    assert captured["patch"] == {"valid_to": NOW}
+    assert result.status == MemoryItemStatus.superseded
+    assert result.valid_to == NOW

--- a/backend/tests/unit/test_knowledge_ledger_write_tools.py
+++ b/backend/tests/unit/test_knowledge_ledger_write_tools.py
@@ -1,0 +1,449 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from models.memory_evidence import ArtifactPreservationState, MemoryEvidence, SourceState
+from models.memory_state_head import MEMORY_STATE_HEAD_SCHEMA_VERSION, MEMORY_STATE_HEAD_SOURCE
+from models.product_memory import (
+    LedgerWriteReason,
+    MemoryItem,
+    MemoryItemStatus,
+    MemoryKind,
+    MemoryLayer,
+    MemorySubjectScope,
+    ProcessingState,
+)
+from utils.memory.jit_trigger_snapshot import read_authoritative_trigger_snapshot
+from utils.retrieval.tools import knowledge_ledger_write_tools as tools
+
+NOW = datetime(2026, 8, 29, tzinfo=timezone.utc)
+CONFIG = {"configurable": {"user_id": "u1"}}
+
+
+def _fact(memory_id: str = "mem_fact", **updates) -> MemoryItem:
+    payload = {
+        "memory_id": memory_id,
+        "uid": "u1",
+        "version": 1,
+        "tier": MemoryLayer.long_term,
+        "status": MemoryItemStatus.active,
+        "processing_state": ProcessingState.processed,
+        "content": "Lives in Brooklyn",
+        "evidence": [],
+        "source_state": SourceState.active,
+        "sensitivity_labels": [],
+        "visibility": "private",
+        "user_asserted": True,
+        "captured_at": NOW,
+        "updated_at": NOW,
+        "ledger_commit_id": "commit-1",
+        "ledger_sequence": 1,
+        "ledger_schema_version": "knowledge_ledger.v1",
+        "kind": MemoryKind.fact,
+        "subject_scope": MemorySubjectScope.primary_user,
+        "slot": "home_city",
+        "valid_from": NOW,
+        "intent_backed": True,
+        "write_reason": LedgerWriteReason.direct_user_statement,
+    }
+    payload.update(updates)
+    return MemoryItem(**payload)
+
+
+# ---------------------------------------------------------------------------
+# save_playbook
+# ---------------------------------------------------------------------------
+
+
+def test_save_playbook_happy_path(monkeypatch):
+    captured = {}
+
+    def fake_write_playbook(uid, description, body, *, provenance, db_client, prior_memory_id=None):
+        captured.update(uid=uid, description=description, body=body, db_client=db_client)
+        return "mem_new_playbook"
+
+    monkeypatch.setattr(tools, "get_firestore_client", lambda: "db")
+    monkeypatch.setattr(tools, "write_playbook", fake_write_playbook)
+
+    result = tools.save_playbook.invoke(
+        {"description": "  Cut a release   candidate  ", "body": "1. Run checks\n2. Publish"},
+        config=CONFIG,
+    )
+
+    assert result == "Playbook saved (mem_new_playbook): Cut a release candidate"
+    assert captured["uid"] == "u1"
+    assert captured["description"] == "Cut a release candidate"
+    assert captured["body"] == "1. Run checks\n2. Publish"
+    assert captured["db_client"] == "db"
+
+
+def test_save_playbook_rejects_oversize_description_and_body(monkeypatch):
+    def fail_if_called(*_args, **_kwargs):
+        pytest.fail("oversize playbook writes must never reach the ledger verb")
+
+    monkeypatch.setattr(tools, "get_firestore_client", lambda: "db")
+    monkeypatch.setattr(tools, "write_playbook", fail_if_called)
+
+    oversize_description = "x" * (tools.MAX_SAVE_PLAYBOOK_DESCRIPTION_CHARACTERS + 1)
+    result = tools.save_playbook.invoke({"description": oversize_description, "body": "body"}, config=CONFIG)
+    assert result.startswith("Error:")
+    assert "description" in result
+
+    oversize_body = "y" * (tools.MAX_SAVE_PLAYBOOK_BODY_CHARACTERS + 1)
+    result = tools.save_playbook.invoke({"description": "Handle", "body": oversize_body}, config=CONFIG)
+    assert result.startswith("Error:")
+    assert "body" in result
+
+
+def test_save_playbook_rejects_blank_input_and_missing_uid(monkeypatch):
+    def fail_if_called(*_args, **_kwargs):
+        pytest.fail("blank playbook writes must never reach the ledger verb")
+
+    monkeypatch.setattr(tools, "write_playbook", fail_if_called)
+
+    assert tools.save_playbook.invoke({"description": "  ", "body": "body"}, config=CONFIG).startswith("Error:")
+    assert tools.save_playbook.invoke({"description": "Handle", "body": "  "}, config=CONFIG).startswith("Error:")
+    assert tools.save_playbook.invoke(
+        {"description": "Handle", "body": "body"}, config={"configurable": {}}
+    ).startswith("Error:")
+
+
+def test_save_playbook_reports_ledger_governance_rejection_without_crashing(monkeypatch):
+    monkeypatch.setattr(tools, "get_firestore_client", lambda: "db")
+
+    def rejecting_write_playbook(*_args, **_kwargs):
+        raise ValueError("playbook body exceeds the ledger limit")
+
+    monkeypatch.setattr(tools, "write_playbook", rejecting_write_playbook)
+    result = tools.save_playbook.invoke({"description": "Handle", "body": "body"}, config=CONFIG)
+    assert result == "Error: playbook body exceeds the ledger limit"
+
+
+# ---------------------------------------------------------------------------
+# create_standing_trigger
+# ---------------------------------------------------------------------------
+
+
+def test_create_standing_trigger_happy_path(monkeypatch):
+    captured = {}
+
+    def fake_create_trigger(uid, description, condition, *, provenance, arguments, db_client, prior_memory_id=None):
+        captured.update(uid=uid, description=description, condition=condition, arguments=arguments, db_client=db_client)
+        return "mem_new_trigger"
+
+    monkeypatch.setattr(tools, "get_firestore_client", lambda: "db")
+    monkeypatch.setattr(tools, "create_trigger", fake_create_trigger)
+
+    result = tools.create_standing_trigger.invoke(
+        {
+            "description": "Tell the user Jane emailed about the contract.",
+            "condition": {"keywords": ["jane", "contract"]},
+        },
+        config=CONFIG,
+    )
+
+    assert result == "Standing trigger created (mem_new_trigger): Tell the user Jane emailed about the contract."
+    assert captured["uid"] == "u1"
+    assert captured["db_client"] == "db"
+    assert captured["arguments"] == {"wakeup_budget_per_day": 1}
+    assert captured["condition"]["action"] == {
+        "type": "agent_prompt",
+        "prompt": "Tell the user Jane emailed about the contract.",
+    }
+    assert captured["condition"]["keywords"] == ["contract", "jane"]
+
+
+def test_create_standing_trigger_rejects_embedding_selector(monkeypatch):
+    def fail_if_called(*_args, **_kwargs):
+        pytest.fail("an embedding selector must never reach the ledger verb")
+
+    monkeypatch.setattr(tools, "create_trigger", fail_if_called)
+
+    result = tools.create_standing_trigger.invoke(
+        {
+            "description": "Watch for tone shifts",
+            "condition": {
+                "embedding": {
+                    "prototype_id": "p1",
+                    "prototype_revision": "r1",
+                    "model_id": "m1",
+                    "model_version": "v1",
+                    "language": "en",
+                }
+            },
+        },
+        config=CONFIG,
+    )
+
+    assert result.startswith("Error:")
+    assert "embedding" in result
+
+
+def test_create_standing_trigger_rejects_unsupported_condition_field(monkeypatch):
+    def fail_if_called(*_args, **_kwargs):
+        pytest.fail("an unsupported field must never reach the ledger verb")
+
+    monkeypatch.setattr(tools, "create_trigger", fail_if_called)
+
+    result = tools.create_standing_trigger.invoke(
+        {"description": "Watch for Jane", "condition": {"action": {"type": "agent_prompt", "prompt": "hijack"}}},
+        config=CONFIG,
+    )
+    assert result.startswith("Error:")
+
+    result = tools.create_standing_trigger.invoke(
+        {"description": "Watch for Jane", "condition": {"made_up_field": True}},
+        config=CONFIG,
+    )
+    assert result.startswith("Error:")
+    assert "made_up_field" in result
+
+
+def test_create_standing_trigger_rejects_oversize_description(monkeypatch):
+    def fail_if_called(*_args, **_kwargs):
+        pytest.fail("oversize trigger writes must never reach the ledger verb")
+
+    monkeypatch.setattr(tools, "create_trigger", fail_if_called)
+
+    oversize_description = "x" * (tools.MAX_TRIGGER_DESCRIPTION_CHARACTERS + 1)
+    result = tools.create_standing_trigger.invoke(
+        {"description": oversize_description, "condition": {"keywords": ["jane"]}}, config=CONFIG
+    )
+    assert result.startswith("Error:")
+
+
+def test_create_standing_trigger_created_row_is_visible_to_desktop_watchlist(monkeypatch):
+    """Prove the exact condition/arguments this tool builds satisfy the paid-work snapshot.
+
+    ``read_authoritative_trigger_snapshot`` is the authority the desktop
+    watchlist reads. This feeds the condition and arguments our tool would
+    send to ``create_trigger`` into a MemoryItem and confirms the snapshot
+    admits it — the row is not just written, it is actually watchable.
+    """
+    captured = {}
+
+    def fake_create_trigger(uid, description, condition, *, provenance, arguments, db_client, prior_memory_id=None):
+        captured.update(condition=condition, arguments=arguments)
+        return "mem_new_trigger"
+
+    monkeypatch.setattr(tools, "get_firestore_client", lambda: "db")
+    monkeypatch.setattr(tools, "create_trigger", fake_create_trigger)
+
+    tools.create_standing_trigger.invoke(
+        {"description": "Tell the user Jane emailed about the contract.", "condition": {"keywords": ["jane"]}},
+        config=CONFIG,
+    )
+
+    item = MemoryItem(
+        memory_id="mem_new_trigger",
+        uid="owner",
+        version=1,
+        tier=MemoryLayer.long_term,
+        status=MemoryItemStatus.active,
+        processing_state=ProcessingState.processed,
+        content="Tell the user Jane emailed about the contract.",
+        evidence=[
+            MemoryEvidence(
+                evidence_id="ev-1",
+                source_type="chat_turn",
+                source_id="turn-1",
+                source_version="v1",
+                artifact_preservation=ArtifactPreservationState.preserved,
+            )
+        ],
+        source_state=SourceState.active,
+        sensitivity_labels=[],
+        visibility="private",
+        user_asserted=True,
+        captured_at=NOW,
+        updated_at=NOW,
+        ledger_commit_id="head-7",
+        ledger_sequence=7,
+        account_generation=3,
+        ledger_schema_version="knowledge_ledger.v1",
+        kind=MemoryKind.trigger,
+        subject_scope=MemorySubjectScope.primary_user,
+        trigger_condition=captured["condition"],
+        intent_backed=True,
+        write_reason=LedgerWriteReason.standing_trigger,
+        arguments=captured["arguments"],
+    )
+
+    result = read_authoritative_trigger_snapshot("owner", firestore_client=_FakeTriggerSnapshotClient([item]))
+
+    assert result.complete is True
+    assert len(result.rows) == 1
+    assert result.rows[0].memory_id == "mem_new_trigger"
+    assert result.rows[0].action.prompt == "Tell the user Jane emailed about the contract."
+    assert result.rows[0].wakeup_budget_per_day == 1
+
+
+class _FakeSnapshot:
+    def __init__(self, identifier, payload):
+        self.id = identifier
+        self._payload = payload
+        self.exists = True
+
+    def to_dict(self):
+        return self._payload
+
+
+class _FakeDocument:
+    def __init__(self, snapshot):
+        self._snapshot = snapshot
+
+    def get(self):
+        return self._snapshot
+
+
+class _FakeQuery:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def where(self, *, filter):  # noqa: A002 - matches the google.cloud.firestore_v1 API shape
+        return self
+
+    def limit(self, _count):
+        return self
+
+    def stream(self):
+        return iter(self._rows)
+
+
+class _FakeTriggerSnapshotClient:
+    """Minimal duck-typed Firestore double matching test_jit_trigger_snapshot.py."""
+
+    def __init__(self, items):
+        self._rows = [_FakeSnapshot(item.memory_id, item.model_dump(mode="python")) for item in items]
+
+    def document(self, _path):
+        return _FakeDocument(
+            _FakeSnapshot(
+                "head",
+                {
+                    "schema_version": MEMORY_STATE_HEAD_SCHEMA_VERSION,
+                    "source": MEMORY_STATE_HEAD_SOURCE,
+                    "uid": "owner",
+                    "account_generation": 3,
+                    "head_commit_id": "head-7",
+                    "commit_sequence": 7,
+                },
+            )
+        )
+
+    def collection(self, _path):
+        return _FakeQuery(self._rows)
+
+
+# ---------------------------------------------------------------------------
+# close_fact
+# ---------------------------------------------------------------------------
+
+
+def test_close_fact_happy_path(monkeypatch):
+    fact = _fact()
+    captured = {}
+
+    def fake_close(uid, memory_id, *, db_client):
+        captured.update(uid=uid, memory_id=memory_id, db_client=db_client)
+        return fact.model_copy(update={"status": MemoryItemStatus.superseded, "valid_to": NOW})
+
+    monkeypatch.setattr(tools, "get_firestore_client", lambda: "db")
+    monkeypatch.setattr(tools, "read_canonical_memory_item", lambda uid, memory_id, *, db_client: fact)
+    monkeypatch.setattr(tools, "close_ledger_fact", fake_close)
+
+    result = tools.close_fact_tool.invoke({"memory_id": "mem_fact", "reason": "moved away"}, config=CONFIG)
+
+    assert result == "Fact closed (mem_fact)."
+    assert captured == {"uid": "u1", "memory_id": "mem_fact", "db_client": "db"}
+
+
+def test_close_fact_rejects_blank_reason_and_invalid_id(monkeypatch):
+    def fail_if_called(*_args, **_kwargs):
+        pytest.fail("an invalid close request must never reach the ledger verb")
+
+    monkeypatch.setattr(tools, "close_ledger_fact", fail_if_called)
+
+    assert tools.close_fact_tool.invoke({"memory_id": "mem_fact", "reason": "  "}, config=CONFIG).startswith("Error:")
+    assert tools.close_fact_tool.invoke({"memory_id": "../other/mem", "reason": "moved"}, config=CONFIG).startswith(
+        "Error:"
+    )
+
+
+def test_close_fact_rejects_foreign_owned_row(monkeypatch):
+    """A memory id belonging to another user is owner-scoped away, never raised."""
+    foreign = _fact(uid="u2")
+
+    def fail_if_called(*_args, **_kwargs):
+        pytest.fail("a foreign-owned row must never be closed")
+
+    monkeypatch.setattr(tools, "get_firestore_client", lambda: "db")
+    monkeypatch.setattr(tools, "read_canonical_memory_item", lambda uid, memory_id, *, db_client: foreign)
+    monkeypatch.setattr(tools, "close_ledger_fact", fail_if_called)
+
+    result = tools.close_fact_tool.invoke({"memory_id": "mem_fact", "reason": "not mine"}, config=CONFIG)
+    assert result == "Fact unavailable."
+
+
+def test_close_fact_rejects_non_fact_and_non_primary_rows(monkeypatch):
+    playbook_kind = _fact(kind=MemoryKind.document, body="steps", slot=None)
+    third_party = _fact(subject_scope=MemorySubjectScope.third_party, subject_entity_id="person-1")
+
+    def fail_if_called(*_args, **_kwargs):
+        pytest.fail("only an owner-scoped primary-user fact may be closed")
+
+    monkeypatch.setattr(tools, "get_firestore_client", lambda: "db")
+    monkeypatch.setattr(tools, "close_ledger_fact", fail_if_called)
+
+    monkeypatch.setattr(tools, "read_canonical_memory_item", lambda uid, memory_id, *, db_client: playbook_kind)
+    assert tools.close_fact_tool.invoke({"memory_id": "mem_fact", "reason": "wrong kind"}, config=CONFIG) == (
+        "Fact unavailable."
+    )
+
+    monkeypatch.setattr(tools, "read_canonical_memory_item", lambda uid, memory_id, *, db_client: third_party)
+    assert tools.close_fact_tool.invoke({"memory_id": "mem_fact", "reason": "wrong scope"}, config=CONFIG) == (
+        "Fact unavailable."
+    )
+
+
+def test_close_fact_double_close_is_a_safe_error_not_a_crash(monkeypatch):
+    """Closing an already-closed fact is a not-found, exactly like a foreign row.
+
+    ``read_canonical_memory_item`` only ever returns an *active* row, so once
+    the first close moves the row's status to ``superseded`` a second close
+    of the same id sees the identical "not found" outcome as a foreign row —
+    a safe string, never a raised exception.
+    """
+    call_count = {"n": 0}
+
+    def read_once_then_gone(uid, memory_id, *, db_client):
+        call_count["n"] += 1
+        return _fact() if call_count["n"] == 1 else None
+
+    def fail_if_called_twice(*_args, **_kwargs):
+        assert call_count["n"] == 1
+        return _fact().model_copy(update={"status": MemoryItemStatus.superseded, "valid_to": NOW})
+
+    monkeypatch.setattr(tools, "get_firestore_client", lambda: "db")
+    monkeypatch.setattr(tools, "read_canonical_memory_item", read_once_then_gone)
+    monkeypatch.setattr(tools, "close_ledger_fact", fail_if_called_twice)
+
+    first = tools.close_fact_tool.invoke({"memory_id": "mem_fact", "reason": "moved away"}, config=CONFIG)
+    second = tools.close_fact_tool.invoke({"memory_id": "mem_fact", "reason": "moved away"}, config=CONFIG)
+
+    assert first == "Fact closed (mem_fact)."
+    assert second == "Fact unavailable."
+
+
+def test_close_fact_ledger_race_is_reported_as_a_safe_error(monkeypatch):
+    """A raised ValueError from the ledger (e.g. a concurrent close) never propagates."""
+
+    def racing_close(*_args, **_kwargs):
+        raise ValueError("ledger row was already closed at a different valid_to")
+
+    monkeypatch.setattr(tools, "get_firestore_client", lambda: "db")
+    monkeypatch.setattr(tools, "read_canonical_memory_item", lambda uid, memory_id, *, db_client: _fact())
+    monkeypatch.setattr(tools, "close_ledger_fact", racing_close)
+
+    result = tools.close_fact_tool.invoke({"memory_id": "mem_fact", "reason": "moved away"}, config=CONFIG)
+    assert result == "Fact is already closed or unavailable."

--- a/backend/tests/unit/test_prompt_cache_integration.py
+++ b/backend/tests/unit/test_prompt_cache_integration.py
@@ -439,10 +439,19 @@ def _get_agentic_module():
         "search_knowledge",
         "read_playbook",
         "search_historical_facts",
+        "save_playbook",
+        "create_standing_trigger",
+        "close_fact_tool",
     ]
+    # ``close_fact_tool`` is the module attribute (matching the import
+    # statement in agentic.py), but the real LangChain tool overrides its
+    # runtime name to "close_fact" (see @tool("close_fact") in
+    # knowledge_ledger_write_tools.py). Mock the divergence explicitly so the
+    # stubbed CORE_TOOLS carries the same name the real JIT gating keys off.
+    tool_name_overrides = {"close_fact_tool": "close_fact"}
     for name in tool_names:
         mock_tool = MagicMock()
-        mock_tool.name = name
+        mock_tool.name = tool_name_overrides.get(name, name)
         # Add args_schema for _convert_tools to work
         mock_schema = MagicMock()
         mock_schema.schema.return_value = {"properties": {"query": {"type": "string"}}, "required": ["query"]}
@@ -673,10 +682,10 @@ def test_static_prefix_exceeds_minimum_cache_tokens():
 # ---------------------------------------------------------------------------
 
 
-def test_core_tools_has_31_tools():
-    """CORE_TOOLS includes the explicit historical-facts tool; web search remains server-built-in."""
+def test_core_tools_has_34_tools():
+    """CORE_TOOLS includes the three JIT-gated ledger write verbs; web search remains server-built-in."""
     agentic_mod = _get_agentic_module()
-    assert len(agentic_mod.CORE_TOOLS) == 31, f"CORE_TOOLS has {len(agentic_mod.CORE_TOOLS)} tools, expected 31"
+    assert len(agentic_mod.CORE_TOOLS) == 34, f"CORE_TOOLS has {len(agentic_mod.CORE_TOOLS)} tools, expected 34"
 
 
 def test_core_tools_list_creates_independent_copy():
@@ -699,9 +708,9 @@ def test_core_tools_list_creates_independent_copy():
     mock_app_tool.name = "custom_app_tool"
     tools_a.append(mock_app_tool)
 
-    assert len(tools_a) == 32
-    assert len(tools_b) == 31
-    assert len(agentic_mod.CORE_TOOLS) == 31, "CORE_TOOLS was mutated!"
+    assert len(tools_a) == 35
+    assert len(tools_b) == 34
+    assert len(agentic_mod.CORE_TOOLS) == 34, "CORE_TOOLS was mutated!"
 
 
 def test_core_tools_order_matches_exports():
@@ -743,6 +752,9 @@ def test_core_tools_order_matches_exports():
         "search_knowledge",
         "read_playbook",
         "search_historical_facts",
+        "save_playbook",
+        "create_standing_trigger",
+        "close_fact",
     ]
 
     actual_names = [t.name for t in agentic_mod.CORE_TOOLS]
@@ -828,6 +840,29 @@ def test_historical_fact_tool_is_registered_after_policy_ratification():
     tool = next(tool for tool in agentic_mod.CORE_TOOLS if tool.name == "search_historical_facts")
     assert "search_historical_facts" in agentic_mod.STANDARD_TOOL_NAMES
     assert agentic_mod.get_tool_display_name(tool.name) == "Searching historical facts"
+
+
+def test_ledger_write_verbs_are_registered_as_jit_only_with_display_names():
+    """The three dormant ledger write verbs are wired as JIT-gated chat tools.
+
+    ``close_fact_tool`` is the Python identifier this stub mocks under; the
+    real tool's runtime name is ``close_fact`` (see JIT_ONLY_TOOL_NAMES in
+    ``utils/retrieval/agentic.py``), matching how ``look_at_frame_tool`` is
+    mocked here under its identifier while its real name is ``look_at_frame``.
+    """
+    agentic_mod = _get_agentic_module()
+
+    tool_schemas, tool_registry = agentic_mod._convert_tools(agentic_mod.CORE_TOOLS)
+    schema_names = {schema.get("name") for schema in tool_schemas}
+    for name, display in (
+        ("save_playbook", "Saving playbook"),
+        ("create_standing_trigger", "Creating standing trigger"),
+        ("close_fact", "Closing fact"),
+    ):
+        assert name in schema_names
+        assert name in tool_registry
+        assert name in agentic_mod.JIT_ONLY_TOOL_NAMES
+        assert agentic_mod.get_tool_display_name(name) == display
 
 
 def test_convert_tools_defers_app_tools():

--- a/backend/utils/memory/knowledge_ledger.py
+++ b/backend/utils/memory/knowledge_ledger.py
@@ -507,6 +507,7 @@ def create_trigger(
     *,
     provenance: LedgerProvenance,
     prior_memory_id: Optional[str] = None,
+    arguments: Optional[Dict[str, Any]] = None,
     db_client: Any = None,
 ) -> str:
     return save_ledger_write(
@@ -518,6 +519,7 @@ def create_trigger(
             provenance=provenance,
             write_reason=LedgerWriteReason.standing_trigger,
             supersedes=[prior_memory_id] if prior_memory_id else [],
+            arguments=arguments or {},
         ),
         db_client=db_client,
     )

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -57,6 +57,9 @@ from utils.retrieval.tools import (
     read_playbook,
     search_historical_facts,
     search_knowledge,
+    save_playbook,
+    create_standing_trigger,
+    close_fact_tool,
 )
 from utils.retrieval.tools.app_tools import load_app_tools, get_tool_status_message
 from utils.retrieval.tools.conversation_jit_gate import (
@@ -270,6 +273,9 @@ CORE_TOOLS = [
     search_knowledge,
     read_playbook,
     search_historical_facts,
+    save_playbook,
+    create_standing_trigger,
+    close_fact_tool,
 ]
 
 # JIT-only tools: schemas must not reach the model for users outside the JIT
@@ -277,7 +283,10 @@ CORE_TOOLS = [
 # only burns tool-call budget on "no entries found" answers and changes chat
 # behavior for the whole fleet. Filtered per request off the same resolved
 # rollout boolean that gates the JIT prompt appendix, keeping the tool block
-# stable per user within a rollout state.
+# stable per user within a rollout state. The three ledger write verbs
+# (save_playbook, create_standing_trigger, close_fact) mutate the same
+# rollout-gated ledger the read tools above expose, so they are gated
+# identically.
 JIT_ONLY_TOOL_NAMES = frozenset(
     tool.name
     for tool in (
@@ -286,6 +295,9 @@ JIT_ONLY_TOOL_NAMES = frozenset(
         search_knowledge,
         read_playbook,
         search_historical_facts,
+        save_playbook,
+        create_standing_trigger,
+        close_fact_tool,
     )
 )
 
@@ -320,6 +332,9 @@ def get_tool_display_name(tool_name: str, tool_obj: Optional[Any] = None) -> str
         'search_knowledge': 'Searching current knowledge',
         'read_playbook': 'Reading playbook',
         'search_historical_facts': 'Searching historical facts',
+        'save_playbook': 'Saving playbook',
+        'create_standing_trigger': 'Creating standing trigger',
+        'close_fact': 'Closing fact',
         'get_action_items_tool': 'Checking action items',
         'create_action_item_tool': 'Creating action item',
         'update_action_item_tool': 'Updating action item',

--- a/backend/utils/retrieval/tools/__init__.py
+++ b/backend/utils/retrieval/tools/__init__.py
@@ -68,6 +68,11 @@ from .knowledge_ledger_tools import (
     search_knowledge,
     search_historical_facts,
 )
+from .knowledge_ledger_write_tools import (
+    close_fact_tool,
+    create_standing_trigger,
+    save_playbook,
+)
 
 __all__ = [
     'get_conversations_tool',
@@ -102,4 +107,7 @@ __all__ = [
     'search_knowledge',
     'read_playbook',
     'search_historical_facts',
+    'save_playbook',
+    'create_standing_trigger',
+    'close_fact_tool',
 ]

--- a/backend/utils/retrieval/tools/knowledge_ledger_write_tools.py
+++ b/backend/utils/retrieval/tools/knowledge_ledger_write_tools.py
@@ -1,0 +1,360 @@
+"""JIT-gated write verbs for the intent-backed knowledge ledger.
+
+These tools are the only production callers of ``write_playbook``,
+``create_trigger``, and ``close_fact`` in ``utils.memory.knowledge_ledger``.
+Each one enforces a narrow, explicit-intent contract before delegating to the
+canonical ledger authority: a playbook only after a recurring workflow has
+actually been reconstructed, a trigger only from articulated standing intent
+using deterministic selectors, and a fact close only for an owner-scoped
+current fact. Errors from bad input or a rejected mutation are returned as
+plain strings; nothing here lets a malformed tool call raise into the agent
+loop.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, Mapping, Optional, cast
+
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import tool  # type: ignore[reportUnknownVariableType]  # langchain @tool decorator partially typed
+
+from database._client import get_firestore_client
+from models.knowledge_ledger_policy import PLAYBOOK_HANDLE_CHARACTER_LIMIT
+from models.memory_contracts import deterministic_contract_id
+from models.product_memory import MAX_LEDGER_PLAYBOOK_BODY_CHARACTERS, MemoryKind, MemorySubjectScope
+from utils.log_sanitizer import sanitize_pii
+from utils.memory.canonical_memory_adapter import read_canonical_memory_item
+from utils.memory.jit_trigger_contract import (
+    DEFAULT_TRIGGER_RUNTIME_POLICY,
+    MAX_TRIGGER_ACTION_PROMPT_CHARS,
+    compile_trigger_condition,
+)
+from utils.memory.knowledge_ledger import (
+    LEDGER_SCHEMA_VERSION,
+    LedgerProvenance,
+    close_fact as close_ledger_fact,
+    create_trigger,
+    write_playbook,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_SAVE_PLAYBOOK_DESCRIPTION_CHARACTERS = PLAYBOOK_HANDLE_CHARACTER_LIMIT
+MAX_SAVE_PLAYBOOK_BODY_CHARACTERS = MAX_LEDGER_PLAYBOOK_BODY_CHARACTERS
+MAX_TRIGGER_DESCRIPTION_CHARACTERS = MAX_TRIGGER_ACTION_PROMPT_CHARS
+MAX_CLOSE_FACT_REASON_CHARACTERS = 500
+MAX_MEMORY_ID_CHARACTERS = 256
+_MEMORY_ID_PATTERN = re.compile(r"[A-Za-z0-9._:-]+")
+
+# Only deterministic local selectors are admitted. ``embedding`` is a known
+# schema field but is intentionally not in this set: TriggerEmbeddingPolicy is
+# disabled pending scorer attestation, so an embedding selector is rejected
+# below with an explicit error rather than silently accepted and then never
+# matching anything.
+_ALLOWED_TRIGGER_CONDITION_FIELDS = frozenset(
+    {"match_mode", "entity_aliases", "keywords", "regex", "apps", "windows", "time", "calendar"}
+)
+
+# The paid-work snapshot (utils.memory.jit_trigger_snapshot) only admits a
+# trigger whose ``arguments.wakeup_budget_per_day`` matches this exact policy
+# value; anything else makes the row invisible to the desktop watchlist.
+_TRIGGER_ARGUMENTS = {"wakeup_budget_per_day": DEFAULT_TRIGGER_RUNTIME_POLICY.planned_notifications_per_trigger_per_day}
+
+
+def _agent_config() -> Optional[Dict[str, Any]]:
+    """Retrieve the agent config dict from the context var, or None if unset."""
+    try:
+        from utils.retrieval.agentic import agent_config_context
+
+        return cast(Optional[Dict[str, Any]], agent_config_context.get())
+    except (ImportError, LookupError):
+        return None
+
+
+def _resolve_uid(config: RunnableConfig | None) -> Optional[str]:
+    cfg: Optional[Dict[str, Any]] = cast(Optional[Dict[str, Any]], config)
+    if cfg is None:
+        cfg = _agent_config()
+    configurable = cfg.get("configurable") if isinstance(cfg, dict) else None
+    uid = configurable.get("user_id") if isinstance(configurable, dict) else None
+    return uid.strip() if isinstance(uid, str) and uid.strip() else None
+
+
+def _write_provenance(
+    uid: str, *, source_version: str, action_payload: Dict[str, Any], config: RunnableConfig
+) -> LedgerProvenance:
+    """Build retry-stable provenance for one agent-authored ledger write verb."""
+    cfg: Optional[Dict[str, Any]] = cast(Optional[Dict[str, Any]], config) or _agent_config()
+    configurable = cfg.get("configurable") if isinstance(cfg, dict) else None
+    configurable = configurable if isinstance(configurable, dict) else {}
+    source_id = str(configurable.get("chat_session_id") or configurable.get("thread_id") or "direct-agent-tool").strip()
+    action_id = (
+        "agent-"
+        + source_version
+        + ":"
+        + deterministic_contract_id(
+            "agent-ledger-write",
+            {"uid": uid, "source_id": source_id, "source_version": source_version, **action_payload},
+        )[:32]
+    )
+    artifact_ref = {"chat_session_id": source_id} if configurable.get("chat_session_id") else {}
+    return LedgerProvenance(
+        source_id=source_id,
+        source_type="agent_chat",
+        source_version=source_version,
+        action_id=action_id,
+        artifact_ref=artifact_ref,
+    )
+
+
+def _reject_disallowed_trigger_condition_fields(condition: Mapping[str, Any]) -> Optional[str]:
+    """Fail closed on any selector this contract does not admit yet.
+
+    Embedding selectors get a dedicated, explicit message: they are a known
+    field on the schema, disabled pending scorer attestation, and must never
+    be silently dropped or accepted as a no-op selector.
+    """
+    if "embedding" in condition:
+        return (
+            "embedding-based trigger selectors are not available (the embedding scorer "
+            "attestation is not enabled); use entity/alias, keyword/regex, app/window, time, or "
+            "calendar selectors instead"
+        )
+    if "action" in condition:
+        return "condition must not set 'action'; describe what to do in the description argument"
+    extra = sorted(set(condition) - _ALLOWED_TRIGGER_CONDITION_FIELDS)
+    if extra:
+        return f"unsupported trigger condition field(s): {', '.join(extra)}"
+    return None
+
+
+def build_paid_trigger_condition(description: str, condition: Mapping[str, Any]) -> Dict[str, Any]:
+    """Compile one deterministic, paid-work-authoritative trigger condition.
+
+    Raises ``ValueError`` (including from pydantic validation) for a
+    malformed or disallowed selector. The returned dict is the exact
+    canonical JSON shape stored as ``MemoryItem.trigger_condition`` and read
+    back by ``utils.memory.jit_trigger_snapshot.read_authoritative_trigger_snapshot``.
+    """
+    rejection = _reject_disallowed_trigger_condition_fields(condition)
+    if rejection is not None:
+        raise ValueError(rejection)
+    full_condition = {**condition, "action": {"type": "agent_prompt", "prompt": description}}
+    compiled = compile_trigger_condition(full_condition)
+    return compiled.as_condition()
+
+
+@tool
+def save_playbook(description: str, body: str, config: RunnableConfig = None) -> str:  # type: ignore[reportAssignmentType]  # langchain injects at runtime; None default for direct calls
+    """Save a reusable step-by-step playbook for a recurring, involved workflow.
+
+    Call this only after you have actually reconstructed a multi-step
+    workflow the user repeats — a release checklist, a weekly report routine,
+    an onboarding sequence — and it is worth recalling verbatim next time.
+
+    Do NOT call this for a one-off task, a simple fact or preference (use
+    ``save_user_preference_tool`` instead), or a workflow you have not
+    actually walked through end to end.
+
+    Args:
+        description: A short, single-line handle for this playbook (at most
+            360 characters). This is what ``search_knowledge`` shows when
+            browsing playbooks, so keep it scannable, e.g. "Cut a release
+            candidate".
+        body: The full step-by-step playbook content (at most 24,000
+            characters).
+    """
+    uid = _resolve_uid(config)
+    if not uid:
+        return "Error: Could not determine user ID"
+
+    normalized_description = " ".join((description or "").split())
+    normalized_body = (body or "").strip()
+    if not normalized_description:
+        return "Error: description must not be blank"
+    if len(normalized_description) > MAX_SAVE_PLAYBOOK_DESCRIPTION_CHARACTERS:
+        return f"Error: description must be at most {MAX_SAVE_PLAYBOOK_DESCRIPTION_CHARACTERS} characters"
+    if not normalized_body:
+        return "Error: body must not be blank"
+    if len(normalized_body) > MAX_SAVE_PLAYBOOK_BODY_CHARACTERS:
+        return f"Error: body must be at most {MAX_SAVE_PLAYBOOK_BODY_CHARACTERS} characters"
+
+    try:
+        firestore_client = get_firestore_client()
+    except Exception as exc:
+        logger.error("Failed to resolve playbook storage error_type=%s", type(exc).__name__)
+        return "Error saving playbook"
+
+    try:
+        provenance = _write_provenance(
+            uid,
+            source_version="save_playbook.v1",
+            action_payload={"description": normalized_description, "body": normalized_body},
+            config=config,
+        )
+        memory_id = write_playbook(
+            uid,
+            normalized_description,
+            normalized_body,
+            provenance=provenance,
+            db_client=firestore_client,
+        )
+        logger.info("Saved playbook: %s", sanitize_pii(normalized_description))
+        return f"Playbook saved ({memory_id}): {normalized_description}"
+    except ValueError as exc:
+        logger.info("Rejected playbook write error_type=%s", type(exc).__name__)
+        return f"Error: {exc}"
+    except Exception as exc:
+        logger.error("Failed to save playbook error_type=%s", type(exc).__name__)
+        return "Error saving playbook"
+
+
+@tool
+def create_standing_trigger(
+    description: str,
+    condition: Dict[str, Any],
+    config: RunnableConfig = None,  # type: ignore[reportAssignmentType]  # langchain injects at runtime; None default for direct calls
+) -> str:
+    """Create a standing watch that notifies the user when a condition recurs.
+
+    Call this ONLY when the user has explicitly articulated a standing
+    intent in this conversation — e.g. "watch for emails from Jane and tell
+    me" or "let me know whenever the deploy channel mentions an incident".
+    Never call it from a pattern you merely noticed in passive behavior; an
+    inferred habit is not standing intent (ratified 12/13).
+
+    ``condition`` must use only deterministic selectors: ``entity_aliases``
+    (a map of entity name to a list of aliases), ``keywords``, ``regex``,
+    ``apps``, ``windows``, ``time`` (``weekdays``/``start``/``end``/
+    ``timezone``), and ``calendar`` (``event_keywords``/``event_types``).
+    ``match_mode`` may be ``"all"`` (default, every selector must match) or
+    ``"any"``. Embedding/semantic selectors are not supported and are
+    rejected.
+
+    Args:
+        description: What to tell the user when this trigger fires, in your
+            own words (at most 2000 characters), e.g. "Tell the user Jane
+            emailed about the contract."
+        condition: The deterministic selector payload described above.
+    """
+    uid = _resolve_uid(config)
+    if not uid:
+        return "Error: Could not determine user ID"
+
+    normalized_description = " ".join((description or "").split())
+    if not normalized_description:
+        return "Error: description must not be blank"
+    if len(normalized_description) > MAX_TRIGGER_DESCRIPTION_CHARACTERS:
+        return f"Error: description must be at most {MAX_TRIGGER_DESCRIPTION_CHARACTERS} characters"
+
+    try:
+        compiled_condition = build_paid_trigger_condition(normalized_description, condition)
+    except ValueError as exc:
+        return f"Error: {exc}"
+
+    try:
+        firestore_client = get_firestore_client()
+    except Exception as exc:
+        logger.error("Failed to resolve trigger storage error_type=%s", type(exc).__name__)
+        return "Error creating standing trigger"
+
+    try:
+        provenance = _write_provenance(
+            uid,
+            source_version="create_standing_trigger.v1",
+            action_payload={"description": normalized_description, "condition": compiled_condition},
+            config=config,
+        )
+        memory_id = create_trigger(
+            uid,
+            normalized_description,
+            compiled_condition,
+            provenance=provenance,
+            arguments=dict(_TRIGGER_ARGUMENTS),
+            db_client=firestore_client,
+        )
+        logger.info("Created standing trigger: %s", sanitize_pii(normalized_description))
+        return f"Standing trigger created ({memory_id}): {normalized_description}"
+    except ValueError as exc:
+        logger.info("Rejected trigger write error_type=%s", type(exc).__name__)
+        return f"Error: {exc}"
+    except Exception as exc:
+        logger.error("Failed to create standing trigger error_type=%s", type(exc).__name__)
+        return "Error creating standing trigger"
+
+
+@tool("close_fact")
+def close_fact_tool(memory_id: str, reason: str, config: RunnableConfig = None) -> str:  # type: ignore[reportAssignmentType]  # langchain injects at runtime; None default for direct calls
+    """Close a current fact that is no longer true, with no replacement fact.
+
+    Call this for "that's no longer true" when nothing should replace the
+    closed fact. If something does replace it, that is an update, not a
+    close — save the new fact instead (the ledger will supersede the old
+    one). The closed row stays in history for audit; it stops appearing as
+    current knowledge.
+
+    Args:
+        memory_id: The current ledger fact's memory id, e.g. from
+            ``search_knowledge``.
+        reason: A short explanation of why the fact no longer holds (kept in
+            logs for audit context, at most 500 characters).
+    """
+    uid = _resolve_uid(config)
+    if not uid:
+        return "Error: Could not determine user ID"
+
+    normalized_memory_id = (memory_id or "").strip()
+    normalized_reason = " ".join((reason or "").split())
+    if (
+        not normalized_memory_id
+        or len(normalized_memory_id) > MAX_MEMORY_ID_CHARACTERS
+        or _MEMORY_ID_PATTERN.fullmatch(normalized_memory_id) is None
+    ):
+        return "Error: invalid memory id"
+    if not normalized_reason:
+        return "Error: reason must not be blank"
+    if len(normalized_reason) > MAX_CLOSE_FACT_REASON_CHARACTERS:
+        return f"Error: reason must be at most {MAX_CLOSE_FACT_REASON_CHARACTERS} characters"
+
+    try:
+        firestore_client = get_firestore_client()
+    except Exception as exc:
+        logger.error("Failed to resolve fact storage error_type=%s", type(exc).__name__)
+        return "Fact could not be closed"
+
+    try:
+        # ``read_canonical_memory_item`` only ever returns an active row, so a
+        # foreign-owned id and an already-closed id (its status moves to
+        # superseded the moment it closes) both land here as a not-found —
+        # the same safe, non-raising outcome ``read_playbook`` uses for its
+        # equivalent cases.
+        item = read_canonical_memory_item(uid, normalized_memory_id, db_client=firestore_client)
+        if (
+            item is None
+            or item.uid != uid
+            or item.ledger_schema_version != LEDGER_SCHEMA_VERSION
+            or item.kind != MemoryKind.fact
+            or item.subject_scope != MemorySubjectScope.primary_user
+        ):
+            return "Fact unavailable."
+        close_ledger_fact(uid, normalized_memory_id, db_client=firestore_client)
+        logger.info("Closed fact reason=%s", sanitize_pii(normalized_reason))
+        return f"Fact closed ({normalized_memory_id})."
+    except ValueError as exc:
+        # A race against a concurrent close/mutation surfaces here even though
+        # the read above found an active row a moment earlier.
+        logger.info("Fact close rejected error_type=%s", type(exc).__name__)
+        return "Fact is already closed or unavailable."
+    except Exception as exc:
+        logger.error("Failed to close fact error_type=%s", type(exc).__name__)
+        return "Fact could not be closed"
+
+
+__all__ = [
+    "build_paid_trigger_condition",
+    "close_fact_tool",
+    "create_standing_trigger",
+    "save_playbook",
+]


### PR DESCRIPTION
## What / why

`backend/utils/memory/knowledge_ledger.py` has implemented `close_fact`, `write_playbook`, and `create_trigger` since the JIT ledger landed, but nothing in production ever called them — no chat tool, no route. This PR wires all three to real, JIT-gated agent chat tools so the ledger's write side is actually reachable, matching the existing read tools (`read_playbook`, `search_historical_facts`, `search_knowledge`).

Required for JIT dogfood completeness: without this, a user could never get a playbook saved, a standing trigger created, or a stale fact closed through chat, even on the JIT rollout.

## Tool contracts

- **`save_playbook(description, body)`** → `write_playbook`. Use only after a recurring, involved workflow has actually been reconstructed. Enforces the existing governance limits from `models/knowledge_ledger_policy.py` (360-char one-line handle, 24,000-char body) at the tool boundary before ever calling the verb; the verb itself re-enforces them (`LedgerWrite.validate_semantics`). Always primary-user scope (the verb never exposes another scope).
- **`create_standing_trigger(description, condition)`** → `create_trigger`. Tool description explicitly restricts this to *explicit standing intent the user articulated* ("watch for X and tell me"), never inferred from passive behavior (ratified 12/13). `condition` accepts only the deterministic selectors from `utils/memory/jit_trigger_contract.py` (`entity_aliases`, `keywords`, `regex`, `apps`, `windows`, `time`, `calendar`); an `embedding` selector is rejected with a clear tool error rather than silently accepted (`TriggerEmbeddingPolicy` stays disabled pending scorer attestation). The tool builds the `action` (`agent_prompt` + the description) and the `wakeup_budget_per_day` argument itself — the agent cannot set either.
- **`close_fact(memory_id, reason)`** → `close_fact`. For "that's no longer true" with no replacement fact. Owner-scoped: `read_canonical_memory_item` only ever returns an active row for the calling uid, so a foreign-owned id and an already-closed id both come back as `"Fact unavailable."` — a safe string, never a raised exception.

## A pre-existing gap in `create_trigger` (fixed, additive)

`create_trigger()` had no way to set `LedgerWrite.arguments`. `utils/memory/jit_trigger_snapshot.py` (the authority the desktop watchlist reads) only admits a trigger row whose `arguments.wakeup_budget_per_day` matches the exact policy value — so **every trigger ever written through the existing verb would have been silently invisible to the desktop watchlist**, with no error anywhere. Added an optional `arguments: Optional[Dict[str, Any]] = None` kwarg (defaults to `{}`, so existing/hypothetical callers are unaffected) and pass `{"wakeup_budget_per_day": 1}` from the new tool. Verified directly: built the exact condition/arguments the tool produces into a `MemoryItem` and confirmed `read_authoritative_trigger_snapshot` admits it (`test_create_standing_trigger_created_row_is_visible_to_desktop_watchlist`).

## Gating

All three tools are registered in `CORE_TOOLS` and `JIT_ONLY_TOOL_NAMES` in `utils/retrieval/agentic.py`, exactly like the existing read tools — invisible in tool schemas and rejected at execution (`routers/agent_tools.py`, which imports both sets from `agentic.py`) for a uid the JIT rollout has not admitted, visible/executable once it has. Covered by new parametrized tests in `tests/unit/test_agent_tools_isolation.py` mirroring the existing `JIT_ONLY_TOOL_NAMES` coverage, plus a stub-based registration test in `tests/unit/test_prompt_cache_integration.py`.

No changes to the JIT conversation-retrieval prompt section — it only documents conversation-history strategy, not ledger write verbs, so there was nothing to extend there.

## Test evidence

Focused backend unit lane (`backend/test.sh` with `BACKEND_UNIT_TEST_FILE_LIST` pinned to the touched/impacted modules): **131 passed, 0 failed** across `test_knowledge_ledger.py`, `test_knowledge_ledger_tools.py`, `test_knowledge_ledger_write_tools.py` (new), `test_agent_tools_isolation.py`, `test_jit_trigger_snapshot.py`, `test_universal_memory_task_authority.py`, `test_tools_agent_route_response_shape.py`, `test_prompt_cache_integration.py`, `test_prompt_cache_optimization.py`.

Coverage includes: happy path per verb (row lands with `kind=document`/`kind=trigger`; fact close sets `valid_to`); governance rejections (oversize playbook handle/body, embedding trigger selector, unsupported trigger condition field); owner-scoping (foreign-owned `close_fact` row, double-close, a concurrent-close race surfaced as a safe string); JIT gating (hidden/rejected pre-rollout, listed/executable post-rollout); and the trigger-visibility proof above.

`backend pyright` (touched files): 0 errors. `black --check --line-length 120 --skip-string-normalization`: clean.

## Product invariants affected

- INV-MEM-4 — `backend/utils/memory/knowledge_ledger.py` changed only inside `create_trigger`, adding an optional `arguments` kwarg that is passed straight through into the existing `LedgerWrite`/`save_ledger_write` path. It does not add, remove, or reorder any Short-term → Long-term consolidation route; ledger rows already commit as intent-backed Long-term writes today, unchanged by this PR.
- INV-MEM-1 — no new tier, no new Short-term/Archive collection, no change to default Archive visibility. The touched function only affects the `trigger` kind's `arguments` field.

## Line-Count-Exception

`backend/utils/retrieval/agentic.py` grew from 1635 to 1650 lines registering the three new tools into the existing `CORE_TOOLS`/`JIT_ONLY_TOOL_NAMES`/display-name tables, following the exact pattern already used for `read_playbook`/`search_historical_facts`/`search_knowledge`. Splitting this file is out of scope for a small, additive registration change.

Line-Count-Exception: backend/utils/retrieval/agentic.py | 1635 -> 1650 | Additive registration of 3 new JIT-gated tools into existing CORE_TOOLS/JIT_ONLY_TOOL_NAMES/display-name tables, same pattern as existing entries; not a candidate for splitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

