### PR TITLE
fix(desktop): prevent realtime playback render stalls

### DIFF
--- a/.github/failure-classes/FC-audio-route-stale-render-capacity.json
+++ b/.github/failure-classes/FC-audio-route-stale-render-capacity.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "id": "FC-audio-route-stale-render-capacity",
+  "violated_contract": "A realtime playback graph rebuilt after an audio route or sample-rate change must accept every render slice size macOS can request; a nominally running engine with a stale lower frame ceiling is not live playback.",
+  "canonical_prevention": "Configure every non-I/O unit in the streaming PCM graph for the documented 4096-frame render capacity before resources are allocated, and reapply that capacity whenever the graph is rebuilt.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/StreamingPCMPlaybackQueueTests.swift"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/FloatingControlBar/StreamingPCMPlayer.swift"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/StreamingPCMPlayer.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/StreamingPCMPlayer.swift
@@ -92,6 +92,29 @@ struct StreamingPCMPlaybackProgress: Equatable, Sendable {
   var isIdle: Bool { remainingBufferCount == 0 }
 }
 
+/// Keeps non-I/O audio units ready for the largest render slice macOS may ask
+/// them to process after an output-route or sample-rate change.
+///
+/// CoreAudio can retain a route-specific `maximumFramesToRender` when an
+/// `AVAudioEngine` graph is rebuilt. A later 512-frame render against a stale
+/// 480-frame ceiling fails with `kAudioUnitErr_TooManyFramesToProcess`; the
+/// player remains nominally running, but no `.dataPlayedBack` callback arrives.
+/// Apple documents 4096 frames as the safe capacity for non-I/O units. This
+/// must be applied while render resources are deallocated.
+enum StreamingPCMRenderCapacity {
+  static let minimumFrames: AUAudioFrameCount = 4096
+
+  @discardableResult
+  static func configure(units: [AUAudioUnit]) -> [AUAudioFrameCount] {
+    units.map { unit in
+      if !unit.renderResourcesAllocated, unit.maximumFramesToRender < minimumFrames {
+        unit.maximumFramesToRender = minimumFrames
+      }
+      return unit.maximumFramesToRender
+    }
+  }
+}
+
 private final class DeferredConfigurationRecoveryAction: @unchecked Sendable {
   let action: () -> Void
 
@@ -180,6 +203,8 @@ final class StreamingPCMPlayer: @unchecked Sendable {
   /// Number of PCM buffers still awaiting a physical completion. This is
   /// queue metadata only; it contains no audio content.
   var scheduledBufferCount: Int { playbackQueue.scheduledBufferCount }
+  /// Bounded render metadata for diagnostics and regression verification.
+  private(set) var renderCapacities: [AUAudioFrameCount] = []
   var onPlaybackScheduled: ((Int) -> Void)?
   /// Called once for every valid physical `.dataPlayedBack` completion,
   /// including non-final buffers. `onPlaybackIdle` remains final-only.
@@ -192,6 +217,7 @@ final class StreamingPCMPlayer: @unchecked Sendable {
       commonFormat: .pcmFormatFloat32, sampleRate: sampleRate, channels: 1, interleaved: false)!
     engine.attach(player)
     engine.connect(player, to: engine.mainMixerNode, format: format)
+    configureRenderCapacity()
     // Output-level tap for the notch speaking animation. Tapping the mixer
     // (not enqueue-time RMS) keeps the visual in sync with what is audibly
     // playing rather than leading it by the scheduled-queue depth. The tap
@@ -259,9 +285,18 @@ final class StreamingPCMPlayer: @unchecked Sendable {
     engine.stop()
     engine.disconnectNodeOutput(player)
     engine.connect(player, to: engine.mainMixerNode, format: format)
+    configureRenderCapacity()
     _ = ensureRunning()
     for buffer in buffersToReplay {
       schedule(buffer)
+    }
+  }
+
+  private func configureRenderCapacity() {
+    renderCapacities = StreamingPCMRenderCapacity.configure(
+      units: [player.auAudioUnit, engine.mainMixerNode.auAudioUnit])
+    if renderCapacities.contains(where: { $0 < StreamingPCMRenderCapacity.minimumFrames }) {
+      log("StreamingPCMPlayer: render capacity remained below 4096 frames: \(renderCapacities)")
     }
   }
 

--- a/desktop/macos/Desktop/Tests/StreamingPCMPlaybackQueueTests.swift
+++ b/desktop/macos/Desktop/Tests/StreamingPCMPlaybackQueueTests.swift
@@ -197,6 +197,29 @@ private final class PendingRecoveryActions: @unchecked Sendable {
 }
 
 final class StreamingPCMPlayerLevelTests: XCTestCase {
+  func testRenderCapacityRaisesRouteChanged480FrameNodeAbove512FrameDeviceSlice() {
+    let engine = AVAudioEngine()
+    let player = AVAudioPlayerNode()
+    engine.attach(player)
+    engine.connect(player, to: engine.mainMixerNode, format: nil)
+    player.auAudioUnit.maximumFramesToRender = 480
+    engine.mainMixerNode.auAudioUnit.maximumFramesToRender = 480
+
+    let capacities = StreamingPCMRenderCapacity.configure(
+      units: [player.auAudioUnit, engine.mainMixerNode.auAudioUnit])
+
+    XCTAssertEqual(capacities, [4096, 4096])
+    XCTAssertGreaterThanOrEqual(player.auAudioUnit.maximumFramesToRender, 512)
+    XCTAssertGreaterThanOrEqual(engine.mainMixerNode.auAudioUnit.maximumFramesToRender, 512)
+  }
+
+  func testStreamingPlayerConfiguresSafeRenderCapacityBeforePlaybackStarts() {
+    let player = StreamingPCMPlayer(sampleRate: 24000)
+    defer { player.stop() }
+
+    XCTAssertEqual(player.renderCapacities, [4096, 4096])
+  }
+
   func testRmsLevelMeasuresSignalAndBoundsToOne() throws {
     let format = try XCTUnwrap(
       AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 24000, channels: 1, interleaved: false))

--- a/desktop/macos/changelog/unreleased/20260830-realtime-voice-render-capacity.json
+++ b/desktop/macos/changelog/unreleased/20260830-realtime-voice-render-capacity.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed push-to-talk replies going silent after an audio device change"
+}


### PR DESCRIPTION
## Summary

- prevent realtime PTT playback graphs from retaining a route-specific frame ceiling
- configure the player and mixer for macOS's documented 4096-frame render capacity before allocation and after graph rebuilds
- add a regression that reproduces the observed 480-frame ceiling against a 512-frame device slice

## Reproduction

The affected Omi Beta turn successfully delivered its proactive card, captured and transcribed the PTT question, and received Gemini audio, then timed out waiting for local playback. Unified logs repeatedly reported `kAudioUnitErr_TooManyFramesToProcess` with `inFramesToProcess=512` and `mMaxFramesPerSlice=480`.

## Verification

- `./scripts/dev-feedback.py --once swift 'StreamingPCM'` (12 tests passed)
- `./scripts/agent-logic-harness.sh --cross-surface-smoke`
- `./scripts/agent-logic-harness.sh`
- full `omi-ptt-playback-capacity` named-bundle build and authenticated proactive-notification to PTT turn
- fixed bundle reported physical playback tail drain and terminal success with no matching CoreAudio frame-capacity errors

## Product invariants affected

- INV-CHAT-1

The change is confined to physical AVAudioUnit render capacity. It does not add transcript storage, continuity state, or a second voice-turn lifecycle owner.

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

