### PR TITLE
fix(desktop): apply memory deletions across devices, and stop resurrecting deleted memories

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -1180,19 +1180,34 @@ class MemoriesViewModel: ObservableObject {
     await loadMemories()
   }
 
-  /// One-time cache reconcile. The local SQLite cache can diverge from the
-  /// backend (the source of truth): stale categories after the server-side
-  /// category cleanup, plus "orphan" rows whose backendId no longer exists on
-  /// the backend. This re-pulls every backend memory (fixing categories via the
-  /// normal upsert) and soft-deletes synced local rows the backend no longer
-  /// has. Local-only unsynced memories are preserved. Runs once per user.
-  private func reconcileCacheIfNeeded() async {
+  /// Reconcile the local SQLite cache against the backend, the source of truth.
+  ///
+  /// The cache diverges two ways: stale categories after the server-side category
+  /// cleanup, and "orphan" rows whose backendId no longer exists because the
+  /// memory was deleted somewhere else. Re-pulling fixes categories through the
+  /// normal upsert; pruning fixes orphans, and is the only thing that makes a
+  /// delete performed on another device take effect here.
+  ///
+  /// Pruning is scoped, not blanket. The earlier version pulled the default scope
+  /// and then refused to prune, because pruning a default-scope pull would delete
+  /// Archive rows the endpoint omits by design. The fix is to make the pull cover
+  /// what the prune claims: `includeArchive` widens it to every tier, so the
+  /// keep-set and `MemoryLayerScope.allIncludingArchive` describe the same
+  /// population. `softDeleteSyncedOrphans` only touches rows with a non-nil
+  /// backendId, so local-only memories that were never synced are never pruned.
+  ///
+  /// Absence is only authoritative when the pull was complete, so a truncated or
+  /// empty result prunes nothing and leaves the cache as it found it.
+  ///
+  /// Runs once per launch rather than once per user: a delete on another device
+  /// can happen at any time, so a permanent one-shot latch would converge the
+  /// cache once and then let it drift again for the life of the install.
+  func reconcileCacheIfNeeded() async {
     let userId = UserDefaults.standard.string(forKey: "auth_userId") ?? "unknown"
-    let reconcileKey = "memoriesCacheReconcile_v2_defaultScopeNoPrune_\(userId)"
 
-    guard !UserDefaults.standard.bool(forKey: reconcileKey) else { return }
+    guard !Self.reconciledUserIDsThisLaunch.contains(userId) else { return }
 
-    log("MemoriesViewModel: Starting one-time cache reconcile for user \(userId)")
+    log("MemoriesViewModel: Starting cache reconcile for user \(userId)")
 
     var cursor: String? = nil
     let batchSize = 500
@@ -1202,7 +1217,7 @@ class MemoriesViewModel: ObservableObject {
     do {
       var truncated = false
       while true {
-        let page = try await APIClient.shared.getMemoriesPage(
+        let page = try await fetchReconcilePage(
           limit: batchSize,
           cursor: cursor,
           authorizationSnapshot: authorizationSnapshot)
@@ -1221,25 +1236,29 @@ class MemoriesViewModel: ObservableObject {
         cursor = nextCursor
       }
 
-      // Guard against pruning on a partial/failed pull: only reconcile when the
-      // backend actually returned memories. An empty result here would otherwise
-      // wrongly delete the entire local cache.
+      // A truncated pull saw only part of the backend, so absence proves nothing.
+      // Leave the cache alone and retry on the next launch.
+      guard !truncated else {
+        log("MemoriesViewModel: Cache reconcile skipped pruning because the list was truncated")
+        return
+      }
+
+      // An empty result is far more likely to be a failed or unauthorized read
+      // than a genuinely empty account, and pruning against it would tombstone
+      // the entire local cache. Treat it as no evidence rather than as absence.
       guard !backendIds.isEmpty else {
         log("MemoriesViewModel: Cache reconcile skipped pruning (no backend memories returned)")
         return
       }
 
-      // The current API does not return authoritative tier-scope/completeness metadata.
-      // Fail closed: sync returned default-scope rows, but do not prune orphans until the
-      // backend can prove this page set is complete for an explicit scope. This preserves
-      // Archive rows when the default endpoint omits them by design.
-      // A truncated pull is incomplete, so do not mark reconcile as done.
-      guard !truncated else {
-        log("MemoriesViewModel: Cache reconcile did not mark completion because the list was truncated")
-        return
+      let pruned = try await MemoryStorage.shared.softDeleteSyncedOrphans(
+        keepingBackendIds: backendIds,
+        within: .allIncludingArchive
+      )
+      Self.reconciledUserIDsThisLaunch.insert(userId)
+      if pruned > 0 {
+        log("MemoriesViewModel: Cache reconcile pruned \(pruned) memories deleted on another device")
       }
-      UserDefaults.standard.set(true, forKey: reconcileKey)
-      log("MemoriesViewModel: Cache reconcile skipped orphan pruning because backend completeness is unknown")
 
       await loadTagCountsFromDatabase()
       await loadMemories()
@@ -1247,6 +1266,31 @@ class MemoriesViewModel: ObservableObject {
       logError("MemoriesViewModel: Cache reconcile failed (will retry next launch)", error: error)
     }
   }
+
+  /// Reconcile's server page read. Injectable so the prune contract can be tested
+  /// without a network: the guards that decide whether absence is authoritative
+  /// are the risky part of this function, not the transport.
+  var reconcilePageFetch: ((Int, String?, RuntimeOwnerAuthorizationSnapshot?) async throws -> APIClient.MemoryListPage)?
+
+  private func fetchReconcilePage(
+    limit: Int,
+    cursor: String?,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot?
+  ) async throws -> APIClient.MemoryListPage {
+    if let reconcilePageFetch {
+      return try await reconcilePageFetch(limit, cursor, authorizationSnapshot)
+    }
+    // Archive is included so the pulled population matches the scope the prune
+    // claims below; a default-scope pull would read Archive rows as absent.
+    return try await APIClient.shared.getMemoriesPage(
+      limit: limit,
+      cursor: cursor,
+      includeArchive: true,
+      authorizationSnapshot: authorizationSnapshot)
+  }
+
+  /// Reconcile runs once per launch per user; see `reconcileCacheIfNeeded`.
+  private static var reconciledUserIDsThisLaunch: Set<String> = []
 
   /// One-time background sync for the backend default memory scope.
   /// Archive requires an explicit backend contract before desktop syncs or reconciles it.
@@ -1584,6 +1628,10 @@ class MemoriesViewModel: ObservableObject {
       rawBackendOffset = max(0, rawBackendOffset - 1)
     } catch {
       logError("Failed to delete memory", error: error)
+      // Restoring the row without saying why is indistinguishable from the delete
+      // being ignored: the memory vanishes, comes back seconds later, and the user
+      // is told nothing. Every other mutation on this model reports its failure.
+      errorMessage = UserFacingErrorPresentation.message(for: error, while: .memoryDeletion)
       do {
         try await MemoryStorage.shared.restoreMemory(surfacedId: memory.id)
       } catch {

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Memories.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Memories.swift
@@ -1054,9 +1054,24 @@ extension APIClient {
       authorizationSnapshot: authorizationSnapshot)
   }
 
-  /// Deletes a memory by ID
+  /// Deletes a memory by ID.
+  ///
+  /// A 404 completes normally. The caller asked for this memory to be gone, and the
+  /// backend reporting it absent already satisfies that — delete is idempotent in
+  /// intent, so "it is not here" is the requested end state, not a failure.
+  ///
+  /// This is load-bearing rather than defensive. The desktop cache routinely outlives
+  /// the backend row: nothing prunes a local row whose memory was deleted on another
+  /// device, because `reconcileCacheIfNeeded` deliberately fails closed while the list
+  /// endpoint cannot prove scope completeness. Every one of those orphans answers 404
+  /// on delete, and treating that as an error made the caller restore the row it had
+  /// just removed — so the memory could never be cleared from this device at all.
   func deleteMemory(id: String) async throws {
-    try await delete("v3/memories/\(id)")
+    do {
+      try await delete("v3/memories/\(id)")
+    } catch APIError.httpError(statusCode: 404, _) {
+      return
+    }
   }
 
   /// Edits a memory's content

--- a/desktop/macos/Desktop/Tests/APIClientMemoryDeleteIdempotencyTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientMemoryDeleteIdempotencyTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Returns a caller-chosen status for every request so a delete can be driven
+/// against each backend answer it actually receives.
+private final class MemoryDeleteStatusStub: URLProtocol, @unchecked Sendable {
+  private static let lock = NSLock()
+  private nonisolated(unsafe) static var _status = 200
+  private nonisolated(unsafe) static var _observed: [(method: String, path: String)] = []
+
+  static var status: Int {
+    get {
+      lock.lock()
+      defer { lock.unlock() }
+      return _status
+    }
+    set {
+      lock.lock()
+      _status = newValue
+      lock.unlock()
+    }
+  }
+
+  static var observed: [(method: String, path: String)] {
+    lock.lock()
+    defer { lock.unlock() }
+    return _observed
+  }
+
+  static func reset() {
+    lock.lock()
+    _status = 200
+    _observed = []
+    lock.unlock()
+  }
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    Self.lock.lock()
+    Self._observed.append((request.httpMethod ?? "GET", request.url?.path ?? ""))
+    let status = Self._status
+    Self.lock.unlock()
+
+    guard let url = request.url,
+      let response = HTTPURLResponse(
+        url: url,
+        statusCode: status,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+      )
+    else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+      return
+    }
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    let payload =
+      status == 404
+      ? Data("{\"detail\":\"Memory not found\"}".utf8)
+      : Data("{\"status\":\"ok\"}".utf8)
+    client?.urlProtocol(self, didLoad: payload)
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+}
+
+/// A memory the backend no longer has must not be resurrected on this device.
+///
+/// The desktop cache outlives backend rows: nothing prunes a local row whose
+/// memory was deleted on another device, because the cache reconcile fails
+/// closed while the list endpoint cannot prove scope completeness. Deleting one
+/// of those orphans answers `404 Memory not found`, and while that read as an
+/// error the caller restored the row it had just removed — the memory could not
+/// be cleared from the machine at all, which is what "I can't delete them on the
+/// desktop app" was.
+final class APIClientMemoryDeleteIdempotencyTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    MemoryDeleteStatusStub.reset()
+    setenv("OMI_PYTHON_API_URL", "http://memory-delete-test:9001", 1)
+  }
+
+  override func tearDown() {
+    unsetenv("OMI_PYTHON_API_URL")
+    MemoryDeleteStatusStub.reset()
+    super.tearDown()
+  }
+
+  private func makeClient() async -> APIClient {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [MemoryDeleteStatusStub.self]
+    let client = APIClient(session: URLSession(configuration: configuration))
+    await client.setTestAuthHeader("Bearer test-token")
+    return client
+  }
+
+  func testDeleteTreatsAlreadyAbsentMemoryAsSuccess() async throws {
+    let client = await makeClient()
+    MemoryDeleteStatusStub.status = 404
+
+    try await client.deleteMemory(id: "orphaned-memory")
+
+    let observed = try XCTUnwrap(MemoryDeleteStatusStub.observed.first)
+    XCTAssertEqual(observed.method, "DELETE")
+    XCTAssertEqual(observed.path, "/v3/memories/orphaned-memory")
+  }
+
+  func testDeleteSucceedsNormally() async throws {
+    let client = await makeClient()
+    MemoryDeleteStatusStub.status = 200
+
+    try await client.deleteMemory(id: "live-memory")
+
+    XCTAssertEqual(MemoryDeleteStatusStub.observed.first?.path, "/v3/memories/live-memory")
+  }
+
+  /// The other direction: swallowing 404 must not swallow real failures, or a
+  /// delete that never happened would read as done and the row would vanish
+  /// locally while the backend still holds it.
+  func testDeleteStillFailsOnServerError() async throws {
+    let client = await makeClient()
+    MemoryDeleteStatusStub.status = 500
+
+    do {
+      try await client.deleteMemory(id: "memory-1")
+      XCTFail("A 500 must surface as an error rather than reading as a completed delete")
+    } catch APIError.httpError(let statusCode, _) {
+      XCTAssertEqual(statusCode, 500)
+    }
+  }
+
+  func testDeleteStillFailsOnForbidden() async throws {
+    let client = await makeClient()
+    MemoryDeleteStatusStub.status = 403
+
+    do {
+      try await client.deleteMemory(id: "locked-memory")
+      XCTFail("A 403 must surface as an error rather than reading as a completed delete")
+    } catch APIError.httpError(let statusCode, _) {
+      XCTAssertEqual(statusCode, 403)
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/MemoriesCacheReconcilePruneTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoriesCacheReconcilePruneTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// A memory deleted on another device must stop appearing on this one.
+///
+/// The reconcile used to pull the default scope and then refuse to prune, so
+/// nothing on the desktop ever removed a row whose backend memory was gone. The
+/// cache only grew stale, which is what "they delete on the app, but they do not
+/// sync across devices" was. Pruning is only safe when the pull is complete, so
+/// these tests pin both directions: absent rows go, and an incomplete pull is
+/// treated as no evidence rather than as proof of absence.
+@MainActor
+final class MemoriesCacheReconcilePruneTests: XCTestCase {
+  private var userDir: URL?
+  private var authSnapshot: RewindStorageTestIsolation.AuthSnapshot?
+
+  override func setUp() async throws {
+    authSnapshot = RewindStorageTestIsolation.captureAuthSnapshot()
+    let fixture = try await RewindStorageTestIsolation.setUp(userIdPrefix: "memories-reconcile-prune")
+    userDir = fixture.userDir
+    RewindStorageTestIsolation.signInForTests(userId: fixture.testUserId)
+  }
+
+  override func tearDown() async throws {
+    if let authSnapshot {
+      RewindStorageTestIsolation.restoreAuthSnapshot(authSnapshot)
+    }
+    if let userDir {
+      await RewindStorageTestIsolation.tearDown(userDir: userDir)
+    }
+  }
+
+  private func page(
+    _ memories: [ServerMemory],
+    truncated: Bool = false
+  ) -> APIClient.MemoryListPage {
+    APIClient.MemoryListPage(
+      memories: memories,
+      nextCursor: nil,
+      canonicalLifecycleExposed: false,
+      deviceScopeSupported: true,
+      defaultMemoryDeleteSupported: true,
+      truncated: truncated
+    )
+  }
+
+  private func makeViewModel(
+    returning page: APIClient.MemoryListPage
+  ) -> MemoriesViewModel {
+    let viewModel = MemoriesViewModel()
+    viewModel.reconcilePageFetch = { _, _, _ in page }
+    return viewModel
+  }
+
+  private func makeMemory(id: String, tier: MemoryLayer) -> ServerMemory {
+    ServerMemory(
+      id: id,
+      content: "Memory \(id)",
+      category: .system,
+      tier: tier,
+      createdAt: Date(timeIntervalSince1970: 1),
+      updatedAt: Date(timeIntervalSince1970: 2),
+      conversationId: nil,
+      reviewed: false,
+      userReview: nil,
+      visibility: "private",
+      manuallyAdded: false,
+      scoring: nil,
+      source: "desktop",
+      confidence: nil,
+      sourceApp: nil,
+      contextSummary: nil,
+      isRead: false,
+      isDismissed: false,
+      tags: [],
+      reasoning: nil,
+      currentActivity: nil,
+      inputDeviceName: nil,
+      windowTitle: nil,
+      headline: nil
+    )
+  }
+
+  func testPrunesMemoryDeletedOnAnotherDevice() async throws {
+    let kept = makeMemory(id: "kept-1", tier: .longTerm)
+    let deletedElsewhere = makeMemory(id: "deleted-elsewhere", tier: .longTerm)
+    try await MemoryStorage.shared.syncServerMemories([kept, deletedElsewhere])
+
+    await makeViewModel(returning: page([kept])).reconcileCacheIfNeeded()
+
+    let goneRecord = try await MemoryStorage.shared.getMemoryByBackendId("deleted-elsewhere")
+    XCTAssertEqual(goneRecord?.deleted, true, "a memory the backend no longer has must be pruned")
+    let keptRecord = try await MemoryStorage.shared.getMemoryByBackendId("kept-1")
+    XCTAssertEqual(keptRecord?.deleted, false, "a memory the backend still has must survive")
+  }
+
+  /// The default-scope pull was the reason pruning was refused. Including
+  /// Archive is what makes the keep-set and the prune scope describe the same
+  /// population — if the pull ever narrows again, this fails.
+  func testPrunesArchiveTierWithoutDeletingArchiveRowsStillPresent()
+    async throws
+  {
+    let archiveKept = makeMemory(id: "archive-kept", tier: .archive)
+    let archiveGone = makeMemory(id: "archive-gone", tier: .archive)
+    try await MemoryStorage.shared.syncServerMemories([archiveKept, archiveGone])
+
+    await makeViewModel(returning: page([archiveKept])).reconcileCacheIfNeeded()
+
+    let keptRecord = try await MemoryStorage.shared.getMemoryByBackendId("archive-kept")
+    XCTAssertEqual(keptRecord?.deleted, false)
+    let goneRecord = try await MemoryStorage.shared.getMemoryByBackendId("archive-gone")
+    XCTAssertEqual(goneRecord?.deleted, true)
+  }
+
+  func testTruncatedPullPrunesNothing() async throws {
+    let present = makeMemory(id: "present", tier: .longTerm)
+    let unseen = makeMemory(id: "unseen-because-truncated", tier: .longTerm)
+    try await MemoryStorage.shared.syncServerMemories([present, unseen])
+
+    await makeViewModel(returning: page([present], truncated: true)).reconcileCacheIfNeeded()
+
+    let record = try await MemoryStorage.shared.getMemoryByBackendId("unseen-because-truncated")
+    XCTAssertEqual(
+      record?.deleted, false,
+      "a truncated pull saw only part of the backend, so absence proves nothing")
+  }
+
+  func testEmptyPullPrunesNothing() async throws {
+    let existing = makeMemory(id: "existing", tier: .longTerm)
+    try await MemoryStorage.shared.syncServerMemories([existing])
+
+    await makeViewModel(returning: page([])).reconcileCacheIfNeeded()
+
+    let record = try await MemoryStorage.shared.getMemoryByBackendId("existing")
+    XCTAssertEqual(
+      record?.deleted, false,
+      "an empty read is far more likely to be a failure than an empty account")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260901-memory-delete-cross-device.json
+++ b/desktop/macos/changelog/unreleased/20260901-memory-delete-cross-device.json
@@ -1,0 +1,3 @@
+{
+  "change": "Memories you delete on another device now disappear here too, and deleting a memory that is already gone no longer makes it reappear a few seconds later"
+}


### PR DESCRIPTION
## Summary

> "I am trying to clean up my memories and I cant delete them on the desktop app. They delete on the app, but they do not sync across devices."

Two defects in the desktop client, and they compound: one manufactures memories that only exist locally, the other makes those memories impossible to remove.

This is the same report as #10446, which was closed COMPLETED on 2026-07-29 **with the cause still unexplained** — the rollout-asymmetry theory posted there was refuted on the issue with live prod evidence (`MEMORY_MODE=off`, so no canonical/legacy split exists to desynchronise). Neither defect below is in the rollout config. Both are in the client.

## 1. Nothing ever removed a memory deleted on another device

`reconcileCacheIfNeeded` carried a doc comment saying it "soft-deletes synced local rows the backend no longer has." It did not. The function ended at:

```
log("MemoriesViewModel: Cache reconcile skipped orphan pruning because backend completeness is unknown")
```

Even its `UserDefaults` key said so: `memoriesCacheReconcile_v2_defaultScopeNoPrune_<uid>`.

The refusal was legitimate at the time — it pulled the **default** scope, and pruning against that would delete Archive rows the endpoint omits by design. But the fix for a pull that is narrower than the prune is to widen the pull, not to skip the prune. `GET /v3/memories` already accepts `include_archive`, and `MemoryStorage.softDeleteSyncedOrphans` already exists and is already used after conversation cascade delete.

So the reconcile now pulls with `includeArchive: true` and prunes within `MemoryLayerScope.allIncludingArchive` — the keep-set and the prune scope describe the same population.

**Absence only counts when the pull proves it.** A truncated pull prunes nothing (it saw part of the backend). An empty pull prunes nothing (far likelier a failed or unauthorized read than a genuinely empty account; pruning there would tombstone the whole cache). `softDeleteSyncedOrphans` only touches rows with a non-nil `backendId`, so local-only memories are structurally exempt, and its tier filter compiles to `tier IN (...)` — SQL `NULL` never matches `IN`, so rows with an unknown tier are excluded from the candidate set rather than deleted. Unknown data fails closed toward keeping.

**Runs once per launch, not once per user.** The old gate was a permanent latch: it would converge the cache exactly once and then let it drift for the life of the install. A delete on another device can happen at any time, so a one-shot latch cannot be the mechanism.

## 2. Deleting an already-absent memory put it back

`DELETE /v3/memories/{id}` returns `404 Memory not found` when the row is gone. Every orphan from defect 1 answers 404. `performActualDelete` caught that like any other error, called `restoreMemory`, and reloaded — so the memory disappeared, came back seconds later, and could never be cleared from the machine.

That is both halves of the report, and it matches #10446's "reappear after ~10–15 seconds" exactly: the 4-second undo window, then the delete, then the reload.

Delete is idempotent in intent. The caller asked for the memory to be gone; the backend reporting it absent already satisfies that. The 404 is now swallowed in `APIClient.deleteMemory`, so all three callers (Memories page, automation bridge, insight storage) get it from one place rather than three call-site patches. Other statuses still throw.

`performActualDelete` also now sets `errorMessage` on a genuine failure, like every other mutation on that model. Restoring the row while saying nothing is indistinguishable from the delete being ignored.

## 3. Corrected the stale doc comment (separate commit)

The comment claiming the reconcile prunes is what sent the previous investigation looking at the backend. It now describes what the code does and why the guards exist.

## Verification

| Check | Result |
|---|---|
| `dev-feedback.py --once swift 'APIClientMemoryDeleteIdempotencyTests\|MemoriesCacheReconcilePruneTests\|MemoryReconciliationScopeTests'` | Executed 12 tests, **0 failures** |
| Same suites against the unfixed code | Executed 8 tests, **3 failures** |
| `make preflight` | PR preflight passed: **22 checks** |

New tests pin both directions, because both directions are dangerous:

- **Delete**: 404 completes; 200 completes; 500 and 403 still throw. Swallowing 404 must not become swallowing failures, or a delete that never happened would read as done.
- **Prune**: a memory absent from a complete pull is pruned; an Archive row still present survives while an absent one is pruned; a truncated pull prunes nothing; an empty pull prunes nothing.

`reconcileCacheIfNeeded` gained a `reconcilePageFetch` seam so the guards — the risky part — are exercised without a network.

### Not verified, stated plainly

The cross-device path was not exercised end to end against a real account: that needs a signed-in session with a memory deleted on a second device, and signing into an account is not an action I take on someone's behalf. The prune contract is proven through the seam and the storage primitive; the transport it replaces is unchanged.

## Tradeoff

Launch-scoped reconcile means a full paged pull per launch where there was previously one ever. For a large account that is a background read of several 500-item pages. The endpoint has no `updated_since` delta, so convergence costs a full read; a delta parameter would be the way to reduce it.

`performFullSyncIfNeeded` still performs its own one-time default-scope pull immediately before this one, so first launch now does two full pulls back to back. Left alone deliberately — collapsing them is a refactor beyond this fix — but it is the obvious follow-up.

## Product invariants

None. `scripts/pr-preflight --suggest` reports no product invariants affected by these paths.

Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift | 3654 -> 3702 | The prune this file refused to do is the fix; +48 lines is the prune call, its guards, and the injectable page fetch that makes those guards testable. Splitting a 3.6k-line view model is a refactor with a far wider blast radius than a delete-sync bug fix, and would bury it.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

