### PR TITLE
ci: add exact-head merge gate

### DIFF
--- a/.github/MERGE_GATE.md
+++ b/.github/MERGE_GATE.md
@@ -1,0 +1,59 @@
+# Omi merge gate
+
+`Omi Merge Gate` is the single status that branch protection should require.
+It is produced by the trusted default-branch
+[`pr-merge-gate.yml`](workflows/pr-merge-gate.yml) controller from the explicit
+[`merge-gate-manifest.json`](merge-gate-manifest.json) inventory. The controller
+observes exact-head Actions metadata; it never executes pull-request content.
+
+The desired protection settings are recorded in
+[`required-branch-policy.json`](required-branch-policy.json). That file is a
+reviewable policy contract, **not** a GitHub REST request body and not proof that
+the live repository is protected.
+
+## Bootstrap and activation
+
+An administrator must perform these steps in order:
+
+1. Merge the controller without making its not-yet-existing status required.
+2. Open one same-repository canary PR and one fork canary PR. On each exact head,
+   verify that `Omi Merge Gate` starts pending and becomes successful only after
+   every applicable workflow succeeds.
+3. Rerun one required workflow. Verify that the aggregate returns to pending on
+   `workflow_run` reconciliation, then follows the rerun to failure or success.
+4. In repository or organization rules, prefer **Require workflows to pass** for
+   `.github/workflows/pr-merge-gate.yml` when that control is available. Otherwise
+   require the exact `Omi Merge Gate` context and select GitHub Actions as its
+   expected source. Require the strict/up-to-date mode.
+5. Apply the remaining review, code-owner, conversation-resolution, admin, and
+   no-bypass settings from `required-branch-policy.json`. Use evaluate mode first
+   when a ruleset provides it; activate only after the canaries pass.
+6. Read the live settings back. Do not infer activation from a successful API
+   response or from this file existing:
+
+   ```bash
+   gh api repos/BasedHardware/omi/branches/main/protection
+   gh api repos/BasedHardware/omi/rulesets --paginate
+   ```
+
+Confirm that exactly one intended rule stack governs `main`, the required gate
+has the expected source, administrators do not bypass it, review settings match
+the policy contract, and no actor has an ordinary merge bypass.
+
+## Recovery
+
+- Fix and rerun the failed underlying workflow. Its requested/in-progress/
+  completed lifecycle automatically reconciles the aggregate.
+- If GitHub did not deliver a reconciliation event, rerun the trusted merge-gate
+  controller or make a harmless PR metadata edit to trigger a new exact-head
+  evaluation. Never post or override the status manually.
+- If the status reports event-association, manifest, or unknown-evidence errors,
+  treat that as a control-plane incident. Repair the evidence path; do not weaken
+  branch protection to clear the PR.
+- Before changing a PR workflow name, trigger, or path filter, update the merge
+  manifest and reconciler list in the same PR. The local contract check enforces
+  this for canonical workflow syntax.
+
+After activation, a periodic audit should compare the two live API responses
+above with `required-branch-policy.json`; configuration drift is a failure, not
+an advisory warning.

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -86,6 +86,11 @@ checks:
     triggers: ["all"]
     lanes: ["local", "ci"]
     reason: "manifest validity and workflow drift guard"
+  - id: exact-head-merge-gate-contract
+    command: ["python3", ".github/scripts/test_pr_merge_gate.py"]
+    triggers: [".github/workflows/**", ".github/MERGE_GATE.md", ".github/merge-gate-manifest.json", ".github/required-branch-policy.json", ".github/scripts/pr_merge_gate.py", ".github/scripts/test_pr_merge_gate.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "PRs #11454 and #11832 merged around exact-head red checks; the one protected status must stay trusted, path-complete, and fail closed"
   - id: backend-production-release-vector-guards
     command: ["python3", ".github/scripts/check_release_rings.py"]
     triggers: [".github/workflows/gcp_backend.yml", ".github/actions/deploy-backend-stack/**", ".github/scripts/check_release_rings.py", ".github/scripts/workflow_composite_contract.py", ".github/checks-manifest.yaml"]

--- a/.github/merge-gate-manifest.json
+++ b/.github/merge-gate-manifest.json
@@ -1,0 +1,129 @@
+{
+  "version": 1,
+  "workflows": [
+    {
+      "path": ".github/workflows/backend-checks.yml",
+      "classification": "required",
+      "reason": "Repository-wide backend static contracts use internal diff selection."
+    },
+    {
+      "path": ".github/workflows/backend-emulator-proofs.yml",
+      "classification": "required",
+      "reason": "Memory and database changes require their hermetic emulator proofs.",
+      "paths": ["backend/utils/memory/**", "backend/database/**", "backend/models/memory_apply.py", "backend/models/product_memory.py", "backend/scripts/*_emulator_test.py", "backend/scripts/run-emulator-proofs.sh", "backend/pylock.toml", "firebase.json", "firestore.rules", ".github/workflows/backend-emulator-proofs.yml"]
+    },
+    {
+      "path": ".github/workflows/backend-hermetic-e2e.yml",
+      "classification": "required",
+      "reason": "The workflow has one explicit gate that excludes its named advisory replay job.",
+      "authoritative_job": "Backend Hermetic Merge Gate"
+    },
+    {
+      "path": ".github/workflows/backend-unit-tests.yml",
+      "classification": "required",
+      "reason": "Backend changes must not merge with a red unit suite.",
+      "paths": [".gitignore", "backend/**", "package.json", "package-lock.json", "config/deployment-setting-classification.json", "firestore.indexes.json", ".github/actions/detect-changes/**", ".github/actions/deploy-backend-stack/**", ".github/actions/release-eligibility/action.yml", ".github/actions/transcription-release-candidate-probe/**", ".github/workflows/backend-checks.yml", ".github/workflows/backend-hermetic-e2e.yml", ".github/workflows/backend-unit-tests.yml", ".github/workflows/desktop-checks.yml", ".github/workflows/desktop-swift-ci.yml", ".github/workflows/desktop_backend_auto_dev.yml", ".github/workflows/desktop_backend_prod.yml", ".github/workflows/repo-checks.yml", ".github/workflows/release-eligibility.yml", ".github/workflows/desktop_promote_beta.yml", ".github/workflows/desktop_rollback_beta.yml", ".github/workflows/desktop_breakglass_rollout_beta.yml", ".github/workflows/desktop_beta_admission_control.yml", ".github/workflows/desktop_promote_prod.yml", ".github/workflows/gcp_backend.yml", ".github/workflows/gcp_backend_auto_dev.yml", ".github/workflows/gcp_cloud_run_metrics_egress.yml", ".github/workflows/gcp_firestore_indexes.yml", ".github/workflows/gcp_backend*.yml", ".github/workflows/gcp_llm_gateway.yml", ".github/workflows/gcp_memory_maintenance_job.yml", ".github/workflows/gcp_memory_maintenance_job_auto_dev.yml", ".github/workflows/gcp_notifications_job.yml", ".github/scripts/check_backend_deploy_source_admission.py", ".github/scripts/verify_auto_backend_release_admission.py", ".github/scripts/verify_backend_release_admission.py", ".github/scripts/verify_release_eligibility.py", ".github/workflows/sync_ledger_fence_cutover.yml", "scripts/changed-files", "scripts/install-git-hooks.sh", "scripts/pre-push", "scripts/pre-push-singleflight", "scripts/dev-harness/dev_harness/jit_vertex_gateway.py", "scripts/voice-provider-probe.sh"]
+    },
+    {
+      "path": ".github/workflows/desktop-backend-contracts.yml",
+      "classification": "required",
+      "reason": "Desktop/backend boundary changes require contract coverage.",
+      "paths": [".github/workflows/desktop-backend-contracts.yml", "backend/testing/contracts/**", "backend/database/conversations.py", "backend/database/helpers.py", "backend/database/memories.py", "backend/models/**", "backend/test.sh", "backend/utils/encryption.py", "contract_tests/**", "desktop/macos/scripts/desktop-core-harness.sh", "desktop/macos/scripts/desktop-flow-lint.py", "desktop/macos/scripts/desktop_flow_contract.py", "desktop/macos/e2e/**", "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift", "desktop/macos/Desktop/Sources/DesktopAutomationOpenOmiShortcutQA.swift", "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift", "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift", "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift", "desktop/macos/Desktop/Sources/Rewind/Core/RewindArtifactGauntlet.swift"]
+    },
+    {
+      "path": ".github/workflows/desktop-checks.yml",
+      "classification": "required",
+      "reason": "Repository-wide desktop agent checks use internal diff selection."
+    },
+    {
+      "path": ".github/workflows/desktop-swift-ci.yml",
+      "classification": "required",
+      "reason": "Repository-wide Swift detection must complete and selected Swift tests must pass."
+    },
+    {
+      "path": ".github/workflows/desktop-windows-ci.yml",
+      "classification": "required",
+      "reason": "Windows changes require typecheck, tests, and package smoke coverage.",
+      "paths": ["desktop/windows/**", ".github/workflows/desktop-windows-ci.yml"]
+    },
+    {
+      "path": ".github/workflows/mobile-app-checks.yml",
+      "classification": "required",
+      "reason": "Repository-wide mobile detection must complete and selected app checks must pass."
+    },
+    {
+      "path": ".github/workflows/openapi-contract.yml",
+      "classification": "required",
+      "reason": "API producers and generated clients must remain synchronized.",
+      "paths": ["backend/**", "docs/api-reference/openapi.json", "docs/api-reference/app-client-openapi.json", "docs/api-reference/integration-public-openapi.json", "app/lib/backend/http/api/**", "app/lib/backend/schema/**", "app/lib/backend/schema/gen/**", "app/lib/models/announcement.dart", "app/lib/models/subscription.dart", "app/lib/models/user_usage.dart", "desktop/windows/src/renderer/src/lib/omiApi.generated.ts", "web/app/src/lib/omiApi.generated.ts", "web/admin/lib/services/omi-api/omiApi.generated.ts", "web/personas-open-source/src/lib/omiApi.generated.ts", "docs/docs.json", ".github/workflows/openapi-contract.yml"]
+    },
+    {
+      "path": ".github/workflows/opentofu-development-wif-pilot-validate.yml",
+      "classification": "required",
+      "reason": "Development WIF infrastructure changes require static validation.",
+      "paths": [".github/scripts/check_opentofu_development_wif_pilot.py", ".github/scripts/test_check_opentofu_development_wif_pilot.py", ".github/workflows/opentofu-development-wif-pilot.yml", ".github/workflows/opentofu-development-wif-pilot-validate.yml", "infrastructure/opentofu/pilots/development-wif-plan/**", "infrastructure/opentofu/probes/development-project-read/**"]
+    },
+    {
+      "path": ".github/workflows/opentofu-foundation-validate.yml",
+      "classification": "required",
+      "reason": "Foundation infrastructure changes require static validation.",
+      "paths": [".github/scripts/check_opentofu_foundation.py", ".github/scripts/test_check_opentofu_foundation.py", ".github/workflows/opentofu-foundation-validate.yml", "infrastructure/opentofu/**"]
+    },
+    {
+      "path": ".github/workflows/pr-declined-comment.yml",
+      "classification": "ignored",
+      "reason": "This pull_request_target workflow runs only after a PR closes and is not CI."
+    },
+    {
+      "path": ".github/workflows/pr-merge-gate.yml",
+      "classification": "ignored",
+      "reason": "The trusted controller cannot wait on its own base-branch workflow run."
+    },
+    {
+      "path": ".github/workflows/public-build-config-preflight.yml",
+      "classification": "required",
+      "reason": "Public build configuration changes require environment preflight.",
+      "paths": [".github/workflows/gcp_admin.yml", ".github/workflows/gcp_app.yml", ".github/workflows/gcp_frontend.yml", ".github/workflows/gcp_personas.yml", ".github/workflows/public-build-config-preflight.yml", ".github/actions/deploy-public-build/**", ".github/actions/prepare-public-build/**", ".github/actions/public-build-candidate-promotion/**", ".github/scripts/check_public_build_contract.py", ".github/scripts/preflight_public_build_config.py", ".github/scripts/preflight_public_build_runtime.py", ".github/scripts/smoke_public_build_browser.py", ".github/scripts/test_check_public_build_contract.py", "config/public-build-contract.json", "config/public-build-values.json", "config/deployment-setting-classification.json", "web/admin/Dockerfile", "web/app/Dockerfile", "web/frontend/Dockerfile", "web/personas-open-source/Dockerfile", "web/admin/components/public-build-canary.tsx", "web/app/src/components/public-build-canary.tsx", "web/frontend/src/components/public-build-canary.tsx", "web/personas-open-source/src/components/public-build-canary.tsx"]
+    },
+    {
+      "path": ".github/workflows/python-cli-ci.yml",
+      "classification": "required",
+      "reason": "Python CLI changes require their platform matrix.",
+      "paths": ["sdks/python-cli/**", ".github/workflows/python-cli-ci.yml"]
+    },
+    {
+      "path": ".github/workflows/repo-checks.yml",
+      "classification": "required",
+      "reason": "The code lane gates hygiene and formatting; metadata events add a separately selected metadata lane.",
+      "selector_job": "Hygiene",
+      "event_selector_jobs": {
+        "edited": "PR Metadata Preflight",
+        "labeled": "PR Metadata Preflight",
+        "unlabeled": "PR Metadata Preflight"
+      }
+    },
+    {
+      "path": ".github/workflows/runtime_image_contracts.yml",
+      "classification": "required",
+      "reason": "Runtime image inputs require source-closure and import smoke checks.",
+      "paths": ["backend/**", "plugins/**", "Makefile", ".github/workflows/runtime_image_contracts.yml", ".github/workflows/desktop_backend_auto_dev.yml", ".github/workflows/gcp_*.yml"]
+    },
+    {
+      "path": ".github/workflows/sdk-rust.yml",
+      "classification": "required",
+      "reason": "Rust SDK changes require format, lint, build, and test coverage.",
+      "paths": ["sdks/rust/**", ".github/workflows/sdk-rust.yml"]
+    },
+    {
+      "path": ".github/workflows/web-checks.yml",
+      "classification": "required",
+      "reason": "Repository-wide web detection must complete and selected lint/build checks must pass."
+    },
+    {
+      "path": ".github/workflows/windows-preflight-portability.yml",
+      "classification": "required",
+      "reason": "Cross-platform preflight changes require native Windows portability coverage.",
+      "paths": [".github/checks-manifest.yaml", ".github/scripts/preflight_runner.py", ".github/scripts/pr_preflight.py", ".github/scripts/run_checks.py", ".github/scripts/test_preflight_runner.py", ".github/scripts/test_run_checks.py", ".github/workflows/windows-preflight-portability.yml", "backend/.python-version", "scripts/pre-push", "scripts/pre-push-singleflight", "scripts/pr-preflight", "scripts/test-pre-push-worktree-fallback.sh"]
+    }
+  ]
+}

--- a/.github/required-branch-policy.json
+++ b/.github/required-branch-policy.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "branch": "main",
+  "required_status_checks": {
+    "strict": true,
+    "checks": [
+      {
+        "context": "Omi Merge Gate",
+        "source": "github-actions"
+      }
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": true,
+    "require_last_push_approval": true,
+    "required_approving_review_count": 1,
+    "bypass_pull_request_allowances": {
+      "apps": [],
+      "teams": [],
+      "users": []
+    }
+  },
+  "required_conversation_resolution": true,
+  "ordinary_merge_bypass_allowances": [],
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}

--- a/.github/scripts/pr_merge_gate.py
+++ b/.github/scripts/pr_merge_gate.py
@@ -1,0 +1,551 @@
+#!/usr/bin/env python3
+"""Publish one fail-closed merge verdict for the exact live PR head.
+
+This controller runs only from the trusted default branch under
+``pull_request_target`` or ``workflow_run``. It observes GitHub Actions
+metadata; it never checks out, downloads, imports, or executes
+pull-request-controlled content.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path, PurePath
+from typing import Any, Callable, Iterable
+
+
+STATUS_CONTEXT = "Omi Merge Gate"
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+PASSING_CONCLUSIONS = {"success"}
+FAILING_CONCLUSIONS = {
+    "action_required",
+    "cancelled",
+    "failure",
+    "neutral",
+    "skipped",
+    "stale",
+    "startup_failure",
+    "timed_out",
+}
+INCOMPLETE_STATUSES = {"expected", "pending", "queued", "in_progress", "requested", "waiting"}
+MAX_PR_FILES = 3000
+
+
+@dataclass(frozen=True)
+class WorkflowSpec:
+    path: str
+    classification: str
+    reason: str
+    paths: tuple[str, ...] = ()
+    authoritative_job: str | None = None
+    selector_job: str | None = None
+    event_selector_jobs: tuple[tuple[str, str], ...] = ()
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "WorkflowSpec":
+        event_jobs = raw.get("event_selector_jobs", {})
+        if not isinstance(event_jobs, dict):
+            raise ValueError(f"{raw.get('path', '<unknown>')}: event_selector_jobs must be an object")
+        return cls(
+            path=str(raw.get("path", "")),
+            classification=str(raw.get("classification", "")),
+            reason=str(raw.get("reason", "")),
+            paths=tuple(str(item) for item in raw.get("paths", [])),
+            authoritative_job=raw.get("authoritative_job"),
+            selector_job=raw.get("selector_job"),
+            event_selector_jobs=tuple(sorted((str(action), str(job)) for action, job in event_jobs.items())),
+        )
+
+
+@dataclass(frozen=True)
+class Evaluation:
+    state: str
+    description: str
+    blockers: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class EventContext:
+    pr_number: int
+    action: str
+    not_before: str
+    expected_head_sha: str
+    trigger_run_id: int = 0
+
+
+def load_manifest(path: Path) -> tuple[WorkflowSpec, ...]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if raw.get("version") != 1 or not isinstance(raw.get("workflows"), list):
+        raise ValueError("merge-gate manifest must have version 1 and a workflows list")
+    specs = tuple(WorkflowSpec.from_dict(item) for item in raw["workflows"])
+    paths = [spec.path for spec in specs]
+    if any(not path.startswith(".github/workflows/") for path in paths):
+        raise ValueError("every merge-gate workflow path must be under .github/workflows")
+    if len(paths) != len(set(paths)):
+        raise ValueError("merge-gate workflow paths must be unique")
+    for spec in specs:
+        if spec.classification not in {"required", "advisory", "ignored"}:
+            raise ValueError(f"{spec.path}: invalid classification {spec.classification!r}")
+        if not spec.reason:
+            raise ValueError(f"{spec.path}: reason is required")
+        if spec.classification != "required" and (
+            spec.paths or spec.authoritative_job or spec.selector_job or spec.event_selector_jobs
+        ):
+            raise ValueError(f"{spec.path}: non-required workflows cannot carry gate selectors")
+        if spec.authoritative_job and spec.selector_job:
+            raise ValueError(f"{spec.path}: authoritative_job and selector_job are mutually exclusive")
+    return specs
+
+
+def trigger_matches(pattern: str, path: str) -> bool:
+    """Match the GitHub path-filter subset used by this repository."""
+    if pattern.endswith("/**") and path.startswith(pattern[:-3].rstrip("/") + "/"):
+        return True
+    if fnmatch.fnmatchcase(path, pattern) or PurePath(path).match(pattern):
+        return True
+    if "/**/" in pattern and fnmatch.fnmatchcase(path, pattern.replace("/**/", "/")):
+        return True
+    return False
+
+
+def applies(spec: WorkflowSpec, changed_files: Iterable[str]) -> bool:
+    return not spec.paths or any(trigger_matches(pattern, path) for pattern in spec.paths for path in changed_files)
+
+
+def normalized_workflow_path(path: str) -> str:
+    return path.split("@", 1)[0]
+
+
+def _run_key(run: dict[str, Any]) -> tuple[str, int, int]:
+    return (str(run.get("created_at", "")), int(run.get("id", 0)), int(run.get("run_attempt", 0)))
+
+
+def _job_key(job: dict[str, Any]) -> tuple[str, int]:
+    return (str(job.get("started_at", "")), int(job.get("id", 0)))
+
+
+def _result_for(conclusion: Any, status: Any, label: str) -> Evaluation:
+    normalized_status = str(status or "").lower()
+    normalized_conclusion = str(conclusion or "").lower()
+    if normalized_status != "completed" or not normalized_conclusion:
+        if normalized_status in INCOMPLETE_STATUSES or not normalized_conclusion:
+            return Evaluation("pending", f"Waiting for {label}", (label,))
+        return Evaluation("error", f"Unknown status for {label}: {normalized_status or '<empty>'}", (label,))
+    if normalized_conclusion in PASSING_CONCLUSIONS:
+        return Evaluation("success", f"{label} passed")
+    if normalized_conclusion in FAILING_CONCLUSIONS:
+        return Evaluation("failure", f"{label} concluded {normalized_conclusion}", (label,))
+    return Evaluation("error", f"Unknown conclusion for {label}: {normalized_conclusion}", (label,))
+
+
+def _latest_run_with_job(
+    runs: list[dict[str, Any]],
+    jobs_by_run: dict[int, list[dict[str, Any]]],
+    job_name: str,
+    *,
+    not_before: str = "",
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    eligible = [run for run in runs if str(run.get("created_at", "")) >= not_before]
+    for run in sorted(eligible, key=_run_key, reverse=True):
+        matches = [job for job in jobs_by_run.get(int(run["id"]), []) if job.get("name") == job_name]
+        if matches:
+            return run, max(matches, key=_job_key)
+    return None
+
+
+def evaluate(
+    specs: Iterable[WorkflowSpec],
+    changed_files: Iterable[str],
+    runs: Iterable[dict[str, Any]],
+    jobs_by_run: dict[int, list[dict[str, Any]]],
+    *,
+    event_action: str = "",
+    event_not_before: str = "",
+) -> Evaluation:
+    """Return a pure aggregate verdict over already-fetched exact-head data."""
+    changed = tuple(changed_files)
+    runs_by_path: dict[str, list[dict[str, Any]]] = {}
+    for run in runs:
+        if run.get("event") != "pull_request":
+            continue
+        runs_by_path.setdefault(normalized_workflow_path(str(run.get("path", ""))), []).append(run)
+
+    failures: list[str] = []
+    errors: list[str] = []
+    pending: list[str] = []
+    applicable_count = 0
+
+    def collect(result: Evaluation) -> None:
+        if result.state == "failure":
+            failures.extend(result.blockers)
+        elif result.state == "error":
+            errors.extend(result.blockers)
+        elif result.state == "pending":
+            pending.extend(result.blockers)
+
+    for spec in specs:
+        if spec.classification != "required" or not applies(spec, changed):
+            continue
+        applicable_count += 1
+        candidates = runs_by_path.get(spec.path, [])
+        label = Path(spec.path).name
+        if not candidates:
+            pending.append(label)
+            continue
+
+        if spec.authoritative_job:
+            latest = max(candidates, key=_run_key)
+            jobs = [job for job in jobs_by_run.get(int(latest["id"]), []) if job.get("name") == spec.authoritative_job]
+            if not jobs:
+                if latest.get("status") == "completed":
+                    errors.append(f"{label}:{spec.authoritative_job} missing")
+                else:
+                    pending.append(f"{label}:{spec.authoritative_job}")
+            else:
+                job = max(jobs, key=_job_key)
+                collect(_result_for(job.get("conclusion"), job.get("status"), f"{label}:{spec.authoritative_job}"))
+        elif spec.selector_job:
+            selected = _latest_run_with_job(candidates, jobs_by_run, spec.selector_job)
+            if selected is None:
+                if any(run.get("status") != "completed" for run in candidates):
+                    pending.append(f"{label}:{spec.selector_job}")
+                else:
+                    errors.append(f"{label}:{spec.selector_job} lane missing")
+            else:
+                run, _job = selected
+                collect(_result_for(run.get("conclusion"), run.get("status"), f"{label}:{spec.selector_job} lane"))
+        else:
+            latest = max(candidates, key=_run_key)
+            collect(_result_for(latest.get("conclusion"), latest.get("status"), label))
+
+        for action, selector_job in spec.event_selector_jobs:
+            if action != event_action and event_action != "reconcile":
+                continue
+            selected = _latest_run_with_job(
+                candidates,
+                jobs_by_run,
+                selector_job,
+                not_before=event_not_before if action == event_action else "",
+            )
+            if selected is None:
+                if event_action == "reconcile":
+                    # A reconciliation may have been triggered by a code lane on
+                    # a SHA that has never had this metadata lane. There is no
+                    # metadata evidence to require in that case.
+                    continue
+                current_event_runs = [run for run in candidates if str(run.get("created_at", "")) >= event_not_before]
+                if any(run.get("status") != "completed" for run in current_event_runs):
+                    pending.append(f"{label}:{selector_job}")
+                else:
+                    errors.append(f"{label}:{selector_job} lane missing")
+            else:
+                run, _job = selected
+                collect(_result_for(run.get("conclusion"), run.get("status"), f"{label}:{selector_job} lane"))
+
+    if failures:
+        first = ", ".join(failures[:3])
+        return Evaluation("failure", f"Required CI failed: {first}"[:140], tuple(failures))
+    if errors:
+        first = ", ".join(errors[:3])
+        return Evaluation("error", f"Merge-gate evidence error: {first}"[:140], tuple(errors))
+    if pending:
+        first = ", ".join(pending[:3])
+        return Evaluation("pending", f"Waiting for required CI: {first}"[:140], tuple(pending))
+    return Evaluation("success", f"All {applicable_count} applicable CI workflows passed")
+
+
+class GitHubClient:
+    def __init__(self, repository: str, token: str) -> None:
+        if not REPOSITORY_RE.fullmatch(repository):
+            raise ValueError(f"invalid repository: {repository!r}")
+        if not token:
+            raise ValueError("GITHUB_TOKEN is required")
+        self.repository = repository
+        self.token = token
+        self.api_root = f"https://api.github.com/repos/{repository}"
+
+    def request(self, method: str, path: str, body: dict[str, Any] | None = None) -> Any:
+        data = json.dumps(body).encode("utf-8") if body is not None else None
+        request = urllib.request.Request(
+            f"{self.api_root}{path}",
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "User-Agent": "omi-exact-head-merge-gate",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                return json.load(response)
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")[:500]
+            raise RuntimeError(f"GitHub API {method} {path} failed ({exc.code}): {detail}") from exc
+
+    def paged(self, path: str, key: str | None = None) -> list[dict[str, Any]]:
+        separator = "&" if "?" in path else "?"
+        collected: list[dict[str, Any]] = []
+        for page in range(1, 101):
+            payload = self.request("GET", f"{path}{separator}per_page=100&page={page}")
+            items = payload[key] if key else payload
+            if not isinstance(items, list):
+                raise RuntimeError(f"GitHub API pagination returned a non-list for {path}")
+            collected.extend(items)
+            if len(items) < 100:
+                return collected
+        raise RuntimeError(f"GitHub API pagination exceeded 10,000 records for {path}")
+
+    def pull_request(self, number: int) -> dict[str, Any]:
+        return self.request("GET", f"/pulls/{number}")
+
+    def changed_files(self, number: int) -> list[str]:
+        files = self.paged(f"/pulls/{number}/files")
+        if len(files) >= MAX_PR_FILES:
+            raise RuntimeError(
+                "GitHub's pull-request files API is capped at 3,000 files; "
+                "cannot prove path-filter completeness, so the merge gate fails closed"
+            )
+        return [str(item["filename"]) for item in files]
+
+    def pull_requests_for_commit(self, sha: str) -> list[dict[str, Any]]:
+        if not SHA_RE.fullmatch(sha):
+            raise ValueError(f"invalid commit SHA: {sha!r}")
+        return self.paged(f"/commits/{sha}/pulls")
+
+    def workflow_runs(self, sha: str) -> list[dict[str, Any]]:
+        query = urllib.parse.urlencode({"event": "pull_request", "head_sha": sha})
+        return self.paged(f"/actions/runs?{query}", "workflow_runs")
+
+    def jobs(self, run_id: int) -> list[dict[str, Any]]:
+        return self.paged(f"/actions/runs/{run_id}/jobs?filter=latest", "jobs")
+
+    def post_status(self, sha: str, state: str, description: str, target_url: str) -> None:
+        if not SHA_RE.fullmatch(sha):
+            raise ValueError(f"invalid target SHA: {sha!r}")
+        self.request(
+            "POST",
+            f"/statuses/{sha}",
+            {"state": state, "context": STATUS_CONTEXT, "description": description[:140], "target_url": target_url},
+        )
+
+
+def _head_sha(pr: dict[str, Any]) -> str:
+    sha = str(pr.get("head", {}).get("sha", ""))
+    if not SHA_RE.fullmatch(sha):
+        raise RuntimeError(f"pull request returned invalid head SHA: {sha!r}")
+    return sha
+
+
+def resolve_event_context(client: GitHubClient, payload: dict[str, Any]) -> EventContext | None:
+    """Resolve a trusted PR event or workflow-run event to one exact open PR."""
+    pull_request = payload.get("pull_request")
+    if isinstance(pull_request, dict):
+        number = int(pull_request.get("number") or payload.get("number") or 0)
+        if number <= 0:
+            raise RuntimeError("pull_request event did not contain a valid PR number")
+        return EventContext(
+            number,
+            str(payload.get("action", "")),
+            str(pull_request.get("updated_at", "")),
+            _head_sha(pull_request),
+        )
+
+    workflow_run = payload.get("workflow_run")
+    if not isinstance(workflow_run, dict) or workflow_run.get("event") != "pull_request":
+        raise RuntimeError("event payload is neither a PR event nor a PR workflow-run event")
+    sha = str(workflow_run.get("head_sha", ""))
+    if not SHA_RE.fullmatch(sha):
+        raise RuntimeError(f"workflow_run event returned invalid head SHA: {sha!r}")
+    associated = client.pull_requests_for_commit(sha)
+    exact = [
+        pr
+        for pr in associated
+        if str(pr.get("head", {}).get("sha", "")) == sha
+        and str(pr.get("base", {}).get("ref", "")) == "main"
+        and str(pr.get("base", {}).get("repo", {}).get("full_name", client.repository)) == client.repository
+    ]
+    open_exact = [pr for pr in exact if pr.get("state") == "open"]
+    if len(open_exact) == 1:
+        number = int(open_exact[0].get("number", 0))
+        if number <= 0:
+            raise RuntimeError("associated open PR did not contain a valid number")
+        return EventContext(number, "reconcile", "", sha, int(workflow_run.get("id", 0)))
+    if not open_exact and exact:
+        # The PR merged or closed before its workflow-run event arrived. A
+        # reopened PR gets a fresh pull_request_target event, so no status is
+        # needed on the now-closed PR.
+        return None
+    raise RuntimeError(f"workflow run {workflow_run.get('id')} maps to {len(open_exact)} exact open PRs")
+
+
+def _job_run_ids(
+    specs: Iterable[WorkflowSpec], changed_files: Iterable[str], runs: Iterable[dict[str, Any]]
+) -> set[int]:
+    applicable_paths = {
+        spec.path
+        for spec in specs
+        if spec.classification == "required"
+        and applies(spec, changed_files)
+        and (spec.authoritative_job or spec.selector_job or spec.event_selector_jobs)
+    }
+    return {
+        int(run["id"])
+        for run in runs
+        if run.get("event") == "pull_request" and normalized_workflow_path(str(run.get("path", ""))) in applicable_paths
+    }
+
+
+def publish_if_current(
+    client: GitHubClient, pr_number: int, target_sha: str, result: Evaluation, target_url: str
+) -> bool:
+    """Publish only to the SHA this controller originally evaluated."""
+    if _head_sha(client.pull_request(pr_number)) != target_sha:
+        print(f"PR head changed; refusing to publish {result.state} for superseded {target_sha}")
+        return False
+    client.post_status(target_sha, result.state, result.description, target_url)
+    return True
+
+
+def run_gate(
+    client: GitHubClient,
+    specs: tuple[WorkflowSpec, ...],
+    pr_number: int,
+    event_action: str,
+    event_not_before: str,
+    target_url: str,
+    timeout_seconds: int,
+    poll_seconds: int,
+    *,
+    expected_head_sha: str = "",
+    trigger_run_id: int = 0,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> Evaluation:
+    target_sha = _head_sha(client.pull_request(pr_number))
+    if expected_head_sha:
+        if not SHA_RE.fullmatch(expected_head_sha):
+            raise ValueError(f"invalid expected head SHA: {expected_head_sha!r}")
+        if expected_head_sha != target_sha:
+            return Evaluation("pending", f"Ignoring superseded workflow evidence for {expected_head_sha[:12]}")
+    changed = client.changed_files(pr_number)
+    client.post_status(target_sha, "pending", "Waiting for exact-head required CI", target_url)
+    deadline = monotonic() + timeout_seconds
+    completed_job_cache: dict[tuple[int, int], list[dict[str, Any]]] = {}
+
+    while True:
+        if _head_sha(client.pull_request(pr_number)) != target_sha:
+            return Evaluation("pending", f"Superseded by a newer PR head than {target_sha[:12]}")
+        runs = client.workflow_runs(target_sha)
+        by_id = {int(run["id"]): run for run in runs}
+        jobs_by_run: dict[int, list[dict[str, Any]]] = {}
+        for run_id in _job_run_ids(specs, changed, runs):
+            run = by_id[run_id]
+            cache_key = (run_id, int(run.get("run_attempt", 0)))
+            if run.get("status") == "completed" and cache_key in completed_job_cache:
+                jobs_by_run[run_id] = completed_job_cache[cache_key]
+                continue
+            jobs_by_run[run_id] = client.jobs(run_id)
+            if run.get("status") == "completed":
+                completed_job_cache[cache_key] = jobs_by_run[run_id]
+        trigger_run = by_id.get(trigger_run_id) if trigger_run_id else None
+        if trigger_run_id and (trigger_run is None or trigger_run.get("status") != "completed"):
+            result = Evaluation("pending", "Waiting for the workflow that triggered reconciliation")
+        else:
+            result = evaluate(
+                specs,
+                changed,
+                runs,
+                jobs_by_run,
+                event_action=event_action,
+                event_not_before=event_not_before,
+            )
+        if result.state != "pending":
+            publish_if_current(client, pr_number, target_sha, result, target_url)
+            return result
+        if monotonic() >= deadline:
+            timed_out = Evaluation("error", f"Timed out: {result.description}"[:140], result.blockers)
+            publish_if_current(client, pr_number, target_sha, timed_out, target_url)
+            return timed_out
+        sleep(poll_seconds)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--pr-number", type=int, default=0)
+    parser.add_argument("--event-file", type=Path)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--event-action", default="")
+    parser.add_argument("--event-not-before", default="")
+    parser.add_argument("--expected-head-sha", default="")
+    parser.add_argument("--trigger-run-id", type=int, default=0)
+    parser.add_argument("--target-url", required=True)
+    parser.add_argument("--timeout-seconds", type=int, default=5400)
+    parser.add_argument("--poll-seconds", type=int, default=15)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    if not args.event_file and args.pr_number <= 0:
+        raise SystemExit("--pr-number must be positive")
+    if args.timeout_seconds <= 0 or args.poll_seconds <= 0:
+        raise SystemExit("poll and timeout values must be positive")
+    client = GitHubClient(args.repository, os.environ.get("GITHUB_TOKEN", ""))
+    if args.event_file:
+        payload = json.loads(args.event_file.read_text(encoding="utf-8"))
+        try:
+            context = resolve_event_context(client, payload)
+        except RuntimeError as exc:
+            workflow_run = payload.get("workflow_run", {})
+            sha = str(workflow_run.get("head_sha", "")) if isinstance(workflow_run, dict) else ""
+            if SHA_RE.fullmatch(sha):
+                client.post_status(sha, "error", f"Merge-gate event resolution failed: {exc}", args.target_url)
+            raise
+        if context is None:
+            print(json.dumps({"state": "closed", "description": "Associated PR is no longer open"}))
+            return 0
+        pr_number = context.pr_number
+        event_action = context.action
+        event_not_before = context.not_before
+        expected_head_sha = context.expected_head_sha
+        trigger_run_id = context.trigger_run_id
+    else:
+        pr_number = args.pr_number
+        event_action = args.event_action
+        event_not_before = args.event_not_before
+        expected_head_sha = args.expected_head_sha
+        trigger_run_id = args.trigger_run_id
+    if pr_number <= 0:
+        raise RuntimeError("resolved PR number must be positive")
+    result = run_gate(
+        client,
+        load_manifest(args.manifest),
+        pr_number,
+        event_action,
+        event_not_before,
+        args.target_url,
+        args.timeout_seconds,
+        args.poll_seconds,
+        expected_head_sha=expected_head_sha,
+        trigger_run_id=trigger_run_id,
+    )
+    print(json.dumps({"state": result.state, "description": result.description, "blockers": result.blockers}))
+    return 0 if result.state in {"success", "pending"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_pr_merge_gate.py
+++ b/.github/scripts/test_pr_merge_gate.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+"""Hermetic regression tests for the exact-head merge gate."""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+from pr_merge_gate import (
+    GitHubClient,
+    Evaluation,
+    WorkflowSpec,
+    evaluate,
+    load_manifest,
+    publish_if_current,
+    resolve_event_context,
+    run_gate,
+)
+from run_checks import load_manifest as load_checks_manifest
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+MANIFEST_PATH = REPO_ROOT / ".github" / "merge-gate-manifest.json"
+CHECKS_MANIFEST_PATH = REPO_ROOT / ".github" / "checks-manifest.yaml"
+POLICY_PATH = REPO_ROOT / ".github" / "required-branch-policy.json"
+WORKFLOW_PATH = WORKFLOWS_DIR / "pr-merge-gate.yml"
+SHA_A = "a" * 40
+SHA_B = "b" * 40
+
+
+def spec(path: str, **kwargs: object) -> WorkflowSpec:
+    return WorkflowSpec(path=f".github/workflows/{path}", classification="required", reason="test", **kwargs)
+
+
+def run(
+    run_id: int,
+    path: str,
+    *,
+    status: str = "completed",
+    conclusion: str | None = "success",
+    created_at: str = "2026-08-26T17:48:00Z",
+    attempt: int = 1,
+) -> dict[str, object]:
+    return {
+        "id": run_id,
+        "path": f".github/workflows/{path}@refs/pull/1/merge",
+        "event": "pull_request",
+        "head_sha": SHA_A,
+        "status": status,
+        "conclusion": conclusion,
+        "created_at": created_at,
+        "run_attempt": attempt,
+    }
+
+
+def job(job_id: int, name: str, conclusion: str = "success", status: str = "completed") -> dict[str, object]:
+    return {
+        "id": job_id,
+        "name": name,
+        "conclusion": conclusion,
+        "status": status,
+        "started_at": "2026-08-26T17:49:00Z",
+    }
+
+
+def _event_block(text: str, event: str) -> list[str] | None:
+    lines = text.splitlines()
+    on_start = next(
+        (
+            index
+            for index, line in enumerate(lines)
+            if re.fullmatch(r"(?:on|'on'|\"on\"):\s*", line)
+        ),
+        None,
+    )
+    if on_start is None:
+        flow_on_index = next(
+            (
+                index
+                for index, line in enumerate(lines)
+                if re.match(r"(?:on|'on'|\"on\"):\s*\S", line)
+            ),
+            None,
+        )
+        if flow_on_index is not None:
+            flow_lines = [lines[flow_on_index]]
+            for line in lines[flow_on_index + 1 :]:
+                if line.strip() and re.match(r"^[A-Za-z_'\"]+\s*:", line):
+                    break
+                flow_lines.append(line)
+            flow_on = "\n".join(flow_lines)
+            if re.search(rf"\b{re.escape(event)}\b", flow_on):
+                raise AssertionError(f"{event} must use canonical block event syntax, not {flow_on!r}")
+        return None
+    on_block: list[str] = []
+    for line in lines[on_start + 1 :]:
+        if line.strip() and not line.lstrip().startswith("#") and len(line) - len(line.lstrip()) == 0:
+            break
+        on_block.append(line)
+    event_re = re.compile(rf"  (?:{re.escape(event)}|'{re.escape(event)}'|\"{re.escape(event)}\"):\s*(.*)")
+    start = None
+    for index, line in enumerate(on_block):
+        match = event_re.fullmatch(line)
+        if not match:
+            continue
+        if match.group(1):
+            raise AssertionError(f"{event} must use canonical block event syntax, not {line!r}")
+        start = index
+        break
+    if start is None:
+        return None
+    block: list[str] = []
+    for line in on_block[start + 1 :]:
+        if line.strip() and not line.lstrip().startswith("#") and len(line) - len(line.lstrip()) <= 2:
+            break
+        block.append(line)
+    return block
+
+
+def workflow_event_paths(path: Path) -> tuple[str, ...] | None:
+    text = path.read_text(encoding="utf-8")
+    block = _event_block(text, "pull_request")
+    if block is None:
+        block = _event_block(text, "pull_request_target")
+    if block is None:
+        return None
+    inline_paths = next(
+        (
+            line
+            for line in block
+            if re.fullmatch(r"    (?:paths|'paths'|\"paths\"):\s*\S.*", line)
+        ),
+        None,
+    )
+    if inline_paths:
+        raise AssertionError(f"paths must use a canonical block sequence, not {inline_paths!r}")
+    paths_start = next(
+        (
+            index
+            for index, line in enumerate(block)
+            if re.fullmatch(r"    (?:paths|'paths'|\"paths\"):\s*", line)
+        ),
+        None,
+    )
+    if paths_start is None:
+        return ()
+    paths: list[str] = []
+    for line in block[paths_start + 1 :]:
+        if line.strip() and len(line) - len(line.lstrip()) <= 4:
+            break
+        match = re.fullmatch(r"\s{6}-\s+(.+?)\s*", line)
+        if match:
+            value = match.group(1)
+            paths.append(str(ast.literal_eval(value)) if value[:1] in {"'", '"'} else value)
+    return tuple(paths)
+
+
+def workflow_display_name(path: Path) -> str:
+    matches = re.findall(r"(?m)^name:\s*(.+?)\s*$", path.read_text(encoding="utf-8"))
+    if len(matches) != 1:
+        raise AssertionError(f"{path} must have exactly one top-level workflow name")
+    value = matches[0]
+    return str(ast.literal_eval(value)) if value[:1] in {"'", '"'} else value
+
+
+def reconciled_workflow_names() -> tuple[str, ...]:
+    block = _event_block(WORKFLOW_PATH.read_text(encoding="utf-8"), "workflow_run")
+    if block is None:
+        return ()
+    start = next(
+        (index for index, line in enumerate(block) if re.fullmatch(r"    workflows:\s*", line)),
+        None,
+    )
+    if start is None:
+        return ()
+    names: list[str] = []
+    for line in block[start + 1 :]:
+        if line.strip() and len(line) - len(line.lstrip()) <= 4:
+            break
+        match = re.fullmatch(r"\s{6}-\s+(.+?)\s*", line)
+        if match:
+            value = match.group(1)
+            names.append(str(ast.literal_eval(value)) if value[:1] in {"'", '"'} else value)
+    return tuple(names)
+
+
+class EvaluationTests(unittest.TestCase):
+    def test_pr_11454_known_red_checks_fail_before_merge(self) -> None:
+        specs = (spec("backend-unit-tests.yml"), spec("repo-checks.yml", selector_job="Hygiene"))
+        runs = [
+            run(1, "backend-unit-tests.yml", conclusion="failure"),
+            run(2, "repo-checks.yml", conclusion="failure"),
+        ]
+        result = evaluate(specs, ["backend/utils/subscription.py"], runs, {2: [job(20, "Hygiene")]})
+        self.assertEqual(result.state, "failure")
+        self.assertIn("backend-unit-tests.yml", result.description)
+
+    def test_pr_11832_stays_pending_then_turns_red(self) -> None:
+        specs = (spec("desktop-swift-ci.yml"),)
+        pending = evaluate(
+            specs,
+            ["desktop/macos/Desktop/Sources/App.swift"],
+            [run(1, "desktop-swift-ci.yml", status="in_progress", conclusion=None)],
+            {},
+        )
+        red = evaluate(
+            specs,
+            ["desktop/macos/Desktop/Sources/App.swift"],
+            [run(1, "desktop-swift-ci.yml", conclusion="failure")],
+            {},
+        )
+        self.assertEqual(pending.state, "pending")
+        self.assertEqual(red.state, "failure")
+
+    def test_missing_applicable_run_never_succeeds(self) -> None:
+        result = evaluate((spec("backend-unit-tests.yml", paths=("backend/**",)),), ["backend/api.py"], [], {})
+        self.assertEqual(result.state, "pending")
+
+    def test_docs_only_diff_does_not_expect_path_filtered_backend(self) -> None:
+        specs = (
+            spec("backend-unit-tests.yml", paths=("backend/**",)),
+            spec("web-checks.yml"),
+        )
+        result = evaluate(specs, ["README.md"], [run(1, "web-checks.yml")], {})
+        self.assertEqual(result.state, "success")
+        self.assertIn("1 applicable", result.description)
+
+    def test_newer_duplicate_supersedes_old_cancelled_run(self) -> None:
+        specs = (spec("backend-unit-tests.yml"),)
+        runs = [
+            run(1, "backend-unit-tests.yml", conclusion="cancelled", created_at="2026-08-26T17:48:00Z"),
+            run(2, "backend-unit-tests.yml", conclusion="success", created_at="2026-08-26T17:49:00Z"),
+        ]
+        self.assertEqual(evaluate(specs, ["backend/a.py"], runs, {}).state, "success")
+
+    def test_newest_cancelled_duplicate_blocks(self) -> None:
+        specs = (spec("backend-unit-tests.yml"),)
+        runs = [
+            run(1, "backend-unit-tests.yml", conclusion="success", created_at="2026-08-26T17:48:00Z"),
+            run(2, "backend-unit-tests.yml", conclusion="cancelled", created_at="2026-08-26T17:49:00Z"),
+        ]
+        self.assertEqual(evaluate(specs, ["backend/a.py"], runs, {}).state, "failure")
+
+    def test_latest_rerun_attempt_is_authoritative(self) -> None:
+        latest_attempt = run(1, "backend-unit-tests.yml", conclusion="success", attempt=2)
+        result = evaluate((spec("backend-unit-tests.yml"),), ["backend/a.py"], [latest_attempt], {})
+        self.assertEqual(result.state, "success")
+
+    def test_repo_metadata_lane_cannot_hide_code_lane_failure(self) -> None:
+        specs = (
+            spec(
+                "repo-checks.yml",
+                selector_job="Hygiene",
+                event_selector_jobs=(("edited", "PR Metadata Preflight"),),
+            ),
+        )
+        runs = [
+            run(1, "repo-checks.yml", conclusion="failure", created_at="2026-08-26T17:48:00Z"),
+            run(2, "repo-checks.yml", conclusion="success", created_at="2026-08-26T17:49:00Z"),
+        ]
+        jobs = {1: [job(10, "Hygiene")], 2: [job(20, "PR Metadata Preflight")]}
+        self.assertEqual(evaluate(specs, ["README.md"], runs, jobs, event_action="edited").state, "failure")
+
+    def test_new_metadata_event_does_not_reuse_older_same_sha_metadata_success(self) -> None:
+        specs = (
+            spec(
+                "repo-checks.yml",
+                selector_job="Hygiene",
+                event_selector_jobs=(("edited", "PR Metadata Preflight"),),
+            ),
+        )
+        runs = [
+            run(1, "repo-checks.yml", conclusion="success", created_at="2026-08-26T17:48:00Z"),
+            run(2, "repo-checks.yml", status="in_progress", conclusion=None, created_at="2026-08-26T18:00:01Z"),
+        ]
+        jobs = {1: [job(10, "Hygiene"), job(11, "PR Metadata Preflight")], 2: []}
+        result = evaluate(
+            specs,
+            ["README.md"],
+            runs,
+            jobs,
+            event_action="edited",
+            event_not_before="2026-08-26T18:00:00Z",
+        )
+        self.assertEqual(result.state, "pending")
+
+    def test_authoritative_job_can_exclude_named_advisory_failure(self) -> None:
+        specs = (spec("backend-hermetic-e2e.yml", authoritative_job="Backend Hermetic Merge Gate"),)
+        workflow = run(1, "backend-hermetic-e2e.yml", conclusion="failure")
+        jobs = {1: [job(10, "Backend Hermetic Merge Gate", "success"), job(11, "Replay advisory", "failure")]}
+        self.assertEqual(evaluate(specs, ["backend/a.py"], [workflow], jobs).state, "success")
+
+    def test_unknown_terminal_conclusion_is_error(self) -> None:
+        unknown = run(1, "backend-unit-tests.yml", conclusion="mystery")
+        result = evaluate((spec("backend-unit-tests.yml"),), ["backend/a.py"], [unknown], {})
+        self.assertEqual(result.state, "error")
+
+
+class SupersessionTests(unittest.TestCase):
+    class Client:
+        def __init__(self) -> None:
+            self.statuses: list[tuple[object, ...]] = []
+
+        def pull_request(self, _number: int) -> dict[str, object]:
+            return {"head": {"sha": SHA_B}}
+
+        def post_status(self, *args: object) -> None:
+            self.statuses.append(args)
+
+    def test_head_supersession_refuses_final_status(self) -> None:
+        client = self.Client()
+        published = publish_if_current(client, 1, SHA_A, Evaluation("success", "passed"), "https://example.test/run")
+        self.assertFalse(published)
+        self.assertEqual(client.statuses, [])
+
+    def test_gate_queries_and_publishes_only_the_exact_live_head(self) -> None:
+        class ExactClient:
+            def __init__(self) -> None:
+                self.queried_shas: list[str] = []
+                self.statuses: list[tuple[str, str]] = []
+
+            def pull_request(self, _number: int) -> dict[str, object]:
+                return {"head": {"sha": SHA_A}}
+
+            def changed_files(self, _number: int) -> list[str]:
+                return ["README.md"]
+
+            def workflow_runs(self, sha: str) -> list[dict[str, object]]:
+                self.queried_shas.append(sha)
+                return [run(1, "web-checks.yml")]
+
+            def jobs(self, _run_id: int) -> list[dict[str, object]]:
+                raise AssertionError("job details are not needed for a workflow-level verdict")
+
+            def post_status(self, sha: str, state: str, _description: str, _target_url: str) -> None:
+                self.statuses.append((sha, state))
+
+        client = ExactClient()
+        result = run_gate(
+            client,  # type: ignore[arg-type]
+            (spec("web-checks.yml"),),
+            1,
+            "synchronize",
+            "2026-08-26T17:47:00Z",
+            "https://example.test/run",
+            60,
+            1,
+        )
+        self.assertEqual(result.state, "success")
+        self.assertEqual(client.queried_shas, [SHA_A])
+        self.assertEqual(client.statuses, [(SHA_A, "pending"), (SHA_A, "success")])
+
+    def test_rerun_attempt_never_reuses_cached_authoritative_job(self) -> None:
+        class RerunClient:
+            def __init__(self) -> None:
+                self.poll = -1
+                self.statuses: list[tuple[str, str]] = []
+
+            def pull_request(self, _number: int) -> dict[str, object]:
+                return {"head": {"sha": SHA_A}}
+
+            def changed_files(self, _number: int) -> list[str]:
+                return ["backend/api.py"]
+
+            def workflow_runs(self, _sha: str) -> list[dict[str, object]]:
+                self.poll += 1
+                if self.poll == 0:
+                    return [
+                        run(1, "backend-hermetic-e2e.yml", attempt=1),
+                        run(2, "web-checks.yml", status="in_progress", conclusion=None),
+                    ]
+                return [
+                    run(1, "backend-hermetic-e2e.yml", attempt=2, conclusion="failure"),
+                    run(2, "web-checks.yml"),
+                ]
+
+            def jobs(self, run_id: int) -> list[dict[str, object]]:
+                if run_id == 1:
+                    conclusion = "success" if self.poll == 0 else "failure"
+                    return [job(10 + self.poll, "Backend Hermetic Merge Gate", conclusion)]
+                return []
+
+            def post_status(self, sha: str, state: str, _description: str, _target_url: str) -> None:
+                self.statuses.append((sha, state))
+
+        client = RerunClient()
+        result = run_gate(
+            client,  # type: ignore[arg-type]
+            (spec("backend-hermetic-e2e.yml", authoritative_job="Backend Hermetic Merge Gate"), spec("web-checks.yml")),
+            1,
+            "reconcile",
+            "",
+            "https://example.test/run",
+            60,
+            1,
+            monotonic=lambda: 0,
+            sleep=lambda _seconds: None,
+        )
+        self.assertEqual(result.state, "failure")
+        self.assertEqual(client.statuses, [(SHA_A, "pending"), (SHA_A, "failure")])
+
+
+class EventResolutionTests(unittest.TestCase):
+    class Client:
+        repository = "BasedHardware/omi"
+
+        def pull_requests_for_commit(self, _sha: str) -> list[dict[str, object]]:
+            return [
+                {
+                    "number": 12441,
+                    "state": "open",
+                    "head": {"sha": SHA_A},
+                    "base": {"ref": "main", "repo": {"full_name": self.repository}},
+                }
+            ]
+
+    def test_empty_workflow_run_pull_requests_resolve_by_exact_commit(self) -> None:
+        payload = {
+            "workflow_run": {
+                "id": 33333553185,
+                "event": "pull_request",
+                "head_sha": SHA_A,
+                "pull_requests": [],
+            }
+        }
+        context = resolve_event_context(self.Client(), payload)  # type: ignore[arg-type]
+        self.assertIsNotNone(context)
+        assert context is not None
+        self.assertEqual((context.pr_number, context.expected_head_sha), (12441, SHA_A))
+        self.assertEqual(context.trigger_run_id, 33333553185)
+
+    def test_ambiguous_exact_open_prs_fail_closed(self) -> None:
+        class AmbiguousClient(self.Client):
+            def pull_requests_for_commit(self, sha: str) -> list[dict[str, object]]:
+                one = super().pull_requests_for_commit(sha)[0]
+                return [one, {**one, "number": 12442}]
+
+        payload = {"workflow_run": {"id": 9, "event": "pull_request", "head_sha": SHA_A}}
+        with self.assertRaisesRegex(RuntimeError, "2 exact open PRs"):
+            resolve_event_context(AmbiguousClient(), payload)  # type: ignore[arg-type]
+
+
+class RepositoryContractTests(unittest.TestCase):
+    def test_inline_pr_event_syntax_is_rejected_instead_of_silently_ignored(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "inline.yml"
+            path.write_text("name: Inline\non: [pull_request]\njobs: {}\n", encoding="utf-8")
+            with self.assertRaisesRegex(AssertionError, "canonical block event syntax"):
+                workflow_event_paths(path)
+
+    def test_multiline_flow_pr_event_syntax_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "multiline-flow.yml"
+            path.write_text(
+                "name: Flow\non: [\n  push,\n  pull_request\n]\njobs: {}\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(AssertionError, "canonical block event syntax"):
+                workflow_event_paths(path)
+
+    def test_quoted_block_pr_event_is_discovered(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "quoted.yml"
+            path.write_text("name: Quoted\n'on':\n  'pull_request':\n    paths:\n      - 'backend/**'\n", encoding="utf-8")
+            self.assertEqual(workflow_event_paths(path), ("backend/**",))
+
+    def test_changed_files_fails_closed_at_github_api_cap(self) -> None:
+        client = object.__new__(GitHubClient)
+        client.paged = lambda _path: [
+            {"filename": f"generated/file-{index}.txt"} for index in range(3000)
+        ]
+
+        with self.assertRaisesRegex(RuntimeError, "3,000 files"):
+            client.changed_files(123)
+
+    def test_manifest_classifies_every_pr_event_workflow_and_matches_paths(self) -> None:
+        specs = load_manifest(MANIFEST_PATH)
+        by_path = {spec.path: spec for spec in specs}
+        discovered: dict[str, tuple[str, ...]] = {}
+        for path in sorted(WORKFLOWS_DIR.glob("*.y*ml")):
+            paths = workflow_event_paths(path)
+            if paths is not None:
+                relative = path.relative_to(REPO_ROOT).as_posix()
+                discovered[relative] = paths
+        self.assertEqual(set(by_path), set(discovered), "every PR/PR-target workflow must be explicitly classified")
+        for path, paths in discovered.items():
+            manifest_spec = by_path[path]
+            if _event_block((REPO_ROOT / path).read_text(encoding="utf-8"), "pull_request") is not None:
+                self.assertEqual(
+                    manifest_spec.classification,
+                    "required",
+                    f"ordinary PR CI cannot be silently ignored: {path}",
+                )
+            if manifest_spec.classification == "required":
+                self.assertEqual(manifest_spec.paths, paths, f"path applicability drifted for {path}")
+
+    def test_workflow_run_reconciles_every_required_workflow_name(self) -> None:
+        specs = load_manifest(MANIFEST_PATH)
+        expected = tuple(
+            workflow_display_name(REPO_ROOT / spec.path)
+            for spec in specs
+            if spec.classification == "required"
+        )
+        actual = reconciled_workflow_names()
+        self.assertEqual(len(actual), len(set(actual)), "workflow_run names must be unique")
+        self.assertEqual(set(actual), set(expected), "every required workflow must retrigger reconciliation")
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertRegex(workflow, r"types: \[requested, in_progress, completed\]")
+
+    def test_every_workflow_change_selects_the_drift_contract(self) -> None:
+        checks = load_checks_manifest(CHECKS_MANIFEST_PATH)
+        contract = next(check for check in checks.checks if check.id == "exact-head-merge-gate-contract")
+        self.assertIn(
+            ".github/workflows/**",
+            contract.triggers,
+            "adding a PR workflow or changing its path filters must rerun the classification contract",
+        )
+
+    def test_trusted_workflow_never_executes_pr_content(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn("pull_request_target:", workflow)
+        self.assertNotRegex(workflow, r"(?m)^  pull_request:\s*$")
+        self.assertNotIn("workflow_dispatch:", workflow)
+        self.assertIn("ref: ${{ github.workflow_sha }}", workflow)
+        self.assertIn("persist-credentials: false", workflow)
+        # The PR head SHA is safe only as non-executable concurrency metadata;
+        # it must never become a checkout ref or an executed input.
+        self.assertEqual(workflow.count("github.event.pull_request.head.sha"), 1)
+        for unsafe in ("ref: ${{ github.event.pull_request.head", "refs/pull/", "github.event.pull_request.merge", "secrets."):
+            self.assertNotIn(unsafe, workflow)
+        self.assertIn("statuses: write", workflow)
+        self.assertIn("actions: read", workflow)
+
+    def test_required_branch_policy_is_fail_closed(self) -> None:
+        policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(policy["branch"], "main")
+        self.assertTrue(policy["required_status_checks"]["strict"])
+        self.assertEqual(
+            policy["required_status_checks"]["checks"],
+            [{"context": "Omi Merge Gate", "source": "github-actions"}],
+        )
+        self.assertTrue(policy["enforce_admins"])
+        reviews = policy["required_pull_request_reviews"]
+        self.assertTrue(reviews["dismiss_stale_reviews"])
+        self.assertTrue(reviews["require_code_owner_reviews"])
+        self.assertTrue(reviews["require_last_push_approval"])
+        self.assertGreaterEqual(reviews["required_approving_review_count"], 1)
+        self.assertEqual(reviews["bypass_pull_request_allowances"], {"apps": [], "teams": [], "users": []})
+        self.assertTrue(policy["required_conversation_resolution"])
+        self.assertEqual(policy["ordinary_merge_bypass_allowances"], [])
+        self.assertFalse(policy["allow_force_pushes"])
+        self.assertFalse(policy["allow_deletions"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -1,0 +1,74 @@
+name: Exact Head Merge Gate Controller
+
+on:
+  # This privileged event is intentional: the controller must come from the
+  # trusted default branch and write a status to the PR head. It never checks
+  # out or executes PR-controlled code or artifacts.
+  pull_request_target:
+    branches: main
+    types: [opened, synchronize, reopened, ready_for_review, edited, labeled, unlabeled]
+  # Reconcile whenever an underlying required workflow starts or finishes. This
+  # invalidates a previously green aggregate during a rerun and lets a repaired
+  # rerun recover without requiring an unrelated PR edit.
+  workflow_run:
+    workflows:
+      - Backend Checks
+      - Backend Emulator Proofs
+      - Backend Hermetic E2E
+      - Backend Unit Tests
+      - Desktop Backend Contracts
+      - Desktop Checks
+      - Desktop Swift CI
+      - Desktop Windows CI
+      - Mobile App Checks
+      - OpenAPI Contract
+      - OpenTofu Development WIF Pilot Validation
+      - OpenTofu Foundation Validation
+      - Public Build Configuration Preflight
+      - Python CLI
+      - Repo Checks
+      - Runtime Image Contracts
+      - Rust SDK
+      - Web Checks
+      - Windows Preflight Portability
+    types: [requested, in_progress, completed]
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+  statuses: write
+
+concurrency:
+  group: pr-merge-gate-${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  controller:
+    name: Trusted exact-head controller
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 95
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Checkout trusted default branch controller
+        uses: actions/checkout@v7
+        with:
+          # Keep the script and manifest on the same immutable trusted commit as
+          # this workflow definition, even if main advances while the run queues.
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Evaluate exact-head required CI
+        run: >-
+          python3 .github/scripts/pr_merge_gate.py
+          --repository "$GITHUB_REPOSITORY"
+          --event-file "$GITHUB_EVENT_PATH"
+          --manifest .github/merge-gate-manifest.json
+          --target-url "$TARGET_URL"
+          --timeout-seconds 5400
+          --poll-seconds 30


### PR DESCRIPTION
## What changed and why

Add one trusted, exact-head `Omi Merge Gate` status that aggregates every applicable PR workflow from an explicit manifest and fails closed on missing, pending, failed, cancelled, skipped, unknown, superseded, path-incomplete, or stale-rerun CI. Trusted `workflow_run` reconciliation invalidates an earlier green verdict whenever an underlying required workflow starts or finishes. Add the machine-readable branch-policy prescription and agent-facing activation/recovery runbook needed to make that verdict, current-head review, code ownership, and no-bypass rules enforceable.

The last-month audit found 1,175 merged PRs; 45 (3.8%) had a latest-head check fail before merge, while the live `main` protection has no required status checks. This closes the highest-leverage control gap first.

Bootstrap is deliberately two-stage: merge this trusted controller while the context is not required, verify it on a canary and fork PR from `main`, then follow `.github/MERGE_GATE.md` to apply and read back `.github/required-branch-policy.json` through repository administration. This PR does not silently mutate live branch settings.

## Product invariants affected

none

## How it was verified

- `python3 .github/scripts/run_checks.py --lane local --check-id exact-head-merge-gate-contract` — 25/25 contract tests pass.
- `python3 .github/scripts/test_run_checks.py` — 47/47 manifest-runner tests pass.
- `actionlint .github/workflows/pr-merge-gate.yml` — clean.
- `python3 -m json.tool` on both new JSON contracts, `py_compile`, and `git diff --check` — clean.
- Read-only replay against live GitHub metadata for merged PRs #11454, #11832, #12028, #12301, and #12427 — the evaluator rejected every known-red exact head; known-green #12421 and #12441 passed.

Not yet verified: the new `pull_request_target` controller cannot run until this workflow exists on the default branch. Branch protection must not be activated until a post-merge canary and fork PR prove status publication and recovery.

## Tests

`.github/scripts/test_pr_merge_gate.py` covers historical red merges, missing and pending runs, cancelled/skipped/unknown conclusions, duplicate runs and reruns (including same-run-ID attempt changes), metadata-event freshness, authoritative/advisory job separation, exact-head supersession, empty or ambiguous workflow-to-PR association, the GitHub 3,000-file API cap, workflow name/classification/path-filter drift, noncanonical event syntax, privileged-workflow trust boundaries, and the prescribed no-bypass branch policy.

## Failure class (fixes)

Failure-Class: none

## New guards (only when adding a check or ratchet)

PRs #11454 and #11832 merged while required-looking exact-head CI was red or still resolving. This *is* the shared primitive: individual path-filtered workflows remain independently useful, while one trusted aggregate exposes a stable status that branch protection can require without GitHub's skipped-workflow deadlock.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

