### PR TITLE
fix(backend): give account deletion exactly one executor

### DIFF
--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -27,9 +27,14 @@ from database.vector_db import (
     delete_transcript_chunk_vectors_batch,
 )
 from utils import stripe as stripe_utils
-from utils.cloud_tasks import enqueue_account_deletion_wipe, is_account_deletion_dispatch_enabled
+from utils.cloud_tasks import (
+    assert_inline_account_deletion_permitted,
+    enqueue_account_deletion_wipe,
+    is_account_deletion_dispatch_enabled,
+)
 from utils.executors import cleanup_executor, submit_with_context
 from utils.log_sanitizer import sanitize
+from utils.observability.fallback import record_fallback
 from utils.other import endpoints as auth
 from utils.memory.canonical_memory_adapter import purge_canonical_derived_user_data
 from utils.memory.memory_service import MemoryService
@@ -420,7 +425,8 @@ def enqueue_deletion_wipe(uid: str, wipe_job_id: str):
         enqueue_account_deletion_wipe(wipe_job_id)
         return
     # Inline dispatch is retained solely for deterministic local/dev/test
-    # execution. Production startup rejects this mode before serving traffic.
+    # execution, and may never reach production data whatever the stage says.
+    assert_inline_account_deletion_permitted()
     submit_with_context(cleanup_executor, background_wipe_user_data, uid)
 
 
@@ -525,7 +531,14 @@ def start_account_deletion(uid: str, reason: str | None = None, reason_details: 
         enqueue_deletion_wipe(uid, wipe_job_id)
     except Exception as e:
         _mark_wipe_failed_after_enqueue_error(uid, e)
-        logger.warning('delete_account queue acceleration failed; durable reconciliation will retry')
+        record_fallback(
+            component='other',
+            from_mode='cloud_tasks',
+            to_mode='durable_reconciliation',
+            reason='enqueue_failed',
+            outcome='degraded',
+            log=logger,
+        )
         # The actionable marker is committed. Queue dispatch is only an
         # acceleration path; reconciliation owns eventual completion.
         return {'status': 'ok', 'message': 'Account deletion started'}
@@ -606,7 +619,11 @@ def reconcile_pending_deletion_wipes(limit: int = 100) -> dict[str, int]:
             skipped += 1
             continue
         try:
-            enqueue_deletion_wipe(uid, wipe_job_id)
+            # Reconciliation re-dispatches; it never executes. Calling the
+            # mode-aware helper here made any inline process - a local run
+            # against prod data - the wipe executor for every account it could
+            # claim, which is how wipes ran outside the OIDC handler entirely.
+            enqueue_account_deletion_wipe(wipe_job_id)
         except Exception as e:
             logger.error(f'delete_account reconciliation enqueue failed for {uid}: {sanitize(str(e))}')
             _mark_wipe_failed_after_enqueue_error(uid, e)

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -1721,18 +1721,17 @@ def test_reconcile_pending_deletion_wipes_re_enqueues(monkeypatch):
     monkeypatch.setattr(account_deletion.users_db, 'get_pending_deletion_wipes', lambda limit=100: pending)
     monkeypatch.setattr(account_deletion.users_db, 'claim_deletion_wipe', lambda uid: uid)
     enqueued = []
+    monkeypatch.setattr(account_deletion, 'enqueue_account_deletion_wipe', lambda job_id: enqueued.append(job_id))
     monkeypatch.setattr(
         account_deletion,
         'submit_with_context',
-        lambda executor, target, uid: enqueued.append((executor, target, uid)),
+        lambda *args, **kwargs: pytest.fail('reconciliation re-dispatches; the OIDC handler executes'),
     )
 
     result = account_deletion.reconcile_pending_deletion_wipes()
 
     assert result == {'requeued': 2, 'skipped': 0}
-    assert len(enqueued) == 2
-    assert enqueued[0] == (account_deletion.cleanup_executor, account_deletion.background_wipe_user_data, 'uid1')
-    assert enqueued[1] == (account_deletion.cleanup_executor, account_deletion.background_wipe_user_data, 'uid2')
+    assert enqueued == ['job-1', 'job-2']
 
 
 def test_reconcile_emits_failure_when_stale_running_wipe_is_reclaimed(monkeypatch):
@@ -1852,16 +1851,12 @@ def test_reconcile_pending_deletion_wipes_skips_already_claimed(monkeypatch):
         lambda uid: uid if uid == 'uid1' else None,
     )
     enqueued = []
-    monkeypatch.setattr(
-        account_deletion,
-        'submit_with_context',
-        lambda executor, target, uid: enqueued.append(uid),
-    )
+    monkeypatch.setattr(account_deletion, 'enqueue_account_deletion_wipe', lambda job_id: enqueued.append(job_id))
 
     result = account_deletion.reconcile_pending_deletion_wipes()
 
     assert result == {'requeued': 1, 'skipped': 1}
-    assert enqueued == ['uid1']
+    assert enqueued == ['job-1']
 
 
 def test_reconcile_pending_deletion_wipes_skips_claim_exception(monkeypatch):
@@ -1887,16 +1882,12 @@ def test_reconcile_pending_deletion_wipes_skips_missing_uid(monkeypatch):
     monkeypatch.setattr(account_deletion.users_db, 'get_pending_deletion_wipes', lambda limit=100: pending)
     monkeypatch.setattr(account_deletion.users_db, 'claim_deletion_wipe', lambda uid: uid)
     enqueued = []
-    monkeypatch.setattr(
-        account_deletion,
-        'submit_with_context',
-        lambda executor, target, uid: enqueued.append(uid),
-    )
+    monkeypatch.setattr(account_deletion, 'enqueue_account_deletion_wipe', lambda job_id: enqueued.append(job_id))
 
     result = account_deletion.reconcile_pending_deletion_wipes()
 
     assert result == {'requeued': 1, 'skipped': 1}
-    assert enqueued == ['uid1']
+    assert enqueued == ['job-1']
 
 
 def test_reconcile_pending_deletion_wipes_handles_query_error(monkeypatch):
@@ -1923,14 +1914,14 @@ def test_reconcile_recovers_deleting_auth_when_user_gone(monkeypatch):
     enqueued = []
     monkeypatch.setattr(
         account_deletion,
-        'submit_with_context',
-        lambda executor, target, uid: enqueued.append(uid),
+        'enqueue_account_deletion_wipe',
+        lambda job_id: enqueued.append(job_id),
     )
 
     result = account_deletion.reconcile_pending_deletion_wipes()
 
     assert result == {'requeued': 1, 'skipped': 0}
-    assert enqueued == ['uid1']
+    assert enqueued == ['job-1']
 
 
 def test_reconcile_recovers_deleting_auth_when_user_exists(monkeypatch):
@@ -1942,13 +1933,13 @@ def test_reconcile_recovers_deleting_auth_when_user_exists(monkeypatch):
     claim = MagicMock(return_value='uid1')
     monkeypatch.setattr(account_deletion.users_db, 'claim_deletion_wipe', claim)
     submit = MagicMock()
-    monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
+    monkeypatch.setattr(account_deletion, 'enqueue_account_deletion_wipe', submit)
 
     result = account_deletion.reconcile_pending_deletion_wipes()
 
     assert result == {'requeued': 1, 'skipped': 0}
     claim.assert_called_once_with('uid1')
-    submit.assert_called_once()
+    submit.assert_called_once_with('job-1')
 
 
 def test_reconcile_does_not_query_auth_for_legacy_durable_intent(monkeypatch):
@@ -1960,11 +1951,11 @@ def test_reconcile_does_not_query_auth_for_legacy_durable_intent(monkeypatch):
     claim = MagicMock(return_value='uid1')
     monkeypatch.setattr(account_deletion.users_db, 'claim_deletion_wipe', claim)
     submit = MagicMock()
-    monkeypatch.setattr(account_deletion, 'submit_with_context', submit)
+    monkeypatch.setattr(account_deletion, 'enqueue_account_deletion_wipe', submit)
 
     result = account_deletion.reconcile_pending_deletion_wipes()
 
     assert result == {'requeued': 1, 'skipped': 0}
     claim.assert_called_once_with('uid1')
-    submit.assert_called_once()
+    submit.assert_called_once_with('job-1')
     account_deletion.auth.get_user.assert_not_called()

--- a/backend/tests/unit/test_account_deletion_single_executor.py
+++ b/backend/tests/unit/test_account_deletion_single_executor.py
@@ -1,0 +1,113 @@
+"""One owner executes a wipe, and it is never a process pointed at production."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from google.api_core.exceptions import NotFound
+
+from services.users import account_deletion
+from utils import cloud_tasks
+
+
+def _pending(uid: str = 'user-1') -> dict:
+    return {'uid': uid, 'wipe_job_id': 'job-1', 'wipe_status': 'failed'}
+
+
+def test_reconciliation_redispatches_and_never_executes(monkeypatch):
+    """Reconciliation owns re-dispatch only; the OIDC handler owns execution."""
+    monkeypatch.setattr(account_deletion.users_db, 'get_pending_deletion_wipes', lambda limit: [_pending()])
+    monkeypatch.setattr(account_deletion.users_db, 'claim_deletion_wipe', lambda uid: uid)
+    monkeypatch.setattr(
+        account_deletion,
+        'background_wipe_user_data',
+        lambda *args, **kwargs: pytest.fail('reconciliation must never execute a wipe'),
+    )
+    enqueued: list[str] = []
+    monkeypatch.setattr(account_deletion, 'enqueue_account_deletion_wipe', lambda job_id: enqueued.append(job_id))
+
+    result = account_deletion.reconcile_pending_deletion_wipes()
+
+    assert enqueued == ['job-1']
+    assert result['requeued'] == 1
+
+
+def test_reconciliation_ignores_inline_mode(monkeypatch):
+    """Inline mode is for local execution; it must not make the reconciler an executor."""
+    monkeypatch.delenv('ACCOUNT_DELETION_DISPATCH_MODE', raising=False)
+    monkeypatch.setattr(account_deletion.users_db, 'get_pending_deletion_wipes', lambda limit: [_pending()])
+    monkeypatch.setattr(account_deletion.users_db, 'claim_deletion_wipe', lambda uid: uid)
+    monkeypatch.setattr(
+        account_deletion,
+        'submit_with_context',
+        lambda *args, **kwargs: pytest.fail('reconciliation must not schedule an in-process wipe'),
+    )
+    monkeypatch.setattr(account_deletion, 'enqueue_account_deletion_wipe', lambda job_id: None)
+
+    assert account_deletion.reconcile_pending_deletion_wipes()['requeued'] == 1
+
+
+@pytest.mark.parametrize('variable', ['GOOGLE_CLOUD_PROJECT', 'SYNC_TASKS_PROJECT'])
+def test_inline_execution_is_refused_against_production_data(monkeypatch, variable):
+    """A local run with .env pointing at prod executed real wipes; the project is the honest test."""
+    monkeypatch.delenv('GOOGLE_CLOUD_PROJECT', raising=False)
+    monkeypatch.delenv('SYNC_TASKS_PROJECT', raising=False)
+    monkeypatch.delenv('OMI_ENV_STAGE', raising=False)
+    monkeypatch.setenv(variable, 'based-hardware')
+
+    with pytest.raises(RuntimeError, match='refusing inline account-deletion execution'):
+        cloud_tasks.assert_inline_account_deletion_permitted()
+
+
+def test_inline_execution_still_runs_against_a_non_production_project(monkeypatch):
+    monkeypatch.setenv('GOOGLE_CLOUD_PROJECT', 'based-hardware-dev')
+    monkeypatch.delenv('SYNC_TASKS_PROJECT', raising=False)
+
+    cloud_tasks.assert_inline_account_deletion_permitted()
+
+
+def test_enqueue_deletion_wipe_refuses_inline_dispatch_against_production(monkeypatch):
+    monkeypatch.delenv('ACCOUNT_DELETION_DISPATCH_MODE', raising=False)
+    monkeypatch.setenv('GOOGLE_CLOUD_PROJECT', 'based-hardware')
+    monkeypatch.setattr(
+        account_deletion,
+        'submit_with_context',
+        lambda *args, **kwargs: pytest.fail('a production-pointed process must not run a wipe'),
+    )
+
+    with pytest.raises(RuntimeError, match='refusing inline account-deletion execution'):
+        account_deletion.enqueue_deletion_wipe('user-1', 'job-1')
+
+
+def test_startup_fails_when_the_configured_queue_does_not_exist(monkeypatch):
+    """Env vars said 'configured' for a month while every dispatch 404'd."""
+    monkeypatch.setenv('SYNC_TASKS_PROJECT', 'based-hardware')
+    monkeypatch.setenv('SYNC_TASKS_LOCATION', 'us-central1')
+    monkeypatch.setenv('ACCOUNT_DELETION_TASKS_QUEUE', 'account-deletion')
+    client = MagicMock()
+    client.queue_path.return_value = 'projects/p/locations/l/queues/account-deletion'
+    client.get_queue.side_effect = NotFound('Queue does not exist')
+
+    with pytest.raises(RuntimeError, match='does not exist'):
+        cloud_tasks.assert_account_deletion_queue_exists(client)
+
+
+def test_an_unreachable_tasks_api_is_not_proof_of_absence(monkeypatch):
+    """Availability is not absence: a transient error must not block startup."""
+    monkeypatch.setenv('SYNC_TASKS_PROJECT', 'based-hardware')
+    monkeypatch.setenv('SYNC_TASKS_LOCATION', 'us-central1')
+    monkeypatch.setenv('ACCOUNT_DELETION_TASKS_QUEUE', 'account-deletion')
+    client = MagicMock()
+    client.queue_path.return_value = 'projects/p/locations/l/queues/account-deletion'
+    client.get_queue.side_effect = TimeoutError('deadline exceeded')
+
+    cloud_tasks.assert_account_deletion_queue_exists(client)
+
+
+def test_queue_probe_is_inert_without_configuration(monkeypatch):
+    monkeypatch.delenv('SYNC_TASKS_PROJECT', raising=False)
+    monkeypatch.delenv('ACCOUNT_DELETION_TASKS_QUEUE', raising=False)
+    client = MagicMock()
+
+    cloud_tasks.assert_account_deletion_queue_exists(client)
+
+    client.get_queue.assert_not_called()

--- a/backend/tests/unit/test_delete_account_purge_storage.py
+++ b/backend/tests/unit/test_delete_account_purge_storage.py
@@ -49,6 +49,8 @@ def users_service():
         "utils.stripe": AutoMockModule("utils.stripe"),
         "utils.executors": AutoMockModule("utils.executors"),
         "utils.log_sanitizer": AutoMockModule("utils.log_sanitizer"),
+        "utils.observability": _pkg("utils.observability"),
+        "utils.observability.fallback": AutoMockModule("utils.observability.fallback"),
         "utils.integration_telemetry": AutoMockModule("utils.integration_telemetry"),
         "utils.other": _pkg("utils.other"),
         "utils.other.endpoints": AutoMockModule("utils.other.endpoints"),

--- a/backend/tests/unit/test_delete_account_stripe_cancel.py
+++ b/backend/tests/unit/test_delete_account_stripe_cancel.py
@@ -52,6 +52,8 @@ def users_service():
         "utils.stripe": AutoMockModule("utils.stripe"),
         "utils.executors": AutoMockModule("utils.executors"),
         "utils.log_sanitizer": AutoMockModule("utils.log_sanitizer"),
+        "utils.observability": _pkg("utils.observability"),
+        "utils.observability.fallback": AutoMockModule("utils.observability.fallback"),
         "utils.integration_telemetry": AutoMockModule("utils.integration_telemetry"),
         "utils.other": _pkg("utils.other"),
         "utils.other.endpoints": AutoMockModule("utils.other.endpoints"),

--- a/backend/utils/cloud_tasks.py
+++ b/backend/utils/cloud_tasks.py
@@ -19,11 +19,13 @@ import uuid
 from typing import Any, Dict, Literal, NamedTuple, Optional
 
 from fastapi import HTTPException, Request
-from google.api_core.exceptions import AlreadyExists
+from google.api_core.exceptions import AlreadyExists, NotFound
 from google.auth.transport import requests as google_auth_requests
 from google.cloud import tasks_v2
 from google.oauth2 import id_token
 from google.protobuf import duration_pb2
+
+from utils.log_sanitizer import sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -89,8 +91,30 @@ def is_audio_merge_dispatch_enabled() -> bool:
     return os.getenv('AUDIO_MERGE_DISPATCH_MODE', 'inline') == 'cloud_tasks'
 
 
+# The production customer data plane, per INV-DATA-1
+# (docs/product/invariants/data-plane-continuity.md).
+PRODUCTION_DATA_PROJECTS = frozenset({'based-hardware'})
+
+
 def is_account_deletion_dispatch_enabled() -> bool:
     return os.getenv('ACCOUNT_DELETION_DISPATCH_MODE', 'inline') == 'cloud_tasks'
+
+
+def assert_inline_account_deletion_permitted() -> None:
+    """Refuse to execute a wipe in-process against production data.
+
+    ``OMI_ENV_STAGE`` is unset on a developer machine, so the production guard
+    below returns early there while ``.env`` still points at the production
+    project. That combination made a local backend run a wipe executor for real
+    accounts. The project a process is pointed at is the honest test, and it is
+    one no local run can forget to set.
+    """
+    project = (os.getenv('GOOGLE_CLOUD_PROJECT') or os.getenv('SYNC_TASKS_PROJECT') or '').strip()
+    if project and project in PRODUCTION_DATA_PROJECTS:
+        raise RuntimeError(
+            f'refusing inline account-deletion execution against production project {project!r}; '
+            'set ACCOUNT_DELETION_DISPATCH_MODE=cloud_tasks so the OIDC handler owns the wipe'
+        )
 
 
 def validate_account_deletion_dispatch_configuration() -> None:
@@ -118,6 +142,33 @@ def validate_account_deletion_dispatch_configuration() -> None:
     missing = [name for name in required_env if not os.getenv(name, '').strip()]
     if missing:
         raise RuntimeError(f'production account-deletion Cloud Tasks config is incomplete: {", ".join(missing)}')
+
+    assert_account_deletion_queue_exists()
+
+
+def assert_account_deletion_queue_exists(client: Any = None) -> None:
+    """Prove the configured queue resolves, not merely that its name is set.
+
+    Reading env vars said "configured" for a month while the queue did not
+    exist, so every dispatch 404'd behind an accepted deletion request. Only a
+    definitive NotFound fails startup; an unreachable Cloud Tasks API is an
+    unanswered question, not a proven absence.
+    """
+    project = os.getenv('SYNC_TASKS_PROJECT', '').strip()
+    location = os.getenv('SYNC_TASKS_LOCATION', '').strip()
+    queue = os.getenv('ACCOUNT_DELETION_TASKS_QUEUE', '').strip()
+    if not all([project, location, queue]):
+        return
+    resolved = client or _get_tasks_client()
+    try:
+        resolved.get_queue(name=resolved.queue_path(project, location, queue))
+    except NotFound as exc:
+        raise RuntimeError(
+            f'account-deletion Cloud Tasks queue {queue!r} does not exist in {project}/{location}; '
+            'an accepted deletion request would have no executor'
+        ) from exc
+    except Exception as exc:  # noqa: BLE001 - availability is not absence
+        logger.warning('account-deletion queue existence probe inconclusive: %s', sanitize(str(exc)))
 
 
 def is_listen_finalization_dispatch_enabled() -> bool:


### PR DESCRIPTION
Relates to #11680, which reported that the durable account-deletion path had never dispatched. That is true, and the reason it went unnoticed for a month is worse than the report: **the wipes were running somewhere else.**

## What is actually happening in production

The `account-deletion` Cloud Tasks queue did not exist in any location, so every dispatch 404'd behind a `{"status":"ok"}` response. Yet accounts were being deleted — 42 of 42 completions since Aug 20 carry `wipe_running_at`, the marker only `background_wipe_user_data` writes, with **no request to the OIDC handler behind any of them**.

The executor is a process running the backend with `ACCOUNT_DELETION_DISPATCH_MODE` unset:

1. `validate_account_deletion_dispatch_configuration()` only rejects when `OMI_ENV_STAGE == 'prod'`. That variable is unset on a developer machine, so the guard returns early there.
2. `_periodic_deletion_wipe_reconcile` then runs every 300s and claims real records out of production Firestore, because `backend/.env` sets `GOOGLE_CLOUD_PROJECT=based-hardware`.
3. `reconcile_pending_deletion_wipes` called the mode-aware `enqueue_deletion_wipe`, which with the mode unset falls through to `submit_with_context(cleanup_executor, background_wipe_user_data, uid)` — **the wipe executes in that process**.

So production account deletions have been executing on machines outside the deployment, while `backend/AGENTS.md:147` states the opposite contract: *"reconciliation only re-dispatches tasks so the OIDC handler is the sole wipe executor."* The code did not implement its own documented rule.

It also explains the stuck records the report flagged: a process without the production vector index fails `require_vector_index`, so it claims a record, fails seconds later, and loops. Records observed today went `claimed → running → failed` within seconds, `wipe_attempts` climbing past 7.

## What changed

**Reconciliation re-dispatches, never executes.** It now calls `enqueue_account_deletion_wipe` directly. There is no longer a mode in which claiming a record can run a wipe in-process.

**Inline execution is refused against production data.** The stage variable is the wrong test because it is absent exactly where the danger is; the project a process talks to is the honest one, and no local run can forget to set it. `assert_inline_account_deletion_permitted()` raises when `GOOGLE_CLOUD_PROJECT`/`SYNC_TASKS_PROJECT` names the production data plane (INV-DATA-1), whatever the stage says. Inline stays available for dev and test projects.

**"Configured" now means "exists".** Startup resolves the queue instead of only checking that its name is set — that check passed for a month over a queue that was not there. A definitive `NotFound` fails startup; an unreachable Cloud Tasks API only warns, because availability is not absence.

**The enqueue-failure path reports.** It was a bare `logger.warning` while still returning `{"status":"ok"}` to the user; it now calls `record_fallback`, per `docs/agents/fallback-telemetry.md`.

Left alone deliberately: the retry backoff. `deletion_wipe_retry_delay` already spaces failed records, and the churn the report saw was driven by the permanent 404, which is now gone. Changing retry semantics in the same PR would obscure whether that fixed it.

## Infrastructure done alongside this

The queue now exists, created with settings identical to its sibling `conversation-finalization` (`maxAttempts=5`, `maxConcurrentDispatches=4`, `minBackoff=0.1s`, `maxBackoff=3600s`):

```
$ gcloud tasks queues create account-deletion --location=us-central1 ...
Created queue [us-central1/account-deletion].   state: RUNNING
```

Backlog at the time of creation: 872 `account_deletions` documents — 465 legacy records with no wipe state, 352 completed, 37 retrying, 12 failed, 4 running, 2 billing_failed. The 49 dispatchable records include one waiting since 2026-07-26. Immediately after creation the constant `404 Queue does not exist` reconciliation errors stopped, and `failed` collapsed from 12 to 1 as records were re-claimed and enqueued.

## Product invariants

INV-MEM-3 (no legacy fallback after canonical selection) is matched by path — this diff touches `services/users/account_deletion.py`, which purges canonical memory during a wipe. It changes who dispatches and who may execute a wipe; the purge sequence, its required-failure handling and every canonical read/write path are untouched.

## Verification

- `backend/tests/unit/test_account_deletion_single_executor.py` — **9 new tests, all passing**: reconciliation re-dispatches and never executes even with the mode unset, inline is refused for either project variable and still permitted against `based-hardware-dev`, and the queue probe fails closed on `NotFound` while tolerating an unreachable API.
- Neighbouring suites unaffected: `test_account_deletion_auth_fence.py`, `test_account_deletion_projection_fence.py`, `test_listen_account_deletion_fence.py`, `test_sync_cloud_tasks.py` — **112 passed** together.
- The handler route is live and protected: an unauthenticated `POST` to `/v1/users/account-deletion-wipes/run` returns **403**, not 404.
- Four pre-existing tests asserted the defect as intended behaviour — that reconciliation submits `background_wipe_user_data` to the cleanup executor. They now assert the documented contract instead, and one fails outright if anything is submitted in-process. The external source for the new expectation is this repo's own `backend/AGENTS.md:147` plus the production measurement above; the rewrite tightens the guard rather than removing it.
- Two Tier-2 isolation suites needed a stub for the new `record_fallback` import, per `backend/docs/test_isolation.md`: **8 passed**.
- `tests/services/users/test_account_deletion.py`: **63 passed**.
- `make preflight` passes.

Not verified: I did not observe a wipe complete through the OIDC handler end to end. A stale executor outside the deployment is still claiming records ahead of it, which is precisely what this PR stops once deployed — and the reason to deploy it promptly.

## Follow-up worth its own issue

Any developer checkout with production credentials can still claim and execute wipes until it picks up this guard. Narrowing what local development can reach in the production project is the real boundary, and it is bigger than this PR.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

