### PR TITLE
fix(backend): recognize the sweep's own committed write on crash replay

### DIFF
--- a/backend/utils/memory/daily_memory_sweep.py
+++ b/backend/utils/memory/daily_memory_sweep.py
@@ -73,6 +73,7 @@ from utils.memory.knowledge_ledger import (
     LedgerProvenance,
     LedgerWrite,
     amend_fact,
+    evidence_id_for_ledger_provenance,
     save_ledger_write,
 )
 from utils.memory.memory_system import ensure_canonical_apply_control_state
@@ -2652,6 +2653,29 @@ def _apply_candidate(
     if candidate.operation == "add":
         occupant = _find_active_slot_or_subject(uid, candidate, db_client=db_client)
         if occupant is not None:
+            # Crash-replay recognition: if the occupant already carries this
+            # exact plan/candidate's evidence identity, the canonical write for
+            # this receipt landed before a crash prevented receipt
+            # finalization. Re-applying would supersede our own row with a
+            # duplicate; recognize the landed effect and complete as a skip.
+            # A next-day sweep derives a different ``_plan_id`` and therefore a
+            # different evidence identity, so legitimate same-slot refreshes
+            # are unaffected.
+            replay_evidence_id = evidence_id_for_ledger_provenance(
+                uid,
+                LedgerProvenance(
+                    source_id=candidate.source_id,
+                    source_type=candidate.source_type,
+                    source_version=candidate.source_version,
+                    action_id=f"{_plan_id(uid, local_date)}:{candidate.source_key}",
+                ),
+            )
+            # An occupant without readable evidence cannot be proven to be our
+            # own replay, so fall through to the ordinary authority rules
+            # rather than suppressing a write we cannot account for.
+            occupant_evidence = getattr(occupant, "evidence", None) or ()
+            if any(getattr(item, "evidence_id", None) == replay_evidence_id for item in occupant_evidence):
+                return occupant.memory_id, "existing_active_slot" if candidate.slot else "existing_active_subject"
             occupant_rank = _target_authority(occupant)
             # A slot is a standing attribute the daily run maintains: a
             # sweep-authored occupant may be refreshed by an equal-rank sweep


### PR DESCRIPTION
## What

The daily memory sweep recognizes its own already-committed canonical write when it replays after a crash, instead of superseding it with a duplicate.

## The defect

`backend/scripts/daily_memory_sweep_emulator_test.py` — the crash-after-canonical-before-receipt scenario — fails deterministically on `main`, and has since #12084 introduced it. Reproduced 3/3 at `origin/main`, at `c01861f3cf34`, and at `2af083251c` itself. It has never passed on merged main.

Two behaviors combine:

1. `_claim_receipt` (`daily_memory_sweep.py:2175`) leases a receipt claim for `RECEIPT_LEASE` (10 min), and the default claimant is a fresh UUID per invocation (`:2854`). The next day's run is therefore always a "different claimant" with an expired lease, so it silently re-claims and redoes the work. That is by design and is safe when the redo is *exact* — the apply layer's deterministic `_row_id` then yields `idempotent_skip`.
2. `_apply_candidate` (`:2653`) breaks exactness for slotted facts. The occupant it finds is *this same candidate's own write from the crashed attempt*, but it matches the `sweep_slot_refresh` rule intended for legitimate day-N+1 refreshes, so it takes the `amend` path. `amend_fact` sets `supersedes=[prior]`, `_row_id()` hashes `supersedes`, the row id changes, and deterministic idempotency never fires.

Result per event: the row self-supersedes. One correct active row remains — this is not data loss and no wrong fact is shown — but it leaves a phantom superseded version, duplicate operation and commit rows, ~4 spurious outbox events that re-trigger downstream consumers, and telemetry reporting `committed` where it should report `skipped`. That last part is why this would not surface during a ramp: the health metric lies in the same direction as the bug.

## The fix

Recognize the replay through the ledger's own sanctioned mechanism. `evidence_id_for_ledger_provenance` hashes `{uid, source_id, source_type, source_version, action_id}`, and the sweep's `action_id` is deterministic per `(uid, local_date, source_key)` — invariant across the add-vs-amend replay, while a next-day sweep derives a different `_plan_id` and therefore a different identity. So a genuine slot refresh is untouched; only the crash replay is recognized.

An occupant whose evidence is unreadable falls through to the ordinary authority rules rather than suppressing a write it cannot account for.

## Evidence

- Emulator proof passes with the change (3 runs) and fails without it (3 runs) — verified by applying and reverting.
- The same test asserts the two behaviors that already worked, so both are held: the crash still leaves exactly one pending receipt, and a concurrent different claimant is still fenced with `source_idempotency_conflict`.
- `tests/unit/test_daily_memory_sweep.py`: 51 passed. The first draft of this change crashed `test_sweep_slot_refresh_amends_sweep_occupant_but_never_user_statements` on an occupant stub without `evidence`; that is what the defensive read above fixes.
- Other scenarios in the emulator proof (deletion race, generation contention, rollover, overlapping runners, paid-wipe) still pass.

## Why this was invisible

No workflow in `.github/workflows/` runs the Firestore emulator proofs — they are local-only. `FC-daily-memory-sweep-fence` names `daily_memory_sweep_emulator_test.py` as its canonical prevention artifact, so the registry reads as covered while the guard was red on main and never executed. Wiring these proofs into CI is the durable fix and is not attempted here.

## Blast radius

The vulnerable window is between the canonical apply commit and the `_finish_receipt` transaction (~100-300 ms per candidate). It does not need a process crash — a residual post-retry failure of that one transaction is enough; a Cloud Run Job task kill mid-batch also lands in it. Because the receipt stays pending and the scheduler revisits pending dates, every crash-in-window deterministically becomes a corruption event on the next run. Order of magnitude ~1e-4 per user-day: negligible at the current 2 enrolled accounts, roughly monthly at ~300, and worse than linear because a larger batch also runs longer.

Failure-Class: FC-daily-memory-sweep-fence

Line-Count-Exception: backend/utils/memory/daily_memory_sweep.py | 4970 -> 4994 | Splitting a ~5000-line transactional module is a strictly larger risk than this 24-line correctness fix, which is an early-return recognition inside one existing branch. The split is worth doing, but not in the same change that repairs a red crash-recovery guard.

## Product invariants affected

- INV-MEM-1 — Held, unchanged. No tier is added, renamed, or split; the change adds no collection and touches no tier assignment or access policy. It only decides whether an already-committed canonical row is re-applied.
- INV-MEM-4 — Held, and strengthened. Canonical promotion remains the sole Long-term authority and every pending item still gets exactly one terminal route. Before this change a crash replay gave one candidate a *second* apply — a duplicate operation and commit against a row that had already taken its route. Recognizing the landed effect restores the one-item-one-route property; the skip is accounted as `skipped` on the receipt rather than silently reported as a fresh `committed`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

