### PR TITLE
fix(backend): NLLB-first translation; Vertex-safe Gemini fallback

### DIFF
--- a/backend/config/translation.py
+++ b/backend/config/translation.py
@@ -46,8 +46,8 @@ def resolve_translation_profile(env: Mapping[str, str] | None = None) -> Transla
     """Resolve mutable environment at the translation call boundary.
 
     The configured list is an ordered provider policy. Unavailable providers
-    are filtered, unsupported tokens are retained as diagnostics, and Gemini is
-    used only when the list is empty or no configured provider is usable.
+    are filtered, unsupported tokens are retained as diagnostics, and NLLB is
+    used when the list is empty or no configured provider is usable.
     """
 
     values = process_environ if env is None else env
@@ -79,7 +79,7 @@ def resolve_translation_profile(env: Mapping[str, str] | None = None) -> Transla
         if provider not in usable_providers:
             usable_providers.append(provider)
 
-    providers = tuple(usable_providers) or (TranslationProvider.gemini,)
+    providers = tuple(usable_providers) or (TranslationProvider.nllb,)
 
     timeout = _positive_float(values.get('TRANSLATION_NLLB_TIMEOUT_SECONDS', '5.0'), 'TRANSLATION_NLLB_TIMEOUT_SECONDS')
     cache_ttl = _positive_int(values.get('TRANSLATION_CACHE_TTL', str(60 * 60 * 24 * 14)), 'TRANSLATION_CACHE_TTL')

--- a/backend/llm_gateway/gateway/vertex_wire.py
+++ b/backend/llm_gateway/gateway/vertex_wire.py
@@ -22,6 +22,7 @@ from utils.llm import vertex_pt_routing as ptr
 
 __all__ = [
     '_bounded_error_text',
+    '_json_schema_to_vertex_response_schema',
     '_nonnegative_int_or_zero',
     '_openai_sse',
     '_openai_sse_done',
@@ -130,7 +131,9 @@ def _vertex_request(request: Mapping[str, Any]) -> dict[str, Any]:
             if not isinstance(json_schema, Mapping) or not isinstance(json_schema.get('schema'), Mapping):
                 raise ProviderFailure(FailureClass.CAPABILITY_MISMATCH)
             generation_config['responseMimeType'] = 'application/json'
-            generation_config['responseSchema'] = dict(cast(Mapping[str, Any], json_schema['schema']))
+            generation_config['responseSchema'] = _json_schema_to_vertex_response_schema(
+                cast(Mapping[str, Any], json_schema['schema'])
+            )
 
     payload: dict[str, Any] = {'contents': contents}
     if system_parts:
@@ -144,6 +147,70 @@ def _vertex_request(request: Mapping[str, Any]) -> dict[str, Any]:
     if tool_config is not None:
         payload['toolConfig'] = tool_config
     return payload
+
+
+_JSON_SCHEMA_META_KEYS = frozenset({'$defs', 'definitions', '$schema', '$id', '$comment'})
+_LOCAL_REF_PREFIXES = ('#/$defs/', '#/definitions/')
+
+
+def _json_schema_to_vertex_response_schema(schema: Mapping[str, Any]) -> dict[str, Any]:
+    """Convert OpenAI/Pydantic JSON Schema into Vertex ``responseSchema``.
+
+    Vertex ``responseSchema`` is an OpenAPI 3 subset that accepts ``defs``/``ref``,
+    not JSON Schema ``$defs``/``$ref``. Copying a nested Pydantic schema as-is
+    yields ``InvalidArgument`` 400. Inline local refs and drop JSON-Schema-only
+    meta keys so a legal nested schema stays a legal Vertex request.
+    """
+    converted = _inline_json_schema(schema, _collect_json_schema_defs(schema), frozenset())
+    if not isinstance(converted, dict):
+        raise ProviderFailure(FailureClass.CAPABILITY_MISMATCH)
+    return converted
+
+
+def _collect_json_schema_defs(schema: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    defs: dict[str, Mapping[str, Any]] = {}
+    for key in ('$defs', 'definitions'):
+        raw = schema.get(key)
+        if not isinstance(raw, Mapping):
+            continue
+        for name, definition in raw.items():
+            if isinstance(name, str) and isinstance(definition, Mapping):
+                defs[name] = cast(Mapping[str, Any], definition)
+    return defs
+
+
+def _inline_json_schema(node: Any, defs: Mapping[str, Mapping[str, Any]], visiting: frozenset[str]) -> Any:
+    if isinstance(node, list):
+        return [_inline_json_schema(item, defs, visiting) for item in cast(list[Any], node)]
+    if not isinstance(node, Mapping):
+        return node
+    typed_node = cast(Mapping[str, Any], node)
+    local_defs = dict(defs)
+    local_defs.update(_collect_json_schema_defs(typed_node))
+    ref = typed_node.get('$ref')
+    if isinstance(ref, str):
+        name = _local_json_schema_ref_name(ref)
+        if name is None or name in visiting:
+            raise ProviderFailure(FailureClass.CAPABILITY_MISMATCH)
+        definition = local_defs.get(name)
+        if not isinstance(definition, Mapping):
+            raise ProviderFailure(FailureClass.CAPABILITY_MISMATCH)
+        merged = {**definition, **{key: value for key, value in typed_node.items() if key != '$ref'}}
+        return _inline_json_schema(merged, local_defs, visiting | {name})
+    return {
+        key: _inline_json_schema(value, local_defs, visiting)
+        for key, value in typed_node.items()
+        if key not in _JSON_SCHEMA_META_KEYS
+    }
+
+
+def _local_json_schema_ref_name(ref: str) -> str | None:
+    for prefix in _LOCAL_REF_PREFIXES:
+        if ref.startswith(prefix):
+            name = ref[len(prefix) :]
+            if name and '/' not in name:
+                return name
+    return None
 
 
 def _output_limit(request: Mapping[str, Any]) -> int | None:

--- a/backend/nllb_translation/README.md
+++ b/backend/nllb_translation/README.md
@@ -126,17 +126,17 @@ See `TUNING_RESULTS.md` for the full tuning sweep across beam sizes, compute typ
 The backend uses NLLB via the `TranslationProvider` enum in `utils/translation.py`. Provider is controlled exclusively by `TRANSLATION_SERVICE_MODELS` — the URL alone never changes provider.
 
 ```bash
-# 1. Gemini only (default — no config needed)
+# 1. NLLB only (default — no config needed)
 # TRANSLATION_SERVICE_MODELS is unset
 
-# 2. NLLB primary with Gemini fallback
+# 2. NLLB primary with Gemini fallback for capacity/outage only (prod/dev listen)
 TRANSLATION_SERVICE_MODELS=nllb,gemini
 
 # 3. NLLB only (errors stay retryable; no implicit Gemini fallback)
 TRANSLATION_SERVICE_MODELS=nllb
 ```
 
-The comma-separated list is the exact provider order: fallbacks are used only when they are named. `HOSTED_TRANSLATION_API_URL` must also be set for `nllb` to activate. If the list is empty or contains no usable provider, the backend defaults to Gemini. The legacy `google` configuration token is accepted during migration but resolves and emits as `gemini`.
+The comma-separated list is the exact provider order: fallbacks are used only when they are named. `HOSTED_TRANSLATION_API_URL` must also be set for `nllb` to activate. If the list is empty or contains no usable provider, the backend defaults to NLLB. Gemini is tried only for NLLB timeout, 429, 5xx, or transport unavailability — not for unsupported languages or invalid responses. The legacy `google` configuration token is accepted during migration but resolves and emits as `gemini`.
 
 ## Deploy
 

--- a/backend/tests/unit/test_llm_gateway_vertex_provider.py
+++ b/backend/tests/unit/test_llm_gateway_vertex_provider.py
@@ -13,8 +13,8 @@ from llm_gateway.gateway.providers import (
     ProviderFailure,
     VertexAccessTokenSupplier,
     VertexGeminiProvider,
-    _vertex_request,
 )
+from llm_gateway.gateway.vertex_wire import _json_schema_to_vertex_response_schema, _vertex_request
 from llm_gateway.gateway.schemas import FailureClass, ProviderRef
 from llm_gateway.routers import dependencies
 from utils.executors import critical_executor
@@ -416,6 +416,89 @@ def test_vertex_request_never_emits_a_message_with_zero_parts():
     payload = _vertex_request({"messages": [{"role": "assistant", "content": None}, {"role": "user", "content": []}]})
     assert payload["contents"][0] == {"role": "model", "parts": [{"text": ""}]}
     assert payload["contents"][1] == {"role": "user", "parts": [{"text": ""}]}
+
+
+def test_vertex_response_schema_inlines_nested_translation_json_schema():
+    """Nested Pydantic json_schema must not be copied into Vertex responseSchema.
+
+    Vertex responseSchema is an OpenAPI subset. JSON Schema $defs/$ref is the
+    400 that made omi:auto:translation 100% InvalidArgument.
+    """
+    from utils.translation_core.providers import GeminiTranslationBatch
+
+    schema = GeminiTranslationBatch.model_json_schema()
+    assert '$defs' in schema
+    assert schema['properties']['translations']['items'] == {'$ref': '#/$defs/GeminiTranslationItem'}
+
+    converted = _json_schema_to_vertex_response_schema(schema)
+    dumped = json.dumps(converted)
+    assert '$ref' not in dumped
+    assert '$defs' not in dumped
+    assert converted['type'] == 'object'
+    assert converted['properties']['translations']['items'] == {
+        'properties': {
+            'text': {'title': 'Text', 'type': 'string'},
+            'detected_language': {'title': 'Detected Language', 'type': 'string'},
+        },
+        'required': ['text', 'detected_language'],
+        'title': 'GeminiTranslationItem',
+        'type': 'object',
+    }
+
+    payload = _vertex_request(
+        {
+            'messages': [{'role': 'user', 'content': 'translate'}],
+            'response_format': {
+                'type': 'json_schema',
+                'json_schema': {'name': 'GeminiTranslationBatch', 'schema': schema},
+            },
+        }
+    )
+    response_schema = payload['generationConfig']['responseSchema']
+    assert '$ref' not in json.dumps(response_schema)
+    assert '$defs' not in json.dumps(response_schema)
+    assert response_schema['properties']['translations']['items']['type'] == 'object'
+
+
+def test_vertex_response_schema_inlines_openai_strict_nested_schema():
+    schema = {
+        '$defs': {
+            'GeminiTranslationItem': {
+                'properties': {
+                    'text': {'title': 'Text', 'type': 'string'},
+                    'detected_language': {'title': 'Detected Language', 'type': 'string'},
+                },
+                'required': ['text', 'detected_language'],
+                'title': 'GeminiTranslationItem',
+                'type': 'object',
+                'additionalProperties': False,
+            }
+        },
+        'properties': {
+            'translations': {
+                'items': {'$ref': '#/$defs/GeminiTranslationItem'},
+                'title': 'Translations',
+                'type': 'array',
+            }
+        },
+        'required': ['translations'],
+        'title': 'GeminiTranslationBatch',
+        'type': 'object',
+        'additionalProperties': False,
+    }
+
+    converted = _json_schema_to_vertex_response_schema(schema)
+    dumped = json.dumps(converted)
+    assert '$ref' not in dumped
+    assert '$defs' not in dumped
+    assert converted['additionalProperties'] is False
+    assert converted['properties']['translations']['items']['additionalProperties'] is False
+    assert converted['properties']['translations']['items']['required'] == ['text', 'detected_language']
+
+
+def test_vertex_response_schema_leaves_flat_schemas_unchanged():
+    schema = {'type': 'object', 'properties': {'title': {'type': 'string'}}}
+    assert _json_schema_to_vertex_response_schema(schema) == schema
 
 
 # --- Desktop company-paid PT policy (moved from the desktop proxy) ---------

--- a/backend/tests/unit/test_llm_gateway_vertex_provider.py
+++ b/backend/tests/unit/test_llm_gateway_vertex_provider.py
@@ -5,6 +5,7 @@ import time
 
 import httpx
 import pytest
+from pydantic import BaseModel
 
 from llm_gateway.gateway import providers as provider_module
 from llm_gateway.gateway.auth import ServiceCaller
@@ -422,9 +423,17 @@ def test_vertex_response_schema_inlines_nested_translation_json_schema():
     """Nested Pydantic json_schema must not be copied into Vertex responseSchema.
 
     Vertex responseSchema is an OpenAPI subset. JSON Schema $defs/$ref is the
-    400 that made omi:auto:translation 100% InvalidArgument.
+    400 that made omi:auto:translation 100% InvalidArgument. Local models match
+    GeminiTranslationBatch / GeminiTranslationItem so this stays a cheap unit
+    test (importing translation providers pulls langchain into call-phase CPU).
     """
-    from utils.translation_core.providers import GeminiTranslationBatch
+
+    class GeminiTranslationItem(BaseModel):
+        text: str
+        detected_language: str
+
+    class GeminiTranslationBatch(BaseModel):
+        translations: list[GeminiTranslationItem]
 
     schema = GeminiTranslationBatch.model_json_schema()
     assert '$defs' in schema

--- a/backend/tests/unit/test_translation_nllb.py
+++ b/backend/tests/unit/test_translation_nllb.py
@@ -46,14 +46,18 @@ def test_config_preserves_exact_ordered_provider_policy():
 def test_config_filters_unavailable_and_records_unsupported_tokens():
     resolved = resolve_translation_profile({'TRANSLATION_SERVICE_MODELS': 'unknown,nllb'})
 
-    assert resolved.providers == (TranslationProvider.google,)
+    assert resolved.providers == (TranslationProvider.nllb,)
     assert resolved.configured_providers == (TranslationProvider.nllb,)
     assert resolved.unsupported_tokens == ('unknown',)
     assert resolved.unavailable_tokens == ('nllb',)
 
 
-def test_empty_config_defaults_to_google():
-    assert resolve_translation_profile({}).providers == (TranslationProvider.google,)
+def test_empty_config_defaults_to_nllb():
+    assert resolve_translation_profile({}).providers == (TranslationProvider.nllb,)
+    assert resolve_translation_profile({'TRANSLATION_SERVICE_MODELS': ''}).providers == (TranslationProvider.nllb,)
+    assert resolve_translation_profile({'TRANSLATION_SERVICE_MODELS': 'unknown'}).providers == (
+        TranslationProvider.nllb,
+    )
 
 
 def test_filtered_configured_primary_records_recovered_fallback_after_google_succeeds():
@@ -121,7 +125,19 @@ def test_invalid_numeric_config_fails_at_the_call_boundary(name, value, message)
         resolve_translation_profile({name: value})
 
 
-def test_nllb_failure_recovers_through_google_with_shared_fallback_event():
+def test_nllb_success_never_calls_gemini():
+    nllb = FakeProvider(TranslationProvider.nllb, responses=[translations(('Hola', 'en'))])
+    google = FakeProvider(TranslationProvider.google, responses=[translations(('should not run', 'en'))])
+    service, _cache = build_service(
+        {TranslationProvider.nllb: nllb, TranslationProvider.google: google},
+        selected_profile=profile((TranslationProvider.nllb, TranslationProvider.google)),
+    )
+
+    assert service.translate_text('es', 'Hello') == ('Hola', 'en')
+    assert google.calls == []
+
+
+def test_nllb_timeout_recovers_through_google_with_shared_fallback_event():
     recorder = FallbackRecorder()
     nllb = FakeProvider(
         TranslationProvider.nllb,
@@ -207,7 +223,60 @@ def test_google_first_can_recover_through_nllb_when_configured():
     assert recorder.events[0].fields['to_mode'] == 'nllb'
 
 
-def test_invalid_primary_response_recovers_through_configured_fallback():
+def test_nllb_transport_failure_recovers_through_gemini():
+    recorder = FallbackRecorder()
+    nllb = FakeProvider(
+        TranslationProvider.nllb,
+        responses=[provider_error(TranslationProvider.nllb, 'other')],
+    )
+    google = FakeProvider(TranslationProvider.google, responses=[translations(('Hola', 'en'))])
+    service, _cache = build_service(
+        {TranslationProvider.nllb: nllb, TranslationProvider.google: google},
+        selected_profile=profile((TranslationProvider.nllb, TranslationProvider.google)),
+        recorder=recorder,
+    )
+
+    assert service.translate_text('es', 'Hello') == ('Hola', 'en')
+    assert recorder.events[0].fields['reason'] == 'other'
+    assert recorder.events[0].fields['outcome'] == 'recovered'
+
+
+def test_nllb_5xx_recovers_through_gemini():
+    recorder = FallbackRecorder()
+    nllb = FakeProvider(
+        TranslationProvider.nllb,
+        responses=[provider_error(TranslationProvider.nllb, 'provider_5xx')],
+    )
+    google = FakeProvider(TranslationProvider.google, responses=[translations(('Hola', 'en'))])
+    service, _cache = build_service(
+        {TranslationProvider.nllb: nllb, TranslationProvider.google: google},
+        selected_profile=profile((TranslationProvider.nllb, TranslationProvider.google)),
+        recorder=recorder,
+    )
+
+    assert service.translate_text('es', 'Hello') == ('Hola', 'en')
+    assert recorder.events[0].fields['reason'] == 'provider_5xx'
+
+
+def test_nllb_429_recovers_through_gemini():
+    recorder = FallbackRecorder()
+    nllb = FakeProvider(
+        TranslationProvider.nllb,
+        responses=[provider_error(TranslationProvider.nllb, 'provider_429')],
+    )
+    google = FakeProvider(TranslationProvider.google, responses=[translations(('Hola', 'en'))])
+    service, _cache = build_service(
+        {TranslationProvider.nllb: nllb, TranslationProvider.google: google},
+        selected_profile=profile((TranslationProvider.nllb, TranslationProvider.google)),
+        recorder=recorder,
+    )
+
+    assert service.translate_text('es', 'Hello') == ('Hola', 'en')
+    assert recorder.events[0].fields['reason'] == 'provider_429'
+    assert len(google.calls) == 1
+
+
+def test_invalid_primary_response_does_not_fall_through_to_gemini():
     recorder = FallbackRecorder()
     nllb = FakeProvider(TranslationProvider.nllb, responses=[[]])
     google = FakeProvider(TranslationProvider.google, responses=[translations(('Hola', 'en'))])
@@ -217,9 +286,31 @@ def test_invalid_primary_response_recovers_through_configured_fallback():
         recorder=recorder,
     )
 
-    assert service.translate_text('es', 'Hello') == ('Hola', 'en')
-    assert recorder.events[0].fields['reason'] == 'invalid_response'
-    assert recorder.events[0].fields['outcome'] == 'recovered'
+    outcomes = service.translate_outcomes('es', [('segment', 'Hello')])
+
+    assert outcomes[0].status == TranslationStatus.failed
+    assert google.calls == []
+    assert recorder.events == []
+
+
+def test_nllb_unsupported_language_does_not_fall_through_to_gemini():
+    recorder = FallbackRecorder()
+    nllb = FakeProvider(
+        TranslationProvider.nllb,
+        responses=[provider_error(TranslationProvider.nllb, 'provider_4xx')],
+    )
+    google = FakeProvider(TranslationProvider.google, responses=[translations(('Hola', 'en'))])
+    service, _cache = build_service(
+        {TranslationProvider.nllb: nllb, TranslationProvider.google: google},
+        selected_profile=profile((TranslationProvider.nllb, TranslationProvider.google)),
+        recorder=recorder,
+    )
+
+    outcomes = service.translate_outcomes('es', [('segment', 'Hello')])
+
+    assert outcomes[0].status == TranslationStatus.failed
+    assert google.calls == []
+    assert recorder.events == []
 
 
 def test_missing_primary_adapter_recovers_without_changing_config_order():
@@ -314,7 +405,7 @@ def test_nllb_adapter_validates_and_maps_response_without_network():
 
 @pytest.mark.parametrize(
     ('status_code', 'reason'),
-    [(429, 'provider_429'), (503, 'provider_5xx'), (400, 'other')],
+    [(429, 'provider_429'), (503, 'provider_5xx'), (400, 'provider_4xx')],
 )
 def test_nllb_adapter_classifies_http_failures(status_code, reason):
     client = FakeHttpClient(FakeResponse({}, status_code=status_code))
@@ -334,6 +425,41 @@ def test_nllb_adapter_rejects_malformed_payloads(body):
     provider = NllbTranslationProvider(client_factory=lambda _profile: FakeHttpClient(FakeResponse(body)))
 
     with pytest.raises(TranslationProviderError, match='response|item|fields') as raised:
+        provider.translate(['Hello'], 'es', 'en', profile((TranslationProvider.nllb,)))
+
+    assert raised.value.reason == 'invalid_response'
+
+
+def test_nllb_adapter_classifies_transport_failures_as_other():
+    class FailingClient:
+        def post(self, path: str, json: dict[str, Any]) -> FakeResponse:
+            raise httpx.ConnectError('connection refused')
+
+    provider = NllbTranslationProvider(client_factory=lambda _profile: FailingClient())
+
+    with pytest.raises(TranslationProviderError) as raised:
+        provider.translate(['Hello'], 'es', 'en', profile((TranslationProvider.nllb,)))
+
+    assert raised.value.reason == 'other'
+
+
+def test_nllb_adapter_classifies_json_decode_failures_as_invalid_response():
+    class BadJsonResponse:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> object:
+            raise ValueError('not json')
+
+    class BadJsonClient:
+        def post(self, path: str, json: dict[str, Any]) -> BadJsonResponse:
+            return BadJsonResponse()
+
+    provider = NllbTranslationProvider(client_factory=lambda _profile: BadJsonClient())
+
+    with pytest.raises(TranslationProviderError) as raised:
         provider.translate(['Hello'], 'es', 'en', profile((TranslationProvider.nllb,)))
 
     assert raised.value.reason == 'invalid_response'

--- a/backend/tests/unit/test_translation_nllb.py
+++ b/backend/tests/unit/test_translation_nllb.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import httpx
+import json
 import pytest
 
 from config.translation import TranslationProvider, resolve_translation_profile
@@ -25,6 +26,7 @@ from utils.translation_core.providers import (
     TranslationProviderChain,
     TranslationProviderError,
 )
+from llm_gateway.gateway.vertex_wire import _json_schema_to_vertex_response_schema
 
 
 def test_config_preserves_exact_ordered_provider_policy():
@@ -537,3 +539,12 @@ def test_gemini_adapter_wraps_sdk_failures_as_typed_provider_errors():
 
     assert raised.value.provider == TranslationProvider.google
     assert raised.value.reason == 'other'
+
+
+def test_gemini_translation_batch_schema_is_inlined_for_vertex():
+    schema = GeminiTranslationBatch.model_json_schema()
+    converted = _json_schema_to_vertex_response_schema(schema)
+    dumped = json.dumps(converted)
+    assert '$ref' not in dumped
+    assert '$defs' not in dumped
+    assert converted['properties']['translations']['items']['type'] == 'object'

--- a/backend/utils/translation_core/providers.py
+++ b/backend/utils/translation_core/providers.py
@@ -138,8 +138,10 @@ class NllbTranslationProvider:
         except httpx.HTTPStatusError as error:
             reason = _http_reason(error.response.status_code)
             raise TranslationProviderError(self.provider, reason, 'NLLB translation request failed') from error
-        except (httpx.RequestError, ValueError, TypeError) as error:
+        except httpx.RequestError as error:
             raise TranslationProviderError(self.provider, 'other', 'NLLB translation request failed') from error
+        except (ValueError, TypeError) as error:
+            raise TranslationProviderError(self.provider, 'invalid_response', 'NLLB response is malformed') from error
 
         if not isinstance(body, dict):
             raise TranslationProviderError(self.provider, 'invalid_response', 'NLLB response has no translations')
@@ -234,13 +236,17 @@ class TranslationProviderChain:
             if first_failure is None:
                 first_failure = failure
                 first_failed_provider = provider_name
-            if index == len(profile.providers) - 1:
+            remaining = profile.providers[index + 1 :]
+            if not remaining:
                 if first_failed_provider is not None and first_failed_provider != provider_name:
                     self._record_fallback(first_failed_provider, provider_name, first_failure.reason, 'exhausted')
                 raise failure
+            next_provider = remaining[0]
+            if not _should_continue_fallback(failure, next_provider):
+                raise failure
 
         raise TranslationProviderError(
-            TranslationProvider.gemini, 'config_incomplete', 'No translation provider configured'
+            TranslationProvider.nllb, 'config_incomplete', 'No translation provider configured'
         )
 
     def _record_fallback(
@@ -368,7 +374,18 @@ def _http_reason(status_code: int) -> str:
         return 'provider_429'
     if status_code >= 500:
         return 'provider_5xx'
-    return 'other'
+    return 'provider_4xx'
+
+
+# Gemini is the capacity/outage fallback only. Application failures (unsupported
+# language, invalid_response, 4xx) must not storm the Vertex translation lane.
+_GEMINI_FALLBACK_REASONS = frozenset({'timeout', 'provider_429', 'provider_5xx', 'other', 'config_incomplete'})
+
+
+def _should_continue_fallback(error: TranslationProviderError, next_provider: TranslationProvider) -> bool:
+    if next_provider != TranslationProvider.gemini:
+        return True
+    return error.reason in _GEMINI_FALLBACK_REASONS
 
 
 def _metric_error(reason: str) -> str:


### PR DESCRIPTION
Closes SCA-390

## What changed and why

2026-08-31 prod: `omi:auto:translation` ran ~4.5 rps `gemini-2.5-flash-lite` **error**, 0 success (~51k translation gateway errors / 8h). Listen already uses `TRANSLATION_SERVICE_MODELS=nllb,gemini`. NLLB is primary; every NLLB miss then stormed Gemini, and Gemini was a 100% Vertex `InvalidArgument` 400.

**RCA.** Listen `get_llm('translation').with_structured_output(GeminiTranslationBatch)` sends OpenAI `response_format.json_schema` with a nested Pydantic **strict** schema (`$defs`, `$ref`, `additionalProperties: false`, `title`). `vertex_wire.py` copied that object as-is into Vertex `generationConfig.responseSchema`. Vertex `responseSchema` is an OpenAPI subset (`ref`/`defs`), not JSON Schema `$ref`/`$defs`. Result: Vertex 400, classified `provider_invalid_request` / `never_fallback`.

NLLB is cheaper while the dedicated L4 exists. Keep NLLB default. Gemini is capacity/outage fallback only, and that fallback must actually work.

**Behavior.**

- Empty / unusable `TRANSLATION_SERVICE_MODELS` now defaults to **NLLB**, not Gemini. Prod and dev listen charts stay `nllb,gemini`.
- After an NLLB miss, Gemini is tried only for `timeout`, `provider_429`, `provider_5xx`, transport-like `other`, or `config_incomplete`. Unsupported language (`provider_4xx`) and `invalid_response` stop the chain.
- Nested JSON Schema is inlined into Vertex `responseSchema` so `$ref`/`$defs` are never dumped raw. Gateway still never-fallbacks on `provider_invalid_request`.

## Product invariants affected

none

## How it was verified

Pinned backend venv (`pylock.macos.toml`):

- `python -m pytest tests/unit/test_translation_nllb.py tests/unit/test_llm_gateway_vertex_provider.py` — 65 passed
- `make preflight` (`OMI_PR_BODY_FILE=pr-body.md`) — 25 checks passed in 5095.77s

Not exercised against live Vertex or the prod NLLB node: the Vertex 400 is a request-shape bug (nested `$defs`/`$ref` on `responseSchema`), and the chain policy is a local classification decision. Both are covered by unit tests through the production seams (`_vertex_request` / `TranslationProviderChain`).

`git show origin/main:backend/charts/backend-listen/prod_omi_backend_listen_values.yaml` still has `TRANSLATION_SERVICE_MODELS=nllb,gemini`.

## Tests

- `test_vertex_response_schema_inlines_nested_translation_json_schema` — `GeminiTranslationBatch.model_json_schema()` is not copied raw into `responseSchema` with `$defs`/`$ref`.
- `test_vertex_response_schema_inlines_openai_strict_nested_schema` — same for the OpenAI-strict shape (nested `$ref` + `additionalProperties: false`).
- Existing flat-schema Vertex test still asserts the previous payload.
- Translation chain: NLLB success never calls Gemini; timeout/5xx/429/transport `other` call Gemini; `invalid_response` / `provider_4xx` do not.
- Empty / no usable providers → NLLB.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

