### PR TITLE
🧪 [testing improvement] Add tests for _export_photo_manifest

### DIFF
--- a/backend/tests/services/users/test_data_export.py
+++ b/backend/tests/services/users/test_data_export.py
@@ -726,3 +726,77 @@ def test_legacy_conversation_photo_without_any_bytes_reference_exports_metadata(
 
     assert manifest["bytes_available"] is False
     assert manifest["bytes_unavailable_reason"] == "no_retained_bytes_reference"
+
+def test_export_photo_manifest_require_bytes_missing_reference():
+    with pytest.raises(
+        data_export.PortabilityExportIncomplete, match="retained image bytes reference is missing or malformed"
+    ):
+        data_export._export_photo_manifest(
+            "uid1",
+            "conv-1",
+            {"id": "photo-1", "base64": "", "storage_id": ""},
+            require_bytes=True,
+        )
+
+
+def test_export_photo_manifest_malformed_inline_bytes_type():
+    with pytest.raises(data_export.PortabilityExportIncomplete, match="retained inline image bytes are malformed"):
+        data_export._export_photo_manifest(
+            "uid1",
+            "conv-1",
+            {"id": "photo-1", "base64": 123},
+            require_bytes=True,
+        )
+
+
+def test_export_photo_manifest_malformed_inline_bytes_encoding():
+    with pytest.raises(data_export.PortabilityExportIncomplete, match="retained inline image bytes are malformed"):
+        data_export._export_photo_manifest(
+            "uid1",
+            "conv-1",
+            {"id": "photo-1", "base64": "invalid base64!"},
+            require_bytes=True,
+        )
+
+
+def test_export_photo_manifest_valid_inline_bytes():
+    import base64
+
+    valid_base64 = base64.b64encode(b"test pixels").decode("ascii")
+    manifest = data_export._export_photo_manifest(
+        "uid1",
+        "conv-1",
+        {"id": "photo-1", "base64": valid_base64},
+        require_bytes=True,
+    )
+    assert manifest["bytes_available"] is True
+    assert manifest["bytes_base64"] == valid_base64
+
+
+def test_export_photo_manifest_empty_storage_object(monkeypatch):
+    monkeypatch.setattr(data_export, "download_frame_request_pixels", MagicMock(return_value=b""))
+    with pytest.raises(data_export.PortabilityExportIncomplete, match="retained image object is empty"):
+        data_export._export_photo_manifest(
+            "uid1",
+            "conv-1",
+            {"id": "photo-1", "storage_id": "storage-1"},
+            require_bytes=True,
+        )
+    data_export.download_frame_request_pixels.assert_called_once_with("uid1", "storage-1")
+
+
+def test_export_photo_manifest_valid_storage_object(monkeypatch):
+    monkeypatch.setattr(
+        data_export, "download_frame_request_pixels", MagicMock(return_value=b"test pixels from storage")
+    )
+    manifest = data_export._export_photo_manifest(
+        "uid1",
+        "conv-1",
+        {"id": "photo-1", "storage_id": "storage-1"},
+        require_bytes=True,
+    )
+    assert manifest["bytes_available"] is True
+    import base64
+
+    assert manifest["bytes_base64"] == base64.b64encode(b"test pixels from storage").decode("ascii")
+    data_export.download_frame_request_pixels.assert_called_once_with("uid1", "storage-1")

--- a/backend/tests/services/users/test_data_export.py
+++ b/backend/tests/services/users/test_data_export.py
@@ -727,7 +727,6 @@ def test_legacy_conversation_photo_without_any_bytes_reference_exports_metadata(
     assert manifest["bytes_available"] is False
     assert manifest["bytes_unavailable_reason"] == "no_retained_bytes_reference"
 
-
 def test_export_photo_manifest_require_bytes_missing_reference():
     with pytest.raises(
         data_export.PortabilityExportIncomplete, match="retained image bytes reference is missing or malformed"

--- a/backend/tests/services/users/test_data_export.py
+++ b/backend/tests/services/users/test_data_export.py
@@ -727,6 +727,7 @@ def test_legacy_conversation_photo_without_any_bytes_reference_exports_metadata(
     assert manifest["bytes_available"] is False
     assert manifest["bytes_unavailable_reason"] == "no_retained_bytes_reference"
 
+
 def test_export_photo_manifest_require_bytes_missing_reference():
     with pytest.raises(
         data_export.PortabilityExportIncomplete, match="retained image bytes reference is missing or malformed"


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for the `_export_photo_manifest` function in `backend/services/users/data_export.py` to ensure correct portability metadata generation.
📊 **Coverage:** Covered edge cases for `require_bytes=True` including missing references, malformed inline bytes, empty storage objects, and successful extraction of both inline bytes and storage payload.
✨ **Result:** Improved test coverage and reliability for data export features.

---
*PR created automatically by Jules for task [6564531978469913391](https://jules.google.com/task/6564531978469913391) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime or export logic modifications.
> 
> **Overview**
> Adds **seven unit tests** in `test_data_export.py` for `_export_photo_manifest` when **`require_bytes=True`** (the frame-request / fail-closed path).
> 
> They lock in **`PortabilityExportIncomplete`** for missing byte references, malformed inline `base64` (wrong type or invalid encoding), and empty downloaded storage objects, with **`download_frame_request_pixels`** mocked where needed. They also assert successful manifests for valid inline base64 and non-empty storage payloads (`bytes_available` and `bytes_base64`).
> 
> **No production code changes** — coverage and regression safety for portability photo manifest behavior only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0a219914dbddfc5a292a58e506e192ca0d1e38c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->