### PR TITLE
fix(listen): fail over at the audio send path, not just the death-monitor poll

### DIFF
--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -132,6 +132,7 @@ class ListenReceiver:
         # reselect one, or a dead primary would be chosen again immediately.
         self._stt_failed_providers: set[str] = set()
         self._stt_rebuild: Optional[Tuple[Any, Any, int]] = None
+        self._stt_failover_lock = asyncio.Lock()
         self.stt_sockets_multi: List[Any] = [None] * len(channel_configs)
         self.multi_opus_decoders: List[Any] = [None] * len(channel_configs)
         self.channel_mix_buffers: List[bytearray] = [bytearray() for _ in channel_configs]
@@ -497,7 +498,18 @@ class ListenReceiver:
 
         Single-channel only. Multi-channel holds several sockets whose segments are
         stitched by channel, so swapping one mid-stream needs its own design.
+
+        Serialized: the death monitor and the audio send path can observe the same
+        death within milliseconds of each other, and the loser of the lock must
+        adopt the winner's replacement instead of burning another chain slot on a
+        second rebuild.
         """
+        async with self._stt_failover_lock:
+            if self.stt_socket is not None and not live_stt_socket_is_dead(self.stt_socket):
+                return True
+            return await self._rebuild_stt_socket_locked()
+
+    async def _rebuild_stt_socket_locked(self) -> bool:
         rebuild = getattr(self, '_stt_rebuild', None)
         if rebuild is None or self.host.is_multi_channel or self.host.use_custom_stt:
             return False
@@ -656,34 +668,44 @@ class ListenReceiver:
 
     async def _flush_stt_buffer(self, buffer: bytearray, *, force: bool = False) -> None:
         request = self.host.request
-        socket_dead = self.stt_socket is not None and live_stt_socket_is_dead(self.stt_socket)
-        decision = decide_stt_buffer_flush(
-            buffer_len=len(buffer),
-            flush_size=stt_buffer_flush_size(request.sample_rate),
-            force=force,
-            socket_dead=socket_dead,
-            socket_available=self.stt_socket is not None,
-            fair_use_dg_budget_exhausted=self.host.state.fair_use_dg_budget_exhausted,
-            fair_use_track_dg_usage=self.host.state.fair_use_track_dg_usage,
-            sample_rate=request.sample_rate,
-        )
-        if not decision.should_flush:
-            return
-        if self.host.state.fair_use_dg_budget_exhausted:
-            buffer.clear()
-            return
-        outbound_audio = bytes(buffer)
-        sent = await flush_live_stt_buffer(
-            request.websocket,
-            self.host.state,
-            stt_socket=self.stt_socket,
-            buffer=buffer,
-            provider=self._serving_provider(),
-            platform=self.host.client_device_context.platform,
-        )
-        if sent:
-            self._capture('capture_outbound_stt', outbound_audio)
-            self.host.state.dg_usage_ms_pending += decision.dg_usage_ms
+        # Bounded retry, not a single attempt: when the send path fails over to
+        # the next provider the chunk is reported unsent with the buffer intact,
+        # and it must reach the replacement socket now — the next client chunk
+        # may be a VAD-gated silence away. `_failover_stt_socket` enforces
+        # MAX_STT_FAILOVERS, so the bound here is a backstop, not the limit.
+        for _ in range(MAX_STT_FAILOVERS + 2):
+            socket_dead = self.stt_socket is not None and live_stt_socket_is_dead(self.stt_socket)
+            decision = decide_stt_buffer_flush(
+                buffer_len=len(buffer),
+                flush_size=stt_buffer_flush_size(request.sample_rate),
+                force=force,
+                socket_dead=socket_dead,
+                socket_available=self.stt_socket is not None,
+                fair_use_dg_budget_exhausted=self.host.state.fair_use_dg_budget_exhausted,
+                fair_use_track_dg_usage=self.host.state.fair_use_track_dg_usage,
+                sample_rate=request.sample_rate,
+            )
+            if not decision.should_flush:
+                return
+            if self.host.state.fair_use_dg_budget_exhausted:
+                buffer.clear()
+                return
+            outbound_audio = bytes(buffer)
+            sent = await flush_live_stt_buffer(
+                request.websocket,
+                self.host.state,
+                stt_socket=self.stt_socket,
+                buffer=buffer,
+                provider=self._serving_provider(),
+                platform=self.host.client_device_context.platform,
+                attempt_failover=self._failover_stt_socket,
+            )
+            if sent:
+                self._capture('capture_outbound_stt', outbound_audio)
+                self.host.state.dg_usage_ms_pending += decision.dg_usage_ms
+                return
+            if self.host.state.stt_terminal_failure:
+                return
 
     async def _handle_multi_channel_audio(self, data: bytes) -> int:
         request = self.host.request

--- a/backend/testing/e2e/fakes/stt.py
+++ b/backend/testing/e2e/fakes/stt.py
@@ -70,11 +70,17 @@ class FakeStreamingSTTSocket:
         self.finish_calls += 1
 
 
-def install_streaming_stt_fake(monkeypatch, *, die_on_first_send=False):
+def install_streaming_stt_fake(monkeypatch, *, die_on_first_send=False, failover_selection=(None, None, None)):
     """Patch the listen receiver provider boundary and return fake sockets.
 
     Deepgram is retired from serving, so the fake now patches the enabled
     provider entry points (Parakeet/Modulate) and returns an enabled service.
+
+    ``die_on_first_send`` kills only the first socket the session creates; a
+    replacement built by a mid-session failover is healthy, mirroring a chain
+    whose next provider serves. ``failover_selection`` is what the receiver's
+    reselection returns after that death — the default ``(None, None, None)``
+    models a chain with no provider left, so a death stays terminal.
     """
     from routers.listen import receiver as listen_receiver
     from routers.listen import runtime as listen_runtime
@@ -83,12 +89,12 @@ def install_streaming_stt_fake(monkeypatch, *, die_on_first_send=False):
     sockets = []
 
     async def fake_process_audio_parakeet(callback, *args, **kwargs):
-        socket = FakeStreamingSTTSocket(callback, die_on_first_send=die_on_first_send)
+        socket = FakeStreamingSTTSocket(callback, die_on_first_send=die_on_first_send and not sockets)
         sockets.append(socket)
         return socket
 
     async def fake_process_audio_modulate(callback, *args, **kwargs):
-        socket = FakeStreamingSTTSocket(callback, die_on_first_send=die_on_first_send)
+        socket = FakeStreamingSTTSocket(callback, die_on_first_send=die_on_first_send and not sockets)
         sockets.append(socket)
         return socket
 
@@ -100,6 +106,14 @@ def install_streaming_stt_fake(monkeypatch, *, die_on_first_send=False):
         listen_runtime,
         "get_stt_service_for_language",
         lambda *_args, **_kwargs: (STTService.parakeet, "en", "parakeet"),
+    )
+    # The receiver's own namespace drives mid-session failover reselection; left
+    # unpatched it reads the real provider chain and reaches for un-faked
+    # network clients.
+    monkeypatch.setattr(
+        listen_receiver,
+        "get_stt_service_for_language",
+        lambda *_args, **_kwargs: failover_selection,
     )
     monkeypatch.setattr(listen_receiver, "is_gate_enabled", lambda: False)
     monkeypatch.setattr(listen_runtime, "record_usage", lambda *args, **kwargs: None)

--- a/backend/testing/e2e/test_listen_pusher_wire_contract.py
+++ b/backend/testing/e2e/test_listen_pusher_wire_contract.py
@@ -375,7 +375,12 @@ def test_listen_pusher_wire_contract_provider_connect_failure_is_terminal(
 def test_listen_pusher_wire_contract_provider_send_failure_is_terminal_after_pusher_connects(
     client, test_uid, monkeypatch, fake_firestore
 ):
-    """A real provider death latch stops the live route before transcript or finalization work."""
+    """A provider death with the chain exhausted stops the live route before pusher work.
+
+    The send path first offers the session a failover (#12469); this harness
+    runs a parakeet-only chain, so reselection finds nothing and the death must
+    still end the route with the bounded terminal contract.
+    """
 
     async def unexpected_finalization(_peer, _frame, _websocket):
         raise AssertionError('provider send failure must not reach pusher finalization')
@@ -387,6 +392,11 @@ def test_listen_pusher_wire_contract_provider_send_failure_is_terminal_after_pus
     pusher = ScriptedPusherPeer(unexpected_finalization).start()
     try:
         _configure_live_wire_contract(monkeypatch, pusher, parakeet.api_url)
+        # Failover reselection reads the receiver's namespace; a parakeet-only
+        # chain means the death latch has nowhere to go and stays terminal.
+        import routers.listen.receiver as listen_receiver
+
+        monkeypatch.setattr(listen_receiver, 'get_stt_service_for_language', lambda *_a, **_k: (None, None, None))
         install_fake_firestore_transactions(monkeypatch, fake_firestore)
         clear_finalization_jobs(fake_firestore, test_uid)
         seed_listen_user(test_uid, uses_custom_stt=False, single_language_mode=True)

--- a/backend/testing/e2e/test_listen_stt.py
+++ b/backend/testing/e2e/test_listen_stt.py
@@ -348,7 +348,13 @@ def test_web_listen_streaming_stt_send_failure_emits_terminal_status_then_closes
     test_uid,
     monkeypatch,
 ):
-    """A provider death is explicit and terminal instead of leaving a green socket."""
+    """With no provider left to fail over to, a death is explicit and terminal.
+
+    The fake's default ``failover_selection`` models an exhausted chain, so the
+    send path's failover attempt (#12469) finds nothing and the session must
+    still end with the bounded ``stt_failed``/1011 wire contract instead of
+    leaving a green socket.
+    """
 
     seed_listen_user(test_uid, uses_custom_stt=False)
     sockets = install_streaming_stt_fake(monkeypatch, die_on_first_send=True)
@@ -398,6 +404,45 @@ def test_web_listen_streaming_stt_send_failure_emits_terminal_status_then_closes
     }
     assert len(sockets) == 1
     assert len(sockets[0].sent_chunks) == 1
+
+
+def test_web_listen_streaming_stt_send_failure_fails_over_and_the_session_survives(
+    client,
+    test_uid,
+    monkeypatch,
+):
+    """A provider death with a provider left in the chain moves the session, not ends it.
+
+    The send path observes the death on the very next audio chunk — before the
+    1s death-monitor poll — and must hand the session to the next provider
+    (#12459's chain, made reachable by #12469): the buffered audio reaches the
+    replacement socket in the same flush, a transcript flows from it, and the
+    client socket never sees ``stt_failed``.
+    """
+    from utils.stt.streaming import STTService
+
+    seed_listen_user(test_uid, uses_custom_stt=False)
+    sockets = install_streaming_stt_fake(
+        monkeypatch,
+        die_on_first_send=True,
+        failover_selection=(STTService.modulate, "en", "modulate-velma-2"),
+    )
+
+    with client.websocket_connect("/v4/web/listen?sample_rate=8000&codec=pcm8&source=desktop") as websocket:
+        websocket.send_text(json.dumps({"type": "auth", "token": "dev-token"}))
+        assert websocket.receive_json() == {"type": "auth_response", "success": True}
+        receive_until(websocket, is_conversation_session_event)
+        receive_until(websocket, is_ready_event)
+
+        websocket.send_bytes(b"\x80" * 320)
+
+        segments = receive_until(websocket, is_streaming_segment_batch)
+
+    assert segments[0]["text"] == "Hermetic streaming STT transcript from the fake socket."
+    assert len(sockets) == 2
+    # The dead socket's buffered audio was retried against the replacement.
+    assert sockets[1].sent_chunks == sockets[0].sent_chunks
+    assert sockets[0].finish_calls >= 1
 
 
 def test_web_listen_reconnect_reuses_active_conversation_id(client, test_uid, monkeypatch):

--- a/backend/tests/unit/test_live_stt_failure.py
+++ b/backend/tests/unit/test_live_stt_failure.py
@@ -228,6 +228,92 @@ async def test_single_channel_dead_socket_preserves_unsent_buffer_and_terminates
 
 
 @pytest.mark.asyncio
+async def test_dead_socket_with_a_successful_failover_is_not_terminal() -> None:
+    """The send path must offer the session's failover before declaring terminal.
+
+    It observes a provider death on the very next audio chunk — hundreds of
+    milliseconds before the 1s death-monitor poll — so terminating here made
+    #12459's failover structurally unreachable for any session with audio
+    flowing: 3,110 modulate sessions terminated in 30 minutes on 2026-08-31
+    with zero failovers fired.
+    """
+    websocket = FakeClientSocket()
+    session = FakeSession()
+    provider_socket = FakeProviderSocket(dead=True)
+    audio = bytearray(b'synthetic-pcm')
+    failover_calls: list[bool] = []
+
+    async def attempt_failover() -> bool:
+        failover_calls.append(True)
+        return True
+
+    sent = await flush_live_stt_buffer(
+        websocket,
+        session,
+        stt_socket=provider_socket,
+        buffer=audio,
+        provider='modulate',
+        platform='ios',
+        attempt_failover=attempt_failover,
+    )
+
+    assert sent is False
+    # The chunk is retained so the caller can retry it against the replacement.
+    assert audio == b'synthetic-pcm'
+    assert failover_calls == [True]
+    assert session.stt_terminal_failure is False
+    assert session.active is True
+    assert websocket.actions == []
+
+
+@pytest.mark.asyncio
+async def test_dead_socket_with_an_exhausted_failover_chain_stays_terminal() -> None:
+    websocket = FakeClientSocket()
+    session = FakeSession()
+
+    async def attempt_failover() -> bool:
+        return False
+
+    sent = await send_live_stt_audio(
+        websocket,
+        session,
+        stt_socket=FakeProviderSocket(dead=True),
+        audio=b'synthetic-pcm',
+        provider='modulate',
+        platform='ios',
+        attempt_failover=attempt_failover,
+    )
+
+    assert sent is False
+    assert session.stt_terminal_failure is True
+    assert websocket.actions[-1] == ('close', LIVE_STT_FAILURE_CLOSE_CODE, LIVE_STT_FAILURE_CLOSE_REASON)
+
+
+@pytest.mark.asyncio
+async def test_a_death_latched_during_send_also_offers_failover() -> None:
+    websocket = FakeClientSocket()
+    session = FakeSession()
+    provider_socket = FakeProviderSocket(die_during_send=True)
+
+    async def attempt_failover() -> bool:
+        return True
+
+    sent = await send_live_stt_audio(
+        websocket,
+        session,
+        stt_socket=provider_socket,
+        audio=b'synthetic-pcm',
+        provider='modulate',
+        platform='ios',
+        attempt_failover=attempt_failover,
+    )
+
+    assert sent is False
+    assert session.stt_terminal_failure is False
+    assert websocket.actions == []
+
+
+@pytest.mark.asyncio
 async def test_unreadable_provider_death_latch_is_terminal() -> None:
     websocket = FakeClientSocket()
     session = FakeSession()

--- a/backend/tests/unit/test_stt_session_failover.py
+++ b/backend/tests/unit/test_stt_session_failover.py
@@ -26,6 +26,7 @@ class FakeSocket:
     def __init__(self, dead: bool = False):
         self._dead = dead
         self.finished = False
+        self.sent: list[bytes] = []
 
     @property
     def is_connection_dead(self) -> bool:
@@ -34,6 +35,12 @@ class FakeSocket:
     @property
     def death_reason(self) -> Optional[str]:
         return 'modulate error: Internal server error' if self._dead else None
+
+    def send(self, audio: bytes) -> bool:
+        if self._dead:
+            return False
+        self.sent.append(audio)
+        return True
 
     def finish(self) -> None:
         self.finished = True
@@ -144,3 +151,66 @@ async def test_failover_is_bounded_so_a_flapping_chain_cannot_loop(monkeypatch):
         return_value=(STTService.soniox, 'en', 'soniox'),
     ):
         assert await receiver._failover_stt_socket() is False
+
+
+@pytest.mark.asyncio
+async def test_failover_adopts_a_replacement_installed_by_the_other_observer(monkeypatch):
+    """The death monitor and the send path race to the same death; the loser of
+    the failover lock must adopt the winner's healthy socket, not rebuild again."""
+    receiver = _receiver_with_dead_socket(monkeypatch, replacement=FakeSocket(dead=False))
+    receiver.stt_socket = FakeSocket(dead=False)
+
+    assert await receiver._failover_stt_socket() is True
+    receiver._create_stt_socket.assert_not_called()
+
+
+def _receiver_with_flowing_audio(monkeypatch: Any, *, primary: Any, replacement: Any):
+    receiver = _receiver_with_dead_socket(monkeypatch, replacement=replacement)
+    receiver.stt_socket = primary
+    host = receiver.host
+    host.state.fair_use_dg_budget_exhausted = False
+    host.state.fair_use_track_dg_usage = False
+    host.state.dg_usage_ms_pending = 0
+    host.request.sample_rate = 16000
+    host.request.websocket = MagicMock(send_json=AsyncMock(), close=AsyncMock())
+    host.client_device_context.platform = 'ios'
+    return receiver
+
+
+@pytest.mark.asyncio
+async def test_a_death_observed_by_the_audio_send_path_fails_over_not_terminates(monkeypatch):
+    """The regression behind the 2026-08-31 outage hours: the send path observes
+    a provider death on the very next audio chunk — before the 1s death-monitor
+    poll — and used to terminate there, so the monitor's failover (#12459) never
+    fired on a session with audio flowing (3,110 terminations, zero failovers in
+    30 minutes). The flush must fail over and deliver the buffered audio to the
+    replacement socket in the same call."""
+    healthy = FakeSocket(dead=False)
+    receiver = _receiver_with_flowing_audio(monkeypatch, primary=FakeSocket(dead=True), replacement=healthy)
+    buffer = bytearray(b'synthetic-pcm')
+
+    with patch(
+        'routers.listen.receiver.get_stt_service_for_language',
+        return_value=(STTService.soniox, 'en', 'soniox'),
+    ):
+        await receiver._flush_stt_buffer(buffer, force=True)
+
+    assert receiver.stt_socket is healthy
+    assert healthy.sent == [b'synthetic-pcm']
+    assert len(buffer) == 0
+    assert receiver.host.state.stt_terminal_failure is False
+    receiver.host.request.websocket.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_the_audio_send_path_still_terminates_once_the_chain_is_exhausted(monkeypatch):
+    receiver = _receiver_with_flowing_audio(
+        monkeypatch, primary=FakeSocket(dead=True), replacement=FakeSocket(dead=False)
+    )
+    buffer = bytearray(b'synthetic-pcm')
+
+    with patch('routers.listen.receiver.get_stt_service_for_language', return_value=(None, None, None)):
+        await receiver._flush_stt_buffer(buffer, force=True)
+
+    assert receiver.host.state.stt_terminal_failure is True
+    receiver.host.request.websocket.close.assert_awaited_once()

--- a/backend/utils/stt/live_failure.py
+++ b/backend/utils/stt/live_failure.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Protocol
+from typing import Any, Awaitable, Callable, Protocol
 
 from models.message_event import MessageServiceStatusEvent
 from utils.metrics import OMI_LIVE_STT_MISALIGNED_FRAMES_TOTAL
@@ -167,8 +167,18 @@ async def send_live_stt_audio(
     audio: bytes,
     provider: str | None,
     platform: str | None,
+    attempt_failover: Callable[[], Awaitable[bool]] | None = None,
 ) -> bool:
-    """Send one audio chunk, terminating the client if the provider is unusable."""
+    """Send one audio chunk, terminating the client if the provider is unusable.
+
+    ``attempt_failover`` is the session's chance to swap a dead provider socket
+    for the next one in the chain before this path declares the failure
+    terminal. The send path observes a provider death on the very next audio
+    chunk — hundreds of milliseconds before the 1s death-monitor poll — so
+    without the gate here the monitor's failover (#12459) loses that race on
+    every session with audio flowing. After a successful failover the chunk is
+    reported unsent so the caller retries it against the replacement socket.
+    """
 
     # Observed on every provider, not just Velma: whether production emits frames that
     # are not whole 16-bit samples is otherwise unmeasurable without exposing users to
@@ -176,6 +186,19 @@ async def send_live_stt_audio(
     if len(audio) % 2:
         OMI_LIVE_STT_MISALIGNED_FRAMES_TOTAL.labels(provider=bounded_provider(provider), stage='buffer').inc()
 
+    async def _recoverable_failure(reason: str) -> None:
+        if attempt_failover is not None and await attempt_failover():
+            return
+        await terminate_live_stt_session(
+            websocket,
+            session,
+            failure=live_stt_upstream_failure(provider),
+            reason=reason,
+            platform=platform,
+        )
+
+    # A None socket means initialization never produced one; there is nothing to
+    # fail over from, so this stays terminal.
     if stt_socket is None:
         await terminate_live_stt_session(
             websocket,
@@ -187,47 +210,23 @@ async def send_live_stt_audio(
         return False
 
     if live_stt_socket_is_dead(stt_socket):
-        await terminate_live_stt_session(
-            websocket,
-            session,
-            failure=live_stt_upstream_failure(provider),
-            reason='connection_lost',
-            platform=platform,
-        )
+        await _recoverable_failure('connection_lost')
         return False
 
     try:
         accepted = stt_socket.send(audio)
     except Exception:
-        await terminate_live_stt_session(
-            websocket,
-            session,
-            failure=live_stt_upstream_failure(provider),
-            reason='send_failed',
-            platform=platform,
-        )
+        await _recoverable_failure('send_failed')
         return False
 
     if accepted is not True:
-        await terminate_live_stt_session(
-            websocket,
-            session,
-            failure=live_stt_upstream_failure(provider),
-            reason='send_failed',
-            platform=platform,
-        )
+        await _recoverable_failure('send_failed')
         return False
 
     # Safe socket wrappers report send failures through the death latch instead
     # of raising so every provider must be checked after the send as well.
     if live_stt_socket_is_dead(stt_socket):
-        await terminate_live_stt_session(
-            websocket,
-            session,
-            failure=live_stt_upstream_failure(provider),
-            reason='send_failed',
-            platform=platform,
-        )
+        await _recoverable_failure('send_failed')
         return False
 
     return True
@@ -241,6 +240,7 @@ async def flush_live_stt_buffer(
     buffer: bytearray,
     provider: str | None,
     platform: str | None,
+    attempt_failover: Callable[[], Awaitable[bool]] | None = None,
 ) -> bool:
     """Send and clear a buffer only after the provider accepted its contents."""
 
@@ -251,6 +251,7 @@ async def flush_live_stt_buffer(
         audio=bytes(buffer),
         provider=provider,
         platform=platform,
+        attempt_failover=attempt_failover,
     )
     if sent:
         buffer.clear()


### PR DESCRIPTION
## Problem

#12459 added mid-session STT failover, but wired it only into `_monitor_stt_death`, which polls the death latch every 1.0s. The audio send path (`send_live_stt_audio`) checks the same latch on every chunk and terminated the session directly (`stt_failed` + WebSocket 1011). With audio flowing, the send path observes a provider death within ~100–300ms of the error frame — always before the 1s poll — so the failover was structurally unreachable exactly when it was needed.

Measured in production during the 2026-08-31 Velma outage (chain `velma → soniox → dg`, image `f125bb8` with #12459 deployed):

```
omi_live_stt_terminal_failures_total{provider="modulate", phase="connection"}: +3,110 in 30 min
'STT failover mid-session' log events: 0
```

Pod logs show the loop users sat in: Velma accepts the upgrade → `Modulate streaming error: Internal server error` ~300ms later → session closed ~200ms after that → the client reconnects → repeat, every ~2 seconds per device.

## Fix

- `send_live_stt_audio` — the single termination authority for the live send path — now accepts an `attempt_failover` callback and only declares a recoverable death terminal once the chain is exhausted. After a successful failover the chunk is reported unsent with the caller's buffer intact. `socket_unavailable` (no socket ever initialized) stays terminal: there is nothing to fail over from.
- `_flush_stt_buffer` passes `_failover_stt_socket` and retries in a bounded loop so the buffered audio reaches the replacement socket in the same call — the next client chunk can be a VAD-gated silence away.
- `_failover_stt_socket` is serialized behind a lock: the death monitor and the send path can observe the same death within milliseconds of each other, and the loser adopts the winner's replacement instead of burning a second chain slot on a redundant rebuild. `MAX_STT_FAILOVERS` still bounds the walk.
- Multi-channel and custom-STT sessions are unchanged; #12459's single-channel-only scope still applies.

The guard surface for this class is now behavioral, not positional: the termination authority itself refuses to declare a recoverable death terminal without offering the failover, and `tests/unit/test_live_stt_failure.py` pins that contract for every current and future caller of the send path.

## E2E wire-contract update

Two hermetic e2e tests asserted the pre-#12459 contract — any provider send failure is *immediately* terminal — and correctly failed on this branch. Per the rewritten-test rule, the external source for the new expected value is the merged #12459 failover design plus the production measurement above: a death is terminal only once reselection finds no provider. Both tests now pin the receiver's reselection to an exhausted chain and keep their exact terminal payload assertions (`stt_failed`, bounded reason, close 1011). The reselection pin is also a harness necessity: failover reselects via the receiver's namespace, which the fakes previously left unpatched, so it read the real provider chain and reached for un-faked network clients (the CI timeouts).

Added `test_web_listen_streaming_stt_send_failure_fails_over_and_the_session_survives`: the wire-level guard for this fix — first socket dies on first send, the session moves to the replacement, the same buffered chunk reaches it in the same flush, a transcript flows, and the client never sees `stt_failed`.

## Verification

Run with the pinned backend venv (`pylock.macos.toml`):

- `pytest testing/e2e/test_listen_stt.py` — 12 passed (new survival test included; terminal test unchanged assertions).
- `pytest testing/e2e/test_listen_pusher_wire_contract.py` — 7 passed.

- `pytest tests/unit/test_stt_session_failover.py` — 11 passed (4 new: a death observed by the send path fails over and delivers the buffered audio to the replacement in the same call; an exhausted chain still terminates; the lock loser adopts the already-installed replacement instead of rebuilding).
- `pytest tests/unit/test_live_stt_failure.py` — 16 passed (3 new: a successful failover is not terminal and preserves the unsent buffer; an exhausted failover stays terminal with the bounded close; a death latched during send also offers failover).
- `pytest tests/unit/test_listen_stt_death_monitor.py` — 4 passed (monitor path unchanged).

Not exercised against live Modulate: reproducing the outage needs Velma to emit mid-session error frames on demand. The regression tests drive the production code through the controllable seam the outage used (`live_stt_socket_is_dead` latch on the socket the flush path holds), and the production numbers above pin the failure mode this would have caught.

## Product invariants affected

none — `scripts/pr-preflight --suggest`: changed paths match no locked invariant globs.

Failure-Class: FC-recoverable-provider-failure-terminal
