### PR TITLE
SCA-393: add chat-quota reset-month to the admin usage CLI

### DIFF
--- a/backend/docs/runbooks/reset-transcription-usage.md
+++ b/backend/docs/runbooks/reset-transcription-usage.md
@@ -45,11 +45,12 @@ cd backend
 python -m scripts.admin.reset_transcription_usage show --uid <UID>
 python -m scripts.admin.reset_transcription_usage show --email user@example.com
 
-# 2) Dry-run listening reset (default — writes nothing):
+# 2) Dry-run listening reset (default — writes nothing).
+#    Refuses unlimited plans (Operator/Architect/Neo listening) unless --force:
 python -m scripts.admin.reset_transcription_usage reset-month --uid <UID> \
     --reason "goodwill: silent open-mic burn"
 
-# 3) Apply listening reset:
+# 3) Apply listening reset (finite cap only, or --force on unlimited):
 python -m scripts.admin.reset_transcription_usage reset-month --uid <UID> \
     --reason "goodwill: silent open-mic burn" --apply --operator "you@"
 
@@ -67,6 +68,11 @@ questions `0` for that UTC month (`get_monthly_chat_usage`).
 
 ## Safety
 
+- **`show` prints `listening throttled: yes/no`.** Unlimited listening is
+  never throttled. Do **not** `reset-month` those accounts just because used
+  minutes look large. `reset-month` exits 2 on unlimited plans unless
+  `--force` (goodwill-zero anyway). Chat is separate: `chat included exhausted`
+  is the included-allowance line; paid overage plans are not hard-cut.
 - **Dry-run by default.** `reset-month` and `reset-chat-month` print
   before/after and exit without writing unless `--apply` is passed.
 - **`--reason` is required** (audited).

--- a/backend/docs/runbooks/reset-transcription-usage.md
+++ b/backend/docs/runbooks/reset-transcription-usage.md
@@ -1,13 +1,23 @@
-# Runbook — reset a user's free-tier transcription (listening) minutes
+# Runbook — inspect / reset monthly listening minutes and chat questions
 
-**Use when:** support needs to inspect or goodwill-reset a user's monthly
-transcription minutes after an unexpected burn (e.g. silent open-mic).
+**Use when:** support needs to inspect a user's current-UTC-month quotas, or
+goodwill-reset listening minutes (unexpected burn, e.g. silent open-mic) or
+chat questions (unexpected chat-quota burn).
 
-**What it touches:** `transcription_seconds` summed from
-`users/{uid}/hourly_usage/{YYYY-MM-DD-HH}` for the current calendar month — the
-exact surface the cap enforces (`utils/subscription.get_remaining_transcription_seconds`).
+**What it touches:**
+
+- **Listening:** `transcription_seconds` summed from
+  `users/{uid}/hourly_usage/{YYYY-MM-DD-HH}` for the current calendar month — the
+  exact surface the cap enforces
+  (`utils/subscription.get_remaining_transcription_seconds`).
+- **Chat:** `quota_questions` on `users/{uid}/llm_usage/{YYYY-MM-DD}` for the
+  current UTC calendar month — the exact surface
+  `database.user_usage.get_monthly_chat_usage` (and
+  `utils/subscription.enforce_chat_quota` / `get_chat_quota_snapshot`) reads.
+
 This is **not** the fair-use speech-hour system (`/v1/admin/fair-use/...`), which
-already has its own reset.
+already has its own HTTP reset. Plan grants / complimentary entitlements / Stripe
+create-or-update are out of scope.
 
 ## Tool
 
@@ -24,56 +34,82 @@ Any account with **prod Firestore write** on the Omi GCP project:
   project's Firestore Writer / Editor role).
 
 `--email` additionally calls Firebase Auth to resolve the uid; `--uid` needs no
-Auth SDK.
+Auth SDK. Never derive a UID from PostHog, Firestore email fields, or Stripe.
 
 ## Commands
 
 ```bash
 cd backend
 
-# 1) Inspect (read-only) — plan / used / limit / remaining / top buckets:
+# 1) Inspect (read-only) — plan / status / listening / chat / fair-use pointer:
 python -m scripts.admin.reset_transcription_usage show --uid <UID>
 python -m scripts.admin.reset_transcription_usage show --email user@example.com
 
-# 2) Dry-run reset (default — writes nothing):
+# 2) Dry-run listening reset (default — writes nothing):
 python -m scripts.admin.reset_transcription_usage reset-month --uid <UID> \
     --reason "goodwill: silent open-mic burn"
 
-# 3) Apply (zeros current-month transcription_seconds, writes audit record):
+# 3) Apply listening reset:
 python -m scripts.admin.reset_transcription_usage reset-month --uid <UID> \
     --reason "goodwill: silent open-mic burn" --apply --operator "you@"
+
+# 4) Dry-run chat-quota reset (default — writes nothing):
+python -m scripts.admin.reset_transcription_usage reset-chat-month --uid <UID> \
+    --reason "goodwill: chat-quota burn"
+
+# 5) Apply chat-quota reset (zeros current-month quota_questions, writes audit):
+python -m scripts.admin.reset_transcription_usage reset-chat-month --uid <UID> \
+    --reason "goodwill: chat-quota burn" --apply --operator "you@"
 ```
+
+`show` after a successful `--apply` of `reset-chat-month` must report chat
+questions `0` for that UTC month (`get_monthly_chat_usage`).
 
 ## Safety
 
-- **Dry-run by default.** `reset-month` prints before/after and exits without
-  writing unless `--apply` is passed.
+- **Dry-run by default.** `reset-month` and `reset-chat-month` print
+  before/after and exit without writing unless `--apply` is passed.
 - **`--reason` is required** (audited).
-- **Before/after totals printed** on every run.
+- **`--operator` is required with `--apply`** (same flag on both reset commands).
+- **Before/after totals printed** on every run. Chat re-reads
+  `get_monthly_chat_usage` after apply.
 - **Audit trail:** on `--apply`, a doc is written to Firestore
-  `admin_audit_log/{auto}` with uid / email / plan / month / reason / operator /
-  before / after / docs-touched / timestamp. Dry-runs print the same record as a
-  JSON line to stdout (not persisted).
-- **No transcript / memory / message data** is read or printed — only the
-  numeric `transcription_seconds` counter and doc ids.
+  `admin_audit_log/{auto}`. Listening records before/after seconds; chat records
+  `action=reset-chat-quota-month` plus before/after questions, uid / email / plan /
+  month / reason / operator / docs-touched / timestamp. Dry-runs print the same
+  record as a JSON line to stdout (not persisted). Stdout is PII-sanitized;
+  Firestore keeps the full record.
+- **No transcript / memory / message data** is read or printed.
 - **No new IAM.** Reuses the backend's existing credential loader
   (`database/google_credentials`).
+- **Chat reset sets `quota_questions` to 0** (does not delete the key). Deleting
+  the key can re-enable legacy fallbacks (`chat.*.call_count`, old
+  `desktop_chat_realtime.call_count`). Telemetry (`call_count`, tokens,
+  `cost_usd`) is left intact. If the only counted surface is legacy
+  `chat.*.call_count`, the tool introduces `backend_chat.quota_questions = 0`
+  instead of wiping those counters.
+- **Never run `--apply` against real users from CI / automated pipelines.**
 
 ## What is intentionally NOT covered
 
-- **Chat-question quota reset** is deferred. Chat usage lives in
-  `users/{uid}/llm_usage/{YYYY-MM-DD}` across several nested/legacy counter
-  shapes (`desktop_chat.quota_questions`, `backend_chat.quota_questions`,
-  legacy `chat.*.call_count`); zeroing it safely needs integration testing
-  against all those shapes, out of scope for this ops tool. Track separately.
-- **Fair-use reset** already exists at `POST /v1/admin/fair-use/user/{uid}/reset`
-  (`backend/routers/fair_use_admin.py`) — use that for speech-hour state.
-- **Automatic goodwill credits / billing policy** — product decision, out of scope.
-- **Prod runs** are operator-initiated; this repo's CI only unit-tests the pure
-  logic. Never run `--apply` in CI / automated pipelines against real users
-  without an operator decision.
+- **Fair-use write** (reset / set-stage) — already
+  `POST /v1/admin/fair-use/user/{uid}/reset`
+  (`backend/routers/fair_use_admin.py`). `show` may print a one-line
+  `fair_use_state/current.stage` if that cheap Firestore field exists; otherwise it
+  prints `GET /v1/admin/fair-use/user/{uid}`. Do not wrap the POST from this CLI.
+- **Plan grants / complimentary entitlements / Stripe create-or-update.**
+- **Deleting `chat_quota_events`** (idempotency log, not the cap).
+- **Zeroing `call_count`, tokens, or `cost_usd`** (telemetry, not the cap).
+- **Redis proactive / trial-cache.**
+- **Account wipe, memory dump, new ADMIN_KEY HTTP routes.**
+- **Prod `--apply` against real users** from this repo's CI (dev/emulator/unit
+  only).
+- **Merge / deploy.**
 
 ## Tests
 
 `backend/tests/unit/test_reset_transcription_usage.py` — pure logic only
-(month aggregation, reset-plan shape, audit record, dry-run vs apply). No GCP.
+(month aggregation, listening reset-plan, chat nested/dotted/`plan_usage`
+shapes, dry-run vs apply shape, audit record including
+`reset-chat-quota-month`, “do not count `desktop_chat.call_count` as quota”).
+No GCP.

--- a/backend/scripts/admin/reset_transcription_usage.py
+++ b/backend/scripts/admin/reset_transcription_usage.py
@@ -1,25 +1,27 @@
 #!/usr/bin/env python3
-"""Admin CLI: inspect / reset a user's monthly transcription usage.
+"""Admin CLI: inspect / reset a user's monthly transcription and chat quotas.
 
-Support-ops tool for the free-tier monthly transcription (listening) minutes
-quota. Reads the same surface the cap enforces — ``transcription_seconds``
-summed across ``users/{uid}/hourly_usage/{YYYY-MM-DD-HH}`` for the current
-calendar month (see ``database/user_usage.get_monthly_usage_stats`` and
-``utils/subscription.get_remaining_transcription_seconds``).
+Support-ops tool for the monthly transcription (listening) minutes quota and
+the chat-question quota. Listening reads the same surface the cap enforces —
+``transcription_seconds`` summed across ``users/{uid}/hourly_usage/{YYYY-MM-DD-HH}``
+for the current calendar month (see ``database/user_usage.get_monthly_usage_stats``
+and ``utils/subscription.get_remaining_transcription_seconds``). Chat questions
+come from ``database.user_usage.get_monthly_chat_usage`` over
+``users/{uid}/llm_usage/{YYYY-MM-DD}``.
 
 Commands
 --------
-``show``       Lookup by --uid (or --email) and print plan / used / limit /
-               remaining for the current month, plus the top hourly buckets.
-               Metadata only — never prints transcripts or memories.
-               (Collapses the issue's ``lookup`` + ``usage show``: a lookup that
-               does not also aggregate has no extra signal, so one command does
-               both.)
-``reset-month``Zero ``transcription_seconds`` on every current-month hourly_usage doc
-               for the user. DRY-RUN by default; requires ``--reason`` and
-               ``--apply`` to write. Prints before/after totals and writes a
-               durable audit record (Firestore ``admin_audit_log`` + a JSON
-               stdout line).
+``show``              Lookup by --uid (or --email) and print plan / status /
+                      listening minutes / chat questions for the current UTC
+                      month. Metadata only — never prints transcripts, memories, or
+                      messages. Fair-use is read-only (stage field or HTTP pointer).
+``reset-month``       Zero ``transcription_seconds`` on every current-month
+                      hourly_usage doc. DRY-RUN by default; requires ``--reason``
+                      and ``--apply`` to write.
+``reset-chat-month``  Zero current-UTC-month ``quota_questions`` (nested, dotted,
+                      and ``plan_usage``). DRY-RUN by default; same
+                      ``--reason`` / ``--apply`` / ``--operator`` / audit contract.
+                      Does not delete keys, wipe telemetry, or reset fair-use.
 
 Credentials
 -----------
@@ -27,7 +29,8 @@ Uses the same loader as the backend (``database.google_credentials``): set
 ``GOOGLE_APPLICATION_CREDENTIALS`` to a service-account JSON file with Firestore
 write on the prod project, or run ``gcloud auth application-default login`` for
 ADC. ``--email`` additionally initializes firebase_admin to resolve the uid
-(Auth lookup); ``--uid`` needs no Auth SDK.
+(Auth lookup); ``--uid`` needs no Auth SDK. Never derive UID from
+PostHog/Firestore email/Stripe.
 
 Examples
 --------
@@ -35,12 +38,20 @@ Examples
     GOOGLE_APPLICATION_CREDENTIALS=svc.json python -m scripts.admin.reset_transcription_usage \
         show --uid <UID>
 
-    # Dry-run reset (default — writes nothing):
+    # Dry-run listening reset (default — writes nothing):
     python -m scripts.admin.reset_transcription_usage reset-month --uid <UID> --reason "goodwill: silent open-mic"
 
-    # Apply:
+    # Apply listening reset:
     python -m scripts.admin.reset_transcription_usage reset-month --uid <UID> \
         --reason "goodwill: silent open-mic" --apply --operator "david@"
+
+    # Dry-run chat-quota reset:
+    python -m scripts.admin.reset_transcription_usage reset-chat-month --uid <UID> \
+        --reason "goodwill: chat-quota burn"
+
+    # Apply chat-quota reset:
+    python -m scripts.admin.reset_transcription_usage reset-chat-month --uid <UID> \
+        --reason "goodwill: chat-quota burn" --apply --operator "david@"
 
 This is an ops tool, not a service: keep heavy backend imports inside the
 command/I-O functions so the pure helpers stay importable without GCP and
@@ -50,6 +61,7 @@ unit-testable.
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import logging
 import os
@@ -57,7 +69,7 @@ import sys
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable, Optional, Sequence
+from typing import Any, Iterable, Mapping, Optional, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +82,13 @@ _BATCH_LIMIT = 400
 
 # How many top hourly buckets ``show`` prints.
 _TOP_BUCKETS = 5
+
+# Audit action written by ``reset-chat-month``.
+_CHAT_RESET_AUDIT_ACTION = "reset-chat-quota-month"
+
+# Fair-use write stays on the existing admin HTTP surface.
+_FAIR_USE_GET_POINTER = "GET /v1/admin/fair-use/user/{uid}"
+_FAIR_USE_RESET_POINTER = "POST /v1/admin/fair-use/user/{uid}/reset"
 
 
 # ---------------------------------------------------------------------------
@@ -224,6 +243,256 @@ def build_audit_record(
     )
 
 
+@dataclass(frozen=True)
+class AccountView:
+    """Plan + limits the enforcement path sees (non-mutating)."""
+
+    plan_name: str
+    status: str
+    listening_limit_seconds: Optional[int]
+    chat_questions_limit: Optional[int]
+    chat_cost_usd_limit: Optional[float]
+
+
+@dataclass(frozen=True)
+class ChatQuotaAuditRecord:
+    """Durable audit trail for a chat-quota reset. Same sanitization as minutes."""
+
+    uid: str
+    email: Optional[str]
+    plan: str
+    month: str
+    reason: str
+    operator: str
+    applied: bool
+    before_questions: int
+    after_questions: int
+    docs_touched: int
+    at: str  # RFC3339 UTC
+    action: str = _CHAT_RESET_AUDIT_ACTION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action": self.action,
+            "uid": self.uid,
+            "email": self.email,
+            "plan": self.plan,
+            "month": self.month,
+            "reason": self.reason,
+            "operator": self.operator,
+            "applied": self.applied,
+            "before_questions": self.before_questions,
+            "after_questions": self.after_questions,
+            "docs_touched": self.docs_touched,
+            "at": self.at,
+        }
+
+
+def build_chat_quota_audit_record(
+    *,
+    uid: str,
+    email: Optional[str],
+    plan: str,
+    month: str,
+    reason: str,
+    operator: str,
+    applied: bool,
+    before_questions: int,
+    after_questions: int,
+    docs_touched: int,
+    now: Optional[datetime] = None,
+) -> ChatQuotaAuditRecord:
+    now = now or datetime.now(timezone.utc)
+    return ChatQuotaAuditRecord(
+        uid=uid,
+        email=email,
+        plan=plan,
+        month=month,
+        reason=reason,
+        operator=operator,
+        applied=applied,
+        before_questions=before_questions,
+        after_questions=after_questions,
+        docs_touched=docs_touched,
+        at=now.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    )
+
+
+def llm_usage_doc_id_in_utc_month(doc_id: str, year: int, month: int) -> bool:
+    """True when ``llm_usage/{YYYY-MM-DD}`` falls in the given UTC calendar month."""
+    if len(doc_id) < 10 or doc_id[4] != "-" or doc_id[7] != "-":
+        return False
+    try:
+        return int(doc_id[0:4]) == year and int(doc_id[5:7]) == month
+    except ValueError:
+        return False
+
+
+def _has_backend_quota_questions(data: Mapping[str, Any]) -> bool:
+    return any(
+        (key == "backend_chat" and isinstance(value, dict) and "quota_questions" in value)
+        or (key == "backend_chat.quota_questions")
+        for key, value in data.items()
+    )
+
+
+def _has_desktop_realtime_quota_questions(data: Mapping[str, Any]) -> bool:
+    return "desktop_chat_realtime.quota_questions" in data or (
+        isinstance(data.get("desktop_chat_realtime"), dict) and "quota_questions" in data["desktop_chat_realtime"]
+    )
+
+
+def _legacy_backend_chat_call_count_would_count(data: Mapping[str, Any]) -> bool:
+    """True when ``get_monthly_chat_usage`` would still count ``chat.*.call_count``."""
+    if _has_backend_quota_questions(data):
+        return False
+    return any(
+        isinstance(value, (int, float)) and key.startswith("chat.") and key.endswith(".call_count")
+        for key, value in data.items()
+    )
+
+
+def _legacy_realtime_call_count_would_count(data: Mapping[str, Any]) -> bool:
+    """True when ``get_monthly_chat_usage`` would still count realtime ``call_count``."""
+    if _has_desktop_realtime_quota_questions(data):
+        return False
+    nested = data.get("desktop_chat_realtime")
+    if isinstance(nested, dict) and int(nested.get("call_count", 0) or 0) != 0:
+        return True
+    dotted = data.get("desktop_chat_realtime.call_count")
+    return isinstance(dotted, (int, float)) and int(dotted) != 0
+
+
+def _set_nested(dest: dict[str, Any], path: tuple[str, ...], value: Any) -> None:
+    cursor = dest
+    for part in path[:-1]:
+        nxt = cursor.get(part)
+        if not isinstance(nxt, dict):
+            nxt = {}
+            cursor[part] = nxt
+        cursor = nxt
+    cursor[path[-1]] = value
+
+
+def build_chat_quota_reset_update(data: Mapping[str, Any]) -> dict[str, Any]:
+    """Firestore ``set(..., merge=True)`` payload that zeros this doc's chat quota.
+
+    Sets ``quota_questions`` to 0 (never deletes the key). Does not touch
+    ``call_count``, tokens, or ``cost_usd``. When legacy ``chat.*.call_count``
+    would still count, introduces ``backend_chat.quota_questions = 0`` so
+    telemetry stays and ``get_monthly_chat_usage`` reports 0. Same idea for
+    ``desktop_chat_realtime`` fallback ``call_count``.
+    """
+    update: dict[str, Any] = {}
+
+    def walk(obj: Mapping[str, Any], path: tuple[str, ...]) -> None:
+        for key, value in obj.items():
+            if isinstance(value, dict):
+                walk(value, path + (key,))
+                continue
+            if key == "quota_questions":
+                if int(value or 0) != 0:
+                    _set_nested(update, path + (key,), 0)
+            elif isinstance(key, str) and key.endswith(".quota_questions") and isinstance(value, (int, float)):
+                if int(value or 0) == 0:
+                    continue
+                if path:
+                    _set_nested(update, path + (key,), 0)
+                else:
+                    update[key] = 0
+
+    walk(data, ())
+
+    if _legacy_backend_chat_call_count_would_count(data):
+        _set_nested(update, ("backend_chat", "quota_questions"), 0)
+
+    if _legacy_realtime_call_count_would_count(data):
+        nested_rt = data.get("desktop_chat_realtime")
+        if isinstance(nested_rt, dict):
+            _set_nested(update, ("desktop_chat_realtime", "quota_questions"), 0)
+        else:
+            update["desktop_chat_realtime.quota_questions"] = 0
+
+    return update
+
+
+def apply_chat_quota_reset_locally(data: Mapping[str, Any], update: Mapping[str, Any]) -> dict[str, Any]:
+    """Deep-merge a reset payload into a document copy (tests / dry-run preview)."""
+    result = copy.deepcopy(dict(data))
+
+    def merge(dest: dict[str, Any], payload: Mapping[str, Any]) -> None:
+        for key, value in payload.items():
+            if isinstance(value, dict):
+                existing = dest.get(key)
+                if isinstance(existing, dict):
+                    merge(existing, value)
+                else:
+                    dest[key] = copy.deepcopy(dict(value))
+            else:
+                dest[key] = value
+
+    merge(result, update)
+    return result
+
+
+def chat_questions_from_doc(data: Mapping[str, Any]) -> int:
+    """Per-document question count matching ``get_monthly_chat_usage``'s inner loop.
+
+    Used by unit tests to assert a reset payload lands questions at 0 without
+    forking a second monthly aggregator. The live CLI still imports
+    ``get_monthly_chat_usage`` for before/after totals.
+    """
+    questions = 0
+    has_desktop_realtime_quota_questions = _has_desktop_realtime_quota_questions(data)
+    has_backend_quota_questions = _has_backend_quota_questions(data)
+    for key, value in data.items():
+        if isinstance(value, dict):
+            if key == "desktop_chat":
+                questions += int(value.get("quota_questions", 0) or 0)
+            elif key == "desktop_chat_realtime" and not has_desktop_realtime_quota_questions:
+                questions += int(value.get("call_count", 0) or 0)
+            elif key == "backend_chat":
+                questions += int(value.get("quota_questions", 0) or 0)
+            continue
+        if not isinstance(value, (int, float)):
+            continue
+        if key.startswith("desktop_chat"):
+            if key == "desktop_chat.quota_questions":
+                questions += int(value)
+            elif key == "desktop_chat_realtime.call_count" and not has_desktop_realtime_quota_questions:
+                questions += int(value)
+        elif key == "backend_chat.quota_questions":
+            questions += int(value)
+        elif key.startswith("chat.") and key.endswith(".call_count") and not has_backend_quota_questions:
+            questions += int(value)
+    return questions
+
+
+@dataclass(frozen=True)
+class ChatResetPlan:
+    """What ``reset-chat-month`` will write, keyed by llm_usage doc id."""
+
+    updates: tuple[tuple[str, dict[str, Any]], ...]  # (doc_id, merge payload)
+
+    @property
+    def doc_ids(self) -> tuple[str, ...]:
+        return tuple(doc_id for doc_id, _payload in self.updates)
+
+    @property
+    def touches(self) -> int:
+        return len(self.updates)
+
+
+def build_chat_reset_plan(docs: Iterable[tuple[str, Mapping[str, Any]]]) -> ChatResetPlan:
+    """Build per-doc merge payloads for the current month. Empty updates are skipped."""
+    updates: list[tuple[str, dict[str, Any]]] = []
+    for doc_id, data in docs:
+        payload = build_chat_quota_reset_update(data)
+        if payload:
+            updates.append((doc_id, payload))
+    return ChatResetPlan(updates=tuple(updates))
+
+
 # ---------------------------------------------------------------------------
 # I/O — thin wrappers over Firestore / Auth. Imports are local so the pure
 # helpers above stay importable without the backend runtime.
@@ -254,6 +523,31 @@ def fetch_monthly_hourly_docs(client: Any, uid: str, year: int, month: int) -> l
     return [(doc.id, (doc.to_dict() or {})) for doc in query.stream()]
 
 
+def fetch_monthly_llm_usage_docs(client: Any, uid: str, now: datetime) -> list[tuple[str, dict[str, Any]]]:
+    """Return ``(doc_id, data)`` for every ``llm_usage/{YYYY-MM-DD}`` in the UTC month.
+
+    Reuses ``database.user_usage._current_month_llm_usage_docs`` (document-id
+    range) so the CLI cannot drift from the enforcement reader.
+    """
+    from database.user_usage import _current_month_llm_usage_docs
+
+    llm_usage_ref = client.collection("users").document(uid).collection("llm_usage")
+    return [(doc.id, (doc.to_dict() or {})) for doc in _current_month_llm_usage_docs(llm_usage_ref, now)]
+
+
+def fetch_fair_use_stage(client: Any, uid: str) -> Optional[str]:
+    """Read-only ``users/{uid}/fair_use_state/current.stage`` if the doc exists."""
+    ref = client.collection("users").document(uid).collection("fair_use_state").document("current")
+    doc = ref.get()
+    if not getattr(doc, "exists", False):
+        return None
+    data = doc.to_dict() or {}
+    stage = data.get("stage")
+    if stage is None or stage == "":
+        return None
+    return str(stage)
+
+
 def resolve_uid(*, uid: Optional[str], email: Optional[str]) -> tuple[str, Optional[str]]:
     """Resolve a target uid from --uid (preferred) or --email (Firebase Auth)."""
     if uid:
@@ -275,6 +569,36 @@ def resolve_uid(*, uid: Optional[str], email: Optional[str]) -> tuple[str, Optio
     return user.uid, email
 
 
+def resolve_account_view(uid: str) -> AccountView:
+    """Return plan / status / listening and chat limits the enforcement path sees.
+
+    Uses ``get_user_valid_subscription(..., provision=False)`` so ``show`` and
+    dry-run never create a default subscription or rewrite a legacy ``free``
+    plan. Expired paid plans fall back to Basic, matching enforcement.
+    """
+    from database import users as users_db
+    from utils.subscription import (
+        get_default_basic_subscription,
+        get_plan_display_name,
+        get_plan_limits,
+    )
+
+    subscription = users_db.get_user_valid_subscription(uid, provision=False)
+    if subscription is None:
+        subscription = get_default_basic_subscription()
+    plan = subscription.plan
+    limits = get_plan_limits(plan)
+    status = getattr(subscription.status, "value", str(subscription.status))
+    listening = limits.transcription_seconds
+    return AccountView(
+        plan_name=get_plan_display_name(plan),
+        status=status,
+        listening_limit_seconds=None if listening is None else listening,
+        chat_questions_limit=limits.chat_questions_per_month,
+        chat_cost_usd_limit=limits.chat_cost_usd_per_month,
+    )
+
+
 def resolve_plan_and_limit(uid: str) -> tuple[str, Optional[int]]:
     """Return ``(plan_name, monthly_seconds_limit_or_None)``.
 
@@ -289,31 +613,15 @@ def resolve_plan_and_limit(uid: str) -> tuple[str, Optional[int]]:
 
     ``None`` limit = unlimited plan (operator/architect/unlimited/neo). The
     transcription cap only bites basic + plus, whose limits come straight from
-    ``utils.subscription.get_plan_limits``.
+    ``utils.subscription.get_plan_limits`` (Free still honors
+    ``BASIC_TIER_MINUTES_LIMIT_PER_MONTH`` via that helper).
     """
-    from database import users as users_db
-    from utils.subscription import (
-        get_default_basic_subscription,
-        get_plan_display_name,
-        get_plan_limits,
-    )
-
-    # get_user_valid_subscription returns None when the stored plan is expired;
-    # enforcement treats that user as Basic, so we do the same here.
-    subscription = users_db.get_user_valid_subscription(uid)
-    if subscription is None:
-        subscription = get_default_basic_subscription()
-    plan = subscription.plan
-    limits = get_plan_limits(plan)
-    limit_seconds = limits.transcription_seconds
-    # `limit_seconds` is None for unlimited plans (typed catalog representation) and a
-    # positive int otherwise. `or None` would also fold a genuine finite 0 into "unlimited",
-    # which is the exact ambiguity the catalog retired — so branch on None explicitly.
-    return get_plan_display_name(plan), (None if limit_seconds is None else limit_seconds)
+    view = resolve_account_view(uid)
+    return view.plan_name, view.listening_limit_seconds
 
 
 def apply_reset(client: Any, uid: str, plan: ResetPlan) -> None:
-    """Zero ``transcription_seconds`` on every doc in the reset plan (batched).."""
+    """Zero ``transcription_seconds`` on every doc in the reset plan (batched)."""
     if not plan.doc_ids:
         return
     hourly = client.collection("users").document(uid).collection("hourly_usage")
@@ -324,14 +632,26 @@ def apply_reset(client: Any, uid: str, plan: ResetPlan) -> None:
         batch.commit()
 
 
-def write_audit(client: Any, record: AuditRecord) -> str:
+def apply_chat_reset(client: Any, uid: str, plan: ChatResetPlan) -> None:
+    """Merge each chat-quota reset payload onto ``llm_usage`` docs (batched)."""
+    if not plan.updates:
+        return
+    llm = client.collection("users").document(uid).collection("llm_usage")
+    for chunk_start in range(0, len(plan.updates), _BATCH_LIMIT):
+        batch = client.batch()
+        for doc_id, payload in plan.updates[chunk_start : chunk_start + _BATCH_LIMIT]:
+            batch.set(llm.document(doc_id), payload, merge=True)
+        batch.commit()
+
+
+def write_audit(client: Any, record: AuditRecord | ChatQuotaAuditRecord) -> str:
     """Persist the audit record to ``admin_audit_log`` and return its doc id."""
     doc_ref = client.collection("admin_audit_log").document()
     doc_ref.set(record.to_dict())
     return doc_ref.id
 
 
-def update_audit(client: Any, audit_id: str, record: AuditRecord) -> None:
+def update_audit(client: Any, audit_id: str, record: AuditRecord | ChatQuotaAuditRecord) -> None:
     """Update an existing audit record after the mutation outcome is known."""
     client.collection("admin_audit_log").document(audit_id).set(record.to_dict())
 
@@ -342,7 +662,7 @@ def update_audit(client: Any, audit_id: str, record: AuditRecord) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _sanitized_audit_payload(record: AuditRecord) -> dict[str, Any]:
+def _sanitized_audit_payload(record: AuditRecord | ChatQuotaAuditRecord) -> dict[str, Any]:
     """Return a copy of the audit record with PII redacted for stdout/logs.
 
     The email and operator-provided reason may contain user-identifiable text;
@@ -370,9 +690,17 @@ def _sanitized_audit_payload(record: AuditRecord) -> dict[str, Any]:
 
 
 def _print_usage(
-    uid: str, email: Optional[str], plan: str, limit_seconds: Optional[int], usage: MonthlyUsage, month: str
+    uid: str,
+    email: Optional[str],
+    view: AccountView,
+    usage: MonthlyUsage,
+    month: str,
+    *,
+    chat_questions: int,
+    fair_use_stage: Optional[str],
 ) -> None:
     used = usage.used_seconds
+    limit_seconds = view.listening_limit_seconds
     if limit_seconds is None:
         limit_min_s = "unlimited"
         remaining_s = "unlimited"
@@ -382,15 +710,43 @@ def _print_usage(
         remaining = max(0, limit_seconds - used)
         remaining_s = f"{seconds_to_minutes(remaining)} min ({remaining} s)"
         pct_s = f"{round(100.0 * used / limit_seconds, 1)}%" if limit_seconds else "n/a"
+
+    chat_limit = view.chat_questions_limit
+    if chat_limit is None:
+        chat_limit_s = "unlimited"
+        chat_remaining_s = "unlimited"
+    else:
+        chat_remaining = max(0, chat_limit - chat_questions)
+        chat_limit_s = f"{chat_limit} questions"
+        chat_remaining_s = f"{chat_remaining} questions"
+
+    if fair_use_stage:
+        fair_use_s = f"stage={fair_use_stage} (read-only; writes: {_FAIR_USE_GET_POINTER.format(uid=uid)})"
+    else:
+        fair_use_s = (
+            f"{_FAIR_USE_GET_POINTER.format(uid=uid)} "
+            f"(read-only; write remains {_FAIR_USE_RESET_POINTER.format(uid=uid)})"
+        )
+
     print(f"uid:           {uid}")
     if email:
         print(f"email:         {email}")
-    print(f"plan:          {plan}")
+    print(f"plan:          {view.plan_name}")
+    print(f"status:        {view.status}")
     print(f"month:         {month} (UTC)")
-    print(f"used:          {seconds_to_minutes(used)} min ({used} s) across {usage.document_count} hourly bucket(s)")
-    print(f"limit:         {limit_min_s}")
-    print(f"remaining:     {remaining_s}")
-    print(f"used of limit: {pct_s}")
+    print(
+        f"listening used:      {seconds_to_minutes(used)} min ({used} s) "
+        f"across {usage.document_count} hourly bucket(s)"
+    )
+    print(f"listening limit:     {limit_min_s}")
+    print(f"listening remaining: {remaining_s}")
+    print(f"listening used of limit: {pct_s}")
+    print(f"chat used:      {chat_questions} questions")
+    print(f"chat limit:     {chat_limit_s}")
+    print(f"chat remaining: {chat_remaining_s}")
+    if view.chat_cost_usd_limit is not None:
+        print(f"chat cost cap:  ${view.chat_cost_usd_limit:g} (architect unit; questions still shown above)")
+    print(f"fair-use:       {fair_use_s}")
     if usage.top_buckets:
         print("top buckets:")
         for b in usage.top_buckets:
@@ -398,18 +754,46 @@ def _print_usage(
             print(f"  {b.doc_id}: {seconds_to_minutes(b.seconds)} min ({b.seconds} s){share}")
 
 
+def _monthly_chat_questions(uid: str, now: datetime, client: Any) -> int:
+    from database.user_usage import get_monthly_chat_usage
+
+    usage = get_monthly_chat_usage(uid, now=now, firestore_client=client)
+    return int(usage.get("questions", 0) or 0)
+
+
+def _require_operator_on_apply(args: argparse.Namespace) -> str:
+    operator = (args.operator or "").strip()
+    if args.apply and (not operator or operator == "unknown"):
+        raise SystemExit("error: --operator is required with --apply")
+    return operator or os.getenv("USER", "unknown")
+
+
 def cmd_show(args: argparse.Namespace) -> int:
     uid, email = resolve_uid(uid=args.uid, email=args.email)
     client = _firestore_client()
     now = datetime.now(timezone.utc)
-    plan, limit_seconds = resolve_plan_and_limit(uid)
+    view = resolve_account_view(uid)
     docs = fetch_monthly_hourly_docs(client, uid, now.year, now.month)
     usage = aggregate_monthly_usage(docs)
-    _print_usage(uid, email, plan, limit_seconds, usage, month_label(now))
+    chat_questions = _monthly_chat_questions(uid, now, client)
+    try:
+        fair_use_stage = fetch_fair_use_stage(client, uid)
+    except Exception:
+        fair_use_stage = None
+    _print_usage(
+        uid,
+        email,
+        view,
+        usage,
+        month_label(now),
+        chat_questions=chat_questions,
+        fair_use_stage=fair_use_stage,
+    )
     return 0
 
 
 def cmd_reset_month(args: argparse.Namespace) -> int:
+    operator = _require_operator_on_apply(args)
     uid, email = resolve_uid(uid=args.uid, email=args.email)
     client = _firestore_client()
     now = datetime.now(timezone.utc)
@@ -427,7 +811,7 @@ def cmd_reset_month(args: argparse.Namespace) -> int:
     print(f"  docs to zero: {reset_plan.touches}")
     print("  after:  0.0 min (0 s)")
     print(f"  reason: {args.reason}")
-    print(f"  operator: {args.operator}")
+    print(f"  operator: {operator}")
 
     record = build_audit_record(
         uid=uid,
@@ -435,7 +819,7 @@ def cmd_reset_month(args: argparse.Namespace) -> int:
         plan=plan_name,
         month=month_label(now),
         reason=args.reason,
-        operator=args.operator,
+        operator=operator,
         applied=args.apply,
         before_seconds=reset_plan.before_total_seconds,
         after_seconds=0,
@@ -458,7 +842,7 @@ def cmd_reset_month(args: argparse.Namespace) -> int:
         plan=plan_name,
         month=month_label(now),
         reason=args.reason,
-        operator=args.operator,
+        operator=operator,
         applied=False,  # updated to True after mutation completes
         before_seconds=reset_plan.before_total_seconds,
         after_seconds=-1,  # sentinel: outcome not yet known
@@ -476,6 +860,72 @@ def cmd_reset_month(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_reset_chat_month(args: argparse.Namespace) -> int:
+    operator = _require_operator_on_apply(args)
+    uid, email = resolve_uid(uid=args.uid, email=args.email)
+    client = _firestore_client()
+    now = datetime.now(timezone.utc)
+    view = resolve_account_view(uid)
+    docs = fetch_monthly_llm_usage_docs(client, uid, now)
+    reset_plan = build_chat_reset_plan(docs)
+    before_questions = _monthly_chat_questions(uid, now, client)
+
+    if not reset_plan.touches and before_questions == 0:
+        print(f"No chat quota_questions to reset for {uid} in {month_label(now)} (already zero).")
+        return 0
+
+    verb = "APPLY" if args.apply else "DRY-RUN (no writes; pass --apply to commit)"
+    print(f"[{verb}] reset-chat-month for uid={uid} month={month_label(now)}")
+    print(f"  before: {before_questions} questions")
+    print(f"  docs to update: {reset_plan.touches}")
+    print("  after:  0 questions")
+    print(f"  reason: {args.reason}")
+    print(f"  operator: {operator}")
+
+    record = build_chat_quota_audit_record(
+        uid=uid,
+        email=email,
+        plan=view.plan_name,
+        month=month_label(now),
+        reason=args.reason,
+        operator=operator,
+        applied=args.apply,
+        before_questions=before_questions,
+        after_questions=0,
+        docs_touched=reset_plan.touches,
+        now=now,
+    )
+
+    if not args.apply:
+        print("audit (not persisted): " + json.dumps(_sanitized_audit_payload(record), sort_keys=True))
+        print("Dry-run complete. Re-run with --apply to commit.")
+        return 0
+
+    pending_record = build_chat_quota_audit_record(
+        uid=uid,
+        email=email,
+        plan=view.plan_name,
+        month=month_label(now),
+        reason=args.reason,
+        operator=operator,
+        applied=False,
+        before_questions=before_questions,
+        after_questions=-1,
+        docs_touched=reset_plan.touches,
+        now=now,
+    )
+    audit_id = write_audit(client, pending_record)
+
+    apply_chat_reset(client, uid, reset_plan)
+    after_questions = _monthly_chat_questions(uid, now, client)
+    final_record = replace(record, applied=True, after_questions=after_questions)
+    update_audit(client, audit_id, final_record)
+    print(f"Applied. Audit written: admin_audit_log/{audit_id}")
+    print(f"  after (re-read via get_monthly_chat_usage): {after_questions} questions")
+    print("audit: " + json.dumps(_sanitized_audit_payload(final_record), sort_keys=True))
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # argparse
 # ---------------------------------------------------------------------------
@@ -487,14 +937,27 @@ def _add_target_args(p: argparse.ArgumentParser) -> None:
     group.add_argument("--email", help="Resolve uid from this email via Firebase Auth.")
 
 
+def _add_reset_flags(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--reason", required=True, help="Operator reason string (required, audited).")
+    p.add_argument("--apply", action="store_true", help="Commit the reset (default is dry-run).")
+    p.add_argument(
+        "--operator",
+        default=os.getenv("USER", "unknown"),
+        help="Operator identity for the audit record. Required with --apply (default: $USER).",
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="reset_transcription_usage",
-        description="Inspect / reset a user's monthly free-tier transcription (listening) minutes.",
+        description="Inspect / reset a user's monthly transcription minutes and chat-question quota.",
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
-    p_show = sub.add_parser("show", help="Show plan / used / limit / top buckets for the current month (read-only).")
+    p_show = sub.add_parser(
+        "show",
+        help="Show plan / status / listening / chat for the current UTC month (read-only).",
+    )
     _add_target_args(p_show)
     p_show.set_defaults(func=cmd_show)
 
@@ -503,14 +966,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Zero current-month transcription_seconds. DRY-RUN by default.",
     )
     _add_target_args(p_reset)
-    p_reset.add_argument("--reason", required=True, help="Operator reason string (required, audited).")
-    p_reset.add_argument("--apply", action="store_true", help="Commit the reset (default is dry-run).")
-    p_reset.add_argument(
-        "--operator",
-        default=os.getenv("USER", "unknown"),
-        help="Operator identity for the audit record (default: $USER).",
-    )
+    _add_reset_flags(p_reset)
     p_reset.set_defaults(func=cmd_reset_month)
+
+    p_chat = sub.add_parser(
+        "reset-chat-month",
+        help="Zero current-month chat quota_questions. DRY-RUN by default.",
+    )
+    _add_target_args(p_chat)
+    _add_reset_flags(p_chat)
+    p_chat.set_defaults(func=cmd_reset_chat_month)
     return parser
 
 

--- a/backend/scripts/admin/reset_transcription_usage.py
+++ b/backend/scripts/admin/reset_transcription_usage.py
@@ -254,6 +254,25 @@ class AccountView:
     chat_cost_usd_limit: Optional[float]
 
 
+def listening_is_throttled(limit_seconds: Optional[int], used_seconds: int) -> bool:
+    """True only when a finite listening cap is exhausted. Unlimited is never throttled."""
+    if limit_seconds is None:
+        return False
+    return used_seconds >= limit_seconds
+
+
+def skip_unlimited_listening_reset(limit_seconds: Optional[int], force: bool) -> bool:
+    """Do not zero minutes on unlimited plans unless the operator passed --force."""
+    return limit_seconds is None and not force
+
+
+_UNLIMITED_LISTENING_SKIP_MESSAGE = (
+    "listening throttled: no (unlimited)\n"
+    "skip reset-month: minutes used do not throttle this plan. "
+    "Pass --force to goodwill-zero anyway."
+)
+
+
 @dataclass(frozen=True)
 class ChatQuotaAuditRecord:
     """Durable audit trail for a chat-quota reset. Same sanitization as minutes."""
@@ -741,9 +760,17 @@ def _print_usage(
     print(f"listening limit:     {limit_min_s}")
     print(f"listening remaining: {remaining_s}")
     print(f"listening used of limit: {pct_s}")
+    listening_throttled = listening_is_throttled(limit_seconds, used)
+    print(f"listening throttled: {'yes' if listening_throttled else 'no'}")
+    if limit_seconds is None:
+        print("listening reset: skip (unlimited; not throttled). Use reset-month --force only for goodwill.")
     print(f"chat used:      {chat_questions} questions")
     print(f"chat limit:     {chat_limit_s}")
     print(f"chat remaining: {chat_remaining_s}")
+    if chat_limit is None:
+        print("chat included exhausted: n/a (unlimited)")
+    else:
+        print(f"chat included exhausted: {'yes' if chat_questions >= chat_limit else 'no'}")
     if view.chat_cost_usd_limit is not None:
         print(f"chat cost cap:  ${view.chat_cost_usd_limit:g} (architect unit; questions still shown above)")
     print(f"fair-use:       {fair_use_s}")
@@ -797,7 +824,11 @@ def cmd_reset_month(args: argparse.Namespace) -> int:
     uid, email = resolve_uid(uid=args.uid, email=args.email)
     client = _firestore_client()
     now = datetime.now(timezone.utc)
-    plan_name, _limit = resolve_plan_and_limit(uid)
+    view = resolve_account_view(uid)
+    plan_name = view.plan_name
+    if skip_unlimited_listening_reset(view.listening_limit_seconds, bool(getattr(args, "force", False))):
+        print(_UNLIMITED_LISTENING_SKIP_MESSAGE)
+        return 2
     docs = fetch_monthly_hourly_docs(client, uid, now.year, now.month)
     reset_plan = build_reset_plan(docs)
 
@@ -963,10 +994,15 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_reset = sub.add_parser(
         "reset-month",
-        help="Zero current-month transcription_seconds. DRY-RUN by default.",
+        help="Zero current-month transcription_seconds. DRY-RUN by default. Refuses unlimited/unthrottled plans unless --force.",
     )
     _add_target_args(p_reset)
     _add_reset_flags(p_reset)
+    p_reset.add_argument(
+        "--force",
+        action="store_true",
+        help="Goodwill-zero listening minutes even when the plan is unlimited (not throttled).",
+    )
     p_reset.set_defaults(func=cmd_reset_month)
 
     p_chat = sub.add_parser(

--- a/backend/tests/unit/test_reset_transcription_usage.py
+++ b/backend/tests/unit/test_reset_transcription_usage.py
@@ -1,8 +1,9 @@
-"""Unit tests for the transcription-usage reset admin CLI pure logic.
+"""Unit tests for the transcription- and chat-quota reset admin CLI pure logic.
 
-Covers: month-key labelling, monthly aggregation, reset-plan construction
-(dry-run vs apply shape), audit-record shape. No GCP — the helpers under test
-take plain dicts mirroring the Firestore snapshot shape.
+Covers: month-key labelling, monthly aggregation, listening reset-plan,
+chat nested/dotted/plan_usage shapes, dry-run vs apply shape, audit records.
+No GCP — the helpers under test take plain dicts mirroring the Firestore
+snapshot shape.
 """
 
 from __future__ import annotations
@@ -16,11 +17,21 @@ BACKEND_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(BACKEND_ROOT))
 
 from scripts.admin.reset_transcription_usage import (  # noqa: E402
+    AccountView,
+    MonthlyUsage,
     aggregate_monthly_usage,
+    apply_chat_quota_reset_locally,
     build_audit_record,
+    build_chat_quota_audit_record,
+    build_chat_quota_reset_update,
+    build_chat_reset_plan,
+    build_parser,
     build_reset_plan,
+    chat_questions_from_doc,
+    llm_usage_doc_id_in_utc_month,
     month_label,
     seconds_to_minutes,
+    _print_usage,
     _sanitized_audit_payload,
 )
 
@@ -282,3 +293,275 @@ def test_pending_audit_record_marks_applied_false_and_sentinel_after() -> None:
 
     assert pending.applied is False
     assert pending.after_seconds == -1  # sentinel: not yet finalized
+
+
+# ---------------------------------------------------------------------------
+# Chat-quota reset — nested / dotted / plan_usage shapes (SCA-393)
+# ---------------------------------------------------------------------------
+
+
+def _chat_doc(doc_id: str, data: dict) -> tuple[str, dict]:
+    return (doc_id, data)
+
+
+def test_llm_usage_doc_id_in_utc_month_filters_yyyy_mm_dd() -> None:
+    assert llm_usage_doc_id_in_utc_month("2026-07-01", 2026, 7) is True
+    assert llm_usage_doc_id_in_utc_month("2026-07-31", 2026, 7) is True
+    assert llm_usage_doc_id_in_utc_month("2026-06-30", 2026, 7) is False
+    assert llm_usage_doc_id_in_utc_month("2026-08-01", 2026, 7) is False
+    assert llm_usage_doc_id_in_utc_month("2025-07-01", 2026, 7) is False
+    assert llm_usage_doc_id_in_utc_month("hourly-not-a-day", 2026, 7) is False
+
+
+def test_chat_questions_from_doc_counts_nested_quota_not_call_count() -> None:
+    data = {
+        "desktop_chat": {
+            "call_count": 5,
+            "quota_questions": 5,
+            "cost_usd": 1.5,
+        },
+        "desktop_chat_realtime": {"call_count": 2, "quota_questions": 2},
+        "chat.gpt-4.call_count": 4,
+        "conv_apps.gpt-5.call_count": 100,
+    }
+    # Nested desktop quota_questions (5) + backend chat.* (4). Realtime has
+    # quota_questions so its call_count is not a fallback. Proactive excluded.
+    assert chat_questions_from_doc(data) == 9
+
+
+def test_chat_questions_from_doc_falls_back_to_realtime_call_count() -> None:
+    data = {
+        "desktop_chat": {"call_count": 7, "cost_usd": 0.4},
+        "desktop_chat_realtime": {"call_count": 7},
+    }
+    assert chat_questions_from_doc(data) == 7
+
+
+def test_reset_nested_quota_questions_and_preserves_telemetry() -> None:
+    data = {
+        "desktop_chat": {
+            "call_count": 5,
+            "quota_questions": 5,
+            "input_tokens": 100,
+            "cost_usd": 1.5,
+        },
+        "backend_chat": {"quota_questions": 3, "call_count": 9},
+        "desktop_chat_realtime": {"quota_questions": 2, "call_count": 2},
+    }
+    update = build_chat_quota_reset_update(data)
+    after = apply_chat_quota_reset_locally(data, update)
+
+    assert after["desktop_chat"]["quota_questions"] == 0
+    assert after["backend_chat"]["quota_questions"] == 0
+    assert after["desktop_chat_realtime"]["quota_questions"] == 0
+    assert after["desktop_chat"]["call_count"] == 5
+    assert after["backend_chat"]["call_count"] == 9
+    assert after["desktop_chat_realtime"]["call_count"] == 2
+    assert after["desktop_chat"]["cost_usd"] == 1.5
+    assert after["desktop_chat"]["input_tokens"] == 100
+    assert chat_questions_from_doc(after) == 0
+    assert "call_count" not in update.get("desktop_chat", {})
+
+
+def test_reset_dotted_quota_questions_keys() -> None:
+    data = {
+        "desktop_chat.quota_questions": 4,
+        "backend_chat.quota_questions": 6,
+        "desktop_chat_realtime.quota_questions": 1,
+        "desktop_chat.call_count": 99,
+    }
+    update = build_chat_quota_reset_update(data)
+    after = apply_chat_quota_reset_locally(data, update)
+
+    assert after["desktop_chat.quota_questions"] == 0
+    assert after["backend_chat.quota_questions"] == 0
+    assert after["desktop_chat_realtime.quota_questions"] == 0
+    assert after["desktop_chat.call_count"] == 99
+    assert chat_questions_from_doc(after) == 0
+
+
+def test_reset_recurses_plan_usage_and_root_counters() -> None:
+    data = {
+        "desktop_chat": {"quota_questions": 5},
+        "plan_usage": {
+            "operator": {
+                "desktop_chat": {"quota_questions": 2, "input_tokens": 10},
+                "backend_chat": {"quota_questions": 1},
+            }
+        },
+    }
+    after = apply_chat_quota_reset_locally(data, build_chat_quota_reset_update(data))
+
+    assert after["desktop_chat"]["quota_questions"] == 0
+    assert after["plan_usage"]["operator"]["desktop_chat"]["quota_questions"] == 0
+    assert after["plan_usage"]["operator"]["backend_chat"]["quota_questions"] == 0
+    assert after["plan_usage"]["operator"]["desktop_chat"]["input_tokens"] == 10
+    assert chat_questions_from_doc(after) == 0
+
+
+def test_reset_introduces_backend_chat_quota_questions_instead_of_wiping_call_count() -> None:
+    data = {"chat.gpt-4.call_count": 4, "chat.migrated.call_count": 3}
+    update = build_chat_quota_reset_update(data)
+    after = apply_chat_quota_reset_locally(data, update)
+
+    assert after["chat.gpt-4.call_count"] == 4
+    assert after["chat.migrated.call_count"] == 3
+    assert after["backend_chat"]["quota_questions"] == 0
+    # Introducing the key disables the legacy chat.*.call_count fallback.
+    assert chat_questions_from_doc(data) == 7
+    assert chat_questions_from_doc(after) == 0
+
+
+def test_reset_does_not_zero_chat_call_count_when_backend_quota_questions_exists() -> None:
+    data = {
+        "backend_chat": {"quota_questions": 8},
+        "chat.gpt-4.call_count": 4,
+    }
+    after = apply_chat_quota_reset_locally(data, build_chat_quota_reset_update(data))
+
+    assert after["chat.gpt-4.call_count"] == 4
+    assert after["backend_chat"]["quota_questions"] == 0
+    assert chat_questions_from_doc(after) == 0
+
+
+def test_reset_introduces_realtime_quota_questions_to_stop_call_count_fallback() -> None:
+    data = {
+        "desktop_chat": {"call_count": 7, "cost_usd": 0.4},
+        "desktop_chat_realtime": {"call_count": 7},
+    }
+    after = apply_chat_quota_reset_locally(data, build_chat_quota_reset_update(data))
+
+    assert after["desktop_chat"]["call_count"] == 7
+    assert after["desktop_chat_realtime"]["call_count"] == 7
+    assert after["desktop_chat_realtime"]["quota_questions"] == 0
+    assert chat_questions_from_doc(after) == 0
+
+
+def test_chat_reset_plan_skips_already_zero_docs() -> None:
+    docs = [
+        _chat_doc("2026-07-01", {"desktop_chat": {"quota_questions": 0, "call_count": 3}}),
+        _chat_doc("2026-07-02", {"desktop_chat": {"quota_questions": 2}}),
+    ]
+    plan = build_chat_reset_plan(docs)
+
+    assert plan.doc_ids == ("2026-07-02",)
+    assert plan.touches == 1
+    assert plan.updates[0][1] == {"desktop_chat": {"quota_questions": 0}}
+
+
+def test_chat_reset_plan_dry_run_and_apply_share_shape() -> None:
+    docs = [_chat_doc("2026-07-10", {"desktop_chat.quota_questions": 9})]
+    plan = build_chat_reset_plan(docs)
+    assert plan.touches == 1
+    after = apply_chat_quota_reset_locally(docs[0][1], plan.updates[0][1])
+    assert chat_questions_from_doc(after) == 0
+
+
+def test_chat_quota_audit_record_includes_action_and_question_totals() -> None:
+    record = build_chat_quota_audit_record(
+        uid="abc123",
+        email="user@example.com",
+        plan="basic",
+        month="2026-07",
+        reason="goodwill: chat-quota burn",
+        operator="david@",
+        applied=True,
+        before_questions=12,
+        after_questions=0,
+        docs_touched=3,
+        now=NOW,
+    )
+    d = record.to_dict()
+    assert d["action"] == "reset-chat-quota-month"
+    assert d["before_questions"] == 12
+    assert d["after_questions"] == 0
+    assert d["docs_touched"] == 3
+    assert d["at"] == "2026-07-27T13:30:00Z"
+
+
+def test_chat_quota_audit_sanitizes_email_and_reason() -> None:
+    record = build_chat_quota_audit_record(
+        uid="abc123",
+        email="user@example.com",
+        plan="basic",
+        month="2026-07",
+        reason="goodwill: user jane@example.com",
+        operator="ops",
+        applied=False,
+        before_questions=4,
+        after_questions=0,
+        docs_touched=1,
+        now=NOW,
+    )
+    payload = _sanitized_audit_payload(record)
+    assert payload["email"] != "user@example.com"
+    assert "jane@example.com" not in payload["reason"]
+    assert payload["action"] == "reset-chat-quota-month"
+    assert payload["before_questions"] == 4
+
+
+def test_reset_chat_month_parser_is_dry_run_by_default() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["reset-chat-month", "--uid", "abc", "--reason", "goodwill"])
+    assert args.apply is False
+    assert args.func.__name__ == "cmd_reset_chat_month"
+
+
+def test_show_parser_still_accepts_uid_and_email() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["show", "--uid", "abc"])
+    assert args.func.__name__ == "cmd_show"
+    args = parser.parse_args(["show", "--email", "user@example.com"])
+    assert args.email == "user@example.com"
+
+
+def test_show_printout_includes_listening_and_chat(capsys) -> None:
+    view = AccountView(
+        plan_name="Free",
+        status="active",
+        listening_limit_seconds=18000,
+        chat_questions_limit=30,
+        chat_cost_usd_limit=None,
+    )
+    usage = MonthlyUsage(used_seconds=600, document_count=2, top_buckets=())
+    _print_usage(
+        "uid-123",
+        "user@example.com",
+        view,
+        usage,
+        "2026-07",
+        chat_questions=12,
+        fair_use_stage=None,
+    )
+    out = capsys.readouterr().out
+    assert "plan:          Free" in out
+    assert "status:        active" in out
+    assert "listening used:" in out
+    assert "chat used:      12 questions" in out
+    assert "chat limit:     30 questions" in out
+    assert "chat remaining: 18 questions" in out
+    assert "GET /v1/admin/fair-use/user/uid-123" in out
+
+
+def test_show_printout_prefers_fair_use_stage_when_present(capsys) -> None:
+    view = AccountView(
+        plan_name="Free",
+        status="active",
+        listening_limit_seconds=None,
+        chat_questions_limit=None,
+        chat_cost_usd_limit=None,
+    )
+    usage = MonthlyUsage(used_seconds=0, document_count=0, top_buckets=())
+    _print_usage(
+        "uid-123",
+        None,
+        view,
+        usage,
+        "2026-07",
+        chat_questions=0,
+        fair_use_stage="off",
+    )
+    out = capsys.readouterr().out
+    assert "fair-use:       stage=off" in out
+    assert "chat limit:     unlimited" in out
+    assert "listening limit:     unlimited" in out

--- a/backend/tests/unit/test_reset_transcription_usage.py
+++ b/backend/tests/unit/test_reset_transcription_usage.py
@@ -28,9 +28,11 @@ from scripts.admin.reset_transcription_usage import (  # noqa: E402
     build_parser,
     build_reset_plan,
     chat_questions_from_doc,
+    listening_is_throttled,
     llm_usage_doc_id_in_utc_month,
     month_label,
     seconds_to_minutes,
+    skip_unlimited_listening_reset,
     _print_usage,
     _sanitized_audit_payload,
 )
@@ -540,6 +542,8 @@ def test_show_printout_includes_listening_and_chat(capsys) -> None:
     assert "chat used:      12 questions" in out
     assert "chat limit:     30 questions" in out
     assert "chat remaining: 18 questions" in out
+    assert "listening throttled: no" in out
+    assert "chat included exhausted: no" in out
     assert "GET /v1/admin/fair-use/user/uid-123" in out
 
 
@@ -565,3 +569,51 @@ def test_show_printout_prefers_fair_use_stage_when_present(capsys) -> None:
     assert "fair-use:       stage=off" in out
     assert "chat limit:     unlimited" in out
     assert "listening limit:     unlimited" in out
+    assert "listening throttled: no" in out
+    assert "listening reset: skip (unlimited; not throttled)" in out
+    assert "chat included exhausted: n/a (unlimited)" in out
+
+
+def test_listening_is_throttled_only_when_finite_cap_exhausted() -> None:
+    assert listening_is_throttled(None, 1_000_000) is False
+    assert listening_is_throttled(18000, 17999) is False
+    assert listening_is_throttled(18000, 18000) is True
+    assert listening_is_throttled(18000, 18001) is True
+
+
+def test_skip_unlimited_listening_reset_requires_force() -> None:
+    assert skip_unlimited_listening_reset(None, force=False) is True
+    assert skip_unlimited_listening_reset(None, force=True) is False
+    assert skip_unlimited_listening_reset(18000, force=False) is False
+
+
+def test_reset_month_parser_accepts_force() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["reset-month", "--uid", "abc", "--reason", "goodwill"])
+    assert args.force is False
+    args = parser.parse_args(["reset-month", "--uid", "abc", "--reason", "goodwill", "--force"])
+    assert args.force is True
+
+
+def test_show_printout_marks_exhausted_free_listening(capsys) -> None:
+    view = AccountView(
+        plan_name="Free",
+        status="active",
+        listening_limit_seconds=18000,
+        chat_questions_limit=30,
+        chat_cost_usd_limit=None,
+    )
+    usage = MonthlyUsage(used_seconds=18000, document_count=1, top_buckets=())
+    _print_usage(
+        "uid-123",
+        None,
+        view,
+        usage,
+        "2026-07",
+        chat_questions=30,
+        fair_use_stage=None,
+    )
+    out = capsys.readouterr().out
+    assert "listening throttled: yes" in out
+    assert "chat included exhausted: yes" in out
+    assert "listening reset: skip" not in out


### PR DESCRIPTION
## What changed and why

SCA-393: extend the support-ops admin CLI so `show` prints listening minutes **and** chat questions, and add `reset-chat-month` to zero the current UTC month of `quota_questions` (the surface `get_monthly_chat_usage` / `enforce_chat_quota` actually sums). Chat reset was deferred in #10747 because of nested/legacy `llm_usage` shapes; this PR handles those shapes without wiping telemetry.

## Product invariants affected

none

## How it was verified

- Focused unit tests: `cd backend && .venv/bin/python -m pytest tests/unit/test_reset_transcription_usage.py -q` → **34 passed**
- `make preflight` against `origin/main` (local lane) after the commit
- `scripts/pr-preflight --suggest` → product invariants **none**; no `fix:` commit so no failure-class declaration is required
- Did **not** run `--apply` against production Firestore (out of scope)

## Tests

- `backend/tests/unit/test_reset_transcription_usage.py` covers:
  - unified `show` printout (listening + chat used/limit/remaining, fair-use pointer or stage)
  - month filter on `llm_usage/{YYYY-MM-DD}`
  - nested maps, dotted root keys, and `plan_usage` recursion
  - `desktop_chat.call_count` is not treated as quota when `quota_questions` exists
  - legacy `chat.*.call_count` is neutralized by introducing `backend_chat.quota_questions = 0` instead of wiping telemetry
  - dry-run vs apply share the same plan shape
  - audit record `action=reset-chat-quota-month`

## Failure class (fixes)

Failure-Class: none

## Test plan

- [ ] `show --uid` prints plan, status, UTC month, listening used/limit/remaining, chat questions used/limit/remaining
- [ ] `reset-chat-month` without `--apply` writes nothing and prints before/after
- [ ] `reset-chat-month --apply --reason ... --operator ...` zeros current-month questions per `get_monthly_chat_usage` and writes `admin_audit_log` with `reset-chat-quota-month`
- [ ] After apply, `show` reports chat questions `0`
- [ ] Fair-use write and plan grants remain out of scope (HTTP-only / not this CLI)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

