### PR TITLE
fix(backend): PTT transcribe-stream fails over at the audio send path

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -58,9 +58,17 @@ from utils.chat import (
 from utils.sync.files import retrieve_file_paths, decode_files_to_wav
 from utils.stt.streaming import STTService, connect_stt_socket_with_fallback, drain_stt_socket
 from utils.stt.streaming import get_stt_service_for_language, process_audio_modulate, process_audio_parakeet
+from utils.stt.live_failure import (
+    MAX_STT_FAILOVERS,
+    live_stt_socket_is_dead,
+    live_stt_upstream_failure,
+    send_live_stt_audio,
+    terminate_live_stt_session,
+)
+from utils.stt.provider_resilience import close_rejected_socket, fallback_socket_is_serving
 from utils.stt.pre_recorded import get_prerecorded_service
 from config.prerecorded_stt import TranscriptionOutcome
-from config.stt_provider_policy import STTServingSurface
+from config.stt_provider_policy import MODULATE_PROVIDER, STTServingSurface, provider_for_service
 from utils.stt.outcomes import TranscriptionFailure, failure_from_exception
 from utils.observability.transcription import TranscriptionAttempt
 from utils.llm.goals import extract_and_update_goal_progress
@@ -1251,6 +1259,24 @@ async def transcribe_voice_message(
         other_file_paths.clear()
 
 
+class _PTTStreamSession:
+    """PTT transcribe-stream state exposed as the shared ``LiveSTTSession``.
+
+    ``send_live_stt_audio`` and ``terminate_live_stt_session`` operate on this
+    protocol, so the PTT surface shares listen's failover-aware send path and
+    terminal handling instead of carrying its own copy. Only the terminal path
+    writes to it; the endpoint's closure state stays authoritative and adopts
+    the verdict (``_mark_stt_terminal``) right after the shared call returns.
+    """
+
+    def __init__(self) -> None:
+        self.active = True
+        self.close_code: Optional[int] = None
+        self.stt_terminal_failure = False
+        self.live_transcription_attempt: Optional[object] = None
+        self.client_live_transcription_attempt: Optional[object] = None
+
+
 @router.websocket("/v2/voice-message/transcribe-stream")
 async def transcribe_voice_message_stream(
     websocket: WebSocket,
@@ -1282,6 +1308,11 @@ async def transcribe_voice_message_stream(
     Server sends: JSON arrays of transcript segments
         [{"speaker": "SPEAKER_00", "start": 0.0, "end": 1.5, "text": "Hello world",
           "is_user": false, "person_id": null}]
+        A recoverable mid-session provider death fails over to the next
+        provider in the chain transparently. When the chain is exhausted the
+        client first receives a service-status event
+        ({"type": "service_status", "status": "stt_failed", ...}) and then a
+        WebSocket close 1011 — the same terminal contract as /v4/listen.
     """
     await websocket.accept()
 
@@ -1352,6 +1383,9 @@ async def transcribe_voice_message_stream(
     # 30ms flush threshold for the live-STT transport (16-bit PCM = 2 bytes per sample per channel).
     bytes_per_second = sample_rate * channels * 2
     stt_buffer_flush_size = int(bytes_per_second * 0.03)
+    # Providers that already died for this session; the failover chain excludes
+    # them so a rebuild never lands on the provider that just failed.
+    stt_failed_providers: set[str] = set()
 
     journey_attempt = ClientJourneyAttempt(
         'realtime_voice',
@@ -1360,6 +1394,10 @@ async def transcribe_voice_message_stream(
             user_agent=websocket.headers.get('user-agent'),
         ),
     )
+    ptt_session = _PTTStreamSession()
+    # The shared terminal path fails this attempt with 'provider_error' itself;
+    # ClientJourneyAttempt is one-shot, so the finally block cannot double-fail.
+    ptt_session.client_live_transcription_attempt = journey_attempt
     stt_service, stt_language, stt_model = get_stt_service_for_language(language, surface=STTServingSurface.PTT)
     if stt_service is None or stt_language is None or stt_model is None:
         journey_attempt.fail('dependency_unavailable')
@@ -1414,32 +1452,153 @@ async def transcribe_voice_message_stream(
                 websocket_active = False
                 break
 
-    async def close_stt_failure() -> None:
-        """Expose an unusable live-STT session before the caller drops audio."""
+    def serving_provider() -> Optional[str]:
+        """Provider actually serving this stream, read at use time.
+
+        The connect-time fallback and the mid-session failover can both hand
+        the session to a different provider, so a value snapshotted before the
+        socket exists attributes the wrong provider's failure (#11306).
+        """
+        return getattr(stt_service, 'value', stt_service)
+
+    def _mark_stt_terminal() -> None:
+        """Adopt a terminal live-STT verdict in this endpoint's closure state."""
         nonlocal websocket_active, stt_send_failed
         if stt_send_failed:
             return
         stt_send_failed = True
         websocket_active = False
-        journey_attempt.fail('provider_error')
         logger.error('event=ptt_transcription_stream outcome=provider_terminal_failure')
-        try:
-            await websocket.close(code=1011, reason='Transcription service unavailable')
-        except Exception:
-            pass
 
-    async def send_stt_audio_or_close(audio: bytes) -> bool:
-        """Require the provider to accept audio before its caller discards it."""
+    async def close_stt_failure(reason: str = 'connection_lost') -> None:
+        """Expose an unusable live-STT session before the caller drops audio."""
         if stt_send_failed:
+            return
+        _mark_stt_terminal()
+        # The shared terminal fails the journey attempt, sends the terminal
+        # service-status event, and closes 1011 — the listen wire contract.
+        await terminate_live_stt_session(
+            websocket,
+            ptt_session,
+            failure=live_stt_upstream_failure(serving_provider()),
+            reason=reason,
+            platform=x_app_platform,
+        )
+
+    async def failover_stt_socket() -> bool:
+        """Swap a dead provider socket for the next one in the PTT chain.
+
+        Same shape as listen's ``_failover_stt_socket``: the send path observes
+        a provider death on the very next chunk — Modulate/Velma accepts the
+        upgrade and only then dies on the first audio send — so a recoverable
+        death must rebuild the socket instead of ending the session with 1011.
+        The PTT surface has no separate death-monitor task, so this single
+        receive loop is the only caller and no failover lock is needed.
+        """
+        nonlocal dg_socket, stt_service, stt_language, stt_model
+        if dg_socket is not None and not live_stt_socket_is_dead(dg_socket):
+            return True
+        if stt_send_failed or not websocket_active:
+            return False
+        dead_provider = provider_for_service(stt_service)
+        if dead_provider:
+            stt_failed_providers.add(dead_provider)
+        if len(stt_failed_providers) > MAX_STT_FAILOVERS:
+            return False
+        service, next_language, next_model = get_stt_service_for_language(
+            language, surface=STTServingSurface.PTT, exclude=frozenset(stt_failed_providers)
+        )
+        if service is None or provider_for_service(service) in stt_failed_providers:
+            # The second check also covers a selector that ignores ``exclude``
+            # and re-offers a provider this session already marked dead.
             return False
         try:
-            accepted = dg_socket is not None and not dg_socket.is_connection_dead and dg_socket.send(audio) is True
+            if service == STTService.parakeet:
+                # A provider is never offered its own failure as a fallback, so
+                # the Modulate leg is omitted once it has died for this session.
+                socket, actual_service = await connect_stt_socket_with_fallback(
+                    primary_service=STTService.parakeet,
+                    connect_primary=lambda: process_audio_parakeet(
+                        stream_transcript,
+                        language=next_language,
+                        sample_rate=sample_rate,
+                        channels=channels,
+                        model=next_model,
+                        keywords=context_keywords,
+                        is_active=lambda: websocket_active,
+                    ),
+                    connect_modulate=(
+                        None
+                        if MODULATE_PROVIDER in stt_failed_providers
+                        else lambda: process_audio_modulate(stream_transcript, sample_rate, next_language)
+                    ),
+                )
+            elif service == STTService.modulate:
+                socket = await process_audio_modulate(stream_transcript, sample_rate, next_language)
+                actual_service = STTService.modulate
+            else:
+                return False
         except Exception:
-            accepted = False
-        if accepted:
-            return True
+            logger.exception('transcribe-stream: STT failover connect raised')
+            return False
+        if socket is None:
+            return False
+        # A provider can accept the upgrade and reject the stream ~150ms later;
+        # treating that as a heal would report recovery for a session that is
+        # already dead again.
+        if not await fallback_socket_is_serving(socket):
+            close_rejected_socket(socket)
+            return False
+        if actual_service == STTService.modulate:
+            next_model = 'velma-2'
+        previous_socket = dg_socket
+        dg_socket = socket
+        stt_service, stt_language, stt_model = actual_service, next_language, next_model
+        record_fallback(
+            component='stt_live_session',
+            from_mode=dead_provider or 'unknown',
+            to_mode=actual_service.value,
+            reason='connection_lost',
+            outcome='recovered',
+        )
+        logger.info(f'STT failover mid-session: {dead_provider} -> {actual_service.value}')
+        if previous_socket is not None:
+            try:
+                previous_socket.finish()
+            except Exception:
+                logger.warning('transcribe-stream: failed to close the dead STT socket before failover')
+        return True
 
-        await close_stt_failure()
+    async def send_stt_audio_or_close(audio: bytes) -> bool:
+        """Require the provider to accept audio before its caller discards it.
+
+        A recoverable send-path death fails over to the next provider and the
+        chunk is retried against the replacement socket instead of being
+        dropped — the chunk stays the caller's until a socket accepted it.
+        """
+        if stt_send_failed:
+            return False
+        # Bounded retry, not a single attempt: ``failover_stt_socket`` enforces
+        # MAX_STT_FAILOVERS, so the bound here is a backstop, not the limit.
+        for _ in range(MAX_STT_FAILOVERS + 2):
+            sent = await send_live_stt_audio(
+                websocket,
+                ptt_session,
+                stt_socket=dg_socket,
+                audio=audio,
+                provider=serving_provider(),
+                platform=x_app_platform,
+                attempt_failover=failover_stt_socket,
+            )
+            if sent:
+                return True
+            if ptt_session.stt_terminal_failure:
+                # The shared terminal already failed the journey attempt and
+                # closed the client; adopt its verdict in the PTT state.
+                _mark_stt_terminal()
+                return False
+            # The failover swapped the socket; retry the chunk against it.
+        await close_stt_failure('send_failed')
         return False
 
     def record_stt_usage_once() -> None:

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -58,13 +58,6 @@ from utils.chat import (
 from utils.sync.files import retrieve_file_paths, decode_files_to_wav
 from utils.stt.streaming import STTService, connect_stt_socket_with_fallback, drain_stt_socket
 from utils.stt.streaming import get_stt_service_for_language, process_audio_modulate, process_audio_parakeet
-from utils.stt.live_failure import (
-    MAX_STT_FAILOVERS,
-    live_stt_socket_is_dead,
-    live_stt_upstream_failure,
-    send_live_stt_audio,
-    terminate_live_stt_session,
-)
 from utils.stt.provider_resilience import close_rejected_socket, fallback_socket_is_serving
 from utils.stt.pre_recorded import get_prerecorded_service
 from config.prerecorded_stt import TranscriptionOutcome
@@ -1314,6 +1307,16 @@ async def transcribe_voice_message_stream(
         ({"type": "service_status", "status": "stt_failed", ...}) and then a
         WebSocket close 1011 — the same terminal contract as /v4/listen.
     """
+    # Lazy: a module-level live_failure import circularly loads
+    # observability.transcription while chat tests import this module.
+    from utils.stt.live_failure import (
+        MAX_STT_FAILOVERS,
+        live_stt_socket_is_dead,
+        live_stt_upstream_failure,
+        send_live_stt_audio,
+        terminate_live_stt_session,
+    )
+
     await websocket.accept()
 
     # Paywalled desktop users — close before opening a provider connection for

--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -43,6 +43,7 @@ from utils.subscription import request_has_llm_byok_key
 from utils.executors import db_executor, run_blocking
 from utils.transcribe_decisions import should_skip_custom_stt_postprocessing
 from utils.stt.live_failure import (
+    MAX_STT_FAILOVERS,
     flush_live_stt_buffer,
     live_stt_initialization_failure,
     live_stt_socket_is_dead,
@@ -87,8 +88,6 @@ logger = logging.getLogger(__name__)
 # Cadence for the frame-independent provider-death monitor (#10028). Short enough
 # to terminate a zombie "Listening" session promptly, far below ws_receive_timeout.
 STT_DEATH_POLL_INTERVAL_SECONDS = 1.0
-# Chain depth is 3 (velma/soniox/deepgram); allow walking it once, not looping.
-MAX_STT_FAILOVERS = 2
 
 # Longest frame the Opus format can carry, in milliseconds.
 OPUS_MAX_FRAME_MS = 120

--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -18,6 +18,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from starlette.websockets import WebSocketDisconnect
 
+# Load the real live-STT failure machinery (and its pydantic status-event
+# models) before this file's autouse fixture stubs ``models.conversation``:
+# ``routers.chat`` imports ``utils.stt.live_failure`` at module scope, and
+# ``models.message_event`` can only build its models against the real
+# ``Conversation`` class.
+import utils.stt.live_failure  # noqa: F401  (import-order dependency)
+
 # ---------------------------------------------------------------------------
 # Module-level stubs (same pattern as test_sync_transcription_prefs.py)
 # ---------------------------------------------------------------------------
@@ -1266,9 +1273,13 @@ class TestTranscribeStreamWebSocket:
                 ), patch.object(
                     module, 'ClientJourneyAttempt', return_value=attempt
                 ):
-                    with pytest.raises(Exception):
+                    with pytest.raises(WebSocketDisconnect) as exc_info:
                         with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
-                            ws.receive_json()  # Should not get here
+                            event = ws.receive_json()
+                            assert event['type'] == 'service_status'
+                            assert event['status'] == 'stt_failed'
+                            ws.receive_json()  # terminal close frame follows the status event
+                    assert exc_info.value.code == 1011
                 attempt.fail.assert_called_once_with('provider_error')
                 attempt.succeed.assert_not_called()
         finally:
@@ -1319,34 +1330,238 @@ class TestTranscribeStreamWebSocket:
             _cleanup_chat_client(saved)
 
     def test_ws_rejected_audio_send_closes_1011_without_charge_or_finalize(self):
-        """A rejected provider send must remain terminal, uncharged, and cleaned up."""
+        """An exhausted failover chain on a rejected send stays terminal, uncharged, cleaned up.
+
+        The safe-socket wrapper contract reports a rejected send through the
+        death latch, and the selector offers no provider this session has not
+        already marked dead — so the failover chain is exhausted and the
+        session must still end in the terminal 1011 path.
+        """
         client, module, saved = _make_chat_client()
         try:
             mock_dg_socket = MagicMock()
             mock_dg_socket.is_connection_dead = False
             mock_dg_socket.death_reason = None
-            mock_dg_socket.send = MagicMock(return_value=False)
+
+            def reject_send(_audio):
+                # Safe socket wrappers latch the death on a rejected send.
+                mock_dg_socket.is_connection_dead = True
+                return False
+
+            mock_dg_socket.send = MagicMock(side_effect=reject_send)
             mock_dg_socket.finalize = MagicMock()
             mock_dg_socket.finish = MagicMock()
 
             async def mock_process_audio_parakeet(stream_transcript, **kwargs):
                 return mock_dg_socket
 
-            with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
-                with patch.object(
-                    module, 'get_stt_service_for_language', return_value=(module.STTService.parakeet, 'en', 'parakeet')
-                ):
-                    with patch.object(module, 'process_audio_parakeet', side_effect=mock_process_audio_parakeet):
-                        with patch.object(module, 'record_actual_duration') as mock_record_duration:
-                            with pytest.raises(WebSocketDisconnect) as exc_info:
-                                with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
-                                    ws.send_bytes(b'\x00' * 960)
-                                    ws.receive_json()
+            def select_provider(_language, **kwargs):
+                if kwargs.get('exclude'):
+                    return None  # every remaining provider already died here
+                return (module.STTService.parakeet, 'en', 'parakeet')
 
+            def provider_for(service):
+                if service == module.STTService.parakeet:
+                    return 'parakeet'
+                return None
+
+            with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+                with patch.object(module, 'get_stt_service_for_language', side_effect=select_provider):
+                    with patch.object(module, 'provider_for_service', side_effect=provider_for, create=True):
+                        with patch.object(module, 'process_audio_parakeet', side_effect=mock_process_audio_parakeet):
+                            with patch.object(module, 'record_actual_duration') as mock_record_duration:
+                                with pytest.raises(WebSocketDisconnect) as exc_info:
+                                    with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
+                                        ws.send_bytes(b'\x00' * 960)
+                                        event = ws.receive_json()
+                                        assert event['status'] == 'stt_failed'
+                                        ws.receive_json()
             assert exc_info.value.code == 1011
             mock_dg_socket.send.assert_called_once_with(b'\x00' * 960)
             mock_dg_socket.finalize.assert_not_called()
             mock_dg_socket.finish.assert_called_once()
+            mock_record_duration.assert_not_called()
+        finally:
+            _cleanup_chat_client(saved)
+
+    def test_ws_send_path_death_fails_over_and_retries_chunk(self):
+        """A mid-session send-path death swaps the provider and retries the chunk.
+
+        Velma/Modulate accepts the upgrade and only then dies on the first
+        audio send — the exact listen outage #12469 described. With a remaining
+        provider in the chain the PTT session must not 1011: it swaps the
+        socket, retries the SAME chunk against the replacement, and a later
+        nonempty transcript still succeeds the journey.
+        """
+        client, module, saved = _make_chat_client()
+        try:
+            attempt = MagicMock(finished=False)
+            attempt.succeed.side_effect = lambda: setattr(attempt, 'finished', True)
+            attempt.fail.side_effect = lambda _issue: setattr(attempt, 'finished', True)
+            attempt.cancel.side_effect = lambda: setattr(attempt, 'finished', True)
+
+            dying_socket = MagicMock()
+            dying_socket.is_connection_dead = False
+            dying_socket.death_reason = 'stream error'
+
+            def die_on_send(_audio):
+                dying_socket.is_connection_dead = True
+                return False
+
+            dying_socket.send = MagicMock(side_effect=die_on_send)
+            dying_socket.finalize = MagicMock()
+            dying_socket.finish = MagicMock()
+
+            replacement_socket = MagicMock()
+            replacement_socket.is_connection_dead = False
+            replacement_socket.death_reason = None
+            replacement_accept_order = []
+
+            async def mock_process_audio_parakeet(stream_transcript, **kwargs):
+                return dying_socket
+
+            async def mock_process_audio_modulate(stream_transcript, sample_rate, language):
+                def accept_and_transcribe(audio):
+                    replacement_accept_order.append(bytes(audio))
+                    stream_transcript(
+                        [
+                            {
+                                'speaker': 'SPEAKER_00',
+                                'start': 0.0,
+                                'end': 1.0,
+                                'text': 'Recovered',
+                                'is_user': False,
+                                'person_id': None,
+                            }
+                        ]
+                    )
+                    return True
+
+                replacement_socket.send = MagicMock(side_effect=accept_and_transcribe)
+                replacement_socket.finalize = MagicMock()
+                replacement_socket.finish = MagicMock()
+                return replacement_socket
+
+            selector_calls = []
+
+            def select_provider(_language, **kwargs):
+                selector_calls.append(kwargs.get('exclude'))
+                if len(selector_calls) == 1:
+                    return (module.STTService.parakeet, 'en', 'parakeet')
+                return (module.STTService.modulate, 'en', 'velma-2')
+
+            # The real provider_for_service reads the enum's ``value``; the
+            # stubbed STTService has none, so map the stub identities here to
+            # exercise the real exclusion logic against them.
+            def provider_for(service):
+                if service == module.STTService.parakeet:
+                    return 'parakeet'
+                if service == module.STTService.modulate:
+                    return 'modulate'
+                return None
+
+            with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+                with patch.object(module, 'get_stt_service_for_language', side_effect=select_provider):
+                    with patch.object(module, 'provider_for_service', side_effect=provider_for, create=True):
+                        with patch.object(module, 'process_audio_parakeet', side_effect=mock_process_audio_parakeet):
+                            with patch.object(
+                                module, 'process_audio_modulate', side_effect=mock_process_audio_modulate
+                            ):
+                                with patch.object(module, 'ClientJourneyAttempt', return_value=attempt):
+                                    with patch.object(module, 'record_actual_duration'):
+                                        with client.websocket_connect(
+                                            '/v2/voice-message/transcribe-stream?language=en&sample_rate=16000',
+                                            headers={'X-App-Platform': 'macos'},
+                                        ) as ws:
+                                            ws.send_bytes(b'\x00' * 960)
+                                            data = ws.receive_json()
+                                            assert isinstance(data, list)
+                                            assert data[0]['text'] == 'Recovered'
+                                            ws.send_text('finalize')
+
+            dying_socket.send.assert_called_once_with(b'\x00' * 960)
+            dying_socket.finish.assert_called_once()
+            # The chunk was retried verbatim against the replacement socket.
+            replacement_socket.send.assert_called_once_with(b'\x00' * 960)
+            attempt.succeed.assert_called_once_with()
+            attempt.fail.assert_not_called()
+            assert len(selector_calls) == 2
+            assert selector_calls[1] == frozenset({'parakeet'})
+        finally:
+            _cleanup_chat_client(saved)
+
+    def test_ws_send_path_death_with_exhausted_chain_closes_1011(self):
+        """A send-path death with no reachable replacement ends provider_error + 1011."""
+        client, module, saved = _make_chat_client()
+        try:
+            attempt = MagicMock(finished=False)
+            attempt.succeed.side_effect = lambda: setattr(attempt, 'finished', True)
+            attempt.fail.side_effect = lambda _issue: setattr(attempt, 'finished', True)
+            attempt.cancel.side_effect = lambda: setattr(attempt, 'finished', True)
+
+            dying_socket = MagicMock()
+            dying_socket.is_connection_dead = False
+            dying_socket.death_reason = 'stream error'
+
+            def die_on_send(_audio):
+                dying_socket.is_connection_dead = True
+                return False
+
+            dying_socket.send = MagicMock(side_effect=die_on_send)
+            dying_socket.finalize = MagicMock()
+            dying_socket.finish = MagicMock()
+
+            rejected_socket = MagicMock()
+            rejected_socket.is_connection_dead = True
+            rejected_socket.death_reason = 'capacity_full'
+            rejected_socket.finish = MagicMock()
+
+            async def mock_process_audio_parakeet(stream_transcript, **kwargs):
+                # Parakeet accepts the reconnect and only then rejects the stream.
+                return rejected_socket
+
+            async def mock_process_audio_modulate(stream_transcript, sample_rate, language):
+                return dying_socket
+
+            selector_calls = []
+
+            def select_provider(_language, **kwargs):
+                selector_calls.append(kwargs.get('exclude'))
+                if len(selector_calls) == 1:
+                    return (module.STTService.modulate, 'en', 'velma-2')
+                return (module.STTService.parakeet, 'en', 'parakeet')
+
+            def provider_for(service):
+                if service == module.STTService.parakeet:
+                    return 'parakeet'
+                if service == module.STTService.modulate:
+                    return 'modulate'
+                return None
+
+            with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+                with patch.object(module, 'get_stt_service_for_language', side_effect=select_provider):
+                    with patch.object(module, 'provider_for_service', side_effect=provider_for, create=True):
+                        with patch.object(module, 'process_audio_parakeet', side_effect=mock_process_audio_parakeet):
+                            with patch.object(
+                                module, 'process_audio_modulate', side_effect=mock_process_audio_modulate
+                            ):
+                                with patch.object(module, 'ClientJourneyAttempt', return_value=attempt):
+                                    with patch.object(module, 'record_actual_duration') as mock_record_duration:
+                                        with pytest.raises(WebSocketDisconnect) as exc_info:
+                                            with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
+                                                ws.send_bytes(b'\x00' * 960)
+                                                event = ws.receive_json()
+                                                assert event['status'] == 'stt_failed'
+                                                ws.receive_json()
+
+            assert exc_info.value.code == 1011
+            dying_socket.send.assert_called_once_with(b'\x00' * 960)
+            # The replacement that never served was released before terminating.
+            rejected_socket.finish.assert_called_once()
+            assert len(selector_calls) == 2
+            assert selector_calls[1] == frozenset({'modulate'})
+            attempt.fail.assert_called_once_with('provider_error')
+            attempt.succeed.assert_not_called()
             mock_record_duration.assert_not_called()
         finally:
             _cleanup_chat_client(saved)
@@ -1375,6 +1590,8 @@ class TestTranscribeStreamWebSocket:
                                 with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
                                     ws.send_bytes(b'\x00' * 500)
                                     ws.send_text('finalize')
+                                    event = ws.receive_json()
+                                    assert event['status'] == 'stt_failed'
                                     ws.receive_json()
 
             assert exc_info.value.code == 1011

--- a/backend/utils/stt/live_failure.py
+++ b/backend/utils/stt/live_failure.py
@@ -20,6 +20,12 @@ logger = logging.getLogger(__name__)
 LIVE_STT_FAILURE_CLOSE_CODE = 1011
 LIVE_STT_FAILURE_CLOSE_REASON = 'transcription_service_unavailable'
 
+
+# Chain depth is 3 (velma/soniox/deepgram); allow walking it once, not looping.
+# Shared by every live surface so a mid-session failover cannot loop a chain
+# forever (#12459, #12469).
+MAX_STT_FAILOVERS = 2
+
 _KNOWN_FAILURE_REASONS = frozenset(
     {
         'initialization_failed',


### PR DESCRIPTION
## Problem

Live 24h `realtime_voice` on the PTT surface (`/v2/voice-message/transcribe-stream`): **4 success, 13 failure — all `provider_error`**, 5 cancelled. Cloud Logging pairs **14** `event=ptt_transcription_stream outcome=provider_terminal_failure` with **14** `Modulate streaming error`, clustered 13:00–14:56 UTC. Not a metrics lie, not a Beta-vs-prod app gap: the same Cloud Run backend serves both, and the serving SHA (`e1eca38`) already carries #12469.

#12469 fixed **listen** mid-session STT failover at the **send path**. PTT still did this on the first rejected send:

```python
async def send_stt_audio_or_close(audio: bytes) -> bool:
    ...
    if accepted:
        return True
    await close_stt_failure()  # 1011 + journey fail('provider_error')
    return False
```

Velma/Modulate accepts the WebSocket upgrade and only then dies ~300ms later on the first audio send — the exact shape #12469 closed for listen. PTT's connect-time `connect_stt_socket_with_fallback` cannot help there, so a recoverable death terminated the session with 1011 while the chain still held a healthy replacement. The 13 failures never received a nonempty transcript; `ClientJourneyAttempt.finish` being one-shot is why the 4 working sessions stayed successes.

Not Beta vs prod. Not dashboard math. Out of scope by design: Grafana/`client_kind` (SCA-388), success-rate PromQL, provider chain order, desktop client changes.

## Fix

Port the listen send-path failover onto PTT — reuse, not a fork:

- `send_stt_audio_or_close` now routes through `utils/stt/live_failure.py::send_live_stt_audio(..., attempt_failover=...)`.
- The callback mirrors listen's `_failover_stt_socket`: dead-provider exclusion set fed to `get_stt_service_for_language(..., surface=PTT, exclude=...)`, bounded by `MAX_STT_FAILOVERS` (moved to `utils/stt/live_failure.py` so both surfaces share one bound), replacement proven serving (`fallback_socket_is_serving`) before adoption, rejected rebuilds released.
- A successful failover reports the chunk unsent and the bounded retry sends it against the replacement socket — no audio dropped (listen's flush contract).
- Terminal handling now shares `terminate_live_stt_session` with listen via a small `_PTTStreamSession` adapter: journey `fail('provider_error')` only when the chain is exhausted (or no socket was ever initialized), one terminal `service_status` event, then close 1011 — the same wire contract as `/v4/listen`. Both desktop PTT lane parsers ignore non-array frames (`Array.isArray` guard in `desktop/windows/src/main/ipc/omiListen.ts`), and the e2e suites collect segment arrays only.
- Kept: `succeed()` on first nonempty transcript; the `event=ptt_transcription_stream outcome=provider_terminal_failure` log line on every terminal; codec/paywall/budget/idle-timeout cancel behavior.

## Verification

- `backend/tests/unit/test_desktop_transcribe.py` — **71 passed**. New behavioral tests:
  - `test_ws_send_path_death_fails_over_and_retries_chunk` (GREEN: swaps parakeet→modulate, retries the same chunk verbatim, no `provider_error`, later transcript `succeed()`s; **RED** against the pre-fix endpoint: same test 1011s with no failover — verified by reverting `routers/chat.py`).
  - `test_ws_send_path_death_with_exhausted_chain_closes_1011` (replacement that never serves is released; `provider_error` + 1011; no usage charge).
  - Updated terminal-wire tests assert the status event before close 1011.
- `test_live_stt_failure.py` + `test_stt_session_failover.py` (listen failover) — **27 passed**. `test_excluding_every_provider_selects_nothing` fails when these files run combined with `test_desktop_transcribe.py`, **identically on pristine `origin/main`** — pre-existing selection-order interaction, untouched by this PR.
- Live self-test (commands + observed behavior): real `uvicorn` serving the real endpoint (auth bypassed via `app.dependency_overrides` only), local fake Parakeet `/v3/stream` WebSocket, dummy Modulate key. Healthy phase: connect-time fallback `from=modulate to=parakeet outcome=recovered`, transcript segment received over the live socket. Killed the provider mid-session: send-path death latched, failover attempted, chain exhausted, terminal `service_status stt_failed` event received, close 1011, `event=ptt_transcription_stream outcome=provider_terminal_failure` logged.
- `scripts/backend-python-format --check`, `backend/scripts/scan_async_blockers.py`, `backend/scripts/check_module_stub_pollution.py`: clean.

Failure-Class: FC-recoverable-provider-failure-terminal


Line-Count-Exception: backend/routers/chat.py | 1935 -> 2097 | PTT send-path failover is session closure state over ~15 endpoint locals (socket, provider selection, journey, buffers), mirroring listen whose equivalent lives inside its receiver class; splitting the endpoint out of chat.py is a separate mechanical PR. +3 lines are a lazy live_failure import to break the chat-test circular import.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


