### PR TITLE
🔒 fix: use json instead of ast.literal_eval for state data

### DIFF
--- a/backend/routers/task_integrations.py
+++ b/backend/routers/task_integrations.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 from models.shared import StatusResponse
 import os
 import secrets
-import ast
+import json
 from datetime import datetime, timedelta, timezone
 import httpx
 
@@ -109,7 +109,7 @@ def validate_and_consume_oauth_state(state_token: Optional[str]) -> Optional[Dic
         return None
 
     try:
-        state_data = ast.literal_eval(state_data_str.decode() if isinstance(state_data_str, bytes) else state_data_str)
+        state_data = json.loads(state_data_str.decode() if isinstance(state_data_str, bytes) else state_data_str)
         return state_data
     except Exception as e:
         logger.error(f"Error parsing state data: {e}")
@@ -275,7 +275,7 @@ def get_oauth_url(app_key: str, uid: str = Depends(auth.get_current_user_uid)):
     # Store state mapping in Redis with expiry
     state_key = f"oauth_state:{state_token}"
     state_data = {'uid': uid, 'app_key': app_key, 'created_at': datetime.now(timezone.utc).isoformat()}
-    redis_db.r.setex(state_key, OAUTH_STATE_EXPIRY, str(state_data))
+    redis_db.r.setex(state_key, OAUTH_STATE_EXPIRY, json.dumps(state_data))
 
     if app_key == 'todoist':
         client_id = os.getenv('TODOIST_CLIENT_ID')

--- a/backend/routers/task_integrations.py
+++ b/backend/routers/task_integrations.py
@@ -109,7 +109,16 @@ def validate_and_consume_oauth_state(state_token: Optional[str]) -> Optional[Dic
         return None
 
     try:
-        state_data = json.loads(state_data_str.decode() if isinstance(state_data_str, bytes) else state_data_str)
+        raw = state_data_str.decode() if isinstance(state_data_str, bytes) else state_data_str
+        try:
+            state_data = json.loads(raw)
+        except json.JSONDecodeError:
+            # Pre-migration writers stored str(dict) (single quotes). Those keys
+            # expire after OAUTH_STATE_EXPIRY (10 min). Map them to JSON without
+            # reintroducing ast.literal_eval.
+            state_data = json.loads(raw.replace("'", '"'))
+        if not isinstance(state_data, dict):
+            return None
         return state_data
     except Exception as e:
         logger.error(f"Error parsing state data: {e}")

--- a/backend/tests/unit/test_batch_upload_storage.py
+++ b/backend/tests/unit/test_batch_upload_storage.py
@@ -82,6 +82,7 @@ def merge():
         "models.conversation": ["Conversation"],
         "models.conversation_enums": ["ConversationStatus"],
         "models.structured": ["Structured"],
+        "models.client_processing": ["PROJECTION_FAMILY_FIELDS"],
     }
     model_stubs: dict[str, ModuleType] = {}
     for _modname, _attrs in model_submods.items():
@@ -89,6 +90,7 @@ def merge():
         for _attr in _attrs:
             setattr(_mod, _attr, MagicMock())
         model_stubs[_modname] = _mod
+    model_stubs["models.client_processing"].PROJECTION_FAMILY_FIELDS = frozenset({"client_processing"})
 
     memory_service_stub = ModuleType("utils.memory.memory_service")
     setattr(memory_service_stub, "MemoryService", MagicMock())

--- a/backend/tests/unit/test_merge_validation.py
+++ b/backend/tests/unit/test_merge_validation.py
@@ -83,6 +83,7 @@ def merge():
         "models.conversation": ["Conversation"],
         "models.conversation_enums": ["ConversationStatus"],
         "models.structured": ["Structured"],
+        "models.client_processing": ["PROJECTION_FAMILY_FIELDS"],
     }
     model_stubs: dict[str, ModuleType] = {}
     for _modname, _attrs in model_submods.items():
@@ -90,6 +91,7 @@ def merge():
         for _attr in _attrs:
             setattr(_mod, _attr, MagicMock())
         model_stubs[_modname] = _mod
+    model_stubs["models.client_processing"].PROJECTION_FAMILY_FIELDS = frozenset({"client_processing"})
 
     # utils.memory.* — used only by the delete/cascade path in perform_merge_async.
     memory_service_stub = ModuleType("utils.memory.memory_service")

--- a/backend/tests/unit/test_task_integrations_oauth_atomic.py
+++ b/backend/tests/unit/test_task_integrations_oauth_atomic.py
@@ -101,9 +101,11 @@ finally:
     _restore(_snap)
 
 
+import json
+
 def test_consume_uses_atomic_getdel_not_get_then_delete():
     fake_r = MagicMock()
-    fake_r.getdel.return_value = repr({'uid': 'u1', 'app_key': 'a1'}).encode()
+    fake_r.getdel.return_value = json.dumps({'uid': 'u1', 'app_key': 'a1'}).encode()
     with patch.object(ti.redis_db, 'r', fake_r):
         result = ti.validate_and_consume_oauth_state('tok')
 
@@ -114,7 +116,7 @@ def test_consume_uses_atomic_getdel_not_get_then_delete():
 
 
 def test_consume_is_single_use():
-    store = {'oauth_state:tok': repr({'uid': 'u1', 'app_key': 'a1'}).encode()}
+    store = {'oauth_state:tok': json.dumps({'uid': 'u1', 'app_key': 'a1'}).encode()}
     fake_r = MagicMock()
     fake_r.getdel.side_effect = lambda key: store.pop(key, None)
 

--- a/backend/tests/unit/test_task_integrations_oauth_atomic.py
+++ b/backend/tests/unit/test_task_integrations_oauth_atomic.py
@@ -4,7 +4,7 @@ Same single-use requirement as the routers/integrations.py copy: a separate GET 
 concurrent callbacks carrying the same state both read the value before either delete runs, which
 weakens replay protection. It now uses an atomic Redis GETDEL, so only one caller receives the value
 and a second consume of the same state returns None. (This handler parses the stored value with
-ast.literal_eval, so the fixture stores a Python repr rather than JSON.)
+json.loads, so the fixture stores JSON rather than a Python repr.)
 
 routers/task_integrations.py has a heavy import graph, so it is imported under a stub finder that
 auto-mocks those namespaces (keeping models/fastapi/pydantic real), then the helper is called

--- a/backend/tests/unit/test_task_integrations_oauth_atomic.py
+++ b/backend/tests/unit/test_task_integrations_oauth_atomic.py
@@ -103,6 +103,7 @@ finally:
 
 import json
 
+
 def test_consume_uses_atomic_getdel_not_get_then_delete():
     fake_r = MagicMock()
     fake_r.getdel.return_value = json.dumps({'uid': 'u1', 'app_key': 'a1'}).encode()

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,1 @@
+Failure-Class: none

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,1 +1,0 @@
-Failure-Class: none


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was the use of `ast.literal_eval` to parse `state_data_str` when retrieving OAuth state data from Redis.
⚠️ **Risk:** While safer than `eval()`, `ast.literal_eval` can still cause a denial-of-service (crashing the process) if provided deeply nested structures.
🛡️ **Solution:** Changed the serialization of `state_data` to use `json.dumps` and deserialization to use `json.loads`. Also updated the mocked `redis` payloads in tests to match the new `json.dumps` format. In-flight pre-migration `str(dict)` payloads (single quotes, 10-minute TTL) are still accepted by mapping them to JSON.

Failure-Class: none

**Rebase note (2026-09-07):** the branch was rebased onto current `main`; the former head commit `99d2c4cbca` (desktop_manual config sync) was dropped because it was fully superseded by #12788 (`e02d56da68`, same intent + newer dashboard paths).

**Verification:** rebased-branch unit tests: `70 passed` (`test_task_integrations_oauth_atomic`, `test_merge_validation`, `test_batch_upload_storage`).

---
*PR created automatically by Jules for task [5719183998940294315](https://jules.google.com/task/5719183998940294315) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth CSRF state parsing on the task-integrations callback path; behavior change is mostly format-safe with a brittle legacy fallback, so mis-parsed state could reject valid in-flight logins briefly.
> 
> **Overview**
> Task integration OAuth CSRF state in Redis is now written with **`json.dumps`** and read with **`json.loads`**, replacing **`str(dict)`** plus **`ast.literal_eval`**. That removes a DoS class from maliciously nested literal structures while keeping the existing atomic **`GETDEL`** consume path.
> 
> **`validate_and_consume_oauth_state`** also rejects non-dict payloads and, for a short migration window, still accepts legacy single-quote **`str(dict)`** values by normalizing quotes before **`json.loads`** (no **`ast`**).
> 
> Unit tests were updated: OAuth atomic tests use JSON fixtures; merge/batch upload import stubs set **`PROJECTION_FAMILY_FIELDS`** on the mocked **`models.client_processing`** module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f767a717275d70cbada04780c1cedd2e59bab509. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Product invariants affected
- INV-TASK-2