### PR TITLE
fix(parakeet): cluster batch diarization offline, not by arrival order

### DIFF
--- a/.github/failure-classes/FC-partition-depends-on-arrival-order.json
+++ b/.github/failure-classes/FC-partition-depends-on-arrival-order.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-partition-depends-on-arrival-order",
+  "violated_contract": "A grouping computed over an input that is already complete — clustering, deduplication, bucketing — must be a function of its members and the distance or key that defines the grouping, never of the order those members were visited. Folding each element into mutable accumulated state as it is visited makes that accumulator a function of history instead, so the same members in a different order yield a different grouping and neither result can be defended as the correct one.",
+  "canonical_prevention": "Collect the whole input first, then derive the grouping in one pass over the complete set using an algorithm whose output depends only on the members. Keep incremental matching only where input genuinely arrives over time and a partial answer must be emitted before the rest exists; where a streaming and a batch consumer both exist, the batch path recomputes from the full set rather than replaying the streaming path's accumulation.",
+  "canonical_prevention_artifact": [
+    "backend/parakeet/transcribe.py",
+    "backend/tests/unit/test_parakeet_offline_diarization.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/parakeet/transcribe.py",
+    "backend/parakeet/speaker_math.py",
+    "backend/utils/stt/speaker_clustering.py"
+  ],
+  "status": "open"
+}

--- a/backend/parakeet/main.py
+++ b/backend/parakeet/main.py
@@ -256,6 +256,15 @@ async def transcribe_v2(
             status_code=422,
             content={"detail": f"min_speakers ({min_speakers}) cannot exceed max_speakers ({max_speakers})"},
         )
+    if num_speakers is not None and (min_speakers is not None or max_speakers is not None):
+        # An exact count and a range are contradictory requests. Rejecting is
+        # consistent with min > max above; silently preferring one would leave the
+        # caller believing a bound they set was honoured.
+        REQUESTS_TOTAL.labels(endpoint="v2_transcribe", status="error").inc()
+        return JSONResponse(
+            status_code=422,
+            content={"detail": "num_speakers cannot be combined with min_speakers or max_speakers"},
+        )
     speaker_bounds: Dict[str, Optional[int]] = {
         "num_speakers": num_speakers,
         "min_speakers": min_speakers,

--- a/backend/parakeet/main.py
+++ b/backend/parakeet/main.py
@@ -243,10 +243,24 @@ async def transcribe(file: UploadFile = File(...)) -> JSONResponse | Dict[str, A
 async def transcribe_v2(
     file: UploadFile = File(...),
     diarize: bool = Form(True),
+    num_speakers: Optional[int] = Form(None, gt=0),
+    min_speakers: Optional[int] = Form(None, gt=0),
+    max_speakers: Optional[int] = Form(None, gt=0),
 ) -> JSONResponse | Dict[str, Any]:
     if gpu_worker is not None and not gpu_worker.is_ready:
         REQUESTS_TOTAL.labels(endpoint="v2_transcribe", status="error").inc()
         return JSONResponse(status_code=503, content={"detail": "Model loading, try again shortly"})
+    if min_speakers is not None and max_speakers is not None and min_speakers > max_speakers:
+        REQUESTS_TOTAL.labels(endpoint="v2_transcribe", status="error").inc()
+        return JSONResponse(
+            status_code=422,
+            content={"detail": f"min_speakers ({min_speakers}) cannot exceed max_speakers ({max_speakers})"},
+        )
+    speaker_bounds: Dict[str, Optional[int]] = {
+        "num_speakers": num_speakers,
+        "min_speakers": min_speakers,
+        "max_speakers": max_speakers,
+    }
     upload_id = str(uuid.uuid4())
     file_path = f"_temp/{upload_id}_{file.filename}"
     ACTIVE_BATCH.inc()
@@ -275,14 +289,20 @@ async def transcribe_v2(
                 Dict[str, Any],
                 await loop.run_in_executor(
                     _diarize_pool,
-                    cast(Any, functools.partial(transcribe_file_v2, file_path, gpu_result=gpu_result, diarize=diarize)),
+                    cast(
+                        Any,
+                        functools.partial(
+                            transcribe_file_v2, file_path, gpu_result=gpu_result, diarize=diarize, **speaker_bounds
+                        ),
+                    ),
                 ),
             )
         else:
             result = cast(
                 Dict[str, Any],
                 await loop.run_in_executor(
-                    _diarize_pool, cast(Any, functools.partial(transcribe_file_v2, file_path, diarize=diarize))
+                    _diarize_pool,
+                    cast(Any, functools.partial(transcribe_file_v2, file_path, diarize=diarize, **speaker_bounds)),
                 ),
             )
         return result

--- a/backend/parakeet/transcribe.py
+++ b/backend/parakeet/transcribe.py
@@ -8,7 +8,8 @@ import httpx
 import numpy as np
 from langdetect import detect as _langdetect_detect_raw  # type: ignore[reportUnknownVariableType]  # langdetect ships partial type info
 from langdetect.lang_detect_exception import LangDetectException
-from speaker_math import cosine_distance as cosine_distance, select_speaker_cluster
+from scipy.cluster.hierarchy import fcluster, linkage
+from speaker_math import SPEAKER_CLUSTERING_MAX_SPEAKERS, cosine_distance as cosine_distance
 
 logger = logging.getLogger(__name__)
 
@@ -183,7 +184,12 @@ def _transcribe_via_gpu_worker(file_path: str) -> Dict[str, Any]:
 
 
 def transcribe_file_v2(
-    file_path: str, gpu_result: Optional[Dict[str, Any]] = None, diarize: bool = True
+    file_path: str,
+    gpu_result: Optional[Dict[str, Any]] = None,
+    diarize: bool = True,
+    num_speakers: Optional[int] = None,
+    min_speakers: Optional[int] = None,
+    max_speakers: Optional[int] = None,
 ) -> Dict[str, Any]:
     if gpu_result is not None:
         base: Dict[str, Any] = _transcribe_from_gpu_result(gpu_result)
@@ -191,7 +197,9 @@ def transcribe_file_v2(
         base = transcribe_file(file_path)
 
     if diarize:
-        base = _diarize_segments(file_path, base)
+        base = _diarize_segments(
+            file_path, base, num_speakers=num_speakers, min_speakers=min_speakers, max_speakers=max_speakers
+        )
     else:
         for seg in base["segments"]:
             seg["speaker"] = "SPEAKER_0"
@@ -202,6 +210,14 @@ def transcribe_file_v2(
 
 SPEAKER_EMBEDDING_URL: str = os.getenv("HOSTED_SPEAKER_EMBEDDING_API_URL", "")
 MIN_SEGMENT_DURATION = 0.6
+
+# Average-linkage AHC cuts the dendrogram on cophenetic merge height — the mean
+# distance between two whole clusters. The online path's SPEAKER_CLUSTERING_THRESHOLD
+# bounds a different quantity, the distance from one embedding to one drifting
+# centroid, so its value does not transfer. Measured on the VoxConverse test subset
+# (backend/tests/container/voxconverse): 0.55 cuts 3+ speaker DER from 0.174 to 0.130
+# while leaving 1-2 speaker DER unchanged, and every value in 0.40-0.55 beats 0.60.
+SPEAKER_AHC_THRESHOLD = float(os.getenv("PARAKEET_SPEAKER_AHC_THRESHOLD", "0.55"))
 
 
 def detect_language_from_text(text: str) -> str:
@@ -250,57 +266,153 @@ def _transcribe_nim(file_path: str) -> Dict[str, Any]:
         raise
 
 
-def _diarize_segments(file_path: str, base: Dict[str, Any]) -> Dict[str, Any]:
+def _diarize_segments(
+    file_path: str,
+    base: Dict[str, Any],
+    num_speakers: Optional[int] = None,
+    min_speakers: Optional[int] = None,
+    max_speakers: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Label every segment with a speaker using offline agglomerative clustering.
+
+    Embeddings for all eligible segments are collected first, then partitioned in
+    a single pass. Clustering the whole file at once makes the partition
+    independent of segment order; the previous online centroid matching could not
+    be, because each match folded the segment into a running mean. Those centroids
+    drifted as noisy segments merged, so a third speaker arriving late was absorbed
+    into whichever centroid had drifted nearest instead of opening its own cluster.
+    """
+    segments: List[Dict[str, Any]] = base["segments"]
+
     if not SPEAKER_EMBEDDING_URL and not has_builtin_embedding():
-        for seg in base["segments"]:
+        for seg in segments:
             seg["speaker"] = "SPEAKER_0"
         return base
 
     with open(file_path, "rb") as f:
         audio_bytes = f.read()
 
-    centroids: List[Any] = []
-    counts: List[int] = []
+    # SPEAKER_0 is the floor for every segment: anything too short to embed, and
+    # any failure below, keeps it unless clustering resolves something better.
+    for seg in segments:
+        seg["speaker"] = "SPEAKER_0"
 
-    for seg in base["segments"]:
-        seg_dur = seg["end"] - seg["start"]
-        if seg_dur < MIN_SEGMENT_DURATION:
-            seg["speaker"] = f"SPEAKER_{len(centroids) - 1}" if centroids else "SPEAKER_0"
+    embeddings: List[Any] = []
+    embedded_indices: List[int] = []
+
+    for index, seg in enumerate(segments):
+        if seg["end"] - seg["start"] < MIN_SEGMENT_DURATION:
             continue
 
         try:
             seg_wav = _extract_segment_wav(audio_bytes, seg["start"], seg["end"])
             if len(seg_wav) < 1000:
-                seg["speaker"] = f"SPEAKER_{len(centroids) - 1}" if centroids else "SPEAKER_0"
                 continue
 
-            emb = _get_embedding(seg_wav)
-            if emb is None:
-                seg["speaker"] = f"SPEAKER_{len(centroids) - 1}" if centroids else "SPEAKER_0"
+            vector = _embedding_vector(_get_embedding(seg_wav))
+            if vector is None:
                 continue
 
-            best_i, create_new, _, capped = select_speaker_cluster(emb, centroids)
-            if not create_new:
-                if capped:
-                    # Standalone image: log is the cap telemetry (no shared
-                    # fallback helper here). Keep the miss out of the running
-                    # mean so the centroid keeps representing its own speaker.
-                    logger.warning(f"Speaker cap ({len(centroids)}) reached; merging miss into SPEAKER_{best_i}")
-                else:
-                    n = counts[best_i]
-                    centroids[best_i] = (centroids[best_i] * n + emb) / (n + 1)
-                    counts[best_i] = n + 1
-                seg["speaker"] = f"SPEAKER_{best_i}"
-            else:
-                centroids.append(emb)
-                counts.append(1)
-                seg["speaker"] = f"SPEAKER_{best_i}"
-
+            embeddings.append(vector)
+            embedded_indices.append(index)
         except Exception as e:
             logger.warning(f"Diarization failed for segment {seg['start']:.1f}-{seg['end']:.1f}: {e}")
-            seg["speaker"] = f"SPEAKER_{len(centroids) - 1}" if centroids else "SPEAKER_0"
 
+    if not embeddings:
+        return base
+
+    try:
+        labels = _cluster_embeddings(embeddings, num_speakers, min_speakers, max_speakers)
+    except Exception as e:
+        logger.warning(f"Speaker clustering failed; every segment stays SPEAKER_0: {e}")
+        return base
+
+    _assign_speaker_labels(segments, embedded_indices, labels)
     return base
+
+
+def _embedding_vector(embedding: Any) -> Optional[Any]:
+    """Flatten an embedding into a finite, non-zero 1-D vector, or None."""
+    if embedding is None:
+        return None
+
+    vector = np.asarray(embedding, dtype=np.float32).reshape(-1)
+    if vector.size == 0 or not bool(np.all(np.isfinite(vector))):
+        return None
+    if float(np.linalg.norm(vector)) <= 0.0:
+        # Cosine distance is undefined against a zero vector: scipy returns NaN
+        # for the pair, which propagates through linkage into every cluster.
+        return None
+    return vector
+
+
+def _cluster_embeddings(
+    embeddings: List[Any],
+    num_speakers: Optional[int],
+    min_speakers: Optional[int],
+    max_speakers: Optional[int],
+) -> List[int]:
+    """Partition embeddings with average-linkage AHC over cosine distance."""
+    total = len(embeddings)
+    if total == 1:
+        # linkage() requires at least two observations.
+        return [0]
+
+    if num_speakers is not None and (min_speakers is not None or max_speakers is not None):
+        logger.warning(f"num_speakers={num_speakers} takes precedence over min_speakers/max_speakers")
+
+    tree = linkage(np.vstack(embeddings), method="average", metric="cosine")
+
+    if num_speakers is not None:
+        return _cut_to_count(tree, num_speakers, total)
+
+    labels = [int(label) for label in fcluster(tree, t=SPEAKER_AHC_THRESHOLD, criterion="distance")]
+    found = len(set(labels))
+
+    if min_speakers is not None and found < min_speakers:
+        labels = _cut_to_count(tree, min_speakers, total)
+        found = len(set(labels))
+
+    # An explicit max_speakers is the caller's ceiling. Without one, the
+    # configured cap still bounds the partition, as it did for the online path.
+    ceiling = max_speakers if max_speakers is not None else SPEAKER_CLUSTERING_MAX_SPEAKERS
+    if found > ceiling:
+        labels = _cut_to_count(tree, ceiling, total)
+
+    return labels
+
+
+def _cut_to_count(tree: Any, count: int, total: int) -> List[int]:
+    """Cut the dendrogram into `count` clusters, clamped to [1, total]."""
+    bounded = max(1, min(count, total))
+    return [int(label) for label in fcluster(tree, t=bounded, criterion="maxclust")]
+
+
+def _assign_speaker_labels(segments: List[Dict[str, Any]], embedded_indices: List[int], labels: List[int]) -> None:
+    """Write SPEAKER_N onto every segment, renumbered by first appearance.
+
+    scipy's cluster ids are arbitrary, so they are renumbered in order of first
+    appearance: SPEAKER_0 is the first voice heard. That is what the online path
+    produced and what downstream speaker identification reads.
+    """
+    ordinals: Dict[int, int] = {}
+    for label in labels:
+        if label not in ordinals:
+            ordinals[label] = len(ordinals)
+
+    speaker_by_segment: Dict[int, int] = {index: ordinals[label] for index, label in zip(embedded_indices, labels)}
+    centers = [(segments[index]["start"] + segments[index]["end"]) / 2.0 for index in embedded_indices]
+
+    for index, seg in enumerate(segments):
+        if index in speaker_by_segment:
+            seg["speaker"] = f"SPEAKER_{speaker_by_segment[index]}"
+            continue
+
+        # Too short to embed: inherit from the nearest clustered segment in time,
+        # rather than from whichever speaker happened to be created most recently.
+        center = (seg["start"] + seg["end"]) / 2.0
+        nearest = min(range(len(centers)), key=lambda k: abs(centers[k] - center))
+        seg["speaker"] = f"SPEAKER_{speaker_by_segment[embedded_indices[nearest]]}"
 
 
 def _extract_segment_wav(wav_bytes: bytes, start: float, end: float) -> bytes:

--- a/backend/parakeet/transcribe.py
+++ b/backend/parakeet/transcribe.py
@@ -383,9 +383,32 @@ def _cluster_embeddings(
 
 
 def _cut_to_count(tree: Any, count: int, total: int) -> List[int]:
-    """Cut the dendrogram into `count` clusters, clamped to [1, total]."""
+    """Cut the dendrogram into `count` clusters, clamped to [1, total].
+
+    The cut is expressed as a distance just below the merge that would take the
+    partition under `count`, not as `criterion="maxclust"`. maxclust resolves
+    near-tied merge heights differently across scipy releases — on 1.14.0 (what
+    backend/pylock.toml installs) three near-orthogonal embeddings at heights
+    0.99761 and 0.99900 collapse into a single cluster, while 1.18.x returns
+    three — so the speaker-count parameters would have been honoured on one
+    deployed stack and silently ignored on the other.
+    """
     bounded = max(1, min(count, total))
-    return [int(label) for label in fcluster(tree, t=bounded, criterion="maxclust")]
+    if bounded == 1:
+        return [1] * total
+
+    # `total - 1` merges, ascending. Keeping the first `total - bounded` of them
+    # leaves `bounded` clusters, so cut immediately below the next merge height.
+    heights = np.sort(np.asarray(tree)[:, 2])
+    cut = float(np.nextafter(heights[total - bounded], -np.inf))
+    labels = [int(label) for label in fcluster(tree, t=cut, criterion="distance")]
+
+    found = len(set(labels))
+    if found != bounded:
+        # Exactly-tied merge heights cannot be separated by any single distance
+        # cut. Report it rather than returning a different count in silence.
+        logger.warning(f"Speaker cut asked for {bounded} clusters but produced {found}; merge heights are tied")
+    return labels
 
 
 def _assign_speaker_labels(segments: List[Dict[str, Any]], embedded_indices: List[int], labels: List[int]) -> None:

--- a/backend/tests/unit/test_parakeet_endpoints.py
+++ b/backend/tests/unit/test_parakeet_endpoints.py
@@ -328,6 +328,65 @@ class TestV2TranscribeEndpoint:
         )
         assert resp.status_code == 503
 
+    def _post_v2_with_mocked_transcriber(self, data):
+        app, mod, _, engine = _make_app_with_mocks(gpu_ready=True)
+
+        async def fake_submit(path, timestamps=True, owns_file=False):
+            return {"text": "v2 result", "timestamp": {"segment": [{"segment": "v2 result", "start": 0.0, "end": 1.0}]}}
+
+        engine.submit = AsyncMock(side_effect=fake_submit)
+
+        with patch("main.transcribe_file_v2") as mock_v2:
+            mock_v2.return_value = {
+                "text": "v2 result",
+                "segments": [{"text": "v2 result", "start": 0.0, "end": 1.0, "speaker": "SPEAKER_0"}],
+                "detected_language": "en",
+            }
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post("/v2/transcribe", files={"file": ("test.wav", b"fake", "audio/wav")}, data=data)
+        return resp, mock_v2
+
+    def test_v2_forwards_speaker_constraints_to_the_transcriber(self):
+        resp, mock_v2 = self._post_v2_with_mocked_transcriber(
+            {"diarize": "true", "num_speakers": "3", "min_speakers": "2", "max_speakers": "5"}
+        )
+
+        assert resp.status_code == 200
+        kwargs = mock_v2.call_args.kwargs
+        assert kwargs["num_speakers"] == 3
+        assert kwargs["min_speakers"] == 2
+        assert kwargs["max_speakers"] == 5
+
+    def test_v2_omitted_speaker_constraints_arrive_as_none(self):
+        resp, mock_v2 = self._post_v2_with_mocked_transcriber({"diarize": "true"})
+
+        assert resp.status_code == 200
+        kwargs = mock_v2.call_args.kwargs
+        assert kwargs["num_speakers"] is None
+        assert kwargs["min_speakers"] is None
+        assert kwargs["max_speakers"] is None
+
+    def test_v2_rejects_min_speakers_above_max_speakers(self):
+        app, mod, _, _ = _make_app_with_mocks(gpu_ready=True)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/v2/transcribe",
+            files={"file": ("test.wav", b"fake", "audio/wav")},
+            data={"diarize": "true", "min_speakers": "4", "max_speakers": "2"},
+        )
+        assert resp.status_code == 422
+        assert "min_speakers" in resp.json()["detail"]
+
+    def test_v2_rejects_non_positive_speaker_counts(self):
+        app, mod, _, _ = _make_app_with_mocks(gpu_ready=True)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/v2/transcribe",
+            files={"file": ("test.wav", b"fake", "audio/wav")},
+            data={"diarize": "true", "num_speakers": "0"},
+        )
+        assert resp.status_code == 422
+
 
 def _make_wav_bytes(duration_s=2.0, sample_rate=16000, channels=1, sampwidth=2):
     buf = io.BytesIO()

--- a/backend/tests/unit/test_parakeet_endpoints.py
+++ b/backend/tests/unit/test_parakeet_endpoints.py
@@ -346,16 +346,25 @@ class TestV2TranscribeEndpoint:
             resp = client.post("/v2/transcribe", files={"file": ("test.wav", b"fake", "audio/wav")}, data=data)
         return resp, mock_v2
 
-    def test_v2_forwards_speaker_constraints_to_the_transcriber(self):
+    def test_v2_forwards_speaker_bounds_to_the_transcriber(self):
         resp, mock_v2 = self._post_v2_with_mocked_transcriber(
-            {"diarize": "true", "num_speakers": "3", "min_speakers": "2", "max_speakers": "5"}
+            {"diarize": "true", "min_speakers": "2", "max_speakers": "5"}
         )
 
         assert resp.status_code == 200
         kwargs = mock_v2.call_args.kwargs
-        assert kwargs["num_speakers"] == 3
         assert kwargs["min_speakers"] == 2
         assert kwargs["max_speakers"] == 5
+        assert kwargs["num_speakers"] is None
+
+    def test_v2_forwards_an_exact_speaker_count_to_the_transcriber(self):
+        resp, mock_v2 = self._post_v2_with_mocked_transcriber({"diarize": "true", "num_speakers": "3"})
+
+        assert resp.status_code == 200
+        kwargs = mock_v2.call_args.kwargs
+        assert kwargs["num_speakers"] == 3
+        assert kwargs["min_speakers"] is None
+        assert kwargs["max_speakers"] is None
 
     def test_v2_omitted_speaker_constraints_arrive_as_none(self):
         resp, mock_v2 = self._post_v2_with_mocked_transcriber({"diarize": "true"})
@@ -376,6 +385,17 @@ class TestV2TranscribeEndpoint:
         )
         assert resp.status_code == 422
         assert "min_speakers" in resp.json()["detail"]
+
+    def test_v2_rejects_num_speakers_combined_with_bounds(self):
+        app, mod, _, _ = _make_app_with_mocks(gpu_ready=True)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/v2/transcribe",
+            files={"file": ("test.wav", b"fake", "audio/wav")},
+            data={"diarize": "true", "num_speakers": "3", "max_speakers": "5"},
+        )
+        assert resp.status_code == 422
+        assert "num_speakers" in resp.json()["detail"]
 
     def test_v2_rejects_non_positive_speaker_counts(self):
         app, mod, _, _ = _make_app_with_mocks(gpu_ready=True)

--- a/backend/tests/unit/test_parakeet_offline_diarization.py
+++ b/backend/tests/unit/test_parakeet_offline_diarization.py
@@ -1,0 +1,351 @@
+"""Offline agglomerative clustering in parakeet batch diarization.
+
+The embedding model and the audio slicer are mocked; `_diarize_segments` itself
+runs unmodified, so these assert the real eligibility, clustering, constraint and
+label-assignment behavior rather than a reimplementation of it.
+
+Voices are hand-placed unit vectors in a 256-dim space, so every distance below
+is arithmetic rather than luck: `_voice_at` positions two voices at a chosen
+angle to each other, and `_voice` gives each speaker its own dimension.
+"""
+
+import math
+import os
+import struct
+import sys
+import wave
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+os.environ.setdefault('PARAKEET_INFERENCE_MODE', 'nemo')
+os.environ.setdefault('PARAKEET_STREAM_MODEL', '')
+os.environ.setdefault('PARAKEET_DEVICE', 'cpu')
+os.environ.setdefault('PARAKEET_TORCH_COMPILE', 'false')
+os.environ.setdefault('PARAKEET_CUDA_GRAPHS', 'false')
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'parakeet'))
+
+import transcribe  # noqa: E402
+from speaker_math import SPEAKER_CLUSTERING_THRESHOLD  # noqa: E402
+
+# Chosen against SPEAKER_AHC_THRESHOLD (0.55) to form a chain:
+#   d(A,B) = 1-cos(45) = 0.293  -> under the cut
+#   d(B,C) = 1-cos(55) = 0.426  -> under the cut
+#   d(A,C) = 1-cos(100) = 1.174 -> over the cut
+# Order-dependent greedy matching resolves this chain differently depending on
+# which end it starts from; average linkage does not.
+VOICE_A_DEG = 0.0
+VOICE_B_DEG = 45.0
+VOICE_C_DEG = 100.0
+
+
+def _voice_at(angle_deg: float) -> np.ndarray:
+    """A unit embedding at `angle_deg` in the first two dimensions."""
+    radians = math.radians(angle_deg)
+    vector = np.zeros((1, 256), dtype=np.float32)
+    vector[0, 0] = math.cos(radians)
+    vector[0, 1] = math.sin(radians)
+    return vector
+
+
+def _voice(index: int) -> np.ndarray:
+    """Distinct speaker `index`; any two sit ~1.0 apart, far above the threshold.
+
+    Each voice owns a dimension, so different indices are near-orthogonal. The
+    small shared component on the last dimension makes every pairwise distance
+    slightly different: without it the dendrogram has tied merge heights, and a
+    `maxclust` cut cannot split a tie into an exact cluster count.
+    """
+    vector = np.zeros((1, 256), dtype=np.float32)
+    vector[0, index] = 1.0
+    vector[0, 255] = 0.02 * (index + 1)
+    return vector
+
+
+def _write_wav(path: Path, duration_s: float = 30.0, sample_rate: int = 16000) -> None:
+    frames = b''.join(struct.pack('<h', 0) for _ in range(int(duration_s * sample_rate)))
+    with wave.open(str(path), 'wb') as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(frames)
+
+
+def _diarize(tmp_path, spans, **constraints):
+    """Run `_diarize_segments` over `spans` and return the assigned speaker labels.
+
+    `spans` is a list of `(start, end, embedding_or_None)`. The audio slicer is
+    replaced by one that encodes the segment start into its payload, so each
+    segment resolves to its own embedding regardless of the order the production
+    code walks them in.
+    """
+    wav_path = tmp_path / 'audio.wav'
+    _write_wav(wav_path)
+
+    embedding_by_start = {round(float(start), 3): embedding for start, _end, embedding in spans}
+
+    def fake_extract(_audio_bytes, start, _end):
+        # Padded past the 1000-byte guard; the prefix carries the segment start.
+        return f'{start:.3f}'.encode().ljust(2000, b'\x00')
+
+    def fake_embedding(wav_bytes):
+        return embedding_by_start[round(float(wav_bytes.rstrip(b"\x00").decode()), 3)]
+
+    base = {
+        'text': 'hello',
+        'segments': [{'text': 'hello', 'start': float(start), 'end': float(end)} for start, end, _ in spans],
+    }
+
+    with patch.object(transcribe, '_extract_segment_wav', fake_extract), patch.object(
+        transcribe, '_get_embedding', fake_embedding
+    ), patch.object(transcribe, 'SPEAKER_EMBEDDING_URL', 'http://fake'):
+        result = transcribe._diarize_segments(str(wav_path), base, **constraints)
+
+    return [segment['speaker'] for segment in result['segments']]
+
+
+def _partition(labels):
+    """Group segment indices by speaker label, ignoring the label names."""
+    groups = {}
+    for index, label in enumerate(labels):
+        groups.setdefault(label, []).append(index)
+    return sorted(tuple(indices) for indices in groups.values())
+
+
+class TestOrderIndependence:
+    def test_chain_partition_is_identical_under_reversed_arrival(self, tmp_path):
+        """The same three voices must partition the same way in either order.
+
+        This is the regression: online centroid matching walked segments in time
+        order and folded each match into a running mean, so the A-B-C chain
+        resolved to {A,B},{C} arriving forwards and {B,C},{A} arriving backwards.
+        """
+        forward = _diarize(
+            tmp_path,
+            [
+                (0.0, 2.0, _voice_at(VOICE_A_DEG)),
+                (3.0, 5.0, _voice_at(VOICE_B_DEG)),
+                (6.0, 8.0, _voice_at(VOICE_C_DEG)),
+            ],
+        )
+        backward = _diarize(
+            tmp_path,
+            [
+                (0.0, 2.0, _voice_at(VOICE_C_DEG)),
+                (3.0, 5.0, _voice_at(VOICE_B_DEG)),
+                (6.0, 8.0, _voice_at(VOICE_A_DEG)),
+            ],
+        )
+
+        # Forward is [A, B, C]; backward is [C, B, A]. Re-index backward onto the
+        # forward voice order so the two partitions are directly comparable.
+        backward_by_voice = [backward[2], backward[1], backward[0]]
+
+        assert _partition(forward) == _partition(backward_by_voice)
+        # A and B pair off; C stands alone, at both arrival orders.
+        assert _partition(forward) == [(0, 1), (2,)]
+
+    def test_shuffled_arrival_of_orthogonal_voices_preserves_grouping(self, tmp_path):
+        voices = [_voice(index) for index in range(3)]
+        interleaved = _diarize(
+            tmp_path,
+            [
+                (0.0, 2.0, voices[0]),
+                (3.0, 5.0, voices[1]),
+                (6.0, 8.0, voices[2]),
+                (9.0, 11.0, voices[0]),
+                (12.0, 14.0, voices[1]),
+            ],
+        )
+        assert _partition(interleaved) == [(0, 3), (1, 4), (2,)]
+
+
+class TestMultiSpeakerSeparation:
+    def test_three_distinct_voices_get_three_labels(self, tmp_path):
+        labels = _diarize(
+            tmp_path,
+            [
+                (0.0, 2.0, _voice(0)),
+                (3.0, 5.0, _voice(1)),
+                (6.0, 8.0, _voice(2)),
+            ],
+        )
+        assert len(set(labels)) == 3
+
+    def test_first_voice_heard_is_speaker_0(self, tmp_path):
+        labels = _diarize(
+            tmp_path,
+            [
+                (0.0, 2.0, _voice(1)),
+                (3.0, 5.0, _voice(0)),
+                (6.0, 8.0, _voice(1)),
+            ],
+        )
+        assert labels[0] == 'SPEAKER_0'
+        assert labels[2] == 'SPEAKER_0'
+        assert labels[1] == 'SPEAKER_1'
+
+    def test_repeat_of_one_voice_stays_single_speaker(self, tmp_path):
+        labels = _diarize(
+            tmp_path,
+            [
+                (0.0, 2.0, _voice_at(VOICE_A_DEG)),
+                (3.0, 5.0, _voice_at(VOICE_A_DEG)),
+                (6.0, 8.0, _voice_at(VOICE_A_DEG)),
+            ],
+        )
+        assert labels == ['SPEAKER_0', 'SPEAKER_0', 'SPEAKER_0']
+
+
+class TestSpeakerConstraints:
+    def test_num_speakers_forces_exact_partition_size(self, tmp_path):
+        spans = [
+            (0.0, 2.0, _voice(0)),
+            (3.0, 5.0, _voice(1)),
+            (6.0, 8.0, _voice(2)),
+        ]
+        assert len(set(_diarize(tmp_path, spans, num_speakers=2))) == 2
+        assert len(set(_diarize(tmp_path, spans, num_speakers=3))) == 3
+
+    def test_num_speakers_is_clamped_to_available_segments(self, tmp_path):
+        labels = _diarize(
+            tmp_path,
+            [(0.0, 2.0, _voice(0)), (3.0, 5.0, _voice(1))],
+            num_speakers=9,
+        )
+        assert len(set(labels)) == 2
+
+    def test_max_speakers_caps_a_partition_the_threshold_would_split_further(self, tmp_path):
+        spans = [(float(i * 3), float(i * 3 + 2), _voice(i)) for i in range(4)]
+        assert len(set(_diarize(tmp_path, spans))) == 4
+        assert len(set(_diarize(tmp_path, spans, max_speakers=2))) == 2
+
+    def test_min_speakers_splits_a_partition_the_threshold_would_merge(self, tmp_path):
+        spans = [
+            (0.0, 2.0, _voice_at(VOICE_A_DEG)),
+            (3.0, 5.0, _voice_at(VOICE_A_DEG)),
+        ]
+        assert len(set(_diarize(tmp_path, spans))) == 1
+        assert len(set(_diarize(tmp_path, spans, min_speakers=2))) == 2
+
+    def test_num_speakers_takes_precedence_over_min_and_max(self, tmp_path):
+        spans = [(float(i * 3), float(i * 3 + 2), _voice(i)) for i in range(4)]
+        labels = _diarize(tmp_path, spans, num_speakers=3, min_speakers=1, max_speakers=2)
+        assert len(set(labels)) == 3
+
+
+class TestShortAndFailedSegments:
+    def test_short_segment_inherits_nearest_clustered_segment_in_time(self, tmp_path):
+        """A sub-threshold clip follows the voice next to it, not the newest cluster.
+
+        The online path assigned `SPEAKER_{len(centroids) - 1}` — whichever speaker
+        was created most recently — so a short clip beside speaker 0 was labelled
+        with speaker 1 purely because speaker 1 had been seen more recently.
+        """
+        labels = _diarize(
+            tmp_path,
+            [
+                (0.0, 2.0, _voice(0)),
+                (2.1, 2.4, None),  # 0.3s, below MIN_SEGMENT_DURATION
+                (10.0, 12.0, _voice(1)),
+            ],
+        )
+        assert labels[1] == labels[0]
+        assert labels[1] != labels[2]
+
+    def test_non_finite_embedding_is_excluded_from_clustering(self, tmp_path):
+        broken = np.full((1, 256), np.nan, dtype=np.float32)
+        labels = _diarize(
+            tmp_path,
+            [
+                (0.0, 2.0, _voice(0)),
+                (3.0, 5.0, broken),
+                (6.0, 8.0, _voice(1)),
+            ],
+        )
+        # Two real voices still separate, and the broken segment inherits a
+        # neighbour instead of poisoning the linkage matrix with NaN.
+        assert labels[0] != labels[2]
+        assert labels[1] in {labels[0], labels[2]}
+
+    def test_zero_vector_embedding_is_excluded_from_clustering(self, tmp_path):
+        zero = np.zeros((1, 256), dtype=np.float32)
+        labels = _diarize(
+            tmp_path,
+            [
+                (0.0, 2.0, _voice(0)),
+                (3.0, 5.0, zero),
+                (6.0, 8.0, _voice(1)),
+            ],
+        )
+        assert labels[0] != labels[2]
+
+    def test_all_segments_short_fall_back_to_speaker_0(self, tmp_path):
+        labels = _diarize(tmp_path, [(0.0, 0.3, None), (1.0, 1.2, None)])
+        assert labels == ['SPEAKER_0', 'SPEAKER_0']
+
+    def test_single_embeddable_segment_is_speaker_0(self, tmp_path):
+        labels = _diarize(tmp_path, [(0.0, 2.0, _voice_at(VOICE_A_DEG))])
+        assert labels == ['SPEAKER_0']
+
+    def test_missing_embedding_does_not_break_the_partition(self, tmp_path):
+        labels = _diarize(
+            tmp_path,
+            [
+                (0.0, 2.0, _voice(0)),
+                (3.0, 5.0, None),  # long enough to embed, but the model returns nothing
+                (6.0, 8.0, _voice(1)),
+            ],
+        )
+        assert labels[0] != labels[2]
+        assert labels[1] in {labels[0], labels[2]}
+
+
+class TestDiarizationGating:
+    def test_no_embedding_source_labels_everything_speaker_0(self, tmp_path):
+        wav_path = tmp_path / 'audio.wav'
+        _write_wav(wav_path)
+        base = {'text': 'hi', 'segments': [{'text': 'hi', 'start': 0.0, 'end': 2.0}]}
+
+        worker = MagicMock()
+        worker.is_ready = False
+        with patch.object(transcribe, '_gpu_worker', worker), patch.object(transcribe, 'SPEAKER_EMBEDDING_URL', ''):
+            result = transcribe._diarize_segments(str(wav_path), base)
+
+        assert result['segments'][0]['speaker'] == 'SPEAKER_0'
+
+
+class TestClusteringThresholdContract:
+    def test_batch_cut_is_separate_from_the_online_clustering_threshold(self):
+        # AHC cuts on cophenetic merge height — the mean distance between two whole
+        # clusters — not on distance to a drifting centroid, so the batch path owns
+        # its own tuned constant. The streaming path's threshold must not move with it.
+        assert transcribe.SPEAKER_AHC_THRESHOLD == 0.55
+        assert SPEAKER_CLUSTERING_THRESHOLD == 0.60
+
+    def test_the_cut_constant_is_what_actually_partitions(self, tmp_path, monkeypatch):
+        # Two voices 0.293 apart: merged under the shipped 0.55 cut, split once the
+        # cut drops below their distance. Proves the constant is load-bearing.
+        spans = [(0.0, 2.0, _voice_at(VOICE_A_DEG)), (3.0, 5.0, _voice_at(VOICE_B_DEG))]
+        assert len(set(_diarize(tmp_path, spans))) == 1
+
+        monkeypatch.setattr(transcribe, 'SPEAKER_AHC_THRESHOLD', 0.20)
+        assert len(set(_diarize(tmp_path, spans))) == 2
+
+    def test_voices_inside_the_threshold_merge_and_outside_it_split(self, tmp_path):
+        assert 1 - math.cos(math.radians(VOICE_B_DEG)) < transcribe.SPEAKER_AHC_THRESHOLD
+        assert 1 - math.cos(math.radians(VOICE_C_DEG)) > transcribe.SPEAKER_AHC_THRESHOLD
+
+        merged = _diarize(
+            tmp_path,
+            [(0.0, 2.0, _voice_at(VOICE_A_DEG)), (3.0, 5.0, _voice_at(VOICE_B_DEG))],
+        )
+        split = _diarize(
+            tmp_path,
+            [(0.0, 2.0, _voice_at(VOICE_A_DEG)), (3.0, 5.0, _voice_at(VOICE_C_DEG))],
+        )
+
+        assert len(set(merged)) == 1
+        assert len(set(split)) == 2

--- a/backend/tests/unit/test_parakeet_offline_diarization.py
+++ b/backend/tests/unit/test_parakeet_offline_diarization.py
@@ -9,6 +9,7 @@ is arithmetic rather than luck: `_voice_at` positions two voices at a chosen
 angle to each other, and `_voice` gives each speaker its own dimension.
 """
 
+import logging
 import math
 import os
 import struct
@@ -55,8 +56,9 @@ def _voice(index: int) -> np.ndarray:
 
     Each voice owns a dimension, so different indices are near-orthogonal. The
     small shared component on the last dimension makes every pairwise distance
-    slightly different: without it the dendrogram has tied merge heights, and a
-    `maxclust` cut cannot split a tie into an exact cluster count.
+    slightly different: exactly tied merge heights cannot be separated by any
+    single distance cut, so an exact cluster count would not be reachable.
+    See `test_exactly_tied_merge_heights_report_the_shortfall` for that case.
     """
     vector = np.zeros((1, 256), dtype=np.float32)
     vector[0, index] = 1.0
@@ -234,6 +236,24 @@ class TestSpeakerConstraints:
         spans = [(float(i * 3), float(i * 3 + 2), _voice(i)) for i in range(4)]
         labels = _diarize(tmp_path, spans, num_speakers=3, min_speakers=1, max_speakers=2)
         assert len(set(labels)) == 3
+
+    def test_exactly_tied_merge_heights_report_the_shortfall(self, tmp_path, caplog):
+        """Four voices 90 degrees apart tie two merges at exactly 1.0.
+
+        No single distance cut can split an exact tie, so an exact count is not
+        always reachable. The cut errs toward more clusters — safer for diarization
+        than merging two speakers — and says so instead of silently returning a
+        different count.
+        """
+        spans = [
+            (float(i * 3), float(i * 3 + 2), _voice_at(degrees)) for i, degrees in enumerate([0.0, 90.0, 180.0, 270.0])
+        ]
+
+        with caplog.at_level(logging.WARNING):
+            labels = _diarize(tmp_path, spans, num_speakers=3)
+
+        assert len(set(labels)) == 4
+        assert 'merge heights are tied' in caplog.text
 
 
 class TestShortAndFailedSegments:


### PR DESCRIPTION
## What this fixes

Closes #8917 (and the multi-speaker symptom in #5470).

`_diarize_segments` in `backend/parakeet/transcribe.py` matched each segment against running-mean centroids while walking the file in time order. The partition was therefore a function of **arrival order**, not of the embeddings. Two failure modes follow:

1. **Centroid drift** — each match folded its embedding into `centroids[i] = (centroids[i] * n + emb) / (n + 1)`. As noisy segments merged, the centroid moved away from the voice it represented, until a genuinely different speaker fell inside its threshold.
2. **Short segments inherited by recency** — a clip under `MIN_SEGMENT_DURATION` was labelled `SPEAKER_{len(centroids) - 1}`: whichever speaker was created *most recently*, not the one speaking beside it.

## The change

Collect every eligible embedding first, then partition once with average-linkage agglomerative clustering over cosine distance. The result depends only on the members, so the same voices in any order produce the same partition.

- Short and failed segments inherit the **nearest clustered segment in time** instead of the most recently created speaker.
- Clusters are renumbered by first appearance, preserving the contract that `SPEAKER_0` is the first voice heard.
- Non-finite and zero-norm embeddings are dropped before clustering — scipy returns `NaN` for cosine against a zero vector, which would spread through the linkage matrix into every cluster.
- `/v2/transcribe` gains optional `num_speakers` / `min_speakers` / `max_speakers`, each validated positive. `min > max` is rejected as 422, and so is `num_speakers` combined with either bound — an exact count and a range are contradictory, and silently preferring one would leave the caller believing a bound they set was honoured. `_diarize_segments` keeps a precedence warning for direct in-process callers, which are not bound by the endpoint contract.

**A separate cut threshold, and why.** AHC cuts the dendrogram on *cophenetic merge height* — the mean distance between two whole clusters. `SPEAKER_CLUSTERING_THRESHOLD` bounds a different quantity: one embedding against one drifting centroid. The value does not transfer, so the batch path takes `SPEAKER_AHC_THRESHOLD` (default `0.55`, env `PARAKEET_SPEAKER_AHC_THRESHOLD`). **The streaming threshold is untouched at 0.60.** The 0.55 default is measured, not guessed — sweep below.

**No new dependency.** `scipy` is already pinned in `backend/parakeet/requirements.txt` (`>=1.11.0`) and `backend/requirements.txt` (`==1.14.0`).

## DER measurement

VoxConverse test subset (the 15 clips and RTTMs already committed under `backend/tests/container/voxconverse`), oracle segmentation. Both algorithms consume **identical segments and identical embeddings** (`pyannote/wespeaker-voxceleb-resnet34-LM`, `window="whole"`, T4 GPU), so the delta is attributable to clustering alone. Missed-speech and false-alarm terms are held near zero; this is speaker-confusion DER.

| | all clips | 3+ speakers | 1–2 speakers |
|---|---|---|---|
| online centroid @ 0.60 | 0.1391 | 0.1742 | 0.0709 |
| **offline AHC @ 0.55** | **0.1101** | **0.1303** | **0.0709** |

**3+ speaker DER falls 25% relative, with no movement at all on 1–2 speaker clips.**

Threshold sweep — the choice is a basin, not a tuned point. Every cut in 0.40–0.55 beats the inherited 0.60:

| cut | all | 3+ | 1–2 |
|---|---|---|---|
| 0.40 | 0.1190 | 0.1385 | 0.0812 |
| 0.50 | 0.1149 | 0.1363 | 0.0735 |
| **0.55** | **0.1101** | **0.1303** | **0.0709** |
| 0.60 | 0.1318 | 0.1632 | 0.0709 |
| 0.70 | 0.1553 | 0.1988 | 0.0709 |

0.55 is picked as the point that maximises the 3+ gain while leaving 1–2 speaker DER exactly at baseline.

Per-clip, 12 of 15 are unchanged. The movement:

| clip | speakers | before | after | delta |
|---|---|---|---|---|
| `eguui` | 3 | 0.4980 | 0.3019 | **−0.1961** — was collapsing all 3 speakers into 1 cluster |
| `tnjoh` | 5 | 0.3065 | 0.1791 | **−0.1274** |
| `bvyvm` | 3 | 0.0161 | 0.0290 | +0.0129 — over-splits to 5 clusters against 3 true speakers |

**Stated plainly:** `num_speakers` is a caller-intent knob, **not** an accuracy improvement. Feeding the ground-truth speaker count gives aggregate DER 0.1390 — indistinguishable from baseline. It helps `eguui` (−0.1961) and `msbyq` (−0.0742) but badly hurts `gkiki` (+0.2258), where forcing a sixth cluster shreds a good five-way partition. Callers who genuinely know the count can ask for it; nobody should expect it to lower error.

`bvyvm` is a real regression and I have not tuned it away — doing so would mean fitting 15 clips.

## Scope

Batch path only. `stream_handler.py` keeps online centroid matching — a live stream cannot cluster over segments it has not received yet. That divergence is pre-existing and left for a follow-up rather than widened into this PR.

Two claims in the issue body did not match current code and were not followed. The issue specifies `SPEAKER_MATCH_THRESHOLD = 0.45`, but that is the *enrollment verification* threshold; batch clustering used `SPEAKER_CLUSTERING_THRESHOLD = 0.60`, and a test pins the two apart. The issue also does not mention the existing `SPEAKER_CLUSTERING_MAX_SPEAKERS` cap, which this change preserves as the default ceiling. The endpoint knobs are `Form` fields rather than the `Query` params the issue sketches, matching the existing `diarize: bool = Form(True)` on the same multipart endpoint.

## Product invariants

none — no invariant in `product/invariants/` covers `backend/parakeet/**`. Confirmed with `scripts/pr-preflight --suggest`.

Failure-Class: new

`FC-partition-depends-on-arrival-order` is added in this PR. A grouping over an already-complete input must be a function of its members, never of the order they were visited; folding each element into mutable accumulated state makes the accumulator a function of history instead, so the same members in a different order yield a different grouping and neither result is defensible. The guard surface is the offline partition in `_diarize_segments` plus the order-independence tests in `backend/tests/unit/test_parakeet_offline_diarization.py`.

## Unit verification

**The regression test fails on the pre-fix code.** With the production change stashed and the new test file left in place:

```
pytest tests/unit/test_parakeet_offline_diarization.py
-> 10 failed, 10 passed
```

```
test_chain_partition_is_identical_under_reversed_arrival
E   assert [(0, 1), (2,)] == [(0,), (1, 2)]
```

Three voices at 0°, 45° and 100° form a chain. Arriving forwards the old code grouped {A,B} and left C alone; arriving backwards it grouped {B,C} and left A alone. Same voices, same distances, different answer.

```
test_non_finite_embedding_is_excluded_from_clustering
E   AssertionError: assert 'SPEAKER_1' in {'SPEAKER_0', 'SPEAKER_2'}
```

The old code minted a phantom `SPEAKER_1` from a NaN embedding.

The remaining 8 pre-fix failures are the constraint and threshold-contract tests, which exercise parameters and a constant that did not exist before.

After the change:

| Command | Result |
|---|---|
| `pytest tests/unit/test_parakeet_offline_diarization.py` | 20 passed |
| `pytest tests/unit/test_parakeet_endpoints.py` | 42 passed (36 before the new endpoint tests) |
| Regression set across 6 parakeet modules | 119 passed |
| `scripts/backend-python-format --check` (4 files) | clean |
| `scripts/failure-class validate` | ok, declaration `new` |
| `make preflight` | 25 of 26 checks pass |

The one preflight failure is `desktop-backend-release-boundary-fixtures`, which fails **identically on unmodified `upstream/main`** because `jq` is not installed on this machine — verified in a clean worktree. CI has `jq`.

**Not run locally:** the full `backend/test.sh` suite (the rest of the backend dependency set does not build on Windows without MSVC build tools) and the container DER benchmark, which needs a GPU with a running Parakeet server. The DER numbers above were measured on a Colab T4 against this branch.

## Credit

This picks up abandoned work from #8919 by @thesohamdatta, which established that offline AHC is the right approach here and drew detailed maintainer review before going quiet. The implementation is independent, but the direction is theirs.