### PR TITLE
fix(backend): complete empty JIT snapshot when admitted owner has no memory head

### DIFF
--- a/.github/failure-classes/FC-proven-empty-rendered-as-denial.json
+++ b/.github/failure-classes/FC-proven-empty-rendered-as-denial.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "id": "FC-proven-empty-rendered-as-denial",
+  "violated_contract": "A read of an authoritative state that is proven empty (the source query ran and the governing document is absent) must be returned as a complete, empty result; it must not be served as an indeterminate incomplete receipt, which correctness-gated clients must discard — so a legitimately empty account can never complete its durable handshake.",
+  "canonical_prevention": "Classify absence once at the shared reader: only absence proven by an exhausted query may map to a complete empty projection carrying a deterministic revision, while unproven absence (read failure, malformed source) keeps the incomplete receipt; prove both directions plus the torn-read fence with behavioral tests on the reader.",
+  "canonical_prevention_artifact": [
+    "backend/utils/memory/jit_trigger_snapshot.py",
+    "backend/tests/unit/test_jit_trigger_snapshot.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/utils/memory/**"
+  ],
+  "status": "open"
+}

--- a/backend/tests/unit/test_jit_trigger_snapshot.py
+++ b/backend/tests/unit/test_jit_trigger_snapshot.py
@@ -56,17 +56,24 @@ class _Query:
 
 
 class _Client:
-    def __init__(self, rows, generation=3, trailing_head=None):
+    def __init__(self, rows, generation=3, trailing_head=None, *, missing_head=False, head_error=False):
         self.rows = rows
         self.generation = generation
         self.trailing_head = trailing_head
+        self.missing_head = missing_head
+        self.head_error = head_error
         self.head_reads = 0
 
     def document(self, _path):
         self.head_reads += 1
-        generation, head_commit_id, commit_sequence = (
-            self.trailing_head if self.head_reads > 1 and self.trailing_head else (self.generation, 'head-7', 7)
-        )
+        if self.head_error:
+            raise RuntimeError('state head read failed')
+        if self.head_reads > 1 and self.trailing_head:
+            generation, head_commit_id, commit_sequence = self.trailing_head
+        elif self.missing_head:
+            return _Document(_Snapshot('head', None, exists=False))
+        else:
+            generation, head_commit_id, commit_sequence = (self.generation, 'head-7', 7)
         return _Document(
             _Snapshot(
                 'head',
@@ -206,6 +213,48 @@ def test_torn_head_read_never_certifies_complete_snapshot():
     assert result.failure_reason == 'authority_changed'
     assert result.snapshot_revision == ''
     assert result.rows == ()
+
+
+def test_missing_head_returns_complete_empty_watchlist():
+    client = _Client([], missing_head=True)
+    result = read_authoritative_trigger_snapshot('owner', firestore_client=client)
+
+    assert result.complete is True
+    assert result.owner_id == 'owner'
+    assert result.account_generation == 0
+    assert result.head_commit_id == ''
+    assert result.commit_sequence == 0
+    assert result.rows == ()
+    assert result.failure_reason is None
+    assert len(result.snapshot_revision) == 64
+    assert client.head_reads == 2, 'absence must be fenced by a trailing re-read'
+
+
+def test_empty_watchlist_revision_is_stable_and_owner_bound():
+    first = read_authoritative_trigger_snapshot('owner', firestore_client=_Client([], missing_head=True))
+    second = read_authoritative_trigger_snapshot('owner', firestore_client=_Client([], missing_head=True))
+    other_owner = read_authoritative_trigger_snapshot('stranger', firestore_client=_Client([], missing_head=True))
+
+    assert first.snapshot_revision == second.snapshot_revision
+    assert first.snapshot_revision != other_owner.snapshot_revision
+
+
+def test_head_appearing_mid_read_never_certifies_empty_generation():
+    result = read_authoritative_trigger_snapshot(
+        'owner', firestore_client=_Client([], missing_head=True, trailing_head=(3, 'head-7', 7))
+    )
+
+    assert result.complete is False
+    assert result.failure_reason == 'generation_unavailable'
+    assert result.snapshot_revision == ''
+    assert result.rows == ()
+
+
+def test_unreadable_head_stays_incomplete():
+    result = read_authoritative_trigger_snapshot('owner', firestore_client=_Client([], head_error=True))
+
+    assert result.complete is False
+    assert result.failure_reason == 'generation_unavailable'
 
 
 def test_revision_binds_condition_action_budget_and_canonical_order():

--- a/backend/utils/memory/jit_trigger_snapshot.py
+++ b/backend/utils/memory/jit_trigger_snapshot.py
@@ -23,7 +23,11 @@ from utils.memory.jit_trigger_contract import (
     TriggerRuntimePolicy,
     compile_memory_item_trigger,
 )
-from utils.memory.v3.account_generation_source import read_memory_v3_trusted_account_generation
+from utils.memory.v3.account_generation_source import (
+    V3AccountGenerationFailureReason,
+    V3TrustedAccountGenerationReadError,
+    read_memory_v3_trusted_account_generation,
+)
 
 MAX_AUTHORITATIVE_TRIGGERS = 500
 
@@ -160,6 +164,12 @@ def _revision(
     return hashlib.sha256(encoded).hexdigest()
 
 
+def _empty_watchlist_revision(uid: str, account_generation: int) -> str:
+    """Deterministic revision for a watchlist proven empty by head absence."""
+    encoded = f'empty-watchlist:{uid}:{account_generation}'.encode('utf-8')
+    return hashlib.sha256(encoded).hexdigest()
+
+
 def read_authoritative_trigger_snapshot(
     uid: str,
     *,
@@ -170,12 +180,35 @@ def read_authoritative_trigger_snapshot(
     Absence is authoritative only after the query is exhausted.  Any malformed,
     mixed-generation, oversized, or actionless active row makes the whole
     snapshot incomplete so ambient work cannot outrank an unseen planned action.
+    A state head proven absent (the owner has no memory-v3 generation at all)
+    yields a complete, empty watchlist with a deterministic revision; unproven
+    absence (read failure, malformed head) stays incomplete.
     """
 
     client = firestore_client or get_firestore_client()
     head = read_memory_v3_trusted_account_generation(uid=uid, db_client=client)
     try:
         account_generation = head.require_account_generation()
+    except V3TrustedAccountGenerationReadError as exc:
+        if exc.reason is not V3AccountGenerationFailureReason.MISSING_STATE_HEAD:
+            return AuthoritativeTriggerSnapshot(uid, 0, '', 0, '', False, (), 'generation_unavailable')
+        # A proven-absent state head means the owner never initialized memory
+        # v3, so the exhaustive watchlist is provably empty.  Fence the absence
+        # exactly like a row scan: certify complete only if the head is still
+        # absent on a trailing re-read, so a head created mid-flight cannot be
+        # certified away as an empty generation.
+        trailing = read_memory_v3_trusted_account_generation(uid=uid, db_client=client)
+        if trailing.read_error_reason is not V3AccountGenerationFailureReason.MISSING_STATE_HEAD:
+            return AuthoritativeTriggerSnapshot(uid, 0, '', 0, '', False, (), 'generation_unavailable')
+        return AuthoritativeTriggerSnapshot(
+            owner_id=uid,
+            account_generation=0,
+            head_commit_id='',
+            commit_sequence=0,
+            snapshot_revision=_empty_watchlist_revision(uid, 0),
+            complete=True,
+            rows=(),
+        )
     except Exception:
         return AuthoritativeTriggerSnapshot(uid, 0, '', 0, '', False, (), 'generation_unavailable')
     head_commit_id = head.head_commit_id or ''


### PR DESCRIPTION
# Admitted JIT trigger snapshot must be complete even with no memory head

## Problem

Desktop Beta (0.12.241 / 12241) on the dev data plane: `GET /v1/jit/rollout-decision` returns 200 and the client treats the lane as on, but `GET /v1/jit/trigger-snapshot` returns a 748B **incomplete** envelope and the local `jit_trigger_snapshot_receipts` table stays at 0 rows.

Dev Firestore has no `memory_state/head` for these dogfood accounts (Beta Auth is prod, the data plane for this API is dev). `read_authoritative_trigger_snapshot` treated the missing head as `generation_unavailable` → `complete=false`, empty ids, default policy. The Swift client `JITTriggerMirror.reconcile` discards incomplete snapshots on purpose (requires `complete == true` and non-empty `snapshotRevision`), so an admitted user could fetch the snapshot but never persist a receipt — dev Beta can never exercise the JIT lane.

## Change

When the rollout admits work (`permits_work`) and the `memory_state/head` document is **proven absent** (`MISSING_STATE_HEAD` — the query ran and the doc does not exist), `read_authoritative_trigger_snapshot` now returns a **complete empty watchlist** instead of the incomplete `generation_unavailable` stub:

- `complete=true`, `rows=[]`, `failure_reason=null`
- `owner_id` = authenticated uid
- `account_generation=0`, `commit_sequence=0`, `head_commit_id=""`
- `snapshot_revision` = deterministic sha256 of `empty-watchlist:{uid}:0` (64 hex, stable across serves)

Certification discipline is preserved:

- Absence is fenced by a trailing head re-read (same discipline as the row-scan `authority_changed` fence): if a head appeared mid-read, the snapshot stays incomplete (`generation_unavailable`) and the client picks up the real snapshot on the next poll.
- Unproven absence — read failure, malformed/unsupported/mismatched head — keeps the existing incomplete `generation_unavailable` receipt. No fake complete.
- No trigger rows are invented; no row scan runs without a head.
- Non-admitted owners keep the existing `rollout_not_enabled` incomplete stub (router gating unchanged).
- The generation fence stays monotonic: when a real head later appears at a higher `account_generation`, Swift `reconcile` treats it as a new authority epoch and accepts it.

Verified against the Swift client contract (`JITTriggerMirror.reconcile`): `headCommitID` is decoded as a plain `String` and never validated for emptiness; acceptance requires `complete`, matching non-empty `ownerID`, non-empty `snapshotRevision`, `accountGeneration >= 0`, `commitSequence >= 0`, and a valid policy — all satisfied. Same `(generation, sequence, revision)` on repeated syncs is idempotent (no `conflictingRevision`).

## Tests

- New: admitted uid with missing head → complete empty snapshot, deterministic non-empty revision, no failure_reason, trailing re-read fence observed (`head_reads == 2`)
- New: revision is stable across serves and owner-bound
- New: head appearing between the two head reads → still incomplete `generation_unavailable` (no certification of a torn absence)
- New: unreadable head (read raises) → still incomplete `generation_unavailable`
- Existing suites green: `test_jit_trigger_snapshot.py` (16), `test_jit_rollout.py` (34, incl. `rollout_not_enabled` stub), `test_jit_first_open_policy.py` + `test_jit_ledger_snapshot.py` (52), `test_jit_proactivity_store.py` + `test_jit_proactivity_eval.py` (26)

Failure-Class: new

Adds `FC-proven-empty-rendered-as-denial` — the mirror of `FC-denial-rendered-as-empty-success`: a proven-empty authoritative state (the head query ran and the document is absent) was served as an indeterminate incomplete receipt that correctness-gated clients must discard, so a legitimately empty account could never persist its snapshot receipt. Guard artifact: the reader plus its behavioral tests.

## Product invariants affected

- INV-MEM-4
- INV-MEM-1

Unblocks SCA-372 (dev Beta dogfood: allowlisted users can GET the snapshot but cannot persist a receipt).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

