### PR TITLE
feat(app): make Installed Apps the primary control, Created by me a filter

### DIFF
--- a/app/lib/pages/apps/explore_install_page.dart
+++ b/app/lib/pages/apps/explore_install_page.dart
@@ -395,16 +395,15 @@ class ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticKe
             bool isSearchActive,
             bool isFilterActive,
             int filterCount,
-            bool isMyAppsSelected,
             bool isInstalledSelected,
             int visibleFilterCount,
             String? firstFilterText,
           })>(
         selector: (context, provider) {
-          // Calculate visible filters (excluding "My Apps" and "Installed Apps")
+          // Installed has its own control; every other filter shows as a chip.
           final visibleFilters = provider.filters.entries.where((entry) {
             if (entry.key == 'Apps') {
-              return entry.value != 'My Apps' && entry.value != 'Installed Apps';
+              return entry.value != 'Installed Apps';
             }
             return true;
           }).toList();
@@ -416,7 +415,6 @@ class ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticKe
             isSearchActive: provider.isSearchActive(),
             isFilterActive: provider.isFilterActive(),
             filterCount: provider.filters.length,
-            isMyAppsSelected: provider.isFilterSelected('My Apps', 'Apps'),
             isInstalledSelected: provider.isFilterSelected('Installed Apps', 'Apps'),
             visibleFilterCount: visibleFilters.length,
             firstFilterText: visibleFilters.isNotEmpty ? filterValueToString(visibleFilters.first.value) : null,
@@ -450,15 +448,11 @@ class ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticKe
                                 duration: const Duration(milliseconds: 200),
                                 curve: Curves.easeInOut,
                                 width: (!state.isSearchActive &&
-                                        (state.isMyAppsSelected ||
-                                            state.isInstalledSelected ||
-                                            state.visibleFilterCount > 0))
+                                        (state.isInstalledSelected || state.visibleFilterCount > 0))
                                     ? 44
                                     : null,
                                 child: (!state.isSearchActive &&
-                                        (state.isMyAppsSelected ||
-                                            state.isInstalledSelected ||
-                                            state.visibleFilterCount > 0))
+                                        (state.isInstalledSelected || state.visibleFilterCount > 0))
                                     ? SizedBox(
                                         height: 44,
                                         child: Container(
@@ -470,16 +464,13 @@ class ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticKe
                                             onPressed: () {
                                               // Clear all filters and expand search
                                               final provider = context.read<AppProvider>();
-                                              if (state.isMyAppsSelected) {
-                                                provider.addOrRemoveFilter('My Apps', 'Apps');
-                                              }
                                               if (state.isInstalledSelected) {
                                                 provider.addOrRemoveFilter('Installed Apps', 'Apps');
                                               }
                                               // Clear other filters
                                               final visibleFilters = state.filters.entries.where((entry) {
                                                 if (entry.key == 'Apps') {
-                                                  return entry.value != 'My Apps' && entry.value != 'Installed Apps';
+                                                  return entry.value != 'Installed Apps';
                                                 }
                                                 return true;
                                               }).toList();
@@ -555,84 +546,6 @@ class ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticKe
                                         ),
                                       ),
                               ),
-
-                              const SizedBox(width: 8),
-
-                              // My Apps button - expands when selected
-                              state.isMyAppsSelected
-                                  ? Expanded(
-                                      child: AnimatedContainer(
-                                        duration: const Duration(milliseconds: 200),
-                                        curve: Curves.easeInOut,
-                                        height: 44,
-                                        decoration: BoxDecoration(
-                                          color: Colors.white.withValues(alpha: 0.22),
-                                          borderRadius: BorderRadius.circular(AppStyles.radiusLarge),
-                                        ),
-                                        child: TextButton.icon(
-                                          onPressed: () {
-                                            HapticFeedback.mediumImpact();
-                                            final provider = context.read<AppProvider>();
-                                            final wasSelected = provider.isFilterSelected('My Apps', 'Apps');
-                                            provider.addOrRemoveFilter('My Apps', 'Apps');
-                                            provider.applyFilters();
-                                            PlatformManager.instance.analytics.appsTypeFilter(
-                                              'My Apps',
-                                              !wasSelected,
-                                            );
-                                          },
-                                          icon: const FaIcon(
-                                            FontAwesomeIcons.solidUser,
-                                            size: 16,
-                                            color: Colors.white,
-                                          ),
-                                          label: Text(
-                                            context.l10n.myApps,
-                                            style: const TextStyle(
-                                              fontSize: 14,
-                                              color: Colors.white,
-                                              fontWeight: FontWeight.w500,
-                                            ),
-                                          ),
-                                          style: TextButton.styleFrom(
-                                            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 0),
-                                          ),
-                                        ),
-                                      ),
-                                    )
-                                  : SizedBox(
-                                      width: 44,
-                                      height: 44,
-                                      child: AnimatedContainer(
-                                        duration: const Duration(milliseconds: 200),
-                                        curve: Curves.easeInOut,
-                                        decoration: BoxDecoration(
-                                          color: AppStyles.backgroundSecondary,
-                                          borderRadius: BorderRadius.circular(AppStyles.radiusLarge),
-                                        ),
-                                        child: IconButton(
-                                          onPressed: () {
-                                            HapticFeedback.mediumImpact();
-                                            final provider = context.read<AppProvider>();
-                                            final wasSelected = provider.isFilterSelected('My Apps', 'Apps');
-                                            provider.addOrRemoveFilter('My Apps', 'Apps');
-                                            provider.applyFilters();
-                                            PlatformManager.instance.analytics.appsTypeFilter(
-                                              'My Apps',
-                                              !wasSelected,
-                                            );
-                                          },
-                                          icon: const FaIcon(
-                                            FontAwesomeIcons.solidUser,
-                                            size: 16,
-                                            color: Colors.white,
-                                          ),
-                                          padding: EdgeInsets.zero,
-                                        ),
-                                      ),
-                                    ),
-
-                              const SizedBox(width: 8),
 
                               // Installed Apps button - expands when selected
                               state.isInstalledSelected

--- a/app/lib/pages/apps/widgets/filter_sheet.dart
+++ b/app/lib/pages/apps/widgets/filter_sheet.dart
@@ -65,6 +65,13 @@ class FilterBottomSheet extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      // Apps
+                      _buildSectionTitle(AppLocalizations.of(context).apps),
+                      const SizedBox(height: 12),
+                      _buildAuthorshipChip(context, provider),
+
+                      const SizedBox(height: 32),
+
                       // Rating
                       _buildSectionTitle(AppLocalizations.of(context).rating),
                       const SizedBox(height: 12),
@@ -202,6 +209,39 @@ class FilterBottomSheet extends StatelessWidget {
           ),
         );
       }).toList(),
+    );
+  }
+
+  Widget _buildAuthorshipChip(BuildContext context, AppProvider provider) {
+    final isSelected = provider.isFilterSelected('My Apps', 'Apps');
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        GestureDetector(
+          onTap: () {
+            provider.addOrRemoveFilter('My Apps', 'Apps');
+            provider.applyFilters();
+            PlatformManager.instance.analytics.appsTypeFilter('My Apps', !isSelected);
+          },
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            decoration: BoxDecoration(
+              color: isSelected ? Colors.white.withValues(alpha: 0.22) : const Color(0xFF35343B),
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Text(
+              AppLocalizations.of(context).myApps,
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w500,
+                color: isSelected ? Colors.white : Colors.grey.shade300,
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 


### PR DESCRIPTION
Finishes #11296.

## Summary

The complaint in #11296 — "My Apps" shows "No apps found" for someone with installed apps — had two halves. The naming half already shipped in #11779: `myApps` reads **"Created by me"** and is translated across all 49 locales. The predicate was never wrong either; `search_apps_db` has taken `my_apps` (authored) and `installed_apps` (enabled) as separate flags all along, and the client passes both.

What was left is placement. On the explore page the two sat as **peer buttons in the same row**, so a filter that is empty for everyone who has not published an app occupied a primary slot beside the one nearly every user wants.

## What changed

- **Installed Apps stays the primary control**, keeping its expand-on-select behaviour and its place in the row.
- **Created by me moves into the filter sheet**, in an "Apps" section above Rating, styled like the category and capability chips it now sits with. When active it appears as an ordinary filter chip in the row, like every other filter.
- **Clear-all stops special-casing it.** It used to toggle the authored filter explicitly *and* sweep the visible filters; now the filter is visible, so the sweep alone clears it — the explicit toggle would have re-added it.
- `isMyAppsSelected` leaves the view state: the chip counts in `visibleFilterCount`, so the flag no longer said anything the count did not.

No backend change, and **no new ARB keys** — both strings (`apps`, `myApps`) already exist, so this needs no `flutter gen-l10n` run and no locale churn.

Explore stays a discovery surface: Installed is one tap away rather than preselected, so opening the page still shows the marketplace rather than the handful of apps you already have.

## Verification

**I could not run `flutter analyze`, the tests, or the app.** The Flutter SDK path is unreadable from my sandbox (`Operation not permitted`), so the push used the documented `PRE_PUSH_SKIP_DART_FORMAT=1`. What I checked by hand instead, since removing a widget block is exactly where a missed reference bites:

- `grep -c isMyAppsSelected` over the explore page returns **0** — the record field, its initialiser and both conditions that read it are all gone together.
- Every remaining `'My Apps'` reference is the internal filter key in `app_provider.dart`, which is deliberately unchanged: it is a lookup key in eight places, not a display string, and renaming it would risk stale persisted state for no user-visible gain.
- Parentheses and braces balance in the edited page, and no line exceeds 120 characters.
- `PlatformManager` and `AppLocalizations` were already imported in the filter sheet, so the moved analytics call and label need no new imports.
- `make preflight` passes.

Worth a look on device before merge: open Explore, confirm the row shows Installed alone, then open Filters and confirm the Apps section toggles "Created by me" and that clearing filters removes it.

## Product invariants

INV-UI-1 (no purple) — this diff moves an existing control and reuses the sheet's existing chip styling; it introduces no colour.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

