### PR TITLE
fix(web): drop the knowledge graph rebuild buttons

### DIFF
--- a/web/app/src/components/memories/KnowledgeGraph.tsx
+++ b/web/app/src/components/memories/KnowledgeGraph.tsx
@@ -4,7 +4,6 @@ import { useRef, useCallback, useEffect, useState } from 'react';
 import dynamic from '@tschk/moonshine-next/dynamic';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
-  RefreshCw,
   Loader2,
   Network,
   X,
@@ -52,16 +51,8 @@ export function KnowledgeGraph({ onNodeSelect }: KnowledgeGraphProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<Set<string>>(new Set());
 
-  const {
-    graphData,
-    loading,
-    error,
-    rebuilding,
-    selectedNode,
-    rebuild,
-    selectNode,
-    getConnectedNodes,
-  } = useKnowledgeGraph();
+  const { graphData, loading, error, selectedNode, selectNode, getConnectedNodes } =
+    useKnowledgeGraph();
 
   // Update dimensions on resize
   useEffect(() => {
@@ -324,23 +315,6 @@ export function KnowledgeGraph({ onNodeSelect }: KnowledgeGraphProps) {
         <p className="text-sm text-text-tertiary max-w-sm mb-4">
           Add more memories to build your personal knowledge network.
         </p>
-        <button
-          onClick={rebuild}
-          disabled={rebuilding}
-          className={cn(
-            'flex items-center gap-2 px-4 py-2 rounded-lg',
-            'bg-white text-black text-sm font-medium',
-            'hover:bg-white/90 transition-colors',
-            'disabled:opacity-50 disabled:cursor-not-allowed',
-          )}
-        >
-          {rebuilding ? (
-            <Loader2 className="w-4 h-4 animate-spin" />
-          ) : (
-            <RefreshCw className="w-4 h-4" />
-          )}
-          {rebuilding ? 'Rebuilding...' : 'Rebuild Graph'}
-        </button>
       </div>
     );
   }
@@ -444,26 +418,6 @@ export function KnowledgeGraph({ onNodeSelect }: KnowledgeGraphProps) {
           <span className="text-sm">Reset</span>
         </button>
 
-        {/* Rebuild */}
-        <button
-          onClick={rebuild}
-          disabled={rebuilding}
-          className={cn(
-            'flex items-center gap-2 px-3 py-2 rounded-lg',
-            'bg-bg-tertiary/80 backdrop-blur-sm border border-bg-quaternary',
-            'text-text-secondary hover:text-text-primary',
-            'transition-colors',
-            'disabled:opacity-50 disabled:cursor-not-allowed',
-          )}
-          title="Rebuild knowledge graph"
-        >
-          {rebuilding ? (
-            <Loader2 className="w-4 h-4 animate-spin" />
-          ) : (
-            <RefreshCw className="w-4 h-4" />
-          )}
-          <span className="text-sm">Rebuild</span>
-        </button>
       </div>
 
       {/* Zoom controls - right side */}

--- a/web/app/src/hooks/useKnowledgeGraph.ts
+++ b/web/app/src/hooks/useKnowledgeGraph.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import type { KnowledgeGraph, KnowledgeGraphNode, KnowledgeGraphEdge, KnowledgeGraphNodeType } from '@/types/conversation';
-import { getKnowledgeGraph, rebuildKnowledgeGraph } from '@/lib/api';
+import { getKnowledgeGraph } from '@/lib/api';
 
 // Node colors matching mobile app
 export const NODE_COLORS: Record<KnowledgeGraphNodeType | 'user', string> = {
@@ -46,11 +46,9 @@ export interface UseKnowledgeGraphReturn {
   graphData: GraphData | null;
   loading: boolean;
   error: string | null;
-  rebuilding: boolean;
   selectedNode: GraphNode | null;
   // Actions
   refresh: () => Promise<void>;
-  rebuild: () => Promise<void>;
   selectNode: (node: GraphNode | null) => void;
   // Helpers
   getNodeById: (id: string) => GraphNode | undefined;
@@ -62,7 +60,6 @@ export function useKnowledgeGraph(): UseKnowledgeGraphReturn {
   const [rawData, setRawData] = useState<KnowledgeGraph | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [rebuilding, setRebuilding] = useState(false);
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
 
   const initialFetchDone = useRef(false);
@@ -152,22 +149,6 @@ export function useKnowledgeGraph(): UseKnowledgeGraphReturn {
     await fetchGraph();
   }, [fetchGraph]);
 
-  // Rebuild graph
-  const rebuild = useCallback(async () => {
-    try {
-      setRebuilding(true);
-      setError(null);
-      await rebuildKnowledgeGraph();
-      // Wait a bit then refresh to get updated data
-      await new Promise((resolve) => setTimeout(resolve, 2000));
-      await fetchGraph();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to rebuild knowledge graph');
-    } finally {
-      setRebuilding(false);
-    }
-  }, [fetchGraph]);
-
   // Select node
   const selectNode = useCallback((node: GraphNode | null) => {
     setSelectedNode(node);
@@ -207,10 +188,8 @@ export function useKnowledgeGraph(): UseKnowledgeGraphReturn {
     graphData,
     loading,
     error,
-    rebuilding,
     selectedNode,
     refresh,
-    rebuild,
     selectNode,
     getNodeById,
     getConnectedNodes,

--- a/web/app/src/lib/api.ts
+++ b/web/app/src/lib/api.ts
@@ -604,15 +604,6 @@ export async function getKnowledgeGraph(): Promise<KnowledgeGraph> {
   return fetchWithAuth<KnowledgeGraph>('/v1/knowledge-graph');
 }
 
-/**
- * Trigger knowledge graph rebuild
- */
-export async function rebuildKnowledgeGraph(): Promise<void> {
-  await fetchWithAuth('/v1/knowledge-graph/rebuild', {
-    method: 'POST',
-  });
-}
-
 // ============================================================================
 // Chat sessions API
 // ============================================================================


### PR DESCRIPTION
## Summary

The web memories view has the same dead affordance #12422 removed from mobile. `POST /v1/knowledge-graph/rebuild` is refused for any account whose canonical graph state is established — `backend/routers/knowledge_graph.py` answers 409 with *"Canonical knowledge graph state is derived from canonical memories and cannot be deleted or rebuilt directly."* — and `KnowledgeGraph.tsx` offered it twice: a "Rebuild Graph" button in the empty state and a "Rebuild" button in the toolbar. Pressing either surfaced the refusal through `useKnowledgeGraph`'s error banner.

The graph builds itself from canonical memories, so there is nothing for a user to trigger.

## What changed

- Both rebuild buttons are gone. The empty state now says only that adding memories builds the network, which is what actually happens.
- `useKnowledgeGraph` drops `rebuild`, the `rebuilding` flag, and the error string that action set. Its exported interface loses those three members.
- `rebuildKnowledgeGraph` in `lib/api.ts` had no other caller and is deleted with them.
- `RefreshCw` was imported only for those buttons and goes too.

## Product invariants

INV-MEM-1 (exactly three product memory tiers) is matched by path: the change is inside `web/app/src/components/memories/`. It removes a UI action and its client function, adds no tier, and touches no memory read or write path.

## Verification

`npx tsc --noEmit` over the three touched files reports nothing from this change. The reused `node_modules` in my worktree is missing `vitest` and `@tschk/moonshine*`, so the run has pre-existing module-resolution errors across the repo, including one on `KnowledgeGraph.tsx` line 4 (`@tschk/moonshine-next/dynamic`) that this diff does not touch. No unused-symbol or missing-reference errors appeared for the edited code, which is what removing an action risks.

**`web-app-checks` could not run locally.** Its runner shells out to bun (`web/app/test.sh` -> `bun run check`), and bun fails in my sandbox with `CouldntReadCurrentDirectory` for `bun run` and `bunx` (`bun install` works, so the dependency set is complete). I ran the same two things it wraps, through node instead:

- `node node_modules/typescript/bin/tsc --noEmit` -> exit 0, no diagnostics.
- `node node_modules/vitest/vitest.mjs run` -> **72 test files, 415 tests, all passing.**

Unrun from that lane: `bun test scripts/moonshine-smoke.test.ts`, which this diff does not touch. The other 10 manifest checks pass; the push used `PRE_PUSH_SKIP_PR_PREFLIGHT=1` with the body file so the failure-class ratchet still ran.

**Not run: prettier.** The install available to me resolves prettier 3.9.6 while `package.json` pins `^2.8.8`, and formatting with the wrong major reshapes files CI then rejects, so I committed with `OMI_SKIP_WEB_FORMAT=1` rather than reformat against the wrong version. The changed lines are hand-kept inside `printWidth: 90` with the repo's single-quote and trailing-comma settings; CI's Formatting job is the first machine to check them.

**Not run: the app.** No browser check of the memories view after the removal.

## Related

The same endpoint is still reachable from mobile developer settings (`DELETE /v1/knowledge-graph`, same refusal); that one is a separate PR.

## Failure class

No class in `.github/failure-classes/` covers a client keeping an action the backend has since made a conflict, and I did not mint one for a single removed button.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

