### PR TITLE
fix(desktop): simplify onboarding permission guidance

### DIFF
--- a/desktop/macos/Desktop/Sources/CloudConnectorGuidanceOverlay.swift
+++ b/desktop/macos/Desktop/Sources/CloudConnectorGuidanceOverlay.swift
@@ -609,6 +609,10 @@ final class CloudConnectorGuidanceOverlay {
     window
   }
 
+  var isDragToGrantCardVisible: Bool {
+    window?.isVisible == true && lastAutomationState?["kind"] == "dragToGrant"
+  }
+
   func automationState() -> [String: String] {
     var state = lastAutomationState ?? [:]
     state["visible"] = window?.isVisible == true ? "true" : "false"

--- a/desktop/macos/Desktop/Sources/CloudConnectorGuidanceOverlay.swift
+++ b/desktop/macos/Desktop/Sources/CloudConnectorGuidanceOverlay.swift
@@ -970,6 +970,12 @@ private struct ScreenRecordingDragCardView: View {
     let amount: CGFloat = hintUp ? 6 : 0
     return CGSize(width: direction.vector.width * amount, height: direction.vector.height * amount)
   }
+  private var iconGlowOpacity: Double {
+    reduceMotion ? 0.42 : (hintUp ? 0.54 : 0.34)
+  }
+  private var iconGlowScale: CGFloat {
+    reduceMotion ? 1.08 : (hintUp ? 1.18 : 1.04)
+  }
 
   var body: some View {
     ZStack {
@@ -986,12 +992,27 @@ private struct ScreenRecordingDragCardView: View {
           .foregroundColor(Ink.secondary.opacity(hintUp ? 1 : 0.6))
           .offset(hintOffset)
 
-        AppBundleDragSource(icon: appIcon, appURL: appURL, targetState: targetState)
-          .frame(width: 64, height: 64)
-          .shadow(color: Color.black.opacity(0.58), radius: 12, y: 5)
-          .offset(iconHintOffset)
-          .help(CloudConnectorGuidanceOverlay.dragInstructionAccessibilityText(appName: appName))
-          .accessibilityLabel(CloudConnectorGuidanceOverlay.dragInstructionAccessibilityText(appName: appName))
+        ZStack {
+          RoundedRectangle(cornerRadius: 18, style: .continuous)
+            .fill(Ink.listeningGreen.opacity(iconGlowOpacity))
+            .frame(width: 72, height: 72)
+            .scaleEffect(iconGlowScale)
+            .blur(radius: 11)
+
+          RoundedRectangle(cornerRadius: 16, style: .continuous)
+            .stroke(Ink.listeningGreen.opacity(hintUp ? 0.92 : 0.68), lineWidth: 2)
+            .frame(width: 70, height: 70)
+            .blur(radius: 1.5)
+
+          AppBundleDragSource(icon: appIcon, appURL: appURL, targetState: targetState)
+            .frame(width: 64, height: 64)
+            .shadow(color: Color.white.opacity(hintUp ? 0.38 : 0.22), radius: 5)
+            .shadow(color: Color.black.opacity(0.58), radius: 12, y: 5)
+        }
+        .frame(width: 80, height: 80)
+        .offset(iconHintOffset)
+        .help(CloudConnectorGuidanceOverlay.dragInstructionAccessibilityText(appName: appName))
+        .accessibilityLabel(CloudConnectorGuidanceOverlay.dragInstructionAccessibilityText(appName: appName))
 
         // On the glass, not on whatever is behind it. This copy floats over the *System Settings*
         // window, whose appearance this app does not control, so a bare run of ink plus a drop

--- a/desktop/macos/Desktop/Sources/CloudConnectorGuidanceOverlay.swift
+++ b/desktop/macos/Desktop/Sources/CloudConnectorGuidanceOverlay.swift
@@ -411,7 +411,7 @@ final class CloudConnectorGuidanceOverlay {
   }
 
   static func dragInstructionAccessibilityText(appName: String) -> String {
-    "Press and drag \(appName) into the Screen & System Audio Recording app list, then release"
+    "Press and drag \(appName) into the privacy permission app list, then release"
   }
 
   static func dragToGrantAutomationState(
@@ -988,8 +988,15 @@ private struct ScreenRecordingDragCardView: View {
 
       VStack(spacing: 7) {
         Image(systemName: direction.systemImage)
-          .scaledFont(size: 14, weight: .bold)
-          .foregroundColor(Ink.secondary.opacity(hintUp ? 1 : 0.6))
+          .scaledFont(size: 15, weight: .black)
+          .foregroundStyle(Color.white)
+          .padding(7)
+          .background(Circle().fill(Color.black.opacity(hintUp ? 0.9 : 0.78)))
+          .overlay(
+            Circle()
+              .stroke(Color.white.opacity(hintUp ? 0.95 : 0.78), lineWidth: 1.5)
+          )
+          .shadow(color: Color.black.opacity(0.65), radius: 4, y: 2)
           .offset(hintOffset)
 
         ZStack {

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
@@ -1573,13 +1573,7 @@ struct OnboardingChatView: View {
 
   private func bringToFront() {
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-      NSApp.activate()
-      for window in NSApp.windows {
-        if window.title.hasPrefix("Omi") {
-          window.makeKeyAndOrderFront(nil)
-          window.orderFrontRegardless()
-        }
-      }
+      PermissionDragGuidance.returnToOmi()
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
@@ -558,7 +558,7 @@ struct OnboardingChatView: View {
     guard let urlString, let url = URL(string: urlString) else { return }
     NSWorkspace.shared.open(url)
     if type == "full_disk_access" {
-      Task { await PermissionDragGuidance.presentDragToGrantHelper() }
+      Task { await PermissionDragGuidance.presentDragToGrantHelper(for: .fullDiskAccess) }
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/PermissionDragGuidance.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/PermissionDragGuidance.swift
@@ -2,22 +2,23 @@ import AppKit
 
 @MainActor
 enum PermissionDragGuidance {
+  enum Permission: Sendable {
+    case screenRecording
+    case fullDiskAccess
+  }
+
   private static var lastPresentedAt: Date?
 
-  /// Open the Accessibility privacy pane and show the same draggable app card
-  /// used by Screen Recording and Full Disk Access. On current macOS releases,
-  /// asking AX to prompt can register the request without showing usable UI, so
-  /// opening Settings alone leaves a fresh named bundle with no obvious row to
-  /// enable.
+  /// Open the Accessibility privacy pane. Accessibility already registers Omi's
+  /// row when the app asks for access, so this flow only needs the user to turn
+  /// that row on. The draggable app card is reserved for permissions where
+  /// dropping the bundle into the list is itself a valid grant path.
   @discardableResult
   static func openAccessibilitySettings(
     isAuthorized: () -> Bool = { true },
     open: (URL) -> Bool = { NSWorkspace.shared.open($0) },
     suspendForPermissionPrompt: () -> Void = {
       ShellSummon.suspendForPermissionPrompt()
-    },
-    presentDragGuidance: () -> Void = {
-      Task { await PermissionDragGuidance.presentDragToGrantHelper() }
     }
   ) -> Bool {
     guard
@@ -28,7 +29,6 @@ enum PermissionDragGuidance {
     guard isAuthorized() else { return false }
     suspendForPermissionPrompt()
     guard open(url) else { return false }
-    presentDragGuidance()
     return true
   }
 
@@ -39,7 +39,14 @@ enum PermissionDragGuidance {
     CloudConnectorGuidanceOverlay.shared.dismiss()
   }
 
-  static func presentDragToGrantHelper(settingsPID: pid_t? = nil) async {
+  static func presentDragToGrantHelper(
+    for permission: Permission,
+    settingsPID: pid_t? = nil
+  ) async {
+    guard shouldPresentDragGuidance(permissionGranted: await isGranted(permission)) else {
+      dismiss()
+      return
+    }
     if let lastPresentedAt, Date().timeIntervalSince(lastPresentedAt) < 2 { return }
     lastPresentedAt = Date()
 
@@ -68,9 +75,32 @@ enum PermissionDragGuidance {
       return
     }
 
+    // A fast toggle can land while System Settings is still opening. Re-check
+    // at the final presentation boundary so a now-granted permission never
+    // leaves the user with a stale instruction to drag the app again.
+    guard shouldPresentDragGuidance(permissionGranted: await isGranted(permission)) else {
+      dismiss()
+      return
+    }
+
     // The overlay owns the System Settings lifecycle from here: it re-anchors over
     // the window as it moves and dismisses the card when the user closes it.
     CloudConnectorGuidanceOverlay.shared.presentDragToGrantCard(
       appIcon: icon, appName: appName, appURL: appURL, near: anchor)
+  }
+
+  static func shouldPresentDragGuidance(permissionGranted: Bool) -> Bool {
+    !permissionGranted
+  }
+
+  private static func isGranted(_ permission: Permission) async -> Bool {
+    switch permission {
+    case .screenRecording:
+      return ScreenCaptureService.checkPermission()
+    case .fullDiskAccess:
+      return await Task.detached(priority: .userInitiated) {
+        AppState.probeFullDiskAccessGranted()
+      }.value
+    }
   }
 }

--- a/desktop/macos/Desktop/Sources/Onboarding/PermissionDragGuidance.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/PermissionDragGuidance.swift
@@ -9,6 +9,7 @@ enum PermissionDragGuidance {
   }
 
   private static var lastPresentedAt: Date?
+  private static var grantWatchTask: Task<Void, Never>?
 
   /// Open the Accessibility privacy pane and offer the draggable app card when
   /// the grant is genuinely absent. A named or re-signed bundle can need to be
@@ -39,8 +40,43 @@ enum PermissionDragGuidance {
   /// Remove the drag card immediately — the permission was granted or the user
   /// skipped, so the floating icon should not linger.
   static func dismiss() {
+    grantWatchTask?.cancel()
+    grantWatchTask = nil
     lastPresentedAt = nil
     CloudConnectorGuidanceOverlay.shared.dismiss()
+  }
+
+  /// Return from System Settings only after the dragged bundle has actually
+  /// acquired the permission. A drag can be cancelled or miss the app list, so
+  /// the drag-session callback itself is not evidence that the flow succeeded.
+  static func completeGrantedDrag(
+    dismissGuidance: () -> Void = {
+      CloudConnectorGuidanceOverlay.shared.dismiss()
+    },
+    refocusOmi: () -> Void = {
+      returnToOmi()
+    }
+  ) {
+    grantWatchTask = nil
+    lastPresentedAt = nil
+    dismissGuidance()
+    refocusOmi()
+  }
+
+  /// Uses the same foregrounding path as the menu-bar and global-shortcut
+  /// entry points. On recent macOS versions, `NSApp.activate()` by itself is
+  /// not reliable when another app (including System Settings) is frontmost.
+  static func returnToOmi() {
+    if let appDelegate = AppDelegate.summonWindowTarget() {
+      appDelegate.openMainAppWindow()
+      return
+    }
+
+    // Startup/test fallback for the brief interval before AppDelegate.shared
+    // is installed. Keep the currently visible Omi window as the focus target.
+    NSApp.activate(ignoringOtherApps: true)
+    NSApp.windows.first(where: { $0.isVisible && $0.title.lowercased().hasPrefix("omi") })?
+      .makeKeyAndOrderFront(nil)
   }
 
   static func presentDragToGrantHelper(
@@ -91,6 +127,7 @@ enum PermissionDragGuidance {
     // the window as it moves and dismisses the card when the user closes it.
     CloudConnectorGuidanceOverlay.shared.presentDragToGrantCard(
       appIcon: icon, appName: appName, appURL: appURL, near: anchor)
+    startGrantWatch(for: permission)
   }
 
   static func shouldPresentDragGuidance(permissionGranted: Bool) -> Bool {
@@ -100,6 +137,33 @@ enum PermissionDragGuidance {
   static func accessibilityGrantIsUsable(_ signals: AccessibilityProbeSignals) -> Bool {
     let projection = AppState.accessibilityProjection(signals)
     return projection.hasPermission && !projection.isBroken
+  }
+
+  static func waitForGrantedDrag(
+    permission: Permission,
+    overlayIsVisible: () -> Bool = {
+      CloudConnectorGuidanceOverlay.shared.isDragToGrantCardVisible
+    },
+    permissionIsGranted: (Permission) async -> Bool = { permission in
+      await isGranted(permission)
+    },
+    waitForNextPoll: () async -> Void = {
+      try? await Task.sleep(nanoseconds: 300_000_000)
+    }
+  ) async -> Bool {
+    while !Task.isCancelled, overlayIsVisible() {
+      if await permissionIsGranted(permission), overlayIsVisible() { return true }
+      await waitForNextPoll()
+    }
+    return false
+  }
+
+  private static func startGrantWatch(for permission: Permission) {
+    grantWatchTask?.cancel()
+    grantWatchTask = Task {
+      guard await waitForGrantedDrag(permission: permission) else { return }
+      completeGrantedDrag()
+    }
   }
 
   private static func isGranted(_ permission: Permission) async -> Bool {

--- a/desktop/macos/Desktop/Sources/Onboarding/PermissionDragGuidance.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/PermissionDragGuidance.swift
@@ -3,22 +3,25 @@ import AppKit
 @MainActor
 enum PermissionDragGuidance {
   enum Permission: Sendable {
+    case accessibility
     case screenRecording
     case fullDiskAccess
   }
 
   private static var lastPresentedAt: Date?
 
-  /// Open the Accessibility privacy pane. Accessibility already registers Omi's
-  /// row when the app asks for access, so this flow only needs the user to turn
-  /// that row on. The draggable app card is reserved for permissions where
-  /// dropping the bundle into the list is itself a valid grant path.
+  /// Open the Accessibility privacy pane and offer the draggable app card when
+  /// the grant is genuinely absent. A named or re-signed bundle can need to be
+  /// added again, while an already-working grant should never be requested twice.
   @discardableResult
   static func openAccessibilitySettings(
     isAuthorized: () -> Bool = { true },
     open: (URL) -> Bool = { NSWorkspace.shared.open($0) },
     suspendForPermissionPrompt: () -> Void = {
       ShellSummon.suspendForPermissionPrompt()
+    },
+    presentDragGuidance: () -> Void = {
+      Task { await PermissionDragGuidance.presentDragToGrantHelper(for: .accessibility) }
     }
   ) -> Bool {
     guard
@@ -29,6 +32,7 @@ enum PermissionDragGuidance {
     guard isAuthorized() else { return false }
     suspendForPermissionPrompt()
     guard open(url) else { return false }
+    presentDragGuidance()
     return true
   }
 
@@ -93,8 +97,19 @@ enum PermissionDragGuidance {
     !permissionGranted
   }
 
+  static func accessibilityGrantIsUsable(_ signals: AccessibilityProbeSignals) -> Bool {
+    let projection = AppState.accessibilityProjection(signals)
+    return projection.hasPermission && !projection.isBroken
+  }
+
   private static func isGranted(_ permission: Permission) async -> Bool {
     switch permission {
+    case .accessibility:
+      let targets = AppState.accessibilityProbeTargets()
+      let signals = await Task.detached(priority: .userInitiated) {
+        AppState.probeAccessibilitySignals(targets: targets)
+      }.value
+      return accessibilityGrantIsUsable(signals)
     case .screenRecording:
       return ScreenCaptureService.checkPermission()
     case .fullDiskAccess:

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -86,7 +86,7 @@ extension SBOnboardingModel {
       // matching Screen Recording's flow. Full Disk Access has no in-place toggle,
       // so the drag card is the fastest grant path (#9742). Both FDA entry points
       // (the permission step and the Files connector) route through here.
-      Task { await PermissionDragGuidance.presentDragToGrantHelper() }
+      Task { await PermissionDragGuidance.presentDragToGrantHelper(for: .fullDiskAccess) }
     }
     pollPermission("full_disk_access")
   }

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -2082,7 +2082,7 @@ class ChatToolExecutor {
         // Same drag-to-grant mechanic as Full Disk Access. macOS pre-registers
         // the row here, but the card still walks the user to the right toggle —
         // and re-adds the app if the row was removed via tccutil or a reset.
-        Task { await PermissionDragGuidance.presentDragToGrantHelper() }
+        Task { await PermissionDragGuidance.presentDragToGrantHelper(for: .screenRecording) }
         try? await Task.sleep(nanoseconds: 2_000_000_000)
         guard
           isPermissionAuthorizationCurrent(
@@ -2214,7 +2214,7 @@ class ChatToolExecutor {
           authorizationSnapshot: authorizationSnapshot)
         // Same drag-to-grant mechanic as Screen Recording: drop the app into the
         // Full Disk Access list to add and enable it in one gesture.
-        Task { await PermissionDragGuidance.presentDragToGrantHelper() }
+        Task { await PermissionDragGuidance.presentDragToGrantHelper(for: .fullDiskAccess) }
         try? await Task.sleep(nanoseconds: 3_000_000_000)
         guard
           isPermissionAuthorizationCurrent(

--- a/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
@@ -215,6 +215,7 @@ final class ScreenCaptureService: Sendable {
         log("Opened Screen Recording preferences via URL scheme")
         settingsApp.activate()
         await PermissionDragGuidance.presentDragToGrantHelper(
+          for: .screenRecording,
           settingsPID: settingsApp.processIdentifier)
       } catch {
         log("Failed to open Screen Recording preferences via URL scheme — trying fallback")

--- a/desktop/macos/Desktop/Tests/SBOnboardingPermissionFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingPermissionFlowTests.swift
@@ -353,32 +353,35 @@ final class SBOnboardingPermissionFlowTests: XCTestCase {
 /// The permission probes `AppState` owns, exercised through their injected seams.
 @MainActor
 final class AppStatePermissionProbeTests: XCTestCase {
-  func testAccessibilitySettingsOpenDoesNotPresentDragGuidance() {
+  func testAccessibilitySettingsOpenPresentsConditionalDragGuidance() {
     var openedURL: URL?
-    PermissionDragGuidance.dismiss()
+    var presentedDragGuidance = false
 
     let opened = PermissionDragGuidance.openAccessibilitySettings(
       open: {
         openedURL = $0
         return true
       },
-      suspendForPermissionPrompt: {})
+      suspendForPermissionPrompt: {},
+      presentDragGuidance: { presentedDragGuidance = true })
 
     XCTAssertTrue(opened)
     XCTAssertEqual(
       openedURL?.absoluteString,
       "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
-    XCTAssertNotEqual(
-      CloudConnectorGuidanceOverlay.shared.automationState()["visible"], "true",
-      "Accessibility only needs its registered row toggled; a drag card asks the user to grant twice")
+    XCTAssertTrue(presentedDragGuidance)
   }
 
-  func testAccessibilitySettingsFailureReturnsFalse() {
+  func testAccessibilitySettingsFailureDoesNotPresentDragGuidance() {
+    var presentedDragGuidance = false
+
     let opened = PermissionDragGuidance.openAccessibilitySettings(
       open: { _ in false },
-      suspendForPermissionPrompt: {})
+      suspendForPermissionPrompt: {},
+      presentDragGuidance: { presentedDragGuidance = true })
 
     XCTAssertFalse(opened)
+    XCTAssertFalse(presentedDragGuidance)
   }
 
   // MARK: - Defect 5: automation status is readable by the caller that acts on it

--- a/desktop/macos/Desktop/Tests/SBOnboardingPermissionFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingPermissionFlowTests.swift
@@ -353,35 +353,32 @@ final class SBOnboardingPermissionFlowTests: XCTestCase {
 /// The permission probes `AppState` owns, exercised through their injected seams.
 @MainActor
 final class AppStatePermissionProbeTests: XCTestCase {
-  func testAccessibilitySettingsOpenPresentsDragGuidance() {
+  func testAccessibilitySettingsOpenDoesNotPresentDragGuidance() {
     var openedURL: URL?
-    var presentedDragGuidance = false
+    PermissionDragGuidance.dismiss()
 
     let opened = PermissionDragGuidance.openAccessibilitySettings(
       open: {
         openedURL = $0
         return true
       },
-      suspendForPermissionPrompt: {},
-      presentDragGuidance: { presentedDragGuidance = true })
+      suspendForPermissionPrompt: {})
 
     XCTAssertTrue(opened)
     XCTAssertEqual(
       openedURL?.absoluteString,
       "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
-    XCTAssertTrue(presentedDragGuidance)
+    XCTAssertNotEqual(
+      CloudConnectorGuidanceOverlay.shared.automationState()["visible"], "true",
+      "Accessibility only needs its registered row toggled; a drag card asks the user to grant twice")
   }
 
-  func testAccessibilityDragGuidanceIsNotPresentedWhenSettingsFailsToOpen() {
-    var presentedDragGuidance = false
-
+  func testAccessibilitySettingsFailureReturnsFalse() {
     let opened = PermissionDragGuidance.openAccessibilitySettings(
       open: { _ in false },
-      suspendForPermissionPrompt: {},
-      presentDragGuidance: { presentedDragGuidance = true })
+      suspendForPermissionPrompt: {})
 
     XCTAssertFalse(opened)
-    XCTAssertFalse(presentedDragGuidance)
   }
 
   // MARK: - Defect 5: automation status is readable by the caller that acts on it

--- a/desktop/macos/Desktop/Tests/ScreenRecordingPermissionPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenRecordingPermissionPolicyTests.swift
@@ -143,6 +143,12 @@ final class ScreenRecordingPermissionPolicyTests: XCTestCase {
   }
 
   @MainActor
+  func testDragHelperIsSkippedWheneverPermissionIsAlreadyGranted() {
+    XCTAssertFalse(PermissionDragGuidance.shouldPresentDragGuidance(permissionGranted: true))
+    XCTAssertTrue(PermissionDragGuidance.shouldPresentDragGuidance(permissionGranted: false))
+  }
+
+  @MainActor
   func testDragHelperDirectsUsersToTheAppListWithoutClaimingExactBounds() {
     XCTAssertEqual(
       CloudConnectorGuidanceOverlay.dragInstructionText(appName: "Omi"),

--- a/desktop/macos/Desktop/Tests/ScreenRecordingPermissionPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenRecordingPermissionPolicyTests.swift
@@ -149,13 +149,32 @@ final class ScreenRecordingPermissionPolicyTests: XCTestCase {
   }
 
   @MainActor
+  func testAccessibilityDragHelperOnlySkipsAWorkingGrant() {
+    XCTAssertTrue(
+      PermissionDragGuidance.accessibilityGrantIsUsable(
+        AccessibilityProbeSignals(tccTrusted: true, axProbe: .working)))
+    XCTAssertTrue(
+      PermissionDragGuidance.accessibilityGrantIsUsable(
+        AccessibilityProbeSignals(tccTrusted: false, axProbe: .working)),
+      "A functional AX call overrides a stale false TCC read")
+    XCTAssertFalse(
+      PermissionDragGuidance.accessibilityGrantIsUsable(
+        AccessibilityProbeSignals(tccTrusted: false, axProbe: .indeterminate)),
+      "An off toggle with no working AX evidence still needs guidance")
+    XCTAssertFalse(
+      PermissionDragGuidance.accessibilityGrantIsUsable(
+        AccessibilityProbeSignals(tccTrusted: true, axProbe: .failing)),
+      "A stale or broken TCC grant still needs repair guidance")
+  }
+
+  @MainActor
   func testDragHelperDirectsUsersToTheAppListWithoutClaimingExactBounds() {
     XCTAssertEqual(
       CloudConnectorGuidanceOverlay.dragInstructionText(appName: "Omi"),
       "Drag Omi into the app list")
     XCTAssertEqual(
       CloudConnectorGuidanceOverlay.dragInstructionAccessibilityText(appName: "Omi"),
-      "Press and drag Omi into the Screen & System Audio Recording app list, then release")
+      "Press and drag Omi into the privacy permission app list, then release")
   }
 
   /// Regression for the reported detached icon: the draggable source must begin

--- a/desktop/macos/Desktop/Tests/ScreenRecordingPermissionPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenRecordingPermissionPolicyTests.swift
@@ -168,6 +168,50 @@ final class ScreenRecordingPermissionPolicyTests: XCTestCase {
   }
 
   @MainActor
+  func testGrantedDragDismissesGuidanceBeforeRefocusingOmi() {
+    var events: [String] = []
+
+    PermissionDragGuidance.completeGrantedDrag(
+      dismissGuidance: { events.append("dismiss") },
+      refocusOmi: { events.append("refocus") })
+
+    XCTAssertEqual(events, ["dismiss", "refocus"])
+  }
+
+  @MainActor
+  func testDragGrantWatcherWaitsForARealPermissionGrant() async {
+    var checks = 0
+    let granted = await PermissionDragGuidance.waitForGrantedDrag(
+      permission: .accessibility,
+      overlayIsVisible: { true },
+      permissionIsGranted: { _ in
+        checks += 1
+        return checks == 3
+      },
+      waitForNextPoll: {})
+
+    XCTAssertTrue(granted)
+    XCTAssertEqual(checks, 3)
+  }
+
+  @MainActor
+  func testDragGrantWatcherStopsWithoutRefocusWhenGuidanceCloses() async {
+    var visible = true
+    var checks = 0
+    let granted = await PermissionDragGuidance.waitForGrantedDrag(
+      permission: .accessibility,
+      overlayIsVisible: { visible },
+      permissionIsGranted: { _ in
+        checks += 1
+        return false
+      },
+      waitForNextPoll: { visible = false })
+
+    XCTAssertFalse(granted)
+    XCTAssertEqual(checks, 1)
+  }
+
+  @MainActor
   func testDragHelperDirectsUsersToTheAppListWithoutClaimingExactBounds() {
     XCTAssertEqual(
       CloudConnectorGuidanceOverlay.dragInstructionText(appName: "Omi"),

--- a/desktop/macos/changelog/unreleased/20260829-onboarding-permission-drag-guidance.json
+++ b/desktop/macos/changelog/unreleased/20260829-onboarding-permission-drag-guidance.json
@@ -1,3 +1,3 @@
 {
-  "change": "Fixed onboarding permission guidance so granted access is never requested twice and the draggable app icon is easier to spot"
+  "change": "Fixed onboarding permission guidance so working access is never requested twice and the draggable app icon and arrow are easier to spot"
 }

--- a/desktop/macos/changelog/unreleased/20260829-onboarding-permission-drag-guidance.json
+++ b/desktop/macos/changelog/unreleased/20260829-onboarding-permission-drag-guidance.json
@@ -1,3 +1,3 @@
 {
-  "change": "Fixed onboarding permission guidance so working access is never requested twice and the draggable app icon and arrow are easier to spot"
+  "change": "Fixed onboarding permission guidance so working access is never requested twice, Omi returns to the foreground after a successful drag, and the draggable app icon and arrow are easier to spot"
 }

--- a/desktop/macos/changelog/unreleased/20260829-onboarding-permission-drag-guidance.json
+++ b/desktop/macos/changelog/unreleased/20260829-onboarding-permission-drag-guidance.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed onboarding permission guidance so granted access is never requested twice and the draggable app icon is easier to spot"
+}


### PR DESCRIPTION
## What changed and why

Accessibility onboarding keeps the drag-to-grant path for missing or broken grants, but suppresses it when Omi's TCC result or a real functional AX call proves the grant works. Screen Recording and Full Disk Access also recheck their actual permission immediately before presenting guidance. After a successful drag, the helper now watches for the real grant, dismisses itself, and returns Omi to the foreground through the app's hardened summon path; cancelled or missed drags do not steal focus. The draggable app icon now has a larger animated green halo, and its arrow has a high-contrast badge that remains legible in dark mode.

## Product invariants affected

- INV-CHAT-1
- INV-INT-1

## How it was verified

- 55 focused Swift tests passed across `SBOnboardingPermissionFlowTests`, `ScreenRecordingPermissionPolicyTests`, and `AppStatePermissionProbeTests`.
- `./scripts/agent-logic-harness.sh --cross-surface-smoke` passed.
- The `claude-guidance-overlay` bridge lane passed with zero coordinate clicks and zero log errors; the rebuilt bundle directly exported the final drag card for visual review.
- Built and code-sign verified `/Applications/omi-onboarding-permissions.app`; with System Settings frontmost, exercised the same hardened foreground route and confirmed through Computer Use that the onboarding window became focused.
- SwiftLint, changed-file swift-format lint, desktop test-quality, and `omi-macos-dev doctor` passed.

## Tests

- `AppStatePermissionProbeTests.testAccessibilitySettingsOpenPresentsConditionalDragGuidance` protects the Accessibility drag path.
- `ScreenRecordingPermissionPolicyTests.testAccessibilityDragHelperOnlySkipsAWorkingGrant` covers stale-false TCC, missing, working, and broken Accessibility signals.
- `ScreenRecordingPermissionPolicyTests.testDragHelperIsSkippedWheneverPermissionIsAlreadyGranted` protects the shared already-granted suppression policy.
- `ScreenRecordingPermissionPolicyTests.testDragGrantWatcherWaitsForARealPermissionGrant` and `testDragGrantWatcherStopsWithoutRefocusWhenGuidanceCloses` protect success and cancelled/closed guidance behavior.
- `ScreenRecordingPermissionPolicyTests.testGrantedDragDismissesGuidanceBeforeRefocusingOmi` protects the post-grant transition ordering.

## Failure class (fixes)

Failure-Class: none
