### PR TITLE
fix(app): drop the developer Delete Knowledge Graph action

### DIFF
--- a/app/lib/backend/http/api/knowledge_graph_api.dart
+++ b/app/lib/backend/http/api/knowledge_graph_api.dart
@@ -34,20 +34,6 @@ class KnowledgeGraphApi {
     }
   }
 
-  static Future<void> deleteKnowledgeGraph() async {
-    final response = await makeApiCall(
-      url: '${Env.apiBaseUrl}v1/knowledge-graph',
-      headers: {},
-      body: '{}',
-      method: 'DELETE',
-    );
-
-    if (response == null || response.statusCode != 200) {
-      throw Exception('Failed to delete knowledge graph: ${response?.body}');
-    }
-    wire.GeneratedDeleteKnowledgeGraphResponse.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
-  }
-
   /// Polls the graph endpoint until the node count stabilizes or timeout is reached.
   /// Returns the final graph data.
   static Future<Map<String, dynamic>> waitForGraphStability({

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -11,7 +11,6 @@ import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import 'package:omi/backend/http/api/knowledge_graph_api.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/pages/home/firmware_mixin.dart';
 import 'package:omi/backend/http/api/users.dart';
@@ -964,95 +963,6 @@ class _DeveloperSettingsPageState extends State<_DeveloperSettingsPageView> {
                             )
                           else
                             FaIcon(FontAwesomeIcons.chevronRight, color: Colors.grey.shade400, size: 16),
-                        ],
-                      ),
-                    ),
-                  ),
-
-                  const SizedBox(height: 32),
-
-                  // Knowledge Graph Section
-                  GestureDetector(
-                    onTap: () {
-                      showDialog(
-                        context: context,
-                        builder: (ctx) => AlertDialog(
-                          backgroundColor: const Color(0xFF1C1C1E),
-                          title: Text(
-                            context.l10n.deleteKnowledgeGraphQuestion,
-                            style: const TextStyle(color: Colors.white),
-                          ),
-                          content: Text(
-                            context.l10n.knowledgeGraphDeleteDescription,
-                            style: const TextStyle(color: Colors.white70),
-                          ),
-                          actions: [
-                            TextButton(
-                              onPressed: () => Navigator.of(ctx).pop(),
-                              child: Text(context.l10n.cancel, style: const TextStyle(color: Colors.grey)),
-                            ),
-                            TextButton(
-                              onPressed: () async {
-                                Navigator.of(ctx).pop();
-                                try {
-                                  // Call delete endpoint
-                                  await KnowledgeGraphApi.deleteKnowledgeGraph();
-                                  if (context.mounted) {
-                                    AppSnackbar.showSnackbar(context.l10n.knowledgeGraphDeletedSuccessfully);
-                                  }
-                                } catch (e) {
-                                  if (context.mounted) {
-                                    AppSnackbar.showSnackbarError(context.l10n.failedToDeleteGraph(e.toString()));
-                                  }
-                                }
-                              },
-                              child: Text(context.l10n.delete, style: const TextStyle(color: Colors.redAccent)),
-                            ),
-                          ],
-                        ),
-                      );
-                    },
-                    child: Container(
-                      padding: const EdgeInsets.all(16),
-                      decoration: BoxDecoration(
-                        color: const Color(0xFF1C1C1E),
-                        borderRadius: BorderRadius.circular(14),
-                      ),
-                      child: Row(
-                        children: [
-                          Container(
-                            width: 40,
-                            height: 40,
-                            decoration: BoxDecoration(
-                              color: const Color(0xFF2A2A2E),
-                              borderRadius: BorderRadius.circular(10),
-                            ),
-                            child: Center(
-                              child: FaIcon(FontAwesomeIcons.trash, color: Colors.redAccent.shade100, size: 16),
-                            ),
-                          ),
-                          const SizedBox(width: 14),
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  context.l10n.deleteKnowledgeGraph,
-                                  style: const TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 16,
-                                    fontWeight: FontWeight.w500,
-                                  ),
-                                ),
-                                const SizedBox(height: 2),
-                                Text(
-                                  context.l10n.clearAllNodesAndConnections,
-                                  style: TextStyle(color: Colors.grey.shade500, fontSize: 13),
-                                ),
-                              ],
-                            ),
-                          ),
-                          FaIcon(FontAwesomeIcons.chevronRight, color: Colors.grey.shade600, size: 14),
                         ],
                       ),
                     ),


### PR DESCRIPTION
## Summary

Developer settings offered "Delete Knowledge Graph", which calls `DELETE /v1/knowledge-graph`. That route is refused for any account whose canonical graph state is established — the same `CANONICAL_GRAPH_MUTATION_CONFLICT` that #12422 removed the rebuild button for. Unlike the rebuild path it did catch the error, then rendered the raw backend JSON into a snackbar through `failedToDeleteGraph(e.toString())`.

Canonical graph state is derived from canonical memories. There is nothing here for a user to delete, so the affordance goes.

## What changed

- The Knowledge Graph tile and its confirmation dialog are removed from `developer.dart`, along with the now-unused `knowledge_graph_api` import.
- `KnowledgeGraphApi.deleteKnowledgeGraph` had no other caller and is deleted with it.

The `deleteKnowledgeGraph*` ARB strings stay: pruning them across every locale needs `flutter gen-l10n`, which I could not run here, and unused strings are inert.

## Product invariants

INV-MEM-1 (exactly three product memory tiers) is matched by path — `app/lib/pages/settings/` and the memories-adjacent API client. This removes a UI action and a dead client method; it adds no tier and touches no memory read or write path.

## Verification

**I could not run `flutter analyze` or the app.** The Flutter SDK path is unreadable from my sandbox (`Operation not permitted`), so the analyzer, tests and `dart format` did not run; the push used the gate's documented `PRE_PUSH_SKIP_DART_FORMAT=1`.

What I checked by hand, because the last removal of this shape broke the build on a missed call site:

- `grep -rn "KnowledgeGraphApi" app/lib` — the remaining callers are `getKnowledgeGraph` (graph page, onboarding wrapper), `rebuildKnowledgeGraph` and `waitForGraphStability` (onboarding wrapper). Nothing references `deleteKnowledgeGraph`.
- The removed import was the file's only use of that library, so no unused-import warning is left behind.
- No consecutive blank lines left where code was cut — that is what failed the formatter last time.

`make preflight` passes. CI's Dart Analyze and Formatting jobs are the first machines to see the result.

## Failure class

No class in `.github/failure-classes/` covers a client keeping an action the backend has since made a conflict, and I did not mint one for a single removed tile.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

