### PR TITLE
chore(charts): serve listen from velma, then soniox, then deepgram

### DIFF
--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -344,7 +344,7 @@ jobs:
           RAPID_API_HOST: ${{ vars.RAPID_API_HOST }}
           REDIS_DB_HOST: ${{ vars.REDIS_DB_HOST }}
           STT_PRERECORDED_MODEL: parakeet,modulate-velma-2
-          STT_SERVICE_MODELS: dg-nova-3,modulate-velma-2,parakeet
+          STT_SERVICE_MODELS: modulate-velma-2,soniox,dg-nova-3
           SYNC_TASKS_HANDLER_URL: ${{ steps.pusher-runtime-targets.outputs.sync_tasks_handler_url }}
           SYNC_TASKS_INVOKER_SA: ${{ steps.pusher-runtime-targets.outputs.sync_tasks_invoker_sa }}
           TYPESENSE_HOST: ${{ vars.TYPESENSE_HOST }}

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -344,7 +344,7 @@ jobs:
           RAPID_API_HOST: ${{ vars.RAPID_API_HOST }}
           REDIS_DB_HOST: ${{ vars.REDIS_DB_HOST }}
           STT_PRERECORDED_MODEL: parakeet,modulate-velma-2
-          STT_SERVICE_MODELS: modulate-velma-2,soniox,dg-nova-3
+          STT_SERVICE_MODELS: modulate-velma-2,soniox,dg-nova-3,parakeet
           SYNC_TASKS_HANDLER_URL: ${{ steps.pusher-runtime-targets.outputs.sync_tasks_handler_url }}
           SYNC_TASKS_INVOKER_SA: ${{ steps.pusher-runtime-targets.outputs.sync_tasks_invoker_sa }}
           TYPESENSE_HOST: ${{ vars.TYPESENSE_HOST }}

--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -260,7 +260,7 @@ env:
   - name: DEEPGRAM_SELF_HOSTED_ENABLED
     value: "false"
   - name: STT_SERVICE_MODELS
-    value: "modulate-velma-2,soniox,dg-nova-3"
+    value: "modulate-velma-2,soniox,dg-nova-3,parakeet"
   - name: NO_SOCKET_TIMEOUT
     value: "true"
   - name: HOSTED_PUSHER_API_URL

--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -260,7 +260,7 @@ env:
   - name: DEEPGRAM_SELF_HOSTED_ENABLED
     value: "false"
   - name: STT_SERVICE_MODELS
-    value: "dg-nova-3,modulate-velma-2,parakeet"
+    value: "modulate-velma-2,soniox,dg-nova-3"
   - name: NO_SOCKET_TIMEOUT
     value: "true"
   - name: HOSTED_PUSHER_API_URL

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -330,7 +330,7 @@ env:
   - name: DEEPGRAM_SELF_HOSTED_ENABLED
     value: "false"
   - name: STT_SERVICE_MODELS
-    value: "dg-nova-3,modulate-velma-2,parakeet"
+    value: "modulate-velma-2,soniox,dg-nova-3"
   - name: HOSTED_TRANSLATION_API_URL
     value: "http://nllb.omi.me"
   - name: TRANSLATION_SERVICE_MODELS

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -330,7 +330,7 @@ env:
   - name: DEEPGRAM_SELF_HOSTED_ENABLED
     value: "false"
   - name: STT_SERVICE_MODELS
-    value: "modulate-velma-2,soniox,dg-nova-3"
+    value: "modulate-velma-2,soniox,dg-nova-3,parakeet"
   - name: HOSTED_TRANSLATION_API_URL
     value: "http://nllb.omi.me"
   - name: TRANSLATION_SERVICE_MODELS

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -280,7 +280,7 @@ env:
   - name: STT_PRERECORDED_MODEL
     value: "parakeet,modulate-velma-2"
   - name: STT_SERVICE_MODELS
-    value: "modulate-velma-2,soniox,dg-nova-3"
+    value: "modulate-velma-2,soniox,dg-nova-3,parakeet"
   - name: BASIC_TIER_MINUTES_LIMIT_PER_MONTH
     value: "1000000"
   - name: BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -280,7 +280,7 @@ env:
   - name: STT_PRERECORDED_MODEL
     value: "parakeet,modulate-velma-2"
   - name: STT_SERVICE_MODELS
-    value: "dg-nova-3,modulate-velma-2,parakeet"
+    value: "modulate-velma-2,soniox,dg-nova-3"
   - name: BASIC_TIER_MINUTES_LIMIT_PER_MONTH
     value: "1000000"
   - name: BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -287,7 +287,7 @@ env:
   - name: STT_PRERECORDED_MODEL
     value: "parakeet,modulate-velma-2"
   - name: STT_SERVICE_MODELS
-    value: "modulate-velma-2,soniox,dg-nova-3"
+    value: "modulate-velma-2,soniox,dg-nova-3,parakeet"
   - name: RAPID_API_KEY
     valueFrom:
       secretKeyRef:

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -287,7 +287,7 @@ env:
   - name: STT_PRERECORDED_MODEL
     value: "parakeet,modulate-velma-2"
   - name: STT_SERVICE_MODELS
-    value: "dg-nova-3,modulate-velma-2,parakeet"
+    value: "modulate-velma-2,soniox,dg-nova-3"
   - name: RAPID_API_KEY
     valueFrom:
       secretKeyRef:

--- a/backend/config/stt_provider_policy.py
+++ b/backend/config/stt_provider_policy.py
@@ -135,10 +135,13 @@ PROVIDER_SERVING_SURFACES: Final[Mapping[str, frozenset[STTServingSurface]]] = {
 # hard stream gate (see parakeet/admission.py), so every listener converges on
 # one cap per serving pod instead of listener-local counters.
 DEFAULT_MODELS_BY_SURFACE: Final[Mapping[STTServingSurface, tuple[str, ...]]] = {
-    # Velma-2 rejects a large, variable share of live connections under production
-    # concurrency and Parakeet streaming is English-only, so neither can hold the
-    # primary slot for a multi-language live product.
-    STTServingSurface.STREAMING: ('dg-nova-3', 'modulate-velma-2', 'parakeet'),
+    # Velma-2 leads on cost, and its failures are now recoverable: a mid-session
+    # error frame hands the stream to Soniox rather than ending it (#12459), which
+    # is what the second slot is for. Deepgram stays last so a BYOK user still
+    # resolves a `dg-*` model — dropping it would strip them of Deepgram entirely.
+    # Parakeet is not listed: streaming Parakeet is English-only and live sessions
+    # are overwhelmingly auto-detect, so it was never selected here.
+    STTServingSurface.STREAMING: ('modulate-velma-2', 'soniox', 'dg-nova-3'),
     # Batch work is queued, so Parakeet's bounded GPU means waiting rather than the
     # user-visible failure it causes on the streaming surface. Prefer the self-hosted
     # provider here and keep Velma as the overflow.

--- a/backend/config/stt_provider_policy.py
+++ b/backend/config/stt_provider_policy.py
@@ -139,9 +139,10 @@ DEFAULT_MODELS_BY_SURFACE: Final[Mapping[STTServingSurface, tuple[str, ...]]] = 
     # error frame hands the stream to Soniox rather than ending it (#12459), which
     # is what the second slot is for. Deepgram stays last so a BYOK user still
     # resolves a `dg-*` model — dropping it would strip them of Deepgram entirely.
-    # Parakeet is not listed: streaming Parakeet is English-only and live sessions
-    # are overwhelmingly auto-detect, so it was never selected here.
-    STTServingSurface.STREAMING: ('modulate-velma-2', 'soniox', 'dg-nova-3'),
+    # Parakeet stays last rather than being dropped: a client can ask for it by
+    # name (`?stt_service=parakeet`), and that preference is only honorable while
+    # the model is listed here.
+    STTServingSurface.STREAMING: ('modulate-velma-2', 'soniox', 'dg-nova-3', 'parakeet'),
     # Batch work is queued, so Parakeet's bounded GPU means waiting rather than the
     # user-visible failure it causes on the streaming surface. Prefer the self-hosted
     # provider here and keep Velma as the overflow.

--- a/backend/deploy/_generate_runtime_env_sources.py
+++ b/backend/deploy/_generate_runtime_env_sources.py
@@ -52,7 +52,7 @@ GKE_CONFIG_MAP_KEYS_PROD_ONLY = [
 
 STT_LITERALS = {
     'STT_PRERECORDED_MODEL': 'parakeet,modulate-velma-2',
-    'STT_SERVICE_MODELS': 'modulate-velma-2,soniox,dg-nova-3',
+    'STT_SERVICE_MODELS': 'modulate-velma-2,soniox,dg-nova-3,parakeet',
 }
 
 

--- a/backend/deploy/_generate_runtime_env_sources.py
+++ b/backend/deploy/_generate_runtime_env_sources.py
@@ -52,7 +52,7 @@ GKE_CONFIG_MAP_KEYS_PROD_ONLY = [
 
 STT_LITERALS = {
     'STT_PRERECORDED_MODEL': 'parakeet,modulate-velma-2',
-    'STT_SERVICE_MODELS': 'dg-nova-3,modulate-velma-2,parakeet',
+    'STT_SERVICE_MODELS': 'modulate-velma-2,soniox,dg-nova-3',
 }
 
 

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -58,7 +58,7 @@ environments:
             value: dev
             category: runtime_identity
           STT_SERVICE_MODELS:
-            value: dg-nova-3,modulate-velma-2,parakeet
+            value: modulate-velma-2,soniox,dg-nova-3
             category: stt_policy
           CONVERSATION_SUMMARIZED_APP_IDS:
             config_map:
@@ -266,7 +266,7 @@ environments:
             value: parakeet,modulate-velma-2
             category: stt_policy
           STT_SERVICE_MODELS:
-            value: dg-nova-3,modulate-velma-2,parakeet
+            value: modulate-velma-2,soniox,dg-nova-3
             category: stt_policy
           GOOGLE_CLOUD_PROJECT:
             value: based-hardware-dev
@@ -344,7 +344,7 @@ environments:
             value: parakeet,modulate-velma-2
           STT_SERVICE_MODELS:
             source: literal
-            value: dg-nova-3,modulate-velma-2,parakeet
+            value: modulate-velma-2,soniox,dg-nova-3
           TYPESENSE_HOST:
             source: environment
           TWILIO_ACCOUNT_SID:
@@ -1253,7 +1253,7 @@ environments:
             value: prod
             category: runtime_identity
           STT_SERVICE_MODELS:
-            value: dg-nova-3,modulate-velma-2,parakeet
+            value: modulate-velma-2,soniox,dg-nova-3
             category: stt_policy
           CONVERSATION_SUMMARIZED_APP_IDS:
             config_map:
@@ -1451,7 +1451,7 @@ environments:
             value: parakeet,modulate-velma-2
           STT_SERVICE_MODELS:
             source: literal
-            value: dg-nova-3,modulate-velma-2,parakeet
+            value: modulate-velma-2,soniox,dg-nova-3
           TYPESENSE_HOST:
             source: environment
           TWILIO_ACCOUNT_SID:

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -58,7 +58,7 @@ environments:
             value: dev
             category: runtime_identity
           STT_SERVICE_MODELS:
-            value: modulate-velma-2,soniox,dg-nova-3
+            value: modulate-velma-2,soniox,dg-nova-3,parakeet
             category: stt_policy
           CONVERSATION_SUMMARIZED_APP_IDS:
             config_map:
@@ -266,7 +266,7 @@ environments:
             value: parakeet,modulate-velma-2
             category: stt_policy
           STT_SERVICE_MODELS:
-            value: modulate-velma-2,soniox,dg-nova-3
+            value: modulate-velma-2,soniox,dg-nova-3,parakeet
             category: stt_policy
           GOOGLE_CLOUD_PROJECT:
             value: based-hardware-dev
@@ -344,7 +344,7 @@ environments:
             value: parakeet,modulate-velma-2
           STT_SERVICE_MODELS:
             source: literal
-            value: modulate-velma-2,soniox,dg-nova-3
+            value: modulate-velma-2,soniox,dg-nova-3,parakeet
           TYPESENSE_HOST:
             source: environment
           TWILIO_ACCOUNT_SID:
@@ -1253,7 +1253,7 @@ environments:
             value: prod
             category: runtime_identity
           STT_SERVICE_MODELS:
-            value: modulate-velma-2,soniox,dg-nova-3
+            value: modulate-velma-2,soniox,dg-nova-3,parakeet
             category: stt_policy
           CONVERSATION_SUMMARIZED_APP_IDS:
             config_map:
@@ -1451,7 +1451,7 @@ environments:
             value: parakeet,modulate-velma-2
           STT_SERVICE_MODELS:
             source: literal
-            value: modulate-velma-2,soniox,dg-nova-3
+            value: modulate-velma-2,soniox,dg-nova-3,parakeet
           TYPESENSE_HOST:
             source: environment
           TWILIO_ACCOUNT_SID:

--- a/backend/deploy/runtime_env/_base.yaml
+++ b/backend/deploy/runtime_env/_base.yaml
@@ -65,7 +65,7 @@ environment_shared:
           value: '{env}'
           category: runtime_identity
         STT_SERVICE_MODELS:
-          value: dg-nova-3,modulate-velma-2,parakeet
+          value: modulate-velma-2,soniox,dg-nova-3
           category: stt_policy
         CONVERSATION_SUMMARIZED_APP_IDS:
           config_map:

--- a/backend/deploy/runtime_env/_base.yaml
+++ b/backend/deploy/runtime_env/_base.yaml
@@ -65,7 +65,7 @@ environment_shared:
           value: '{env}'
           category: runtime_identity
         STT_SERVICE_MODELS:
-          value: modulate-velma-2,soniox,dg-nova-3
+          value: modulate-velma-2,soniox,dg-nova-3,parakeet
           category: stt_policy
         CONVERSATION_SUMMARIZED_APP_IDS:
           config_map:

--- a/backend/deploy/runtime_env/dev.overlay.yaml
+++ b/backend/deploy/runtime_env/dev.overlay.yaml
@@ -115,7 +115,7 @@ overlay:
           value: parakeet,modulate-velma-2
           category: stt_policy
         STT_SERVICE_MODELS:
-          value: modulate-velma-2,soniox,dg-nova-3
+          value: modulate-velma-2,soniox,dg-nova-3,parakeet
           category: stt_policy
         GOOGLE_CLOUD_PROJECT:
           value: based-hardware-dev
@@ -193,7 +193,7 @@ overlay:
           value: parakeet,modulate-velma-2
         STT_SERVICE_MODELS:
           source: literal
-          value: modulate-velma-2,soniox,dg-nova-3
+          value: modulate-velma-2,soniox,dg-nova-3,parakeet
         TYPESENSE_HOST:
           source: environment
         TWILIO_ACCOUNT_SID:

--- a/backend/deploy/runtime_env/dev.overlay.yaml
+++ b/backend/deploy/runtime_env/dev.overlay.yaml
@@ -115,7 +115,7 @@ overlay:
           value: parakeet,modulate-velma-2
           category: stt_policy
         STT_SERVICE_MODELS:
-          value: dg-nova-3,modulate-velma-2,parakeet
+          value: modulate-velma-2,soniox,dg-nova-3
           category: stt_policy
         GOOGLE_CLOUD_PROJECT:
           value: based-hardware-dev
@@ -193,7 +193,7 @@ overlay:
           value: parakeet,modulate-velma-2
         STT_SERVICE_MODELS:
           source: literal
-          value: dg-nova-3,modulate-velma-2,parakeet
+          value: modulate-velma-2,soniox,dg-nova-3
         TYPESENSE_HOST:
           source: environment
         TWILIO_ACCOUNT_SID:

--- a/backend/deploy/runtime_env/prod.overlay.yaml
+++ b/backend/deploy/runtime_env/prod.overlay.yaml
@@ -100,7 +100,7 @@ overlay:
           value: parakeet,modulate-velma-2
         STT_SERVICE_MODELS:
           source: literal
-          value: dg-nova-3,modulate-velma-2,parakeet
+          value: modulate-velma-2,soniox,dg-nova-3
         TYPESENSE_HOST:
           source: environment
         TWILIO_ACCOUNT_SID:

--- a/backend/deploy/runtime_env/prod.overlay.yaml
+++ b/backend/deploy/runtime_env/prod.overlay.yaml
@@ -100,7 +100,7 @@ overlay:
           value: parakeet,modulate-velma-2
         STT_SERVICE_MODELS:
           source: literal
-          value: modulate-velma-2,soniox,dg-nova-3
+          value: modulate-velma-2,soniox,dg-nova-3,parakeet
         TYPESENSE_HOST:
           source: environment
         TWILIO_ACCOUNT_SID:

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -1025,7 +1025,7 @@ def test_deployment_stt_models_must_match_the_central_serving_policy():
         ),
         validator.ValidationError(
             'prod/gke/backend-listen',
-            "STT_SERVICE_MODELS must match stt_provider_policy: expected 'dg-nova-3,modulate-velma-2,parakeet', got 'modulate-velma-2'",
+            "STT_SERVICE_MODELS must match stt_provider_policy: expected 'modulate-velma-2,soniox,dg-nova-3', got 'modulate-velma-2'",
         ),
     ]
 

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -1025,7 +1025,7 @@ def test_deployment_stt_models_must_match_the_central_serving_policy():
         ),
         validator.ValidationError(
             'prod/gke/backend-listen',
-            "STT_SERVICE_MODELS must match stt_provider_policy: expected 'modulate-velma-2,soniox,dg-nova-3', got 'modulate-velma-2'",
+            "STT_SERVICE_MODELS must match stt_provider_policy: expected 'modulate-velma-2,soniox,dg-nova-3,parakeet', got 'modulate-velma-2'",
         ),
     ]
 

--- a/backend/tests/unit/test_parakeet_prerecorded.py
+++ b/backend/tests/unit/test_parakeet_prerecorded.py
@@ -548,8 +548,10 @@ class TestStreamingFactoryRouting:
             env_backup = os.environ.pop('HOSTED_PARAKEET_API_URL', None)
             try:
                 service, lang, model = get_stt_service_for_language('en')
-                assert service == STTService.deepgram
-                assert model == 'nova-3'
+                # The policy default now leads with Velma; Parakeet without its
+                # endpoint falls through to whatever heads that chain.
+                assert service == STTService.modulate
+                assert model == 'velma-2'
             finally:
                 if env_backup:
                     os.environ['HOSTED_PARAKEET_API_URL'] = env_backup

--- a/backend/tests/unit/test_soniox_streaming.py
+++ b/backend/tests/unit/test_soniox_streaming.py
@@ -205,9 +205,17 @@ def _empty_stream():
     return gen()
 
 
-def test_soniox_is_streaming_only_and_off_by_default():
+def test_soniox_serves_streaming_only_and_backs_velma_there():
+    """Soniox was opt-in while it was being trialled; it is now the streaming fallback.
+
+    The batch path still has no Soniox client, so it must stay absent from the
+    non-streaming surfaces however the streaming chain is ordered.
+    """
     assert provider_is_enabled(SONIOX_PROVIDER, STTServingSurface.STREAMING)
     assert not provider_is_enabled(SONIOX_PROVIDER, STTServingSurface.PRERECORDED)
     assert not provider_is_enabled(SONIOX_PROVIDER, STTServingSurface.PTT)
-    for surface in STTServingSurface:
+
+    streaming = default_models_for_surface(STTServingSurface.STREAMING)
+    assert streaming.index('soniox') == streaming.index('modulate-velma-2') + 1
+    for surface in (STTServingSurface.PRERECORDED, STTServingSurface.PTT):
         assert 'soniox' not in default_models_for_surface(surface)

--- a/backend/tests/unit/test_stt_provider_policy.py
+++ b/backend/tests/unit/test_stt_provider_policy.py
@@ -53,7 +53,7 @@ def test_self_hosted_deepgram_is_explicitly_limited_to_streaming():
 
 def test_policy_owns_the_safe_model_order_for_every_serving_surface():
     expected = {
-        STTServingSurface.STREAMING: 'modulate-velma-2,soniox,dg-nova-3',
+        STTServingSurface.STREAMING: 'modulate-velma-2,soniox,dg-nova-3,parakeet',
         STTServingSurface.PRERECORDED: 'parakeet,modulate-velma-2',
         STTServingSurface.PTT: 'modulate-velma-2,parakeet',
     }

--- a/backend/tests/unit/test_stt_provider_policy.py
+++ b/backend/tests/unit/test_stt_provider_policy.py
@@ -53,7 +53,7 @@ def test_self_hosted_deepgram_is_explicitly_limited_to_streaming():
 
 def test_policy_owns_the_safe_model_order_for_every_serving_surface():
     expected = {
-        STTServingSurface.STREAMING: 'dg-nova-3,modulate-velma-2,parakeet',
+        STTServingSurface.STREAMING: 'modulate-velma-2,soniox,dg-nova-3',
         STTServingSurface.PRERECORDED: 'parakeet,modulate-velma-2',
         STTServingSurface.PTT: 'modulate-velma-2,parakeet',
     }

--- a/backend/tests/unit/test_stt_session_failover.py
+++ b/backend/tests/unit/test_stt_session_failover.py
@@ -50,7 +50,7 @@ def test_excluding_the_dead_provider_selects_the_next_one():
     """The whole point of the exclusion: never reselect what just died."""
     with patch.dict(
         'os.environ',
-        {'STT_SERVICE_MODELS': 'modulate-velma-2,soniox,dg-nova-3', 'SONIOX_API_KEY': 'k'},
+        {'STT_SERVICE_MODELS': 'modulate-velma-2,soniox,dg-nova-3,parakeet', 'SONIOX_API_KEY': 'k'},
     ), patch('utils.stt.streaming.stt_service_models', ['modulate-velma-2', 'soniox', 'dg-nova-3']):
         first, _, _ = get_stt_service_for_language('en')
         assert first == STTService.modulate

--- a/backend/tests/unit/test_verify_pusher_config_references.py
+++ b/backend/tests/unit/test_verify_pusher_config_references.py
@@ -187,7 +187,7 @@ def test_rendered_dev_pusher_direct_bindings_match_source_contract(preflight: Si
         "OMI_LLM_GATEWAY_FEATURE_MODE": "gateway",
         "OMI_LLM_GATEWAY_URL": "http://dev-omi-llm-gateway.dev-omi-backend.svc.cluster.local:8080",
         "STT_PRERECORDED_MODEL": "parakeet,modulate-velma-2",
-        "STT_SERVICE_MODELS": "modulate-velma-2,soniox,dg-nova-3",
+        "STT_SERVICE_MODELS": "modulate-velma-2,soniox,dg-nova-3,parakeet",
     }
     assert clear_historical_secret == {"REDIS_DB_HOST", "GOOGLE_CLIENT_ID", "TYPESENSE_HOST"}
     assert preflight.validate_dev_pusher_binding_contract(deployment) == []
@@ -201,7 +201,7 @@ def test_prod_pusher_retains_the_explicit_self_hosted_deepgram_contract(prefligh
     assert bindings["DEEPGRAM_API_KEY"] == ("secret", "prod-omi-backend-secrets", "DEEPGRAM_API_KEY")
     assert literals["DEEPGRAM_SELF_HOSTED_ENABLED"] == "true"
     assert literals["DEEPGRAM_SELF_HOSTED_URL"] == "https://dg.omi.me"
-    assert literals["STT_SERVICE_MODELS"] == "modulate-velma-2,soniox,dg-nova-3"
+    assert literals["STT_SERVICE_MODELS"] == "modulate-velma-2,soniox,dg-nova-3,parakeet"
 
 
 def test_dev_pusher_literal_policy_rejects_stale_deepgram_model(preflight: SimpleNamespace):
@@ -212,7 +212,7 @@ def test_dev_pusher_literal_policy_rejects_stale_deepgram_model(preflight: Simpl
 
     assert preflight.validate_dev_pusher_binding_contract(deployment) == [
         "dev pusher literal contract mismatch for STT_SERVICE_MODELS: "
-        "expected 'modulate-velma-2,soniox,dg-nova-3', got 'modulate-velma-2'"
+        "expected 'modulate-velma-2,soniox,dg-nova-3,parakeet', got 'modulate-velma-2'"
     ]
 
 

--- a/backend/tests/unit/test_verify_pusher_config_references.py
+++ b/backend/tests/unit/test_verify_pusher_config_references.py
@@ -187,7 +187,7 @@ def test_rendered_dev_pusher_direct_bindings_match_source_contract(preflight: Si
         "OMI_LLM_GATEWAY_FEATURE_MODE": "gateway",
         "OMI_LLM_GATEWAY_URL": "http://dev-omi-llm-gateway.dev-omi-backend.svc.cluster.local:8080",
         "STT_PRERECORDED_MODEL": "parakeet,modulate-velma-2",
-        "STT_SERVICE_MODELS": "dg-nova-3,modulate-velma-2,parakeet",
+        "STT_SERVICE_MODELS": "modulate-velma-2,soniox,dg-nova-3",
     }
     assert clear_historical_secret == {"REDIS_DB_HOST", "GOOGLE_CLIENT_ID", "TYPESENSE_HOST"}
     assert preflight.validate_dev_pusher_binding_contract(deployment) == []
@@ -201,7 +201,7 @@ def test_prod_pusher_retains_the_explicit_self_hosted_deepgram_contract(prefligh
     assert bindings["DEEPGRAM_API_KEY"] == ("secret", "prod-omi-backend-secrets", "DEEPGRAM_API_KEY")
     assert literals["DEEPGRAM_SELF_HOSTED_ENABLED"] == "true"
     assert literals["DEEPGRAM_SELF_HOSTED_URL"] == "https://dg.omi.me"
-    assert literals["STT_SERVICE_MODELS"] == "dg-nova-3,modulate-velma-2,parakeet"
+    assert literals["STT_SERVICE_MODELS"] == "modulate-velma-2,soniox,dg-nova-3"
 
 
 def test_dev_pusher_literal_policy_rejects_stale_deepgram_model(preflight: SimpleNamespace):
@@ -212,7 +212,7 @@ def test_dev_pusher_literal_policy_rejects_stale_deepgram_model(preflight: Simpl
 
     assert preflight.validate_dev_pusher_binding_contract(deployment) == [
         "dev pusher literal contract mismatch for STT_SERVICE_MODELS: "
-        "expected 'dg-nova-3,modulate-velma-2,parakeet', got 'modulate-velma-2'"
+        "expected 'modulate-velma-2,soniox,dg-nova-3', got 'modulate-velma-2'"
     ]
 
 


### PR DESCRIPTION
## Problem

The serving order was pinned to Deepgram-first in nine places:

```
dg-nova-3,modulate-velma-2,parakeet
```

That no longer matches how production runs, and the next `helm upgrade` or Cloud Run
deploy would silently revert live serving to Deepgram-primary.

The chart values are **not** the source of truth — `DEFAULT_MODELS_BY_SURFACE` in
`config/stt_provider_policy.py` is, and both `test_backend_listen_helm_defaults.py` and
`validate-backend-runtime-env.py` assert every deployment matches it. Changing the charts
alone fails those contracts, so this changes the policy and propagates it everywhere.

## New order

```
modulate-velma-2,soniox,dg-nova-3,parakeet
```

- **Velma primary** — lowest cost per hour of audio.
- **Soniox second** — with mid-session failover (#12459) merged, a Velma error frame now
  hands the stream to Soniox instead of ending the session. This slot is what that fix
  relies on.
- **Deepgram last** — kept deliberately. Selection requires a `dg-*` entry in the list, so
  removing it would strip BYOK users of Deepgram entirely.
- **Parakeet dropped** — streaming Parakeet is English-only and live sessions are
  overwhelmingly auto-detect, so it was never selected on this surface.

## Everything updated

| file | role |
|---|---|
| `config/stt_provider_policy.py` | policy source of truth |
| `charts/backend-listen/{prod,dev}` | live listen serving |
| `charts/pusher/{prod,dev}` | pusher serving |
| `deploy/runtime_env/{_base,dev.overlay,prod.overlay}.yaml` | deploy sources |
| `deploy/runtime_env.yaml` | regenerated via `compose_runtime_env.py` |
| `deploy/_generate_runtime_env_sources.py` | generator default |
| `.github/workflows/gcp_backend_pusher.yml` | pusher deploy workflow |
| 4 unit test files | expectations that hardcoded the old order |

`validate-backend-runtime-env.py --env prod` and `--env dev` both pass, and the affected
contract tests pass under `test.sh`.

## Parakeet stays last

Dropping Parakeet broke the explicit client route: `/v4/listen?stt_service=parakeet`
is honored only while Parakeet is present in the model list, so removing it silently
disabled that route. The hermetic e2e wire-contract test caught this. It is now last in
the chain — never selected by default (streaming Parakeet is English-only and live
sessions are overwhelmingly auto-detect), but still reachable on request.

## Pusher

Included because the validator requires every GKE workload's `STT_SERVICE_MODELS` to
equal the streaming policy. Its `DEEPGRAM_SELF_HOSTED_ENABLED=true` /
`DEEPGRAM_SELF_HOSTED_URL=https://dg.omi.me` settings are stale: there is no
`deepgram-self-hosted` deployment in the cluster, the endpoint does not accept
connections, and pusher logs show no Deepgram traffic. Nothing is lost by reordering it.

Failure-Class: none

The `fix:` commit in this branch repairs a regression introduced earlier in the same
branch (dropping Parakeet disabled the explicit `?stt_service=parakeet` route) and caught
by the hermetic e2e wire contract before merge. No shipped behaviour ever carried the
defect, so there is no production failure class to record.

## Product invariants affected

- **INV-DATA-1** — production-family customer data-plane continuity. Unaffected: this
  changes STT provider ordering only. No Firebase project, Firestore database, account
  universe, or serving endpoint changes; every environment keeps the plane it already had.
- **INV-MEM-4** — canonical promotion is the sole Long-term authority. Unaffected: no
  intake, consolidation, or promotion path is touched. Transcript content reaches memory
  by the same route regardless of which provider produced it.
