### PR TITLE
SCA-374: degrade memories first-page 503s by type, not detail string

### DIFF
--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -15,7 +15,6 @@ from models.memories import MemoryDB, Memory, MemoryCategory
 from models.memory_imports import MemoryImportBatchRequest, MemoryImportBatchResponse
 from utils.apps import update_personas_async
 from utils.memory.memory_service import (
-    MEMORY_LIST_SCAN_BUDGET_DETAIL,
     MemoryBackingStoreUnavailable,
     MemoryPayload,
     MemoryService,

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -16,10 +16,12 @@ from models.memory_imports import MemoryImportBatchRequest, MemoryImportBatchRes
 from utils.apps import update_personas_async
 from utils.memory.memory_service import (
     MEMORY_LIST_SCAN_BUDGET_DETAIL,
+    MemoryBackingStoreUnavailable,
     MemoryPayload,
     MemoryService,
     fetch_memory_dict,
 )
+from utils.observability.fallback import record_fallback
 from testing.parity_pack_v0.live_capture import SurfaceParityCapture
 from utils.memory.import_write_guard import (
     import_write_block_mode,
@@ -629,30 +631,27 @@ def get_memories(
                 include_archive=include_archive,
                 request_budget=budget,
             )
-        except HTTPException as exc:
+        except MemoryBackingStoreUnavailable as exc:
             # First page must succeed whenever the legacy offset read can serve
-            # it. The cursor path 503s on a missing cursor secret
-            # ("Memory cursor unavailable"); the canonical keyset scan wraps any
-            # underlying failure as "Canonical memory unavailable"; the
-            # historical keyset scan wraps its own as "Historical memory
-            # unavailable". The keyset scans order by (updated_at DESC,
-            # __name__) and so fail while that composite index is building,
-            # which the offset read's single-field order does not — so all three
-            # fall back to read(). The keyset scans also walk past every row they
-            # must not emit before they can fill the page, so an account whose
-            # historical set is fully suppressed by canonical exhausts the scan
-            # row budget ("Memory scan budget exceeded") — that walk is what took
-            # the first page past the 30s edge timeout in prod on 2026-08-18, and
-            # the offset read serves it without the walk.
-            # Unrelated errors (4xx, other 503s) propagate. The fallback runs on
-            # the SAME request budget, never a fresh unbudgeted window (#11831).
-            if exc.status_code != 503 or exc.detail not in (
-                "Memory cursor unavailable",
-                "Canonical memory unavailable",
-                "Historical memory unavailable",
-                MEMORY_LIST_SCAN_BUDGET_DETAIL,
-            ):
-                raise
+            # it. Catch the typed backing-store failure — not detail strings —
+            # so a renamed or newly added unavailable message still degrades
+            # instead of escaping as a hard 503. The cursor path, both keyset
+            # scans, and the scan-row budget all raise this type. Unrelated
+            # errors (4xx, other 503s) propagate. The fallback runs on the
+            # SAME request budget, never a fresh unbudgeted window (#11831).
+            record_fallback(
+                component='firestore_read',
+                from_mode='cursor_page',
+                to_mode='offset_read',
+                reason='other',
+                outcome='degraded',
+                log=logger,
+            )
+            logger.warning(
+                "memories first-page cursor scan unavailable; falling back to offset read stream=%s detail=%s",
+                exc.stream,
+                exc.detail,
+            )
         else:
             return _finalize(
                 page.memories,

--- a/backend/tests/unit/test_firestore_query_contract.py
+++ b/backend/tests/unit/test_firestore_query_contract.py
@@ -40,6 +40,9 @@ from database.firestore_index_registry import (
     UNIVERSAL_CANONICAL_LIST_SCAN_QUERY,
     UNIVERSAL_HISTORICAL_CREATED_LIST_SCAN_QUERY,
     UNIVERSAL_HISTORICAL_UPDATED_LIST_SCAN_QUERY,
+    QUERY_SPECS,
+    FirestoreIndexField,
+    _index_fields_need_composite_manifest,
     firebase_index_manifest,
 )
 from scripts import firestore_query_coverage, generate_firestore_indexes
@@ -775,3 +778,91 @@ def test_query_source_paths_are_posix_canonical_on_every_host_platform():
     assert firestore_query_coverage.canonical_source_path(
         windows_path
     ) == firestore_query_coverage.canonical_source_path(posix_path)
+
+
+def _asc(field_path: str) -> FirestoreIndexField:
+    return FirestoreIndexField(field_path, order='ASCENDING')
+
+
+def _desc(field_path: str) -> FirestoreIndexField:
+    return FirestoreIndexField(field_path, order='DESCENDING')
+
+
+def _contains(field_path: str) -> FirestoreIndexField:
+    return FirestoreIndexField(field_path, array_config='CONTAINS')
+
+
+def _platform_requires_composite(index_fields: tuple[FirestoreIndexField, ...]) -> bool:
+    """Firestore's automatic single-field rule, restated from platform docs.
+
+    Independent of ``_index_fields_need_composite_manifest``. Automatic indexes
+    cover ``field ASC, __name__ ASC`` and ``field DESC, __name__ DESC`` only.
+    Opposite-direction ``field`` + ``__name__`` and any multi-field order need
+    a declared composite. Array-contains (+ ``__name__``) stays automatic.
+    https://firebase.google.com/docs/firestore/query-data/index-overview
+    """
+    non_name = [field for field in index_fields if field.field_path != '__name__']
+    name_fields = [field for field in index_fields if field.field_path == '__name__']
+    if any(field.array_config is not None for field in index_fields):
+        return False
+    if len(non_name) > 1:
+        return True
+    if len(non_name) != 1 or len(name_fields) != 1:
+        return False
+    ordered = non_name[0]
+    name = name_fields[0]
+    if ordered.order is None or name.order is None:
+        return False
+    return ordered.order != name.order
+
+
+@pytest.mark.parametrize(
+    ('fields', 'needs_composite'),
+    [
+        ((_desc('updated_at'), _desc('__name__')), False),
+        ((_asc('updated_at'), _asc('__name__')), False),
+        ((_desc('updated_at'), _asc('__name__')), True),
+        ((_asc('updated_at'), _desc('__name__')), True),
+        ((_asc('status'), _desc('updated_at'), _asc('__name__')), True),
+        ((_contains('source_ids'), _asc('__name__')), False),
+        ((_desc('updated_at'),), False),
+    ],
+)
+def test_manifest_generator_classifies_the_firestore_single_field_rule(fields, needs_composite):
+    assert _index_fields_need_composite_manifest(fields) is needs_composite
+
+
+def test_every_composite_requiring_query_spec_is_declared_in_the_checked_in_manifest():
+    """Independent of the generator: the checked-in file must declare each needed composite.
+
+    ``test_generated_firestore_manifest_matches_the_checked_in_contract`` compares
+    the generator to the file, so a generator shortcut makes both sides wrong
+    together. This oracle restates Firestore's rule and then reads the file.
+    The three list-scan specs from #11684 are named so deleting them from
+    ``QUERY_SPECS`` cannot make the test vacuous.
+    """
+    outage_required_specs = (
+        UNIVERSAL_CANONICAL_LIST_SCAN_QUERY,
+        UNIVERSAL_HISTORICAL_UPDATED_LIST_SCAN_QUERY,
+        UNIVERSAL_HISTORICAL_CREATED_LIST_SCAN_QUERY,
+    )
+    for spec in outage_required_specs:
+        assert spec in QUERY_SPECS
+        assert _platform_requires_composite(spec.index_fields)
+
+    manifest_path = Path(__file__).resolve().parents[3] / 'firestore.indexes.json'
+    checked_in = json.loads(manifest_path.read_text(encoding='utf-8'))
+    declared = {
+        (
+            index['collectionGroup'],
+            index['queryScope'],
+            tuple((field['fieldPath'], field.get('order') or field.get('arrayConfig')) for field in index['fields']),
+        )
+        for index in checked_in['indexes']
+    }
+    missing = [
+        spec.identifier
+        for spec in QUERY_SPECS
+        if _platform_requires_composite(spec.index_fields) and spec.index_requirement.signature not in declared
+    ]
+    assert missing == []

--- a/backend/tests/unit/test_list_read_budget_contract.py
+++ b/backend/tests/unit/test_list_read_budget_contract.py
@@ -1076,7 +1076,7 @@ def test_memories_route_scan_budget_fallback_shares_the_request_budget():
     """Scan-budget 503 still falls back to the offset read — on the same budget."""
     service = MagicMock()
     service.read_page.side_effect = mem_mod.MemoryBackingStoreUnavailable(
-        mem_mod.MEMORY_LIST_SCAN_BUDGET_DETAIL, stream='historical'
+        'Memory scan budget exceeded', stream='historical'
     )
     service.read.return_value = []
     scope_request = SimpleNamespace(device_scope='all', client_device_id=None)

--- a/backend/tests/unit/test_list_read_budget_contract.py
+++ b/backend/tests/unit/test_list_read_budget_contract.py
@@ -1074,10 +1074,10 @@ def test_memories_route_complete_page_keeps_cursor_header():
 
 def test_memories_route_scan_budget_fallback_shares_the_request_budget():
     """Scan-budget 503 still falls back to the offset read — on the same budget."""
-    from fastapi import HTTPException
-
     service = MagicMock()
-    service.read_page.side_effect = HTTPException(status_code=503, detail=mem_mod.MEMORY_LIST_SCAN_BUDGET_DETAIL)
+    service.read_page.side_effect = mem_mod.MemoryBackingStoreUnavailable(
+        mem_mod.MEMORY_LIST_SCAN_BUDGET_DETAIL, stream='historical'
+    )
     service.read.return_value = []
     scope_request = SimpleNamespace(device_scope='all', client_device_id=None)
     budget = _budget(FakeClock())

--- a/backend/tests/unit/test_memories_pagination_clamp.py
+++ b/backend/tests/unit/test_memories_pagination_clamp.py
@@ -262,9 +262,7 @@ def test_first_page_falls_back_to_offset_read_when_scan_row_budget_is_exhausted(
     walk suppressed rows, so the first page must fall back to it.
     """
     service = MagicMock()
-    service.read_page.side_effect = MemoryBackingStoreUnavailable(
-        mem_mod.MEMORY_LIST_SCAN_BUDGET_DETAIL, stream="historical"
-    )
+    service.read_page.side_effect = MemoryBackingStoreUnavailable("Memory scan budget exceeded", stream="historical")
     service.read.return_value = ['memory-from-offset-read']
 
     result = _get_first_page(service)

--- a/backend/tests/unit/test_memories_pagination_clamp.py
+++ b/backend/tests/unit/test_memories_pagination_clamp.py
@@ -108,6 +108,19 @@ finally:
     if _remove_python_multipart_stub:
         sys.modules.pop('python_multipart', None)
 
+from fastapi import HTTPException
+
+
+class MemoryBackingStoreUnavailable(HTTPException):
+    """Stand-in for the real type: this module imports the router under stubs."""
+
+    def __init__(self, detail, *, stream):
+        super().__init__(status_code=503, detail=detail)
+        self.stream = stream
+
+
+mem_mod.MemoryBackingStoreUnavailable = MemoryBackingStoreUnavailable
+
 
 def _call(limit, offset):
     service = MagicMock()
@@ -155,10 +168,8 @@ def test_blank_cursor_falls_back_to_offset_read_when_cursor_secret_missing():
     MEMORY_V3_GET_ENABLED is unused on the route. A blank ``?cursor=`` must not
     skip the first-page fallback, or MEMORY_ENABLED=on still 503s list.
     """
-    from fastapi import HTTPException
-
     service = MagicMock()
-    service.read_page.side_effect = HTTPException(status_code=503, detail="Memory cursor unavailable")
+    service.read_page.side_effect = MemoryBackingStoreUnavailable("Memory cursor unavailable", stream="cursor")
     service.read.return_value = []
     scope_request = types.SimpleNamespace(device_scope='all', client_device_id=None)
     with (
@@ -209,10 +220,8 @@ def test_first_page_falls_back_to_offset_read_when_canonical_scan_unavailable():
     The offset ``read`` path does not use the scan, so the first page must be
     served from ``read`` instead of failing the whole list endpoint.
     """
-    from fastapi import HTTPException
-
     service = MagicMock()
-    service.read_page.side_effect = HTTPException(status_code=503, detail="Canonical memory unavailable")
+    service.read_page.side_effect = MemoryBackingStoreUnavailable("Canonical memory unavailable", stream="canonical")
     service.read.return_value = ['memory-from-offset-read']
 
     result = _get_first_page(service)
@@ -232,10 +241,8 @@ def test_first_page_falls_back_to_offset_read_when_historical_scan_unavailable()
     match that index, and could serve the page — so this detail must fall back
     like the other two scan failures instead of failing the list endpoint.
     """
-    from fastapi import HTTPException
-
     service = MagicMock()
-    service.read_page.side_effect = HTTPException(status_code=503, detail="Historical memory unavailable")
+    service.read_page.side_effect = MemoryBackingStoreUnavailable("Historical memory unavailable", stream="historical")
     service.read.return_value = ['memory-from-offset-read']
 
     result = _get_first_page(service)
@@ -254,10 +261,10 @@ def test_first_page_falls_back_to_offset_read_when_scan_row_budget_is_exhausted(
     The walk now stops at the scan row budget; the offset ``read`` path does not
     walk suppressed rows, so the first page must fall back to it.
     """
-    from fastapi import HTTPException
-
     service = MagicMock()
-    service.read_page.side_effect = HTTPException(status_code=503, detail=mem_mod.MEMORY_LIST_SCAN_BUDGET_DETAIL)
+    service.read_page.side_effect = MemoryBackingStoreUnavailable(
+        mem_mod.MEMORY_LIST_SCAN_BUDGET_DETAIL, stream="historical"
+    )
     service.read.return_value = ['memory-from-offset-read']
 
     result = _get_first_page(service)
@@ -267,9 +274,57 @@ def test_first_page_falls_back_to_offset_read_when_scan_row_budget_is_exhausted(
     service.read.assert_called_once()
 
 
-def test_first_page_propagates_unrelated_503_detail():
-    from fastapi import HTTPException
+def test_first_page_falls_back_on_typed_unavailable_regardless_of_detail():
+    """A new or renamed detail on the typed exception must still degrade."""
+    service = MagicMock()
+    service.read_page.side_effect = MemoryBackingStoreUnavailable("Brand new backing-store message", stream="canonical")
+    service.read.return_value = ['memory-from-offset-read']
 
+    result = _get_first_page(service)
+
+    assert result == ['memory-from-offset-read']
+    service.read.assert_called_once()
+
+
+def test_first_page_does_not_match_unavailable_detail_strings():
+    """The 2026-08-17 outage class: a matching string on a plain 503 is not enough."""
+    import pytest
+
+    service = MagicMock()
+    service.read_page.side_effect = HTTPException(status_code=503, detail="Historical memory unavailable")
+
+    with pytest.raises(HTTPException) as exc_info:
+        _get_first_page(service)
+
+    assert exc_info.value.detail == "Historical memory unavailable"
+    service.read.assert_not_called()
+
+
+def test_first_page_fallback_records_degraded_firestore_read():
+    service = MagicMock()
+    service.read_page.side_effect = MemoryBackingStoreUnavailable("Historical memory unavailable", stream="historical")
+    service.read.return_value = []
+    recorded = []
+
+    def _record(**kwargs):
+        recorded.append(kwargs)
+
+    with patch.object(mem_mod, 'record_fallback', _record):
+        _get_first_page(service)
+
+    assert recorded == [
+        {
+            'component': 'firestore_read',
+            'from_mode': 'cursor_page',
+            'to_mode': 'offset_read',
+            'reason': 'other',
+            'outcome': 'degraded',
+            'log': mem_mod.logger,
+        }
+    ]
+
+
+def test_first_page_propagates_unrelated_503_detail():
     import pytest
 
     service = MagicMock()
@@ -284,8 +339,6 @@ def test_first_page_propagates_unrelated_503_detail():
 
 
 def test_first_page_propagates_non_503_errors():
-    from fastapi import HTTPException
-
     import pytest
 
     service = MagicMock()

--- a/backend/tests/unit/test_universal_memory_list_cursor.py
+++ b/backend/tests/unit/test_universal_memory_list_cursor.py
@@ -424,6 +424,7 @@ def test_fully_suppressed_historical_set_stops_at_the_scan_row_budget(service_mo
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == service_mod.MEMORY_LIST_SCAN_BUDGET_DETAIL
+    assert isinstance(exc_info.value, service_mod.MemoryBackingStoreUnavailable)
     # The walk stopped at the budget instead of scanning every historical row.
     scanned = sum(call.kwargs["limit"] for call in updated_mock.call_args_list)
     assert scanned <= 150
@@ -1379,6 +1380,8 @@ def test_canonical_scan_failure_logs_underlying_exception_and_503s(service_mod, 
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "Canonical memory unavailable"
+    assert isinstance(exc_info.value, service_mod.MemoryBackingStoreUnavailable)
+    assert exc_info.value.stream == "canonical"
     assert isinstance(exc_info.value.__cause__, RuntimeError)
     assert "canonical list scan page failed" in caplog.text
     assert "RuntimeError" in caplog.text
@@ -1388,10 +1391,10 @@ def test_canonical_scan_failure_logs_underlying_exception_and_503s(service_mod, 
 def test_building_index_failure_is_the_historical_unavailable_detail(service_mod):
     """Pin the detail the historical keyset scan raises while an index builds.
 
-    ``routers.memories`` matches this exact string to fall the first page back
-    to the legacy offset read (the 2026-08-18 5.5h GET /v3/memories outage), so
-    a rename here would silently reopen it. Drives the real adapter with the
-    Firestore error prod raised.
+    ``routers.memories`` catches ``MemoryBackingStoreUnavailable`` to fall the
+    first page back to the legacy offset read (the 2026-08-18 5.5h GET
+    /v3/memories outage). The detail is preserved for the 503 body. Drives the
+    real adapter with the Firestore error prod raised.
     """
     from fastapi import HTTPException
     from google.api_core import exceptions as gcloud_exceptions
@@ -1411,4 +1414,6 @@ def test_building_index_failure_is_the_historical_unavailable_detail(service_mod
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "Historical memory unavailable"
+    assert isinstance(exc_info.value, service_mod.MemoryBackingStoreUnavailable)
+    assert exc_info.value.stream == "historical"
     assert isinstance(exc_info.value.__cause__, gcloud_exceptions.FailedPrecondition)

--- a/backend/utils/memory/ARCHITECTURE.md
+++ b/backend/utils/memory/ARCHITECTURE.md
@@ -214,10 +214,11 @@ The supported controls and rollback floor are documented in
   on with `MEMORY_CANONICAL_MAINTENANCE_FLEX=true`.
 - `MEMORY_CANONICAL_CONSOLIDATION_ENABLED` and its batch/candidate settings are
   global cost/incident controls.
-- `GET /v3/memories` first page uses `read_page`, which 503s
-  `Memory cursor unavailable` when `MEMORY_V3_CURSOR_SECRET` is missing. That is
-  the list fence, not `MEMORY_V3_GET_ENABLED` (unused on the route). First page
-  falls back to offset `read()` for that 503.
+- `GET /v3/memories` first page uses `read_page`, which raises
+  `MemoryBackingStoreUnavailable` (503 `Memory cursor unavailable`) when
+  `MEMORY_V3_CURSOR_SECRET` is missing. That is the list fence, not
+  `MEMORY_V3_GET_ENABLED` (unused on the route). First page falls back to
+  offset `read()` for that typed failure — not by matching detail strings.
 
 The universal dual-format reader is the rollback floor. A rollback may stop new
 canonical intake or L2 maintenance globally, but must keep the universal reader

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -104,6 +104,23 @@ from utils.metrics import (
 
 logger = logging.getLogger(__name__)
 
+MemoryBackingStoreStream = Literal['canonical', 'historical', 'cursor']
+
+
+class MemoryBackingStoreUnavailable(HTTPException):
+    """Recoverable backing-store failure for mixed-list reads.
+
+    Subclasses ``HTTPException`` so existing callers keep the same 503 body.
+    ``GET /v3/memories`` first-page fallback catches this type instead of
+    matching ``detail`` strings — a renamed or newly added unavailable
+    message must not escape to clients as a hard 503.
+    """
+
+    def __init__(self, detail: str, *, stream: MemoryBackingStoreStream) -> None:
+        super().__init__(status_code=503, detail=detail)
+        self.stream = stream
+
+
 MemoryPayload = Dict[str, Any]
 McpSearchPayload = Dict[str, Any]
 
@@ -760,7 +777,7 @@ class HistoricalMemoryAdapter:
         except ListReadBudgetExhausted:
             raise
         except Exception as exc:
-            raise HTTPException(status_code=503, detail="Historical memory unavailable") from exc
+            raise MemoryBackingStoreUnavailable("Historical memory unavailable", stream="historical") from exc
         adapted: Dict[str, HistoricalMemoryRecord] = {}
         for raw in raw_rows:
             record = self._adapt(uid, raw)
@@ -842,7 +859,7 @@ class HistoricalMemoryAdapter:
             )
             return records[bounded_offset : bounded_offset + bounded_limit]
         except Exception as exc:
-            raise HTTPException(status_code=503, detail="Historical memory unavailable") from exc
+            raise MemoryBackingStoreUnavailable("Historical memory unavailable", stream="historical") from exc
         records.sort(
             key=lambda record: (
                 -self._timestamp(record.memory).timestamp(),
@@ -922,7 +939,7 @@ class HistoricalMemoryAdapter:
         except (HTTPException, ListReadBudgetExhausted):
             raise
         except Exception as exc:
-            raise HTTPException(status_code=503, detail="Historical memory unavailable") from exc
+            raise MemoryBackingStoreUnavailable("Historical memory unavailable", stream="historical") from exc
         slots = self._adapt_scan_payloads(
             uid,
             payloads,
@@ -956,7 +973,7 @@ class HistoricalMemoryAdapter:
         except (HTTPException, ListReadBudgetExhausted):
             raise
         except Exception as exc:
-            raise HTTPException(status_code=503, detail="Historical memory unavailable") from exc
+            raise MemoryBackingStoreUnavailable("Historical memory unavailable", stream="historical") from exc
         slots = self._adapt_scan_payloads(
             uid,
             payloads,
@@ -971,7 +988,7 @@ class HistoricalMemoryAdapter:
         try:
             raw = memories_db.get_memory(uid, memory_id, **self._firestore_kwargs())
         except Exception as exc:
-            raise HTTPException(status_code=503, detail="Historical memory unavailable") from exc
+            raise MemoryBackingStoreUnavailable("Historical memory unavailable", stream="historical") from exc
         if not raw:
             return None
         return self._adapt(uid, raw)
@@ -995,7 +1012,7 @@ class HistoricalMemoryAdapter:
         try:
             rows = memories_db.get_memories_by_ids(uid, ids, **self._firestore_kwargs())
         except Exception as exc:
-            raise HTTPException(status_code=503, detail="Historical memory unavailable") from exc
+            raise MemoryBackingStoreUnavailable("Historical memory unavailable", stream="historical") from exc
         by_id: Dict[str, HistoricalMemoryRecord] = {}
         for raw in rows:
             record = self._adapt(uid, raw)
@@ -1125,7 +1142,7 @@ class HistoricalMemoryAdapter:
                 **({"firestore_client": db_client} if db_client is not None else {}),
             )
         except Exception as exc:
-            raise HTTPException(status_code=503, detail="Historical memory unavailable") from exc
+            raise MemoryBackingStoreUnavailable("Historical memory unavailable", stream="historical") from exc
         start = max(0, offset)
         selected = ids[start:] if limit is None else ids[start : start + max(1, limit)]
         return [memory_id for memory_id in selected if memory_id]
@@ -1206,20 +1223,20 @@ class _ScanRowBudget:
             self._deadline = clock() + max(0.0, float(seconds))
         self._clock = clock
 
-    def check(self) -> None:
+    def check(self, stream: MemoryBackingStoreStream = "historical") -> None:
         # Parent exhaustion is checked first and wins: a request out of time
         # must truncate, not fall back into another read.
         if self._parent is not None:
             self._parent.check()
         if self._remaining < 0 or self._clock() >= self._deadline:
-            raise HTTPException(status_code=503, detail=MEMORY_LIST_SCAN_BUDGET_DETAIL)
+            raise MemoryBackingStoreUnavailable(MEMORY_LIST_SCAN_BUDGET_DETAIL, stream=stream)
 
-    def charge(self) -> None:
+    def charge(self, stream: MemoryBackingStoreStream = "historical") -> None:
         self._remaining -= 1
         if self._parent is not None:
             # Rows the scan walks past still crossed the wire for this request.
             self._parent.charge(1)
-        self.check()
+        self.check(stream=stream)
 
 
 class _HistoricalRawStream:
@@ -1280,7 +1297,7 @@ class _HistoricalRawStream:
         except (HTTPException, ListReadBudgetExhausted):
             raise
         except Exception as exc:
-            raise HTTPException(status_code=503, detail="Historical memory unavailable") from exc
+            raise MemoryBackingStoreUnavailable("Historical memory unavailable", stream="historical") from exc
         self._slots = [
             (
                 record,
@@ -1503,7 +1520,7 @@ class _CanonicalCursorStream:
     def _ensure_slots(self) -> None:
         if self._slot_index < len(self._slots) or self.exhausted:
             return
-        self._budget.check()
+        self._budget.check(stream="canonical")
         start_after: Optional[CanonicalScanCursor] = None
         if self.scan_keyset is not None:
             start_after = self._service.stream_keyset_to_scan_cursor(self.scan_keyset)
@@ -1529,7 +1546,7 @@ class _CanonicalCursorStream:
                 type(exc).__name__,
                 exc,
             )
-            raise HTTPException(status_code=503, detail="Canonical memory unavailable") from exc
+            raise MemoryBackingStoreUnavailable("Canonical memory unavailable", stream="canonical") from exc
         self._slots = [
             (
                 truncate_locked_memory_preview(memory) if memory is not None else None,
@@ -1553,14 +1570,14 @@ class _CanonicalCursorStream:
             memory, scan_keyset = self._slots[self._slot_index]
             # Raw scan position advances for filtered rows too.
             if memory is None:
-                self._budget.charge()
+                self._budget.charge(stream="canonical")
                 self.scan_keyset = scan_keyset
                 self._advance_raw_slot()
                 continue
             if self.emitted_keyset is not None and self._service.memory_cursor_sort_key(memory) <= (
                 self._service.keyset_sort_key(self.emitted_keyset)
             ):
-                self._budget.charge()
+                self._budget.charge(stream="canonical")
                 self.scan_keyset = scan_keyset
                 self._advance_raw_slot()
                 continue
@@ -2630,7 +2647,7 @@ class MemoryService:
         try:
             secret = cursor_secret()
         except UniversalListCursorError as exc:
-            raise HTTPException(status_code=503, detail="Memory cursor unavailable") from exc
+            raise MemoryBackingStoreUnavailable("Memory cursor unavailable", stream="cursor") from exc
 
         if cursor:
             try:


### PR DESCRIPTION
## What changed and why

SCA-374: rebase the remaining memories-503 hardening onto current `main`.
The generator mixed-direction rule and the `"Historical memory unavailable"`
allowlist entry are already on `main` and are not re-shipped.

`GET /v3/memories` first-page recoverability was still keyed on a detail-string
allowlist that has grown from 2 entries to 4 for the same bug. This PR replaces
that allowlist with `MemoryBackingStoreUnavailable` (stream:
`canonical` / `historical` / `cursor`), so a renamed or newly added unavailable
message degrades to the offset read instead of escaping as a hard 503.
The degraded path now calls `record_fallback` and logs the failing stream.

An independent-oracle test restates Firestore's automatic single-field rule
and asserts every composite-requiring `QUERY_SPEC` is in the checked-in
manifest — including the three list-scan specs from #11684 — so a generator
shortcut cannot make both sides of the existing generator-vs-file test wrong
together.

Closes SCA-374

## Product invariants affected

- INV-MEM-1
- INV-MEM-3
- INV-MEM-4

Line-Count-Exception: backend/utils/memory/memory_service.py | 3922 -> 3939 | add MemoryBackingStoreUnavailable and convert list-scan 503s onto that type in the module the issue names as the owner

## How it was verified

```
: > /tmp/omi-backend-unit-failures.txt
echo tests/unit/test_firestore_query_contract.py >> /tmp/omi-backend-unit-failures.txt
echo tests/unit/test_memories_pagination_clamp.py >> /tmp/omi-backend-unit-failures.txt
echo tests/unit/test_list_read_budget_contract.py >> /tmp/omi-backend-unit-failures.txt
echo tests/unit/test_universal_memory_list_cursor.py >> /tmp/omi-backend-unit-failures.txt
BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-backend-unit-failures.txt bash test.sh
```

Result: all four files passed
(`test_firestore_query_contract.py` 47 passed / 2 deselected;
`test_memories_pagination_clamp.py` 12 passed;
`test_list_read_budget_contract.py` 34 passed;
`test_universal_memory_list_cursor.py` 20 passed).

Did not exercise a live Firestore `FAILED_PRECONDITION` against production;
the unit tests drive the typed exception through the real first-page fallback
and the historical adapter with the prod index-building error.

## Tests

- `test_first_page_falls_back_on_typed_unavailable_regardless_of_detail` —
  a new detail string on the typed exception still degrades.
- `test_first_page_does_not_match_unavailable_detail_strings` — a matching
  string on a plain HTTPException does not fall back.
- `test_first_page_fallback_records_degraded_firestore_read` — `record_fallback`
  fires with `component=firestore_read`, `from_mode=cursor_page`,
  `to_mode=offset_read`, `outcome=degraded`.
- `test_every_composite_requiring_query_spec_is_declared_in_the_checked_in_manifest`
  plus `_platform_requires_composite` and
  `test_manifest_generator_classifies_the_firestore_single_field_rule`.

## Failure class (fixes)

Failure-Class: FC-undeclared-serving-query-index

## New guards (only when adding a check or ratchet)

The independent-oracle test would have caught the #11684 generator shortcut
that shipped GET /v3/memories 503 on 2026-08-17: the existing
generator-vs-checked-in-file test passes when both sides are wrong together.
It lives next to that contract in `test_firestore_query_contract.py` rather
than a new shared primitive because the rule is Firestore-index-specific.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

