### PR TITLE
fix(desktop): stop Telegram meeting notes leaking Speaker 1

### DIFF
--- a/.github/failure-classes/FC-meeting-identity-catalog-split.json
+++ b/.github/failure-classes/FC-meeting-identity-catalog-split.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "id": "FC-meeting-identity-catalog-split",
+  "violated_contract": "The catalog that classifies a desktop session as a meeting must be the same catalog identity extractors use to look for participants, and conversation notes must not persist diarization placeholders as if they were people. MeetingDetector already treated Telegram (and Discord/Slack/WhatsApp) as native call apps, but on-device and backend identity extractors only searched Meet/Zoom/Teams/Webex/FaceTime, so a Telegram desktop call produced empty identity and notes copied Speaker 1. Prompt wording that already forbade narrating Speaker 1 said that is not a storage boundary.",
+  "canonical_prevention": "Share ConferencingApps.messagingCallApps with the on-device extractor and mirror the same app-name catalog in meeting_context.py. Treat a name-shaped native-call window title as roster-equivalent only with in-call chrome or one dominant call window, keep rejecting bare Chrome calendar-tile names, and strip leftover Speaker N / SPEAKER_00 tokens from Structured notes after parse.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/OnDeviceMeetingIdentityExtractorTests.swift",
+    "backend/tests/unit/test_screen_activity_identity.py",
+    "backend/tests/unit/test_conversation_notes_v2.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/CalendarMeetingContext/**",
+    "desktop/macos/Desktop/Sources/ConferencingApps.swift",
+    "backend/utils/conversations/meeting_context.py",
+    "backend/utils/llm/conversation_processing.py"
+  ],
+  "status": "open"
+}

--- a/backend/tests/unit/test_conversation_notes_v2.py
+++ b/backend/tests/unit/test_conversation_notes_v2.py
@@ -83,7 +83,7 @@ def test_merged_note_call_projects_sections_and_preserves_action_detail(monkeypa
         def invoke(self, messages):
             captured['messages'] = messages
             return SimpleNamespace(content='''{
-                  "title":"Ash and David Discuss Agent Infrastructure",
+                  "title":"Speaker 1 and Ash Discuss Agent Infrastructure",
                   "overview":"compatibility",
                   "emoji":"🔐",
                   "category":"technology",
@@ -108,6 +108,7 @@ def test_merged_note_call_projects_sections_and_preserves_action_detail(monkeypa
     )
 
     assert result.overview == '## Agent operations\n\nAsh runs ~12 long-running agents.'
+    assert re.search(r'(?i)\b(?:speaker[ _]\d+|SPEAKER_\d+)\b', result.title) is None
     assert result.events == []
     assert result.action_items[0].owner_name == 'David'
     assert result.action_items[0].due_certainty == 'tentative'
@@ -117,6 +118,8 @@ def test_merged_note_call_projects_sections_and_preserves_action_detail(monkeypa
     assert 'Never normalize or "correct" an uncertain name from general knowledge' in instructions
     assert 'participant email domain corroborates' in instructions
     assert 'fulcradynamics.com corroborates "Fulcra Dynamics" over ASR "Vulcra"' in instructions
+    assert 'NEVER emit diarization placeholders' in instructions
+    assert 'whether or not calendar' in instructions
     assert 'Ash Kalb <ash@fulcradynamics.com>' in prefix.context
 
 
@@ -203,51 +206,40 @@ def test_action_item_new_fields_round_trip():
     assert ActionItem.model_validate_json(item.model_dump_json()) == item
 
 
-def test_notes_without_calendar_context_strip_speaker_placeholders(monkeypatch):
-    from utils.llm import conversation_processing
-    from utils.llm.conversation_prompt_prefix import build_conversation_prompt_prefix
-
-    prefix = build_conversation_prompt_prefix(
-        conversation_id='conv-no-cal',
-        transcript='Speaker 1: the budget is late\nSpeaker 0: noted',
-        started_at=datetime(2026, 8, 18, 14, 0, tzinfo=timezone.utc),
-        timezone_name='America/New_York',
-        language_code='en',
-    )
-    captured = {}
-
-    class Model:
-        def invoke(self, messages):
-            captured['instructions'] = messages[-1].content
-            return SimpleNamespace(content='''{
-                  "title":"Speaker 1 Reviews Budget",
-                  "overview":"Speaker 1 said the budget is late.",
-                  "emoji":"💬",
-                  "category":"work",
-                  "sections":[{"heading":"Budget","body_markdown":"- Speaker 1: budget is late\\n- SPEAKER_00 agreed","source_segment_ids":["s1"]}],
-                  "action_items":[{"description":"Follow up with Speaker 1","owner_name":"Speaker 1","source_segment_ids":["s1"]}],
-                  "events":[]
-                }''')
-
-    monkeypatch.setattr(conversation_processing, 'get_llm', lambda *args, **kwargs: Model())
-    monkeypatch.setattr(conversation_processing, 'shared_conversation_cache_supported', lambda: False)
-    result = conversation_processing.get_conversation_notes(
-        prefix,
-        started_at=datetime(2026, 8, 18, 14, 0, tzinfo=timezone.utc),
-        language_code='en',
-        output_language_code='en',
-        tz='America/New_York',
-        task_intelligence_capture=False,
-    )
+def test_notes_without_calendar_context_strip_speaker_placeholders():
+    from utils.llm.conversation_processing import sanitize_structured_speaker_placeholders
 
     leftover = re.compile(r'(?i)\b(?:speaker[ _]\d+|SPEAKER_\d+)\b')
-    assert leftover.search(result.title) is None
-    assert leftover.search(result.overview) is None
-    assert leftover.search(result.sections[0].body_markdown) is None
-    assert leftover.search(result.action_items[0].description) is None
-    assert result.action_items[0].owner_name is None
-    assert 'Speaker 0' in captured['instructions']
-    assert 'whether or not' in captured['instructions'].lower() or 'calendar' in captured['instructions'].lower()
+    structured = Structured.model_validate(
+        {
+            'title': 'Speaker 1 Reviews Budget',
+            'overview': 'Speaker 1 said the budget is late.',
+            'emoji': '💬',
+            'category': 'work',
+            'sections': [
+                {
+                    'heading': 'Budget',
+                    'body_markdown': '- Speaker 1: budget is late\n- SPEAKER_00 agreed',
+                    'source_segment_ids': ['s1'],
+                }
+            ],
+            'action_items': [
+                {
+                    'description': 'Follow up with Speaker 1',
+                    'owner_name': 'Speaker 1',
+                    'source_segment_ids': ['s1'],
+                }
+            ],
+            'events': [],
+        }
+    )
+    sanitize_structured_speaker_placeholders(structured)
+
+    assert leftover.search(structured.title) is None
+    assert leftover.search(structured.overview) is None
+    assert leftover.search(structured.sections[0].body_markdown) is None
+    assert leftover.search(structured.action_items[0].description) is None
+    assert structured.action_items[0].owner_name is None
 
 
 def test_telegram_screen_identity_prefix_uses_real_name_not_speaker_placeholder():

--- a/backend/tests/unit/test_conversation_notes_v2.py
+++ b/backend/tests/unit/test_conversation_notes_v2.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from types import SimpleNamespace
+import re
 
 import pytest
 
@@ -200,3 +201,78 @@ def test_action_item_new_fields_round_trip():
         due_certainty='tentative',
     )
     assert ActionItem.model_validate_json(item.model_dump_json()) == item
+
+
+def test_notes_without_calendar_context_strip_speaker_placeholders(monkeypatch):
+    from utils.llm import conversation_processing
+    from utils.llm.conversation_prompt_prefix import build_conversation_prompt_prefix
+
+    prefix = build_conversation_prompt_prefix(
+        conversation_id='conv-no-cal',
+        transcript='Speaker 1: the budget is late\nSpeaker 0: noted',
+        started_at=datetime(2026, 8, 18, 14, 0, tzinfo=timezone.utc),
+        timezone_name='America/New_York',
+        language_code='en',
+    )
+    captured = {}
+
+    class Model:
+        def invoke(self, messages):
+            captured['instructions'] = messages[-1].content
+            return SimpleNamespace(content='''{
+                  "title":"Speaker 1 Reviews Budget",
+                  "overview":"Speaker 1 said the budget is late.",
+                  "emoji":"💬",
+                  "category":"work",
+                  "sections":[{"heading":"Budget","body_markdown":"- Speaker 1: budget is late\\n- SPEAKER_00 agreed","source_segment_ids":["s1"]}],
+                  "action_items":[{"description":"Follow up with Speaker 1","owner_name":"Speaker 1","source_segment_ids":["s1"]}],
+                  "events":[]
+                }''')
+
+    monkeypatch.setattr(conversation_processing, 'get_llm', lambda *args, **kwargs: Model())
+    monkeypatch.setattr(conversation_processing, 'shared_conversation_cache_supported', lambda: False)
+    result = conversation_processing.get_conversation_notes(
+        prefix,
+        started_at=datetime(2026, 8, 18, 14, 0, tzinfo=timezone.utc),
+        language_code='en',
+        output_language_code='en',
+        tz='America/New_York',
+        task_intelligence_capture=False,
+    )
+
+    leftover = re.compile(r'(?i)\b(?:speaker[ _]\d+|SPEAKER_\d+)\b')
+    assert leftover.search(result.title) is None
+    assert leftover.search(result.overview) is None
+    assert leftover.search(result.sections[0].body_markdown) is None
+    assert leftover.search(result.action_items[0].description) is None
+    assert result.action_items[0].owner_name is None
+    assert 'Speaker 0' in captured['instructions']
+    assert 'whether or not' in captured['instructions'].lower() or 'calendar' in captured['instructions'].lower()
+
+
+def test_telegram_screen_identity_prefix_uses_real_name_not_speaker_placeholder():
+    from utils.conversations.meeting_context import context_from_screen_activity
+    from utils.llm.conversation_prompt_prefix import build_conversation_prompt_prefix
+
+    context = context_from_screen_activity(
+        [
+            {
+                'appName': 'Telegram',
+                'windowTitle': 'Alice Chen',
+                'ocrText': 'Mute\nEnd Call\nVideo',
+            }
+        ],
+        started_at=datetime(2026, 8, 18, 14, 0, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 8, 18, 14, 30, tzinfo=timezone.utc),
+    )
+    assert context is not None
+    prefix = build_conversation_prompt_prefix(
+        conversation_id='conv-telegram',
+        transcript='Speaker 1: the flight is at noon\n',
+        started_at=datetime(2026, 8, 18, 14, 0, tzinfo=timezone.utc),
+        timezone_name='America/New_York',
+        language_code='en',
+        calendar_context=context,
+    )
+    assert 'Alice Chen' in prefix.context
+    assert 'Speaker 1:' not in prefix.context

--- a/backend/tests/unit/test_screen_activity_identity.py
+++ b/backend/tests/unit/test_screen_activity_identity.py
@@ -241,6 +241,63 @@ class TestPrecisionFirst:
         )
         assert context is None
 
+    def test_telegram_call_window_title_with_call_control_yields_participant(self):
+        context = context_from_screen_activity(
+            [
+                {
+                    'appName': 'Telegram',
+                    'windowTitle': 'Alice Chen',
+                    'ocrText': 'Mute\nEnd Call\nVideo',
+                }
+            ],
+            started_at=CONVERSATION_START,
+            finished_at=CONVERSATION_END,
+        )
+        assert context is not None
+        assert [p.name for p in context.participants] == ['Alice Chen']
+        assert context.platform == 'Telegram'
+        assert context.calendar_source == 'screen_activity'
+
+    def test_telegram_chat_titles_without_call_control_yield_no_participants(self):
+        context = context_from_screen_activity(
+            [
+                {'appName': 'Telegram', 'windowTitle': 'Saved Messages', 'ocrText': 'sticker'},
+                {'appName': 'Telegram', 'windowTitle': 'Alice Chen', 'ocrText': 'yesterday'},
+                {'appName': 'Telegram', 'windowTitle': 'Bob Martinez', 'ocrText': 'photo'},
+                {'appName': 'Telegram', 'windowTitle': 'Design Review', 'ocrText': 'ok'},
+                {'appName': 'Telegram', 'windowTitle': 'Nikita Petrov', 'ocrText': 'typing'},
+            ],
+            started_at=CONVERSATION_START,
+            finished_at=CONVERSATION_END,
+        )
+        assert context is None
+
+    def test_chrome_calendar_tile_without_meet_roster_yields_no_participants(self):
+        context = context_from_screen_activity(
+            [
+                {
+                    'appName': 'Google Chrome',
+                    'windowTitle': 'Meet - amc-iajq-asx',
+                    'ocrText': 'Aryan Gupta and Nik\nBlocked users\nCoinflow Portal',
+                }
+            ],
+            started_at=CONVERSATION_START,
+            finished_at=CONVERSATION_END,
+        )
+        assert context is None
+
+    def test_telegram_call_control_does_not_ingest_unrelated_chat_titles(self):
+        context = context_from_screen_activity(
+            [
+                {'appName': 'Telegram', 'windowTitle': 'Alice Chen', 'ocrText': 'Mute\nEnd Call'},
+                {'appName': 'Telegram', 'windowTitle': 'Bob Martinez', 'ocrText': 'hey'},
+            ],
+            started_at=CONVERSATION_START,
+            finished_at=CONVERSATION_END,
+        )
+        assert context is not None
+        assert [p.name for p in context.participants] == ['Alice Chen']
+
     def test_participants_are_capped(self):
         roster = ', '.join(f'Person Number{index}' for index in range(20)) + ' are in this call'
         assert len(participants_from_ocr([roster])) <= 12

--- a/backend/utils/conversations/meeting_context.py
+++ b/backend/utils/conversations/meeting_context.py
@@ -41,6 +41,9 @@ _CALL_CONTROL_MARKERS = (
     'camera off',
     'camera on',
 )
+_CALL_CONTROL_PATTERN = re.compile(
+    r'(?<!\w)(?:' + '|'.join(re.escape(marker) for marker in _CALL_CONTROL_MARKERS) + r')(?!\w)'
+)
 # A Google Meet tab is titled with the bare meeting code ("Meet - amc-iajq-asx").
 # Once the call is joined the omnibox URL is often scrolled out of the capture, so
 # the title is the only marker left. The code shape keeps this precise.
@@ -71,7 +74,7 @@ def _is_messaging_call_app(app_name: str) -> bool:
 
 def _has_call_control(row: dict[str, Any]) -> bool:
     hay = f'{row.get("windowTitle") or ""} {row.get("ocrText") or ""}'.casefold()
-    return any(re.search(rf'(?<!\w){re.escape(marker)}(?!\w)', hay) for marker in _CALL_CONTROL_MARKERS)
+    return _CALL_CONTROL_PATTERN.search(hay) is not None
 
 
 def _is_conferencing_row(row: dict[str, Any]) -> bool:
@@ -169,7 +172,8 @@ def _split_roster(people: str) -> Iterable[str]:
 def _roster_names(text: str) -> Iterable[str]:
     for raw_line in text.splitlines():
         line = _clean_line(raw_line)
-        if not line:
+        # Roster sentences are short UI chrome, never a 4k-character OCR smear.
+        if not line or len(line) > 200:
             continue
         for pattern in _ROSTER_PATTERNS:
             match = pattern.match(line)
@@ -179,6 +183,8 @@ def _roster_names(text: str) -> Iterable[str]:
 
 
 def _emails(text: str) -> Iterable[str]:
+    if '@' not in text:
+        return
     for match in _EMAIL_PATTERN.finditer(text):
         yield match.group(0).strip('.').casefold()
 
@@ -205,9 +211,9 @@ def _row_identity_signal(text: str, row: Optional[dict[str, Any]] = None) -> int
     score = 0
     if any(True for _ in _roster_names(text)):
         score += 2
-    if _EMAIL_PATTERN.search(text):
+    if '@' in text and _EMAIL_PATTERN.search(text):
         score += 1
-    if row is not None and _has_call_control(row):
+    if row is not None and _is_messaging_call_app(str(row.get('appName') or '')) and _has_call_control(row):
         score += 2
     return score
 

--- a/backend/utils/conversations/meeting_context.py
+++ b/backend/utils/conversations/meeting_context.py
@@ -23,6 +23,24 @@ MEETING_SEARCH_TOLERANCE_MINUTES = 30
 
 _CONFERENCING_MARKERS = ('zoom', 'microsoft teams', 'webex', 'facetime', 'google meet', 'meet.google')
 _CONFERENCING_URL_MARKERS = ('meet.google.com/', 'zoom.us/j/', 'teams.microsoft.com/l/meetup', 'webex.com/meet')
+# Native messaging-call apps already in the desktop ConferencingApps catalog.
+# Matched on appName only — a Chrome tab titled "Discord" is not a call.
+_MESSAGING_CALL_APPS = ('telegram', 'discord', 'slack', 'whatsapp')
+_CALL_CONTROL_MARKERS = (
+    'mute',
+    'unmute',
+    'end call',
+    'hang up',
+    'leave call',
+    'stop video',
+    'start video',
+    'screen share',
+    'screenshare',
+    'in call',
+    'in-call',
+    'camera off',
+    'camera on',
+)
 # A Google Meet tab is titled with the bare meeting code ("Meet - amc-iajq-asx").
 # Once the call is joined the omnibox URL is often scrolled out of the capture, so
 # the title is the only marker left. The code shape keeps this precise.
@@ -46,7 +64,19 @@ _OCR_UI_WORDS = {
 }
 
 
+def _is_messaging_call_app(app_name: str) -> bool:
+    hay = (app_name or '').casefold()
+    return any(marker in hay for marker in _MESSAGING_CALL_APPS)
+
+
+def _has_call_control(row: dict[str, Any]) -> bool:
+    hay = f'{row.get("windowTitle") or ""} {row.get("ocrText") or ""}'.casefold()
+    return any(re.search(rf'(?<!\w){re.escape(marker)}(?!\w)', hay) for marker in _CALL_CONTROL_MARKERS)
+
+
 def _is_conferencing_row(row: dict[str, Any]) -> bool:
+    if _is_messaging_call_app(str(row.get('appName') or '')):
+        return True
     haystack = f'{row.get("appName", "")} {row.get("windowTitle", "")}'.casefold()
     if any(marker in haystack for marker in _CONFERENCING_MARKERS):
         return True
@@ -168,7 +198,7 @@ def _decorated_name_lines(text: str) -> Iterable[str]:
             yield line
 
 
-def _row_identity_signal(text: str) -> int:
+def _row_identity_signal(text: str, row: Optional[dict[str, Any]] = None) -> int:
     """Rank rows by how much identity they carry, so the bounded budget is spent
     on the pre-join/roster frames rather than on whichever frames happen to be
     chronologically first."""
@@ -177,6 +207,8 @@ def _row_identity_signal(text: str) -> int:
         score += 2
     if _EMAIL_PATTERN.search(text):
         score += 1
+    if row is not None and _has_call_control(row):
+        score += 2
     return score
 
 
@@ -190,7 +222,7 @@ def _select_conferencing_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]
     ]
     # Highest identity signal first; chronological order breaks ties so the budget
     # stays deterministic.
-    combined.sort(key=lambda item: (-_row_identity_signal(item[2]), item[0]))
+    combined.sort(key=lambda item: (-_row_identity_signal(item[2], item[1]), item[0]))
 
     selected: list[dict[str, Any]] = []
     used_characters = 0
@@ -270,6 +302,51 @@ def participants_from_ocr(texts: Iterable[str]) -> list[MeetingParticipant]:
     return participants[:12]
 
 
+def _dominating_call_windows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    counts: dict[str, int] = {}
+    for row in rows:
+        title = _clean_line(str(row.get('windowTitle') or ''))
+        if not title:
+            continue
+        counts[title] = counts.get(title, 0) + 1
+    titled_count = sum(counts.values())
+    if not titled_count:
+        return []
+    top_title, top_count = max(counts.items(), key=lambda item: item[1])
+    if not _looks_like_person_name(top_title):
+        return []
+    runner_up = max((count for title, count in counts.items() if title != top_title), default=0)
+    if top_count * 2 <= titled_count or top_count <= runner_up:
+        return []
+    return [row for row in rows if _clean_line(str(row.get('windowTitle') or '')) == top_title]
+
+
+def _messaging_call_participants(rows: list[dict[str, Any]]) -> list[MeetingParticipant]:
+    """Name-shaped native-call window titles, only with call chrome or a dominant window.
+
+    Telegram/Discord/Slack/WhatsApp do not print Meet-style roster sentences. The
+    call window's title *is* the other party, but only when in-call chrome (mute /
+    end call / video) corroborates a live call, or one title dominates the interval.
+    Browsing many chats in the same window must not invent a roster.
+    """
+    messaging = [row for row in rows if _is_messaging_call_app(str(row.get('appName') or ''))]
+    if not messaging:
+        return []
+    source = [row for row in messaging if _has_call_control(row)] or _dominating_call_windows(messaging)
+    names: list[str] = []
+    for row in source:
+        title = _clean_line(str(row.get('windowTitle') or ''))
+        if not _looks_like_person_name(title):
+            continue
+        if title.casefold() in _OCR_UI_WORDS:
+            continue
+        if title.casefold() == str(row.get('appName') or '').casefold():
+            continue
+        if title not in names:
+            names.append(title)
+    return [MeetingParticipant(name=name) for name in names[:12]]
+
+
 def context_from_screen_activity(
     rows: list[dict[str, Any]],
     *,
@@ -288,6 +365,8 @@ def context_from_screen_activity(
         return None
 
     participants = participants_from_ocr(str(row.get('ocrText') or '') for row in selected)
+    if not participants:
+        participants = _messaging_call_participants(rows)
     if not participants:
         return None
 

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import unicodedata
 from datetime import datetime, timedelta, timezone
 from difflib import SequenceMatcher
@@ -1116,6 +1117,39 @@ def render_sections_markdown(sections: List[Any]) -> str:
     return '\n\n'.join(rendered)
 
 
+# Diarization placeholders are transcript machinery, not people. Prompt wording alone
+# does not hold — v2 already forbade "Speaker 1 said that" and still leaked the token.
+_SPEAKER_PLACEHOLDER_RE = re.compile(r'(?i)\b(?:speaker[ _]\d+|SPEAKER_\d+)\b:?[ \t]*')
+
+
+def strip_speaker_placeholders(text: str) -> str:
+    """Drop leftover Speaker N / SPEAKER_00 tokens rather than inventing a name."""
+    if not text:
+        return text
+    cleaned = _SPEAKER_PLACEHOLDER_RE.sub('', text)
+    cleaned = re.sub(r'[^\S\n]+', ' ', cleaned)
+    cleaned = re.sub(r' *\n *', '\n', cleaned)
+    cleaned = re.sub(r'\n{3,}', '\n\n', cleaned)
+    return cleaned.strip()
+
+
+def sanitize_structured_speaker_placeholders(structured: Structured) -> Structured:
+    """Strip diarization placeholders from every user-visible notes field."""
+    structured.title = strip_speaker_placeholders(structured.title)
+    structured.overview = strip_speaker_placeholders(structured.overview)
+    for section in structured.sections:
+        section.heading = strip_speaker_placeholders(section.heading)
+        section.body_markdown = strip_speaker_placeholders(section.body_markdown)
+    for item in structured.action_items:
+        item.description = strip_speaker_placeholders(item.description)
+        if item.owner_name:
+            cleaned_owner = strip_speaker_placeholders(item.owner_name)
+            item.owner_name = cleaned_owner or None
+        if item.context:
+            item.context = strip_speaker_placeholders(item.context)
+    return structured
+
+
 # Whole-transcript structuring produces the title and summary a conversation cannot be finalized
 # without, so like the test-prompt summary above it must not inherit the shared gateway transport
 # deadline (15s to first response byte), which is sized for background feature calls. In prod on
@@ -1179,6 +1213,11 @@ NOTE BODY — WRITE FOR SKIMMING, NOT FOR READING
 - Lead each bullet with the specific: the name, number, product, or decision. Never open a
   bullet with narration such as "They discussed", "The conversation turned to", or
   "Speaker 1 said that". Attribute inline only when who-said-it is the point.
+- NEVER emit diarization placeholders (`Speaker 0`, `Speaker 1`, `Speaker 2`, `SPEAKER_00`)
+  in the title, overview, section bullets, or action items, whether or not calendar or
+  screen context exists. Use a real person name only when it appears in meeting-identity
+  metadata or is already a non-placeholder transcript label. If identity is unknown,
+  write the fact without a speaker label.
 - No preamble, no scene-setting, no wrap-up bullet restating the section.
 - Merge overlapping points instead of restating them across sections.
 - Headings are short noun phrases (2-5 words), specific to this conversation.
@@ -1256,6 +1295,7 @@ DATE CONTEXT
     projected_overview = render_sections_markdown(structured.sections)
     if projected_overview:
         structured.overview = projected_overview
+    sanitize_structured_speaker_placeholders(structured)
     return structured
 
 

--- a/desktop/macos/Desktop/Sources/CalendarMeetingContext/OnDeviceMeetingIdentityService.swift
+++ b/desktop/macos/Desktop/Sources/CalendarMeetingContext/OnDeviceMeetingIdentityService.swift
@@ -62,7 +62,10 @@ enum OnDeviceMeetingIdentityExtractor {
   ) -> DesktopMeetingPayload? {
     let selected = selectConferencingRows(snapshots)
     guard !selected.isEmpty else { return nil }
-    let participants = participants(from: selected.map(\.combinedText))
+    var participants = participants(from: selected.map(\.combinedText))
+    if participants.isEmpty {
+      participants = messagingCallParticipants(from: snapshots)
+    }
     guard !participants.isEmpty else { return nil }
 
     let title = selected.compactMap(meetingTitle).first ?? "Video meeting"
@@ -164,6 +167,9 @@ enum OnDeviceMeetingIdentityExtractor {
     }
     if metadata.contains("webex") || snapshot.combinedText.lowercased().contains("webex.com/meet") { return "Webex" }
     if metadata.contains("facetime") { return "FaceTime" }
+    if ConferencingApps.isMessagingCallApp(appName: snapshot.appName) {
+      return ConferencingApps.nativeCallPlatform(forAppName: snapshot.appName)
+    }
     return nil
   }
 
@@ -174,9 +180,67 @@ enum OnDeviceMeetingIdentityExtractor {
 
     // A native conferencing app owns its window title. A browser row recognized
     // only from OCR does not: its tab/window title might describe any other page.
+    if ConferencingApps.nativeCallPlatform(forAppName: snapshot.appName) != nil {
+      return title
+    }
     let app = snapshot.appName.lowercased()
     let nativeMarkers = ["zoom", "microsoft teams", "webex", "facetime", "google meet"]
     return nativeMarkers.contains(where: app.contains) ? title : nil
+  }
+
+  private static let callControlMarkers: [String] = [
+    "mute", "unmute", "end call", "hang up", "leave call",
+    "stop video", "start video", "screen share", "screenshare",
+    "in call", "in-call", "camera off", "camera on",
+  ]
+
+  private static func hasCallControlChrome(_ snapshot: MeetingScreenActivitySnapshot) -> Bool {
+    let haystack = snapshot.combinedText.lowercased()
+    return callControlMarkers.contains { marker in
+      let pattern = "\\b\(NSRegularExpression.escapedPattern(for: marker))\\b"
+      return haystack.range(of: pattern, options: .regularExpression) != nil
+    }
+  }
+
+  /// For native messaging-call apps only: a name-shaped window title is a
+  /// participation assertion when the row also shows in-call chrome, or when one
+  /// stable call window dominates the interval. Unrelated chat titles are ignored.
+  private static func messagingCallParticipants(from snapshots: [MeetingScreenActivitySnapshot])
+    -> [DesktopMeetingParticipant]
+  {
+    let messaging = snapshots.filter { ConferencingApps.isMessagingCallApp(appName: $0.appName) }
+    guard !messaging.isEmpty else { return [] }
+    let callRows = messaging.filter(hasCallControlChrome)
+    let source = callRows.isEmpty ? dominatingCallWindows(in: messaging) : callRows
+    guard !source.isEmpty else { return [] }
+
+    var names: [String] = []
+    for snapshot in source {
+      let title = cleanLine(snapshot.windowTitle ?? "")
+      guard looksLikePersonName(title), !uiTitles.contains(title.lowercased()) else { continue }
+      if title.lowercased() == snapshot.appName.lowercased() { continue }
+      if !names.contains(title) { names.append(title) }
+    }
+    return names.prefix(maximumParticipants).map { DesktopMeetingParticipant(name: $0, email: nil) }
+  }
+
+  private static func dominatingCallWindows(in snapshots: [MeetingScreenActivitySnapshot])
+    -> [MeetingScreenActivitySnapshot]
+  {
+    var counts: [String: Int] = [:]
+    for snapshot in snapshots {
+      let title = cleanLine(snapshot.windowTitle ?? "")
+      guard !title.isEmpty else { continue }
+      counts[title, default: 0] += 1
+    }
+    let titledCount = counts.values.reduce(0, +)
+    guard titledCount > 0, let (topTitle, topCount) = counts.max(by: { $0.value < $1.value }) else {
+      return []
+    }
+    guard looksLikePersonName(topTitle) else { return [] }
+    let runnerUp = counts.filter { $0.key != topTitle }.map(\.value).max() ?? 0
+    guard topCount * 2 > titledCount, topCount > runnerUp else { return [] }
+    return snapshots.filter { cleanLine($0.windowTitle ?? "") == topTitle }
   }
 
   private static func rosterNames(in text: String) -> [String] {

--- a/desktop/macos/Desktop/Sources/ConferencingApps.swift
+++ b/desktop/macos/Desktop/Sources/ConferencingApps.swift
@@ -17,16 +17,26 @@ enum ConferencingApps {
     "ru.keepcoder.telegram",
   ]
 
+  /// Chat apps whose native voice/video calls are meetings. Identity extraction
+  /// treats a name-shaped call-window title as roster-equivalent only for this set —
+  /// not for browsers, where a capitalized tab title is usually something else.
+  static let messagingCallApps: Set<String> = [
+    "Telegram",
+    "Discord",
+    "Slack",
+    "WhatsApp",
+  ]
+
   /// Apps that host audio/video calls. Matched by app/owner name, which is
   /// available from `NSRunningApplication` and `CGWindowList` **without** Screen Recording
   /// permission.
   ///
   /// Includes chat apps whose calls hold the microphone (Discord voice, Slack huddles,
-  /// WhatsApp calls) — same shape as Teams. Meeting gating still requires the app to be
-  /// *using the microphone* (`nativeCallBundleIDs` + `callAppIsUsingMicrophone()`), so an
-  /// idle Slack/Discord/WhatsApp window does not start capture; this owner-name list only
-  /// feeds the call-window/share-indicator screen paths.
-  static let nativeCallApps: Set<String> = [
+  /// WhatsApp calls, Telegram calls) — same shape as Teams. Meeting gating still requires
+  /// the app to be *using the microphone* (`nativeCallBundleIDs` + `callAppIsUsingMicrophone()`),
+  /// so an idle Slack/Discord/WhatsApp/Telegram window does not start capture; this
+  /// owner-name list only feeds the call-window/share-indicator screen paths.
+  static let nativeCallApps: Set<String> = Set([
     "Microsoft Teams",
     "zoom.us",
     "FaceTime",
@@ -34,10 +44,19 @@ enum ConferencingApps {
     "Cisco Webex Meetings",
     "GoTo Meeting",
     "GoToMeeting",
-    "Discord",
-    "Slack",
-    "WhatsApp",
-  ]
+  ]).union(messagingCallApps)
+
+  /// Whether `appName` is a native messaging-call app (Telegram / Discord / Slack / WhatsApp).
+  static func isMessagingCallApp(appName: String) -> Bool {
+    let lower = appName.lowercased()
+    return messagingCallApps.contains { $0.lowercased() == lower }
+  }
+
+  /// Canonical platform label for a native call app name, or nil if it is not in the catalog.
+  static func nativeCallPlatform(forAppName appName: String) -> String? {
+    let lower = appName.lowercased()
+    return nativeCallApps.first { $0.lowercased() == lower }
+  }
 
   /// Browser app names. Browser-based calls are matched by window title.
   static let browserApps: Set<String> = [

--- a/desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift
+++ b/desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift
@@ -30,6 +30,10 @@ import XCTest
       XCTAssertTrue(ConferencingApps.isCallWindow(ownerName: "Discord", title: nil))
       XCTAssertTrue(ConferencingApps.isCallWindow(ownerName: "Slack", title: "#general | Acme"))
       XCTAssertTrue(ConferencingApps.isCallWindow(ownerName: "WhatsApp", title: nil))
+      XCTAssertTrue(ConferencingApps.isCallWindow(ownerName: "Telegram", title: nil))
+      XCTAssertTrue(ConferencingApps.isMessagingCallApp(appName: "Telegram"))
+      XCTAssertTrue(ConferencingApps.isMessagingCallApp(appName: "discord"))
+      XCTAssertFalse(ConferencingApps.isMessagingCallApp(appName: "Google Chrome"))
     }
 
     /// A *joined* Google Meet tab is titled with the bare meeting code and contains none of

--- a/desktop/macos/Desktop/Tests/OnDeviceMeetingIdentityExtractorTests.swift
+++ b/desktop/macos/Desktop/Tests/OnDeviceMeetingIdentityExtractorTests.swift
@@ -127,6 +127,68 @@ final class OnDeviceMeetingIdentityExtractorTests: XCTestCase {
     XCTAssertEqual(payload.title, "Video meeting")
   }
 
+  func testTelegramCallWindowTitleWithCallControlOCRYieldsParticipant() throws {
+    let snapshot = MeetingScreenActivitySnapshot(
+      timestamp: start,
+      appName: "Telegram",
+      windowTitle: "Alice Chen",
+      ocrText: "Mute\nEnd Call\nVideo")
+    let payload = try XCTUnwrap(
+      OnDeviceMeetingIdentityExtractor.payload(
+        from: [snapshot], overlapping: DateInterval(start: start, end: end)))
+    XCTAssertEqual(payload.participants.compactMap(\.name), ["Alice Chen"])
+    XCTAssertEqual(payload.platform, "Telegram")
+    XCTAssertFalse(payload.participants.contains { $0.name == "Speaker 1" })
+  }
+
+  func testTelegramChatTitlesWithoutCallControlYieldNoParticipants() {
+    let chats: [(String, String)] = [
+      ("Saved Messages", "sticker"),
+      ("Alice Chen", "yesterday"),
+      ("Bob Martinez", "photo"),
+      ("Design Review", "ok"),
+      ("Nikita Petrov", "typing"),
+    ]
+    let snapshots = chats.enumerated().map { index, pair in
+      MeetingScreenActivitySnapshot(
+        timestamp: start.addingTimeInterval(TimeInterval(index)),
+        appName: "Telegram",
+        windowTitle: pair.0,
+        ocrText: pair.1)
+    }
+    XCTAssertNil(
+      OnDeviceMeetingIdentityExtractor.payload(
+        from: snapshots, overlapping: DateInterval(start: start, end: end)))
+  }
+
+  func testChromeCalendarTileWithoutMeetRosterYieldsNoParticipants() {
+    let snapshot = MeetingScreenActivitySnapshot(
+      timestamp: start,
+      appName: "Google Chrome",
+      windowTitle: "Meet - amc-iajq-asx",
+      ocrText: "Aryan Gupta and Nik\nBlocked users\nCoinflow Portal")
+    XCTAssertNil(
+      OnDeviceMeetingIdentityExtractor.payload(
+        from: [snapshot], overlapping: DateInterval(start: start, end: end)))
+  }
+
+  func testTelegramCallControlDoesNotIngestUnrelatedChatTitles() throws {
+    let call = MeetingScreenActivitySnapshot(
+      timestamp: start,
+      appName: "Telegram",
+      windowTitle: "Alice Chen",
+      ocrText: "Mute\nEnd Call")
+    let chat = MeetingScreenActivitySnapshot(
+      timestamp: start.addingTimeInterval(1),
+      appName: "Telegram",
+      windowTitle: "Bob Martinez",
+      ocrText: "hey")
+    let payload = try XCTUnwrap(
+      OnDeviceMeetingIdentityExtractor.payload(
+        from: [call, chat], overlapping: DateInterval(start: start, end: end)))
+    XCTAssertEqual(payload.participants.compactMap(\.name), ["Alice Chen"])
+  }
+
   private func rows(_ texts: String...) -> [MeetingScreenActivitySnapshot] {
     texts.enumerated().map { index, text in
       MeetingScreenActivitySnapshot(

--- a/desktop/macos/changelog/unreleased/20260831-telegram-meeting-notes-speaker-placeholder.json
+++ b/desktop/macos/changelog/unreleased/20260831-telegram-meeting-notes-speaker-placeholder.json
@@ -1,0 +1,3 @@
+{
+  "change": "Stop meeting notes from labeling Telegram (and other native messaging-app) calls as Speaker 1 when the other party's name is on the call window."
+}


### PR DESCRIPTION
## Problem

Desktop meeting detection already treats Telegram (and Discord / Slack / WhatsApp) as native call apps via `ConferencingApps.nativeCallBundleIDs`. Identity extractors did not: Swift `OnDeviceMeetingIdentityExtractor.conferencingPlatform` and Python `_CONFERENCING_MARKERS` only recognized Meet / Zoom / Teams / Webex / FaceTime.

On a Telegram desktop call that MeetingDetector recorded as a meeting, every `personId` was null and notes copied **Speaker 1** into the overview. Telegram call UI never says `"X are in this call"`, so the precision roster extractor (kept after #12036) returned empty identity. Prefix remapping only fires for exactly one leftover placeholder plus one leftover name, which this two-speaker transcript does not satisfy. V2 notes already said not to open a bullet with "Speaker 1 said that" and still leaked the token.

## Fix

Three stacked boundaries; prompt-only would not hold.

1. **Catalog.** Share `ConferencingApps.messagingCallApps` (Telegram, Discord, Slack, WhatsApp) with the on-device extractor, and mirror the same app-name catalog in `meeting_context.py`. Telegram is also in `nativeCallApps` so the owner-name catalog matches the bundle-ID catalog MeetingDetector already used.

2. **Precision.** For those native messaging-call apps only, a **name-shaped window title** is a roster-equivalent participation assertion when the row also shows in-call chrome (mute / end call / video / screen share) **or** one stable call window dominates the interval. Unrelated chat titles in the same window are not a roster. Chrome / browser OCR still requires a Meet/Zoom roster sentence or email corroboration (#12036 stays green).

3. **Notes sanitizer.** V2 task instructions now forbid `Speaker 0/1` / `SPEAKER_00` whether or not calendar context exists. After parse, leftover placeholders are stripped from title, overview, sections, and action items rather than invented into names.

Prod `CONVERSATION_OCR_CONTEXT_ENABLED` is unchanged. Voiceprint enrolment / #10954 is out of scope.

## Verification

- Red on `origin/main`: Telegram call-window fixture and notes-without-calendar Speaker-1 leakage.
- Green:
  - `xcrun swift test --package-path Desktop --filter OnDeviceMeetingIdentityExtractorTests` — 9 passed (Telegram call chrome names the participant; many chat titles without chrome → nil; Chrome Meet calendar-tile without roster → nil).
  - `pytest tests/unit/test_screen_activity_identity.py tests/unit/test_conversation_notes_v2.py` — 34 passed (same Telegram / Chrome fixtures; notes without calendar_context strip `Speaker 1` / `SPEAKER_00`; Telegram identity prefix remaps `Speaker 1:` to the real name).

## Product invariants affected

none — `scripts/pr-preflight --suggest`: changed paths match no locked invariant globs.

Line-Count-Exception: backend/utils/llm/conversation_processing.py | 1765 -> 1805 | Notes v2 sanitizer and unconditional Speaker-N prompt live at the parse boundary that writes Structured notes; extracting them would split the save-path contract this leak requires.

Failure-Class: new

Closes SCA-391


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

