### PR TITLE
feat(monitoring): page on capture/chat/pusher journey SLI outcomes

### DIFF
--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -10284,7 +10284,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(sum by (journey) (increase(omi_journey_accepted_total{journey=~\"pusher_session|capture_finalization\"}[1h])) < bool 1) * on() group_left() (sum(increase(llm_gateway_requests_total[1h])) > bool 100)",
+          "expr": "(sum by (journey) (increase(omi_journey_accepted_total{journey=~\"pusher_session|capture_finalization\"}[1h])) < bool 1) * on() group_left() (sum(increase(llm_gateway_requests_total[1h])) > bool 100) or (sum by (journey) (increase(omi_journey_accepted_total{journey=\"chat_response\"}[1h])) < bool 1) * on() group_left() (sum(increase(llm_gateway_requests_total{lane_id=\"omi:auto:chat-agent\"}[1h])) > bool 20)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -10377,7 +10377,7 @@
         }
       }
     ],
-    "updated": "2026-08-21T00:00:00Z",
+    "updated": "2026-08-30T00:00:00Z",
     "noDataState": "Alerting",
     "execErrState": "Error",
     "for": "30m",
@@ -11130,6 +11130,256 @@
       "alert_identity": "omi-firestore-metric-stale",
       "component": "firestore",
       "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-journey-capture-success-critical",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Capture finalization - success rate below paging floor",
+    "condition": "D",
+    "data": [
+      {"refId": "A", "queryType": "", "relativeTimeRange": {"from": 1800, "to": 0}, "datasourceUid": "prometheus", "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_accepted_total{journey=\"capture_finalization\"}[30m]))", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}},
+      {"refId": "B", "queryType": "", "relativeTimeRange": {"from": 1800, "to": 0}, "datasourceUid": "prometheus", "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=\"success\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=~\"success|failure\"}[30m])), 1)", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B"}},
+      {"refId": "C", "queryType": "", "relativeTimeRange": {"from": 0, "to": 0}, "datasourceUid": "__expr__", "model": {"datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "$A >= 20 && $B < 0.90", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "C", "type": "math"}},
+      {"refId": "D", "queryType": "", "relativeTimeRange": {"from": 0, "to": 0}, "datasourceUid": "__expr__", "model": {"conditions": [{"evaluator": {"params": [], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["D"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "C", "intervalMs": 1000, "maxDataPoints": 43200, "reducer": "last", "refId": "D", "type": "reduce"}}
+    ],
+    "updated": "2026-08-30T00:00:00Z",
+    "noDataState": "NoData",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-core-features",
+      "__panelId__": "2",
+      "summary": "Capture finalization success share below the 90% paging floor while at least 20 journeys were accepted in 30m",
+      "threshold": "accepted >= 20 per 30m and success / (success + failure) < 0.90",
+      "user_impact": "Voice recordings are accepted but not becoming conversations; users lose captures entirely.",
+      "scope": "The capture-finalization journey outcome on backend-listen.",
+      "verification": "Confirm the success tile and the accepted-vs-settled panel on the linked Core Features dashboard before intervention.",
+      "safe_next_action": "Follow the real-traffic journeys runbook; treat a low success share with real accepted traffic as a user-facing outage, not a capacity signal.",
+      "runbook": "backend/docs/runbooks/real-traffic-journeys.md"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "speech-processing",
+      "alert_identity": "omi-journey-capture-success-critical",
+      "component": "speech-processing",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-journey-pusher-success-critical",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Pusher session - success rate below paging floor",
+    "condition": "D",
+    "data": [
+      {"refId": "A", "queryType": "", "relativeTimeRange": {"from": 1800, "to": 0}, "datasourceUid": "prometheus", "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_accepted_total{journey=\"pusher_session\"}[30m]))", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}},
+      {"refId": "B", "queryType": "", "relativeTimeRange": {"from": 1800, "to": 0}, "datasourceUid": "prometheus", "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_terminal_total{journey=\"pusher_session\",outcome=\"success\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"pusher_session\",outcome=~\"success|failure\"}[30m])), 1)", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B"}},
+      {"refId": "C", "queryType": "", "relativeTimeRange": {"from": 0, "to": 0}, "datasourceUid": "__expr__", "model": {"datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "$A >= 20 && $B < 0.90", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "C", "type": "math"}},
+      {"refId": "D", "queryType": "", "relativeTimeRange": {"from": 0, "to": 0}, "datasourceUid": "__expr__", "model": {"conditions": [{"evaluator": {"params": [], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["D"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "C", "intervalMs": 1000, "maxDataPoints": 43200, "reducer": "last", "refId": "D", "type": "reduce"}}
+    ],
+    "updated": "2026-08-30T00:00:00Z",
+    "noDataState": "NoData",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-core-features",
+      "__panelId__": "3",
+      "summary": "Pusher session success share below the 90% paging floor while at least 20 journeys were accepted in 30m",
+      "threshold": "accepted >= 20 per 30m and success / (success + failure) < 0.90",
+      "user_impact": "Live sessions are ending in failure; users lose realtime transcription sessions.",
+      "scope": "The pusher-session journey outcome on backend-listen.",
+      "verification": "Confirm the success tile and the accepted-vs-settled panel on the linked Core Features dashboard before intervention.",
+      "safe_next_action": "Follow the real-traffic journeys runbook; treat a low success share with real accepted traffic as a user-facing outage, not a capacity signal.",
+      "runbook": "backend/docs/runbooks/real-traffic-journeys.md"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "live-transcription",
+      "alert_identity": "omi-journey-pusher-success-critical",
+      "component": "live-transcription",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-journey-chat-success-critical",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Chat response - success rate below paging floor",
+    "condition": "D",
+    "data": [
+      {"refId": "A", "queryType": "", "relativeTimeRange": {"from": 1800, "to": 0}, "datasourceUid": "prometheus", "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_accepted_total{journey=\"chat_response\"}[30m]))", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}},
+      {"refId": "B", "queryType": "", "relativeTimeRange": {"from": 1800, "to": 0}, "datasourceUid": "prometheus", "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_terminal_total{journey=\"chat_response\",outcome=\"success\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"chat_response\",outcome=~\"success|failure\"}[30m])), 1)", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B"}},
+      {"refId": "C", "queryType": "", "relativeTimeRange": {"from": 0, "to": 0}, "datasourceUid": "__expr__", "model": {"datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "$A >= 20 && $B < 0.90", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "C", "type": "math"}},
+      {"refId": "D", "queryType": "", "relativeTimeRange": {"from": 0, "to": 0}, "datasourceUid": "__expr__", "model": {"conditions": [{"evaluator": {"params": [], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["D"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "C", "intervalMs": 1000, "maxDataPoints": 43200, "reducer": "last", "refId": "D", "type": "reduce"}}
+    ],
+    "updated": "2026-08-30T00:00:00Z",
+    "noDataState": "NoData",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-core-features",
+      "__panelId__": "4",
+      "summary": "Chat response success share below the 90% paging floor while at least 20 journeys were accepted in 30m",
+      "threshold": "accepted >= 20 per 30m and success / (success + failure) < 0.90",
+      "user_impact": "Chat requests are terminalizing as failures; users cannot get AI chat responses.",
+      "scope": "The chat-response journey outcome on the Cloud Run backend, ingested via the cloud-run-application-metrics bridge.",
+      "verification": "Confirm the success tile and the accepted-vs-settled panel on the linked Core Features dashboard before intervention.",
+      "safe_next_action": "Follow the real-traffic journeys runbook; treat a low success share with real accepted traffic as a user-facing outage, not a capacity signal.",
+      "runbook": "backend/docs/runbooks/real-traffic-journeys.md"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "ai-chat",
+      "alert_identity": "omi-journey-chat-success-critical",
+      "component": "ai-chat",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-journey-capture-settle-gap",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Capture finalization - accepted work is not settling",
+    "condition": "D",
+    "data": [
+      {"refId": "A", "queryType": "", "relativeTimeRange": {"from": 3600, "to": 0}, "datasourceUid": "prometheus", "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_accepted_total{journey=\"capture_finalization\"}[1h]))", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}},
+      {"refId": "B", "queryType": "", "relativeTimeRange": {"from": 3600, "to": 0}, "datasourceUid": "prometheus", "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(omi_journey_accepted_total{journey=\"capture_finalization\"}[1h])) - sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\"}[1h]))", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "B"}},
+      {"refId": "C", "queryType": "", "relativeTimeRange": {"from": 0, "to": 0}, "datasourceUid": "__expr__", "model": {"datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "$A >= 100 && $B > 50", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "C", "type": "math"}},
+      {"refId": "D", "queryType": "", "relativeTimeRange": {"from": 0, "to": 0}, "datasourceUid": "__expr__", "model": {"conditions": [{"evaluator": {"params": [], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["D"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "C", "intervalMs": 1000, "maxDataPoints": 43200, "reducer": "last", "refId": "D", "type": "reduce"}}
+    ],
+    "updated": "2026-08-30T00:00:00Z",
+    "noDataState": "NoData",
+    "execErrState": "Error",
+    "for": "15m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-core-features",
+      "__panelId__": "7",
+      "summary": "At least 100 capture journeys were accepted in 1h while more than 50 of them per hour never reached any terminal outcome",
+      "threshold": "accepted >= 100 per 1h and accepted - settled > 50 per 1h",
+      "user_impact": "Captures are queueing without outcomes; the finalization backlog grows and users do not get their conversations.",
+      "scope": "The capture-finalization accept and terminal counters on backend-listen.",
+      "verification": "Confirm the accepted-vs-settled gap and the oldest unfinished job on the linked Core Features dashboard before intervention.",
+      "safe_next_action": "Follow the real-traffic journeys runbook; inspect finalization worker health and the Firestore job queue before any pod restarts.",
+      "runbook": "backend/docs/runbooks/real-traffic-journeys.md"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "speech-processing",
+      "alert_identity": "omi-journey-capture-settle-gap",
+      "component": "speech-processing",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-capture-oldest-nonterminal",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Capture finalization - oldest unfinished job too old",
+    "condition": "C",
+    "data": [
+      {"refId": "A", "queryType": "", "relativeTimeRange": {"from": 300, "to": 0}, "datasourceUid": "prometheus", "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "max(listen_finalization_oldest_nonterminal_age_seconds)", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}},
+      {"refId": "B", "queryType": "", "relativeTimeRange": {"from": 0, "to": 0}, "datasourceUid": "__expr__", "model": {"conditions": [{"evaluator": {"params": [], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "intervalMs": 1000, "maxDataPoints": 43200, "reducer": "last", "refId": "B", "type": "reduce"}},
+      {"refId": "C", "queryType": "", "relativeTimeRange": {"from": 0, "to": 0}, "datasourceUid": "__expr__", "model": {"conditions": [{"evaluator": {"params": [3600], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["C"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "B", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "C", "type": "threshold"}}
+    ],
+    "updated": "2026-08-30T00:00:00Z",
+    "noDataState": "Alerting",
+    "execErrState": "Error",
+    "for": "15m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-core-features",
+      "__panelId__": "30",
+      "summary": "The oldest unfinished capture finalization job has been waiting longer than 1 hour",
+      "threshold": "max oldest nonterminal age > 3600s for 15m",
+      "user_impact": "At least one user capture has been stuck for over an hour; sustained backlogs mean many users are missing conversations.",
+      "scope": "The finalization job queue age gauge republished by backend-listen.",
+      "verification": "Confirm the oldest unfinished job tile and the unfinished-jobs panel on the linked Core Features dashboard before intervention.",
+      "safe_next_action": "Follow the real-traffic journeys runbook; the gauge aggregates with max across listener pods, so verify one pod is not reporting a stale value.",
+      "runbook": "backend/docs/runbooks/real-traffic-journeys.md"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "speech-processing",
+      "alert_identity": "omi-capture-oldest-nonterminal",
+      "component": "speech-processing",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-capture-dead-letter-surge",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Capture finalization - dead-letter surge",
+    "condition": "C",
+    "data": [
+      {"refId": "A", "queryType": "", "relativeTimeRange": {"from": 3600, "to": 0}, "datasourceUid": "prometheus", "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(increase(listen_finalization_dead_letter_total[1h]))", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}},
+      {"refId": "B", "queryType": "", "relativeTimeRange": {"from": 0, "to": 0}, "datasourceUid": "__expr__", "model": {"conditions": [{"evaluator": {"params": [], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "intervalMs": 1000, "maxDataPoints": 43200, "reducer": "last", "refId": "B", "type": "reduce"}},
+      {"refId": "C", "queryType": "", "relativeTimeRange": {"from": 0, "to": 0}, "datasourceUid": "__expr__", "model": {"conditions": [{"evaluator": {"params": [50], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["C"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "B", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "C", "type": "threshold"}}
+    ],
+    "updated": "2026-08-30T00:00:00Z",
+    "noDataState": "Alerting",
+    "execErrState": "Error",
+    "for": "15m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-core-features",
+      "__panelId__": "31",
+      "summary": "More than 50 capture finalization jobs were terminalized as dead letters in 1h",
+      "threshold": "increase over 1h > 50",
+      "user_impact": "Each dead letter is a user capture that failed every retry and will never become a conversation.",
+      "scope": "The finalization dead-letter counter on backend-listen.",
+      "verification": "Confirm the dead-letter tile and the retries panel on the linked Core Features dashboard before intervention.",
+      "safe_next_action": "Follow the real-traffic journeys runbook; dead letters after a backlog often point at the finalization worker, not the listener.",
+      "runbook": "backend/docs/runbooks/real-traffic-journeys.md"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "speech-processing",
+      "alert_identity": "omi-capture-dead-letter-surge",
+      "component": "speech-processing",
+      "impact": "user-experience"
     },
     "isPaused": false,
     "notification_settings": {

--- a/backend/charts/monitoring/alerts/resilience.json
+++ b/backend/charts/monitoring/alerts/resilience.json
@@ -1514,7 +1514,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(sum by (journey) (increase(omi_journey_accepted_total{journey=~\"pusher_session|capture_finalization\"}[1h])) < bool 1) * on() group_left() (sum(increase(llm_gateway_requests_total[1h])) > bool 100)",
+          "expr": "(sum by (journey) (increase(omi_journey_accepted_total{journey=~\"pusher_session|capture_finalization\"}[1h])) < bool 1) * on() group_left() (sum(increase(llm_gateway_requests_total[1h])) > bool 100) or (sum by (journey) (increase(omi_journey_accepted_total{journey=\"chat_response\"}[1h])) < bool 1) * on() group_left() (sum(increase(llm_gateway_requests_total{lane_id=\"omi:auto:chat-agent\"}[1h])) > bool 20)",
           "instant": true,
           "intervalMs": 1000,
           "maxDataPoints": 43200,
@@ -1607,7 +1607,7 @@
         }
       }
     ],
-    "updated": "2026-08-21T00:00:00Z",
+    "updated": "2026-08-30T00:00:00Z",
     "noDataState": "Alerting",
     "execErrState": "Error",
     "for": "30m",
@@ -1629,6 +1629,852 @@
       "instatus_component": "observability",
       "component": "observability",
       "impact": "infrastructure"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-journey-capture-success-critical",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Capture finalization - success rate below paging floor",
+    "condition": "D",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_accepted_total{journey=\"capture_finalization\"}[30m]))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=\"success\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\",outcome=~\"success|failure\"}[30m])), 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "$A >= 20 && $B < 0.90",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "math"
+        }
+      },
+      {
+        "refId": "D",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "D"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "C",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "D",
+          "type": "reduce"
+        }
+      }
+    ],
+    "updated": "2026-08-30T00:00:00Z",
+    "noDataState": "NoData",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-core-features",
+      "__panelId__": "2",
+      "summary": "Capture finalization success share below the 90% paging floor while at least 20 journeys were accepted in 30m",
+      "threshold": "accepted >= 20 per 30m and success / (success + failure) < 0.90",
+      "user_impact": "Voice recordings are accepted but not becoming conversations; users lose captures entirely.",
+      "scope": "The capture-finalization journey outcome on backend-listen.",
+      "verification": "Confirm the success tile and the accepted-vs-settled panel on the linked Core Features dashboard before intervention.",
+      "safe_next_action": "Follow the real-traffic journeys runbook; treat a low success share with real accepted traffic as a user-facing outage, not a capacity signal.",
+      "runbook": "backend/docs/runbooks/real-traffic-journeys.md"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "speech-processing",
+      "alert_identity": "omi-journey-capture-success-critical",
+      "component": "speech-processing",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-journey-pusher-success-critical",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Pusher session - success rate below paging floor",
+    "condition": "D",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_accepted_total{journey=\"pusher_session\"}[30m]))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"pusher_session\",outcome=\"success\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"pusher_session\",outcome=~\"success|failure\"}[30m])), 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "$A >= 20 && $B < 0.90",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "math"
+        }
+      },
+      {
+        "refId": "D",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "D"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "C",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "D",
+          "type": "reduce"
+        }
+      }
+    ],
+    "updated": "2026-08-30T00:00:00Z",
+    "noDataState": "NoData",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-core-features",
+      "__panelId__": "3",
+      "summary": "Pusher session success share below the 90% paging floor while at least 20 journeys were accepted in 30m",
+      "threshold": "accepted >= 20 per 30m and success / (success + failure) < 0.90",
+      "user_impact": "Live sessions are ending in failure; users lose realtime transcription sessions.",
+      "scope": "The pusher-session journey outcome on backend-listen.",
+      "verification": "Confirm the success tile and the accepted-vs-settled panel on the linked Core Features dashboard before intervention.",
+      "safe_next_action": "Follow the real-traffic journeys runbook; treat a low success share with real accepted traffic as a user-facing outage, not a capacity signal.",
+      "runbook": "backend/docs/runbooks/real-traffic-journeys.md"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "live-transcription",
+      "alert_identity": "omi-journey-pusher-success-critical",
+      "component": "live-transcription",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-journey-chat-success-critical",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Chat response - success rate below paging floor",
+    "condition": "D",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_accepted_total{journey=\"chat_response\"}[30m]))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 1800,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_terminal_total{journey=\"chat_response\",outcome=\"success\"}[30m])) / clamp_min(sum(increase(omi_journey_terminal_total{journey=\"chat_response\",outcome=~\"success|failure\"}[30m])), 1)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "$A >= 20 && $B < 0.90",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "math"
+        }
+      },
+      {
+        "refId": "D",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "D"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "C",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "D",
+          "type": "reduce"
+        }
+      }
+    ],
+    "updated": "2026-08-30T00:00:00Z",
+    "noDataState": "NoData",
+    "execErrState": "Error",
+    "for": "10m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-core-features",
+      "__panelId__": "4",
+      "summary": "Chat response success share below the 90% paging floor while at least 20 journeys were accepted in 30m",
+      "threshold": "accepted >= 20 per 30m and success / (success + failure) < 0.90",
+      "user_impact": "Chat requests are terminalizing as failures; users cannot get AI chat responses.",
+      "scope": "The chat-response journey outcome on the Cloud Run backend, ingested via the cloud-run-application-metrics bridge.",
+      "verification": "Confirm the success tile and the accepted-vs-settled panel on the linked Core Features dashboard before intervention.",
+      "safe_next_action": "Follow the real-traffic journeys runbook; treat a low success share with real accepted traffic as a user-facing outage, not a capacity signal.",
+      "runbook": "backend/docs/runbooks/real-traffic-journeys.md"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "ai-chat",
+      "alert_identity": "omi-journey-chat-success-critical",
+      "component": "ai-chat",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-journey-capture-settle-gap",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Capture finalization - accepted work is not settling",
+    "condition": "D",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 3600,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_accepted_total{journey=\"capture_finalization\"}[1h]))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 3600,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(omi_journey_accepted_total{journey=\"capture_finalization\"}[1h])) - sum(increase(omi_journey_terminal_total{journey=\"capture_finalization\"}[1h]))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "B"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "$A >= 100 && $B > 50",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "math"
+        }
+      },
+      {
+        "refId": "D",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "D"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "C",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "D",
+          "type": "reduce"
+        }
+      }
+    ],
+    "updated": "2026-08-30T00:00:00Z",
+    "noDataState": "NoData",
+    "execErrState": "Error",
+    "for": "15m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-core-features",
+      "__panelId__": "7",
+      "summary": "At least 100 capture journeys were accepted in 1h while more than 50 of them per hour never reached any terminal outcome",
+      "threshold": "accepted >= 100 per 1h and accepted - settled > 50 per 1h",
+      "user_impact": "Captures are queueing without outcomes; the finalization backlog grows and users do not get their conversations.",
+      "scope": "The capture-finalization accept and terminal counters on backend-listen.",
+      "verification": "Confirm the accepted-vs-settled gap and the oldest unfinished job on the linked Core Features dashboard before intervention.",
+      "safe_next_action": "Follow the real-traffic journeys runbook; inspect finalization worker health and the Firestore job queue before any pod restarts.",
+      "runbook": "backend/docs/runbooks/real-traffic-journeys.md"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "speech-processing",
+      "alert_identity": "omi-journey-capture-settle-gap",
+      "component": "speech-processing",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-capture-oldest-nonterminal",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Capture finalization - oldest unfinished job too old",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 300,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(listen_finalization_oldest_nonterminal_age_seconds)",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  3600
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-08-30T00:00:00Z",
+    "noDataState": "Alerting",
+    "execErrState": "Error",
+    "for": "15m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-core-features",
+      "__panelId__": "30",
+      "summary": "The oldest unfinished capture finalization job has been waiting longer than 1 hour",
+      "threshold": "max oldest nonterminal age > 3600s for 15m",
+      "user_impact": "At least one user capture has been stuck for over an hour; sustained backlogs mean many users are missing conversations.",
+      "scope": "The finalization job queue age gauge republished by backend-listen.",
+      "verification": "Confirm the oldest unfinished job tile and the unfinished-jobs panel on the linked Core Features dashboard before intervention.",
+      "safe_next_action": "Follow the real-traffic journeys runbook; the gauge aggregates with max across listener pods, so verify one pod is not reporting a stale value.",
+      "runbook": "backend/docs/runbooks/real-traffic-journeys.md"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "speech-processing",
+      "alert_identity": "omi-capture-oldest-nonterminal",
+      "component": "speech-processing",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
+  },
+  {
+    "uid": "omi-capture-dead-letter-surge",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Capture finalization - dead-letter surge",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 3600,
+          "to": 0
+        },
+        "datasourceUid": "prometheus",
+        "model": {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(listen_finalization_dead_letter_total[1h]))",
+          "instant": true,
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "B"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "last",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  50
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-08-30T00:00:00Z",
+    "noDataState": "Alerting",
+    "execErrState": "Error",
+    "for": "15m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "__dashboardUid__": "omi-core-features",
+      "__panelId__": "31",
+      "summary": "More than 50 capture finalization jobs were terminalized as dead letters in 1h",
+      "threshold": "increase over 1h > 50",
+      "user_impact": "Each dead letter is a user capture that failed every retry and will never become a conversation.",
+      "scope": "The finalization dead-letter counter on backend-listen.",
+      "verification": "Confirm the dead-letter tile and the retries panel on the linked Core Features dashboard before intervention.",
+      "safe_next_action": "Follow the real-traffic journeys runbook; dead letters after a backlog often point at the finalization worker, not the listener.",
+      "runbook": "backend/docs/runbooks/real-traffic-journeys.md"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "speech-processing",
+      "alert_identity": "omi-capture-dead-letter-surge",
+      "component": "speech-processing",
+      "impact": "user-experience"
     },
     "isPaused": false,
     "notification_settings": {

--- a/backend/charts/monitoring/expected-targets.prod.yaml
+++ b/backend/charts/monitoring/expected-targets.prod.yaml
@@ -31,6 +31,10 @@ no_data_semantics:
   traffic_gated_journey: NoData
   live_transcription_journey: OK
   scrape_health: Alerting
+  # Page-class finalization queue series (oldest-nonterminal age, dead-letter
+  # counter): unlabeled and zero-initialized on every backend-listen replica,
+  # so absence during real traffic means the emitter or its scrape is gone.
+  finalization_queue_health: Alerting
 
 managed_gke_exclusions:
   # Owned by #9138 / PR #11093 — do not page TargetDown for these.

--- a/backend/docs/runbooks/real-traffic-journeys.md
+++ b/backend/docs/runbooks/real-traffic-journeys.md
@@ -183,6 +183,55 @@ deployment health, not read as zero traffic.
 The live-transcription failure alert uses Grafana `noDataState: OK`: an empty
 result is expected before that traffic exists and is not an outage.
 
+## Page-class journey SLI alerts
+
+The warning-class rules above report degradations; they did not page during
+the 2026-08-30 capture-finalization outage, when `capture_finalization`
+success sat at 0% for hours (failure ~360/h, stale ~290/h, accepted ~750/h)
+while listen pods, WebSockets, LB traffic, and 5xx rates all stayed green.
+These `severity: critical` rules page on the user outcome itself. All live in
+the `Resilience` group and link the matching **Omi Core Features** panel.
+
+| Rule | Fires when | Traffic gate | `noDataState` |
+| --- | --- | --- | --- |
+| `omi-journey-capture-success-critical` | capture success share < 0.90 for 10m | ≥ 20 accepted in 30m | `NoData` |
+| `omi-journey-pusher-success-critical` | pusher success share < 0.90 for 10m | ≥ 20 accepted in 30m | `NoData` |
+| `omi-journey-chat-success-critical` | chat success share < 0.90 for 10m | ≥ 20 accepted in 30m | `NoData` |
+| `omi-journey-capture-settle-gap` | accepted − settled > 50 per 1h for 15m | ≥ 100 accepted in 1h | `NoData` |
+| `omi-capture-oldest-nonterminal` | oldest nonterminal job age > 3600s for 15m | none (queue-age is traffic-independent) | `Alerting` |
+| `omi-capture-dead-letter-surge` | dead letters > 50 per 1h for 15m | none (each is a lost capture) | `Alerting` |
+
+The success-share numerator and denominator both read `omi_journey_terminal_total`
+for the same `journey` from the same emitter, gated on `omi_journey_accepted_total`
+for that journey, so quiet hours cannot page and a partial emitter outage cannot
+fake a healthy ratio. A total terminal stall with real accepted traffic yields a
+0 share through `clamp_min(..., 1)` and pages here too.
+
+Calibration (initial, from the 2026-08-30 incident fingerprint and documented
+measurements; replay against production history when the rules are imported):
+
+- **0.90 paging floor** — the Core Features tiles display 95/99 thresholds; a
+  sustained 90% floor with real traffic is unambiguous user harm. The incident
+  sat at 0% for hours.
+- **≥ 20 accepted / 30m** — the incident ran ~375 accepted per 30m; 20 is the
+  same floor the existing warning rules use for terminal outcomes.
+- **Gap > 50 / 1h at ≥ 100 accepted / 1h** — the incident left ~100 journeys
+  per hour accepted-but-never-settled while the backlog aged to 5.9 days;
+  normal in-flight work settles in minutes, so a 1h window gap stays near zero.
+- **Oldest job > 3600s** — healthy finalization drains in minutes; the
+  incident's oldest job was ~5.9 days old.
+- **Dead letters > 50 / 1h** — the incident produced ~2.5k dead letters per
+  day (~104/h); each dead letter is a capture that exhausted every retry.
+- **Chat liveness gate** (`omi-journey-signal-dead` chat arm) — the
+  `omi:auto:chat-agent` lane measured min 9, p01 15, p05 23 requests/hour
+  over 7 production days; `> 20/1h` demands liveness only at above-p05
+  chat demand.
+
+The two queue rules use `noDataState: Alerting` because their series are
+unlabeled and zero-initialized: every scraped backend-listen replica exports
+them at zero, so absence means the emitter or its scrape is gone, which is
+itself page-worthy during real traffic.
+
 Known blind spots: a server can only observe the SSE/WS boundary it controls,
 not client rendering; process restarts may defer a terminal metric until the
 durable worker/reconciler resumes; and a durable job still within its bounded

--- a/backend/docs/runbooks/silent-failure-detection.md
+++ b/backend/docs/runbooks/silent-failure-detection.md
@@ -19,10 +19,12 @@ alert fired. Nothing was down in the sense any existing alert could observe:
   `llm_gateway_request_rejections_total`, not by `llm_gateway_requests_total`.
   For the whole outage the chat lane's request counter showed
   **100% success**, because the failing requests never reached it.
-- `omi-journey-chat-fail` already existed and is shaped correctly, but
-  `omi_journey_accepted_total{journey="chat_response"}` is emitted by the
-  Cloud Run `backend` service, which Prometheus does not scrape. The counter
-  has been flat at zero for its whole existence, so the rule could never fire.
+- `omi-journey-chat-fail` already existed and is shaped correctly, but at the
+  time `omi_journey_accepted_total{journey="chat_response"}` was emitted by the
+  Cloud Run `backend` service, which Prometheus did not scrape. The counter
+  had been flat at zero for its whole existence, so the rule could never fire.
+  (Resolved since: the Cloud Run metrics bridge delivers these series today,
+  and `chat_response` is covered by `omi-journey-signal-dead`.)
 - Only one client population was affected. A second, larger population on the
   same endpoint stayed healthy and kept every aggregate ratio green.
 
@@ -95,16 +97,23 @@ touching configuration.
 `omi-journey-signal-dead`
 
 ```promql
-(sum by (journey) (increase(omi_journey_accepted_total{journey=~"pusher_session|capture_finalization"}[1h])) < bool 1) * on() group_left() (sum(increase(llm_gateway_requests_total[1h])) > bool 100)
+(sum by (journey) (increase(omi_journey_accepted_total{journey=~"pusher_session|capture_finalization"}[1h])) < bool 1) * on() group_left() (sum(increase(llm_gateway_requests_total[1h])) > bool 100) or (sum by (journey) (increase(omi_journey_accepted_total{journey="chat_response"}[1h])) < bool 1) * on() group_left() (sum(increase(llm_gateway_requests_total{lane_id="omi:auto:chat-agent"}[1h])) > bool 20)
 ```
 
 This is the alert for the alerts. Every real-traffic journey rule assumes its
 journey counter is being scraped. When that assumption breaks, the rule does not
 fail loudly — it goes quiet, which looks exactly like health.
 
-The rule fires when a journey reports **zero** accepted attempts in an hour while
-the platform is demonstrably serving traffic. `noDataState` is `Alerting`: if the
-series vanish entirely, that is the failure, not the absence of one.
+The first arm covers the backend-listen journeys (`pusher_session`,
+`capture_finalization`) and gates on total gateway traffic. The second arm
+covers `chat_response`, whose counter arrives through the Cloud Run metrics
+bridge, and gates on the chat-agent lane instead: that lane measured min 9,
+p01 15, p05 23 requests/hour over 7 production days, so `> 20` demands
+liveness only at above-p05 chat demand and stays silent in quiet hours.
+
+The rule fires when a journey reports **zero** accepted attempts in an hour
+while its own traffic gate proves demand exists. `noDataState` is `Alerting`:
+if the series vanish entirely, that is the failure, not the absence of one.
 
 **Verify:** check whether the emitting service is still running *and* still
 scraped, in that order. Do not treat a missing journey signal as evidence that
@@ -117,21 +126,19 @@ dead has no alerting coverage at all until it is scraped again.
 
 `tz_chat_agent_requests_zero` — `< 5` requests in 1h, sustained 30m.
 
-The threshold is set from measurement, not intuition. Sampled at 15-minute
-resolution across the seven days before this rule was written, `omi:auto:chat-agent`
-had a floor of 9 requests per hour, p01 of 15, p05 of 23, and a median of 55. Zero
-evaluations fell below 5.
-
 ## What these alerts still cannot see
 
-Anything emitted only by a Cloud Run service. `backend`, `desktop-backend`,
-`backend-sync`, and `backend-integration` have no application-metrics scrape
-path; Prometheus scrapes GKE pods only. `omi-journey-signal-dead` deliberately
-does **not** include `journey="chat_response"` yet, because that counter is
-emitted from Cloud Run and is expected to read zero until an ingestion path
-exists. Add it to the rule in the same change that makes those metrics arrive —
-otherwise the rule pages permanently and gets muted, which is worse than the
-gap it describes.
+Anything emitted only by a Cloud Run service and not covered by the bridge
+alerts. `backend` and `desktop-backend` application metrics now arrive through
+the Cloud Run GMP sidecar → Cloud Monitoring → isolated exporter path
+(`job="cloud-run-application-metrics"`), verified live at ~28MB / 52,662
+`omi_*` series per prod scrape (#12146). That bridge is itself guarded:
+`omi-cloud-run-egress-down`, `omi-cloud-run-egress-query-rejected`, and
+`omi-cloud-run-metric-names-unnormalized` page when it breaks, and
+`chat_response` is inside `omi-journey-signal-dead`'s selector, so a bridge
+regression that silences the chat counters pages on its own. `backend-sync`
+and `backend-integration` still have no application-metrics path; alerts that
+would read their in-process counters do not exist.
 
 ## Adding a journey alert later
 
@@ -145,12 +152,12 @@ ship again. Any rule whose expression selects `journey="..."` on an `omi_journey
 `omi_client_journey_*` metric must have that journey inside `omi-journey-signal-dead`'s
 selector, so a dead counter pages on its own.
 
-The only escape is `LIVENESS_EXEMPT_JOURNEYS` in the contract test, which requires a
-written reason. There is one entry today — `chat_response`, because it is emitted from
-Cloud Run and cannot arrive at all. **Delete that exemption in the same change that gives
-Cloud Run services a metrics ingestion path**, and add `chat_response` to the liveness
-rule at the same time. The test asserts a journey is never both exempt and covered, so
-the two cannot silently disagree.
+The only escape is `LIVENESS_EXEMPT_JOURNEYS` in the contract test, which
+requires a written reason. It is empty as of 2026-08-30: the last entry
+(`chat_response`, kept while its counter could not arrive) was deleted in the
+same change that added `chat_response` to the liveness rule behind a
+chat-agent-lane traffic gate. The test asserts a journey is never both exempt
+and covered, so the two cannot silently disagree.
 
 ## Backtest
 

--- a/backend/tests/unit/test_monitoring_alert_rule_contract.py
+++ b/backend/tests/unit/test_monitoring_alert_rule_contract.py
@@ -378,11 +378,15 @@ def test_journey_signal_dead_alert_treats_missing_evidence_as_the_failure():
         assert "omi_journey_accepted_total" in expression, export_name
         assert "llm_gateway_requests_total" in expression, export_name
         assert rule["noDataState"] == "Alerting", export_name
-        assert rule["labels"]["severity"] == "critical"
-        # chat_response is emitted from Cloud Run, which Prometheus does not
-        # scrape. Including it before an ingestion path exists would page
-        # permanently and train operators to mute the rule.
-        assert "chat_response" not in expression, export_name
+        assert rule["labels"]["severity"] == "critical", export_name
+        # chat_response arrives through the Cloud Run metrics bridge, verified
+        # live at ~28MB / 52,662 omi_ series per prod scrape (#12146). Its
+        # liveness arm is gated on the chat-agent lane so quiet hours do not
+        # page: that lane measured min 9, p01 15, p05 23 requests/hour over
+        # 7 production days, so > 20/1h only demands liveness at above-p05
+        # chat demand.
+        assert 'journey="chat_response"' in expression, export_name
+        assert 'lane_id="omi:auto:chat-agent"' in expression, export_name
 
 
 def test_silent_failure_alerts_link_the_shared_runbook():
@@ -405,9 +409,66 @@ def test_chat_traffic_zero_threshold_sits_below_the_measured_weekly_floor():
     """
     for export_name, rules in _all_rule_exports().items():
         rule = rules[CHAT_TRAFFIC_ZERO_RULE]
-        assert rule["data"][2]["model"]["conditions"][0]["evaluator"]["params"] == [5], export_name
-        assert rule["data"][2]["model"]["conditions"][0]["evaluator"]["type"] == "lt"
+        assert rule["data"][2]["model"]["conditions"][0]["evaluator"]["type"] == "lt", export_name
         assert 'lane_id="omi:auto:chat-agent"' in rule["data"][0]["model"]["expr"]
+
+
+# 2026-08-30 capture-finalization outage: success stayed at 0% for hours
+# (failure ~360/h, stale ~290/h, accepted ~750/h, oldest job ~5.9 days, dead
+# letters ~2.5k/day) while every listen/pusher critical stayed Normal because
+# they only watch LB traffic, ready pods, WS counts, and 5xx rates. Warning
+# journey rules existed (#11991) but nothing page-class watched the user
+# outcome. These rules page on that exact fingerprint.
+PAGE_CLASS_JOURNEY_RULES = {
+    "omi-journey-capture-success-critical": ("speech-processing", "NoData", "$A >= 20 && $B < 0.90"),
+    "omi-journey-pusher-success-critical": ("live-transcription", "NoData", "$A >= 20 && $B < 0.90"),
+    "omi-journey-chat-success-critical": ("ai-chat", "NoData", "$A >= 20 && $B < 0.90"),
+    "omi-journey-capture-settle-gap": ("speech-processing", "NoData", "$A >= 100 && $B > 50"),
+    "omi-capture-oldest-nonterminal": ("speech-processing", "Alerting", None),
+    "omi-capture-dead-letter-surge": ("speech-processing", "Alerting", None),
+}
+
+
+def test_page_class_journey_rules_cover_the_capture_outage_fingerprint():
+    """Every Core Features journey tile has a page-class rule behind it."""
+    for export_name, rules in _all_rule_exports().items():
+        for uid, (component, no_data, gate) in PAGE_CLASS_JOURNEY_RULES.items():
+            rule = rules[uid]  # missing from an export fails the lookup
+            assert rule["labels"]["severity"] == "critical", f"{export_name}:{uid}"
+            assert rule["labels"]["instatus_component"] == component, f"{export_name}:{uid}"
+            assert rule["labels"]["impact"] == "user-experience", f"{export_name}:{uid}"
+            assert rule["noDataState"] == no_data, f"{export_name}:{uid}"
+            assert rule["for"] in {"10m", "15m"}, f"{export_name}:{uid}"
+            assert rule["notification_settings"]["receiver"] == "Omi - Services Alerting (Telegram)"
+            math_nodes = [d["model"]["expression"] for d in rule["data"] if d["model"].get("type") == "math"]
+            if gate is not None:
+                assert math_nodes == [gate], f"{export_name}:{uid}"
+            else:
+                assert not math_nodes, f"{export_name}:{uid}"
+
+
+def test_page_class_success_rules_pair_numerator_and_denominator_from_one_emitter():
+    """A success ratio is only meaningful when both sides come from the same counter."""
+    for export_name, rules in _all_rule_exports().items():
+        for uid, journey in (
+            ("omi-journey-capture-success-critical", "capture_finalization"),
+            ("omi-journey-pusher-success-critical", "pusher_session"),
+            ("omi-journey-chat-success-critical", "chat_response"),
+        ):
+            exprs = [d["model"]["expr"] for d in rules[uid]["data"] if d["model"].get("expr")]
+            assert all(
+                f'omi_journey_terminal_total{{journey="{journey}"' in e for e in exprs[1:]
+            ), f"{export_name}:{uid}"
+            assert f'omi_journey_accepted_total{{journey="{journey}"}}' in exprs[0], f"{export_name}:{uid}"
+
+
+def test_finalization_queue_rules_read_the_replicated_series_correctly():
+    """The age gauge aggregates with max; the dead-letter counter with increase."""
+    for export_name, rules in _all_rule_exports().items():
+        age_expr = rules["omi-capture-oldest-nonterminal"]["data"][0]["model"]["expr"]
+        assert age_expr == "max(listen_finalization_oldest_nonterminal_age_seconds)", export_name
+        dead_expr = rules["omi-capture-dead-letter-surge"]["data"][0]["model"]["expr"]
+        assert dead_expr == "sum(increase(listen_finalization_dead_letter_total[1h]))", export_name
 
 
 RESILIENCE_DASHBOARD = MONITORING / "dashboards/omi-services/resilience-fallbacks.json"
@@ -445,15 +506,11 @@ JOURNEY_SELECTOR = re.compile(r'journey="([a-z_]+)"')
 JOURNEY_METRIC_PREFIXES = ("omi_journey_", "omi_client_journey_")
 # A journey may be exempt from liveness coverage only while its counter provably
 # cannot arrive. Each entry needs a reason and must be deleted in the same change
-# that makes the counter reachable.
-LIVENESS_EXEMPT_JOURNEYS = {
-    "chat_response": (
-        "Emitted by backend/routers/chat.py from the Cloud Run backend service. Prometheus "
-        "scrapes GKE pods only, so this counter reads zero and including it in the liveness "
-        "rule would page permanently. Remove this exemption in the change that gives Cloud "
-        "Run services a metrics ingestion path, and add the journey to the liveness rule."
-    ),
-}
+# that makes the counter reachable. chat_response was the last exemption: its
+# counter now arrives through the verified Cloud Run metrics bridge (#11998,
+# #12146 measured a live ~28MB / 52,662-series prod scrape), and the liveness
+# rule covers it with a chat-agent-lane traffic gate.
+LIVENESS_EXEMPT_JOURNEYS: dict[str, str] = {}
 
 
 def _journeys_alerted_on(rules: dict[str, dict]) -> dict[str, set[str]]:


### PR DESCRIPTION
## Why this change

On 2026-08-30 a voice-capture outage left `capture_finalization` success at **0% for hours** while every existing critical stayed Normal: listen ready=5, listen WS≈325, pusher WS≈326, LB traffic flowing, 5xx rps=0. The existing criticals only watch zero LB traffic, zero ready pods, WS < 10, and 5xx rates. The rules that did read user outcomes (`omi-journey-*-fail`, #11991) are **warning-class**, and the [Omi Core Features dashboard](https://monitor.omi.me/d/omi-core-features/omi-core-features) that plots these SLIs is visualization-only — panel thresholds, zero alert rules. **Dashboard ≠ alert**: the signal existed, nothing paged on it.

Incident fingerprint (last 1h at peak): `omi_journey_terminal_total{journey="capture_finalization"}` success=0, failure≈360, stale≈290; accepted≈750; oldest unfinished finalization job ≈ 5.9 days; dead letters ≈ 2.5k/24h.

## What was added

Six `severity: critical` rules in the `Resilience` group (split source `backend/charts/monitoring/alerts/resilience.json`, mirrored into the combined `backend/charts/monitoring/alert-rules.json`), plus one rule change. Every rule links the Core Features panel that plots its own signal.

| Metric / SLI | Existing rule (git = live mirror) | False-negative class this incident hit | New / changed UID | noDataState | Traffic gate |
|---|---|---|---|---|---|
| `capture_finalization` success share | `omi-journey-capture-fail` (warning, #11991; reads `listen_finalization_durable_jobs` deltas) | warning-class — ticket lane, no page; incident kept it out of the paging path | `omi-journey-capture-success-critical` | `NoData` | ≥ 20 accepted / 30m |
| accepted-without-terminal (accepted vs settled) | `omi-capture-finalization-dead-emission` (warning; fires only on **zero** terminal movement) | incident had *flowing* failure/stale terminals, so the zero-terminal condition never applied at page class | `omi-journey-capture-settle-gap` | `NoData` | ≥ 100 accepted / 1h |
| `listen_finalization_dead_letter_total` | **missing** (dashboard panel only) | ~2.5k dead letters/day with zero alerts reading it | `omi-capture-dead-letter-surge` | `Alerting` | none — each dead letter is a lost capture (> 50/1h) |
| `listen_finalization_oldest_nonterminal_age_seconds` | **missing** (backlog panel from #12211 only) | oldest job aged to 5.9 days with zero alerts reading it | `omi-capture-oldest-nonterminal` | `Alerting` | none — queue age is traffic-independent (> 3600s) |
| `pusher_session` success share | `omi-journey-pusher-fail` (warning) | warning-class only | `omi-journey-pusher-success-critical` | `NoData` | ≥ 20 accepted / 30m |
| `chat_response` success share | `omi-journey-chat-fail` (warning; unfirable for its whole life before the Cloud Run bridge) | warning-class + counter historically absent from Prometheus | `omi-journey-chat-success-critical` | `NoData` | ≥ 20 accepted / 30m |
| journey counter liveness | `omi-journey-signal-dead` covered only `pusher_session\|capture_finalization`; `chat_response` exempt | a dead chat counter would silently disarm every chat alert (the exact 2026-08-19 hole) | `omi-journey-signal-dead` **changed** — adds a `chat_response` arm | `Alerting` | chat arm gated on `llm_gateway_requests_total{lane_id="omi:auto:chat-agent"} > 20/1h` |

### PromQL

Success-rate rules pair numerator and denominator from the same emitter (`omi_journey_terminal_total` for one `journey`), gated on that journey's accepted counter (example: capture):

```promql
# A — gate
sum(increase(omi_journey_accepted_total{journey="capture_finalization"}[30m]))
# B — success share (a total terminal stall with real traffic reads 0 and pages)
sum(increase(omi_journey_terminal_total{journey="capture_finalization",outcome="success"}[30m]))
  / clamp_min(sum(increase(omi_journey_terminal_total{journey="capture_finalization",outcome=~"success|failure"}[30m])), 1)
# C — $A >= 20 && $B < 0.90, for 10m
```

Settle gap (accepted minus all terminal outcomes, 1h): `$A >= 100 && $B > 50`, for 15m.
Oldest job: `max(listen_finalization_oldest_nonterminal_age_seconds) > 3600`, for 15m.
Dead letters: `sum(increase(listen_finalization_dead_letter_total[1h])) > 50`, for 15m.
Liveness chat arm (added to `omi-journey-signal-dead`):

```promql
or (sum by (journey) (increase(omi_journey_accepted_total{journey="chat_response"}[1h])) < bool 1)
   * on() group_left() (sum(increase(llm_gateway_requests_total{lane_id="omi:auto:chat-agent"}[1h])) > bool 20)
```

### noData semantics

- Success-rate and gap rules: `NoData` (the documented `traffic_gated_journey` class) — missing series are visible as NoData, never healthy; counter death pages via `omi-journey-signal-dead` and `omi-journey-scrape-missing`.
- Queue rules (`oldest-nonterminal`, `dead-letter`): `Alerting` — both series are unlabeled and zero-initialized on every backend-listen replica, so absence during real traffic means the emitter or its scrape is gone. Documented as `finalization_queue_health` in `expected-targets.prod.yaml`.

### Threshold calibration (documented in `backend/docs/runbooks/real-traffic-journeys.md`)

- 0.90 paging floor vs the dashboard's 95/99 display thresholds; the incident sat at 0%.
- ≥ 20 accepted/30m gate (same floor the existing warning rules use); the incident ran ~375 accepted/30m.
- Gap > 50/h at ≥ 100 accepted/h: the incident left ~100/h accepted-but-never-settled; healthy in-flight work settles in minutes.
- Oldest job > 1h: healthy drain is minutes; incident oldest was ~5.9 days.
- Dead letters > 50/h: incident ran ~104/h (2.5k/day).
- Chat liveness gate > 20/h sits above the chat-agent lane's measured p05 (min 9, p01 15, p05 23, median 55 req/h over 7 prod days), so quiet hours do not page.

These are incident-calibrated initial values; replay them against production history when importing (the repo has no live Prometheus access from a PR-checkout environment).

## Live vs git reconciliation

- Live Grafana (issue-verified 2026-08-30 ~23:30 UTC): **68 unified rules**; git before this PR: **80**. The 12-rule delta is recently merged rules not yet imported (Firestore #12193/#12201/#12241, cloud-run ingestion #11998/#12146, etc.) — the documented apply path is a maintainer import of `alert-rules.json`; no CI writes Grafana, and this PR follows that path (no API writes).
- The pre-incident journey rules (from #11991, merged 2026-08-22) predate the outage window; their gap was severity class, not presence.
- Metric label sets were discovered from the emitter contract, not guessed: `utils/metrics.py`, `utils/observability/journeys.py` (`journey` ∈ {`chat_response`, `pusher_session`, `capture_finalization`}; `outcome` ∈ {`success`, `failure`, `cancelled`, `stale`}), `services/conversation_finalization.py` (unlabeled dead-letter counter, unlabeled oldest-age gauge, `state`-labeled durable gauge), and the closed vocabulary in `backend/docs/runbooks/real-traffic-journeys.md`. Direct live Prometheus/Grafana queries were not available from this environment (auth required); the `chat_response` ingestion path is evidenced by #12146's measured live prod scrape (~28MB, 52,662 `omi_*` series).

## Tests

Extended `test_monitoring_alert_rule_contract.py`:

- `LIVENESS_EXEMPT_JOURNEYS` is now empty — the `chat_response` exemption's own deletion clause fired once the Cloud Run bridge was verified live; `test_every_alerted_journey_is_covered_by_the_liveness_rule` now enforces chat coverage instead.
- New: `test_page_class_journey_rules_cover_the_capture_outage_fingerprint` (severity, component, noData, `for` window, receiver, exact math gates), `test_page_class_success_rules_pair_numerator_and_denominator_from_one_emitter`, `test_finalization_queue_rules_read_the_replicated_series_correctly` (max-aggregation for the replicated gauge).

## Verification

```bash
cd backend && .venv/bin/python -m pytest \
  tests/unit/test_journey_observability.py \
  tests/unit/test_monitoring_alert_rule_contract.py \
  tests/unit/test_monitoring_dashboard_absence_contract.py \
  tests/unit/test_monitoring_telemetry_contract.py -q
# 63 passed  (the exact set scripts/select_backend_unit_tests.py selects for these changed files)

make preflight   # PR preflight passed: 11 checks in 28.55s
```

Closes SCA-379


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

