### PR TITLE
fix(backend): degrade embeddings to direct when the gateway has no route

### DIFF
--- a/backend/tests/unit/test_embeddings_gateway.py
+++ b/backend/tests/unit/test_embeddings_gateway.py
@@ -8,7 +8,7 @@ embeddings.
 from __future__ import annotations
 
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -188,3 +188,145 @@ def test_gateway_embeddings_helpers_post_to_the_embeddings_surface(monkeypatch):
     query = gateway_client.invoke_gemini_embedding_gateway('q', task_type='RETRIEVAL_QUERY')
     assert query == [0.1, 0.2]
     assert GEMINI_EMBEDDINGS_AUTO_LANE_ID.encode() in seen[1]['body']
+
+
+# --- gateway/backend deploy skew: a gateway older than its caller -------------
+#
+# Regression cover for the 2026-08-30 prod finalization outage. The prod gateway
+# was deployed 2026-08-20, /v1/embeddings landed 2026-08-28 (fe3df5ac00), and the
+# backend half shipped on merge -- so every conversation finalization died on a
+# 404 with a working direct embeddings path sitting right behind it.
+
+
+def _route_absent_error() -> httpx.HTTPStatusError:
+    """A 404 shaped like Starlette's answer for a path the app never registered."""
+    request = httpx.Request('POST', 'http://gateway/v1/embeddings')
+    response = httpx.Response(404, json={'detail': 'Not Found'}, request=request)
+    return httpx.HTTPStatusError('Client error 404', request=request, response=response)
+
+
+def _model_not_found_error() -> httpx.HTTPStatusError:
+    """A 404 the gateway itself emits: it owns the route, it rejected the lane."""
+    request = httpx.Request('POST', 'http://gateway/v1/embeddings')
+    response = httpx.Response(
+        404,
+        json={'error': {'message': 'unknown model', 'type': 'api_error', 'code': 'model_not_found'}},
+        request=request,
+    )
+    return httpx.HTTPStatusError('Client error 404', request=request, response=response)
+
+
+@pytest.fixture(autouse=True)
+def _reset_route_absent_warning(monkeypatch):
+    """The skew warning is once-per-process; each test needs a fresh process view."""
+    monkeypatch.setattr(clients, '_gateway_embeddings_route_absent_warned', False, raising=False)
+
+
+def test_route_absent_discriminates_on_body_not_status():
+    assert gateway_client.is_gateway_route_absent(_route_absent_error()) is True
+    # Same status, gateway-owned rejection: must NOT be read as deploy skew.
+    assert gateway_client.is_gateway_route_absent(_model_not_found_error()) is False
+    assert gateway_client.is_gateway_route_absent(RuntimeError('boom')) is False
+
+
+def test_route_absent_treats_a_non_json_404_as_missing_route():
+    request = httpx.Request('POST', 'http://gateway/v1/embeddings')
+    response = httpx.Response(404, text='<html>404</html>', request=request)
+    error = httpx.HTTPStatusError('Client error 404', request=request, response=response)
+    assert gateway_client.is_gateway_route_absent(error) is True
+
+
+def test_embed_query_falls_back_to_direct_when_gateway_route_is_absent(monkeypatch):
+    _gateway_mode(monkeypatch)
+    direct = MagicMock()
+    direct.embed_query.return_value = [0.7, 0.8]
+
+    with patch.object(
+        clients, 'invoke_openai_embeddings_gateway', MagicMock(side_effect=_route_absent_error())
+    ), patch.object(clients, 'get_byok_key', MagicMock(return_value=None)), patch.object(
+        clients._OpenAIEmbeddingsProxy, '_resolve', MagicMock(return_value=direct)
+    ):
+        vector = clients.embeddings.embed_query('q')
+
+    assert vector == [0.7, 0.8]
+    direct.embed_query.assert_called_once_with('q')
+
+
+def test_embed_documents_falls_back_to_direct_when_gateway_route_is_absent(monkeypatch):
+    _gateway_mode(monkeypatch)
+    direct = MagicMock()
+    direct.embed_documents.return_value = [[0.1], [0.2]]
+
+    with patch.object(
+        clients, 'invoke_openai_embeddings_gateway', MagicMock(side_effect=_route_absent_error())
+    ), patch.object(clients, 'get_byok_key', MagicMock(return_value=None)), patch.object(
+        clients._OpenAIEmbeddingsProxy, '_resolve', MagicMock(return_value=direct)
+    ):
+        vectors = clients.embeddings.embed_documents(['a', 'b'])
+
+    assert vectors == [[0.1], [0.2]]
+    direct.embed_documents.assert_called_once_with(['a', 'b'])
+
+
+@pytest.mark.asyncio
+async def test_aembed_query_falls_back_to_direct_when_gateway_route_is_absent(monkeypatch):
+    _gateway_mode(monkeypatch)
+    direct = MagicMock()
+    direct.aembed_query = AsyncMock(return_value=[0.3, 0.4])
+
+    with patch.object(
+        clients, 'ainvoke_openai_embeddings_gateway', AsyncMock(side_effect=_route_absent_error())
+    ), patch.object(clients, 'get_byok_key', MagicMock(return_value=None)), patch.object(
+        clients._OpenAIEmbeddingsProxy, '_resolve', MagicMock(return_value=direct)
+    ):
+        vector = await clients.embeddings.aembed_query('q')
+
+    assert vector == [0.3, 0.4]
+    direct.aembed_query.assert_awaited_once_with('q')
+
+
+def test_embed_query_still_raises_when_the_gateway_owns_the_route(monkeypatch):
+    """model_not_found is a real gateway rejection; masking it would hide lane drift."""
+    _gateway_mode(monkeypatch)
+
+    with patch.object(
+        clients, 'invoke_openai_embeddings_gateway', MagicMock(side_effect=_model_not_found_error())
+    ), patch.object(clients, 'get_byok_key', MagicMock(return_value=None)), patch.object(
+        clients._OpenAIEmbeddingsProxy,
+        '_resolve',
+        MagicMock(side_effect=AssertionError('direct path must not be used')),
+    ):
+        with pytest.raises(httpx.HTTPStatusError) as excinfo:
+            clients.embeddings.embed_query('q')
+
+    assert excinfo.value.response.status_code == 404
+
+
+def test_gemini_embed_query_falls_back_to_direct_when_gateway_route_is_absent(monkeypatch):
+    _gateway_mode(monkeypatch)
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={'embedding': {'values': [0.6]}})
+
+    with patch.object(clients, 'get_byok_key', MagicMock(return_value=None)), patch.object(
+        clients, 'invoke_gemini_embedding_gateway', MagicMock(side_effect=_route_absent_error())
+    ), patch.object(
+        clients.httpx,
+        'post',
+        MagicMock(
+            side_effect=lambda url, **kwargs: httpx.Client(transport=httpx.MockTransport(handler)).post(url, **kwargs)
+        ),
+    ):
+        values = clients.gemini_embed_query('screen activity')
+
+    assert values == [0.6]
+
+
+def test_gemini_embed_query_still_raises_when_the_gateway_owns_the_route(monkeypatch):
+    _gateway_mode(monkeypatch)
+
+    with patch.object(clients, 'get_byok_key', MagicMock(return_value=None)), patch.object(
+        clients, 'invoke_gemini_embedding_gateway', MagicMock(side_effect=_model_not_found_error())
+    ), patch.object(clients.httpx, 'post', MagicMock(side_effect=AssertionError('direct path must not be used'))):
+        with pytest.raises(httpx.HTTPStatusError):
+            clients.gemini_embed_query('q')

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -81,6 +81,7 @@ try:
         feature_auto_lane_id,
         invoke_gemini_embedding_gateway,
         invoke_openai_embeddings_gateway,
+        is_gateway_route_absent,
         raise_if_gateway_feature_mode_blocks_direct_model_surface,
         should_route_chat_agent_through_gateway,
         should_route_features_through_gateway,
@@ -103,6 +104,9 @@ except ImportError as exc:
 
     def raise_if_gateway_feature_mode_blocks_direct_model_surface(_surface: str) -> None:
         return None
+
+    def is_gateway_route_absent(_error: object) -> bool:
+        return False
 
     def invoke_openai_embeddings_gateway(*_args, **_kwargs):
         raise RuntimeError('Omi gateway embeddings client is unavailable')
@@ -236,6 +240,29 @@ def get_direct_anthropic_client(*, byok_api_key: str | None = None) -> anthropic
     return anthropic_client._default_client()
 
 
+_gateway_embeddings_route_absent_warned = False
+
+
+def _warn_gateway_embeddings_route_absent(operation: str) -> None:
+    """Report gateway/backend deploy skew once per process.
+
+    Once per process, not per call: this condition holds until the gateway is
+    redeployed, and the callers behind it run thousands of embeddings an hour.
+    The gateway's own access log keeps counting the 404s, so nothing is lost by
+    not repeating ourselves here.
+    """
+    global _gateway_embeddings_route_absent_warned
+    if _gateway_embeddings_route_absent_warned:
+        return
+    _gateway_embeddings_route_absent_warned = True
+    logger.error(
+        'LLM gateway serves no /v1/embeddings route: the deployed gateway predates this backend. '
+        'Falling back to direct embeddings; gateway ledger accounting is lost for embeddings until '
+        'the gateway is redeployed. operation=%s',
+        operation,
+    )
+
+
 class _OpenAIEmbeddingsProxy:
     """Transparent proxy for OpenAIEmbeddings that uses BYOK OpenAI when set."""
 
@@ -309,6 +336,22 @@ class _OpenAIEmbeddingsProxy:
             return True
         return self._is_key_failure(error)
 
+    def _reraise_unless_route_absent(self, error: Exception, operation: str) -> None:
+        """Swallow only "this gateway has no embeddings route" so the caller
+        falls through to the direct path; re-raise everything else.
+
+        A gateway deployed before this backend 404s the route, and embeddings
+        are load-bearing for memory and vector search -- without this, that
+        skew fails every conversation finalization instead of costing us the
+        gateway ledger row. This is the same availability-over-accounting
+        trade ``_gateway_mode`` already makes for a misconfigured rollout,
+        applied to the one skew it could not see: a healthy gateway that is
+        simply older than its client.
+        """
+        if not is_gateway_route_absent(error):
+            raise error
+        _warn_gateway_embeddings_route_absent(operation)
+
     def _gateway_embed_texts(self, texts: List[str]) -> List[List[float]]:
         byok = get_byok_key('openai')
         try:
@@ -339,7 +382,10 @@ class _OpenAIEmbeddingsProxy:
 
     def embed_query(self, text: str) -> List[float]:
         if self._gateway_mode():
-            return self._gateway_embed_texts([text])[0]
+            try:
+                return self._gateway_embed_texts([text])[0]
+            except Exception as e:
+                self._reraise_unless_route_absent(e, 'embed_query')
         inst = self._resolve()
         try:
             return inst.embed_query(text)
@@ -353,7 +399,10 @@ class _OpenAIEmbeddingsProxy:
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         if self._gateway_mode():
-            return self._gateway_embed_texts(texts)
+            try:
+                return self._gateway_embed_texts(texts)
+            except Exception as e:
+                self._reraise_unless_route_absent(e, 'embed_documents')
         inst = self._resolve()
         try:
             return inst.embed_documents(texts)
@@ -367,7 +416,10 @@ class _OpenAIEmbeddingsProxy:
 
     async def aembed_query(self, text: str) -> List[float]:
         if self._gateway_mode():
-            return (await self._agateway_embed_texts([text]))[0]
+            try:
+                return (await self._agateway_embed_texts([text]))[0]
+            except Exception as e:
+                self._reraise_unless_route_absent(e, 'aembed_query')
         inst = self._resolve()
         try:
             return await inst.aembed_query(text)
@@ -381,7 +433,10 @@ class _OpenAIEmbeddingsProxy:
 
     async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
         if self._gateway_mode():
-            return await self._agateway_embed_texts(texts)
+            try:
+                return await self._agateway_embed_texts(texts)
+            except Exception as e:
+                self._reraise_unless_route_absent(e, 'aembed_documents')
         inst = self._resolve()
         try:
             return await inst.aembed_documents(texts)
@@ -875,7 +930,12 @@ def gemini_embed_query(text: str) -> List[float]:
     """
     byok_key = get_byok_key('gemini')
     if _embeddings_gateway_mode() and not byok_key:
-        return invoke_gemini_embedding_gateway(text, task_type='RETRIEVAL_QUERY')
+        try:
+            return invoke_gemini_embedding_gateway(text, task_type='RETRIEVAL_QUERY')
+        except Exception as e:
+            if not is_gateway_route_absent(e):
+                raise
+            _warn_gateway_embeddings_route_absent('gemini_embed_query')
     api_key = byok_key or os.environ.get('GEMINI_API_KEY', '')
     url = 'https://generativelanguage.googleapis.com/v1beta/models/embedding-001:embedContent'
     payload = {

--- a/backend/utils/llm/gateway_client.py
+++ b/backend/utils/llm/gateway_client.py
@@ -116,6 +116,29 @@ def is_gateway_transport_status_code(status_code: object) -> bool:
     return isinstance(status_code, int) and status_code in GATEWAY_TRANSPORT_STATUS_CODES
 
 
+def is_gateway_route_absent(error: object) -> bool:
+    """Whether a gateway failure means the deployed gateway has no such route.
+
+    A gateway older than its caller answers an unknown path with Starlette's
+    bare ``{"detail": "Not Found"}``. A gateway that owns the route answers a
+    real rejection with an OpenAI-shaped ``{"error": {...}}`` body -- and
+    ``model_not_found`` is also a 404. So the *body*, not the status, is what
+    separates "server predates client" from "server rejected this request";
+    treating every 404 as route-absence would silently swallow lane
+    misconfiguration.
+    """
+    if not isinstance(error, httpx.HTTPStatusError):
+        return False
+    if error.response.status_code != 404:
+        return False
+    try:
+        body: object = error.response.json()
+    except Exception:
+        # A non-JSON 404 is not something this gateway's error path can emit.
+        return True
+    return not (isinstance(body, Mapping) and isinstance(body.get('error'), Mapping))
+
+
 def _as_json_dict(value: object) -> JsonDict | None:
     return cast(JsonDict, value) if isinstance(value, dict) else None
 


### PR DESCRIPTION
## The outage

Since 2026-08-30 the prod pusher failed **every** conversation finalization:

```
ERROR:database.vector_db:find_similar_action_items failed uid=...: Client error '404 Not Found'
for url 'http://prod-omi-llm-gateway.prod-omi-backend.svc.cluster.local:8080/v1/embeddings'
```

~1,300/h, 100% in the pusher container. Live voice captures dead-lettered to
`processing_failed`; "Conversation processed by pusher" went to ~0/h.

## Root cause: the client shipped, the server didn't

| | |
| --- | --- |
| Prod gateway last deployed | 2026-08-20, run [32428978705](https://github.com/BasedHardware/omi/actions/runs/32428978705), SHA `48bb6e799f` |
| `/v1/embeddings` route added | 2026-08-28, `fe3df5ac00` (#12337, SCA-365) |
| `fe3df5ac00` is an ancestor of `48bb6e799f`? | **No** — the deployed gateway is 800 commits behind main |

`#12337` added both halves of the hop: the gateway route *and* the backend client
that calls it. The backend auto-deploys on merge to main; `gcp_llm_gateway.yml`
is `workflow_dispatch`-only. So the caller reached prod and the callee never did.

Ruled out, not assumed:

- **Route not mounted** — `main.py` does `app.include_router(embeddings.router)` on main.
- **Feature-mode mismatch** — the gateway is serving `/v1/chat/completions` **200**
  and `/v1/embeddings` **404** in the same 30-minute window, from the same pods.
  Feature mode is on; the route is what's missing.
- **A route the gateway declines to serve** — the 404 is Starlette's unrouted-path
  answer, not a `GatewayError`.

## What this PR changes

It does **not** redeploy the gateway — that is still required, and is tracked
separately. It removes the gateway's ability to take embeddings down when it is
behind.

`_gateway_mode` already trades ledger accounting for availability when a rollout
is misconfigured — it catches `RuntimeError` and degrades to direct, because
embeddings are load-bearing for memory and vector search. It could not see this
skew: the gateway is healthy, it is simply older than its client. Meanwhile a
working direct embeddings path sat three lines behind that 404 the entire outage.

**Status alone cannot carry route-absence** — the gateway also returns 404 for
`model_not_found` (`_status_code_for_error`). The bodies differ, so
`is_gateway_route_absent` discriminates on the body:

| 404 body | Meaning | Behaviour |
| --- | --- | --- |
| `{"detail": "Not Found"}` (Starlette, unrouted) | server predates client | degrade to direct, log once |
| `{"error": {...}}` (OpenAI-shaped) | gateway owns the route, rejected the request | **raise**, unchanged |

Applied to all four `_OpenAIEmbeddingsProxy` embedding methods and to
`gemini_embed_query`, which reaches the same `/v1/embeddings` route for
screen-activity search and had the identical defect.

The skew is logged once per process rather than per call: the condition holds
until the gateway is redeployed, the callers behind it run thousands of
embeddings an hour, and the gateway's own access log keeps counting the 404s.

## Tests

`backend/tests/unit/test_embeddings_gateway.py`, driven through the real seam
(`clients.embeddings` / `clients.gemini_embed_query`) with real `httpx` responses:

- 6 new tests fail on the unfixed tree with exactly the production symptom
  (`httpx.HTTPStatusError: Client error 404` escaping `embed_query`), pass with the fix.
- 2 of the new tests pass **both** before and after — deliberately: they pin that
  `model_not_found` still raises, so the fallback cannot widen into masking lane drift.

```
17 passed  tests/unit/test_embeddings_gateway.py
521 passed  all 41 gateway/embedding test files
```

## Follow-ups (not in this PR)

- **The gateway still needs redeploying.** This PR restores availability; it does
  not restore the embeddings ledger rows, which stay unaccounted while the gateway
  is behind.
- The 800-commit gateway drift is the standing risk. A backend↔gateway route
  dependency has no equivalent of the release-lane probe that this failure class's
  canonical prevention installed for the Windows update feed.

Failure-Class: FC-ship-before-required-route


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

