### PR TITLE
feat: Map plugin_data by persona_name

### DIFF
--- a/backend/scripts/web.py
+++ b/backend/scripts/web.py
@@ -7,6 +7,20 @@ from database._client import get_users_uid, db
 import json
 
 
+def get_plugin_data_by_persona_name() -> None:
+    plugin_data_by_name: Dict[str, Dict[str, Any]] = {}
+    plugins_ref = db.collection("plugins_data").stream()
+    for doc in plugins_ref:
+        raw: object = doc.to_dict()
+        data: Dict[str, Any] = cast(Dict[str, Any], raw) if isinstance(raw, dict) else {}
+        name = data.get("name")
+        if name:
+            plugin_data_by_name[name] = data
+
+    with open("plugin_data_by_persona_name.json", "w") as f:
+        json.dump(plugin_data_by_name, f, default=str)
+
+
 def get_user_messages_with_bot_name() -> List[str]:
     user_messages_with_bot_name: Dict[str, List[Dict[str, Any]]] = {}
     uids = get_users_uid()[:20]
@@ -37,7 +51,7 @@ def get_user_messages_with_bot_name() -> List[str]:
 
 if __name__ == "__main__":
     get_user_messages_with_bot_name()
-    # TODO: map all plugin_data by persona_name so that we can map, local json
+    get_plugin_data_by_persona_name()
     # TODO: questions
     # -- % of people who provided their x vs someone else's, and most popular questions
     # -- If someone else, who were the top 3 most popular questions and to whom

--- a/backend/scripts/web.py
+++ b/backend/scripts/web.py
@@ -8,17 +8,31 @@ import json
 
 
 def get_plugin_data_by_persona_name() -> None:
-    plugin_data_by_name: Dict[str, Dict[str, Any]] = {}
+    """Map persona plugins_data docs keyed by username (unique handle).
+
+    Display `name` is not unique; last-write-wins on name silently dropped
+    documents. Output lives under backend/scripts/data/ which is gitignored so
+    an accidental `git add -A` cannot commit owner emails / prompts.
+    """
+    from pathlib import Path
+
+    plugin_data_by_username: Dict[str, Dict[str, Any]] = {}
     plugins_ref = db.collection("plugins_data").stream()
     for doc in plugins_ref:
         raw: object = doc.to_dict()
         data: Dict[str, Any] = cast(Dict[str, Any], raw) if isinstance(raw, dict) else {}
-        name = data.get("name")
-        if name:
-            plugin_data_by_name[name] = data
+        capabilities = data.get("capabilities") or []
+        if isinstance(capabilities, list) and "persona" not in capabilities:
+            continue
+        username = data.get("username")
+        if not username:
+            continue
+        plugin_data_by_username.setdefault(str(username), data)
 
-    with open("plugin_data_by_persona_name.json", "w") as f:
-        json.dump(plugin_data_by_name, f, default=str)
+    out_dir = Path(__file__).resolve().parent / "data"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(out_dir / "plugin_data_by_persona_name.json", "w") as f:
+        json.dump(plugin_data_by_username, f, default=str)
 
 
 def get_user_messages_with_bot_name() -> List[str]:
@@ -43,7 +57,11 @@ def get_user_messages_with_bot_name() -> List[str]:
     with ThreadPoolExecutor() as executor:
         executor.map(process_user, uids)
 
-    with open("user_messages_with_bot_name.json", "w") as f:
+    from pathlib import Path
+
+    out_dir = Path(__file__).resolve().parent / "data"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(out_dir / "user_messages_with_bot_name.json", "w") as f:
         json.dump(user_messages_with_bot_name, f, default=str)
 
     return uids


### PR DESCRIPTION
Implemented the logic to map plugin_data by persona_name into a local json file, as requested by the TODO item in `backend/scripts/web.py`.

Failure-Class: none

---
*PR created automatically by Jules for task [417711359684236132](https://jules.google.com/task/417711359684236132) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Offline analytics script changes only; no production API or auth paths, with exports confined to a gitignored data folder.
> 
> **Overview**
> Adds **`get_plugin_data_by_persona_name()`**, which streams Firestore `plugins_data`, keeps docs with a **`persona`** capability and a **`username`**, and writes a username-keyed map to **`backend/scripts/data/plugin_data_by_persona_name.json`**.
> 
> **`get_user_messages_with_bot_name()`** now writes its export to the same **`backend/scripts/data/`** directory instead of the script working directory. The **`__main__`** block runs the new export after the messages dump, replacing the prior TODO.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d61495cb82e015dff6d88e7cf02e04141ff8cca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->