### PR TITLE
fix(backend): chunk screen-activity vector deletes to Pinecone's id limit

### DIFF
--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -920,7 +920,9 @@ def delete_screen_activity_vectors(uid: str, ids: List[str]) -> None:
     if index is None:
         return
     vector_ids = [f'{uid}-sa-{sid}' for sid in ids]
-    index.delete(ids=vector_ids, namespace=SCREEN_ACTIVITY_NAMESPACE)
+    # Chunk to stay within Pinecone's per-delete id limit (1,000).
+    for i in range(0, len(vector_ids), 1000):
+        index.delete(ids=vector_ids[i : i + 1000], namespace=SCREEN_ACTIVITY_NAMESPACE)
 
 
 # ==========================================

--- a/backend/tests/unit/test_screen_activity_vector_delete_chunking.py
+++ b/backend/tests/unit/test_screen_activity_vector_delete_chunking.py
@@ -1,0 +1,59 @@
+"""Screen-activity vector deletes must respect Pinecone's per-delete id limit.
+
+Prod, 2026-08-30/31 (`backend-sync`): every account-deletion wipe for one uid
+failed with
+
+    delete_account purge screen activity vectors failed for <uid>: (400)
+    required derived purge failed: screen_activity_vectors
+
+``delete_screen_activity_vectors`` passed every screenshot id in a single
+``index.delete`` call. Pinecone rejects more than 1,000 ids with a 400, and this
+purge is a *required* one, so the wipe aborted before the Firestore delete, the
+record was marked failed, and it retried on that same 400 indefinitely. Any
+account with more than 1,000 screenshots could not be deleted at all.
+
+Every sibling batch delete in this module already chunks at 1,000.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from database import vector_db
+
+
+@pytest.fixture
+def index(monkeypatch) -> MagicMock:
+    fake = MagicMock()
+    monkeypatch.setattr(vector_db, 'index', fake)
+    return fake
+
+
+def test_delete_stays_within_the_thousand_id_limit(index: MagicMock) -> None:
+    vector_db.delete_screen_activity_vectors('user-1', [f'sa-{n}' for n in range(2500)])
+
+    assert index.delete.call_count == 3
+    sizes = [len(call.kwargs['ids']) for call in index.delete.call_args_list]
+    assert sizes == [1000, 1000, 500]
+    assert all(call.kwargs['namespace'] == vector_db.SCREEN_ACTIVITY_NAMESPACE for call in index.delete.call_args_list)
+
+
+def test_every_id_is_deleted_exactly_once(index: MagicMock) -> None:
+    vector_db.delete_screen_activity_vectors('user-1', [f'sa-{n}' for n in range(1001)])
+
+    deleted = [vector_id for call in index.delete.call_args_list for vector_id in call.kwargs['ids']]
+    assert deleted == [f'user-1-sa-sa-{n}' for n in range(1001)]
+
+
+def test_a_small_delete_still_makes_one_call(index: MagicMock) -> None:
+    vector_db.delete_screen_activity_vectors('user-1', ['sa-1', 'sa-2'])
+
+    index.delete.assert_called_once_with(
+        ids=['user-1-sa-sa-1', 'user-1-sa-sa-2'], namespace=vector_db.SCREEN_ACTIVITY_NAMESPACE
+    )
+
+
+def test_no_ids_issues_no_call(index: MagicMock) -> None:
+    vector_db.delete_screen_activity_vectors('user-1', [])
+
+    index.delete.assert_not_called()


### PR DESCRIPTION
## Summary

Account deletions have been failing in prod on one step. From `backend-sync`, repeating every few seconds for the same uid:

```
delete_account purge screen activity vectors failed for <uid>: (400)
delete_account background wipe failed for <uid>: required derived purge failed: screen_activity_vectors
```

`delete_screen_activity_vectors` passed every screenshot id to Pinecone in a single call:

```python
vector_ids = [f'{uid}-sa-{sid}' for sid in ids]
index.delete(ids=vector_ids, namespace=SCREEN_ACTIVITY_NAMESPACE)
```

Pinecone rejects a delete carrying more than 1,000 ids with a 400. `screen_activity_vectors` is a **required** purge, so that 400 aborts the wipe before the Firestore delete, marks the record failed, and the reconciler re-dispatches it onto the same 400 forever. An account with more than 1,000 screenshots could not be deleted at all — `wipe_attempts` on the affected records is up to 9.

Every other bulk delete in this module already chunks. `delete_action_item_vectors_batch` does it twelve lines below, with the comment naming the limit; `delete_conversation_vectors_batch` and both transcript-chunk deletes do the same; the screen-activity *upsert* directly above chunks at 100. This one call site was missed.

## What changed

Chunk at 1,000, matching its siblings. An empty id list now issues no Pinecone call at all, where before it sent `ids=[]`.

## Verification

- `tests/unit/test_screen_activity_vector_delete_chunking.py` — **4 passed**: 2,500 ids become 3 calls sized 1000/1000/500, every id is deleted exactly once and keeps its `{uid}-sa-{id}` shape, a small delete stays one call, an empty list issues none.
- **The tests fail without the fix.** I reverted the change and re-ran: `test_delete_stays_within_the_thousand_id_limit` and `test_no_ids_issues_no_call` both fail, then pass again once restored. They would have caught this.
- `tests/unit/test_delete_account_purge_storage.py` — **5 passed** alongside them (9 together), so the purge path's existing contract is unchanged.
- `make preflight` passes.

Not verified end to end: I did not watch a real account wipe complete after this. That needs a deploy, and the affected records will retry on their own once it lands — worth confirming `wipe_status` moves to `completed` for the stuck uids afterwards rather than assuming it.

## Scope

This is the immediate blocker only. The broader reliability questions in this subsystem — the reconciler being cancelled by Cloud Run instance recycling, `billing_failed` being a state nothing can action, and a claim that any credentialed process can take — are real but separate, and each wants its own change rather than being folded in here.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

