### PR TITLE
SCA-377: make iOS chat citation cards the only tappable source list

### DIFF
--- a/.github/failure-classes/FC-ancestor-chrome-steals-control-taps.json
+++ b/.github/failure-classes/FC-ancestor-chrome-steals-control-taps.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "id": "FC-ancestor-chrome-steals-control-taps",
+  "violated_contract": "A control that owns a tap must remain the hit-test target for its own bounds, and a tap that cannot complete must surface a failure. An ancestor installed for an orthogonal concern — wrapping SelectionArea, a full-width jump-to-latest overlay, or a last-message min-height spacer — must not absorb those hits or shove the control under another surface. A lookup miss must not return silently.",
+  "canonical_prevention": "Keep text selection on markdown only so citation GestureDetectors are not SelectionArea descendants; size overlay chrome to the visible chip and pad the list so it does not cover sources; drop last-message min-height spacers that bury citations; resolve a cited conversation from the local map then fetch by id, and show a snackbar when the fetch returns null.",
+  "canonical_prevention_artifact": [
+    "app/test/widgets/chat_citation_taps_test.dart"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "app/lib/pages/chat/**"
+  ],
+  "status": "open"
+}

--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -21,6 +21,7 @@ import 'package:omi/backend/schema/message.dart';
 import 'package:omi/gen/assets.gen.dart';
 import 'package:omi/pages/apps/widgets/capability_apps_page.dart';
 import 'package:omi/pages/chat/widgets/ai_message.dart';
+import 'package:omi/pages/chat/widgets/jump_to_latest_button.dart';
 import 'package:omi/pages/settings/widgets/plans_sheet.dart';
 import 'package:omi/pages/chat/widgets/user_message.dart';
 import 'package:omi/pages/chat/widgets/voice_recorder_widget.dart';
@@ -91,8 +92,6 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
   @override
   bool get wantKeepAlive => true;
 
-  bool _allowSpacer = false;
-
   @override
   void initState() {
     apps = prefs.appsList;
@@ -147,9 +146,6 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
         // Wait for messages to load first, then add auto-message
         Future.delayed(const Duration(milliseconds: 800), () {
           if (mounted) {
-            setState(() {
-              _allowSpacer = true;
-            });
             final aiMessage = ServerMessage(
               const Uuid().v4(),
               DateTime.now(),
@@ -245,121 +241,111 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                           ],
                         )
                       : provider.isClearingChat
-                          ? Column(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                const CircularProgressIndicator(
-                                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white)),
-                                const SizedBox(height: 16),
-                                Text(context.l10n.deletingMessages, style: const TextStyle(color: Colors.white)),
-                              ],
-                            )
-                          : (provider.messages.isEmpty)
-                              ? Center(
-                                  child: Padding(
-                                    padding: const EdgeInsets.only(bottom: 100.0),
-                                    child: Text(
-                                      connectivityProvider.isConnected
-                                          ? context.l10n.noMessagesYet
-                                          : context.l10n.noInternetConnection,
-                                      textAlign: TextAlign.center,
-                                      style: const TextStyle(color: Colors.white),
+                      ? Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            const CircularProgressIndicator(valueColor: AlwaysStoppedAnimation<Color>(Colors.white)),
+                            const SizedBox(height: 16),
+                            Text(context.l10n.deletingMessages, style: const TextStyle(color: Colors.white)),
+                          ],
+                        )
+                      : (provider.messages.isEmpty)
+                      ? Center(
+                          child: Padding(
+                            padding: const EdgeInsets.only(bottom: 100.0),
+                            child: Text(
+                              connectivityProvider.isConnected
+                                  ? context.l10n.noMessagesYet
+                                  : context.l10n.noInternetConnection,
+                              textAlign: TextAlign.center,
+                              style: const TextStyle(color: Colors.white),
+                            ),
+                          ),
+                        )
+                      : LayoutBuilder(
+                          builder: (context, constraints) {
+                            return Theme(
+                              data: Theme.of(context).copyWith(
+                                textSelectionTheme: TextSelectionThemeData(
+                                  selectionColor: Colors.white.withValues(alpha: 0.3),
+                                  selectionHandleColor: Colors.blue,
+                                ),
+                              ),
+                              child: Stack(
+                                alignment: Alignment.bottomCenter,
+                                children: [
+                                  Positioned.fill(
+                                    child: NotificationListener<ScrollNotification>(
+                                      onNotification: _handleScrollNotification,
+                                      child: ListView.builder(
+                                        shrinkWrap: false,
+                                        reverse: false,
+                                        controller: scrollController,
+                                        padding: EdgeInsets.fromLTRB(
+                                          18,
+                                          16,
+                                          18,
+                                          _chatScrollMode == _ChatScrollMode.freeScrolling ? 72 : 10,
+                                        ),
+                                        itemCount: provider.messages.length,
+                                        itemBuilder: (context, chatIndex) {
+                                          if (!_hasInitialScrolled && provider.messages.isNotEmpty) {
+                                            _hasInitialScrolled = true;
+                                            _schedulePostFrameModeAwareScroll();
+                                          }
+
+                                          final message = provider.messages[chatIndex];
+                                          double topPadding = chatIndex == provider.messages.length - 1 ? 8 : 16;
+                                          double bottomPadding = chatIndex == 0 ? 16 : 0;
+
+                                          return Padding(
+                                            key: ValueKey(message.id),
+                                            padding: EdgeInsets.only(bottom: bottomPadding, top: topPadding),
+                                            child: message.sender == MessageSender.ai
+                                                ? AIMessage(
+                                                    showTypingIndicator:
+                                                        provider.showTypingIndicator &&
+                                                        chatIndex == provider.messages.length - 1,
+                                                    showThinkingAfterText: provider.agentThinkingAfterText,
+                                                    message: message,
+                                                    sendMessage: _sendMessageUtil,
+                                                    onAskOmi: (text) {
+                                                      setState(() {
+                                                        _selectedContext = text;
+                                                      });
+                                                      textFieldFocusNode.requestFocus();
+                                                    },
+                                                    displayOptions: provider.messages.length <= 1,
+                                                    appSender: provider.messageSenderApp(message.appId),
+                                                    updateConversation: (ServerConversation conversation) {
+                                                      context.read<ConversationProvider>().updateConversation(
+                                                        conversation,
+                                                      );
+                                                    },
+                                                    setMessageNps: (int value, {String? reason}) {
+                                                      provider.setMessageNps(message, value, reason: reason);
+                                                    },
+                                                  )
+                                                : HumanMessage(
+                                                    message: message,
+                                                    onAskOmi: (text) {
+                                                      setState(() {
+                                                        _selectedContext = text;
+                                                      });
+                                                      textFieldFocusNode.requestFocus();
+                                                    },
+                                                  ),
+                                          );
+                                        },
+                                      ),
                                     ),
                                   ),
-                                )
-                              : LayoutBuilder(
-                                  builder: (context, constraints) {
-                                    return Theme(
-                                      data: Theme.of(context).copyWith(
-                                        textSelectionTheme: TextSelectionThemeData(
-                                          selectionColor: Colors.white.withValues(alpha: 0.3),
-                                          selectionHandleColor: Colors.blue,
-                                        ),
-                                      ),
-                                      child: Stack(
-                                        children: [
-                                          NotificationListener<ScrollNotification>(
-                                            onNotification: _handleScrollNotification,
-                                            child: ListView.builder(
-                                              shrinkWrap: false,
-                                              reverse: false,
-                                              controller: scrollController,
-                                              padding: const EdgeInsets.fromLTRB(18, 16, 18, 10),
-                                              itemCount: provider.messages.length,
-                                              itemBuilder: (context, chatIndex) {
-                                                if (!_hasInitialScrolled && provider.messages.isNotEmpty) {
-                                                  _hasInitialScrolled = true;
-                                                  _schedulePostFrameModeAwareScroll();
-                                                }
-
-                                                final message = provider.messages[chatIndex];
-                                                double topPadding = chatIndex == provider.messages.length - 1 ? 8 : 16;
-                                                double bottomPadding = chatIndex == 0 ? 16 : 0;
-
-                                                return Padding(
-                                                  key: ValueKey(message.id),
-                                                  padding: EdgeInsets.only(bottom: bottomPadding, top: topPadding),
-                                                  child: message.sender == MessageSender.ai
-                                                      ? Builder(
-                                                          builder: (context) {
-                                                            final child = AIMessage(
-                                                              showTypingIndicator: provider.showTypingIndicator &&
-                                                                  chatIndex == provider.messages.length - 1,
-                                                              showThinkingAfterText: provider.agentThinkingAfterText,
-                                                              message: message,
-                                                              sendMessage: _sendMessageUtil,
-                                                              onAskOmi: (text) {
-                                                                setState(() {
-                                                                  _selectedContext = text;
-                                                                });
-                                                                textFieldFocusNode.requestFocus();
-                                                              },
-                                                              displayOptions: provider.messages.length <= 1,
-                                                              appSender: provider.messageSenderApp(message.appId),
-                                                              updateConversation: (ServerConversation conversation) {
-                                                                context.read<ConversationProvider>().updateConversation(
-                                                                      conversation,
-                                                                    );
-                                                              },
-                                                              setMessageNps: (int value, {String? reason}) {
-                                                                provider.setMessageNps(message, value, reason: reason);
-                                                              },
-                                                            );
-
-                                                            // Dynamic spacer logic
-                                                            if (chatIndex == provider.messages.length - 1 &&
-                                                                _allowSpacer) {
-                                                              return Container(
-                                                                constraints: BoxConstraints(
-                                                                  minHeight: MediaQuery.of(context).size.height * 0.5,
-                                                                ),
-                                                                alignment: Alignment.topLeft,
-                                                                child: child,
-                                                              );
-                                                            }
-                                                            return child;
-                                                          },
-                                                        )
-                                                      : HumanMessage(
-                                                          message: message,
-                                                          onAskOmi: (text) {
-                                                            setState(() {
-                                                              _selectedContext = text;
-                                                            });
-                                                            textFieldFocusNode.requestFocus();
-                                                          },
-                                                        ),
-                                                );
-                                              },
-                                            ),
-                                          ),
-                                          if (_chatScrollMode == _ChatScrollMode.freeScrolling)
-                                            _buildJumpToLatestButton(),
-                                        ],
-                                      ),
-                                    );
-                                  },
-                                ),
+                                  if (_chatScrollMode == _ChatScrollMode.freeScrolling) _buildJumpToLatestButton(),
+                                ],
+                              ),
+                            );
+                          },
+                        ),
                 ),
                 // Send message area
                 Container(
@@ -525,9 +511,9 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                                 bottom: widget.isPivotBottom
                                     ? 6
                                     : (textFieldFocusNode.hasFocus &&
-                                            (textController.text.length > 40 || textController.text.contains('\n'))
-                                        ? 4
-                                        : 10),
+                                              (textController.text.length > 40 || textController.text.contains('\n'))
+                                          ? 4
+                                          : 10),
                               ),
                               child: Stack(
                                 clipBehavior: Clip.none,
@@ -721,8 +707,8 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                                                         FontAwesomeIcons.arrowUp,
                                                         color:
                                                             voiceRecorderProvider.state == VoiceRecorderState.recording
-                                                                ? const Color(0xFF1f1f25)
-                                                                : Colors.grey.shade400,
+                                                            ? const Color(0xFF1f1f25)
+                                                            : Colors.grey.shade400,
                                                         size: 16,
                                                       ),
                                                     ),
@@ -762,7 +748,8 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                                                     bool hasText = value.text.trim().isNotEmpty;
                                                     if (!hasText) return const SizedBox.shrink();
 
-                                                    bool canSend = hasText &&
+                                                    bool canSend =
+                                                        hasText &&
                                                         !provider.sendingMessage &&
                                                         !provider.isUploadingFiles &&
                                                         connectivityProvider.isConnected;
@@ -977,7 +964,6 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
 
     String? currentContext = _selectedContext;
     setState(() {
-      _allowSpacer = true;
       _selectedContext = null;
     });
 
@@ -1052,10 +1038,7 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
     final existing = _chatScope;
     final l10n = context.l10n;
     final next = (existing != null && existing.type == 'conversation')
-        ? existing.copyWith(
-            startDate: start.toUtc().toIso8601String(),
-            endDate: end.toUtc().toIso8601String(),
-          )
+        ? existing.copyWith(startDate: start.toUtc().toIso8601String(), endDate: end.toUtc().toIso8601String())
         : ChatPageContext(
             type: 'recap',
             title: preset == 'today' ? l10n.chatScopeToday : l10n.chatScopeThisWeek,
@@ -1153,53 +1136,7 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
   }
 
   Widget _buildJumpToLatestButton() {
-    return Positioned(
-      left: 0,
-      right: 0,
-      bottom: 16,
-      child: Center(
-        child: Semantics(
-          label: context.l10n.jumpToLatestMessage,
-          button: true,
-          child: Tooltip(
-            message: context.l10n.jumpToLatestMessage,
-            child: Material(
-              color: Colors.transparent,
-              child: InkWell(
-                borderRadius: BorderRadius.circular(24),
-                onTap: () => _resumeFollowingAndScroll(animated: true),
-                child: Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-                  decoration: BoxDecoration(
-                    color: const Color(0xFF1F1F25).withValues(alpha: 0.95),
-                    borderRadius: BorderRadius.circular(24),
-                    border: Border.all(color: Colors.white.withValues(alpha: 0.18), width: 1),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withValues(alpha: 0.28),
-                        blurRadius: 12,
-                        offset: const Offset(0, 4),
-                      ),
-                    ],
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      const Icon(Icons.keyboard_arrow_down_rounded, color: Colors.white, size: 22),
-                      const SizedBox(width: 6),
-                      Text(
-                        context.l10n.latest,
-                        style: const TextStyle(color: Colors.white, fontSize: 14, fontWeight: FontWeight.w600),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
+    return ChatJumpToLatestButton(label: context.l10n.latest, onTap: () => _resumeFollowingAndScroll(animated: true));
   }
 
   void scrollToBottomOnSend() {
@@ -1354,10 +1291,6 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
   void _selectApp(String appId, AppProvider appProvider) async {
     if (!mounted) return;
 
-    setState(() {
-      _allowSpacer = false;
-    });
-
     // Mark that we're no longer on initial load to prevent auto-focus
     _isInitialLoad = false;
 
@@ -1384,9 +1317,6 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
     // Get the selected app and send initial message if needed
     var app = appProvider.getSelectedApp();
     if (messageProvider.messages.isEmpty) {
-      setState(() {
-        _allowSpacer = true;
-      });
       messageProvider.sendInitialAppMessage(app);
     }
   }
@@ -1677,18 +1607,18 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
               child: FaIcon(FontAwesomeIcons.solidCircleCheck, color: Colors.white, size: 18),
             )
           : appId != null && onConfirmDelete != null
-              ? GestureDetector(
-                  onTap: () {
-                    setState(() {
-                      _pendingDeleteAppId = appId;
-                    });
-                  },
-                  child: const Padding(
-                    padding: EdgeInsets.only(left: 2, top: 1),
-                    child: FaIcon(FontAwesomeIcons.solidTrashCan, color: Colors.white38, size: 16),
-                  ),
-                )
-              : null,
+          ? GestureDetector(
+              onTap: () {
+                setState(() {
+                  _pendingDeleteAppId = appId;
+                });
+              },
+              child: const Padding(
+                padding: EdgeInsets.only(left: 2, top: 1),
+                child: FaIcon(FontAwesomeIcons.solidTrashCan, color: Colors.white38, size: 16),
+              ),
+            )
+          : null,
       selected: isSelected,
       selectedTileColor: Colors.white.withValues(alpha: 0.1),
       onTap: onTap,

--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -241,111 +241,113 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                           ],
                         )
                       : provider.isClearingChat
-                      ? Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            const CircularProgressIndicator(valueColor: AlwaysStoppedAnimation<Color>(Colors.white)),
-                            const SizedBox(height: 16),
-                            Text(context.l10n.deletingMessages, style: const TextStyle(color: Colors.white)),
-                          ],
-                        )
-                      : (provider.messages.isEmpty)
-                      ? Center(
-                          child: Padding(
-                            padding: const EdgeInsets.only(bottom: 100.0),
-                            child: Text(
-                              connectivityProvider.isConnected
-                                  ? context.l10n.noMessagesYet
-                                  : context.l10n.noInternetConnection,
-                              textAlign: TextAlign.center,
-                              style: const TextStyle(color: Colors.white),
-                            ),
-                          ),
-                        )
-                      : LayoutBuilder(
-                          builder: (context, constraints) {
-                            return Theme(
-                              data: Theme.of(context).copyWith(
-                                textSelectionTheme: TextSelectionThemeData(
-                                  selectionColor: Colors.white.withValues(alpha: 0.3),
-                                  selectionHandleColor: Colors.blue,
-                                ),
-                              ),
-                              child: Stack(
-                                alignment: Alignment.bottomCenter,
-                                children: [
-                                  Positioned.fill(
-                                    child: NotificationListener<ScrollNotification>(
-                                      onNotification: _handleScrollNotification,
-                                      child: ListView.builder(
-                                        shrinkWrap: false,
-                                        reverse: false,
-                                        controller: scrollController,
-                                        padding: EdgeInsets.fromLTRB(
-                                          18,
-                                          16,
-                                          18,
-                                          _chatScrollMode == _ChatScrollMode.freeScrolling ? 72 : 10,
-                                        ),
-                                        itemCount: provider.messages.length,
-                                        itemBuilder: (context, chatIndex) {
-                                          if (!_hasInitialScrolled && provider.messages.isNotEmpty) {
-                                            _hasInitialScrolled = true;
-                                            _schedulePostFrameModeAwareScroll();
-                                          }
-
-                                          final message = provider.messages[chatIndex];
-                                          double topPadding = chatIndex == provider.messages.length - 1 ? 8 : 16;
-                                          double bottomPadding = chatIndex == 0 ? 16 : 0;
-
-                                          return Padding(
-                                            key: ValueKey(message.id),
-                                            padding: EdgeInsets.only(bottom: bottomPadding, top: topPadding),
-                                            child: message.sender == MessageSender.ai
-                                                ? AIMessage(
-                                                    showTypingIndicator:
-                                                        provider.showTypingIndicator &&
-                                                        chatIndex == provider.messages.length - 1,
-                                                    showThinkingAfterText: provider.agentThinkingAfterText,
-                                                    message: message,
-                                                    sendMessage: _sendMessageUtil,
-                                                    onAskOmi: (text) {
-                                                      setState(() {
-                                                        _selectedContext = text;
-                                                      });
-                                                      textFieldFocusNode.requestFocus();
-                                                    },
-                                                    displayOptions: provider.messages.length <= 1,
-                                                    appSender: provider.messageSenderApp(message.appId),
-                                                    updateConversation: (ServerConversation conversation) {
-                                                      context.read<ConversationProvider>().updateConversation(
-                                                        conversation,
-                                                      );
-                                                    },
-                                                    setMessageNps: (int value, {String? reason}) {
-                                                      provider.setMessageNps(message, value, reason: reason);
-                                                    },
-                                                  )
-                                                : HumanMessage(
-                                                    message: message,
-                                                    onAskOmi: (text) {
-                                                      setState(() {
-                                                        _selectedContext = text;
-                                                      });
-                                                      textFieldFocusNode.requestFocus();
-                                                    },
-                                                  ),
-                                          );
-                                        },
-                                      ),
+                          ? Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                const CircularProgressIndicator(
+                                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white)),
+                                const SizedBox(height: 16),
+                                Text(context.l10n.deletingMessages, style: const TextStyle(color: Colors.white)),
+                              ],
+                            )
+                          : (provider.messages.isEmpty)
+                              ? Center(
+                                  child: Padding(
+                                    padding: const EdgeInsets.only(bottom: 100.0),
+                                    child: Text(
+                                      connectivityProvider.isConnected
+                                          ? context.l10n.noMessagesYet
+                                          : context.l10n.noInternetConnection,
+                                      textAlign: TextAlign.center,
+                                      style: const TextStyle(color: Colors.white),
                                     ),
                                   ),
-                                  if (_chatScrollMode == _ChatScrollMode.freeScrolling) _buildJumpToLatestButton(),
-                                ],
-                              ),
-                            );
-                          },
-                        ),
+                                )
+                              : LayoutBuilder(
+                                  builder: (context, constraints) {
+                                    return Theme(
+                                      data: Theme.of(context).copyWith(
+                                        textSelectionTheme: TextSelectionThemeData(
+                                          selectionColor: Colors.white.withValues(alpha: 0.3),
+                                          selectionHandleColor: Colors.blue,
+                                        ),
+                                      ),
+                                      child: Stack(
+                                        alignment: Alignment.bottomCenter,
+                                        children: [
+                                          Positioned.fill(
+                                            child: NotificationListener<ScrollNotification>(
+                                              onNotification: _handleScrollNotification,
+                                              child: ListView.builder(
+                                                shrinkWrap: false,
+                                                reverse: false,
+                                                controller: scrollController,
+                                                padding: EdgeInsets.fromLTRB(
+                                                  18,
+                                                  16,
+                                                  18,
+                                                  _chatScrollMode == _ChatScrollMode.freeScrolling ? 72 : 10,
+                                                ),
+                                                itemCount: provider.messages.length,
+                                                itemBuilder: (context, chatIndex) {
+                                                  if (!_hasInitialScrolled && provider.messages.isNotEmpty) {
+                                                    _hasInitialScrolled = true;
+                                                    _schedulePostFrameModeAwareScroll();
+                                                  }
+
+                                                  final message = provider.messages[chatIndex];
+                                                  double topPadding =
+                                                      chatIndex == provider.messages.length - 1 ? 8 : 16;
+                                                  double bottomPadding = chatIndex == 0 ? 16 : 0;
+
+                                                  return Padding(
+                                                    key: ValueKey(message.id),
+                                                    padding: EdgeInsets.only(bottom: bottomPadding, top: topPadding),
+                                                    child: message.sender == MessageSender.ai
+                                                        ? AIMessage(
+                                                            showTypingIndicator: provider.showTypingIndicator &&
+                                                                chatIndex == provider.messages.length - 1,
+                                                            showThinkingAfterText: provider.agentThinkingAfterText,
+                                                            message: message,
+                                                            sendMessage: _sendMessageUtil,
+                                                            onAskOmi: (text) {
+                                                              setState(() {
+                                                                _selectedContext = text;
+                                                              });
+                                                              textFieldFocusNode.requestFocus();
+                                                            },
+                                                            displayOptions: provider.messages.length <= 1,
+                                                            appSender: provider.messageSenderApp(message.appId),
+                                                            updateConversation: (ServerConversation conversation) {
+                                                              context.read<ConversationProvider>().updateConversation(
+                                                                    conversation,
+                                                                  );
+                                                            },
+                                                            setMessageNps: (int value, {String? reason}) {
+                                                              provider.setMessageNps(message, value, reason: reason);
+                                                            },
+                                                          )
+                                                        : HumanMessage(
+                                                            message: message,
+                                                            onAskOmi: (text) {
+                                                              setState(() {
+                                                                _selectedContext = text;
+                                                              });
+                                                              textFieldFocusNode.requestFocus();
+                                                            },
+                                                          ),
+                                                  );
+                                                },
+                                              ),
+                                            ),
+                                          ),
+                                          if (_chatScrollMode == _ChatScrollMode.freeScrolling)
+                                            _buildJumpToLatestButton(),
+                                        ],
+                                      ),
+                                    );
+                                  },
+                                ),
                 ),
                 // Send message area
                 Container(
@@ -511,9 +513,9 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                                 bottom: widget.isPivotBottom
                                     ? 6
                                     : (textFieldFocusNode.hasFocus &&
-                                              (textController.text.length > 40 || textController.text.contains('\n'))
-                                          ? 4
-                                          : 10),
+                                            (textController.text.length > 40 || textController.text.contains('\n'))
+                                        ? 4
+                                        : 10),
                               ),
                               child: Stack(
                                 clipBehavior: Clip.none,
@@ -707,8 +709,8 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                                                         FontAwesomeIcons.arrowUp,
                                                         color:
                                                             voiceRecorderProvider.state == VoiceRecorderState.recording
-                                                            ? const Color(0xFF1f1f25)
-                                                            : Colors.grey.shade400,
+                                                                ? const Color(0xFF1f1f25)
+                                                                : Colors.grey.shade400,
                                                         size: 16,
                                                       ),
                                                     ),
@@ -748,8 +750,7 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                                                     bool hasText = value.text.trim().isNotEmpty;
                                                     if (!hasText) return const SizedBox.shrink();
 
-                                                    bool canSend =
-                                                        hasText &&
+                                                    bool canSend = hasText &&
                                                         !provider.sendingMessage &&
                                                         !provider.isUploadingFiles &&
                                                         connectivityProvider.isConnected;
@@ -1607,18 +1608,18 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
               child: FaIcon(FontAwesomeIcons.solidCircleCheck, color: Colors.white, size: 18),
             )
           : appId != null && onConfirmDelete != null
-          ? GestureDetector(
-              onTap: () {
-                setState(() {
-                  _pendingDeleteAppId = appId;
-                });
-              },
-              child: const Padding(
-                padding: EdgeInsets.only(left: 2, top: 1),
-                child: FaIcon(FontAwesomeIcons.solidTrashCan, color: Colors.white38, size: 16),
-              ),
-            )
-          : null,
+              ? GestureDetector(
+                  onTap: () {
+                    setState(() {
+                      _pendingDeleteAppId = appId;
+                    });
+                  },
+                  child: const Padding(
+                    padding: EdgeInsets.only(left: 2, top: 1),
+                    child: FaIcon(FontAwesomeIcons.solidTrashCan, color: Colors.white38, size: 16),
+                  ),
+                )
+              : null,
       selected: isSelected,
       selectedTileColor: Colors.white.withValues(alpha: 0.1),
       onTap: onTap,

--- a/app/lib/pages/chat/widgets/ai_message.dart
+++ b/app/lib/pages/chat/widgets/ai_message.dart
@@ -19,6 +19,7 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/app.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/message.dart';
+import 'package:omi/models/chat_evidence_reference.dart';
 import 'package:omi/pages/chat/widgets/files_handler_widget.dart';
 import 'package:omi/pages/chat/widgets/typing_indicator.dart';
 import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
@@ -60,7 +61,8 @@ Widget _buildAppIcon(BuildContext context, String appId, {double size = 15, doub
   final appProvider = Provider.of<AppProvider>(context, listen: false);
   final messageProvider = Provider.of<MessageProvider>(context, listen: false);
   // Check both public apps and user's installed chat apps (includes private MCP apps)
-  final app = appProvider.apps.firstWhereOrNull((a) => a.id == appId) ??
+  final app =
+      appProvider.apps.firstWhereOrNull((a) => a.id == appId) ??
       messageProvider.chatApps.firstWhereOrNull((a) => a.id == appId);
 
   if (app != null) {
@@ -170,6 +172,44 @@ Widget _buildThinkingIconWidget(String thinkingText, {double size = 15, Color co
   return FaIcon(_getThinkingIcon(thinkingText), size: size, color: color);
 }
 
+/// Conversation-shaped evidence is the same source list as [ServerMessage.memories].
+/// Keep those citations on [MemoriesMessageWidget] only.
+bool isConversationSourceEvidence(ChatEvidenceReferenceKind kind) {
+  return kind == ChatEvidenceReferenceKind.conversationSummary || kind == ChatEvidenceReferenceKind.conversationSegment;
+}
+
+/// Supplemental chrome to render beside the answer. Conversation sources that
+/// already appear as citation cards are stripped so the message has one list.
+ChatEvidenceReferenceEnvelope? visibleSupplementalEvidence(ServerMessage message) {
+  final evidence = message.evidenceEnvelope;
+  if (evidence == null || evidence.isEmpty) return null;
+  if (message.memories.isEmpty) return evidence;
+  final leftover = evidence.references.where((ref) => !isConversationSourceEvidence(ref.kind)).toList();
+  if (leftover.isEmpty) return null;
+  return ChatEvidenceReferenceEnvelope(
+    schemaVersion: evidence.schemaVersion,
+    requestId: evidence.requestId,
+    references: leftover,
+  );
+}
+
+/// Resolve a cited conversation from the local grouped map, then fetch by id.
+/// A miss in the map is not a failure — the fetch is the second authority.
+Future<ServerConversation?> resolveChatCitationConversation({
+  required ConversationProvider conversations,
+  required String conversationId,
+  required Future<ServerConversation?> Function(String id) fetchConversation,
+}) async {
+  final located = conversations.getConversationDateAndIndexById(conversationId);
+  if (located != null) {
+    final group = conversations.groupedConversations[located.$1];
+    if (group != null && located.$2 >= 0 && located.$2 < group.length) {
+      return group[located.$2];
+    }
+  }
+  return fetchConversation(conversationId);
+}
+
 class AIMessage extends StatefulWidget {
   final bool showTypingIndicator;
   final bool showThinkingAfterText;
@@ -180,6 +220,7 @@ class AIMessage extends StatefulWidget {
   final App? appSender;
   final Function(ServerConversation) updateConversation;
   final Function(int, {String? reason}) setMessageNps;
+  final Future<ServerConversation?> Function(String id)? fetchConversation;
 
   const AIMessage({
     super.key,
@@ -192,6 +233,7 @@ class AIMessage extends StatefulWidget {
     this.appSender,
     this.showTypingIndicator = false,
     this.showThinkingAfterText = false,
+    this.fetchConversation,
   });
 
   @override
@@ -212,21 +254,19 @@ class _AIMessageState extends State<AIMessage> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        SelectionArea(
-          contextMenuBuilder: (context, selectableRegionState) {
-            return omiSelectionMenuBuilder(context, selectableRegionState, widget.onAskOmi ?? (text) {});
-          },
-          child: buildMessageWidget(
-            widget.message,
-            widget.sendMessage,
-            widget.showTypingIndicator,
-            widget.displayOptions,
-            widget.appSender,
-            widget.updateConversation,
-            widget.setMessageNps,
-            onAskOmi: widget.onAskOmi,
-            showThinkingAfterText: widget.showThinkingAfterText,
-          ),
+        // Selection stays on markdown text only. Wrapping citation
+        // GestureDetectors in SelectionArea eats taps on iOS.
+        buildMessageWidget(
+          widget.message,
+          widget.sendMessage,
+          widget.showTypingIndicator,
+          widget.displayOptions,
+          widget.appSender,
+          widget.updateConversation,
+          widget.setMessageNps,
+          onAskOmi: widget.onAskOmi,
+          showThinkingAfterText: widget.showThinkingAfterText,
+          fetchConversation: widget.fetchConversation,
         ),
       ],
     );
@@ -243,18 +283,20 @@ Widget buildMessageWidget(
   Function(int, {String? reason}) sendMessageNps, {
   Function(String)? onAskOmi,
   bool showThinkingAfterText = false,
+  Future<ServerConversation?> Function(String id)? fetchConversation,
 }) {
   final Widget messageWidget;
   if (message.memories.isNotEmpty) {
     messageWidget = MemoriesMessageWidget(
       showTypingIndicator: showTypingIndicator,
-      messageMemories: message.memories.length > 3 ? message.memories.sublist(0, 3) : message.memories,
+      messageMemories: message.memories,
       messageText: message.isEmpty ? '...' : message.text.decodeString,
       updateConversation: updateConversation,
       message: message,
       setMessageNps: sendMessageNps,
       date: message.createdAt,
       onAskOmi: onAskOmi,
+      fetchConversation: fetchConversation,
     );
   } else if (message.type == MessageType.daySummary) {
     messageWidget = DaySummaryWidget(
@@ -282,8 +324,8 @@ Widget buildMessageWidget(
     );
   }
 
-  final evidence = message.evidenceEnvelope;
-  if (evidence == null || evidence.isEmpty) return messageWidget;
+  final evidence = visibleSupplementalEvidence(message);
+  if (evidence == null) return messageWidget;
   return Column(
     crossAxisAlignment: CrossAxisAlignment.start,
     mainAxisSize: MainAxisSize.min,
@@ -644,6 +686,7 @@ class MemoriesMessageWidget extends StatefulWidget {
   final Function(int, {String? reason}) setMessageNps;
   final DateTime date;
   final Function(String)? onAskOmi;
+  final Future<ServerConversation?> Function(String id)? fetchConversation;
 
   const MemoriesMessageWidget({
     super.key,
@@ -655,6 +698,7 @@ class MemoriesMessageWidget extends StatefulWidget {
     required this.setMessageNps,
     required this.date,
     this.onAskOmi,
+    this.fetchConversation,
   });
 
   @override
@@ -779,28 +823,28 @@ class _MemoriesMessageWidgetState extends State<MemoriesMessageWidget> {
                 ),
               )
             : widget.showTypingIndicator
-                ? const Row(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    children: [SizedBox(width: 4), TypingIndicator(), Spacer()],
-                  )
-                : Builder(
-                    builder: (context) {
-                      String? selectedText;
-                      return SelectionArea(
-                        onSelectionChanged: (SelectedContent? selectedContent) {
-                          selectedText = selectedContent?.plainText;
-                        },
-                        contextMenuBuilder: (context, selectableRegionState) {
-                          return omiSelectionMenuBuilder(context, selectableRegionState, (text) {
-                            widget.onAskOmi?.call(text);
-                          }, selectedText: selectedText);
-                        },
-                        child: getMarkdownWidget(context, widget.messageText, onAskOmi: widget.onAskOmi),
-                      );
+            ? const Row(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [SizedBox(width: 4), TypingIndicator(), Spacer()],
+              )
+            : Builder(
+                builder: (context) {
+                  String? selectedText;
+                  return SelectionArea(
+                    onSelectionChanged: (SelectedContent? selectedContent) {
+                      selectedText = selectedContent?.plainText;
                     },
-                  ),
+                    contextMenuBuilder: (context, selectableRegionState) {
+                      return omiSelectionMenuBuilder(context, selectableRegionState, (text) {
+                        widget.onAskOmi?.call(text);
+                      }, selectedText: selectedText);
+                    },
+                    child: getMarkdownWidget(context, widget.messageText, onAskOmi: widget.onAskOmi),
+                  );
+                },
+              ),
         if (widget.messageText.isNotEmpty && widget.messageText != '...' && !widget.showTypingIndicator)
           MessageActionBar(
             messageText: widget.messageText,
@@ -815,102 +859,115 @@ class _MemoriesMessageWidgetState extends State<MemoriesMessageWidget> {
         else if (widget.showTypingIndicator && widget.message.thinkings.any((t) => t.toLowerCase().contains('chart')))
           _buildChartShimmer(),
         const SizedBox(height: 16),
-        for (var data in widget.messageMemories.indexed) ...[
-          Padding(
-            padding: const EdgeInsetsDirectional.fromSTEB(0.0, 4.0, 0.0, 4.0),
-            child: GestureDetector(
-              onTap: () async {
-                final connectivityProvider = Provider.of<ConnectivityProvider>(context, listen: false);
-                if (connectivityProvider.isConnected) {
-                  var memProvider = Provider.of<ConversationProvider>(context, listen: false);
-                  // Groups are keyed by the local day of `startedAt ?? createdAt`; deriving the
-                  // key from the message's raw UTC `createdAt` missed the group for anyone off
-                  // UTC and the tap silently did nothing (#10980).
-                  final located = memProvider.getConversationDateAndIndexById(data.$2.id);
-                  var idx = located?.$2 ?? -1;
-                  var date = located?.$1 ?? conversationLocalDayKey(data.$2.createdAt);
-
-                  if (idx != -1) {
-                    context.read<ConversationDetailProvider>().updateConversation(data.$2.id, date);
-                    var m = memProvider.groupedConversations[date]![idx];
-                    PlatformManager.instance.analytics.chatMessageConversationClicked(m);
-                    await Navigator.of(
-                      context,
-                    ).push(MaterialPageRoute(builder: (c) => ConversationDetailPage(conversation: m)));
-                  } else {
-                    if (conversationDetailLoading[data.$1]) return;
-                    setState(() => conversationDetailLoading[data.$1] = true);
-                    ServerConversation? m = await getConversationById(data.$2.id);
-                    if (m == null) return;
-                    (idx, date) = memProvider.addConversationWithDateGrouped(m);
-                    PlatformManager.instance.analytics.chatMessageConversationClicked(m);
-                    setState(() => conversationDetailLoading[data.$1] = false);
-                    if (context.mounted) {
-                      context.read<ConversationDetailProvider>().updateConversation(m.id, date);
-                      await Navigator.of(
-                        context,
-                      ).push(MaterialPageRoute(builder: (c) => ConversationDetailPage(conversation: m)));
-                    }
-                    if (SharedPreferencesUtil().modifiedConversationDetails?.id == m.id) {
-                      ServerConversation modifiedDetails = SharedPreferencesUtil().modifiedConversationDetails!;
-                      widget.updateConversation(SharedPreferencesUtil().modifiedConversationDetails!);
-                      var copy = List<MessageConversation>.from(widget.messageMemories);
-                      copy[data.$1] = MessageConversation(
-                        modifiedDetails.id,
-                        modifiedDetails.createdAt,
-                        MessageConversationStructured(
-                          modifiedDetails.structured.title,
-                          modifiedDetails.structured.emoji,
+        Column(
+          key: const ValueKey('chat-citation-list'),
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            for (var data in widget.messageMemories.indexed)
+              Padding(
+                padding: const EdgeInsetsDirectional.fromSTEB(0.0, 4.0, 0.0, 4.0),
+                child: GestureDetector(
+                  key: ValueKey('chat-citation-${data.$2.id}'),
+                  onTap: () => _openCitedConversation(data.$1, data.$2),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12),
+                    width: double.maxFinite,
+                    decoration: BoxDecoration(
+                      color: const Color(0xFF1F1F25),
+                      borderRadius: BorderRadius.circular(16.0),
+                    ),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            '${tryDecodeText(data.$2.structured.emoji)} ${data.$2.structured.title}',
+                            style: Theme.of(context).textTheme.bodyMedium,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
                         ),
-                      );
-                      widget.messageMemories.clear();
-                      widget.messageMemories.addAll(copy);
-                      SharedPreferencesUtil().modifiedConversationDetails = null;
-                      setState(() {});
-                    }
-                  }
-                } else {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text(context.l10n.pleaseCheckInternetConnection),
-                      duration: const Duration(seconds: 2),
+                        const SizedBox(width: 8),
+                        conversationDetailLoading[data.$1]
+                            ? const SizedBox(
+                                height: 16,
+                                width: 16,
+                                child: CircularProgressIndicator(
+                                  valueColor: AlwaysStoppedAnimation<Color>(Colors.white54),
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const FaIcon(FontAwesomeIcons.chevronRight, size: 16, color: Colors.white54),
+                      ],
                     ),
-                  );
-                }
-              },
-              child: Container(
-                padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12),
-                width: double.maxFinite,
-                decoration: BoxDecoration(color: const Color(0xFF1F1F25), borderRadius: BorderRadius.circular(16.0)),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        '${tryDecodeText(data.$2.structured.emoji)} ${data.$2.structured.title}',
-                        style: Theme.of(context).textTheme.bodyMedium,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                    const SizedBox(width: 8),
-                    conversationDetailLoading[data.$1]
-                        ? const SizedBox(
-                            height: 16,
-                            width: 16,
-                            child: CircularProgressIndicator(
-                              valueColor: AlwaysStoppedAnimation<Color>(Colors.white54),
-                              strokeWidth: 2,
-                            ),
-                          )
-                        : const FaIcon(FontAwesomeIcons.chevronRight, size: 16, color: Colors.white54),
-                  ],
+                  ),
                 ),
               ),
-            ),
-          ),
-        ],
+          ],
+        ),
       ],
     );
+  }
+
+  Future<void> _openCitedConversation(int index, MessageConversation citation) async {
+    final connectivityProvider = Provider.of<ConnectivityProvider>(context, listen: false);
+    if (!connectivityProvider.isConnected) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(context.l10n.pleaseCheckInternetConnection), duration: const Duration(seconds: 2)),
+      );
+      return;
+    }
+
+    final memProvider = Provider.of<ConversationProvider>(context, listen: false);
+    final fetch = widget.fetchConversation ?? getConversationById;
+    ServerConversation? conversation = await resolveChatCitationConversation(
+      conversations: memProvider,
+      conversationId: citation.id,
+      fetchConversation: (id) async {
+        if (conversationDetailLoading[index]) return null;
+        setState(() => conversationDetailLoading[index] = true);
+        try {
+          return await fetch(id);
+        } finally {
+          if (mounted) setState(() => conversationDetailLoading[index] = false);
+        }
+      },
+    );
+
+    if (!mounted) return;
+    if (conversation == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(context.l10n.conversationNotFoundOrDeleted), duration: const Duration(seconds: 2)),
+      );
+      return;
+    }
+
+    var located = memProvider.getConversationDateAndIndexById(conversation.id);
+    var date = located?.$1;
+    if (date == null) {
+      (_, date) = memProvider.addConversationWithDateGrouped(conversation);
+    }
+
+    PlatformManager.instance.analytics.chatMessageConversationClicked(conversation);
+    if (!context.mounted) return;
+    context.read<ConversationDetailProvider>().updateConversation(conversation.id, date);
+    await Navigator.of(
+      context,
+    ).push(MaterialPageRoute(builder: (c) => ConversationDetailPage(conversation: conversation!)));
+
+    if (SharedPreferencesUtil().modifiedConversationDetails?.id == conversation.id) {
+      final modifiedDetails = SharedPreferencesUtil().modifiedConversationDetails!;
+      widget.updateConversation(modifiedDetails);
+      final copy = List<MessageConversation>.from(widget.messageMemories);
+      copy[index] = MessageConversation(
+        modifiedDetails.id,
+        modifiedDetails.createdAt,
+        MessageConversationStructured(modifiedDetails.structured.title, modifiedDetails.structured.emoji),
+      );
+      widget.messageMemories.clear();
+      widget.messageMemories.addAll(copy);
+      SharedPreferencesUtil().modifiedConversationDetails = null;
+      if (mounted) setState(() {});
+    }
   }
 
   String tryDecodeText(String text) {

--- a/app/lib/pages/chat/widgets/ai_message.dart
+++ b/app/lib/pages/chat/widgets/ai_message.dart
@@ -61,8 +61,7 @@ Widget _buildAppIcon(BuildContext context, String appId, {double size = 15, doub
   final appProvider = Provider.of<AppProvider>(context, listen: false);
   final messageProvider = Provider.of<MessageProvider>(context, listen: false);
   // Check both public apps and user's installed chat apps (includes private MCP apps)
-  final app =
-      appProvider.apps.firstWhereOrNull((a) => a.id == appId) ??
+  final app = appProvider.apps.firstWhereOrNull((a) => a.id == appId) ??
       messageProvider.chatApps.firstWhereOrNull((a) => a.id == appId);
 
   if (app != null) {
@@ -823,28 +822,28 @@ class _MemoriesMessageWidgetState extends State<MemoriesMessageWidget> {
                 ),
               )
             : widget.showTypingIndicator
-            ? const Row(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisAlignment: MainAxisAlignment.start,
-                children: [SizedBox(width: 4), TypingIndicator(), Spacer()],
-              )
-            : Builder(
-                builder: (context) {
-                  String? selectedText;
-                  return SelectionArea(
-                    onSelectionChanged: (SelectedContent? selectedContent) {
-                      selectedText = selectedContent?.plainText;
+                ? const Row(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: [SizedBox(width: 4), TypingIndicator(), Spacer()],
+                  )
+                : Builder(
+                    builder: (context) {
+                      String? selectedText;
+                      return SelectionArea(
+                        onSelectionChanged: (SelectedContent? selectedContent) {
+                          selectedText = selectedContent?.plainText;
+                        },
+                        contextMenuBuilder: (context, selectableRegionState) {
+                          return omiSelectionMenuBuilder(context, selectableRegionState, (text) {
+                            widget.onAskOmi?.call(text);
+                          }, selectedText: selectedText);
+                        },
+                        child: getMarkdownWidget(context, widget.messageText, onAskOmi: widget.onAskOmi),
+                      );
                     },
-                    contextMenuBuilder: (context, selectableRegionState) {
-                      return omiSelectionMenuBuilder(context, selectableRegionState, (text) {
-                        widget.onAskOmi?.call(text);
-                      }, selectedText: selectedText);
-                    },
-                    child: getMarkdownWidget(context, widget.messageText, onAskOmi: widget.onAskOmi),
-                  );
-                },
-              ),
+                  ),
         if (widget.messageText.isNotEmpty && widget.messageText != '...' && !widget.showTypingIndicator)
           MessageActionBar(
             messageText: widget.messageText,

--- a/app/lib/pages/chat/widgets/ai_message.dart
+++ b/app/lib/pages/chat/widgets/ai_message.dart
@@ -951,7 +951,7 @@ class _MemoriesMessageWidgetState extends State<MemoriesMessageWidget> {
     context.read<ConversationDetailProvider>().updateConversation(conversation.id, date);
     await Navigator.of(
       context,
-    ).push(MaterialPageRoute(builder: (c) => ConversationDetailPage(conversation: conversation!)));
+    ).push(MaterialPageRoute(builder: (c) => ConversationDetailPage(conversation: conversation)));
 
     if (SharedPreferencesUtil().modifiedConversationDetails?.id == conversation.id) {
       final modifiedDetails = SharedPreferencesUtil().modifiedConversationDetails!;

--- a/app/lib/pages/chat/widgets/jump_to_latest_button.dart
+++ b/app/lib/pages/chat/widgets/jump_to_latest_button.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+/// Compact "Latest" chip. Sized to its child so a Stack can place it over the
+/// transcript without a full-width hit-test absorber covering citation cards.
+class ChatJumpToLatestButton extends StatelessWidget {
+  const ChatJumpToLatestButton({super.key, required this.label, required this.onTap});
+
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Semantics(
+        label: label,
+        button: true,
+        child: Tooltip(
+          message: label,
+          child: Material(
+            color: Colors.transparent,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(24),
+              onTap: onTap,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF1F1F25).withValues(alpha: 0.95),
+                  borderRadius: BorderRadius.circular(24),
+                  border: Border.all(color: Colors.white.withValues(alpha: 0.18), width: 1),
+                  boxShadow: [
+                    BoxShadow(color: Colors.black.withValues(alpha: 0.28), blurRadius: 12, offset: const Offset(0, 4)),
+                  ],
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(Icons.keyboard_arrow_down_rounded, color: Colors.white, size: 22),
+                    const SizedBox(width: 6),
+                    Text(
+                      label,
+                      style: const TextStyle(color: Colors.white, fontSize: 14, fontWeight: FontWeight.w600),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/test/widgets/chat_citation_taps_test.dart
+++ b/app/test/widgets/chat_citation_taps_test.dart
@@ -12,7 +12,6 @@ import 'package:omi/pages/chat/widgets/ai_message.dart';
 import 'package:omi/pages/chat/widgets/jump_to_latest_button.dart';
 import 'package:omi/providers/connectivity_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
-import 'package:omi/utils/other/temp.dart';
 import 'package:omi/widgets/components/chat_evidence_card.dart';
 
 void main() {
@@ -87,8 +86,8 @@ void main() {
   });
 
   testWidgets('a memories message renders one source list and all attached citations', (tester) async {
-    final evidence = ChatEvidenceReferenceEnvelope(
-      references: const [
+    const evidence = ChatEvidenceReferenceEnvelope(
+      references: [
         ChatEvidenceReference(
           id: 'summary-0',
           kind: ChatEvidenceReferenceKind.conversationSummary,

--- a/app/test/widgets/chat_citation_taps_test.dart
+++ b/app/test/widgets/chat_citation_taps_test.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/message.dart';
+import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/models/chat_evidence_reference.dart';
+import 'package:omi/pages/chat/widgets/ai_message.dart';
+import 'package:omi/pages/chat/widgets/jump_to_latest_button.dart';
+import 'package:omi/providers/connectivity_provider.dart';
+import 'package:omi/providers/conversation_provider.dart';
+import 'package:omi/utils/other/temp.dart';
+import 'package:omi/widgets/components/chat_evidence_card.dart';
+
+void main() {
+  ServerMessage messageWithMemories({int memoryCount = 3, ChatEvidenceReferenceEnvelope? evidence}) {
+    final createdAt = DateTime.parse('2026-08-23T12:00:00Z');
+    final memories = List<MessageConversation>.generate(
+      memoryCount,
+      (index) =>
+          MessageConversation('convo-$index', createdAt, MessageConversationStructured('Conversation $index', '🧠')),
+    );
+    return ServerMessage(
+      'ai-1',
+      createdAt,
+      'You talked about shipping the citation fix.',
+      MessageSender.ai,
+      MessageType.text,
+      null,
+      false,
+      const [],
+      const [],
+      memories,
+      evidenceEnvelope: evidence,
+    );
+  }
+
+  Future<void> pumpCitations(
+    WidgetTester tester, {
+    required ServerMessage message,
+    Future<ServerConversation?> Function(String id)? fetchConversation,
+    ConversationProvider? conversations,
+  }) async {
+    final ownedProvider = conversations == null;
+    final conversationProvider = conversations ?? ConversationProvider(isSignedIn: () => false);
+    if (ownedProvider) {
+      addTearDown(conversationProvider.dispose);
+    }
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider.value(value: conversationProvider),
+          ChangeNotifierProvider(create: (_) => ConnectivityProvider()),
+        ],
+        child: MaterialApp(
+          theme: ThemeData.dark(),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: AIMessage(
+                message: message,
+                sendMessage: (_) {},
+                displayOptions: false,
+                updateConversation: (_) {},
+                setMessageNps: (int value, {String? reason}) {},
+                fetchConversation: fetchConversation,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('citation GestureDetectors are not wrapped by SelectionArea', (tester) async {
+    await pumpCitations(tester, message: messageWithMemories());
+
+    final citation = find.byKey(const ValueKey('chat-citation-convo-0'));
+    expect(citation, findsOneWidget);
+    expect(find.ancestor(of: citation, matching: find.byType(SelectionArea)), findsNothing);
+    expect(find.ancestor(of: find.byType(MarkdownBody), matching: find.byType(SelectionArea)), findsOneWidget);
+  });
+
+  testWidgets('a memories message renders one source list and all attached citations', (tester) async {
+    final evidence = ChatEvidenceReferenceEnvelope(
+      references: const [
+        ChatEvidenceReference(
+          id: 'summary-0',
+          kind: ChatEvidenceReferenceKind.conversationSummary,
+          state: ChatEvidenceReferenceState.available,
+          conversationId: 'convo-0',
+          title: 'Conversation 0',
+          summary: 'Standup overview that must not duplicate the citation pills.',
+        ),
+        ChatEvidenceReference(
+          id: 'summary-1',
+          kind: ChatEvidenceReferenceKind.conversationSummary,
+          state: ChatEvidenceReferenceState.available,
+          conversationId: 'convo-1',
+          title: 'Conversation 1',
+          summary: 'Another dead overview card.',
+        ),
+      ],
+    );
+
+    await pumpCitations(tester, message: messageWithMemories(memoryCount: 5, evidence: evidence));
+
+    expect(find.byKey(const ValueKey('chat-citation-list')), findsOneWidget);
+    expect(find.byKey(const ValueKey('chat-evidence-reference-list')), findsNothing);
+    expect(find.byType(ChatEvidenceReferenceCard), findsNothing);
+    for (var index = 0; index < 5; index++) {
+      expect(find.byKey(ValueKey('chat-citation-convo-$index')), findsOneWidget);
+      expect(find.textContaining('Conversation $index'), findsOneWidget);
+    }
+  });
+
+  testWidgets('citation tap fetches by id on a local miss and surfaces failure', (tester) async {
+    final fetchedIds = <String>[];
+    final conversations = ConversationProvider(isSignedIn: () => false);
+    addTearDown(conversations.dispose);
+
+    await pumpCitations(
+      tester,
+      message: messageWithMemories(memoryCount: 1),
+      conversations: conversations,
+      fetchConversation: (id) async {
+        fetchedIds.add(id);
+        return null;
+      },
+    );
+
+    await tester.tap(find.byKey(const ValueKey('chat-citation-convo-0')));
+    await tester.pumpAndSettle();
+
+    expect(fetchedIds, ['convo-0']);
+    expect(find.text('Conversation not found or has been deleted'), findsOneWidget);
+  });
+
+  test('resolveChatCitationConversation fetches when the grouped map misses', () async {
+    final conversations = ConversationProvider(isSignedIn: () => false);
+    addTearDown(conversations.dispose);
+
+    var fetched = false;
+    final fetchedConversation = ServerConversation(
+      id: 'remote-1',
+      createdAt: DateTime.parse('2026-08-23T12:00:00Z'),
+      structured: Structured('Remote', 'Overview', emoji: '🧠'),
+    );
+
+    final resolved = await resolveChatCitationConversation(
+      conversations: conversations,
+      conversationId: 'remote-1',
+      fetchConversation: (id) async {
+        fetched = true;
+        expect(id, 'remote-1');
+        return fetchedConversation;
+      },
+    );
+
+    expect(fetched, isTrue);
+    expect(resolved, same(fetchedConversation));
+  });
+
+  test('resolveChatCitationConversation uses the local group and skips the fetch', () async {
+    final conversations = ConversationProvider(isSignedIn: () => false);
+    addTearDown(conversations.dispose);
+    final local = ServerConversation(
+      id: 'local-1',
+      createdAt: DateTime.parse('2026-08-23T12:00:00Z'),
+      structured: Structured('Local', 'Overview', emoji: '🧠'),
+    );
+    conversations.conversations = [local];
+    conversations.groupedConversations = {
+      conversationLocalDayKey(local.createdAt): [local],
+    };
+
+    var fetched = false;
+    final resolved = await resolveChatCitationConversation(
+      conversations: conversations,
+      conversationId: 'local-1',
+      fetchConversation: (_) async {
+        fetched = true;
+        return null;
+      },
+    );
+
+    expect(fetched, isFalse);
+    expect(resolved, same(local));
+  });
+
+  testWidgets('Latest chip does not absorb taps beside itself', (tester) async {
+    var behindTapped = false;
+    var chipTapped = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 400,
+          height: 400,
+          child: Stack(
+            alignment: Alignment.bottomCenter,
+            children: [
+              Positioned.fill(
+                child: GestureDetector(
+                  onTap: () => behindTapped = true,
+                  behavior: HitTestBehavior.opaque,
+                  child: const ColoredBox(color: Color(0xFF111111)),
+                ),
+              ),
+              ChatJumpToLatestButton(label: 'Latest', onTap: () => chipTapped = true),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await tester.tapAt(const Offset(24, 372));
+    expect(behindTapped, isTrue);
+    expect(chipTapped, isFalse);
+
+    await tester.tap(find.text('Latest'));
+    expect(chipTapped, isTrue);
+  });
+}


### PR DESCRIPTION
## What changed and why

iOS chat was showing the same cited conversations twice: tappable emoji+title pills, then dead evidence overview cards underneath. Taps on the real cards were eaten by a parent `SelectionArea`, a full-width Latest overlay, and a last-AI-message `minHeight: 50%` spacer that shoved sources under the composer. This PR keeps one source list (all attached memories, matching the backend cap of 5), keeps selection on markdown only, hit-tests only the Latest chip, drops the spacer, and fetches by id on a local miss instead of returning silently.

Branched from `origin/main` at `f85535b9957a90115b0f9cd0a1111e09273f41bf`.

Closes SCA-377

## Product invariants affected

none

## How it was verified

Focused Flutter widget/unit tests (no physical iOS device in this session):

```
cd app && flutter test test/widgets/chat_citation_taps_test.dart test/widgets/chat_evidence_card_test.dart
```

Result: `10: All tests passed!`

Could not exercise the live iOS chat surface on David's device. Widget tests prove the tap, overlay, and duplicate-list contracts.

## Tests

`app/test/widgets/chat_citation_taps_test.dart` is the regression suite:

- Citation `GestureDetector`s are not descendants of `SelectionArea`; markdown still is
- A memories message with conversation-summary evidence builds one citation list and all 5 attached memories, not the dead overview cards
- Local group miss calls the injected `getConversationById` and shows `conversationNotFoundOrDeleted` instead of a silent return
- Latest chip does not absorb taps beside itself

Existing `app/test/widgets/chat_evidence_card_test.dart` still passes for messages that only have supplemental evidence.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative

`FC-ancestor-chrome-steals-control-taps` — a control that owns a tap must remain the hit-test target for its own bounds, and a tap that cannot complete must surface a failure. Ancestors installed for text selection, jump-to-latest chrome, or last-message min-height must not steal those hits or bury the control. Guard: `app/test/widgets/chat_citation_taps_test.dart`. `evidence_prs` is empty because this PR is the first instance.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

