### PR TITLE
fix(backend): pin the data-plane Firestore seam to the mounted service account

### DIFF
--- a/.github/failure-classes/FC-ambient-credentials-assumed-cross-plane.json
+++ b/.github/failure-classes/FC-ambient-credentials-assumed-cross-plane.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "id": "FC-ambient-credentials-assumed-cross-plane",
+  "violated_contract": "A client pinned to a Firestore project outside its compute project must carry credentials proven to hold IAM there; ambient ADC identity is only valid for the compute project's own data plane.",
+  "canonical_prevention": "Cross-plane Firestore clients resolve explicit mounted service-account credentials (the same SA the proven cross-plane writers use) and fail closed on a project mismatch, instead of pinning bare ADC to a foreign project and discovering the missing IAM as request-time 403s after a green deploy.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_data_plane_firestore_client.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": ["backend/database/_client.py", "backend/database/google_credentials.py", "backend/deploy/runtime_env/**"],
+  "status": "open"
+}

--- a/backend/database/_client.py
+++ b/backend/database/_client.py
@@ -194,6 +194,25 @@ def _build_data_plane_firestore_client() -> Any:
     if not data_plane_project:
         return get_firestore_client()
 
+    # Bare ADC pinned to another project is not enough: the dev compute
+    # service account has no data-plane Firestore IAM (writes came back 403
+    # the first time this seam served traffic). The data-plane SA is already
+    # mounted for exactly this split — SERVICE_ACCOUNT_JSON env on listen /
+    # Python / jobs, FIREBASE_AUTH_CREDENTIALS_PATH file on desktop-backend —
+    # so the seam pins those credentials, the same way entitlement reads do.
+    pinned = customer_entitlement_service_account()
+    if pinned is not None:
+        credentials, sa_project = pinned
+        if sa_project != data_plane_project:
+            # Writing user data to whatever project the mounted SA happens to
+            # serve would be silent cross-plane corruption; refuse instead.
+            raise RuntimeError(
+                "OMI_FIRESTORE_DATA_PLANE_PROJECT="
+                f"{data_plane_project} does not match the mounted service account's "
+                f"project {sa_project}"
+            )
+        return firestore.Client(credentials=credentials, project=data_plane_project)
+
     prepare_google_credentials()
     return firestore.Client(project=data_plane_project)
 

--- a/backend/tests/unit/test_data_plane_firestore_client.py
+++ b/backend/tests/unit/test_data_plane_firestore_client.py
@@ -116,3 +116,65 @@ def test_data_plane_db_lazy_proxy_defers_until_first_attribute_access(monkeypatc
     getter.assert_not_called()
     assert client_module.data_plane_db.collection("users") == "lazy-ref"
     getter.assert_called_once_with()
+
+
+def test_uses_mounted_data_plane_credentials_when_available(monkeypatch):
+    _reset_caches(monkeypatch)
+    monkeypatch.delenv("FIRESTORE_EMULATOR_HOST", raising=False)
+    monkeypatch.setenv("OMI_FIRESTORE_DATA_PLANE_PROJECT", "based-hardware")
+
+    fake_credentials = object()
+    monkeypatch.setattr(
+        client_module,
+        "customer_entitlement_service_account",
+        MagicMock(return_value=(fake_credentials, "based-hardware")),
+    )
+    fake_client = SimpleNamespace()
+    firestore_client_ctor = MagicMock(return_value=fake_client)
+    monkeypatch.setattr(client_module.firestore, "Client", firestore_client_ctor)
+    monkeypatch.setattr(
+        client_module,
+        "prepare_google_credentials",
+        MagicMock(side_effect=AssertionError("explicit credentials must not fall back to ADC")),
+    )
+
+    result = client_module.get_data_plane_firestore_client()
+
+    assert result is fake_client
+    firestore_client_ctor.assert_called_once_with(credentials=fake_credentials, project="based-hardware")
+
+
+def test_refuses_mounted_credentials_for_a_different_project(monkeypatch):
+    _reset_caches(monkeypatch)
+    monkeypatch.delenv("FIRESTORE_EMULATOR_HOST", raising=False)
+    monkeypatch.setenv("OMI_FIRESTORE_DATA_PLANE_PROJECT", "based-hardware")
+
+    monkeypatch.setattr(
+        client_module,
+        "customer_entitlement_service_account",
+        MagicMock(return_value=(object(), "some-other-project")),
+    )
+
+    import pytest
+
+    with pytest.raises(RuntimeError, match="does not match the mounted service account"):
+        client_module.get_data_plane_firestore_client()
+
+
+def test_falls_back_to_pinned_adc_without_mounted_credentials(monkeypatch):
+    _reset_caches(monkeypatch)
+    monkeypatch.delenv("FIRESTORE_EMULATOR_HOST", raising=False)
+    monkeypatch.setenv("OMI_FIRESTORE_DATA_PLANE_PROJECT", "based-hardware")
+
+    monkeypatch.setattr(client_module, "customer_entitlement_service_account", MagicMock(return_value=None))
+    fake_client = SimpleNamespace()
+    firestore_client_ctor = MagicMock(return_value=fake_client)
+    prepare_credentials = MagicMock()
+    monkeypatch.setattr(client_module.firestore, "Client", firestore_client_ctor)
+    monkeypatch.setattr(client_module, "prepare_google_credentials", prepare_credentials)
+
+    result = client_module.get_data_plane_firestore_client()
+
+    assert result is fake_client
+    prepare_credentials.assert_called_once()
+    firestore_client_ctor.assert_called_once_with(project="based-hardware")


### PR DESCRIPTION
## What
Follow-up to #12390. The seam's ADC-pinned client 403s in dev (`google.api_core.exceptions.PermissionDenied: 403 Missing or insufficient permissions` on `POST /v1/screen-activity/sync`, first observed 2026-08-29T16:41:25Z on revision `desktop-backend-df918555e98b`): the dev compute SA has no Firestore IAM on `based-hardware`. The daily-memory-sweep-job writes prod through the mounted `SERVICE_ACCOUNT_JSON` credentials, not ADC — the seam now does the same via `customer_entitlement_service_account()` (env on listen/Python/jobs, `FIREBASE_AUTH_CREDENTIALS_PATH` file on desktop-backend), and fails closed with a RuntimeError if the mounted SA's project does not match `OMI_FIRESTORE_DATA_PLANE_PROJECT` instead of writing user data cross-plane.

No workflow or manifest changes: the credential file is already mounted on desktop-backend in both environments.

## Failure class (fixes)
Failure-Class: new

## Test plan
- [x] `tests/unit/test_data_plane_firestore_client.py` — 9 passed (3 new: mounted-credentials path, project-mismatch refusal, ADC fallback)
- [x] `test_jit_ledger_snapshot.py`, `test_jit_proactivity_store.py`, `test_memory_apply_store.py`, `test_firestore_di_seam.py` — all passed
- [x] black clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

