### PR TITLE
fix(charts): give the pusher the memory fence its finalization path requires

### DIFF
--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -139,6 +139,8 @@ env:
       secretKeyRef:
         name: dev-omi-backend-secrets
         key: OMI_LLM_GATEWAY_SERVICE_TOKEN
+  - name: MEMORY_ENABLED
+    value: "on"
   - name: FAL_KEY
     valueFrom:
       secretKeyRef:

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -139,6 +139,8 @@ env:
       secretKeyRef:
         name: prod-omi-backend-secrets
         key: OMI_LLM_GATEWAY_SERVICE_TOKEN
+  - name: MEMORY_ENABLED
+    value: "on"
   - name: FAL_KEY
     valueFrom:
       secretKeyRef:

--- a/backend/tests/unit/test_pusher_helm_memory_contract.py
+++ b/backend/tests/unit/test_pusher_helm_memory_contract.py
@@ -1,0 +1,62 @@
+"""The pusher runs conversation finalization, so its chart owns the memory fence.
+
+On 2026-08-30 the prod pusher rolled forward from 2026-07-01 and every
+conversation stopped finalizing at 15:21:42Z. The pusher chart carries a much
+smaller env set than backend-listen, and `MEMORY_ENABLED` was not in it.
+`rollout_mode_env_value` fail-closes to `off` when the flag is unset, so
+`MemoryService.ensure_canonical_mutation_ready` -- called unconditionally by
+`_extract_memories_inner` for every non-discarded conversation -- raised
+HTTPException(503). `finalizer.py` logs only `type(error).__name__`, so prod
+showed 16k/hour of bare `error=HTTPException` with no status, detail, or
+traceback to name the cause.
+
+Presence of the key is not the contract. The contract is that the env the chart
+ships must resolve to a mode that permits memory writes, which is what the
+finalization path requires to complete.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from config.memory_rollout import MemoryRolloutMode, rollout_mode_env_value
+
+ROOT = Path(__file__).resolve().parents[3]
+PUSHER_CHART = ROOT / 'backend' / 'charts' / 'pusher'
+LISTEN_CHART = ROOT / 'backend' / 'charts' / 'backend-listen'
+
+
+def _literal_env(path: Path) -> dict[str, str]:
+    loaded = yaml.safe_load(path.read_text(encoding='utf-8'))
+    assert isinstance(loaded, dict)
+    return {
+        str(entry['name']): str(entry['value'])
+        for entry in loaded.get('env', [])
+        if isinstance(entry, dict) and 'name' in entry and 'value' in entry
+    }
+
+
+@pytest.mark.parametrize('environment', ['dev', 'prod'])
+def test_pusher_env_permits_memory_writes(environment: str) -> None:
+    """A pusher that cannot write memories cannot finalize a conversation."""
+    env = _literal_env(PUSHER_CHART / f'{environment}_omi_pusher_values.yaml')
+
+    mode = rollout_mode_env_value(env)
+
+    assert mode in {MemoryRolloutMode.write.value, MemoryRolloutMode.read.value}, (
+        f'{environment} pusher resolves memory rollout mode to {mode!r}; '
+        'ensure_canonical_mutation_ready() raises HTTPException(503) for every '
+        'conversation under any other mode'
+    )
+
+
+@pytest.mark.parametrize('environment', ['dev', 'prod'])
+def test_pusher_memory_fence_matches_backend_listen(environment: str) -> None:
+    """Both run the same finalization code, so both need the same fence."""
+    pusher = _literal_env(PUSHER_CHART / f'{environment}_omi_pusher_values.yaml')
+    listen = _literal_env(LISTEN_CHART / f'{environment}_omi_backend_listen_values.yaml')
+
+    assert rollout_mode_env_value(pusher) == rollout_mode_env_value(listen)


### PR DESCRIPTION
## What broke

Live-captured conversations stopped finalizing in production at **2026-08-30T15:21:42Z** and are still failing.

The pusher had not deployed since **2026-07-01** (`2ae7f78841`). #12429 fixed the pre-Helm capacity gate that was failing the lane, and the rollout that followed (Helm applied 15:16:28Z, complete 15:28:51Z) carried two months of change onto a Deployment whose environment was never extended to match.

The old pusher never ran this code. Its opcode-104 handler called `process_conversation` directly and never touched the durable-job architecture. Today is the **first time the pusher has ever executed `finalize_persisted_conversation`** — cold activation of a dormant subsystem, not a contract drift. Verified: `backend/routers/pusher.py`, `backend/utils/listen_pusher_session.py` and `_claim_finalization_job_txn` are byte-identical across `6f7c57ac15..6134ebd6cf`.

## Root cause

The pusher chart ships **68 env vars where backend-listen ships 115**, and `MEMORY_ENABLED` is among the 50 it lacks. Confirmed against the live cluster:

```
prod-omi-pusher          68 env vars, zero MEMORY_* vars
prod-omi-backend-listen  115 env vars, MEMORY_ENABLED=on
```

`rollout_mode_env_value()` fail-closes to `off` when the flag is unset (`backend/config/memory_rollout.py`). `MemoryService.ensure_canonical_mutation_ready()` — called **unconditionally and unwrapped** by `_extract_memories_inner` for every non-discarded conversation — then raises `HTTPException(503, "Memory writes are globally paused")`. `finalizer.py` converts that to `ConversationFinalizationError('processing_failed')`, and the listen session retries roughly 4x per conversation.

Measured distribution in a clean window (23:00–23:10Z, all entries):

| Exception | Count | Share |
| --- | --- | --- |
| `HTTPException` (this bug) | 366 | 89.5% |
| `LegalHoldAuthorityUnavailable` | 43 | 10.5% |

This PR fixes the 89.5%. The remainder is a separate, older regression — see below.

## Why nothing paged

`finalizer.py` logs only `type(error).__name__`. Production emitted ~16k/hour of bare `error=HTTPException` carrying no status code, no detail and no traceback, so the signature read as already-known. The listener itself stayed healthy throughout — WS connections in band, 5/5 ready pods, listen-LB 5xx at zero, every `Backend-listen` critical rule inactive, and no client-side Sentry spike. Audio was captured and transcribed; it simply never became a conversation.

## The fix

Set `MEMORY_ENABLED=on` for dev and prod pusher, matching backend-listen. It is a plain literal, so it requires no key from the pusher's ExternalSecret — deliberately avoiding the failure class from #12298, where a chart consumed a secret key the ExternalSecret did not enumerate.

The test asserts the **contract**, not the key: the env a chart ships must resolve to a mode that permits memory writes, and the two co-hosts may not disagree. Against the charts as they stood during the incident it fails with `assert 'off' == 'write'`.

## Failure class

This reopens an existing class. Its prevention artifact, `test_conversation_notes_v2_beta_rollout.py`, pins three named flags across backend-listen and the Cloud Run backend. It does not generalize to other flags, and it does not know the pusher is now a third host of `process_conversation`.

Failure-Class: FC-rollout-flag-absent-from-a-cohost-of-its-code-path

## Deliberately not in this PR

- **The other 49 missing env vars**, including `GEMINI_API_KEY`, `USE_VERTEX_AI`, `LISTEN_FINALIZATION_ORPHAN_STALE_SECONDS` and the `FAIR_USE_*` set. Real exposure, but several are secret refs and widening them under incident pressure risks the #12298 class. Needs its own change.
- **`LegalHoldAuthorityUnavailable`** (10.5% of failures) — `current_destructive_operation_token()` at `backend/database/legal_holds.py:403`, reached from `canonical_memory_adapter.py:2029`, requires an active `destructive_operation_gate(...)` context that this call site never enters. Introduced by #12084, first seen in prod 2026-08-28T01:51:36Z and firing continuously for ~2.5 days on `/v1/conversations/from-segments`. Independent of this bug and of today's deploy.
- **`/v1/embeddings` 404s at the LLM gateway.** `prod-omi-llm-gateway` runs image `c61d815` (2026-08-20), which predates #12337's gateway embeddings route; `gcp_llm_gateway.yml` is dispatch-only and was never run after that merge. Swallowed at `vector_db.py`, so not user-visible as an error — but `save_structured_vector` has been failing silently since ~13:44Z, meaning **no conversation created since then has a summary vector in Pinecone**, and it will not self-heal without a backfill. Fix is to deploy the gateway, not to change code.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

