### PR TITLE
fix(backend): degrade file chat on missing gateway lane

### DIFF
--- a/backend/tests/unit/test_chat_file_gateway_surface.py
+++ b/backend/tests/unit/test_chat_file_gateway_surface.py
@@ -14,6 +14,7 @@ os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import openai
 import pytest
 
 import utils.other.chat_file as cf  # noqa: E402
@@ -72,6 +73,22 @@ async def _fake_stream(*_args, **_kwargs):
         yield SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content='answer'))])
 
     return iterator()
+
+
+async def _failing_stream(*_args, **_kwargs):
+    async def iterator():
+        yield SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content='partial'))])
+        raise RuntimeError('direct stream failed')
+
+    return iterator()
+
+
+def _not_found(*, code=None, param=None):
+    return openai.NotFoundError(
+        message='not found',
+        response=SimpleNamespace(request=None, status_code=404, headers={}),
+        body={'message': 'not found', 'type': 'api_error', 'code': code, 'param': param},
+    )
 
 
 @pytest.mark.asyncio
@@ -185,3 +202,115 @@ async def test_async_entrypoint_routes_through_gateway(monkeypatch):
 
     assert output == 'answer'
     assert gateway_client.chat.completions.create.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_completion_falls_back_direct_when_deployed_gateway_lacks_lane(monkeypatch):
+    _gateway_mode(monkeypatch)
+    gateway_client = MagicMock()
+    gateway_client.chat.completions.create = AsyncMock(side_effect=_not_found(code='model_not_found'))
+    direct_client = MagicMock()
+    direct_client.chat.completions.create = AsyncMock(side_effect=_fake_stream)
+    fallback = MagicMock()
+
+    tool = _tool(_pdf_files())
+    callback = _callback()
+    with patch.object(cf, 'get_file_chat_gateway_async_client', return_value=gateway_client), patch.object(
+        cf, '_get_async_openai', return_value=direct_client
+    ), patch.object(
+        cf.FileChatTool, '_completion_messages', AsyncMock(return_value=[{'role': 'user', 'content': 'q'}])
+    ), patch.object(
+        cf, 'record_fallback', fallback
+    ):
+        output = await tool._ask_files_stream('q', _pdf_files(), callback)
+
+    assert output == 'answer'
+    assert direct_client.chat.completions.create.call_args.kwargs['model'] == cf._FILE_CHAT_DOCUMENT_MODEL
+    fallback.assert_called_once_with(
+        component='llm_gateway',
+        from_mode='gateway_file_chat',
+        to_mode='direct_file_chat',
+        reason='capability_mismatch',
+        outcome='recovered',
+        log=cf.logger,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_completion_records_exhausted_when_direct_fallback_fails(monkeypatch):
+    _gateway_mode(monkeypatch)
+    gateway_client = MagicMock()
+    gateway_client.chat.completions.create = AsyncMock(side_effect=_not_found(code='model_not_found'))
+    direct_client = MagicMock()
+    direct_client.chat.completions.create = AsyncMock(side_effect=_failing_stream)
+    fallback = MagicMock()
+
+    tool = _tool(_pdf_files())
+    callback = _callback()
+    with patch.object(cf, 'get_file_chat_gateway_async_client', return_value=gateway_client), patch.object(
+        cf, '_get_async_openai', return_value=direct_client
+    ), patch.object(
+        cf.FileChatTool, '_completion_messages', AsyncMock(return_value=[{'role': 'user', 'content': 'q'}])
+    ), patch.object(
+        cf, 'record_fallback', fallback
+    ):
+        with pytest.raises(RuntimeError, match='direct stream failed'):
+            await tool._ask_files_stream('q', _pdf_files(), callback)
+
+    fallback.assert_called_once_with(
+        component='llm_gateway',
+        from_mode='gateway_file_chat',
+        to_mode='direct_file_chat',
+        reason='capability_mismatch',
+        outcome='exhausted',
+        log=cf.logger,
+    )
+    callback.end.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_gateway_file_404_stays_a_stale_attachment_failure(monkeypatch):
+    _gateway_mode(monkeypatch)
+    gateway_client = MagicMock()
+    gateway_client.chat.completions.create = AsyncMock(side_effect=_not_found(param='file_id'))
+    direct_client = MagicMock()
+    fallback = MagicMock()
+
+    tool = _tool(_pdf_files())
+    callback = _callback()
+    with patch.object(cf, 'get_file_chat_gateway_async_client', return_value=gateway_client), patch.object(
+        cf, '_get_async_openai', return_value=direct_client
+    ), patch.object(
+        cf.FileChatTool, '_completion_messages', AsyncMock(return_value=[{'role': 'user', 'content': 'q'}])
+    ), patch.object(
+        cf, 'record_fallback', fallback
+    ):
+        with pytest.raises(cf.StaleChatFileError):
+            await tool._ask_files_stream('q', _pdf_files(), callback)
+
+    direct_client.chat.completions.create.assert_not_called()
+    fallback.assert_not_called()
+
+
+def test_sync_completion_falls_back_direct_when_deployed_gateway_lacks_lane(monkeypatch):
+    _gateway_mode(monkeypatch)
+    gateway_client = MagicMock()
+    gateway_client.chat.completions.create = MagicMock(side_effect=_not_found(code='model_not_found'))
+    direct_response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content='ok'))])
+    direct_client = MagicMock()
+    direct_client.chat.completions.create = MagicMock(return_value=direct_response)
+    fallback = MagicMock()
+
+    tool = _tool(_pdf_files())
+    with patch.object(cf, 'get_file_chat_gateway_sync_client', return_value=gateway_client), patch.object(
+        cf, '_get_sync_openai', return_value=direct_client
+    ), patch.object(
+        cf.FileChatTool, '_completion_messages_sync', MagicMock(return_value=[{'role': 'user', 'content': 'q'}])
+    ), patch.object(
+        cf, 'record_fallback', fallback
+    ):
+        result = tool._ask_files('q', _pdf_files())
+
+    assert result == 'ok'
+    assert direct_client.chat.completions.create.call_args.kwargs['model'] == cf._FILE_CHAT_DOCUMENT_MODEL
+    fallback.assert_called_once()

--- a/backend/utils/llm/gateway_client.py
+++ b/backend/utils/llm/gateway_client.py
@@ -139,6 +139,27 @@ def is_gateway_route_absent(error: object) -> bool:
     return not (isinstance(body, Mapping) and isinstance(body.get('error'), Mapping))
 
 
+def is_gateway_model_not_found(error: object) -> bool:
+    """Whether an OpenAI-compatible gateway rejected an unknown lane id.
+
+    The OpenAI SDK exposes the gateway's ``error.code`` as ``error.code``;
+    direct-provider file 404s have the same HTTP status but no
+    ``model_not_found`` code. Keep that distinction closed so deploy skew can
+    degrade without misclassifying a genuinely deleted attachment.
+    """
+    if getattr(error, 'status_code', None) != 404:
+        return False
+    if getattr(error, 'code', None) == 'model_not_found':
+        return True
+    body = getattr(error, 'body', None)
+    if not isinstance(body, Mapping):
+        return False
+    if body.get('code') == 'model_not_found':
+        return True
+    nested_error = body.get('error')
+    return isinstance(nested_error, Mapping) and nested_error.get('code') == 'model_not_found'
+
+
 def _as_json_dict(value: object) -> JsonDict | None:
     return cast(JsonDict, value) if isinstance(value, dict) else None
 

--- a/backend/utils/other/chat_file.py
+++ b/backend/utils/other/chat_file.py
@@ -1,4 +1,5 @@
 import base64
+import logging
 import mimetypes
 import re
 from pathlib import Path
@@ -21,9 +22,10 @@ from utils.llm.gateway_client import (
     file_chat_feature_header,
     get_file_chat_gateway_async_client,
     get_file_chat_gateway_sync_client,
+    is_gateway_model_not_found,
     should_route_features_through_gateway,
 )
-import logging
+from utils.observability.fallback import record_fallback
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +107,11 @@ def _get_async_openai() -> AsyncOpenAI:
     return _async_openai
 
 
+def _get_sync_openai() -> Any:
+    """Injectable seam around the OpenAI module's lazy synchronous client."""
+    return openai
+
+
 def _file_chat_gateway_enabled() -> bool:
     """Whether the model call uses the gateway file-chat lanes.
 
@@ -137,9 +144,27 @@ def _completion_model(files: List[FileChat]) -> str:
     pdf = bool(files) and any(f.is_pdf() for f in files)
     if _file_chat_gateway_enabled():
         return file_chat_auto_lane_id(pdf=pdf)
+    return _direct_completion_model(files)
+
+
+def _direct_completion_model(files: List[FileChat]) -> str:
+    """Provider model for the feature-off and compatibility fallback paths."""
+    pdf = bool(files) and any(f.is_pdf() for f in files)
     if pdf:
         return _FILE_CHAT_DOCUMENT_MODEL
     return _FILE_CHAT_VISION_MODEL
+
+
+def _record_gateway_file_chat_fallback(outcome: str) -> None:
+    """Record the terminal result of an admitted gateway compatibility fallback."""
+    record_fallback(
+        component='llm_gateway',
+        from_mode='gateway_file_chat',
+        to_mode='direct_file_chat',
+        reason='capability_mismatch',
+        outcome=outcome,
+        log=logger,
+    )
 
 
 class _StreamingCallbackProtocol:
@@ -287,77 +312,105 @@ class FileChatTool:
         """One Chat Completions stream: images as base64 image_url, PDFs as file parts."""
         assert callback is not None
         output_list: List[str] = []
+        gateway_fallback_used = False
         try:
             try:
-                messages = await self._completion_messages(question, files)
-                model = _completion_model(files)
-                if _file_chat_gateway_enabled():
-                    # Gateway lanes accept max_completion_tokens on every model
-                    # and stay in the ledger; typed SDK errors keep their meaning.
-                    stream = await get_file_chat_gateway_async_client().chat.completions.create(
-                        model=model,
-                        messages=messages,
-                        stream=True,
-                        max_completion_tokens=_FILE_CHAT_COMPLETION_TOKENS,
-                        extra_headers=file_chat_feature_header(model, uid=self.uid),
-                    )
-                else:
-                    client = _get_async_openai()
-                    if model.startswith('gpt-5'):
-                        stream = await client.chat.completions.create(
+                try:
+                    messages = await self._completion_messages(question, files)
+                    gateway_enabled = _file_chat_gateway_enabled()
+                    model = _completion_model(files)
+                    if gateway_enabled:
+                        # Gateway lanes accept max_completion_tokens on every model
+                        # and stay in the ledger; typed SDK errors keep their meaning.
+                        try:
+                            stream = await get_file_chat_gateway_async_client().chat.completions.create(
+                                model=model,
+                                messages=messages,
+                                stream=True,
+                                max_completion_tokens=_FILE_CHAT_COMPLETION_TOKENS,
+                                extra_headers=file_chat_feature_header(model, uid=self.uid),
+                            )
+                        except openai.NotFoundError as error:
+                            if not is_gateway_model_not_found(error):
+                                raise
+                            gateway_fallback_used = True
+                            model = _direct_completion_model(files)
+                            stream = await _get_async_openai().chat.completions.create(
+                                model=model,
+                                messages=messages,
+                                stream=True,
+                                max_completion_tokens=_FILE_CHAT_COMPLETION_TOKENS,
+                            )
+                    else:
+                        model = _direct_completion_model(files)
+                        stream = await _get_async_openai().chat.completions.create(
                             model=model,
                             messages=messages,
                             stream=True,
                             max_completion_tokens=_FILE_CHAT_COMPLETION_TOKENS,
                         )
-                    else:
-                        stream = await client.chat.completions.create(
-                            model=model,
-                            messages=messages,
-                            stream=True,
-                            max_tokens=_FILE_CHAT_COMPLETION_TOKENS,
-                        )
-            except (openai.NotFoundError, openai.BadRequestError) as error:
-                _reraise_provider_file_error(error)
-            async for chunk in stream:
-                delta = chunk.choices[0].delta if chunk.choices else None
-                if delta and delta.content:
-                    await callback.put_data(delta.content)
-                    output_list.append(delta.content)
-        finally:
-            await callback.end()
+                except (openai.NotFoundError, openai.BadRequestError) as error:
+                    _reraise_provider_file_error(error)
+                async for chunk in stream:
+                    delta = chunk.choices[0].delta if chunk.choices else None
+                    if delta and delta.content:
+                        await callback.put_data(delta.content)
+                        output_list.append(delta.content)
+            finally:
+                await callback.end()
+        except Exception:
+            if gateway_fallback_used:
+                _record_gateway_file_chat_fallback('exhausted')
+            raise
+        if gateway_fallback_used:
+            _record_gateway_file_chat_fallback('recovered')
         return ''.join(output_list)
 
     def _ask_files(self, question: str, files: List[FileChat]) -> str:
         """Non-streaming Chat Completions path used by search_files_tool."""
+        gateway_fallback_used = False
         try:
-            messages = self._completion_messages_sync(question, files)
-            model = _completion_model(files)
-            if _file_chat_gateway_enabled():
-                response = get_file_chat_gateway_sync_client().chat.completions.create(
-                    model=model,
-                    messages=messages,
-                    max_completion_tokens=_FILE_CHAT_COMPLETION_TOKENS,
-                    extra_headers=file_chat_feature_header(model, uid=self.uid),
-                )
-            elif model.startswith('gpt-5'):
-                response = openai.chat.completions.create(
-                    model=model,
-                    messages=messages,
-                    max_completion_tokens=_FILE_CHAT_COMPLETION_TOKENS,
-                )
-            else:
-                response = openai.chat.completions.create(
-                    model=model,
-                    messages=messages,
-                    max_tokens=_FILE_CHAT_COMPLETION_TOKENS,
-                )
-        except (openai.NotFoundError, openai.BadRequestError) as error:
-            _reraise_provider_file_error(error)
-        choice = response.choices[0] if response.choices else None
-        content = choice.message.content if choice and choice.message else None
-        if not content:
-            raise ProviderRejectedChatFileError("The file could not be processed.")
+            try:
+                messages = self._completion_messages_sync(question, files)
+                gateway_enabled = _file_chat_gateway_enabled()
+                model = _completion_model(files)
+                if gateway_enabled:
+                    try:
+                        response = get_file_chat_gateway_sync_client().chat.completions.create(
+                            model=model,
+                            messages=messages,
+                            max_completion_tokens=_FILE_CHAT_COMPLETION_TOKENS,
+                            extra_headers=file_chat_feature_header(model, uid=self.uid),
+                        )
+                    except openai.NotFoundError as error:
+                        if not is_gateway_model_not_found(error):
+                            raise
+                        gateway_fallback_used = True
+                        model = _direct_completion_model(files)
+                        response = _get_sync_openai().chat.completions.create(
+                            model=model,
+                            messages=messages,
+                            max_completion_tokens=_FILE_CHAT_COMPLETION_TOKENS,
+                        )
+                else:
+                    model = _direct_completion_model(files)
+                    response = _get_sync_openai().chat.completions.create(
+                        model=model,
+                        messages=messages,
+                        max_completion_tokens=_FILE_CHAT_COMPLETION_TOKENS,
+                    )
+            except (openai.NotFoundError, openai.BadRequestError) as error:
+                _reraise_provider_file_error(error)
+            choice = response.choices[0] if response.choices else None
+            content = choice.message.content if choice and choice.message else None
+            if not content:
+                raise ProviderRejectedChatFileError("The file could not be processed.")
+        except Exception:
+            if gateway_fallback_used:
+                _record_gateway_file_chat_fallback('exhausted')
+            raise
+        if gateway_fallback_used:
+            _record_gateway_file_chat_fallback('recovered')
         return content
 
     async def _completion_messages(self, question: str, files: List[FileChat]) -> List[ChatCompletionMessageParam]:


### PR DESCRIPTION
## What changed and why

File chat now treats an OpenAI-compatible `404` with the typed `model_not_found` code as a gateway capability-skew signal and retries the completion through the existing direct-provider kill-switch path. It records the recovery through shared fallback telemetry, while genuine provider file `404`s remain typed stale-attachment failures.

Production evidence on 2026-08-30 showed the backend calling the new `omi:auto:file-chat-*` lanes added by #12337 while the serving gateway image still predated those lanes. Every observable `llm_gateway_request_rejected ... error_class=model_not_found` event matched a backend `StaleChatFileError` chat failure; the status-only attachment classifier had hidden the actual gateway rejection.

## Product invariants affected

none

## How it was verified

- Live production logs: 21 gateway `model_not_found` rejections on the current backend revision matched 21 file-chat `StaleChatFileError` failures one-for-one by timestamp. The earlier backend revision contributed four more file-chat failures; its gateway pod logs had already rolled over.
- `cd backend && PYTHONPATH=. .venv/bin/python -m pytest -q tests/unit/test_chat_file_gateway_surface.py tests/unit/test_chat_file_completions.py` — 16 passed.
- `cd backend && ./scripts/typecheck.sh` — 0 errors.
- `git diff --check` — passed.
- `make preflight` — passed after commit against `origin/main`.

The fix was not deployed from this branch. Live log correlation proves the incident path; the regression suite exercises the recovery seam without sending user data or provider traffic.

## Tests

`backend/tests/unit/test_chat_file_gateway_surface.py` now proves:

- async streaming falls back only for a typed gateway `model_not_found` rejection;
- a genuine file `404` does not fall back and remains `StaleChatFileError`;
- a direct fallback that fails mid-stream records `exhausted`, never `recovered`;
- the synchronous file-search completion path has the same compatibility behavior;
- successful gateway routing remains gateway-only.

## Failure class (fixes)

Failure-Class: FC-ship-before-required-route


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

