### PR TITLE
ci(backend): run the Firestore emulator proofs

### DIFF
--- a/.github/workflows/backend-emulator-proofs.yml
+++ b/.github/workflows/backend-emulator-proofs.yml
@@ -70,7 +70,7 @@ jobs:
       # The Firestore emulator is a Java process. The runner's default JDK is
       # not guaranteed, so pin one rather than inherit whatever the image ships.
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'

--- a/.github/workflows/backend-emulator-proofs.yml
+++ b/.github/workflows/backend-emulator-proofs.yml
@@ -1,0 +1,96 @@
+name: Backend Emulator Proofs
+
+# The canonical-memory and JIT emulator proofs, which nothing ran automatically
+# before 2026-08-30. They cover crash recovery, deletion races, generation
+# contention, day rollover, overlapping runners and writer cutover against a
+# real Firestore emulator -- the classes that fakes cannot reach and that a
+# green deploy does not reveal.
+#
+# The daily-sweep crash-replay proof sat red on main from the day #12084
+# introduced it until #12403 repaired it, undetected, while
+# .github/failure-classes/FC-daily-memory-sweep-fence.json listed it as that
+# class's canonical prevention artifact.
+#
+# This lane is not in branch protection, so it reports without blocking. Promote
+# it to a required check once it has a stable green history.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/utils/memory/**'
+      - 'backend/database/**'
+      - 'backend/models/memory_apply.py'
+      - 'backend/models/product_memory.py'
+      - 'backend/scripts/*_emulator_test.py'
+      - 'backend/scripts/run-emulator-proofs.sh'
+      - 'backend/pylock.toml'
+      - 'firebase.json'
+      - 'firestore.rules'
+      - '.github/workflows/backend-emulator-proofs.yml'
+  pull_request:
+    paths:
+      - 'backend/utils/memory/**'
+      - 'backend/database/**'
+      - 'backend/models/memory_apply.py'
+      - 'backend/models/product_memory.py'
+      - 'backend/scripts/*_emulator_test.py'
+      - 'backend/scripts/run-emulator-proofs.sh'
+      - 'backend/pylock.toml'
+      - 'firebase.json'
+      - 'firestore.rules'
+      - '.github/workflows/backend-emulator-proofs.yml'
+
+concurrency:
+  group: backend-emulator-proofs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  emulator-proofs:
+    name: Backend emulator proofs
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: backend/.python-version
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84
+        with:
+          enable-cache: true
+          cache-dependency-glob: backend/pylock*.toml
+
+      # The Firestore emulator is a Java process. The runner's default JDK is
+      # not guaranteed, so pin one rather than inherit whatever the image ships.
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: |
+          uv venv .venv
+          uv pip sync pylock.toml --python .venv/bin/python
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+
+      - name: Install firebase-tools
+        run: npm install -g firebase-tools@15
+
+      # emulators:exec starts the emulator, exports FIRESTORE_EMULATOR_HOST from
+      # firebase.json (127.0.0.1:8085), runs the command, and shuts down -- so a
+      # failing proof cannot leave a stray emulator holding the port.
+      - name: Run emulator proofs
+        run: |
+          firebase emulators:exec \
+            --only firestore \
+            --project demo-omi-jit-qa \
+            'bash backend/scripts/run-emulator-proofs.sh'

--- a/backend/scripts/run-emulator-proofs.sh
+++ b/backend/scripts/run-emulator-proofs.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# LIFECYCLE: permanent
+# Run the canonical-memory / JIT Firestore emulator proofs.
+#
+# These are the strongest correctness evidence the memory system has: they
+# exercise crash recovery, deletion races, account-generation contention, day
+# rollover, overlapping runners and writer cutover against a real Firestore
+# emulator, which unit tests with fakes cannot reach.
+#
+# Until 2026-08-30 nothing ran them automatically. The daily-sweep crash-replay
+# proof was red on main from the day #12084 introduced it, while
+# .github/failure-classes/FC-daily-memory-sweep-fence.json named that very file
+# as its canonical prevention artifact -- so the registry read as covered while
+# the guard was never executed. A guard artifact CI does not run is worse than
+# no guard, because it is counted as coverage.
+#
+# Expects a Firestore emulator already listening; run under
+# `firebase emulators:exec --only firestore --project demo-omi-jit-qa`, which
+# exports FIRESTORE_EMULATOR_HOST from firebase.json (127.0.0.1:8085).
+#
+# The environment below mirrors _subprocess_env() in
+# backend/scripts/jit_qa_orchestrated_dogfood.py. MEMORY_MODE=read is required:
+# the production canonical-intake fence defaults to off, and without it every
+# write-path scenario fails closed with CanonicalMemoryIntakePausedError, which
+# is a harness precondition rather than a defect.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BACKEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$BACKEND_DIR"
+
+if [[ -z "${FIRESTORE_EMULATOR_HOST:-}" ]]; then
+  echo "FIRESTORE_EMULATOR_HOST is required; run this under 'firebase emulators:exec'" >&2
+  exit 2
+fi
+
+PYTHON="${PYTHON:-python}"
+
+export GOOGLE_CLOUD_PROJECT="${GOOGLE_CLOUD_PROJECT:-demo-omi-jit-qa}"
+export GCLOUD_PROJECT="$GOOGLE_CLOUD_PROJECT"
+export FIREBASE_PROJECT_ID="$GOOGLE_CLOUD_PROJECT"
+export PROVIDER_MODE=offline
+export MEMORY_MODE=read
+export ENCRYPTION_SECRET="${ENCRYPTION_SECRET:-omi_emulator_proof_key_32_bytes_ok}"  # pragma: allowlist secret
+export GOOGLE_AUTH_DISABLE_GCE_CHECK=true
+export GCE_METADATA_HOST=127.0.0.1:9
+export NO_PROXY=127.0.0.1,localhost,::1
+export no_proxy="$NO_PROXY"
+
+failures=()
+
+run_proof() {
+  local label="$1"
+  shift
+  echo "::group::${label}"
+  if "$@"; then
+    echo "PASS ${label}"
+  else
+    echo "FAIL ${label}"
+    failures+=("$label")
+  fi
+  echo "::endgroup::"
+}
+
+# Runs a proof for signal without letting it decide the lane's colour.
+#
+# Reserved for the arbitration proof, which is intermittent against a freshly
+# started emulator. It deliberately runs concurrent transactions to prove
+# cross-device reservation, and a cold Firestore emulator sometimes loses them:
+# `google.api_core.exceptions.Aborted: 409 Transaction lock timeout` surfacing
+# as `ValueError: Failed to commit transaction in 5 attempts`. That is an
+# emulator limit, not an assertion failure -- when it completes it reports
+# correct semantics (`planned=['reserved','rejected']`,
+# `full_turns=['rejected','reserved']`).
+#
+# Measured 2026-08-30: 3/3 passes against a long-warmed emulator; then two
+# consecutive failures and one pass under fresh `emulators:exec`, including a
+# failure when run alone, so it is not accumulated state from earlier proofs.
+# Warm-up appears to matter, but the evidence is a handful of runs, not a
+# characterisation -- treat that as the leading hypothesis, not the cause.
+#
+# Making it fatal would redden the lane unpredictably, and a lane that fails for
+# reasons nobody trusts is one nobody reads -- the exact failure this lane exists
+# to correct. Making it silent would lose the signal. So it runs, it reports, and
+# it does not gate. Characterise the contention (warm-up transaction, or a larger
+# transaction retry budget under the emulator), then move it back to run_proof.
+run_proof_for_signal_only() {
+  local label="$1"
+  shift
+  echo "::group::${label} [non-gating]"
+  if "$@"; then
+    echo "PASS ${label} (non-gating -- intermittent, so one pass is not evidence the contention is gone)"
+  else
+    echo "::warning::${label} failed -- known intermittent emulator transaction contention, not gating this lane"
+  fi
+  echo "::endgroup::"
+}
+
+run_proof "daily-sweep (crash / deletion / generation / paid-wipe)" \
+  "$PYTHON" scripts/daily_memory_sweep_emulator_test.py
+run_proof "ledger correction, revert, standalone reopen, privacy fence" \
+  "$PYTHON" scripts/knowledge_ledger_correction_emulator_test.py
+run_proof_for_signal_only "planned + ambient proactivity arbitration" \
+  "$PYTHON" scripts/jit_proactivity_reservation_emulator_test.py
+# Module execution, not a file path: this older proof has no sys.path bootstrap
+# and relies on backend/ staying the import root.
+run_proof "writer cutover / rollback / rollforward" \
+  "$PYTHON" -m scripts.knowledge_ledger_writer_transition_emulator_test
+
+if (( ${#failures[@]} )); then
+  echo
+  echo "Emulator proofs failed: ${#failures[@]}"
+  for name in "${failures[@]}"; do
+    echo "  - ${name}"
+  done
+  exit 1
+fi
+
+echo
+echo "All emulator proofs passed."


### PR DESCRIPTION
## Why

Nothing runs the Firestore emulator proofs. Verified 2026-08-30: no workflow in `.github/workflows/` invokes `emulators:exec`, and none references any `*_emulator_test.py`. They execute only when someone runs them by hand.

They are the strongest correctness evidence the memory system has — crash recovery, deletion races, account-generation contention, day rollover, overlapping runners, writer cutover — against a real Firestore emulator, covering classes that fakes cannot reach and a green deploy does not reveal.

The cost of that gap is concrete. The daily-sweep crash-replay proof was **red on `main` from the day #12084 introduced it until #12403 repaired it**, and nobody knew. Worse, `.github/failure-classes/FC-daily-memory-sweep-fence.json` names `daily_memory_sweep_emulator_test.py` as that class's `canonical_prevention_artifact` — so the registry read as covered while the guard was never executed. A guard artifact CI does not run is worse than no guard, because it is counted as coverage.

In the same window, #12084 also shipped two live production regressions of exactly the class these proofs cover (`LegalHoldAuthorityUnavailable` on conversation finalization, since fixed in #12410; and a duplicate `new_memory_id` on `/v3/memories`, still open). Both ran for two days. Neither was surfaced by a test or an alarm — they were found by grepping service logs after an unrelated deploy.

## What this adds

`backend/scripts/run-emulator-proofs.sh` and a `Backend Emulator Proofs` workflow that runs it under `firebase emulators:exec`, on backend memory/database changes.

`firebase.json` already pins the Firestore emulator to `127.0.0.1:8085`, so `emulators:exec` supplies `FIRESTORE_EMULATOR_HOST` and tears the emulator down afterwards — a failing proof cannot leave one holding the port.

The script's environment mirrors `_subprocess_env()` in `jit_qa_orchestrated_dogfood.py`. `MEMORY_MODE=read` is required: the production canonical-intake fence defaults to off, and without it every write-path scenario fails closed with `CanonicalMemoryIntakePausedError` — a harness precondition, not a defect.

Gating proofs:

- daily sweep — crash / deletion / generation / paid-wipe
- ledger correction, revert, standalone reopen, privacy fence
- writer cutover / rollback / rollforward

## The arbitration proof runs but does not gate

`jit_proactivity_reservation_emulator_test.py` is intermittent against a freshly started emulator. It deliberately runs concurrent transactions to prove cross-device reservation, and a cold emulator sometimes loses them: `Aborted: 409 Transaction lock timeout`, surfacing as `ValueError: Failed to commit transaction in 5 attempts`. When it completes it reports correct semantics (`planned=['reserved','rejected']`, `full_turns=['rejected','reserved']`), so this is an emulator limit rather than an assertion failure.

Measured today: 3/3 passes against a long-warmed emulator; then two consecutive failures and one pass under fresh `emulators:exec`, including a failure when run alone — so it is not accumulated state from the preceding proofs. Warm-up looks like the mechanism, but that is a handful of runs, not a characterisation, and the comment in the script says so.

It therefore runs, reports, and does not gate. Making it fatal would redden the lane unpredictably, and a lane that fails for reasons nobody trusts is one nobody reads — precisely the failure this lane exists to correct. Making it silent would throw away the signal. Characterising the contention and promoting it back to gating is the obvious follow-up.

## Not a required check

A new workflow is not automatically in branch protection, so this reports without blocking. Promote it to required once it has a stable green history — deliberately not done here, since a brand-new lane gating every backend memory change is how a lane gets disabled instead of fixed.

## Verification

Run end to end locally against `origin/main` under `firebase emulators:exec` with Temurin 21: all three gating proofs pass, and the full run reports `All emulator proofs passed.` The script was also observed correctly failing the lane (exit 1, named failure) when a proof genuinely failed, before the arbitration proof was made non-gating.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

