### PR TITLE
harden(devex): converge backend Python formatting automatically

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -24,6 +24,11 @@ checks:
     triggers: ["scripts/pre-commit", "scripts/test-pre-commit-pinned-toolchains.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "#11304: the hook's floating prettier fallback (prettier 3 against web/frontend's pinned ^2.8.8) rewrote getPlatformLink in web/frontend/src/app/apps/[id]/page.tsx into a CI-rejected shape and polluted four PRs in one day; an unpinned formatter must refuse, never silently rewrite"
+  - id: backend-python-format-contract
+    command: ["bash", "scripts/test-backend-python-format.sh"]
+    triggers: ["scripts/backend-python-format", "scripts/test-backend-python-format.sh", "scripts/pre-commit", "scripts/pre-push", ".github/workflows/repo-checks.yml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "PR #11454 reached CI with two backend Python files that the pinned formatter rejected; local auto-format, pre-push, and CI must converge through one cached formatter primitive"
   - id: pre-push-backend-test-cap
     command: ["bash", "scripts/test-pre-push-backend-test-cap.sh"]
     triggers: ["scripts/pre-push", "scripts/test-pre-push-backend-test-cap.sh", ".github/checks-manifest.yaml"]

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -214,6 +214,13 @@ jobs:
           scripts/changed-files "${{ needs.changes.outputs.diff_base }}"...HEAD > /tmp/changed-files.txt
           cat /tmp/changed-files.txt
 
+      - name: Set up uv for Python formatting
+        if: needs.changes.outputs.has_python == 'true'
+        uses: astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84
+        with:
+          version: "0.11.13"
+          enable-cache: true
+
       - name: Setup Flutter
         if: needs.changes.outputs.has_dart == 'true'
         uses: subosito/flutter-action@v2
@@ -239,12 +246,9 @@ jobs:
       - name: Check Python formatting
         if: needs.changes.outputs.has_python == 'true'
         run: |
-          # Pinned: an unpinned black drifts from local/pre-commit formatting on
-          # every black release, making this check fail on untouched files.
-          pip install -q black==26.5.1
           FILES=$(grep 'backend/.*\.py$' /tmp/changed-files.txt | while IFS= read -r f; do [ -f "$f" ] && echo "$f"; done || true)
           if [ -n "$FILES" ]; then
-            echo "$FILES" | xargs black --check --line-length 120 --skip-string-normalization
+            echo "$FILES" | xargs scripts/backend-python-format --check
           fi
 
       - name: Check ARB formatting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ The pre-commit hook (installed by `make setup`) auto-formats staged files. Verif
 | Language | Manual command |
 |----------|----------------|
 | Dart (`app/`) | `dart format --line-length 120 <files>` |
-| Python (`backend/`) | `black --line-length 120 --skip-string-normalization <files>` |
+| Python (`backend/`) | `scripts/backend-python-format --write <files>` |
 | ARB (`app/lib/l10n/`) | `jq --indent 4 '.' <file> > tmp && mv tmp <file>` |
 | C/C++ (firmware) | `clang-format -i <files>` |
 | Swift (`desktop/macos/Desktop/`) | `desktop/macos/scripts/swift-format-wrapper.sh format -i <files>` |

--- a/scripts/backend-python-format
+++ b/scripts/backend-python-format
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This is the single backend Python formatter authority for hooks and CI.
+# An exact version keeps local auto-formatting and CI checks convergent.
+readonly BLACK_VERSION="26.5.1"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/backend-python-format --write|--check <backend Python files...>
+       scripts/backend-python-format --version
+EOF
+}
+
+if [ "${1:-}" = "--version" ]; then
+  printf '%s\n' "$BLACK_VERSION"
+  exit 0
+fi
+
+mode="${1:-}"
+case "$mode" in
+  --write)
+    black_args=(--line-length 120 --skip-string-normalization)
+    ;;
+  --check)
+    black_args=(--check --line-length 120 --skip-string-normalization)
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+shift
+
+# Empty changed-file selections are a normal no-op in hooks and CI.
+if [ "$#" -eq 0 ]; then
+  exit 0
+fi
+
+black_version() {
+  local output
+  output="$("$@" --version 2>/dev/null || true)"
+  if [[ "$output" =~ ^black,\ (version\ )?([^[:space:]]+) ]]; then
+    printf '%s\n' "${BASH_REMATCH[2]}"
+  fi
+}
+
+formatter=()
+if command -v black >/dev/null 2>&1 && [ "$(black_version black)" = "$BLACK_VERSION" ]; then
+  formatter=(black)
+elif command -v python3 >/dev/null 2>&1 && [ "$(black_version python3 -m black)" = "$BLACK_VERSION" ]; then
+  formatter=(python3 -m black)
+elif command -v uvx >/dev/null 2>&1; then
+  # uvx reuses its cache, so a missing or stale global Black fixes itself once
+  # without changing the developer's global environment.
+  formatter=(uvx --from "black==$BLACK_VERSION" black)
+else
+  echo "Backend formatting needs Black $BLACK_VERSION, but the installed tool is missing or stale." >&2
+  echo "Install uv from https://docs.astral.sh/uv/getting-started/installation/ and retry; no global Black install is required." >&2
+  exit 1
+fi
+
+exec "${formatter[@]}" "${black_args[@]}" "$@"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -76,16 +76,8 @@ fi
 STAGED_PYTHON_FILES=$(git diff --cached --name-only --diff-filter=ACM "backend/**.py")
 
 if [ -n "$STAGED_PYTHON_FILES" ]; then
-  echo "Formatting staged Python files in backend/..."
-  if command -v black >/dev/null 2>&1; then
-    BLACK_CMD="black"
-  elif python3 -m black --version >/dev/null 2>&1; then
-    BLACK_CMD="python3 -m black"
-  else
-    echo "black is not installed. Please run 'pip install black'" >&2
-    exit 1
-  fi
-  echo "$STAGED_PYTHON_FILES" | xargs $BLACK_CMD --line-length 120 --skip-string-normalization
+  echo "Formatting staged Python files in backend/ with the pinned formatter..."
+  echo "$STAGED_PYTHON_FILES" | xargs "$ROOT/scripts/backend-python-format" --write
   echo "$STAGED_PYTHON_FILES" | xargs git add
 fi
 

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -225,7 +225,6 @@ check_optional_formatters() {
   local -a arb_files=()
   local -a firmware_files=()
   local file
-  local -a black_cmd=()
 
   for file in "${CHANGED_FILES[@]}"; do
     [ -f "$file" ] || continue
@@ -270,18 +269,8 @@ check_optional_formatters() {
   fi
 
   if [ "${#python_files[@]}" -gt 0 ]; then
-    if command -v black >/dev/null 2>&1; then
-      black_cmd=(black)
-    elif "$PYTHON_BIN" -m black --version >/dev/null 2>&1; then
-      black_cmd=("$PYTHON_BIN" -m black)
-    fi
-
-    if [ "${#black_cmd[@]}" -gt 0 ]; then
-      echo "==> black --check (${#python_files[@]} file(s))"
-      "${black_cmd[@]}" --check --line-length 120 --skip-string-normalization "${python_files[@]}"
-    else
-      echo "Skipping Python format check; black is not installed."
-    fi
+    echo "==> pinned backend Python format check (${#python_files[@]} file(s))"
+    scripts/backend-python-format --check "${python_files[@]}"
   fi
 
   if [ "${#arb_files[@]}" -gt 0 ]; then

--- a/scripts/test-backend-python-format.sh
+++ b/scripts/test-backend-python-format.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORMATTER="$ROOT/scripts/backend-python-format"
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+STUBS="$WORK/stubs"
+mkdir -p "$STUBS"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+make_black_stub() {
+  cat > "$STUBS/black" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "--version" ]; then
+  echo "black, ${STUB_BLACK_VERSION} (compiled: yes)"
+  exit 0
+fi
+printf '%s\n' "$@" > "$BLACK_LOG"
+STUB
+  chmod +x "$STUBS/black"
+}
+
+make_python_stub() {
+  cat > "$STUBS/python3" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+  chmod +x "$STUBS/python3"
+}
+
+make_uvx_stub() {
+  cat > "$STUBS/uvx" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$UVX_LOG"
+STUB
+  chmod +x "$STUBS/uvx"
+}
+
+export BLACK_LOG="$WORK/black.log" UVX_LOG="$WORK/uvx.log"
+make_black_stub
+make_python_stub
+make_uvx_stub
+
+# An exact installed Black is the zero-download fast path.
+export STUB_BLACK_VERSION=26.5.1
+PATH="$STUBS:/usr/bin:/bin" "$FORMATTER" --write backend/example.py
+test ! -e "$UVX_LOG" || fail "exact Black unexpectedly used uvx"
+grep -Fxq -- '--line-length' "$BLACK_LOG" || fail "write mode did not pass formatter options"
+grep -Fxq -- 'backend/example.py' "$BLACK_LOG" || fail "write mode did not pass the file"
+
+# A suffixed build is not exact and converges through the pinned uvx environment.
+rm -f "$BLACK_LOG" "$UVX_LOG"
+export STUB_BLACK_VERSION=26.5.1.dev1
+PATH="$STUBS:/usr/bin:/bin" "$FORMATTER" --check backend/example.py
+test "$(sed -n '1p' "$UVX_LOG")" = "--from" || fail "uvx is missing --from"
+test "$(sed -n '2p' "$UVX_LOG")" = "black==26.5.1" || fail "uvx did not receive the pinned Black version"
+test "$(sed -n '3p' "$UVX_LOG")" = "black" || fail "uvx did not invoke Black"
+grep -Fxq -- '--check' "$UVX_LOG" || fail "check mode did not reach Black"
+
+# Without an exact Black or uvx, fail with one actionable install path.
+rm -f "$STUBS/uvx" "$UVX_LOG"
+if output="$(PATH="$STUBS:/usr/bin:/bin" "$FORMATTER" --check backend/example.py 2>&1)"; then
+  fail "missing formatter prerequisites unexpectedly passed"
+fi
+case "$output" in
+  *"https://docs.astral.sh/uv/getting-started/installation/"*) ;;
+  *) fail "missing formatter error did not point to the uv install path" ;;
+esac
+
+# The pin lives only in the shared primitive; all callers delegate to it.
+for caller in scripts/pre-commit scripts/pre-push .github/workflows/repo-checks.yml; do
+  grep -Fq 'scripts/backend-python-format' "$ROOT/$caller" || fail "$caller bypasses the formatter primitive"
+  if grep -Eq 'black==[0-9]+\.[0-9]+\.[0-9]+' "$ROOT/$caller"; then
+    fail "$caller duplicates the Black version pin"
+  fi
+done
+
+echo "backend Python formatter contract tests passed"

--- a/scripts/test-pre-commit-pinned-toolchains.sh
+++ b/scripts/test-pre-commit-pinned-toolchains.sh
@@ -7,13 +7,15 @@ unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE GIT_OBJECT_DIRECTORY G
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HOOK="$ROOT/scripts/pre-commit"
+BACKEND_FORMATTER="$ROOT/scripts/backend-python-format"
 TMPDIR="$(mktemp -d)"
 cleanup() { rm -rf "$TMPDIR"; }
 trap cleanup EXIT
 
 REPO="$TMPDIR/repo"
 STUBS="$TMPDIR/stubs"
-mkdir -p "$REPO/web/frontend/src" "$REPO/app/lib" "$REPO/.github/workflows" "$REPO/.github/scripts" "$STUBS"
+mkdir -p "$REPO/web/frontend/src" "$REPO/app/lib" "$REPO/.github/workflows" "$REPO/.github/scripts" "$REPO/scripts" "$STUBS"
+cp "$BACKEND_FORMATTER" "$REPO/scripts/backend-python-format"
 git -C "$REPO" init -q
 git -C "$REPO" config user.email test@example.com
 git -C "$REPO" config user.name test
@@ -111,6 +113,22 @@ for f in "$@"; do
 done
 STUB
   chmod +x "$STUBS/flutter" "$STUBS/dart"
+}
+
+make_black_stub() {
+  cat >"$STUBS/black" <<'STUB'
+#!/bin/sh
+if [ "${1:-}" = "--version" ]; then
+  echo "black, 26.5.1 (compiled: yes)"
+  exit 0
+fi
+for arg in "$@"; do
+  case "$arg" in
+    *.py) printf 'PYTHON_FORMATTED\n' >"$arg" ;;
+  esac
+done
+STUB
+  chmod +x "$STUBS/black"
 }
 
 run_hook() {
@@ -287,5 +305,16 @@ printf 'const nolock = {b:1}\n' >"$REPO/web/nolock/src/a.ts"
 git -C "$REPO" add web/nolock/src/a.ts web/nolock/package.json
 expect_refusal "missing lockfile with same-major prettier"
 test "$(cat "$REPO/web/nolock/src/a.ts")" = "const nolock = {b:1}"
+
+# --- Backend Python uses the shared pinned formatter and re-stages its output ---
+git -C "$REPO" reset -q --hard
+mkdir -p "$REPO/backend"
+printf 'x=  1\n' >"$REPO/backend/example.py"
+git -C "$REPO" add backend/example.py
+make_black_stub
+run_hook >/dev/null
+test "$(cat "$REPO/backend/example.py")" = "PYTHON_FORMATTED"
+git -C "$REPO" diff --exit-code -- backend/example.py >/dev/null
+git -C "$REPO" diff --cached -- backend/example.py | grep -q 'PYTHON_FORMATTED'
 
 echo "pre-commit pinned-toolchain refusal tests passed"


### PR DESCRIPTION
## What changed and why

Make backend Python formatting converge automatically through one pinned wrapper used by pre-commit, pre-push, and CI. PR #11454 reached its final CI run with two Python files that local checks had allowed through; the exact failure is visible in [Repo Checks run 32996234890](https://github.com/BasedHardware/omi/actions/runs/32996234890/job/98266511125).

The wrapper uses an already-installed Black 26.5.1 when available and otherwise resolves that exact version through cached `uvx`. This does not add a status check, approval, checklist, or deploy step; it replaces three disagreeing formatter paths in the existing workflow.

## Product invariants affected

none

## How it was verified

- `bash scripts/test-backend-python-format.sh` — exact, stale, and missing formatter paths passed.
- `bash scripts/test-pre-commit-pinned-toolchains.sh` — existing hook toolchain contracts passed.
- `bash scripts/test-pre-push-backend-test-cap.sh` — existing bounded pre-push behavior passed.
- `python3 .github/scripts/test_run_checks.py` — 47 manifest contract tests passed.
- `python3 .github/scripts/check_agents_md_lean.py` — all nine agent guides stayed within budget.
- `actionlint -shellcheck '' .github/workflows/repo-checks.yml` — workflow syntax passed.
- `OMI_PR_BODY_FILE=/tmp/omi-backend-formatter-pr-body.md make preflight` — all 110 repository checks passed after rebasing onto current `origin/main`.
- Bounded pre-push checks passed for formatter contracts, backend type checking (0 errors), runtime-image closure, 28 focused backend tests, OpenAPI compatibility/generation, workflow contracts, and desktop-flow lint. The unrelated desktop Swift compile was retried with `PRE_PUSH_SKIP_DESKTOP_SWIFT=1` after SwiftPM's FluidAudio cache lacked commit `19600a485baa4998812e4654b70d2bab8f2c9949`; this PR changes no desktop source.

## Tests

`scripts/test-backend-python-format.sh` is the regression test: it proves all three callers delegate to the shared pin, exact local Black avoids a download, stale Black self-corrects through `uvx`, and a machine missing both gets the canonical uv install path.

## Failure class (fixes)

Failure-Class: none

## New guards (only when adding a check or ratchet)

The guard would have caught PR #11454 / run 32996234890 before its late CI formatting failure. It is a shared primitive rather than a parallel policy check: the contract test protects the single formatter executable that every existing local and CI caller now invokes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

