### PR TITLE
fix(app): refresh the auth token the server rejects as expired

### DIFF
--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -10,6 +10,7 @@ import 'package:omi/backend/http/clock_skew_detector.dart';
 import 'package:omi/backend/http/http_pool_manager.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/env/env.dart';
+import 'package:omi/utils/jwt_expiry.dart';
 import 'package:omi/services/account_cutover/account_cutover_runtime.dart';
 import 'package:omi/services/auth/auth_token_result.dart';
 import 'package:omi/services/auth_service.dart';
@@ -62,8 +63,12 @@ Future<String> getAuthHeader({bool expireTerminalSession = true}) async {
     throw AuthTokenUnavailableException(const AuthTokenMissingUser());
   }
 
-  final expiry = DateTime.fromMillisecondsSinceEpoch(SharedPreferencesUtil().tokenExpirationTime);
-  bool hasAuthToken = SharedPreferencesUtil().authToken.isNotEmpty;
+  final storedToken = SharedPreferencesUtil().authToken;
+  // The token's own exp outranks the cached copy: #11694 saw clients present a
+  // three-day-dead token because the cached expiry had advanced without it.
+  final expiry =
+      jwtExpiry(storedToken) ?? DateTime.fromMillisecondsSinceEpoch(SharedPreferencesUtil().tokenExpirationTime);
+  bool hasAuthToken = storedToken.isNotEmpty;
 
   bool isExpirationDateValid = !(expiry.isBefore(DateTime.now()) ||
       expiry.isAtSameMomentAs(DateTime.fromMillisecondsSinceEpoch(0)) ||

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -82,6 +82,9 @@ class CaptureController extends ChangeNotifier
 
   TranscriptSegmentSocketService? _socket;
   Timer? _keepAliveTimer;
+
+  static const Duration _rejectedTokenRefreshInterval = Duration(seconds: 30);
+  DateTime? _lastRejectedTokenRefreshAt;
   DateTime? _keepAliveLastExecutedAt;
   Timer? _inProgressConversationRefreshTimer;
   int _inProgressConversationRefreshAttempts = 0;
@@ -1717,6 +1720,10 @@ class CaptureController extends ChangeNotifier
       externalActions.markAsOutOfCreditsAndRefresh();
     }
 
+    if (closeCode == 4001) {
+      unawaited(_refreshRejectedAuthToken());
+    }
+
     // Reflect the transcription pipeline break in recordingState. Before this
     // change the UI kept reading "record" while the socket was dead, which
     // looked like active capture to the user (issue #6499). Only flip when we
@@ -1787,6 +1794,26 @@ class CaptureController extends ChangeNotifier
 
       await _reconnectActiveCapture();
     });
+  }
+
+  /// Close code 4001 is the server saying the presented token is expired.
+  ///
+  /// It is the only authority on that: the local expiry copy and the device
+  /// clock can both call a dead token valid, which is how #11694's clients
+  /// re-presented a three-day-expired token every ~15s indefinitely. Refresh
+  /// before the next attempt so the reconnect carries a new credential.
+  Future<void> _refreshRejectedAuthToken() async {
+    final now = DateTime.now();
+    final last = _lastRejectedTokenRefreshAt;
+    if (last != null && now.difference(last) < _rejectedTokenRefreshInterval) return;
+    _lastRejectedTokenRefreshAt = now;
+    try {
+      // refreshIdToken persists the new token and its expiry itself.
+      final result = await AuthService.instance.refreshIdToken();
+      Logger.debug('[Provider] token refresh after 4001: ${result.runtimeType}');
+    } catch (e) {
+      Logger.debug('[Provider] token refresh after 4001 failed: $e');
+    }
   }
 
   Future<void> _reconnectActiveCapture() async {

--- a/app/lib/utils/jwt_expiry.dart
+++ b/app/lib/utils/jwt_expiry.dart
@@ -1,0 +1,20 @@
+import 'dart:convert';
+
+/// Reads `exp` out of a JWT, or null when the token cannot be read.
+///
+/// The token carries its own expiry, so a second copy of it kept beside the
+/// token can only ever drift: a stored expiry that advances while the stored
+/// token does not leaves the client certain a dead credential is fresh.
+DateTime? jwtExpiry(String token) {
+  final segments = token.split('.');
+  if (segments.length < 2) return null;
+  try {
+    final payload = jsonDecode(utf8.decode(base64Url.decode(base64Url.normalize(segments[1]))));
+    if (payload is! Map) return null;
+    final exp = payload['exp'];
+    if (exp is! int || exp <= 0) return null;
+    return DateTime.fromMillisecondsSinceEpoch(exp * 1000, isUtc: true).toLocal();
+  } catch (_) {
+    return null;
+  }
+}

--- a/app/test/unit/error_message_test.dart
+++ b/app/test/unit/error_message_test.dart
@@ -17,7 +17,7 @@ void main() {
   });
 
   test('reads a PlatformException message instead of its dump', () {
-    const error = PlatformException(
+    final error = PlatformException(
       code: 'Unexpected security result code',
       message: 'The specified item already exists in the keychain.',
       details: -25299,
@@ -27,7 +27,7 @@ void main() {
   });
 
   test('falls back to the platform code when the message is empty', () {
-    const error = PlatformException(code: 'channel-error', message: '  ');
+    final error = PlatformException(code: 'channel-error', message: '  ');
 
     expect(readableError(error), 'channel-error');
   });

--- a/app/test/unit/jwt_expiry_test.dart
+++ b/app/test/unit/jwt_expiry_test.dart
@@ -1,0 +1,46 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/utils/jwt_expiry.dart';
+
+String _token(Map<String, dynamic> payload) {
+  String segment(Map<String, dynamic> value) =>
+      base64Url.encode(utf8.encode(jsonEncode(value))).replaceAll('=', '');
+  return '${segment({'alg': 'RS256'})}.${segment(payload)}.signature';
+}
+
+void main() {
+  test('reads exp out of the token', () {
+    final expiry = DateTime.utc(2026, 8, 16, 12, 0, 0);
+
+    final result = jwtExpiry(_token({'exp': expiry.millisecondsSinceEpoch ~/ 1000}));
+
+    expect(result?.toUtc(), expiry);
+  });
+
+  test('an expired token reports a past expiry', () {
+    final past = DateTime.now().toUtc().subtract(const Duration(days: 3));
+
+    final result = jwtExpiry(_token({'exp': past.millisecondsSinceEpoch ~/ 1000}));
+
+    expect(result!.isBefore(DateTime.now()), isTrue);
+  });
+
+  test('returns null for anything it cannot read, so the caller keeps its fallback', () {
+    expect(jwtExpiry(''), isNull);
+    expect(jwtExpiry('not-a-jwt'), isNull);
+    expect(jwtExpiry('header.%%%.signature'), isNull);
+    expect(jwtExpiry(_token({'sub': 'user-1'})), isNull);
+    expect(jwtExpiry(_token({'exp': 'soon'})), isNull);
+    expect(jwtExpiry(_token({'exp': 0})), isNull);
+  });
+
+  test('tolerates base64 padding the encoder omitted', () {
+    // Firebase strips '=' padding; base64Url.decode rejects that without normalize.
+    final token = _token({'exp': 1786900104, 'sub': 'padding-sensitive'});
+
+    expect(token.split('.')[1].contains('='), isFalse);
+    expect(jwtExpiry(token), isNotNull);
+  });
+}

--- a/app/test/unit/jwt_expiry_test.dart
+++ b/app/test/unit/jwt_expiry_test.dart
@@ -5,8 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:omi/utils/jwt_expiry.dart';
 
 String _token(Map<String, dynamic> payload) {
-  String segment(Map<String, dynamic> value) =>
-      base64Url.encode(utf8.encode(jsonEncode(value))).replaceAll('=', '');
+  String segment(Map<String, dynamic> value) => base64Url.encode(utf8.encode(jsonEncode(value))).replaceAll('=', '');
   return '${segment({'alg': 'RS256'})}.${segment(payload)}.signature';
 }
 


### PR DESCRIPTION
Fixes #11694.

## Summary

Prod `backend-listen` rejects live-transcription upgrades from clients presenting a token that expired **days** earlier:

```
WebSocket auth failed: code=4001 error=Token expired, 1786634034 < 1786900104
```

I measured prod today, two weeks after the report: individual clients are still being rejected **35–44 times per 10 minutes** — a reconnect every ~15 seconds, per client, indefinitely. Those users capture nothing at all, and the retries land on the listen tier at times outnumbering real traffic.

The client does refresh when it believes the token is expired. The belief is the bug — it is assembled from two local sources, and the one authoritative source is discarded.

**It never asks the token.** `getAuthHeader` gates the refresh on `SharedPreferencesUtil().tokenExpirationTime`, a *separate stored copy* of the expiry. `refreshIdToken` writes that copy and the token in sequence, so any failure between them leaves the expiry advanced while the token is not — and the client is then certain a dead credential is fresh. That is not hypothetical: until #12420 landed this morning, the token write was fire-and-forget with no error handling, so a keychain failure lost it silently.

**It trusts the device clock.** `expiry.isBefore(DateTime.now())` compares against the phone's own clock. A device running days behind considers a long-dead token valid and never refreshes. This repo already ships `ClockSkewDetector` because skew happens in this fleet — but it only reports; nothing feeds it into the auth decision.

**And the server's verdict was thrown away.** Close code `4001` is mapped in `pure_socket.dart` to the string `'auth_token_refresh_required'` — for a log label. Nothing performed the refresh the constant names. `capture_controller.onClosed` handles `4002` (out of credits) and ignores `4001` entirely.

So every input the client consults says "no refresh needed", and the one input that says otherwise is only printed.

## What changed

- **`jwtExpiry()`** reads `exp` out of the token. A JWT carries its own expiry; a second copy beside it can only drift.
- **`getAuthHeader` prefers it**, falling back to the cached value only when the token cannot be parsed — so an unreadable token is no worse off than today.
- **`onClosed` acts on 4001**, refreshing before the next reconnect. This is the half that matters most: it is correct regardless of *why* the local view was wrong, including a skewed clock, which parsing `exp` alone cannot fix. Throttled to once per 30s so a persistently rejected credential cannot turn reconnects into a refresh storm.

## Verification

**I could not run `flutter test`, `flutter analyze`, or the app** — the Flutter SDK path is unreadable from my sandbox, so the push used `PRE_PUSH_SKIP_DART_FORMAT=1`. Please run:

```
cd app && flutter test test/unit/jwt_expiry_test.dart
```

To avoid shipping parsing logic I could not execute, I reimplemented `jwtExpiry` in Python and ran every test vector through it: a valid `exp` decodes; a missing, non-integer, or zero `exp`, a non-JWT string, invalid base64, and an empty string all return null. The padding case is real rather than theoretical — Firebase strips `=`, and the encoded payload in that test has `len % 4 == 3`, which `base64Url.decode` rejects without the `normalize` call the implementation makes.

Also checked by hand: `unawaited` and `Logger` were already imported in `capture_controller.dart`, `refreshIdToken` persists the token and expiry itself (so the handler adds no second write), and no changed line exceeds 120 characters.

The push also used `PRE_PUSH_SKIP_FLUTTER_GENERATED=1`, which needs `flutter pub get` to have resolved app dependencies — blocked by the same missing SDK. It checks generated output is current; this diff adds no ARB keys and touches no generator input.

`make preflight` passes.

## What this does not fix

The 15 affected clients only get this when they update. If they are on an old build — the issue never established which versions, and the upgrade URL carries no app version — they keep looping until then. A server-side answer (closing with `4004` for a repeatedly-expired credential, or backing off the rejected upgrade) would cover them without a release, and is worth its own issue rather than being folded in here.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

