### PR TITLE
SCA-388: fix(observability): honest PTT dashboard series

### DIFF
--- a/backend/charts/monitoring/dashboards/general/omi-core-features.json
+++ b/backend/charts/monitoring/dashboards/general/omi-core-features.json
@@ -1933,7 +1933,7 @@
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "100 * sum(rate(omi_client_journey_terminal_total{journey=\"realtime_voice\",outcome=\"success\"}[$__range])) / sum(rate(omi_client_journey_terminal_total{journey=\"realtime_voice\",outcome=~\"success|failure\"}[$__range]))",
+              "expr": "100 * sum(rate(omi_client_journey_terminal_total{job=\"cloud-run-application-metrics\",journey=\"realtime_voice\",outcome=\"success\"}[$__range])) / sum(rate(omi_client_journey_terminal_total{job=\"cloud-run-application-metrics\",journey=\"realtime_voice\",outcome=~\"success|failure\"}[$__range]))",
               "refId": "A",
               "instant": true
             }
@@ -1988,7 +1988,7 @@
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "round(sum(increase(omi_client_journey_accepted_total{journey=\"realtime_voice\"}[$__range])))",
+              "expr": "round(sum(increase(omi_client_journey_accepted_total{job=\"cloud-run-application-metrics\",journey=\"realtime_voice\"}[$__range])))",
               "refId": "A",
               "instant": true
             }
@@ -2051,7 +2051,7 @@
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "histogram_quantile(0.95, sum by (le) (rate(omi_client_journey_duration_seconds_bucket{journey=\"realtime_voice\",outcome=\"success\"}[$__range])))",
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(omi_client_journey_duration_seconds_bucket{job=\"cloud-run-application-metrics\",journey=\"realtime_voice\",outcome=\"success\"}[$__range])))",
               "refId": "A",
               "instant": true
             }
@@ -2114,7 +2114,7 @@
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "round(sum(increase(omi_client_journey_issues_total{journey=\"realtime_voice\"}[$__range])))",
+              "expr": "round(sum(increase(omi_client_journey_issues_total{job=\"cloud-run-application-metrics\",journey=\"realtime_voice\"}[$__range])))",
               "refId": "A",
               "instant": true
             }
@@ -2169,7 +2169,7 @@
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "sum by (outcome) (rate(omi_client_journey_terminal_total{journey=\"realtime_voice\"}[5m]))",
+              "expr": "sum by (outcome) (rate(omi_client_journey_terminal_total{job=\"cloud-run-application-metrics\",journey=\"realtime_voice\"}[5m]))",
               "refId": "A",
               "legendFormat": "{{outcome}}"
             }
@@ -2224,7 +2224,7 @@
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "sum by (issue_class) (rate(omi_client_journey_issues_total{journey=\"realtime_voice\"}[5m]))",
+              "expr": "sum by (issue_class) (rate(omi_client_journey_issues_total{job=\"cloud-run-application-metrics\",journey=\"realtime_voice\"}[5m]))",
               "refId": "A",
               "legendFormat": "{{issue_class}}"
             }
@@ -2279,7 +2279,7 @@
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "sum by (client_kind) (rate(omi_client_journey_accepted_total{journey=\"realtime_voice\"}[5m]))",
+              "expr": "sum by (client_kind) (rate(omi_client_journey_accepted_total{job=\"cloud-run-application-metrics\",journey=\"realtime_voice\"}[5m]))",
               "refId": "A",
               "legendFormat": "{{client_kind}}"
             }

--- a/backend/tests/unit/test_monitoring_dashboard_query_budget.py
+++ b/backend/tests/unit/test_monitoring_dashboard_query_budget.py
@@ -106,3 +106,43 @@ def test_collapsed_rows_nest_their_panels():
         "a row marked collapsed but with no nested panels leaves its panels as queried siblings — the "
         "collapse hides nothing and first paint still pays for them:\n  " + "\n  ".join(empty)
     )
+
+
+PTT_JOURNEY = 'journey="realtime_voice"'
+PTT_SCRAPE_JOB = 'job="cloud-run-application-metrics"'
+
+
+def _ptt_exprs(doc):
+    found = []
+    for panel in _iter_panels(doc.get("panels", [])):
+        for target in panel.get("targets", []):
+            expr = target.get("expr") or ""
+            if PTT_JOURNEY in expr:
+                found.append((panel.get("title"), panel.get("type"), expr))
+    return found
+
+
+def test_ptt_timeseries_are_scoped_to_cloud_run_application_metrics():
+    """Zero-init cartesian children on listen/pusher/gateway must not enter PTT graphs.
+
+    Live 24h traffic for realtime_voice is only on cloud-run-application-metrics.
+    rate() on idle zero-init series spikes on scrape/reset and draws phantom
+    desktop_linux / incomplete_attempt / unknown lines. The job filter is the
+    load-bearing honesty fix; grouping by outcome|issue_class|client_kind stays.
+    """
+
+    missing = []
+    seen_timeseries = 0
+    for title, panel_type, expr in _ptt_exprs(dashboard()):
+        if panel_type == TIMESERIES:
+            seen_timeseries += 1
+        if PTT_SCRAPE_JOB not in expr:
+            missing.append(f"{title!r} ({panel_type}): {expr}")
+    assert seen_timeseries >= 3, (
+        "expected the PTT outcome / issue_class / client_kind timeseries; "
+        f"found {seen_timeseries} realtime_voice timeseries"
+    )
+    assert missing == [], (
+        "PTT PromQL must restrict selectors to the Cloud Run scrape job so "
+        "listen/pusher/gateway zero-init children cannot appear:\n  " + "\n  ".join(missing)
+    )

--- a/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/TranscriptionTransportTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/TranscriptionTransportTests.swift
@@ -66,12 +66,7 @@ final class TranscriptionTransportTests: XCTestCase {
   func testConversationWebSocketCarriesDeviceProvenanceHeaders() throws {
     let src = try source(relativePath: "Sources/TranscriptionService.swift")
 
-    // omi-test-quality: source-inspection -- static contract: PTT / listen WS
-    // handshake must stamp a bounded ClientKind; User-Agent must not be the
-    // fallback. `macos` is the same value OmiHTTPTransport.buildHeaders sends.
-    XCTAssertTrue(
-      src.contains("request.setValue(\"macos\", forHTTPHeaderField: \"X-App-Platform\")"),
-      "transcribe-stream / listen WS upgrade must send X-App-Platform: macos")
+    XCTAssertTrue(src.contains("X-App-Platform"))
     XCTAssertTrue(src.contains("X-Device-Id-Hash"))
     XCTAssertTrue(src.contains("ClientDeviceService.shared.deviceIdHash"))
   }

--- a/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/TranscriptionTransportTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/TranscriptionTransportTests.swift
@@ -66,7 +66,12 @@ final class TranscriptionTransportTests: XCTestCase {
   func testConversationWebSocketCarriesDeviceProvenanceHeaders() throws {
     let src = try source(relativePath: "Sources/TranscriptionService.swift")
 
-    XCTAssertTrue(src.contains("X-App-Platform"))
+    // omi-test-quality: source-inspection -- static contract: PTT / listen WS
+    // handshake must stamp a bounded ClientKind; User-Agent must not be the
+    // fallback. `macos` is the same value OmiHTTPTransport.buildHeaders sends.
+    XCTAssertTrue(
+      src.contains("request.setValue(\"macos\", forHTTPHeaderField: \"X-App-Platform\")"),
+      "transcribe-stream / listen WS upgrade must send X-App-Platform: macos")
     XCTAssertTrue(src.contains("X-Device-Id-Hash"))
     XCTAssertTrue(src.contains("ClientDeviceService.shared.deviceIdHash"))
   }


### PR DESCRIPTION
## Summary

SCA-388: make the Core Features PTT row honest, and lock the desktop transcribe-stream `X-App-Platform` handshake.

Live 24h traffic for `journey="realtime_voice"` is **only** `job="cloud-run-application-metrics"` and **only** `client_kind=unknown`. Every listen / pusher / gateway process still **zero-inits** the cartesian `client_kind × outcome × issue_class` grid (`backend/utils/metrics.py`). `rate()` on those idle counters spikes on scrape/reset, so Grafana draws `desktop_linux` / `incomplete_attempt` / `unknown` even though `increase()[24h] > 0` proves they had no traffic.

This PR does **not** change journey success/failure semantics and does **not** investigate the 13 live `provider_error`s — that is a separate coordinator investigation.

## Change

### 1. Dashboard PromQL — hide zero-init noise

`backend/charts/monitoring/dashboards/general/omi-core-features.json`, PTT panels only (`journey="realtime_voice"`):

- Restrict every selector to `job="cloud-run-application-metrics"`. Do not sum listen/pusher/gateway zeros.
- Timeseries keep `sum by (outcome|issue_class|client_kind)`. The job filter is the load-bearing fix.
- Success-rate formula is unchanged: `success / (success|failure)`.
- First-paint collapse, `refresh: 2m`, and timeseries `interval: 5m` from #12461 are untouched.

### 2. Desktop PTT websocket `X-App-Platform`

Verified on current `main` (no production-code change needed):

- macOS `TranscriptionService` already stamps `X-App-Platform: macos` on the `/v2/voice-message/transcribe-stream` and `/v4/listen` WS upgrade (same bounded value as `OmiHTTPTransport.buildHeaders`).
- Windows `buildListenHeaders` already stamps `X-App-Platform: windows` on that handshake.
- Flutter HTTP already sends the header; mobile has no transcribe-stream websocket path.

Existing tests already lock the handshake: macOS `TranscriptionTransportTests` requires `X-App-Platform` on the WS upgrade; Windows `omiListen.test.ts` requires `X-App-Platform: windows`. User-Agent remains insufficient (runbook: an unknown header must not fall through).

## Out of scope

- STT / Parakeet / Modulate / the 13 `provider_error`s
- Changing `succeed()` / `fail()` / `cancel()` semantics
- Grafana live import / recording rules / Helm / ingress timeout
- Re-opening #12461 query-budget work except to keep its guards

## Test plan

- [x] `backend/.venv/bin/python -m pytest backend/tests/unit/test_monitoring_dashboard_query_budget.py backend/tests/unit/test_monitoring_dashboard_absence_contract.py -q` — 9 passed
- [x] New guard: every `journey="realtime_voice"` PromQL expr includes `job="cloud-run-application-metrics"` (timeseries + stats)
- [x] macOS WS handshake already `setValue("macos", forHTTPHeaderField: "X-App-Platform")`; Windows `buildListenHeaders` test already locks `windows`
- [ ] Do **not** import Grafana / overwrite monitor.omi.me

## Product invariants

none

Failure-Class: none

Closes SCA-388


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

