### PR TITLE
fix(listen): fail a live STT session over to the next provider

### DIFF
--- a/backend/config/stt_provider_policy.py
+++ b/backend/config/stt_provider_policy.py
@@ -264,3 +264,22 @@ def default_models_for_surface(surface: STTServingSurface) -> tuple[str, ...]:
 def canonical_model_config(surface: STTServingSurface) -> str:
     """Return the deployment-safe comma-separated model preference."""
     return ','.join(default_models_for_surface(surface))
+
+
+def provider_for_service(service: object) -> str | None:
+    """Return the provider token a serving ``STTService`` belongs to.
+
+    The inverse of ``provider_for_model_token`` for callers holding a resolved
+    service rather than a configured model string, so a mid-session failover can
+    exclude the provider that just died.
+    """
+    value = getattr(service, 'value', service)
+    if value == 'modulate':
+        return MODULATE_PROVIDER
+    if value == 'soniox':
+        return SONIOX_PROVIDER
+    if value == 'parakeet':
+        return PARAKEET_PROVIDER
+    if value == 'deepgram':
+        return DEEPGRAM_CLOUD_PROVIDER
+    return None

--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -9,7 +9,7 @@ import logging
 import time
 import uuid
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 lc3: Any = None
 lc3_import_error: Optional[BaseException] = None
@@ -50,10 +50,13 @@ from utils.stt.live_failure import (
     send_live_stt_audio,
     terminate_live_stt_session,
 )
+from config.stt_provider_policy import provider_for_service
+from utils.stt.provider_resilience import close_rejected_socket, fallback_socket_is_serving
 from utils.stt.streaming import (
     STTService,
     connect_stt_socket_with_fallback,
     deepgram_fallback_model,
+    get_stt_service_for_language,
     make_stream_callback,
     modulate_is_configured_fallback,
     parakeet_is_configured_fallback,
@@ -84,6 +87,8 @@ logger = logging.getLogger(__name__)
 # Cadence for the frame-independent provider-death monitor (#10028). Short enough
 # to terminate a zombie "Listening" session promptly, far below ws_receive_timeout.
 STT_DEATH_POLL_INTERVAL_SECONDS = 1.0
+# Chain depth is 3 (velma/soniox/deepgram); allow walking it once, not looping.
+MAX_STT_FAILOVERS = 2
 
 # Longest frame the Opus format can carry, in milliseconds.
 OPUS_MAX_FRAME_MS = 120
@@ -123,6 +128,10 @@ class ListenReceiver:
         self.channel_configs = channel_configs
         self.channel_id_to_index = channel_id_to_index
         self.stt_socket: Any = None
+        # Providers whose socket already died this session; a failover must not
+        # reselect one, or a dead primary would be chosen again immediately.
+        self._stt_failed_providers: set[str] = set()
+        self._stt_rebuild: Optional[Tuple[Any, Any, int]] = None
         self.stt_sockets_multi: List[Any] = [None] * len(channel_configs)
         self.multi_opus_decoders: List[Any] = [None] * len(channel_configs)
         self.channel_mix_buffers: List[bytearray] = [bytearray() for _ in channel_configs]
@@ -461,6 +470,9 @@ class ListenReceiver:
             self.stt_socket = (
                 GatedSTTSocket(raw, gate=self.vad_gate, passthrough_audio=passthrough) if self.vad_gate else raw
             )
+            # Retained so a mid-session failover can rebuild the socket against the
+            # next provider without re-deriving the callbacks or the gate.
+            self._stt_rebuild = (parakeet_callback, modulate_callback, request.sample_rate)
             self.host.spawn(self._monitor_stt_death(), name='stt_death_monitor')
             return True
         except Exception as error:
@@ -473,6 +485,78 @@ class ListenReceiver:
                 platform=self.host.client_device_context.platform,
             )
             return False
+
+    async def _failover_stt_socket(self) -> bool:
+        """Move a live session onto the next provider after its socket died.
+
+        Modulate accepts the WebSocket and only then sends an error frame, so its
+        outages land mid-session where ``connect_stt_socket_with_fallback`` — which
+        only runs at connect time — cannot help. Without this the chain is inert
+        against the failure it exists for: during the 2026-08-30 outage Velma failed
+        82% of sessions while Soniox and Deepgram served zero.
+
+        Single-channel only. Multi-channel holds several sockets whose segments are
+        stitched by channel, so swapping one mid-stream needs its own design.
+        """
+        rebuild = getattr(self, '_stt_rebuild', None)
+        if rebuild is None or self.host.is_multi_channel or self.host.use_custom_stt:
+            return False
+        if not self.host.state.active or self.host.state.stt_terminal_failure:
+            return False
+
+        dead_provider = provider_for_service(self.host.stt_service)
+        if dead_provider:
+            self._stt_failed_providers.add(dead_provider)
+        if len(self._stt_failed_providers) > MAX_STT_FAILOVERS:
+            return False
+
+        service, language, model = get_stt_service_for_language(
+            self.host.language,
+            multi_lang_enabled=self.host.multi_lang_enabled,
+            exclude=frozenset(self._stt_failed_providers),
+        )
+        if service is None:
+            return False
+
+        parakeet_callback, modulate_callback, sample_rate = rebuild
+        previous = self.stt_socket
+        self.host.stt_service, self.host.stt_language, self.host.stt_model = service, language, model
+        try:
+            raw = await self._create_stt_socket(
+                parakeet_callback,
+                sample_rate,
+                modulate_callback=modulate_callback,
+            )
+        except Exception:
+            logger.exception('STT failover connect raised')
+            return False
+        if raw is None:
+            return False
+        # A provider can accept the upgrade and reject the stream ~150ms later;
+        # treating that as a heal would report recovery for a session that is
+        # already dead again.
+        if not await fallback_socket_is_serving(raw):
+            close_rejected_socket(raw)
+            return False
+
+        passthrough = self.host.stt_service == STTService.modulate
+        self.stt_socket = (
+            GatedSTTSocket(raw, gate=self.vad_gate, passthrough_audio=passthrough) if self.vad_gate else raw
+        )
+        record_fallback(
+            component='stt_live_session',
+            from_mode=dead_provider or 'unknown',
+            to_mode=service.value,
+            reason='connection_lost',
+            outcome='recovered',
+        )
+        logger.info(f'STT failover mid-session: {dead_provider} -> {service.value}')
+        if previous is not None:
+            try:
+                previous.finish()
+            except Exception:
+                logger.warning('Failed to close the STT socket that died before failover')
+        return True
 
     async def _monitor_stt_death(self) -> None:
         """Terminate the client session promptly when the provider STT socket dies.
@@ -487,6 +571,8 @@ class ListenReceiver:
         while self.host.state.active and not self.host.state.stt_terminal_failure:
             socket = self.stt_socket
             if socket is not None and live_stt_socket_is_dead(socket):
+                if await self._failover_stt_socket():
+                    continue
                 await terminate_live_stt_session(
                     self.host.request.websocket,
                     self.host.state,

--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -332,9 +332,11 @@ class ListenSessionRuntime:
             request.onboarding_mode,
             base.transcription_prefs.get('single_language_mode', False),
         )
+        # Retained so a mid-session failover reselects under the same language policy.
+        self.multi_lang_enabled = not single_language_mode
         self.stt_service, self.stt_language, self.stt_model = get_stt_service_for_language(
             self.language,
-            multi_lang_enabled=not single_language_mode,
+            multi_lang_enabled=self.multi_lang_enabled,
             preferred_service=request.stt_service,
         )
         # The provider the serving policy chose, captured before `_create_stt_socket`

--- a/backend/tests/unit/test_listen_stt_death_monitor.py
+++ b/backend/tests/unit/test_listen_stt_death_monitor.py
@@ -40,6 +40,13 @@ def _monitor_self(*, dead: bool, stt_service=STTService.parakeet):
     )
     monitor_self = SimpleNamespace(host=host, stt_socket=SimpleNamespace(is_connection_dead=dead))
     monitor_self._serving_provider = lambda: ListenReceiver._serving_provider(monitor_self)
+
+    # The monitor now offers the session to the next provider before terminating.
+    # These cases cover the terminal path, so failover declines.
+    async def _no_failover():
+        return False
+
+    monitor_self._failover_stt_socket = _no_failover
     return monitor_self
 
 

--- a/backend/tests/unit/test_stt_session_failover.py
+++ b/backend/tests/unit/test_stt_session_failover.py
@@ -18,6 +18,7 @@ from config.stt_provider_policy import (
     SONIOX_PROVIDER,
     provider_for_service,
 )
+from routers.listen.receiver import MAX_STT_FAILOVERS, ListenReceiver
 from utils.stt.streaming import STTService, get_stt_service_for_language
 
 
@@ -68,8 +69,6 @@ def test_excluding_every_provider_selects_nothing():
 
 
 def _receiver_with_dead_socket(monkeypatch: Any, *, replacement: Any):
-    from routers.listen.receiver import ListenReceiver
-
     host = MagicMock()
     host.is_multi_channel = False
     host.use_custom_stt = False
@@ -137,8 +136,6 @@ async def test_multi_channel_sessions_do_not_failover(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_failover_is_bounded_so_a_flapping_chain_cannot_loop(monkeypatch):
-    from routers.listen.receiver import MAX_STT_FAILOVERS
-
     receiver = _receiver_with_dead_socket(monkeypatch, replacement=FakeSocket(dead=False))
     receiver._stt_failed_providers = {f'p{i}' for i in range(MAX_STT_FAILOVERS + 1)}
 

--- a/backend/tests/unit/test_stt_session_failover.py
+++ b/backend/tests/unit/test_stt_session_failover.py
@@ -1,0 +1,149 @@
+"""A live session must survive a provider that dies after the socket is open.
+
+Modulate accepts the WebSocket upgrade and only then sends an error frame, so its
+outages land mid-session where ``connect_stt_socket_with_fallback`` — which runs
+once, at connect time — cannot reach them. On 2026-08-30 that gap took Velma to
+82% failure while Soniox and Deepgram served zero sessions: the fallback chain was
+configured correctly and was structurally unable to fire.
+"""
+
+from typing import Any, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from config.stt_provider_policy import (
+    DEEPGRAM_CLOUD_PROVIDER,
+    MODULATE_PROVIDER,
+    SONIOX_PROVIDER,
+    provider_for_service,
+)
+from utils.stt.streaming import STTService, get_stt_service_for_language
+
+
+class FakeSocket:
+    def __init__(self, dead: bool = False):
+        self._dead = dead
+        self.finished = False
+
+    @property
+    def is_connection_dead(self) -> bool:
+        return self._dead
+
+    @property
+    def death_reason(self) -> Optional[str]:
+        return 'modulate error: Internal server error' if self._dead else None
+
+    def finish(self) -> None:
+        self.finished = True
+
+
+def test_provider_for_service_round_trips_every_serving_provider():
+    assert provider_for_service(STTService.modulate) == MODULATE_PROVIDER
+    assert provider_for_service(STTService.soniox) == SONIOX_PROVIDER
+    assert provider_for_service(STTService.deepgram) == DEEPGRAM_CLOUD_PROVIDER
+    assert provider_for_service('nonsense') is None
+
+
+def test_excluding_the_dead_provider_selects_the_next_one():
+    """The whole point of the exclusion: never reselect what just died."""
+    with patch.dict(
+        'os.environ',
+        {'STT_SERVICE_MODELS': 'modulate-velma-2,soniox,dg-nova-3', 'SONIOX_API_KEY': 'k'},
+    ), patch('utils.stt.streaming.stt_service_models', ['modulate-velma-2', 'soniox', 'dg-nova-3']):
+        first, _, _ = get_stt_service_for_language('en')
+        assert first == STTService.modulate
+
+        second, _, _ = get_stt_service_for_language('en', exclude=frozenset({MODULATE_PROVIDER}))
+        assert second == STTService.soniox
+
+
+def test_excluding_every_provider_selects_nothing():
+    """Exhausting the chain must report no provider, not loop back to the first."""
+    with patch('utils.stt.streaming.stt_service_models', ['modulate-velma-2', 'soniox']), patch.dict(
+        'os.environ', {'SONIOX_API_KEY': 'k'}
+    ):
+        service, _, _ = get_stt_service_for_language('en', exclude=frozenset({MODULATE_PROVIDER, SONIOX_PROVIDER}))
+        assert service is None
+
+
+def _receiver_with_dead_socket(monkeypatch: Any, *, replacement: Any):
+    from routers.listen.receiver import ListenReceiver
+
+    host = MagicMock()
+    host.is_multi_channel = False
+    host.use_custom_stt = False
+    host.state.active = True
+    host.state.stt_terminal_failure = False
+    host.language = 'en'
+    host.multi_lang_enabled = True
+    host.stt_service = STTService.modulate
+
+    receiver = ListenReceiver(host, [], {})
+    receiver.stt_socket = FakeSocket(dead=True)
+    receiver.vad_gate = None
+    receiver._stt_rebuild = (lambda _s: None, lambda _s: None, 16000)
+    receiver._create_stt_socket = AsyncMock(return_value=replacement)
+    return receiver
+
+
+@pytest.mark.asyncio
+async def test_a_dead_primary_moves_the_session_to_the_next_provider(monkeypatch):
+    healthy = FakeSocket(dead=False)
+    receiver = _receiver_with_dead_socket(monkeypatch, replacement=healthy)
+    dead = receiver.stt_socket
+
+    with patch(
+        'routers.listen.receiver.get_stt_service_for_language',
+        return_value=(STTService.soniox, 'en', 'soniox'),
+    ):
+        assert await receiver._failover_stt_socket() is True
+
+    assert receiver.stt_socket is healthy
+    assert receiver.host.stt_service == STTService.soniox
+    # The dead socket is released rather than leaked for the session's lifetime.
+    assert dead.finished is True
+    assert MODULATE_PROVIDER in receiver._stt_failed_providers
+
+
+@pytest.mark.asyncio
+async def test_a_replacement_that_dies_immediately_is_not_treated_as_recovery(monkeypatch):
+    """A provider can accept the upgrade and reject the stream ~150ms later."""
+    receiver = _receiver_with_dead_socket(monkeypatch, replacement=FakeSocket(dead=True))
+
+    with patch(
+        'routers.listen.receiver.get_stt_service_for_language',
+        return_value=(STTService.soniox, 'en', 'soniox'),
+    ):
+        assert await receiver._failover_stt_socket() is False
+
+
+@pytest.mark.asyncio
+async def test_failover_stops_once_the_chain_is_exhausted(monkeypatch):
+    receiver = _receiver_with_dead_socket(monkeypatch, replacement=FakeSocket(dead=False))
+
+    with patch('routers.listen.receiver.get_stt_service_for_language', return_value=(None, None, None)):
+        assert await receiver._failover_stt_socket() is False
+
+
+@pytest.mark.asyncio
+async def test_multi_channel_sessions_do_not_failover(monkeypatch):
+    """Multi-channel stitches segments across sockets; swapping one needs its own design."""
+    receiver = _receiver_with_dead_socket(monkeypatch, replacement=FakeSocket(dead=False))
+    receiver.host.is_multi_channel = True
+
+    assert await receiver._failover_stt_socket() is False
+
+
+@pytest.mark.asyncio
+async def test_failover_is_bounded_so_a_flapping_chain_cannot_loop(monkeypatch):
+    from routers.listen.receiver import MAX_STT_FAILOVERS
+
+    receiver = _receiver_with_dead_socket(monkeypatch, replacement=FakeSocket(dead=False))
+    receiver._stt_failed_providers = {f'p{i}' for i in range(MAX_STT_FAILOVERS + 1)}
+
+    with patch(
+        'routers.listen.receiver.get_stt_service_for_language',
+        return_value=(STTService.soniox, 'en', 'soniox'),
+    ):
+        assert await receiver._failover_stt_socket() is False

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -24,6 +24,7 @@ from config.stt_provider_policy import (
     modulate_supports_language,
     normalized_stt_language,
     parakeet_supports_language,
+    provider_for_model_token,
     provider_is_enabled,
     supports_live_multilingual_mode,
 )
@@ -479,8 +480,13 @@ def get_stt_service_for_language(
     *,
     surface: STTServingSurface = STTServingSurface.STREAMING,
     preferred_service: Optional[str] = None,
+    exclude: frozenset[str] = frozenset(),
 ) -> Tuple[Optional[STTService], Optional[str], Optional[str]]:
     """Select a serving STT provider allowed for the requested product surface.
+
+    ``exclude`` holds provider tokens that already died for this session, so a
+    mid-session failover asks for the next provider down the chain rather than
+    reselecting the one that just failed.
 
     A ``dg-*`` configuration serves from whichever Deepgram deployment the
     runtime is configured for — self-hosted when its endpoint is set, otherwise
@@ -503,6 +509,8 @@ def get_stt_service_for_language(
         parakeet_fallback_reason: Optional[str] = None
         for model in _models_with_preferred_service(models, preferred_service=preferred_service):
             model = model.strip()
+            if provider_for_model_token(model) in exclude:
+                continue
             if (
                 model.startswith('dg-')
                 and provider_is_enabled(deepgram_provider_for_runtime(is_dg_self_hosted), surface)


### PR DESCRIPTION
## Problem

`connect_stt_socket_with_fallback` runs once, at connect time. Modulate accepts the
WebSocket upgrade and *then* sends an error frame seconds later, so its outages land
mid-session, where the fallback chain cannot reach them. When the primary dies mid-stream
the session is terminated (`stt_failed` + WebSocket 1011) rather than moved to the next
provider.

Measured in production on 2026-08-30, with the chain configured `velma → soniox → dg`:

```
velma     428 established, 352 errors → 82%
soniox      0 sessions
deepgram    0 sessions
```

The chain was correct and structurally unable to fire. Users ate the full 82%.

## Fix

`_monitor_stt_death` now attempts a failover before terminating. On death it marks the
dead provider, reselects excluding it, rebuilds the socket via the existing
`_create_stt_socket` path, and swaps it in; the session continues. Termination happens
only once the chain is exhausted.

Supporting pieces:
- `get_stt_service_for_language(..., exclude=...)` skips providers that already died, so
  a failover can't reselect the one that just failed.
- `provider_for_service()` — inverse of `provider_for_model_token` for callers holding a
  resolved service.
- The receiver retains the callbacks and sample rate so the socket can be rebuilt without
  re-deriving them or the VAD gate.

Guards:
- **Bounded** — `MAX_STT_FAILOVERS = 2` walks the 3-provider chain once; a flapping
  provider can't loop.
- **Liveness-checked** — reuses `fallback_socket_is_serving`, so a replacement that is
  accepted then rejected ~150ms later isn't counted as recovery.
- **Old socket released** rather than leaked for the session's lifetime.
- **Single-channel only** — multi-channel stitches segments across several sockets by
  channel; swapping one mid-stream needs its own design and is unchanged here.

Emits `record_fallback(component='stt_live_session', outcome='recovered')` so failovers
are visible rather than silent.

## Tests

8 new tests: successful failover, exclusion picks the next provider, exhausted chain
selects nothing, a replacement that dies immediately is not recovery, multi-channel is
skipped, the bound holds, and provider/service mapping round-trips. Existing Soniox
tests still pass (19 total).

Note: the full `tests/unit` run dumps core in this environment on a clean checkout of
`main` as well, so it is pre-existing and unrelated.

Failure-Class: FC-recoverable-provider-failure-terminal

Line-Count-Exception: backend/utils/stt/streaming.py | 1707 -> 1715 | exclude parameter and its guard at the selection point
