### PR TITLE
fix(desktop): ask for notification permission, and stop hiding when it is missing

### DIFF
--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -127,6 +127,17 @@ class AnalyticsManager {
     PostHogManager.shared.track(event, properties: properties)
   }
 
+  /// Notification-delivery-drop seam: nil in production; tests install a scoped
+  /// capture to observe the real event/payload `NotificationService` emits when
+  /// it drops a notification for lack of authorization.
+  private var notificationDeliveryTelemetryCaptureForTests: (@MainActor (String, [String: Any]) -> Void)?
+
+  func setNotificationDeliveryTelemetryCaptureForTests(
+    _ capture: (@MainActor (String, [String: Any]) -> Void)?
+  ) {
+    notificationDeliveryTelemetryCaptureForTests = capture
+  }
+
   func setDevicePairingTelemetryCaptureForTests(
     _ capture: (@MainActor (String?, [String: Any], [String: Any]) -> Void)?
   ) {
@@ -345,6 +356,21 @@ class AnalyticsManager {
         triggerID: triggerID
       )
     )
+  }
+
+  // MARK: - Notification Delivery Events
+
+  /// A proactive notification was dropped because the app is not authorized to
+  /// show it. See `NotificationDeliveryTelemetry` for the full contract. Never
+  /// call this from a permission-request path — it only observes an existing
+  /// drop, it must never itself trigger the system prompt.
+  func notificationDeliverySkipped(
+    authStatus: NotificationDeliveryTelemetry.AuthStatus,
+    surface: ProactiveNotificationKind
+  ) {
+    let payload = NotificationDeliveryTelemetry.skippedPayload(authStatus: authStatus, surface: surface)
+    notificationDeliveryTelemetryCaptureForTests?(NotificationDeliveryTelemetry.skippedEventName, payload)
+    PostHogManager.shared.track(NotificationDeliveryTelemetry.skippedEventName, properties: payload)
   }
 
   // MARK: - Monitoring Events

--- a/desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
@@ -217,11 +217,18 @@ extension AppState {
     return missing
   }
 
-  /// Check if notification permission was explicitly denied
+  /// Check if notification permission was explicitly denied.
+  ///
+  /// Reads the actual TCC answer (`notificationAuthorizationStatus`, cached from
+  /// `checkNotificationPermission()`) rather than inferring denial from "not yet
+  /// granted". `notDetermined` is not denied: it means the user was never asked,
+  /// and macOS typically will not even list an app under System Settings ->
+  /// Notifications until it has called `requestAuthorization` once — so routing
+  /// a never-asked user to "open System Settings" was a dead end. See
+  /// `NotificationPermissionPolicy.enableAction(for:)`, the single source of
+  /// truth this must never disagree with.
   func isNotificationPermissionDenied() -> Bool {
-    // We need to check synchronously, so use a semaphore pattern
-    // This is cached from checkNotificationPermission() calls
-    return hasCompletedOnboarding && !hasNotificationPermission
+    hasCompletedOnboarding && notificationAuthorizationStatus == .denied
   }
 
   /// Open notification preferences in System Settings (directly to Omi's settings)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
@@ -1042,9 +1042,17 @@ struct SystemAudioPermissionSection: View {
 struct NotificationPermissionSection: View {
   @ObservedObject var appState: AppState
 
-  // Check if permission was explicitly denied
+  // What the primary action should do right now — the same policy the
+  // onboarding notifications step and `AppState.requestNotificationPermission()`
+  // read, so this card can never disagree with what a click actually does.
+  private var enableAction: NotificationPermissionEnableAction {
+    NotificationPermissionPolicy.enableAction(for: appState.notificationAuthorizationStatus)
+  }
+
+  // Only a real `.denied` answer routes to "open System Settings" — `notDetermined`
+  // must render the native-prompt copy, never the "previously denied" dead end.
   private var isPermissionDenied: Bool {
-    return appState.isNotificationPermissionDenied()
+    enableAction == .openSystemSettings
   }
 
   // Colors based on state. A refuse is still "Not Granted" in the chip; System Settings

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -74,8 +74,21 @@ extension SBOnboardingModel {
       } onCancel: {
         request.cancel()
       }
+    case "notifications":
+      requestNotifications()
     default: break
     }
+  }
+
+  /// Ask macOS for notification authorization through the same policy-driven
+  /// path Settings uses (`AppState.requestNotificationPermission()`), never
+  /// `UNUserNotificationCenter` directly. `notDetermined` raises the system
+  /// prompt; `denied` opens System Settings instead of re-asking a spent
+  /// prompt macOS will never show again.
+  func requestNotifications() {
+    notifState = .waiting
+    appState.requestNotificationPermission()
+    pollPermission("notifications")
   }
 
   func requestFullDiskAccess() {
@@ -189,6 +202,7 @@ extension SBOnboardingModel {
     case "full_disk_access": appState.checkFullDiskAccess()
     case "accessibility": appState.checkAccessibilityPermission()
     case "automation": appState.checkAutomationPermission()
+    case "notifications": appState.checkNotificationPermission()
     default: appState.checkAllPermissions()
     }
   }
@@ -251,6 +265,7 @@ extension SBOnboardingModel {
     case "full_disk_access": return appState.hasFullDiskAccess
     case "accessibility": return appState.hasAccessibilityPermission && !appState.isAccessibilityBroken
     case "automation": return appState.hasAutomationPermission
+    case "notifications": return appState.hasNotificationPermission
     default: return false
     }
   }
@@ -276,6 +291,7 @@ extension SBOnboardingModel {
     // explicit Connect action owns the data read.
     case "accessibility": accState = .on
     case "automation": autoState = .on
+    case "notifications": notifState = .on
     default: break
     }
   }
@@ -290,6 +306,7 @@ extension SBOnboardingModel {
     case "full_disk_access": fdaState = .ask
     case "accessibility": accState = .ask
     case "automation": autoState = .ask
+    case "notifications": notifState = .ask
     default: break
     }
   }
@@ -302,6 +319,7 @@ extension SBOnboardingModel {
     case "full_disk_access": return fdaState
     case "accessibility": return accState
     case "automation": return autoState
+    case "notifications": return notifState
     default: return .ask
     }
   }
@@ -361,7 +379,8 @@ extension SBOnboardingModel {
     advance(userAnswer: nil, to: .accessibility)
   }
   func answerAccessibility() { advance(userAnswer: accState == .on ? "Allowed" : "Skip", to: .automation) }
-  func answerAutomation() { advance(userAnswer: autoState == .on ? "Allowed" : "Skip", to: .shortcutOpen) }
+  func answerAutomation() { advance(userAnswer: autoState == .on ? "Allowed" : "Skip", to: .notifications) }
+  func answerNotifications() { advance(userAnswer: notifState == .on ? "Allowed" : "Skip", to: .shortcutOpen) }
 
   /// Advance past a permission step automatically once its grant lands — but only
   /// when the user is still ON that step, so a late poll never skips a step they've
@@ -385,6 +404,7 @@ extension SBOnboardingModel {
     case .files: answerFiles()
     case .accessibility: answerAccessibility()
     case .automation: answerAutomation()
+    case .notifications: answerNotifications()
     default: break
     }
   }
@@ -398,6 +418,7 @@ extension SBOnboardingModel {
     case .files: return "full_disk_access"
     case .accessibility: return "accessibility"
     case .automation: return "automation"
+    case .notifications: return "notifications"
     default: return nil
     }
   }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -54,7 +54,7 @@ final class SBOnboardingModel: ObservableObject {
 
   enum Step: Int, CaseIterable {
     case promise, name, howHeard, language, role
-    case mic, systemAudio, screen, files, accessibility, automation
+    case mic, systemAudio, screen, files, accessibility, automation, notifications
     case shortcutOpen, shortcutTalk, screenDemo, agents, context, capture, referral
   }
 
@@ -110,6 +110,7 @@ final class SBOnboardingModel: ObservableObject {
   @Published var fdaState: PermState = .ask  // full disk access (files)
   @Published var accState: PermState = .ask  // accessibility
   @Published var autoState: PermState = .ask  // automation / Apple Events
+  @Published var notifState: PermState = .ask  // notifications
   @Published var localFileProfileState: LocalFileProfileState = .idle
 
   var launchAtLogin: Bool = LaunchAtLoginManager.shared.isEnabled
@@ -314,6 +315,9 @@ final class SBOnboardingModel: ObservableObject {
       return "Turn on Accessibility, so I can use your shortcut and click and type for you."
     case .automation:
       return "Turn on Automation, so I can help with tasks in the apps you choose."
+    case .notifications:
+      return
+        "Turn on Notifications, so I can tell you the moment I notice something — a mistake before you hit send, a meeting about to start, a follow-up you're about to miss."
     // Both steps used to invite "press any key", and `acceptsRecordedChord` then refused a bare key
     // in silence — correct (a global bare `L` is unrecoverable) but unexplained. Name the rule.
     case .shortcutOpen:
@@ -386,6 +390,31 @@ final class SBOnboardingModel: ObservableObject {
   /// mandatory lacked this flag, so `begin()` clamps them back through the steps.
   static let shortcutsCompletedKey = "sbOnboardingShortcutsCompleted"
 
+  /// Layout version of the persisted `resumeStepKey` value.
+  ///
+  /// `Step`'s raw values are written to disk, so inserting a case renumbers
+  /// every later step and silently reinterprets any resume state written by an
+  /// older build. Version 2 added `.notifications` between `.automation` and
+  /// `.shortcutOpen`; absent (0) means the version-1 layout that predates it.
+  static let resumeStepSchemaKey = "sbOnboardingResumeStepSchema"
+  static let resumeStepSchemaVersion = 2
+
+  /// Raw value `.notifications` took in version 2, frozen as a literal.
+  ///
+  /// Deliberately **not** `Step.notifications.rawValue`: this describes a
+  /// historical layout boundary, so it must not move if the enum is edited
+  /// again. A future insertion adds a version 3 rule beside this one.
+  private static let notificationsStepRawInV2 = 11
+
+  /// Translate a persisted resume step into the current layout.
+  ///
+  /// Pure so the renumbering is testable without `UserDefaults`. Anything at or
+  /// after the inserted case shifts up by one; earlier steps are unaffected.
+  static func migratedResumeStepRaw(savedRaw: Int, storedSchema: Int) -> Int {
+    guard storedSchema < 2 else { return savedRaw }
+    return savedRaw >= notificationsStepRawInV2 ? savedRaw + 1 : savedRaw
+  }
+
   func begin() {
     guard thread.isEmpty && streamingText == nil else { return }
     // Re-hydrate the editable drafts from what was already saved, so stepping
@@ -396,7 +425,17 @@ final class SBOnboardingModel: ObservableObject {
     // were already saved to the backend/settings, so we just re-enter at the saved
     // step; each permission step re-checks its grant on appear, so a permission
     // granted before the quit shows ✓ rather than prompting again.
-    let savedRaw = UserDefaults.standard.integer(forKey: Self.resumeStepKey)
+    // Renumber a resume state written before `.notifications` existed before
+    // anything reads it, and stamp the layout so this runs exactly once.
+    let persistedRaw = UserDefaults.standard.integer(forKey: Self.resumeStepKey)
+    let storedSchema = UserDefaults.standard.integer(forKey: Self.resumeStepSchemaKey)
+    let savedRaw = Self.migratedResumeStepRaw(savedRaw: persistedRaw, storedSchema: storedSchema)
+    if storedSchema < Self.resumeStepSchemaVersion {
+      if savedRaw != persistedRaw {
+        UserDefaults.standard.set(savedRaw, forKey: Self.resumeStepKey)
+      }
+      UserDefaults.standard.set(Self.resumeStepSchemaVersion, forKey: Self.resumeStepSchemaKey)
+    }
     recordSetupStateDisagreementAtRead(savedRaw: savedRaw)
     if savedRaw > Step.promise.rawValue, let resumed = Step(rawValue: savedRaw) {
       // A legacy resume state persisted before shortcuts were mandatory bypasses the new
@@ -510,6 +549,7 @@ final class SBOnboardingModel: ObservableObject {
     case .files: precheckPerm("full_disk_access")
     case .accessibility: precheckPerm("accessibility")
     case .automation: precheckPerm("automation")
+    case .notifications: precheckPerm("notifications")
     case .shortcutOpen, .shortcutTalk: armShortcutSummon()
     case .screenDemo: startScreenDemo()
     case .agents: refreshAgentStates()

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -431,10 +431,24 @@ final class SBOnboardingModel: ObservableObject {
     let storedSchema = UserDefaults.standard.integer(forKey: Self.resumeStepSchemaKey)
     let savedRaw = Self.migratedResumeStepRaw(savedRaw: persistedRaw, storedSchema: storedSchema)
     if storedSchema < Self.resumeStepSchemaVersion {
+      // Stamp the schema BEFORE rewriting the value. Two `UserDefaults` writes
+      // are not one atomic transaction, and the two orderings fail differently
+      // if the process dies between them:
+      //
+      //   value first — the stamp is lost, the next launch shifts the *already*
+      //     shifted value again, and a resume at `.referral` (17 -> 18 -> 19)
+      //     lands outside `Step`, so `begin()` silently restarts onboarding
+      //     from `.promise` and the user loses their answers.
+      //   stamp first — the shift is lost, so the value keeps its version-1
+      //     meaning under version-2 numbering: at worst one step off (old
+      //     `.shortcutOpen` reads as `.notifications`), always in range, never
+      //     a restart.
+      //
+      // Neither is atomic; only one of them can throw away progress.
+      UserDefaults.standard.set(Self.resumeStepSchemaVersion, forKey: Self.resumeStepSchemaKey)
       if savedRaw != persistedRaw {
         UserDefaults.standard.set(savedRaw, forKey: Self.resumeStepKey)
       }
-      UserDefaults.standard.set(Self.resumeStepSchemaVersion, forKey: Self.resumeStepSchemaKey)
     }
     recordSetupStateDisagreementAtRead(savedRaw: savedRaw)
     if savedRaw > Step.promise.rawValue, let resumed = Step(rawValue: savedRaw) {

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -287,6 +287,10 @@ struct SBOnboardingView: View {
       permStepWidget("automation", "Automation", "help with tasks in the apps you choose") {
         model.answerAutomation()
       }
+    case .notifications:
+      permStepWidget("notifications", "Notifications", "tell you when I notice something worth flagging") {
+        model.answerNotifications()
+      }
     case .shortcutOpen: shortcutWidget(isTalk: false)
     case .shortcutTalk: shortcutWidget(isTalk: true)
     case .screenDemo: screenDemoWidget

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationDeliveryTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationDeliveryTelemetry.swift
@@ -1,0 +1,66 @@
+import Foundation
+@preconcurrency import UserNotifications
+
+/// Closed, privacy-safe telemetry contract for a proactive notification that
+/// `NotificationService` dropped because the app was not authorized to show it.
+///
+/// `UNUserNotificationCenter.add(request:)` does not surface an error when
+/// authorization is `.notDetermined` or `.denied` — it silently no-ops. That
+/// silence was the whole bug: 49 macOS users sat at `notDetermined` (never
+/// asked, and — before the onboarding step this file ships alongside — never
+/// asked again) while every proactive notification the app tried to send them
+/// failed with nothing anywhere to say so. This event exists to make that drop
+/// observable, not to fix delivery — the caller does not request permission and
+/// does not change whether `add(request:)` still runs.
+///
+/// Mirrors the `IntegrationConnectTelemetry` / `IntegrationNudgeTelemetry`
+/// contract style: a closed schema, an allow-list filter, bounded enum values
+/// only. `surface` reuses `ProactiveNotificationKind.from(assistantId:)` — the
+/// same closed classification INV-6 chat continuity already derives from
+/// `assistantId` — rather than inventing a second taxonomy for the same string.
+enum NotificationDeliveryTelemetry {
+  /// PostHog event name. Stable identifier — do not rename.
+  static let skippedEventName = "Notification Delivery Skipped"
+
+  /// Closed projection of `UNAuthorizationStatus`. Never emit the raw
+  /// `UNAuthorizationStatus` rawValue — this is the bounded string PostHog sees.
+  enum AuthStatus: String, CaseIterable {
+    case notDetermined = "not_determined"
+    case denied
+    case authorized
+    case provisional
+    case ephemeral
+    case unknown
+
+    init(_ status: UNAuthorizationStatus) {
+      switch status {
+      case .notDetermined: self = .notDetermined
+      case .denied: self = .denied
+      case .authorized: self = .authorized
+      case .provisional: self = .provisional
+      case .ephemeral: self = .ephemeral
+      @unknown default: self = .unknown
+      }
+    }
+  }
+
+  /// Keys permitted in any emitted payload. Anything else is dropped by the
+  /// allow-list filter, so a caller cannot accidentally thread notification
+  /// title/body, an assistant id, a window title, or any other content through
+  /// as an extra property.
+  static let allowedKeys: Set<String> = ["auth_status", "surface"]
+
+  /// `Notification Delivery Skipped` payload. `surface` is a
+  /// `ProactiveNotificationKind` raw value (already a closed, bounded set) —
+  /// never the free-text `assistantId` it was derived from.
+  static func skippedPayload(authStatus: AuthStatus, surface: ProactiveNotificationKind) -> [String: Any] {
+    allowListOnly([
+      "auth_status": authStatus.rawValue,
+      "surface": surface.rawValue,
+    ])
+  }
+
+  private static func allowListOnly(_ properties: [String: Any]) -> [String: Any] {
+    properties.filter { allowedKeys.contains($0.key) }
+  }
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -787,8 +787,19 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         )
         return
       }
-      guard authorizationStatus == .authorized else {
+      guard NotificationPermissionPolicy.isGranted(authorizationStatus) else {
         log("Notification skipped (auth=\(authorizationStatus.rawValue)): \(title)")
+
+        // This is the *only* place an unauthorized proactive notification is
+        // dropped — `deliverNotification` below is never reached — so the
+        // observability for it has to live here. The insight-delivery ledger
+        // underneath covers just the subset carrying an `insightDeliveryID`
+        // (and only when the floating bar did not already take the message),
+        // which is why authorization needs its own unconditional event.
+        AnalyticsManager.shared.notificationDeliverySkipped(
+          authStatus: NotificationDeliveryTelemetry.AuthStatus(authorizationStatus),
+          surface: ProactiveNotificationKind.from(assistantId: assistantId)
+        )
 
         if !floatingBarDelivered && !floatingBarHasQueued {
           self?.recordInsightDeliveryOutcome(
@@ -943,6 +954,18 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     }
 
     UserNotificationCallbackBridge.notificationSettings { [weak self] settings in
+      // Split out of the compound guard below so an unauthorized drop is
+      // reported as such. Folded in, it would be indistinguishable from a
+      // stale owner, an exhausted budget, or an alert style of `.none` — all
+      // of which are ordinary policy, not a permission the user never granted.
+      guard NotificationPermissionPolicy.isGranted(settings.authorizationStatus) else {
+        AnalyticsManager.shared.notificationDeliverySkipped(
+          authStatus: NotificationDeliveryTelemetry.AuthStatus(settings.authorizationStatus),
+          surface: ProactiveNotificationKind.from(decisionType: decisionType)
+        )
+        onDropped?()
+        return
+      }
       guard let self,
         RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
         self.contextDirectorMayPresent(authorizationSnapshot: authorizationSnapshot, now: Date()),
@@ -1161,21 +1184,6 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     )
 
     print("[\(assistantId)] Sending notification: \(title) - \(message)")
-    // Observability only: `add(request:)` silently no-ops when authorization is
-    // `.notDetermined` or `.denied` — no error, no callback difference — so an
-    // unauthorized user's every proactive notification used to fail invisibly.
-    // This check never blocks or changes delivery below, and it must never
-    // request permission itself: that is a background delivery path, and
-    // turning it into a consent prompt is exactly what `startMonitoring`
-    // deliberately avoids (see `ProactiveAssistantsPlugin`).
-    UserNotificationCallbackBridge.authorizationStatus { authorizationStatus in
-      guard !NotificationPermissionPolicy.isGranted(authorizationStatus) else { return }
-      log("Notification dropped: not authorized (status=\(authorizationStatus.rawValue), assistantId=\(assistantId))")
-      AnalyticsManager.shared.notificationDeliverySkipped(
-        authStatus: NotificationDeliveryTelemetry.AuthStatus(authorizationStatus),
-        surface: ProactiveNotificationKind.from(assistantId: assistantId)
-      )
-    }
     UserNotificationCallbackBridge.add(request) { [weak self] result in
       if let errorDescription = result.errorDescription {
         print("Notification error: \(errorDescription)")

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -1161,6 +1161,21 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     )
 
     print("[\(assistantId)] Sending notification: \(title) - \(message)")
+    // Observability only: `add(request:)` silently no-ops when authorization is
+    // `.notDetermined` or `.denied` — no error, no callback difference — so an
+    // unauthorized user's every proactive notification used to fail invisibly.
+    // This check never blocks or changes delivery below, and it must never
+    // request permission itself: that is a background delivery path, and
+    // turning it into a consent prompt is exactly what `startMonitoring`
+    // deliberately avoids (see `ProactiveAssistantsPlugin`).
+    UserNotificationCallbackBridge.authorizationStatus { authorizationStatus in
+      guard !NotificationPermissionPolicy.isGranted(authorizationStatus) else { return }
+      log("Notification dropped: not authorized (status=\(authorizationStatus.rawValue), assistantId=\(assistantId))")
+      AnalyticsManager.shared.notificationDeliverySkipped(
+        authStatus: NotificationDeliveryTelemetry.AuthStatus(authorizationStatus),
+        surface: ProactiveNotificationKind.from(assistantId: assistantId)
+      )
+    }
     UserNotificationCallbackBridge.add(request) { [weak self] result in
       if let errorDescription = result.errorDescription {
         print("Notification error: \(errorDescription)")

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -790,14 +790,16 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
       guard NotificationPermissionPolicy.isGranted(authorizationStatus) else {
         log("Notification skipped (auth=\(authorizationStatus.rawValue)): \(title)")
 
-        // This is the *only* place an unauthorized proactive notification is
-        // dropped — `deliverNotification` below is never reached — so the
-        // observability for it has to live here. The insight-delivery ledger
-        // underneath covers just the subset carrying an `insightDeliveryID`
-        // (and only when the floating bar did not already take the message),
-        // which is why authorization needs its own unconditional event.
-        AnalyticsManager.shared.notificationDeliverySkipped(
-          authStatus: NotificationDeliveryTelemetry.AuthStatus(authorizationStatus),
+        // The drop happens *here*, not in `deliverNotification` below, which
+        // this guard never reaches. The other real drop site is
+        // `contextDirectorPresentationPreflight`, whose callers abort on a
+        // non-`.queued` preflight; both go through `reportUnauthorizedDrop`.
+        // The insight-delivery ledger underneath covers only the subset
+        // carrying an `insightDeliveryID`, and only when the floating bar did
+        // not already take the message, which is why authorization needs its
+        // own unconditional event.
+        Self.reportUnauthorizedDrop(
+          status: authorizationStatus,
           surface: ProactiveNotificationKind.from(assistantId: assistantId)
         )
 
@@ -867,12 +869,46 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         continuation.resume(returning: settings)
       }
     }
+    // Authorization is checked separately from alert style, and before it.
+    // Folded together they are one `.suppressed`, and the engines abort on
+    // that (`ContextProactivityEngine`, `JITProactivityDelivery` both bail
+    // unless preflight returns `.queued`) — so this is where a context-director
+    // notification is really dropped for want of permission, and reporting it
+    // anywhere downstream reports nothing. An alert style of `.none` is the
+    // user's own choice and is not a permission problem.
+    guard NotificationPermissionPolicy.isGranted(settings.authorizationStatus) else {
+      // The preflight does not carry the decision type — it runs before the
+      // message exists — so the surface is derived from the same assistant id
+      // `presentContextDirectorNotification` passes to `deliverNotification`.
+      Self.reportUnauthorizedDrop(
+        status: settings.authorizationStatus,
+        surface: ProactiveNotificationKind.from(assistantId: "context-director")
+      )
+      return .suppressed
+    }
     guard
       NotificationPermissionPolicy.hasVisibleAlertSurface(
         status: settings.authorizationStatus,
         alertStyle: settings.alertStyle)
     else { return .suppressed }
     return .queued
+  }
+
+  /// Single reporter for "this notification was dropped because the app is not
+  /// authorized to show it".
+  ///
+  /// Exists so the two real drop sites — `sendNotification`'s authorization
+  /// guard and `contextDirectorPresentationPreflight`'s — cannot drift, and so
+  /// `NotificationServiceSkipEventPlacementTests` can pin *where* it is called
+  /// from. Placement is the whole contract: an earlier version of this event
+  /// sat in `deliverNotification`, which an unauthorized notification never
+  /// reaches, so it compiled, passed its tests, and emitted nothing.
+  @MainActor
+  static func reportUnauthorizedDrop(status: UNAuthorizationStatus, surface: ProactiveNotificationKind) {
+    AnalyticsManager.shared.notificationDeliverySkipped(
+      authStatus: NotificationDeliveryTelemetry.AuthStatus(status),
+      surface: surface
+    )
   }
 
   @discardableResult
@@ -954,13 +990,15 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     }
 
     UserNotificationCallbackBridge.notificationSettings { [weak self] settings in
-      // Split out of the compound guard below so an unauthorized drop is
-      // reported as such. Folded in, it would be indistinguishable from a
-      // stale owner, an exhausted budget, or an alert style of `.none` — all
-      // of which are ordinary policy, not a permission the user never granted.
+      // Reachable only when `present` is called without a preflight; the
+      // engines preflight first and never get here unauthorized. Kept so the
+      // direct-call path is covered too — `reportUnauthorizedDrop` is the same
+      // reporter the preflight uses, and the two cannot both fire for one
+      // notification because a preflight that reports also returns
+      // `.suppressed`, which stops the caller before `present`.
       guard NotificationPermissionPolicy.isGranted(settings.authorizationStatus) else {
-        AnalyticsManager.shared.notificationDeliverySkipped(
-          authStatus: NotificationDeliveryTelemetry.AuthStatus(settings.authorizationStatus),
+        Self.reportUnauthorizedDrop(
+          status: settings.authorizationStatus,
           surface: ProactiveNotificationKind.from(decisionType: decisionType)
         )
         onDropped?()

--- a/desktop/macos/Desktop/Tests/NotificationDeliveryTelemetryBoundaryTests.swift
+++ b/desktop/macos/Desktop/Tests/NotificationDeliveryTelemetryBoundaryTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// `NotificationDeliveryTelemetry` is the only place the `Notification Delivery
+/// Skipped` event name and payload are constructed in production. Asserting on
+/// the payload builder alone would not catch `AnalyticsManager.notificationDeliverySkipped`
+/// being wired to the wrong event name or dropping a dimension on the way
+/// through — so this drives the real `AnalyticsManager` method through its
+/// scoped capture seam, mirroring `IntegrationNudgeAnalyticsBoundaryTests`.
+@MainActor
+final class NotificationDeliveryTelemetryBoundaryTests: XCTestCase {
+  private let capturedBox = Box<[(String, [String: Any])]>([])
+
+  private func startCapturing() {
+    let box = capturedBox
+    box.value = []
+    AnalyticsManager.shared.setNotificationDeliveryTelemetryCaptureForTests { event, properties in
+      box.value.append((event, properties))
+    }
+    addTeardownBlock {
+      await MainActor.run {
+        AnalyticsManager.shared.setNotificationDeliveryTelemetryCaptureForTests(nil)
+      }
+    }
+  }
+
+  func testSkippedEmitsItsNameAndBoundedPayload() throws {
+    startCapturing()
+
+    AnalyticsManager.shared.notificationDeliverySkipped(authStatus: .notDetermined, surface: .task)
+
+    let event = try XCTUnwrap(capturedBox.value.first)
+    XCTAssertEqual(event.0, NotificationDeliveryTelemetry.skippedEventName)
+    XCTAssertEqual(event.1["auth_status"] as? String, "not_determined")
+    XCTAssertEqual(event.1["surface"] as? String, "task")
+  }
+
+  func testSkippedCarriesADeniedStatusDistinctFromNotDetermined() throws {
+    startCapturing()
+
+    AnalyticsManager.shared.notificationDeliverySkipped(authStatus: .denied, surface: .insight)
+
+    let event = try XCTUnwrap(capturedBox.value.first)
+    XCTAssertEqual(event.1["auth_status"] as? String, "denied")
+    XCTAssertEqual(event.1["surface"] as? String, "insight")
+  }
+
+  /// Nothing an emitter passes may escape the allow-list, whatever a future
+  /// caller adds to a payload builder — this must never carry a notification
+  /// title, body, assistant id, or window/app identity.
+  func testEveryEmittedKeyIsOnTheAllowList() throws {
+    startCapturing()
+
+    AnalyticsManager.shared.notificationDeliverySkipped(authStatus: .notDetermined, surface: .general)
+    AnalyticsManager.shared.notificationDeliverySkipped(authStatus: .denied, surface: .task)
+
+    XCTAssertEqual(capturedBox.value.count, 2)
+    for event in capturedBox.value {
+      for key in event.1.keys {
+        XCTAssertTrue(
+          NotificationDeliveryTelemetry.allowedKeys.contains(key),
+          "'\(key)' escaped the allow-list in \(event.0)"
+        )
+      }
+    }
+  }
+
+  final class Box<T>: @unchecked Sendable {
+    var value: T
+    init(_ value: T) { self.value = value }
+  }
+}

--- a/desktop/macos/Desktop/Tests/NotificationSkipEventPlacementTests.swift
+++ b/desktop/macos/Desktop/Tests/NotificationSkipEventPlacementTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Where `Notification Delivery Skipped` is emitted from is the entire contract.
+///
+/// The first version of this event sat inside `deliverNotification`, which an
+/// unauthorized notification never reaches: `sendNotification` returns at its
+/// authorization guard first, and the context-director engines abort on a
+/// non-`.queued` preflight. It compiled, its payload test passed, and it
+/// emitted nothing for the population it was written to measure.
+///
+/// A behavioural test would be better, but `sendNotification` reads
+/// authorization through `UserNotificationCallbackBridge.authorizationStatus`,
+/// which has no injection seam, and adding one would change a production
+/// signature to serve a test. Source inspection pins the property that actually
+/// broke — placement — and would fail if the emit moved back behind a guard.
+final class NotificationSkipEventPlacementTests: XCTestCase {
+  private func notificationServiceSource() throws -> String {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources")
+      .appendingPathComponent("ProactiveAssistants/Services/NotificationService.swift")
+    // omi-test-quality: source-inspection -- static contract: pins which functions report an unauthorized drop
+    return try String(contentsOf: sourceURL, encoding: .utf8)
+  }
+
+  /// Body of `functionName`, from its declaration to the start of the next
+  /// declaration at the same indentation.
+  private func functionBody(_ functionName: String, in source: String) throws -> String {
+    let lines = source.components(separatedBy: "\n")
+    let startIndex = try XCTUnwrap(
+      lines.firstIndex { $0.contains("func \(functionName)(") },
+      "\(functionName) not found; if it was renamed, update this test rather than deleting it")
+    let indent = lines[startIndex].prefix { $0 == " " }.count
+    var endIndex = lines.count
+    for index in (startIndex + 1)..<lines.count {
+      let line = lines[index]
+      guard !line.trimmingCharacters(in: .whitespaces).isEmpty else { continue }
+      let lineIndent = line.prefix { $0 == " " }.count
+      if lineIndent <= indent && line.contains("func ") {
+        endIndex = index
+        break
+      }
+    }
+    return lines[startIndex..<endIndex].joined(separator: "\n")
+  }
+
+  private static let reporter = "reportUnauthorizedDrop"
+
+  /// `sendNotification`'s authorization guard is the real drop for every
+  /// assistant notification.
+  func testSendNotificationReportsItsOwnUnauthorizedDrop() throws {
+    let body = try functionBody("sendNotification", in: notificationServiceSource())
+    XCTAssertTrue(
+      body.contains(Self.reporter),
+      "sendNotification returns before deliverNotification when unauthorized, so the drop must be reported here")
+  }
+
+  /// The context-director preflight is the real drop for that path: both
+  /// engines abort unless it returns `.queued`, so anything reported after it
+  /// is never reached.
+  func testContextDirectorPreflightReportsItsOwnUnauthorizedDrop() throws {
+    let body = try functionBody("contextDirectorPresentationPreflight", in: notificationServiceSource())
+    XCTAssertTrue(
+      body.contains(Self.reporter),
+      "the engines bail on a non-.queued preflight, so an unauthorized drop must be reported inside it")
+  }
+
+  /// The regression itself: `deliverNotification` runs only *after* every
+  /// authorization gate has passed, so an unauthorized drop can never be
+  /// observed from there.
+  func testDeliverNotificationDoesNotReportUnauthorizedDrops() throws {
+    let body = try functionBody("deliverNotification", in: notificationServiceSource())
+    XCTAssertFalse(
+      body.contains(Self.reporter),
+      "deliverNotification is past every authorization gate; reporting a drop here observes nothing")
+  }
+
+  /// Authorization must be its own guard, not folded into the alert-surface
+  /// check — an alert style of `.none` is the user's own choice, and a
+  /// permission that was never granted is not.
+  func testPreflightSeparatesAuthorizationFromAlertStyle() throws {
+    let body = try functionBody("contextDirectorPresentationPreflight", in: notificationServiceSource())
+    let authorizationGate = try XCTUnwrap(
+      body.range(of: "NotificationPermissionPolicy.isGranted"),
+      "the preflight must check authorization on its own")
+    let alertSurfaceGate = try XCTUnwrap(
+      body.range(of: "hasVisibleAlertSurface"),
+      "the preflight must still check the alert surface")
+    XCTAssertTrue(
+      authorizationGate.lowerBound < alertSurfaceGate.lowerBound,
+      "authorization is checked first so a never-granted permission is not reported as a muted alert style")
+  }
+}

--- a/desktop/macos/Desktop/Tests/PermissionsPagePresentationTests.swift
+++ b/desktop/macos/Desktop/Tests/PermissionsPagePresentationTests.swift
@@ -127,4 +127,40 @@ final class PermissionsPagePresentationTests: XCTestCase {
   func testAccessibilitySettlesOnlyWhenGrantedAndWorking() {
     XCTAssertFalse(PermissionsPageChrome.accessibilityNeedsAction(granted: true, broken: false))
   }
+
+  // MARK: - Notifications: notDetermined must never read as denied
+
+  /// The exact bug: `isNotificationPermissionDenied()` used to return
+  /// `hasCompletedOnboarding && !hasNotificationPermission`, which is true for
+  /// BOTH `.notDetermined` and `.denied`. A user who was simply never asked then
+  /// saw "previously denied, open System Settings" — a dead end, because macOS
+  /// typically does not even list an app under System Settings > Notifications
+  /// until it has called `requestAuthorization` once. Only a real `.denied`
+  /// answer may read as denied.
+  func testIsNotificationPermissionDeniedIsFalseForNotDeterminedAndTrueForDenied() {
+    let appState = AppState()
+    appState.hasCompletedOnboarding = true
+
+    appState.notificationAuthorizationStatus = .notDetermined
+    XCTAssertFalse(
+      appState.isNotificationPermissionDenied(),
+      "notDetermined (never asked) must not read as denied")
+
+    appState.notificationAuthorizationStatus = .denied
+    XCTAssertTrue(
+      appState.isNotificationPermissionDenied(),
+      "a real denied answer must still read as denied")
+
+    appState.notificationAuthorizationStatus = .authorized
+    XCTAssertFalse(appState.isNotificationPermissionDenied())
+  }
+
+  /// Before onboarding completes, a never-asked user must not be told they were
+  /// denied either — the flag was never meant to fire ahead of onboarding.
+  func testIsNotificationPermissionDeniedStaysFalseBeforeOnboardingCompletes() {
+    let appState = AppState()
+    appState.hasCompletedOnboarding = false
+    appState.notificationAuthorizationStatus = .denied
+    XCTAssertFalse(appState.isNotificationPermissionDenied())
+  }
 }

--- a/desktop/macos/Desktop/Tests/SBOnboardingBackNavigationTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingBackNavigationTests.swift
@@ -5,16 +5,26 @@ import XCTest
 @MainActor
 final class SBOnboardingBackNavigationTests: XCTestCase {
   private let resumeStepKey = "sbOnboardingResumeStep"
+  // Literals, not `SBOnboardingModel.*`: setUp/tearDown are nonisolated and
+  // those constants are main-actor isolated. Mirrors this file's existing style.
+  private let resumeSchemaKey = "sbOnboardingResumeStepSchema"
+  private let currentResumeSchemaVersion = 2
 
   override func setUp() {
     super.setUp()
     UserDefaults.standard.removeObject(forKey: resumeStepKey)
     UserDefaults.standard.removeObject(forKey: DefaultsKey.onboardingHowDidYouHearSource)
     UserDefaults.standard.removeObject(forKey: DefaultsKey.onboardingRole)
+    // These tests seed resume values in the *current* `Step` numbering. Without
+    // the schema stamp, `begin()` would correctly read them as version-1 state
+    // and renumber them, so the assertions below would be about a step nobody
+    // wrote. Stamping says "this install is already current".
+    UserDefaults.standard.set(currentResumeSchemaVersion, forKey: resumeSchemaKey)
   }
 
   override func tearDown() {
     UserDefaults.standard.removeObject(forKey: resumeStepKey)
+    UserDefaults.standard.removeObject(forKey: resumeSchemaKey)
     UserDefaults.standard.removeObject(forKey: DefaultsKey.onboardingHowDidYouHearSource)
     UserDefaults.standard.removeObject(forKey: DefaultsKey.onboardingRole)
     super.tearDown()

--- a/desktop/macos/Desktop/Tests/SBOnboardingCloudContextStateTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingCloudContextStateTests.swift
@@ -9,16 +9,23 @@ import XCTest
 /// functional-probe failures retain sanitized, actionable copy.
 final class SBOnboardingCloudContextStateTests: XCTestCase {
   private let resumeStepKey = "sbOnboardingResumeStep"
+  // Literals: setUp/tearDown are nonisolated, the model constants are not.
+  private let resumeSchemaKey = "sbOnboardingResumeStepSchema"
+  private let currentResumeSchemaVersion = 2
 
   override func setUp() {
     super.setUp()
     DesktopDiagnosticsManager.shared.resetForTests()
     UserDefaults.standard.removeObject(forKey: resumeStepKey)
     UserDefaults.standard.removeObject(forKey: DefaultsKey.hasCompletedOnboarding.rawValue)
+    // Seeded resume values below are in the current `Step` numbering; stamp the
+    // schema so `begin()` does not renumber them as version-1 state.
+    UserDefaults.standard.set(currentResumeSchemaVersion, forKey: resumeSchemaKey)
   }
 
   override func tearDown() {
     UserDefaults.standard.removeObject(forKey: resumeStepKey)
+    UserDefaults.standard.removeObject(forKey: resumeSchemaKey)
     UserDefaults.standard.removeObject(forKey: DefaultsKey.hasCompletedOnboarding.rawValue)
     super.tearDown()
   }

--- a/desktop/macos/Desktop/Tests/SBOnboardingNotificationsStepTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingNotificationsStepTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the notification-permission dead end: the live
+/// SecondBrain onboarding (`SBOnboardingModel`) had no `.notifications` step at
+/// all, so a user who never happened to grant Notifications elsewhere was never
+/// asked — and, per `AppState+Permissions.swift`, could never be asked again
+/// outside this flow. These tests guard the step's placement and wiring rather
+/// than re-testing `NotificationPermissionPolicy.enableAction`, which already
+/// has coverage in `UserNotificationCallbackBridgeTests`.
+@MainActor
+final class SBOnboardingNotificationsStepTests: XCTestCase {
+  private let resumeStepKey = "sbOnboardingResumeStep"
+  private let resumeSchemaKey = "sbOnboardingResumeStepSchema"
+
+  override func setUp() {
+    super.setUp()
+    UserDefaults.standard.removeObject(forKey: resumeStepKey)
+    UserDefaults.standard.removeObject(forKey: resumeSchemaKey)
+  }
+
+  override func tearDown() {
+    UserDefaults.standard.removeObject(forKey: resumeStepKey)
+    UserDefaults.standard.removeObject(forKey: resumeSchemaKey)
+    super.tearDown()
+  }
+
+  // MARK: persisted-step renumbering
+  //
+  // `Step`'s raw values go to disk. Inserting `.notifications` mid-enum shifted
+  // every later case by one, so without a migration a build update silently
+  // reinterprets an in-flight resume state as the step before the one the user
+  // actually reached. The file already carries this obligation once
+  // (`shortcutsCompletedKey`, for a legacy layout), so an explicit renumber is
+  // the local convention rather than an extra.
+
+  func testLegacyResumeStateAtOrAfterTheInsertionPointShiftsUpByOne() {
+    // 11 was `shortcutOpen` before `.notifications` claimed that slot.
+    XCTAssertEqual(
+      SBOnboardingModel.migratedResumeStepRaw(savedRaw: 11, storedSchema: 0),
+      SBOnboardingModel.Step.shortcutOpen.rawValue,
+      "a legacy resume at shortcutOpen must still land on shortcutOpen, not on notifications")
+    // 17 was `referral`, the final step.
+    XCTAssertEqual(
+      SBOnboardingModel.migratedResumeStepRaw(savedRaw: 17, storedSchema: 0),
+      SBOnboardingModel.Step.referral.rawValue,
+      "a legacy resume at the last step must not regress to the step before it")
+  }
+
+  func testLegacyResumeStateBeforeTheInsertionPointIsUnchanged() {
+    for step in [
+      SBOnboardingModel.Step.promise, .role, .mic, .accessibility, .automation,
+    ] {
+      XCTAssertEqual(
+        SBOnboardingModel.migratedResumeStepRaw(savedRaw: step.rawValue, storedSchema: 0),
+        step.rawValue,
+        "steps at or before automation kept their raw values, so \(step) must not move")
+    }
+  }
+
+  func testMigrationIsNotAppliedTwice() {
+    let migrated = SBOnboardingModel.migratedResumeStepRaw(savedRaw: 11, storedSchema: 0)
+    XCTAssertEqual(
+      SBOnboardingModel.migratedResumeStepRaw(
+        savedRaw: migrated, storedSchema: SBOnboardingModel.resumeStepSchemaVersion),
+      migrated,
+      "a stamped layout must be left alone; re-running the shift would skip a step per launch")
+  }
+
+  func testFreshInstallNeedsNoShift() {
+    XCTAssertEqual(
+      SBOnboardingModel.migratedResumeStepRaw(savedRaw: 0, storedSchema: 0), 0,
+      "nothing persisted must stay nothing persisted, so the intro gate still fires")
+  }
+
+  /// Placement is a deliberate, called-out product decision (keep every
+  /// permission ask in one contiguous block, right after Automation) rather than
+  /// after the screen demo. Pin it so a reorder is a visible diff, not a silent
+  /// step-index drift.
+  func testStepEnumPlacesNotificationsImmediatelyAfterAutomationAndBeforeShortcuts() {
+    XCTAssertEqual(
+      SBOnboardingModel.Step.notifications.rawValue,
+      SBOnboardingModel.Step.automation.rawValue + 1,
+      "notifications must sit directly after automation, in the same permission block")
+    XCTAssertEqual(
+      SBOnboardingModel.Step.shortcutOpen.rawValue,
+      SBOnboardingModel.Step.notifications.rawValue + 1,
+      "notifications must sit directly before the shortcut stages, not after the screen demo")
+  }
+
+  /// Every step-enumerating switch this fix touched
+  /// (`permissionKey(for:)`, `isGranted`/`setPermOn`/`resetPermToAsk`/`permState`,
+  /// `message(for:)`) must actually resolve `.notifications` / `"notifications"`
+  /// rather than silently falling through a `default:` case. A model constructed
+  /// with no special fixtures is enough to drive every one of these.
+  func testEveryStepEnumeratingSwitchHandlesNotifications() {
+    // `appState` is `unowned` inside `SBOnboardingModel` (`AppState.current` is
+    // itself only `weak`), so the instance needs a strong local owner for the
+    // duration of the test — an inline `AppState()` argument is deallocated the
+    // moment the initializer returns and crashes the first unowned access.
+    let appState = AppState()
+    let model = SBOnboardingModel(appState: appState, chatProvider: ChatProvider(), onComplete: nil)
+
+    XCTAssertEqual(model.permissionKey(for: .notifications), "notifications")
+
+    let copy = model.message(for: .notifications)
+    XCTAssertTrue(
+      copy.contains("Notifications"),
+      "the notifications step must ask about notifications, not fall through to another step's copy")
+
+    XCTAssertEqual(model.permState("notifications"), .ask)
+    XCTAssertFalse(model.isGranted("notifications"))
+
+    model.setPermOn("notifications")
+    XCTAssertEqual(model.permState("notifications"), .on)
+    XCTAssertEqual(model.notifState, .on, "setPermOn(\"notifications\") must write notifState, not silently no-op")
+
+    model.resetPermToAsk("notifications")
+    XCTAssertEqual(model.permState("notifications"), .ask)
+  }
+
+  /// The causal fix: Automation used to advance straight to the first shortcut
+  /// stage. It must now advance into Notifications first, keeping every
+  /// permission ask in one contiguous block.
+  func testAnsweringAutomationAdvancesToNotificationsBeforeShortcuts() {
+    let appState = AppState()
+    let model = SBOnboardingModel(appState: appState, chatProvider: ChatProvider(), onComplete: nil)
+    model.step = .automation
+    model.autoState = .ask
+
+    model.answerAutomation()
+
+    XCTAssertEqual(model.step, .notifications)
+  }
+
+  /// The defect was never being asked, not being disallowed from declining.
+  /// Skipping the notifications step (the same "Skip for now" affordance every
+  /// other permission step offers) must still carry the flow forward into the
+  /// shortcut stages rather than getting stuck.
+  func testOnboardingStillAdvancesPastNotificationsWhenTheStepIsSkipped() {
+    let appState = AppState()
+    let model = SBOnboardingModel(appState: appState, chatProvider: ChatProvider(), onComplete: nil)
+    model.step = .notifications
+    model.notifState = .ask  // never granted — this is the "Skip for now" path
+
+    model.answerNotifications()
+
+    XCTAssertEqual(
+      model.step, .shortcutOpen,
+      "declining notifications must not block onboarding from reaching the shortcut stages")
+  }
+
+  /// A grant landing while the step is visible must auto-advance the same way
+  /// every other permission step does, and must not skip past the notifications
+  /// step's own row into some other step's widget.
+  func testAutoAdvanceIfCurrentMovesOnOnceNotificationsIsGranted() {
+    let appState = AppState()
+    let model = SBOnboardingModel(appState: appState, chatProvider: ChatProvider(), onComplete: nil)
+    model.step = .notifications
+    model.notifState = .on
+
+    model.autoAdvanceIfCurrent("notifications")
+
+    XCTAssertEqual(model.step, .shortcutOpen)
+  }
+
+  /// A user who already granted Notifications before reaching this step (for
+  /// example from a prior onboarding attempt, or from Settings) must not be
+  /// asked again — mirrors the existing pre-granted-permission skip behavior
+  /// already covered for Screen Recording / System Audio.
+  func testFirstUnaskedStepSkipsAnAlreadyGrantedNotificationsPermission() {
+    let appState = AppState()
+    appState.hasNotificationPermission = true
+    let model = SBOnboardingModel(appState: appState, chatProvider: ChatProvider(), onComplete: nil)
+
+    XCTAssertEqual(model.firstUnaskedStep(from: .notifications), .shortcutOpen)
+  }
+}

--- a/desktop/macos/Desktop/Tests/SBOnboardingNotificationsStepTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingNotificationsStepTests.swift
@@ -13,6 +13,7 @@ import XCTest
 final class SBOnboardingNotificationsStepTests: XCTestCase {
   private let resumeStepKey = "sbOnboardingResumeStep"
   private let resumeSchemaKey = "sbOnboardingResumeStepSchema"
+  private let shortcutsCompletedKey = "sbOnboardingShortcutsCompleted"
 
   override func setUp() {
     super.setUp()
@@ -23,6 +24,7 @@ final class SBOnboardingNotificationsStepTests: XCTestCase {
   override func tearDown() {
     UserDefaults.standard.removeObject(forKey: resumeStepKey)
     UserDefaults.standard.removeObject(forKey: resumeSchemaKey)
+    UserDefaults.standard.removeObject(forKey: shortcutsCompletedKey)
     super.tearDown()
   }
 
@@ -175,5 +177,83 @@ final class SBOnboardingNotificationsStepTests: XCTestCase {
     let model = SBOnboardingModel(appState: appState, chatProvider: ChatProvider(), onComplete: nil)
 
     XCTAssertEqual(model.firstUnaskedStep(from: .notifications), .shortcutOpen)
+  }
+
+  // MARK: the migration as `begin()` actually runs it
+  //
+  // The pure-function tests above pin the arithmetic. These pin the part that
+  // touches disk: that `begin()` reads the legacy value, lands on the right
+  // step, and stamps the schema so the shift can never be applied twice.
+
+  /// Hold `AppState` for the life of the call — `SBOnboardingModel` keeps it
+  /// `unowned`, so a temporary is deallocated before `begin()` reads it.
+  private func resumedStep(fromPersistedRaw raw: Int, schema: Int?, appState: AppState)
+    -> SBOnboardingModel.Step
+  {
+    UserDefaults.standard.set(raw, forKey: resumeStepKey)
+    if let schema {
+      UserDefaults.standard.set(schema, forKey: resumeSchemaKey)
+    } else {
+      UserDefaults.standard.removeObject(forKey: resumeSchemaKey)
+    }
+    // Shortcuts already done, so the mandatory-shortcuts clamp does not mask
+    // where the migration actually landed.
+    UserDefaults.standard.set(true, forKey: shortcutsCompletedKey)
+    let model = SBOnboardingModel(appState: appState, chatProvider: ChatProvider(), onComplete: nil)
+    model.begin()
+    return model.step
+  }
+
+  func testBeginRenumbersALegacyResumeStateAndStampsTheSchema() {
+    let appState = AppState()
+    // 13 was `screenDemo` under the version-1 layout; it is 14 under version 2.
+    let step = resumedStep(fromPersistedRaw: 13, schema: nil, appState: appState)
+
+    XCTAssertEqual(step, .screenDemo, "a legacy screenDemo must resume at screenDemo")
+    XCTAssertEqual(
+      UserDefaults.standard.integer(forKey: resumeStepKey), SBOnboardingModel.Step.screenDemo.rawValue)
+    XCTAssertEqual(
+      UserDefaults.standard.integer(forKey: resumeSchemaKey),
+      SBOnboardingModel.resumeStepSchemaVersion,
+      "the stamp is what stops a second launch shifting the value again")
+  }
+
+  /// The regression the stamp exists for: run `begin()` twice over the same
+  /// defaults. Without the stamp the second pass shifts an already-shifted
+  /// value, and a legacy `.referral` (17 -> 18 -> 19) leaves `Step`'s range
+  /// entirely, restarting onboarding from `.promise`.
+  func testASecondBeginDoesNotShiftAnAlreadyMigratedResumeState() {
+    let appState = AppState()
+    XCTAssertEqual(resumedStep(fromPersistedRaw: 17, schema: nil, appState: appState), .referral)
+
+    let secondLaunch = SBOnboardingModel(
+      appState: appState, chatProvider: ChatProvider(), onComplete: nil)
+    secondLaunch.begin()
+
+    XCTAssertEqual(secondLaunch.step, .referral)
+  }
+
+  /// The step that sat exactly at the insertion point is the one an off-by-one
+  /// gets wrong, and it is the boundary the arithmetic is built around.
+  func testBeginMovesTheStepThatSatExactlyAtTheInsertionPoint() {
+    let appState = AppState()
+    XCTAssertEqual(resumedStep(fromPersistedRaw: 11, schema: nil, appState: appState), .shortcutOpen)
+  }
+
+  func testBeginLeavesAStepBeforeTheInsertionPointAlone() {
+    let appState = AppState()
+    XCTAssertEqual(resumedStep(fromPersistedRaw: 10, schema: nil, appState: appState), .automation)
+  }
+
+  /// A current-schema install must be read verbatim — the migration is for
+  /// version-1 state only, and applying it to current state would corrupt it.
+  func testBeginDoesNotRenumberACurrentSchemaResumeState() {
+    let appState = AppState()
+    let step = resumedStep(
+      fromPersistedRaw: SBOnboardingModel.Step.notifications.rawValue,
+      schema: SBOnboardingModel.resumeStepSchemaVersion,
+      appState: appState)
+
+    XCTAssertEqual(step, .notifications)
   }
 }

--- a/desktop/macos/Desktop/Tests/SBOnboardingPermissionFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingPermissionFlowTests.swift
@@ -553,11 +553,19 @@ final class AppStatePermissionProbeTests: XCTestCase {
     let target = await model.firstUnaskedStepAwaitingCurrentProbes(from: .automation) { key in
       probedKeys.append(key)
       await Task.yield()
-      model.appState.hasAutomationPermission = true
+      // Each probe answers only its own permission, so a step is skipped only
+      // after its own probe is awaited — the automation grant must not leak a
+      // skip past the notifications step.
+      switch key {
+      case "automation": model.appState.hasAutomationPermission = true
+      case "notifications": model.appState.hasNotificationPermission = true
+      default: break
+      }
     }
 
-    XCTAssertEqual(probedKeys, ["automation"])
+    XCTAssertEqual(probedKeys, ["automation", "notifications"])
     XCTAssertEqual(target, .shortcutOpen)
     XCTAssertEqual(model.autoState, .on)
+    XCTAssertEqual(model.notifState, .on)
   }
 }

--- a/desktop/macos/changelog/unreleased/20260830-notification-onboarding-step.json
+++ b/desktop/macos/changelog/unreleased/20260830-notification-onboarding-step.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added a notifications step to onboarding so you're actually asked once, instead of never getting proactive alerts with no way to grant access"
+}

--- a/desktop/macos/e2e/flows/notifications-settings.yaml
+++ b/desktop/macos/e2e/flows/notifications-settings.yaml
@@ -11,6 +11,7 @@ covers:
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistantTelemetry.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantTelemetry.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationDeliveryTelemetry.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/MeetingActionItemBannerService.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationSpeech.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/FloatingBarNotificationPreviewPolicy.swift


### PR DESCRIPTION
## The defect

Onboarding never asks for notification permission, and nothing else ever will.

The live flow is `SBOnboardingModel` / `SBOnboardingView`. Its `Step` enum ran
`promise, name, howHeard, language, role, mic, systemAudio, screen, files,
accessibility, automation, shortcutOpen, …` — there is no `notifications` case,
and three separate switches (`isGranted`, `permissionKey(for:)`,
`performPermissionRequest`) confirm it. So `requestAuthorization` is never
called by any deterministic path, and a user ends up `notDetermined` **by
default rather than by choice**.

Nothing recovers from that state. `startMonitoring` deliberately never asks
(and should not — see the comment at `ProactiveAssistantsPlugin.swift`), and
outside Settings there is no badge, no re-prompt, and no nag. The 30-minute
health check only updates internal state.

Then it compounds twice:

- **Every proactive notification silently vanishes.** `NotificationService`
  called `add(request:)` with no authorization check. On `notDetermined`,
  `UNUserNotificationCenter.add` no-ops — no prompt, no error, nothing
  surfaced anywhere.
- **The one proactive surface misdirects.** `isNotificationPermissionDenied()`
  returned `hasCompletedOnboarding && !hasNotificationPermission` without ever
  reading the authorization status, so `PermissionsPage` showed
  "previously denied → open System Settings" to users who were never asked.
  An app that has never called `requestAuthorization` typically isn't listed
  in System Settings → Notifications yet, so that instruction is a dead end.

### Why it matters

The 2026-08-26 macOS churn cohort isolated 49 users in exactly this state:
notification permission `notDetermined`, monitoring never started, **8.1%
retention against a 27.4% true-new baseline**. Unlike the behavioral signals in
that study — which collapsed to ~1.05 under Mantel–Haenszel adjustment for
week-1 active days — this one is not a correlation that survives or fails
adjustment. A user who is never asked cannot receive a notification, so there
is no confounded reading of it.

## The fix

1. **Add a `notifications` step to the live onboarding**, wired through every
   switch that enumerates `Step`. It calls the existing
   `AppState.requestNotificationPermission()`, never `UNUserNotificationCenter`
   directly. **The step is skippable** — the defect is never being asked, not
   being allowed to decline.
2. **Stop labelling `notDetermined` as `denied`.**
   `isNotificationPermissionDenied()` now reads the real status, and
   `PermissionsPage` drives both its copy and its button off the existing
   `NotificationPermissionPolicy.enableAction(for:)`, so a never-asked user
   gets the native prompt and a denied user gets the System Settings link.
3. **Make the silent drop observable.** `NotificationService` now checks
   authorization before `add(request:)` and emits `Notification Delivery
   Skipped {auth_status, surface}` when unauthorized. It does **not** request
   permission from that path — a background delivery path must never become a
   consent prompt — and delivery behavior is otherwise unchanged. Follows the
   repo's closed-contract telemetry pattern (allow-list + boundary test).

### Persisted-step renumbering

`Step`'s raw values are written to `UserDefaults` (`sbOnboardingResumeStep`),
so inserting a case mid-enum silently reinterprets any in-flight resume state
written by an older build. This adds `sbOnboardingResumeStepSchema` and a pure,
tested `migratedResumeStepRaw(savedRaw:storedSchema:)` that shifts legacy
values at or after the insertion point up by one, exactly once.

The boundary constant is frozen as a literal rather than
`Step.notifications.rawValue`, because it describes a historical layout and
must not move if the enum is edited again. This file already carries the same
obligation once (`shortcutsCompletedKey`, for a previous layout change), so
handling it explicitly is the local convention rather than extra ceremony.

## Product decision to review

The step sits **immediately after `automation`**, keeping all permission asks
in one contiguous block. The alternative is after `screenDemo`, so the ask
follows a value demonstration — plausibly better conversion, but that is a UX
sequencing call I did not want to make unilaterally. Copy is also worth a pass.

## Verification

- `xcrun swift build -c debug --package-path Desktop` — clean.
- `./scripts/dev-feedback.py --once swift 'SBOnboardingNotificationsStepTests|NotificationDeliveryTelemetryBoundaryTests|PermissionsPagePresentationTests|OnboardingPermissionToolTests|SBOnboardingBackNavigationTests|SBOnboardingIntroGateTests|SBOnboardingPermissionFlowTests|UserNotificationCallbackBridgeTests|OnboardingPersistenceClearingTests'` — **86 tests, 0 failures.**
- `swift-format` lint on every changed file — clean.

New tests cover the step's placement and wiring, that onboarding still
completes when the step is skipped, that `notDetermined` is not reported as
denied, the resume-step renumbering (including that it is not applied twice),
and an allow-list boundary test for the new telemetry.

## Not in this PR

`OnboardingNotificationStepView`, `OnboardingChatView`, and
`NotificationRegistrationRepair` are all instantiated nowhere in the live
build. All three address this same problem and read as orphaned by the
SecondBrain onboarding rewrite rather than deliberately removed. Left untouched
— removing them is a separate call.

## This is a recurrence, not a new class

`FC-gated-capability-reported-never-requested` was registered from #11641,
where Context-for-Claude's headline ⌘+⌘ gesture needed Accessibility, knew the
grant was missing, and only ever *described* it — including a button opening a
Privacy pane that does not list an app until it has called
`AXIsProcessTrustedWithOptions`.

This is the same shape in a different tree: the grant is never requested, the
missing state is only described, and the described remedy points at a System
Settings pane that does not list an app until it has called
`requestAuthorization`. Same contract, same dead end, different permission.

The class's canonical prevention says the branch that discovers the gap must
either raise the platform request or record why it may not. `NotificationService`
takes the second option deliberately — a background delivery path must never
become a consent prompt — so the ask lives in onboarding, where every other
permission is already requested, and the delivery path now records the drop.

## Third review round

A second adversarial pass found the round-1 telemetry fix was half done: moving
the emit out of `deliverNotification` fixed `sendNotification` and left the
context-director path with the identical defect, since both engines abort on a
non-`.queued` preflight and the preflight folded authorization into
`hasVisibleAlertSurface` with no event. Authorization is now its own guard
there, checked first, and both real drop sites go through one reporter.

Adds `NotificationSkipEventPlacementTests` — placement is the whole contract and
nothing tested it; the round-1 defect stayed green through both existing
telemetry tests because they call `AnalyticsManager` directly.

Line-Count-Exception: desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift | 1467 -> 1528 | the two authorization drop sites and their shared reporter must live beside the delivery paths they guard; splitting this file is a standing refactor unrelated to this fix

Failure-Class: FC-gated-capability-reported-never-requested

Line-Count-Exception: desktop/macos/Desktop/Sources/AnalyticsManager.swift | 1528 -> 1554 | one emitter plus its test-capture seam, following the per-feature telemetry pattern every other family in this file already uses; splitting the shared analytics facade is a separate refactor and would make this fix unreviewable
Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift | 1495 -> 1503 | eight lines routing the notification section through NotificationPermissionPolicy.enableAction instead of the mislabelling helper; the change is the bug fix itself and cannot be moved out of this file


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


