### PR TITLE
feat(desktop): make the Activity hour rail one continuous scrollable ribbon

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineHourRail.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineHourRail.swift
@@ -19,10 +19,24 @@ import OmiTheme
 import SwiftUI
 
 struct SpineHourRail: View {
-  /// One entry per hour, indexed 0…23, each 0…1 against the day's own busiest hour.
-  let density: [Double]
-  /// The hour under the top of the list, or nil before anything has been read.
-  let currentHour: Int?
+  /// Every loaded day, newest first — the whole strip, not just the one being read. See
+  /// `SpineRibbon`.
+  let days: [SpineRibbonDay]
+  /// Where the strip sits, in strip points — already blended between the two rows nearest the
+  /// reading line, so it moves every frame the list moves. See `SpineReadingPosition`.
+  ///
+  /// A closure rather than a value because the scale of the strip is the column's own height (one
+  /// day is one column) and only the `GeometryReader` below knows it.
+  let depth: (CGFloat) -> CGFloat
+  /// Whether any hour is being read. `false` when no row has been reported — every day folded shut,
+  /// or nothing read yet — where the strip still parks somewhere but lights nothing.
+  let highlightsMarker: Bool
+  /// The hour to *say*. Which hour is drawn heavier is derived from `depth`, but speech has no
+  /// column height to derive anything from, and "Reading 12 PM" is the one part of this column a
+  /// listener cannot get from the headline. `nil` when nothing is being read.
+  let readingHour: Int?
+  /// The list's scroll view, so a wheel over the ribbon moves the list. See `SpineScrollLink`.
+  let scrollLink: SpineScrollLink
   /// The headline: how much screen capture the day being read holds, or `nil` while that day's index
   /// is still being read. `nil` is not zero — see `headlineCaption`.
   let momentCount: Int?
@@ -55,13 +69,6 @@ struct SpineHourRail: View {
   /// shortened forms out of 10,234 and removes the coin flip.
   private nonisolated static let scopeFitBudget: CGFloat = contentWidth - 1
 
-  /// Labelled hours. Four is enough to orient without turning the rail into an axis.
-  private static let labelledHours: Set<Int> = [0, 6, 12, 18]
-
-  /// A bar this fraction of the peak or more is drawn heavier. Not a hue — the rail is one ink at
-  /// two weights, like every other ranking in this system.
-  private static let hotThreshold = 0.6
-
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
       // Number, noun, day — "0 screen moments, Yesterday", read straight down. **The day goes last,
@@ -80,7 +87,7 @@ struct SpineHourRail: View {
         }
       }
 
-      bars
+      ribbon
 
       if let footer = Self.footer(conversationCount: conversationCount) {
         Text(footer)
@@ -98,7 +105,7 @@ struct SpineHourRail: View {
           momentCount: momentCount,
           dayTitle: dayTitle,
           conversationCount: conversationCount,
-          currentHour: currentHour)))
+          currentHour: readingHour)))
   }
 
   /// **The rail counts one day of screen capture; the panel's corner counts the whole account.**
@@ -237,63 +244,27 @@ struct SpineHourRail: View {
     return text
   }
 
-  /// The bars themselves, drawn 23 → 0 top to bottom.
-  private var bars: some View {
-    VStack(alignment: .leading, spacing: 0) {
-      ForEach(Self.renderedHours, id: \.self) { hour in
-        SpineHourBar(
-          hour: hour,
-          weight: density.indices.contains(hour) ? density[hour] : 0,
-          isHot: (density.indices.contains(hour) ? density[hour] : 0) >= Self.hotThreshold,
-          isCurrent: hour == currentHour,
-          label: Self.labelledHours.contains(hour) ? SpineFormat.hourLabel(hour) : nil
-        )
-        .frame(maxHeight: .infinity)
-      }
+  /// The strip, and the wheel target over it.
+  ///
+  /// Inside a `GeometryReader` because the strip's scale is the column's own height — one day is one
+  /// column (`SpineRibbonGeometry.dayHeight`), so the position can only be worked out where that
+  /// height is known. The forwarder sits on top rather than the ribbon owning a scroll view, because
+  /// there is only ever one scroll here and it belongs to the list — see `SpineScrollLink`.
+  ///
+  /// **No `.animation` on the position, deliberately.** The strip is told where to be several times
+  /// a second while scrolling, and an animation on a value that keeps changing never settles: the
+  /// strip spends the whole scroll interpolating towards a target it has already been given a newer
+  /// version of, which is what "laggy" was. The position is continuous at source now — that is where
+  /// smoothness belongs, and an easing curve laid over it could only add delay.
+  private var ribbon: some View {
+    GeometryReader { proxy in
+      SpineRibbon(
+        days: days,
+        depth: depth(proxy.size.height),
+        highlightsMarker: highlightsMarker
+      )
+      .overlay(SpineWheelForwarder(link: scrollLink))
     }
     .frame(maxHeight: .infinity)
-  }
-}
-
-/// One hour.
-struct SpineHourBar: View {
-  let hour: Int
-  let weight: Double
-  let isHot: Bool
-  let isCurrent: Bool
-  let label: String?
-
-  /// The shortest a bar is ever drawn. An hour with nothing in it is still an hour, and a gap in the
-  /// column would read as the rail having ended.
-  private static let minimumWidth: CGFloat = 14
-  private static let maximumExtra: CGFloat = 78
-
-  /// The hour being read, when it is not one of the four the rail labels anyway.
-  ///
-  /// **The marker is the bar itself, not a band behind it.** A full-width wash across the current
-  /// row was the first attempt and it read as a stray scrollbar — a long dark rule among short pale
-  /// pills looks like chrome that escaped, not like "you are here". Now the current hour is simply
-  /// the darkest bar with its hour named beside it: one object getting heavier, which is how every
-  /// other ranking in this system is drawn, and unmistakably part of the rail.
-  private var caption: String? {
-    if let label { return label }
-    return isCurrent ? SpineFormat.hourLabel(hour) : nil
-  }
-
-  var body: some View {
-    HStack(spacing: 7) {
-      Capsule()
-        .fill(Ink.primary.opacity(isCurrent ? 0.85 : (isHot ? 0.42 : 0.2)))
-        .frame(width: Self.minimumWidth + CGFloat(weight) * Self.maximumExtra, height: isCurrent ? 6 : 5)
-      if let caption {
-        Text(caption)
-          .font(.system(size: 9, weight: isCurrent ? .semibold : .regular))
-          .tracking(0.6)
-          .foregroundStyle(isCurrent ? Ink.primary : Ink.secondary)
-          .lineLimit(1)
-          .fixedSize()
-      }
-    }
-    .frame(maxWidth: .infinity, alignment: .leading)
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineRibbon.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineRibbon.swift
@@ -1,0 +1,252 @@
+//
+//  SpineRibbon.swift — every loaded day as one strip, drawn once.
+//
+//  The rail beside the spine used to be twenty-four bars belonging to whichever day the top row was
+//  in, and it **swapped** when the top row crossed midnight: the whole column's contents changed at
+//  once, so a continuous scroll produced a discontinuous rail. The list next to it never does that —
+//  it runs through the day boundary like the boundary is just another row — and a navigator that
+//  jumps beside a list that flows is a navigator nobody reads as position.
+//
+//  So the ribbon is one strip: every loaded day, newest at the top, each day's hours running 23 → 0
+//  the same direction the list runs, separated by a labelled break rather than a cut. The reading
+//  position is a **fixed marker** and the strip slides under it, which is the only arrangement that
+//  survives more days than fit on screen.
+//
+//  **Compact, not calendar-scaled.** A day with nothing in it is not drawn at all. Ribbon length is
+//  therefore proportional to how much history is loaded, never to elapsed time — a quiet fortnight
+//  is not a fortnight of empty strip to wheel past.
+//
+//  Drawn in a `Canvas` because at a few hundred days this is tens of thousands of bars, and a
+//  `VStack` of them is tens of thousands of view identities re-evaluated on every scroll tick. Only
+//  the days inside the viewport are drawn (`SpineRibbonGeometry.visibleDays`), so the cost is the
+//  window, not the corpus.
+//
+
+import OmiTheme
+import SwiftUI
+
+// MARK: - Geometry
+
+/// Where a moment in time lands on the strip. Pure arithmetic, no view — this is the part a test can
+/// hold, and the part the wheel, the marker and the day breaks all have to agree about.
+enum SpineRibbonGeometry {
+  /// The band between two days, carrying the hairline and the day's name.
+  static let dayBreakHeight: CGFloat = 20
+
+  /// **One day is exactly one column.** The rail this replaced sized its twenty-four bars with
+  /// `maxHeight: .infinity`, so a day filled whatever height the column had; keeping that means the
+  /// strip looks like the rail always did and the only thing that changed is that it no longer ends
+  /// at midnight. It also keeps the ribbon adaptive: a taller window gets a taller day, never a
+  /// tighter one, and no hour spacing is baked into a constant that was right on one screen.
+  static func dayHeight(viewport: CGFloat) -> CGFloat { max(dayBreakHeight + 24, viewport) }
+
+  /// One hour, at that size.
+  static func hourHeight(viewport: CGFloat) -> CGFloat {
+    (dayHeight(viewport: viewport) - dayBreakHeight) / 24
+  }
+
+  /// How far down the ribbon's viewport the reading marker sits.
+  ///
+  /// Not at the very top: the strip above the marker is the part already read, and a navigator that
+  /// shows none of where you came from is a progress bar. Not the middle either — the list's own
+  /// reading line is near its top, and the two should roughly agree.
+  static let markerFraction: CGFloat = 0.34
+
+  /// Distance from the top of the whole strip to a moment, in points.
+  ///
+  /// Hours run **backwards** inside a day — hour 23 at the top — because the spine is newest-first
+  /// and a rail ascending beside a descending list is the disagreement this file exists to remove.
+  /// Minutes run backwards within the hour for the same reason: 23:59 sits at the very top of its
+  /// day, 00:00 at the very bottom.
+  static func depth(dayIndex: Int, hour: Int, minute: Int, viewport: CGFloat) -> CGFloat {
+    let withinDay = (24 - CGFloat(hour) - CGFloat(minute) / 60) * hourHeight(viewport: viewport)
+    return CGFloat(dayIndex) * dayHeight(viewport: viewport) + dayBreakHeight + withinDay
+  }
+
+  /// Which day and hour sit at a point on the strip — the inverse of `depth`.
+  ///
+  /// The reading position is continuous, so the hour to draw heavier is the one the marker is
+  /// *inside*, not the hour of whichever row last reported. Deriving it from the same number that
+  /// positions the strip is what stops the heavy bar from ever being a bar other than the one under
+  /// the marker.
+  static func marker(atDepth depth: CGFloat, viewport: CGFloat) -> (dayIndex: Int, hour: Int) {
+    let day = dayHeight(viewport: viewport)
+    let dayIndex = max(0, Int((depth / day).rounded(.down)))
+    let withinDay = depth - CGFloat(dayIndex) * day - dayBreakHeight
+    let hour = 24 - withinDay / hourHeight(viewport: viewport)
+    return (dayIndex, min(23, max(0, Int(hour.rounded(.down)))))
+  }
+
+  /// The days with any part inside a viewport of `height` reading at `depth`.
+  ///
+  /// Empty when there is nothing loaded, and clamped to the ends: scrolling past the newest or the
+  /// oldest day is a strip that runs out, not an index that goes negative.
+  static func visibleDays(depth: CGFloat, height: CGFloat, count: Int) -> Range<Int> {
+    guard count > 0, height > 0 else { return 0..<0 }
+    let day = dayHeight(viewport: height)
+    let top = depth - height * markerFraction
+    let first = max(0, Int((top / day).rounded(.down)))
+    let last = min(count - 1, Int(((top + height) / day).rounded(.down)))
+    guard first <= last else { return 0..<0 }
+    return first..<(last + 1)
+  }
+}
+
+// MARK: - One day's worth of strip
+
+/// What the ribbon needs to draw a day: who it is, what to call the break above it, and its shape.
+struct SpineRibbonDay: Equatable, Identifiable {
+  let id: Date
+  let title: String
+  /// 24 values, indexed by hour, each 0…1 against that day's own busiest hour — the same
+  /// per-day normalisation `SpineStore.density(for:)` documents. Scaling every day against a
+  /// record-breaking one months ago would flatten every ordinary day into a straight line, and that
+  /// is no less true now that the days are drawn end to end.
+  let density: [Double]
+
+  func weight(_ hour: Int) -> Double { density.indices.contains(hour) ? density[hour] : 0 }
+}
+
+// MARK: - The strip
+
+/// The strip itself, sliding under a fixed marker.
+///
+/// `Animatable` on the depth, so a scroll that moves the anchor nine hours in one step glides there
+/// instead of teleporting. Interpolating the value the `Canvas` reads is the only way to animate a
+/// `Canvas` at all — there is no view whose frame is changing for `.animation` to work on.
+struct SpineRibbon: View, Animatable {
+  /// Every loaded day, newest first.
+  let days: [SpineRibbonDay]
+  /// Where the marker is reading, in strip points. See `SpineRibbonGeometry.depth`.
+  var depth: CGFloat
+  /// Whether any hour is lit at all. `false` before the list has reported a row — every day folded
+  /// shut, or nothing read yet — where the strip still parks somewhere but nothing on it is being
+  /// read. Which hour is lit is not passed in: it is derived from `depth`, so it cannot disagree
+  /// with where the strip actually sits.
+  let highlightsMarker: Bool
+
+  /// `nonisolated` because `Animatable` is: SwiftUI interpolates this off the view's own isolation.
+  /// Safe here because everything it touches is a `Sendable` value.
+  nonisolated var animatableData: CGFloat {
+    get { depth }
+    set { depth = newValue }
+  }
+
+  /// A bar this fraction of its day's peak or more is drawn heavier. One ink at three weights, like
+  /// every other ranking in this system.
+  private static let hotThreshold = 0.6
+  /// The bar's own metrics, unchanged from the per-day rail: the shortest a bar is ever drawn (an
+  /// hour with nothing in it is still an hour, and a gap would read as the rail having ended), and
+  /// how much the busiest hour adds to it.
+  private static let minimumBarWidth: CGFloat = 14
+  private static let maximumBarExtra: CGFloat = 78
+  /// The gap between a bar and its caption. The caption follows the bar rather than sitting in a
+  /// fixed column, which is how the rail has always drawn it.
+  private static let captionGap: CGFloat = 7
+  /// How far into the break band the hairline sits, leaving the day's name room underneath.
+  private static let breakRuleOffset: CGFloat = 4
+
+  /// Hours named on every day, so the strip stays readable without becoming an axis.
+  private nonisolated static let labelledHours: Set<Int> = [0, 6, 12, 18]
+
+  var body: some View {
+    Canvas(opaque: false, rendersAsynchronously: false) { context, size in
+      draw(in: &context, size: size)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .accessibilityHidden(true)
+  }
+
+  private func draw(in context: inout GraphicsContext, size: CGSize) {
+    // Where the reading position sits in the column. **Nothing is drawn here** — the hour under it
+    // is already the one heavy, named bar on the strip, and a second mark saying the same thing
+    // twice is the stray-scrollbar look the per-day rail removed once already.
+    let translate = size.height * SpineRibbonGeometry.markerFraction - depth
+    let dayHeight = SpineRibbonGeometry.dayHeight(viewport: size.height)
+    let hourHeight = SpineRibbonGeometry.hourHeight(viewport: size.height)
+    let marker = SpineRibbonGeometry.marker(atDepth: depth, viewport: size.height)
+    let window = SpineRibbonGeometry.visibleDays(
+      depth: depth, height: size.height, count: days.count)
+
+    for index in window {
+      let day = days[index]
+      let dayTop = translate + CGFloat(index) * dayHeight
+      // No break above the newest day: the strip starts there, it does not resume there.
+      if index > 0 { drawBreak(&context, day: day, top: dayTop, width: size.width) }
+      let litHour = highlightsMarker && index == marker.dayIndex ? marker.hour : nil
+      for hour in SpineHourRail.renderedHours {
+        drawBar(
+          &context, day: day, hour: hour, litHour: litHour, dayTop: dayTop, hourHeight: hourHeight,
+          height: size.height)
+      }
+    }
+  }
+
+  /// The hairline sits high in the band and the name hangs **below** it.
+  ///
+  /// Both parts are load-bearing. The day above ends with its midnight hour, which is captioned
+  /// "12 AM" — a name drawn level with the rule lands on that caption, which is what the first
+  /// version did. Below the rule the band is empty until the next day's 11 PM bar, so the name has
+  /// the width of the column to itself and clearly belongs to the day starting under it rather than
+  /// the one ending over it.
+  private func drawBreak(
+    _ context: inout GraphicsContext, day: SpineRibbonDay, top: CGFloat, width: CGFloat
+  ) {
+    let ruleY = top + Self.breakRuleOffset
+    context.fill(
+      Path(CGRect(x: 0, y: ruleY, width: width, height: 1)),
+      with: .color(Ink.separator))
+    guard let label = SpineHourRail.headlineScope(day.title) else { return }
+    let text =
+      Text(label.uppercased())
+      .font(.system(size: 8, weight: .semibold))
+      .tracking(0.7)
+      .foregroundStyle(Ink.secondary)
+    context.draw(text, at: CGPoint(x: 0, y: ruleY + 3), anchor: .topLeading)
+  }
+
+  private func drawBar(
+    _ context: inout GraphicsContext, day: SpineRibbonDay, hour: Int, litHour: Int?,
+    dayTop: CGFloat, hourHeight: CGFloat, height: CGFloat
+  ) {
+    let slotTop = dayTop + SpineRibbonGeometry.dayBreakHeight + CGFloat(23 - hour) * hourHeight
+    let centerY = slotTop + hourHeight / 2
+    // Off the top or bottom of the column: nothing to draw, and skipping it here is what keeps a
+    // redraw proportional to what is actually on screen.
+    guard centerY > -hourHeight, centerY < height + hourHeight else { return }
+
+    let weight = day.weight(hour)
+    let isCurrent = hour == litHour
+    let barHeight: CGFloat = isCurrent ? 6 : 5
+    let barWidth = Self.minimumBarWidth + CGFloat(weight) * Self.maximumBarExtra
+    let opacity = isCurrent ? 0.85 : (weight >= Self.hotThreshold ? 0.42 : 0.2)
+    context.fill(
+      Path(
+        roundedRect: CGRect(x: 0, y: centerY - barHeight / 2, width: barWidth, height: barHeight),
+        cornerRadius: barHeight / 2, style: .continuous),
+      with: .color(Ink.primary.opacity(opacity)))
+
+    guard let hourLabel = Self.caption(for: hour, isLit: isCurrent) else { return }
+    let text =
+      Text(hourLabel)
+      .font(.system(size: 9, weight: isCurrent ? .semibold : .regular))
+      .tracking(0.6)
+      .foregroundStyle(isCurrent ? Ink.primary : Ink.secondary)
+    context.draw(
+      text, at: CGPoint(x: barWidth + Self.captionGap, y: centerY), anchor: .leading)
+  }
+
+  /// Which hours say their name.
+  ///
+  /// **Exactly the rule the per-day rail has always used**: the four fixed hours orient every day
+  /// without turning the strip into an axis, and the hour being read names itself when it is not one
+  /// of them. Nothing is suppressed. An earlier version here dropped a fixed label within an hour of
+  /// the marker, to stop two captions colliding — a real collision, but only at the six-point hour
+  /// spacing that version drew at. At one day per column an hour is more than twenty points and the
+  /// two captions never touch, so the rule was deleting labels to prevent an overlap that cannot
+  /// happen, and made the strip read differently from the rail it replaced.
+  nonisolated static func caption(for hour: Int, isLit: Bool) -> String? {
+    if labelledHours.contains(hour) { return SpineFormat.hourLabel(hour) }
+    return isLit ? SpineFormat.hourLabel(hour) : nil
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineRibbon.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineRibbon.swift
@@ -63,20 +63,6 @@ enum SpineRibbonGeometry {
     return CGFloat(dayIndex) * dayHeight(viewport: viewport) + dayBreakHeight + withinDay
   }
 
-  /// Which day and hour sit at a point on the strip — the inverse of `depth`.
-  ///
-  /// The reading position is continuous, so the hour to draw heavier is the one the marker is
-  /// *inside*, not the hour of whichever row last reported. Deriving it from the same number that
-  /// positions the strip is what stops the heavy bar from ever being a bar other than the one under
-  /// the marker.
-  static func marker(atDepth depth: CGFloat, viewport: CGFloat) -> (dayIndex: Int, hour: Int) {
-    let day = dayHeight(viewport: viewport)
-    let dayIndex = max(0, Int((depth / day).rounded(.down)))
-    let withinDay = depth - CGFloat(dayIndex) * day - dayBreakHeight
-    let hour = 24 - withinDay / hourHeight(viewport: viewport)
-    return (dayIndex, min(23, max(0, Int(hour.rounded(.down)))))
-  }
-
   /// The days with any part inside a viewport of `height` reading at `depth`.
   ///
   /// Empty when there is nothing loaded, and clamped to the ends: scrolling past the newest or the
@@ -135,6 +121,49 @@ struct SpineRibbon: View, Animatable {
   /// A bar this fraction of its day's peak or more is drawn heavier. One ink at three weights, like
   /// every other ranking in this system.
   private static let hotThreshold = 0.6
+
+  /// **How lit a bar is, from `0` to `1`, by how near the marker is to it.**
+  ///
+  /// The strip's position is continuous, but "which hour is lit" was not: a bar was lit or it was
+  /// not, so the one thing the eye follows ticked from slot to slot while everything around it slid.
+  /// Sharing the highlight with the neighbour the marker is leaving is what closes that gap, in
+  /// phase with the scroll rather than trailing it — an easing curve on a value that keeps changing
+  /// never settles, and would put the highlight behind the finger.
+  ///
+  /// **The nearest bar is always fully lit, and that is the whole shape of this curve.** Sharing the
+  /// weight evenly between the two neighbours was the obvious version and it made the highlight
+  /// disappear: at the moment the marker sits between two slots each got half of it, so the one
+  /// thing on the strip that has to be findable was drawn at half strength for most of every scroll.
+  /// A bar within half an hour of the marker — there is always exactly one — is therefore at full
+  /// `1`, exactly the weight the rail has always drawn the hour being read at, and only the *second*
+  /// nearest fades, from full at the hand-over down to nothing an hour out. The highlight never dims;
+  /// it stretches across the gap and lets go.
+  nonisolated static func litness(slotCentre: CGFloat, marker: CGFloat, hourHeight: CGFloat)
+    -> CGFloat
+  {
+    guard hourHeight > 0 else { return 0 }
+    return min(1, max(0, 2 * (1 - abs(slotCentre - marker) / hourHeight)))
+  }
+
+  /// Whether this bar is the one being read — the single slot the marker is inside.
+  ///
+  /// Separate from `litness` because it answers a different question. Lit-ness is how a bar is
+  /// *drawn*, and is deliberately shared during a hand-over; this is which bar the strip is *about*,
+  /// and there is only ever one. It is what decides who says the time: a partly lit neighbour
+  /// captioning itself put two hours on screen at once and left the reader to work out which of them
+  /// the list was actually showing.
+  /// **Half-open, not symmetric**, so the answer is yes for exactly one slot at every position the
+  /// marker can take. `abs(...) < half` reads like the same thing and is not: with the marker
+  /// exactly midway between two slots it is false for both, and the time blinks out for the frame
+  /// the strip spends there.
+  nonisolated static func isBeingRead(slotCentre: CGFloat, marker: CGFloat, hourHeight: CGFloat)
+    -> Bool
+  {
+    guard hourHeight > 0 else { return false }
+    let offset = marker - slotCentre
+    return offset >= -hourHeight / 2 && offset < hourHeight / 2
+  }
+
   /// The bar's own metrics, unchanged from the per-day rail: the shortest a bar is ever drawn (an
   /// hour with nothing in it is still an hour, and a gap would read as the rail having ended), and
   /// how much the busiest hour adds to it.
@@ -143,6 +172,13 @@ struct SpineRibbon: View, Animatable {
   /// The gap between a bar and its caption. The caption follows the bar rather than sitting in a
   /// fixed column, which is how the rail has always drawn it.
   private static let captionGap: CGFloat = 7
+  /// The two ends every bar interpolates between, unchanged from the rail's own values: a plain bar,
+  /// a busy one, and the one being read.
+  private static let plainOpacity: CGFloat = 0.2
+  private static let hotOpacity: CGFloat = 0.42
+  private static let litOpacity: CGFloat = 0.85
+  private static let plainBarHeight: CGFloat = 5
+  private static let litBarHeight: CGFloat = 6
   /// How far into the break band the hairline sits, leaving the day's name room underneath.
   private static let breakRuleOffset: CGFloat = 4
 
@@ -164,7 +200,9 @@ struct SpineRibbon: View, Animatable {
     let translate = size.height * SpineRibbonGeometry.markerFraction - depth
     let dayHeight = SpineRibbonGeometry.dayHeight(viewport: size.height)
     let hourHeight = SpineRibbonGeometry.hourHeight(viewport: size.height)
-    let marker = SpineRibbonGeometry.marker(atDepth: depth, viewport: size.height)
+    // The marker never moves; the strip slides under it. In strip coordinates that is `depth`, and
+    // in the column's own coordinates it is this — which is what every bar measures itself against.
+    let markerY = size.height * SpineRibbonGeometry.markerFraction
     let window = SpineRibbonGeometry.visibleDays(
       depth: depth, height: size.height, count: days.count)
 
@@ -173,11 +211,10 @@ struct SpineRibbon: View, Animatable {
       let dayTop = translate + CGFloat(index) * dayHeight
       // No break above the newest day: the strip starts there, it does not resume there.
       if index > 0 { drawBreak(&context, day: day, top: dayTop, width: size.width) }
-      let litHour = highlightsMarker && index == marker.dayIndex ? marker.hour : nil
       for hour in SpineHourRail.renderedHours {
         drawBar(
-          &context, day: day, hour: hour, litHour: litHour, dayTop: dayTop, hourHeight: hourHeight,
-          height: size.height)
+          &context, day: day, hour: hour, dayTop: dayTop, hourHeight: hourHeight,
+          height: size.height, markerY: highlightsMarker ? markerY : nil)
       }
     }
   }
@@ -206,8 +243,8 @@ struct SpineRibbon: View, Animatable {
   }
 
   private func drawBar(
-    _ context: inout GraphicsContext, day: SpineRibbonDay, hour: Int, litHour: Int?,
-    dayTop: CGFloat, hourHeight: CGFloat, height: CGFloat
+    _ context: inout GraphicsContext, day: SpineRibbonDay, hour: Int, dayTop: CGFloat,
+    hourHeight: CGFloat, height: CGFloat, markerY: CGFloat?
   ) {
     let slotTop = dayTop + SpineRibbonGeometry.dayBreakHeight + CGFloat(23 - hour) * hourHeight
     let centerY = slotTop + hourHeight / 2
@@ -216,22 +253,33 @@ struct SpineRibbon: View, Animatable {
     guard centerY > -hourHeight, centerY < height + hourHeight else { return }
 
     let weight = day.weight(hour)
-    let isCurrent = hour == litHour
-    let barHeight: CGFloat = isCurrent ? 6 : 5
+    let lit = markerY.map { Self.litness(slotCentre: centerY, marker: $0, hourHeight: hourHeight) } ?? 0
+    let isRead =
+      markerY.map { Self.isBeingRead(slotCentre: centerY, marker: $0, hourHeight: hourHeight) }
+      ?? false
+    // The bar's resting look is exactly the rail's: heavier past the day's own busy threshold, plain
+    // otherwise. Being read lifts it from there to `litOpacity`, so the bar the marker is leaving
+    // settles back to whichever of the two it was.
+    let resting = weight >= Self.hotThreshold ? Self.hotOpacity : Self.plainOpacity
+    let opacity = resting + (Self.litOpacity - resting) * lit
+    let barHeight = Self.plainBarHeight + (Self.litBarHeight - Self.plainBarHeight) * lit
     let barWidth = Self.minimumBarWidth + CGFloat(weight) * Self.maximumBarExtra
-    let opacity = isCurrent ? 0.85 : (weight >= Self.hotThreshold ? 0.42 : 0.2)
     context.fill(
       Path(
         roundedRect: CGRect(x: 0, y: centerY - barHeight / 2, width: barWidth, height: barHeight),
         cornerRadius: barHeight / 2, style: .continuous),
       with: .color(Ink.primary.opacity(opacity)))
 
-    guard let hourLabel = Self.caption(for: hour, isLit: isCurrent) else { return }
+    // **Only the hour being read says its time**, plus the four the strip labels on every day. The
+    // caption does not cross-fade with the bar: a half-drawn time is a time somebody has to squint
+    // at to decide whether it is the answer, and two of them at once is worse than a caption that
+    // simply moves.
+    guard let hourLabel = Self.caption(for: hour, isLit: isRead) else { return }
     let text =
       Text(hourLabel)
-      .font(.system(size: 9, weight: isCurrent ? .semibold : .regular))
+      .font(.system(size: 9, weight: isRead ? .semibold : .regular))
       .tracking(0.6)
-      .foregroundStyle(isCurrent ? Ink.primary : Ink.secondary)
+      .foregroundStyle(isRead ? Ink.primary : Ink.secondary)
     context.draw(
       text, at: CGPoint(x: barWidth + Self.captionGap, y: centerY), anchor: .leading)
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineScrollLink.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineScrollLink.swift
@@ -1,0 +1,118 @@
+//
+//  SpineScrollLink.swift — the ribbon is the scrollbar.
+//
+//  The ribbon shows where the list is; wheeling over it should move the list. The tempting way to do
+//  that is to give the ribbon its own scroll view and map its offset onto the list proportionally —
+//  and that mapping is a lie, because spine rows are not the same height. A day of one conversation
+//  and a day of forty occupy the same length of ribbon and wildly different lengths of list, so the
+//  two would drift apart within a screen and the ribbon would stop being a position.
+//
+//  So there is exactly **one** scroll: the list's. A wheel over the ribbon is handed to the list's
+//  `NSScrollView`, the list scrolls, the list reports its new top row, and the ribbon follows the way
+//  it already does. Nothing to keep in sync, because nothing is second.
+//
+
+import AppKit
+import SwiftUI
+
+/// The list's scroll view, once AppKit has one. Held weakly and read on demand — nothing observes
+/// this, so no publish and no redraw.
+@MainActor
+final class SpineScrollLink {
+  /// Internal rather than `fileprivate` so the forwarding arithmetic below — direction, line
+  /// conversion, clamping — is reachable by a test. Nothing outside this file assigns it.
+  weak var scrollView: NSScrollView?
+
+  /// Applies one wheel event's worth of movement to the list. `false` when there is no list to
+  /// scroll yet, so the caller can fall through to normal event handling.
+  ///
+  /// **The offset is computed here rather than handed to `NSScrollView.scrollWheel(with:)`, and
+  /// that is not a preference — forwarding does not work.** A real trackpad or Magic Mouse event
+  /// carries a gesture `phase`, and AppKit routes those through responsive scrolling, which tracks
+  /// the gesture against the view that was actually hit. A scroll view told to handle an event it
+  /// was not hit for ignores it, so the list simply did not move. The bug hid behind the test for
+  /// it: a synthetic `CGEvent` has no phase, takes the legacy path, and scrolls — so forwarding
+  /// looked verified while a real two-finger swipe over the ribbon did nothing at all.
+  ///
+  /// Momentum is not lost by doing the arithmetic here. macOS delivers the coast after a flick as
+  /// its own stream of events with decaying deltas, so applying each one as it arrives *is* the
+  /// inertia; there is nothing for `NSScrollView` to add that the events do not already carry.
+  @discardableResult
+  func scroll(by event: NSEvent) -> Bool {
+    guard let scrollView, let document = scrollView.documentView else { return false }
+    let clip = scrollView.contentView
+    // Precise deltas are already in points. Line-based ones (an old mouse wheel) are in lines.
+    let delta = event.hasPreciseScrollingDeltas ? event.scrollingDeltaY : event.scrollingDeltaY * 16
+    guard delta != 0 else { return true }
+    let limit = max(0, document.frame.height - clip.bounds.height)
+    var origin = clip.bounds.origin
+    origin.y = min(max(0, origin.y - delta), limit)
+    guard origin.y != clip.bounds.origin.y else { return true }
+    clip.scroll(to: origin)
+    scrollView.reflectScrolledClipView(clip)
+    return true
+  }
+}
+
+/// Put behind the list's content: finds the scroll view SwiftUI made and hands it to the link.
+struct SpineScrollAnchor: NSViewRepresentable {
+  let link: SpineScrollLink
+
+  func makeNSView(context: Context) -> NSView { AnchorView(link: link) }
+
+  func updateNSView(_ nsView: NSView, context: Context) {
+    (nsView as? AnchorView)?.resolve()
+  }
+
+  private final class AnchorView: NSView {
+    private let link: SpineScrollLink
+
+    init(link: SpineScrollLink) {
+      self.link = link
+      super.init(frame: .zero)
+    }
+
+    @available(*, unavailable) required init?(coder: NSCoder) { nil }
+
+    override func viewDidMoveToWindow() {
+      super.viewDidMoveToWindow()
+      resolve()
+    }
+
+    /// SwiftUI can replace the backing scroll view while a long list is laid out, so this re-reads
+    /// rather than latching once — but only when what it holds has actually gone. `updateNSView`
+    /// runs on every re-evaluation of the list, which during a scroll is constant, and walking the
+    /// view hierarchy each time is work on the one thread the scroll needs.
+    func resolve() {
+      guard link.scrollView == nil || link.scrollView?.window == nil else { return }
+      link.scrollView = enclosingScrollView
+    }
+  }
+}
+
+/// Put over the ribbon: turns a wheel there into a scroll of the list.
+struct SpineWheelForwarder: NSViewRepresentable {
+  let link: SpineScrollLink
+
+  func makeNSView(context: Context) -> NSView { ForwarderView(link: link) }
+
+  func updateNSView(_ nsView: NSView, context: Context) {}
+
+  private final class ForwarderView: NSView {
+    private let link: SpineScrollLink
+
+    init(link: SpineScrollLink) {
+      self.link = link
+      super.init(frame: .zero)
+    }
+
+    @available(*, unavailable) required init?(coder: NSCoder) { nil }
+
+    /// The wheel is the only thing this takes. It answers `hitTest` because AppKit routes scroll
+    /// events through it, but it adds no click, drag or gesture — the ribbon is a scrollbar, not a
+    /// scrubber.
+    override func scrollWheel(with event: NSEvent) {
+      if !link.scroll(by: event) { super.scrollWheel(with: event) }
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineStore.swift
@@ -21,6 +21,14 @@ import Foundation
 final class SpineStore: ObservableObject {
   /// What the list renders: composed, then narrowed by the chip and the query.
   @Published private(set) var days: [SpineDay] = []
+  /// The same days, as the ribbon draws them: title plus hour histogram, in the same order and with
+  /// the same indices as `days`.
+  ///
+  /// Derived here rather than in the rail because the rail redraws several times a second while
+  /// scrolling, and rebuilding a histogram per day per redraw is the class of waste this store
+  /// exists to avoid. It moves only when `days` does.
+  @Published private(set) var ribbonDays: [SpineRibbonDay] = []
+
   /// True only for the first fill. A refresh behind an already-populated spine is not a spinner.
   @Published private(set) var isPreparing = true
 
@@ -289,6 +297,11 @@ final class SpineStore: ObservableObject {
       composed, kind: kind, query: request.term, earliest: request.range.earliest())
     days = filtered
     matchCount = filtered.reduce(0) { $0 + $1.matchCount }
+    // Histograms stay full-day even when the list is narrowed — the ribbon is a timeline navigator,
+    // not a result count. `SpineRailColumn.railDayTitle` is what says so on screen.
+    ribbonDays = filtered.map {
+      SpineRibbonDay(id: $0.id, title: $0.title, density: density(for: $0.id))
+    }
   }
 
   // MARK: - Digests

--- a/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineStream.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineStream.swift
@@ -41,36 +41,82 @@ import SwiftUI
 /// because of.
 @MainActor
 final class SpineViewport: ObservableObject {
-  @Published private(set) var dayID: Date?
-  @Published private(set) var hour: Int?
+  /// Where the list is being read, continuously. `nil` before the list has reported anything.
+  @Published private(set) var position: SpineReadingPosition?
 
-  func report(dayID: Date, hour: Int) {
+  /// The day under the reading line, for everything that is still a per-day question — the
+  /// headline's count, its scope line, the footer.
+  var dayID: Date? { position?.row.dayID }
+
+  func report(_ position: SpineReadingPosition) {
     // Assign only on a real change: an identical publish is a redraw of the rail for nothing.
-    if self.dayID != dayID { self.dayID = dayID }
-    if self.hour != hour { self.hour = hour }
+    guard self.position != position else { return }
+    self.position = position
   }
 }
 
-/// What one row tells the viewport about itself. The row nearest the top of the list wins.
-private struct SpineRowAnchor: Equatable {
+/// What one row tells the viewport about itself, in the list's own coordinate space.
+struct SpineRowAnchor: Equatable {
   let dayID: Date
   let hour: Int
-  /// The row's bottom edge in the list's coordinate space. A row whose bottom is above the reading
-  /// line has scrolled behind the sticky header; among the rest, the smallest bottom is the topmost
-  /// visible row.
+  let minute: Int
+  /// The row's edges. A row whose bottom is above the reading line has scrolled behind the sticky
+  /// header; among the rest, the smallest bottom is the topmost visible row. `top` is what makes the
+  /// position between two rows knowable — see `SpineReadingPosition.fraction`.
+  let top: CGFloat
   let bottom: CGFloat
 }
 
-private struct SpineTopRowKey: PreferenceKey {
-  static let defaultValue: SpineRowAnchor? = nil
+/// **Where the list is being read, as a continuous quantity rather than a row index.**
+///
+/// The rail used to be told only *which* row was under the reading line. That is a step function:
+/// it holds still for the whole height of a row and then changes all at once, so the ribbon stalled
+/// and jumped, stalled and jumped, however smoothly the list itself was moving. Softening it with an
+/// animation only traded the jump for a lag — the strip was then always a beat behind, which is
+/// worse, because a position indicator that disagrees with the thing it indicates is not a position
+/// indicator.
+///
+/// So the viewport reports the row at the reading line **and the one after it**, plus how far the
+/// first has travelled past that line. Blending between their two positions gives a value that moves
+/// every frame the list moves, lands exactly on the next row's position at the moment that row takes
+/// over, and needs no animation at all — the smoothness is the data, not an easing curve laid over
+/// a coarse one.
+struct SpineReadingPosition: Equatable {
+  /// The row at the reading line.
+  let row: SpineRowAnchor
+  /// The row after it, when there is one. `nil` at the very end of the loaded stream, where there is
+  /// nothing further to blend towards.
+  let next: SpineRowAnchor?
 
-  static func reduce(value: inout SpineRowAnchor?, nextValue: () -> SpineRowAnchor?) {
-    guard let next = nextValue(), next.bottom > SpineLayout.readingLine else { return }
-    guard let current = value else {
-      value = next
-      return
+  /// `0` when `row` has just reached the reading line, `1` when it is about to leave it.
+  var fraction: CGFloat {
+    let span = row.bottom - row.top
+    guard span > 0 else { return 0 }
+    return min(1, max(0, (SpineLayout.readingLine - row.top) / span))
+  }
+
+  /// Keeps the two rows nearest the reading line out of everything the list reported.
+  ///
+  /// At most four candidates ever meet here — two from each side of a `reduce` — so the sort is on
+  /// a fixed, tiny array and this stays proportional to the rows on screen, not to the corpus.
+  static func merge(_ lhs: SpineReadingPosition?, _ rhs: SpineReadingPosition?) -> SpineReadingPosition? {
+    var candidates: [SpineRowAnchor] = []
+    for side in [lhs, rhs] {
+      guard let side else { continue }
+      candidates.append(side.row)
+      if let next = side.next { candidates.append(next) }
     }
-    if next.bottom < current.bottom { value = next }
+    guard !candidates.isEmpty else { return nil }
+    candidates.sort { $0.bottom < $1.bottom }
+    return SpineReadingPosition(row: candidates[0], next: candidates.count > 1 ? candidates[1] : nil)
+  }
+}
+
+private struct SpineTopRowKey: PreferenceKey {
+  static let defaultValue: SpineReadingPosition? = nil
+
+  static func reduce(value: inout SpineReadingPosition?, nextValue: () -> SpineReadingPosition?) {
+    value = SpineReadingPosition.merge(value, nextValue())
   }
 }
 
@@ -110,13 +156,16 @@ struct SpineStream: View {
   /// Which days are folded shut. Lives with the view rather than with the store because it is a
   /// reading position, not data: it is worth exactly as long as this list is on screen.
   @State private var collapse = SpineDayCollapse()
+  /// The list's scroll view, so a wheel over the ribbon scrolls the list. See `SpineScrollLink`.
+  @State private var scrollLink = SpineScrollLink()
 
   var body: some View {
     GeometryReader { proxy in
       HStack(spacing: 0) {
         if proxy.size.width >= SpineLayout.railBreakpoint {
           SpineRailColumn(
-            store: store, viewport: viewport, collapse: collapse, request: request)
+            store: store, viewport: viewport, collapse: collapse, request: request,
+            scrollLink: scrollLink)
           Rectangle().fill(Ink.separator).frame(width: 1)
         }
         Group {
@@ -230,11 +279,15 @@ struct SpineStream: View {
       }
       .padding(.horizontal, OmiSpacing.sm)
       .padding(.bottom, OmiSpacing.md)
+      .background(SpineScrollAnchor(link: scrollLink))
     }
     .coordinateSpace(name: SpineLayout.coordinateSpace)
-    .onPreferenceChange(SpineTopRowKey.self) { anchor in
-      guard let anchor else { return }
-      Task { @MainActor in viewport.report(dayID: anchor.dayID, hour: anchor.hour) }
+    // `assumeIsolated` rather than a `Task`: SwiftUI delivers preference changes on the main thread
+    // during a view update, and with a continuous position this fires on every frame of a scroll —
+    // one `Task` allocation per frame, to hop to the actor it is already on.
+    .onPreferenceChange(SpineTopRowKey.self) { position in
+      guard let position else { return }
+      MainActor.assumeIsolated { viewport.report(position) }
     }
     .glassScrollFade(bottom: 18)
   }
@@ -244,13 +297,21 @@ struct SpineStream: View {
   /// thousand.
   private func anchor(for row: SpineRow, in day: SpineDay) -> some View {
     GeometryReader { proxy in
+      let frame = proxy.frame(in: .named(SpineLayout.coordinateSpace))
       Color.clear.preference(
         key: SpineTopRowKey.self,
-        value: SpineRowAnchor(
-          dayID: day.id,
-          hour: Calendar.current.component(.hour, from: row.anchor),
-          bottom: proxy.frame(in: .named(SpineLayout.coordinateSpace)).maxY
-        )
+        // A row entirely above the reading line is behind the sticky header and is not what anybody
+        // is looking at, so it offers nothing rather than competing to be the position.
+        value: frame.maxY > SpineLayout.readingLine
+          ? SpineReadingPosition(
+            row: SpineRowAnchor(
+              dayID: day.id,
+              hour: Calendar.current.component(.hour, from: row.anchor),
+              minute: Calendar.current.component(.minute, from: row.anchor),
+              top: frame.minY,
+              bottom: frame.maxY
+            ), next: nil)
+          : nil
       )
     }
   }
@@ -394,6 +455,7 @@ private struct SpineRailColumn: View {
   @ObservedObject var viewport: SpineViewport
   let collapse: SpineDayCollapse
   let request: QueryShellRequest
+  let scrollLink: SpineScrollLink
 
   /// The day the rail describes.
   ///
@@ -409,11 +471,36 @@ private struct SpineRailColumn: View {
 
   private var day: SpineDay? { store.days.first { $0.id == dayID } }
 
-  /// The hour marker belongs to the day the list actually reported. Carrying it onto a day chosen by
-  /// the fallback above would light up an hour on a rail for a day nobody is reading.
-  private var currentHour: Int? {
+  /// The reading position, but only while it belongs to the day the rail is describing. A folded
+  /// day still reports nothing, so a position left over from before it folded would light an hour on
+  /// a strip for a day nobody is reading.
+  private var position: SpineReadingPosition? {
     guard let dayID, dayID == viewport.dayID else { return nil }
-    return viewport.hour
+    return viewport.position
+  }
+
+  /// Where a row sits in the strip. `store.ribbonDays` is `store.days` in the same order, so one
+  /// index serves both; a row whose day has gone from the list under us falls back to the newest.
+  private func depth(of anchor: SpineRowAnchor, viewport height: CGFloat) -> CGFloat {
+    SpineRibbonGeometry.depth(
+      dayIndex: store.days.firstIndex { $0.id == anchor.dayID } ?? 0,
+      hour: anchor.hour, minute: anchor.minute, viewport: height)
+  }
+
+  /// **The blend that makes the strip continuous.** Between the row at the reading line and the one
+  /// after it, by how far the first has travelled past that line — so the strip arrives at the next
+  /// row's position exactly as that row takes over, and never has to jump to catch up.
+  ///
+  /// With nothing reported it parks on the day the headline is describing, at that day's latest
+  /// minute: the top of its block, which is where reading it would start.
+  private func depth(viewport height: CGFloat) -> CGFloat {
+    guard let position else {
+      let index = store.days.firstIndex { $0.id == dayID } ?? 0
+      return SpineRibbonGeometry.depth(dayIndex: index, hour: 23, minute: 59, viewport: height)
+    }
+    let from = depth(of: position.row, viewport: height)
+    guard let next = position.next else { return from }
+    return from + (depth(of: next, viewport: height) - from) * position.fraction
   }
 
   /// The rail remains a timeline navigator while the list narrows. Its capture histogram and
@@ -429,8 +516,11 @@ private struct SpineRailColumn: View {
 
   var body: some View {
     SpineHourRail(
-      density: dayID.map(store.density(for:)) ?? Array(repeating: 0, count: 24),
-      currentHour: currentHour,
+      days: store.ribbonDays,
+      depth: { depth(viewport: $0) },
+      highlightsMarker: position != nil,
+      readingHour: position?.row.hour,
+      scrollLink: scrollLink,
       momentCount: dayID.flatMap(store.momentCount(for:)),
       dayTitle: railDayTitle,
       // Filtered results no longer carry the complete day's conversation count. The footer is

--- a/desktop/macos/Desktop/Tests/SpineCompositionTests.swift
+++ b/desktop/macos/Desktop/Tests/SpineCompositionTests.swift
@@ -577,6 +577,218 @@ final class SpineCompositionTests: XCTestCase {
       "every step goes back in time, exactly as the list under it does")
   }
 
+  // MARK: - The ribbon is continuous
+
+  /// The column height every geometry test measures against. One day is one column, so this stands
+  /// in for the real rail's height without any test depending on the window being a given size.
+  private static let ribbonViewport: CGFloat = 600
+
+  /// **The defect this ribbon replaced:** the rail drew one day at a time, so crossing midnight
+  /// swapped the whole column at once. Depth is monotonic across the day boundary now — one more
+  /// minute into the past is one step further down the strip, whether or not that minute is in a
+  /// different day.
+  func testDepthNeverJumpsBackwardsAcrossADayBoundary() {
+    var previous = -CGFloat.greatestFiniteMagnitude
+    for dayIndex in 0..<3 {
+      for hour in SpineHourRail.renderedHours {
+        for minute in [59, 30, 0] {
+          let depth = SpineRibbonGeometry.depth(
+            dayIndex: dayIndex, hour: hour, minute: minute, viewport: Self.ribbonViewport)
+          XCTAssertGreaterThan(
+            depth, previous,
+            "day \(dayIndex) \(hour):\(minute) went back up the strip")
+          previous = depth
+        }
+      }
+    }
+  }
+
+  /// The last minute of a day and the first of the next are adjacent in time, so they are adjacent
+  /// on the strip: one day break apart and nothing else. This is what makes the midnight crossing
+  /// glide rather than cut.
+  func testMidnightIsOneBreakWideAndNotACut() {
+    let viewport = Self.ribbonViewport
+    let lastOfDay = SpineRibbonGeometry.depth(
+      dayIndex: 0, hour: 0, minute: 0, viewport: viewport)
+    let firstOfNext = SpineRibbonGeometry.depth(
+      dayIndex: 1, hour: 23, minute: 59, viewport: viewport)
+    XCTAssertEqual(
+      firstOfNext - lastOfDay,
+      SpineRibbonGeometry.dayBreakHeight + SpineRibbonGeometry.hourHeight(viewport: viewport) / 60,
+      accuracy: 0.001)
+  }
+
+  /// **One day is one column**, the way the per-day rail always sized itself. The strip is longer
+  /// than the rail was; it is not drawn tighter, so nothing about how a single day reads changed.
+  func testOneDayFillsTheColumnAtAnySize() {
+    for viewport in [CGFloat(320), 600, 1400] {
+      XCTAssertEqual(SpineRibbonGeometry.dayHeight(viewport: viewport), viewport, accuracy: 0.001)
+      XCTAssertEqual(
+        SpineRibbonGeometry.hourHeight(viewport: viewport) * 24
+          + SpineRibbonGeometry.dayBreakHeight,
+        viewport, accuracy: 0.001)
+    }
+    XCTAssertGreaterThan(
+      SpineRibbonGeometry.hourHeight(viewport: 0), 0,
+      "a column with no height yet must not collapse an hour to nothing")
+  }
+
+  /// **A day with no reported row still parks the strip on that day.**
+  ///
+  /// The rail describes a fallback day whenever the reported one has been folded shut, and the hour
+  /// marker is deliberately dropped in that case — it belongs to a row nobody can see. The first
+  /// version carried that one `nil` into the strip's position too, so the headline named the
+  /// fallback day while the strip scrolled to the newest one. Position and highlight are separate
+  /// inputs now; this pins that they stay separate.
+  func testAnUnreportedDayStillParksTheStripOnThatDay() {
+    let height = Self.ribbonViewport
+    let parked = SpineRibbonGeometry.depth(
+      dayIndex: 4, hour: 23, minute: 59, viewport: height)
+    XCTAssertTrue(
+      SpineRibbonGeometry.visibleDays(depth: parked, height: height, count: 9).contains(4),
+      "the strip has to be showing the day the headline is describing")
+    XCTAssertNotEqual(
+      parked,
+      SpineRibbonGeometry.depth(dayIndex: 0, hour: 23, minute: 59, viewport: height),
+      "parking an unreported day must not collapse to the newest day")
+  }
+
+  /// **The strip labels exactly what the per-day rail labelled, and suppresses nothing.**
+  ///
+  /// Four fixed hours orient every day, and the hour being read names itself when it is not one of
+  /// them. An earlier version of the strip also *dropped* a fixed label within an hour of the marker,
+  /// to stop two captions colliding — a real collision, but only at the six-point hour spacing that
+  /// version drew at. At one day per column an hour is more than twenty points, so the rule deleted
+  /// labels to prevent an overlap that cannot happen, and made the strip read differently from the
+  /// rail it replaced.
+  func testTheStripLabelsTheSameHoursTheRailAlwaysDid() {
+    for hour in [0, 6, 12, 18] {
+      XCTAssertEqual(
+        SpineRibbon.caption(for: hour, isLit: false), SpineFormat.hourLabel(hour),
+        "a fixed label is drawn on every day, read or not")
+      XCTAssertEqual(SpineRibbon.caption(for: hour, isLit: true), SpineFormat.hourLabel(hour))
+    }
+    XCTAssertNil(
+      SpineRibbon.caption(for: 19, isLit: false),
+      "an unread hour that is not one of the four stays unnamed")
+    XCTAssertEqual(
+      SpineRibbon.caption(for: 19, isLit: true), "7 PM",
+      "the hour being read names itself even when it is not one of the four")
+    XCTAssertEqual(
+      SpineRibbon.caption(for: 17, isLit: false), SpineRibbon.caption(for: 17, isLit: false),
+      "and a label near the one being read is never taken away")
+    XCTAssertEqual(
+      SpineRibbon.caption(for: 18, isLit: false), "6 PM",
+      "including the fixed label directly beside it")
+  }
+
+  /// The heavy bar is derived from where the strip actually sits, so it can never be a bar other
+  /// than the one under the marker. `marker` is the inverse of `depth`.
+  func testTheLitHourIsTheOneTheStripIsSittingOn() {
+    let viewport = Self.ribbonViewport
+    for dayIndex in [0, 3] {
+      for hour in [0, 7, 12, 23] {
+        let at = SpineRibbonGeometry.marker(
+          atDepth: SpineRibbonGeometry.depth(
+            dayIndex: dayIndex, hour: hour, minute: 30, viewport: viewport),
+          viewport: viewport)
+        XCTAssertEqual(at.dayIndex, dayIndex)
+        XCTAssertEqual(at.hour, hour)
+      }
+    }
+  }
+
+  // MARK: - The reading position is continuous
+
+  private func anchor(hour: Int, minute: Int = 0, top: CGFloat, bottom: CGFloat) -> SpineRowAnchor {
+    SpineRowAnchor(dayID: Date(timeIntervalSince1970: 0), hour: hour, minute: minute, top: top, bottom: bottom)
+  }
+
+  /// **The whole point of reporting two rows.** As the row at the reading line travels past it, the
+  /// fraction runs 0 → 1; the strip blends towards the next row over that span and therefore moves
+  /// every frame the list does, instead of holding still for a whole row and then jumping.
+  func testTheFractionRunsTheLengthOfTheRow() {
+    let line = SpineLayout.readingLine
+    let justArrived = SpineReadingPosition(
+      row: anchor(hour: 12, top: line, bottom: line + 100), next: nil)
+    XCTAssertEqual(justArrived.fraction, 0, accuracy: 0.001)
+
+    let halfway = SpineReadingPosition(
+      row: anchor(hour: 12, top: line - 50, bottom: line + 50), next: nil)
+    XCTAssertEqual(halfway.fraction, 0.5, accuracy: 0.001)
+
+    let leaving = SpineReadingPosition(
+      row: anchor(hour: 12, top: line - 100, bottom: line), next: nil)
+    XCTAssertEqual(leaving.fraction, 1, accuracy: 0.001)
+  }
+
+  /// A row taller than the whole scroll, and a zero-height one, both have to produce a fraction the
+  /// blend can use rather than a NaN or a value outside 0…1 that would throw the strip off its ends.
+  func testTheFractionStaysInsideItsRange() {
+    let line = SpineLayout.readingLine
+    XCTAssertEqual(
+      SpineReadingPosition(row: anchor(hour: 12, top: line, bottom: line), next: nil).fraction, 0,
+      accuracy: 0.001, "a row with no height cannot be part-way past anything")
+    XCTAssertEqual(
+      SpineReadingPosition(row: anchor(hour: 12, top: line + 10, bottom: line + 20), next: nil)
+        .fraction, 0, accuracy: 0.001, "a row not yet at the line is at the start of its travel")
+    XCTAssertEqual(
+      SpineReadingPosition(row: anchor(hour: 12, top: line - 900, bottom: line - 1), next: nil)
+        .fraction, 1, accuracy: 0.001, "and one already past it is at the end")
+  }
+
+  /// The two rows kept are the two nearest the reading line, whatever order the list reported them
+  /// in — a `PreferenceKey` reduce sees them in no guaranteed order.
+  func testTheTwoRowsNearestTheReadingLineWin() {
+    let line = SpineLayout.readingLine
+    let first = SpineReadingPosition(row: anchor(hour: 12, top: line - 10, bottom: line + 10), next: nil)
+    let second = SpineReadingPosition(row: anchor(hour: 11, top: line + 10, bottom: line + 60), next: nil)
+    let far = SpineReadingPosition(row: anchor(hour: 9, top: line + 300, bottom: line + 400), next: nil)
+
+    for order in [[first, second, far], [far, second, first], [second, far, first]] {
+      let merged = order.reduce(nil) { SpineReadingPosition.merge($0, $1) }
+      XCTAssertEqual(merged?.row.hour, 12, "the row at the line is the position")
+      XCTAssertEqual(merged?.next?.hour, 11, "and the one after it is what to blend towards")
+    }
+    XCTAssertNil(SpineReadingPosition.merge(nil, nil))
+  }
+
+  /// At the end of the loaded stream there is no row to blend towards, and the position simply rests
+  /// on the last one rather than blending towards nothing.
+  func testTheLastRowHasNothingToBlendTowards() {
+    let line = SpineLayout.readingLine
+    let last = SpineReadingPosition(row: anchor(hour: 3, top: line - 20, bottom: line + 20), next: nil)
+    XCTAssertNil(last.next)
+    XCTAssertEqual(SpineReadingPosition.merge(nil, last)?.row.hour, 3)
+  }
+
+  /// Only the days on screen are drawn — the strip is the whole account, and drawing all of it on
+  /// every scroll tick is the cost a `Canvas` was chosen to avoid.
+  func testOnlyTheDaysInTheViewportAreDrawn() {
+    let height = Self.ribbonViewport
+    let window = SpineRibbonGeometry.visibleDays(
+      depth: SpineRibbonGeometry.depth(
+        dayIndex: 40, hour: 12, minute: 0, viewport: height),
+      height: height, count: 300)
+    XCTAssertTrue(window.contains(40))
+    XCTAssertLessThanOrEqual(
+      window.count,
+      Int((height / SpineRibbonGeometry.dayHeight(viewport: height)).rounded(.up)) + 1)
+  }
+
+  /// The strip runs out at both ends rather than the index going out of bounds: reading the newest
+  /// day means there is nothing above it, and an empty account has no strip at all.
+  func testTheVisibleWindowStaysInsideTheLoadedDays() {
+    let height = Self.ribbonViewport
+    let atNewest = SpineRibbonGeometry.visibleDays(
+      depth: SpineRibbonGeometry.depth(dayIndex: 0, hour: 23, minute: 59, viewport: height),
+      height: height, count: 2)
+    XCTAssertEqual(atNewest.lowerBound, 0)
+    XCTAssertLessThanOrEqual(atNewest.upperBound, 2)
+    XCTAssertTrue(SpineRibbonGeometry.visibleDays(depth: 0, height: height, count: 0).isEmpty)
+    XCTAssertTrue(SpineRibbonGeometry.visibleDays(depth: 0, height: 0, count: 5).isEmpty)
+  }
+
   /// **A day nobody has read yet is not a day with nothing on it.**
   ///
   /// Screen days are read lazily, three at a time, and an empty result is deliberately never stored

--- a/desktop/macos/Desktop/Tests/SpineCompositionTests.swift
+++ b/desktop/macos/Desktop/Tests/SpineCompositionTests.swift
@@ -682,19 +682,69 @@ final class SpineCompositionTests: XCTestCase {
       "including the fixed label directly beside it")
   }
 
-  /// The heavy bar is derived from where the strip actually sits, so it can never be a bar other
-  /// than the one under the marker. `marker` is the inverse of `depth`.
-  func testTheLitHourIsTheOneTheStripIsSittingOn() {
-    let viewport = Self.ribbonViewport
-    for dayIndex in [0, 3] {
-      for hour in [0, 7, 12, 23] {
-        let at = SpineRibbonGeometry.marker(
-          atDepth: SpineRibbonGeometry.depth(
-            dayIndex: dayIndex, hour: hour, minute: 30, viewport: viewport),
-          viewport: viewport)
-        XCTAssertEqual(at.dayIndex, dayIndex)
-        XCTAssertEqual(at.hour, hour)
+  /// **The bar being read is always at full strength, and only its outgoing neighbour fades.**
+  ///
+  /// Sharing the weight evenly was the obvious way to make the highlight glide and it made the
+  /// highlight vanish: with the marker between two slots each bar got half of it, so the one thing
+  /// on the strip that has to be findable was drawn at half strength for most of every scroll.
+  func testTheBarBeingReadIsNeverDimmedByTheHandover() {
+    let hour: CGFloat = 24
+    let marker: CGFloat = 300
+
+    XCTAssertEqual(
+      SpineRibbon.litness(slotCentre: marker, marker: marker, hourHeight: hour), 1, accuracy: 0.001)
+    for offset in [CGFloat(0), 0.1, 0.25, 0.4, 0.49] {
+      XCTAssertEqual(
+        SpineRibbon.litness(slotCentre: marker + hour * offset, marker: marker, hourHeight: hour), 1,
+        accuracy: 0.001,
+        "every bar the marker is inside is fully lit, wherever inside it sits")
+    }
+
+    XCTAssertEqual(
+      SpineRibbon.litness(slotCentre: marker + hour * 0.75, marker: marker, hourHeight: hour), 0.5,
+      accuracy: 0.001, "the bar being left fades across the second half")
+    XCTAssertEqual(
+      SpineRibbon.litness(slotCentre: marker + hour, marker: marker, hourHeight: hour), 0,
+      accuracy: 0.001, "an hour away is where it lets go")
+    XCTAssertEqual(
+      SpineRibbon.litness(slotCentre: marker + hour * 3, marker: marker, hourHeight: hour), 0,
+      accuracy: 0.001, "and it never goes negative further out")
+    XCTAssertEqual(
+      SpineRibbon.litness(slotCentre: marker, marker: marker, hourHeight: 0), 0, accuracy: 0.001,
+      "a column with no height yet lights nothing rather than dividing by zero")
+  }
+
+  /// **One hour says the time, never two.** A partly lit neighbour captioning itself put two hours
+  /// on screen at once and left the reader to work out which of them the list was actually showing.
+  func testOnlyTheHourBeingReadSaysTheTime() {
+    let hour: CGFloat = 24
+    let marker: CGFloat = 300
+
+    XCTAssertTrue(
+      SpineRibbon.isBeingRead(slotCentre: marker, marker: marker, hourHeight: hour))
+    XCTAssertTrue(
+      SpineRibbon.isBeingRead(slotCentre: marker + hour * 0.49, marker: marker, hourHeight: hour))
+    XCTAssertFalse(
+      SpineRibbon.isBeingRead(slotCentre: marker + hour * 0.51, marker: marker, hourHeight: hour),
+      "the neighbour is lit during the hand-over but is not the hour being read")
+    XCTAssertTrue(
+      SpineRibbon.isBeingRead(slotCentre: marker + hour / 2, marker: marker, hourHeight: hour),
+      "the boundary belongs to one side, so the hand-over has no gap in it")
+    XCTAssertFalse(
+      SpineRibbon.isBeingRead(slotCentre: marker - hour / 2, marker: marker, hourHeight: hour),
+      "and not to both")
+    XCTAssertFalse(
+      SpineRibbon.isBeingRead(slotCentre: marker - hour * 0.75, marker: marker, hourHeight: hour))
+    XCTAssertFalse(
+      SpineRibbon.isBeingRead(slotCentre: marker, marker: marker, hourHeight: 0))
+
+    // Exactly one slot on the strip owns the caption, wherever the marker falls between them.
+    for shift in stride(from: CGFloat(0), through: 0.95, by: 0.05) {
+      let centres = [marker - hour * shift, marker + hour * (1 - shift)]
+      let owning = centres.filter {
+        SpineRibbon.isBeingRead(slotCentre: $0, marker: marker, hourHeight: hour)
       }
+      XCTAssertEqual(owning.count, 1, "two adjacent slots, one of them reading")
     }
   }
 

--- a/desktop/macos/Desktop/Tests/SpineScrollLinkTests.swift
+++ b/desktop/macos/Desktop/Tests/SpineScrollLinkTests.swift
@@ -44,28 +44,32 @@ final class SpineScrollLinkTests: XCTestCase {
 
   /// A wheel event. `phase` is the axis the shipped bug turned on: `.none` is the legacy path an
   /// old mouse takes, anything else is the trackpad gesture path.
-  private func wheel(deltaY: Double, precise: Bool = true, phase: CGScrollPhase? = nil) -> NSEvent {
-    let event = CGEvent(
-      scrollWheelEvent2Source: nil, units: precise ? .pixel : .line, wheelCount: 1,
-      wheel1: Int32(deltaY), wheel2: 0, wheel3: 0)!
+  private func wheel(
+    deltaY: Double, precise: Bool = true, phase: CGScrollPhase? = nil,
+    file: StaticString = #filePath, line: UInt = #line
+  ) throws -> NSEvent {
+    let event = try XCTUnwrap(
+      CGEvent(
+        scrollWheelEvent2Source: nil, units: precise ? .pixel : .line, wheelCount: 1,
+        wheel1: Int32(deltaY), wheel2: 0, wheel3: 0), file: file, line: line)
     event.setIntegerValueField(.scrollWheelEventIsContinuous, value: precise ? 1 : 0)
     if let phase {
       event.setIntegerValueField(.scrollWheelEventScrollPhase, value: Int64(phase.rawValue))
     }
-    return NSEvent(cgEvent: event)!
+    return try XCTUnwrap(NSEvent(cgEvent: event), file: file, line: line)
   }
 
   /// **A real two-finger swipe moves the list.** This is the regression: the whole gesture — the
   /// `.began`, the run of `.changed`, the `.ended` — has to land on the list, because a trackpad
   /// sends nothing else.
-  func testATrackpadGestureWithPhasesScrollsTheList() {
+  func testATrackpadGestureWithPhasesScrollsTheList() throws {
     let scrollView = makeScrollView()
     let link = SpineScrollLink()
     link.scrollView = scrollView
 
-    link.scroll(by: wheel(deltaY: -10, phase: .began))
-    for _ in 0..<3 { link.scroll(by: wheel(deltaY: -10, phase: .changed)) }
-    link.scroll(by: wheel(deltaY: 0, phase: .ended))
+    link.scroll(by: try wheel(deltaY: -10, phase: .began))
+    for _ in 0..<3 { link.scroll(by: try wheel(deltaY: -10, phase: .changed)) }
+    link.scroll(by: try wheel(deltaY: 0, phase: .ended))
 
     XCTAssertEqual(
       scrollView.contentView.bounds.origin.y, 40, accuracy: 0.001,
@@ -74,14 +78,14 @@ final class SpineScrollLinkTests: XCTestCase {
 
   /// The coast after a flick is a stream of events macOS sends on its own with decaying deltas, so
   /// applying each one as it arrives *is* the inertia.
-  func testTheMomentumTailKeepsMovingTheList() {
+  func testTheMomentumTailKeepsMovingTheList() throws {
     let scrollView = makeScrollView()
     let link = SpineScrollLink()
     link.scrollView = scrollView
 
-    link.scroll(by: wheel(deltaY: -20, phase: .began))
+    link.scroll(by: try wheel(deltaY: -20, phase: .began))
     for decay in [-16.0, -12, -8, -4, -2, -1] {
-      link.scroll(by: wheel(deltaY: decay, phase: .none))
+      link.scroll(by: try wheel(deltaY: decay, phase: .none))
     }
     XCTAssertEqual(scrollView.contentView.bounds.origin.y, 63, accuracy: 0.001)
   }
@@ -89,15 +93,15 @@ final class SpineScrollLinkTests: XCTestCase {
   /// **Down the wheel is down the list.** A sign flip here would send the ribbon and the list in
   /// opposite directions, which is the one failure that makes the ribbon read as broken rather than
   /// as merely imprecise.
-  func testWheelingDownMovesTheListTowardsTheOlderEnd() {
+  func testWheelingDownMovesTheListTowardsTheOlderEnd() throws {
     let scrollView = makeScrollView()
     let link = SpineScrollLink()
     link.scrollView = scrollView
 
-    XCTAssertTrue(link.scroll(by: wheel(deltaY: -40)))
+    try XCTAssertTrue(link.scroll(by: wheel(deltaY: -40)))
     XCTAssertEqual(scrollView.contentView.bounds.origin.y, 40, accuracy: 0.001)
 
-    XCTAssertTrue(link.scroll(by: wheel(deltaY: 15)))
+    try XCTAssertTrue(link.scroll(by: wheel(deltaY: 15)))
     XCTAssertEqual(
       scrollView.contentView.bounds.origin.y, 25, accuracy: 0.001,
       "wheeling back up has to undo exactly what wheeling down did")
@@ -105,12 +109,12 @@ final class SpineScrollLinkTests: XCTestCase {
 
   /// A trackpad reports points; an old mouse wheel reports lines. Forwarding the raw number for both
   /// makes a real mouse move the list about a pixel a notch.
-  func testALineWheelTravelsFurtherThanASinglePoint() {
+  func testALineWheelTravelsFurtherThanASinglePoint() throws {
     let scrollView = makeScrollView()
     let link = SpineScrollLink()
     link.scrollView = scrollView
 
-    link.scroll(by: wheel(deltaY: -1, precise: false))
+    link.scroll(by: try wheel(deltaY: -1, precise: false))
     XCTAssertGreaterThan(
       scrollView.contentView.bounds.origin.y, 1,
       "a line-based notch is worth more than one point of list")
@@ -118,17 +122,17 @@ final class SpineScrollLinkTests: XCTestCase {
 
   /// The list stops at both ends. Without the clamp the ribbon can drive the content off its own
   /// document and leave the spine showing blank space it can never scroll back from.
-  func testTheListStopsAtBothEnds() {
+  func testTheListStopsAtBothEnds() throws {
     let scrollView = makeScrollView(documentHeight: 2_000, viewportHeight: 500)
     let link = SpineScrollLink()
     link.scrollView = scrollView
 
-    for _ in 0..<100 { link.scroll(by: wheel(deltaY: -200)) }
+    for _ in 0..<100 { link.scroll(by: try wheel(deltaY: -200)) }
     XCTAssertEqual(
       scrollView.contentView.bounds.origin.y, 1_500, accuracy: 0.001,
       "the oldest thing loaded is the bottom of the document, not past it")
 
-    for _ in 0..<100 { link.scroll(by: wheel(deltaY: 200)) }
+    for _ in 0..<100 { link.scroll(by: try wheel(deltaY: 200)) }
     XCTAssertEqual(
       scrollView.contentView.bounds.origin.y, 0, accuracy: 0.001,
       "and the newest is the top, not above it")
@@ -136,15 +140,15 @@ final class SpineScrollLinkTests: XCTestCase {
 
   /// A list shorter than its viewport has nowhere to go, and a ribbon with no list yet must not
   /// swallow the wheel — the caller falls through to normal handling on `false`.
-  func testAWheelWithNothingToScrollIsHarmless() {
+  func testAWheelWithNothingToScrollIsHarmless() throws {
     let link = SpineScrollLink()
-    XCTAssertFalse(
+    try XCTAssertFalse(
       link.scroll(by: wheel(deltaY: -40)),
       "no list resolved yet: the event has to go back to AppKit, not vanish")
 
     let shortList = makeScrollView(documentHeight: 200, viewportHeight: 500)
     link.scrollView = shortList
-    XCTAssertTrue(link.scroll(by: wheel(deltaY: -40)))
+    try XCTAssertTrue(link.scroll(by: wheel(deltaY: -40)))
     XCTAssertEqual(shortList.contentView.bounds.origin.y, 0, accuracy: 0.001)
   }
 }

--- a/desktop/macos/Desktop/Tests/SpineScrollLinkTests.swift
+++ b/desktop/macos/Desktop/Tests/SpineScrollLinkTests.swift
@@ -1,0 +1,150 @@
+//
+//  SpineScrollLinkTests.swift — the ribbon is the scrollbar, and this is the arithmetic that makes
+//  it one.
+//
+//  A wheel over the hour ribbon moves the list's own `NSScrollView` rather than a second scroll view
+//  of the ribbon's own (see `SpineScrollLink` for why a proportional mapping between the two would
+//  drift). Three decisions carry that: which way the wheel moves the list, what a line-based wheel is
+//  worth in points, and where the list stops.
+//
+//  **The phased-event case below is the one that matters most, because its absence shipped a bug.**
+//  An earlier version handed the event to `NSScrollView.scrollWheel(with:)` instead of computing the
+//  offset, on the reasoning that AppKit should own momentum and rubber-banding. It does — but only
+//  for events it was hit for: a real trackpad event carries a gesture `phase` and goes through
+//  responsive scrolling, which ignores an event force-fed to a scroll view the gesture did not
+//  start in. A two-finger swipe over the ribbon did nothing at all. The tests passed anyway, because
+//  every event they built was a synthetic `CGEvent` with no phase, which takes the legacy path and
+//  scrolls. A test suite that can only produce the one kind of event the broken path still handles
+//  is a suite that certifies the break.
+//
+
+import AppKit
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class SpineScrollLinkTests: XCTestCase {
+  /// A list taller than its viewport: 2,000 points of document in a 500 point window.
+  private func makeScrollView(documentHeight: CGFloat = 2_000, viewportHeight: CGFloat = 500)
+    -> NSScrollView
+  {
+    let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 300, height: viewportHeight))
+    let document = FlippedView(frame: NSRect(x: 0, y: 0, width: 300, height: documentHeight))
+    scrollView.documentView = document
+    scrollView.layoutSubtreeIfNeeded()
+    return scrollView
+  }
+
+  /// SwiftUI's `ScrollView` lays its content out top-down, so the document view is flipped and
+  /// `bounds.origin.y` grows downward. The forwarding maths only reads correctly against that.
+  private final class FlippedView: NSView {
+    override var isFlipped: Bool { true }
+  }
+
+  /// A wheel event. `phase` is the axis the shipped bug turned on: `.none` is the legacy path an
+  /// old mouse takes, anything else is the trackpad gesture path.
+  private func wheel(deltaY: Double, precise: Bool = true, phase: CGScrollPhase? = nil) -> NSEvent {
+    let event = CGEvent(
+      scrollWheelEvent2Source: nil, units: precise ? .pixel : .line, wheelCount: 1,
+      wheel1: Int32(deltaY), wheel2: 0, wheel3: 0)!
+    event.setIntegerValueField(.scrollWheelEventIsContinuous, value: precise ? 1 : 0)
+    if let phase {
+      event.setIntegerValueField(.scrollWheelEventScrollPhase, value: Int64(phase.rawValue))
+    }
+    return NSEvent(cgEvent: event)!
+  }
+
+  /// **A real two-finger swipe moves the list.** This is the regression: the whole gesture — the
+  /// `.began`, the run of `.changed`, the `.ended` — has to land on the list, because a trackpad
+  /// sends nothing else.
+  func testATrackpadGestureWithPhasesScrollsTheList() {
+    let scrollView = makeScrollView()
+    let link = SpineScrollLink()
+    link.scrollView = scrollView
+
+    link.scroll(by: wheel(deltaY: -10, phase: .began))
+    for _ in 0..<3 { link.scroll(by: wheel(deltaY: -10, phase: .changed)) }
+    link.scroll(by: wheel(deltaY: 0, phase: .ended))
+
+    XCTAssertEqual(
+      scrollView.contentView.bounds.origin.y, 40, accuracy: 0.001,
+      "a phased gesture has to move the list exactly as far as its deltas say")
+  }
+
+  /// The coast after a flick is a stream of events macOS sends on its own with decaying deltas, so
+  /// applying each one as it arrives *is* the inertia.
+  func testTheMomentumTailKeepsMovingTheList() {
+    let scrollView = makeScrollView()
+    let link = SpineScrollLink()
+    link.scrollView = scrollView
+
+    link.scroll(by: wheel(deltaY: -20, phase: .began))
+    for decay in [-16.0, -12, -8, -4, -2, -1] {
+      link.scroll(by: wheel(deltaY: decay, phase: .none))
+    }
+    XCTAssertEqual(scrollView.contentView.bounds.origin.y, 63, accuracy: 0.001)
+  }
+
+  /// **Down the wheel is down the list.** A sign flip here would send the ribbon and the list in
+  /// opposite directions, which is the one failure that makes the ribbon read as broken rather than
+  /// as merely imprecise.
+  func testWheelingDownMovesTheListTowardsTheOlderEnd() {
+    let scrollView = makeScrollView()
+    let link = SpineScrollLink()
+    link.scrollView = scrollView
+
+    XCTAssertTrue(link.scroll(by: wheel(deltaY: -40)))
+    XCTAssertEqual(scrollView.contentView.bounds.origin.y, 40, accuracy: 0.001)
+
+    XCTAssertTrue(link.scroll(by: wheel(deltaY: 15)))
+    XCTAssertEqual(
+      scrollView.contentView.bounds.origin.y, 25, accuracy: 0.001,
+      "wheeling back up has to undo exactly what wheeling down did")
+  }
+
+  /// A trackpad reports points; an old mouse wheel reports lines. Forwarding the raw number for both
+  /// makes a real mouse move the list about a pixel a notch.
+  func testALineWheelTravelsFurtherThanASinglePoint() {
+    let scrollView = makeScrollView()
+    let link = SpineScrollLink()
+    link.scrollView = scrollView
+
+    link.scroll(by: wheel(deltaY: -1, precise: false))
+    XCTAssertGreaterThan(
+      scrollView.contentView.bounds.origin.y, 1,
+      "a line-based notch is worth more than one point of list")
+  }
+
+  /// The list stops at both ends. Without the clamp the ribbon can drive the content off its own
+  /// document and leave the spine showing blank space it can never scroll back from.
+  func testTheListStopsAtBothEnds() {
+    let scrollView = makeScrollView(documentHeight: 2_000, viewportHeight: 500)
+    let link = SpineScrollLink()
+    link.scrollView = scrollView
+
+    for _ in 0..<100 { link.scroll(by: wheel(deltaY: -200)) }
+    XCTAssertEqual(
+      scrollView.contentView.bounds.origin.y, 1_500, accuracy: 0.001,
+      "the oldest thing loaded is the bottom of the document, not past it")
+
+    for _ in 0..<100 { link.scroll(by: wheel(deltaY: 200)) }
+    XCTAssertEqual(
+      scrollView.contentView.bounds.origin.y, 0, accuracy: 0.001,
+      "and the newest is the top, not above it")
+  }
+
+  /// A list shorter than its viewport has nowhere to go, and a ribbon with no list yet must not
+  /// swallow the wheel — the caller falls through to normal handling on `false`.
+  func testAWheelWithNothingToScrollIsHarmless() {
+    let link = SpineScrollLink()
+    XCTAssertFalse(
+      link.scroll(by: wheel(deltaY: -40)),
+      "no list resolved yet: the event has to go back to AppKit, not vanish")
+
+    let shortList = makeScrollView(documentHeight: 200, viewportHeight: 500)
+    link.scrollView = shortList
+    XCTAssertTrue(link.scroll(by: wheel(deltaY: -40)))
+    XCTAssertEqual(shortList.contentView.bounds.origin.y, 0, accuracy: 0.001)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260830-activity-hour-ribbon.json
+++ b/desktop/macos/changelog/unreleased/20260830-activity-hour-ribbon.json
@@ -1,0 +1,3 @@
+{
+  "change": "The Activity timeline's hour rail is now one continuous ribbon across every loaded day instead of restarting at each midnight, and you can scroll the list by hovering it and using the wheel or trackpad."
+}

--- a/desktop/macos/e2e/flows/home-spine.yaml
+++ b/desktop/macos/e2e/flows/home-spine.yaml
@@ -6,8 +6,8 @@ description: >-
   produced and the screen moments from the same minutes, grouped by day with sticky day headers.
   Verifies the spine renders real account data, that the type chips and the query field both
   narrow it in place, that a soloed kind flattens the indent and gives every row its own
-  timestamp, that the hour rail tracks the topmost visible row, and that every row hands off to
-  the page that owns it (INV-NAV-1).
+  timestamp, that the hour ribbon runs unbroken across every loaded day and can scroll the list
+  itself, and that every row hands off to the page that owns it (INV-NAV-1).
 app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Spine/SpineModel.swift
@@ -15,6 +15,8 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Spine/SpineStream.swift
   - desktop/macos/Desktop/Sources/MainWindow/Spine/SpineRowViews.swift
   - desktop/macos/Desktop/Sources/MainWindow/Spine/SpineHourRail.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Spine/SpineRibbon.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Spine/SpineScrollLink.swift
   - desktop/macos/Desktop/Sources/MainWindow/Spine/SpineScreenIndex.swift
   - desktop/macos/Desktop/Sources/MainWindow/Spine/SpineHydration.swift
   - desktop/macos/Desktop/Sources/MainWindow/ServerPaging.swift
@@ -38,6 +40,23 @@ steps:
         - Conversations
         - Memories
         - Rewind
+
+  - id: S1b
+    name: The ribbon runs through midnight instead of restarting at it
+    do: >-
+      Scroll the spine until the list crosses from one day into the next. The rail does not swap
+      its contents: the hours continue past midnight into a thin rule labelled with the next day's
+      name, and then that day's hours, as one strip sliding under a fixed reading position. The
+      heavy, labelled bar hands over to its neighbour as the strip moves rather than jumping
+      between them, and only ever one hour states its time.
+
+  - id: S1c
+    name: The ribbon is the scrollbar
+    do: >-
+      Put the pointer over the ribbon itself — not the list — and scroll with the wheel or a
+      two-finger swipe. The list scrolls, at the same speed and with the same momentum as
+      scrolling the list directly, and the ribbon follows it. Nothing is dragged: press and drag
+      on the ribbon does not scrub.
 
   - id: S2
     name: Memories and screen moments sit under the conversation that produced them


### PR DESCRIPTION
## What

The Activity spine's hour rail drew one day at a time and swapped the whole
column when the top row crossed midnight — a navigator that jumped beside a list
that flows. It is now one continuous ribbon across every loaded day, and you can
scroll the list by hovering it and using the wheel or trackpad.

```
   BEFORE (swaps at midnight)       AFTER (one strip)
 ┌──────────────┐                  ┌──────────────┐
 │ ▬▬▬▬▬  12 PM │                  │ ▬▬▬▬▬  12 PM │
 │ ▬ 12 AM      │ ← column         │ ─── FRI 28 ──│ ← labelled break
 └──────────────┘   cross-fades    │ ▬▬▬  10 AM   │
   one day only     to next day    └──────────────┘
```

A single day still reads exactly as before: one day is one column, the size the
rail's `maxHeight: .infinity` bars always were, with the same widths, weights and
captions.

## Three things worth reviewing

**The position is continuous, not animated.** The rail was told only which *row*
was under the reading line — a step function, so it stalled then jumped. An
animation only trades the jump for a lag. Each row now reports its top as well as
its bottom, the viewport keeps the two rows nearest the reading line, and the
strip blends between them. It moves every frame the list does and needs no easing.

**The highlight hands over rather than dimming.** Sharing the weight evenly
between the two neighbouring bars made the highlight vanish at half strength for
most of a scroll. The bar within half an hour of the marker — always exactly one —
stays at full strength; only the second nearest fades out. One hour states its
time, never two.

**The ribbon drives the list's scroll view, not its own.** A second scroll view
would need a proportional mapping onto a list whose rows differ in height, and
would drift within a screen. The offset is computed in `SpineScrollLink` rather
than forwarded to `NSScrollView.scrollWheel(with:)`, because a real trackpad event
carries a gesture phase and forwarding it is silently ignored. Momentum still
works — macOS sends the coast as its own decaying events.

## Verification

- `xcrun swift test --package-path Desktop --filter "Spine|QueryShell"` → **110
  tests, 0 failures**
- `make preflight` → **22 checks pass**
- Exercised on the `omi-omi-timeline` dev bundle with synthesised phased trackpad
  gestures: a swipe over the ribbon scrolls the list Today → Yesterday → Thursday
  27 August and back, with the headline, lit hour and day breaks tracking at every
  stop.

Geometry, reading position and highlight falloff are pure functions, so the rules
are pinned in tests rather than left to a screenshot. Writing the "exactly one
hour states its time" test caught a real one: a symmetric `abs(d) < half` is false
for *both* slots at the exact midpoint, blinking the time out for that frame.

No product invariants matched the changed paths; no failure class needed (both
behavioural commits are `feat:`). `SpineHourBar` is gone — the `Canvas` draws the
bars now, with its metrics moved across unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## One commit outside this feature

`OnboardingFlowTests.testOnboardingProceedActionsUseDefaultActionKeyboardShortcut`
has been failing on `main` since ff96bff7bb, unrelated to this change. That
commit added the "Open the doors" button to `SBOnboardingView`; the button
registers Return correctly, but the test's hardcoded expectation of eight
`isDefaultAction: true` sites did not move with it. Every desktop PR since then
fails Desktop Swift Static & Test Contracts on it, with Build & Tests failing as
a rollup. Verified by running the same test on clean `upstream/main` with none of
this branch's code present.

The count is not redundant with the per-title assertions above it: those name
specific buttons, so only the total can catch a proceed action added *without*
`isDefaultAction`. Raised to nine and annotated with what the number guards.
Happy to split it out if you would rather it landed on its own.
