### PR TITLE
fix(deploy): model Pusher surge capacity the way the scheduler and autoscaler do

### DIFF
--- a/backend/scripts/verify_pusher_live_deployment_gate.py
+++ b/backend/scripts/verify_pusher_live_deployment_gate.py
@@ -2,10 +2,22 @@
 """Fail closed before a Pusher Helm mutation when live capacity cannot surge.
 
 This command is deliberately read-only.  It renders the exact digest-pinned
-chart input, reads Kubernetes metadata, and proves that the desired surge pods
-can fit on currently Ready, schedulable nodes that satisfy Pusher's placement
-constraints.  It never reads ConfigMap/Secret payloads and never creates a
-resource or sends application traffic.
+chart input, reads Kubernetes metadata, and proves the desired surge pods have
+somewhere to land under Pusher's placement constraints.  It never reads
+ConfigMap/Secret payloads other than the cluster-autoscaler status, and never
+creates a resource or sends application traffic.
+
+Capacity is modelled the way the scheduler and the cluster autoscaler behave:
+
+* surge pods are placed one at a time across the matching nodes, because
+  Kubernetes never requires a rollout's surge pods to share a node;
+* when the matching nodes are full, a node pool that has not reached its
+  autoscaler maximum can still supply the room, so remaining growth counts as
+  capacity when one fresh node of that pool would fit a pod.
+
+The gate stays closed for what it was written to catch: a pod that cannot be
+placed anywhere, a pool already at its maximum, and a pool whose nodes are too
+small for the request even when empty.
 """
 
 from __future__ import annotations
@@ -262,11 +274,60 @@ def surge_count(current_deployment: dict[str, Any], desired_deployment: dict[str
     return surge
 
 
+def _owned_by_daemonset(pod: dict[str, Any]) -> bool:
+    metadata = pod.get("metadata") if isinstance(pod.get("metadata"), dict) else {}
+    owners = metadata.get("ownerReferences") if isinstance(metadata.get("ownerReferences"), list) else []
+    return any(isinstance(owner, dict) and owner.get("kind") == "DaemonSet" for owner in owners)
+
+
+def parse_autoscaler_groups(status: str | None) -> list[dict[str, Any]]:
+    """Read node-group growth limits out of the cluster-autoscaler status document.
+
+    Returns an empty list when the status is absent or unreadable, which leaves
+    the gate with existing nodes only — the fail-closed answer.
+    """
+    if not status:
+        return []
+    try:
+        document = yaml.safe_load(status)
+    except yaml.YAMLError:
+        return []
+    if not isinstance(document, dict):
+        return []
+    groups = document.get("nodeGroups")
+    if not isinstance(groups, list):
+        return []
+    parsed: list[dict[str, Any]] = []
+    for group in groups:
+        if not isinstance(group, dict):
+            continue
+        name = group.get("name")
+        health = group.get("health") if isinstance(group.get("health"), dict) else {}
+        maximum = health.get("maxSize")
+        counts = health.get("nodeCounts") if isinstance(health.get("nodeCounts"), dict) else {}
+        registered = counts.get("registered") if isinstance(counts.get("registered"), dict) else {}
+        current = registered.get("total")
+        if not isinstance(name, str) or not isinstance(maximum, int) or not isinstance(current, int):
+            continue
+        # GKE names a group's nodes after its instance group, minus the -grp suffix.
+        prefix = name.rsplit("/", 1)[-1]
+        parsed.append(
+            {"prefix": prefix[:-4] if prefix.endswith("-grp") else prefix, "max": maximum, "current": current}
+        )
+    return parsed
+
+
+def _group_for_node(name: str, groups: list[dict[str, Any]]) -> dict[str, Any] | None:
+    matches = [group for group in groups if name.startswith(f"{group['prefix']}-")]
+    return max(matches, key=lambda group: len(group["prefix"])) if matches else None
+
+
 def capacity_evidence(
     desired_deployment: dict[str, Any],
     current_deployment: dict[str, Any],
     nodes: list[dict[str, Any]],
     pods: list[dict[str, Any]],
+    autoscaler_status: str | None = None,
 ) -> tuple[list[str], dict[str, int]]:
     """Return fail-closed capacity findings for the next exact Pusher surge wave."""
 
@@ -281,13 +342,17 @@ def capacity_evidence(
     surge = surge_count(current_deployment, desired_deployment)
     needed = Resources(requested.cpu_millicores * surge, requested.memory_bytes * surge)
     usage = {node_name(node): ZERO for node in nodes}
+    daemon_usage = {node_name(node): ZERO for node in nodes}
     for pod in pods:
         spec = pod.get("spec") if isinstance(pod.get("spec"), dict) else {}
         status = pod.get("status") if isinstance(pod.get("status"), dict) else {}
         node = spec.get("nodeName")
         if not isinstance(node, str) or node not in usage or status.get("phase") in {"Succeeded", "Failed"}:
             continue
-        usage[node] = usage[node].add(pod_requests(pod))
+        requests = pod_requests(pod)
+        usage[node] = usage[node].add(requests)
+        if _owned_by_daemonset(pod):
+            daemon_usage[node] = daemon_usage[node].add(requests)
     candidates: list[tuple[str, Resources]] = []
     for node in nodes:
         if not node_matches_pod(node, pod_spec):
@@ -296,20 +361,62 @@ def capacity_evidence(
         candidates.append((name, node_allocatable(node).subtract(usage[name])))
     if not candidates:
         return (["no Ready, schedulable node satisfies the rendered Pusher node affinity and tolerations"], {})
-    fitting = [(name, available) for name, available in candidates if needed.fits_in(available)]
+
+    # One pod at a time: a rollout's surge pods never have to share a node.
+    remaining = surge
+    placed_on_nodes = 0
+    for _, available in candidates:
+        room = available
+        while remaining and requested.fits_in(room):
+            room = room.subtract(requested)
+            remaining -= 1
+            placed_on_nodes += 1
+
+    placed_by_growth = 0
+    groups = parse_autoscaler_groups(autoscaler_status)
+    if remaining and groups:
+        # A fresh node of a pool carries the same DaemonSets its siblings do.
+        fresh: dict[str, Resources] = {}
+        headroom: dict[str, int] = {}
+        for node in nodes:
+            if not node_matches_pod(node, pod_spec):
+                continue
+            name = node_name(node)
+            group = _group_for_node(name, groups)
+            if group is None:
+                continue
+            capacity = node_allocatable(node).subtract(daemon_usage[name])
+            known = fresh.get(group["prefix"])
+            if known is None or capacity.fits_in(known):
+                fresh[group["prefix"]] = capacity
+            headroom[group["prefix"]] = max(group["max"] - group["current"], 0)
+        for prefix, capacity in fresh.items():
+            per_node = 0
+            room = capacity
+            while requested.fits_in(room):
+                room = room.subtract(requested)
+                per_node += 1
+            while remaining and headroom.get(prefix, 0) > 0 and per_node:
+                take = min(remaining, per_node)
+                remaining -= take
+                placed_by_growth += take
+                headroom[prefix] -= 1
+
     details = {
         "candidate_nodes": len(candidates),
-        "fitting_nodes": len(fitting),
         "surge_pods": surge,
+        "placed_on_existing_nodes": placed_on_nodes,
+        "placed_by_pool_growth": placed_by_growth,
         "required_cpu_millicores": needed.cpu_millicores,
         "required_memory_bytes": needed.memory_bytes,
     }
-    if fitting:
+    if not remaining:
         return [], details
     return (
         [
             "insufficient schedulable Pusher headroom for the next surge wave: "
-            f"need {needed.cpu_millicores}m CPU and {needed.memory_bytes} bytes memory for {surge} surge pod(s)"
+            f"need {needed.cpu_millicores}m CPU and {needed.memory_bytes} bytes memory for {surge} surge pod(s); "
+            f"placed {placed_on_nodes} on existing nodes and {placed_by_growth} through node-pool growth"
         ],
         details,
     )
@@ -377,6 +484,21 @@ def render_deployment(root: Path, environment: str, image: str) -> dict[str, Any
     return documents[0]
 
 
+def autoscaler_status() -> str | None:
+    """Return the cluster-autoscaler status document, or None when unavailable.
+
+    A cluster without it is treated as one that cannot grow, which is the
+    fail-closed reading.
+    """
+    try:
+        payload = kubectl_json(["-n", "kube-system", "get", "configmap", "cluster-autoscaler-status"])
+    except GateError:
+        return None
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    status = data.get("status")
+    return status if isinstance(status, str) else None
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--environment", required=True, choices=("dev", "prod"))
@@ -397,6 +519,7 @@ def main() -> int:
             current,
             [item for item in nodes if isinstance(item, dict)],
             [item for item in pods if isinstance(item, dict)],
+            autoscaler_status(),
         )
     except GateError as exc:
         failures = [str(exc)]
@@ -407,9 +530,11 @@ def main() -> int:
         return 1
     print(
         "OK: live Pusher capacity gate passed: "
-        f"{evidence['fitting_nodes']}/{evidence['candidate_nodes']} matching nodes fit "
         f"{evidence['surge_pods']} surge pod(s) requiring {evidence['required_cpu_millicores']}m CPU and "
-        f"{evidence['required_memory_bytes']} bytes memory."
+        f"{evidence['required_memory_bytes']} bytes memory have room across "
+        f"{evidence['candidate_nodes']} matching node(s): "
+        f"{evidence['placed_on_existing_nodes']} on existing nodes, "
+        f"{evidence['placed_by_pool_growth']} through node-pool growth."
     )
     return 0
 

--- a/backend/tests/unit/test_verify_pusher_live_deployment_gate.py
+++ b/backend/tests/unit/test_verify_pusher_live_deployment_gate.py
@@ -65,6 +65,34 @@ def existing_pod(cpu: str, memory: str) -> dict:
     }
 
 
+def named_node(name: str, *, cpu: str = "4", memory: str = "16Gi") -> dict:
+    payload = node(cpu=cpu, memory=memory)
+    payload["metadata"]["name"] = name
+    return payload
+
+
+def pod_on(node_name: str, cpu: str, memory: str, *, daemon: bool = False) -> dict:
+    payload = existing_pod(cpu, memory)
+    payload["spec"]["nodeName"] = node_name
+    if daemon:
+        payload["metadata"] = {"ownerReferences": [{"kind": "DaemonSet", "name": "fluentbit"}]}
+    return payload
+
+
+def autoscaler(prefix: str, *, current: int, maximum: int) -> str:
+    return (
+        "nodeGroups:\n"
+        "- health:\n"
+        f"    maxSize: {maximum}\n"
+        "    minSize: 0\n"
+        "    nodeCounts:\n"
+        "      registered:\n"
+        f"        total: {current}\n"
+        "  name: https://www.googleapis.com/compute/v1/projects/p/zones/z/instanceGroups/"
+        f"{prefix}-grp\n"
+    )
+
+
 def test_requires_exact_digest_identity(gate: SimpleNamespace) -> None:
     with pytest.raises(gate.GateError, match="exact repository@sha256"):
         gate.parse_image_reference("gcr.io/based-hardware/pusher:latest")
@@ -113,7 +141,7 @@ def test_reports_real_headroom_for_the_rendered_surge_wave(gate: SimpleNamespace
 
     assert failures == []
     assert evidence["surge_pods"] == 2
-    assert evidence["fitting_nodes"] == 1
+    assert evidence["placed_on_existing_nodes"] == 2
     assert evidence["required_cpu_millicores"] == 1400
     assert evidence["required_memory_bytes"] == 8 * 1024**3
 
@@ -126,7 +154,7 @@ def test_fails_closed_when_matching_node_lacks_next_surge_capacity(gate: SimpleN
         [existing_pod("1", "4Gi")],
     )
 
-    assert evidence["fitting_nodes"] == 0
+    assert evidence["placed_on_existing_nodes"] == 1
     assert any("insufficient schedulable Pusher headroom" in failure for failure in failures)
 
 
@@ -157,3 +185,84 @@ def test_counts_init_container_peak_and_pod_overhead(gate: SimpleNamespace) -> N
     }
 
     assert gate.pod_requests(pod) == gate.Resources(1000, 2 * 1024**3 + 64 * 1024**2)
+
+
+def test_surge_pods_spread_across_nodes_that_each_fit_one(gate: SimpleNamespace) -> None:
+    """The scheduler never makes a rollout's surge pods share a node, so neither does the gate."""
+    nodes = [named_node("pusher-a", cpu="1930m", memory="12Gi"), named_node("pusher-b", cpu="1930m", memory="12Gi")]
+    pods = [pod_on("pusher-a", "1000m", "6Gi"), pod_on("pusher-b", "1000m", "6Gi")]
+
+    failures, evidence = gate.capacity_evidence(desired(), {"status": {"replicas": 2}}, nodes, pods)
+
+    assert failures == []
+    assert evidence["placed_on_existing_nodes"] == 2
+    assert evidence["placed_by_pool_growth"] == 0
+
+
+def test_full_nodes_pass_when_the_pool_can_still_grow(gate: SimpleNamespace) -> None:
+    """#11245: the autoscaler supplies the node, but only once a pod is pending for it."""
+    nodes = [named_node("gke-pool-v3-abc-1zht", cpu="1930m", memory="12Gi")]
+    pods = [
+        pod_on("gke-pool-v3-abc-1zht", "1500m", "9Gi"),
+        pod_on("gke-pool-v3-abc-1zht", "200m", "512Mi", daemon=True),
+    ]
+
+    failures, evidence = gate.capacity_evidence(
+        desired(),
+        {"status": {"replicas": 1}},
+        nodes,
+        pods,
+        autoscaler("gke-pool-v3-abc", current=1, maximum=10),
+    )
+
+    assert failures == []
+    assert evidence["placed_on_existing_nodes"] == 0
+    assert evidence["placed_by_pool_growth"] == 2
+
+
+def test_fails_closed_when_the_pool_is_already_at_its_maximum(gate: SimpleNamespace) -> None:
+    nodes = [named_node("gke-pool-v3-abc-1zht", cpu="1930m", memory="12Gi")]
+    pods = [pod_on("gke-pool-v3-abc-1zht", "1500m", "9Gi")]
+
+    failures, _ = gate.capacity_evidence(
+        desired(),
+        {"status": {"replicas": 1}},
+        nodes,
+        pods,
+        autoscaler("gke-pool-v3-abc", current=10, maximum=10),
+    )
+
+    assert failures and "insufficient schedulable Pusher headroom" in failures[0]
+
+
+def test_fails_closed_when_a_fresh_node_of_the_pool_is_too_small(gate: SimpleNamespace) -> None:
+    """Growth is only capacity when an empty node, minus its DaemonSets, fits the request."""
+    nodes = [named_node("gke-pool-tiny-abc-1zht", cpu="900m", memory="3Gi")]
+    pods = [
+        pod_on("gke-pool-tiny-abc-1zht", "500m", "1Gi"),
+        pod_on("gke-pool-tiny-abc-1zht", "400m", "1Gi", daemon=True),
+    ]
+
+    failures, _ = gate.capacity_evidence(
+        desired(),
+        {"status": {"replicas": 1}},
+        nodes,
+        pods,
+        autoscaler("gke-pool-tiny-abc", current=1, maximum=10),
+    )
+
+    assert failures and "insufficient schedulable Pusher headroom" in failures[0]
+
+
+def test_fails_closed_without_an_autoscaler_status(gate: SimpleNamespace) -> None:
+    nodes = [named_node("gke-pool-v3-abc-1zht", cpu="1930m", memory="12Gi")]
+    pods = [pod_on("gke-pool-v3-abc-1zht", "1500m", "9Gi")]
+
+    failures, _ = gate.capacity_evidence(desired(), {"status": {"replicas": 1}}, nodes, pods, None)
+
+    assert failures and "insufficient schedulable Pusher headroom" in failures[0]
+
+
+def test_unreadable_autoscaler_status_is_no_growth(gate: SimpleNamespace) -> None:
+    assert gate.parse_autoscaler_groups("::not yaml::") == []
+    assert gate.parse_autoscaler_groups(None) == []


### PR DESCRIPTION
Fixes #11245.

## Summary

The live Pusher capacity gate has been failing both deploy lanes on a condition that is not a capacity shortage. It asked whether **every surge pod fits on one already-Ready node**. Two things are wrong with that question.

**Kubernetes never makes a rollout's surge pods share a node.** The scheduler places them independently, so requiring the aggregate on a single node is stricter than the thing it is modelling.

**A node pool below its autoscaler maximum can still supply the room.** The autoscaler provisions a node when a pod is Pending — but this gate runs *before* Helm, so no Pending pod ever exists for it to react to. The pool is never asked, and its remaining growth is invisible to the check. That is the deadlock #11245 describes for dev, where the lane has been red since 2026-08-05.

Prod is the same shape, and worse: `pusher-pool-v3` runs 6 nodes of a maximum 50, each with about **150m CPU and 3.2Gi free**, while `maxSurge: 2` at 700m/4.5Gi asks for 1400m and 9.66Gi on one node. An `n4-highmem-2` has 1930m allocatable, so after the DaemonSets no node of that pool can *ever* hold both surge pods. The prod lane was not intermittently unlucky; it was permanently red.

## What changed

`capacity_evidence` now models placement the way the cluster behaves:

- surge pods are placed one at a time across the matching nodes;
- when those are full, remaining pool growth counts as capacity — but only when one **fresh** node of that pool would fit a pod, measured as its allocatable minus the DaemonSet requests its siblings carry, since a new node inherits those too.

Growth comes from the `kube-system/cluster-autoscaler-status` ConfigMap, which GKE already publishes with each group's `maxSize` and registered node count. No new credential, CLI, or workflow input.

The gate stays closed on exactly what it was written to catch: nothing placeable anywhere, a pool already at its maximum, a pool whose empty nodes are too small for the request, and a cluster that publishes no autoscaler status at all (treated as "cannot grow").

## Verification

**Run against the live prod cluster**, read-only, with the digest the failing deploy was carrying:

```
$ verify_pusher_live_deployment_gate.py --environment prod --namespace prod-omi-backend \
    --image gcr.io/based-hardware/pusher@sha256:2711daf1…
OK: live Pusher capacity gate passed: 2 surge pod(s) requiring 1400m CPU and 9663676416 bytes
    memory have room across 6 matching node(s): 0 on existing nodes, 2 through node-pool growth.
```

The same command on `main` produces the failure that killed runs 33314737324 and 33316563662: `insufficient schedulable Pusher headroom … need 1400m CPU and 9663676416 bytes memory for 2 surge pod(s)`. The evidence line is deliberately explicit that both pods come from growth rather than existing headroom.

Measured on that cluster while diagnosing, for the record:

| node (pusher-pool-v3) | free CPU | free memory | surge pods it fits |
|---|---|---|---|
| ×6 | 112–169m | ~3.2Gi | 0 |

Pool: 6 nodes, autoscaler max 50. An empty `n4-highmem-2` (1930m / 12.9Gi) fits both.

`backend/tests/unit/test_verify_pusher_live_deployment_gate.py`: **14 passed**, six of them new — spread placement across two nodes, growth supplying full nodes, and fail-closed for pool-at-max, fresh-node-too-small, absent autoscaler status, and unparseable status. `test_pusher_deployment_control_workflow.py` also passes (20 together).

Two pre-existing assertions changed: they asserted `fitting_nodes`, a count of nodes that could each hold the *whole* surge wave, which no longer exists as a concept. Both now assert `placed_on_existing_nodes`, and **both still assert the same pass/fail outcome they did before** — the first still passes with room on one node, the second still fails closed when a node can hold only one of two pods. The rewrite renames the evidence, it does not relax the guard.

Not verified: I did not run a real deploy. That needs the prod approval gate and is the next step after this merges.

## Not in this PR

#11245 also asks for a break-glass on the dev auto-deploy lane, which has no `workflow_dispatch` at all. The prod lane already has `skip_live_capacity_gate`. That is a workflow change with its own review surface, so it stays separate — this PR removes the reason to need it.

## Failure class

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

