### PR TITLE
fix(app): drop the knowledge graph rebuild action

### DIFF
--- a/app/lib/pages/home/home_content.dart
+++ b/app/lib/pages/home/home_content.dart
@@ -431,8 +431,6 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
                 showAppBar: false,
                 showShareButton: false,
                 trackOpenEvent: false,
-                autoRebuildIfEmpty: false,
-                hideRebuildButtonWhenEmpty: true,
                 initialZoom: 0.6,
               ),
             ),

--- a/app/lib/pages/memories/widgets/memory_graph_page.dart
+++ b/app/lib/pages/memories/widgets/memory_graph_page.dart
@@ -224,8 +224,6 @@ class MemoryGraphPage extends StatefulWidget {
   final bool showAppBar;
   final bool showShareButton;
   final bool trackOpenEvent;
-  final bool autoRebuildIfEmpty;
-  final bool hideRebuildButtonWhenEmpty;
   final double initialZoom;
 
   const MemoryGraphPage({
@@ -234,8 +232,6 @@ class MemoryGraphPage extends StatefulWidget {
     this.showAppBar = true,
     this.showShareButton = true,
     this.trackOpenEvent = true,
-    this.autoRebuildIfEmpty = false,
-    this.hideRebuildButtonWhenEmpty = false,
     this.initialZoom = 1.0,
   });
 
@@ -261,14 +257,12 @@ class _MemoryGraphPageState extends State<MemoryGraphPage> with SingleTickerProv
   Offset? _lastPanStart;
 
   bool _isLoading = true;
-  bool _isRebuilding = false;
   String? _error;
 
   final _repaintNotifier = ValueNotifier<int>(0);
 
   String? _selectedNodeId;
   final Set<String> _highlightedNodeIds = {};
-  int _autoRebuildAttempts = 0;
 
   @override
   void initState() {
@@ -373,38 +367,6 @@ class _MemoryGraphPageState extends State<MemoryGraphPage> with SingleTickerProv
       if (!currentIds.contains(n['id'])) return false;
     }
     return true;
-  }
-
-  Future<void> _rebuildGraph() async {
-    setState(() {
-      _isRebuilding = true;
-      _error = null;
-    });
-
-    try {
-      PlatformManager.instance.analytics.brainMapRebuilt();
-      await KnowledgeGraphApi.rebuildKnowledgeGraph();
-      if (!mounted) return;
-
-      final data = await KnowledgeGraphApi.waitForGraphStability();
-      if (!mounted) return;
-
-      _populateGraph(data);
-      _runLayoutSync();
-
-      simulation.wake();
-    } catch (e) {
-      if (!mounted) return;
-      setState(() {
-        _error = e.toString();
-      });
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isRebuilding = false;
-        });
-      }
-    }
   }
 
   void _populateGraph(Map<String, dynamic> data) {
@@ -661,13 +623,6 @@ class _MemoryGraphPageState extends State<MemoryGraphPage> with SingleTickerProv
         simulation.nodes.isEmpty || (simulation.nodes.length == 1 && simulation.nodes.first.id == 'user-node');
 
     if (isEmpty) {
-      if (widget.autoRebuildIfEmpty && !_isRebuilding && _autoRebuildAttempts < 3) {
-        _autoRebuildAttempts++;
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (mounted) _rebuildGraph();
-        });
-      }
-
       return Center(
         child: Padding(
           padding: EdgeInsets.all(widget.embedded ? 16.0 : 32.0),
@@ -682,32 +637,10 @@ class _MemoryGraphPageState extends State<MemoryGraphPage> with SingleTickerProv
                 Text(context.l10n.noKnowledgeGraphYet, style: const TextStyle(color: Colors.white70, fontSize: 18)),
                 const SizedBox(height: 12),
                 Text(
-                  _isRebuilding
-                      ? context.l10n.buildingKnowledgeGraphFromMemories
-                      : context.l10n.knowledgeGraphWillBuildAutomatically,
+                  context.l10n.knowledgeGraphWillBuildAutomatically,
                   textAlign: TextAlign.center,
                   style: const TextStyle(color: Colors.white38, fontSize: 14),
                 ),
-                const SizedBox(height: 24),
-                if (_isRebuilding)
-                  SizedBox(
-                    width: 200,
-                    child: LinearProgressIndicator(
-                      backgroundColor: Colors.white10,
-                      color: Colors.purpleAccent,
-                      borderRadius: BorderRadius.circular(2),
-                    ),
-                  )
-                else if (!widget.hideRebuildButtonWhenEmpty)
-                  ElevatedButton.icon(
-                    onPressed: _rebuildGraph,
-                    icon: const Icon(Icons.auto_fix_high),
-                    label: Text(context.l10n.buildGraphButton),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.purpleAccent.withValues(alpha: 0.2),
-                      foregroundColor: Colors.purpleAccent,
-                    ),
-                  ),
               ],
             ),
           ),

--- a/app/lib/pages/onboarding/knowledge_graph_step.dart
+++ b/app/lib/pages/onboarding/knowledge_graph_step.dart
@@ -51,8 +51,6 @@ class OnboardingKnowledgeGraphStep extends StatelessWidget {
                     trackOpenEvent: false,
                     showAppBar: false,
                     showShareButton: false,
-                    autoRebuildIfEmpty: true,
-                    hideRebuildButtonWhenEmpty: true,
                     initialZoom: 0.72,
                   ),
                 ),

--- a/app/lib/utils/analytics/analytics_manager.dart
+++ b/app/lib/utils/analytics/analytics_manager.dart
@@ -934,7 +934,6 @@ class AnalyticsManager {
 
   void brainMapShareClicked() => track('Brain Map Share Clicked');
 
-
   // Summarized Apps Sheet Events
   void summarizedAppSheetViewed({required String conversationId, String? currentSummarizedAppId}) {
     track(

--- a/app/lib/utils/analytics/analytics_manager.dart
+++ b/app/lib/utils/analytics/analytics_manager.dart
@@ -934,7 +934,6 @@ class AnalyticsManager {
 
   void brainMapShareClicked() => track('Brain Map Share Clicked');
 
-  void brainMapRebuilt() => track('Brain Map Rebuilt');
 
   // Summarized Apps Sheet Events
   void summarizedAppSheetViewed({required String conversationId, String? currentSummarizedAppId}) {


### PR DESCRIPTION
## Summary

Opening the knowledge graph page (or reaching it through onboarding) with an empty graph put the backend's refusal on screen verbatim:

```
Exception: Failed to rebuild knowledge graph: {"detail":"Canonical knowledge graph state is derived from canonical memories and cannot be deleted or rebuilt directly."}
```

`backend/routers/knowledge_graph.py` treats the legacy rebuild/delete as a conflict for any account whose canonical graph state is established — the graph is derived from canonical memories and owns itself. The app never caught up: `MemoryGraphPage` still offered a "Build Graph" button, and the onboarding step auto-fired the same call up to three times whenever the graph looked empty, so the raw 409 body became the page.

## What changed

- Removed the "Build Graph" button, the `autoRebuildIfEmpty` auto-trigger, `hideRebuildButtonWhenEmpty`, `_rebuildGraph`, and the rebuilding progress state from `MemoryGraphPage`.
- The empty state now shows only "the graph builds automatically", which is what actually happens.
- Dropped the `brainMapRebuilt` analytics event, which had no other caller.

Left alone deliberately:

- `_prebuildKnowledgeGraph` in `onboarding/wrapper.dart` still calls the rebuild endpoint. Accounts without canonical state are still allowed to rebuild, and the call already swallows the refusal (`.catchError((_) {})`), so it never reaches the user.
- The `buildGraphButton` / `buildingKnowledgeGraphFromMemories` strings stay in the ARBs. Removing them across every locale needs `flutter gen-l10n`, which I could not run here (see below), and unused strings are inert.
- `web/app/src/components/memories/KnowledgeGraph.tsx` has the same "Rebuild Graph" button against the same endpoint and will fail the same way. Different surface from the one reported — say the word and I'll take it in a separate PR.

## Product invariants

INV-MEM-1 (exactly three product memory tiers) is matched by path — this diff is UI removal inside `app/lib/pages/memories/`. It adds no tier, renames nothing in the tier vocabulary, and changes no memory read or write path, so the invariant's guard behaviour is untouched.

## Verification

**I could not run `flutter test` or launch the app for this change.** The Flutter SDK path on this machine is unreadable from the agent sandbox (`Operation not permitted` on every file under it), so the suite, the analyzer, and `dart format` did not run here; the push used the pre-push gate's documented `PRE_PUSH_SKIP_DART_FORMAT=1` hatch. `make preflight` passes.

No test accompanies this change and I want that on the record: no test covered `MemoryGraphPage`, and the page reaches `KnowledgeGraphApi` statically with no seam to construct it without live HTTP, so a widget test would only exercise the error state it always lands in under `flutter test`. The change is the deletion of one affordance and its state.

Worth a look on device before merge: open the graph page on an account with an empty graph and confirm the empty state reads cleanly with no build button, and that the onboarding graph step still renders.

## Failure class

No class in `.github/failure-classes/` describes a client offering an action the backend has since made a conflict; I did not mint one for a single affordance.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

