### PR TITLE
fix(desktop): stop chat history repeating Focus on proactive notifications

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/ChatContinuityInvariants.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatContinuityInvariants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum ProactiveNotificationKind: String, Equatable {
+enum ProactiveNotificationKind: String, Equatable, CaseIterable {
   case general
   case suggestion
   case insight

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarNotificationCardLead.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarNotificationCardLead.swift
@@ -1,0 +1,57 @@
+import OmiTheme
+import SwiftUI
+
+/// Lead of the generic floating-bar notification card: kind glyph plus the
+/// category-aware copy stack. Extracted so `FloatingControlBarView` does not
+/// grow past the product-file line-count freeze while the title/body layout
+/// learns not to shout the Settings category louder than the actual content.
+struct FloatingBarNotificationCardLead: View {
+  let copy: ProactiveNotificationCopy.CardLines
+
+  var body: some View {
+    HStack(alignment: .top, spacing: OmiSpacing.md) {
+      ZStack {
+        RoundedRectangle(cornerRadius: 13, style: .continuous)
+          .fill(
+            LinearGradient(
+              colors: [Color.white.opacity(0.18), Color.white.opacity(0.08)],
+              startPoint: .top,
+              endPoint: .bottom
+            )
+          )
+          .overlay(
+            RoundedRectangle(cornerRadius: 13, style: .continuous)
+              .strokeBorder(Color.white.opacity(0.12), lineWidth: 1)
+          )
+          .frame(width: 44, height: 44)
+
+        Image(systemName: copy.systemImage)
+          .font(.system(size: 18, weight: .semibold))
+          .foregroundColor(.white)
+      }
+
+      VStack(alignment: .leading, spacing: 3) {
+        if let caption = copy.caption {
+          Text(caption)
+            .scaledFont(size: OmiType.caption, weight: .semibold)
+            .foregroundColor(.white.opacity(0.5))
+            .lineLimit(1)
+        }
+        Text(copy.heading)
+          .scaledFont(size: OmiType.subheading, weight: .semibold)
+          .foregroundColor(.white)
+          .lineLimit(copy.detail == nil ? 3 : 1)
+          .multilineTextAlignment(.leading)
+          .fixedSize(horizontal: false, vertical: true)
+        if let detail = copy.detail, !detail.isEmpty {
+          Text(detail)
+            .scaledFont(size: OmiType.body)
+            .foregroundColor(.white.opacity(0.78))
+            .lineLimit(3)
+            .lineSpacing(1.5)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarNotificationJournalCopy.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarNotificationJournalCopy.swift
@@ -1,5 +1,146 @@
 import Foundation
 
+/// Copy policy for proactive notifications across the floating-bar card and the
+/// one chat row they journal into.
+///
+/// Two independent redundancies showed up live:
+/// 1. The director's title/body contract names the same referent twice
+///    (`notificationJournalText` already drops a headline the body restates).
+/// 2. Several producers use the Settings category as the title (`Focus`,
+///    `Insight`, `Memory Saved`). The chat row already prints that category as
+///    `ProactiveNotificationBadge.label`, so journaling it as a first line made
+///    the row say "Focus / Focus / meet with…".
+enum ProactiveNotificationCopy {
+  /// Headlines that only name the Settings category (or a known alias). The
+  /// chat badge already carries that word; keeping it as a title is chrome.
+  static func isCategoryChrome(_ text: String, kind: ProactiveNotificationKind? = nil) -> Bool {
+    let normalized = normalizeHeadline(text)
+    guard !normalized.isEmpty else { return true }
+    if let kind {
+      return chromeHeadlines(for: kind).contains(normalized)
+    }
+    return allChromeHeadlines.contains(normalized)
+  }
+
+  /// The body a chat row should render under the category badge. Strips a
+  /// journaled first line that is only category chrome, and kind-specific
+  /// prefixes such as `New memory:`, so already-persisted history is repaired
+  /// without rewriting the journal.
+  static func displayBody(_ text: String, kind: ProactiveNotificationKind) -> String {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return trimmed }
+    let parts = splitFirstLine(trimmed)
+    var body = trimmed
+    if isCategoryChrome(parts.first, kind: kind) {
+      body = parts.rest
+    }
+    body = stripBodyChrome(body, kind: kind)
+    return body.isEmpty ? trimmed : body
+  }
+
+  /// Body prefixes that only restated the category. Applied both when journaling
+  /// and when rendering already-journaled rows.
+  static func stripBodyChrome(_ text: String, kind: ProactiveNotificationKind) -> String {
+    var result = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    switch kind {
+    case .memory:
+      result = stripPrefix(result, "new memory:")
+    default:
+      break
+    }
+    return result
+  }
+
+  /// Lines the generic floating-bar card should draw. A category-only title
+  /// becomes a quiet caption so the actual content is the heading, matching the
+  /// Focus suggestion card and the meeting-share card.
+  struct CardLines: Equatable {
+    let caption: String?
+    let heading: String
+    let detail: String?
+    let systemImage: String
+
+    static func of(title: String, message: String, kind: ProactiveNotificationKind) -> Self {
+      let badge = ProactiveNotificationBadge(kind: kind)
+      let headline = title.trimmingCharacters(in: .whitespacesAndNewlines)
+      let body = ProactiveNotificationCopy.stripBodyChrome(
+        message.trimmingCharacters(in: .whitespacesAndNewlines), kind: kind)
+
+      if ProactiveNotificationCopy.isCategoryChrome(headline, kind: kind) {
+        if body.isEmpty {
+          return Self(
+            caption: nil,
+            heading: headline.isEmpty ? badge.label : headline,
+            detail: nil,
+            systemImage: badge.systemImage)
+        }
+        return Self(caption: badge.label, heading: body, detail: nil, systemImage: badge.systemImage)
+      }
+
+      let heading = headline.isEmpty ? body : headline
+      let detail = (body.isEmpty || body == heading) ? nil : body
+      return Self(caption: nil, heading: heading, detail: detail, systemImage: badge.systemImage)
+    }
+  }
+
+  fileprivate static func chromeHeadlines(for kind: ProactiveNotificationKind) -> Set<String> {
+    switch kind {
+    case .suggestion:
+      return ["focus", "suggestion", "suggested by omi"]
+    case .insight, .resurface:
+      return ["insight"]
+    case .goal:
+      return ["insight", "new goal"]
+    case .task, .meetingNotes:
+      return ["task"]
+    case .memory:
+      return ["memory", "memory saved"]
+    case .integration:
+      return ["integration"]
+    case .general:
+      return ["notification"]
+    }
+  }
+
+  private static let allChromeHeadlines: Set<String> = {
+    var all = Set<String>()
+    for kind in ProactiveNotificationKind.allCases {
+      all.formUnion(chromeHeadlines(for: kind))
+    }
+    return all
+  }()
+
+  static func normalizeHeadline(_ text: String) -> String {
+    var value = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    while let first = value.first, "#*_`".contains(first) {
+      value.removeFirst()
+      value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    while let last = value.last, "*_`".contains(last) {
+      value.removeLast()
+      value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    return value.lowercased()
+      .split(whereSeparator: \.isWhitespace)
+      .joined(separator: " ")
+  }
+
+  private static func splitFirstLine(_ text: String) -> (first: String, rest: String) {
+    guard let newline = text.firstIndex(of: "\n") else {
+      return (text, "")
+    }
+    let first = String(text[..<newline]).trimmingCharacters(in: .whitespacesAndNewlines)
+    let rest = String(text[text.index(after: newline)...])
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    return (first, rest)
+  }
+
+  private static func stripPrefix(_ text: String, _ prefix: String) -> String {
+    guard text.lowercased().hasPrefix(prefix) else { return text }
+    return String(text.dropFirst(prefix.count)).trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+}
+
 /// Copy policy for the one chat row a proactive notification journals into.
 extension FloatingControlBarManager {
   /// The director's copy contract (5a076e10b3) makes the title AND the message both
@@ -8,13 +149,39 @@ extension FloatingControlBarManager {
   /// contract reads as saying everything twice ("Latest Omi desktop app download
   /// link" / "The latest Omi desktop app download link is …"), so the headline is
   /// kept only when it adds words the body does not already carry.
-  nonisolated static func notificationJournalText(title: String, body: String) -> String {
+  ///
+  /// A second, later redundancy: several producers used the Settings category as
+  /// the title (`Focus`, `Insight`, `Memory Saved`). The chat row already draws
+  /// that category as a badge, so a category-only title is dropped the same way.
+  nonisolated static func notificationJournalText(
+    title: String, body: String, kind: ProactiveNotificationKind? = nil
+  ) -> String {
     let headline = title.trimmingCharacters(in: .whitespacesAndNewlines)
-    let detail = body.trimmingCharacters(in: .whitespacesAndNewlines)
+    var detail = body.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let kind {
+      detail = ProactiveNotificationCopy.stripBodyChrome(detail, kind: kind)
+    }
     if headline.isEmpty { return detail }
+    if ProactiveNotificationCopy.isCategoryChrome(headline, kind: kind) {
+      return detail.isEmpty ? headline : detail
+    }
     if detail.isEmpty || detail == headline { return headline }
     if bodyRestatesTitle(title: headline, body: detail) { return detail }
     return "\(headline)\n\(detail)"
+  }
+
+  /// Body a chat-history row should render under the category badge. Historical
+  /// rows already contain a redundant first line; this repairs them without a
+  /// journal rewrite.
+  nonisolated static func chatDisplayText(_ text: String, kind: ProactiveNotificationKind) -> String {
+    ProactiveNotificationCopy.displayBody(text, kind: kind)
+  }
+
+  /// Lines the generic floating-bar card should draw for this title/message/kind.
+  nonisolated static func notificationCardCopy(
+    title: String, message: String, kind: ProactiveNotificationKind
+  ) -> ProactiveNotificationCopy.CardLines {
+    .of(title: title, message: message, kind: kind)
   }
 
   /// Whether every content-bearing token of the title already appears in the body,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -1273,49 +1273,7 @@ struct FloatingControlBarView: View {
       FloatingControlBarManager.shared.openNotificationAsChat(notification)
     } label: {
       HStack(alignment: .top, spacing: OmiSpacing.md) {
-        ZStack {
-          RoundedRectangle(cornerRadius: 13, style: .continuous)
-            .fill(
-              LinearGradient(
-                colors: [Color.white.opacity(0.18), Color.white.opacity(0.08)],
-                startPoint: .top,
-                endPoint: .bottom
-              )
-            )
-            .overlay(
-              RoundedRectangle(cornerRadius: 13, style: .continuous)
-                .strokeBorder(Color.white.opacity(0.12), lineWidth: 1)
-            )
-            .frame(width: 44, height: 44)
-
-          Image(systemName: copy.systemImage)
-            .font(.system(size: 18, weight: .semibold))
-            .foregroundColor(.white)
-        }
-
-        VStack(alignment: .leading, spacing: 3) {
-          if let caption = copy.caption {
-            Text(caption)
-              .scaledFont(size: OmiType.caption, weight: .semibold)
-              .foregroundColor(.white.opacity(0.5))
-              .lineLimit(1)
-          }
-          Text(copy.heading)
-            .scaledFont(size: OmiType.subheading, weight: .semibold)
-            .foregroundColor(.white)
-            .lineLimit(copy.detail == nil ? 3 : 1)
-            .multilineTextAlignment(.leading)
-            .fixedSize(horizontal: false, vertical: true)
-          if let detail = copy.detail, !detail.isEmpty {
-            Text(detail)
-              .scaledFont(size: OmiType.body)
-              .foregroundColor(.white.opacity(0.78))
-              .lineLimit(3)
-              .lineSpacing(1.5)
-              .fixedSize(horizontal: false, vertical: true)
-          }
-        }
-
+        FloatingBarNotificationCardLead(copy: copy)
         Spacer(minLength: 0)
 
         // Reserve space so text never runs under the overlaid action buttons.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -1264,7 +1264,12 @@ struct FloatingControlBarView: View {
     // nothing. Wrapping the whole card in a single Button with
     // contentShape(Rectangle()) makes every pixel clickable. The dismiss
     // (X) button sits in an overlay on top so it keeps its own hit region.
-    Button {
+    let copy = FloatingControlBarManager.notificationCardCopy(
+      title: notification.title,
+      message: notification.message,
+      kind: notification.kind
+    )
+    return Button {
       FloatingControlBarManager.shared.openNotificationAsChat(notification)
     } label: {
       HStack(alignment: .top, spacing: OmiSpacing.md) {
@@ -1283,23 +1288,32 @@ struct FloatingControlBarView: View {
             )
             .frame(width: 44, height: 44)
 
-          Image(systemName: "bell.badge.fill")
+          Image(systemName: copy.systemImage)
             .font(.system(size: 18, weight: .semibold))
             .foregroundColor(.white)
         }
 
         VStack(alignment: .leading, spacing: 3) {
-          Text(notification.title)
+          if let caption = copy.caption {
+            Text(caption)
+              .scaledFont(size: OmiType.caption, weight: .semibold)
+              .foregroundColor(.white.opacity(0.5))
+              .lineLimit(1)
+          }
+          Text(copy.heading)
             .scaledFont(size: OmiType.subheading, weight: .semibold)
             .foregroundColor(.white)
-            .lineLimit(1)
-
-          Text(notification.message)
-            .scaledFont(size: OmiType.body)
-            .foregroundColor(.white.opacity(0.78))
-            .lineLimit(3)
-            .lineSpacing(1.5)
+            .lineLimit(copy.detail == nil ? 3 : 1)
+            .multilineTextAlignment(.leading)
             .fixedSize(horizontal: false, vertical: true)
+          if let detail = copy.detail, !detail.isEmpty {
+            Text(detail)
+              .scaledFont(size: OmiType.body)
+              .foregroundColor(.white.opacity(0.78))
+              .lineLimit(3)
+              .lineSpacing(1.5)
+              .fixedSize(horizontal: false, vertical: true)
+          }
         }
 
         Spacer(minLength: 0)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -4363,7 +4363,8 @@ class FloatingControlBarManager {
     // presentation surface while this async write is pending.
     let messageText = Self.notificationJournalText(
       title: notification.title,
-      body: notification.message)
+      body: notification.message,
+      kind: notification.kind)
     let continuityKey = ChatContinuityInvariants.proactiveNotificationContinuityKey(
       id: notification.id,
       kind: notification.kind)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -4362,9 +4362,7 @@ class FloatingControlBarManager {
     // admission. The notification card itself remains an independent
     // presentation surface while this async write is pending.
     let messageText = Self.notificationJournalText(
-      title: notification.title,
-      body: notification.message,
-      kind: notification.kind)
+      title: notification.title, body: notification.message, kind: notification.kind)
     let continuityKey = ChatContinuityInvariants.proactiveNotificationContinuityKey(
       id: notification.id,
       kind: notification.kind)

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
@@ -202,6 +202,11 @@ struct ChatProactivePushRow: View {
     ProactiveNotificationBadge(kind: kind)
   }
 
+  /// Category chrome already lives on the badge; do not also draw it as the body.
+  private var displayText: String {
+    FloatingControlBarManager.chatDisplayText(text, kind: kind)
+  }
+
   var body: some View {
     HStack(alignment: .top, spacing: OmiSpacing.sm) {
       Image(systemName: badge.systemImage)
@@ -217,7 +222,11 @@ struct ChatProactivePushRow: View {
         Text(badge.label)
           .scaledFont(size: OmiType.micro, weight: .semibold)
           .foregroundColor(Ink.secondary)
-        OmiMarkdown(text: text, sender: .ai)
+        if !displayText.isEmpty {
+          if !displayText.isEmpty {
+            OmiMarkdown(text: displayText, sender: .ai)
+          }
+        }
       }
       Spacer(minLength: 0)
     }
@@ -231,7 +240,8 @@ struct ChatProactivePushRow: View {
         .stroke(Ink.glassEdge, lineWidth: 1)
     )
     .accessibilityElement(children: .combine)
-    .accessibilityLabel("\(badge.label): \(text)")
+    .accessibilityLabel(
+      displayText.isEmpty ? badge.label : "\(badge.label): \(displayText)")
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
@@ -223,9 +223,7 @@ struct ChatProactivePushRow: View {
           .scaledFont(size: OmiType.micro, weight: .semibold)
           .foregroundColor(Ink.secondary)
         if !displayText.isEmpty {
-          if !displayText.isEmpty {
-            OmiMarkdown(text: displayText, sender: .ai)
-          }
+          OmiMarkdown(text: displayText, sender: .ai)
         }
       }
       Spacer(minLength: 0)

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
@@ -289,8 +289,10 @@ actor MemoryAssistant: ProactiveAssistant {
   ) async {
     // One category, one name: every memory notification presents as "Memory" — the
     // "Wisdom Captured" variant read as an unclassifiable notification type.
+    // The category lives on the badge / system-banner title; the body is the
+    // memory itself. Prefixing "New memory:" stacked a third copy of the same word.
     let title = "Memory Saved"
-    let message = "New memory: \(memory.content)"
+    let message = memory.content
     let context = FloatingBarNotificationContext(
       sourceTitle: title,
       assistantId: identifier,

--- a/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
@@ -365,12 +365,135 @@ final class ChatRowPresentationTests: XCTestCase {
   func testNotificationJournalTextPreservesTheHeadlineAndBody() {
     XCTAssertEqual(
       FloatingControlBarManager.notificationJournalText(
-        title: "Insight",
-        body: "PR blocked, needs review"),
-      "Insight\nPR blocked, needs review")
+        title: "PR blocked, needs review",
+        body: "The deploy is waiting on your approval."),
+      "PR blocked, needs review\nThe deploy is waiting on your approval.")
     XCTAssertEqual(
       FloatingControlBarManager.notificationJournalText(title: "Meeting notes ready", body: ""),
       "Meeting notes ready")
+  }
+
+  /// Producers send the category word as `title` so the system banner has a
+  /// headline. The chat row already draws that category as a badge, so journaling
+  /// it again is the "Focus / Focus / meet with…" row observed in history.
+  func testJournalDropsACategoryTitleTheBadgeAlreadyNames() {
+    XCTAssertEqual(
+      FloatingControlBarManager.notificationJournalText(
+        title: "Focus",
+        body: "Meet with Aryan Gupta for Omi project discussion",
+        kind: .suggestion),
+      "Meet with Aryan Gupta for Omi project discussion")
+    XCTAssertEqual(
+      FloatingControlBarManager.notificationJournalText(
+        title: "Insight",
+        body: "PR blocked, needs review",
+        kind: .insight),
+      "PR blocked, needs review")
+    XCTAssertEqual(
+      FloatingControlBarManager.notificationJournalText(
+        title: "Insight",
+        body: "PR blocked, needs review"),
+      "PR blocked, needs review")
+    XCTAssertEqual(
+      FloatingControlBarManager.notificationJournalText(
+        title: "Memory Saved",
+        body: "New memory: David prefers morning reviews",
+        kind: .memory),
+      "David prefers morning reviews")
+    XCTAssertEqual(
+      FloatingControlBarManager.notificationJournalText(
+        title: "New Goal",
+        body: "Ship 200k users",
+        kind: .goal),
+      "Ship 200k users")
+    // A unique task headline is content, not the category word — keep it.
+    XCTAssertEqual(
+      FloatingControlBarManager.notificationJournalText(
+        title: "Send the quarterly report",
+        body: "You promised it by 5pm.",
+        kind: .task),
+      "Send the quarterly report\nYou promised it by 5pm.")
+  }
+
+  /// Historical rows already contain the redundant first line; the renderer must
+  /// drop it even when the journaled text is never rewritten.
+  func testChatDisplayDropsARedundantCategoryFirstLineForEveryKind() {
+    XCTAssertEqual(
+      FloatingControlBarManager.chatDisplayText(
+        "Focus\nMeet with Aryan Gupta for Omi project discussion",
+        kind: .suggestion),
+      "Meet with Aryan Gupta for Omi project discussion")
+    XCTAssertEqual(
+      FloatingControlBarManager.chatDisplayText(
+        "**Focus**\nMeet with Aryan Gupta for Omi project discussion",
+        kind: .suggestion),
+      "Meet with Aryan Gupta for Omi project discussion")
+    XCTAssertEqual(
+      FloatingControlBarManager.chatDisplayText(
+        "Insight\nPR blocked, needs review",
+        kind: .insight),
+      "PR blocked, needs review")
+    XCTAssertEqual(
+      FloatingControlBarManager.chatDisplayText(
+        "Memory Saved\nNew memory: David prefers morning reviews",
+        kind: .memory),
+      "David prefers morning reviews")
+    XCTAssertEqual(
+      FloatingControlBarManager.chatDisplayText(
+        "New Goal\nShip 200k users",
+        kind: .goal),
+      "Ship 200k users")
+    XCTAssertEqual(
+      FloatingControlBarManager.chatDisplayText(
+        "Task\nSend the quarterly report",
+        kind: .task),
+      "Send the quarterly report")
+    XCTAssertEqual(
+      FloatingControlBarManager.chatDisplayText(
+        "Integration\nOmi can read your inbox",
+        kind: .integration),
+      "Omi can read your inbox")
+    // Unique headlines stay, including when they share a function word with the badge.
+    XCTAssertEqual(
+      FloatingControlBarManager.chatDisplayText(
+        "Send the quarterly report\nYou promised it by 5pm.",
+        kind: .task),
+      "Send the quarterly report\nYou promised it by 5pm.")
+  }
+
+  func testFloatingBarCardPromotesTheMessageWhenTheTitleIsCategoryChrome() {
+    let focus = FloatingControlBarManager.notificationCardCopy(
+      title: "Focus",
+      message: "Meet with Aryan Gupta for Omi project discussion",
+      kind: .suggestion)
+    XCTAssertEqual(focus.caption, "Focus")
+    XCTAssertEqual(focus.heading, "Meet with Aryan Gupta for Omi project discussion")
+    XCTAssertNil(focus.detail)
+    XCTAssertEqual(focus.systemImage, ProactiveNotificationBadge.suggestionSystemImage)
+
+    let insight = FloatingControlBarManager.notificationCardCopy(
+      title: "Insight",
+      message: "PR blocked, needs review",
+      kind: .insight)
+    XCTAssertEqual(insight.caption, "Insight")
+    XCTAssertEqual(insight.heading, "PR blocked, needs review")
+    XCTAssertNil(insight.detail)
+
+    let memory = FloatingControlBarManager.notificationCardCopy(
+      title: "Memory Saved",
+      message: "New memory: David prefers morning reviews",
+      kind: .memory)
+    XCTAssertEqual(memory.caption, "Memory")
+    XCTAssertEqual(memory.heading, "David prefers morning reviews")
+    XCTAssertNil(memory.detail)
+
+    let task = FloatingControlBarManager.notificationCardCopy(
+      title: "Send the quarterly report",
+      message: "You promised it by 5pm.",
+      kind: .task)
+    XCTAssertNil(task.caption)
+    XCTAssertEqual(task.heading, "Send the quarterly report")
+    XCTAssertEqual(task.detail, "You promised it by 5pm.")
   }
 
   /// The director's copy contract makes the title and the message both name the same

--- a/desktop/macos/changelog/unreleased/20260829-proactive-notification-category-redundancy.json
+++ b/desktop/macos/changelog/unreleased/20260829-proactive-notification-category-redundancy.json
@@ -1,0 +1,3 @@
+{
+  "change": "Stopped proactive chat rows from repeating the category (Focus, Insight, Memory) above the same word in the body"
+}

--- a/desktop/macos/e2e/flows/floating-bar-functional.yaml
+++ b/desktop/macos/e2e/flows/floating-bar-functional.yaml
@@ -7,6 +7,7 @@ covers:
   - desktop/macos/Desktop/Sources/Chat/AgentCompletionVoiceDelivery.swift
   - desktop/macos/Desktop/Sources/Chat/ChatDraftStore.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarNotificationCardLead.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarNotificationJournalCopy.swift
   - desktop/macos/Desktop/Sources/MainWindow/ClickThroughView.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/AskAIInputView.swift


### PR DESCRIPTION
## Summary
- Chat history already badges proactive rows with the Settings category (Focus, Insight, Task, Memory, Integration), then journaled that same word as a title, so Focus/Insight/Memory cards said the category twice.
- Drop category-only titles at journal time, strip already-persisted first lines at render time, and promote the actual message on the generic floating-bar card.
- Memory notifications no longer prefix the body with "New memory:".

## Product invariants affected
- INV-CHAT-1

## Failure class (fixes)
Failure-Class: none

## Test plan
- [x] `./scripts/dev-feedback.py --once swift 'ChatRowPresentationTests'` — 14/14 pass, including new coverage that Focus/Insight/Memory Saved/New Goal/Task/Integration chrome is dropped from journal text, chat display, and floating-bar card copy
- [ ] In chat history, a Focus notification shows the Focus badge once, then the suggestion body (no second "Focus" heading)
- [ ] Insight, Memory, and Goal rows keep a single category label over the content
- [ ] Task notifications with a unique headline still show that headline plus the why/action body
- [ ] Existing journaled Focus rows (already in history) no longer repeat the category

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

