### PR TITLE
fix(app): stop chat transcript scrunching on scroll

### DIFF
--- a/.github/failure-classes/FC-scroll-rebuild-collapses-list-extents.json
+++ b/.github/failure-classes/FC-scroll-rebuild-collapses-list-extents.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "id": "FC-scroll-rebuild-collapses-list-extents",
+  "violated_contract": "A scrolling list of intrinsically sized children (chat markdown, citation rows) must keep stable sliver extents across a user drag. setState on every pointer-move, or changing ListView padding when follow-mode flips, may cache a tight/zero child extent so already-visible text and citation titles scrunch after a tiny scroll even though first paint and newly appended messages looked fine.",
+  "canonical_prevention": "Rebuild the transcript only when follow-mode actually changes; keep list padding independent of follow-mode. Cover with a ListView.builder drag that asserts citation RenderBox height and title text still present — pumping AIMessage in a SingleChildScrollView is not this contract.",
+  "canonical_prevention_artifact": [
+    "app/test/widgets/chat_scroll_layout_test.dart",
+    "app/lib/pages/chat/chat_scroll_policy.dart"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "app/lib/pages/chat/**"
+  ],
+  "status": "open"
+}

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -94,6 +94,7 @@ PR CI runs `flutter test` and an analyzer ratchet (`app/scripts/analyze_ratchet.
 - Mock singletons (SharedPreferencesUtil, AuthService, FirebaseAuth) since they aren't injectable
 - Test state machine logic via minimal abstractions mirroring production flow
 - Everything under `test/` must be hermetic — no network, live backends, or real devices — because `bash test.sh` (the CI suite) runs all of it.
+- Chat transcript layout: a test that only pumps `AIMessage` in a `SingleChildScrollView` misses scroll-extent bugs. Chat list changes must keep `test/widgets/chat_scroll_layout_test.dart` green (ListView drag + citation/markdown sizes). That file is the Mobile App Checks contract for this class.
 - A test that needs a live service, device, or real API goes under `integration_test/`, which `test.sh`/CI never runs. For integration tests against a local backend, set `OMI_APP_TEST_API_BASE_URL=http://127.0.0.1:<port>/`; use `OMI_APP_TEST_USE_PROD_API_DEFAULT=1` only when a test intentionally needs the prod API default. State in the PR how you ran it; it must not be the only evidence the change works.
 - Coverage rules (bug fix → regression test; feature → core + main error path): see root `AGENTS.md` → Testing.
 

--- a/app/lib/pages/chat/chat_scroll_policy.dart
+++ b/app/lib/pages/chat/chat_scroll_policy.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/widgets.dart';
+
+enum ChatScrollMode { followingBottom, freeScrolling }
+
+/// Scroll-follow policy for the chat transcript.
+///
+/// Rebuilds and list padding must stay stable during a drag. Changing
+/// [ListView] padding or calling setState on every pointer-move corrupts
+/// sliver child extents and scrunches markdown/citation text.
+class ChatScrollPolicy {
+  static const liveEdgePx = 24.0;
+
+  /// Extra space so the Latest chip can overlay the list without covering
+  /// the last message. Must not depend on [ChatScrollMode] — a padding
+  /// change mid-drag relayouts every child.
+  static const transcriptBottomPadding = 72.0;
+
+  static bool atLiveEdge(ScrollMetrics metrics) {
+    return metrics.maxScrollExtent - metrics.pixels <= liveEdgePx && metrics.maxScrollExtent > 0;
+  }
+
+  /// Next mode, or null if the transcript should not rebuild.
+  static ChatScrollMode? nextMode({
+    required ChatScrollMode current,
+    required bool isUserOrDragScroll,
+    required bool atLiveEdge,
+  }) {
+    if (atLiveEdge) {
+      if (current == ChatScrollMode.freeScrolling) {
+        return ChatScrollMode.followingBottom;
+      }
+      return null;
+    }
+    if (isUserOrDragScroll && current == ChatScrollMode.followingBottom) {
+      return ChatScrollMode.freeScrolling;
+    }
+    return null;
+  }
+}

--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -20,6 +20,7 @@ import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/message.dart';
 import 'package:omi/gen/assets.gen.dart';
 import 'package:omi/pages/apps/widgets/capability_apps_page.dart';
+import 'package:omi/pages/chat/chat_scroll_policy.dart';
 import 'package:omi/pages/chat/widgets/ai_message.dart';
 import 'package:omi/pages/chat/widgets/jump_to_latest_button.dart';
 import 'package:omi/pages/settings/widgets/plans_sheet.dart';
@@ -39,8 +40,6 @@ import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/other/temp.dart';
 import 'package:omi/widgets/dialog.dart';
 import 'package:omi/widgets/bottom_nav_bar.dart';
-
-enum _ChatScrollMode { followingBottom, freeScrolling }
 
 class ChatPage extends StatefulWidget {
   final bool isPivotBottom;
@@ -69,7 +68,7 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
   bool _hasInitialScrolled = false;
   MessageProvider? _messageProvider;
 
-  _ChatScrollMode _chatScrollMode = _ChatScrollMode.followingBottom;
+  ChatScrollMode _chatScrollMode = ChatScrollMode.followingBottom;
   final List<Timer> _pendingScrollTimers = [];
   bool _isProgrammaticScroll = false;
   int _lastObservedMessageCount = 0;
@@ -282,11 +281,11 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                                                 shrinkWrap: false,
                                                 reverse: false,
                                                 controller: scrollController,
-                                                padding: EdgeInsets.fromLTRB(
+                                                padding: const EdgeInsets.fromLTRB(
                                                   18,
                                                   16,
                                                   18,
-                                                  _chatScrollMode == _ChatScrollMode.freeScrolling ? 72 : 10,
+                                                  ChatScrollPolicy.transcriptBottomPadding,
                                                 ),
                                                 itemCount: provider.messages.length,
                                                 itemBuilder: (context, chatIndex) {
@@ -341,7 +340,7 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                                               ),
                                             ),
                                           ),
-                                          if (_chatScrollMode == _ChatScrollMode.freeScrolling)
+                                          if (_chatScrollMode == ChatScrollMode.freeScrolling)
                                             _buildJumpToLatestButton(),
                                         ],
                                       ),
@@ -1101,7 +1100,7 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
       return;
     }
 
-    if (_chatScrollMode == _ChatScrollMode.followingBottom &&
+    if (_chatScrollMode == ChatScrollMode.followingBottom &&
         (addedMessages || lastMessageChanged || streamedTextChanged || streamedBlocksChanged)) {
       _scheduleModeAwareScroll(delayMs: 0, animated: streamedTextChanged || streamedBlocksChanged);
     }
@@ -1115,24 +1114,16 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
 
     if (_isProgrammaticScroll && !isUserScroll && !isDragScroll) return false;
 
-    // Resume live following when the reader scrolls back to the live edge.
-    // maxScrollExtent - pixels <= threshold means we're at/near the bottom.
-    if (notification.metrics.maxScrollExtent - notification.metrics.pixels <= 24 &&
-        notification.metrics.maxScrollExtent > 0) {
-      if (_chatScrollMode == _ChatScrollMode.freeScrolling) {
-        _chatScrollMode = _ChatScrollMode.followingBottom;
-        _cancelPendingScrolls();
-        if (mounted) setState(() {});
-      }
-      return false;
-    }
+    final next = ChatScrollPolicy.nextMode(
+      current: _chatScrollMode,
+      isUserOrDragScroll: isUserScroll || isDragScroll,
+      atLiveEdge: ChatScrollPolicy.atLiveEdge(notification.metrics),
+    );
+    if (next == null) return false;
 
-    if (isUserScroll || isDragScroll) {
-      _chatScrollMode = _ChatScrollMode.freeScrolling;
-      _cancelPendingScrolls();
-      if (mounted) setState(() {});
-    }
-
+    _chatScrollMode = next;
+    _cancelPendingScrolls();
+    if (mounted) setState(() {});
     return false;
   }
 
@@ -1146,7 +1137,7 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
 
   void _resumeFollowingAndScroll({int delayMs = 0, bool animated = false}) {
     _cancelPendingScrolls();
-    _chatScrollMode = _ChatScrollMode.followingBottom;
+    _chatScrollMode = ChatScrollMode.followingBottom;
     if (mounted) setState(() {});
     _scheduleModeAwareScroll(delayMs: delayMs, animated: animated, force: true);
   }
@@ -1180,7 +1171,7 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
 
   void _scrollToBottom({bool animated = false, bool force = false}) {
     if (!scrollController.hasClients) return;
-    if (!force && _chatScrollMode != _ChatScrollMode.followingBottom) return;
+    if (!force && _chatScrollMode != ChatScrollMode.followingBottom) return;
 
     final position = scrollController.position;
     final target = position.maxScrollExtent;

--- a/app/test/widgets/chat_scroll_layout_test.dart
+++ b/app/test/widgets/chat_scroll_layout_test.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:omi/backend/schema/message.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/chat/chat_scroll_policy.dart';
+import 'package:omi/pages/chat/widgets/ai_message.dart';
+import 'package:omi/providers/connectivity_provider.dart';
+import 'package:omi/providers/conversation_provider.dart';
+
+void main() {
+  ServerMessage messageWithMemories({int memoryCount = 5}) {
+    final createdAt = DateTime.parse('2026-08-23T12:00:00Z');
+    final memories = List<MessageConversation>.generate(
+      memoryCount,
+      (index) => MessageConversation(
+        'convo-$index',
+        createdAt,
+        MessageConversationStructured('Conversation $index', '🧠'),
+      ),
+    );
+    return ServerMessage(
+      'ai-1',
+      createdAt,
+      'You talked about shipping the citation fix. What is up.',
+      MessageSender.ai,
+      MessageType.text,
+      null,
+      false,
+      const [],
+      const [],
+      memories,
+    );
+  }
+
+  test(
+    'continued drag while already free-scrolling does not request a rebuild',
+    () {
+      expect(
+        ChatScrollPolicy.nextMode(
+          current: ChatScrollMode.freeScrolling,
+          isUserOrDragScroll: true,
+          atLiveEdge: false,
+        ),
+        isNull,
+      );
+    },
+  );
+
+  test('first user drag while following requests free-scrolling once', () {
+    expect(
+      ChatScrollPolicy.nextMode(
+        current: ChatScrollMode.followingBottom,
+        isUserOrDragScroll: true,
+        atLiveEdge: false,
+      ),
+      ChatScrollMode.freeScrolling,
+    );
+  });
+
+  test('transcript bottom padding does not depend on scroll mode', () {
+    expect(ChatScrollPolicy.transcriptBottomPadding, 72);
+  });
+
+  testWidgets('a drag while following rebuilds the transcript at most once', (
+    tester,
+  ) async {
+    final rebuilds = <int>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: _ScrollHost(
+          onRebuild: () => rebuilds.add(1),
+          child: ListView(
+            children: List.generate(
+              30,
+              (i) => SizedBox(height: 80, child: Text('row $i')),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.drag(find.byType(ListView), const Offset(0, -120));
+    await tester.pump();
+
+    expect(rebuilds.length, lessThanOrEqualTo(1));
+  });
+
+  testWidgets(
+    'citation titles and heights survive a ListView drag under keyboard inset',
+    (tester) async {
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1.0;
+      tester.view.viewInsets = const FakeViewPadding(bottom: 336);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.view.resetViewInsets);
+
+      final conversationProvider = ConversationProvider(
+        isSignedIn: () => false,
+      );
+      addTearDown(conversationProvider.dispose);
+      final message = messageWithMemories();
+
+      await tester.pumpWidget(
+        MultiProvider(
+          providers: [
+            ChangeNotifierProvider.value(value: conversationProvider),
+            ChangeNotifierProvider(create: (_) => ConnectivityProvider()),
+          ],
+          child: MaterialApp(
+            theme: ThemeData.dark(),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: _ScrollHost(
+                child: ListView.builder(
+                  padding: const EdgeInsets.fromLTRB(
+                    18,
+                    16,
+                    18,
+                    ChatScrollPolicy.transcriptBottomPadding,
+                  ),
+                  itemCount: 4,
+                  itemBuilder: (context, index) {
+                    return Padding(
+                      key: ValueKey('msg-$index'),
+                      padding: const EdgeInsets.only(top: 16),
+                      child: AIMessage(
+                        message: message,
+                        sendMessage: (_) {},
+                        displayOptions: false,
+                        updateConversation: (_) {},
+                        setMessageNps: (int value, {String? reason}) {},
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final citation = find.byKey(const ValueKey('chat-citation-convo-0')).first;
+      expect(citation, findsOneWidget);
+      final before = tester.getSize(citation);
+      expect(before.height, greaterThanOrEqualTo(40));
+      expect(find.textContaining('Conversation 0'), findsWidgets);
+      expect(find.textContaining('What is up'), findsWidgets);
+
+      await tester.drag(find.byType(ListView), const Offset(0, -24));
+      await tester.pump();
+
+      expect(find.byKey(const ValueKey('chat-citation-convo-0')), findsWidgets);
+      final after = tester.getSize(
+        find.byKey(const ValueKey('chat-citation-convo-0')).first,
+      );
+      expect(after.height, greaterThanOrEqualTo(40));
+      expect(after.height, closeTo(before.height, 1));
+      expect(find.textContaining('Conversation 0'), findsWidgets);
+      expect(find.textContaining('What is up'), findsWidgets);
+    },
+  );
+}
+
+class _ScrollHost extends StatefulWidget {
+  const _ScrollHost({required this.child, this.onRebuild});
+
+  final Widget child;
+  final VoidCallback? onRebuild;
+
+  @override
+  State<_ScrollHost> createState() => _ScrollHostState();
+}
+
+class _ScrollHostState extends State<_ScrollHost> {
+  ChatScrollMode _mode = ChatScrollMode.followingBottom;
+
+  bool _onNotification(ScrollNotification notification) {
+    if (notification.depth != 0) return false;
+    final isUserScroll = notification is UserScrollNotification && notification.direction != ScrollDirection.idle;
+    final isDragScroll = notification is ScrollUpdateNotification && notification.dragDetails != null;
+    final next = ChatScrollPolicy.nextMode(
+      current: _mode,
+      isUserOrDragScroll: isUserScroll || isDragScroll,
+      atLiveEdge: ChatScrollPolicy.atLiveEdge(notification.metrics),
+    );
+    if (next == null) return false;
+    setState(() {
+      _mode = next;
+      widget.onRebuild?.call();
+    });
+    return false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return NotificationListener<ScrollNotification>(
+      onNotification: _onNotification,
+      child: widget.child,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Mobile chat transcript scrunches markdown and citation pills after a tiny scroll-up, while first paint and newly appended messages look fine.

Root cause: `ChatPage` called `setState` on every drag frame and flipped `ListView` padding `10 → 72` when entering free-scroll. That relayouts intrinsically sized `MarkdownBody` / citation `Text` children and can cache tiny sliver extents.

## Approach
- Rebuild only when follow-mode actually changes (`ChatScrollPolicy.nextMode` returns null otherwise).
- Keep transcript bottom padding at a constant 72 so the Latest overlay does not change list geometry mid-drag.
- Add `app/test/widgets/chat_scroll_layout_test.dart`: policy unit tests plus a `ListView.builder` drag under keyboard insets that asserts citation height and titles. Sabotage of the old always-rebuild policy fails this test (rebuild count 3, nextMode non-null).
- Register `FC-scroll-rebuild-collapses-list-extents`. Existing citation tests that pump `AIMessage` in a `SingleChildScrollView` do not cover this class.

## Test plan
- [x] `cd app && bash test.sh test/widgets/chat_scroll_layout_test.dart` (5 passed)
- [x] `cd app && bash test.sh test/widgets/chat_citation_taps_test.dart`
- [x] `app/scripts/analyze_ratchet.sh` passed
- [ ] Mobile App Checks on this PR (flutter test includes the new file)

## Failure-Class
Failure-Class: new

## Risk
Low. Follow/Latest behavior is unchanged except the list no longer relayouts per pointer-move. Extra 72px bottom padding is always present (previously only while free-scrolling).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

