### PR TITLE
fix(app): stop a duplicate keychain item from crashing the app

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -32,25 +32,16 @@ class SharedPreferencesUtil {
   static const String _authTokenSecureKey = 'authToken';
   static const String _authTokenMigratedPrefsKey = 'authTokenSecureMigrated';
 
-  /// Plain prefs mirror for the Android background socket, the one native
-  /// reader that cannot reach secure storage. Other platforms keep the token in
-  /// the keychain only, so the migration is not undone by the mirror.
+  /// Plain prefs mirror for in-tree native readers (Android background socket).
   static const String _nativeAuthTokenPrefsKey = 'nativeAuthToken';
 
   static bool _mirrorNativeAuthToken = false;
 
-  /// `errSecDuplicateItem`. The keychain plugin writes with a check-then-add,
-  /// so an entry its probe cannot see — stored under another accessibility, or
-  /// added by a write racing this one — makes the add collide instead of update.
   static const int _duplicateKeychainItem = -25299;
 
-  /// Deletes with no accessibility in the query match the entry whatever
-  /// accessibility it was stored under; the default query would miss it.
   static const IOSOptions _anyAccessibilityIos = IOSOptions(accessibility: null);
   static const MacOsOptions _anyAccessibilityMacOs = MacOsOptions(accessibility: null);
 
-  /// Serializes keychain calls. The plugin answers each call on a background
-  /// queue, so two overlapping writes both take its add path and one loses.
   static Future<void> _secureQueue = Future<void>.value();
 
   factory SharedPreferencesUtil() {
@@ -62,8 +53,6 @@ class SharedPreferencesUtil {
   String get deviceIdHash => _preferences?.getString('deviceIdHash') ?? '';
   set deviceIdHash(String value) => _preferences?.setString('deviceIdHash', value);
 
-  /// [mirrorNativeAuthToken] exists because the host running `flutter test` is
-  /// never the Android device whose native reader the mirror serves.
   static Future<void> init({FlutterSecureStorage? secureStorage, bool? mirrorNativeAuthToken}) async {
     _preferences = await SharedPreferences.getInstance();
     _mirrorNativeAuthToken = mirrorNativeAuthToken ?? Platform.isAndroid;
@@ -111,11 +100,7 @@ class SharedPreferencesUtil {
       final existingSecure = await _readSecureAuthToken();
       if ((existingSecure == null || existingSecure.isEmpty) && legacyToken != null && legacyToken.isNotEmpty) {
         final persisted = await _writeSecureAuthToken(legacyToken);
-        if (!persisted) {
-          // Keychain unreachable (locked since boot). Keep the prefs copy and
-          // leave the flag unset so the next launch retries.
-          return;
-        }
+        if (!persisted) return;
       }
       if (legacyToken != null) {
         await prefs.remove('authToken');
@@ -128,9 +113,6 @@ class SharedPreferencesUtil {
     }
   }
 
-  /// Runs one keychain call after the previous one finishes. A failure is
-  /// reported as `null` rather than thrown: callers are fire-and-forget, and an
-  /// unhandled async error here is recorded as a fatal crash.
   static Future<T?> _runSecure<T extends Object>(String op, Future<T?> Function() action) {
     final result = Completer<T?>();
     _secureQueue = _secureQueue.then((_) async {
@@ -156,9 +138,6 @@ class SharedPreferencesUtil {
     return _runSecure<String>('read', () => storage.read(key: _authTokenSecureKey));
   }
 
-  /// Returns whether the token reached secure storage. A keychain locked since
-  /// boot fails every call, so callers that drop a plaintext copy must check
-  /// this instead of assuming the write landed.
   static Future<bool> _writeSecureAuthToken(String value) async {
     final fallback = _testSecureFallback;
     if (fallback != null) {
@@ -172,8 +151,6 @@ class SharedPreferencesUtil {
         await storage.write(key: _authTokenSecureKey, value: value);
       } on PlatformException catch (e) {
         if (!_isDuplicateKeychainItem(e)) rethrow;
-        // The entry exists but the plugin added instead of updated. Drop it at
-        // any accessibility and re-add, so the session survives the collision.
         await storage.delete(
           key: _authTokenSecureKey,
           iOptions: _anyAccessibilityIos,
@@ -206,10 +183,8 @@ class SharedPreferencesUtil {
     await _syncNativeAuthToken('');
   }
 
-  /// Android's background streaming service reads SharedPreferences natively,
-  /// so the live token is mirrored there for it. Where nothing reads the mirror
-  /// the token would sit in plaintext for no one, so the key is cleared instead
-  /// — including a copy an earlier build left behind.
+  /// Native Android still reads SharedPreferences. Mirror the live token there
+  /// under a dedicated key so background streaming survives the secure migration.
   static Future<void> _syncNativeAuthToken(String value) async {
     final prefs = _preferences;
     if (prefs == null) return;

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io' show Platform;
 
 import 'package:collection/collection.dart';
+import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -33,6 +34,20 @@ class SharedPreferencesUtil {
 
   /// Plain prefs mirror for in-tree native readers (Android background socket).
   static const String _nativeAuthTokenPrefsKey = 'nativeAuthToken';
+
+  /// `errSecDuplicateItem`. The keychain plugin writes with a check-then-add,
+  /// so an entry its probe cannot see — stored under another accessibility, or
+  /// added by a write racing this one — makes the add collide instead of update.
+  static const int _duplicateKeychainItem = -25299;
+
+  /// Deletes with no accessibility in the query match the entry whatever
+  /// accessibility it was stored under; the default query would miss it.
+  static const IOSOptions _anyAccessibilityIos = IOSOptions(accessibility: null);
+  static const MacOsOptions _anyAccessibilityMacOs = MacOsOptions(accessibility: null);
+
+  /// Serializes keychain calls. The plugin answers each call on a background
+  /// queue, so two overlapping writes both take its add path and one loses.
+  static Future<void> _secureQueue = Future<void>.value();
 
   factory SharedPreferencesUtil() {
     return _instance;
@@ -88,7 +103,12 @@ class SharedPreferencesUtil {
     try {
       final existingSecure = await _readSecureAuthToken();
       if ((existingSecure == null || existingSecure.isEmpty) && legacyToken != null && legacyToken.isNotEmpty) {
-        await _writeSecureAuthToken(legacyToken);
+        final persisted = await _writeSecureAuthToken(legacyToken);
+        if (!persisted) {
+          // Keychain unreachable (locked since boot). Keep the prefs copy and
+          // leave the flag unset so the next launch retries.
+          return;
+        }
       }
       if (legacyToken != null) {
         await prefs.remove('authToken');
@@ -101,19 +121,62 @@ class SharedPreferencesUtil {
     }
   }
 
+  /// Runs one keychain call after the previous one finishes. A failure is
+  /// reported as `null` rather than thrown: callers are fire-and-forget, and an
+  /// unhandled async error here is recorded as a fatal crash.
+  static Future<T?> _runSecure<T extends Object>(String op, Future<T?> Function() action) {
+    final result = Completer<T?>();
+    _secureQueue = _secureQueue.then((_) async {
+      try {
+        result.complete(await action());
+      } catch (e, stack) {
+        Logger.debug('Secure storage $op failed: $e');
+        Logger.debug('Stack: $stack');
+        result.complete(null);
+      }
+    });
+    return result.future;
+  }
+
+  static bool _isDuplicateKeychainItem(PlatformException e) =>
+      e.details == _duplicateKeychainItem || (e.message?.contains('$_duplicateKeychainItem') ?? false);
+
   static Future<String?> _readSecureAuthToken() async {
     final fallback = _testSecureFallback;
     if (fallback != null) return fallback[_authTokenSecureKey];
-    return _secureStorage?.read(key: _authTokenSecureKey);
+    final storage = _secureStorage;
+    if (storage == null) return null;
+    return _runSecure<String>('read', () => storage.read(key: _authTokenSecureKey));
   }
 
-  static Future<void> _writeSecureAuthToken(String value) async {
+  /// Returns whether the token reached secure storage. A keychain locked since
+  /// boot fails every call, so callers that drop a plaintext copy must check
+  /// this instead of assuming the write landed.
+  static Future<bool> _writeSecureAuthToken(String value) async {
     final fallback = _testSecureFallback;
     if (fallback != null) {
       fallback[_authTokenSecureKey] = value;
-      return;
+      return true;
     }
-    await _secureStorage?.write(key: _authTokenSecureKey, value: value);
+    final storage = _secureStorage;
+    if (storage == null) return false;
+    final wrote = await _runSecure<bool>('write', () async {
+      try {
+        await storage.write(key: _authTokenSecureKey, value: value);
+      } on PlatformException catch (e) {
+        if (!_isDuplicateKeychainItem(e)) rethrow;
+        // The entry exists but the plugin added instead of updated. Drop it at
+        // any accessibility and re-add, so the session survives the collision.
+        await storage.delete(
+          key: _authTokenSecureKey,
+          iOptions: _anyAccessibilityIos,
+          mOptions: _anyAccessibilityMacOs,
+        );
+        await storage.write(key: _authTokenSecureKey, value: value);
+      }
+      return true;
+    });
+    return wrote ?? false;
   }
 
   static Future<void> _deleteSecureAuthToken() async {
@@ -121,7 +184,17 @@ class SharedPreferencesUtil {
     if (fallback != null) {
       fallback.remove(_authTokenSecureKey);
     } else {
-      await _secureStorage?.delete(key: _authTokenSecureKey);
+      final storage = _secureStorage;
+      if (storage != null) {
+        await _runSecure<bool>('delete', () async {
+          await storage.delete(
+            key: _authTokenSecureKey,
+            iOptions: _anyAccessibilityIos,
+            mOptions: _anyAccessibilityMacOs,
+          );
+          return true;
+        });
+      }
     }
     await _syncNativeAuthToken('');
   }

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -32,8 +32,12 @@ class SharedPreferencesUtil {
   static const String _authTokenSecureKey = 'authToken';
   static const String _authTokenMigratedPrefsKey = 'authTokenSecureMigrated';
 
-  /// Plain prefs mirror for in-tree native readers (Android background socket).
+  /// Plain prefs mirror for the Android background socket, the one native
+  /// reader that cannot reach secure storage. Other platforms keep the token in
+  /// the keychain only, so the migration is not undone by the mirror.
   static const String _nativeAuthTokenPrefsKey = 'nativeAuthToken';
+
+  static bool _mirrorNativeAuthToken = false;
 
   /// `errSecDuplicateItem`. The keychain plugin writes with a check-then-add,
   /// so an entry its probe cannot see — stored under another accessibility, or
@@ -58,8 +62,11 @@ class SharedPreferencesUtil {
   String get deviceIdHash => _preferences?.getString('deviceIdHash') ?? '';
   set deviceIdHash(String value) => _preferences?.setString('deviceIdHash', value);
 
-  static Future<void> init({FlutterSecureStorage? secureStorage}) async {
+  /// [mirrorNativeAuthToken] exists because the host running `flutter test` is
+  /// never the Android device whose native reader the mirror serves.
+  static Future<void> init({FlutterSecureStorage? secureStorage, bool? mirrorNativeAuthToken}) async {
     _preferences = await SharedPreferences.getInstance();
+    _mirrorNativeAuthToken = mirrorNativeAuthToken ?? Platform.isAndroid;
     if (secureStorage != null) {
       _secureStorage = secureStorage;
       _testSecureFallback = null;
@@ -199,12 +206,14 @@ class SharedPreferencesUtil {
     await _syncNativeAuthToken('');
   }
 
-  /// Native Android still reads SharedPreferences. Mirror the live token there
-  /// under a dedicated key so background streaming survives the secure migration.
+  /// Android's background streaming service reads SharedPreferences natively,
+  /// so the live token is mirrored there for it. Where nothing reads the mirror
+  /// the token would sit in plaintext for no one, so the key is cleared instead
+  /// — including a copy an earlier build left behind.
   static Future<void> _syncNativeAuthToken(String value) async {
     final prefs = _preferences;
     if (prefs == null) return;
-    if (value.isEmpty) {
+    if (value.isEmpty || !_mirrorNativeAuthToken) {
       await prefs.remove(_nativeAuthTokenPrefsKey);
     } else {
       await prefs.setString(_nativeAuthTokenPrefsKey, value);

--- a/app/test/unit/auth_token_secure_storage_migration_test.dart
+++ b/app/test/unit/auth_token_secure_storage_migration_test.dart
@@ -1,3 +1,6 @@
+import 'dart:math';
+
+import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -81,4 +84,122 @@ void main() {
     expect(prefs.containsKey('authToken'), isFalse);
     expect(prefs.getBool('authTokenSecureMigrated'), isTrue);
   });
+
+  test('a duplicate-item keychain write deletes the stale entry and rewrites', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = _FakeSecureStorage()..duplicateWrites = 1;
+    await SharedPreferencesUtil.init(secureStorage: storage);
+
+    SharedPreferencesUtil().authToken = 'fresh-token';
+    await pumpEventQueue();
+
+    expect(storage.store['authToken'], 'fresh-token');
+    expect(storage.calls, containsAllInOrder(<String>['write', 'delete', 'write']));
+    expect(SharedPreferencesUtil().authToken, 'fresh-token');
+  });
+
+  test('overlapping token writes never run concurrently in the keychain', () async {
+    SharedPreferences.setMockInitialValues({});
+    final storage = _FakeSecureStorage();
+    await SharedPreferencesUtil.init(secureStorage: storage);
+
+    SharedPreferencesUtil().authToken = 'token-a';
+    SharedPreferencesUtil().authToken = 'token-b';
+    await pumpEventQueue();
+
+    expect(storage.maxConcurrent, 1);
+    expect(storage.store['authToken'], 'token-b');
+  });
+
+  test('migration keeps the prefs token when the keychain rejects the write', () async {
+    SharedPreferences.setMockInitialValues({'authToken': 'legacy-session-token'});
+    final storage = _FakeSecureStorage()..writeError = _keychainError(-25308, 'Interaction is not allowed.');
+    await SharedPreferencesUtil.init(secureStorage: storage);
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getString('authToken'), 'legacy-session-token');
+    expect(prefs.getBool('authTokenSecureMigrated'), isNull);
+    // The session still works this launch; the next launch retries the move.
+    expect(SharedPreferencesUtil().authToken, 'legacy-session-token');
+  });
+}
+
+PlatformException _keychainError(int status, String message) {
+  return PlatformException(
+    code: 'Unexpected security result code',
+    message: 'Code: $status, Message: $message',
+    details: status,
+  );
+}
+
+/// Stands in for the plugin so a keychain failure is reachable from a test.
+class _FakeSecureStorage extends FlutterSecureStorage {
+  _FakeSecureStorage();
+
+  final Map<String, String> store = <String, String>{};
+  final List<String> calls = <String>[];
+
+  /// Number of leading writes that fail with `errSecDuplicateItem`.
+  int duplicateWrites = 0;
+
+  /// Failure every write raises, for keychains that never accept the entry.
+  PlatformException? writeError;
+
+  int maxConcurrent = 0;
+  int _inFlight = 0;
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    _inFlight++;
+    maxConcurrent = max(maxConcurrent, _inFlight);
+    try {
+      await Future<void>.delayed(Duration.zero);
+      calls.add('write');
+      if (writeError != null) throw writeError!;
+      if (duplicateWrites > 0) {
+        duplicateWrites--;
+        throw _keychainError(-25299, 'The specified item already exists in the keychain.');
+      }
+      store[key] = value!;
+    } finally {
+      _inFlight--;
+    }
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    calls.add('read');
+    return store[key];
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    calls.add('delete');
+    store.remove(key);
+  }
 }

--- a/app/test/unit/auth_token_secure_storage_migration_test.dart
+++ b/app/test/unit/auth_token_secure_storage_migration_test.dart
@@ -139,7 +139,6 @@ void main() {
     final prefs = await SharedPreferences.getInstance();
     expect(prefs.getString('authToken'), 'legacy-session-token');
     expect(prefs.getBool('authTokenSecureMigrated'), isNull);
-    // The session still works this launch; the next launch retries the move.
     expect(SharedPreferencesUtil().authToken, 'legacy-session-token');
   });
 }
@@ -152,17 +151,13 @@ PlatformException _keychainError(int status, String message) {
   );
 }
 
-/// Stands in for the plugin so a keychain failure is reachable from a test.
 class _FakeSecureStorage extends FlutterSecureStorage {
   _FakeSecureStorage();
 
   final Map<String, String> store = <String, String>{};
   final List<String> calls = <String>[];
 
-  /// Number of leading writes that fail with `errSecDuplicateItem`.
   int duplicateWrites = 0;
-
-  /// Failure every write raises, for keychains that never accept the entry.
   PlatformException? writeError;
 
   int maxConcurrent = 0;

--- a/app/test/unit/auth_token_secure_storage_migration_test.dart
+++ b/app/test/unit/auth_token_secure_storage_migration_test.dart
@@ -19,7 +19,7 @@ void main() {
     FlutterSecureStorage.setMockInitialValues({});
 
     const secure = FlutterSecureStorage();
-    await SharedPreferencesUtil.init(secureStorage: secure);
+    await SharedPreferencesUtil.init(secureStorage: secure, mirrorNativeAuthToken: true);
 
     expect(SharedPreferencesUtil().authToken, 'legacy-session-token');
     expect(await secure.read(key: 'authToken'), 'legacy-session-token');
@@ -34,7 +34,7 @@ void main() {
 
     // Second init must not wipe the secure token or re-read a prefs copy.
     await prefs.setString('authToken', 'should-be-ignored');
-    await SharedPreferencesUtil.init(secureStorage: secure);
+    await SharedPreferencesUtil.init(secureStorage: secure, mirrorNativeAuthToken: true);
     expect(SharedPreferencesUtil().authToken, 'legacy-session-token');
     expect(await secure.read(key: 'authToken'), 'legacy-session-token');
     expect(prefs.containsKey('authToken'), isFalse);
@@ -59,7 +59,7 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     FlutterSecureStorage.setMockInitialValues({});
     const secure = FlutterSecureStorage();
-    await SharedPreferencesUtil.init(secureStorage: secure);
+    await SharedPreferencesUtil.init(secureStorage: secure, mirrorNativeAuthToken: true);
 
     SharedPreferencesUtil().authToken = 'fresh-token';
     // Allow the fire-and-forget write to complete.
@@ -83,6 +83,26 @@ void main() {
     final prefs = await SharedPreferences.getInstance();
     expect(prefs.containsKey('authToken'), isFalse);
     expect(prefs.getBool('authTokenSecureMigrated'), isTrue);
+  });
+
+  test('the plaintext mirror is cleared where no native reader consumes it', () async {
+    SharedPreferences.setMockInitialValues({
+      'nativeAuthToken': 'copy-left-by-an-earlier-build',
+      'authTokenSecureMigrated': true,
+    });
+    FlutterSecureStorage.setMockInitialValues({'authToken': 'secure-token'});
+
+    const secure = FlutterSecureStorage();
+    await SharedPreferencesUtil.init(secureStorage: secure, mirrorNativeAuthToken: false);
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.containsKey('nativeAuthToken'), isFalse);
+
+    SharedPreferencesUtil().authToken = 'rotated-token';
+    await pumpEventQueue();
+
+    expect(prefs.containsKey('nativeAuthToken'), isFalse);
+    expect(await secure.read(key: 'authToken'), 'rotated-token');
   });
 
   test('a duplicate-item keychain write deletes the stale entry and rewrites', () async {


### PR DESCRIPTION
## Summary

Crashlytics reports a fatal `PlatformException(Unexpected security result code, Code: -25299, Message: The specified item already exists in the keychain.)` from `SharedPreferencesUtil._writeSecureAuthToken` (preferences.dart:116). Two defects meet there.

**The failure is fatal for no reason.** The `authToken` setter fires its secure-storage write unawaited, so a keychain rejection escapes as an unhandled async error and `main.dart` records it through `recordError(..., fatal: true)`. The app keeps running; only the crash report says otherwise.

**-25299 is reachable in normal use.** `flutter_secure_storage` 9.2.4 writes with a check-then-add (`ios/Classes/FlutterSecureStorage.swift:172-222`): `containsKey` first, then `SecItemAdd` when the probe reports absent. The probe misses an entry that exists in two ways we hit:

- Entries written between #11917 and #12053 carry the plugin default `kSecAttrAccessibleWhenUnlocked`; #12053 switched writes to `first_unlock`. A `WhenUnlocked` entry cannot be matched while the device is locked — and the app refreshes tokens in the background during BLE streaming and CoreBluetooth restore — so the probe says absent and the add collides. The plugin's own repair path (delete at every accessibility, then add) only runs when the probe *found* the entry, so it never fires here.
- The setter is fire-and-forget and the plugin answers each method call on a background dispatch queue, so two overlapping writes both probe "absent" and both add.

## What changed

- Keychain calls are serialized through one queue, so overlapping writes cannot both take the add path.
- Failures are reported as a value and logged instead of thrown, so a keychain that refuses the write never becomes a fatal crash. The in-memory token keeps the session alive.
- On -25299 the entry is deleted with no accessibility in the query — the only query that matches whatever accessibility it was stored under — and re-added.
- Sign-out deletes use that same query. Previously they ran with `first_unlock` in the query, so a legacy `unlocked` entry survived logout in the keychain.
- The migration checks whether the write landed before dropping the prefs copy, so a keychain that never accepts the entry still retries on the next launch instead of losing the token.

Second commit, adjacent defect in the same function: #12053's plaintext mirror (`nativeAuthToken`) exists for the Android background streaming service, whose Kotlin cannot reach the Flutter keychain wrapper (`OmiBackgroundAudioStreamer.kt:306`). It runs on every platform, so on iOS and macOS #11917's move of the token into the Keychain was undone by a plaintext `NSUserDefaults` copy that nothing reads. It is now written only where a native reader exists, and cleared everywhere else so an earlier build's copy is dropped on the next launch.

If the keychain is genuinely locked since boot, the recovery delete cannot match either and the write still fails — now logged rather than fatal, and it self-heals through the plugin's own update path on the next write after unlock.

## Tests

`app/test/unit/auth_token_secure_storage_migration_test.dart`, via a `FlutterSecureStorage` fake that can reject writes:

- a duplicate-item write recovers by deleting the stale entry and rewriting;
- overlapping token writes never run concurrently in the keychain (`maxConcurrent == 1`), the regression that produced the collision;
- a keychain that rejects the write leaves the prefs token and the migration flag intact, so the next launch retries;
- the plaintext mirror is cleared where no native reader consumes it, and a token rotation does not write it back.

## Verification

**I could not run `flutter test` for this change.** The Flutter SDK path on this machine is unreadable from the agent sandbox (`Operation not permitted` on every file under it), so the suite and `dart format` did not run here. The deterministic manifest did: `make preflight` passes all 13 checks, and the push used the pre-push gate's documented `PRE_PUSH_SKIP_DART_FORMAT=1` hatch, so CI's `app-dart-format` is the first machine to see the formatting. The four tests above are written but unexecuted; please run:

```
cd app && flutter test test/unit/auth_token_secure_storage_migration_test.dart
```

Device check worth doing before merge: sign out and back in on iOS, confirm the session survives a cold start, and confirm the crash stops appearing in Crashlytics for builds carrying this change.

## Failure class

No existing class in `.github/failure-classes/` describes this contract — a fire-and-forget platform write whose rejection escapes as a fatal error, over a store whose existence probe cannot distinguish absent from inaccessible. I did not mint one for a single instance; say the word if you want it registered.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

