### PR TITLE
fix(app): show a readable error instead of a raw exception dump

### DIFF
--- a/app/lib/pages/apps/app_detail/app_detail.dart
+++ b/app/lib/pages/apps/app_detail/app_detail.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:omi/utils/error_message.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -184,7 +185,7 @@ class _AppDetailPageState extends State<AppDetailPage> {
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(context.l10n.errorWithMessage(e.toString())), backgroundColor: Colors.red),
+          SnackBar(content: Text(context.l10n.errorWithMessage(readableError(e))), backgroundColor: Colors.red),
         );
       }
     } finally {

--- a/app/lib/pages/apps/app_detail/reviews_list_page.dart
+++ b/app/lib/pages/apps/app_detail/reviews_list_page.dart
@@ -10,6 +10,7 @@ import 'package:omi/backend/schema/app.dart';
 import 'package:omi/pages/apps/app_detail/app_detail.dart';
 import 'package:omi/pages/apps/app_detail/widgets/review_avatar.dart';
 import 'package:omi/providers/app_provider.dart';
+import 'package:omi/utils/error_message.dart';
 import 'package:omi/widgets/extensions/string.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
@@ -127,7 +128,7 @@ class _ReviewsListPageState extends State<ReviewsListPage> {
                           if (context.mounted) {
                             ScaffoldMessenger.of(context).showSnackBar(
                               SnackBar(
-                                content: Text(context.l10n.failedToSendReply(e.toString())),
+                                content: Text(context.l10n.failedToSendReply(readableError(e))),
                                 backgroundColor: Colors.red,
                               ),
                             );

--- a/app/lib/pages/apps/providers/add_app_provider.dart
+++ b/app/lib/pages/apps/providers/add_app_provider.dart
@@ -17,6 +17,7 @@ import 'package:omi/backend/schema/app.dart';
 import 'package:omi/providers/app_provider.dart';
 import 'package:omi/app_globals.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
+import 'package:omi/utils/error_message.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/widgets/extensions/string.dart';
@@ -771,7 +772,7 @@ class AddAppProvider extends ChangeNotifier {
         } catch (e) {
           Logger.debug('🖼️ FilePicker general error: $e');
           AppSnackbar.showSnackbarError(
-            globalNavigatorKey.currentContext!.l10n.addAppErrorSelectingImage(e.toString()),
+            globalNavigatorKey.currentContext!.l10n.addAppErrorSelectingImage(readableError(e)),
           );
         }
       } else {
@@ -839,7 +840,7 @@ class AddAppProvider extends ChangeNotifier {
         } catch (e) {
           Logger.debug('🖼️ FilePicker general error (thumbnail): $e');
           AppSnackbar.showSnackbarError(
-            globalNavigatorKey.currentContext!.l10n.addAppErrorSelectingThumbnail(e.toString()),
+            globalNavigatorKey.currentContext!.l10n.addAppErrorSelectingThumbnail(readableError(e)),
           );
           return;
         }

--- a/app/lib/pages/apps/widgets/api_keys_widget.dart
+++ b/app/lib/pages/apps/widgets/api_keys_widget.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 import 'package:omi/backend/schema/app.dart';
 import 'package:omi/pages/apps/providers/add_app_provider.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
+import 'package:omi/utils/error_message.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 class ApiKeysWidget extends StatefulWidget {
@@ -65,7 +66,7 @@ class _ApiKeysWidgetState extends State<ApiKeysWidget> {
       }
     } catch (e) {
       if (mounted) {
-        AppSnackbar.showSnackbarError(context.l10n.failedToCreateApiKey(e.toString()));
+        AppSnackbar.showSnackbarError(context.l10n.failedToCreateApiKey(readableError(e)));
       }
     } finally {
       setState(() {
@@ -117,7 +118,7 @@ class _ApiKeysWidgetState extends State<ApiKeysWidget> {
       }
     } catch (e) {
       if (mounted) {
-        AppSnackbar.showSnackbarError(context.l10n.failedToRevokeApiKey(e.toString()));
+        AppSnackbar.showSnackbarError(context.l10n.failedToRevokeApiKey(readableError(e)));
       }
     } finally {
       setState(() {

--- a/app/lib/pages/conversations/local_storage_page.dart
+++ b/app/lib/pages/conversations/local_storage_page.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/providers/sync_provider.dart';
+import 'package:omi/utils/error_message.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 class LocalStoragePage extends StatefulWidget {
@@ -43,7 +44,7 @@ class _LocalStoragePageState extends State<LocalStoragePage> {
       setState(() => _isSaving = false);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(context.l10n.failedToUpdateSettings(e.toString())), backgroundColor: Colors.red),
+          SnackBar(content: Text(context.l10n.failedToUpdateSettings(readableError(e))), backgroundColor: Colors.red),
         );
       }
     }

--- a/app/lib/pages/conversations/private_cloud_sync_page.dart
+++ b/app/lib/pages/conversations/private_cloud_sync_page.dart
@@ -5,6 +5,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:provider/provider.dart';
 
 import 'package:omi/providers/user_provider.dart';
+import 'package:omi/utils/error_message.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 class PrivateCloudSyncPage extends StatefulWidget {
@@ -40,7 +41,7 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
       if (!mounted) return;
       setState(() => _isSaving = false);
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(context.l10n.failedToUpdateSettings(e.toString())), backgroundColor: Colors.red),
+        SnackBar(content: Text(context.l10n.failedToUpdateSettings(readableError(e))), backgroundColor: Colors.red),
       );
     }
   }

--- a/app/lib/pages/conversations/wal_item_detail/wal_item_detail_page.dart
+++ b/app/lib/pages/conversations/wal_item_detail/wal_item_detail_page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
+import 'package:omi/utils/error_message.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:provider/provider.dart';
@@ -492,7 +493,7 @@ class _WalItemDetailPageState extends State<WalItemDetailPage> {
       }
     } catch (e) {
       if (mounted) {
-        _showSnackBar(context.l10n.transferFailedMessage(e.toString()), Colors.red);
+        _showSnackBar(context.l10n.transferFailedMessage(readableError(e)), Colors.red);
       }
     }
   }

--- a/app/lib/pages/home/device.dart
+++ b/app/lib/pages/home/device.dart
@@ -1,3 +1,4 @@
+import 'package:omi/utils/error_message.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -243,7 +244,7 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(context.l10n.errorConnectingRayBanMeta(e.toString())), backgroundColor: Colors.red),
+        SnackBar(content: Text(context.l10n.errorConnectingRayBanMeta(readableError(e))), backgroundColor: Colors.red),
       );
     }
   }

--- a/app/lib/pages/home/firmware_update_dialog.dart
+++ b/app/lib/pages/home/firmware_update_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
+import 'package:omi/utils/error_message.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 class FirmwareUpdateStep {
@@ -74,7 +75,7 @@ class _FirmwareUpdateSheetState extends State<FirmwareUpdateSheet> {
       widget.onUpdateStart();
     } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(context.l10n.failedToStartUpdate(e.toString())), backgroundColor: Colors.red),
+        SnackBar(content: Text(context.l10n.failedToStartUpdate(readableError(e))), backgroundColor: Colors.red),
       );
     }
   }

--- a/app/lib/pages/onboarding/apple_watch_permission_page.dart
+++ b/app/lib/pages/onboarding/apple_watch_permission_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:omi/services/devices/connectors/apple_watch_connection.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
+import 'package:omi/utils/error_message.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/responsive/responsive_helper.dart';
 
@@ -158,7 +159,7 @@ class _AppleWatchPermissionPageState extends State<AppleWatchPermissionPage> {
 
       if (mounted) {
         AppSnackbar.showSnackbar(
-          context.l10n.errorRequestingPermission(e.toString()),
+          context.l10n.errorRequestingPermission(readableError(e)),
           duration: const Duration(seconds: 3),
         );
       }
@@ -186,7 +187,7 @@ class _AppleWatchPermissionPageState extends State<AppleWatchPermissionPage> {
     } catch (e) {
       if (mounted) {
         AppSnackbar.showSnackbar(
-          context.l10n.errorStartingRecording(e.toString()),
+          context.l10n.errorStartingRecording(readableError(e)),
           duration: const Duration(seconds: 3),
         );
       }

--- a/app/lib/pages/onboarding/find_device/found_devices.dart
+++ b/app/lib/pages/onboarding/find_device/found_devices.dart
@@ -12,6 +12,7 @@ import 'package:omi/providers/device_provider.dart';
 import 'package:omi/providers/onboarding_provider.dart';
 import 'package:omi/services/devices/connectors/apple_watch_connection.dart';
 import 'package:omi/services/devices/discovery/rayban_meta_discoverer.dart';
+import 'package:omi/utils/error_message.dart';
 import 'package:omi/widgets/rayban_meta_setup_sheet.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/utils/device.dart';
@@ -79,7 +80,7 @@ class _FoundDevicesState extends State<FoundDevices> {
       Logger.debug('Error handling Ray-Ban Meta onboarding: $e');
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(context.l10n.errorConnectingRayBanMeta(e.toString())), backgroundColor: Colors.red),
+        SnackBar(content: Text(context.l10n.errorConnectingRayBanMeta(readableError(e))), backgroundColor: Colors.red),
       );
     }
   }
@@ -119,7 +120,7 @@ class _FoundDevicesState extends State<FoundDevices> {
       Logger.debug('Error handling Apple Watch onboarding: $e');
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(context.l10n.errorConnectingAppleWatch(e.toString())), backgroundColor: Colors.red),
+        SnackBar(content: Text(context.l10n.errorConnectingAppleWatch(readableError(e))), backgroundColor: Colors.red),
       );
     }
   }

--- a/app/lib/pages/settings/ai_app_generator_provider.dart
+++ b/app/lib/pages/settings/ai_app_generator_provider.dart
@@ -11,6 +11,7 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/app_globals.dart';
 import 'package:omi/providers/app_provider.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
+import 'package:omi/utils/error_message.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/logger.dart';
 
@@ -200,7 +201,7 @@ class AiAppGeneratorProvider extends ChangeNotifier {
     } catch (e) {
       Logger.debug('Error generating app: $e');
       _state = GenerationState.error;
-      _errorMessage = globalNavigatorKey.currentContext!.l10n.aiGenErrorOccurredWithDetails(e.toString());
+      _errorMessage = globalNavigatorKey.currentContext!.l10n.aiGenErrorOccurredWithDetails(readableError(e));
       notifyListeners();
       return false;
     }

--- a/app/lib/pages/settings/import_history_page.dart
+++ b/app/lib/pages/settings/import_history_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:omi/utils/error_message.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -229,7 +230,7 @@ class _ImportHistoryPageState extends State<ImportHistoryPage> {
       if (mounted) {
         setState(() => _isUploading = false);
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(context.l10n.importErrorGeneric(e.toString())), backgroundColor: Colors.red.shade700),
+          SnackBar(content: Text(context.l10n.importErrorGeneric(readableError(e))), backgroundColor: Colors.red.shade700),
         );
       }
     }

--- a/app/lib/pages/settings/transcription_settings_page.dart
+++ b/app/lib/pages/settings/transcription_settings_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:omi/utils/error_message.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -592,7 +593,7 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(context.l10n.errorSaving(e.toString())), backgroundColor: Colors.red.shade700),
+          SnackBar(content: Text(context.l10n.errorSaving(readableError(e))), backgroundColor: Colors.red.shade700),
         );
       }
     } finally {
@@ -1935,10 +1936,10 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
         if (mounted) {
           setState(() {
             _isDownloadingModel = false;
-            _modelDownloadStatus = context.l10n.errorWithMessage(e.toString());
+            _modelDownloadStatus = context.l10n.errorWithMessage(readableError(e));
           });
           ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(context.l10n.downloadErrorWithMessage(e.toString())), backgroundColor: Colors.red),
+            SnackBar(content: Text(context.l10n.downloadErrorWithMessage(readableError(e))), backgroundColor: Colors.red),
           );
         }
       }

--- a/app/lib/utils/error_message.dart
+++ b/app/lib/utils/error_message.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart' show PlatformException;
+
+/// Reduces a caught error to one short line fit for a snackbar.
+///
+/// Call sites interpolate this into an `{error}` placeholder. Passing
+/// `e.toString()` there puts `Exception:` prefixes, raw JSON response bodies and
+/// `PlatformException(...)` dumps in front of the user; the sentence inside them
+/// is what they can act on.
+String readableError(Object? error, {int maxLength = 160}) {
+  final text = _unwrap(error).trim();
+  if (text.length <= maxLength) return text;
+  return '${text.substring(0, maxLength - 1).trimRight()}…';
+}
+
+String _unwrap(Object? error) {
+  if (error == null) return '';
+  if (error is PlatformException) {
+    final message = error.message?.trim();
+    return (message != null && message.isNotEmpty) ? message : error.code;
+  }
+  final text = error.toString().trim().replaceFirst(RegExp(r'^_?\w*(Exception|Error):\s*'), '');
+  return _detailFromJson(text) ?? text;
+}
+
+String? _detailFromJson(String text) {
+  final start = text.indexOf('{');
+  final end = text.lastIndexOf('}');
+  if (start == -1 || end <= start) return null;
+  try {
+    final decoded = jsonDecode(text.substring(start, end + 1));
+    if (decoded is Map) {
+      for (final key in const ['detail', 'message', 'error']) {
+        final value = decoded[key];
+        if (value is String && value.trim().isNotEmpty) return value.trim();
+      }
+    }
+  } catch (_) {}
+  return null;
+}

--- a/app/lib/widgets/apple_watch_setup_bottom_sheet.dart
+++ b/app/lib/widgets/apple_watch_setup_bottom_sheet.dart
@@ -5,6 +5,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:omi/gen/assets.gen.dart';
 import 'package:omi/gen/pigeon_communicator.g.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
+import 'package:omi/utils/error_message.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/responsive/responsive_helper.dart';
 
@@ -236,7 +237,7 @@ class _AppleWatchSetupBottomSheetState extends State<AppleWatchSetupBottomSheet>
     } catch (e) {
       if (mounted) {
         AppSnackbar.showSnackbar(
-          context.l10n.errorCheckingConnection(e.toString()),
+          context.l10n.errorCheckingConnection(readableError(e)),
           duration: const Duration(seconds: 3),
         );
       }

--- a/app/test/unit/error_message_test.dart
+++ b/app/test/unit/error_message_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/utils/error_message.dart';
+
+void main() {
+  test('lifts the detail out of an API error body', () {
+    final error = Exception(
+      'Failed to rebuild knowledge graph: {"detail":"Canonical knowledge graph state is derived from '
+      'canonical memories and cannot be deleted or rebuilt directly."}',
+    );
+
+    expect(
+      readableError(error),
+      'Canonical knowledge graph state is derived from canonical memories and cannot be deleted or rebuilt directly.',
+    );
+  });
+
+  test('reads a PlatformException message instead of its dump', () {
+    const error = PlatformException(
+      code: 'Unexpected security result code',
+      message: 'The specified item already exists in the keychain.',
+      details: -25299,
+    );
+
+    expect(readableError(error), 'The specified item already exists in the keychain.');
+  });
+
+  test('falls back to the platform code when the message is empty', () {
+    const error = PlatformException(code: 'channel-error', message: '  ');
+
+    expect(readableError(error), 'channel-error');
+  });
+
+  test('strips the exception prefix from a plain message', () {
+    expect(readableError(Exception('Device is not connected')), 'Device is not connected');
+    expect(readableError(const FormatException('Unexpected end of input')), 'Unexpected end of input');
+  });
+
+  test('keeps a body it cannot parse rather than inventing one', () {
+    expect(readableError('offline'), 'offline');
+    expect(readableError(Exception('Failed to save: {not json}')), 'Failed to save: {not json}');
+  });
+
+  test('truncates a long body to one snackbar line', () {
+    final result = readableError(Exception('x' * 400));
+
+    expect(result.length, 160);
+    expect(result.endsWith('…'), isTrue);
+  });
+
+  test('renders a null error as empty rather than the word null', () {
+    expect(readableError(null), isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary

Fifteen places in the app interpolated a caught error straight into a snackbar, so users saw whatever the throw site happened to produce:

```
Failed to create provider API key: Exception: Failed to create key: {"detail":"Provider key already registered for this account"}
Transfer failed: PlatformException(Unexpected security result code, Code: -25299, Message: ..., -25299, null)
```

The sentence a user can act on is inside those strings, wrapped in an exception prefix, a JSON body, or a platform dump. The knowledge-graph 409 that produced #12422 reached users exactly this way.

## What changed

`readableError(Object?)` in `app/lib/utils/error_message.dart` reduces an error to one line:

- lifts `detail`, `message` or `error` out of a JSON body embedded in the text;
- takes a `PlatformException`'s `message`, falling back to its `code`, instead of the whole dump;
- strips a leading `Exception:` / `FormatException:` style prefix;
- truncates to 160 characters with an ellipsis;
- returns the original text unchanged when it cannot parse something better, so no error becomes less informative than it was.

The 15 call sites now pass `readableError(e)` where they passed `e.toString()`. The ARB strings keep their `{error}` placeholder, so **no `flutter gen-l10n` run is needed** and no locale file changes.

`developer.dart` also has one of these; it is deleted in #12426 instead, so this PR leaves it alone rather than conflicting.

## Verification

**I could not run `flutter test` or `flutter analyze`.** The Flutter SDK path is unreadable from my sandbox (`Operation not permitted`), so the new test file is written but unexecuted, and the push used the documented `PRE_PUSH_SKIP_DART_FORMAT=1`. Please run:

```
cd app && flutter test test/unit/error_message_test.dart
```

Seven cases cover it, two of them built from errors this repo actually produced: the knowledge-graph 409 body and the keychain `-25299` `PlatformException`. The rest cover the prefix strip, the unparseable-body passthrough, the empty-message fallback to `code`, truncation, and a null error rendering as empty rather than the word "null".

What I checked by hand, since the analyzer could not:

- every converted line is a single call-site substitution — `readableError(e)` is shorter than `e.toString()`, so no line grew past 120 characters (the >120 lines the check reports in `app_detail.dart` are pre-existing and untouched);
- the helper import is placed alphabetically inside each file's `package:omi/` block;
- no site was missed: `grep -rn "(e.toString())" app/lib | grep -i snackbar` is empty apart from `developer.dart`.

The push also used `PRE_PUSH_SKIP_FLUTTER_GENERATED=1`: that gate needs `flutter pub get` to have resolved app dependencies, which the same missing SDK prevents. It verifies generated output is current; this diff adds no ARB keys and touches no generator input, so there is nothing for it to regenerate.

`make preflight` passes.

## Product invariants

INV-MEM-1 is matched by path (`app/lib/pages/conversations/`). This changes error message formatting only — no tier, no memory read or write path.

## Failure class

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

