### PR TITLE
fix(dev-harness): flag a Node version too old for the pinned firebase-tools

### DIFF
--- a/.github/failure-classes/FC-prereq-check-verifies-presence-not-usability.json
+++ b/.github/failure-classes/FC-prereq-check-verifies-presence-not-usability.json
@@ -1,0 +1,16 @@
+{
+    "schema_version": 1,
+    "id": "FC-prereq-check-verifies-presence-not-usability",
+    "violated_contract": "A dev-harness prerequisite check that reports a dependency as available must verify it is actually usable for what the harness needs — the right runtime version, a functioning binary behind the name — not merely that a binary of that name resolves on PATH. A name-only PATH lookup lets an unusable dependency pass the check silently, and the real failure only surfaces later as an opaque downstream timeout (a stuck emulator, a hung health check) that names none of the actual cause.",
+    "canonical_prevention": "Every prerequisite entry that gates a versioned or runtime-dependent tool must probe actual usability — run the binary and parse its reported version, or execute a smoke invocation — before reporting it present, the way `_java_runtime_present` distinguishes macOS's always-on-PATH Java stub from a real JVM and `_node_major_version`/`_firebase_tools_min_node_major` distinguish a present-but-too-old Node from one the repo-pinned firebase-tools can actually run under.",
+    "canonical_prevention_artifact": [
+        "scripts/dev-harness/tests/test_cli.py"
+    ],
+    "evidence_prs": [
+        11569
+    ],
+    "scope_hints": [
+        "scripts/dev-harness/**"
+    ],
+    "status": "open"
+}

--- a/.github/failure-classes/FC-prereq-check-verifies-presence-not-usability.json
+++ b/.github/failure-classes/FC-prereq-check-verifies-presence-not-usability.json
@@ -2,12 +2,13 @@
     "schema_version": 1,
     "id": "FC-prereq-check-verifies-presence-not-usability",
     "violated_contract": "A dev-harness prerequisite check that reports a dependency as available must verify it is actually usable for what the harness needs — the right runtime version, a functioning binary behind the name — not merely that a binary of that name resolves on PATH. A name-only PATH lookup lets an unusable dependency pass the check silently, and the real failure only surfaces later as an opaque downstream timeout (a stuck emulator, a hung health check) that names none of the actual cause.",
-    "canonical_prevention": "Every prerequisite entry that gates a versioned or runtime-dependent tool must probe actual usability — run the binary and parse its reported version, or execute a smoke invocation — before reporting it present, the way `_java_runtime_present` distinguishes macOS's always-on-PATH Java stub from a real JVM and `_node_major_version`/`_firebase_tools_min_node_major` distinguish a present-but-too-old Node from one the repo-pinned firebase-tools can actually run under.",
+    "canonical_prevention": "Every prerequisite entry that gates a versioned or runtime-dependent tool must probe actual usability — run the binary and parse its reported version, or execute a smoke invocation — before reporting it present, the way `_java_runtime_present` distinguishes macOS's always-on-PATH Java stub from a real JVM and `_node_major_version`/`_minimum_node_major_for_firebase_tools` distinguish a present-but-too-old Node from one the repo-pinned firebase-tools can actually run under.",
     "canonical_prevention_artifact": [
         "scripts/dev-harness/tests/test_cli.py"
     ],
     "evidence_prs": [
-        11569
+        11569,
+        12541
     ],
     "scope_hints": [
         "scripts/dev-harness/**"


### PR DESCRIPTION
## Summary
- `prerequisite_report()` in `scripts/dev-harness/dev_harness/cli.py` only checked that a `node` binary existed on PATH. It never checked *which* version — the repo-pinned `firebase-tools` (`package-lock.json`) requires Node >= 20, so an older Node on PATH passed the check today and only failed later as an opaque emulator startup issue instead of a clear prerequisite error.
- Added `_node_major_version()` (parses `node --version`) and `_firebase_tools_min_node_major()` (reads the minimum Node major straight out of the repo-pinned `firebase-tools` entry in `package-lock.json`, so it tracks future version bumps automatically instead of a second hardcoded constant), and wired both into `prerequisite_report()`.
- Closes #12394.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: new

This is the same root pattern as the Java-stub fix in #11569 (a prerequisite check that verifies a binary resolves on PATH, not that it's actually usable for what the harness needs), which was never registered as a failure class. Registered `FC-prereq-check-verifies-presence-not-usability` in this PR, citing #11569 as the real prior incident and this PR's own `_java_runtime_present`-style checks as the canonical prevention pattern, so the next "just check `_which()`" prerequisite bug in this file has a guard to match against.

## Test plan
- [x] `bash scripts/dev-harness/run-tests.sh` — all dev-harness unit tests pass (new tests: `_node_major_version` parsing, `_firebase_tools_min_node_major` reading the pinned lockfile entry, an outdated-Node prerequisite failure, and a supported-Node pass-through)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

