### PR TITLE
fix(deploy): pin backend-integration capacity for hosted MCP

### DIFF
--- a/.github/actions/deploy-backend-stack/action.yml
+++ b/.github/actions/deploy-backend-stack/action.yml
@@ -639,6 +639,12 @@ runs:
           ${{ inputs.deploy_profile == 'auto-dev' && format('--tag={0}', inputs.candidate_tag) || '' }}
           --remove-env-vars=HOSTED_PUSHER_API_URL,MEMORY_ENABLED_USERS,MEMORY_CANONICAL_PROMOTION_CRON_ENABLED,MEMORY_CANONICAL_PROMOTION_CRON_INTERVAL_HOURS,MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED
           ${{ steps.runtime-env.outputs.cloud_run_flags }}
+          --cpu=2
+          --memory=2Gi
+          --concurrency=40
+          --min-instances=3
+          --max-instances=50
+          --no-cpu-throttling
         env_vars: ${{ steps.runtime-env.outputs.backend_integration_env_vars }}
         secrets: ${{ steps.runtime-env.outputs.backend_integration_secrets }}
 

--- a/backend/tests/unit/test_render_backend_runtime_env.py
+++ b/backend/tests/unit/test_render_backend_runtime_env.py
@@ -444,6 +444,37 @@ def test_backend_service_deploys_remove_retired_canonical_memory_env_vars():
         assert f'--remove-env-vars={retired}' in job_flags, f'memory-maintenance-job for {env} must strip {retired}'
 
 
+def _deploy_backend_stack_step_flags(step_id: str) -> str:
+    action = Path(__file__).resolve().parents[3] / '.github/actions/deploy-backend-stack/action.yml'
+    text = action.read_text(encoding='utf-8')
+    marker = f'id: {step_id}\n'
+    start = text.index(marker)
+    flags_key = text.index('flags: >-', start)
+    env_key = text.index('env_vars:', flags_key)
+    return text[flags_key:env_key]
+
+
+def test_backend_integration_deploy_pins_mcp_serving_capacity():
+    # Live prod backend-integration was maxScale=25, minScale=1, concurrency=300
+    # on 1 CPU. ChatGPT openai-mcp POSTs then 503 with "no available instance"
+    # because I/O-bound MCP work does not trip CPU scale-out. Pin scale-out
+    # here only; do not copy onto backend / backend-sync.
+    integration_flags = _deploy_backend_stack_step_flags('deploy-backend-integration')
+    backend_flags = _deploy_backend_stack_step_flags('deploy-backend')
+    sync_flags = _deploy_backend_stack_step_flags('deploy-backend-sync')
+    for flag in (
+        '--cpu=2',
+        '--memory=2Gi',
+        '--concurrency=40',
+        '--min-instances=3',
+        '--max-instances=50',
+        '--no-cpu-throttling',
+    ):
+        assert flag in integration_flags, flag
+        assert flag not in backend_flags, flag
+        assert flag not in sync_flags, flag
+
+
 VERTEX_PT_CONTRACT = 'Vertex PT: 5 GSU gemini-2.5-flash us-central1, expires ~2027-05-28'
 
 


### PR DESCRIPTION
## What changed and why

ChatGPT hosted MCP (`openai-mcp`) hits Cloud Run `backend-integration`. Prod was serving that service at **minScale 1, maxScale 25, concurrency 300, 1 CPU**. I/O-bound MCP POSTs fill an instance without tripping CPU scale-out, then Cloud Run returns fast **503** ("no available instance") which ChatGPT surfaces as upstream 502.

This pins **integration-only** serving capacity on deploy:

- `--concurrency=40` (was 300 live)
- `--min-instances=3` (was 1)
- `--max-instances=50` (was 25)
- `--cpu=2 --memory=2Gi --no-cpu-throttling`

`backend` and `backend-sync` are unchanged.

Does not merge with the MCP payload/instruction PR. Does not deploy by itself.

## Product invariants affected

none

## How it was verified

- `python -m pytest -q tests/unit/test_render_backend_runtime_env.py::test_backend_integration_deploy_pins_mcp_serving_capacity` — passed.
- Confirmed the new flags appear only on `id: deploy-backend-integration`.

## Tests

`test_backend_integration_deploy_pins_mcp_serving_capacity` reads the deploy action and asserts the capacity flags are on integration and absent from backend/sync.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

