### PR TITLE
SCA-378: stop chat-agent loop guard from aborting a collected answer

### DIFF
--- a/.github/failure-classes/FC-loop-guard-aborts-collected-answer.json
+++ b/.github/failure-classes/FC-loop-guard-aborts-collected-answer.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-loop-guard-aborts-collected-answer",
+  "violated_contract": "A chat-agent safety guard may emit the canned stuck abort only when the next tool call is an exact repeat of a recent (tool_name, canonical params) pair and no retrieval context has been collected. Treating shared defaults or overlapping keys as a loop, or showing \"stuck, rephrase\" after conversations_collected (or equivalent) is already non-empty, replaces a deliverable answer with a user-facing abort.",
+  "canonical_prevention": "Compare loop membership on exact canonical (tool_name, params) with None treated as missing. When a repeat is detected and collected results are non-empty, raise CollectedContextReady so the runner stops tools and lets the model answer. Keep the hard max_tool_calls and context-size caps. Pin the cases with behavioral tests: different queries sharing a window do not trip; identical params still guard; collected results raise CollectedContextReady; the canned stuck text is forbidden once results exist.",
+  "canonical_prevention_artifact": [
+    "backend/utils/retrieval/safety.py",
+    "backend/tests/unit/test_chat_agent_loop_guard.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/utils/retrieval/safety.py",
+    "backend/utils/retrieval/agentic.py",
+    "backend/tests/unit/test_chat_agent_loop_guard.py"
+  ],
+  "status": "open"
+}

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -64,13 +64,13 @@ backend/
     llm/                  #   LLM orchestration (14 files): chat processing, conversation post-processing,
                           #   memory extraction, persona management, proactive notifications, goal tracking,
                           #   app generation, fair-use classification, usage tracking
-      clients.py          #     Model instances: OpenAI (Luna/Nano), Anthropic (claude-sonnet-4-6),
+      clients.py          #     Model instances: OpenAI (Luna/Nano), leftover Anthropic (desktop),
                           #     OpenRouter (gemini-flash), with prompt caching and usage callbacks
     stt/                  #   Speech-to-text (7 files): Parakeet/Modulate and explicit self-hosted Deepgram streaming, VAD gating, speech profiles,
                           #   pre-recorded batch transcription, speaker embeddings
     conversations/        #   Conversation lifecycle (6 files): ingestion, memory extraction, action items,
                           #   merge, post-processing, search
-    retrieval/            #   RAG pipeline (25+ files): agentic RAG via Claude with 18 tool types —
+    retrieval/            #   RAG pipeline (25+ files): agentic RAG via gateway Luna (gpt-5.6-luna) with 18 tool types —
                           #   action items, calendar, Gmail, Apple Health, conversations, memories,
                           #   screen activity, files, Perplexity web search, notifications, etc.
     other/                #   Storage (GCS), auth dependencies, timeout middleware, Hume emotion detection

--- a/backend/docs/llm/model_endpoint_inventory.yaml
+++ b/backend/docs/llm/model_endpoint_inventory.yaml
@@ -96,13 +96,13 @@ surfaces:
     gateway_lane_capability_needed: generated feature lanes
     migration_status: gateway_capable_central_flip
     test_guardrail_coverage: backend/tests/unit/test_llm_gateway_coverage_guardrails.py
-  - surface: anthropic_agentic_chat
-    code_path: backend/utils/llm/gateway_anthropic.py:_GatewayAnthropicStream
-    current_provider_model: anthropic/chat_agent
-    request_shape: streaming, native tool calling, server-side web search
-    gateway_lane_capability_needed: native anthropic.messages surface with streaming and tools on omi:auto:chat-agent
-    migration_status: gateway_only_fail_closed; transport failures and an open circuit return a typed gateway-unavailable error without constructing or calling a direct Anthropic client
-    test_guardrail_coverage: backend/tests/unit/test_gateway_anthropic_client.py
+  - surface: openai_agentic_chat
+    code_path: backend/utils/retrieval/agentic.py:_run_openai_agent_stream
+    current_provider_model: gateway lane omi:auto:chat-agent (openai/gpt-5.6-luna); direct OpenAI only when OMI_LLM_CHAT_AGENT_ROUTE=direct
+    request_shape: streaming OpenAI chat-completions with function tools; independent tool_use blocks run concurrently
+    gateway_lane_capability_needed: openai.chat_completions surface with streaming and tools on omi:auto:chat-agent
+    migration_status: gateway_luna_chat_agent; Omi-managed traffic is get_llm('chat_agent') through the generated OpenAI lane and fails closed on gateway transport / open circuit. Anthropic Messages (gateway_anthropic / anthropic_messages router) remains for desktop specialist/BYOK callers, not this chat lane.
+    test_guardrail_coverage: backend/tests/unit/test_chat_agent_provider_retry.py and backend/tests/unit/test_chat_agent_loop_guard.py
   - surface: perplexity_web_search_tool
     code_path: backend/utils/retrieval/tools/perplexity_tools.py:perplexity_web_search_tool
     current_provider_model: perplexity/web_search

--- a/backend/docs/runbooks/llm-gateway-fallback.md
+++ b/backend/docs/runbooks/llm-gateway-fallback.md
@@ -51,6 +51,6 @@ OMI_LLM_GATEWAY_FEATURE_MODE=off
 ```
 (optional also set `CHAT_AGENT_ROUTE=direct`)
 
-**Contract:** `should_route_chat_agent_through_gateway()` requires **both** chat-agent route=`gateway` **and** feature mode on. Direct Anthropic BYOK still bypasses the managed lane.
+**Contract:** `should_route_chat_agent_through_gateway()` requires **both** chat-agent route=`gateway` **and** feature mode on. Omi-managed chat-agent traffic is always the OpenAI/Luna runner (`get_llm('chat_agent')`); Anthropic BYOK no longer selects a second Messages path on this lane. `CHAT_AGENT_ROUTE=direct` is the chat-only kill switch onto direct OpenAI.
 
 **Severity:** Ticket — investigate during business hours unless user-facing chat error rates also rise.

--- a/backend/tests/integration/test_qos_all_features_l1.py
+++ b/backend/tests/integration/test_qos_all_features_l1.py
@@ -31,7 +31,7 @@ from utils.llm.clients import (
 SIMPLE_PROMPT = "Reply with exactly one word: hello"
 
 # Features that can't use get_llm() — need their own client
-_ANTHROPIC_FEATURES = {'chat_agent'}
+_ANTHROPIC_FEATURES: set[str] = set()
 _PERPLEXITY_FEATURES = {'web_search'}
 _SKIP_GET_LLM = _ANTHROPIC_FEATURES | _PERPLEXITY_FEATURES
 
@@ -75,19 +75,17 @@ class TestPremiumAllFeatures:
         print(f"  PASS {feature}: {model} [{provider}] -> {text[:60]}")
 
     @pytest.mark.asyncio
-    async def test_premium_chat_agent(self):
-        """Test chat_agent via Anthropic client."""
+    def test_premium_chat_agent(self):
+        """Test chat_agent via get_llm (OpenAI/Luna)."""
         if _active_profile_name != 'premium':
             pytest.skip("MODEL_QOS is not premium")
         model = get_model('chat_agent')
-        response = await anthropic_client.messages.create(
-            model=model,
-            max_tokens=50,
-            messages=[{"role": "user", "content": SIMPLE_PROMPT}],
-        )
-        text = response.content[0].text.strip()
+        assert model == 'gpt-5.6-luna'
+        llm = get_llm('chat_agent')
+        response = llm.invoke(SIMPLE_PROMPT)
+        text = response.content.strip() if hasattr(response, 'content') else str(response).strip()
         assert text, f"FAIL chat_agent ({model}) returned empty"
-        print(f"  PASS chat_agent: {model} [anthropic] -> {text[:60]}")
+        print(f"  PASS chat_agent: {model} [openai] -> {text[:60]}")
 
     def test_premium_web_search(self):
         """Test web_search via Perplexity."""

--- a/backend/tests/integration/test_qos_live_cp9.py
+++ b/backend/tests/integration/test_qos_live_cp9.py
@@ -190,7 +190,7 @@ class TestP5_BYOKProfileFixed:
 
     def test_byok_mostly_openai(self):
         """byok profile should use OpenAI for most features (chat_agent/web_search are exceptions)."""
-        exceptions = {'chat_agent': 'anthropic', 'web_search': 'perplexity', 'wrapped_analysis': 'openrouter'}
+        exceptions = {'web_search': 'perplexity', 'wrapped_analysis': 'openrouter'}
         for feature, (model, provider) in MODEL_QOS_PROFILES['byok'].items():
             if feature in exceptions:
                 assert provider == exceptions[feature], f'byok {feature} expected {exceptions[feature]}, got {provider}'

--- a/backend/tests/integration/test_qos_real_llm.py
+++ b/backend/tests/integration/test_qos_real_llm.py
@@ -199,21 +199,17 @@ class TestPremiumOpenRouter:
 # ---------------------------------------------------------------------------
 # Premium profile — Anthropic (via get_model + anthropic_client)
 # ---------------------------------------------------------------------------
-class TestPremiumAnthropic:
-    """Test chat_agent via Anthropic client (get_model, not get_llm)."""
+class TestPremiumChatAgent:
+    """Test chat_agent via get_llm (OpenAI/Luna)."""
 
-    @pytest.mark.asyncio
-    async def test_chat_agent_anthropic(self):
+    def test_chat_agent_luna(self):
         model = get_model('chat_agent')
-        assert model == 'claude-sonnet-4-6', f"chat_agent should be claude-sonnet-4-6, got {model}"
+        assert model == 'gpt-5.6-luna', f"chat_agent should be gpt-5.6-luna, got {model}"
         assert model == ANTHROPIC_AGENT_MODEL
 
-        response = await anthropic_client.messages.create(
-            model=model,
-            max_tokens=50,
-            messages=[{"role": "user", "content": SIMPLE_PROMPT}],
-        )
-        text = response.content[0].text.strip()
+        llm = get_llm('chat_agent')
+        response = llm.invoke(SIMPLE_PROMPT)
+        text = response.content.strip() if hasattr(response, 'content') else str(response).strip()
         assert text, f"chat_agent ({model}) returned empty response"
         print(f"  chat_agent ({model}): {text[:60]}")
 

--- a/backend/tests/unit/test_agentic_web_search_taint.py
+++ b/backend/tests/unit/test_agentic_web_search_taint.py
@@ -178,11 +178,15 @@ def test_unknown_producer_is_treated_as_private(monkeypatch):
 
 
 def test_withheld_path_is_recorded_once_per_loop(monkeypatch):
-    """Telemetry marks the transition, not every subsequent request."""
+    """Telemetry marks the transition, not every subsequent request.
+
+    The second memories call must use different params so the shared exact-repeat
+    loop guard does not abort the leftover Anthropic runner mid-loop.
+    """
     registry = {'get_memories_tool': _FakeTool('get_memories_tool', 'private')}
     turns = [
-        (_response('tool_use', [_tool_use('use_1', 'get_memories_tool')]), []),
-        (_response('tool_use', [_tool_use('use_2', 'get_memories_tool')]), []),
+        (_response('tool_use', [_tool_use('use_1', 'get_memories_tool', {'query': 'deck'})]), []),
+        (_response('tool_use', [_tool_use('use_2', 'get_memories_tool', {'query': 'passphrase'})]), []),
         (_response('end_turn', [_answer('done')]), [_text_delta('done')]),
     ]
     requests, fallbacks = _drive_loop(monkeypatch, turns=turns, registry=registry)
@@ -193,10 +197,13 @@ def test_withheld_path_is_recorded_once_per_loop(monkeypatch):
     assert len(fallbacks) == 1
 
 
-def test_convert_tools_still_offers_web_search():
-    """The gate belongs in the loop; composition keeps offering the capability."""
+def test_convert_tools_does_not_offer_anthropic_server_web_search():
+    """Live composition is OpenAI function tools; Anthropic web_search is leftover-only."""
     schemas, _ = agentic._convert_tools([], [])
-    assert WEB_SEARCH_NAME in [schema.get('name') for schema in schemas]
+    top_level_names = [schema.get('name') for schema in schemas]
+    function_names = [schema.get('function', {}).get('name') for schema in schemas if isinstance(schema, dict)]
+    assert WEB_SEARCH_NAME not in top_level_names
+    assert WEB_SEARCH_NAME not in function_names
 
 
 @pytest.mark.parametrize(
@@ -239,17 +246,23 @@ def test_anthropic_classifier_reads_wire_shape(messages, expected):
 
 
 def test_managed_lane_never_ships_the_provider_executed_tool():
-    """The gate is scoped to the direct Anthropic lane on purpose.
+    """The gate is scoped to the leftover Anthropic lane on purpose.
 
-    The managed (OpenAI-compatible) lane drops server tools when it converts the
-    schemas — they carry no ``input_schema`` — and reaches the public web through
-    the in-process Perplexity function tool instead, which does pass through
-    ``_execute_tool``. If that conversion ever started forwarding server tools,
-    the managed lane would acquire the same unguarded egress path with no gate in
-    front of it.
+    Live ``_convert_tools`` emits OpenAI function schemas only. The leftover
+    converter still drops Anthropic server tools (no ``input_schema``) so a
+    specialist fixture cannot smuggle ``web_search`` onto the managed lane.
+    Public web search on the live path is the in-process Perplexity function
+    tool, which does pass through ``_execute_tool``.
     """
     schemas, _ = agentic._convert_tools([], [])
-    converted = agentic._convert_anthropic_tools_to_openai(schemas)
+    live_names = [
+        schema.get('function', {}).get('name') if isinstance(schema.get('function'), dict) else schema.get('name')
+        for schema in schemas
+    ]
+    assert WEB_SEARCH_NAME not in live_names
 
-    assert WEB_SEARCH_NAME in [schema.get('name') for schema in schemas]
+    converted = agentic._convert_anthropic_tools_to_openai(
+        [agentic.WEB_SEARCH_TOOL, agentic.TOOL_SEARCH_TOOL, _schema('lookup')]
+    )
     assert WEB_SEARCH_NAME not in [tool['function']['name'] for tool in converted]
+    assert [tool['function']['name'] for tool in converted] == ['lookup']

--- a/backend/tests/unit/test_chat_agent_loop_guard.py
+++ b/backend/tests/unit/test_chat_agent_loop_guard.py
@@ -1,0 +1,182 @@
+"""Loop-guard and parallel-tool contracts for agentic chat.
+
+David's iOS recall (yesterday / friends / bars / jobs) hit the 80% key-overlap
+gate because search_conversations shares a date window and defaults; only
+``query`` changed. Hits were already in conversations_collected.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from utils.retrieval.safety import AgentSafetyGuard, CollectedContextReady, SafetyGuardError
+
+from tests.unit.test_chat_agent_provider_retry import _FakeChatModel, _openai_chunk
+from tests.unit.test_prompt_cache_integration import _get_agentic_module
+
+
+def _search_params(query: str) -> dict:
+    return {
+        'query': query,
+        'start_date': '2026-08-29',
+        'end_date': '2026-08-30',
+        'limit': 10,
+        'include_transcript': True,
+    }
+
+
+class TestSearchConversationsLoopGuard:
+    def test_different_queries_same_window_do_not_trip(self):
+        guard = AgentSafetyGuard()
+        guard.validate_tool_call('search_conversations', _search_params('yesterday'))
+        guard.validate_tool_call('search_conversations', _search_params('friends'))
+        guard.validate_tool_call('search_conversations', _search_params('bars'))
+        guard.validate_tool_call('search_conversations', _search_params('jobs'))
+        assert guard.tool_call_count == 4
+
+    def test_identical_params_twice_still_guard(self):
+        guard = AgentSafetyGuard()
+        params = _search_params('yesterday')
+        guard.validate_tool_call('search_conversations', params)
+        with pytest.raises(SafetyGuardError, match='stuck trying to answer'):
+            guard.validate_tool_call('search_conversations', dict(params))
+
+    def test_identical_params_with_collected_results_do_not_emit_stuck(self):
+        guard = AgentSafetyGuard()
+        params = _search_params('yesterday')
+        guard.validate_tool_call('search_conversations', params)
+        collected = [{'id': 'conv-1', 'title': 'Dinner'}]
+        with pytest.raises(CollectedContextReady):
+            guard.validate_tool_call('search_conversations', dict(params), collected_results=collected)
+
+
+@pytest.mark.asyncio
+async def test_abort_with_collected_results_is_forbidden():
+    """The canned stuck message must not replace an answer once retrieval collected hits."""
+    agentic_mod = _get_agentic_module()
+    guard = AgentSafetyGuard()
+    collected = [{'id': 'conv-1'}]
+    tool_calls = [
+        {'id': 'call_1', 'name': 'search_conversations', 'input': _search_params('yesterday')},
+        {'id': 'call_2', 'name': 'search_conversations', 'input': _search_params('yesterday')},
+    ]
+    callback = agentic_mod.AsyncStreamingCallback()
+    full_response = []
+
+    with patch.object(agentic_mod, '_execute_tool', new=AsyncMock(return_value='found dinner')):
+        results = await agentic_mod._execute_independent_tool_calls(
+            tool_calls,
+            name_of=lambda call: call['name'],
+            input_of=lambda call: call['input'],
+            id_of=lambda call: call['id'],
+            tool_registry={'search_conversations': MagicMock()},
+            configurable={'conversations_collected': collected},
+            safety_guard=guard,
+            callback=callback,
+            full_response=full_response,
+            result_factory=lambda call, result: {'id': call['id'], 'content': result},
+        )
+
+    assert results is not None
+    assert 'stuck trying to answer' not in ''.join(full_response)
+    assert results[-1]['content'] == agentic_mod._COLLECTED_CONTEXT_TOOL_STUB
+    assert guard.tool_call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_parallel_tool_calls_in_one_turn_overlap():
+    """Two tool_use blocks in one turn must start concurrently, not wait serially."""
+    agentic_mod = _get_agentic_module()
+    started: list[str] = []
+
+    async def fake_execute(tool_name, _tool_input, _registry, _configurable):
+        started.append(tool_name)
+        while len(started) < 2:
+            await asyncio.sleep(0)
+        return f'result-{tool_name}'
+
+    safety_guard = AgentSafetyGuard()
+    callback = agentic_mod.AsyncStreamingCallback()
+    full_response = []
+    tool_calls = [
+        {'id': 'call_1', 'name': 'lookup_a', 'input': {'query': 'a'}},
+        {'id': 'call_2', 'name': 'lookup_b', 'input': {'query': 'b'}},
+    ]
+
+    async def go():
+        return await agentic_mod._execute_independent_tool_calls(
+            tool_calls,
+            name_of=lambda call: call['name'],
+            input_of=lambda call: call['input'],
+            id_of=lambda call: call['id'],
+            tool_registry={'lookup_a': MagicMock(), 'lookup_b': MagicMock()},
+            configurable={'conversations_collected': []},
+            safety_guard=safety_guard,
+            callback=callback,
+            full_response=full_response,
+            result_factory=lambda call, result: {'id': call['id'], 'content': result},
+        )
+
+    with patch.object(agentic_mod, '_execute_tool', new=fake_execute):
+        results = await asyncio.wait_for(go(), timeout=1.0)
+
+    assert [item['content'] for item in results] == ['result-lookup_a', 'result-lookup_b']
+    assert set(started) == {'lookup_a', 'lookup_b'}
+    assert safety_guard.tool_call_count == 2
+    assert 'stuck' not in ''.join(full_response)
+
+
+@pytest.mark.asyncio
+async def test_managed_loop_runs_two_tool_calls_without_serial_wait():
+    agentic_mod = _get_agentic_module()
+    started: list[str] = []
+
+    async def fake_execute(tool_name, _tool_input, _registry, _configurable):
+        started.append(tool_name)
+        while len(started) < 2:
+            await asyncio.sleep(0)
+        return f'result-{tool_name}'
+
+    scripts = [
+        [
+            type(
+                'Chunk',
+                (),
+                {
+                    'content': '',
+                    'tool_call_chunks': [
+                        {'index': 0, 'id': 'call_1', 'name': 'lookup_a', 'args': '{}'},
+                        {'index': 1, 'id': 'call_2', 'name': 'lookup_b', 'args': '{}'},
+                    ],
+                },
+            )()
+        ],
+        [_openai_chunk('both done')],
+    ]
+    safety_guard = AgentSafetyGuard()
+    callback = agentic_mod.AsyncStreamingCallback()
+    full_response: list[str] = []
+
+    async def go():
+        with patch.object(agentic_mod, 'get_llm', return_value=_FakeChatModel(scripts)), patch.object(
+            agentic_mod, '_execute_tool', new=fake_execute
+        ), patch.object(agentic_mod, 'handle_llm_error_async', new=AsyncMock()), patch.object(
+            agentic_mod, 'record_fallback'
+        ):
+            return await agentic_mod._run_openai_agent_stream(
+                'SYSTEM',
+                [{'role': 'user', 'content': 'question'}],
+                [],
+                {'lookup_a': MagicMock(), 'lookup_b': MagicMock()},
+                callback,
+                full_response,
+                safety_guard,
+                {},
+            )
+
+    result = await asyncio.wait_for(go(), timeout=1.0)
+    assert result is None
+    assert set(started) == {'lookup_a', 'lookup_b'}
+    assert safety_guard.tool_call_count == 2
+    assert 'both done' in ''.join(full_response)

--- a/backend/tests/unit/test_chat_agent_provider_retry.py
+++ b/backend/tests/unit/test_chat_agent_provider_retry.py
@@ -519,9 +519,10 @@ async def test_gateway_mode_selects_openai_agent_runner(agentic_mod):
     assert [schema['function']['name'] for schema in seen['schemas']] == ['perplexity_web_search_tool']
 
 
-async def test_anthropic_byok_keeps_agentic_chat_on_direct_runner(agentic_mod):
+async def test_anthropic_byok_stays_on_openai_agent_runner(agentic_mod):
+    """Chat-agent BYOK Anthropic is dropped: one Luna/OpenAI path, no second Messages lane."""
     callback_data = {}
-    seen = {'direct': False}
+    seen = {'openai': False}
 
     async def fake_run_blocking(_executor, function, *_args, **_kwargs):
         if function is agentic_mod.get_user_timezone:
@@ -532,28 +533,26 @@ async def test_anthropic_byok_keeps_agentic_chat_on_direct_runner(agentic_mod):
             return []
         raise AssertionError(f'unexpected blocking setup call: {function}')
 
-    async def direct_runner(_system, _messages, _schemas, _registry, callback, full_response, _guard, _configurable):
-        seen['direct'] = True
-        full_response.append('direct answer')
-        await callback.put_data('direct answer')
+    async def openai_runner(_system, _messages, _schemas, _registry, callback, full_response, _guard, _configurable):
+        seen['openai'] = True
+        full_response.append('managed answer')
+        await callback.put_data('managed answer')
         await callback.end()
         return None
 
-    async def gateway_runner(*_args):
-        raise AssertionError('Anthropic BYOK must not select the gateway runner')
+    async def anthropic_runner(*_args):
+        raise AssertionError('Anthropic BYOK must not select the leftover Messages runner')
 
     with patch.object(agentic_mod, 'should_route_chat_agent_through_gateway', return_value=True), patch.object(
-        agentic_mod, 'get_byok_key', return_value='sk-ant-test'
-    ), patch.object(agentic_mod, 'run_blocking', new=fake_run_blocking), patch.object(
-        agentic_mod, '_convert_tools', return_value=([], {})
-    ), patch.object(
+        agentic_mod, 'run_blocking', new=fake_run_blocking
+    ), patch.object(agentic_mod, '_convert_tools', return_value=([], {})), patch.object(
         agentic_mod, '_messages_to_anthropic', return_value=[{'role': 'user', 'content': 'hello'}]
     ), patch.object(
         agentic_mod, '_inject_current_datetime', side_effect=lambda messages, _block: messages
     ), patch.object(
-        agentic_mod, '_run_openai_agent_stream', new=gateway_runner
+        agentic_mod, '_run_openai_agent_stream', new=openai_runner
     ), patch.object(
-        agentic_mod, '_run_anthropic_agent_stream', new=direct_runner
+        agentic_mod, '_run_anthropic_agent_stream', new=anthropic_runner
     ):
         chunks = [
             chunk
@@ -565,8 +564,8 @@ async def test_anthropic_byok_keeps_agentic_chat_on_direct_runner(agentic_mod):
             )
         ]
 
-    assert chunks == [f'think: {agentic_mod.AGENT_STREAM_SETUP_PROGRESS}', 'data: direct answer', None]
-    assert seen['direct'] is True
+    assert chunks == [f'think: {agentic_mod.AGENT_STREAM_SETUP_PROGRESS}', 'data: managed answer', None]
+    assert seen['openai'] is True
 
 
 async def test_safety_guard_message_becomes_the_answer(agentic_mod):
@@ -610,7 +609,7 @@ async def test_unrecovered_provider_failure_is_reported_to_the_caller(agentic_mo
         return 'provider_ReadTimeout'
 
     callback_data = {}
-    with patch.object(agentic_mod, '_run_anthropic_agent_stream', new=producer):
+    with patch.object(agentic_mod, '_run_openai_agent_stream', new=producer):
         await _drain(
             agentic_mod.execute_agentic_chat_stream(
                 'uid_test',
@@ -632,7 +631,7 @@ async def test_successful_turn_reports_no_error(agentic_mod):
         return None
 
     callback_data = {}
-    with patch.object(agentic_mod, '_run_anthropic_agent_stream', new=producer):
+    with patch.object(agentic_mod, '_run_openai_agent_stream', new=producer):
         await _drain(
             agentic_mod.execute_agentic_chat_stream(
                 'uid_test',

--- a/backend/tests/unit/test_chat_async_offload.py
+++ b/backend/tests/unit/test_chat_async_offload.py
@@ -62,7 +62,7 @@ async def _collect_agentic_chunks(producer, callback_data=None):
         stack.enter_context(patch.object(agentic, '_convert_tools', lambda _core, _app: ([], {})))
         stack.enter_context(patch.object(agentic, '_messages_to_anthropic', lambda _messages: []))
         stack.enter_context(patch.object(agentic, '_inject_current_datetime', lambda messages, _block: messages))
-        stack.enter_context(patch.object(agentic, '_run_anthropic_agent_stream', producer))
+        stack.enter_context(patch.object(agentic, '_run_openai_agent_stream', producer))
         return [
             chunk
             async for chunk in agentic.execute_agentic_chat_stream(
@@ -410,7 +410,7 @@ async def test_agentic_setup_reads_run_off_loop():
     ), patch.object(
         agentic, '_inject_current_datetime', lambda anthropic_messages, block: []
     ), patch.object(
-        agentic, '_run_anthropic_agent_stream', fake_agent_stream
+        agentic, '_run_openai_agent_stream', fake_agent_stream
     ):
         chunks = []
         async for chunk in agentic.execute_agentic_chat_stream(
@@ -461,7 +461,7 @@ async def test_agentic_chat_uses_server_rollout_for_jit_gate_and_config():
     ), patch.object(
         agentic, '_inject_current_datetime', side_effect=lambda messages, _block: messages
     ), patch.object(
-        agentic, '_run_anthropic_agent_stream', new=fake_agent_stream
+        agentic, '_run_openai_agent_stream', new=fake_agent_stream
     ):
         chunks = [
             chunk
@@ -689,7 +689,7 @@ async def test_agentic_setup_budget_does_not_consume_first_event_deadline():
     ), patch.object(
         agentic, '_inject_current_datetime', lambda messages, _block: messages
     ), patch.object(
-        agentic, '_run_anthropic_agent_stream', quick_producer
+        agentic, '_run_openai_agent_stream', quick_producer
     ), patch.object(
         agentic, 'AGENT_STREAM_SETUP_TIMEOUT_SECONDS', 2.0
     ), patch.object(

--- a/backend/tests/unit/test_llm_gateway_client_config.py
+++ b/backend/tests/unit/test_llm_gateway_client_config.py
@@ -528,6 +528,58 @@ def test_perplexity_gateway_response_preserves_top_level_citations():
     assert 'https://example.com/source' in formatted
 
 
+def test_get_llm_chat_agent_uses_generated_auto_lane_in_gateway_mode(monkeypatch):
+    captured = {}
+    gateway = FakeChatModel(name='gateway', calls=[])
+    legacy = FakeChatModel(name='legacy', calls=[])
+
+    def fake_gateway(lane_id, streaming=False, options=None, *, feature=None):
+        captured['lane_id'] = lane_id
+        captured['streaming'] = streaming
+        captured['feature'] = feature
+        return gateway
+
+    monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.setenv(LLM_CHAT_AGENT_ROUTE_ENV_VAR, 'luna')
+    monkeypatch.setenv('OMI_ENV_STAGE', 'dev')
+    monkeypatch.delenv(gateway_shadow.DEV_SHADOW_ALL_ENABLED_ENV, raising=False)
+    monkeypatch.setattr(clients, 'get_or_create_omi_gateway_llm', fake_gateway)
+    monkeypatch.setattr(clients, 'get_default_client', lambda *args, **kwargs: legacy)
+
+    result = clients.get_llm('chat_agent', streaming=True)
+
+    assert result is gateway
+    assert captured == {
+        'lane_id': feature_auto_lane_id('chat_agent'),
+        'streaming': True,
+        'feature': 'chat_agent',
+    }
+    assert captured['lane_id'] == 'omi:auto:chat-agent'
+    assert legacy.calls == []
+
+
+def test_get_llm_chat_agent_kill_switch_stays_on_direct_openai(monkeypatch):
+    captured = {}
+    gateway = FakeChatModel(name='gateway', calls=[])
+    legacy = FakeChatModel(name='legacy', calls=[])
+
+    def fake_gateway(*args, **kwargs):
+        captured['used_gateway'] = True
+        return gateway
+
+    monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.setenv(LLM_CHAT_AGENT_ROUTE_ENV_VAR, 'direct')
+    monkeypatch.setenv('OMI_ENV_STAGE', 'dev')
+    monkeypatch.delenv(gateway_shadow.DEV_SHADOW_ALL_ENABLED_ENV, raising=False)
+    monkeypatch.setattr(clients, 'get_or_create_omi_gateway_llm', fake_gateway)
+    monkeypatch.setattr(clients, 'get_default_client', lambda *args, **kwargs: legacy)
+
+    result = clients.get_llm('chat_agent', streaming=True)
+
+    assert result is legacy
+    assert captured == {}
+
+
 def test_chat_agent_route_direct_while_feature_mode_gateway(monkeypatch):
     """Chat can stay direct while other features use the gateway."""
     monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')

--- a/backend/tests/unit/test_llm_gateway_config.py
+++ b/backend/tests/unit/test_llm_gateway_config.py
@@ -34,7 +34,7 @@ def test_gateway_route_overrides_do_not_change_the_legacy_model_profile():
     assert get_model('conv_discard') == 'gpt-5-nano'
     assert get_model('memories') == 'gpt-5.6-luna'
     assert get_model('fair_use') == 'gpt-5.6-luna'
-    assert get_model('chat_agent') == 'claude-sonnet-4-6'
+    assert get_model('chat_agent') == 'gpt-5.6-luna'
 
     assert config.route_artifacts['route.conv_discard.model_config.001'].primary.model == 'gpt-5-nano'
     assert config.route_artifacts['route.memories.model_config.001'].primary.model == 'gpt-5.6-luna'

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -245,7 +245,6 @@ class TestModelQosProfiles:
         """Each profile should have features across expected providers."""
         for profile_name, profile in MODEL_QOS_PROFILES.items():
             providers = {provider for _model, provider in profile.values()}
-            assert 'anthropic' in providers, f'{profile_name} missing Anthropic models'
             assert 'perplexity' in providers, f'{profile_name} missing Perplexity models'
             assert 'openrouter' in providers, f'{profile_name} should have OpenRouter (wrapped_analysis)'
         # OpenAI-based profiles must have OpenAI provider
@@ -288,6 +287,7 @@ class TestModelQosProfiles:
             'desktop_proactive_reasoning',
             'file_chat_vision',
             'file_chat_documents',
+            'chat_agent',
         }
         nano_features = {
             'conv_app_select',
@@ -314,7 +314,7 @@ class TestModelQosProfiles:
         assert premium['onboarding'] == ('gemini-2.5-flash-lite', 'gemini')
         assert premium['app_integration'] == ('gemini-2.5-flash-lite', 'gemini')
         assert premium['trends'] == ('gemini-2.5-flash-lite', 'gemini')
-        assert premium['chat_agent'] == ('claude-sonnet-4-6', 'anthropic')
+        assert premium['chat_agent'] == ('gpt-5.6-luna', 'openai')
         assert premium['web_search'] == ('sonar-pro', 'perplexity')
 
     def test_max_profile_model_variants(self):
@@ -324,7 +324,6 @@ class TestModelQosProfiles:
         expected = {
             'gpt-5.6-luna',
             'gpt-5-nano',
-            'claude-sonnet-4-6',
             'gemini-2.5-flash-lite',
             'gemini-3-flash-preview',
             'sonar-pro',
@@ -360,9 +359,9 @@ class TestGetModel:
     def test_pinned_feature_ignores_profile(self):
         assert get_model('fair_use') == 'gpt-5.6-luna'
 
-    def test_anthropic_feature_returns_model_string(self):
+    def test_chat_agent_returns_luna(self):
         model = get_model('chat_agent')
-        assert 'claude' in model
+        assert model == 'gpt-5.6-luna'
 
     def test_persona_chat_returns_model_string(self):
         model = get_model('persona_chat')
@@ -584,7 +583,7 @@ class TestGetQosInfo:
 
     def test_provider_classification_correct(self):
         info = get_qos_info()
-        assert info['chat_agent']['provider'] == 'anthropic'
+        assert info['chat_agent']['provider'] == 'openai'
         assert info['web_search']['provider'] == 'perplexity'
         assert info['conv_action_items']['provider'] == 'openai'
         # persona_chat uses direct OpenAI API in both profiles
@@ -597,7 +596,7 @@ class TestGetQosInfo:
     def test_get_provider_matches_profile(self):
         """get_provider() returns the explicit provider from the profile."""
         assert get_provider('conv_action_items') == 'openai'
-        assert get_provider('chat_agent') == 'anthropic'
+        assert get_provider('chat_agent') == 'openai'
         assert get_provider('web_search') == 'perplexity'
         assert get_provider('wrapped_analysis') == 'openrouter'
         assert get_provider('followup') == 'gemini'
@@ -617,8 +616,9 @@ class TestPinnedFeatures:
 class TestProviderClassification:
     """Verify provider routing from profile entries."""
 
-    def test_chat_agent_is_anthropic_only(self):
-        assert 'chat_agent' in _ANTHROPIC_ONLY_FEATURES
+    def test_chat_agent_is_not_anthropic_only(self):
+        assert 'chat_agent' not in _ANTHROPIC_ONLY_FEATURES
+        assert _ANTHROPIC_ONLY_FEATURES == set()
 
     def test_web_search_is_perplexity_only(self):
         assert 'web_search' in _PERPLEXITY_ONLY_FEATURES
@@ -645,9 +645,9 @@ class TestProviderClassification:
 class TestProviderSafetyGuard:
     """Verify get_llm() rejects Anthropic/Perplexity features and cross-provider overrides."""
 
-    def test_get_llm_rejects_anthropic_only_feature(self):
-        with pytest.raises(ValueError, match='Anthropic'):
-            get_llm('chat_agent')
+    def test_get_llm_accepts_chat_agent(self):
+        llm = get_llm('chat_agent')
+        assert hasattr(llm, 'invoke')
 
     def test_get_llm_rejects_perplexity_only_feature(self):
         with pytest.raises(ValueError, match='Perplexity'):
@@ -1020,7 +1020,6 @@ class TestBYOKProfile:
         bk = MODEL_QOS_PROFILES['byok']
         for feature, (model, provider) in bk.items():
             if feature in (
-                'chat_agent',
                 'web_search',
                 'wrapped_analysis',
                 'translation',
@@ -1041,7 +1040,6 @@ class TestBYOKProfile:
         expected = {
             'gpt-5.6-luna',
             'gpt-5-nano',
-            'claude-sonnet-4-6',
             'gemini-2.5-flash-lite',
             'gemini-3-flash-preview',
             'sonar-pro',

--- a/backend/tests/unit/test_prompt_cache_integration.py
+++ b/backend/tests/unit/test_prompt_cache_integration.py
@@ -775,31 +775,29 @@ def test_core_tools_not_accidentally_duplicated():
 # ---------------------------------------------------------------------------
 
 
-def test_convert_tools_produces_valid_anthropic_schemas():
-    """
-    _convert_tools should produce valid Anthropic tool schemas from CORE_TOOLS,
-    filtering out the 'config' parameter and preserving tool order.
-    """
+def _openai_tool_name(schema: dict) -> str:
+    return schema.get('function', {}).get('name') or schema.get('name')
+
+
+def test_convert_tools_produces_valid_openai_schemas():
+    """_convert_tools produces OpenAI chat-completions function schemas from CORE_TOOLS."""
     agentic_mod = _get_agentic_module()
 
     tool_schemas, tool_registry = agentic_mod._convert_tools(agentic_mod.CORE_TOOLS)
 
-    # +1 for web_search server tool
-    assert len(tool_schemas) == len(agentic_mod.CORE_TOOLS) + 1, "Should produce one schema per tool + web_search"
+    assert len(tool_schemas) == len(agentic_mod.CORE_TOOLS), "Should produce one schema per core tool"
     assert len(tool_registry) == len(agentic_mod.CORE_TOOLS), "Should register all client tools"
+    assert all(schema.get('type') != 'web_search_20260209' for schema in tool_schemas)
 
-    # First schema should be web_search server tool
-    assert tool_schemas[0]["type"] == "web_search_20260209"
-
-    for schema in tool_schemas[1:]:  # Skip web_search server tool
-        assert "name" in schema, "Schema must have a name"
-        assert "description" in schema, "Schema must have a description"
-        assert "input_schema" in schema, "Schema must have input_schema"
-        # Config parameter should be filtered out
-        props = schema["input_schema"].get("properties", {})
-        assert "config" not in props, f"Tool {schema['name']} should not expose 'config' parameter"
-        # Core tools should NOT have defer_loading
-        assert "defer_loading" not in schema, f"Core tool {schema['name']} should not have defer_loading"
+    for schema in tool_schemas:
+        function = schema['function']
+        assert schema['type'] == 'function'
+        assert function['name']
+        assert 'description' in function
+        assert 'parameters' in function
+        props = function['parameters'].get('properties', {})
+        assert 'config' not in props, f"Tool {function['name']} should not expose 'config' parameter"
+        assert 'defer_loading' not in schema, f"Core tool {function['name']} should not have defer_loading"
 
 
 def test_entity_timeline_is_registered_with_schema_and_display_status():
@@ -809,10 +807,10 @@ def test_entity_timeline_is_registered_with_schema_and_display_status():
     timeline_tool = next(tool for tool in agentic_mod.CORE_TOOLS if tool.name == "get_entity_timeline_tool")
     tool_schemas, tool_registry = agentic_mod._convert_tools(agentic_mod.CORE_TOOLS)
 
-    timeline_schema = next(schema for schema in tool_schemas if schema.get("name") == timeline_tool.name)
+    timeline_schema = next(schema for schema in tool_schemas if _openai_tool_name(schema) == timeline_tool.name)
     raw_schema = timeline_tool.args_schema.schema()
-    assert timeline_schema["input_schema"]["properties"] == raw_schema["properties"]
-    assert timeline_schema["input_schema"]["required"] == raw_schema["required"]
+    assert timeline_schema["function"]["parameters"]["properties"] == raw_schema["properties"]
+    assert timeline_schema["function"]["parameters"]["required"] == raw_schema["required"]
     assert tool_registry[timeline_tool.name] is timeline_tool
     assert agentic_mod.get_tool_display_name(timeline_tool.name) == "Reviewing entity timeline"
 
@@ -822,7 +820,7 @@ def test_knowledge_ledger_tools_are_registered_with_progressive_disclosure_names
     agentic_mod = _get_agentic_module()
 
     tool_schemas, tool_registry = agentic_mod._convert_tools(agentic_mod.CORE_TOOLS)
-    schema_names = {schema.get("name") for schema in tool_schemas}
+    schema_names = {_openai_tool_name(schema) for schema in tool_schemas}
     for name, display in (
         ("search_knowledge", "Searching current knowledge"),
         ("read_playbook", "Reading playbook"),
@@ -853,7 +851,7 @@ def test_ledger_write_verbs_are_registered_as_jit_only_with_display_names():
     agentic_mod = _get_agentic_module()
 
     tool_schemas, tool_registry = agentic_mod._convert_tools(agentic_mod.CORE_TOOLS)
-    schema_names = {schema.get("name") for schema in tool_schemas}
+    schema_names = {_openai_tool_name(schema) for schema in tool_schemas}
     for name, display in (
         ("save_playbook", "Saving playbook"),
         ("create_standing_trigger", "Creating standing trigger"),
@@ -865,11 +863,8 @@ def test_ledger_write_verbs_are_registered_as_jit_only_with_display_names():
         assert agentic_mod.get_tool_display_name(name) == display
 
 
-def test_convert_tools_defers_app_tools():
-    """
-    App tools should be marked with defer_loading=True and tool_search_tool
-    should be added when app tools are present.
-    """
+def test_convert_tools_exposes_app_tools_directly():
+    """Live chat-agent lane exposes app tools by name; no Anthropic tool_search."""
     agentic_mod = _get_agentic_module()
 
     mock_app_tool = MagicMock()
@@ -881,19 +876,10 @@ def test_convert_tools_defers_app_tools():
 
     tool_schemas, tool_registry = agentic_mod._convert_tools(agentic_mod.CORE_TOOLS, [mock_app_tool])
 
-    # Should have web_search + tool_search_tool + core tools + 1 app tool
-    assert len(tool_schemas) == len(agentic_mod.CORE_TOOLS) + 3  # +1 web_search, +1 search tool, +1 app tool
-
-    # First should be web_search server tool
-    assert tool_schemas[0]["type"] == "web_search_20260209"
-    # Second should be tool_search_tool
-    assert tool_schemas[1]["type"] == "tool_search_tool_regex_20251119"
-
-    # Last should be the deferred app tool
-    assert tool_schemas[-1]["name"] == "custom_weather_app"
-    assert tool_schemas[-1]["defer_loading"] is True
-
-    # Registry should include all tools
+    assert len(tool_schemas) == len(agentic_mod.CORE_TOOLS) + 1
+    assert all(schema.get('type') == 'function' for schema in tool_schemas)
+    assert _openai_tool_name(tool_schemas[-1]) == "custom_weather_app"
+    assert "defer_loading" not in tool_schemas[-1]
     assert "custom_weather_app" in tool_registry
 
 
@@ -906,8 +892,7 @@ def test_convert_tools_preserves_core_tool_order():
 
     tool_schemas, _ = agentic_mod._convert_tools(agentic_mod.CORE_TOOLS)
 
-    # Skip web_search server tool (first element) when checking core tool order
-    schema_names = [s["name"] for s in tool_schemas[1:]]
+    schema_names = [_openai_tool_name(s) for s in tool_schemas]
     core_names = [t.name for t in agentic_mod.CORE_TOOLS]
     assert schema_names == core_names, "Tool schema order must match CORE_TOOLS order"
 

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -580,6 +580,12 @@ def get_llm(
     get_model(feature) to get the model string and the provider-specific client.
     """
     gateway_feature_mode = should_route_features_through_gateway()
+    # Chat-agent has its own kill switch. FEATURE_MODE=gateway plus
+    # CHAT_AGENT_ROUTE=direct must stay on direct OpenAI/Luna, not the gateway lane
+    # and not a leftover Anthropic Messages client.
+    route_through_gateway = (
+        should_route_chat_agent_through_gateway() if feature == 'chat_agent' else gateway_feature_mode
+    )
 
     if is_anthropic_only_feature(feature) and not gateway_feature_mode:
         raise ValueError(
@@ -674,7 +680,7 @@ def get_llm(
     # VertexGeminiProvider._reject_byok() — Gemini BYOK must use the direct
     # OpenAI-compatible client, not the gateway lane.
     gateway_accepts_byok = effective_provider != "gemini"
-    if byok_key and gateway_feature_mode and effective_provider == lane_provider and gateway_accepts_byok:
+    if byok_key and route_through_gateway and effective_provider == lane_provider and gateway_accepts_byok:
         result = get_or_create_omi_gateway_llm_for_byok(
             feature_auto_lane_id(feature),
             provider=effective_provider,
@@ -689,7 +695,7 @@ def get_llm(
             if byok_client is not None
             else get_default_client(model, provider, streaming, get_route_options(feature, model, provider))
         )
-    elif gateway_feature_mode:
+    elif route_through_gateway:
         gateway_options = {}
         if request_timeout is not None:
             gateway_options["request_timeout"] = request_timeout

--- a/backend/utils/llm/model_config.py
+++ b/backend/utils/llm/model_config.py
@@ -73,6 +73,7 @@ _TWO_TIER_MODEL_PROFILE: Dict[str, Tuple[str, str]] = {
     'chat_responses': ('gpt-5.6-luna', 'openai'),
     'file_chat_vision': ('gpt-5.6-luna', 'openai'),
     'file_chat_documents': ('gpt-5.6-luna', 'openai'),
+    'chat_agent': ('gpt-5.6-luna', 'openai'),
     'chat_extraction': ('gpt-5.6-luna', 'openai'),
     'chat_graph': ('gpt-5.6-luna', 'openai'),
     'goals': ('gpt-5.6-luna', 'openai'),
@@ -102,7 +103,6 @@ _TWO_TIER_MODEL_PROFILE: Dict[str, Tuple[str, str]] = {
     'trends': ('gemini-2.5-flash-lite', 'gemini'),
     'translation': ('gemini-2.5-flash-lite', 'gemini'),
     'screen_frame_judge': ('gemini-2.5-flash-lite', 'gemini'),
-    'chat_agent': ('claude-sonnet-4-6', 'anthropic'),
     'wrapped_analysis': ('gemini-3-flash-preview', 'openrouter'),
     'web_search': ('sonar-pro', 'perplexity'),
 }
@@ -129,7 +129,8 @@ _byok_profile_name = 'byok'
 _byok_profile = MODEL_QOS_PROFILES[_byok_profile_name]
 
 # Features that can't go through get_llm() (non-ChatOpenAI providers).
-_ANTHROPIC_ONLY_FEATURES = {'chat_agent'}
+# chat_agent is OpenAI/Luna via get_llm(); the Anthropic Messages path is not a chat lane.
+_ANTHROPIC_ONLY_FEATURES: set[str] = set()
 _PERPLEXITY_ONLY_FEATURES = {'web_search'}
 
 

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -438,8 +438,7 @@ class AsyncStreamingCallback(BaseCallbackHandler):
 
 def _langchain_tool_parameters(lc_tool) -> tuple[str, str, dict]:
     """Shared name/description/JSON-schema extraction for both wire formats."""
-    schema_fn = getattr(lc_tool.args_schema, 'model_json_schema', None)
-    schema = schema_fn() if callable(schema_fn) else lc_tool.args_schema.schema()
+    schema = lc_tool.args_schema.schema()
     properties = {k: v for k, v in schema.get('properties', {}).items() if k != 'config'}
     required = [r for r in schema.get('required', []) if r != 'config']
     cleaned_properties = {}

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -69,18 +69,18 @@ from utils.retrieval.tool_result_boundaries import preserve_chat_memory_tool_res
 from utils.retrieval.chat_scope import build_chat_scope
 from utils.retrieval.safety import (
     AgentSafetyGuard,
+    CollectedContextReady,
     SafetyGuardError,
     fit_within_budget,
     provider_fallback_reason,
     should_retry_provider_error,
     INPUT_TOO_LONG_MESSAGE,
 )
-from utils.retrieval.web_search_gate import SERVER_WEB_SEARCH_NAME, WEB_SEARCH_TOOL, request_tools_after_private_taint
+from utils.retrieval.web_search_gate import WEB_SEARCH_TOOL, request_tools_after_private_taint
 from utils.observability.fallback import record_fallback
 from utils.llm.byok_errors import handle_llm_error_async
 from utils.llm.clients import anthropic_client, ANTHROPIC_AGENT_MODEL, get_llm, num_tokens_from_string
 from utils.llm.usage_tracker import reset_usage_context, set_usage_context
-from utils.byok import get_byok_key
 from utils.llm.chat import _get_agentic_qa_prompt, get_current_datetime_block, get_user_timezone
 from utils.executors import run_blocking, db_executor
 from utils.jit_rollout import JITDecisionStage, resolve_jit_rollout
@@ -220,6 +220,14 @@ AGENT_STREAM_PROVIDER_MIN_RETRY_HEADROOM_SECONDS = _positive_timeout_from_env(
 AGENT_STREAM_PROVIDER_MAX_ATTEMPTS = _positive_int_from_env('AGENT_STREAM_PROVIDER_MAX_ATTEMPTS', 3)
 AGENT_STREAM_PROVIDER_RETRY_BACKOFF_SECONDS = _positive_timeout_from_env(
     'AGENT_STREAM_PROVIDER_RETRY_BACKOFF_SECONDS', 1.0
+)
+# Independent tool_use blocks in one model turn run concurrently. Sequential is
+# only required when a later call depends on an earlier result in the same turn
+# (rare; default is parallel). Each call still counts toward the safety cap.
+AGENT_TOOL_TURN_CONCURRENCY = _positive_int_from_env('AGENT_TOOL_TURN_CONCURRENCY', 8)
+_COLLECTED_CONTEXT_TOOL_STUB = (
+    'Relevant conversations are already collected. Answer the user from that context '
+    'without calling this tool again.'
 )
 AGENT_STREAM_PROGRESS_HEARTBEAT = 'Still working…'
 AGENT_STREAM_SETUP_PROGRESS = 'Preparing response…'
@@ -423,30 +431,51 @@ class AsyncStreamingCallback(BaseCallbackHandler):
 
 
 # ---------------------------------------------------------------------------
-# Tool schema conversion: LangChain @tool -> Anthropic tool format
+# Tool schema conversion: LangChain @tool -> OpenAI chat-completions (live)
+# and Anthropic Messages (leftover specialist tests only).
 # ---------------------------------------------------------------------------
 
 
-def _langchain_tool_to_anthropic(lc_tool, defer_loading: bool = False) -> dict:
-    """Convert a LangChain @tool to Anthropic tool schema format."""
-    schema = lc_tool.args_schema.schema()
+def _langchain_tool_parameters(lc_tool) -> tuple[str, str, dict]:
+    """Shared name/description/JSON-schema extraction for both wire formats."""
+    schema_fn = getattr(lc_tool.args_schema, 'model_json_schema', None)
+    schema = schema_fn() if callable(schema_fn) else lc_tool.args_schema.schema()
     properties = {k: v for k, v in schema.get('properties', {}).items() if k != 'config'}
     required = [r for r in schema.get('required', []) if r != 'config']
-
-    # Clean up schema: remove 'title' keys that Pydantic adds (not needed by Anthropic)
     cleaned_properties = {}
-    for k, v in properties.items():
-        cleaned = {pk: pv for pk, pv in v.items() if pk != 'title'}
-        cleaned_properties[k] = cleaned
-
-    tool_def = {
-        "name": lc_tool.name,
-        "description": lc_tool.description,
-        "input_schema": {
-            "type": "object",
-            "properties": cleaned_properties,
-            "required": required,
+    for key, value in properties.items():
+        cleaned_properties[key] = {pk: pv for pk, pv in value.items() if pk != 'title'}
+    return (
+        lc_tool.name,
+        lc_tool.description,
+        {
+            'type': 'object',
+            'properties': cleaned_properties,
+            'required': required,
         },
+    )
+
+
+def _langchain_tool_to_openai(lc_tool) -> dict:
+    """Convert a LangChain @tool to the chat-completions function shape."""
+    name, description, parameters = _langchain_tool_parameters(lc_tool)
+    return {
+        'type': 'function',
+        'function': {
+            'name': name,
+            'description': description,
+            'parameters': parameters,
+        },
+    }
+
+
+def _langchain_tool_to_anthropic(lc_tool, defer_loading: bool = False) -> dict:
+    """Leftover Anthropic Messages schema. Not the live chat-agent path."""
+    name, description, parameters = _langchain_tool_parameters(lc_tool)
+    tool_def = {
+        "name": name,
+        "description": description,
+        "input_schema": parameters,
     }
     if defer_loading:
         tool_def["defer_loading"] = True
@@ -461,37 +490,109 @@ TOOL_SEARCH_TOOL = {
 
 
 def _convert_tools(core_tools: list, app_tools: list = None) -> tuple:
-    """Convert all tools and build name->object registry.
+    """Convert tools to the live OpenAI chat-completions function shape.
 
-    Core tools are always visible to Claude. App tools are marked with
-    defer_loading=True so Claude discovers them on-demand via tool search,
-    keeping the context window small.
-
-    Returns:
-        (tool_schemas, tool_registry) where tool_schemas is a list of Anthropic
-        tool definitions and tool_registry maps tool name -> LangChain tool object.
+    Anthropic server tools (``web_search``, ``tool_search_tool_regex``) are not
+    part of this contract. App tools are exposed directly so the model can call
+    them by name.
     """
-    schemas = []
-
-    # Add built-in server tools
-    schemas.append(WEB_SEARCH_TOOL)
-
-    # Add tool search tool if there are app tools to discover
-    if app_tools:
-        schemas.append(TOOL_SEARCH_TOOL)
-
-    # Core tools — always visible
-    for t in core_tools:
-        schemas.append(_langchain_tool_to_anthropic(t, defer_loading=False))
-
-    # App tools — deferred, discovered on-demand
-    for t in app_tools or []:
-        schemas.append(_langchain_tool_to_anthropic(t, defer_loading=True))
-
-    # Registry includes ALL tools (core + app) for execution
     all_tools = list(core_tools) + list(app_tools or [])
+    schemas = [_langchain_tool_to_openai(t) for t in all_tools]
     registry = {t.name: t for t in all_tools}
     return schemas, registry
+
+
+def _collected_results_from_config(configurable: dict | None) -> Any:
+    if not isinstance(configurable, dict):
+        return None
+    collected = configurable.get('conversations_collected')
+    if collected:
+        return collected
+    evidence = configurable.get('evidence_references')
+    return evidence or None
+
+
+async def _execute_independent_tool_calls(
+    tool_calls: list,
+    *,
+    name_of,
+    input_of,
+    id_of,  # noqa: ARG001 — caller-facing symmetry with name/input
+    tool_registry: dict,
+    configurable: dict,
+    safety_guard: AgentSafetyGuard,
+    callback: 'AsyncStreamingCallback',
+    full_response: list,
+    result_factory,
+) -> list | None:
+    """Validate sequentially, run independent tools concurrently, preserve order.
+
+    Returns the provider-shaped tool results, or ``None`` when a hard safety
+    limit ended the stream. ``CollectedContextReady`` stubs remaining calls so
+    the model can answer from already-collected conversations.
+    """
+    collected = _collected_results_from_config(configurable)
+    validated: list = []
+    stub_after = False
+    for call in tool_calls:
+        try:
+            safety_guard.validate_tool_call(name_of(call), input_of(call), collected_results=collected)
+            warning = safety_guard.should_warn_user()
+            if warning:
+                await callback.put_thought(warning)
+            validated.append(call)
+        except CollectedContextReady:
+            stub_after = True
+            break
+        except SafetyGuardError as error:
+            await _put_answer_text(callback, full_response, f'\n\n{str(error)}')
+            logger.error('Safety Guard blocked tool call: %s', error)
+            await callback.end()
+            return None
+
+    for call in validated:
+        tool_name = name_of(call)
+        await callback.put_thought(
+            get_tool_display_name(tool_name, tool_registry.get(tool_name)), app_id=_extract_app_id(tool_name)
+        )
+
+    async def _run_one(call):
+        tool_name = name_of(call)
+        try:
+            return await _execute_tool(tool_name, input_of(call), tool_registry, configurable)
+        except Exception as error:
+            logger.error('Tool execution error (%s): %s', tool_name, error)
+            return f'Error executing tool: {str(error)}'
+
+    results_text: list[str] = []
+    if validated:
+        semaphore = asyncio.Semaphore(AGENT_TOOL_TURN_CONCURRENCY)
+
+        async def _bounded(call):
+            async with semaphore:
+                return await _run_one(call)
+
+        results_text = list(await asyncio.gather(*[_bounded(call) for call in validated]))
+
+    tool_results = []
+    for call, result in zip(validated, results_text):
+        tool_name = name_of(call)
+        logger.info('Tool ended: %s', tool_name)
+        await _emit_calendar_status(callback, tool_name, result)
+        try:
+            safety_guard.check_context_size(result)
+        except SafetyGuardError as error:
+            await _put_answer_text(callback, full_response, f'\n\n{str(error)}')
+            logger.error('Safety Guard blocked due to context size: %s', error)
+            await callback.end()
+            return None
+        tool_results.append(result_factory(call, result))
+
+    if stub_after:
+        for call in tool_calls[len(validated) :]:
+            tool_results.append(result_factory(call, _COLLECTED_CONTEXT_TOOL_STUB))
+
+    return tool_results
 
 
 def _convert_anthropic_tools_to_openai(tool_schemas: list[dict]) -> list[dict]:
@@ -884,52 +985,26 @@ async def _run_anthropic_agent_stream(
         if response.stop_reason != "tool_use":
             break
 
-        # Execute tool calls
+        # Execute independent tool_use blocks concurrently (leftover Anthropic path).
         tool_use_blocks = [b for b in response.content if b.type == "tool_use"]
-        tool_results = []
-        should_stop = False
-
-        for block in tool_use_blocks:
-            # Safety guard: validate before execution
-            try:
-                safety_guard.validate_tool_call(block.name, block.input)
-                warning = safety_guard.should_warn_user()
-                if warning:
-                    await callback.put_thought(warning)
-            except SafetyGuardError as e:
-                await _put_answer_text(callback, full_response, f"\n\n{str(e)}")
-                logger.error(f"Safety Guard blocked tool call: {e}")
-                await callback.end()
-                return None
-
-            # Execute tool
-            try:
-                result = await _execute_tool(block.name, block.input, tool_registry, configurable)
-            except Exception as e:
-                logger.error(f"Tool execution error ({block.name}): {e}")
-                result = f"Error executing tool: {str(e)}"
-
-            logger.info(f"Tool ended: {block.name}")
-
-            # Calendar status messages
-            await _emit_calendar_status(callback, block.name, result)
-
-            # Safety guard: check context size after execution
-            try:
-                safety_guard.check_context_size(result)
-            except SafetyGuardError as e:
-                await _put_answer_text(callback, full_response, f"\n\n{str(e)}")
-                logger.error(f"Safety Guard blocked due to context size: {e}")
-                await callback.end()
-                return None
-
-            tool_results.append(
-                {
-                    "type": "tool_result",
-                    "tool_use_id": block.id,
-                    "content": result,
-                }
-            )
+        tool_results = await _execute_independent_tool_calls(
+            tool_use_blocks,
+            name_of=lambda block: block.name,
+            input_of=lambda block: block.input,
+            id_of=lambda block: block.id,
+            tool_registry=tool_registry,
+            configurable=configurable,
+            safety_guard=safety_guard,
+            callback=callback,
+            full_response=full_response,
+            result_factory=lambda block, result: {
+                "type": "tool_result",
+                "tool_use_id": block.id,
+                "content": result,
+            },
+        )
+        if tool_results is None:
+            return None
 
         # Append assistant message + tool results for next iteration
         # Serialize content blocks for the messages array
@@ -1157,38 +1232,24 @@ async def _run_openai_agent_stream(
         if not tool_calls:
             break
 
-        tool_results = []
-        for tool_call in tool_calls:
-            try:
-                safety_guard.validate_tool_call(tool_call['name'], tool_call['input'])
-                warning = safety_guard.should_warn_user()
-                if warning:
-                    await callback.put_thought(warning)
-            except SafetyGuardError as error:
-                await _put_answer_text(callback, full_response, f'\n\n{str(error)}')
-                logger.error('Safety Guard blocked tool call: %s', error)
-                await callback.end()
-                return None
-
-            tool_name = tool_call['name']
-            tool_obj = tool_registry.get(tool_name)
-            await callback.put_thought(get_tool_display_name(tool_name, tool_obj), app_id=_extract_app_id(tool_name))
-            try:
-                result = await _execute_tool(tool_name, tool_call['input'], tool_registry, configurable)
-            except Exception as error:
-                logger.error('Tool execution error (%s): %s', tool_name, error)
-                result = f'Error executing tool: {str(error)}'
-
-            logger.info('Tool ended: %s', tool_name)
-            await _emit_calendar_status(callback, tool_name, result)
-            try:
-                safety_guard.check_context_size(result)
-            except SafetyGuardError as error:
-                await _put_answer_text(callback, full_response, f'\n\n{str(error)}')
-                logger.error('Safety Guard blocked due to context size: %s', error)
-                await callback.end()
-                return None
-            tool_results.append({'role': 'tool', 'tool_call_id': tool_call['id'], 'content': result})
+        tool_results = await _execute_independent_tool_calls(
+            tool_calls,
+            name_of=lambda tool_call: tool_call['name'],
+            input_of=lambda tool_call: tool_call['input'],
+            id_of=lambda tool_call: tool_call['id'],
+            tool_registry=tool_registry,
+            configurable=configurable,
+            safety_guard=safety_guard,
+            callback=callback,
+            full_response=full_response,
+            result_factory=lambda tool_call, result: {
+                'role': 'tool',
+                'tool_call_id': tool_call['id'],
+                'content': result,
+            },
+        )
+        if tool_results is None:
+            return None
 
         assistant_message = {
             'role': 'assistant',
@@ -1278,7 +1339,7 @@ def _consume_agent_task_exception(task: asyncio.Task) -> None:
         logger.error('Detached agent stream producer failed error_type=%s', type(error).__name__)
 
 
-@_traceable(name="chat.anthropic.stream", run_type="chain")
+@_traceable(name="chat.openai.stream", run_type="chain")
 async def execute_agentic_chat_stream(
     uid: str,
     messages: List[Message],
@@ -1331,8 +1392,11 @@ async def execute_agentic_chat_stream(
         if setup_remaining <= 0:
             raise asyncio.TimeoutError()
         async with asyncio.timeout(setup_remaining):
-            # BYOK Anthropic and CHAT_AGENT_ROUTE=direct stay off the managed OpenAI lane.
-            gateway_feature_mode = should_route_chat_agent_through_gateway() and not bool(get_byok_key('anthropic'))
+            # Omi-managed chat-agent is always the OpenAI/Luna runner. Anthropic BYOK
+            # no longer selects a second Messages path. CHAT_AGENT_ROUTE=direct is
+            # honored inside get_llm() as a kill switch onto direct OpenAI.
+            gateway_feature_mode = should_route_chat_agent_through_gateway()
+            logger.debug('Chat agent live runner=openai gateway_lane=%s', gateway_feature_mode)
             tz = tz or await run_blocking(db_executor, get_user_timezone, uid)
             city = await get_mobile_city(uid, platform) if current_datetime_block is None else None
             jit_conversation_retrieval_enabled = await _resolve_jit_conversation_retrieval(uid)
@@ -1367,12 +1431,12 @@ async def execute_agentic_chat_stream(
             if not jit_conversation_retrieval_enabled:
                 core_tools = [tool for tool in core_tools if tool.name not in JIT_ONLY_TOOL_NAMES]
 
-            # Dynamic app tools — deferred for Anthropic; exposed directly in managed mode
+            # Dynamic app tools — exposed directly on the OpenAI/Luna chat-agent lane
             app_tools = []
             try:
                 app_tools = await run_blocking(db_executor, load_app_tools, uid)
                 if app_tools:
-                    logger.info(f"Loaded {len(app_tools)} app tools (deferred via tool search)")
+                    logger.info(f"Loaded {len(app_tools)} app tools")
             except Exception as error:
                 logger.error('Error loading app tools error_type=%s', type(error).__name__)
     except asyncio.TimeoutError:
@@ -1417,8 +1481,7 @@ async def execute_agentic_chat_stream(
             # Tool names are prefixed with app_id; extract the human-readable app name from description
             app_names.add(t.name)
         app_tool_names = ", ".join(sorted(app_names))
-        if gateway_feature_mode:
-            system_prompt += f"""
+        system_prompt += f"""
 
 <available_app_tools>
 You have access to additional tools from the user's connected apps. Call the relevant tool directly when the user asks about an external service (e.g. GitHub, Twitter, Slack, Google Calendar, Notion, Shopify, WhatsApp, Splitwise, etc.).
@@ -1427,40 +1490,20 @@ Available app tool names: {app_tool_names}
 
 IMPORTANT: Always call a matching integration tool when relevant. Never tell the user you don't have access to an integration if a matching tool exists above.
 </available_app_tools>"""
-        else:
-            system_prompt += f"""
 
-<available_app_tools>
-You have access to additional tools from the user's connected apps. These tools are discoverable via the tool_search_tool_regex tool. When the user asks you to do something related to an external service (e.g. GitHub, Twitter, Slack, Google Calendar, Notion, Shopify, WhatsApp, Splitwise, etc.), search for the relevant tool using tool_search_tool_regex with a keyword like "github", "issue", "tweet", etc.
-
-Available app tool names: {app_tool_names}
-
-IMPORTANT: Always search for and use these tools when relevant. Never tell the user you don't have access to an integration if a matching tool exists above.
-</available_app_tools>"""
-
-    # Instruct Claude to use fetch_url_tool for any direct URL in the conversation.
-    # Without this, Claude's built-in "I can't browse links" behavior takes over.
+    # Instruct the model to use fetch_url_tool for any direct URL in the conversation.
     system_prompt += """
 
 <url_fetching_instructions>
 You have fetch_url_tool available. When the user shares any URL (starting with http:// or https://), you MUST call fetch_url_tool to read its content before responding. Never say you cannot browse, visit, or read a URL. Always attempt to fetch it first.
 </url_fetching_instructions>"""
 
-    # Build the canonical tool schemas once. Direct mode keeps Anthropic's shape;
-    # managed mode converts function tools to the OpenAI-compatible shape below.
+    # Live chat-agent tools are OpenAI chat-completions functions. Perplexity
+    # covers web search; Anthropic server tools are not on this lane.
     tool_schemas, tool_registry = _convert_tools(core_tools, app_tools)
-    if gateway_feature_mode:
-        # Anthropic's native web_search server tool is not understood by the
-        # OpenAI-compatible gateway. Expose the existing Perplexity-backed
-        # function tool in the managed lane and register the same object for
-        # execution; direct Anthropic mode keeps the native server tool above.
-        tool_registry = dict(tool_registry)
-        tool_registry[perplexity_web_search_tool.name] = perplexity_web_search_tool
-        tool_schemas = [
-            *tool_schemas,
-            _langchain_tool_to_anthropic(perplexity_web_search_tool, defer_loading=False),
-        ]
-        tool_schemas = _convert_anthropic_tools_to_openai(tool_schemas)
+    tool_registry = dict(tool_registry)
+    tool_registry[perplexity_web_search_tool.name] = perplexity_web_search_tool
+    tool_schemas = [*tool_schemas, _langchain_tool_to_openai(perplexity_web_search_tool)]
 
     # Build the provider-neutral role/content message shape. The current datetime is injected
     # into the user turn (not the system prompt) so the direct Anthropic cache prefix stays stable.
@@ -1515,10 +1558,8 @@ You have fetch_url_tool available. When the user shares any URL (starting with h
                 'references': evidence_references[:24],
             }
 
-    # Start the provider-specific agent task. Direct mode retains the native Anthropic
-    # Messages contract for BYOK/specialist callers; managed feature mode uses the gateway's
-    # OpenAI-compatible chat-completions contract.
-    agent_runner = _run_openai_agent_stream if gateway_feature_mode else _run_anthropic_agent_stream
+    # Live path is always the OpenAI-compatible runner (gateway Luna or direct OpenAI).
+    agent_runner = _run_openai_agent_stream
     task = asyncio.create_task(
         agent_runner(
             system_prompt,

--- a/backend/utils/retrieval/safety.py
+++ b/backend/utils/retrieval/safety.py
@@ -27,6 +27,44 @@ class SafetyGuardError(Exception):
     pass
 
 
+class CollectedContextReady(Exception):
+    """Identical tool call after retrieval already collected context.
+
+    The agent should stop the tool loop and answer from collected results
+    instead of emitting the canned stuck message.
+    """
+
+
+def _canonical_params(params: Dict[str, Any]) -> tuple:
+    """Stable comparable form. Missing keys and None are equivalent."""
+    if not params:
+        return ()
+    items = []
+    for key in sorted(params):
+        value = params[key]
+        if value is None:
+            continue
+        items.append((key, _canonical_value(value)))
+    return tuple(items)
+
+
+def _canonical_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return _canonical_params(value)
+    if isinstance(value, (list, tuple)):
+        return tuple(_canonical_value(item) for item in value)
+    return value
+
+
+def _has_collected_results(collected_results: Any) -> bool:
+    if not collected_results:
+        return False
+    try:
+        return len(collected_results) > 0
+    except TypeError:
+        return True
+
+
 class AgentSafetyGuard:
     """
     Safety guard for ReAct agents to prevent:
@@ -49,16 +87,25 @@ class AgentSafetyGuard:
         # Loop detection window (check last N calls)
         self.loop_detection_window = 3
 
-    def validate_tool_call(self, tool_name: str, params: Dict[str, Any]) -> None:
+    def validate_tool_call(
+        self,
+        tool_name: str,
+        params: Dict[str, Any],
+        *,
+        collected_results: Any = None,
+    ) -> None:
         """
         Validate a tool call before execution.
 
         Args:
             tool_name: Name of the tool being called
             params: Parameters for the tool call
+            collected_results: Conversations (or equivalent) already gathered this turn.
+                A loop after a non-empty collection must not emit the stuck message.
 
         Raises:
-            SafetyGuardError: If any safety limit is exceeded
+            SafetyGuardError: If a hard safety limit is exceeded
+            CollectedContextReady: Exact-duplicate tool call after useful results exist
         """
         # Check tool call limit
         if self.tool_call_count >= self.max_tool_calls:
@@ -69,6 +116,8 @@ class AgentSafetyGuard:
 
         # Check for tool call loops
         if self._is_loop_detected(tool_name, params):
+            if _has_collected_results(collected_results):
+                raise CollectedContextReady()
             raise SafetyGuardError(
                 "I seem to be stuck trying to answer your question. " "Could you rephrase it in a different way?"
             )
@@ -118,63 +167,29 @@ class AgentSafetyGuard:
         )
 
     def _is_loop_detected(self, tool_name: str, params: Dict[str, Any]) -> bool:
-        """
-        Detect if the same tool is being called repeatedly with similar parameters.
+        """Detect an exact ``(tool_name, canonical params)`` repeat in the recent window.
 
-        Args:
-            tool_name: Name of the tool
-            params: Tool parameters
-
-        Returns:
-            True if a loop is detected
+        Shared defaults must not trip the gate: two ``search_conversations`` calls that
+        differ only in ``query`` are not a loop. A second call with identical params is.
         """
-        if len(self.tool_call_history) < self.loop_detection_window:
+        if not self.tool_call_history:
             return False
 
-        # Check last N calls
+        canonical = _canonical_params(params)
         recent_calls = self.tool_call_history[-self.loop_detection_window :]
-
-        # Count how many times this exact tool+params combination appears
-        similar_count = 0
         for past_tool, past_params, _ in recent_calls:
-            if past_tool == tool_name and self._params_similar(params, past_params):
-                similar_count += 1
-
-        # If more than half of recent calls are the same tool with similar params, it's likely a loop
-        return similar_count >= (self.loop_detection_window // 2 + 1)
+            if past_tool == tool_name and _canonical_params(past_params) == canonical:
+                return True
+        return False
 
     def _params_similar(self, params1: Dict[str, Any], params2: Dict[str, Any], threshold: float = 0.8) -> bool:
+        """Exact canonical match. Shared defaults plus a different query are not similar.
+
+        ``threshold`` is retained for call-site compatibility and ignored: key-overlap
+        ratios treated ``query`` as one of N keys and aborted David's recall searches.
         """
-        Check if two parameter sets are similar (for loop detection).
-
-        Args:
-            params1: First parameter set
-            params2: Second parameter set
-            threshold: Similarity threshold (0-1)
-
-        Returns:
-            True if parameters are similar
-        """
-        # Get keys from both dicts
-        all_keys = set(params1.keys()) | set(params2.keys())
-        if not all_keys:
-            return True
-
-        # Count matching values
-        matching = 0
-        for key in all_keys:
-            val1 = params1.get(key)
-            val2 = params2.get(key)
-
-            # Consider None and missing keys as equivalent
-            if val1 is None and val2 is None:
-                matching += 1
-            elif val1 == val2:
-                matching += 1
-
-        # Calculate similarity ratio
-        similarity = matching / len(all_keys)
-        return similarity >= threshold
+        del threshold
+        return _canonical_params(params1) == _canonical_params(params2)
 
     def get_stats(self) -> Dict[str, Any]:
         """


### PR DESCRIPTION
Closes SCA-378

## What changed and why

David's iOS recall (yesterday / friends / bars / jobs) hit the 80% key-overlap loop gate because `search_conversations` shares a date window and defaults; only `query` changed. Hits were already in `conversations_collected`, and the canned "stuck, rephrase" abort replaced the answer. Loop membership is now an exact `(tool_name, canonical params)` repeat. A repeat after non-empty collected results raises `CollectedContextReady` so the runner stops tools and lets the model answer. `max_tool_calls=25` and the context-size cap stay.

Managed Omi chat-agent is one Luna path: LLM Gateway `omi:auto:chat-agent` → `openai / gpt-5.6-luna` with `reasoning_effort: none` (OpenAI rejects tools + medium/high on this model). No `AsyncAnthropic` / `api.anthropic.com` on the chat-agent path in gateway mode. Chat-agent BYOK Anthropic is dropped. `CHAT_AGENT_ROUTE=direct` is a kill switch onto **direct OpenAI**, not Anthropic.

Independent `tool_use` blocks in one turn run through `asyncio.gather`, bounded by `AGENT_TOOL_TURN_CONCURRENCY` (default 8). They still count toward the safety cap.

## Provider / model / lane

| Mode | Client | Model |
| --- | --- | --- |
| Managed (`FEATURE_MODE=gateway` and `CHAT_AGENT_ROUTE=gateway`) | Gateway OpenAI-compatible | `omi:auto:chat-agent` → `gpt-5.6-luna` |
| Kill switch (`CHAT_AGENT_ROUTE=direct`) | Direct OpenAI | `gpt-5.6-luna` |

## Loop-guard contract

- Different queries with shared defaults do **not** trip.
- A second call with identical canonical params still guards.
- If `conversations_collected` (or `evidence_references`) is already non-empty, never emit the canned stuck text — stub remaining calls and let the model answer.

## Parallel-tool contract

Independent tool calls in one model turn execute concurrently (semaphore-bounded) and still increment the 25-call safety counter.

## What Anthropic remains, and why

`gateway_anthropic.py` and `llm_gateway/routers/anthropic_messages.py` stay: desktop specialist / BYOK Messages traffic, **not** the managed chat-agent lane. `_run_anthropic_agent_stream` remains for leftover unit tests and still applies the private-tool web_search taint gate. `ANTHROPIC_AGENT_MODEL` is now an alias for `get_model('chat_agent')` (`gpt-5.6-luna`).

Parked: a batch `queries: list[str]` search tool.

## Product invariants affected

none

Line-Count-Exception: backend/utils/retrieval/agentic.py | 1650 -> 1690 | Parallel tool execution and OpenAI schema conversion stay on the existing runner rather than a new module.

## How it was verified

Focused backend unit tests through `backend/test.sh` file isolation (and the same files run alone when collection stubs pollute a shared session):

- `test_chat_agent_loop_guard.py` — 7 passed (exact-repeat vs shared-window queries, collected-results must not emit stuck, two tools overlap in one turn)
- `test_chat_agent_provider_retry.py`, `test_prompt_cache_integration.py`, `test_llm_gateway_config.py`, `test_llm_gateway_coverage_guardrails.py`, `test_llm_gateway_executor.py`, `test_llm_gateway_readiness.py`, `test_llm_gateway_client_config.py`, `test_chat_async_offload.py`, `test_agentic_web_search_taint.py`, `test_chat_agent_cost_report.py` — passed
- `test_omi_qos_tiers.py` — 95 passed in isolation (`chat_agent` is luna/openai, not Anthropic-only)

Not verified: live gateway/OpenAI traffic against production Luna, and the QoS integration suites (`test_qos_real_llm.py`, `test_qos_live_cp9.py`, `test_qos_all_features_l1.py`) which need live credentials.

## Tests

`backend/tests/unit/test_chat_agent_loop_guard.py` is the regression that would have caught David's recall abort. Gateway client tests pin `get_llm('chat_agent')` to `omi:auto:chat-agent` in gateway mode and direct OpenAI on the kill switch. Taint tests still drive the leftover Anthropic runner and now assert live `_convert_tools` never ships provider-executed `web_search`.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative

**Violated contract:** a loop guard that treated overlapping keys as a repeat, or that emitted "stuck, rephrase" after retrieval had already collected hits, aborted a deliverable answer.

**Canonical guard:** exact canonical `(tool_name, params)` membership; `CollectedContextReady` when results exist; behavioral tests in `backend/tests/unit/test_chat_agent_loop_guard.py`.

**Definition added:** `.github/failure-classes/FC-loop-guard-aborts-collected-answer.json` (`evidence_prs` empty — this PR is the first evidence).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

