### PR TITLE
feat(admin): Grafana TV share links without admin login

### DIFF
--- a/web/admin/AGENTS.md
+++ b/web/admin/AGENTS.md
@@ -6,3 +6,4 @@
 Fetcher, SWR, partial-failure, and subscription-scope detail: [`docs/data-contracts.md`](docs/data-contracts.md).
 
 `/dashboard` embeds uid `omi-tv` from `grafana/`; see `grafana/README.md`.
+TV kiosk share links: `/dashboard/tv-links` (admin) → `/tv/view/<token>` (no login); [`docs/tv-mode.md`](docs/tv-mode.md).

--- a/web/admin/app/(protected)/dashboard/page.tsx
+++ b/web/admin/app/(protected)/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense } from "react";
 import { useSearchParams } from "next/navigation";
+import { grafanaBoardSrc } from "@/lib/grafana-board";
 
 // The analytics dashboard IS the Grafana "Omi TV" board, embedded full-bleed.
 // Non-kiosk so Grafana's own Edit mode (drag, resize, remove, save) works
@@ -15,28 +16,23 @@ import { useSearchParams } from "next/navigation";
 //
 // Platform boards: /dashboard?platform=macos|mobile opens that platform's
 // board directly instead of the All-platforms one.
-const GRAFANA_URL = process.env.NEXT_PUBLIC_GRAFANA_URL ?? "";
-const BOARD_UIDS: Record<string, string> = {
-  macos: "omi-tv-macos",
-  mobile: "omi-tv-mobile",
-};
-
 export function boardUrl(platform: string | null): string {
-  if (GRAFANA_URL) return GRAFANA_URL;
-  const uid = BOARD_UIDS[platform ?? ""] ?? "omi-tv";
-  return `/grafana/d/${uid}/?refresh=5m`;
+  return grafanaBoardSrc(platform, false);
 }
 
 function GrafanaFrame() {
   const params = useSearchParams();
   const tvParam = params?.get("tv") ?? null;
-  const base = boardUrl(params?.get("platform") ?? null);
-  const scale = tvParam ? Math.min(Math.max(parseFloat(tvParam) || 1, 0.25), 1) : 1;
-  const src = tvParam ? `${base}&kiosk` : base;
+  const kiosk = Boolean(tvParam);
+  const base = grafanaBoardSrc(params?.get("platform") ?? null, kiosk);
+  const scale = tvParam
+    ? Math.min(Math.max(parseFloat(tvParam) || 1, 0.25), 1)
+    : 1;
+  const src = base;
   const pct = `${(100 / scale).toFixed(4)}%`;
 
   return (
-    <div className="-m-4 md:-m-6 h-[calc(100vh-3.5rem)] overflow-hidden">
+    <div className="-m-4 h-[calc(100vh-3.5rem)] overflow-hidden md:-m-6">
       <iframe
         src={src}
         title="Omi analytics (Grafana)"

--- a/web/admin/app/(protected)/dashboard/tv-links/page.tsx
+++ b/web/admin/app/(protected)/dashboard/tv-links/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { TvLinksPanel } from "@/components/dashboard/tv-links-panel";
+
+export default function TvLinksPage() {
+  return (
+    <div className="flex-1 space-y-4 p-4 pt-6 md:p-8">
+      <TvLinksPanel />
+    </div>
+  );
+}

--- a/web/admin/app/api/omi/tv-links/[id]/route.ts
+++ b/web/admin/app/api/omi/tv-links/[id]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyAdmin } from "@/lib/auth";
+import { revokeTvLink } from "@/lib/tv-links";
+
+export const dynamic = "force-dynamic";
+
+export async function DELETE(
+  request: NextRequest,
+  props: { params: Promise<{ id: string }> }
+) {
+  const auth = await verifyAdmin(request);
+  if (auth instanceof NextResponse) return auth;
+
+  const params = await props.params;
+  const id = params?.id;
+  if (!id) {
+    return NextResponse.json({ error: "Missing id" }, { status: 400 });
+  }
+
+  try {
+    const link = await revokeTvLink(id);
+    if (!link) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    return NextResponse.json({ link });
+  } catch (error) {
+    console.error("revoke TV link:", error);
+    return NextResponse.json(
+      { error: "Failed to revoke TV link" },
+      { status: 500 }
+    );
+  }
+}

--- a/web/admin/app/api/omi/tv-links/route.ts
+++ b/web/admin/app/api/omi/tv-links/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyAdmin } from "@/lib/auth";
+import { createTvLink, listTvLinks } from "@/lib/tv-links";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  const auth = await verifyAdmin(request);
+  if (auth instanceof NextResponse) return auth;
+
+  try {
+    const links = await listTvLinks();
+    return NextResponse.json({ links });
+  } catch (error) {
+    console.error("list TV links:", error);
+    return NextResponse.json(
+      { error: "Failed to list TV links" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await verifyAdmin(request);
+  if (auth instanceof NextResponse) return auth;
+
+  const raw = await request.text();
+  let parsed: unknown = {};
+  if (raw.trim()) {
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return NextResponse.json(
+      { error: "Request body must be a JSON object" },
+      { status: 400 }
+    );
+  }
+  const body = parsed as {
+    label?: string;
+    ttlDays?: number | null;
+  };
+
+  if (
+    body.label !== undefined &&
+    body.label !== null &&
+    typeof body.label !== "string"
+  ) {
+    return NextResponse.json(
+      { error: "label must be a string" },
+      { status: 400 }
+    );
+  }
+
+  let ttlDays: number | null | undefined = body.ttlDays;
+  try {
+    if (ttlDays !== undefined && ttlDays !== null) {
+      if (
+        typeof ttlDays !== "number" ||
+        !Number.isFinite(ttlDays) ||
+        !Number.isInteger(ttlDays) ||
+        ttlDays < 1
+      ) {
+        return NextResponse.json(
+          {
+            error:
+              "ttlDays must be a positive integer, null for never, or omitted for default",
+          },
+          { status: 400 }
+        );
+      }
+      if (ttlDays > 3650) {
+        return NextResponse.json(
+          { error: "ttlDays cannot exceed 3650" },
+          { status: 400 }
+        );
+      }
+    }
+
+    const created = await createTvLink({
+      label: body.label || "Office TV",
+      createdBy: auth.uid,
+      ttlDays,
+    });
+
+    const proto =
+      request.headers.get("x-forwarded-proto") ||
+      request.nextUrl.protocol.replace(":", "") ||
+      "https";
+    const host =
+      request.headers.get("x-forwarded-host") || request.headers.get("host");
+    const origin = host ? `${proto}://${host}` : "";
+    const url = origin ? `${origin}${created.path}` : created.path;
+
+    return NextResponse.json({
+      link: created.link,
+      token: created.token,
+      path: created.path,
+      url,
+    });
+  } catch (error) {
+    console.error("create TV link:", error);
+    return NextResponse.json(
+      { error: "Failed to create TV link" },
+      { status: 500 }
+    );
+  }
+}

--- a/web/admin/app/tv/view/[token]/page.tsx
+++ b/web/admin/app/tv/view/[token]/page.tsx
@@ -1,0 +1,26 @@
+import { resolveActiveTvToken } from "@/lib/tv-links";
+import { GrafanaKiosk } from "@/components/dashboard/grafana-kiosk";
+
+export const dynamic = "force-dynamic";
+
+export default async function TvKioskPage(props: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await props.params;
+  const link = await resolveActiveTvToken(token);
+  if (!link) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-neutral-950 px-6 text-center text-neutral-200">
+        <div>
+          <h1 className="text-xl font-semibold">Invalid TV link</h1>
+          <p className="mt-2 text-sm text-neutral-400">
+            This link is missing, expired, or revoked. Ask an admin to generate
+            a new one from TV wall links.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  return <GrafanaKiosk />;
+}

--- a/web/admin/components/auth-provider.tsx
+++ b/web/admin/components/auth-provider.tsx
@@ -52,6 +52,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
   const isTvKiosk = pathname?.startsWith("/tv/view/") ?? false;
+  const isTvKioskRef = React.useRef(isTvKiosk);
+  isTvKioskRef.current = isTvKiosk;
 
   const signOut = async () => {
     try {
@@ -65,10 +67,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   useEffect(() => {
-    if (isTvKiosk) {
-      setLoading(false);
-      return;
-    }
     if (bypassAuth) {
       setUser(createBypassUser());
       setIsAdmin(true);
@@ -94,17 +92,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             console.warn(
               `User ${currentUser.email} is not an admin. Signing out.`
             );
-            await firebaseSignOut(auth);
             setUser(null);
             setIsAdmin(false);
-            router.push("/login?error=unauthorized"); // Redirect non-admin to login
+            // Kiosk must not sign out or redirect — a TV may share a browser
+            // with an admin session, and kiosk→dashboard must not bounce login.
+            if (!isTvKioskRef.current) {
+              await firebaseSignOut(auth);
+              router.push("/login?error=unauthorized");
+            }
           }
         } catch (error) {
           console.error("Error checking admin status:", error);
-          await firebaseSignOut(auth);
           setUser(null);
           setIsAdmin(false);
-          router.push("/login?error=check_failed"); // Redirect on error
+          if (!isTvKioskRef.current) {
+            await firebaseSignOut(auth);
+            router.push("/login?error=check_failed");
+          }
         }
       } else {
         setUser(null);
@@ -115,7 +119,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     // Cleanup subscription on unmount
     return () => unsubscribe();
-  }, [bypassAuth, isTvKiosk, router]);
+  }, [bypassAuth, router]);
 
   return (
     <AuthContext.Provider value={{ user, isAdmin, loading, signOut }}>

--- a/web/admin/components/auth-provider.tsx
+++ b/web/admin/components/auth-provider.tsx
@@ -1,11 +1,25 @@
-'use client';
+"use client";
 
-import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
-import { User, onAuthStateChanged, signOut as firebaseSignOut } from 'firebase/auth';
-import { doc, getDoc } from 'firebase/firestore';
-import { getFirebaseAuth, getFirebaseDb } from '@/lib/firebase/client';
-import { DEV_BYPASS_ENABLED, DEV_BYPASS_TOKEN, DEV_BYPASS_UID } from '@/lib/dev-auth';
-import { useRouter } from 'next/navigation'; // Use next/navigation for App Router
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  ReactNode,
+} from "react";
+import {
+  User,
+  onAuthStateChanged,
+  signOut as firebaseSignOut,
+} from "firebase/auth";
+import { doc, getDoc } from "firebase/firestore";
+import { getFirebaseAuth, getFirebaseDb } from "@/lib/firebase/client";
+import {
+  DEV_BYPASS_ENABLED,
+  DEV_BYPASS_TOKEN,
+  DEV_BYPASS_UID,
+} from "@/lib/dev-auth";
+import { usePathname, useRouter } from "next/navigation"; // Use next/navigation for App Router
 
 interface AuthContextProps {
   user: User | null;
@@ -30,23 +44,31 @@ function createBypassUser(): User {
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const bypassAuth = DEV_BYPASS_ENABLED;
-  const [user, setUser] = useState<User | null>(bypassAuth ? createBypassUser() : null);
+  const [user, setUser] = useState<User | null>(
+    bypassAuth ? createBypassUser() : null
+  );
   const [isAdmin, setIsAdmin] = useState<boolean>(bypassAuth);
   const [loading, setLoading] = useState<boolean>(!bypassAuth);
   const router = useRouter();
+  const pathname = usePathname();
+  const isTvKiosk = pathname?.startsWith("/tv/view/") ?? false;
 
   const signOut = async () => {
     try {
       await firebaseSignOut(getFirebaseAuth());
       setUser(null);
       setIsAdmin(false);
-      router.push('/login'); // Redirect to login after sign out
+      router.push("/login"); // Redirect to login after sign out
     } catch (error) {
-      console.error('Error signing out:', error);
+      console.error("Error signing out:", error);
     }
   };
 
   useEffect(() => {
+    if (isTvKiosk) {
+      setLoading(false);
+      return;
+    }
     if (bypassAuth) {
       setUser(createBypassUser());
       setIsAdmin(true);
@@ -59,9 +81,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
       setLoading(true);
       if (currentUser) {
-        console.log('currentUser', currentUser);
+        console.log("currentUser", currentUser);
         // Check if user is an Omi admin by looking for their UID in the specific product path
-        const adminDocRef = doc(db, 'adminData', currentUser.uid);
+        const adminDocRef = doc(db, "adminData", currentUser.uid);
         try {
           const adminDoc = await getDoc(adminDocRef);
           if (adminDoc.exists()) {
@@ -69,18 +91,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             setIsAdmin(true);
             console.log(`Admin user ${currentUser.email} signed in.`);
           } else {
-            console.warn(`User ${currentUser.email} is not an admin. Signing out.`);
+            console.warn(
+              `User ${currentUser.email} is not an admin. Signing out.`
+            );
             await firebaseSignOut(auth);
             setUser(null);
             setIsAdmin(false);
-            router.push('/login?error=unauthorized'); // Redirect non-admin to login
+            router.push("/login?error=unauthorized"); // Redirect non-admin to login
           }
         } catch (error) {
-          console.error('Error checking admin status:', error);
+          console.error("Error checking admin status:", error);
           await firebaseSignOut(auth);
           setUser(null);
           setIsAdmin(false);
-          router.push('/login?error=check_failed'); // Redirect on error
+          router.push("/login?error=check_failed"); // Redirect on error
         }
       } else {
         setUser(null);
@@ -91,7 +115,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     // Cleanup subscription on unmount
     return () => unsubscribe();
-  }, [bypassAuth, router]); // Add router to dependency array
+  }, [bypassAuth, isTvKiosk, router]);
 
   return (
     <AuthContext.Provider value={{ user, isAdmin, loading, signOut }}>
@@ -100,4 +124,4 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 }
 
-export const useAuth = () => useContext(AuthContext); 
+export const useAuth = () => useContext(AuthContext);

--- a/web/admin/components/dashboard/grafana-kiosk.tsx
+++ b/web/admin/components/dashboard/grafana-kiosk.tsx
@@ -19,6 +19,7 @@ function GrafanaKioskFrame() {
         src={base}
         title="Omi TV"
         className="border-0"
+        referrerPolicy="no-referrer"
         allow="fullscreen"
         style={{
           width: pct,

--- a/web/admin/components/dashboard/grafana-kiosk.tsx
+++ b/web/admin/components/dashboard/grafana-kiosk.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import { grafanaBoardSrc } from "@/lib/grafana-board";
+
+function GrafanaKioskFrame() {
+  const params = useSearchParams();
+  const tvParam = params?.get("tv") ?? null;
+  const base = grafanaBoardSrc(params?.get("platform") ?? null, true);
+  const scale = tvParam
+    ? Math.min(Math.max(parseFloat(tvParam) || 1, 0.25), 1)
+    : 1;
+  const pct = `${(100 / scale).toFixed(4)}%`;
+
+  return (
+    <div className="h-screen w-screen overflow-hidden bg-black">
+      <iframe
+        src={base}
+        title="Omi TV"
+        className="border-0"
+        allow="fullscreen"
+        style={{
+          width: pct,
+          height: pct,
+          transform: `scale(${scale})`,
+          transformOrigin: "top left",
+        }}
+      />
+    </div>
+  );
+}
+
+export function GrafanaKiosk() {
+  return (
+    <Suspense fallback={<div className="h-screen w-screen bg-black" />}>
+      <GrafanaKioskFrame />
+    </Suspense>
+  );
+}

--- a/web/admin/components/dashboard/sidebar.tsx
+++ b/web/admin/components/dashboard/sidebar.tsx
@@ -24,6 +24,7 @@ import {
   Handshake,
   Star,
   MessageSquarePlus,
+  Tv,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -54,6 +55,11 @@ export function DashboardSidebar() {
       title: "Dashboard",
       href: "/dashboard",
       icon: LayoutGrid,
+    },
+    {
+      title: "TV wall links",
+      href: "/dashboard/tv-links",
+      icon: Tv,
     },
     {
       title: "Apps",

--- a/web/admin/components/dashboard/tv-links-panel.tsx
+++ b/web/admin/components/dashboard/tv-links-panel.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useAuthFetch, useAuthToken } from "@/hooks/useAuthToken";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Tv, Copy, Trash2, ArrowLeft, ExternalLink } from "lucide-react";
+
+type TvLinkRow = {
+  id: string;
+  prefix: string;
+  token: string | null;
+  path: string | null;
+  label: string;
+  createdBy: string;
+  createdAt: number;
+  expiresAt: number | null;
+  revokedAt: number | null;
+  lastUsedAt: number | null;
+  status: "active" | "expired" | "revoked";
+};
+
+function parseTtlDays(
+  raw: string
+): { ok: true; value: number | null } | { ok: false; error: string } {
+  const trimmed = raw.trim();
+  if (trimmed === "") return { ok: true, value: null };
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) {
+    return {
+      ok: false,
+      error:
+        "Expiry must be a positive whole number of days, or empty for never.",
+    };
+  }
+  if (n > 3650) {
+    return { ok: false, error: "Expiry cannot exceed 3650 days." };
+  }
+  return { ok: true, value: n };
+}
+
+function absoluteUrl(path: string | null): string | null {
+  if (!path) return null;
+  if (typeof window === "undefined") return path;
+  return `${window.location.origin}${path}`;
+}
+
+async function copyText(text: string) {
+  await navigator.clipboard.writeText(text);
+}
+
+/** Create / list / revoke secret Grafana kiosk URLs. */
+export function TvLinksPanel() {
+  const { fetchWithAuth, token } = useAuthFetch();
+  const { loading: authLoading } = useAuthToken();
+  const [links, setLinks] = useState<TvLinkRow[]>([]);
+  const [label, setLabel] = useState("Office TV");
+  const [ttlDays, setTtlDays] = useState("90");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!token) return;
+    try {
+      const res = await fetchWithAuth("/api/omi/tv-links");
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setLinks([]);
+        setError(body.error || `Failed to load TV links (${res.status})`);
+        return;
+      }
+      const data = await res.json();
+      setLinks(data.links || []);
+      setError(null);
+    } catch (e) {
+      setLinks([]);
+      setError(e instanceof Error ? e.message : "Failed to load TV links");
+    }
+  }, [fetchWithAuth, token]);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!token) {
+      setError("Sign in required to manage TV links");
+      return;
+    }
+    void refresh();
+  }, [authLoading, token, refresh]);
+
+  const markCopied = (id: string) => {
+    setCopiedId(id);
+    window.setTimeout(
+      () => setCopiedId((cur) => (cur === id ? null : cur)),
+      1500
+    );
+  };
+
+  const onCreate = async () => {
+    setBusy(true);
+    try {
+      const parsed = parseTtlDays(ttlDays);
+      if (!parsed.ok) {
+        setError(parsed.error);
+        return;
+      }
+      const res = await fetchWithAuth("/api/omi/tv-links", {
+        method: "POST",
+        body: JSON.stringify({
+          label,
+          ttlDays: parsed.value,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || "Create failed");
+      const url = data.url || (data.path ? absoluteUrl(data.path) : null);
+      if (url) {
+        try {
+          await copyText(url);
+          markCopied(data.link?.id || "new");
+        } catch {
+          // Clipboard may be blocked; still refresh so the new link is visible.
+        }
+      }
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onCopy = async (row: TvLinkRow) => {
+    const url = absoluteUrl(row.path);
+    if (!url) {
+      setError(
+        "This legacy link has no stored token — revoke and create a new one."
+      );
+      return;
+    }
+    try {
+      await copyText(url);
+      markCopied(row.id);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Copy failed");
+    }
+  };
+
+  const onRevoke = async (id: string) => {
+    if (
+      !confirm(
+        "Revoke this TV link? The wall URL will stop working immediately."
+      )
+    ) {
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await fetchWithAuth(`/api/omi/tv-links/${id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Revoke failed");
+      }
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="flex items-center gap-2 text-3xl font-bold tracking-tight">
+            <Tv className="h-7 w-7" />
+            TV wall links
+          </h2>
+          <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+            Secret kiosk URLs for office displays. No Google / admin login on
+            the TV — they open the live Grafana Omi TV board. Copy anytime.
+            Revoke to kill a link.
+          </p>
+        </div>
+        <Button asChild variant="outline" size="sm">
+          <Link href="/dashboard">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Dashboard
+          </Link>
+        </Button>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm">
+          {error}
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Create link</CardTitle>
+          <CardDescription>
+            Default expiry 90 days. New links are copied to the clipboard when
+            possible and stay copyable from the table below.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="tv-label">Label</Label>
+              <Input
+                id="tv-label"
+                value={label}
+                onChange={(e) => setLabel(e.target.value)}
+                placeholder="Office TV"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="tv-ttl">Expiry (days, empty = never)</Label>
+              <Input
+                id="tv-ttl"
+                value={ttlDays}
+                onChange={(e) => setTtlDays(e.target.value)}
+                placeholder="90"
+                inputMode="numeric"
+              />
+            </div>
+          </div>
+          <Button onClick={() => void onCreate()} disabled={busy || !token}>
+            Generate TV link
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Existing links</CardTitle>
+          <CardDescription>
+            Copy opens the full kiosk URL. Optional query params on the URL:{" "}
+            <code>?tv=0.55</code> (Fire TV scale) and{" "}
+            <code>&platform=macos</code> or <code>mobile</code>.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left">
+                  <th className="py-2 pr-3">Label</th>
+                  <th className="py-2 pr-3">URL</th>
+                  <th className="py-2 pr-3">Status</th>
+                  <th className="py-2 pr-3">Created</th>
+                  <th className="py-2 pr-3">Expires</th>
+                  <th className="py-2 pr-3">Last used</th>
+                  <th className="py-2"> </th>
+                </tr>
+              </thead>
+              <tbody>
+                {links.map((l) => {
+                  const url = absoluteUrl(l.path);
+                  return (
+                    <tr key={l.id} className="border-b border-border/60">
+                      <td className="py-2 pr-3 font-medium">{l.label}</td>
+                      <td className="max-w-[18rem] py-2 pr-3">
+                        {url ? (
+                          <code className="break-all text-xs">{url}</code>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">
+                            {l.prefix}… (recreate to copy)
+                          </span>
+                        )}
+                      </td>
+                      <td className="py-2 pr-3">{l.status}</td>
+                      <td className="whitespace-nowrap py-2 pr-3">
+                        {new Date(l.createdAt).toLocaleString()}
+                      </td>
+                      <td className="whitespace-nowrap py-2 pr-3">
+                        {l.expiresAt
+                          ? new Date(l.expiresAt).toLocaleDateString()
+                          : "never"}
+                      </td>
+                      <td className="whitespace-nowrap py-2 pr-3">
+                        {l.lastUsedAt
+                          ? new Date(l.lastUsedAt).toLocaleString()
+                          : "—"}
+                      </td>
+                      <td className="py-2">
+                        <div className="flex items-center justify-end gap-1">
+                          {url && l.status === "active" ? (
+                            <>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                disabled={busy}
+                                onClick={() => void onCopy(l)}
+                                aria-label={`Copy ${l.label}`}
+                                title="Copy URL"
+                              >
+                                <Copy className="h-4 w-4" />
+                                {copiedId === l.id ? (
+                                  <span className="ml-1 text-xs">Copied</span>
+                                ) : null}
+                              </Button>
+                              <Button size="sm" variant="ghost" asChild>
+                                <a
+                                  href={url}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  title="Open"
+                                >
+                                  <ExternalLink className="h-4 w-4" />
+                                </a>
+                              </Button>
+                            </>
+                          ) : null}
+                          {l.status === "active" && (
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              disabled={busy}
+                              onClick={() => void onRevoke(l.id)}
+                              aria-label={`Revoke ${l.label}`}
+                              title="Revoke"
+                            >
+                              <Trash2 className="h-4 w-4 text-destructive" />
+                            </Button>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+                {links.length === 0 && !error && (
+                  <tr>
+                    <td
+                      colSpan={7}
+                      className="py-6 text-center text-muted-foreground"
+                    >
+                      {authLoading || !token
+                        ? "Loading…"
+                        : "No TV links yet — generate one to open the wall view"}
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/web/admin/components/dashboard/tv-links-panel.tsx
+++ b/web/admin/components/dashboard/tv-links-panel.tsx
@@ -128,10 +128,16 @@ export function TvLinksPanel() {
           await copyText(url);
           markCopied(data.link?.id || "new");
         } catch {
-          // Clipboard may be blocked; still refresh so the new link is visible.
+          // Clipboard may be blocked; still keep the new link visible below.
         }
       }
       await refresh();
+      if (data.link) {
+        setLinks((current) => [
+          data.link,
+          ...current.filter((link) => link.id !== data.link.id),
+        ]);
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {

--- a/web/admin/docs/tv-mode.md
+++ b/web/admin/docs/tv-mode.md
@@ -1,0 +1,24 @@
+# Admin TV share links
+
+Kiosk wall = Grafana `omi-tv` (same board as `/dashboard`), opened via a
+secret URL. No custom metrics board.
+
+| Surface | Auth | Role |
+| --- | --- | --- |
+| `/dashboard` | Firebase admin | Grafana embed (edit chrome) |
+| `/dashboard/tv-links` | Firebase admin | Create / list / copy / revoke |
+| `/tv/view/<token>` | Capability token | Kiosk Grafana (`&kiosk`) |
+| `GET/POST /api/omi/tv-links` | Firebase admin | Manage |
+| `DELETE /api/omi/tv-links/[id]` | Firebase admin | Revoke (`await props.params`) |
+
+Optional query on the kiosk URL: `?tv=0.55` (Fire TV scale), `&platform=macos|mobile`.
+
+Firestore `admin_tv_links`; doc id = sha256 hex; store `tokenHash` + `token`.
+Default TTL 90d. TV tokens unlock the kiosk page only — they do not change
+Grafana's own auth. Live Grafana is already anonymously readable at
+`/grafana/d/omi-tv`; the share link is a revocable, login-free wrapper.
+
+`AuthProvider` must skip admin check/sign-out/redirect on `/tv/view/*`.
+
+Local: `NEXT_PUBLIC_DEV_BYPASS_AUTH=1 npm run dev`. Kiosk without Firestore:
+`/tv/view/dev-kiosk`. Mint/revoke still needs `FIREBASE_*` Admin SDK env.

--- a/web/admin/lib/__tests__/tv-mode.test.ts
+++ b/web/admin/lib/__tests__/tv-mode.test.ts
@@ -1,0 +1,82 @@
+import { createHash } from "crypto";
+import { describe, expect, it } from "vitest";
+
+import { grafanaBoardPath, grafanaBoardSrc } from "../grafana-board";
+import {
+  generateTvToken,
+  hashTvToken,
+  isTvLinkActive,
+  safeEqualHex,
+  tvLinkStatus,
+} from "../tv-links";
+
+describe("tv-links crypto", () => {
+  it("hashes tokens with sha256 hex", () => {
+    const token = "test-token-value";
+    expect(hashTvToken(token)).toBe(
+      createHash("sha256").update(token, "utf8").digest("hex")
+    );
+  });
+
+  it("generates high-entropy tokens with matching hash/prefix", () => {
+    const a = generateTvToken();
+    const b = generateTvToken();
+    expect(a.token).not.toEqual(b.token);
+    expect(a.token.length).toBeGreaterThanOrEqual(40);
+    expect(a.tokenHash).toBe(hashTvToken(a.token));
+    expect(a.prefix).toBe(a.token.slice(0, 8));
+  });
+
+  it("compares hex digests in constant-time style", () => {
+    const h = hashTvToken("abc");
+    expect(safeEqualHex(h, h)).toBe(true);
+    expect(safeEqualHex(h, hashTvToken("xyz"))).toBe(false);
+    expect(safeEqualHex("aa", "aabb")).toBe(false);
+  });
+});
+
+describe("tv link status", () => {
+  const now = 1_700_000_000_000;
+
+  it("marks active / expired / revoked correctly", () => {
+    expect(tvLinkStatus({ revokedAt: null, expiresAt: null }, now)).toBe(
+      "active"
+    );
+    expect(tvLinkStatus({ revokedAt: null, expiresAt: now + 1000 }, now)).toBe(
+      "active"
+    );
+    expect(tvLinkStatus({ revokedAt: null, expiresAt: now - 1 }, now)).toBe(
+      "expired"
+    );
+    expect(tvLinkStatus({ revokedAt: now, expiresAt: null }, now)).toBe(
+      "revoked"
+    );
+    expect(isTvLinkActive({ revokedAt: null, expiresAt: now + 1 }, now)).toBe(
+      true
+    );
+    expect(isTvLinkActive({ revokedAt: now, expiresAt: null }, now)).toBe(
+      false
+    );
+  });
+});
+
+describe("grafana board src", () => {
+  it("uses omi-tv by default and kiosk query when asked", () => {
+    expect(grafanaBoardPath(null, false)).toBe("/grafana/d/omi-tv/?refresh=5m");
+    expect(grafanaBoardPath(null, true)).toBe(
+      "/grafana/d/omi-tv/?refresh=5m&kiosk"
+    );
+    expect(grafanaBoardPath("macos", true)).toBe(
+      "/grafana/d/omi-tv-macos/?refresh=5m&kiosk"
+    );
+    expect(grafanaBoardPath("mobile", false)).toBe(
+      "/grafana/d/omi-tv-mobile/?refresh=5m"
+    );
+  });
+
+  it("falls back to path when NEXT_PUBLIC_GRAFANA_URL is unset", () => {
+    expect(grafanaBoardSrc(null, true)).toBe(
+      "/grafana/d/omi-tv/?refresh=5m&kiosk"
+    );
+  });
+});

--- a/web/admin/lib/__tests__/tv-mode.test.ts
+++ b/web/admin/lib/__tests__/tv-mode.test.ts
@@ -23,6 +23,7 @@ describe("tv-links crypto", () => {
     const b = generateTvToken();
     expect(a.token).not.toEqual(b.token);
     expect(a.token.length).toBeGreaterThanOrEqual(40);
+    expect(a.token).toMatch(/^[A-Za-z0-9_-]{32,64}$/);
     expect(a.tokenHash).toBe(hashTvToken(a.token));
     expect(a.prefix).toBe(a.token.slice(0, 8));
   });
@@ -71,6 +72,12 @@ describe("grafana board src", () => {
     );
     expect(grafanaBoardPath("mobile", false)).toBe(
       "/grafana/d/omi-tv-mobile/?refresh=5m"
+    );
+    expect(grafanaBoardPath("constructor", true)).toBe(
+      "/grafana/d/omi-tv/?refresh=5m&kiosk"
+    );
+    expect(grafanaBoardPath("__proto__", false)).toBe(
+      "/grafana/d/omi-tv/?refresh=5m"
     );
   });
 

--- a/web/admin/lib/grafana-board.ts
+++ b/web/admin/lib/grafana-board.ts
@@ -8,7 +8,10 @@ export function grafanaBoardPath(
   platform: string | null | undefined,
   kiosk = false
 ): string {
-  const uid = GRAFANA_BOARD_UIDS[platform ?? ""] ?? "omi-tv";
+  const key = platform ?? "";
+  const uid = Object.hasOwn(GRAFANA_BOARD_UIDS, key)
+    ? GRAFANA_BOARD_UIDS[key]
+    : "omi-tv";
   const qs = kiosk ? "refresh=5m&kiosk" : "refresh=5m";
   return `/grafana/d/${uid}/?${qs}`;
 }

--- a/web/admin/lib/grafana-board.ts
+++ b/web/admin/lib/grafana-board.ts
@@ -1,0 +1,31 @@
+export const GRAFANA_BOARD_UIDS: Record<string, string> = {
+  macos: "omi-tv-macos",
+  mobile: "omi-tv-mobile",
+};
+
+/** Same-origin Grafana path used by /dashboard and TV kiosk iframes. */
+export function grafanaBoardPath(
+  platform: string | null | undefined,
+  kiosk = false
+): string {
+  const uid = GRAFANA_BOARD_UIDS[platform ?? ""] ?? "omi-tv";
+  const qs = kiosk ? "refresh=5m&kiosk" : "refresh=5m";
+  return `/grafana/d/${uid}/?${qs}`;
+}
+
+/**
+ * Iframe src. `NEXT_PUBLIC_GRAFANA_URL` overrides the whole URL (local dev)
+ * and ignores platform, matching /dashboard.
+ */
+export function grafanaBoardSrc(
+  platform: string | null | undefined,
+  kiosk = false
+): string {
+  const override = process.env.NEXT_PUBLIC_GRAFANA_URL ?? "";
+  if (override) {
+    if (!kiosk) return override;
+    if (/(?:[?&])kiosk(?:&|=|$)/.test(override)) return override;
+    return override.includes("?") ? `${override}&kiosk` : `${override}?kiosk`;
+  }
+  return grafanaBoardPath(platform, kiosk);
+}

--- a/web/admin/lib/tv-links.ts
+++ b/web/admin/lib/tv-links.ts
@@ -198,7 +198,8 @@ export async function resolveActiveTvToken(
   if (DEV_BYPASS_ENABLED && rawToken === "dev-kiosk") {
     return { id: "dev-kiosk", label: "Dev TV" };
   }
-  if (!rawToken || rawToken.length < 16) return null;
+  // Reject junk before a Firestore read (base64url from generateTvToken).
+  if (!/^[A-Za-z0-9_-]{32,64}$/.test(rawToken)) return null;
   try {
     const tokenHash = hashTvToken(rawToken);
     const ref = getDb().collection(TV_LINKS_COLLECTION).doc(tokenHash);

--- a/web/admin/lib/tv-links.ts
+++ b/web/admin/lib/tv-links.ts
@@ -1,0 +1,216 @@
+import { createHash, randomBytes, timingSafeEqual } from "crypto";
+import { DEV_BYPASS_ENABLED } from "@/lib/dev-auth";
+import { getDb } from "@/lib/firebase/admin";
+
+export const TV_LINKS_COLLECTION = "admin_tv_links";
+export const DEFAULT_TV_LINK_TTL_DAYS = 90;
+
+export type TvLinkRecord = {
+  tokenHash: string;
+  /** Full token so admins can re-copy the kiosk URL anytime. */
+  token: string;
+  prefix: string;
+  label: string;
+  createdBy: string;
+  createdAt: number;
+  expiresAt: number | null;
+  revokedAt: number | null;
+  lastUsedAt: number | null;
+};
+
+export type TvLinkPublic = {
+  id: string;
+  prefix: string;
+  token: string | null;
+  path: string | null;
+  label: string;
+  createdBy: string;
+  createdAt: number;
+  expiresAt: number | null;
+  revokedAt: number | null;
+  lastUsedAt: number | null;
+  status: "active" | "expired" | "revoked";
+};
+
+export function hashTvToken(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+export function generateTvToken(): {
+  token: string;
+  tokenHash: string;
+  prefix: string;
+} {
+  const token = randomBytes(32).toString("base64url");
+  const tokenHash = hashTvToken(token);
+  return { token, tokenHash, prefix: token.slice(0, 8) };
+}
+
+export function tvLinkStatus(
+  link: Pick<TvLinkRecord, "revokedAt" | "expiresAt">,
+  now = Date.now()
+): "active" | "expired" | "revoked" {
+  if (link.revokedAt != null) return "revoked";
+  if (link.expiresAt != null && link.expiresAt <= now) return "expired";
+  return "active";
+}
+
+export function isTvLinkActive(
+  link: Pick<TvLinkRecord, "revokedAt" | "expiresAt">,
+  now = Date.now()
+): boolean {
+  return tvLinkStatus(link, now) === "active";
+}
+
+/** Constant-time compare of hex digests. */
+export function safeEqualHex(a: string, b: string): boolean {
+  try {
+    const ba = Buffer.from(a, "hex");
+    const bb = Buffer.from(b, "hex");
+    if (ba.length !== bb.length || ba.length === 0) return false;
+    return timingSafeEqual(ba, bb);
+  } catch {
+    return false;
+  }
+}
+
+function toPublic(id: string, data: TvLinkRecord): TvLinkPublic {
+  const token =
+    typeof data.token === "string" && data.token.length >= 16
+      ? data.token
+      : null;
+  return {
+    id,
+    prefix: data.prefix,
+    token,
+    path: token ? `/tv/view/${token}` : null,
+    label: data.label,
+    createdBy: data.createdBy,
+    createdAt: data.createdAt,
+    expiresAt: data.expiresAt,
+    revokedAt: data.revokedAt,
+    lastUsedAt: data.lastUsedAt,
+    status: tvLinkStatus(data),
+  };
+}
+
+/**
+ * List TV links newest-first. Pages through Firestore so older active links
+ * remain revocable (a hard limit would hide leaked long-lived URLs).
+ */
+export async function listTvLinks(): Promise<TvLinkPublic[]> {
+  const pageSize = 200;
+  const maxPages = 25; // hard cap 5_000 rows
+  const out: TvLinkPublic[] = [];
+  let last: FirebaseFirestore.QueryDocumentSnapshot | undefined;
+
+  for (let page = 0; page < maxPages; page++) {
+    let q = getDb()
+      .collection(TV_LINKS_COLLECTION)
+      .orderBy("createdAt", "desc")
+      .limit(pageSize);
+    if (last) q = q.startAfter(last);
+    const snap = await q.get();
+    if (snap.empty) break;
+    for (const d of snap.docs) {
+      const pub = toPublic(d.id, d.data() as TvLinkRecord);
+      if (pub.status === "revoked") continue;
+      out.push(pub);
+    }
+    last = snap.docs[snap.docs.length - 1];
+    if (snap.size < pageSize) break;
+  }
+  return out;
+}
+
+export async function createTvLink(input: {
+  label: string;
+  createdBy: string;
+  ttlDays?: number | null;
+}): Promise<{ link: TvLinkPublic; token: string; path: string }> {
+  const label = input.label.trim() || "Office TV";
+  const { token, tokenHash, prefix } = generateTvToken();
+  const now = Date.now();
+  let ttlDays: number | null;
+  if (input.ttlDays === null) {
+    ttlDays = null;
+  } else if (typeof input.ttlDays === "number") {
+    if (
+      !Number.isFinite(input.ttlDays) ||
+      !Number.isInteger(input.ttlDays) ||
+      input.ttlDays < 1
+    ) {
+      throw new Error("ttlDays must be a positive integer or null");
+    }
+    ttlDays = input.ttlDays;
+  } else {
+    ttlDays = DEFAULT_TV_LINK_TTL_DAYS;
+  }
+  const expiresAt =
+    ttlDays == null ? null : now + ttlDays * 24 * 60 * 60 * 1000;
+
+  const record: TvLinkRecord = {
+    tokenHash,
+    token,
+    prefix,
+    label,
+    createdBy: input.createdBy,
+    createdAt: now,
+    expiresAt,
+    revokedAt: null,
+    lastUsedAt: null,
+  };
+
+  await getDb().collection(TV_LINKS_COLLECTION).doc(tokenHash).set(record);
+  return {
+    link: toPublic(tokenHash, record),
+    token,
+    path: `/tv/view/${token}`,
+  };
+}
+
+export async function revokeTvLink(id: string): Promise<TvLinkPublic | null> {
+  const ref = getDb().collection(TV_LINKS_COLLECTION).doc(id);
+  const snap = await ref.get();
+  if (!snap.exists) return null;
+  const data = snap.data() as TvLinkRecord;
+  if (data.revokedAt == null) {
+    const revokedAt = Date.now();
+    await ref.update({ revokedAt });
+    data.revokedAt = revokedAt;
+  }
+  return toPublic(id, data);
+}
+
+export type ResolvedTvLink = {
+  id: string;
+  label: string;
+};
+
+/**
+ * Resolve a raw TV path token to an active link.
+ * Updates lastUsedAt at most once per minute.
+ */
+export async function resolveActiveTvToken(
+  rawToken: string
+): Promise<ResolvedTvLink | null> {
+  // ponytail: local QA only — production disables DEV_BYPASS. Use Firestore tokens in prod.
+  if (DEV_BYPASS_ENABLED && rawToken === "dev-kiosk") {
+    return { id: "dev-kiosk", label: "Dev TV" };
+  }
+  if (!rawToken || rawToken.length < 16) return null;
+  const tokenHash = hashTvToken(rawToken);
+  const ref = getDb().collection(TV_LINKS_COLLECTION).doc(tokenHash);
+  const snap = await ref.get();
+  if (!snap.exists) return null;
+  const data = snap.data() as TvLinkRecord;
+  if (!safeEqualHex(data.tokenHash || tokenHash, tokenHash)) return null;
+  if (!isTvLinkActive(data)) return null;
+
+  const now = Date.now();
+  if (!data.lastUsedAt || now - data.lastUsedAt > 60_000) {
+    await ref.update({ lastUsedAt: now }).catch(() => undefined);
+  }
+
+  return { id: snap.id, label: data.label };
+}

--- a/web/admin/lib/tv-links.ts
+++ b/web/admin/lib/tv-links.ts
@@ -199,18 +199,23 @@ export async function resolveActiveTvToken(
     return { id: "dev-kiosk", label: "Dev TV" };
   }
   if (!rawToken || rawToken.length < 16) return null;
-  const tokenHash = hashTvToken(rawToken);
-  const ref = getDb().collection(TV_LINKS_COLLECTION).doc(tokenHash);
-  const snap = await ref.get();
-  if (!snap.exists) return null;
-  const data = snap.data() as TvLinkRecord;
-  if (!safeEqualHex(data.tokenHash || tokenHash, tokenHash)) return null;
-  if (!isTvLinkActive(data)) return null;
+  try {
+    const tokenHash = hashTvToken(rawToken);
+    const ref = getDb().collection(TV_LINKS_COLLECTION).doc(tokenHash);
+    const snap = await ref.get();
+    if (!snap.exists) return null;
+    const data = snap.data() as TvLinkRecord;
+    if (!safeEqualHex(data.tokenHash || tokenHash, tokenHash)) return null;
+    if (!isTvLinkActive(data)) return null;
 
-  const now = Date.now();
-  if (!data.lastUsedAt || now - data.lastUsedAt > 60_000) {
-    await ref.update({ lastUsedAt: now }).catch(() => undefined);
+    const now = Date.now();
+    if (!data.lastUsedAt || now - data.lastUsedAt > 60_000) {
+      await ref.update({ lastUsedAt: now }).catch(() => undefined);
+    }
+
+    return { id: snap.id, label: data.label };
+  } catch (error) {
+    console.error("resolve TV token:", error);
+    return null;
   }
-
-  return { id: snap.id, label: data.label };
 }


### PR DESCRIPTION
## Summary
- Secret Grafana kiosk URLs at `/tv/view/<token>` (no Firebase/admin login)
- Manage (create / copy anytime / revoke) on `/dashboard/tv-links`
- Embeds the live `omi-tv` Grafana board (`&kiosk`); optional `?tv=0.55` and `?platform=macos|mobile`
- Does **not** ship the custom Next TV board from #11280

## Test plan
- [x] `npm test -- lib/__tests__/tv-mode.test.ts`
- [ ] Sidebar → TV wall links → generate → open kiosk (no login) → revoke → invalid page
- [ ] Local: `NEXT_PUBLIC_DEV_BYPASS_AUTH=1 npm run dev` then `/tv/view/dev-kiosk`

## Failure class (fixes)
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

