### PR TITLE
Scaffold secure external OAuth control plane

### DIFF
--- a/backend/config/external_oauth_admission.json
+++ b/backend/config/external_oauth_admission.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "scope_registry_revision": "google-read-v1",
+  "connectors": {
+    "google_calendar": {
+      "enabled": false,
+      "project_alias": "google_calendar_prod",
+      "client_alias": "google_calendar_prod",
+      "project_number_sha256": "",
+      "client_id_sha256": "",
+      "redirect_uri": "",
+      "scope_digest": "",
+      "verification": {
+        "approved": false,
+        "evidence_id": "",
+        "valid_through": ""
+      }
+    },
+    "gmail": {
+      "enabled": false,
+      "project_alias": "google_gmail_prod",
+      "client_alias": "google_gmail_prod",
+      "project_number_sha256": "",
+      "client_id_sha256": "",
+      "redirect_uri": "",
+      "scope_digest": "",
+      "verification": {
+        "approved": false,
+        "evidence_id": "",
+        "valid_through": ""
+      },
+      "casa": {
+        "approved": false,
+        "evidence_id": "",
+        "valid_through": ""
+      }
+    }
+  }
+}

--- a/backend/docs/integrations/oauth-control-plane.md
+++ b/backend/docs/integrations/oauth-control-plane.md
@@ -1,0 +1,221 @@
+# Outbound OAuth control plane
+
+Status: approval-independent implementation seam; production admission is closed.
+
+This design owns delegated credentials that let Omi read data from an external
+provider. It does not replace Omi sign-in, Omi's first-party developer OAuth,
+inbound app OAuth, or task-provider OAuth. Those are separate trust boundaries
+even when they share PKCE/state helpers.
+
+The live Python backend is the serving authority. The TypeScript rewrite may
+adopt these ports later, but is not a launch dependency and must not read live
+Python credential rows directly.
+
+## Product and provider boundaries
+
+Product authorization uses only these capabilities:
+
+- `calendar.events.read`
+- `mail.messages.read`
+
+Provider scopes are an implementation detail in
+`utils/external_oauth/scopes.py`. Calendar and Gmail are separate grant
+families, clients, projects, consent attempts, credentials, and lifecycle rows:
+
+| Connector | Exact scopes | Client alias |
+| --- | --- | --- |
+| Google Calendar | `openid`, `email`, `calendar.events.readonly` | `google_calendar_prod` |
+| Gmail | `openid`, `email`, `gmail.readonly` | `google_gmail_prod` |
+
+The alias registry canonicalizes Google's documented `userinfo.email` alias.
+Any other added scope, or any missing scope, rejects activation. Gmail remains
+a restricted-scope integration: `gmail.readonly` requires both Google OAuth
+verification and current CASA evidence when Omi's backend receives the data.
+
+The provider kill switch and deployment evidence live in
+`config/external_oauth_admission.json`. The checked-in manifest is deliberately
+disabled and contains no project/client evidence. A production process must not
+construct routes, workers, or consumers unless `admit_connector` validates:
+
+1. exact project-number, OAuth-client, redirect-URI, and scope digests;
+2. current Google verification evidence;
+3. current CASA evidence for Gmail; and
+4. an explicit per-connector `enabled: true` switch.
+
+No environment variable alone enables a connector.
+
+## Required ports and dependency direction
+
+`utils/external_oauth/contracts.py` defines the boundary:
+
+- `OAuthProviderPort` constructs the fixed authorization URL and performs code
+  exchange, refresh, principal validation, and revoke.
+- `ExternalSecretExecutor` creates/destroys encrypted versions and executes a
+  callback only inside a purpose-bound lease. It never returns token bytes.
+- `ExternalConnectionRepository` owns metadata, attempts, generations,
+  lifecycle CAS, and tombstones.
+- `ExternalAuthorizationComposer` proves both Omi product authorization and an
+  active provider grant.
+- `MailReadPort` and `CalendarReadPort` return normalized product DTOs.
+
+Routes and support/admin/status modules depend on semantic ports and nonsecret
+DTOs. They must not import `vault.py`, provider token response types, or a KMS
+adapter. Provider HTTP executors may receive a secret only through a lease.
+
+The current PR supplies a concurrency-capable in-memory repository and fake
+provider to freeze behavior. A production Firestore repository and Google
+exchange adapter are intentionally not registered until cloud facts, IAM, and
+reviewed infrastructure exist.
+
+## Records and cardinality
+
+A production repository must create these separate collections. None may store
+plaintext token bytes.
+
+- `external_connections`: random immutable `connection_id` and
+  `external_owner_id`, current Omi-account mapping, connector, grant family,
+  provider/client aliases, immutable first provider subject, masked identity,
+  lifecycle state, monotonic generation, scope-registry revision/digest,
+  deletion epoch, timestamps, and sanitized error code.
+- `external_provider_grants`: requested/effective canonical scopes, registry
+  revision, provider grant status, consent timestamps, verification evidence
+  revision.
+- `oauth_consent_attempts`: SHA-256 state hash, exact connection/owner/
+  connector/client/scope/generation bindings, fixed return-target ID, expiry,
+  consume/result fields, and encrypted attempt-secret reference.
+- `external_secret_versions`: AES-256-GCM ciphertext/nonce, KMS-wrapped random
+  DEK, KMS key version, AAD digest, generation/version/status.
+- `external_auth_operations`: leased refresh/revoke/delete work, attempt,
+  next-retry, retention deadline, typed outcome, idempotency key, generation and
+  deletion epoch.
+- `external_auth_audit_events`: immutable content-free lifecycle/security
+  events with a shared run/operation ID.
+
+Enforce at most one non-terminal connection per
+`(external_owner_id, connector, grant_family)`. `external_owner_id` is a random,
+migration-stable identity and must not be derived from email or provider `sub`.
+Connection ID and the first activated provider `sub` never change. A generation
+only increases. Different-sub reconnect requires explicit replace-account;
+never silently switch the browser-selected Google account.
+
+## Secret custody
+
+`EnvelopeSecretExecutor` uses a random 256-bit DEK for every secret version and
+AES-256-GCM. AAD binds:
+
+`external_owner_id + connection_id + provider + client_alias + generation + secret_version`.
+
+Only Cloud KMS wraps/unwraps the DEK in production. There is no local-key or
+plaintext fallback. KMS errors, AAD mismatch, stale generation, missing
+authorization, or missing adapter fail closed. Cloud KMS rewrap may change the
+KEK only while AAD is unchanged; an AAD migration requires a bounded trusted
+decrypt/re-encrypt worker.
+
+Provision distinct service identities/roles for callback exchange, read,
+refresh, revoke/delete, and rewrap. Ciphertext read must not imply KMS decrypt.
+The revocation role can unwrap a fenced generation only for a fixed Google
+revoke request bound to operation ID and deletion epoch. It cannot refresh,
+read content, or return plaintext.
+
+Backup restore must restore connection heads, tombstones, deletion epochs, and
+revocation dispositions before any secret becomes leasable. A pre-disconnect or
+pre-deletion backup must not resurrect authority.
+
+## Consent and callback
+
+Authorization start creates 256-bit state, PKCE S256 verifier/challenge, and an
+OIDC nonce. Firestore receives only the state hash. PKCE verifier and nonce are
+encrypted as short-lived attempt material. The attempt is bound to initiating
+owner, connector, client, scope digest, connection generation, expiry, and a
+fixed return-target identifier; a caller cannot supply an arbitrary redirect.
+
+Callback consumption is atomic. Exactly one worker can claim the attempt and
+exchange the code. Concurrent/replayed callbacks receive only a sanitized
+completion class and never exchange again. Before activation the provider
+adapter must validate OIDC issuer/audience/nonce/subject and the exact effective
+scope set. A new grant never inherits an old refresh token.
+
+## Lifecycle and revocation policy
+
+`utils/external_oauth/lifecycle.py` is the executable transition source. The
+allowed state transitions are:
+
+- `pending_consent -> active | cancelled | expired`
+- `active -> reauth_required | blocked_by_admin | revoke_pending |
+  deletion_pending | revoked`
+- `reauth_required -> pending_consent | blocked_by_admin | revoke_pending |
+  deletion_pending | revoked`
+- `blocked_by_admin -> pending_consent | revoke_pending | deletion_pending |
+  revoked`
+- `revoke_pending -> revoked | revocation_failed | deletion_pending`
+- `revocation_failed -> revoke_pending | deletion_pending`
+- `deletion_pending -> deletion_pending | revoked`
+
+`revoked`, `cancelled`, and `expired` are closed terminal rows. A future
+connection gets a new connection ID. Refresh and exchange are leased operations,
+not connection states.
+
+Moving to reauth/admin/revoke/delete fences reads and increments generation.
+Revoke/delete states expose only revoke-purpose authority. Disconnect retry
+delays are 1m, 5m, 30m, 2h, 6h, then 6h with escalation after 2h. Seven days is
+a normal-disconnect review deadline, never permission to discard the only
+revoke credential. Account deletion has a 24-hour privacy deadline, after which
+the ratified disposition destroys ciphertext and retains only an
+`upstream_revoke_unconfirmed_credentials_destroyed` tombstone.
+
+The only terminal revocation dispositions are provider-confirmed revoke,
+provider-proven invalid credential, dated security-owner decommission approval,
+or the ratified 24-hour account-deletion disposition. Retry exhaustion is not a
+terminal disposition.
+
+Reconnect is permitted only after the old grant is provider-proven invalid or
+project-wide revocation completes. Revoking a project grant after replacement
+authorization can revoke the replacement too, so ordering is mandatory.
+
+## Provider HTTP and semantic reads
+
+`google_reads.py` fixes Google hosts and paths, disables redirects, bounds
+response size, and returns only `MailMessage` or `CalendarEvent` DTOs. Tokens,
+provider envelopes, arbitrary URLs, and toolkit identifiers do not escape.
+Production adapters must additionally pin TLS defaults, reject private-address
+or DNS-rebinding results, use shared backend async clients/semaphores, classify
+retryable status with bounded budgets and `Retry-After`, and recheck generation
+and deletion epoch before returning normalized data.
+
+## Legacy containment and migration
+
+The generic `PUT /v1/integrations/{app_key}` retains deprecated credential
+fields only for released-client schema compatibility, but rejects every
+registered server-OAuth provider key before persistence. It therefore cannot
+inject or replace an OAuth credential. `GET /v1/task-integrations` returns
+typed status projections rather than stored dictionaries.
+
+`migrations/008_external_oauth_legacy_disposition.py` is a pure classification
+helper and performs no database I/O. The safe default for the broad/plaintext
+legacy `google_calendar` grant is revoke then explicit consent into separate
+Calendar/Gmail clients. Do not copy or merge it into the new vault. If an
+approved per-account exception cannot revoke immediately, the only alternative
+is vault-only legacy quarantine: no reads, refresh, route exposure, or migration
+into a new grant.
+
+## Production gates and rollback
+
+Before any cohort opens, all of the following need independent evidence:
+
+1. redacted GCP inventory proves separate sign-in, Calendar, and Gmail projects
+   and exact clients/redirects;
+2. Calendar verification and Gmail verification plus CASA are current;
+3. reviewed Firestore repository/transactions/indexes and immutable audit sink;
+4. dedicated KMS key, Data Access logs, least-authority IAM identities, Secret
+   Manager client secrets, and ciphertext-only database/IAM review;
+5. KMS rotation, backup/restore anti-resurrection, concurrent callback/refresh,
+   revoke retry/deadline, account-deletion, provider outage, and stale-generation
+   drills;
+6. producer-side and consumer-side observations share a run ID; and
+7. compatibility clients pass with no credential fields in OpenAPI or responses.
+
+Rollback closes connector/cohort switches, stops new starts and semantic reads,
+and leaves encrypted/fenced credentials for controlled revoke/recovery. It must
+never copy credentials back to legacy plaintext fields. Existing legacy
+Calendar users remain untouched until an explicit per-account migration or
+re-consent decision.

--- a/backend/migrations/008_external_oauth_legacy_disposition.py
+++ b/backend/migrations/008_external_oauth_legacy_disposition.py
@@ -1,0 +1,64 @@
+"""Pure planner for legacy OAuth records; intentionally performs no database I/O.
+
+The safe migration is explicit re-consent into separate grants. This helper lets
+an approved inventory job classify record shapes without copying credentials or
+user content. It is not imported by application runtime and cannot mutate data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping
+
+
+class LegacyDisposition(str, Enum):
+    NO_CREDENTIAL = 'no_credential'
+    REVOKE_AND_RECONSENT = 'revoke_and_reconsent'
+    VAULT_ONLY_QUARANTINE = 'vault_only_legacy_quarantine'
+    UNKNOWN_REVIEW_REQUIRED = 'unknown_review_required'
+
+
+SECRET_FIELDS = frozenset({'access_token', 'refresh_token', 'token', 'credentials'})
+
+
+@dataclass(frozen=True)
+class LegacyGrantClassification:
+    integration_key: str
+    has_credential: bool
+    has_calendar_scope: bool
+    has_gmail_scope: bool
+    disposition: LegacyDisposition
+
+
+def classify_legacy_grant(integration_key: str, record: Mapping[str, object]) -> LegacyGrantClassification:
+    scopes = record.get('granted_scopes')
+    normalized_scopes = set(scopes) if isinstance(scopes, (list, tuple, set, frozenset)) else set()
+    has_credential = any(bool(record.get(field)) for field in SECRET_FIELDS)
+    has_calendar = any('calendar' in str(scope) for scope in normalized_scopes)
+    has_gmail = any('gmail.' in str(scope) for scope in normalized_scopes)
+    if not has_credential:
+        disposition = LegacyDisposition.NO_CREDENTIAL
+    elif integration_key == 'google_calendar':
+        # Never copy this plaintext/broad credential into the new grant family.
+        disposition = LegacyDisposition.REVOKE_AND_RECONSENT
+    else:
+        disposition = LegacyDisposition.UNKNOWN_REVIEW_REQUIRED
+    return LegacyGrantClassification(
+        integration_key=integration_key,
+        has_credential=has_credential,
+        has_calendar_scope=has_calendar,
+        has_gmail_scope=has_gmail,
+        disposition=disposition,
+    )
+
+
+def public_inventory_row(classification: LegacyGrantClassification) -> dict[str, object]:
+    """Content-free output safe for aggregate inventory reports."""
+    return {
+        'integration_key': classification.integration_key,
+        'has_credential': classification.has_credential,
+        'has_calendar_scope': classification.has_calendar_scope,
+        'has_gmail_scope': classification.has_gmail_scope,
+        'disposition': classification.disposition.value,
+    }

--- a/backend/routers/integrations.py
+++ b/backend/routers/integrations.py
@@ -142,11 +142,15 @@ def validate_and_consume_oauth_state(state_token: Optional[str]) -> Optional[Dic
 
 # Request/Response models
 class IntegrationData(BaseModel):
-    """Data for an integration connection"""
+    """Compatibility input for integrations without a server OAuth flow.
+
+    Deprecated credential fields remain in the released app-client schema, but
+    registered OAuth providers are rejected before any value is persisted.
+    """
 
     connected: bool = True
-    access_token: Optional[str] = None
-    refresh_token: Optional[str] = None
+    access_token: Optional[str] = Field(default=None, deprecated=True)
+    refresh_token: Optional[str] = Field(default=None, deprecated=True)
 
 
 class AppleHealthSyncData(BaseModel):
@@ -308,7 +312,15 @@ def get_integration(app_key: str, uid: str = Depends(auth.get_current_user_uid))
 
 @router.put("/v1/integrations/{app_key}", tags=['integrations'], response_model=IntegrationMutationResponse)
 def save_integration(app_key: str, data: IntegrationData, uid: str = Depends(auth.get_current_user_uid)):
-    """Save or update an integration connection."""
+    """Save non-secret state for integrations without server-managed OAuth.
+
+    OAuth credentials are accepted only from a provider callback into the
+    encrypted control plane. This legacy compatibility route cannot inject or
+    replace a provider token.
+    """
+    resolved = resolve_integration_provider(app_key)
+    if resolved and resolved[1]['kind'] == 'oauth':
+        raise HTTPException(status_code=409, detail='oauth_integration_requires_authorization_flow')
     # Convert Pydantic model to dict, excluding None values
     integration_data = data.model_dump(exclude_none=True)
 

--- a/backend/routers/task_integrations.py
+++ b/backend/routers/task_integrations.py
@@ -146,10 +146,19 @@ class TaskIntegrationData(BaseModel):
     list_name: Optional[str] = None
 
 
+class TaskIntegrationStatus(BaseModel):
+    """Non-secret projection safe for clients, support tooling, and OpenAPI."""
+
+    model_config = {'extra': 'forbid'}
+
+    app_key: str
+    connected: bool
+
+
 class TaskIntegrationsResponse(BaseModel):
     """Response containing all task integrations"""
 
-    integrations: Dict[str, Any] = Field(description="Map of app_key to connection details")
+    integrations: Dict[str, TaskIntegrationStatus] = Field(description="Map of app_key to non-secret status")
     default_app: Optional[str] = Field(description="Default task integration app key")
 
 
@@ -198,7 +207,12 @@ class ClickUpListsResponse(BaseModel):
 @router.get("/v1/task-integrations", response_model=TaskIntegrationsResponse, tags=['task-integrations'])
 def get_task_integrations(uid: str = Depends(auth.get_current_user_uid)):
     """Get all task integration connections for the current user."""
-    integrations = users_db.get_task_integrations(uid)
+    stored_integrations = users_db.get_task_integrations(uid)
+    integrations = {
+        app_key: TaskIntegrationStatus(app_key=app_key, connected=bool(value.get('connected')))
+        for app_key, value in stored_integrations.items()
+        if isinstance(value, dict)
+    }
     default_app = users_db.get_default_task_integration(uid)
 
     return TaskIntegrationsResponse(integrations=integrations, default_app=default_app)

--- a/backend/tests/unit/external_oauth/test_admission.py
+++ b/backend/tests/unit/external_oauth/test_admission.py
@@ -1,0 +1,82 @@
+import copy
+import hashlib
+
+import pytest
+
+from utils.external_oauth.admission import AdmissionDenied, DeploymentFacts, admit_connector
+from utils.external_oauth.contracts import Connector
+from utils.external_oauth.scopes import GRANT_FAMILIES, SCOPE_REGISTRY_REVISION, scope_digest
+
+
+def _entry(connector: Connector) -> dict:
+    return {
+        'enabled': True,
+        'project_alias': GRANT_FAMILIES[connector].client_alias,
+        'client_alias': GRANT_FAMILIES[connector].client_alias,
+        'project_number_sha256': hashlib.sha256(b'1234').hexdigest(),
+        'client_id_sha256': hashlib.sha256(b'client-id').hexdigest(),
+        'redirect_uri': f'https://api.omi.me/v2/external-oauth/{connector.value}/callback',
+        'scope_digest': scope_digest(GRANT_FAMILIES[connector].scopes),
+        'verification': {'approved': True, 'evidence_id': 'verification-123', 'valid_through': '2027-01-01'},
+        'casa': {'approved': True, 'evidence_id': 'casa-123', 'valid_through': '2027-01-01'},
+    }
+
+
+def _facts(connector: Connector) -> DeploymentFacts:
+    return DeploymentFacts(
+        environment='production',
+        project_number='1234',
+        oauth_client_id='client-id',
+        redirect_uri=f'https://api.omi.me/v2/external-oauth/{connector.value}/callback',
+    )
+
+
+def _manifest() -> dict:
+    return {
+        'schema_version': 1,
+        'scope_registry_revision': SCOPE_REGISTRY_REVISION,
+        'connectors': {connector.value: _entry(connector) for connector in Connector},
+    }
+
+
+@pytest.mark.parametrize('connector', list(Connector))
+def test_exact_current_evidence_admits_connector(connector):
+    admitted = admit_connector(_manifest(), connector, _facts(connector), now_iso_date='2026-08-30')
+    assert admitted.connector == connector
+
+
+@pytest.mark.parametrize(
+    ('field', 'value'),
+    [
+        ('enabled', False),
+        ('project_number_sha256', 'wrong'),
+        ('client_id_sha256', 'wrong'),
+        ('redirect_uri', 'https://attacker.invalid/callback'),
+        ('scope_digest', 'wrong'),
+        ('client_alias', 'wrong'),
+        ('project_alias', 'wrong'),
+    ],
+)
+def test_identity_scope_and_kill_switch_mismatches_fail_closed(field, value):
+    manifest = _manifest()
+    manifest['connectors']['gmail'][field] = value
+    with pytest.raises(AdmissionDenied):
+        admit_connector(manifest, Connector.GMAIL, _facts(Connector.GMAIL), now_iso_date='2026-08-30')
+
+
+def test_gmail_requires_current_casa_in_addition_to_verification():
+    manifest = _manifest()
+    manifest['connectors']['gmail']['casa']['approved'] = False
+    with pytest.raises(AdmissionDenied, match='CASA'):
+        admit_connector(manifest, Connector.GMAIL, _facts(Connector.GMAIL), now_iso_date='2026-08-30')
+
+
+def test_calendar_does_not_require_casa_but_requires_verification():
+    manifest = _manifest()
+    del manifest['connectors']['google_calendar']['casa']
+    admit_connector(manifest, Connector.GOOGLE_CALENDAR, _facts(Connector.GOOGLE_CALENDAR), now_iso_date='2026-08-30')
+    manifest['connectors']['google_calendar']['verification']['valid_through'] = '2026-08-29'
+    with pytest.raises(AdmissionDenied, match='stale'):
+        admit_connector(
+            manifest, Connector.GOOGLE_CALENDAR, _facts(Connector.GOOGLE_CALENDAR), now_iso_date='2026-08-30'
+        )

--- a/backend/tests/unit/external_oauth/test_google_reads.py
+++ b/backend/tests/unit/external_oauth/test_google_reads.py
@@ -1,0 +1,166 @@
+import base64
+import json
+import os
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives.keywrap import aes_key_unwrap, aes_key_wrap
+
+from utils.external_oauth.contracts import Capability, Connector, SecretBinding, SecretLeaseContext, SecretPurpose
+from utils.external_oauth.google_reads import GoogleCalendarReadAdapter, GoogleMailReadAdapter
+from utils.external_oauth.vault import EnvelopeSecretExecutor, InMemoryCiphertextStore
+
+
+class FakeKeyWrapper:
+    key_version = 'fake-kms/versions/1'
+
+    def __init__(self):
+        self.kek = os.urandom(32)
+
+    async def wrap(self, dek: bytes) -> bytes:
+        return aes_key_wrap(self.kek, dek)
+
+    async def unwrap(self, wrapped_dek: bytes, *, key_version: str) -> bytes:
+        return aes_key_unwrap(self.kek, wrapped_dek)
+
+
+async def _allow_read(secret, context):
+    assert context.purpose == SecretPurpose.READ
+
+
+class FakeAuthorization:
+    async def authorize(self, *, external_owner_id, connector, capability, operation_id):
+        expected = {
+            Connector.GMAIL: Capability.MAIL_MESSAGES_READ,
+            Connector.GOOGLE_CALENDAR: Capability.CALENDAR_EVENTS_READ,
+        }
+        assert expected[connector] == capability
+        return SecretLeaseContext('connection-1', 1, 0, operation_id, SecretPurpose.READ)
+
+
+class FakeLocator:
+    def __init__(self, secret_id):
+        self.secret_id = secret_id
+
+    async def active_secret_id(self, *, connection_id, generation):
+        assert connection_id == 'connection-1' and generation == 1
+        return self.secret_id
+
+
+async def _vault():
+    executor = EnvelopeSecretExecutor(
+        key_wrapper=FakeKeyWrapper(), store=InMemoryCiphertextStore(), authorize=_allow_read
+    )
+    credential = json.dumps({'access_token': base64.b64encode(b'leased-token').decode()}).encode()
+    secret = await executor.create(
+        binding=SecretBinding('owner-1', 'connection-1', 'google', 'client-1', 1, 1), plaintext=credential
+    )
+    return executor, secret.secret_id
+
+
+@pytest.mark.asyncio
+async def test_gmail_adapter_uses_fixed_metadata_reads_and_returns_semantic_dto():
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        assert request.headers['authorization'] == 'Bearer leased-token'
+        if request.url.path.endswith('/messages'):
+            return httpx.Response(200, json={'messages': [{'id': 'm1'}]})
+        return httpx.Response(
+            200,
+            json={
+                'id': 'm1',
+                'threadId': 't1',
+                'snippet': 'hello',
+                'internalDate': '1000',
+                'payload': {'headers': [{'name': 'From', 'value': 'sender'}, {'name': 'Subject', 'value': 'subject'}]},
+            },
+        )
+
+    vault, secret_id = await _vault()
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        adapter = GoogleMailReadAdapter(
+            authorization=FakeAuthorization(),
+            secrets_executor=vault,
+            credential_locator=FakeLocator(secret_id),
+            http=client,
+        )
+        messages = await adapter.list_messages(external_owner_id='owner-1', limit=1)
+    assert messages[0].message_id == 'm1'
+    assert messages[0].subject == 'subject'
+    assert all(request.url.host == 'gmail.googleapis.com' for request in requests)
+    assert 'leased-token' not in repr(messages)
+
+
+@pytest.mark.asyncio
+async def test_calendar_adapter_uses_fixed_primary_calendar_and_returns_semantic_dto():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.host == 'www.googleapis.com'
+        assert request.url.path == '/calendar/v3/calendars/primary/events'
+        assert request.headers['authorization'] == 'Bearer leased-token'
+        return httpx.Response(
+            200,
+            json={
+                'items': [
+                    {
+                        'id': 'event-1',
+                        'summary': 'Planning',
+                        'start': {'dateTime': '2026-08-30T10:00:00Z'},
+                        'end': {'dateTime': '2026-08-30T11:00:00Z'},
+                        'attendees': [{}, {}],
+                    }
+                ]
+            },
+        )
+
+    vault, secret_id = await _vault()
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        adapter = GoogleCalendarReadAdapter(
+            authorization=FakeAuthorization(),
+            secrets_executor=vault,
+            credential_locator=FakeLocator(secret_id),
+            http=client,
+        )
+        events = await adapter.list_events(
+            external_owner_id='owner-1',
+            starts_after=datetime(2026, 8, 30, tzinfo=timezone.utc),
+            ends_before=datetime(2026, 8, 31, tzinfo=timezone.utc),
+            limit=10,
+        )
+    assert events[0].event_id == 'event-1'
+    assert events[0].attendee_count == 2
+    assert 'leased-token' not in repr(events)
+
+
+@pytest.mark.asyncio
+async def test_calendar_all_day_dates_are_normalized_to_utc():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                'items': [
+                    {
+                        'id': 'all-day',
+                        'start': {'date': '2026-08-30'},
+                        'end': {'date': '2026-08-31'},
+                    }
+                ]
+            },
+        )
+
+    vault, secret_id = await _vault()
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        adapter = GoogleCalendarReadAdapter(
+            authorization=FakeAuthorization(),
+            secrets_executor=vault,
+            credential_locator=FakeLocator(secret_id),
+            http=client,
+        )
+        events = await adapter.list_events(
+            external_owner_id='owner-1',
+            starts_after=datetime(2026, 8, 30, tzinfo=timezone.utc),
+            ends_before=datetime(2026, 9, 1, tzinfo=timezone.utc),
+        )
+    assert events[0].starts_at == datetime(2026, 8, 30, tzinfo=timezone.utc)

--- a/backend/tests/unit/external_oauth/test_legacy_disposition.py
+++ b/backend/tests/unit/external_oauth/test_legacy_disposition.py
@@ -1,0 +1,44 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[3] / 'migrations' / '008_external_oauth_legacy_disposition.py'
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location('external_oauth_legacy_disposition', MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_plaintext_legacy_google_grant_requires_revoke_and_reconsent():
+    module = _module()
+    classified = module.classify_legacy_grant(
+        'google_calendar',
+        {
+            'access_token': 'never-export-this',
+            'refresh_token': 'never-export-this-either',
+            'granted_scopes': [
+                'https://www.googleapis.com/auth/calendar',
+                'https://www.googleapis.com/auth/gmail.readonly',
+            ],
+        },
+    )
+    assert classified.disposition.value == 'revoke_and_reconsent'
+    assert module.public_inventory_row(classified) == {
+        'integration_key': 'google_calendar',
+        'has_credential': True,
+        'has_calendar_scope': True,
+        'has_gmail_scope': True,
+        'disposition': 'revoke_and_reconsent',
+    }
+
+
+def test_public_inventory_never_contains_secret_values():
+    module = _module()
+    row = module.public_inventory_row(module.classify_legacy_grant('google_calendar', {'refresh_token': 'top-secret'}))
+    assert 'top-secret' not in repr(row)
+    assert not set(row) & module.SECRET_FIELDS

--- a/backend/tests/unit/external_oauth/test_scope_lifecycle.py
+++ b/backend/tests/unit/external_oauth/test_scope_lifecycle.py
@@ -1,0 +1,103 @@
+from datetime import timedelta
+
+import pytest
+
+from utils.external_oauth.contracts import ConnectionState, Connector, ExternalOAuthError, RevocationDisposition
+from utils.external_oauth.lifecycle import (
+    ACCOUNT_DELETION_REVOKE_DEADLINE,
+    ALLOWED_TRANSITIONS,
+    DISCONNECT_RETENTION_DEADLINE,
+    TERMINAL_STATES,
+    revocation_retry_delay,
+    transition_decision,
+)
+from utils.external_oauth.scopes import (
+    CALENDAR_EVENTS_READONLY,
+    EMAIL,
+    GMAIL_READONLY,
+    OPENID,
+    canonicalize_scopes,
+    require_exact_scopes,
+)
+
+
+def test_calendar_and_gmail_grants_are_exact_and_separate():
+    assert require_exact_scopes(Connector.GOOGLE_CALENDAR, [OPENID, EMAIL, CALENDAR_EVENTS_READONLY]) == frozenset(
+        {OPENID, EMAIL, CALENDAR_EVENTS_READONLY}
+    )
+    assert require_exact_scopes(Connector.GMAIL, [OPENID, EMAIL, GMAIL_READONLY]) == frozenset(
+        {OPENID, EMAIL, GMAIL_READONLY}
+    )
+    with pytest.raises(ExternalOAuthError, match='provider_scope_set_mismatch'):
+        require_exact_scopes(Connector.GMAIL, [OPENID, EMAIL, GMAIL_READONLY, CALENDAR_EVENTS_READONLY])
+
+
+def test_provider_alias_is_canonicalized_but_unknown_scope_fails_closed():
+    assert canonicalize_scopes(['https://www.googleapis.com/auth/userinfo.email']) == frozenset({EMAIL})
+    with pytest.raises(ExternalOAuthError, match='provider_returned_unknown_scope'):
+        canonicalize_scopes(['https://www.googleapis.com/auth/drive.readonly'])
+
+
+def test_all_declared_transitions_are_executable_and_terminals_are_closed():
+    for source, targets in ALLOWED_TRANSITIONS.items():
+        for target in targets:
+            disposition = None
+            if target == ConnectionState.REVOKED:
+                disposition = RevocationDisposition.PROVIDER_ALREADY_INVALID
+            elif target == ConnectionState.PENDING_CONSENT:
+                disposition = RevocationDisposition.PROVIDER_CONFIRMED_REVOKE
+            decision = transition_decision(
+                source,
+                target,
+                disposition=disposition,
+                admin_clearance=source == ConnectionState.BLOCKED_BY_ADMIN,
+            )
+            assert decision.secret_use in {'none', 'read_refresh', 'revoke_only'}
+    for terminal in TERMINAL_STATES:
+        assert not ALLOWED_TRANSITIONS[terminal]
+        with pytest.raises(ValueError):
+            transition_decision(terminal, ConnectionState.ACTIVE)
+
+
+def test_revocation_policy_deadlines_and_backoff_are_encoded():
+    assert DISCONNECT_RETENTION_DEADLINE == timedelta(days=7)
+    assert ACCOUNT_DELETION_REVOKE_DEADLINE == timedelta(hours=24)
+    assert [revocation_retry_delay(i) for i in range(1, 7)] == [
+        timedelta(minutes=1),
+        timedelta(minutes=5),
+        timedelta(minutes=30),
+        timedelta(hours=2),
+        timedelta(hours=6),
+        timedelta(hours=6),
+    ]
+
+
+def test_revoke_and_delete_fence_generation_and_limit_secret_use():
+    for target in (ConnectionState.REVOKE_PENDING, ConnectionState.DELETION_PENDING):
+        decision = transition_decision(ConnectionState.ACTIVE, target)
+        assert decision.increments_generation
+        assert decision.secret_use == 'revoke_only'
+
+
+def test_reconnect_and_terminal_disposition_guards_are_executable():
+    with pytest.raises(ValueError, match='terminal disposition'):
+        transition_decision(ConnectionState.REAUTH_REQUIRED, ConnectionState.PENDING_CONSENT)
+    with pytest.raises(ValueError, match='independent clearance'):
+        transition_decision(
+            ConnectionState.BLOCKED_BY_ADMIN,
+            ConnectionState.PENDING_CONSENT,
+            disposition=RevocationDisposition.PROVIDER_ALREADY_INVALID,
+        )
+    with pytest.raises(ValueError, match='terminal disposition'):
+        transition_decision(ConnectionState.REVOKE_PENDING, ConnectionState.REVOKED)
+    with pytest.raises(ValueError, match='allowed terminal'):
+        transition_decision(
+            ConnectionState.ACTIVE,
+            ConnectionState.REVOKED,
+            disposition=RevocationDisposition.SECURITY_APPROVED_DECOMMISSION,
+        )
+
+
+def test_deletion_retry_does_not_advance_generation():
+    decision = transition_decision(ConnectionState.DELETION_PENDING, ConnectionState.DELETION_PENDING)
+    assert not decision.increments_generation

--- a/backend/tests/unit/external_oauth/test_service.py
+++ b/backend/tests/unit/external_oauth/test_service.py
@@ -1,0 +1,120 @@
+import asyncio
+import os
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from cryptography.hazmat.primitives.keywrap import aes_key_unwrap, aes_key_wrap
+
+from utils.external_oauth.contracts import Connector, SecretPurpose
+from utils.external_oauth.fake_provider import FakeOAuthProvider
+from utils.external_oauth.repository import InMemoryExternalConnectionRepository
+from utils.external_oauth.scopes import GRANT_FAMILIES
+from utils.external_oauth.service import ExternalOAuthService
+from utils.external_oauth.vault import EnvelopeSecretExecutor, InMemoryCiphertextStore
+
+
+class FakeKeyWrapper:
+    key_version = 'fake-kms/versions/1'
+
+    def __init__(self):
+        self.kek = os.urandom(32)
+
+    async def wrap(self, dek: bytes) -> bytes:
+        return aes_key_wrap(self.kek, dek)
+
+    async def unwrap(self, wrapped_dek: bytes, *, key_version: str) -> bytes:
+        return aes_key_unwrap(self.kek, wrapped_dek)
+
+
+async def _authorize(secret, context):
+    if secret.binding.connection_id != context.connection_id or secret.binding.generation != context.generation:
+        raise PermissionError('lease binding mismatch')
+    if context.purpose not in {SecretPurpose.CALLBACK_EXCHANGE, SecretPurpose.REVOKE}:
+        raise PermissionError('purpose denied')
+
+
+def _service(connector: Connector = Connector.GMAIL):
+    repository = InMemoryExternalConnectionRepository()
+    store = InMemoryCiphertextStore()
+    provider = FakeOAuthProvider(scopes=GRANT_FAMILIES[connector].scopes)
+    vault = EnvelopeSecretExecutor(key_wrapper=FakeKeyWrapper(), store=store, authorize=_authorize)
+    service = ExternalOAuthService(repository=repository, secrets_executor=vault, providers={connector: provider})
+    return service, repository, store, provider
+
+
+@pytest.mark.asyncio
+async def test_start_stores_only_hashed_state_and_encrypted_pkce_nonce():
+    service, repository, store, _provider = _service()
+    started = await service.start(
+        external_owner_id='owner-1', connector=Connector.GMAIL, fixed_return_target_id='desktop'
+    )
+    raw_state = parse_qs(urlparse(started.authorization_url).query)['state'][0]
+    assert raw_state not in repository.attempts
+    assert all(raw_state.encode() not in record.ciphertext for record in store.records.values())
+    assert 'code_challenge_method=S256' in started.authorization_url
+
+
+@pytest.mark.asyncio
+async def test_callback_activates_exact_scope_grant_and_replay_never_reexchanges():
+    service, repository, _store, provider = _service()
+    started = await service.start(
+        external_owner_id='owner-1', connector=Connector.GMAIL, fixed_return_target_id='desktop'
+    )
+    state = parse_qs(urlparse(started.authorization_url).query)['state'][0]
+    assert await service.callback(raw_state=state, code='authorization-code') == 'connected'
+    assert await service.callback(raw_state=state, code='authorization-code') == 'connected'
+    assert provider.exchange_count == 1
+    assert len(_store.records) == 1  # active credential only; attempt material is destroyed
+    connection = await repository.get(external_owner_id='owner-1', connector=Connector.GMAIL)
+    assert connection is not None
+    assert connection.state.value == 'active'
+    assert connection.provider_subject == 'provider-subject-1'
+
+
+@pytest.mark.asyncio
+async def test_concurrent_callbacks_exchange_at_most_once():
+    service, _repository, _store, provider = _service()
+    started = await service.start(
+        external_owner_id='owner-1', connector=Connector.GMAIL, fixed_return_target_id='desktop'
+    )
+    state = parse_qs(urlparse(started.authorization_url).query)['state'][0]
+    results = await asyncio.gather(
+        service.callback(raw_state=state, code='authorization-code'),
+        service.callback(raw_state=state, code='authorization-code'),
+    )
+    assert provider.exchange_count == 1
+    assert 'connected' in results
+    assert set(results) <= {'connected', 'exchange_claimed'}
+
+
+@pytest.mark.asyncio
+async def test_partial_or_extra_scope_grant_never_activates():
+    service, repository, _store, provider = _service()
+    provider.scopes = frozenset({'openid', 'email'})
+    started = await service.start(
+        external_owner_id='owner-1', connector=Connector.GMAIL, fixed_return_target_id='desktop'
+    )
+    state = parse_qs(urlparse(started.authorization_url).query)['state'][0]
+    with pytest.raises(Exception, match='provider_scope_set_mismatch'):
+        await service.callback(raw_state=state, code='authorization-code')
+    assert not _store.records
+    assert await service.callback(raw_state=state, code='authorization-code') == 'callback_failed'
+    connection = await repository.get(external_owner_id='owner-1', connector=Connector.GMAIL)
+    assert connection is not None
+    assert connection.state.value == 'pending_consent'
+
+
+@pytest.mark.asyncio
+async def test_calendar_and_gmail_have_independent_cardinality_and_grants():
+    repository = InMemoryExternalConnectionRepository()
+    store = InMemoryCiphertextStore()
+    vault = EnvelopeSecretExecutor(key_wrapper=FakeKeyWrapper(), store=store, authorize=_authorize)
+    providers = {connector: FakeOAuthProvider(scopes=GRANT_FAMILIES[connector].scopes) for connector in Connector}
+    service = ExternalOAuthService(repository=repository, secrets_executor=vault, providers=providers)
+    for connector in Connector:
+        await service.start(external_owner_id='owner-1', connector=connector, fixed_return_target_id='desktop')
+    assert len(repository.connections) == 2
+    assert {connection.grant_family for connection in repository.connections.values()} == {
+        'google_calendar_read',
+        'google_gmail_read',
+    }

--- a/backend/tests/unit/external_oauth/test_vault.py
+++ b/backend/tests/unit/external_oauth/test_vault.py
@@ -1,0 +1,95 @@
+import os
+
+import pytest
+from cryptography.hazmat.primitives.keywrap import aes_key_unwrap, aes_key_wrap
+
+from utils.external_oauth.contracts import SecretBinding, SecretLeaseContext, SecretPurpose
+from utils.external_oauth.vault import EnvelopeSecretExecutor, InMemoryCiphertextStore
+
+
+class FakeKeyWrapper:
+    key_version = 'fake-kms/versions/1'
+
+    def __init__(self):
+        self.kek = os.urandom(32)
+
+    async def wrap(self, dek: bytes) -> bytes:
+        return aes_key_wrap(self.kek, dek)
+
+    async def unwrap(self, wrapped_dek: bytes, *, key_version: str) -> bytes:
+        assert key_version == self.key_version
+        return aes_key_unwrap(self.kek, wrapped_dek)
+
+
+def _binding(generation: int = 1) -> SecretBinding:
+    return SecretBinding('owner-1', 'connection-1', 'google', 'google_gmail_prod', generation, 1)
+
+
+def _context(purpose: SecretPurpose, generation: int = 1) -> SecretLeaseContext:
+    return SecretLeaseContext('connection-1', generation, 0, 'operation-1', purpose)
+
+
+async def _authorize(secret, context):
+    if secret.binding.connection_id != context.connection_id:
+        raise PermissionError('wrong connection')
+    if context.purpose not in {SecretPurpose.READ, SecretPurpose.REFRESH, SecretPurpose.REVOKE}:
+        raise PermissionError('role cannot use this purpose')
+
+
+@pytest.mark.asyncio
+async def test_ciphertext_store_never_contains_plaintext_and_read_is_purpose_bound():
+    store = InMemoryCiphertextStore()
+    executor = EnvelopeSecretExecutor(key_wrapper=FakeKeyWrapper(), store=store, authorize=_authorize)
+    created = await executor.create(binding=_binding(), plaintext=b'super-secret-refresh-token')
+    assert b'super-secret-refresh-token' not in created.ciphertext
+    assert b'super-secret-refresh-token' not in created.wrapped_dek
+
+    async def consume(value: memoryview) -> bytes:
+        return bytes(value)
+
+    assert (
+        await executor.with_secret_lease(
+            secret_id=created.secret_id, context=_context(SecretPurpose.READ), operation=consume
+        )
+        == b'super-secret-refresh-token'
+    )
+
+
+@pytest.mark.asyncio
+async def test_stale_generation_cannot_decrypt():
+    executor = EnvelopeSecretExecutor(
+        key_wrapper=FakeKeyWrapper(), store=InMemoryCiphertextStore(), authorize=_authorize
+    )
+    created = await executor.create(binding=_binding(), plaintext=b'secret')
+
+    async def consume(value: memoryview) -> None:
+        raise AssertionError('operation must not execute')
+
+    with pytest.raises(PermissionError, match='generation'):
+        await executor.with_secret_lease(
+            secret_id=created.secret_id, context=_context(SecretPurpose.READ, generation=2), operation=consume
+        )
+
+
+@pytest.mark.asyncio
+async def test_only_revoke_lease_can_destroy_secret():
+    store = InMemoryCiphertextStore()
+    executor = EnvelopeSecretExecutor(key_wrapper=FakeKeyWrapper(), store=store, authorize=_authorize)
+    created = await executor.create(binding=_binding(), plaintext=b'secret')
+    with pytest.raises(PermissionError, match='revocation'):
+        await executor.destroy(secret_id=created.secret_id, context=_context(SecretPurpose.READ))
+    await executor.destroy(secret_id=created.secret_id, context=_context(SecretPurpose.REVOKE))
+    assert created.secret_id not in store.records
+
+
+@pytest.mark.asyncio
+async def test_stale_generation_cannot_destroy_secret_even_if_authorizer_allows_it():
+    store = InMemoryCiphertextStore()
+    executor = EnvelopeSecretExecutor(key_wrapper=FakeKeyWrapper(), store=store, authorize=_authorize)
+    created = await executor.create(binding=_binding(), plaintext=b'secret')
+    with pytest.raises(PermissionError, match='generation'):
+        await executor.destroy(
+            secret_id=created.secret_id,
+            context=_context(SecretPurpose.REVOKE, generation=2),
+        )
+    assert created.secret_id in store.records

--- a/backend/tests/unit/test_external_oauth_public_contract.py
+++ b/backend/tests/unit/test_external_oauth_public_contract.py
@@ -1,0 +1,45 @@
+"""Structural containment checks avoid importing the routers' cloud graph."""
+
+import ast
+from pathlib import Path
+
+BACKEND = Path(__file__).resolve().parents[2]
+
+
+def _class_fields(path: Path, class_name: str) -> set[str]:
+    tree = ast.parse(path.read_text(encoding='utf-8'))
+    node = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == class_name)
+    return {
+        statement.target.id
+        for statement in node.body
+        if isinstance(statement, ast.AnnAssign) and isinstance(statement.target, ast.Name)
+    }
+
+
+def test_generic_integration_oauth_write_is_provider_restricted():
+    fields = _class_fields(BACKEND / 'routers' / 'integrations.py', 'IntegrationData')
+    assert {'connected', 'access_token', 'refresh_token'} <= fields
+    source = (BACKEND / 'routers' / 'integrations.py').read_text(encoding='utf-8')
+    save_route = source[source.index('def save_integration') : source.index('def delete_integration')]
+    assert "resolved[1]['kind'] == 'oauth'" in save_route
+    assert 'oauth_integration_requires_authorization_flow' in save_route
+
+
+def test_task_integration_listing_uses_typed_nonsecret_projection():
+    fields = _class_fields(BACKEND / 'routers' / 'task_integrations.py', 'TaskIntegrationStatus')
+    assert fields == {'app_key', 'connected'}
+    source = (BACKEND / 'routers' / 'task_integrations.py').read_text(encoding='utf-8')
+    response_class = source[
+        source.index('class TaskIntegrationsResponse') : source.index('class DefaultTaskIntegrationRequest')
+    ]
+    assert 'access_token' not in response_class
+    assert 'refresh_token' not in response_class
+    assert 'Dict[str, Any]' not in response_class
+
+
+def test_checked_in_production_admission_is_closed():
+    import json
+
+    manifest = json.loads((BACKEND / 'config' / 'external_oauth_admission.json').read_text(encoding='utf-8'))
+    assert manifest['connectors']
+    assert all(entry['enabled'] is False for entry in manifest['connectors'].values())

--- a/backend/utils/external_oauth/__init__.py
+++ b/backend/utils/external_oauth/__init__.py
@@ -1,0 +1,6 @@
+"""Approval-independent outbound OAuth control-plane primitives.
+
+Nothing in this package enables a provider by import. Runtime admission is an
+explicit, fail-closed decision made from the checked-in manifest plus deployed
+evidence.
+"""

--- a/backend/utils/external_oauth/admission.py
+++ b/backend/utils/external_oauth/admission.py
@@ -1,0 +1,97 @@
+"""Fail-closed admission for production OAuth clients and scope evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+from utils.external_oauth.contracts import Connector
+from utils.external_oauth.scopes import GRANT_FAMILIES, SCOPE_REGISTRY_REVISION, scope_digest
+
+
+class AdmissionDenied(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class DeploymentFacts:
+    environment: str
+    project_number: str
+    oauth_client_id: str
+    redirect_uri: str
+
+
+@dataclass(frozen=True)
+class AdmittedClient:
+    connector: Connector
+    project_alias: str
+    client_alias: str
+    redirect_uri: str
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def load_manifest(path: Path) -> Mapping[str, object]:
+    data = json.loads(path.read_text(encoding='utf-8'))
+    if not isinstance(data, dict):
+        raise AdmissionDenied('oauth admission manifest is not an object')
+    return data
+
+
+def admit_connector(
+    manifest: Mapping[str, object], connector: Connector, facts: DeploymentFacts, *, now_iso_date: str
+) -> AdmittedClient:
+    if facts.environment != 'production':
+        raise AdmissionDenied('external OAuth runtime is production-admitted only through explicit evidence')
+    if manifest.get('schema_version') != 1 or manifest.get('scope_registry_revision') != SCOPE_REGISTRY_REVISION:
+        raise AdmissionDenied('oauth admission manifest revision mismatch')
+    connectors = manifest.get('connectors')
+    if not isinstance(connectors, dict):
+        raise AdmissionDenied('oauth admission manifest has no connectors')
+    entry = connectors.get(connector.value)
+    if not isinstance(entry, dict) or entry.get('enabled') is not True:
+        raise AdmissionDenied('connector kill switch is closed')
+
+    required_strings = ('project_alias', 'client_alias', 'project_number_sha256', 'client_id_sha256', 'redirect_uri')
+    if any(not isinstance(entry.get(name), str) or not entry[name] for name in required_strings):
+        raise AdmissionDenied('oauth admission identity evidence is incomplete')
+    expected_alias = GRANT_FAMILIES[connector].client_alias
+    if entry['project_alias'] != expected_alias or entry['client_alias'] != expected_alias:
+        raise AdmissionDenied('oauth project/client alias mismatch')
+    if entry['project_number_sha256'] != _digest(facts.project_number):
+        raise AdmissionDenied('oauth project evidence mismatch')
+    if entry['client_id_sha256'] != _digest(facts.oauth_client_id):
+        raise AdmissionDenied('oauth client evidence mismatch')
+    if entry['redirect_uri'] != facts.redirect_uri:
+        raise AdmissionDenied('oauth redirect evidence mismatch')
+    if entry.get('scope_digest') != scope_digest(GRANT_FAMILIES[connector].scopes):
+        raise AdmissionDenied('oauth scope evidence mismatch')
+
+    verification = entry.get('verification')
+    if not isinstance(verification, dict) or verification.get('approved') is not True:
+        raise AdmissionDenied('Google verification is not proven')
+    if not isinstance(verification.get('evidence_id'), str) or not verification['evidence_id']:
+        raise AdmissionDenied('Google verification evidence is missing')
+    if not isinstance(verification.get('valid_through'), str) or verification['valid_through'] < now_iso_date:
+        raise AdmissionDenied('Google verification evidence is stale')
+
+    if connector == Connector.GMAIL:
+        casa = entry.get('casa')
+        if not isinstance(casa, dict) or casa.get('approved') is not True:
+            raise AdmissionDenied('Gmail CASA is not proven')
+        if not isinstance(casa.get('evidence_id'), str) or not casa['evidence_id']:
+            raise AdmissionDenied('Gmail CASA evidence is missing')
+        if not isinstance(casa.get('valid_through'), str) or casa['valid_through'] < now_iso_date:
+            raise AdmissionDenied('Gmail CASA evidence is stale')
+
+    return AdmittedClient(
+        connector=connector,
+        project_alias=str(entry['project_alias']),
+        client_alias=str(entry['client_alias']),
+        redirect_uri=str(entry['redirect_uri']),
+    )

--- a/backend/utils/external_oauth/authorization.py
+++ b/backend/utils/external_oauth/authorization.py
@@ -1,0 +1,41 @@
+"""Two-authority authorization composition for semantic provider operations."""
+
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+
+from utils.external_oauth.contracts import (
+    Capability,
+    ConnectionState,
+    Connector,
+    ExternalConnectionRepository,
+    SecretLeaseContext,
+    SecretPurpose,
+)
+from utils.external_oauth.scopes import GRANT_FAMILIES
+
+ProductCapabilityCheck = Callable[[str, Capability], Awaitable[bool]]
+
+
+class RepositoryAuthorizationComposer:
+    def __init__(self, *, repository: ExternalConnectionRepository, product_capability_check: ProductCapabilityCheck):
+        self._repository = repository
+        self._product_capability_check = product_capability_check
+
+    async def authorize(
+        self, *, external_owner_id: str, connector: Connector, capability: Capability, operation_id: str
+    ) -> SecretLeaseContext:
+        if GRANT_FAMILIES[connector].capability != capability:
+            raise PermissionError('connector does not implement requested product capability')
+        if not await self._product_capability_check(external_owner_id, capability):
+            raise PermissionError('product capability is not authorized')
+        connection = await self._repository.get(external_owner_id=external_owner_id, connector=connector)
+        if connection is None or connection.state != ConnectionState.ACTIVE:
+            raise PermissionError('provider grant is not active')
+        return SecretLeaseContext(
+            connection_id=connection.connection_id,
+            generation=connection.generation,
+            deletion_epoch=connection.deletion_epoch,
+            operation_id=operation_id,
+            purpose=SecretPurpose.READ,
+        )

--- a/backend/utils/external_oauth/contracts.py
+++ b/backend/utils/external_oauth/contracts.py
@@ -1,0 +1,262 @@
+"""Provider-neutral contracts for delegated external authorization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Awaitable, Callable, Mapping, Optional, Protocol, Sequence, TypeVar
+
+
+class Connector(str, Enum):
+    GOOGLE_CALENDAR = 'google_calendar'
+    GMAIL = 'gmail'
+
+
+class Capability(str, Enum):
+    CALENDAR_EVENTS_READ = 'calendar.events.read'
+    MAIL_MESSAGES_READ = 'mail.messages.read'
+
+
+class ConnectionState(str, Enum):
+    PENDING_CONSENT = 'pending_consent'
+    ACTIVE = 'active'
+    REAUTH_REQUIRED = 'reauth_required'
+    BLOCKED_BY_ADMIN = 'blocked_by_admin'
+    REVOKE_PENDING = 'revoke_pending'
+    REVOCATION_FAILED = 'revocation_failed'
+    DELETION_PENDING = 'deletion_pending'
+    REVOKED = 'revoked'
+    CANCELLED = 'cancelled'
+    EXPIRED = 'expired'
+
+
+class RevocationDisposition(str, Enum):
+    PROVIDER_CONFIRMED_REVOKE = 'provider_confirmed_revoke'
+    PROVIDER_ALREADY_INVALID = 'provider_already_invalid'
+    SECURITY_APPROVED_DECOMMISSION = 'security_approved_decommission'
+    DELETION_DEADLINE_DESTROYED = 'upstream_revoke_unconfirmed_credentials_destroyed'
+
+
+class SecretPurpose(str, Enum):
+    CALLBACK_EXCHANGE = 'callback_exchange'
+    READ = 'read'
+    REFRESH = 'refresh'
+    REVOKE = 'revoke'
+    REWRAP = 'rewrap'
+
+
+class ProviderErrorKind(str, Enum):
+    RETRYABLE = 'retryable'
+    INVALID_GRANT = 'invalid_grant'
+    ADMIN_POLICY = 'admin_policy_enforced'
+    ACCESS_DENIED = 'access_denied'
+    SCOPE_MISMATCH = 'scope_mismatch'
+    ACCOUNT_MISMATCH = 'provider_account_mismatch'
+    CONFIGURATION = 'configuration_error'
+
+
+class ExternalOAuthError(RuntimeError):
+    """Typed, content-free failure safe to classify and count."""
+
+    def __init__(self, kind: ProviderErrorKind, safe_code: str):
+        self.kind = kind
+        self.safe_code = safe_code
+        super().__init__(safe_code)
+
+
+@dataclass(frozen=True)
+class ProviderPrincipal:
+    subject: str
+    masked_identity: str
+
+
+@dataclass(frozen=True)
+class TokenGrant:
+    access_token: bytes
+    refresh_token: Optional[bytes]
+    effective_scopes: frozenset[str]
+    expires_at: Optional[datetime]
+    principal: ProviderPrincipal
+
+
+@dataclass(frozen=True)
+class Connection:
+    connection_id: str
+    external_owner_id: str
+    connector: Connector
+    grant_family: str
+    provider: str
+    client_alias: str
+    state: ConnectionState
+    generation: int
+    scope_registry_revision: str
+    effective_scope_digest: Optional[str] = None
+    provider_subject: Optional[str] = None
+    masked_identity: Optional[str] = None
+    deletion_epoch: int = 0
+    reauth_reason: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ConsentAttempt:
+    attempt_id: str
+    connection_id: str
+    external_owner_id: str
+    state_hash: str
+    connector: Connector
+    client_alias: str
+    requested_scope_digest: str
+    generation: int
+    fixed_return_target_id: str
+    expires_at: datetime
+    encrypted_pkce_verifier_ref: str
+    consumed_at: Optional[datetime] = None
+    terminal_result: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class AttemptConsumeResult:
+    attempt: ConsentAttempt
+    claimed: bool
+
+
+@dataclass(frozen=True)
+class SecretBinding:
+    external_owner_id: str
+    connection_id: str
+    provider: str
+    client_alias: str
+    generation: int
+    secret_version: int
+
+
+@dataclass(frozen=True)
+class SecretLeaseContext:
+    connection_id: str
+    generation: int
+    deletion_epoch: int
+    operation_id: str
+    purpose: SecretPurpose
+
+
+@dataclass(frozen=True)
+class EncryptedSecretVersion:
+    secret_id: str
+    binding: SecretBinding
+    ciphertext: bytes
+    nonce: bytes
+    wrapped_dek: bytes
+    kms_key_version: str
+    aad_digest: str
+    status: str = 'active'
+
+
+@dataclass(frozen=True)
+class AuthorizationStart:
+    authorization_url: str
+    attempt_id: str
+    expires_at: datetime
+
+
+@dataclass(frozen=True)
+class ConnectionStatus:
+    connector: Connector
+    connected: bool
+    state: Optional[ConnectionState]
+    reauth_required: bool = False
+
+
+@dataclass(frozen=True)
+class MailMessage:
+    message_id: str
+    thread_id: str
+    sender: str
+    subject: str
+    snippet: str
+    received_at: datetime
+
+
+@dataclass(frozen=True)
+class CalendarEvent:
+    event_id: str
+    calendar_id: str
+    title: str
+    starts_at: datetime
+    ends_at: datetime
+    attendee_count: int = 0
+
+
+class OAuthProviderPort(Protocol):
+    def authorization_url(self, *, state: str, code_challenge: str, nonce: str) -> str: ...
+
+    async def exchange_code(self, *, code: str, code_verifier: str, expected_nonce: str) -> TokenGrant: ...
+
+    async def refresh(self, *, refresh_token: bytes) -> TokenGrant: ...
+
+    async def revoke(self, *, token: bytes) -> None: ...
+
+
+class ExternalConnectionRepository(Protocol):
+    async def create_pending(self, connection: Connection, attempt: ConsentAttempt) -> None: ...
+
+    async def consume_attempt(self, *, state_hash: str, now: datetime) -> AttemptConsumeResult: ...
+
+    async def finish_attempt(self, state_hash: str, result: str) -> None: ...
+
+    async def activate(
+        self, *, attempt: ConsentAttempt, grant: TokenGrant, effective_scope_digest: str, secret_id: str
+    ) -> Connection: ...
+
+    async def get(self, *, external_owner_id: str, connector: Connector) -> Optional[Connection]: ...
+
+    async def transition(
+        self,
+        *,
+        connection_id: str,
+        generation: int,
+        target: ConnectionState,
+        reason: Optional[str] = None,
+        disposition: Optional[RevocationDisposition] = None,
+        admin_clearance: bool = False,
+    ) -> Connection: ...
+
+
+T = TypeVar('T')
+SecretOperation = Callable[[memoryview], Awaitable[T]]
+
+
+class ExternalSecretExecutor(Protocol):
+    async def create(self, *, binding: SecretBinding, plaintext: bytes) -> EncryptedSecretVersion: ...
+
+    async def with_secret_lease(
+        self, *, secret_id: str, context: SecretLeaseContext, operation: SecretOperation[T]
+    ) -> T: ...
+
+    async def destroy(self, *, secret_id: str, context: SecretLeaseContext) -> None: ...
+
+
+class ExternalAuthorizationComposer(Protocol):
+    async def authorize(
+        self, *, external_owner_id: str, connector: Connector, capability: Capability, operation_id: str
+    ) -> SecretLeaseContext: ...
+
+
+class MailReadPort(Protocol):
+    async def list_messages(self, *, external_owner_id: str, limit: int = 25) -> Sequence[MailMessage]: ...
+
+
+class CalendarReadPort(Protocol):
+    async def list_events(
+        self, *, external_owner_id: str, starts_after: datetime, ends_before: datetime, limit: int = 100
+    ) -> Sequence[CalendarEvent]: ...
+
+
+@dataclass(frozen=True)
+class AuditEvent:
+    event_type: str
+    connection_id: str
+    generation: int
+    operation_id: str
+    occurred_at: datetime
+    attributes: Mapping[str, str] = field(default_factory=dict)

--- a/backend/utils/external_oauth/fake_provider.py
+++ b/backend/utils/external_oauth/fake_provider.py
@@ -1,0 +1,48 @@
+"""Deterministic fake provider for lifecycle and consumer conformance tests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from urllib.parse import urlencode
+
+from utils.external_oauth.contracts import ProviderPrincipal, TokenGrant
+
+
+class FakeOAuthProvider:
+    def __init__(self, *, scopes: frozenset[str], subject: str = 'provider-subject-1'):
+        self.scopes = scopes
+        self.subject = subject
+        self.exchange_count = 0
+        self.refresh_count = 0
+        self.revoke_count = 0
+        self.error: Optional[Exception] = None
+
+    def authorization_url(self, *, state: str, code_challenge: str, nonce: str) -> str:
+        return 'https://provider.invalid/authorize?' + urlencode(
+            {'state': state, 'code_challenge': code_challenge, 'code_challenge_method': 'S256', 'nonce': nonce}
+        )
+
+    def _grant(self, refresh_token: Optional[bytes]) -> TokenGrant:
+        if self.error:
+            raise self.error
+        return TokenGrant(
+            access_token=b'fake-access-token',
+            refresh_token=refresh_token,
+            effective_scopes=self.scopes,
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            principal=ProviderPrincipal(subject=self.subject, masked_identity='u***@example.invalid'),
+        )
+
+    async def exchange_code(self, *, code: str, code_verifier: str, expected_nonce: str) -> TokenGrant:
+        self.exchange_count += 1
+        return self._grant(b'fake-refresh-token')
+
+    async def refresh(self, *, refresh_token: bytes) -> TokenGrant:
+        self.refresh_count += 1
+        return self._grant(None)
+
+    async def revoke(self, *, token: bytes) -> None:
+        if self.error:
+            raise self.error
+        self.revoke_count += 1

--- a/backend/utils/external_oauth/google_reads.py
+++ b/backend/utils/external_oauth/google_reads.py
@@ -1,0 +1,200 @@
+"""Google REST semantic read adapters.
+
+These adapters accept only Omi product vocabulary and return normalized DTOs.
+The provider token is injected inside a purpose-bound secret lease and never
+returned to a route or caller.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime, timezone
+from typing import Any, Mapping, Protocol, Sequence
+
+import httpx
+
+from utils.external_oauth.contracts import (
+    CalendarEvent,
+    Capability,
+    Connector,
+    ExternalAuthorizationComposer,
+    ExternalSecretExecutor,
+    MailMessage,
+)
+
+GMAIL_MESSAGES_URL = 'https://gmail.googleapis.com/gmail/v1/users/me/messages'
+CALENDAR_EVENTS_URL = 'https://www.googleapis.com/calendar/v3/calendars/primary/events'
+MAX_PROVIDER_RESPONSE_BYTES = 2 * 1024 * 1024
+
+
+class CredentialLocator(Protocol):
+    async def active_secret_id(self, *, connection_id: str, generation: int) -> str: ...
+
+
+def _google_datetime(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace('Z', '+00:00'))
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+def _access_token(secret: memoryview) -> str:
+    record = json.loads(bytes(secret))
+    encoded = record.get('access_token')
+    if not isinstance(encoded, str):
+        raise PermissionError('active credential has no access token')
+    return base64.b64decode(encoded, validate=True).decode()
+
+
+def _bounded_json(response: httpx.Response) -> Mapping[str, Any]:
+    if len(response.content) > MAX_PROVIDER_RESPONSE_BYTES:
+        raise ValueError('provider_response_too_large')
+    response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, dict):
+        raise ValueError('provider_response_shape_invalid')
+    return payload
+
+
+class GoogleMailReadAdapter:
+    def __init__(
+        self,
+        *,
+        authorization: ExternalAuthorizationComposer,
+        secrets_executor: ExternalSecretExecutor,
+        credential_locator: CredentialLocator,
+        http: httpx.AsyncClient,
+    ):
+        self._authorization = authorization
+        self._secrets = secrets_executor
+        self._locator = credential_locator
+        self._http = http
+
+    async def list_messages(self, *, external_owner_id: str, limit: int = 25) -> Sequence[MailMessage]:
+        if limit < 1 or limit > 100:
+            raise ValueError('mail limit must be between 1 and 100')
+        context = await self._authorization.authorize(
+            external_owner_id=external_owner_id,
+            connector=Connector.GMAIL,
+            capability=Capability.MAIL_MESSAGES_READ,
+            operation_id=f'mail-list:{external_owner_id}',
+        )
+        secret_id = await self._locator.active_secret_id(
+            connection_id=context.connection_id, generation=context.generation
+        )
+
+        async def execute(secret: memoryview) -> Sequence[MailMessage]:
+            token = _access_token(secret)
+            listing = await self._http.get(
+                GMAIL_MESSAGES_URL,
+                headers={'Authorization': f'Bearer {token}'},
+                params={'maxResults': limit},
+                follow_redirects=False,
+            )
+            refs = _bounded_json(listing).get('messages', [])
+            if not isinstance(refs, list):
+                raise ValueError('provider_response_shape_invalid')
+            messages: list[MailMessage] = []
+            for ref in refs[:limit]:
+                if not isinstance(ref, dict) or not isinstance(ref.get('id'), str):
+                    continue
+                detail = await self._http.get(
+                    f'{GMAIL_MESSAGES_URL}/{ref["id"]}',
+                    headers={'Authorization': f'Bearer {token}'},
+                    params={
+                        'format': 'metadata',
+                        'metadataHeaders': ['From', 'Subject', 'Date'],
+                    },
+                    follow_redirects=False,
+                )
+                payload = _bounded_json(detail)
+                headers = {
+                    item.get('name', '').lower(): item.get('value', '')
+                    for item in payload.get('payload', {}).get('headers', [])
+                    if isinstance(item, dict)
+                }
+                messages.append(
+                    MailMessage(
+                        message_id=str(payload['id']),
+                        thread_id=str(payload.get('threadId', '')),
+                        sender=str(headers.get('from', '')),
+                        subject=str(headers.get('subject', '')),
+                        snippet=str(payload.get('snippet', '')),
+                        received_at=datetime.fromtimestamp(int(payload.get('internalDate', 0)) / 1000, tz=timezone.utc),
+                    )
+                )
+            return messages
+
+        return await self._secrets.with_secret_lease(secret_id=secret_id, context=context, operation=execute)
+
+
+class GoogleCalendarReadAdapter:
+    def __init__(
+        self,
+        *,
+        authorization: ExternalAuthorizationComposer,
+        secrets_executor: ExternalSecretExecutor,
+        credential_locator: CredentialLocator,
+        http: httpx.AsyncClient,
+    ):
+        self._authorization = authorization
+        self._secrets = secrets_executor
+        self._locator = credential_locator
+        self._http = http
+
+    async def list_events(
+        self, *, external_owner_id: str, starts_after: datetime, ends_before: datetime, limit: int = 100
+    ) -> Sequence[CalendarEvent]:
+        if limit < 1 or limit > 250 or starts_after >= ends_before:
+            raise ValueError('invalid calendar read bounds')
+        context = await self._authorization.authorize(
+            external_owner_id=external_owner_id,
+            connector=Connector.GOOGLE_CALENDAR,
+            capability=Capability.CALENDAR_EVENTS_READ,
+            operation_id=f'calendar-list:{external_owner_id}',
+        )
+        secret_id = await self._locator.active_secret_id(
+            connection_id=context.connection_id, generation=context.generation
+        )
+
+        async def execute(secret: memoryview) -> Sequence[CalendarEvent]:
+            token = _access_token(secret)
+            response = await self._http.get(
+                CALENDAR_EVENTS_URL,
+                headers={'Authorization': f'Bearer {token}'},
+                params={
+                    'timeMin': starts_after.isoformat(),
+                    'timeMax': ends_before.isoformat(),
+                    'singleEvents': 'true',
+                    'orderBy': 'startTime',
+                    'maxResults': limit,
+                },
+                follow_redirects=False,
+            )
+            items = _bounded_json(response).get('items', [])
+            if not isinstance(items, list):
+                raise ValueError('provider_response_shape_invalid')
+            events: list[CalendarEvent] = []
+            for item in items[:limit]:
+                if not isinstance(item, dict) or not isinstance(item.get('id'), str):
+                    continue
+                start = item.get('start', {})
+                end = item.get('end', {})
+                starts_at = start.get('dateTime') or start.get('date')
+                ends_at = end.get('dateTime') or end.get('date')
+                if not isinstance(starts_at, str) or not isinstance(ends_at, str):
+                    continue
+                events.append(
+                    CalendarEvent(
+                        event_id=item['id'],
+                        calendar_id='primary',
+                        title=str(item.get('summary', '')),
+                        starts_at=_google_datetime(starts_at),
+                        ends_at=_google_datetime(ends_at),
+                        attendee_count=(
+                            len(item.get('attendees', [])) if isinstance(item.get('attendees', []), list) else 0
+                        ),
+                    )
+                )
+            return events
+
+        return await self._secrets.with_secret_lease(secret_id=secret_id, context=context, operation=execute)

--- a/backend/utils/external_oauth/lifecycle.py
+++ b/backend/utils/external_oauth/lifecycle.py
@@ -1,0 +1,144 @@
+"""Executable external-connection lifecycle and retry policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Mapping
+
+from utils.external_oauth.contracts import ConnectionState, RevocationDisposition
+
+DISCONNECT_RETENTION_DEADLINE = timedelta(days=7)
+ACCOUNT_DELETION_REVOKE_DEADLINE = timedelta(hours=24)
+REVOCATION_RETRY_DELAYS = (
+    timedelta(minutes=1),
+    timedelta(minutes=5),
+    timedelta(minutes=30),
+    timedelta(hours=2),
+    timedelta(hours=6),
+)
+REVOCATION_STEADY_RETRY = timedelta(hours=6)
+REVOCATION_ESCALATION_AFTER = timedelta(hours=2)
+
+TERMINAL_STATES = frozenset({ConnectionState.REVOKED, ConnectionState.CANCELLED, ConnectionState.EXPIRED})
+
+ALLOWED_TRANSITIONS: Mapping[ConnectionState, frozenset[ConnectionState]] = {
+    ConnectionState.PENDING_CONSENT: frozenset(
+        {
+            ConnectionState.ACTIVE,
+            ConnectionState.CANCELLED,
+            ConnectionState.EXPIRED,
+            ConnectionState.DELETION_PENDING,
+        }
+    ),
+    ConnectionState.ACTIVE: frozenset(
+        {
+            ConnectionState.REAUTH_REQUIRED,
+            ConnectionState.BLOCKED_BY_ADMIN,
+            ConnectionState.REVOKE_PENDING,
+            ConnectionState.DELETION_PENDING,
+            ConnectionState.REVOKED,
+        }
+    ),
+    ConnectionState.REAUTH_REQUIRED: frozenset(
+        {
+            ConnectionState.PENDING_CONSENT,
+            ConnectionState.BLOCKED_BY_ADMIN,
+            ConnectionState.REVOKE_PENDING,
+            ConnectionState.DELETION_PENDING,
+            ConnectionState.REVOKED,
+        }
+    ),
+    ConnectionState.BLOCKED_BY_ADMIN: frozenset(
+        {
+            ConnectionState.PENDING_CONSENT,
+            ConnectionState.REVOKE_PENDING,
+            ConnectionState.DELETION_PENDING,
+            ConnectionState.REVOKED,
+        }
+    ),
+    ConnectionState.REVOKE_PENDING: frozenset(
+        {ConnectionState.REVOKED, ConnectionState.REVOCATION_FAILED, ConnectionState.DELETION_PENDING}
+    ),
+    ConnectionState.REVOCATION_FAILED: frozenset({ConnectionState.REVOKE_PENDING, ConnectionState.DELETION_PENDING}),
+    ConnectionState.DELETION_PENDING: frozenset({ConnectionState.DELETION_PENDING, ConnectionState.REVOKED}),
+    ConnectionState.REVOKED: frozenset(),
+    ConnectionState.CANCELLED: frozenset(),
+    ConnectionState.EXPIRED: frozenset(),
+}
+
+
+@dataclass(frozen=True)
+class TransitionDecision:
+    increments_generation: bool
+    secret_use: str
+
+
+def transition_decision(
+    source: ConnectionState,
+    target: ConnectionState,
+    *,
+    disposition: RevocationDisposition | None = None,
+    admin_clearance: bool = False,
+) -> TransitionDecision:
+    if target not in ALLOWED_TRANSITIONS[source]:
+        raise ValueError(f'illegal external connection transition: {source.value}->{target.value}')
+
+    reconnect_dispositions = {
+        RevocationDisposition.PROVIDER_CONFIRMED_REVOKE,
+        RevocationDisposition.PROVIDER_ALREADY_INVALID,
+    }
+    if target == ConnectionState.PENDING_CONSENT:
+        if disposition not in reconnect_dispositions:
+            raise ValueError('reconnect requires terminal disposition of the old grant')
+        if source == ConnectionState.BLOCKED_BY_ADMIN and not admin_clearance:
+            raise ValueError('admin-blocked reconnect requires independent clearance')
+
+    if target == ConnectionState.REVOKED:
+        permitted = {
+            RevocationDisposition.PROVIDER_CONFIRMED_REVOKE,
+            RevocationDisposition.PROVIDER_ALREADY_INVALID,
+            RevocationDisposition.SECURITY_APPROVED_DECOMMISSION,
+        }
+        if source in {
+            ConnectionState.ACTIVE,
+            ConnectionState.REAUTH_REQUIRED,
+            ConnectionState.BLOCKED_BY_ADMIN,
+        }:
+            permitted = {RevocationDisposition.PROVIDER_ALREADY_INVALID}
+        elif source == ConnectionState.DELETION_PENDING:
+            permitted.add(RevocationDisposition.DELETION_DEADLINE_DESTROYED)
+        if disposition not in permitted:
+            raise ValueError('revoked transition requires an allowed terminal disposition')
+
+    fences = target in {
+        ConnectionState.REAUTH_REQUIRED,
+        ConnectionState.BLOCKED_BY_ADMIN,
+        ConnectionState.REVOKE_PENDING,
+        ConnectionState.DELETION_PENDING,
+        ConnectionState.REVOKED,
+        ConnectionState.PENDING_CONSENT,
+    }
+    if source == target == ConnectionState.DELETION_PENDING:
+        fences = False
+    if source == ConnectionState.REAUTH_REQUIRED and target == ConnectionState.BLOCKED_BY_ADMIN:
+        fences = False
+    if target == ConnectionState.ACTIVE:
+        secret_use = 'read_refresh'
+    elif target in {
+        ConnectionState.REVOKE_PENDING,
+        ConnectionState.REVOCATION_FAILED,
+        ConnectionState.DELETION_PENDING,
+    }:
+        secret_use = 'revoke_only'
+    else:
+        secret_use = 'none'
+    return TransitionDecision(increments_generation=fences, secret_use=secret_use)
+
+
+def revocation_retry_delay(attempt: int) -> timedelta:
+    if attempt < 1:
+        raise ValueError('attempt is one-based')
+    if attempt <= len(REVOCATION_RETRY_DELAYS):
+        return REVOCATION_RETRY_DELAYS[attempt - 1]
+    return REVOCATION_STEADY_RETRY

--- a/backend/utils/external_oauth/repository.py
+++ b/backend/utils/external_oauth/repository.py
@@ -1,0 +1,124 @@
+"""Repository fake that executes the production CAS/cardinality contract."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from datetime import datetime
+from typing import Dict, Optional
+
+from utils.external_oauth.contracts import (
+    AttemptConsumeResult,
+    Connection,
+    ConnectionState,
+    Connector,
+    ConsentAttempt,
+    RevocationDisposition,
+    TokenGrant,
+)
+from utils.external_oauth.lifecycle import TERMINAL_STATES, transition_decision
+
+
+class InMemoryExternalConnectionRepository:
+    """Concurrency-capable fake. Firestore implementation must preserve these CAS rules."""
+
+    def __init__(self):
+        self.connections: Dict[str, Connection] = {}
+        self.attempts: Dict[str, ConsentAttempt] = {}
+        self.secret_ids: Dict[str, str] = {}
+        self._lock = asyncio.Lock()
+
+    async def create_pending(self, connection: Connection, attempt: ConsentAttempt) -> None:
+        async with self._lock:
+            key = (connection.external_owner_id, connection.connector, connection.grant_family)
+            for existing in self.connections.values():
+                existing_key = (existing.external_owner_id, existing.connector, existing.grant_family)
+                if existing_key == key and existing.state not in TERMINAL_STATES:
+                    raise ValueError('non-terminal external connection already exists')
+            self.connections[connection.connection_id] = connection
+            self.attempts[attempt.state_hash] = attempt
+
+    async def consume_attempt(self, *, state_hash: str, now: datetime) -> AttemptConsumeResult:
+        async with self._lock:
+            attempt = self.attempts.get(state_hash)
+            if attempt is None or attempt.expires_at <= now:
+                raise ValueError('oauth attempt unavailable')
+            if attempt.consumed_at is not None:
+                return AttemptConsumeResult(attempt=attempt, claimed=False)
+            consumed = replace(attempt, consumed_at=now, terminal_result='exchange_claimed')
+            self.attempts[state_hash] = consumed
+            return AttemptConsumeResult(attempt=consumed, claimed=True)
+
+    async def finish_attempt(self, state_hash: str, result: str) -> None:
+        async with self._lock:
+            self.attempts[state_hash] = replace(self.attempts[state_hash], terminal_result=result)
+
+    async def activate(
+        self, *, attempt: ConsentAttempt, grant: TokenGrant, effective_scope_digest: str, secret_id: str
+    ) -> Connection:
+        async with self._lock:
+            current = self.connections[attempt.connection_id]
+            if current.state != ConnectionState.PENDING_CONSENT or current.generation != attempt.generation:
+                raise ValueError('oauth activation lost generation CAS')
+            if current.provider_subject and current.provider_subject != grant.principal.subject:
+                raise ValueError('provider_account_mismatch')
+            active = replace(
+                current,
+                state=ConnectionState.ACTIVE,
+                provider_subject=grant.principal.subject,
+                masked_identity=grant.principal.masked_identity,
+                effective_scope_digest=effective_scope_digest,
+                reauth_reason=None,
+            )
+            self.connections[current.connection_id] = active
+            self.secret_ids[current.connection_id] = secret_id
+            return active
+
+    async def get(self, *, external_owner_id: str, connector: Connector) -> Optional[Connection]:
+        async with self._lock:
+            matches = [
+                connection
+                for connection in self.connections.values()
+                if connection.external_owner_id == external_owner_id
+                and connection.connector == connector
+                and connection.state not in TERMINAL_STATES
+            ]
+            if len(matches) > 1:
+                raise RuntimeError('external connection cardinality violated')
+            return matches[0] if matches else None
+
+    async def transition(
+        self,
+        *,
+        connection_id: str,
+        generation: int,
+        target: ConnectionState,
+        reason: Optional[str] = None,
+        disposition: Optional[RevocationDisposition] = None,
+        admin_clearance: bool = False,
+    ) -> Connection:
+        async with self._lock:
+            current = self.connections[connection_id]
+            if current.generation != generation:
+                raise ValueError('external connection generation CAS failed')
+            decision = transition_decision(
+                current.state,
+                target,
+                disposition=disposition,
+                admin_clearance=admin_clearance,
+            )
+            updated = replace(
+                current,
+                state=target,
+                generation=current.generation + int(decision.increments_generation),
+                reauth_reason=reason,
+            )
+            self.connections[connection_id] = updated
+            return updated
+
+    async def active_secret_id(self, *, connection_id: str, generation: int) -> str:
+        async with self._lock:
+            connection = self.connections[connection_id]
+            if connection.state != ConnectionState.ACTIVE or connection.generation != generation:
+                raise PermissionError('external connection is not active at requested generation')
+            return self.secret_ids[connection_id]

--- a/backend/utils/external_oauth/scopes.py
+++ b/backend/utils/external_oauth/scopes.py
@@ -1,0 +1,82 @@
+"""Exact capability-to-provider-scope registry and canonicalization."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+from utils.external_oauth.contracts import Capability, Connector, ExternalOAuthError, ProviderErrorKind
+
+SCOPE_REGISTRY_REVISION = 'google-read-v1'
+OPENID = 'openid'
+EMAIL = 'email'
+CALENDAR_EVENTS_READONLY = 'https://www.googleapis.com/auth/calendar.events.readonly'
+GMAIL_READONLY = 'https://www.googleapis.com/auth/gmail.readonly'
+
+
+@dataclass(frozen=True)
+class GrantFamily:
+    connector: Connector
+    client_alias: str
+    grant_family: str
+    capability: Capability
+    scopes: frozenset[str]
+
+
+GRANT_FAMILIES: Mapping[Connector, GrantFamily] = {
+    Connector.GOOGLE_CALENDAR: GrantFamily(
+        connector=Connector.GOOGLE_CALENDAR,
+        client_alias='google_calendar_prod',
+        grant_family='google_calendar_read',
+        capability=Capability.CALENDAR_EVENTS_READ,
+        scopes=frozenset({OPENID, EMAIL, CALENDAR_EVENTS_READONLY}),
+    ),
+    Connector.GMAIL: GrantFamily(
+        connector=Connector.GMAIL,
+        client_alias='google_gmail_prod',
+        grant_family='google_gmail_read',
+        capability=Capability.MAIL_MESSAGES_READ,
+        scopes=frozenset({OPENID, EMAIL, GMAIL_READONLY}),
+    ),
+}
+
+# Google can return canonical URLs or documented aliases. Unknown additions are
+# never ignored: they fail activation so scope expansion cannot happen silently.
+PROVIDER_SCOPE_ALIASES: Mapping[str, str] = {
+    OPENID: OPENID,
+    EMAIL: EMAIL,
+    CALENDAR_EVENTS_READONLY: CALENDAR_EVENTS_READONLY,
+    GMAIL_READONLY: GMAIL_READONLY,
+    'https://www.googleapis.com/auth/userinfo.email': EMAIL,
+}
+
+
+def canonicalize_scopes(scopes: Iterable[str]) -> frozenset[str]:
+    canonical: set[str] = set()
+    unknown: list[str] = []
+    for scope in scopes:
+        normalized = scope.strip()
+        if not normalized:
+            continue
+        mapped = PROVIDER_SCOPE_ALIASES.get(normalized)
+        if mapped is None:
+            unknown.append(normalized)
+        else:
+            canonical.add(mapped)
+    if unknown:
+        raise ExternalOAuthError(ProviderErrorKind.SCOPE_MISMATCH, 'provider_returned_unknown_scope')
+    return frozenset(canonical)
+
+
+def require_exact_scopes(connector: Connector, scopes: Iterable[str]) -> frozenset[str]:
+    effective = canonicalize_scopes(scopes)
+    expected = GRANT_FAMILIES[connector].scopes
+    if effective != expected:
+        raise ExternalOAuthError(ProviderErrorKind.SCOPE_MISMATCH, 'provider_scope_set_mismatch')
+    return effective
+
+
+def scope_digest(scopes: Iterable[str]) -> str:
+    canonical = sorted(canonicalize_scopes(scopes))
+    return hashlib.sha256('\n'.join(canonical).encode()).hexdigest()

--- a/backend/utils/external_oauth/service.py
+++ b/backend/utils/external_oauth/service.py
@@ -1,0 +1,201 @@
+"""Provider-neutral authorization lifecycle orchestration."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from utils.external_oauth.contracts import (
+    AuthorizationStart,
+    Connection,
+    ConnectionState,
+    Connector,
+    ConsentAttempt,
+    ExternalConnectionRepository,
+    ExternalSecretExecutor,
+    OAuthProviderPort,
+    SecretBinding,
+    SecretLeaseContext,
+    SecretPurpose,
+    TokenGrant,
+)
+from utils.external_oauth.scopes import GRANT_FAMILIES, SCOPE_REGISTRY_REVISION, require_exact_scopes, scope_digest
+
+CONSENT_TTL = timedelta(minutes=10)
+
+
+def _state_hash(raw_state: str) -> str:
+    return hashlib.sha256(raw_state.encode()).hexdigest()
+
+
+def _pkce_challenge(verifier: str) -> str:
+    return base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b'=').decode()
+
+
+def _serialize_grant(grant: TokenGrant) -> bytes:
+    return json.dumps(
+        {
+            'access_token': base64.b64encode(grant.access_token).decode(),
+            'refresh_token': base64.b64encode(grant.refresh_token).decode() if grant.refresh_token else None,
+            'expires_at': grant.expires_at.isoformat() if grant.expires_at else None,
+        },
+        separators=(',', ':'),
+    ).encode()
+
+
+class ExternalOAuthService:
+    """Lifecycle logic independent of FastAPI, Firestore, Google, and KMS."""
+
+    def __init__(
+        self,
+        *,
+        repository: ExternalConnectionRepository,
+        secrets_executor: ExternalSecretExecutor,
+        providers: dict[Connector, OAuthProviderPort],
+    ):
+        self._repository = repository
+        self._secrets = secrets_executor
+        self._providers = providers
+
+    async def start(
+        self,
+        *,
+        external_owner_id: str,
+        connector: Connector,
+        fixed_return_target_id: str,
+        now: datetime | None = None,
+    ) -> AuthorizationStart:
+        now = now or datetime.now(timezone.utc)
+        raw_state = secrets.token_urlsafe(32)
+        verifier = secrets.token_urlsafe(64)
+        nonce = secrets.token_urlsafe(32)
+        connection_id = str(uuid.uuid4())
+        attempt_id = str(uuid.uuid4())
+        family = GRANT_FAMILIES[connector]
+        connection = Connection(
+            connection_id=connection_id,
+            external_owner_id=external_owner_id,
+            connector=connector,
+            grant_family=family.grant_family,
+            provider='google',
+            client_alias=family.client_alias,
+            state=ConnectionState.PENDING_CONSENT,
+            generation=1,
+            scope_registry_revision=SCOPE_REGISTRY_REVISION,
+        )
+        pkce_binding = SecretBinding(
+            external_owner_id=external_owner_id,
+            connection_id=connection_id,
+            provider='google',
+            client_alias=family.client_alias,
+            generation=1,
+            secret_version=0,
+        )
+        attempt_secret = json.dumps({'pkce_verifier': verifier, 'oidc_nonce': nonce}, separators=(',', ':')).encode()
+        pkce_secret = await self._secrets.create(binding=pkce_binding, plaintext=attempt_secret)
+        attempt = ConsentAttempt(
+            attempt_id=attempt_id,
+            connection_id=connection_id,
+            external_owner_id=external_owner_id,
+            state_hash=_state_hash(raw_state),
+            connector=connector,
+            client_alias=family.client_alias,
+            requested_scope_digest=scope_digest(family.scopes),
+            generation=1,
+            fixed_return_target_id=fixed_return_target_id,
+            expires_at=now + CONSENT_TTL,
+            encrypted_pkce_verifier_ref=pkce_secret.secret_id,
+        )
+        try:
+            await self._repository.create_pending(connection, attempt)
+        except Exception:
+            cleanup_context = SecretLeaseContext(
+                connection_id=connection_id,
+                generation=1,
+                deletion_epoch=0,
+                operation_id=attempt_id,
+                purpose=SecretPurpose.REVOKE,
+            )
+            await self._secrets.destroy(secret_id=pkce_secret.secret_id, context=cleanup_context)
+            raise
+        url = self._providers[connector].authorization_url(
+            state=raw_state, code_challenge=_pkce_challenge(verifier), nonce=nonce
+        )
+        return AuthorizationStart(authorization_url=url, attempt_id=attempt_id, expires_at=attempt.expires_at)
+
+    async def callback(self, *, raw_state: str, code: str, now: datetime | None = None) -> str:
+        """Consume once and return a sanitized completion class.
+
+        Replays and concurrent losers never exchange a code. They receive the
+        already-sanitized terminal result, or ``callback_already_claimed`` while
+        the winner is still completing.
+        """
+        now = now or datetime.now(timezone.utc)
+        consumed = await self._repository.consume_attempt(state_hash=_state_hash(raw_state), now=now)
+        attempt = consumed.attempt
+        if not consumed.claimed:
+            return attempt.terminal_result or 'callback_already_claimed'
+        context = SecretLeaseContext(
+            connection_id=attempt.connection_id,
+            generation=attempt.generation,
+            deletion_epoch=0,
+            operation_id=attempt.attempt_id,
+            purpose=SecretPurpose.CALLBACK_EXCHANGE,
+        )
+
+        async def exchange(attempt_secret: memoryview) -> TokenGrant:
+            ephemeral = json.loads(bytes(attempt_secret))
+            return await self._providers[attempt.connector].exchange_code(
+                code=code,
+                code_verifier=ephemeral['pkce_verifier'],
+                expected_nonce=ephemeral['oidc_nonce'],
+            )
+
+        cleanup_context = SecretLeaseContext(
+            connection_id=attempt.connection_id,
+            generation=attempt.generation,
+            deletion_epoch=0,
+            operation_id=attempt.attempt_id,
+            purpose=SecretPurpose.REVOKE,
+        )
+        credential_id: str | None = None
+        activated = False
+        try:
+            grant = await self._secrets.with_secret_lease(
+                secret_id=attempt.encrypted_pkce_verifier_ref, context=context, operation=exchange
+            )
+            effective = require_exact_scopes(attempt.connector, grant.effective_scopes)
+            if scope_digest(effective) != attempt.requested_scope_digest:
+                raise ValueError('callback scope binding mismatch')
+            secret_binding = SecretBinding(
+                external_owner_id=attempt.external_owner_id,
+                connection_id=attempt.connection_id,
+                provider='google',
+                client_alias=attempt.client_alias,
+                generation=attempt.generation,
+                secret_version=1,
+            )
+            credential = await self._secrets.create(binding=secret_binding, plaintext=_serialize_grant(grant))
+            credential_id = credential.secret_id
+            await self._repository.activate(
+                attempt=attempt,
+                grant=grant,
+                effective_scope_digest=scope_digest(effective),
+                secret_id=credential.secret_id,
+            )
+            activated = True
+            await self._repository.finish_attempt(attempt.state_hash, 'connected')
+            return 'connected'
+        except Exception:
+            await self._repository.finish_attempt(attempt.state_hash, 'callback_failed')
+            raise
+        finally:
+            # Attempt material is always short-lived. A credential that lost the
+            # activation CAS is also destroyed instead of becoming an orphan.
+            await self._secrets.destroy(secret_id=attempt.encrypted_pkce_verifier_ref, context=cleanup_context)
+            if credential_id is not None and not activated:
+                await self._secrets.destroy(secret_id=credential_id, context=cleanup_context)

--- a/backend/utils/external_oauth/vault.py
+++ b/backend/utils/external_oauth/vault.py
@@ -1,0 +1,134 @@
+"""Application-level envelope-encryption custody with purpose-bound leases.
+
+The executor intentionally has no default KMS or persistence implementation.
+Production construction must inject reviewed adapters; missing adapters cannot
+fall back to plaintext or a local key.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from dataclasses import asdict
+from typing import Awaitable, Callable, Dict, Protocol, TypeVar
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from utils.external_oauth.contracts import (
+    EncryptedSecretVersion,
+    SecretBinding,
+    SecretLeaseContext,
+    SecretOperation,
+    SecretPurpose,
+)
+
+
+class KeyWrapper(Protocol):
+    @property
+    def key_version(self) -> str: ...
+
+    async def wrap(self, dek: bytes) -> bytes: ...
+
+    async def unwrap(self, wrapped_dek: bytes, *, key_version: str) -> bytes: ...
+
+
+class SecretVersionStore(Protocol):
+    async def put(self, secret: EncryptedSecretVersion) -> None: ...
+
+    async def get(self, secret_id: str) -> EncryptedSecretVersion: ...
+
+    async def destroy(self, secret_id: str) -> None: ...
+
+
+LeaseAuthorizer = Callable[[EncryptedSecretVersion, SecretLeaseContext], Awaitable[None]]
+T = TypeVar('T')
+
+
+def binding_aad(binding: SecretBinding) -> bytes:
+    # Stable external_owner_id is deliberately included; mutable Omi UID/email is not.
+    payload = json.dumps(asdict(binding), sort_keys=True, separators=(',', ':')).encode()
+    return b'omi.external-oauth.secret.v1\x00' + payload
+
+
+class EnvelopeSecretExecutor:
+    def __init__(self, *, key_wrapper: KeyWrapper, store: SecretVersionStore, authorize: LeaseAuthorizer):
+        self._key_wrapper = key_wrapper
+        self._store = store
+        self._authorize = authorize
+
+    async def create(self, *, binding: SecretBinding, plaintext: bytes) -> EncryptedSecretVersion:
+        if not plaintext:
+            raise ValueError('refusing to persist an empty external secret')
+        dek = bytearray(os.urandom(32))
+        nonce = os.urandom(12)
+        aad = binding_aad(binding)
+        try:
+            ciphertext = AESGCM(bytes(dek)).encrypt(nonce, plaintext, aad)
+            wrapped_dek = await self._key_wrapper.wrap(bytes(dek))
+        finally:
+            dek[:] = b'\x00' * len(dek)
+        secret = EncryptedSecretVersion(
+            secret_id=str(uuid.uuid4()),
+            binding=binding,
+            ciphertext=ciphertext,
+            nonce=nonce,
+            wrapped_dek=wrapped_dek,
+            kms_key_version=self._key_wrapper.key_version,
+            aad_digest=hashlib.sha256(aad).hexdigest(),
+        )
+        await self._store.put(secret)
+        return secret
+
+    async def with_secret_lease(
+        self, *, secret_id: str, context: SecretLeaseContext, operation: SecretOperation[T]
+    ) -> T:
+        secret = await self._store.get(secret_id)
+        if secret.binding.connection_id != context.connection_id:
+            raise PermissionError('external secret connection is fenced')
+        if secret.binding.generation != context.generation:
+            raise PermissionError('external secret generation is fenced')
+        await self._authorize(secret, context)
+        if secret.status != 'active':
+            raise PermissionError('external secret generation is fenced')
+        if context.purpose == SecretPurpose.REWRAP:
+            raise PermissionError('rewrap does not expose plaintext to an operation')
+        aad = binding_aad(secret.binding)
+        if hashlib.sha256(aad).hexdigest() != secret.aad_digest:
+            raise PermissionError('external secret AAD mismatch')
+        dek = bytearray(await self._key_wrapper.unwrap(secret.wrapped_dek, key_version=secret.kms_key_version))
+        plaintext = bytearray()
+        try:
+            plaintext.extend(AESGCM(bytes(dek)).decrypt(secret.nonce, secret.ciphertext, aad))
+            return await operation(memoryview(plaintext))
+        finally:
+            plaintext[:] = b'\x00' * len(plaintext)
+            dek[:] = b'\x00' * len(dek)
+
+    async def destroy(self, *, secret_id: str, context: SecretLeaseContext) -> None:
+        secret = await self._store.get(secret_id)
+        if secret.binding.connection_id != context.connection_id:
+            raise PermissionError('external secret connection is fenced')
+        if secret.binding.generation != context.generation:
+            raise PermissionError('external secret generation is fenced')
+        await self._authorize(secret, context)
+        if context.purpose != SecretPurpose.REVOKE:
+            raise PermissionError('only a revocation lease may destroy a credential')
+        await self._store.destroy(secret_id)
+
+
+class InMemoryCiphertextStore:
+    """Ciphertext-only fake used by conformance tests; never a runtime default."""
+
+    def __init__(self):
+        self.records: Dict[str, EncryptedSecretVersion] = {}
+
+    async def put(self, secret: EncryptedSecretVersion) -> None:
+        self.records[secret.secret_id] = secret
+
+    async def get(self, secret_id: str) -> EncryptedSecretVersion:
+        return self.records[secret_id]
+
+    async def destroy(self, secret_id: str) -> None:
+        del self.records[secret_id]

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -4065,9 +4065,14 @@ export interface TaskIntegrationMutationResponse {
   status: string;
 }
 
+export interface TaskIntegrationStatus {
+  app_key: string;
+  connected: boolean;
+}
+
 export interface TaskIntegrationsResponse {
   default_app: string | null;
-  integrations: Record<string, unknown>;
+  integrations: Record<string, TaskIntegrationStatus>;
 }
 
 export type TaskIntelligenceFeedbackAction = "do_now" | "later" | "dismiss" | "accept_candidate" | "edit" | "complete";
@@ -5196,6 +5201,7 @@ export interface OmiApiSchemas {
   "TaskGoalLinkImportRequest": TaskGoalLinkImportRequest;
   "TaskIntegrationData": TaskIntegrationData;
   "TaskIntegrationMutationResponse": TaskIntegrationMutationResponse;
+  "TaskIntegrationStatus": TaskIntegrationStatus;
   "TaskIntegrationsResponse": TaskIntegrationsResponse;
   "TaskIntelligenceFeedbackAction": TaskIntelligenceFeedbackAction;
   "TaskIntelligenceFeedbackReason": TaskIntelligenceFeedbackReason;

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -14657,7 +14657,7 @@
         "type": "string"
       },
       "IntegrationData": {
-        "description": "Data for an integration connection",
+        "description": "Compatibility input for integrations without a server OAuth flow.\n\nDeprecated credential fields remain in the released app-client schema, but\nregistered OAuth providers are rejected before any value is persisted.",
         "properties": {
           "access_token": {
             "anyOf": [
@@ -14668,6 +14668,7 @@
                 "type": "null"
               }
             ],
+            "deprecated": true,
             "title": "Access Token"
           },
           "connected": {
@@ -14684,6 +14685,7 @@
                 "type": "null"
               }
             ],
+            "deprecated": true,
             "title": "Refresh Token"
           }
         },
@@ -24802,6 +24804,26 @@
         "title": "TaskIntegrationMutationResponse",
         "type": "object"
       },
+      "TaskIntegrationStatus": {
+        "additionalProperties": false,
+        "description": "Non-secret projection safe for clients, support tooling, and OpenAPI.",
+        "properties": {
+          "app_key": {
+            "title": "App Key",
+            "type": "string"
+          },
+          "connected": {
+            "title": "Connected",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "app_key",
+          "connected"
+        ],
+        "title": "TaskIntegrationStatus",
+        "type": "object"
+      },
       "TaskIntegrationsResponse": {
         "description": "Response containing all task integrations",
         "properties": {
@@ -24818,8 +24840,10 @@
             "title": "Default App"
           },
           "integrations": {
-            "additionalProperties": true,
-            "description": "Map of app_key to connection details",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/TaskIntegrationStatus"
+            },
+            "description": "Map of app_key to non-secret status",
             "title": "Integrations",
             "type": "object"
           }
@@ -47207,7 +47231,7 @@
         ]
       },
       "put": {
-        "description": "Save or update an integration connection.",
+        "description": "Save non-secret state for integrations without server-managed OAuth.\n\nOAuth credentials are accepted only from a provider callback into the\nencrypted control plane. This legacy compatibility route cannot inject or\nreplace a provider token.",
         "operationId": "save_integration_v1_integrations__app_key__put",
         "parameters": [
           {

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -4065,9 +4065,14 @@ export interface TaskIntegrationMutationResponse {
   status: string;
 }
 
+export interface TaskIntegrationStatus {
+  app_key: string;
+  connected: boolean;
+}
+
 export interface TaskIntegrationsResponse {
   default_app: string | null;
-  integrations: Record<string, unknown>;
+  integrations: Record<string, TaskIntegrationStatus>;
 }
 
 export type TaskIntelligenceFeedbackAction = "do_now" | "later" | "dismiss" | "accept_candidate" | "edit" | "complete";
@@ -5196,6 +5201,7 @@ export interface OmiApiSchemas {
   "TaskGoalLinkImportRequest": TaskGoalLinkImportRequest;
   "TaskIntegrationData": TaskIntegrationData;
   "TaskIntegrationMutationResponse": TaskIntegrationMutationResponse;
+  "TaskIntegrationStatus": TaskIntegrationStatus;
   "TaskIntegrationsResponse": TaskIntegrationsResponse;
   "TaskIntelligenceFeedbackAction": TaskIntelligenceFeedbackAction;
   "TaskIntelligenceFeedbackReason": TaskIntelligenceFeedbackReason;

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -4065,9 +4065,14 @@ export interface TaskIntegrationMutationResponse {
   status: string;
 }
 
+export interface TaskIntegrationStatus {
+  app_key: string;
+  connected: boolean;
+}
+
 export interface TaskIntegrationsResponse {
   default_app: string | null;
-  integrations: Record<string, unknown>;
+  integrations: Record<string, TaskIntegrationStatus>;
 }
 
 export type TaskIntelligenceFeedbackAction = "do_now" | "later" | "dismiss" | "accept_candidate" | "edit" | "complete";
@@ -5196,6 +5201,7 @@ export interface OmiApiSchemas {
   "TaskGoalLinkImportRequest": TaskGoalLinkImportRequest;
   "TaskIntegrationData": TaskIntegrationData;
   "TaskIntegrationMutationResponse": TaskIntegrationMutationResponse;
+  "TaskIntegrationStatus": TaskIntegrationStatus;
   "TaskIntegrationsResponse": TaskIntegrationsResponse;
   "TaskIntelligenceFeedbackAction": TaskIntelligenceFeedbackAction;
   "TaskIntelligenceFeedbackReason": TaskIntelligenceFeedbackReason;

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -4065,9 +4065,14 @@ export interface TaskIntegrationMutationResponse {
   status: string;
 }
 
+export interface TaskIntegrationStatus {
+  app_key: string;
+  connected: boolean;
+}
+
 export interface TaskIntegrationsResponse {
   default_app: string | null;
-  integrations: Record<string, unknown>;
+  integrations: Record<string, TaskIntegrationStatus>;
 }
 
 export type TaskIntelligenceFeedbackAction = "do_now" | "later" | "dismiss" | "accept_candidate" | "edit" | "complete";
@@ -5196,6 +5201,7 @@ export interface OmiApiSchemas {
   "TaskGoalLinkImportRequest": TaskGoalLinkImportRequest;
   "TaskIntegrationData": TaskIntegrationData;
   "TaskIntegrationMutationResponse": TaskIntegrationMutationResponse;
+  "TaskIntegrationStatus": TaskIntegrationStatus;
   "TaskIntegrationsResponse": TaskIntegrationsResponse;
   "TaskIntelligenceFeedbackAction": TaskIntelligenceFeedbackAction;
   "TaskIntelligenceFeedbackReason": TaskIntelligenceFeedbackReason;


### PR DESCRIPTION
## Summary

- contain legacy credential exposure by rejecting generic writes for registered OAuth providers and projecting task-integration status through a typed non-secret DTO
- add a provider-neutral external OAuth control-plane contract, executable lifecycle, deterministic fake provider, replay-safe callback orchestration, exact Google scope/grant families, and semantic Gmail/Calendar read adapters
- add application-level AES-256-GCM envelope-encryption custody seams with immutable AAD bindings, purpose/generation-bound leases, and no plaintext/local-key fallback
- add a checked-in production admission manifest that is disabled and empty until exact GCP client, Verification Center, and Gmail CASA evidence is supplied
- document the live-product architecture, migration boundary, tests, rollout gates, and rollback; the legacy migration helper is classification-only and performs no database or cloud writes

## Security and compatibility boundary

- Calendar and Gmail use separate grant families and client aliases; scopes must match the versioned registry exactly after canonicalizing only known Google aliases.
- The old app-client request fields remain deprecated in OpenAPI solely to preserve released-client schema compatibility. Registered OAuth providers are rejected before persistence, so the route cannot inject or replace OAuth credentials.
- The credential executor exposes plaintext only inside a purpose-bound callback, verifies connection and generation independently of the injected authorizer, and zeroes mutable plaintext/DEK buffers on exit.
- Terminal revocation and reconnect transitions require explicit dispositions; admin-blocked reconnect also requires independent clearance.
- No connector is registered with the live app and the production admission kill switches remain closed.

## Validation

- `35 passed`: new external OAuth/admission/vault/lifecycle/read-adapter/public-contract suite
- `52 passed`: pre-hardening relevant existing integration/OAuth regressions
- isolated existing task-integration and Gmail scope-gating regressions passed (`3 passed`, `9 passed`); a combined in-process run demonstrated existing test-module monkeypatch leakage, while the repository runner isolates files
- targeted pyright: `0 errors` (strict warnings remain for dynamically validated provider/manifest JSON)
- app-client OpenAPI export is current and directional compatibility passes against merge-base `0e2bd09785b512842725a6f2a9cdef9c0b239778`
- broad `backend/test.sh` ran the 1,013-file isolated suite for about 16 minutes with no observed failure; it was manually stopped in a pre-existing very-slow `test_mentor_notifications.py` path after reaching 56% of that file, following successful completion of the other emitted shards
- `git diff --check`

## Deliberately not live / required finishing work

- no verified GCP project numbers, OAuth client IDs/redirects, Google verification evidence, or Gmail CASA evidence has been added
- no production Firestore repository, indexes, transactions, immutable audit sink, KMS key/IAM adapter, Secret Manager client-secret adapter, or Data Access logging configuration
- no live Google exchange/OIDC validation adapter or authorization/callback/status route registration
- no durable refresh/revoke workers, account-deletion integration, backup/restore anti-resurrection implementation, or cloud deployment
- no production/legacy database inventory or token migration; existing credentials remain untouched and the documented safe default is revoke plus explicit re-consent
- semantic adapters still require production transport hardening (shared bounded clients, DNS/private-address defenses, typed retry budgets, generation/deletion-epoch result rechecks) before registration

## Rollback

The new subsystem is unreachable and both admission switches are closed, so rollback is to leave it unregistered or revert this commit. If reverting containment, preserve a typed non-secret status response and never reopen generic OAuth token persistence. Close future connector/cohort switches before reverting any registered runtime adapter.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

