### PR TITLE
fix(desktop): return undated voice tasks, and stop assuming the Mac's language

### DIFF
--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -445,14 +445,23 @@ class TestCreateActionItemDateValidation:
         assert "Error" in result
         assert "Invalid due_at format" in result
 
-    def test_no_due_date_defaults_to_24h(self):
-        """No due date should default to 24h from now."""
+    def test_no_due_date_stays_undated(self):
+        """A task the user never dated must be written with no due date.
+
+        Inventing ``now + 24h`` put it in neither the overdue nor the due-today
+        bucket any reader uses, so "remind me to X" followed by "what's on my
+        list" deterministically answered that there was nothing.
+        """
+        action_items_db.create_action_item.reset_mock()
         result = create_action_item_tool(
             description="No due date task",
             due_at=None,
             config=_make_config(),
         )
         assert "in the past" not in result
+        action_items_db.create_action_item.assert_called_once()
+        written = action_items_db.create_action_item.call_args.args[1]
+        assert written.get("due_at") is None, f"expected no invented due date, got {written.get('due_at')!r}"
 
     def test_boundary_23h_ago_accepted(self):
         """Due date 23h ago should be accepted (within 1-day grace)."""

--- a/backend/utils/retrieval/tool_services/action_items.py
+++ b/backend/utils/retrieval/tool_services/action_items.py
@@ -178,8 +178,9 @@ def create_action_item_text(
         except ValueError as e:
             return f"Error: Invalid due_at format: {e}"
     else:
-        now = datetime.now(datetime.now().astimezone().tzinfo)
-        action_item_data['due_at'] = now + timedelta(hours=24)
+        # No invented due date: see create_action_item_tool. A task with no date
+        # the user gave belongs in the undated bucket, not tomorrow's.
+        pass
 
     try:
         action_item_id = action_items_db.create_action_item(uid, action_item_data)

--- a/backend/utils/retrieval/tools/action_item_tools.py
+++ b/backend/utils/retrieval/tools/action_item_tools.py
@@ -460,11 +460,11 @@ def create_action_item_tool(
         except ValueError as e:
             return f"Error: Invalid due_at format. Expected YYYY-MM-DDTHH:MM:SS+HH:MM in user's timezone: {due_at} - {str(e)}"
     else:
-        # Set default due date to 24 hours from now in UTC
-        now = datetime.now(datetime.now().astimezone().tzinfo)
-        default_due = now + timedelta(hours=24)
-        action_item_data['due_at'] = default_due
-        logger.info(f"📅 No due date provided, setting default to 24h from now: {default_due}")
+        # A task the user never dated has no due date. Inventing now+24h put it in
+        # neither the overdue nor the due-today bucket any reader uses, so
+        # "remind me to X" followed by "what's on my list" deterministically
+        # returned nothing. `due_at` is Optional everywhere; leave it unset.
+        logger.info("📅 No due date provided, leaving due_at unset")
 
     # Create the action item
     try:

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
@@ -539,13 +539,19 @@ extension RealtimeHubController {
       }
       let overdue = TasksStore.shared.overdueTasks
       let today = TasksStore.shared.todaysTasks
+      // `loadDashboardTasks` already fetches this bucket. Dropping it here is why
+      // "remind me to X" followed by "what's on my list" answered "no tasks": a
+      // task the user never dated belongs to no date, so it appeared in neither
+      // of the other two buckets and was silently discarded on the way out.
+      let undated = TasksStore.shared.tasksWithoutDueDate
       func list(_ items: [TaskActionItem]) -> String {
         items.prefix(15).map { "- \($0.description) [id:\($0.id)]" }.joined(separator: "\n")
       }
       var output = ""
       if !overdue.isEmpty { output += "Overdue (\(overdue.count)):\n\(list(overdue))\n" }
       if !today.isEmpty { output += "Due today (\(today.count)):\n\(list(today))\n" }
-      return .succeeded(output.isEmpty ? "No tasks overdue or due today." : output)
+      if !undated.isEmpty { output += "No due date (\(undated.count)):\n\(list(undated))\n" }
+      return .succeeded(output.isEmpty ? "No tasks overdue, due today, or waiting without a date." : output)
 
     case .thinkDeeper:
       let query = (command.input["query"] as? String) ?? turnTranscript

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -7,11 +7,15 @@ import Foundation
 // execution profile, and durable run identity before Swift executes anything.
 
 enum RealtimeHubTools {
-  static func resolvedVoiceLanguages(
-    explicit codes: [String],
-    preferredLanguages: [String] = Locale.preferredLanguages
-  ) -> [String] {
-    let source = codes.isEmpty ? preferredLanguages : codes
+  /// Only what the user actually configured. There is deliberately no fallback to
+  /// `Locale.preferredLanguages`: the macOS UI language is a claim about the
+  /// interface, not about the person, and the line built from this asserts the user
+  /// speaks ONLY these languages and that anything else "was misheard". Pinning an
+  /// unconfigured bilingual user to their menu-bar language told the model to
+  /// reinterpret their real speech as a mishearing. The Windows port already omits
+  /// the line for an unconfigured user; this brings macOS to parity.
+  static func resolvedVoiceLanguages(explicit codes: [String]) -> [String] {
+    let source = codes
     var seen = Set<String>()
     var resolved: [String] = []
     for code in source {
@@ -25,8 +29,8 @@ enum RealtimeHubTools {
 
   /// One line telling the model which languages the user actually speaks, so a short or
   /// ambiguous utterance is never interpreted (or transcribed, where the provider allows
-  /// it) as some third language. Falls back to the Mac's preferred language when the user
-  /// has not configured an explicit voice-language set.
+  /// it) as some third language. Empty when the user has configured no voice languages —
+  /// a user who has claimed nothing must not have a claim made for them.
   private static func userLanguagesLine(_ codes: [String]) -> String {
     let resolved = resolvedVoiceLanguages(explicit: codes)
     guard !resolved.isEmpty else { return "" }

--- a/desktop/macos/Desktop/Tests/RealtimeVoiceLanguageAndTaskBucketTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeVoiceLanguageAndTaskBucketTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+
+@testable import Omi_Computer
+
+#if DEBUG
+  /// Two deterministic voice-lane defects: a claim made on the user's behalf about
+  /// which languages they speak, and a written task that its paired read could
+  /// never return.
+  @MainActor
+  final class RealtimeVoiceLanguageAndTaskBucketTests: XCTestCase {
+
+    // MARK: - Reply language
+
+    func testUnconfiguredUserGetsNoLanguageClaim() {
+      // The macOS UI language describes the interface, not the person. Falling back
+      // to it told the model an unconfigured bilingual user speaks ONLY their
+      // menu-bar language and that anything else "was misheard".
+      XCTAssertTrue(RealtimeHubTools.resolvedVoiceLanguages(explicit: []).isEmpty)
+    }
+
+    func testUnconfiguredUserInstructionOmitsTheSpeaksOnlyLine() {
+      let instruction = RealtimeHubTools.systemInstruction(userLanguages: [])
+      XCTAssertFalse(instruction.contains("speaks ONLY"))
+    }
+
+    func testConfiguredLanguagesAreNamedAndDeduplicated() {
+      let resolved = RealtimeHubTools.resolvedVoiceLanguages(explicit: ["ru-RU", "en-US", "ru"])
+      XCTAssertEqual(resolved, ["ru", "en"])
+
+      let instruction = RealtimeHubTools.systemInstruction(userLanguages: ["ru", "en"])
+      XCTAssertTrue(instruction.contains("speaks ONLY"))
+      XCTAssertTrue(instruction.contains("Russian"))
+      XCTAssertTrue(instruction.contains("English"))
+    }
+  }
+#endif

--- a/desktop/macos/changelog/unreleased/20260830-voice-tasks-and-language.json
+++ b/desktop/macos/changelog/unreleased/20260830-voice-tasks-and-language.json
@@ -1,0 +1,3 @@
+{
+  "change": "Asking Omi by voice what's on your list now returns tasks you added without a date, and Omi no longer assumes you only speak your Mac's menu-bar language"
+}


### PR DESCRIPTION
## What changed and why

Two independent deterministic defects in the desktop push-to-talk lane. Neither depends on the other or on #12414; both were verified live against `origin/main` before being fixed. Evidence: `omi-knowledge-base` → `projects/ptt-improvement/` (2026-08-27 baseline over 2,188 judged production turns, plus the Opus root-cause lanes).

**Undated voice tasks were invisible to the read that should return them.** "Remind me to X" followed by "what's on my list" deterministically answered that there was nothing, because the write and the read disagreed about the same domain. The backend invented `due_at = now + 24h` for a task the user never dated, which falls in neither the overdue nor the due-today bucket; and the realtime `get_tasks` executor loaded `TasksStore.tasksWithoutDueDate` and then dropped it while formatting its answer. The write now leaves `due_at` unset — it is `Optional` at every layer already — and the read returns the third bucket it was holding the whole time. Both halves are needed: fixing either alone still yields an empty list.

**An unconfigured user was told which languages they speak.** `resolvedVoiceLanguages` fell back to `Locale.preferredLanguages` when the user had configured no voice languages, and the prompt line built from it asserts the user "speaks ONLY these languages" and that an utterance in any other "was misheard; interpret it as <primary>". That turns a menu-bar setting into a claim about the person: an unconfigured bilingual user had their real speech reinterpreted as a mishearing. A user who has claimed nothing now gets no claim made for them. This is exactly what the Windows port already does (`desktop/windows/src/renderer/src/lib/voice/systemInstruction.ts`), so this brings macOS to parity rather than inventing a policy.

Deliberately unchanged: the "primary: X … interpret it as X" phrasing for a user who *has* configured several languages. That is their own configuration talking, and Windows phrases it identically; changing it would diverge the two ports and is a separate prompt-semantics decision.

## Product invariants affected

- INV-VOICE-1: the reducer remains the sole lifecycle owner; neither change touches turn lifecycle, ownership, or the glow.
- INV-AGENT-*: tool authorization and the generated capability manifest are unchanged; `get_tasks` returns more of what it already fetched, under the same authorization.
- INV-CHAT-1: no new transcript or chat store; the task tool reads the same already-loaded dashboard buckets and writes through the same backend create path.

## How it was verified

- `cd desktop/macos && swift test --filter RealtimeVoiceLanguageAndTaskBucketTests` — 3 tests passed.
- `backend`: `pytest tests/unit/test_action_item_date_validation.py` — 26 passed, including the rewritten contract test.
- Neighbours that could depend on the old default were run individually and pass: `test_tools_router.py` (103), `test_chat_first_e2e_fixture.py` (9), `test_chat_first_proactive_intents.py` (13), `test_action_item_tool_result_bound.py` (7).
- `test_action_item_canonical_contract.py` fails to import on this machine (`ModuleNotFoundError: langchain_anthropic`); identical on unmodified `origin/main`, so it is a local venv gap, not a regression from this change.

## Tests

- `RealtimeVoiceLanguageAndTaskBucketTests` — an unconfigured user resolves to no languages and their system instruction contains no "speaks ONLY" line; configured codes are still named, region-stripped, and deduplicated.
- `test_action_item_date_validation.py::test_no_due_date_stays_undated` — replaces `test_no_due_date_defaults_to_24h`, which pinned the defect. It now asserts on what the tool actually writes (`due_at is None`) rather than only on the absence of an error string.

## Failure class (fixes)

Failure-Class: FC-decoded-outcome-discarded-before-canonical-record

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift | 1520 -> 1526 | Returns the undated task bucket the executor already loads, in the `get_tasks` case that formats the answer; the fix has to live where the buckets are assembled.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

