### PR TITLE
fix(backend): stop stale finalization retry loops

### DIFF
--- a/backend/routers/conversation_finalization.py
+++ b/backend/routers/conversation_finalization.py
@@ -114,8 +114,18 @@ async def run_listen_finalization_job(
         claim_status = claim['status']
         if claim_status == 'completed':
             return JSONResponse(status_code=200, content={'status': 'acked', 'job_status': 'completed'})
-        if claim_status in {'leased', 'stale_generation'}:
+        if claim_status == 'leased':
             return JSONResponse(status_code=409, content={'status': claim_status})
+        if claim_status == 'stale_generation':
+            # The reconciler has already enqueued the newer generation. An old
+            # named task is no longer actionable and must be acknowledged so
+            # Cloud Tasks does not retry this permanently fenced payload.
+            logger.info(
+                'listen finalization stale generation task acknowledged job=%s dispatch_generation=%s',
+                job_id,
+                dispatch_generation,
+            )
+            return JSONResponse(status_code=200, content={'status': 'dropped', 'reason': claim_status})
         if claim_status != 'claimed':
             return JSONResponse(status_code=200, content={'status': 'dropped', 'reason': claim_status})
         claimed_lease_epoch = claim['lease_epoch']

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -10,7 +10,7 @@ from starlette.websockets import WebSocketState
 
 import database.conversations as conversations_db
 from database import users as users_db
-from utils.pusher_finalization import process_conversation_task
+from utils.pusher_finalization import FINALIZATION_RESULT_PROTOCOL_LEGACY, process_conversation_task
 from utils.pusher_protocol import (
     BUFFERED_AUDIO_MAX_BYTES,
     MAX_SAMPLE_RATE,
@@ -61,6 +61,16 @@ import logging
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _parse_finalization_result_protocol(value: Any) -> int:
+    """Return the result capability, defaulting callers to the legacy wire contract."""
+    if value is None:
+        return FINALIZATION_RESULT_PROTOCOL_LEGACY
+    if isinstance(value, bool) or not isinstance(value, int) or value < FINALIZATION_RESULT_PROTOCOL_LEGACY:
+        raise ValueError('finalization_result_protocol must be a positive integer')
+    return value
+
 
 # Constants for speaker sample extraction
 SPEAKER_SAMPLE_PROCESS_INTERVAL = 15.0
@@ -518,6 +528,9 @@ async def _websocket_util_trigger(
                     byok_keys = res.get('byok_keys') or None
                     finalization_job_id = res.get('finalization_job_id')
                     dispatch_generation = res.get('dispatch_generation')
+                    finalization_result_protocol = _parse_finalization_result_protocol(
+                        res.get('finalization_result_protocol')
+                    )
                     if conversation_id is not None and not isinstance(conversation_id, str):
                         raise ValueError('conversation_id must be a string')
                     if not isinstance(language, str):
@@ -545,10 +558,15 @@ async def _websocket_util_trigger(
                                 conversation_id,
                                 language,
                                 websocket,
-                                byok_keys,
-                                finalization_job_id if isinstance(finalization_job_id, str) else None,
-                                dispatch_generation if isinstance(dispatch_generation, int) else None,
-                                resolved_client_kind,
+                                byok_keys=byok_keys,
+                                finalization_job_id=(
+                                    finalization_job_id if isinstance(finalization_job_id, str) else None
+                                ),
+                                dispatch_generation=(
+                                    dispatch_generation if isinstance(dispatch_generation, int) else None
+                                ),
+                                client_kind=resolved_client_kind,
+                                finalization_result_protocol=finalization_result_protocol,
                             ),
                             name=f'pusher_finalization:{uid}:{conversation_id}',
                         )

--- a/backend/tests/unit/test_listen_finalization_cloud_tasks.py
+++ b/backend/tests/unit/test_listen_finalization_cloud_tasks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import runpy
@@ -543,6 +544,31 @@ async def test_worker_retries_processing_failure_before_final_attempt(monkeypatc
     retryable.assert_called_once_with('job-1', 1, 1, 'processing_failed')
 
 
+@pytest.mark.anyio
+async def test_worker_acknowledges_stale_generation_without_cloud_task_retry(monkeypatch, caplog):
+    # Reconciliation has already enqueued the newer generation. Retrying this
+    # old named task would return stale_generation forever without claiming an
+    # attempt or making progress.
+    caplog.set_level(logging.INFO, logger=finalization_router.__name__)
+    monkeypatch.setattr(finalization_router, 'run_blocking', _inline_run_blocking)
+    monkeypatch.setattr(finalization_router, 'try_acquire_job_run_lock', lambda key: 'lock-token')
+    monkeypatch.setattr(finalization_router, 'release_job_run_lock', lambda key, token: None)
+    monkeypatch.setattr(jobs_db, 'claim_finalization_job', lambda *args, **kwargs: {'status': 'stale_generation'})
+
+    response = await finalization_router.run_listen_finalization_job(
+        _Request({'job_id': 'job-1', 'dispatch_generation': 1}), task_retry_count=2
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.body) == {'status': 'dropped', 'reason': 'stale_generation'}
+    assert any(
+        record.levelno == logging.INFO
+        and record.getMessage()
+        == 'listen finalization stale generation task acknowledged job=job-1 dispatch_generation=1'
+        for record in caplog.records
+    )
+
+
 def test_final_failed_attempt_records_client_failure_after_dead_letter(monkeypatch):
     job = {
         'created_at': datetime(2026, 1, 1, tzinfo=timezone.utc),
@@ -1066,6 +1092,55 @@ async def test_pusher_tells_the_live_session_a_dead_lettered_job_is_terminal(mon
         'conversation_id': 'conversation-1',
         'error': 'job_dead_letter',
         'terminal': True,
+    }
+
+
+@pytest.mark.anyio
+async def test_legacy_pusher_result_keeps_stale_generation_response_backward_compatible(monkeypatch):
+    websocket = _PusherWebSocket()
+    monkeypatch.setattr(pusher_finalization, 'run_blocking', _inline_run_blocking)
+    monkeypatch.setattr(
+        jobs_db,
+        'claim_finalization_job',
+        lambda *args, **kwargs: {'status': 'stale_generation', 'lease_epoch': None, 'attempt_count': 0},
+    )
+
+    await pusher_finalization.process_conversation_task(
+        'uid-1', 'conversation-1', 'en', websocket, finalization_job_id='job-1', dispatch_generation=3
+    )
+
+    assert json.loads(websocket.sent[0][4:]) == {
+        'conversation_id': 'conversation-1',
+        'error': 'job_stale_generation',
+        'terminal': False,
+    }
+
+
+@pytest.mark.anyio
+async def test_v2_pusher_result_includes_rejected_generation(monkeypatch):
+    websocket = _PusherWebSocket()
+    monkeypatch.setattr(pusher_finalization, 'run_blocking', _inline_run_blocking)
+    monkeypatch.setattr(
+        jobs_db,
+        'claim_finalization_job',
+        lambda *args, **kwargs: {'status': 'stale_generation', 'lease_epoch': None, 'attempt_count': 0},
+    )
+
+    await pusher_finalization.process_conversation_task(
+        'uid-1',
+        'conversation-1',
+        'en',
+        websocket,
+        finalization_job_id='job-1',
+        dispatch_generation=3,
+        finalization_result_protocol=2,
+    )
+
+    assert json.loads(websocket.sent[0][4:]) == {
+        'conversation_id': 'conversation-1',
+        'error': 'job_stale_generation',
+        'dispatch_generation': 3,
+        'terminal': False,
     }
 
 

--- a/backend/tests/unit/test_pusher_runtime_protocol.py
+++ b/backend/tests/unit/test_pusher_runtime_protocol.py
@@ -65,6 +65,7 @@ async def test_invalid_sample_rate_closes_with_policy_violation(sample_rate):
         struct.pack('<I', 102) + b'[]',
         struct.pack('<I', 102) + json.dumps({'segments': 'invalid'}).encode(),
         struct.pack('<I', 104) + json.dumps({'conversation_id': 1}).encode(),
+        struct.pack('<I', 104) + json.dumps({'conversation_id': 'conv', 'finalization_result_protocol': True}).encode(),
         struct.pack('<I', 105) + json.dumps({'segment_ids': 'invalid'}).encode(),
     ],
 )
@@ -74,6 +75,51 @@ async def test_malformed_frame_closes_with_unsupported_data(runtime, frame):
     await pusher._websocket_util_trigger(websocket, 'uid', 8000)
 
     assert websocket.close_code == 1003
+
+
+@pytest.mark.asyncio
+async def test_pusher_forwards_finalization_result_protocol_to_worker(runtime, monkeypatch):
+    calls = []
+    tasks = []
+
+    async def process(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    def start(coro, *, name):
+        task = asyncio.create_task(coro, name=name)
+        tasks.append(task)
+        return task
+
+    monkeypatch.setattr(pusher, 'process_conversation_task', process)
+    monkeypatch.setattr(pusher, 'start_background_task', start)
+    websocket = FakeWebSocket(
+        [
+            struct.pack('<I', 104)
+            + json.dumps(
+                {
+                    'conversation_id': 'conv-1',
+                    'language': 'en',
+                    'finalization_job_id': 'job-1',
+                    'dispatch_generation': 2,
+                    'finalization_result_protocol': 2,
+                }
+            ).encode()
+        ]
+    )
+
+    await pusher._websocket_util_trigger(websocket, 'uid', 8000)
+    await asyncio.gather(*tasks)
+
+    assert len(calls) == 1
+    assert calls[0][1]['finalization_result_protocol'] == 2
+
+
+def test_finalization_result_protocol_defaults_to_legacy_and_validates_integer():
+    assert pusher._parse_finalization_result_protocol(None) == 1
+    assert pusher._parse_finalization_result_protocol(2) == 2
+    for value in (True, 0, '2'):
+        with pytest.raises(ValueError, match='finalization_result_protocol'):
+            pusher._parse_finalization_result_protocol(value)
 
 
 def test_bounded_append_reports_and_drops_oldest(monkeypatch):

--- a/backend/tests/unit/utils/test_listen_pusher_session.py
+++ b/backend/tests/unit/utils/test_listen_pusher_session.py
@@ -6,6 +6,8 @@ import pytest
 
 from utils.listen_pusher_session import (
     FINALIZATION_IN_FLIGHT_ERROR,
+    FINALIZATION_RESULT_PROTOCOL,
+    FINALIZATION_STALE_GENERATION_ERROR,
     TARGET_SAMPLE_RATE,
     ListenPusherSession,
     ListenPusherSessionConfig,
@@ -63,6 +65,18 @@ def in_flight_response_201(conversation_id: str):
     payload = json.dumps(
         {"conversation_id": conversation_id, "error": FINALIZATION_IN_FLIGHT_ERROR, "terminal": False}
     ).encode("utf-8")
+    return struct.pack("<I", 201) + payload
+
+
+def stale_generation_response_201(conversation_id: str, dispatch_generation=None, terminal: bool = False):
+    payload = {
+        "conversation_id": conversation_id,
+        "error": FINALIZATION_STALE_GENERATION_ERROR,
+        "terminal": terminal,
+    }
+    if dispatch_generation is not None:
+        payload["dispatch_generation"] = dispatch_generation
+    payload = json.dumps(payload).encode("utf-8")
     return struct.pack("<I", 201) + payload
 
 
@@ -195,6 +209,7 @@ async def test_finalization_job_identity_survives_pusher_reconnect():
             'byok_keys': {'openai': 'key'},
             'finalization_job_id': 'job-1',
             'dispatch_generation': 3,
+            'finalization_result_protocol': FINALIZATION_RESULT_PROTOCOL,
         },
         {
             'conversation_id': 'conv-1',
@@ -202,6 +217,7 @@ async def test_finalization_job_identity_survives_pusher_reconnect():
             'byok_keys': {'openai': 'key'},
             'finalization_job_id': 'job-1',
             'dispatch_generation': 3,
+            'finalization_result_protocol': FINALIZATION_RESULT_PROTOCOL,
         },
     ]
 
@@ -406,6 +422,76 @@ async def test_in_flight_finalization_lease_does_not_consume_the_retry_burst():
     pending = session.pending_conversation_requests['conv-1']
     assert pending['retries'] == 0
     assert pending['sent_at'] == session.deps.now()
+
+
+@pytest.mark.anyio
+async def test_stale_finalization_generation_drops_live_request_for_durable_replay():
+    active_ref = {"active": True}
+    ws = FakePusherWebSocket(incoming=[stale_generation_response_201("conv-1", 2)])
+    ws.on_recv = lambda: active_ref.update(active=False)
+    session = make_session(ws=ws, active_ref=active_ref)
+    await session.connect()
+    await session.request_conversation_processing("conv-1", "job-1", 2)
+
+    await session.pusher_receive()
+
+    # The reconciler owns the newer dispatch generation; a live retry of 2
+    # can never claim it and must not consume the session's retry burst.
+    assert session.pending_conversation_requests == {}
+    finalization_frames = [frame for frame in ws.sent if frame_type(frame) == 104]
+    assert len(finalization_frames) == 1
+
+
+@pytest.mark.anyio
+async def test_delayed_stale_finalization_response_does_not_drop_newer_pending_generation():
+    active_ref = {"active": True}
+    ws = FakePusherWebSocket(incoming=[stale_generation_response_201("conv-1", 1)])
+    ws.on_recv = lambda: active_ref.update(active=False)
+    session = make_session(ws=ws, active_ref=active_ref)
+    await session.connect()
+    await session.request_conversation_processing("conv-1", "job-1", 2)
+
+    await session.pusher_receive()
+
+    assert session.pending_conversation_requests["conv-1"]["dispatch_generation"] == 2
+    finalization_frames = [frame for frame in ws.sent if frame_type(frame) == 104]
+    assert len(finalization_frames) == 1
+
+
+@pytest.mark.anyio
+async def test_legacy_pusher_stale_response_without_generation_preserves_newer_pending_generation():
+    active_ref = {"active": True}
+    ws = FakePusherWebSocket(incoming=[stale_generation_response_201("conv-1")])
+    ws.on_recv = lambda: active_ref.update(active=False)
+    session = make_session(ws=ws, active_ref=active_ref)
+    await session.connect()
+    await session.request_conversation_processing("conv-1", "job-1", 2)
+
+    await session.pusher_receive()
+
+    # A pre-v2 pusher cannot identify which pending generation it rejected.
+    assert session.pending_conversation_requests["conv-1"]["dispatch_generation"] == 2
+    finalization_frames = [frame for frame in ws.sent if frame_type(frame) == 104]
+    assert len(finalization_frames) == 1
+
+
+@pytest.mark.anyio
+async def test_stale_generation_one_drops_pending_job_with_omitted_generation():
+    active_ref = {"active": True}
+    ws = FakePusherWebSocket(incoming=[stale_generation_response_201("conv-1", 1)])
+    ws.on_recv = lambda: active_ref.update(active=False)
+    session = make_session(ws=ws, active_ref=active_ref)
+    await session.connect()
+    await session.request_conversation_processing("conv-1", "job-1")
+
+    await session.pusher_receive()
+
+    # The wire serializer defaults an omitted generation to 1, so the stale
+    # response must match that effective generation and drop the request.
+    assert session.pending_conversation_requests == {}
+    finalization_frames = [frame for frame in ws.sent if frame_type(frame) == 104]
+    assert len(finalization_frames) == 1
+    assert frame_json(finalization_frames[0])["dispatch_generation"] == 1
 
 
 @pytest.mark.anyio

--- a/backend/utils/listen_pusher_session.py
+++ b/backend/utils/listen_pusher_session.py
@@ -49,6 +49,10 @@ PENDING_REQUEST_RECOVERY_COOLDOWN = 300
 # lease is already finalizing this job reports the non-terminal `job_leased`
 # error. That is healthy in-flight work, not a failed attempt.
 FINALIZATION_IN_FLIGHT_ERROR = 'job_leased'
+# Advertise the generation-aware opcode-201 result handling capability. A
+# pusher only sends generation-aware stale responses after seeing this value.
+FINALIZATION_RESULT_PROTOCOL = 2
+FINALIZATION_STALE_GENERATION_ERROR = 'job_stale_generation'
 
 
 @dataclass
@@ -176,6 +180,7 @@ class ListenPusherSession:
             if pending.get('finalization_job_id'):
                 payload['finalization_job_id'] = pending['finalization_job_id']
                 payload['dispatch_generation'] = pending.get('dispatch_generation') or 1
+                payload['finalization_result_protocol'] = FINALIZATION_RESULT_PROTOCOL
             data.extend(bytes(json.dumps(payload), "utf-8"))
             await self.pusher_ws.send(cast(bytes, data))
             logger.info(f"Sent process_conversation request to pusher: {conversation_id} {self.uid} {self.session_id}")
@@ -316,7 +321,41 @@ class ListenPusherSession:
                     conversation_id = result.get("conversation_id")
 
                     if "error" in result:
-                        if result.get("terminal"):
+                        if result.get("error") == FINALIZATION_STALE_GENERATION_ERROR:
+                            # A delayed stale response must not delete a newer
+                            # request for this conversation. Only drop when the
+                            # response identifies the generation still pending.
+                            pending = self.pending_conversation_requests.get(conversation_id)
+                            rejected_generation = result.get("dispatch_generation")
+                            pending_generation = (
+                                (pending.get('dispatch_generation') or 1) if pending is not None else None
+                            )
+                            if (
+                                pending is not None
+                                and isinstance(rejected_generation, int)
+                                and not isinstance(rejected_generation, bool)
+                                and pending_generation == rejected_generation
+                            ):
+                                self.pending_conversation_requests.pop(conversation_id, None)
+                                logger.info(
+                                    'Conversation finalization superseded by durable replay '
+                                    'conversation=%s dispatch_generation=%s uid=%s session=%s',
+                                    conversation_id,
+                                    rejected_generation,
+                                    self.uid,
+                                    self.session_id,
+                                )
+                            else:
+                                logger.info(
+                                    'Ignoring delayed stale finalization response '
+                                    'conversation=%s rejected_generation=%s pending_generation=%s uid=%s session=%s',
+                                    conversation_id,
+                                    rejected_generation,
+                                    pending_generation,
+                                    self.uid,
+                                    self.session_id,
+                                )
+                        elif result.get("terminal"):
                             # The job reached its attempt budget and is now
                             # dead-lettered. Retrying it would never converge.
                             self.pending_conversation_requests.pop(conversation_id, None)

--- a/backend/utils/pusher_finalization.py
+++ b/backend/utils/pusher_finalization.py
@@ -23,6 +23,9 @@ from utils.observability.journeys import (
 
 logger = logging.getLogger('routers.pusher')
 
+FINALIZATION_RESULT_PROTOCOL_LEGACY = 1
+FINALIZATION_RESULT_PROTOCOL_V2 = 2
+
 
 async def process_conversation_task(
     uid: str,
@@ -33,6 +36,7 @@ async def process_conversation_task(
     finalization_job_id: Optional[str] = None,
     dispatch_generation: Optional[int] = None,
     client_kind: str = 'unknown',
+    finalization_result_protocol: int = FINALIZATION_RESULT_PROTOCOL_LEGACY,
 ) -> None:
     """Process a leased conversation job and send a minimal result to listen.
 
@@ -138,6 +142,20 @@ async def process_conversation_task(
             return
         if claim_status == 'completed':
             await send_result({'conversation_id': conversation_id, 'success': True})
+            return
+        if claim_status == 'stale_generation':
+            # The generation-aware response is opt-in so either side can be
+            # rolled out first. Legacy listeners treat unknown non-terminal
+            # errors as their existing bounded retry path; only a v2 listener
+            # can safely match and drop the superseded pending generation.
+            result: Dict[str, Any] = {
+                'conversation_id': conversation_id,
+                'error': 'job_stale_generation',
+                'terminal': False,
+            }
+            if finalization_result_protocol >= FINALIZATION_RESULT_PROTOCOL_V2:
+                result['dispatch_generation'] = generation
+            await send_result(result)
             return
         if claim_status != 'claimed':
             await send_result(

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -371,6 +371,24 @@ by `(uid, conversation_id, finalization_revision)`. A task is a named,
 at-least-once wake-up only; duplicate delivery, reconnect replay, and manual
 reconciliation must first acquire the Firestore lease.
 
+If reconciliation supersedes a queued or expired lease, it increments
+`dispatch_generation` and enqueues the newer generation. Once both sides
+negotiate result protocol `2`, any already-delivered live callback or Cloud Task
+carrying the old generation is acknowledged and dropped: the live session
+removes its pending request, and the durable task for the newer generation owns
+recovery. Returning an old-generation rejection as a retryable error would
+replay the same fenced payload indefinitely without consuming an attempt. The
+pusher callback includes the rejected generation only when the listener
+advertises result protocol `2` in opcode 104.
+Either deployment order is data-safe: a v2 pusher talking to a legacy listener
+retains the pre-fix non-terminal response shape, while a v2 listener talking to
+a legacy pusher leaves the no-generation response on its bounded timeout path.
+Mixed versions therefore retain the pre-fix retry behavior; rollout is complete
+only after both backend-listen and pusher use protocol v2. Once both sides use
+v2, the listener compares the rejected generation with its current pending
+entry before dropping it, preventing a delayed generation-1 response from
+deleting a newer generation-2 request.
+
 ```mermaid
 stateDiagram-v2
     [*] --> queued: persisted conversation + platform key


### PR DESCRIPTION
## What changed and why

Stop permanently stale conversation-finalization generations from retrying forever after durable reconciliation transfers ownership to a newer generation. Cloud Tasks acknowledge superseded payloads, while a negotiated listener/Pusher result protocol correlates delayed callbacks without deleting newer work.

## Product invariants affected

none

## How it was verified

- Four focused finalization suites — 194 passed.
- Repository pre-push gate — passed, including full backend typecheck with zero errors and runtime-image source closure.
- `git diff --check` — passed.
- Independent code review exercised the delayed generation-1 response against a pending generation-2 request and the mixed-version wire contract.

The production queue was inspected read-only and was running with no queued tasks; no production mutation or deployment was performed for this PR. Either service may roll first without losing newer work, but retry convergence requires deploying both backend-listen and Pusher with protocol v2.

## Tests

Regression coverage now pins stale Cloud Task acknowledgement and logging, old-listener terminal compatibility, matching-generation cleanup, missing-generation normalization to generation 1, and delayed stale responses preserving newer pending work.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

