### PR TITLE
SCA-392: keep Interject PTT cards readable and barge-in on the live path

### DIFF
--- a/.github/failure-classes/FC-generic-deadline-revokes-in-flight-owner.json
+++ b/.github/failure-classes/FC-generic-deadline-revokes-in-flight-owner.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "id": "FC-generic-deadline-revokes-in-flight-owner",
+  "violated_contract": "A generic listening, warm, or drain signal must not collapse or fail-close a more specific in-flight owner. A barge-in replacement that is still connecting during recording must stay admissible after hub_warm; a live selected-voice fallback lease is a playing owner, not a native hang; a mounted Interject notification card must keep notification chrome while PTT listening is also true.",
+  "canonical_prevention": "Admit the specific owner first. Defer hub_warm omni fallback while recording and providerConnection is replacing, restore the manager-owned warm rescue when replacement becomes ready, treat non-native playback drain as keepPlaying, and size collapsed chrome from the mounted notification (unioned with listening) rather than the listening island.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Sources/VoiceTurnDomain/VoiceTurnStateMachine.swift",
+    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift",
+    "desktop/macos/Desktop/Tests/VoiceTurnDomainTests/VoiceTurnReducerTests.swift",
+    "desktop/macos/Desktop/Tests/VoiceTurnOutputOwnershipTests.swift",
+    "desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/VoiceTurnDomain/**",
+    "desktop/macos/Desktop/Sources/FloatingControlBar/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -637,9 +637,18 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
     leaseID expectedLeaseID: VoiceLeaseID? = nil,
     armNextResponse: Bool = false
   ) -> Bool {
-    if let expectedLeaseID, activePTTLease?.id != expectedLeaseID {
-      log("FloatingBarVoicePlaybackService: ignored stale playback stop lease=\(expectedLeaseID)")
+    switch VoiceOutputHandoffPolicy.playbackStopAdmission(
+      activeLease: activePTTLease,
+      requestedLeaseID: expectedLeaseID,
+      activeTurnID: VoiceTurnCoordinator.shared.activeTurnID
+    ) {
+    case .stale:
+      log("FloatingBarVoicePlaybackService: ignored stale playback stop lease=\(expectedLeaseID?.description ?? "nil")")
       return false
+    case .alreadyComplete:
+      return true
+    case .apply:
+      break
     }
     if let currentResponseID {
       interruptedResponseID = currentResponseID
@@ -680,6 +689,9 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
       }
       audioPlayer = player
       activePlayerFallbackText = fallbackText
+      if let lease = activePTTLease {
+        _ = VoiceTurnCoordinator.shared.noteOutputProgress(lease)
+      }
       if let acknowledgement = activeRealtimeSlowToolAcknowledgement,
         activePTTLease?.lane == .deterministicAgentAck
       {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift
@@ -325,4 +325,73 @@ enum FloatingControlBarGeometry {
       placement: .pill(draggable: draggable, canonicalCompactFrame: compactSourceFrame)
     )
   }
+
+  static func unionSize(_ a: NSSize, _ b: NSSize) -> NSSize {
+    NSSize(width: max(a.width, b.width), height: max(a.height, b.height))
+  }
+
+  /// Closed-conversation chrome size. A mounted notification card wins over
+  /// listening/thinking island sizes (or the union if listening is larger).
+  static func collapsedSurfaceSize(
+    hasMountedNotification: Bool,
+    isVoiceListening: Bool,
+    isThinking: Bool,
+    notificationSize: NSSize,
+    listeningSize: NSSize,
+    thinkingSize: NSSize,
+    idleSize: NSSize
+  ) -> NSSize {
+    if hasMountedNotification {
+      var size = notificationSize
+      if isVoiceListening { size = unionSize(size, listeningSize) }
+      if isThinking { size = unionSize(size, thinkingSize) }
+      return size
+    }
+    if isVoiceListening { return listeningSize }
+    if isThinking { return thinkingSize }
+    return idleSize
+  }
+
+  static func windowResizeMinimumSize(
+    showingAIConversation: Bool,
+    hasMountedNotification: Bool,
+    isVoiceListening: Bool,
+    isHovering: Bool,
+    usesNotchIsland: Bool,
+    conversationWidth: CGFloat,
+    notificationSize: NSSize,
+    listeningWidth: CGFloat,
+    hoverWidth: CGFloat,
+    idleSize: NSSize
+  ) -> NSSize {
+    if showingAIConversation {
+      return NSSize(width: conversationWidth, height: idleSize.height)
+    }
+    if hasMountedNotification {
+      var size = notificationSize
+      if isVoiceListening {
+        size = unionSize(size, NSSize(width: listeningWidth, height: notificationSize.height))
+      }
+      return size
+    }
+    if isVoiceListening && !usesNotchIsland {
+      return NSSize(width: listeningWidth, height: idleSize.height)
+    }
+    if isHovering {
+      return NSSize(width: hoverWidth, height: idleSize.height)
+    }
+    return idleSize
+  }
+
+  /// Insight teasers collapse to one line unless the pointer is over the card
+  /// or Interject PTT is holding a reply against it.
+  static func interjectInsightTeaserLineLimit(
+    kindIsInsight: Bool,
+    isHovering: Bool,
+    interjectBarHovering: Bool,
+    interjectPTTHoldActive: Bool
+  ) -> Int {
+    guard kindIsInsight else { return 3 }
+    return (isHovering || interjectBarHovering || interjectPTTHoldActive) ? 6 : 1
+  }
 }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -1625,8 +1625,12 @@ struct FloatingControlBarView: View {
   }
 
   private func interjectInsightTeaserLimit(_ notification: FloatingBarNotification) -> Int {
-    guard InterjectFeature.isEnabled, notification.kind == .insight else { return 3 }
-    return (isHovering || state.interjectBarHovering) ? 6 : 1
+    FloatingControlBarGeometry.interjectInsightTeaserLineLimit(
+      kindIsInsight: InterjectFeature.isEnabled && notification.kind == .insight,
+      isHovering: isHovering,
+      interjectBarHovering: state.interjectBarHovering,
+      interjectPTTHoldActive: state.interjectReplyingToTitle != nil
+    )
   }
 
   private var aiInputView: some View {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -885,15 +885,8 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       size = NSSize(width: expandedContentWidth, height: height)
     } else if !state.pttHintText.isEmpty {
       size = pttHintSurfaceSize(usesNotchIsland: notchModeEnabled)
-    } else if state.isVoiceListening {
-      size = notchModeEnabled ? notchSize(active: true) : Self.voiceBarSize
-    } else if state.currentNotification != nil {
-      size = NSSize(
-        width: Self.notificationWidth,
-        height: notchChromeHeightForCurrentScreen + Self.notificationSpacing + Self.notificationHeight
-      )
     } else {
-      size = notchModeEnabled ? notchIdleOrHoverSurfaceSize() : collapsedBarSize
+      size = collapsedChromeSurfaceSize(usesNotchIsland: notchModeEnabled)
     }
     let windowSize = responseGlowWindowSizeForCurrentScreen(forSurfaceSize: size)
     return NSRect(origin: defaultTopCenteredOrigin(for: windowSize), size: windowSize)
@@ -919,24 +912,57 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     if !state.pttHintText.isEmpty {
       return pttHintSurfaceSize(usesNotchIsland: usesNotchIsland)
     }
-    if state.isVoiceListening {
-      return usesNotchIsland ? notchSize(active: true) : Self.voiceBarSize
-    }
-    if state.currentNotification != nil {
-      let barHeight =
-        usesNotchIsland
-        ? notchChromeHeightForCurrentScreen
-        : (state.isHoveringBar ? Self.expandedBarSize.height : Self.minBarSize.height)
-      return NSSize(
-        width: Self.notificationWidth,
-        height: barHeight + Self.notificationSpacing + Self.notificationHeight
-      )
-    }
-    return usesNotchIsland ? notchIdleOrHoverSurfaceSize() : Self.minBarSize
+    return collapsedChromeSurfaceSize(usesNotchIsland: usesNotchIsland)
   }
 
   private func currentSurfaceSizeForCurrentScreen(frameIncludesVoiceGlow: Bool? = nil) -> NSSize {
     currentSurfaceSize(usesNotchIsland: notchModeEnabled, frameIncludesVoiceGlow: frameIncludesVoiceGlow)
+  }
+
+  /// Shared closed-conversation size: a mounted notification card wins over
+  /// the listening/thinking island so Interject PTT cannot crush the card.
+  private func collapsedChromeSurfaceSize(usesNotchIsland: Bool, screen: NSScreen? = nil) -> NSSize {
+    let barHeight: CGFloat
+    if usesNotchIsland {
+      barHeight = screen.map { Self.notchChromeHeight(for: $0) } ?? notchChromeHeightForCurrentScreen
+    } else {
+      barHeight = state.isHoveringBar ? Self.expandedBarSize.height : Self.minBarSize.height
+    }
+    let notificationSize = NSSize(
+      width: Self.notificationWidth,
+      height: barHeight + Self.notificationSpacing + Self.notificationHeight
+    )
+    let listeningSize: NSSize
+    if usesNotchIsland {
+      listeningSize =
+        screen.map { notchSize(sideWidth: Self.notchActiveSideWidth, for: $0) }
+        ?? notchSize(active: true)
+    } else {
+      listeningSize = Self.voiceBarSize
+    }
+    let thinkingSize: NSSize
+    if usesNotchIsland {
+      thinkingSize =
+        screen.map { notchSize(sideWidth: Self.notchThinkingSideWidth, for: $0) }
+        ?? notchSize(sideWidth: Self.notchThinkingSideWidth)
+    } else {
+      thinkingSize = Self.minBarSize
+    }
+    let idleSize: NSSize
+    if usesNotchIsland {
+      idleSize = screen.map { notchIdleOrHoverSurfaceSize(for: $0) } ?? notchIdleOrHoverSurfaceSize()
+    } else {
+      idleSize = Self.minBarSize
+    }
+    return FloatingControlBarGeometry.collapsedSurfaceSize(
+      hasMountedNotification: state.currentNotification != nil,
+      isVoiceListening: state.isVoiceListening,
+      isThinking: state.isThinking || state.isVoiceResponseWaiting,
+      notificationSize: notificationSize,
+      listeningSize: listeningSize,
+      thinkingSize: thinkingSize,
+      idleSize: idleSize
+    )
   }
 
   private func frameForCurrentState(on screen: NSScreen, usesNotchIsland: Bool) -> NSRect {
@@ -953,19 +979,8 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       )
     } else if !state.pttHintText.isEmpty {
       size = pttHintSurfaceSize(usesNotchIsland: usesNotchIsland, screen: screen)
-    } else if state.isVoiceListening {
-      size = usesNotchIsland ? notchSize(sideWidth: Self.notchActiveSideWidth, for: screen) : Self.voiceBarSize
-    } else if state.currentNotification != nil {
-      let barHeight =
-        usesNotchIsland
-        ? Self.notchChromeHeight(for: screen)
-        : (state.isHoveringBar ? Self.expandedBarSize.height : Self.minBarSize.height)
-      size = NSSize(
-        width: Self.notificationWidth,
-        height: barHeight + Self.notificationSpacing + Self.notificationHeight
-      )
     } else {
-      size = usesNotchIsland ? notchIdleOrHoverSurfaceSize(for: screen) : Self.minBarSize
+      size = collapsedChromeSurfaceSize(usesNotchIsland: usesNotchIsland, screen: screen)
     }
     let windowSize = responseGlowWindowSize(forSurfaceSize: size, usesNotchIsland: usesNotchIsland)
     return NSRect(
@@ -2207,7 +2222,10 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   /// The window frame for the current active sub-state, in the given mode.
   private func activeIslandTargetFrame(on screen: NSScreen, island: Bool) -> NSRect {
     let size: NSSize
-    if island {
+    if state.currentNotification != nil, !state.showingAIConversation {
+      let surface = collapsedChromeSurfaceSize(usesNotchIsland: island, screen: screen)
+      size = responseGlowWindowSize(forSurfaceSize: surface, usesNotchIsland: island)
+    } else if island {
       let base: NSSize
       if state.isVoiceListening {
         base = notchSize(sideWidth: Self.notchActiveSideWidth, for: screen)
@@ -2594,22 +2612,23 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   }
 
   func windowWillResize(_ sender: NSWindow, to frameSize: NSSize) -> NSSize {
-    let minimumWidth: CGFloat
-    if state.showingAIConversation {
-      minimumWidth = expandedContentWidth
-    } else if state.currentNotification != nil {
-      minimumWidth = FloatingControlBarWindow.notificationWidth
-    } else if state.isVoiceListening && !notchModeEnabled {
-      minimumWidth = FloatingControlBarWindow.voiceBarSize.width
-    } else if state.isHoveringBar {
-      minimumWidth = FloatingControlBarWindow.expandedBarSize.width
-    } else {
-      minimumWidth = collapsedBarSize.width
-    }
-
+    let notificationSize = collapsedChromeSurfaceSize(
+      usesNotchIsland: notchModeEnabled)
+    let minimum = FloatingControlBarGeometry.windowResizeMinimumSize(
+      showingAIConversation: state.showingAIConversation,
+      hasMountedNotification: state.currentNotification != nil,
+      isVoiceListening: state.isVoiceListening,
+      isHovering: state.isHoveringBar,
+      usesNotchIsland: notchModeEnabled,
+      conversationWidth: expandedContentWidth,
+      notificationSize: notificationSize,
+      listeningWidth: Self.voiceBarSize.width,
+      hoverWidth: Self.expandedBarSize.width,
+      idleSize: collapsedBarSize
+    )
     return NSSize(
-      width: max(frameSize.width, minimumWidth),
-      height: max(frameSize.height, FloatingControlBarWindow.minBarSize.height)
+      width: max(frameSize.width, minimum.width),
+      height: max(frameSize.height, minimum.height)
     )
   }
 

--- a/desktop/macos/Desktop/Sources/VoiceTurnDomain/VoiceTurnStateMachine.swift
+++ b/desktop/macos/Desktop/Sources/VoiceTurnDomain/VoiceTurnStateMachine.swift
@@ -200,6 +200,18 @@ package struct VoiceOutputSnapshot: Equatable, Sendable {
   }
 }
 
+package enum VoicePlaybackStopAdmission: Equatable, Sendable {
+  case apply
+  case alreadyComplete
+  case stale
+}
+
+package enum VoicePlaybackDrainAdmission: Equatable, Sendable {
+  case failClosed
+  case alreadyComplete
+  case keepPlaying
+}
+
 package enum VoiceOutputHandoffPolicy {
   package static func fillerCanYield(
     active: VoiceOutputLease,
@@ -207,6 +219,34 @@ package enum VoiceOutputHandoffPolicy {
     turnID: VoiceTurnID
   ) -> Bool {
     active.turnID == turnID && active.lane == .filler && incomingLane != .filler
+  }
+
+  /// A fallback TTS stop for the active turn is never stale, even when the
+  /// service already released or rotated the exact lease id.
+  package static func playbackStopAdmission(
+    activeLease: VoiceOutputLease?,
+    requestedLeaseID: VoiceLeaseID?,
+    activeTurnID: VoiceTurnID?
+  ) -> VoicePlaybackStopAdmission {
+    guard let requestedLeaseID else { return .apply }
+    if activeLease?.id == requestedLeaseID { return .apply }
+    if activeLease == nil { return .alreadyComplete }
+    if let activeTurnID, activeLease?.turnID == activeTurnID {
+      return .apply
+    }
+    return .stale
+  }
+
+  /// Native realtime uses PCM progress to refresh the watchdog, so silence is
+  /// fail-closed. A still-owned fallback lease is a live owner, not a hang.
+  package static func playbackDrainAdmission(
+    phase: VoiceTurnPhase,
+    activeLease: VoiceOutputLease?
+  ) -> VoicePlaybackDrainAdmission {
+    guard case .playing = phase else { return .alreadyComplete }
+    guard let activeLease else { return .alreadyComplete }
+    if activeLease.lane == .nativeRealtime { return .failClosed }
+    return .keepPlaying
   }
 }
 
@@ -1493,6 +1533,12 @@ struct VoiceTurnReducer {
       model.turn?.providerConnection = .ready
       model.turn?.sessionID = sessionID
       bindProviderReadyHubRoute(sessionID: sessionID, in: &model)
+      // A hubWarm fire during recording+replacing consumes the deadline so
+      // replacement can still be admitted. Restore the manager-owned warm
+      // rescue now that the socket is ready.
+      if model.turn?.route == .hubWarmWait, model.turn?.deadlines.contains(.hubWarm) != true {
+        schedule(.hubWarm, after: deadlines.hubWarm, in: &model, effects: &effects)
+      }
       if shouldProjectProviderConnectionAsAwaitingResponse(turn) {
         model.turn?.phase = .awaitingResponse
       }
@@ -1956,6 +2002,12 @@ struct VoiceTurnReducer {
       case .captureStart:
         terminate(&model, reason: .captureFailed, effects: &effects)
       case .hubWarm:
+        if shouldDeferHubWarmFallback(turn) {
+          // Replacement is still connecting while the user holds. Do not
+          // commit omni; keep `.replacing` so provider_replacement_ready stays
+          // admissible. bargeInReplacement remains the omni fence.
+          return VoiceTurnReduction(model: model, effects: effects)
+        }
         // A replacement may still be connecting when the bounded warm window
         // expires. Once batch STT owns the turn, a late provider-ready callback
         // must not restore the hub route or replay the same capture there.
@@ -2001,7 +2053,30 @@ struct VoiceTurnReducer {
           in: &model,
           effects: &effects)
       case .playbackDrain:
-        terminate(&model, reason: .playbackFailed, effects: &effects)
+        switch VoiceOutputHandoffPolicy.playbackDrainAdmission(
+          phase: turn.phase,
+          activeLease: turn.activeLease
+        ) {
+        case .alreadyComplete:
+          model.turn?.activeLease = nil
+          model.turn?.projection.isResponseActive = false
+          if completionFencesSatisfied(model.turn) {
+            terminate(&model, reason: .success, effects: &effects)
+          } else if model.turn?.providerFinished == true {
+            model.turn?.phase = .awaitingJournal
+            model.turn?.projection.isThinking = true
+            model.turn?.projection.isResponseWaiting = false
+          } else {
+            model.turn?.phase = .awaitingResponse
+            model.turn?.projection.isResponseWaiting = true
+            schedule(
+              .providerResponse, after: deadlines.providerResponse, in: &model, effects: &effects)
+          }
+        case .keepPlaying:
+          schedule(.playbackDrain, after: deadlines.playbackDrain, in: &model, effects: &effects)
+        case .failClosed:
+          terminate(&model, reason: .playbackFailed, effects: &effects)
+        }
       case .providerReconnect:
         guard turn.phase.isRecording || turn.phase == .finalizing || turn.hubCommitPending else {
           terminate(&model, reason: .providerFailed, effects: &effects)
@@ -2110,6 +2185,14 @@ struct VoiceTurnReducer {
   /// response projection during connection churn.
   private func shouldProjectProviderConnectionAsAwaitingResponse(_ turn: VoiceTurn) -> Bool {
     acceptsProviderOutput(turn.phase) || turn.hubCommitPending
+  }
+
+  /// A barge-in replacement that is still connecting during recording must not
+  /// treat the generic one-second warm hint as a committed omni fallback.
+  private func shouldDeferHubWarmFallback(_ turn: VoiceTurn) -> Bool {
+    guard turn.phase.isRecording else { return false }
+    if case .replacing = turn.providerConnection { return true }
+    return false
   }
 
   /// Binds a freshly ready provider session to the hub route without stealing a

--- a/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
@@ -603,6 +603,82 @@ final class FloatingBarGeometryTests: XCTestCase {
         acceptsMouseHit: { _ in true }),
       "an ordered-out panel must never retain event ownership")
   }
+
+  func testMountedNotificationWinsOverListeningIsland() {
+    let notification = NSSize(width: 508, height: 194)
+    let listening = NSSize(width: 351, height: 58)
+    let idle = NSSize(width: 40, height: 14)
+    let size = FloatingControlBarGeometry.collapsedSurfaceSize(
+      hasMountedNotification: true,
+      isVoiceListening: true,
+      isThinking: false,
+      notificationSize: notification,
+      listeningSize: listening,
+      thinkingSize: listening,
+      idleSize: idle
+    )
+    XCTAssertGreaterThanOrEqual(size.width, notification.width)
+    XCTAssertGreaterThanOrEqual(size.height, notification.height)
+    XCTAssertNotEqual(size, listening)
+  }
+
+  func testPTTReleaseWithMountedCardDoesNotCollapseToListeningIsland() {
+    let notification = NSSize(width: 508, height: 194)
+    let listening = NSSize(width: 351, height: 58)
+    let afterHold = FloatingControlBarGeometry.collapsedSurfaceSize(
+      hasMountedNotification: true,
+      isVoiceListening: true,
+      isThinking: true,
+      notificationSize: notification,
+      listeningSize: listening,
+      thinkingSize: NSSize(width: 351, height: 58),
+      idleSize: NSSize(width: 40, height: 14)
+    )
+    XCTAssertGreaterThanOrEqual(afterHold.width, 508)
+    XCTAssertGreaterThanOrEqual(afterHold.height, 194)
+  }
+
+  func testWindowResizeKeepsNotificationMinimumWhileListening() {
+    let notification = NSSize(width: 508, height: 194)
+    let minimum = FloatingControlBarGeometry.windowResizeMinimumSize(
+      showingAIConversation: false,
+      hasMountedNotification: true,
+      isVoiceListening: true,
+      isHovering: false,
+      usesNotchIsland: true,
+      conversationWidth: 382,
+      notificationSize: notification,
+      listeningWidth: 351,
+      hoverWidth: 224,
+      idleSize: NSSize(width: 40, height: 14)
+    )
+    XCTAssertGreaterThanOrEqual(minimum.width, 508)
+    XCTAssertGreaterThanOrEqual(minimum.height, 194)
+  }
+
+  func testInsightTeaserStaysExpandedDuringInterjectPTTHold() {
+    XCTAssertEqual(
+      FloatingControlBarGeometry.interjectInsightTeaserLineLimit(
+        kindIsInsight: true,
+        isHovering: false,
+        interjectBarHovering: false,
+        interjectPTTHoldActive: true),
+      6)
+    XCTAssertEqual(
+      FloatingControlBarGeometry.interjectInsightTeaserLineLimit(
+        kindIsInsight: true,
+        isHovering: false,
+        interjectBarHovering: false,
+        interjectPTTHoldActive: false),
+      1)
+    XCTAssertEqual(
+      FloatingControlBarGeometry.interjectInsightTeaserLineLimit(
+        kindIsInsight: false,
+        isHovering: false,
+        interjectBarHovering: false,
+        interjectPTTHoldActive: true),
+      3)
+  }
 }
 
 // MARK: - Notch top re-anchoring

--- a/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/VoiceTurnReducerTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/VoiceTurnReducerTests.swift
@@ -240,6 +240,93 @@ final class VoiceTurnReducerTests: XCTestCase {
       timedOut.effects.contains(.fallbackToTranscription(turnID: turnID, reason: .hubWarmTimeout)))
   }
 
+  func testHubWarmTimeoutDuringRecordingReplacementDoesNotFallbackToOmni() {
+    let turnID = VoiceTurnID()
+    let replacementResponseID = VoiceResponseID("in-flight-replacement")
+    var model = reduce(.idle, .start(turnID: turnID, ownerID: nil, intent: .hold)).model
+    model = reduce(model, .selectRoute(turnID: turnID, route: .hubWarmWait)).model
+    let reservation = reserveIdentity(model, turnID: turnID)
+    model =
+      reduce(
+        reservation.model,
+        .providerReplacementStarted(
+          turnID: turnID,
+          identity: reservation.identity,
+          previousResponseID: nil,
+          nextResponseID: replacementResponseID)
+      ).model
+    XCTAssertEqual(model.turn?.phase, .recording)
+    XCTAssertTrue(model.turn?.deadlines.contains(.hubWarm) == true)
+
+    let timedOut = reduce(model, .deadlineFired(turnID: turnID, deadline: .hubWarm))
+
+    XCTAssertEqual(timedOut.model.turn?.route, .hubWarmWait)
+    XCTAssertEqual(timedOut.model.turn?.phase, .recording)
+    if case .replacing = timedOut.model.turn?.providerConnection {
+    } else {
+      XCTFail("replacement must stay in flight after hub_warm during recording")
+    }
+    XCTAssertFalse(
+      timedOut.effects.contains(
+        .fallbackToTranscription(turnID: turnID, reason: .hubWarmTimeout)))
+    XCTAssertTrue(timedOut.model.turn?.deadlines.contains(.bargeInReplacement) == true)
+  }
+
+  func testReplacementReadyAfterHubWarmWhileRecordingAdmitsLivePath() {
+    let turnID = VoiceTurnID()
+    let sessionID = VoiceSessionID()
+    let replacementResponseID = VoiceResponseID("ready-after-warm")
+    var model = reduce(.idle, .start(turnID: turnID, ownerID: nil, intent: .hold)).model
+    model = reduce(model, .selectRoute(turnID: turnID, route: .hubWarmWait)).model
+    let reservation = reserveIdentity(model, turnID: turnID)
+    model =
+      reduce(
+        reservation.model,
+        .providerReplacementStarted(
+          turnID: turnID,
+          identity: reservation.identity,
+          previousResponseID: nil,
+          nextResponseID: replacementResponseID)
+      ).model
+    model = reduce(model, .deadlineFired(turnID: turnID, deadline: .hubWarm)).model
+
+    let ready = reduce(
+      model,
+      .providerReplacementReady(
+        turnID: turnID,
+        identity: reservation.identity,
+        sessionID: sessionID,
+        responseID: replacementResponseID))
+
+    XCTAssertEqual(ready.model.staleEventCount, 0)
+    XCTAssertEqual(ready.model.turn?.providerConnection, .ready)
+    XCTAssertEqual(ready.model.turn?.sessionID, sessionID)
+    XCTAssertEqual(ready.model.turn?.route, .hubWarmWait)
+    XCTAssertNotEqual(ready.model.turn?.route, .deepgramBatch)
+    XCTAssertEqual(ready.model.turn?.phase, .recording)
+    XCTAssertTrue(ready.model.turn?.deadlines.contains(.hubWarm) == true)
+  }
+
+  func testSelectedVoiceFallbackDrainKeepsPlayingOwner() throws {
+    let (awaiting, turnID, _, _) = awaitingHubResponse()
+    let lease = VoiceOutputLease(
+      id: VoiceLeaseID(), turnID: turnID, lane: .selectedVoiceFallback)
+    let playing = reduce(awaiting, .playbackStarted(turnID: turnID, lease: lease)).model
+
+    let drained = reduce(playing, .deadlineFired(turnID: turnID, deadline: .playbackDrain))
+
+    XCTAssertEqual(drained.model.turn?.phase, .playing(.selectedVoiceFallback))
+    XCTAssertEqual(drained.model.turn?.activeLease?.id, playing.turn?.activeLease?.id)
+    XCTAssertNil(drained.model.turn?.terminalReason)
+    XCTAssertTrue(drained.model.turn?.deadlines.contains(.playbackDrain) == true)
+    XCTAssertTrue(
+      drained.effects.contains(
+        .scheduleDeadline(
+          turnID: turnID,
+          deadline: .playbackDrain,
+          after: reducer.deadlines.playbackDrain)))
+  }
+
   func testBargeInReplacementUsesTheBoundedReconnectWindow() {
     XCTAssertEqual(reducer.deadlines.bargeInReplacement, 3)
     XCTAssertEqual(reducer.deadlines.providerReconnect, 3)

--- a/desktop/macos/Desktop/Tests/VoiceTurnOutputOwnershipTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnOutputOwnershipTests.swift
@@ -159,6 +159,63 @@ final class VoiceTurnOutputOwnershipTests: XCTestCase {
         turnID: VoiceTurnID()))
   }
 
+  func testFallbackStopForActiveTurnIsNeverStale() {
+    let turnID = VoiceTurnID()
+    let lease = syntheticLease(.selectedVoiceFallback, turnID: turnID)
+
+    XCTAssertEqual(
+      VoiceOutputHandoffPolicy.playbackStopAdmission(
+        activeLease: lease,
+        requestedLeaseID: lease.id,
+        activeTurnID: turnID),
+      .apply)
+    XCTAssertEqual(
+      VoiceOutputHandoffPolicy.playbackStopAdmission(
+        activeLease: lease,
+        requestedLeaseID: VoiceLeaseID(),
+        activeTurnID: turnID),
+      .apply)
+    XCTAssertEqual(
+      VoiceOutputHandoffPolicy.playbackStopAdmission(
+        activeLease: nil,
+        requestedLeaseID: lease.id,
+        activeTurnID: turnID),
+      .alreadyComplete)
+    XCTAssertEqual(
+      VoiceOutputHandoffPolicy.playbackStopAdmission(
+        activeLease: syntheticLease(.selectedVoiceFallback, turnID: VoiceTurnID()),
+        requestedLeaseID: lease.id,
+        activeTurnID: turnID),
+      .stale)
+  }
+
+  func testPlaybackDrainAdmissionKeepsFallbackOwnerAndFailsClosedForNative() {
+    let turnID = VoiceTurnID()
+    let fallback = syntheticLease(.selectedVoiceFallback, turnID: turnID)
+    let native = syntheticLease(.nativeRealtime, turnID: turnID)
+
+    XCTAssertEqual(
+      VoiceOutputHandoffPolicy.playbackDrainAdmission(
+        phase: .playing(.selectedVoiceFallback),
+        activeLease: fallback),
+      .keepPlaying)
+    XCTAssertEqual(
+      VoiceOutputHandoffPolicy.playbackDrainAdmission(
+        phase: .playing(.nativeRealtime),
+        activeLease: native),
+      .failClosed)
+    XCTAssertEqual(
+      VoiceOutputHandoffPolicy.playbackDrainAdmission(
+        phase: .playing(.selectedVoiceFallback),
+        activeLease: nil),
+      .alreadyComplete)
+    XCTAssertEqual(
+      VoiceOutputHandoffPolicy.playbackDrainAdmission(
+        phase: .awaitingResponse,
+        activeLease: fallback),
+      .alreadyComplete)
+  }
+
   func testFillerReleaseDoesNotFinishProviderAndRealOutputCanTakeLease() throws {
     let (coordinator, turnID) = awaitingCoordinator()
     let filler = try XCTUnwrap(tryLease(coordinator.acquireOutput(.filler, turnID: turnID)))

--- a/desktop/macos/changelog/unreleased/20260831-interject-ptt-island-and-barge-in.json
+++ b/desktop/macos/changelog/unreleased/20260831-interject-ptt-island-and-barge-in.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Interject reply cards shrinking into an unreadable notch island, and follow-up PTT no longer drops to a fallback voice that then fails"
+}


### PR DESCRIPTION
## What changed and why

Interject PTT on a mounted Memory card was crushing the island to listening size (351×58) while the card was still in the tree, and a follow-up hold was letting `hub_warm` commit omni before barge-in replacement was ready — so Gemini's later ready callback was stale, audio replay was discarded, and selected-voice fallback then died on `playback_drain`.

Collapsed chrome now sizes from the mounted notification (unioned with listening). `hub_warm` during recording + `.replacing` no longer emits omni fallback; `provider_replacement_ready` stays admissible and restores the manager-owned warm rescue if needed. Selected-voice fallback drain keeps the playing owner; native realtime remains fail-closed. Fallback TTS start now refreshes the drain watchdog, and a stop for the active turn is not stale just because the exact lease id was already released.

Closes SCA-392

## Product invariants affected

- INV-CHAT-1 — FloatingControlBar paths matched the glob; this PR only changes collapsed island size, Interject teaser line limits, and fallback TTS drain/stop admission. It does not add a second transcript store or give Swift session identity.
- INV-VOICE-1 — Playback stop/drain and hub_warm admission stay inside `VoiceTurnCoordinator` / the reducer. No parallel PTT lifecycle, and native realtime drain remains fail-closed.

## How it was verified

- `python3 scripts/check_desktop_test_quality.py` — OK (debt at or below baseline).
- `xcrun swift test --package-path Desktop --filter 'VoiceTurnReducerTests/testHubWarmTimeoutDuringRecordingReplacementDoesNotFallbackToOmni|VoiceTurnReducerTests/testReplacementReadyAfterHubWarmWhileRecordingAdmitsLivePath|VoiceTurnReducerTests/testSelectedVoiceFallbackDrainKeepsPlayingOwner|VoiceTurnReducerTests/testHubWarmTimeoutFallsBackWithoutTerminatingOrDroppingTurn|VoiceTurnReducerTests/testLateReplacementReadyCannotReclaimHubWarmBatchFallback|VoiceTurnReducerTests/testWarmWaitRescueDeadlineSurvivesReplacementReady|VoiceTurnReducerTests/testPlaybackDrainWithoutProgressFailsClosed|VoiceTurnOutputOwnershipTests/testFallbackStopForActiveTurnIsNeverStale|VoiceTurnOutputOwnershipTests/testPlaybackDrainAdmissionKeepsFallbackOwnerAndFailsClosedForNative'` — 9 passed, 0 failed.
- `xcrun swift test --package-path Desktop --filter 'FloatingBarGeometryTests'` plus the four new notification-size / teaser tests — passed.
- `./scripts/agent-logic-harness.sh --swift-only` — passed (435.80s focused Swift lifecycle/state tests).
- Did not launch a named-bundle Interject PTT session against Omi Beta; geometry and reducer tests drive the production size/admission policies through the seams the 0.12.251 traces used.

## Tests

Regression tests that would have caught the Beta 0.12.251 traces:

- `testMountedNotificationWinsOverListeningIsland` / `testPTTReleaseWithMountedCardDoesNotCollapseToListeningIsland` / `testWindowResizeKeepsNotificationMinimumWhileListening` — notification chrome wins over listening island.
- `testInsightTeaserStaysExpandedDuringInterjectPTTHold` — insight teaser stays 6 lines while Interject PTT is holding.
- `testHubWarmTimeoutDuringRecordingReplacementDoesNotFallbackToOmni` — hub_warm during recording replacement does not emit omni fallback.
- `testReplacementReadyAfterHubWarmWhileRecordingAdmitsLivePath` — later replacement-ready is not stale.
- `testSelectedVoiceFallbackDrainKeepsPlayingOwner` — fallback drain reschedules instead of `playback_failed`.
- `testFallbackStopForActiveTurnIsNeverStale` / `testPlaybackDrainAdmissionKeepsFallbackOwnerAndFailsClosedForNative` — stop/drain admission policy.

Existing contracts kept green: `testHubWarmTimeoutFallsBackWithoutTerminatingOrDroppingTurn`, `testLateReplacementReadyCannotReclaimHubWarmBatchFallback`, `testWarmWaitRescueDeadlineSurvivesReplacementReady`, `testPlaybackDrainWithoutProgressFailsClosed`.

## Failure class (fixes)

Failure-Class: new

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift | 5687 -> 5706 | Shared collapsed-chrome helper so a mounted Interject card keeps notification size during PTT.
Line-Count-Exception: desktop/macos/Desktop/Sources/VoiceTurnDomain/VoiceTurnStateMachine.swift | 2343 -> 2426 | Typed stop/drain admission and hub_warm deferral so barge-in replacement stays the in-flight owner.
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift | 3138 -> 3142 | Teaser line limit now includes Interject PTT hold.

## Failure-class transition narrative

`FC-generic-deadline-revokes-in-flight-owner`: a generic listening/warm/drain signal must not revoke a more specific in-flight owner. Guard is the typed admission helpers plus the reducer/geometry tests above. `evidence_prs` is `[]` because this PR is the first evidence.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

