### PR TITLE
fix(backend): resolve trigger feedback on the same data plane the snapshot reads

### DIFF
--- a/.github/failure-classes/FC-plane-seam-adopted-by-reader-not-writer.json
+++ b/.github/failure-classes/FC-plane-seam-adopted-by-reader-not-writer.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-plane-seam-adopted-by-reader-not-writer",
+  "violated_contract": "When a data-plane seam is introduced, every call site on the same logical surface must resolve the same plane. A reader that adopts the seam while its sibling writer keeps a compute-plane default splits one feature's authority across two projects.",
+  "canonical_prevention": "Adopt a new plane seam by enumerating the surface's call sites rather than the files the seam touches, and pin the plane at each one with a test that asserts the resolved client is threaded through -- not merely that the handler was called. A split is invisible in every environment where the two projects coincide, so it cannot be caught by deploying and watching for errors.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_jit_rollout.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/database/_client.py",
+    "backend/routers/jit_rollout.py",
+    "backend/utils/memory/canonical_memory_adapter.py",
+    "backend/utils/memory/jit_trigger_snapshot.py"
+  ],
+  "status": "open"
+}

--- a/backend/routers/jit_rollout.py
+++ b/backend/routers/jit_rollout.py
@@ -30,6 +30,7 @@ from models.jit_proactivity import (
     JITProactivityOperation,
 )
 from models.jit_trigger_feedback import JITTriggerFeedbackAction, JITTriggerFeedbackReceipt
+from database._client import get_data_plane_firestore_client
 from database.jit_proactivity_store import JITProactivityReservationError, reserve_jit_proactivity_event
 from database.memory_apply_store import MemoryFirestoreApplyError
 from database.read_boundary import MalformedDocError
@@ -235,6 +236,21 @@ async def get_jit_trigger_snapshot(
     )
 
 
+def _apply_trigger_feedback_on_data_plane(uid: str, memory_id: str, **kwargs):
+    """Apply trigger feedback against the plane the trigger snapshot reads.
+
+    The canonical adapter defaults to the compute-plane client. This router is
+    mounted on desktop-backend, whose compute project differs from the customer
+    data plane in development, so that default would look for the trigger row
+    in the wrong project and fail every retraction.
+
+    Resolving the client here rather than in the route keeps the (blocking)
+    first-use client construction off the event loop.
+    """
+
+    return apply_canonical_trigger_feedback(uid, memory_id, db_client=get_data_plane_firestore_client(), **kwargs)
+
+
 @router.post(_TRIGGER_FEEDBACK_PATH, response_model=JITTriggerFeedbackEnvelope)
 async def post_jit_trigger_feedback(
     request: JITTriggerFeedbackRequest,
@@ -257,7 +273,7 @@ async def post_jit_trigger_feedback(
         )
         result = await run_blocking(
             db_executor,
-            apply_canonical_trigger_feedback,
+            _apply_trigger_feedback_on_data_plane,
             uid,
             request.trigger_memory_id,
             event_id=request.event_id,

--- a/backend/tests/unit/test_jit_rollout.py
+++ b/backend/tests/unit/test_jit_rollout.py
@@ -1000,9 +1000,49 @@ def test_trigger_feedback_is_owner_authenticated_and_remains_available_while_rol
     assert response.status_code == 200
     assert response.json()['applied'] is True
     assert response.json()['trigger_revision'] == 5
-    assert observed['function'] is jit_rollout.apply_canonical_trigger_feedback
+    assert observed['function'] is jit_rollout._apply_trigger_feedback_on_data_plane
     assert observed['uid'] == 'owner'
     assert observed['kwargs']['event_id'] == 'e' * 64
+
+
+def test_trigger_feedback_writes_through_the_same_data_plane_the_snapshot_reads(monkeypatch):
+    """Feedback must resolve the trigger row where the snapshot published it.
+
+    This route is served by desktop-backend, whose compute project differs
+    from the customer data plane in development. Letting the canonical
+    adapter fall back to its compute-plane default would look for the trigger
+    in the wrong project, so every retraction would 409 while the trigger kept
+    firing -- with the rollout flag off, this is the user's only off switch.
+    """
+
+    observed = {}
+    data_plane = object()
+    compute_plane = object()
+
+    def record(uid, memory_id, **kwargs):
+        observed.update(uid=uid, memory_id=memory_id, kwargs=kwargs)
+        return 'applied'
+
+    monkeypatch.setattr(jit_rollout, 'apply_canonical_trigger_feedback', record)
+    monkeypatch.setattr(jit_rollout, 'get_data_plane_firestore_client', lambda: data_plane)
+
+    result = jit_rollout._apply_trigger_feedback_on_data_plane(
+        'owner',
+        'trigger-1',
+        event_id='e' * 64,
+        expected_account_generation=3,
+        expected_item_revision=4,
+        feedback=None,
+    )
+
+    assert result == 'applied'
+    assert observed['uid'] == 'owner'
+    assert observed['memory_id'] == 'trigger-1'
+    assert observed['kwargs']['event_id'] == 'e' * 64
+    # The point of the test: the plane is pinned, not left to the adapter's
+    # compute-plane default, which on desktop-backend is a different project.
+    assert observed['kwargs']['db_client'] is data_plane
+    assert observed['kwargs']['db_client'] is not compute_plane
 
 
 def test_trigger_feedback_rejects_stale_authority_without_leaking_details(monkeypatch):


### PR DESCRIPTION
## What

`POST /v1/jit/trigger-feedback` resolves the customer data plane the same way the trigger snapshot on the same router already does.

## Why

`#12390` introduced `OMI_FIRESTORE_DATA_PLANE_PROJECT` and adopted it across the JIT surface, including `jit_trigger_snapshot`, which is what publishes a user's trigger watchlist. It missed the sibling writer: `apply_canonical_trigger_feedback` was called without a `db_client`, so it fell back to `canonical_memory_adapter`'s compute-plane default.

`jit_rollout.router` is mounted on `desktop_backend`, which is the one deployment where those two projects differ — dev desktop-backend runs compute on `based-hardware-dev` while the ledger lives in `based-hardware`. The result: the snapshot serves a trigger from the data plane, the user hits snooze / not-useful / disable, the feedback path looks for that trigger row in the compute plane, does not find it, and the route returns `409 Trigger feedback authority changed or is unavailable` — permanently, while the trigger keeps firing.

That route's own docstring says it "intentionally remains available while the proactive rollout is disabled or killed," because it is the user's authority path. With the rollout flag off, notification feedback is the *only* way to retract a standing trigger — there is no `close_trigger` chat verb — so this made the off switch the one broken verb.

Invisible in production, where the compute project and the data plane are the same project. That is the whole difficulty of this class: deploying and watching for errors cannot find it.

## Test

`test_trigger_feedback_writes_through_the_same_data_plane_the_snapshot_reads` asserts the resolved data-plane client is threaded into the canonical call, not merely that the handler was invoked. Verified it fails without the one-line change and passes with it. Full file: 47 passed.

## Failure class

Registering a new one. The existing `FC-ambient-credentials-assumed-cross-plane` covers *credentials* for a cross-plane client; `FC-customer-data-plane-divergence` covers *client artifacts* binding to the wrong plane. Neither covers a seam adopted by a reader but not its sibling writer, which is what happened here and is the generalizable mistake: the adoption sweep enumerated the files the seam touched rather than the call sites on the surface.

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

