### PR TITLE
fix(dev-harness): use repo-pinned Firebase CLI

### DIFF
--- a/.github/failure-classes/FC-dev-harness-system-global-tool-shadows-repo-pinned.json
+++ b/.github/failure-classes/FC-dev-harness-system-global-tool-shadows-repo-pinned.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-dev-harness-system-global-tool-shadows-repo-pinned",
+  "violated_contract": "A dev-harness script that resolves a CLI tool by searching PATH first silently uses whatever global version is installed on the developer's machine, which may be on an incompatible Node version, drift from the version pinned in package.json, and cause the emulator to hang until a health-check timeout.",
+  "canonical_prevention": "Invoke the tool exclusively through the repo-pinned devDependency version (npx --prefix <repo_root> --yes <package>@<exact-pinned-version>), reject any PATH-resolved global, and fail fast with a clear message when package.json does not carry an exact (no range) pin.",
+  "canonical_prevention_artifact": [
+    "scripts/dev-harness/dev_harness/cli.py"
+  ],
+  "evidence_prs": [
+    12393
+  ],
+  "scope_hints": [
+    "scripts/dev-harness/**"
+  ],
+  "status": "open"
+}

--- a/scripts/dev-harness/dev_harness/cli.py
+++ b/scripts/dev-harness/dev_harness/cli.py
@@ -663,11 +663,17 @@ def _firebase_command(cfg: config.HarnessConfig) -> list[str]:
     firestore["rules"] = str(cfg.repo_root / "firestore.rules")
     firestore["indexes"] = str(cfg.repo_root / "firestore.indexes.json")
     _write_json(config_path, payload)
-    # `--yes` is required: the emulator runs detached with its output redirected to a
-    # log file, so npx's "Need to install the following packages / Ok to proceed? (y)"
-    # prompt has no terminal to answer it and the process blocks there forever. The
-    # health check then fails on a timeout that says nothing about the real cause.
-    base = ["firebase"] if _which("firebase") else ["npx", "--yes", "firebase-tools"]
+    # Always invoke the exact repo-pinned CLI through npx. A globally installed
+    # Firebase CLI can silently drift from package.json (and commonly runs under an
+    # unsupported Node version), leaving the detached emulator stuck until health
+    # checks time out. `--yes` prevents an install prompt and `--prefix` scopes
+    # resolution to this checkout instead of global state.
+    package = _load_json(cfg.repo_root / "package.json", {})
+    dev_dependencies = package.get("devDependencies", {})
+    pinned = dev_dependencies.get("firebase-tools") if isinstance(dev_dependencies, dict) else None
+    if not isinstance(pinned, str) or not pinned or any(marker in pinned for marker in ("^", "~", "*", ">", "<")):
+        raise RuntimeError("package.json must pin an exact firebase-tools version")
+    base = ["npx", "--prefix", str(cfg.repo_root), "--yes", f"firebase-tools@{pinned}"]
     return [
         *base,
         "emulators:start",

--- a/scripts/dev-harness/tests/test_cli.py
+++ b/scripts/dev-harness/tests/test_cli.py
@@ -151,12 +151,21 @@ def test_npx_firebase_tools_does_not_wait_on_an_install_prompt(
     blocks forever and the failure presents as a health-check timeout instead.
     """
     monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
-    monkeypatch.setattr(cli, "_which", lambda name: None if name == "firebase" else f"/usr/bin/{name}")
     cfg = config.load_config(REPO_ROOT, create_layout=True)
 
     command = cli._firebase_command(cfg)
 
-    assert command[:3] == ["npx", "--yes", "firebase-tools"]
+    assert command[:5] == ["npx", "--prefix", str(REPO_ROOT), "--yes", "firebase-tools@15.22.0"]
+
+
+def test_firebase_command_ignores_global_cli_and_uses_repo_pin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
+    monkeypatch.setattr(cli, "_which", lambda name: "/opt/homebrew/bin/firebase" if name == "firebase" else None)
+    cfg = config.load_config(REPO_ROOT, create_layout=True)
+
+    command = cli._firebase_command(cfg)
+
+    assert command[:5] == ["npx", "--prefix", str(REPO_ROOT), "--yes", "firebase-tools@15.22.0"]
 
 
 def test_firebase_command_writes_the_configured_emulator_ports(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- The dev-harness Firestore emulator resolves `firebase` via `_which("firebase")` first, falling back to `npx --yes firebase-tools` — so a globally installed Firebase CLI (often on an unsupported Node version, and free to drift from `package.json`) silently wins over the repo-pinned version, and the emulator can hang until the health check times out.
- Always invoke the exact `firebase-tools` version pinned in the repo's `package.json` devDependencies via `npx --prefix <repo_root> --yes firebase-tools@<pinned>`, ignoring any global `firebase` binary. Fails fast with a clear error if `package.json` doesn't pin an exact version (no `^`/`~`/`*`/range).

## Test plan
- [x] `bash scripts/dev-harness/run-tests.sh` — 120 passed, 7 skipped, 1 pre-existing unrelated failure (`test_nondefault_port_offset_propagates_to_every_harness_service`, fails identically on `main`, tracked separately)
- [x] Confirmed `node_modules/firebase-tools` already matches the pinned version exactly (`15.22.0`), so this resolves without a network fetch in the common case

Failure-Class: new

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->