### PR TITLE
fix(desktop): keep chat scroll ownership until input ends

### DIFF
--- a/.github/failure-classes/FC-wall-clock-gesture-ownership.json
+++ b/.github/failure-classes/FC-wall-clock-gesture-ownership.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-wall-clock-gesture-ownership",
+  "violated_contract": "A live viewport gesture owns the transcript until the platform reports that input has ended; reader ownership must not expire on a fixed wall-clock delay while trackpad momentum or another native scroll transaction is still active.",
+  "canonical_prevention": "Centralize input ownership in the AppKit scroll detector, emit an end callback from native live-scroll completion or the bounded fallback for inputs without a native lifecycle, and make every auto-following chat surface release its active-scroll state only from that callback.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/ChatScrollLiveEdgeTests.swift",
+    "desktop/macos/Desktop/Tests/ChatTranscriptGestureHarnessTests.swift"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift",
+    "desktop/macos/Desktop/Sources/MainWindow/Components/ChatScrollBehavior.swift"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -398,7 +398,6 @@ struct ChatMessagesView<WelcomeContent: View>: View {
   /// Set immediately by the scroll wheel monitor to win the race against
   /// throttled programmatic scrolls during streaming.
   @State private var userIsScrolling = false
-  @State private var userScrollEndWorkItem: DispatchWorkItem?
   /// Tracks work items for delayed initial bottom scrolls so they can be
   /// canceled on user scroll or disappear.
   @State private var initialScrollWorkItems: [DispatchWorkItem] = []
@@ -890,7 +889,7 @@ struct ChatMessagesView<WelcomeContent: View>: View {
     }
   }
 
-  /// Cancels all pending scheduled scrolls (throttle, initial, user-scroll-end).
+  /// Cancels all pending scheduled scrolls (throttle and initial placement).
   private func cancelAllPendingScrolls() {
     scrollThrottleWorkItem?.cancel()
     scrollThrottleWorkItem = nil
@@ -900,8 +899,6 @@ struct ChatMessagesView<WelcomeContent: View>: View {
     // when it changes: this runs on every scroll event, and an unconditional
     // `@State` write there is a body invalidation per event.
     if hasQueuedFollowScroll { hasQueuedFollowScroll = false }
-    userScrollEndWorkItem?.cancel()
-    userScrollEndWorkItem = nil
     for item in initialScrollWorkItems {
       item.cancel()
     }
@@ -1068,24 +1065,16 @@ struct ChatMessagesView<WelcomeContent: View>: View {
         transcriptGeometry.setFollowingLiveEdge(false)
         transcriptGeometry.releaseSelection()
         cancelPendingScrollsForUserInteraction()
-        let endWork = DispatchWorkItem {
-          userIsScrolling = false
-        }
-        userScrollEndWorkItem = endWork
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: endWork)
+      } onUserScrollEnded: {
+        userIsScrolling = false
       } onScrollSettledAtBottom: {
         // The detector reports a settle only once the input that produced it
         // genuinely finished: AppKit's `didEndLiveScroll` for wheel/trackpad
         // (momentum included), or the bounded timer for keyboard and scrollbar
         // input. Both are stronger evidence than the wall-clock
-        // `userIsScrolling` latch, which exists only to stop programmatic
-        // scrolls fighting a gesture still in flight. Consulting the latch here
-        // made this resume unreachable: `didEndLiveScroll` delivers on the very
-        // next main-thread turn, ~0.3s before the latch clears, so a reader who
-        // returned to the live edge could never resume live following.
-        userScrollEndWorkItem?.cancel()
-        userScrollEndWorkItem = nil
-        userIsScrolling = false
+        // `userIsScrolling` state, which the detector's native end-of-input
+        // callback releases immediately before this bottom-only callback.
+        // A separate timer here let reader ownership expire during long input.
         guard
           ChatScrollLiveEdge.canResumeFollowing(
             source: .settledUserScroll,

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatScrollBehavior.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatScrollBehavior.swift
@@ -126,6 +126,7 @@ private final class ScrollDetectorHostView: NSView {
 /// keyboard scroll-navigation on the enclosing NSScrollView.
 struct UserScrollDetector: NSViewRepresentable {
   let onUserScroll: () -> Void
+  var onUserScrollEnded: () -> Void = {}
   var onScrollSettledAtBottom: () -> Void = {}
 
   func makeNSView(context: Context) -> NSView {
@@ -149,11 +150,16 @@ struct UserScrollDetector: NSViewRepresentable {
   }
 
   func makeCoordinator() -> Coordinator {
-    Coordinator(onUserScroll: onUserScroll, onScrollSettledAtBottom: onScrollSettledAtBottom)
+    Coordinator(
+      onUserScroll: onUserScroll,
+      onUserScrollEnded: onUserScrollEnded,
+      onScrollSettledAtBottom: onScrollSettledAtBottom
+    )
   }
 
   final class Coordinator: NSObject, @unchecked Sendable {
     let onUserScroll: () -> Void
+    let onUserScrollEnded: () -> Void
     let onScrollSettledAtBottom: () -> Void
     private var monitor: Any?
     private weak var installedScrollView: NSScrollView?
@@ -169,6 +175,7 @@ struct UserScrollDetector: NSViewRepresentable {
     /// delta, so a long lazy transcript is not invalidated while AppKit is
     /// still delivering momentum to its current scroll view.
     private var wheelGestureOwnsViewport = false
+    private var nativeLiveScrollIsActive = false
     private var willStartLiveScrollObservation: NSObjectProtocol?
     private var didEndLiveScrollObservation: NSObjectProtocol?
     private var verticalWheelPassthroughObservation: NSObjectProtocol?
@@ -184,8 +191,13 @@ struct UserScrollDetector: NSViewRepresentable {
       119,  // End
     ]
 
-    init(onUserScroll: @escaping () -> Void, onScrollSettledAtBottom: @escaping () -> Void) {
+    init(
+      onUserScroll: @escaping () -> Void,
+      onUserScrollEnded: @escaping () -> Void = {},
+      onScrollSettledAtBottom: @escaping () -> Void
+    ) {
       self.onUserScroll = onUserScroll
+      self.onUserScrollEnded = onUserScrollEnded
       self.onScrollSettledAtBottom = onScrollSettledAtBottom
     }
 
@@ -220,7 +232,7 @@ struct UserScrollDetector: NSViewRepresentable {
           object: targetScrollView,
           queue: .main
         ) { [weak self] _ in
-          self?.beginUserScroll()
+          self?.beginNativeLiveScroll()
         }
         didEndLiveScrollObservation = NotificationCenter.default.addObserver(
           forName: NSScrollView.didEndLiveScrollNotification,
@@ -228,7 +240,7 @@ struct UserScrollDetector: NSViewRepresentable {
           queue: .main
         ) { [weak self, weak targetScrollView] _ in
           guard let self, let targetScrollView else { return }
-          self.finishUserScroll(on: targetScrollView)
+          self.finishNativeLiveScroll(on: targetScrollView)
         }
         verticalWheelPassthroughObservation = NotificationCenter.default.addObserver(
           forName: .chatVerticalWheelPassthrough,
@@ -238,7 +250,8 @@ struct UserScrollDetector: NSViewRepresentable {
           guard let self, let targetScrollView else { return }
           self.beginUserScroll()
           if let event = notification.userInfo?["event"] as? NSEvent,
-            event.phase.isEmpty, event.momentumPhase.isEmpty
+            event.phase.isEmpty, event.momentumPhase.isEmpty,
+            !self.nativeLiveScrollIsActive
           {
             self.scheduleUnphasedWheelEnd(for: targetScrollView)
           }
@@ -260,7 +273,9 @@ struct UserScrollDetector: NSViewRepresentable {
               guard targetScrollView.bounds.contains(wheelLocation) else { break }
               if event.scrollingDeltaY != 0 || event.scrollingDeltaX != 0 {
                 self.beginUserScroll()
-                if event.phase.isEmpty, event.momentumPhase.isEmpty {
+                if event.phase.isEmpty, event.momentumPhase.isEmpty,
+                  !self.nativeLiveScrollIsActive
+                {
                   self.scheduleUnphasedWheelEnd(for: targetScrollView)
                 }
               }
@@ -303,6 +318,7 @@ struct UserScrollDetector: NSViewRepresentable {
         pressOriginScrollTop = nil
         pressCandidateOwnsViewport = false
         wheelGestureOwnsViewport = false
+        nativeLiveScrollIsActive = false
         if let willStartLiveScrollObservation {
           NotificationCenter.default.removeObserver(willStartLiveScrollObservation)
         }
@@ -389,6 +405,16 @@ struct UserScrollDetector: NSViewRepresentable {
       onUserScroll()
     }
 
+    private func beginNativeLiveScroll() {
+      nativeLiveScrollIsActive = true
+      beginUserScroll()
+    }
+
+    private func finishNativeLiveScroll(on scrollView: NSScrollView) {
+      nativeLiveScrollIsActive = false
+      finishUserScroll(on: scrollView)
+    }
+
     private func finishUserScroll(on scrollView: NSScrollView) {
       settleWorkItem?.cancel()
       settleWorkItem = nil
@@ -397,9 +423,11 @@ struct UserScrollDetector: NSViewRepresentable {
       // transaction. Read the final clip bounds on the next main turn, after
       // the scroll view has committed its terminal position.
       let workItem = DispatchWorkItem { [weak self, weak scrollView] in
-        guard let self, let scrollView, Self.isAtBottom(scrollView) else { return }
-        self.onScrollSettledAtBottom()
+        guard let self else { return }
+        self.onUserScrollEnded()
         self.settleWorkItem = nil
+        guard let scrollView, Self.isAtBottom(scrollView) else { return }
+        self.onScrollSettledAtBottom()
       }
       settleWorkItem = workItem
       DispatchQueue.main.async(execute: workItem)
@@ -414,6 +442,7 @@ struct UserScrollDetector: NSViewRepresentable {
       let workItem = DispatchWorkItem { [weak self, weak scrollView] in
         guard let self else { return }
         self.wheelGestureOwnsViewport = false
+        self.onUserScrollEnded()
         guard let scrollView, Self.isAtBottom(scrollView) else {
           self.settleWorkItem = nil
           return
@@ -435,9 +464,11 @@ struct UserScrollDetector: NSViewRepresentable {
       // never use this timer because momentum can outlive it.
       settleWorkItem?.cancel()
       let workItem = DispatchWorkItem { [weak self, weak scrollView] in
-        guard let self, let scrollView, Self.isAtBottom(scrollView) else { return }
-        self.onScrollSettledAtBottom()
+        guard let self else { return }
+        self.onUserScrollEnded()
         self.settleWorkItem = nil
+        guard let scrollView, Self.isAtBottom(scrollView) else { return }
+        self.onScrollSettledAtBottom()
       }
       settleWorkItem = workItem
       DispatchQueue.main.asyncAfter(
@@ -583,7 +614,6 @@ struct ChatScrollContainer<Content: View>: View {
   @State private var userIsScrolling = false
   @State private var hasActivityBelow = false
   @State private var scrollThrottleWorkItem: DispatchWorkItem?
-  @State private var userScrollEndWorkItem: DispatchWorkItem?
   @State private var settleWorkItems: [DispatchWorkItem] = []
   @State private var lastViewportSize: CGSize = .zero
   @State private var lastFollowScrollTime: TimeInterval?
@@ -634,18 +664,9 @@ struct ChatScrollContainer<Content: View>: View {
       userIsScrolling = true
       hasActivityBelow = false
       cancelAllPendingScrolls()
-      let endWork = DispatchWorkItem {
-        userIsScrolling = false
-      }
-      userScrollEndWorkItem = endWork
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: endWork)
-    } onScrollSettledAtBottom: {
-      // Same contract as ChatMessagesView: the detector only reports a settle
-      // once the input finished, so release the wall-clock latch here rather
-      // than consulting it — it is still true on this very run-loop turn.
-      userScrollEndWorkItem?.cancel()
-      userScrollEndWorkItem = nil
+    } onUserScrollEnded: {
       userIsScrolling = false
+    } onScrollSettledAtBottom: {
       guard
         ChatScrollLiveEdge.canResumeFollowing(
           source: .settledUserScroll,
@@ -777,8 +798,6 @@ struct ChatScrollContainer<Content: View>: View {
     scrollThrottleWorkItem?.cancel()
     scrollThrottleWorkItem = nil
     if hasQueuedFollowScroll { hasQueuedFollowScroll = false }
-    userScrollEndWorkItem?.cancel()
-    userScrollEndWorkItem = nil
     for item in settleWorkItems {
       item.cancel()
     }

--- a/desktop/macos/Desktop/Tests/ChatScrollLiveEdgeTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatScrollLiveEdgeTests.swift
@@ -249,9 +249,11 @@ final class UserScrollDetectorTests: XCTestCase {
   func testRapidLiveScrollHandsOwnershipToReaderAndDoesNotRearmAwayFromBottom() {
     let (scrollView, hostView) = makeScrollViewAtBottom()
     var userScrollStarts = 0
+    var userScrollEnds = 0
     var settledAtBottom = 0
     let coordinator = UserScrollDetector.Coordinator(
       onUserScroll: { userScrollStarts += 1 },
+      onUserScrollEnded: { userScrollEnds += 1 },
       onScrollSettledAtBottom: { settledAtBottom += 1 }
     )
     coordinator.install(for: hostView)
@@ -264,6 +266,7 @@ final class UserScrollDetectorTests: XCTestCase {
     for scrollTop in [620.0, 400.0, 160.0] {
       scrollView.contentView.setBoundsOrigin(NSPoint(x: 0, y: scrollTop))
     }
+    XCTAssertEqual(userScrollEnds, 0, "reader ownership must remain active until AppKit ends live scroll")
     NotificationCenter.default.post(
       name: NSScrollView.didEndLiveScrollNotification,
       object: scrollView
@@ -271,6 +274,7 @@ final class UserScrollDetectorTests: XCTestCase {
     drainMainQueue()
 
     XCTAssertEqual(userScrollStarts, 1, "native live scroll must immediately give the reader ownership")
+    XCTAssertEqual(userScrollEnds, 1, "native live-scroll completion must release reader ownership")
     XCTAssertEqual(
       settledAtBottom,
       0,

--- a/desktop/macos/Desktop/Tests/ChatTranscriptGestureHarnessTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatTranscriptGestureHarnessTests.swift
@@ -156,6 +156,13 @@ final class ChatTranscriptGestureHarnessTests: XCTestCase {
     harness.performUpwardGesture(events: 30, endGesture: false)
     let readerPosition = harness.scrollTop
 
+    // Keep the native live-scroll transaction open beyond the old 300 ms
+    // ownership timer. A slow SwiftUI update or a brief pause during a real
+    // trackpad gesture must not make the viewport available to send-start.
+    harness.pump(0.4)
+    XCTAssertEqual(
+      harness.scrollTop, readerPosition, accuracy: 4,
+      "an open live-scroll transaction must retain the reader's viewport")
     harness.model.isSending = true
     harness.pump(0.7)
 
@@ -765,6 +772,13 @@ final class ChatTranscriptGestureHarnessTests: XCTestCase {
           wheel1: deltaY, wheel2: 0, wheel3: 0)
       else { return nil }
       cgEvent.setIntegerValueField(isContinuousField, value: 1)
+      // These events sit inside the explicit AppKit live-scroll transaction
+      // posted by the gesture helpers. Mark them as phased trackpad updates so
+      // the detector does not also arm its classic-wheel timeout fallback.
+      cgEvent.setIntegerValueField(
+        .scrollWheelEventScrollPhase,
+        value: Int64(NSEvent.Phase.changed.rawValue)
+      )
       guard let event = NSEvent(cgEvent: cgEvent) else { return nil }
       // A CGEvent-derived NSEvent carries no window, so production's
       // `event.window == scrollView.window` guard would drop it. Give it the

--- a/desktop/macos/changelog/unreleased/20260829-chat-scroll-ownership.json
+++ b/desktop/macos/changelog/unreleased/20260829-chat-scroll-ownership.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed chat jumping to the latest message while you are still scrolling"
+}


### PR DESCRIPTION
## What changed and why

Fixes the `ChatTranscriptGestureHarnessTests.testSendStartingWhileTheReaderScrollsDoesNotSeizeTheViewport` flake reported in #12039. The transcript released reader ownership after a fixed 300 ms even when AppKit's live-scroll transaction was still active, so a delayed `isSending` update could snap the reader to the live edge under CI load.

- `UserScrollDetector` now publishes a single end-of-input callback from AppKit's native live-scroll completion, with the existing bounded fallback retained for keyboard, scrollbar, and unphased wheel input
- both the main transcript and shared floating/notch scroll container release `userIsScrolling` only from that callback
- the mounted transcript harness now emits phased trackpad events and holds the gesture open beyond the former timeout, making the CI race deterministic

This addresses only the chat-transcript occurrence in #12039. The separate `KernelTurnRecordedProjectionTests` and `SuggestedTasksStoreTests` causes remain open.

## Product invariants affected

- INV-CHAT-1 — no transcript/session ownership or persistence changes; the shared transcript surfaces continue using the same scroll primitive
- INV-CHAT-2 — reader movement remains authoritative until the platform reports that input ended

## How it was verified

- Red proof: with the old 300 ms expiry reintroduced against the strengthened regression, the viewport jumped to `4713` instead of preserving `3513`
- Green proof: `ChatTranscriptGestureHarnessTests | UserScrollDetectorTests | MarkdownNestedScrollTests` — 23 tests, 0 failures
- Stress proof: exact former flake executed 10 consecutive times through the built XCTest bundle — 10/10 passed
- `python3 scripts/check_desktop_test_quality.py` — passed at the existing ratchet (54 source-reading files / 147 sites, 16 waits)
- `./scripts/swiftlint-wrapper.sh lint` — 0 violations across 1,444 files
- changed-file pinned `swift-format` lint and `git diff --check` — passed
- `./scripts/omi-macos-dev doctor` — passed; no active local bundle conflicts

No iOS, Android, BLE, or physical-device path is involved. The behavioral proof mounts the real macOS `ChatMessagesView` in `NSHostingView` and drives its AppKit scroll lifecycle.

## Tests

- `ChatTranscriptGestureHarnessTests.testSendStartingWhileTheReaderScrollsDoesNotSeizeTheViewport` now keeps the native gesture open beyond 300 ms and verifies both the pre-send and post-send viewport
- `UserScrollDetectorTests.testRapidLiveScrollHandsOwnershipToReaderAndDoesNotRearmAwayFromBottom` verifies ownership is not released before `didEndLiveScroll` and is released exactly when AppKit ends the gesture

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative (only when needed)

Adds `FC-wall-clock-gesture-ownership`.

- Violated contract: a native viewport gesture owns the transcript until the platform says the input ended; a wall-clock timeout cannot revoke that ownership while momentum or a live-scroll transaction is active
- Canonical prevention: centralize start/end ownership in `UserScrollDetector`, use AppKit completion for native gestures, and reserve bounded timers for input paths without a native lifecycle
- Guard artifacts: `ChatScrollLiveEdgeTests.swift` pins the coordinator lifecycle; `ChatTranscriptGestureHarnessTests.swift` pins the mounted SwiftUI/AppKit race that failed in CI run 32542769839

## New guards (only when adding a check or ratchet)

The mounted regression would have caught the real #12039 / run 32542769839 failure deterministically. This is implemented as a shared detector primitive plus behavioral contract tests, not as a new static check or ratchet.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

