### PR TITLE
fix(local-dev): complete Google sign-in against the Auth emulator on LAN

### DIFF
--- a/.github/failure-classes/FC-emulator-authorize-opens-browser.json
+++ b/.github/failure-classes/FC-emulator-authorize-opens-browser.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-emulator-authorize-opens-browser",
+  "violated_contract": "When FIREBASE_AUTH_EMULATOR_HOST is set, /v1/auth/authorize must complete PKCE against the Auth emulator (JSON code or app-scheme redirect) instead of redirecting to Google or Apple. The offline harness has no OAuth client, and iOS will not render the plain-HTTP authorize page, so launching Safari leaves the user on a blank screen. A production deployment without the emulator must reject response_mode=json.",
+  "canonical_prevention": "Gate the emulator completion on FIREBASE_AUTH_EMULATOR_HOST, reject response_mode=json when the emulator is unset, and have the local_dev client skip Safari and GET authorize with response_mode=json. Behavioral tests drive auth_authorize and the JSON-callback helpers without a browser.",
+  "canonical_prevention_artifact": [
+    "backend/routers/auth.py",
+    "backend/tests/unit/test_auth_redirect_uri.py",
+    "app/lib/services/auth_service.dart",
+    "app/test/unit/emulator_authorize_callback_test.dart"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/routers/auth.py",
+    "app/lib/services/auth_service.dart"
+  ],
+  "status": "open"
+}

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -123,6 +123,7 @@ PR CI runs `flutter test` and an analyzer ratchet (`app/scripts/analyze_ratchet.
 ### Auth Methods
 - Google Sign In (`google_sign_in` package)
 - Apple Sign In (`sign_in_with_apple` package, includes PKCE via nonce+sha256)
+- Web OAuth (`USE_WEB_AUTH`) via `/v1/auth/authorize`; `local_dev` completes this against the Firebase Auth emulator without Safari
 - Firebase Auth as the identity layer
 
 ### Request Headers

--- a/app/README.md
+++ b/app/README.md
@@ -47,11 +47,11 @@ Before getting started, make sure your device is connected and unlocked. If you'
 
    `bash setup.sh ios` is the safe local-development path: it uses the local
    API/emulator harness and the `demo-omi-local` Firebase project. For a real
-   iPhone, set `OMI_DEV_HOST` to the Mac's LAN address (RFC 1918, e.g.
-   `192.168.x.x`) before running both `setup.sh ios` and `make dev-up` (export
-   it so both commands see it) — the harness now binds there too, not just the
-   app build. Sign in with Google on the device completes against the Auth
-   emulator; rebuild after changing `OMI_DEV_HOST`.
+   iPhone, set `OMI_DEV_HOST` to the Mac's LAN or Tailscale address (RFC 1918
+   `192.168.x.x` or CGNAT `100.x.x.x`) before running both `setup.sh ios` and
+   `make dev-up` (export it so both commands see it) — the harness now binds
+   there too, not just the app build. Sign in with Google on the device
+   completes against the Auth emulator; rebuild after changing `OMI_DEV_HOST`.
 
    iOS setup requires macOS/Xcode, so Windows developers should use the Android setup path.
 

--- a/app/README.md
+++ b/app/README.md
@@ -47,9 +47,11 @@ Before getting started, make sure your device is connected and unlocked. If you'
 
    `bash setup.sh ios` is the safe local-development path: it uses the local
    API/emulator harness and the `demo-omi-local` Firebase project. For a real
-   iPhone, set `OMI_DEV_HOST` to the Mac's LAN or Tailscale address before
-   running both `setup.sh ios` and `make dev-up` (export it so both commands
-   see it) — the harness now binds there too, not just the app build.
+   iPhone, set `OMI_DEV_HOST` to the Mac's LAN address (RFC 1918, e.g.
+   `192.168.x.x`) before running both `setup.sh ios` and `make dev-up` (export
+   it so both commands see it) — the harness now binds there too, not just the
+   app build. Sign in with Google on the device completes against the Auth
+   emulator; rebuild after changing `OMI_DEV_HOST`.
 
    iOS setup requires macOS/Xcode, so Windows developers should use the Android setup path.
 

--- a/app/ios/Runner/Info-Dev.plist
+++ b/app/ios/Runner/Info-Dev.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>AppGroupIdentifier</key>
-	<string>$(APP_GROUP_IDENTIFIER)</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>daily-summary</string>

--- a/app/ios/Runner/Info-Dev.plist
+++ b/app/ios/Runner/Info-Dev.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AppGroupIdentifier</key>
+	<string>$(APP_GROUP_IDENTIFIER)</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>daily-summary</string>
@@ -142,6 +144,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Omi talks to the development server on your Mac so you can sign in and use the local API.</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Omi uses Bluetooth to connect to your Omi wearable and stream its microphone audio to your phone — for example, to transcribe your meetings into notes and check the device's battery.</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>

--- a/app/lib/providers/auth_provider.dart
+++ b/app/lib/providers/auth_provider.dart
@@ -162,7 +162,7 @@ class AuthenticationProvider extends BaseProvider {
           Env.profile.usesFirebaseAuthEmulator
               ? 'Authentication failed: $e'
               : (globalNavigatorKey.currentContext?.l10n.authenticationFailed ??
-                     'Authentication failed. Please try again.'),
+                    'Authentication failed. Please try again.'),
         );
       }
       setLoadingState(false);

--- a/app/lib/providers/auth_provider.dart
+++ b/app/lib/providers/auth_provider.dart
@@ -158,11 +158,11 @@ class AuthenticationProvider extends BaseProvider {
         }
       } catch (e) {
         Logger.debug('OAuth Google sign in error: $e');
+        final authFailedMsg = globalNavigatorKey.currentContext?.l10n.authenticationFailed;
         AppSnackbar.showSnackbarError(
           Env.profile.usesFirebaseAuthEmulator
               ? 'Authentication failed: $e'
-              : (globalNavigatorKey.currentContext?.l10n.authenticationFailed ??
-                    'Authentication failed. Please try again.'),
+              : authFailedMsg ?? 'Authentication failed. Please try again.',
         );
       }
       setLoadingState(false);

--- a/app/lib/providers/auth_provider.dart
+++ b/app/lib/providers/auth_provider.dart
@@ -162,7 +162,7 @@ class AuthenticationProvider extends BaseProvider {
           Env.profile.usesFirebaseAuthEmulator
               ? 'Authentication failed: $e'
               : (globalNavigatorKey.currentContext?.l10n.authenticationFailed ??
-                    'Authentication failed. Please try again.'),
+                     'Authentication failed. Please try again.'),
         );
       }
       setLoadingState(false);

--- a/app/lib/providers/auth_provider.dart
+++ b/app/lib/providers/auth_provider.dart
@@ -159,7 +159,10 @@ class AuthenticationProvider extends BaseProvider {
       } catch (e) {
         Logger.debug('OAuth Google sign in error: $e');
         AppSnackbar.showSnackbarError(
-          globalNavigatorKey.currentContext?.l10n.authenticationFailed ?? 'Authentication failed. Please try again.',
+          Env.profile.usesFirebaseAuthEmulator
+              ? 'Authentication failed: $e'
+              : (globalNavigatorKey.currentContext?.l10n.authenticationFailed ??
+                    'Authentication failed. Please try again.'),
         );
       }
       setLoadingState(false);

--- a/app/lib/services/auth_service.dart
+++ b/app/lib/services/auth_service.dart
@@ -71,10 +71,33 @@ Future<ProviderLinkResult> resolveProviderCredentialCollision({
   required Future<String?> Function() establishDestination,
 }) async {
   final sourceToken = sourceIsAnonymous ? await captureSourceToken() : null;
-  final anonymousSourceMigration =
-      sourceToken == null ? null : AnonymousSourceMigration(uid: sourceUid, token: sourceToken);
+  final anonymousSourceMigration = sourceToken == null
+      ? null
+      : AnonymousSourceMigration(uid: sourceUid, token: sourceToken);
   final destinationUid = await establishDestination();
   return ProviderLinkResult(destinationUid: destinationUid, anonymousSourceMigration: anonymousSourceMigration);
+}
+
+/// Local-dev authorize calls skip Safari and ask the backend for a JSON code.
+@visibleForTesting
+Uri emulatorJsonAuthorizeUri(Uri authorizeUrl) {
+  return authorizeUrl.replace(queryParameters: {...authorizeUrl.queryParameters, 'response_mode': 'json'});
+}
+
+/// Rebuilds the custom-scheme callback the browser flow would have delivered.
+@visibleForTesting
+String emulatorAuthorizeCallbackUri({required String callbackScheme, required Map<String, dynamic> body}) {
+  final code = body['code'];
+  if (code is! String || code.isEmpty) {
+    throw Exception('No authorization code received');
+  }
+  final state = body['state'];
+  return Uri(
+    scheme: callbackScheme,
+    host: 'auth',
+    path: '/callback',
+    queryParameters: {'code': code, if (state is String && state.isNotEmpty) 'state': state},
+  ).toString();
 }
 
 class AuthService {
@@ -82,11 +105,11 @@ class AuthService {
   static AuthService get instance => _instance;
 
   AuthService._internal()
-      : _tokenGateway = _FirebaseAuthTokenGateway(),
-        _refreshAttemptTimeout = _defaultRefreshAttemptTimeout,
-        _refreshDelay = _defaultRefreshDelay,
-        _recordTelemetry = _recordProductionTelemetry,
-        _telemetryContextProvider = _productionTelemetryContext;
+    : _tokenGateway = _FirebaseAuthTokenGateway(),
+      _refreshAttemptTimeout = _defaultRefreshAttemptTimeout,
+      _refreshDelay = _defaultRefreshDelay,
+      _recordTelemetry = _recordProductionTelemetry,
+      _telemetryContextProvider = _productionTelemetryContext;
 
   @visibleForTesting
   AuthService.forTesting({
@@ -95,11 +118,11 @@ class AuthService {
     Duration? refreshAttemptTimeout,
     AuthTelemetryRecorder? recordTelemetry,
     AuthTelemetryContextProvider? telemetryContextProvider,
-  })  : _tokenGateway = tokenGateway,
-        _refreshAttemptTimeout = refreshAttemptTimeout ?? _defaultRefreshAttemptTimeout,
-        _refreshDelay = refreshDelay ?? _defaultRefreshDelay,
-        _recordTelemetry = recordTelemetry ?? ((eventName, properties) {}),
-        _telemetryContextProvider = telemetryContextProvider ?? (() => const {});
+  }) : _tokenGateway = tokenGateway,
+       _refreshAttemptTimeout = refreshAttemptTimeout ?? _defaultRefreshAttemptTimeout,
+       _refreshDelay = refreshDelay ?? _defaultRefreshDelay,
+       _recordTelemetry = recordTelemetry ?? ((eventName, properties) {}),
+       _telemetryContextProvider = telemetryContextProvider ?? (() => const {});
 
   static const int _maxRefreshAttempts = 3;
 
@@ -144,10 +167,10 @@ class AuthService {
   }
 
   static Map<String, dynamic> _productionTelemetryContext() => {
-        'platform': PlatformManager.instance.platform,
-        'app_version': PlatformManager.instance.appVersion,
-        'release_channel': Env.isTestFlight ? 'testflight' : (F.env == Environment.prod ? 'app_store' : 'dev'),
-      };
+    'platform': PlatformManager.instance.platform,
+    'app_version': PlatformManager.instance.appVersion,
+    'release_channel': Env.isTestFlight ? 'testflight' : (F.env == Environment.prod ? 'app_store' : 'dev'),
+  };
 
   bool isSignedIn() => FirebaseAuth.instance.currentUser != null && !FirebaseAuth.instance.currentUser!.isAnonymous;
 
@@ -483,58 +506,23 @@ class AuthService {
 
       Logger.debug('Starting OAuth flow for provider: $provider');
 
-      final authUrl = Uri.parse('${Env.authApiBaseUrl}v1/auth/authorize').replace(
-        queryParameters: {
-          'provider': provider,
-          'redirect_uri': redirectUri,
-          'state': state,
-          'code_challenge': codeChallenge,
-          'code_challenge_method': 'S256',
-        },
-      ).toString();
+      final authUrl = Uri.parse('${Env.authApiBaseUrl}v1/auth/authorize')
+          .replace(
+            queryParameters: {
+              'provider': provider,
+              'redirect_uri': redirectUri,
+              'state': state,
+              'code_challenge': codeChallenge,
+              'code_challenge_method': 'S256',
+            },
+          )
+          .toString();
 
       Logger.debug('Authorization URL: $authUrl');
 
-      // Set up listeners before launching URL
-      final appLinks = AppLinks();
-      late StreamSubscription linkSubscription;
-      final completer = Completer<String>();
-
-      // Listen via app_links
-      linkSubscription = appLinks.uriLinkStream.listen(
-        (Uri uri) {
-          Logger.debug('Received callback URI via app_links: $uri');
-          if (uri.scheme == callbackScheme && uri.host == 'auth' && uri.path == '/callback') {
-            if (!completer.isCompleted) {
-              linkSubscription.cancel();
-              completer.complete(uri.toString());
-            }
-          }
-        },
-        onError: (error) {
-          Logger.debug('App link error: $error');
-          if (!completer.isCompleted) {
-            linkSubscription.cancel();
-            completer.completeError(error);
-          }
-        },
-      );
-
-      // Now launch the URL
-      final launched = await launchUrl(Uri.parse(authUrl), mode: LaunchMode.inAppBrowserView);
-
-      if (!launched) {
-        linkSubscription.cancel();
-        throw Exception('Failed to launch authentication URL');
-      }
-
-      final result = await completer.future.timeout(
-        const Duration(minutes: 5),
-        onTimeout: () {
-          linkSubscription.cancel();
-          throw Exception('Authentication timeout');
-        },
-      );
+      final result = Env.profile.usesFirebaseAuthEmulator
+          ? await _completeEmulatorAuthorization(authUrl: authUrl, callbackScheme: callbackScheme)
+          : await _launchAuthorizationAndWaitForCallback(authUrl: authUrl, callbackScheme: callbackScheme);
 
       final uri = Uri.parse(result);
       final code = uri.queryParameters['code'];
@@ -566,7 +554,72 @@ class AuthService {
     } catch (e) {
       Logger.debug('OAuth authentication error: $e');
       Logger.handle(e, StackTrace.current, message: 'Authentication failed');
+      if (Env.profile.usesFirebaseAuthEmulator) {
+        rethrow;
+      }
       return null;
+    }
+  }
+
+  Future<String> _completeEmulatorAuthorization({required String authUrl, required String callbackScheme}) async {
+    final response = await http.get(emulatorJsonAuthorizeUri(Uri.parse(authUrl))).timeout(const Duration(seconds: 20));
+    if (response.statusCode != 200) {
+      throw Exception('Emulator authorization failed: ${response.statusCode} ${response.body}');
+    }
+    final decoded = json.decode(response.body);
+    if (decoded is! Map) {
+      throw Exception('Emulator authorization returned an unexpected body');
+    }
+    return emulatorAuthorizeCallbackUri(callbackScheme: callbackScheme, body: Map<String, dynamic>.from(decoded));
+  }
+
+  Future<String> _launchAuthorizationAndWaitForCallback({
+    required String authUrl,
+    required String callbackScheme,
+  }) async {
+    final appLinks = AppLinks();
+    late StreamSubscription linkSubscription;
+    final completer = Completer<String>();
+
+    linkSubscription = appLinks.uriLinkStream.listen(
+      (Uri uri) {
+        Logger.debug('Received callback URI via app_links: $uri');
+        if (uri.scheme == callbackScheme && uri.host == 'auth' && uri.path == '/callback') {
+          if (!completer.isCompleted) {
+            linkSubscription.cancel();
+            completer.complete(uri.toString());
+          }
+        }
+      },
+      onError: (error) {
+        Logger.debug('App link error: $error');
+        if (!completer.isCompleted) {
+          linkSubscription.cancel();
+          completer.completeError(error);
+        }
+      },
+    );
+
+    // SFSafariViewController rejects the plain-HTTP URL used by the local
+    // harness on current iOS. Open local HTTP auth externally; production HTTPS
+    // auth remains inside the app browser and uses the same deep link.
+    final authLaunchMode = authUrl.startsWith('http://') ? LaunchMode.externalApplication : LaunchMode.inAppBrowserView;
+    final launched = await launchUrl(Uri.parse(authUrl), mode: authLaunchMode);
+
+    if (!launched) {
+      linkSubscription.cancel();
+      throw Exception('Failed to launch authentication URL');
+    }
+
+    try {
+      return await completer.future.timeout(
+        const Duration(minutes: 5),
+        onTimeout: () {
+          throw Exception('Authentication timeout');
+        },
+      );
+    } finally {
+      await linkSubscription.cancel();
     }
   }
 
@@ -610,8 +663,12 @@ class AuthService {
     final useCustomToken = Env.useAuthCustomToken;
     final customToken = oauthCredentials['custom_token'];
 
-    // Use custom token if enabled and available
-    if (useCustomToken && customToken != null) {
+    // Local_dev always signs in with an emulator custom token. Real Google/Apple
+    // ID tokens are not issued by the offline harness.
+    if (Env.profile.usesFirebaseAuthEmulator || (useCustomToken && customToken != null)) {
+      if (customToken == null) {
+        throw Exception('Auth emulator requires a Firebase custom token');
+      }
       Logger.debug('Signing in with Firebase custom token from $provider');
       return await FirebaseAuth.instance.signInWithCustomToken(customToken);
     }
@@ -756,13 +813,15 @@ class AuthService {
           Logger.debug('Web platform detected - attempting updateProfile with caution');
 
           // Try with a timeout to prevent hanging
-          await user.updateProfile(displayName: fullName).timeout(
-            const Duration(seconds: 5),
-            onTimeout: () {
-              Logger.debug('updateProfile timed out on web platform');
-              throw TimeoutException('updateProfile timed out', const Duration(seconds: 5));
-            },
-          );
+          await user
+              .updateProfile(displayName: fullName)
+              .timeout(
+                const Duration(seconds: 5),
+                onTimeout: () {
+                  Logger.debug('updateProfile timed out on web platform');
+                  throw TimeoutException('updateProfile timed out', const Duration(seconds: 5));
+                },
+              );
         } else {
           await user.updateProfile(displayName: fullName);
         }
@@ -821,51 +880,23 @@ class AuthService {
 
       Logger.debug('Starting OAuth linking flow for provider: $provider');
 
-      final authUrl = Uri.parse('${Env.authApiBaseUrl}v1/auth/authorize').replace(
-        queryParameters: {
-          'provider': provider,
-          'redirect_uri': redirectUri,
-          'state': state,
-          'code_challenge': codeChallenge,
-          'code_challenge_method': 'S256',
-        },
-      ).toString();
+      final authUrl = Uri.parse('${Env.authApiBaseUrl}v1/auth/authorize')
+          .replace(
+            queryParameters: {
+              'provider': provider,
+              'redirect_uri': redirectUri,
+              'state': state,
+              'code_challenge': codeChallenge,
+              'code_challenge_method': 'S256',
+            },
+          )
+          .toString();
 
       Logger.debug('Authorization URL: $authUrl');
 
-      final launched = await launchUrl(Uri.parse(authUrl), mode: LaunchMode.inAppBrowserView);
-
-      if (!launched) {
-        throw Exception('Failed to launch authentication URL');
-      }
-
-      // Listen for the callback URL using app_links
-      final appLinks = AppLinks();
-      late StreamSubscription linkSubscription;
-      final completer = Completer<String>();
-
-      linkSubscription = appLinks.uriLinkStream.listen(
-        (Uri uri) {
-          Logger.debug('Received callback URI: $uri');
-          if (uri.scheme == callbackScheme && uri.host == 'auth' && uri.path == '/callback') {
-            linkSubscription.cancel();
-            completer.complete(uri.toString());
-          }
-        },
-        onError: (error) {
-          Logger.debug('App link error: $error');
-          linkSubscription.cancel();
-          completer.completeError(error);
-        },
-      );
-
-      final result = await completer.future.timeout(
-        const Duration(minutes: 5),
-        onTimeout: () {
-          linkSubscription.cancel();
-          throw Exception('Authentication timeout');
-        },
-      );
+      final result = Env.profile.usesFirebaseAuthEmulator
+          ? await _completeEmulatorAuthorization(authUrl: authUrl, callbackScheme: callbackScheme)
+          : await _launchAuthorizationAndWaitForCallback(authUrl: authUrl, callbackScheme: callbackScheme);
 
       final uri = Uri.parse(result);
       final code = uri.queryParameters['code'];
@@ -884,6 +915,12 @@ class AuthService {
 
       if (oauthCredentials == null) {
         throw Exception('Failed to exchange code for OAuth credentials');
+      }
+
+      if (Env.profile.usesFirebaseAuthEmulator) {
+        final signedIn = await _signInWithOAuthCredentials(oauthCredentials);
+        await _updateUserPreferences(signedIn, provider);
+        return ProviderLinkResult(destinationUid: signedIn.user?.uid);
       }
 
       // Create Firebase credential

--- a/app/lib/services/auth_service.dart
+++ b/app/lib/services/auth_service.dart
@@ -71,9 +71,8 @@ Future<ProviderLinkResult> resolveProviderCredentialCollision({
   required Future<String?> Function() establishDestination,
 }) async {
   final sourceToken = sourceIsAnonymous ? await captureSourceToken() : null;
-  final anonymousSourceMigration = sourceToken == null
-      ? null
-      : AnonymousSourceMigration(uid: sourceUid, token: sourceToken);
+  final anonymousSourceMigration =
+      sourceToken == null ? null : AnonymousSourceMigration(uid: sourceUid, token: sourceToken);
   final destinationUid = await establishDestination();
   return ProviderLinkResult(destinationUid: destinationUid, anonymousSourceMigration: anonymousSourceMigration);
 }
@@ -105,11 +104,11 @@ class AuthService {
   static AuthService get instance => _instance;
 
   AuthService._internal()
-    : _tokenGateway = _FirebaseAuthTokenGateway(),
-      _refreshAttemptTimeout = _defaultRefreshAttemptTimeout,
-      _refreshDelay = _defaultRefreshDelay,
-      _recordTelemetry = _recordProductionTelemetry,
-      _telemetryContextProvider = _productionTelemetryContext;
+      : _tokenGateway = _FirebaseAuthTokenGateway(),
+        _refreshAttemptTimeout = _defaultRefreshAttemptTimeout,
+        _refreshDelay = _defaultRefreshDelay,
+        _recordTelemetry = _recordProductionTelemetry,
+        _telemetryContextProvider = _productionTelemetryContext;
 
   @visibleForTesting
   AuthService.forTesting({
@@ -118,11 +117,11 @@ class AuthService {
     Duration? refreshAttemptTimeout,
     AuthTelemetryRecorder? recordTelemetry,
     AuthTelemetryContextProvider? telemetryContextProvider,
-  }) : _tokenGateway = tokenGateway,
-       _refreshAttemptTimeout = refreshAttemptTimeout ?? _defaultRefreshAttemptTimeout,
-       _refreshDelay = refreshDelay ?? _defaultRefreshDelay,
-       _recordTelemetry = recordTelemetry ?? ((eventName, properties) {}),
-       _telemetryContextProvider = telemetryContextProvider ?? (() => const {});
+  })  : _tokenGateway = tokenGateway,
+        _refreshAttemptTimeout = refreshAttemptTimeout ?? _defaultRefreshAttemptTimeout,
+        _refreshDelay = refreshDelay ?? _defaultRefreshDelay,
+        _recordTelemetry = recordTelemetry ?? ((eventName, properties) {}),
+        _telemetryContextProvider = telemetryContextProvider ?? (() => const {});
 
   static const int _maxRefreshAttempts = 3;
 
@@ -167,10 +166,10 @@ class AuthService {
   }
 
   static Map<String, dynamic> _productionTelemetryContext() => {
-    'platform': PlatformManager.instance.platform,
-    'app_version': PlatformManager.instance.appVersion,
-    'release_channel': Env.isTestFlight ? 'testflight' : (F.env == Environment.prod ? 'app_store' : 'dev'),
-  };
+        'platform': PlatformManager.instance.platform,
+        'app_version': PlatformManager.instance.appVersion,
+        'release_channel': Env.isTestFlight ? 'testflight' : (F.env == Environment.prod ? 'app_store' : 'dev'),
+      };
 
   bool isSignedIn() => FirebaseAuth.instance.currentUser != null && !FirebaseAuth.instance.currentUser!.isAnonymous;
 
@@ -506,17 +505,15 @@ class AuthService {
 
       Logger.debug('Starting OAuth flow for provider: $provider');
 
-      final authUrl = Uri.parse('${Env.authApiBaseUrl}v1/auth/authorize')
-          .replace(
-            queryParameters: {
-              'provider': provider,
-              'redirect_uri': redirectUri,
-              'state': state,
-              'code_challenge': codeChallenge,
-              'code_challenge_method': 'S256',
-            },
-          )
-          .toString();
+      final authUrl = Uri.parse('${Env.authApiBaseUrl}v1/auth/authorize').replace(
+        queryParameters: {
+          'provider': provider,
+          'redirect_uri': redirectUri,
+          'state': state,
+          'code_challenge': codeChallenge,
+          'code_challenge_method': 'S256',
+        },
+      ).toString();
 
       Logger.debug('Authorization URL: $authUrl');
 
@@ -813,15 +810,13 @@ class AuthService {
           Logger.debug('Web platform detected - attempting updateProfile with caution');
 
           // Try with a timeout to prevent hanging
-          await user
-              .updateProfile(displayName: fullName)
-              .timeout(
-                const Duration(seconds: 5),
-                onTimeout: () {
-                  Logger.debug('updateProfile timed out on web platform');
-                  throw TimeoutException('updateProfile timed out', const Duration(seconds: 5));
-                },
-              );
+          await user.updateProfile(displayName: fullName).timeout(
+            const Duration(seconds: 5),
+            onTimeout: () {
+              Logger.debug('updateProfile timed out on web platform');
+              throw TimeoutException('updateProfile timed out', const Duration(seconds: 5));
+            },
+          );
         } else {
           await user.updateProfile(displayName: fullName);
         }
@@ -880,17 +875,15 @@ class AuthService {
 
       Logger.debug('Starting OAuth linking flow for provider: $provider');
 
-      final authUrl = Uri.parse('${Env.authApiBaseUrl}v1/auth/authorize')
-          .replace(
-            queryParameters: {
-              'provider': provider,
-              'redirect_uri': redirectUri,
-              'state': state,
-              'code_challenge': codeChallenge,
-              'code_challenge_method': 'S256',
-            },
-          )
-          .toString();
+      final authUrl = Uri.parse('${Env.authApiBaseUrl}v1/auth/authorize').replace(
+        queryParameters: {
+          'provider': provider,
+          'redirect_uri': redirectUri,
+          'state': state,
+          'code_challenge': codeChallenge,
+          'code_challenge_method': 'S256',
+        },
+      ).toString();
 
       Logger.debug('Authorization URL: $authUrl');
 

--- a/app/scripts/generate_ios_dev_info_plist.sh
+++ b/app/scripts/generate_ios_dev_info_plist.sh
@@ -18,4 +18,5 @@ cp "$SOURCE_PLIST" "$OUTPUT_PLIST"
 # NSAllowsLocalNetworking and silently reverted the CGNAT fix on every run.
 /usr/libexec/PlistBuddy -c 'Add :NSAppTransportSecurity dict' "$OUTPUT_PLIST"
 /usr/libexec/PlistBuddy -c 'Add :NSAppTransportSecurity:NSAllowsArbitraryLoads bool true' "$OUTPUT_PLIST"
+/usr/libexec/PlistBuddy -c 'Add :NSLocalNetworkUsageDescription string Omi talks to the development server on your Mac so you can sign in and use the local API.' "$OUTPUT_PLIST"
 plutil -lint "$OUTPUT_PLIST" >/dev/null

--- a/app/test/shell/ios_dev_ats_config_test.sh
+++ b/app/test/shell/ios_dev_ats_config_test.sh
@@ -54,6 +54,13 @@ else
   pass "output does not declare NSAllowsLocalNetworking"
 fi
 
+usage=$(/usr/libexec/PlistBuddy -c 'Print :NSLocalNetworkUsageDescription' "$work/Info-Dev.plist" 2>/dev/null || true)
+if [[ -n "$usage" ]]; then
+  pass "output declares NSLocalNetworkUsageDescription (LAN device prompt)"
+else
+  fail "output is missing NSLocalNetworkUsageDescription — iOS will not prompt for local-network access to a LAN harness"
+fi
+
 rm -rf "$work"
 
 echo

--- a/app/test/unit/emulator_authorize_callback_test.dart
+++ b/app/test/unit/emulator_authorize_callback_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/env/environment_profile.dart';
+import 'package:omi/services/auth_service.dart';
+
+void main() {
+  test('local_dev asks the backend for a JSON authorize code instead of Safari', () {
+    expect(AppEnvironmentProfile.localDev.usesFirebaseAuthEmulator, isTrue);
+    expect(AppEnvironmentProfile.production.usesFirebaseAuthEmulator, isFalse);
+
+    final authorize = Uri.parse('http://192.168.1.20:8000/v1/auth/authorize').replace(
+      queryParameters: {
+        'provider': 'google',
+        'redirect_uri': 'omi-dev://auth/callback',
+        'state': 'abc',
+        'code_challenge': 'challenge',
+        'code_challenge_method': 'S256',
+      },
+    );
+
+    expect(emulatorJsonAuthorizeUri(authorize).queryParameters['response_mode'], 'json');
+  });
+
+  test('emulator JSON authorize response rebuilds the custom-scheme callback', () {
+    expect(
+      emulatorAuthorizeCallbackUri(callbackScheme: 'omi-dev', body: {'code': 'auth-code', 'state': 'abc'}),
+      'omi-dev://auth/callback?code=auth-code&state=abc',
+    );
+  });
+
+  test('emulator JSON authorize response without a code fails closed', () {
+    expect(
+      () => emulatorAuthorizeCallbackUri(callbackScheme: 'omi-dev', body: {'state': 'abc'}),
+      throwsA(isA<Exception>()),
+    );
+  });
+}

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -448,7 +448,6 @@ async def auth_authorize(
     # page — both would leave the user on a blank screen.
     if _auth_emulator_active():
         auth_code = await _issue_emulator_auth_code(session_data)
-        app_redirect_uri = session_data.get("redirect_uri", _DEFAULT_MOBILE_REDIRECT)
         _log_auth_event(
             provider=provider,
             stage="auth_code_created",
@@ -464,10 +463,8 @@ async def auth_authorize(
             redirect_scheme=redirect_scheme,
         )
         if normalized_response_mode == "json":
-            return JSONResponse({"code": auth_code, "state": session_data.get("state") or ""})
-        return RedirectResponse(
-            url=_build_callback_redirect_url(app_redirect_uri, auth_code, session_data.get("state"))
-        )
+            return JSONResponse({"code": auth_code, "state": state or ""})
+        return RedirectResponse(url=_build_callback_redirect_url(redirect_uri, auth_code, state))
 
     # Redirect to provider OAuth
     if provider == 'google':

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -11,7 +11,7 @@ from urllib.parse import quote, urlencode, urlparse, urlsplit, urlunsplit
 from cryptography.hazmat.primitives import serialization
 from jwt.algorithms import RSAAlgorithm
 from fastapi import APIRouter, Request, HTTPException, Form
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 import pathlib
 import firebase_admin.auth
@@ -235,6 +235,39 @@ def _redirect_scheme(redirect_uri: Optional[str]) -> str:
     return (urlparse(redirect_uri).scheme or "missing").lower()[:64]
 
 
+def _auth_emulator_active() -> bool:
+    return bool(os.environ.get("FIREBASE_AUTH_EMULATOR_HOST", "").strip())
+
+
+def _emulator_oauth_credentials(provider: str) -> str:
+    return json.dumps(
+        {
+            "provider": provider,
+            "id_token": "emulator",
+            "access_token": "emulator",
+            "provider_id": "emulator.local",
+            "emulator": True,
+            "email": f"{provider}-local@omi.test",
+            "full_name": "Local Dev",
+        }
+    )
+
+
+async def _issue_emulator_auth_code(session_data: Dict[str, Any]) -> str:
+    """Mint a one-time auth code without contacting Google or Apple.
+
+    The local harness has no OAuth client secrets and iOS will not render the
+    HTTP authorize page, so local_dev completes the PKCE loop against the
+    Firebase Auth emulator instead.
+    """
+    provider = session_data.get("provider") or "google"
+    auth_code = str(uuid.uuid4())
+    app_redirect_uri = session_data.get("redirect_uri", _DEFAULT_MOBILE_REDIRECT)
+    code_data = _auth_code_data_from_session(_emulator_oauth_credentials(provider), app_redirect_uri, session_data)
+    await run_blocking(critical_executor, set_auth_code, auth_code, code_data, 300)
+    return auth_code
+
+
 def _build_callback_redirect_url(redirect_uri: str, code: str, state: Optional[str]) -> str:
     """Append the one-time callback parameters without losing a URI fragment.
 
@@ -321,6 +354,7 @@ async def auth_authorize(
     state: Optional[str] = None,
     code_challenge: Optional[str] = None,
     code_challenge_method: Optional[str] = None,
+    response_mode: Optional[str] = None,
 ):
     """
     User authentication authorization endpoint for the main Omi app
@@ -345,6 +379,28 @@ async def auth_authorize(
             redirect_scheme=redirect_scheme,
         )
         raise HTTPException(status_code=400, detail="Unsupported provider")
+
+    normalized_response_mode = (response_mode or "").strip().lower()
+    if normalized_response_mode not in {"", "json"}:
+        _log_auth_event(
+            provider=provider,
+            stage="authorize_validated",
+            outcome="failed",
+            auth_flow_id=auth_flow_id,
+            failure_class="unsupported_response_mode",
+            redirect_scheme=redirect_scheme,
+        )
+        raise HTTPException(status_code=400, detail="Unsupported response_mode")
+    if normalized_response_mode == "json" and not _auth_emulator_active():
+        _log_auth_event(
+            provider=provider,
+            stage="authorize_validated",
+            outcome="failed",
+            auth_flow_id=auth_flow_id,
+            failure_class="emulator_response_mode_without_emulator",
+            redirect_scheme=redirect_scheme,
+        )
+        raise HTTPException(status_code=400, detail="response_mode=json requires the Firebase Auth emulator")
 
     # Strict allowlist on where we'll deliver the auth code post-callback.
     try:
@@ -385,6 +441,33 @@ async def auth_authorize(
         auth_flow_id=auth_flow_id,
         redirect_scheme=redirect_scheme,
     )
+
+    # Local harness: complete PKCE against the Auth emulator instead of
+    # redirecting to Google/Apple. The offline child env has no OAuth client
+    # ID, and iOS Safari View Controller will not render the HTTP authorize
+    # page — both would leave the user on a blank screen.
+    if _auth_emulator_active():
+        auth_code = await _issue_emulator_auth_code(session_data)
+        app_redirect_uri = session_data.get("redirect_uri", _DEFAULT_MOBILE_REDIRECT)
+        _log_auth_event(
+            provider=provider,
+            stage="auth_code_created",
+            outcome="succeeded",
+            auth_flow_id=auth_flow_id,
+            redirect_scheme=redirect_scheme,
+        )
+        _log_auth_event(
+            provider=provider,
+            stage="authorize_redirect_created",
+            outcome="succeeded",
+            auth_flow_id=auth_flow_id,
+            redirect_scheme=redirect_scheme,
+        )
+        if normalized_response_mode == "json":
+            return JSONResponse({"code": auth_code, "state": session_data.get("state") or ""})
+        return RedirectResponse(
+            url=_build_callback_redirect_url(app_redirect_uri, auth_code, session_data.get("state"))
+        )
 
     # Redirect to provider OAuth
     if provider == 'google':
@@ -729,12 +812,16 @@ async def auth_token(
                     auth_flow_id=auth_flow_id,
                     redirect_scheme=redirect_scheme,
                 )
-                custom_token = await _generate_custom_token(
-                    provider,
-                    id_token,
-                    access_token,
-                    display_name=full_name,
-                    referral_code=referral_code,
+                custom_token = (
+                    await _generate_emulator_custom_token(oauth_credentials)
+                    if oauth_credentials.get("emulator")
+                    else await _generate_custom_token(
+                        provider,
+                        id_token,
+                        access_token,
+                        display_name=full_name,
+                        referral_code=referral_code,
+                    )
                 )
                 response["custom_token"] = custom_token
                 _log_auth_event(
@@ -1049,6 +1136,27 @@ async def _exchange_apple_code_for_oauth_credentials(code: str, session_data: Di
             status_code=500,
         )
         raise HTTPException(status_code=500, detail="Failed to exchange Apple code for tokens")
+
+
+async def _generate_emulator_custom_token(oauth_credentials: Dict[str, Any]) -> str:
+    """Mint a Firebase custom token for a stable local-dev emulator user."""
+    if not _auth_emulator_active():
+        raise Exception("Auth emulator is not configured")
+
+    provider = oauth_credentials.get("provider") or "google"
+    uid = f"local-{provider}"
+    email = oauth_credentials.get("email") or f"{provider}-local@omi.test"
+    display_name = oauth_credentials.get("full_name") or "Local Dev"
+
+    def _mint() -> str:
+        try:
+            firebase_admin.auth.get_user(uid)
+        except firebase_admin.auth.UserNotFoundError:
+            firebase_admin.auth.create_user(uid=uid, email=email, display_name=display_name)
+        token = firebase_admin.auth.create_custom_token(uid)
+        return token.decode("utf-8") if isinstance(token, bytes) else cast(str, token)
+
+    return await run_blocking(critical_executor, _mint)
 
 
 async def _generate_custom_token(

--- a/backend/tests/unit/test_auth_redirect_uri.py
+++ b/backend/tests/unit/test_auth_redirect_uri.py
@@ -79,6 +79,16 @@ firebase_admin_stub.__path__ = []
 firebase_auth_stub = _install_module("firebase_admin.auth")
 firebase_auth_stub.verify_id_token = MagicMock()
 
+
+class _UserNotFoundError(Exception):
+    pass
+
+
+firebase_auth_stub.UserNotFoundError = _UserNotFoundError
+firebase_auth_stub.get_user = MagicMock()
+firebase_auth_stub.create_user = MagicMock()
+firebase_auth_stub.create_custom_token = MagicMock(return_value=b"emulator-custom-token")
+
 jwt_stub = _install_module("jwt")
 jwt_stub.__path__ = []
 jwt_stub.encode = MagicMock(return_value="test-jwt")
@@ -226,6 +236,7 @@ def test_default_omi_redirect_unchanged() -> None:
 # at /v1/auth/token exchange time (#7020)
 # ---------------------------------------------------------------------------
 
+from fastapi.responses import JSONResponse, RedirectResponse
 from unittest.mock import AsyncMock
 
 from routers.auth import (  # noqa: E402
@@ -239,6 +250,11 @@ from routers.auth import (  # noqa: E402
 
 _PKCE_VERIFIER = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
 _PKCE_CHALLENGE = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+
+@pytest.fixture(autouse=True)
+def _clear_auth_emulator_host(monkeypatch):
+    monkeypatch.delenv("FIREBASE_AUTH_EMULATOR_HOST", raising=False)
 
 
 class TestPkceBinding:
@@ -830,3 +846,127 @@ class TestTokenEdgeCases:
                 )
             )
         assert exc_info.value.status_code == 400
+
+
+class TestEmulatorAuthorize:
+    """Local_dev completes PKCE against the Auth emulator — no Google client ID."""
+
+    def test_json_mode_rejected_without_emulator(self, monkeypatch):
+        import asyncio
+
+        monkeypatch.delenv("FIREBASE_AUTH_EMULATOR_HOST", raising=False)
+        request = MagicMock()
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.get_event_loop().run_until_complete(
+                auth_authorize(
+                    request=request,
+                    provider="google",
+                    redirect_uri="omi-dev://auth/callback",
+                    state="state",
+                    code_challenge=_PKCE_CHALLENGE,
+                    code_challenge_method="S256",
+                    response_mode="json",
+                )
+            )
+        assert exc_info.value.status_code == 400
+        assert "emulator" in exc_info.value.detail.lower()
+
+    def test_json_mode_returns_code_when_emulator_active(self, monkeypatch):
+        import asyncio
+
+        monkeypatch.setenv("FIREBASE_AUTH_EMULATOR_HOST", "127.0.0.1:9099")
+        request = MagicMock()
+        request.cookies.get.return_value = None
+        with patch("routers.auth.set_auth_session"), patch("routers.auth.set_auth_code") as mock_set_code, patch(
+            "routers.auth._google_auth_redirect",
+            new_callable=AsyncMock,
+        ) as google:
+            result = asyncio.get_event_loop().run_until_complete(
+                auth_authorize(
+                    request=request,
+                    provider="google",
+                    redirect_uri="omi-dev://auth/callback",
+                    state="flow1",
+                    code_challenge=_PKCE_CHALLENGE,
+                    code_challenge_method="S256",
+                    response_mode="json",
+                )
+            )
+        google.assert_not_called()
+        assert isinstance(result, JSONResponse)
+        body = json.loads(result.body)
+        assert body["state"] == "flow1"
+        assert isinstance(body["code"], str) and body["code"]
+        mock_set_code.assert_called_once()
+
+    def test_emulator_redirects_to_app_scheme_without_google(self, monkeypatch):
+        import asyncio
+
+        monkeypatch.setenv("FIREBASE_AUTH_EMULATOR_HOST", "127.0.0.1:9099")
+        request = MagicMock()
+        request.cookies.get.return_value = None
+        with patch("routers.auth.set_auth_session"), patch("routers.auth.set_auth_code"), patch(
+            "routers.auth._google_auth_redirect",
+            new_callable=AsyncMock,
+        ) as google:
+            result = asyncio.get_event_loop().run_until_complete(
+                auth_authorize(
+                    request=request,
+                    provider="google",
+                    redirect_uri="omi-dev://auth/callback",
+                    state="flow2",
+                    code_challenge=_PKCE_CHALLENGE,
+                    code_challenge_method="S256",
+                )
+            )
+        google.assert_not_called()
+        assert isinstance(result, RedirectResponse)
+        location = result.headers["location"]
+        assert location.startswith("omi-dev://auth/callback")
+        assert "code=" in location
+        assert "state=flow2" in location
+
+    def test_token_mints_emulator_custom_token(self, monkeypatch):
+        import asyncio
+
+        monkeypatch.setenv("FIREBASE_AUTH_EMULATOR_HOST", "127.0.0.1:9099")
+        code_data = json.dumps(
+            {
+                "credentials": json.dumps(
+                    {
+                        "provider": "google",
+                        "id_token": "emulator",
+                        "access_token": "emulator",
+                        "provider_id": "emulator.local",
+                        "emulator": True,
+                        "email": "google-local@omi.test",
+                    }
+                ),
+                "redirect_uri": "omi-dev://auth/callback",
+                "code_challenge": _PKCE_CHALLENGE,
+                "code_challenge_method": "S256",
+            }
+        )
+        request = MagicMock()
+        with patch("routers.auth.get_auth_code", return_value=code_data), patch("routers.auth.delete_auth_code"), patch(
+            "routers.auth._generate_emulator_custom_token",
+            new_callable=AsyncMock,
+            return_value="emu-custom-token",
+        ) as mint, patch(
+            "routers.auth._generate_custom_token",
+            new_callable=AsyncMock,
+        ) as google_mint:
+            result = asyncio.get_event_loop().run_until_complete(
+                auth_token(
+                    request=request,
+                    grant_type="authorization_code",
+                    code="c",
+                    redirect_uri="omi-dev://auth/callback",
+                    use_custom_token=True,
+                    code_verifier=_PKCE_VERIFIER,
+                )
+            )
+        google_mint.assert_not_called()
+        mint.assert_called_once()
+        assert result["custom_token"] == "emu-custom-token"
+        assert result["provider"] == "google"

--- a/docs/doc/developer/AppSetup.mdx
+++ b/docs/doc/developer/AppSetup.mdx
@@ -149,15 +149,15 @@ data requires the explicit `beta` profile (see [Mobile beta](https://github.com/
 <Tip>
 The automatic setup runs entirely on your machine — local API, local emulators,
 no production data — making it the fastest way to start building apps and making
-changes. On a physical iPhone, set `OMI_DEV_HOST` to your Mac's LAN address
-(RFC 1918, e.g. `192.168.x.x`) before running both `setup.sh ios` and
-`make dev-up` (in the same shell, or exported so both commands see it) — this
-now makes the harness itself listen there too, not just the app you build.
-Only a private address works; a public address is rejected. Use
-`OMI_DEV_BIND_HOST` instead if you want the harness to bind a different address
-than the one the app is compiled to reach. Sign in with Google on the device
-completes against the Auth emulator (no Safari, no Google OAuth client).
-Rebuild the app after changing `OMI_DEV_HOST`.
+changes. On a physical iPhone, set `OMI_DEV_HOST` to your Mac's LAN or
+Tailscale address (RFC 1918 `192.168.x.x` or CGNAT `100.x.x.x`) before
+running both `setup.sh ios` and `make dev-up` (in the same shell, or exported
+so both commands see it) — this now makes the harness itself listen there too,
+not just the app you build. Only a private address works; a public address is
+rejected. Use `OMI_DEV_BIND_HOST` instead if you want the harness to bind a
+different address than the one the app is compiled to reach. Sign in with
+Google on the device completes against the Auth emulator (no Safari, no Google
+OAuth client). Rebuild the app after changing `OMI_DEV_HOST`.
 </Tip>
 
 ---
@@ -333,12 +333,12 @@ ln -s -f ../../scripts/pre-commit .git/hooks/pre-commit
     Run `make dev-up` from the repo root first, and confirm with `make dev-status`.
 
     On a physical device, `127.0.0.1` is the phone — set `OMI_DEV_HOST` to your
-    Mac's LAN address (RFC 1918, e.g. `192.168.x.x`) before running **both**
-    `setup.sh` (so the build points at your machine) and `make dev-up` (so the
-    harness actually listens there — it defaults to loopback-only otherwise,
-    which is why a device build alone used to reach nothing). Export it in the
-    same shell so both commands see it. The Android emulator uses `10.0.2.2`
-    by default.
+    Mac's LAN or Tailscale address (RFC 1918 `192.168.x.x` or CGNAT
+    `100.x.x.x`) before running **both** `setup.sh` (so the build points at
+    your machine) and `make dev-up` (so the harness actually listens there —
+    it defaults to loopback-only otherwise, which is why a device build alone
+    used to reach nothing). Export it in the same shell so both commands see
+    it. The Android emulator uses `10.0.2.2` by default.
   </Accordion>
   <Accordion title="Sign in with Google shows a blank Safari screen" icon="globe">
     The local harness has no Google OAuth client, and iOS will not render the

--- a/docs/doc/developer/AppSetup.mdx
+++ b/docs/doc/developer/AppSetup.mdx
@@ -149,13 +149,15 @@ data requires the explicit `beta` profile (see [Mobile beta](https://github.com/
 <Tip>
 The automatic setup runs entirely on your machine — local API, local emulators,
 no production data — making it the fastest way to start building apps and making
-changes. On a physical iPhone, set `OMI_DEV_HOST` to your Mac's LAN or Tailscale
-address before running both `setup.sh ios` and `make dev-up` (in the same shell,
-or exported so both commands see it) — this now makes the harness itself listen
-there too, not just the app you build. Only a private address works (LAN, e.g.
-`192.168.x.x`, or Tailscale/CGNAT, e.g. `100.x.x.x`); a public address is
-rejected. Use `OMI_DEV_BIND_HOST` instead if you want the harness to bind a
-different address than the one the app is compiled to reach.
+changes. On a physical iPhone, set `OMI_DEV_HOST` to your Mac's LAN address
+(RFC 1918, e.g. `192.168.x.x`) before running both `setup.sh ios` and
+`make dev-up` (in the same shell, or exported so both commands see it) — this
+now makes the harness itself listen there too, not just the app you build.
+Only a private address works; a public address is rejected. Use
+`OMI_DEV_BIND_HOST` instead if you want the harness to bind a different address
+than the one the app is compiled to reach. Sign in with Google on the device
+completes against the Auth emulator (no Safari, no Google OAuth client).
+Rebuild the app after changing `OMI_DEV_HOST`.
 </Tip>
 
 ---
@@ -331,11 +333,23 @@ ln -s -f ../../scripts/pre-commit .git/hooks/pre-commit
     Run `make dev-up` from the repo root first, and confirm with `make dev-status`.
 
     On a physical device, `127.0.0.1` is the phone — set `OMI_DEV_HOST` to your
-    Mac's LAN or Tailscale address before running **both** `setup.sh` (so the
-    build points at your machine) and `make dev-up` (so the harness actually
-    listens there — it defaults to loopback-only otherwise, which is why a
-    device build alone used to reach nothing). Export it in the same shell so
-    both commands see it. The Android emulator uses `10.0.2.2` by default.
+    Mac's LAN address (RFC 1918, e.g. `192.168.x.x`) before running **both**
+    `setup.sh` (so the build points at your machine) and `make dev-up` (so the
+    harness actually listens there — it defaults to loopback-only otherwise,
+    which is why a device build alone used to reach nothing). Export it in the
+    same shell so both commands see it. The Android emulator uses `10.0.2.2`
+    by default.
+  </Accordion>
+  <Accordion title="Sign in with Google shows a blank Safari screen" icon="globe">
+    The local harness has no Google OAuth client, and iOS will not render the
+    plain-HTTP `/v1/auth/authorize` page in an in-app Safari view. `local_dev`
+    completes Google sign-in against the Firebase Auth emulator over HTTP
+    instead. Confirm `OMI_APP_PROFILE=local_dev`, the harness is up with
+    `OMI_DEV_HOST` set, and the app was rebuilt after that change.
+
+    Two Home Screen icons can both be named **Omi Dev**. Open the one built
+    against the current `OMI_DEV_HOST`; an older install still opens Safari
+    against a backend the phone cannot reach.
   </Accordion>
   <Accordion title="Sign-in works but every request returns 401" icon="triangle-exclamation">
     The app and the backend are on **different Firebase projects**. Firebase ID


### PR DESCRIPTION
## Summary

- `local_dev` Google sign-in on a physical iPhone no longer opens Safari against plain-HTTP `/v1/auth/authorize` (blank page; offline harness has no Google client). The app asks for `response_mode=json`, exchanges the PKCE code, and signs in with an Auth-emulator custom token.
- Document the physical-device path as **LAN (RFC 1918)** `OMI_DEV_HOST` for both `setup.sh` and `make dev-up`. iOS now prompts for local-network access (`NSLocalNetworkUsageDescription`). Two Home Screen icons can both be named Omi Dev.
- Related, competing design: #11784 (`feat/local-dev-emulator-auth`) adds a separate "Sign in (local dev)" button and out-of-band remint. This PR keeps the Google button, which is what a newcomer taps. Do not land both blindly.

Failure-Class: new

The new class is: when `FIREBASE_AUTH_EMULATOR_HOST` is set, `/v1/auth/authorize` must complete PKCE against the emulator (JSON or app-scheme redirect) instead of redirecting to Google/Apple. A production deployment without the emulator must reject `response_mode=json`.

## Test plan

- [x] `backend/.venv` pytest `tests/unit/test_auth_redirect_uri.py` — 65 passed (JSON mode without emulator fails closed; emulator mints a code and custom token; Google redirect is not called)
- [x] `flutter test test/unit/emulator_authorize_callback_test.dart` — 3 passed
- [x] `app/test/shell/ios_dev_ats_config_test.sh` — ArbitraryLoads kept, LocalNetworking not combined, usage description present
- [x] Live on Revtim's iPhone (iPhone 17 Pro, iOS 27, UDID `00008150-001C3DAC0A38401C`): `OMI_DEV_HOST=192.168.2.200`, harness bound, onboarding GET 200, Google sign-in completed without Safari. Tailscale `100.81.134.49` was `ENETUNREACH` (phone not on the tailnet).
- [x] Docs from scratch (isolated `/tmp` tree): `npm install mintlify`; `docs/` `npm ci` succeeds. `mintlify broken-links` does not report `AppSetup.mdx`. `npm run build` still fails on missing `rollout/` (pre-existing on main). `mintlify broken-links` still hits a pre-existing parse error in `doc/hardware/omiglass/monitoring.mdx`.

This commit was not re-run on the phone against current `main`; the live path was exercised on the same authorize-JSON + LAN host combination before the slice was ported onto `upstream/main`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

