### PR TITLE
fix(backend): drop task-intelligence manifest paths deleted by the desktop refactor

### DIFF
--- a/.github/failure-classes/FC-cross-tree-path-reference-outruns-test-selection.json
+++ b/.github/failure-classes/FC-cross-tree-path-reference-outruns-test-selection.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "id": "FC-cross-tree-path-reference-outruns-test-selection",
+  "violated_contract": "A config or manifest that names source paths in another tree must be kept resolvable by the change that moves those paths. Path-based test selection decides which checks a diff runs from the diff's own paths, so a validator that resolves cross-tree references is never selected for the very change that invalidates them.",
+  "canonical_prevention": "Either select the validating test from the referenced paths as well as from the config's own path, or make the reference resistant to relocation (glob, symbol lookup, or a generated index) rather than a literal path. Both directions must be guarded: the refactor that relocates a referenced file has to fail fast, not hand a red default branch to the next unrelated contributor whose diff happens to trigger the full suite.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_task_intelligence_contract_freeze.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/config/task_intelligence_sources_v1.json",
+    "backend/utils/task_intelligence/contracts.py"
+  ],
+  "status": "open"
+}

--- a/backend/config/task_intelligence_sources_v1.json
+++ b/backend/config/task_intelligence_sources_v1.json
@@ -34,7 +34,6 @@
         "desktop/macos/Desktop/Sources/Stores/TasksStore.swift",
         "desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift",
         "desktop/macos/Desktop/Sources/APIClient.swift",
-        "desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstTasksPage.swift",
         "desktop/macos/Desktop/Sources/MainWindow/Dashboard/WhatMattersNowSection.swift",
         "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift",
         "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift",
@@ -47,9 +46,7 @@
       ],
       "test_adapter": "direct_command_contract",
       "writer_anchors": [
-        {"path": "desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstTasksPage.swift", "symbol": "client.createTask", "discover": true},
         {"path": "desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift", "symbol": "client.createTask", "discover": true},
-        {"path": "desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstTasksPage.swift", "symbol": "client.updateTask", "discover": true},
         {"path": "backend/routers/desktop_core.py", "symbol": "action_items_db.create_action_item", "discover": true}
       ]
     },


### PR DESCRIPTION
## main is red

`tests/unit/test_task_intelligence_contract_freeze.py` fails on clean `origin/main` (21084f70ca) with three failures, all from one cause:

```
ValueError: source desktop_manual has missing owner path:
  desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstTasksPage.swift
```

`validate_source_manifest` raises on the unresolvable owner path before reaching any later check, which is why three separate tests fail on it.

`a3a811a98f refactor(desktop): eliminate duplicate destination UIs` deleted `ChatFirst/ChatFirstTasksPage.swift` (654 lines) and consolidated onto `MainWindow/Pages/TasksPage.swift`. `backend/config/task_intelligence_sources_v1.json` still named the deleted file in `owner_paths` and in two `writer_anchors`.

## Change

Delete the three lines naming the removed file. `MainWindow/Pages/TasksPage.swift` is already an owner path, so the entry was a leftover duplicate. The two writer anchors are dropped rather than repointed: `client.createTask` and `client.updateTask` no longer appear anywhere under `desktop/macos/Desktop/Sources` — the consolidated page does not call them, so there is no surviving path to move them to.

`test_task_intelligence_contract_freeze.py`: 29 passed.

## Why the refactor's own CI was green

Backend unit test selection is driven by the changed paths of a diff. `a3a811a98f` changed only Swift files, so the backend suite that validates this manifest was never selected — while the manifest it invalidated lives in `backend/config/` and points *into* the desktop tree. Nothing in that PR could have caught it.

The cost lands on unrelated contributors: any later PR touching a backend file with no test-selection contract runs the full 997-file suite and fails on a defect it did not introduce. That is how this surfaced — on an unrelated JIT change.

Registering the class rather than only fixing the instance, because the hazard is structural and will recur wherever a config names paths in another tree.

Failure-Class: new

## Product invariants affected

- INV-TASK-2 — Held, unchanged. The manifest is a registry of which source paths own task-writing behavior; this change removes three references to a file the desktop refactor already deleted. It adds no writer, removes no writer that still exists, and alters no capture policy, Candidate lifecycle, or acceptance gesture. The `desktop_manual` source keeps its `direct_command` policy class and its surviving owner paths, including the consolidated `MainWindow/Pages/TasksPage.swift` that replaced the removed file. Manual desktop creation carries a real user gesture and is explicitly out of INV-TASK-2's scope either way.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

