### PR TITLE
fix(backend): stop treating an empty extraction as a memory deletion

### DIFF
--- a/.github/failure-classes/FC-destructive-gate-keyed-on-proxy-for-intent.json
+++ b/.github/failure-classes/FC-destructive-gate-keyed-on-proxy-for-intent.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-destructive-gate-keyed-on-proxy-for-intent",
+  "violated_contract": "A destructive-operation gate must be keyed on whether the operation actually destroys something, never on a proxy that conflates it with a benign outcome. An empty replacement set means 'remove this source's rows' only when rows exist to remove; it equally means 'this source produced nothing', which is ordinary and requires no authority.",
+  "canonical_prevention": "When adding a safety precondition to a shared write boundary, enumerate every existing caller and prove each can satisfy it, rather than adding it at the boundary and assuming callers already hold the authority. Where the boundary cannot distinguish intents, either take intent as an explicit argument or return before the boundary in the provably-benign case -- and keep a test that the genuinely destructive case is still refused, so the repair cannot quietly become a relaxation.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_conversation_replacement_backoff.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/utils/memory/canonical_memory_adapter.py",
+    "backend/database/memory_apply_store.py",
+    "backend/database/legal_holds.py"
+  ],
+  "status": "open"
+}

--- a/backend/tests/unit/test_conversation_replacement_backoff.py
+++ b/backend/tests/unit/test_conversation_replacement_backoff.py
@@ -179,3 +179,56 @@ def test_caller_owning_an_outer_loop_keeps_immediate_rounds(monkeypatch):
 
     assert injector.calls == 3
     assert sleeps == []
+
+
+def test_conversation_yielding_no_memories_is_a_noop_not_a_deletion(monkeypatch):
+    """A conversation that extracts nothing must not enter the deletion boundary.
+
+    Prod regression (2026-08-28 -> 08-30): #12084 began requiring an
+    ``explicit_memory_deletion`` gate token for any empty replacement, because
+    an empty replacement normally *removes* a conversation's rows. Conversation
+    finalization holds no such gate, so a conversation that simply produced no
+    memories raised ``LegalHoldAuthorityUnavailable`` and returned 500. It ran
+    at a 74% failure rate on ``/v1/conversations/from-segments`` for two days.
+
+    With no extracted items and no prior rows for the conversation, there is
+    nothing to write and nothing to retract, so the call must resolve as a
+    no-op without reaching the destructive path at all.
+    """
+
+    db = _extraction_db()
+    injector = _install_injector(monkeypatch, conflicts=0)
+
+    result = replace_conversation_sourced_memories(UID, CONVERSATION_ID, [], db_client=db)
+
+    assert result["committed_memory_ids"] == []
+    assert result["retracted_memory_ids"] == []
+    assert result["reactivated_memory_ids"] == []
+    # The destructive boundary was never reached, so no gate was ever needed.
+    assert injector.calls == 0
+    # And the account's control state is untouched.
+    assert db.docs[f"users/{UID}/memory_state/apply_control"]["source_generation"] == 1
+
+
+def test_empty_replacement_over_existing_rows_still_demands_the_gate(monkeypatch):
+    """The compliance rule itself must survive the no-op shortcut.
+
+    This is the other half of the fix: emptying a conversation that *does* have
+    canonical rows genuinely retracts them, so it must still be refused without
+    ``explicit_memory_deletion`` authority. Only the provably-nothing-to-do case
+    returns early.
+    """
+
+    from database.legal_holds import LegalHoldAuthorityUnavailable
+
+    db = _extraction_db()
+    items = _extracted_items()
+    replace_conversation_sourced_memories(UID, CONVERSATION_ID, items, db_client=db)
+    assert db.docs[f"users/{UID}/memory_items/{items[0]['id']}"]["status"] == MemoryItemStatus.active.value
+
+    # Same conversation, now extracting nothing: this removes the row above.
+    with pytest.raises(LegalHoldAuthorityUnavailable):
+        replace_conversation_sourced_memories(UID, CONVERSATION_ID, [], db_client=db)
+
+    # Fail-closed: the row survives the refused deletion.
+    assert db.docs[f"users/{UID}/memory_items/{items[0]['id']}"]["status"] == MemoryItemStatus.active.value

--- a/backend/utils/memory/canonical_memory_adapter.py
+++ b/backend/utils/memory/canonical_memory_adapter.py
@@ -42,7 +42,11 @@ from database.memory_apply_store import (
     tombstone_memory_items_firestore,
     privacy_deletion_receipt_id,
 )
-from database.legal_holds import current_destructive_operation_token, destructive_operation_gate
+from database.legal_holds import (
+    LegalHoldAuthorityUnavailable,
+    current_destructive_operation_token,
+    destructive_operation_gate,
+)
 from database.memory_vector_repair_outbox import build_vector_repair_purge_outbox_records
 from database.memory_vector_metadata import canonical_memory_provider_id
 from database.account_deletion_projection_fence import read_account_deletion_projection_fence
@@ -1950,6 +1954,43 @@ def replace_conversation_sourced_memories(
             )
             if item.source_state == SourceState.active and not _item_sourced_from_conversation(item, conversation_id)
         ]
+        if not items and not expected_source_items:
+            # Nothing extracted, and nothing of this conversation's already in
+            # the ledger. Falling through sends an empty write set into
+            # ``replace_conversation_source_firestore``, whose empty-replacement
+            # branch demands an ``explicit_memory_deletion`` token -- a
+            # deliberate rule, because emptying a conversation normally
+            # *retracts* its rows.
+            #
+            # Emptiness alone cannot tell the two callers apart. An explicit
+            # retraction that happens to remove nothing must still be recorded,
+            # advancing the source generation (WS-J delete-privacy contract).
+            # Conversation finalization that simply extracted nothing is an
+            # ordinary outcome owing no record, and holds no gate -- so it died
+            # here with LegalHoldAuthorityUnavailable.
+            #
+            # The gate itself is what distinguishes them, so ask it without
+            # letting the answer be fatal. Holding it means a deliberate
+            # deletion: fall through and record. Not holding it means there is
+            # provably nothing to do and no authority is required.
+            #
+            # This never relaxes the rule: an empty replacement that would
+            # genuinely retract rows has a non-empty ``expected_source_items``,
+            # never reaches here, and is still refused without authority.
+            # ``expected_reactivation_items`` derives from
+            # ``terminal_source_ids``, itself derived from
+            # ``expected_source_items``, so it is necessarily empty here too.
+            try:
+                current_destructive_operation_token(uid, kind="explicit_memory_deletion")
+            except LegalHoldAuthorityUnavailable:
+                return {
+                    "retracted_memory_ids": [],
+                    "committed_memory_ids": [],
+                    "reactivated_memory_ids": [],
+                    "vector_delete_ids": [],
+                    "tombstoned_evidence_ids": [],
+                    "source_generation": observed_control.source_generation,
+                }
         confirmed_control = _read_replacement_control(uid, db_client=client)
         if (
             observed_control.head_commit_id != confirmed_control.head_commit_id


### PR DESCRIPTION
## Live production regression

`https://api.omi.me/v1/conversations/from-segments` on PROD has been returning 500 for most requests since 2026-08-28T01:58Z. Measured over the 6h to 2026-08-30T01:00Z: **393x 500, 130x 200, 6x 422 — a 74% failure rate**, steady at 200-480 exceptions/hour.

Every failure is:

```
LegalHoldAuthorityUnavailable: destructive operation gate is not active in this context
```

## Cause

Bisected by log sampling: zero occurrences at 2026-08-27T12/16/20Z and 2026-08-28T00Z; first occurrence 2026-08-28T01:58:07Z on prod revision `backend-add08a4-33114042056-1` (created 01:43Z), the deploy after `backend-932e2f5-33095639201-1`. The only commit in `932e2f5..add08a4` touching the implicated files is `2af083251c` — **#12084, the JIT knowledge ledger foundation** — which added both the import and the failing line.

`replace_conversation_source_firestore` requires `explicit_memory_deletion` authority for an empty write set (`memory_apply_store.py:1345`, *"empty replacement requires privacy gate authority"*). That rule is deliberate and correct: emptying a conversation's replacement set normally **retracts** its canonical rows.

The caller keys that decision on `not items`. Emptiness is a proxy for two different things:

- *"remove this conversation's rows"* — genuinely destructive, and the explicit-deletion callers hold a `destructive_operation_gate` (7 sites in `canonical_memory_adapter.py`, plus `memory_service.py:137`), so those work;
- *"this conversation produced no memories"* — an ordinary outcome. Conversation finalization holds no gate, so `routers/developer.py:1824 -> process_conversation -> memory_service.py:3848 -> replace_conversation_sourced_memories` raised and the request 500'd unhandled through the ASGI stack.

## Change

Emptiness cannot distinguish the two callers, but the gate can — so ask it, without letting the answer be fatal. When there are no extracted items **and** no existing rows for the conversation, attempt to read the deletion token: holding it means a deliberate deletion, so fall through unchanged; not holding it means there is provably nothing to do and no authority is required, so return a no-op.

Three cases, all preserved:

| State | Behavior |
|---|---|
| No items, no existing rows, no gate — conversation extracted nothing | No-op return. **This is the prod fix.** |
| No items, no existing rows, gate held — explicit retraction removing nothing | Falls through and still records the replacement, advancing `source_generation`. |
| No items, existing rows to retract | Never reaches the short-circuit; still refused without authority. |

**This does not relax the gate.** An empty replacement that would genuinely retract rows has a non-empty `expected_source_items` and never reaches this branch.

A first attempt short-circuited on emptiness alone. The repo's pre-push gate caught it: `test_ws_j_delete_privacy.py::test_memory_service_retract_records_empty_source_replacement` asserts that an explicit retraction removing nothing must *still* be recorded (`source_generation` 1 -> 2). That WS-J audit contract is why the condition keys on the gate rather than on emptiness.

## Tests

Two added, in the file that already owns this boundary's contract:

- `test_conversation_yielding_no_memories_is_a_noop_not_a_deletion` — reproduces the exact production exception without the change, and asserts the destructive path is never reached (`injector.calls == 0`) and control state is untouched.
- `test_empty_replacement_over_existing_rows_still_demands_the_gate` — commits a row, then empties the same conversation, and asserts `LegalHoldAuthorityUnavailable` is still raised and the row survives. This is the half that keeps the repair from becoming a relaxation.

The pre-existing `test_memory_service_retract_records_empty_source_replacement` is the guard for the recorded-retraction case and passes unchanged.

Verified by reverting: the first new test fails with the production exception, the second passes in both states. With the change: 5 + 3 + 39 passed across `test_conversation_replacement_backoff.py`, `test_cascade_retract_convergence.py`, and `test_ws_j_delete_privacy.py`.

## Note on scope

Fixing this on `main` reaches development only. **The production deploy is a separate authorized step and is not part of this PR.**

Two things worth checking separately, not addressed here: `process_conversation` is shared with normal mobile/desktop conversation finalization, so the blast radius is likely wider than the developer endpoint; and prod shows scattered 500s on `/v3/memories/{id}` (many distinct ids, ~1 each) that may be unrelated.

Failure-Class: new

Line-Count-Exception: backend/utils/memory/canonical_memory_adapter.py | 3450 -> 3491 | The change is a 12-line guarded early return plus a multi-line import; the remaining lines are the comment explaining why returning before the destructive boundary is not a relaxation of the deletion gate. That reasoning is the part a future reader most needs, and a subtle compliance boundary is the wrong place to trade it for line count. Splitting this module is worth doing, but not in the change repairing a live 74%-failure production regression.

## Product invariants affected

- INV-MEM-4 — Held, and restored. Canonical promotion remains the sole Long-term authority, and every pending item still takes exactly one terminal route. The short-circuit fires only when there are no items and no existing conversation-sourced rows, so no item exists to be routed and none is created, promoted, archived, or retracted. Before this change that state did not take a route at all — it raised, failing the whole conversation enrichment, so the conversation got neither memories nor a summary.
- INV-MEM-1 — Held, unchanged. No tier is added, renamed, or split; no collection is created; no tier assignment or access policy is touched. The change only decides whether to enter a write boundary that would perform no writes.

## Blast radius (measured after opening this PR)

The developer endpoint is not the only caller. Grouping the app frames across 25 prod tracebacks from the last 2h, every one converges on the same call site — `canonical_memory_adapter.py:2029`, via `memory_service.py:3831` and `process_conversation.py` — but they arrive from three different entries:

| Entry frame | Occurrences |
|---|---|
| `routers/conversations.py:336` | 8 |
| `utils/conversations/lifecycle.py:323` | 7 |
| `routers/developer.py:1776` | 4 |

`routers/conversations.py` is the ordinary client-facing conversation route, so this is affecting real client traffic, not only the developer API. Because all paths funnel through the single guarded call site, this change covers all of them.

Backend 5xx by endpoint over 3h for context: `/v3/memories/{id}` 263, `/v1/conversations/from-segments` 157, `/v3/memories` 153, `/v1/conversations` 15, `/v1/conversations/{id}/reprocess` 8. In a 90-minute sample of ERROR entries, 26 of 27 were this exception.

**Not characterized:** whether the `/v3/memories` and `/v3/memories/{id}` 5xx share this cause. They did not appear as entry frames in the traceback sample, and HTTP-request log entries do not join 1:1 with traceback entries, so they may be a separate fault. One `RuntimeError: canonical write failed: ApplyStatus.invalid_patch (add patch new_memory_id already exists)` also appeared. Worth a look independently of this change.
