### PR TITLE
admin: floating-bar panel measures queries per user, not opens

### DIFF
--- a/web/admin/grafana/build_dashboards.py
+++ b/web/admin/grafana/build_dashboards.py
@@ -49,7 +49,7 @@ PLATFORM_ROUTES = ("viral-metrics", "dau-trends", "retention/posthog", "k-factor
 # panel-for-panel identical without mislabeling desktop data as mobile.
 # (Floating bar is a macOS-only feature; mobile sends no crash telemetry.)
 DESKTOP_ONLY_TITLES = {
-    "Floating bar sessions per user", "Floating bar queries",
+    "Floating bar queries per user", "Floating bar queries",
     "Floating bar notification CTR", "Crash-free rate (today)",
     "Crash-free rate", "Omi Desktop rating — daily",
 }

--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -2572,7 +2572,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Sessions/user"
+              "options": "Queries/user"
             },
             "properties": [
               {
@@ -2656,8 +2656,8 @@
               "type": "timestamp"
             },
             {
-              "selector": "avg_sessions_per_user",
-              "text": "Sessions/user",
+              "selector": "avg_per_user",
+              "text": "Queries/user",
               "type": "number"
             },
             {
@@ -2684,7 +2684,7 @@
         }
       ],
       "timeFrom": "30d",
-      "title": "Floating bar sessions per user  \u00b7  ${d_fbs}",
+      "title": "Floating bar queries per user  \u00b7  ${d_fbs}",
       "type": "timeseries"
     },
     {
@@ -4597,7 +4597,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Ffloating-bar-usage%3Fdays%3D30&root=data&fields=avg_sessions_per_user&agg=avg&window=15&label=vs+prev+15d",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Ffloating-bar-usage%3Fdays%3D30&root=data&fields=avg_per_user&agg=avg&window=15&label=vs+prev+15d",
             "url_options": {
               "data": "",
               "method": "GET"

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -2481,7 +2481,7 @@
     {
       "id": 36,
       "type": "text",
-      "title": "Floating bar sessions per user",
+      "title": "Floating bar queries per user",
       "gridPos": {
         "x": 0,
         "y": 42,

--- a/web/admin/grafana/dashboards/omi-tv.json
+++ b/web/admin/grafana/dashboards/omi-tv.json
@@ -3235,7 +3235,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Sessions/user"
+              "options": "Queries/user"
             },
             "properties": [
               {
@@ -3319,8 +3319,8 @@
               "type": "timestamp"
             },
             {
-              "selector": "avg_sessions_per_user",
-              "text": "Sessions/user",
+              "selector": "avg_per_user",
+              "text": "Queries/user",
               "type": "number"
             },
             {
@@ -3347,7 +3347,7 @@
         }
       ],
       "timeFrom": "30d",
-      "title": "Floating bar sessions per user  \u00b7  ${d_fbs}",
+      "title": "Floating bar queries per user  \u00b7  ${d_fbs}",
       "type": "timeseries"
     },
     {
@@ -6230,7 +6230,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Ffloating-bar-usage%3Fdays%3D30&root=data&fields=avg_sessions_per_user&agg=avg&window=15&label=vs+prev+15d",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Ffloating-bar-usage%3Fdays%3D30&root=data&fields=avg_per_user&agg=avg&window=15&label=vs+prev+15d",
             "url_options": {
               "data": "",
               "method": "GET"


### PR DESCRIPTION
Replace the "Floating bar sessions per user" Grafana panel with **"Floating bar queries per user"** — avg `floating_bar_query_sent` per active user per day, the metric the trusted PostHog insight shows. The old panel counted `floating_bar_ask_omi_opened` per opener (panel opens): PTT voice queries and follow-ups never fire an open, so it structurally undercounted usage and diverged from the queries chart.

- `omi-tv.json`: panel title, series selector `avg_sessions_per_user` → `avg_per_user`, legend "Sessions/user" → "Queries/user", delta-chip compare fields swapped. Unique-users series unchanged; every other panel untouched.
- macOS/mobile boards regenerated via `build_dashboards.py` (its desktop-only title set renamed to match).
- `avg_per_user` is already served by the deployed `/api/omi/stats/floating-bar-usage` — no API change needed.

Verification: rendered the exact built JSON in the local TV Grafana (:3999, Infinity → auth proxy → live admin.omi.me API): panel shows "Floating bar queries per user · ▲ +25.0% vs prev 15d" with both series drawn (30d of live data); delta chip works against the new field. Screenshot in PR thread.

## Product invariants affected

none

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

