### PR TITLE
feat(desktop): bridge the JIT knowledge-ledger tools into the agent runtime

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess+JITKnowledgeToolsGate.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess+JITKnowledgeToolsGate.swift
@@ -1,0 +1,27 @@
+extension AgentRuntimeProcess {
+  /// Client-side UX gate for the desktop's JIT knowledge-ledger tools
+  /// (search_knowledge, save_playbook, close_fact, etc.): admits only the
+  /// server's own `effective` verdict. `unknown` — the fail-closed result of
+  /// any transport, decode, or authorization-race failure in
+  /// `ProactiveLaneClient.jitProactivityFlags` — and `disabled` both resolve
+  /// to `false` here, same as `JITProactivityFlags.permitsNewLane` refuses to
+  /// re-derive a looser verdict from raw flags. The backend independently
+  /// re-checks entitlement on every `/v1/agent/execute-tool` call, so a stale
+  /// or wrong value here only changes which tools the model is offered.
+  static func jitKnowledgeToolsEnabled(from flags: JITProactivityFlags) -> Bool {
+    flags.effective == .enabled
+  }
+
+  /// Resolve the gate for one outgoing query. `jitProactivityFlags` caches
+  /// per-owner against the server's own `cache_ttl_seconds` (15s-15min), so
+  /// this is a cache hit on every query except the first after login/TTL
+  /// expiry — the same signal `JITProactivityRuntime` reads for the
+  /// ambient/planned proactive lanes.
+  static func resolvedJitKnowledgeToolsEnabled(
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot
+  ) async -> Bool {
+    let flags = await ProactiveLaneClient.shared.jitProactivityFlags(
+      authorizationSnapshot: authorizationSnapshot)
+    return jitKnowledgeToolsEnabled(from: flags)
+  }
+}

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -1549,7 +1549,8 @@ actor AgentRuntimeProcess {
     attachments: [AgentQueryAttachment],
     producingTurnId: String?,
     expectedContext: AgentContextFreshness?,
-    reasoningEffort: String? = nil
+    reasoningEffort: String? = nil,
+    jitKnowledgeToolsEnabled: Bool = false
   ) -> [String: Any] {
     var message = protocolEnvelope(
       type: "query",
@@ -1565,6 +1566,11 @@ actor AgentRuntimeProcess {
     if !attachments.isEmpty { message["attachments"] = attachments.map(\.dictionary) }
     if let producingTurnId, !producingTurnId.isEmpty { message["producingTurnId"] = producingTurnId }
     if let reasoningEffort, !reasoningEffort.isEmpty { message["reasoningEffort"] = reasoningEffort }
+    // UX gate only: the backend independently re-checks JIT entitlement on
+    // every /v1/agent/execute-tool call. Omitted (not `false`) when the
+    // rollout verdict isn't `enabled`, matching how the runtime treats an
+    // absent field as false.
+    if jitKnowledgeToolsEnabled { message["jitKnowledgeToolsEnabled"] = true }
     if let expectedContext {
       message["expectedContextSnapshotVersion"] = expectedContext.version
       message["expectedContextSnapshotGeneration"] = expectedContext.generation
@@ -2360,6 +2366,10 @@ actor AgentRuntimeProcess {
     guard isBridgeReady else { throw BridgeError.stopped }
     try assertAuthorization(authorizationSnapshot)
 
+    // See AgentRuntimeProcess+JITKnowledgeToolsGate.swift: fail-closed UX gate only.
+    let jitKnowledgeToolsEnabled = await Self.resolvedJitKnowledgeToolsEnabled(
+      authorizationSnapshot: authorizationSnapshot)
+
     return try await withCheckedThrowingContinuation { continuation in
       let surfaceRef = surface
       let request = ActiveRequest(
@@ -2394,7 +2404,8 @@ actor AgentRuntimeProcess {
         attachments: attachments,
         producingTurnId: producingTurnId,
         expectedContext: expectedContext,
-        reasoningEffort: reasoningEffort
+        reasoningEffort: reasoningEffort,
+        jitKnowledgeToolsEnabled: jitKnowledgeToolsEnabled
       )
       sendJson(queryDict)
     }

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
@@ -461,12 +461,100 @@ enum GeneratedToolCapabilities {
       "Pass a clean standalone fact: strip the command and lightly clean pronouns. Do not invent names, dates, or facts the user did not ask to persist, and do not infer from the rest of the chat.",
       "Do not call for a mere statement of fact, a question, or a negative request such as 'do not remember this'.",
       "This writes short-term memory through the authorized desktop backend path; it does not promote, edit, or delete long-term memory.",
+      "For a durable fact correction, a reusable multi-step playbook, or a standing watch request, use the knowledge-ledger tools instead.",
       "When the current user message explicitly and affirmatively asks Omi to remember or save something, call this tool with a clean standalone fact.",
       "Strip the command (for example, 'Please remember that I prefer tea' → 'I prefer tea'). Light rewrite and pronoun cleanup are OK; do not invent names, dates, or facts the user did not ask to persist.",
       "Do not infer from the rest of the chat, and do not call for a mere statement of fact, a question, or a negative request such as 'do not remember this'.",
       "Confirm the save in one line. Never tell the user about validators or internal save rules.",
       "This is a one-way non-idempotent write. Do not retry automatically after an unknown outcome; tell the user the save status is uncertain.",
-      "The backend stores this as a short-term memory candidate. Do not claim it was promoted to long-term memory."
+      "The backend stores this as a short-term memory candidate. Do not claim it was promoted to long-term memory.",
+      "For a durable fact correction ('that's no longer true'), a reusable multi-step playbook, or a standing watch request, use the knowledge-ledger tools (close_fact / save_playbook / create_standing_trigger) instead of create_memory."
+    ]
+    ),
+    Capability(
+      toolName: "search_knowledge",
+      title: "Search Knowledge",
+      latency: .fastNetwork,
+      surfaces: Set([.desktopChat]),
+      summary: "Search current facts, playbook handles, and trigger descriptions in the knowledge ledger.",
+      bullets: [
+      "Use for durable user facts, saved playbooks, and standing triggers — not short-term memory or filesystem documents.",
+      "For a document result, call read_playbook with its memory id to load the full body.",
+      "For a durable user fact, correction, saved playbook, or standing watch, use the knowledge-ledger tools (this one, read_playbook, save_playbook, create_standing_trigger, close_fact) rather than create_memory or a filesystem document.",
+      "Use a comma-separated kinds filter (fact, document, trigger) to narrow to one ledger kind."
+    ]
+    ),
+    Capability(
+      toolName: "read_playbook",
+      title: "Read Playbook",
+      latency: .fastNetwork,
+      surfaces: Set([.desktopChat]),
+      summary: "Load the full body of one current playbook found via search_knowledge.",
+      bullets: [
+      "Only active, non-rejected, non-locked playbooks are readable.",
+      "Call only after search_knowledge returns a document handle; never guess a memory id."
+    ]
+    ),
+    Capability(
+      toolName: "search_historical_facts",
+      title: "Search Historical Facts",
+      latency: .fastNetwork,
+      surfaces: Set([.desktopChat]),
+      summary: "Search closed, superseded, or historical canonical facts when current knowledge is insufficient.",
+      bullets: [
+      "Rejected facts are audit-only negative evidence and must never be treated as true user knowledge.",
+      "Call only after search_knowledge shows current knowledge is insufficient; do not call from historical keywords alone.",
+      "Facts marked rejected are audit-only negative evidence; request include_rejected only for an explicit audit and never treat those rows as true."
+    ]
+    ),
+    Capability(
+      toolName: "get_entity_timeline_tool",
+      title: "Get Entity Timeline",
+      latency: .fastNetwork,
+      surfaces: Set([.desktopChat]),
+      summary: "Read a bounded multi-source timeline for one canonical entity.",
+      bullets: [
+      "Never exposes transcripts, OCR text, alias emails, playbook bodies, or trigger conditions.",
+      "Set include_history only when current knowledge is insufficient and closed/superseded/rejected ledger facts are actually needed.",
+      "The response never includes transcripts, OCR text, alias emails, playbook bodies, or trigger conditions."
+    ]
+    ),
+    Capability(
+      toolName: "save_playbook",
+      title: "Save Playbook",
+      latency: .fastNetwork,
+      surfaces: Set([.desktopChat]),
+      summary: "Save a reusable step-by-step playbook for a recurring, multi-step workflow.",
+      bullets: [
+      "Use when the user asks to save a playbook, checklist, or repeatable procedure — never write it to the filesystem instead.",
+      "Call only after the multi-step workflow has actually been reconstructed end to end.",
+      "Call this — not a filesystem document and not create_memory — whenever the user asks to save a playbook, checklist, or repeatable procedure.",
+      "Call only after you have actually reconstructed the multi-step workflow end to end; do not call for a one-off task or a simple fact or preference."
+    ]
+    ),
+    Capability(
+      toolName: "create_standing_trigger",
+      title: "Create Standing Trigger",
+      latency: .fastNetwork,
+      surfaces: Set([.desktopChat]),
+      summary: "Create a standing watch that notifies the user when a described condition recurs.",
+      bullets: [
+      "Only from explicit standing intent the user stated in this conversation, never an inferred habit.",
+      "Call this for an explicit standing-intent request such as 'watch for X and tell me' or 'let me know whenever Y happens'.",
+      "Never call it from a pattern you merely noticed in passive behavior; an inferred habit is not standing intent.",
+      "Embedding/semantic selectors are not supported; use keywords, regex, apps, windows, time, or calendar selectors instead."
+    ]
+    ),
+    Capability(
+      toolName: "close_fact",
+      title: "Close Fact",
+      latency: .fastNetwork,
+      surfaces: Set([.desktopChat]),
+      summary: "Close a current ledger fact that is no longer true, with no replacement.",
+      bullets: [
+      "If a new fact replaces it, save the new fact instead so the ledger supersedes the old one.",
+      "Call this for 'that's no longer true' when nothing should replace the closed fact.",
+      "If something replaces it, that is an update: save the new fact instead so the ledger supersedes the old one, and do not call close_fact."
     ]
     ),
     Capability(

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
@@ -16,6 +16,13 @@ enum GeneratedSwiftTool: String, CaseIterable {
   case getMemories = "get_memories"
   case searchMemories = "search_memories"
   case createMemory = "create_memory"
+  case searchKnowledge = "search_knowledge"
+  case readPlaybook = "read_playbook"
+  case searchHistoricalFacts = "search_historical_facts"
+  case getEntityTimelineTool = "get_entity_timeline_tool"
+  case savePlaybook = "save_playbook"
+  case createStandingTrigger = "create_standing_trigger"
+  case closeFact = "close_fact"
   case getActionItems = "get_action_items"
   case createActionItem = "create_action_item"
   case updateActionItem = "update_action_item"
@@ -47,8 +54,8 @@ enum GeneratedSwiftToolExecutor: String {
 
 enum GeneratedToolExecutors {
   static let manifestVersion = 1
-  static let manifestDigest = "sha256:c925e828464d1df69740ba5dc30bb254ce1dcd79df9eea63443a7ea57711eab4"
-  static let chatFirstManifestDigest = "sha256:1d169c8c74c87e688c4fef43a2cdc902e12efabdf4e0d9d375d93de881567d16"
+  static let manifestDigest = "sha256:9cd462c76d7eeb7ea2655ccd7bb6ac40557f853383a7f11f1072f9b32213d5e5"
+  static let chatFirstManifestDigest = "sha256:17988ae5508eade38e4ad536194ca7d51ccd6cfc182f523f3a95a048abcc5d0b"
 
   static let aliasToCanonical: [String: GeneratedSwiftTool] = [
     "search_screen_history": .semanticSearch,
@@ -71,6 +78,13 @@ enum GeneratedToolExecutors {
     .getMemories: .chatToolExecutor,
     .searchMemories: .chatToolExecutor,
     .createMemory: .chatToolExecutor,
+    .searchKnowledge: .chatToolExecutor,
+    .readPlaybook: .chatToolExecutor,
+    .searchHistoricalFacts: .chatToolExecutor,
+    .getEntityTimelineTool: .chatToolExecutor,
+    .savePlaybook: .chatToolExecutor,
+    .createStandingTrigger: .chatToolExecutor,
+    .closeFact: .chatToolExecutor,
     .getActionItems: .chatToolExecutor,
     .createActionItem: .chatToolExecutor,
     .updateActionItem: .chatToolExecutor,
@@ -138,6 +152,13 @@ enum GeneratedToolExecutors {
     case getMemories
     case searchMemories
     case createMemory
+    case searchKnowledge
+    case readPlaybook
+    case searchHistoricalFacts
+    case getEntityTimelineTool
+    case savePlaybook
+    case createStandingTrigger
+    case closeFact
     case getActionItems
     case createActionItem
     case updateActionItem
@@ -176,6 +197,13 @@ enum GeneratedToolExecutors {
     case .getMemories: return .getMemories
     case .searchMemories: return .searchMemories
     case .createMemory: return .createMemory
+    case .searchKnowledge: return .searchKnowledge
+    case .readPlaybook: return .readPlaybook
+    case .searchHistoricalFacts: return .searchHistoricalFacts
+    case .getEntityTimelineTool: return .getEntityTimelineTool
+    case .savePlaybook: return .savePlaybook
+    case .createStandingTrigger: return .createStandingTrigger
+    case .closeFact: return .closeFact
     case .getActionItems: return .getActionItems
     case .createActionItem: return .createActionItem
     case .updateActionItem: return .updateActionItem

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -473,6 +473,17 @@ class ChatToolExecutor {
         expectedOwnerID: expectedOwnerID,
         api: backendAPIClient)
 
+    // JIT knowledge-ledger tools — generic passthrough to the Python backend's
+    // /v1/agent/execute-tool endpoint. These have no bespoke typed REST route:
+    // the backend re-validates the JIT rollout server-side on every call, so
+    // this client dispatch is UX-only, not an authorization boundary.
+    case .searchKnowledge, .readPlaybook, .searchHistoricalFacts, .getEntityTimelineTool,
+      .savePlaybook, .createStandingTrigger, .closeFact:
+      return await executeAgentLedgerTool(
+        toolCall,
+        expectedOwnerID: expectedOwnerID,
+        api: backendAPIClient)
+
     case .unhandled:
       if toolCall.name == "get_local_status" {
         return await executeLocalStatus(expectedOwnerID: expectedOwnerID)
@@ -3352,6 +3363,35 @@ class ChatToolExecutor {
       }
     } catch {
       log("Backend tool error (\(toolCall.name)): \(error)")
+      return "Error calling backend: \(error.localizedDescription)"
+    }
+  }
+
+  /// Generic passthrough for the JIT-gated knowledge-ledger tools (search_knowledge,
+  /// read_playbook, search_historical_facts, get_entity_timeline_tool, save_playbook,
+  /// create_standing_trigger, close_fact). Unlike the typed `/v1/tools/*` routes above,
+  /// these share one backend contract — `POST /v1/agent/execute-tool` with
+  /// `{tool_name, params}` — so there is no bespoke per-tool Swift wrapper. The backend
+  /// re-validates the JIT rollout for `tool_name` on every call regardless of whether the
+  /// manifest advertised it, so this dispatch is a UX convenience, not an authorization
+  /// decision.
+  private static func executeAgentLedgerTool(
+    _ toolCall: ToolCall,
+    expectedOwnerID: String?,
+    api: APIClient
+  ) async -> String {
+    do {
+      let resp = try await api.executeAgentTool(
+        toolName: toolCall.name,
+        params: toolCall.arguments,
+        expectedOwnerId: expectedOwnerID,
+        authorizationSnapshot: currentOwnerAuthorizationSnapshot)
+      if let error = resp.error, !error.isEmpty {
+        return "Error: \(error)"
+      }
+      return resp.result ?? ""
+    } catch {
+      log("Agent ledger tool error (\(toolCall.name)): \(error)")
       return "Error calling backend: \(error.localizedDescription)"
     }
   }

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Tools.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Tools.swift
@@ -323,4 +323,36 @@ extension APIClient {
       authorizationSnapshot: authorizationSnapshot)
   }
 
+  // MARK: - JIT Knowledge Ledger Tools (generic passthrough)
+
+  /// Response envelope for `POST /v1/agent/execute-tool` (backend/routers/agent_tools.py).
+  /// This is a distinct, narrower contract than `ToolResponse` above: no `sources`, and
+  /// failures come back as a populated `error` string rather than an HTTP error.
+  struct AgentExecuteToolResponse: Decodable {
+    let result: String?
+    let error: String?
+  }
+
+  /// Generic dispatch for the seven JIT-gated knowledge-ledger tools (search_knowledge,
+  /// read_playbook, search_historical_facts, get_entity_timeline_tool, save_playbook,
+  /// create_standing_trigger, close_fact). They share one backend route keyed by
+  /// `tool_name`, so there is no per-tool typed wrapper the way the `/v1/tools/*` routes
+  /// above have. The backend independently re-checks the JIT rollout for `toolName` on
+  /// every call; a 404 there means the tool is unavailable for this user regardless of
+  /// what the desktop manifest advertised.
+  func executeAgentTool(
+    toolName: String,
+    params: [String: Any],
+    expectedOwnerId: String? = nil,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
+  ) async throws -> AgentExecuteToolResponse {
+    let body = OmiAnyCodable(["tool_name": toolName, "params": params] as [String: Any])
+    return try await post(
+      "v1/agent/execute-tool",
+      body: body,
+      customBaseURL: nil,
+      expectedOwnerId: expectedOwnerId,
+      authorizationSnapshot: authorizationSnapshot)
+  }
+
 }

--- a/desktop/macos/Desktop/Tests/KernelContractWireTests.swift
+++ b/desktop/macos/Desktop/Tests/KernelContractWireTests.swift
@@ -152,6 +152,79 @@ final class KernelContractWireTests: XCTestCase {
     }
   }
 
+  func testQueryWireOmitsJitKnowledgeToolsFlagByDefaultAndCarriesItOnlyWhenTrue() {
+    let disabled = AgentRuntimeProcess.queryWireMessage(
+      clientId: "client",
+      requestId: "request",
+      ownerId: nil,
+      sessionId: "session",
+      surfaceKind: "main_chat",
+      prompt: "hello",
+      mode: nil,
+      imageData: nil,
+      attachments: [],
+      producingTurnId: nil,
+      expectedContext: nil
+    )
+    XCTAssertNil(disabled["jitKnowledgeToolsEnabled"])
+
+    let explicitlyFalse = AgentRuntimeProcess.queryWireMessage(
+      clientId: "client",
+      requestId: "request",
+      ownerId: nil,
+      sessionId: "session",
+      surfaceKind: "main_chat",
+      prompt: "hello",
+      mode: nil,
+      imageData: nil,
+      attachments: [],
+      producingTurnId: nil,
+      expectedContext: nil,
+      jitKnowledgeToolsEnabled: false
+    )
+    XCTAssertNil(explicitlyFalse["jitKnowledgeToolsEnabled"])
+
+    let enabled = AgentRuntimeProcess.queryWireMessage(
+      clientId: "client",
+      requestId: "request",
+      ownerId: nil,
+      sessionId: "session",
+      surfaceKind: "main_chat",
+      prompt: "hello",
+      mode: nil,
+      imageData: nil,
+      attachments: [],
+      producingTurnId: nil,
+      expectedContext: nil,
+      jitKnowledgeToolsEnabled: true
+    )
+    XCTAssertEqual(enabled["jitKnowledgeToolsEnabled"] as? Bool, true)
+  }
+
+  func testJitKnowledgeToolsGateAdmitsOnlyTheServersEnabledVerdictAndFailsClosedOtherwise() {
+    XCTAssertTrue(
+      AgentRuntimeProcess.jitKnowledgeToolsEnabled(
+        from: JITProactivityFlags(rollout: .unknown, killSwitch: .unknown, effective: .enabled)),
+      "The server's own effective=enabled verdict must admit the tools regardless of raw rollout/kill-switch state."
+    )
+    XCTAssertFalse(
+      AgentRuntimeProcess.jitKnowledgeToolsEnabled(
+        from: JITProactivityFlags(rollout: .enabled, killSwitch: .disabled, effective: .disabled)),
+      "An explicit effective=disabled verdict must hide the tools even with a permissive raw pair."
+    )
+    XCTAssertFalse(
+      AgentRuntimeProcess.jitKnowledgeToolsEnabled(
+        from: JITProactivityFlags(rollout: .unknown, killSwitch: .unknown, effective: .unknown)),
+      "An unknown verdict — the fail-closed result of any transport/decode/auth-race error — must hide the tools."
+    )
+    XCTAssertFalse(
+      AgentRuntimeProcess.jitKnowledgeToolsEnabled(
+        from: JITProactivityFlags(rollout: .enabled, killSwitch: .disabled)),
+      "Omitting `effective` (older-server compatibility default) must hide the tools; the client must not "
+        + "re-derive a looser verdict from the raw rollout/kill-switch pair."
+    )
+  }
+
   func testQueryFreshnessFenceIsAbsentOrComplete() {
     let unfenced = AgentRuntimeProcess.queryWireMessage(
       clientId: "client",

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -1384,6 +1384,9 @@ function buildMcpServers(
     if (context?.screenContext === true) {
       omiToolsEnv.push({ name: "OMI_SCREEN_CONTEXT", value: "true" });
     }
+    if (context?.jitKnowledgeToolsEnabled === true) {
+      omiToolsEnv.push({ name: "OMI_JIT_KNOWLEDGE_TOOLS_ENABLED", value: "true" });
+    }
     // Keep the exact surface marker for every typed chat run. Legacy typed
     // chat uses it to project coordinator-only writes (such as create_memory),
     // while the optional chat-first flags remain main-chat rollout-gated below.

--- a/desktop/macos/agent/src/omi-tools-stdio.ts
+++ b/desktop/macos/agent/src/omi-tools-stdio.ts
@@ -153,12 +153,14 @@ async function requestSwiftTool(
 
 const isOnboarding = process.env.OMI_ONBOARDING === "true";
 const hasScreenContext = process.env.OMI_SCREEN_CONTEXT === "true";
+const hasJitKnowledgeTools = process.env.OMI_JIT_KNOWLEDGE_TOOLS_ENABLED === "true";
 const executionRole = process.env.OMI_EXECUTION_ROLE === "leaf" ? "leaf" : "coordinator";
 const chatFirstUi = process.env.OMI_CHAT_FIRST_UI === "true" && process.env.OMI_SURFACE_KIND === "main_chat";
 const controlGeneration = Number(process.env.OMI_CHAT_FIRST_CONTROL_GENERATION);
 const projectionContext = {
   onboarding: isOnboarding,
   screenContext: hasScreenContext,
+  jitKnowledgeToolsEnabled: hasJitKnowledgeTools,
   executionRole,
   surfaceKind: process.env.OMI_SURFACE_KIND,
   chatFirstUi,

--- a/desktop/macos/agent/src/protocol.ts
+++ b/desktop/macos/agent/src/protocol.ts
@@ -48,6 +48,14 @@ export interface QueryMessage extends ProtocolEnvelope {
    * x-omi-reasoning-effort header; never interpreted by the runtime.
    */
   reasoningEffort?: string;
+  /**
+   * Per-turn client-computed capability flag: true when the desktop's JIT
+   * knowledge-ledger rollout is enabled for the current user. This is a UX
+   * gate only — the backend independently re-checks entitlement on every
+   * `/v1/agent/execute-tool` call, so an absent or stale value only affects
+   * which tools the model is offered, never authorization.
+   */
+  jitKnowledgeToolsEnabled?: boolean;
 }
 
 export interface QueryAttachment {

--- a/desktop/macos/agent/src/runtime/desktop-tool-policy.ts
+++ b/desktop/macos/agent/src/runtime/desktop-tool-policy.ts
@@ -75,6 +75,10 @@ const TASK_WRITE_TOOLS = new Set([
   "complete_onboarding",
 ]);
 const MEMORY_WRITE_TOOLS = new Set(["create_memory"]);
+// JIT knowledge-ledger write verbs (save_playbook, create_standing_trigger,
+// close_fact) mutate the same backend memory/knowledge store as create_memory,
+// so they share its bundle rather than inventing a new one.
+const LEDGER_WRITE_TOOLS = new Set(["save_playbook", "create_standing_trigger", "close_fact"]);
 const SCREEN_IMAGE_TOOLS = new Set(["get_screenshot", "look_at_frame", "capture_screen"]);
 const SCREEN_SUMMARY_TOOLS = new Set(["semantic_search", "get_work_context"]);
 // Coordinator policy classifies this as a production user-approved operation;
@@ -94,6 +98,10 @@ const LOCAL_READ_TOOLS = new Set([
   "get_action_items",
   "get_email_insights",
   "get_local_status",
+  "search_knowledge",
+  "read_playbook",
+  "search_historical_facts",
+  "get_entity_timeline_tool",
 ]);
 
 function isSqlWrite(sql: string): boolean {
@@ -129,7 +137,7 @@ function bundlesForOmiTool(tool: OmiToolManifestEntry): DesktopCoordinatorBundle
   if (SCREEN_SUMMARY_TOOLS.has(tool.name)) bundles.add("desktop.context.screen_summary");
   if (SCREEN_IMAGE_TOOLS.has(tool.name)) bundles.add("desktop.context.screenshot_image");
   if (TASK_WRITE_TOOLS.has(tool.name)) bundles.add("desktop.tasks.readwrite");
-  if (MEMORY_WRITE_TOOLS.has(tool.name)) bundles.add("desktop.memories.write");
+  if (MEMORY_WRITE_TOOLS.has(tool.name) || LEDGER_WRITE_TOOLS.has(tool.name)) bundles.add("desktop.memories.write");
   if (AUTOMATION_READ_TOOLS.has(tool.name)) bundles.add("desktop.automation.read");
   if (PERMISSION_REQUEST_TOOLS.has(tool.name)) bundles.add("desktop.permissions.request");
   if (EXTERNAL_SEND_TOOLS.has(tool.name)) bundles.add("external.write_send");

--- a/desktop/macos/agent/src/runtime/jsonl-transport.ts
+++ b/desktop/macos/agent/src/runtime/jsonl-transport.ts
@@ -37,6 +37,8 @@ export interface McpServerBuildContext {
   adapterId?: string;
   includeSwiftBackedTools?: boolean;
   screenContext?: boolean;
+  /** See `QueryMessage.jitKnowledgeToolsEnabled` — relayed opaquely, client-side UX gate only. */
+  jitKnowledgeToolsEnabled?: boolean;
   executionRole?: "coordinator" | "leaf";
   /** Server-authoritative projection admitted into this exact run snapshot. */
   chatFirstUi?: boolean;
@@ -118,6 +120,7 @@ const QUERY_WIRE_FIELDS = new Set([
   "expectedContextRendererFingerprint",
   "expectedCapabilityVersion",
   "reasoningEffort",
+  "jitKnowledgeToolsEnabled",
 ]);
 
 export class JsonlTransport {
@@ -500,6 +503,7 @@ export class JsonlTransport {
         screenContext: snapshot.sourceOutcomes.some(
           (source) => source.source === "screen" && source.outcome === "available",
         ),
+        jitKnowledgeToolsEnabled: message.jitKnowledgeToolsEnabled === true,
         chatFirstUi: snapshot.capabilities.chatFirstUi === true,
         chatFirstControlGeneration: snapshot.capabilities.chatFirstControlGeneration,
       }),
@@ -519,6 +523,7 @@ export class JsonlTransport {
         contextRendererFingerprint: snapshot.rendererFingerprint,
         contextCapabilityVersion: snapshot.capabilityVersion,
         ...(message.reasoningEffort ? { reasoningEffort: message.reasoningEffort } : {}),
+        ...(message.jitKnowledgeToolsEnabled === true ? { jitKnowledgeToolsEnabled: true } : {}),
       },
     };
   }

--- a/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
@@ -15,7 +15,8 @@ export type OmiToolCondition =
   | "coordinatorOnly"
   | "typedChatCoordinatorOnly"
   | "screenContext"
-  | "screenContextOrOnboarding";
+  | "screenContextOrOnboarding"
+  | "jitKnowledgeToolsEnabled";
 export type OmiToolExecutorKind = "swiftTool" | "runtimeControl" | "nodeTool" | "localApiOnly";
 export type OmiToolTimeoutClass = "normal" | "long";
 export type OmiToolSurface = "desktop_chat" | "realtime_voice" | "onboarding" | "task_chat";
@@ -102,6 +103,17 @@ interface OmiToolSurfacePatch {
 export interface OmiToolProjectionContext {
   onboarding?: boolean;
   screenContext?: boolean;
+  /**
+   * Client-side UX gate for the backend JIT knowledge-ledger tools
+   * (search_knowledge, read_playbook, search_historical_facts,
+   * get_entity_timeline_tool, save_playbook, create_standing_trigger,
+   * close_fact). Sourced from `QueryMessage.jitKnowledgeToolsEnabled`, a
+   * per-turn boolean the desktop app computes from its own JIT rollout
+   * decision. The backend independently re-checks entitlement on every
+   * `/v1/agent/execute-tool` call, so an absent/stale value here only hides
+   * or shows tools — it never grants or denies access.
+   */
+  jitKnowledgeToolsEnabled?: boolean;
   executionRole?: "coordinator" | "leaf";
   surfaceKind?: string;
   chatFirstUi?: boolean;
@@ -426,7 +438,70 @@ const swiftToolSurfacePatches: Record<string, OmiToolSurfacePatch> = {
         "Pass a clean standalone fact: strip the command and lightly clean pronouns. Do not invent names, dates, or facts the user did not ask to persist, and do not infer from the rest of the chat.",
         "Do not call for a mere statement of fact, a question, or a negative request such as 'do not remember this'.",
         "This writes short-term memory through the authorized desktop backend path; it does not promote, edit, or delete long-term memory.",
+        "For a durable fact correction, a reusable multi-step playbook, or a standing watch request, use the knowledge-ledger tools instead.",
       ],
+    ),
+  },
+  search_knowledge: {
+    surfaces: ["desktop_chat"],
+    capabilityDoc: doc(
+      "Search Knowledge",
+      "Search current facts, playbook handles, and trigger descriptions in the knowledge ledger.",
+      [
+        "Use for durable user facts, saved playbooks, and standing triggers — not short-term memory or filesystem documents.",
+        "For a document result, call read_playbook with its memory id to load the full body.",
+      ],
+    ),
+  },
+  read_playbook: {
+    surfaces: ["desktop_chat"],
+    capabilityDoc: doc(
+      "Read Playbook",
+      "Load the full body of one current playbook found via search_knowledge.",
+      ["Only active, non-rejected, non-locked playbooks are readable."],
+    ),
+  },
+  search_historical_facts: {
+    surfaces: ["desktop_chat"],
+    capabilityDoc: doc(
+      "Search Historical Facts",
+      "Search closed, superseded, or historical canonical facts when current knowledge is insufficient.",
+      ["Rejected facts are audit-only negative evidence and must never be treated as true user knowledge."],
+    ),
+  },
+  get_entity_timeline_tool: {
+    surfaces: ["desktop_chat"],
+    capabilityDoc: doc(
+      "Get Entity Timeline",
+      "Read a bounded multi-source timeline for one canonical entity.",
+      ["Never exposes transcripts, OCR text, alias emails, playbook bodies, or trigger conditions."],
+    ),
+  },
+  save_playbook: {
+    surfaces: ["desktop_chat"],
+    capabilityDoc: doc(
+      "Save Playbook",
+      "Save a reusable step-by-step playbook for a recurring, multi-step workflow.",
+      [
+        "Use when the user asks to save a playbook, checklist, or repeatable procedure — never write it to the filesystem instead.",
+        "Call only after the multi-step workflow has actually been reconstructed end to end.",
+      ],
+    ),
+  },
+  create_standing_trigger: {
+    surfaces: ["desktop_chat"],
+    capabilityDoc: doc(
+      "Create Standing Trigger",
+      "Create a standing watch that notifies the user when a described condition recurs.",
+      ["Only from explicit standing intent the user stated in this conversation, never an inferred habit."],
+    ),
+  },
+  close_fact: {
+    surfaces: ["desktop_chat"],
+    capabilityDoc: doc(
+      "Close Fact",
+      "Close a current ledger fact that is no longer true, with no replacement.",
+      ["If a new fact replaces it, save the new fact instead so the ledger supersedes the old one."],
     ),
   },
   get_action_items: {
@@ -1125,6 +1200,7 @@ const swiftToolManifestDrafts: OmiToolManifestEntryDraft[] = [
       "Confirm the save in one line. Never tell the user about validators or internal save rules.",
       "This is a one-way non-idempotent write. Do not retry automatically after an unknown outcome; tell the user the save status is uncertain.",
       "The backend stores this as a short-term memory candidate. Do not claim it was promoted to long-term memory.",
+      "For a durable fact correction ('that's no longer true'), a reusable multi-step playbook, or a standing watch request, use the knowledge-ledger tools (close_fact / save_playbook / create_standing_trigger) instead of create_memory.",
     ],
     latency: "fast network",
     inputSchema: schema(
@@ -1146,6 +1222,203 @@ const swiftToolManifestDrafts: OmiToolManifestEntryDraft[] = [
       "The Swift executor selects the new short-term-memory endpoint and legacy-memory fallback as supported by the installed app/backend.",
     ],
     adapters: piAndStdio("typedChatCoordinatorOnly"),
+  },
+  {
+    name: "search_knowledge",
+    label: "Search Knowledge",
+    description:
+      "Search current facts, playbook handles, and trigger descriptions in the user's knowledge ledger. Use for 'what do you know about X', 'do we have a playbook for Y', or checking whether a standing trigger already exists.",
+    promptSnippet: "search_knowledge - Search current ledger facts, playbooks, and triggers",
+    promptGuidelines: [
+      "For a durable user fact, correction, saved playbook, or standing watch, use the knowledge-ledger tools (this one, read_playbook, save_playbook, create_standing_trigger, close_fact) rather than create_memory or a filesystem document.",
+      "Use a comma-separated kinds filter (fact, document, trigger) to narrow to one ledger kind.",
+      "For a document result, call read_playbook with its memory id to load the full body.",
+    ],
+    latency: "fast network",
+    inputSchema: schema(
+      {
+        query: { type: "string", description: "Search text; matches current facts, playbook handles, and trigger descriptions." },
+        kinds: { type: "string", description: "Optional comma-separated filter: fact, document, trigger." },
+        limit: { type: "number", description: "Maximum results, 1-20 (default 8)." },
+      },
+      ["query"],
+    ),
+    annotations: readOnlyLocal,
+    timeoutClass: "normal",
+    executor: { kind: "swiftTool" },
+    intendedForAgents: true,
+    runtimePreconditions: ["Requires authenticated backend access and the desktop JIT knowledge-ledger rollout."],
+    adapters: piAndStdio("jitKnowledgeToolsEnabled"),
+  },
+  {
+    name: "read_playbook",
+    label: "Read Playbook",
+    description:
+      "Load the full body of one current playbook returned by search_knowledge. Only active, non-rejected, non-locked playbooks are readable; other ids are reported unavailable.",
+    promptSnippet: "read_playbook - Load a playbook body found via search_knowledge",
+    promptGuidelines: ["Call only after search_knowledge returns a document handle; never guess a memory id."],
+    latency: "fast network",
+    inputSchema: schema(
+      { memory_id: { type: "string", description: "The playbook's memory id, from search_knowledge." } },
+      ["memory_id"],
+    ),
+    annotations: readOnlyLocal,
+    timeoutClass: "normal",
+    executor: { kind: "swiftTool" },
+    intendedForAgents: true,
+    runtimePreconditions: ["Requires authenticated backend access and the desktop JIT knowledge-ledger rollout."],
+    adapters: piAndStdio("jitKnowledgeToolsEnabled"),
+  },
+  {
+    name: "search_historical_facts",
+    label: "Search Historical Facts",
+    description:
+      "Search closed, superseded, or historical canonical facts when current knowledge is insufficient. Rejected facts are excluded by default and are audit-only negative evidence, never true user knowledge.",
+    promptSnippet: "search_historical_facts - Search bounded historical/closed facts",
+    promptGuidelines: [
+      "Call only after search_knowledge shows current knowledge is insufficient; do not call from historical keywords alone.",
+      "Facts marked rejected are audit-only negative evidence; request include_rejected only for an explicit audit and never treat those rows as true.",
+    ],
+    latency: "fast network",
+    inputSchema: schema(
+      {
+        query: { type: "string", description: "Search text; matches exact lexical tokens in historical fact content." },
+        limit: { type: "number", description: "Maximum results, 1-20 (default 8)." },
+        offset: { type: "number", description: "Pagination offset for a repeated call (default 0)." },
+        include_rejected: {
+          type: "boolean",
+          description: "Include rejected facts for explicit audit only; never treat them as true (default false).",
+        },
+      },
+      ["query"],
+    ),
+    annotations: readOnlyLocal,
+    timeoutClass: "normal",
+    executor: { kind: "swiftTool" },
+    intendedForAgents: true,
+    runtimePreconditions: ["Requires authenticated backend access and the desktop JIT knowledge-ledger rollout."],
+    adapters: piAndStdio("jitKnowledgeToolsEnabled"),
+  },
+  {
+    name: "get_entity_timeline_tool",
+    label: "Get Entity Timeline",
+    description:
+      "Read a bounded multi-source timeline (ledger, conversations, calendar, screen) for one canonical entity such as 'user'/'me' or 'person:<stable_person_id>'.",
+    promptSnippet: "get_entity_timeline_tool - Read a bounded multi-source timeline for one entity",
+    promptGuidelines: [
+      "Set include_history only when current knowledge is insufficient and closed/superseded/rejected ledger facts are actually needed.",
+      "The response never includes transcripts, OCR text, alias emails, playbook bodies, or trigger conditions.",
+    ],
+    latency: "fast network",
+    inputSchema: schema(
+      {
+        entity: { type: "string", description: "'user'/'me', or a stable reference such as 'person:<stable_person_id>' or 'project:<name>'." },
+        sources: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional subset of: ledger, conversations, calendar, screen.",
+        },
+        include_history: { type: "boolean", description: "Include closed, superseded, or historical ledger facts (default false)." },
+        include_rejected: { type: "boolean", description: "Include rejected facts for audit only; requires include_history (default false)." },
+        limit: { type: "number", description: "Maximum timeline entries (default 20)." },
+        start_date: { type: "string", description: "Optional ISO-8601 start date bound." },
+        end_date: { type: "string", description: "Optional ISO-8601 end date bound." },
+      },
+      ["entity"],
+    ),
+    annotations: readOnlyLocal,
+    timeoutClass: "normal",
+    executor: { kind: "swiftTool" },
+    intendedForAgents: true,
+    runtimePreconditions: ["Requires authenticated backend access and the desktop JIT knowledge-ledger rollout."],
+    adapters: piAndStdio("jitKnowledgeToolsEnabled"),
+  },
+  {
+    name: "save_playbook",
+    label: "Save Playbook",
+    description:
+      "Save a reusable step-by-step playbook for a recurring, multi-step workflow the user repeats, so it can be recalled verbatim next time.",
+    promptSnippet: "save_playbook - Save a reusable step-by-step playbook to the knowledge ledger",
+    promptGuidelines: [
+      "Call this — not a filesystem document and not create_memory — whenever the user asks to save a playbook, checklist, or repeatable procedure.",
+      "Call only after you have actually reconstructed the multi-step workflow end to end; do not call for a one-off task or a simple fact or preference.",
+    ],
+    latency: "fast network",
+    inputSchema: schema(
+      {
+        description: {
+          type: "string",
+          description: "Short single-line handle for this playbook, e.g. 'Cut a release candidate' (at most 360 characters).",
+        },
+        body: { type: "string", description: "Full step-by-step playbook content (at most 24,000 characters)." },
+      },
+      ["description", "body"],
+    ),
+    annotations: localWrite,
+    timeoutClass: "normal",
+    executor: { kind: "swiftTool" },
+    intendedForAgents: true,
+    runtimePreconditions: ["Requires authenticated backend access and the desktop JIT knowledge-ledger rollout."],
+    adapters: piAndStdio("jitKnowledgeToolsEnabled"),
+  },
+  {
+    name: "create_standing_trigger",
+    label: "Create Standing Trigger",
+    description:
+      "Create a standing watch that notifies the user when a described condition recurs, using deterministic keyword/app/window/time/calendar selectors.",
+    promptSnippet: "create_standing_trigger - Create a standing watch for a described condition",
+    promptGuidelines: [
+      "Call this for an explicit standing-intent request such as 'watch for X and tell me' or 'let me know whenever Y happens'.",
+      "Never call it from a pattern you merely noticed in passive behavior; an inferred habit is not standing intent.",
+      "Embedding/semantic selectors are not supported; use keywords, regex, apps, windows, time, or calendar selectors instead.",
+    ],
+    latency: "fast network",
+    inputSchema: schema(
+      {
+        description: {
+          type: "string",
+          description: "What to tell the user when this trigger fires, in your own words (at most 2000 characters).",
+        },
+        condition: {
+          type: "object",
+          properties: {},
+          additionalProperties: true,
+          description:
+            "Deterministic selector payload: match_mode, entity_aliases, keywords, regex, apps, windows, time, calendar.",
+        },
+      },
+      ["description", "condition"],
+    ),
+    annotations: localWrite,
+    timeoutClass: "normal",
+    executor: { kind: "swiftTool" },
+    intendedForAgents: true,
+    runtimePreconditions: ["Requires authenticated backend access and the desktop JIT knowledge-ledger rollout."],
+    adapters: piAndStdio("jitKnowledgeToolsEnabled"),
+  },
+  {
+    name: "close_fact",
+    label: "Close Fact",
+    description: "Close a current ledger fact that is no longer true, with no replacement fact.",
+    promptSnippet: "close_fact - Close a current fact that no longer holds",
+    promptGuidelines: [
+      "Call this for 'that's no longer true' when nothing should replace the closed fact.",
+      "If something replaces it, that is an update: save the new fact instead so the ledger supersedes the old one, and do not call close_fact.",
+    ],
+    latency: "fast network",
+    inputSchema: schema(
+      {
+        memory_id: { type: "string", description: "The current ledger fact's memory id, e.g. from search_knowledge." },
+        reason: { type: "string", description: "Short explanation of why the fact no longer holds (kept for audit, at most 500 characters)." },
+      },
+      ["memory_id", "reason"],
+    ),
+    annotations: localWrite,
+    timeoutClass: "normal",
+    executor: { kind: "swiftTool" },
+    intendedForAgents: true,
+    runtimePreconditions: ["Requires authenticated backend access and the desktop JIT knowledge-ledger rollout."],
+    adapters: piAndStdio("jitKnowledgeToolsEnabled"),
   },
   {
     name: "get_action_items",
@@ -1943,6 +2216,7 @@ export function isToolAvailableForContext(
   }
   if (availability.condition === "screenContext") return context.screenContext === true;
   if (availability.condition === "screenContextOrOnboarding") return context.screenContext === true || context.onboarding === true;
+  if (availability.condition === "jitKnowledgeToolsEnabled") return context.jitKnowledgeToolsEnabled === true;
   return true;
 }
 

--- a/desktop/macos/agent/src/runtime/run-tool-capability.ts
+++ b/desktop/macos/agent/src/runtime/run-tool-capability.ts
@@ -279,6 +279,7 @@ export class RunToolCapabilityBroker {
     const projectionContext = {
       executionRole: persisted.profile.executionRole,
       screenContext: persisted.screenContext,
+      jitKnowledgeToolsEnabled: persisted.jitKnowledgeToolsEnabled,
       surfaceKind: persisted.surfaceKind,
       chatFirstUi: persisted.chatFirstUi,
       controlGeneration: persisted.chatFirstControlGeneration,
@@ -725,6 +726,7 @@ export class RunToolCapabilityBroker {
     runMode: RunMode;
     chatMode: string | null;
     screenContext: boolean;
+    jitKnowledgeToolsEnabled: boolean;
     chatFirstUi: boolean;
     chatFirstControlGeneration: number | null;
     /** Spawn-time child tool restriction; null = no policy, [] = no tools (fail closed). */
@@ -788,6 +790,7 @@ export class RunToolCapabilityBroker {
       runMode: text(row.mode) === "act" ? "act" : "ask",
       chatMode: typeof metadata.chatMode === "string" ? metadata.chatMode : null,
       screenContext: admittedScreenContext(runInput),
+      jitKnowledgeToolsEnabled: metadata.jitKnowledgeToolsEnabled === true,
       chatFirstUi,
       chatFirstControlGeneration: chatFirstUi && Number.isSafeInteger(controlGeneration) && controlGeneration >= 0
         ? controlGeneration

--- a/desktop/macos/agent/tests/desktop-tool-policy.test.ts
+++ b/desktop/macos/agent/tests/desktop-tool-policy.test.ts
@@ -175,6 +175,45 @@ describe("desktop tool policy", () => {
     expect(granted.decision).toBe("allow");
   });
 
+  it("allows the JIT knowledge-ledger read tools without dispatch", () => {
+    for (const toolName of ["search_knowledge", "read_playbook", "search_historical_facts", "get_entity_timeline_tool"]) {
+      const result = evaluateDesktopToolPolicy({
+        toolName,
+        selectedBundles: ["desktop.context.local_read"],
+      });
+
+      expect(result.decision, toolName).toBe("allow");
+      expect(result.requiredBundles, toolName).toEqual(["desktop.context.local_read"]);
+      expect(result.descriptor.approvalPolicy, toolName).toBe("allow");
+      expect(result.descriptor.readOnly, toolName).toBe(true);
+    }
+  });
+
+  it("classifies the JIT knowledge-ledger write verbs as approved memory writes, like create_memory", () => {
+    for (const toolName of ["save_playbook", "create_standing_trigger", "close_fact"]) {
+      const result = evaluateDesktopToolPolicy({
+        toolName,
+        selectedBundles: ["desktop.memories.write"],
+        userExplicitMutation: true,
+      });
+
+      expect(result.requiredBundles, toolName).toEqual(["desktop.memories.write"]);
+      expect(result.decision, toolName).toBe("dispatch_required");
+      expect(result.descriptor.readOnly, toolName).toBe(false);
+      expect(result.descriptor.approvalPolicy, toolName).toBe("user_approval");
+    }
+  });
+
+  it("denies the JIT knowledge-ledger write verbs when the memory-write bundle is not selected", () => {
+    const result = evaluateDesktopToolPolicy({
+      toolName: "save_playbook",
+      selectedBundles: [],
+    });
+
+    expect(result.decision).toBe("deny");
+    expect(result.reason).toContain("Missing selected bundle");
+  });
+
   it("honors scoped allow grants without broadening other sensitive requests", () => {
     const nowMs = 1_000;
     const granted = evaluateDesktopToolPolicy({

--- a/desktop/macos/agent/tests/fixtures/tool-manifest.json
+++ b/desktop/macos/agent/tests/fixtures/tool-manifest.json
@@ -3929,7 +3929,8 @@
       "Do not infer from the rest of the chat, and do not call for a mere statement of fact, a question, or a negative request such as 'do not remember this'.",
       "Confirm the save in one line. Never tell the user about validators or internal save rules.",
       "This is a one-way non-idempotent write. Do not retry automatically after an unknown outcome; tell the user the save status is uncertain.",
-      "The backend stores this as a short-term memory candidate. Do not claim it was promoted to long-term memory."
+      "The backend stores this as a short-term memory candidate. Do not claim it was promoted to long-term memory.",
+      "For a durable fact correction ('that's no longer true'), a reusable multi-step playbook, or a standing watch request, use the knowledge-ledger tools (close_fact / save_playbook / create_standing_trigger) instead of create_memory."
     ],
     "latency": "fast network",
     "inputSchema": {
@@ -3981,7 +3982,481 @@
         "Use only when the user explicitly and affirmatively asks you to remember or save something.",
         "Pass a clean standalone fact: strip the command and lightly clean pronouns. Do not invent names, dates, or facts the user did not ask to persist, and do not infer from the rest of the chat.",
         "Do not call for a mere statement of fact, a question, or a negative request such as 'do not remember this'.",
-        "This writes short-term memory through the authorized desktop backend path; it does not promote, edit, or delete long-term memory."
+        "This writes short-term memory through the authorized desktop backend path; it does not promote, edit, or delete long-term memory.",
+        "For a durable fact correction, a reusable multi-step playbook, or a standing watch request, use the knowledge-ledger tools instead."
+      ]
+    }
+  },
+  {
+    "name": "search_knowledge",
+    "label": "Search Knowledge",
+    "description": "Search current facts, playbook handles, and trigger descriptions in the user's knowledge ledger. Use for 'what do you know about X', 'do we have a playbook for Y', or checking whether a standing trigger already exists.",
+    "promptSnippet": "search_knowledge - Search current ledger facts, playbooks, and triggers",
+    "promptGuidelines": [
+      "For a durable user fact, correction, saved playbook, or standing watch, use the knowledge-ledger tools (this one, read_playbook, save_playbook, create_standing_trigger, close_fact) rather than create_memory or a filesystem document.",
+      "Use a comma-separated kinds filter (fact, document, trigger) to narrow to one ledger kind.",
+      "For a document result, call read_playbook with its memory id to load the full body."
+    ],
+    "latency": "fast network",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Search text; matches current facts, playbook handles, and trigger descriptions."
+        },
+        "kinds": {
+          "type": "string",
+          "description": "Optional comma-separated filter: fact, document, trigger."
+        },
+        "limit": {
+          "type": "number",
+          "description": "Maximum results, 1-20 (default 8)."
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "additionalProperties": false
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "openWorldHint": false
+    },
+    "timeoutClass": "normal",
+    "executor": {
+      "kind": "swiftTool",
+      "executorName": "chatToolExecutor"
+    },
+    "intendedForAgents": true,
+    "runtimePreconditions": [
+      "Requires authenticated backend access and the desktop JIT knowledge-ledger rollout."
+    ],
+    "adapters": {
+      "pi-mono": {
+        "advertised": true,
+        "condition": "jitKnowledgeToolsEnabled"
+      },
+      "omi-tools-stdio": {
+        "advertised": true,
+        "condition": "jitKnowledgeToolsEnabled"
+      }
+    },
+    "surfaces": [
+      "desktop_chat"
+    ],
+    "capabilityDoc": {
+      "title": "Search Knowledge",
+      "summary": "Search current facts, playbook handles, and trigger descriptions in the knowledge ledger.",
+      "bullets": [
+        "Use for durable user facts, saved playbooks, and standing triggers — not short-term memory or filesystem documents.",
+        "For a document result, call read_playbook with its memory id to load the full body."
+      ]
+    }
+  },
+  {
+    "name": "read_playbook",
+    "label": "Read Playbook",
+    "description": "Load the full body of one current playbook returned by search_knowledge. Only active, non-rejected, non-locked playbooks are readable; other ids are reported unavailable.",
+    "promptSnippet": "read_playbook - Load a playbook body found via search_knowledge",
+    "promptGuidelines": [
+      "Call only after search_knowledge returns a document handle; never guess a memory id."
+    ],
+    "latency": "fast network",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "memory_id": {
+          "type": "string",
+          "description": "The playbook's memory id, from search_knowledge."
+        }
+      },
+      "required": [
+        "memory_id"
+      ],
+      "additionalProperties": false
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "openWorldHint": false
+    },
+    "timeoutClass": "normal",
+    "executor": {
+      "kind": "swiftTool",
+      "executorName": "chatToolExecutor"
+    },
+    "intendedForAgents": true,
+    "runtimePreconditions": [
+      "Requires authenticated backend access and the desktop JIT knowledge-ledger rollout."
+    ],
+    "adapters": {
+      "pi-mono": {
+        "advertised": true,
+        "condition": "jitKnowledgeToolsEnabled"
+      },
+      "omi-tools-stdio": {
+        "advertised": true,
+        "condition": "jitKnowledgeToolsEnabled"
+      }
+    },
+    "surfaces": [
+      "desktop_chat"
+    ],
+    "capabilityDoc": {
+      "title": "Read Playbook",
+      "summary": "Load the full body of one current playbook found via search_knowledge.",
+      "bullets": [
+        "Only active, non-rejected, non-locked playbooks are readable."
+      ]
+    }
+  },
+  {
+    "name": "search_historical_facts",
+    "label": "Search Historical Facts",
+    "description": "Search closed, superseded, or historical canonical facts when current knowledge is insufficient. Rejected facts are excluded by default and are audit-only negative evidence, never true user knowledge.",
+    "promptSnippet": "search_historical_facts - Search bounded historical/closed facts",
+    "promptGuidelines": [
+      "Call only after search_knowledge shows current knowledge is insufficient; do not call from historical keywords alone.",
+      "Facts marked rejected are audit-only negative evidence; request include_rejected only for an explicit audit and never treat those rows as true."
+    ],
+    "latency": "fast network",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Search text; matches exact lexical tokens in historical fact content."
+        },
+        "limit": {
+          "type": "number",
+          "description": "Maximum results, 1-20 (default 8)."
+        },
+        "offset": {
+          "type": "number",
+          "description": "Pagination offset for a repeated call (default 0)."
+        },
+        "include_rejected": {
+          "type": "boolean",
+          "description": "Include rejected facts for explicit audit only; never treat them as true (default false)."
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "additionalProperties": false
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "openWorldHint": false
+    },
+    "timeoutClass": "normal",
+    "executor": {
+      "kind": "swiftTool",
+      "executorName": "chatToolExecutor"
+    },
+    "intendedForAgents": true,
+    "runtimePreconditions": [
+      "Requires authenticated backend access and the desktop JIT knowledge-ledger rollout."
+    ],
+    "adapters": {
+      "pi-mono": {
+        "advertised": true,
+        "condition": "jitKnowledgeToolsEnabled"
+      },
+      "omi-tools-stdio": {
+        "advertised": true,
+        "condition": "jitKnowledgeToolsEnabled"
+      }
+    },
+    "surfaces": [
+      "desktop_chat"
+    ],
+    "capabilityDoc": {
+      "title": "Search Historical Facts",
+      "summary": "Search closed, superseded, or historical canonical facts when current knowledge is insufficient.",
+      "bullets": [
+        "Rejected facts are audit-only negative evidence and must never be treated as true user knowledge."
+      ]
+    }
+  },
+  {
+    "name": "get_entity_timeline_tool",
+    "label": "Get Entity Timeline",
+    "description": "Read a bounded multi-source timeline (ledger, conversations, calendar, screen) for one canonical entity such as 'user'/'me' or 'person:<stable_person_id>'.",
+    "promptSnippet": "get_entity_timeline_tool - Read a bounded multi-source timeline for one entity",
+    "promptGuidelines": [
+      "Set include_history only when current knowledge is insufficient and closed/superseded/rejected ledger facts are actually needed.",
+      "The response never includes transcripts, OCR text, alias emails, playbook bodies, or trigger conditions."
+    ],
+    "latency": "fast network",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "entity": {
+          "type": "string",
+          "description": "'user'/'me', or a stable reference such as 'person:<stable_person_id>' or 'project:<name>'."
+        },
+        "sources": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional subset of: ledger, conversations, calendar, screen."
+        },
+        "include_history": {
+          "type": "boolean",
+          "description": "Include closed, superseded, or historical ledger facts (default false)."
+        },
+        "include_rejected": {
+          "type": "boolean",
+          "description": "Include rejected facts for audit only; requires include_history (default false)."
+        },
+        "limit": {
+          "type": "number",
+          "description": "Maximum timeline entries (default 20)."
+        },
+        "start_date": {
+          "type": "string",
+          "description": "Optional ISO-8601 start date bound."
+        },
+        "end_date": {
+          "type": "string",
+          "description": "Optional ISO-8601 end date bound."
+        }
+      },
+      "required": [
+        "entity"
+      ],
+      "additionalProperties": false
+    },
+    "annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false,
+      "openWorldHint": false
+    },
+    "timeoutClass": "normal",
+    "executor": {
+      "kind": "swiftTool",
+      "executorName": "chatToolExecutor"
+    },
+    "intendedForAgents": true,
+    "runtimePreconditions": [
+      "Requires authenticated backend access and the desktop JIT knowledge-ledger rollout."
+    ],
+    "adapters": {
+      "pi-mono": {
+        "advertised": true,
+        "condition": "jitKnowledgeToolsEnabled"
+      },
+      "omi-tools-stdio": {
+        "advertised": true,
+        "condition": "jitKnowledgeToolsEnabled"
+      }
+    },
+    "surfaces": [
+      "desktop_chat"
+    ],
+    "capabilityDoc": {
+      "title": "Get Entity Timeline",
+      "summary": "Read a bounded multi-source timeline for one canonical entity.",
+      "bullets": [
+        "Never exposes transcripts, OCR text, alias emails, playbook bodies, or trigger conditions."
+      ]
+    }
+  },
+  {
+    "name": "save_playbook",
+    "label": "Save Playbook",
+    "description": "Save a reusable step-by-step playbook for a recurring, multi-step workflow the user repeats, so it can be recalled verbatim next time.",
+    "promptSnippet": "save_playbook - Save a reusable step-by-step playbook to the knowledge ledger",
+    "promptGuidelines": [
+      "Call this — not a filesystem document and not create_memory — whenever the user asks to save a playbook, checklist, or repeatable procedure.",
+      "Call only after you have actually reconstructed the multi-step workflow end to end; do not call for a one-off task or a simple fact or preference."
+    ],
+    "latency": "fast network",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Short single-line handle for this playbook, e.g. 'Cut a release candidate' (at most 360 characters)."
+        },
+        "body": {
+          "type": "string",
+          "description": "Full step-by-step playbook content (at most 24,000 characters)."
+        }
+      },
+      "required": [
+        "description",
+        "body"
+      ],
+      "additionalProperties": false
+    },
+    "annotations": {
+      "readOnlyHint": false,
+      "destructiveHint": false,
+      "openWorldHint": false
+    },
+    "timeoutClass": "normal",
+    "executor": {
+      "kind": "swiftTool",
+      "executorName": "chatToolExecutor"
+    },
+    "intendedForAgents": true,
+    "runtimePreconditions": [
+      "Requires authenticated backend access and the desktop JIT knowledge-ledger rollout."
+    ],
+    "adapters": {
+      "pi-mono": {
+        "advertised": true,
+        "condition": "jitKnowledgeToolsEnabled"
+      },
+      "omi-tools-stdio": {
+        "advertised": true,
+        "condition": "jitKnowledgeToolsEnabled"
+      }
+    },
+    "surfaces": [
+      "desktop_chat"
+    ],
+    "capabilityDoc": {
+      "title": "Save Playbook",
+      "summary": "Save a reusable step-by-step playbook for a recurring, multi-step workflow.",
+      "bullets": [
+        "Use when the user asks to save a playbook, checklist, or repeatable procedure — never write it to the filesystem instead.",
+        "Call only after the multi-step workflow has actually been reconstructed end to end."
+      ]
+    }
+  },
+  {
+    "name": "create_standing_trigger",
+    "label": "Create Standing Trigger",
+    "description": "Create a standing watch that notifies the user when a described condition recurs, using deterministic keyword/app/window/time/calendar selectors.",
+    "promptSnippet": "create_standing_trigger - Create a standing watch for a described condition",
+    "promptGuidelines": [
+      "Call this for an explicit standing-intent request such as 'watch for X and tell me' or 'let me know whenever Y happens'.",
+      "Never call it from a pattern you merely noticed in passive behavior; an inferred habit is not standing intent.",
+      "Embedding/semantic selectors are not supported; use keywords, regex, apps, windows, time, or calendar selectors instead."
+    ],
+    "latency": "fast network",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "What to tell the user when this trigger fires, in your own words (at most 2000 characters)."
+        },
+        "condition": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true,
+          "description": "Deterministic selector payload: match_mode, entity_aliases, keywords, regex, apps, windows, time, calendar."
+        }
+      },
+      "required": [
+        "description",
+        "condition"
+      ],
+      "additionalProperties": false
+    },
+    "annotations": {
+      "readOnlyHint": false,
+      "destructiveHint": false,
+      "openWorldHint": false
+    },
+    "timeoutClass": "normal",
+    "executor": {
+      "kind": "swiftTool",
+      "executorName": "chatToolExecutor"
+    },
+    "intendedForAgents": true,
+    "runtimePreconditions": [
+      "Requires authenticated backend access and the desktop JIT knowledge-ledger rollout."
+    ],
+    "adapters": {
+      "pi-mono": {
+        "advertised": true,
+        "condition": "jitKnowledgeToolsEnabled"
+      },
+      "omi-tools-stdio": {
+        "advertised": true,
+        "condition": "jitKnowledgeToolsEnabled"
+      }
+    },
+    "surfaces": [
+      "desktop_chat"
+    ],
+    "capabilityDoc": {
+      "title": "Create Standing Trigger",
+      "summary": "Create a standing watch that notifies the user when a described condition recurs.",
+      "bullets": [
+        "Only from explicit standing intent the user stated in this conversation, never an inferred habit."
+      ]
+    }
+  },
+  {
+    "name": "close_fact",
+    "label": "Close Fact",
+    "description": "Close a current ledger fact that is no longer true, with no replacement fact.",
+    "promptSnippet": "close_fact - Close a current fact that no longer holds",
+    "promptGuidelines": [
+      "Call this for 'that's no longer true' when nothing should replace the closed fact.",
+      "If something replaces it, that is an update: save the new fact instead so the ledger supersedes the old one, and do not call close_fact."
+    ],
+    "latency": "fast network",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "memory_id": {
+          "type": "string",
+          "description": "The current ledger fact's memory id, e.g. from search_knowledge."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Short explanation of why the fact no longer holds (kept for audit, at most 500 characters)."
+        }
+      },
+      "required": [
+        "memory_id",
+        "reason"
+      ],
+      "additionalProperties": false
+    },
+    "annotations": {
+      "readOnlyHint": false,
+      "destructiveHint": false,
+      "openWorldHint": false
+    },
+    "timeoutClass": "normal",
+    "executor": {
+      "kind": "swiftTool",
+      "executorName": "chatToolExecutor"
+    },
+    "intendedForAgents": true,
+    "runtimePreconditions": [
+      "Requires authenticated backend access and the desktop JIT knowledge-ledger rollout."
+    ],
+    "adapters": {
+      "pi-mono": {
+        "advertised": true,
+        "condition": "jitKnowledgeToolsEnabled"
+      },
+      "omi-tools-stdio": {
+        "advertised": true,
+        "condition": "jitKnowledgeToolsEnabled"
+      }
+    },
+    "surfaces": [
+      "desktop_chat"
+    ],
+    "capabilityDoc": {
+      "title": "Close Fact",
+      "summary": "Close a current ledger fact that is no longer true, with no replacement.",
+      "bullets": [
+        "If a new fact replaces it, save the new fact instead so the ledger supersedes the old one."
       ]
     }
   },

--- a/desktop/macos/agent/tests/jsonl-transport.test.ts
+++ b/desktop/macos/agent/tests/jsonl-transport.test.ts
@@ -972,4 +972,33 @@ describe("JsonlTransport kernel-owned query contract", () => {
     expect(adapter.executed).toHaveLength(2);
     store.close();
   });
+
+  it("relays the per-turn JIT knowledge-ledger gate into the MCP build context and run metadata", async () => {
+    let capturedContext: Record<string, unknown> | undefined;
+    const buildMcpServers: McpServerBuilder = (_mode, _cwd, _sessionKey, context) => {
+      capturedContext = context as unknown as Record<string, unknown>;
+      return [];
+    };
+    const { store, session, transport } = fixture(buildMcpServers);
+
+    await transport.handleQuery(query(session.sessionId, {
+      requestId: "jit-on",
+      jitKnowledgeToolsEnabled: true,
+    }));
+    expect(capturedContext?.jitKnowledgeToolsEnabled).toBe(true);
+    const onMetadata = JSON.parse(String(store.getRow(
+      "SELECT input_json FROM runs WHERE request_id = ?",
+      ["jit-on"],
+    ).input_json)).metadata;
+    expect(onMetadata.jitKnowledgeToolsEnabled).toBe(true);
+
+    await transport.handleQuery(query(session.sessionId, { requestId: "jit-off" }));
+    expect(capturedContext?.jitKnowledgeToolsEnabled).toBe(false);
+    const offMetadata = JSON.parse(String(store.getRow(
+      "SELECT input_json FROM runs WHERE request_id = ?",
+      ["jit-off"],
+    ).input_json)).metadata;
+    expect(offMetadata.jitKnowledgeToolsEnabled).toBeUndefined();
+    store.close();
+  });
 });

--- a/desktop/macos/agent/tests/omi-tool-manifest.test.ts
+++ b/desktop/macos/agent/tests/omi-tool-manifest.test.ts
@@ -355,6 +355,96 @@ describe("omi tool manifest", () => {
     expect(snapshot.disabled.some((tool) => tool.name === "get_email_insights")).toBe(true);
   });
 
+  describe("JIT knowledge-ledger tools", () => {
+    const READ_TOOLS = ["search_knowledge", "read_playbook", "search_historical_facts", "get_entity_timeline_tool"];
+    const WRITE_TOOLS = ["save_playbook", "create_standing_trigger", "close_fact"];
+    const ALL_LEDGER_TOOLS = [...READ_TOOLS, ...WRITE_TOOLS];
+
+    it("are hidden from every adapter by default (fail closed)", () => {
+      for (const adapterId of ["pi-mono", "omi-tools-stdio"] as const) {
+        const names = toolNamesForAdapter(adapterId);
+        for (const toolName of ALL_LEDGER_TOOLS) {
+          expect(names, `${adapterId} should not advertise ${toolName} by default`).not.toContain(toolName);
+        }
+      }
+      // Explicitly false, and every other context flag on, is still hidden.
+      const names = toolNamesForAdapter("pi-mono", {
+        jitKnowledgeToolsEnabled: false,
+        onboarding: true,
+        screenContext: true,
+      });
+      for (const toolName of ALL_LEDGER_TOOLS) {
+        expect(names).not.toContain(toolName);
+      }
+    });
+
+    it("are advertised to pi-mono and omi-tools-stdio once the JIT rollout gate is on", () => {
+      for (const adapterId of ["pi-mono", "omi-tools-stdio"] as const) {
+        const names = toolNamesForAdapter(adapterId, { jitKnowledgeToolsEnabled: true });
+        for (const toolName of ALL_LEDGER_TOOLS) {
+          expect(names, `${adapterId} should advertise ${toolName} when gated on`).toContain(toolName);
+        }
+      }
+    });
+
+    it("declares a swiftTool/chatToolExecutor dispatch for every ledger tool", () => {
+      for (const toolName of ALL_LEDGER_TOOLS) {
+        const tool = omiToolManifest.find((entry) => entry.name === toolName);
+        expect(tool, `${toolName} manifest entry`).toBeTruthy();
+        expect(tool?.executor).toEqual({ kind: "swiftTool", executorName: "chatToolExecutor" });
+        expect(tool?.surfaces).toEqual(["desktop_chat"]);
+        expect(tool?.latency).toBe("fast network");
+        expect(tool?.intendedForAgents).toBe(true);
+      }
+    });
+
+    it("marks the four read tools read-only and the three write verbs as writes", () => {
+      for (const toolName of READ_TOOLS) {
+        const tool = omiToolManifest.find((entry) => entry.name === toolName);
+        expect(tool?.annotations.readOnlyHint, `${toolName} readOnlyHint`).toBe(true);
+      }
+      for (const toolName of WRITE_TOOLS) {
+        const tool = omiToolManifest.find((entry) => entry.name === toolName);
+        expect(tool?.annotations.readOnlyHint, `${toolName} readOnlyHint`).toBe(false);
+      }
+    });
+
+    it("keeps faithful, minimal input schemas matching the backend tool contracts", () => {
+      const enabled = toolsForAdapter("pi-mono", { jitKnowledgeToolsEnabled: true });
+      const byName = Object.fromEntries(enabled.map((tool) => [tool.name, tool]));
+
+      expect(byName.search_knowledge.inputSchema.required).toEqual(["query"]);
+      expect(byName.search_knowledge.inputSchema.properties).toHaveProperty("kinds");
+      expect(byName.search_knowledge.inputSchema.properties).toHaveProperty("limit");
+
+      expect(byName.read_playbook.inputSchema.required).toEqual(["memory_id"]);
+
+      expect(byName.search_historical_facts.inputSchema.required).toEqual(["query"]);
+      expect(byName.search_historical_facts.inputSchema.properties).toHaveProperty("include_rejected");
+
+      expect(byName.get_entity_timeline_tool.inputSchema.required).toEqual(["entity"]);
+      expect(byName.get_entity_timeline_tool.inputSchema.properties).toHaveProperty("sources");
+
+      expect(byName.save_playbook.inputSchema.required).toEqual(["description", "body"]);
+      expect(byName.create_standing_trigger.inputSchema.required).toEqual(["description", "condition"]);
+      expect(byName.close_fact.inputSchema.required).toEqual(["memory_id", "reason"]);
+    });
+
+    it("steers durable facts, playbooks, standing intent, and closures away from generic tools", () => {
+      const createMemory = omiToolManifest.find((entry) => entry.name === "create_memory");
+      const searchKnowledge = omiToolManifest.find((entry) => entry.name === "search_knowledge");
+      const savePlaybook = omiToolManifest.find((entry) => entry.name === "save_playbook");
+      const createStandingTrigger = omiToolManifest.find((entry) => entry.name === "create_standing_trigger");
+      const closeFact = omiToolManifest.find((entry) => entry.name === "close_fact");
+
+      expect(createMemory?.promptGuidelines?.join("\n")).toContain("knowledge-ledger tools");
+      expect(searchKnowledge?.promptGuidelines?.join("\n")).toContain("rather than create_memory or a filesystem document");
+      expect(savePlaybook?.promptGuidelines?.join("\n")).toContain("not a filesystem document and not create_memory");
+      expect(createStandingTrigger?.promptGuidelines?.join("\n")).toContain("explicit standing-intent request");
+      expect(closeFact?.promptGuidelines?.join("\n")).toContain("nothing should replace the closed fact");
+    });
+  });
+
   it("requires surfaces and capabilityDoc on every manifest entry", () => {
     // spawn_background_agent is the coordinator-RPC-only entrypoint and is
     // deliberately advertised on no agent-facing surface (see sibling test).

--- a/desktop/macos/agent/tests/run-tool-capability.test.ts
+++ b/desktop/macos/agent/tests/run-tool-capability.test.ts
@@ -877,3 +877,73 @@ describe("RunToolCapabilityBroker spawn-time tool policy", () => {
     }
   });
 });
+
+describe("RunToolCapabilityBroker JIT knowledge-ledger gate", () => {
+  const LEDGER_TOOLS = [
+    "search_knowledge",
+    "read_playbook",
+    "search_historical_facts",
+    "get_entity_timeline_tool",
+    "save_playbook",
+    "create_standing_trigger",
+    "close_fact",
+  ];
+
+  it("keeps the ledger tools out of the authorized allowlist by default", () => {
+    const { store, session, run, attempt } = fixture("coordinator");
+    const broker = createBroker(store);
+    const capability = broker.register({
+      ownerId: session.ownerId,
+      sessionId: session.sessionId,
+      runId: run.runId,
+      attemptId: attempt.attemptId,
+    });
+
+    for (const toolName of LEDGER_TOOLS) {
+      expect(capability.allowedToolNames, toolName).not.toContain(toolName);
+    }
+    expectCode(
+      () => broker.authorize({
+        capabilityRef: capability.capabilityRef,
+        invocationId: "ledger-gate-off-1",
+        runId: run.runId,
+        attemptId: attempt.attemptId,
+        activeOwnerId: session.ownerId,
+        toolName: "search_knowledge",
+        toolInput: { query: "release checklist" },
+      }),
+      "tool_not_allowed",
+    );
+    store.close();
+  });
+
+  it("authorizes the ledger tools once the run's admitted metadata carries the JIT gate", () => {
+    const { store, session, run, attempt } = fixture("coordinator");
+    store.execute("UPDATE runs SET input_json = ? WHERE run_id = ?", [
+      JSON.stringify({ prompt: "save a playbook", metadata: { jitKnowledgeToolsEnabled: true } }),
+      run.runId,
+    ]);
+    const broker = createBroker(store);
+    const capability = broker.register({
+      ownerId: session.ownerId,
+      sessionId: session.sessionId,
+      runId: run.runId,
+      attemptId: attempt.attemptId,
+    });
+
+    for (const toolName of LEDGER_TOOLS) {
+      expect(capability.allowedToolNames, toolName).toContain(toolName);
+    }
+    const authorized = broker.authorize({
+      capabilityRef: capability.capabilityRef,
+      invocationId: "ledger-gate-on-1",
+      runId: run.runId,
+      attemptId: attempt.attemptId,
+      activeOwnerId: session.ownerId,
+      toolName: "search_knowledge",
+      toolInput: { query: "release checklist" },
+    });
+    expect(authorized.canonicalToolName).toBe("search_knowledge");
+    store.close();
+  });
+});

--- a/desktop/macos/changelog/unreleased/20260829-jit-knowledge-ledger-tool-bridge.json
+++ b/desktop/macos/changelog/unreleased/20260829-jit-knowledge-ledger-tool-bridge.json
@@ -1,0 +1,3 @@
+{
+  "change": "Chat can now save playbooks, standing watches, and durable facts to your knowledge ledger"
+}

--- a/desktop/macos/e2e/flows/chat-first-cohesive.yaml
+++ b/desktop/macos/e2e/flows/chat-first-cohesive.yaml
@@ -17,6 +17,7 @@ covers:
   - desktop/macos/agent/src/runtime/kernel-core.ts
   - desktop/macos/agent/src/index.ts
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+  - desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess+JITKnowledgeToolsGate.swift
   # S1a's authorized executor result is projected through this store before
   # the fixture card becomes visible at S1b.
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeStatusStore.swift

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -59,6 +59,7 @@ covers:
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeJournalContracts.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeMessageKind.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess+BackendRouting.swift
+  - desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess+JITKnowledgeToolsGate.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimeBridgeLifecycle.swift
 preconditions:


### PR DESCRIPTION
## Why

Verified live on 2026-08-29: a desktop request to save a playbook was routed to a
background agent that wrote the playbook to the filesystem, because the desktop
agent's tool registry (`desktop/macos/agent/src/runtime/omi-tool-manifest.ts` +
`desktop-tool-policy.ts`) has no verbs for the backend's JIT-gated knowledge
ledger. The backend already serves these tools via `GET /v1/agent/tools` and
`POST /v1/agent/execute-tool` (`backend/routers/agent_tools.py`), gated per-uid
by `resolve_jit_rollout` (`backend/utils/retrieval/agentic.py` /
`JIT_ONLY_TOOL_NAMES`), and the generated Swift client
(`OmiApi.generated.swift`) already has the endpoints — nothing called them yet.

This PR bridges the seven tools into the desktop runtime so "save a playbook",
"watch for X", and "that's no longer true" route to the ledger instead of a
generic filesystem/task path.

## The seven tools

- Read (allowed, no approval): `search_knowledge`, `read_playbook`,
  `search_historical_facts`, `get_entity_timeline_tool`
- Write (requires user approval): `save_playbook`, `create_standing_trigger`,
  `close_fact`

Schemas and descriptions are drawn from
`backend/utils/retrieval/tools/knowledge_ledger_tools.py` and
`knowledge_ledger_write_tools.py`, condensed for desktop use. Manifest prompt
guidance steers durable facts/corrections, playbook saves, standing-watch
requests, and fact closures to the ledger tools instead of `create_memory` or
a filesystem document (added cross-link bullets on `create_memory` and
`search_knowledge`).

## Dispatch

Mirrors the existing backend-RAG tools' pattern exactly — `swiftTool` /
`chatToolExecutor` in the manifest, dispatched through
`ChatToolExecutor.executeUnchecked`. Unlike `get_conversations` /
`search_memories` / etc., these seven have no bespoke typed `/v1/tools/*`
route on the backend — they share one generic contract,
`POST /v1/agent/execute-tool` with `{tool_name, params}`. So instead of seven
typed wrappers, `ChatToolExecutor.executeAgentLedgerTool` calls one new
generic `APIClient.executeAgentTool` (`APIClient+Tools.swift`), which reuses
the app's existing owner-bound `post(...)` transport (auth headers, owner
checks) against the endpoint the generated client already exposes.

**Spec deviation, flagged as requested:** the task description says the
backend contract is `{tool_name, arguments}`. The actual backend Pydantic
model (`ExecuteToolRequest` in `agent_tools.py`) is `{tool_name, params}`. I
implemented against the real backend contract (`params`), not the prompt's
paraphrase.

## Gating

Client gating is UX only — `backend/routers/agent_tools.py` independently
re-checks `resolve_jit_rollout` on every `execute-tool` call and 404s an
ungated tool regardless of what the client advertised.

The TS runtime has **no existing access** to the JIT rollout decision
(`JITProactivityFlags` / `JITProactivityRuntime` live entirely on the Swift
side, e.g. `ProactiveAssistants/Core/JITProactivityRuntime.swift`; nothing in
`desktop/macos/agent/src` references it). Per the task's fallback instruction,
I added a new manifest capability flag, `jitKnowledgeToolsEnabled`, plumbed
through the runtime the same way the existing `screenContext` /
`onboardingOnly` conditions are:

- `QueryMessage.jitKnowledgeToolsEnabled` (new optional per-turn field,
  `protocol.ts`)
- → `McpServerBuildContext.jitKnowledgeToolsEnabled` (`jsonl-transport.ts`),
  and into run metadata (`metadata.jitKnowledgeToolsEnabled`), mirroring the
  existing `reasoningEffort` field exactly
- → `OMI_JIT_KNOWLEDGE_TOOLS_ENABLED` env var into the `omi-tools` MCP
  subprocess (`index.ts` → `omi-tools-stdio.ts`), mirroring
  `OMI_SCREEN_CONTEXT`
- → `RunToolCapabilityBroker`'s persisted-run projection context
  (`run-tool-capability.ts`), so the authorized-invocation allowlist doesn't
  diverge from what's advertised
- → new `jitKnowledgeToolsEnabled` condition in
  `isToolAvailableForContext` (`omi-tool-manifest.ts`), applied to all seven
  tools via `piAndStdio("jitKnowledgeToolsEnabled")`

**Swift now actually populates this flag, so the gate is live, not inert.**
`AgentRuntimeProcess.query(...)` (`Chat/AgentRuntimeProcess.swift`) already
receives the caller's `RuntimeOwnerAuthorizationSnapshot` on every query. It
now awaits `ProactiveLaneClient.shared.jitProactivityFlags(authorizationSnapshot:)`
— the exact same client-observable rollout signal `JITProactivityRuntime`
already reads for the ambient/planned proactive lanes (`GET
/v1/jit/rollout-decision`, server-cached 15s–15min per the response's own
`cache_ttl_seconds`, so this is a cache hit on every query except the first
after login/TTL expiry) — before building the wire message, and sets
`jitKnowledgeToolsEnabled` from a new pure helper in a new extension file,
`Chat/AgentRuntimeProcess+JITKnowledgeToolsGate.swift`
(`AgentRuntimeProcess.jitKnowledgeToolsEnabled(from:)`; the gate logic lives
in its own file rather than the base `AgentRuntimeProcess.swift` specifically
to respect that file's `desktop-agent-runtime-convergence-ratchet` line cap,
mirroring the existing `AgentRuntimeProcess+BackendRouting.swift` /
`+ChatFirstJournal.swift` extraction convention):

```swift
static func jitKnowledgeToolsEnabled(from flags: JITProactivityFlags) -> Bool {
  flags.effective == .enabled
}
```

This admits only the server's own `effective == .enabled` verdict — the same
authority `JITProactivityFlags.permitsNewLane` treats as owning admission,
never re-derived from the raw `rollout`/`kill_switch` pair. Any transport,
decode, or owner-authorization-race failure inside `jitProactivityFlags`
already resolves to `.effective == .unknown` (fail-closed), which this helper
maps to `false`. `queryWireMessage` only emits the wire key when true
(`if jitKnowledgeToolsEnabled { message["jitKnowledgeToolsEnabled"] = true }`),
matching how the TS side already treats an absent field as `false`.

Net effect: an enrolled account (server `effective: "enabled"`) now actually
sees and can use the seven tools in chat; everyone else — disabled, unknown,
or any error — sees the pre-existing behavior, unchanged.

## Policy

- Reads added to `LOCAL_READ_TOOLS` → `desktop.context.local_read` bundle,
  `approvalPolicy: "allow"` (matches `get_conversations` / `search_memories`
  convention for authenticated backend reads).
- The three write verbs mutate the same backend memory/knowledge-ledger
  store as `create_memory`, so they share its `desktop.memories.write`
  bundle (new `LEDGER_WRITE_TOOLS` set) rather than inventing a new bundle.
  `approvalPolicy` is derived automatically from the `localWrite` annotation
  → `"user_approval"`, matching the existing write/sensitive convention.

## Tests

`desktop/macos/agent/tests/`:
- `omi-tool-manifest.test.ts` — manifest entry validity (executor, surfaces,
  latency, read/write annotations), schema shape per backend contract,
  fail-closed-by-default gating, gating-on advertising, prompt-guidance
  cross-links.
- `desktop-tool-policy.test.ts` — reads decision `allow`, writes decision
  `dispatch_required`/`user_approval` (same as `create_memory`), denial when
  the memory-write bundle isn't selected.
- `jsonl-transport.test.ts` — the per-turn `jitKnowledgeToolsEnabled` flag
  reaches both the MCP-build context and persisted run metadata correctly on
  and off.
- `run-tool-capability.test.ts` — the authorized-invocation allowlist
  excludes the ledger tools by default and includes them (and authorizes a
  `search_knowledge` call) once the run's admitted metadata carries the gate.
- Regenerated `tests/fixtures/tool-manifest.json` via
  `scripts/generate-tool-surfaces.mjs` (also regenerates the two touched
  generated Swift files, `GeneratedToolCapabilities.swift` /
  `GeneratedToolExecutors.swift`).

`desktop/macos/Desktop/Tests/KernelContractWireTests.swift`:
- `testQueryWireOmitsJitKnowledgeToolsFlagByDefaultAndCarriesItOnlyWhenTrue` —
  the wire key is absent by default and when explicitly `false`, present
  (`true`) only when the gate is on.
- `testJitKnowledgeToolsGateAdmitsOnlyTheServersEnabledVerdictAndFailsClosedOtherwise`
  — `jitKnowledgeToolsEnabled(from:)` is `true` only for
  `effective == .enabled`; `false` for an explicit `effective == .disabled`
  (even with a permissive raw rollout/kill-switch pair), for
  `effective == .unknown` (the fail-closed shape of any transport/decode/
  owner-race error), and for the older-server-compatibility default where
  `effective` is omitted entirely.

The `effective`-verdict derivation itself (`enabled`/`disabled`/`unknown` from
the raw HTTP response, TTL caching, fail-closed on error) was already covered
by the pre-existing `ProactiveLaneClientTests.swift` (24 tests, unchanged,
still green) — this PR adds the new mapping from that verdict into the query
wire message on top of it.

### Verbatim results

`npm run build` (tsc): clean, no errors.

`npm test` (vitest): **707 passed, 0 failed** (59 test files) — up from 695
passed before this change (12 new tests added).

`node --experimental-strip-types scripts/generate-tool-surfaces.mjs --check`:
`generate-tool-surfaces: all outputs match (--check)`

`xcrun swift build -c debug --package-path Desktop`: `Build complete!`
(both the initial dispatch-layer build and the follow-up gating-wiring build
succeeded; only a pre-existing unrelated libwebp linker version warning).

`./scripts/dev-feedback.py --once swift 'ChatToolExecutor'`: **44 tests, 0
failures**.

`./scripts/dev-feedback.py --once swift 'AgentRuntimeProcessTests'`: **71
tests, 0 failures**.

`./scripts/dev-feedback.py --once swift 'KernelContractWireTests'`: **17
tests, 0 failures** (15 pre-existing + 2 new).

`./scripts/dev-feedback.py --once swift 'ProactiveLaneClientTests'`: **24
tests, 0 failures** (unchanged — confirms the gating wiring didn't disturb the
existing rollout-decision coverage).

`./scripts/agent-logic-harness.sh --cross-surface-smoke`: **Harness passed**
on both rounds.

`./scripts/swiftlint-wrapper.sh lint` (full repo scope, includes every
touched file): **0 violations, 0 serious**.

`./scripts/swift-format-wrapper.sh lint` on every hand-edited Swift file:
clean (exit 0).

## Product invariants affected

- INV-AGENT-*
- INV-CHAT-1

Both are cited because this PR touches `desktop/macos/agent/src/runtime/**`
and `ChatToolExecutor.swift`. No violation: the seven new tools are ordinary
authenticated backend RAG-style dispatch (same shape as `get_conversations` /
`search_memories`), gated through the existing capability/allowlist and
approval-policy machinery rather than a new authority path; they do not touch
session/run/attempt identity, execution-role authorization, or the kernel
transcript store.

## Line-count exceptions

Line-Count-Exception: desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift | 3457 -> 3497 | Adds one generic dispatch case (7 enum cases routed to one function) plus the `executeAgentLedgerTool` passthrough for the 7 new JIT knowledge-ledger tools, mirroring the existing `executeBackendTool` pattern in the same file; this is the file every other backend-tool dispatch case already lives in, so splitting it is a separate refactor out of scope for this bridge PR.

Line-Count-Exception: desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift | 4376 -> 4387 | Adds a one-line call into the new AgentRuntimeProcess+JITKnowledgeToolsGate.swift extension (gate logic lives there to respect this file's own convergence-ratchet cap) plus one new parameter on the existing queryWireMessage builder, the single call site that already sends every other query field.

## Not ready for merge

Draft PR — gating is now live end-to-end (see above), but this stays a draft
per the task's instructions pending human review before marking ready.
