### PR TITLE
feat(backend): conversation tasks are tasks on clients with no Suggested surface

### DIFF
--- a/.github/scripts/check_task_capture_authority.py
+++ b/.github/scripts/check_task_capture_authority.py
@@ -1,21 +1,23 @@
 #!/usr/bin/env python3
-"""INV-TASK-2 guard: automatic task capture proposes, it never writes a task.
+"""INV-TASK-2 guard: capture that proposes may never accept or create.
 
-Four structural facts, each the shape of a defect that actually shipped:
+Three structural facts, each the shape of a defect that actually shipped:
 
 1. No capture-policy outcome may mean "create a task now". The policy used to
    return ``auto_accept_silent`` / ``create_direct``, and the adapter turned
    both into create-then-accept in one request.
 2. The conversation adapter may not accept a Candidate. Acceptance is the
    user's gesture.
-3. ``_save_action_items`` may not call an action-item writer. A fallback there
-   wrote a whole conversation's items straight into the task list.
-4. The desktop screen-capture client may not expose an ``accept`` at all — a
+3. The desktop screen-capture client may not expose an ``accept`` at all — a
    delivery path that can accept will eventually be wired to.
 
 Plus a manifest fact: a task source governed by the shared capture policy must
-declare no action-item *create* anchor, so a new extraction writer cannot be
-registered without failing this guard.
+declare no action-item *create* anchor, so a proposing source cannot acquire a
+writer without failing this guard.
+
+Which conversations propose and which write is behaviour, not text, and is
+covered by tests/unit/test_backend_candidate_capture.py — it runs both paths
+through ``_save_action_items``.
 
 Stdlib-only, no network. Wired from .github/checks-manifest.yaml.
 """
@@ -31,7 +33,6 @@ ROOT = Path(__file__).resolve().parents[2]
 
 CAPTURE_POLICY = ROOT / "backend/utils/task_intelligence/capture_policy.py"
 CONVERSATION_CAPTURE = ROOT / "backend/utils/task_intelligence/conversation_capture.py"
-PROCESS_CONVERSATION = ROOT / "backend/utils/conversations/process_conversation.py"
 SCREEN_ADAPTER = ROOT / "desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/ScreenCandidateAdapter.swift"
 SOURCES_MANIFEST = ROOT / "backend/config/task_intelligence_sources_v1.json"
 
@@ -40,7 +41,6 @@ SOURCES_MANIFEST = ROOT / "backend/config/task_intelligence_sources_v1.json"
 FORBIDDEN_PY_OUTCOME = re.compile(r"""CapturePolicyResult\(\s*['"](auto_accept_silent|create_direct)['"]""")
 FORBIDDEN_SWIFT_OUTCOME = re.compile(r"return\s+\.(autoAcceptSilent|createDirect)\b")
 ACCEPT_CALL = re.compile(r"candidate_service\.accept_candidate\s*\(")
-WRITER_CALL = re.compile(r"action_items_db\.create_action_items?(?:_batch)?\s*\(")
 SWIFT_ACCEPT_DECL = re.compile(r"^\s*func\s+accept\s*\(", re.MULTILINE)
 CAPTURE_POLICY_CLASS = "shared_capture_policy"
 CREATE_SYMBOLS = ("action_items_db.create_action_item", "action_items_db.create_action_items_batch")
@@ -51,15 +51,6 @@ def _read(path: Path, failures: list[str]) -> str:
         failures.append(f"missing required source: {path.relative_to(ROOT)}")
         return ""
     return path.read_text(encoding="utf-8")
-
-
-def _save_action_items_body(text: str) -> str:
-    """Return the body of _save_action_items, or '' when absent."""
-    start = text.find("def _save_action_items(")
-    if start == -1:
-        return ""
-    nxt = re.search(r"\n(?=(?:def |@|# ))", text[start + 1 :])
-    return text[start : start + 1 + nxt.start()] if nxt else text[start:]
 
 
 def _client_protocol_body(text: str) -> str:
@@ -89,13 +80,6 @@ def main() -> int:
         failures.append(
             "conversation_capture.py calls accept_candidate. INV-TASK-2: extraction proposes; "
             "only an explicit user gesture accepts."
-        )
-
-    body = _save_action_items_body(_read(PROCESS_CONVERSATION, failures))
-    if WRITER_CALL.search(body):
-        failures.append(
-            "_save_action_items calls an action-item writer. INV-TASK-2: conversation extraction "
-            "writes Candidates only."
         )
 
     swift = _read(SCREEN_ADAPTER, failures)
@@ -134,7 +118,7 @@ def main() -> int:
             print(f"- {failure}")
         return 1
 
-    print("check_task_capture_authority: INV-TASK-2 holds (automatic capture proposes only)")
+    print("check_task_capture_authority: INV-TASK-2 holds (proposing capture never accepts or creates)")
     return 0
 
 

--- a/.github/scripts/test_check_task_capture_authority.py
+++ b/.github/scripts/test_check_task_capture_authority.py
@@ -43,38 +43,9 @@ class ForbiddenOutcomeTests(unittest.TestCase):
         self.assertIsNone(guard.FORBIDDEN_SWIFT_OUTCOME.search("    return .pendingCandidate"))
 
 
-class AcceptAndWriteTests(unittest.TestCase):
+class AcceptTests(unittest.TestCase):
     def test_rejects_extraction_accepting_a_candidate(self):
         self.assertTrue(guard.ACCEPT_CALL.search("candidate_service.accept_candidate(uid, cid)"))
-
-    def test_rejects_both_action_item_writers(self):
-        for call in ("action_items_db.create_action_item(uid, data)", "action_items_db.create_action_items_batch(uid, rows)"):
-            with self.subTest(call=call):
-                self.assertTrue(guard.WRITER_CALL.search(call))
-
-    def test_reading_action_items_is_not_a_write(self):
-        self.assertIsNone(guard.WRITER_CALL.search("action_items_db.get_action_items_by_conversation(uid, cid)"))
-
-
-class BodyExtractionTests(unittest.TestCase):
-    def test_only_scans_the_save_function(self):
-        text = (
-            "def _save_action_items(uid, conversation):\n"
-            "    conversation_capture.process_conversation_before_legacy(uid, conversation)\n"
-            "\n\n"
-            "def unrelated(uid):\n"
-            "    action_items_db.create_action_item(uid, {})\n"
-        )
-        body = guard._save_action_items_body(text)
-        self.assertIn("process_conversation_before_legacy", body)
-        self.assertIsNone(guard.WRITER_CALL.search(body))
-
-    def test_catches_a_writer_inside_the_save_function(self):
-        text = "def _save_action_items(uid, conversation):\n    action_items_db.create_action_items_batch(uid, rows)\n"
-        self.assertTrue(guard.WRITER_CALL.search(guard._save_action_items_body(text)))
-
-    def test_missing_function_yields_empty_body(self):
-        self.assertEqual(guard._save_action_items_body("def other(): pass\n"), "")
 
 
 class ClientProtocolTests(unittest.TestCase):

--- a/backend/config/task_intelligence_sources_v1.json
+++ b/backend/config/task_intelligence_sources_v1.json
@@ -104,6 +104,16 @@
       ]
     },
     {
+      "id": "mobile_conversation_extraction",
+      "policy_class": "direct_command",
+      "owner_paths": ["backend/utils/conversations/process_conversation.py"],
+      "test_adapter": "direct_command_contract",
+      "writer_anchors": [
+        {"path": "backend/utils/conversations/process_conversation.py", "symbol": "action_items_db.create_action_items_batch", "discover": true},
+        {"path": "backend/utils/conversations/process_conversation.py", "symbol": "action_items_db.delete_action_items_for_conversation", "discover": true}
+      ]
+    },
+    {
       "id": "desktop_screen_extraction",
       "policy_class": "shared_capture_policy",
       "owner_paths": ["desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift"],

--- a/backend/testing/e2e/test_conversation_processing.py
+++ b/backend/testing/e2e/test_conversation_processing.py
@@ -143,10 +143,11 @@ def test_conversation_create_process_finalize_lifecycle(client, auth_headers, mo
     assert body["structured"]["title"] == "Hermetic Conversation Lifecycle"
     assert body["transcript_segments"][0]["text"] == "We should ship deterministic conversation lifecycle coverage."
 
-    # INVARIANT I1: extraction proposes only. The summary still lists the item,
-    # but the user's action_items collection must stay empty — a task appears
-    # there only through an explicit user gesture.
-    assert read_action_items("123") == []
+    # INV-TASK-2: an omi conversation has no Suggested surface to review a
+    # proposal on, so what the extractor admits lands in the task list.
+    written = read_action_items("123")
+    assert [item["description"] for item in written] == ["Ship deterministic conversation lifecycle coverage"]
+    assert {item["conversation_id"] for item in written} == {processed.id}
     memories_response = client.get("/v3/memories", headers=auth_headers)
     assert memories_response.status_code == 200, memories_response.text
     memories = memories_response.json()

--- a/backend/tests/unit/test_backend_candidate_capture.py
+++ b/backend/tests/unit/test_backend_candidate_capture.py
@@ -7,6 +7,7 @@ import pytest
 os.environ.setdefault('TYPESENSE_API_KEY', 'test-key-not-real')
 
 from models.candidate import CandidateRecord, CandidateStatus
+from models.conversation_enums import ConversationSource
 from models.task_intelligence import TaskWorkflowControl
 from utils.conversations import process_conversation
 from utils.task_intelligence.backend_capture import BackendCaptureSignals, adapt_backend_capture
@@ -54,10 +55,12 @@ def _action(
     )
 
 
-def _conversation(*actions):
+def _conversation(*actions, source=ConversationSource.desktop):
+    """Desktop by default: this file covers the surface that still proposes Candidates."""
     return SimpleNamespace(
         id='conversation-1',
         is_locked=False,
+        source=source,
         structured=SimpleNamespace(action_items=list(actions)),
     )
 
@@ -447,6 +450,7 @@ def test_wake_word_adjudication_logs_question_descope_and_task_omission_without_
 def test_save_action_items_runs_wake_adjudication_even_when_extractor_returned_no_items(monkeypatch):
     conversation = SimpleNamespace(
         id='conversation-1',
+        source=ConversationSource.desktop,
         structured=SimpleNamespace(action_items=[]),
     )
     prepare = SimpleNamespace(calls=0)
@@ -712,6 +716,85 @@ def test_extraction_only_proposes_and_never_accepts_or_writes_a_task(monkeypatch
             },
         }
     ]
+
+
+@pytest.mark.parametrize(
+    'source',
+    [
+        ConversationSource.omi,
+        ConversationSource.phone,
+        ConversationSource.phone_call,
+        ConversationSource.apple_watch,
+        ConversationSource.sdcard,
+    ],
+)
+def test_non_desktop_conversation_writes_tasks_and_never_proposes(monkeypatch, source):
+    """A client with no Suggested surface gets tasks, not proposals that expire unseen."""
+    monkeypatch.setattr(
+        conversation_capture.candidate_service,
+        'create_candidate',
+        lambda *a, **kw: pytest.fail('a client with no Suggested surface must not be proposed to'),
+    )
+    monkeypatch.setattr(
+        process_conversation.conversation_capture,
+        'prepare_wake_word_capture_gate',
+        lambda *a, **kw: pytest.fail('wake adjudication belongs to the Candidate path'),
+    )
+    monkeypatch.setattr(process_conversation.action_items_db, 'get_action_items_by_conversation', lambda *a: [])
+    monkeypatch.setattr(process_conversation.action_items_db, 'delete_action_items_for_conversation', lambda *a: 0)
+    monkeypatch.setattr(process_conversation, 'upsert_action_item_vectors_batch', lambda *a: None)
+    monkeypatch.setattr(process_conversation, 'submit_with_context', lambda *a, **kw: None)
+    monkeypatch.setattr(process_conversation, 'emit_product_event', lambda **event: None)
+    written = []
+
+    def create_batch(uid, action_items_data, **kwargs):
+        written.extend(action_items_data)
+        return [f'action-item-{index}' for index, _ in enumerate(action_items_data)]
+
+    monkeypatch.setattr(process_conversation.action_items_db, 'create_action_items_batch', create_batch)
+
+    process_conversation._save_action_items(
+        'user-1',
+        _conversation(
+            _action('Send the budget', capture_kind='clear_commitment', capture_owner='user'),
+            _action('Call the dentist', capture_kind='explicit_command', capture_owner='user'),
+            source=source,
+        ),
+    )
+
+    assert [item['description'] for item in written] == ['Send the budget', 'Call the dentist']
+    assert {item['conversation_id'] for item in written} == {'conversation-1'}
+    assert {item['source'] for item in written} == {'conversation'}
+
+
+def test_non_desktop_reprocess_replaces_the_conversations_previous_tasks(monkeypatch):
+    deleted = []
+    monkeypatch.setattr(
+        process_conversation.action_items_db,
+        'get_action_items_by_conversation',
+        lambda *a: [{'id': 'stale-1'}],
+    )
+    monkeypatch.setattr(
+        process_conversation.action_items_db,
+        'delete_action_items_for_conversation',
+        lambda uid, conversation_id: deleted.append(conversation_id),
+    )
+    monkeypatch.setattr(process_conversation, 'delete_action_item_vectors_batch', lambda uid, ids: deleted.extend(ids))
+    monkeypatch.setattr(process_conversation, 'upsert_action_item_vectors_batch', lambda *a: None)
+    monkeypatch.setattr(process_conversation, 'submit_with_context', lambda *a, **kw: None)
+    monkeypatch.setattr(process_conversation, 'emit_product_event', lambda **event: None)
+    monkeypatch.setattr(
+        process_conversation.action_items_db,
+        'create_action_items_batch',
+        lambda uid, data, **kw: ['action-item-0'],
+    )
+
+    process_conversation._save_action_items(
+        'user-1',
+        _conversation(_action('Send the budget'), source=ConversationSource.phone),
+    )
+
+    assert deleted == ['stale-1', 'conversation-1']
 
 
 def test_off_mode_still_only_proposes_and_never_reaches_a_writer(monkeypatch):

--- a/backend/tests/unit/test_process_conversation_usage_context.py
+++ b/backend/tests/unit/test_process_conversation_usage_context.py
@@ -1131,13 +1131,12 @@ def test_action_items_skipped_on_discard():
 
 
 def test_conversation_action_items_never_fall_back_to_a_task_writer(monkeypatch):
-    """I1: conversation extraction proposes Candidates and writes nothing else.
+    """A proposing surface stays proposing when its capture path is unavailable.
 
-    The old contract (legacy batch writer on postprocess_executor) died with the
-    writer. The contract that replaces it: even when the canonical capture path
-    reports itself unavailable (``process_conversation_before_legacy`` -> False,
-    e.g. rollout control unreadable), `_save_action_items` must NOT fall back to
-    writing action items — the previous bugs were all in exactly this fallback.
+    Desktop conversations propose Candidates. Even when the canonical capture
+    path reports itself unavailable (``process_conversation_before_legacy`` ->
+    False, e.g. rollout control unreadable), `_save_action_items` must NOT fall
+    back to writing action items — the previous bugs were all in that fallback.
     """
     action_item = MagicMock()
     action_item.description = 'Send the forecast'
@@ -1150,6 +1149,7 @@ def test_conversation_action_items_never_fall_back_to_a_task_writer(monkeypatch)
     conversation = MagicMock()
     conversation.id = 'conversation-1'
     conversation.is_locked = False
+    conversation.source = ConversationSource.desktop
     conversation.transcript_segments = []
     conversation.structured.action_items = [action_item]
 

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -30,7 +30,11 @@ import database.action_items as action_items_db
 import database.folders as folders_db
 import database.calendar_meetings as calendar_db
 import database.screen_activity as screen_activity_db
-from database.vector_db import find_similar_action_items
+from database.vector_db import (
+    find_similar_action_items,
+    upsert_action_item_vectors_batch,
+    delete_action_item_vectors_batch,
+)
 from database.apps import record_app_usage, get_omi_personas_by_uid_db, get_app_by_id_db
 from database.vector_db import upsert_vector2, update_vector_metadata, upsert_transcript_chunk_vectors
 from utils.conversations.transcript_chunks import build_transcript_chunks
@@ -121,6 +125,7 @@ from utils.other.hume import (
 from utils.retrieval.rag import retrieve_rag_conversation_context
 from utils.webhooks import conversation_created_webhook
 from utils.notifications import send_action_item_data_message
+from utils.task_sync import auto_sync_action_items_batch
 from utils.task_intelligence import conversation_capture
 from utils.conversations.calendar_linking import (
     get_overlapping_calendar_event,
@@ -291,6 +296,16 @@ def _primary_user_name(uid: str) -> Optional[str]:
     return raw_name.strip() if isinstance(raw_name, str) and raw_name.strip() else None
 
 
+def _proposes_task_candidates(conversation: Any) -> bool:
+    """Whether this conversation's action items become Candidates instead of tasks.
+
+    Desktop has a Suggested surface to review them on. Every other client — phone,
+    pendant, watch — has none, so a proposal there is invisible and expires unseen:
+    what the extractor admits is a task.
+    """
+    return getattr(conversation, 'source', None) == ConversationSource.desktop
+
+
 def _get_structured(
     uid: str,
     language_code: str,
@@ -300,7 +315,7 @@ def _get_structured(
     conversation_id: Optional[str] = None,
 ) -> Tuple[Structured, bool]:
     try:
-        task_intelligence_capture = conversation_capture.capture_enabled(uid)
+        task_intelligence_capture = _proposes_task_candidates(conversation)
         tz: Optional[str] = notification_db.get_user_time_zone(uid)
         tz_str: str = tz or ''
         user_language = users_db.get_user_language_preference(uid) or language_code
@@ -1589,15 +1604,85 @@ def send_new_memories_notification(user_id: str, memories: List[MemoryDB]) -> No
     send_notification(user_id, "omi" + ' says', message, NotificationMessage.get_message_as_dict(ai_message))
 
 
-def _save_action_items(uid: str, conversation: Conversation, people: Sequence[Person] = ()):
-    """Propose a conversation's extracted action items as Candidates.
+def _write_action_items(uid: str, conversation: Conversation):
+    """Write the extracted items as tasks, replacing whatever this conversation wrote before."""
+    if not conversation.structured.action_items:
+        return
 
-    INVARIANT I1: nothing here writes an ``action_item``. Extraction produces
-    suggestions only; a task exists when the user says so. The items also stay
-    on ``conversation.structured``, which is what the summary view renders and
-    what its "Add to Tasks" button acts on.
+    now = datetime.now(timezone.utc)
+    is_locked = conversation.is_locked
+    action_items_data: List[Dict[str, Any]] = [
+        {
+            'description': action_item.description,
+            'completed': action_item.completed,
+            'created_at': action_item.created_at or now,
+            'updated_at': action_item.updated_at or now,
+            'due_at': action_item.due_at,
+            'completed_at': action_item.completed_at,
+            'conversation_id': conversation.id,
+            'is_locked': is_locked,
+            **conversation_capture.canonical_conversation_fields(action_item, conversation),
+        }
+        for action_item in conversation.structured.action_items
+    ]
+
+    old_ids = [item['id'] for item in action_items_db.get_action_items_by_conversation(uid, conversation.id)]
+    if old_ids:
+        delete_action_item_vectors_batch(uid, old_ids)
+    action_items_db.delete_action_items_for_conversation(uid, conversation.id)
+
+    action_item_ids = action_items_db.create_action_items_batch(uid, action_items_data)
+    logger.info(f"Saved {len(action_item_ids)} action items for conversation {conversation.id}")
+
+    emit_product_event(
+        uid=uid,
+        event='Task Extracted',
+        properties={
+            'task_count': len(action_item_ids),
+            'conversation_id': conversation.id,
+            'task_source': 'transcript',
+            'persistence_path': 'action_items',
+        },
+    )
+
+    for idx, action_item in enumerate(conversation.structured.action_items):
+        if action_item.due_at and idx < len(action_item_ids):
+            send_action_item_data_message(
+                user_id=uid,
+                action_item_id=action_item_ids[idx],
+                description=action_item.description,
+                due_at=action_item.due_at.isoformat(),
+            )
+
+    created_items = [{"id": aid, **data} for aid, data in zip(action_item_ids, action_items_data)]
+
+    def _run_auto_sync():
+        asyncio.run(auto_sync_action_items_batch(uid, created_items))
+
+    submit_with_context(postprocess_executor, _run_auto_sync)
+
+    upsert_action_item_vectors_batch(
+        uid,
+        [
+            {'action_item_id': aid, 'description': data['description']}
+            for aid, data in zip(action_item_ids, action_items_data)
+        ],
+    )
+
+
+def _save_action_items(uid: str, conversation: Conversation, people: Sequence[Person] = ()):
+    """Persist a conversation's extracted action items.
+
+    Desktop conversations propose Candidates for its Suggested surface. Everywhere
+    else the conservative extraction prompt is the filter — it admits explicit
+    commands and the few real commitments, or nothing — and what it admits is
+    written as a task.
     """
     if not conversation.structured:
+        return
+
+    if not _proposes_task_candidates(conversation):
+        _write_action_items(uid, conversation)
         return
 
     try:

--- a/backend/utils/task_intelligence/contracts.py
+++ b/backend/utils/task_intelligence/contracts.py
@@ -37,6 +37,7 @@ REQUIRED_SOURCE_IDS = {
     'mcp_tools',
     'developer_api',
     'backend_conversation_extraction',
+    'mobile_conversation_extraction',
     'desktop_screen_extraction',
     'sharing_imports',
     'recurrence',

--- a/docs/product/invariants/README.md
+++ b/docs/product/invariants/README.md
@@ -64,7 +64,7 @@ to handle a rule in flux — not delaying the lock.
 | INV-DATA-1 | Production-family customer data-plane continuity | locked | [data-plane-continuity.md](./data-plane-continuity.md) |
 | INV-NAV-1 | Feature parity across desktop shells | locked | [desktop-shell-feature-parity.md](./desktop-shell-feature-parity.md) |
 | INV-TASK-1 | Complete dated task buckets with bounded No Deadline paging | locked | [task-dated-bucket-completeness.md](./task-dated-bucket-completeness.md) |
-| INV-TASK-2 | Automatic task capture proposes, it never writes | locked | [task-capture-suggestion-only.md](./task-capture-suggestion-only.md) |
+| INV-TASK-2 | Capture proposes only where a Suggested surface exists | locked | [task-capture-suggestion-only.md](./task-capture-suggestion-only.md) |
 | INV-VOICE-1 | One desktop voice-turn lifecycle owner | locked | [desktop-voice-turns.md](./desktop-voice-turns.md) |
 | INV-CUTOVER-1 | Whole-account cohort cutover authority | locked | [account-cohort-cutover.md](./account-cohort-cutover.md) |
 

--- a/docs/product/invariants/task-capture-suggestion-only.md
+++ b/docs/product/invariants/task-capture-suggestion-only.md
@@ -1,37 +1,41 @@
-# INV-TASK-2: Automatic task capture proposes, it never writes
+# INV-TASK-2: Capture proposes only where a Suggested surface exists
 
 **Status:** locked
 
-**Statement:** A task the user did not ask for is never written to their task list. Every automatically derived task — from a conversation, from the screen, from a proactive notification — is a pending Candidate that becomes an action item only through an explicit user gesture, and a Candidate nobody acts on expires rather than accumulating.
+**Statement:** Screen capture, proactive capture, and desktop conversation capture never write a task. Each derived task is a pending Candidate that becomes an action item only through an explicit user gesture, and a Candidate nobody acts on expires rather than accumulating. A client with no Suggested surface is not proposed to at all: its conversation extraction writes what the conservative prompt admits, and admits nothing when nothing qualifies.
 
 ## Why
 
 Measured on a dogfood account on 2026-08-20: of 124 surviving action items, 3 carried `source='manual'`. 340 of 353 accepted Candidates were accepted within two seconds of creation — machine acceptance, not a human gesture — and 1,014 Candidates sat pending with no expiry, growing by ~100/day. Four independent code paths were writing automatic tasks directly, each of them a fallback rather than a happy path.
 
+That volume is a property of screen capture, which samples continuously. Conversation extraction is bounded by the conversation and gated by a prompt that admits explicit "Hey Omi" commands and the few concrete commitments, or returns nothing. Proposing from it on a client with nowhere to review proposals is the failure this invariant exists to prevent, one level up: between 2026-08-23 and 2026-08-30 every phone, pendant and watch conversation produced Candidates no mobile surface renders, and they expired unseen at two days. Where review is possible the queue holds; where it is not, the extractor's own filter decides and the result is a task.
+
 ## MUST NOT
 
 - Return a capture-policy outcome that means "create a task now". `auto_accept_silent` and `create_direct` are deleted, not disabled.
 - Create a Candidate and accept it in the same request, on any surface.
-- Fall back to an action-item writer when the Candidate path is unavailable, disabled, or errors. Defer and retry instead; silence is the correct failure.
+- Fall back to an action-item writer when the Candidate path is unavailable, disabled, or errors on a proposing surface. Defer and retry instead; silence is the correct failure.
 - Let a rollout, workflow mode, or capability default route capture onto a writer. `off` is what a control endpoint reports when its own read fails, so it must be inert, never "legacy staging".
 - Expose an acceptance path on a capture-delivery client. A pipeline that *can* accept eventually will.
 - Let one rejected extraction item drag its siblings onto a writer. Policy rejection is per item.
-- Admit a proposal the Suggested surface will not show. A stored, invisible Candidate is a dropped one that also costs storage.
+- Propose to a client whose Suggested surface does not exist. A Candidate nothing renders is a dropped task that also costs storage.
+- Give a writing surface the loose extraction prompt. Without a review queue, the prompt is the filter.
 - Let the backend and desktop capture policies diverge. They share one frozen fixture.
 
 ## Surfaces
 
-- Backend conversation extraction, the shared capture policy, and the Candidate lifecycle
+- Desktop conversation extraction, the shared capture policy, and the Candidate lifecycle
 - Desktop screen extraction, candidate delivery, and the suggestion moment
-- Suggested-task projections on desktop and mobile, and the conversation-summary action-item list
+- Suggested-task projections on desktop, and the conversation-summary action-item list
+- Conversation extraction on clients with no Suggested surface — in scope for the writing half: the source predicate and the conservative prompt
 - Chat, MCP, developer API and manual create — **out of scope**: these carry a real user gesture and write directly by design
 
 ## Guard tests
 
-- `.github/scripts/check_task_capture_authority.py` — static: no creating outcome, no accept in extraction, no writer in `_save_action_items`, no accept on the capture client, and no create anchor on a source governed by the shared capture policy
+- `.github/scripts/check_task_capture_authority.py` — static: no creating outcome, no accept in extraction, no accept on the capture client, and no create anchor on a source governed by the shared capture policy
 - `.github/scripts/test_check_task_capture_authority.py` — proves that guard fails on each shape that shipped
 - `backend/tests/unit/test_conversation_suggestion_visibility.py` — every admitted capture kind reaches the Suggested surface
-- `backend/tests/unit/test_backend_candidate_capture.py` — extraction proposes and never accepts; a rejected item is dropped alone
+- `backend/tests/unit/test_backend_candidate_capture.py` — behavioural: a desktop conversation proposes and never accepts or writes, a rejected item is dropped alone, and every other client's conversation writes its tasks and proposes nothing
 - `backend/tests/unit/test_task_intelligence_contract_freeze.py` — the frozen fixture's outcomes stay disjoint from the creating ones
 - `backend/tests/unit/test_process_conversation_usage_context.py` — capture reporting itself unavailable still touches no writer
 - `desktop/macos/Desktop/Tests/TaskIntelligenceContractFixtureTests.swift` — no workflow mode permits a legacy effect; delivery leaves the proposal pending


### PR DESCRIPTION
## Summary

Since #11974 (Aug 23), action items extracted from a conversation stop existing for anyone on a phone. Two changes landed together in that PR and compound:

1. **The write disappeared.** `_save_action_items` proposes a Candidate per item and writes no `action_item`.
2. **The prompt got looser.** `task_intelligence_capture = capture_enabled(uid)` is `bool(uid)` — true for everyone — and that flag switches the extraction prompt from *"Only extract action items that are truly important and need tracking. When in doubt, DON'T extract"* to *"Always extract concrete explicit commands, direct requests, and clear commitments; Candidate policy decides whether they become tasks or quiet suggestions."*

Filtering moved from the extractor into a review queue. Desktop has that queue (`SuggestedTasksStore`). Mobile has none — the Flutter app never calls `/v1/candidates`, and its generated wire models for candidates are imported by no file. So on a phone every proposal is invisible and expires after `SUGGESTION_TTL = 2 days`. Even "Hey Omi, remind me to call the dentist" only earns a suggestion: the policy comment says so directly — *"A command heard in ambient audio is still a model's reading of speech, not a user gesture against a surface. It proposes; it does not create."*

## What changed

Capture is now scoped by conversation origin, using the seam `process_conversation.py` already uses twice for per-client policy (trial paywall, deferred processing):

- **Desktop conversations** keep proposing Candidates into the Suggested surface. Unchanged.
- **Every other client** — `omi`, `friend`, `phone`, `phone_call`, `apple_watch`, `sdcard`, and any source added later — writes its extracted items as tasks. The same predicate picks the prompt, so those conversations get the conservative filter back: explicit commands and the few concrete commitments, or nothing at all. Restoring the writer also restores what it drove — due-date notifications and task-integration sync.
- Reprocessing replaces that conversation's items, as it did before #11974.

**Screen capture is untouched.** It posts to `/v1/candidates` from `TaskAssistant.swift`, never enters this path, and stays suggestion-only — the guard rules that hold it there are unchanged.

**No app release needed.** The items land in `/v1/action-items`, which the Tasks page already reads.

## Product invariants

**INV-TASK-2** — rescoped, not deleted. It was written against a measured flood: ~100 Candidates/day on a dogfood account, four code paths auto-writing tasks. That volume is a property of screen capture, which samples continuously; conversation extraction is bounded by the conversation and gated by a prompt that returns nothing when nothing qualifies. The invariant now reads: capture proposes only where a Suggested surface exists to review the proposal on. Its own MUST NOT — *"Admit a proposal the Suggested surface will not show. A stored, invisible Candidate is a dropped one"* — is what mobile has been violating for a week; this enforces it one level up, by not proposing there at all.

**INV-MEM-4** (canonical promotion is the sole Long-term authority) is matched by path: this diff touches `process_conversation.py`, which also hosts memory postprocessing. It changes no memory intake, consolidation, or promotion path — only how a conversation's action items are persisted.

The guard changes shape with it. The static rule banning a writer inside `_save_action_items` cannot express which conversations propose, and a source-string check would be a tripwire rather than coverage, so it is replaced by behavioural tests that run both paths through the real function. The three facts the guard can prove — no creating outcome in the policy, no accept inside capture, no accept on the delivery client — plus the manifest rule that a shared-policy source declares no create anchor, all stay. The writer is registered as its own source (`mobile_conversation_extraction`, `direct_command`), so it is visible to that manifest rule rather than hidden from it.

## Verification

Every command below was run locally in this worktree.

| Suite | Result |
|---|---|
| `tests/unit/test_backend_candidate_capture.py` | both paths — desktop proposes and never writes; `omi`/`phone`/`phone_call`/`apple_watch`/`sdcard` write and never propose; reprocess replaces |
| `testing/e2e/test_conversation_processing.py` | 5 passed — hermetic lifecycle drives `process_conversation` for an `omi` conversation and reads the written item back out of `action_items` |
| `tests/unit/test_process_conversation_usage_context.py` | 51 passed |
| `tests/unit/test_task_intelligence_contract_freeze.py` | 29 passed |
| `tests/unit/test_conversation_suggestion_visibility.py` | 6 passed |
| `tests/unit/test_surface_parity_capture.py`, `test_listen_parity_capture.py` | 14 passed |
| `tests/unit/test_upstream_boundary.py` | 5 passed |
| `.github/scripts/test_check_task_capture_authority.py` | 8 passed; guard exits 0 on this checkout |

Environment note for anyone reproducing: the checked-in backend venv is missing `langchain-anthropic`, which `requirements.txt` pins at 1.1.0. Every task-intelligence test file fails collection without it, on `main` too. I ran with it supplied on `PYTHONPATH` rather than mutating the venv.

Not verified: no device run. The behaviour is backend-side and covered by the hermetic lifecycle test, but seeing tasks appear on a phone after a real conversation is worth doing before this reaches users.

## Follow-up, deliberately not here

Desktop conversations still propose, so their tasks are reviewable only on desktop. Surfacing those suggestions on mobile is the next piece; when it lands, the split this PR introduces can close in whichever direction the data supports.

Line-Count-Exception: backend/utils/conversations/process_conversation.py | 2476 -> 2561 | restores the action-item writer #11974 deleted from this file; extracting it to a new module would still grow the file and would spread one conversation-postprocess decision across two places


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

