### PR TITLE
fix(backend): sanitize Speaker N placeholders on legacy summary writers

### DIFF
--- a/backend/tests/unit/test_conversation_speaker_placeholder_persistence.py
+++ b/backend/tests/unit/test_conversation_speaker_placeholder_persistence.py
@@ -1,0 +1,209 @@
+"""Legacy summary writers must never persist Speaker N placeholders (SCA-395).
+
+`sanitize_structured_speaker_placeholders` (#12503) only ran inside the v2 note
+path (`get_conversation_notes`). Prod runs `CONVERSATION_NOTES_V2_ENABLED=false`,
+so the legacy writers below produced most summaries — and could persist
+`Speaker 1` / `SPEAKER_00` verbatim. Speaker N is a diarization placeholder that
+is not stable across conversations; it must never reach the saved Structured.
+
+Each test drives the real writer with a mocked LLM chain whose response carries
+placeholder tokens with NO calendar context, then asserts the returned model is
+clean. Red on origin/main before the sanitizer call was added to these writers.
+"""
+
+import re
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# firebase_admin reaches google.auth.credentials lazily; same guard as test_conversation_notes_v2.
+import google.auth.credentials  # noqa: F401
+
+from testing.import_isolation import stub_modules
+
+
+@pytest.fixture(scope='module', autouse=True)
+def isolated_imports():
+    with stub_modules({}):
+        # Import the production module under test inside the isolation context.
+        import utils.llm.conversation_processing  # noqa: F401
+
+        yield
+
+
+_SPEAKER_LEFTOVER = re.compile(r'(?i)\b(?:speaker[ _]\d+|SPEAKER_\d+)\b')
+
+_STARTED_AT = datetime(2026, 8, 31, 12, 0, tzinfo=timezone.utc)
+
+
+def _conv_proc():
+    from utils.llm import conversation_processing
+
+    return conversation_processing
+
+
+def _poisoned_structured():
+    """What a non-compliant model returns: placeholders everywhere, no real names."""
+    from models.structured import Section
+    from utils.llm.conversation_processing import ActionItem, Structured
+
+    return Structured(
+        title='Speaker 1 Discusses Budget',
+        overview='SPEAKER_00 covers the budget delay; Speaker 1 agreed to the plan.',
+        emoji='💬',
+        category='work',
+        sections=[Section(heading='Budget', body_markdown='- Speaker 1: budget is late')],
+        action_items=[
+            ActionItem(
+                description='Follow up with Speaker 1',
+                owner_name='Speaker 1',
+                context='Speaker 1: raised the delay',
+            )
+        ],
+        events=[],
+    )
+
+
+def _run_with_chain(response, fn, **kwargs):
+    """Run a writer end-to-end with the LLM chain mocked to return `response`."""
+    conv_proc = _conv_proc()
+
+    mock_chain = MagicMock()
+    mock_chain.invoke.return_value = response
+    mock_chain.__or__ = MagicMock(return_value=mock_chain)
+
+    mock_llm = MagicMock()
+    mock_llm.__or__ = MagicMock(return_value=mock_chain)
+
+    mock_prompt = MagicMock()
+    mock_prompt.__or__ = MagicMock(return_value=mock_chain)
+
+    with patch.object(conv_proc, 'get_llm', return_value=mock_llm), patch.object(
+        conv_proc, 'ChatPromptTemplate'
+    ) as mock_prompt_cls:
+        mock_prompt_cls.from_messages.return_value = mock_prompt
+        result = fn(**kwargs)
+
+    return result, mock_prompt_cls
+
+
+def _system_text(mock_prompt_cls):
+    parts = []
+    for message in mock_prompt_cls.from_messages.call_args[0][0]:
+        if isinstance(message, tuple):
+            parts.append(message[1])
+        else:
+            parts.append(str(getattr(message, 'content', message)))
+    return '\n'.join(parts)
+
+
+def test_get_transcript_structure_strips_speaker_placeholders(monkeypatch):
+    conv_proc = _conv_proc()
+    monkeypatch.setattr(conv_proc, '_should_run_conversation_structure_shadow', lambda *a, **k: False)
+
+    structured, _prompt_cls = _run_with_chain(
+        _poisoned_structured(),
+        conv_proc.get_transcript_structure,
+        transcript='Speaker 0: We need the budget numbers. Speaker 1: They are late.',
+        started_at=_STARTED_AT,
+        language_code='en',
+        tz='UTC',
+        uid='u1',
+    )
+
+    assert _SPEAKER_LEFTOVER.search(structured.title) is None
+    assert _SPEAKER_LEFTOVER.search(structured.overview) is None
+    assert _SPEAKER_LEFTOVER.search(structured.sections[0].body_markdown) is None
+    assert _SPEAKER_LEFTOVER.search(structured.action_items[0].description) is None
+    assert _SPEAKER_LEFTOVER.search(structured.action_items[0].context) is None
+    assert structured.action_items[0].owner_name is None
+    # The fact survives; only the fake label is dropped.
+    assert 'Budget' in structured.title
+    assert 'budget delay' in structured.overview
+
+
+def test_get_reprocess_transcript_structure_strips_speaker_placeholders():
+    structured, _prompt_cls = _run_with_chain(
+        _poisoned_structured(),
+        _conv_proc().get_reprocess_transcript_structure,
+        transcript='Speaker 0: We need the budget numbers. Speaker 1: They are late.',
+        started_at=_STARTED_AT,
+        language_code='en',
+        tz='UTC',
+    )
+
+    assert _SPEAKER_LEFTOVER.search(structured.title) is None
+    assert _SPEAKER_LEFTOVER.search(structured.overview) is None
+    assert _SPEAKER_LEFTOVER.search(structured.sections[0].body_markdown) is None
+    assert _SPEAKER_LEFTOVER.search(structured.action_items[0].description) is None
+    assert structured.action_items[0].owner_name is None
+    assert 'Budget' in structured.title
+
+
+def test_extract_action_items_strips_speaker_placeholders(monkeypatch):
+    from models.structured_extraction import ActionItemsExtraction, ExtractedActionItem
+
+    conv_proc = _conv_proc()
+    monkeypatch.setattr(conv_proc, '_should_run_conversation_action_items_shadow', lambda *a, **k: False)
+
+    poisoned = ActionItemsExtraction(
+        action_items=[
+            ExtractedActionItem(
+                description='Follow up with Speaker 1 about SPEAKER_00 budget',
+                owner_name='Speaker 1',
+                context='Speaker 1: raised the delay',
+            )
+        ]
+    )
+
+    items, _prompt_cls = _run_with_chain(
+        poisoned,
+        conv_proc.extract_action_items,
+        transcript='Speaker 0: Send the budget numbers. Speaker 1: They are late.',
+        started_at=_STARTED_AT,
+        language_code='en',
+        tz='UTC',
+    )
+
+    assert len(items) == 1
+    assert _SPEAKER_LEFTOVER.search(items[0].description) is None
+    assert _SPEAKER_LEFTOVER.search(items[0].context) is None
+    assert items[0].owner_name is None
+    assert 'budget' in items[0].description.lower()
+
+
+def test_legacy_prompts_forbid_placeholders_unconditionally(monkeypatch):
+    """The prompt rule must not be gated on calendar context (the #12503 leak)."""
+    conv_proc = _conv_proc()
+    monkeypatch.setattr(conv_proc, '_should_run_conversation_structure_shadow', lambda *a, **k: False)
+    monkeypatch.setattr(conv_proc, '_should_run_conversation_action_items_shadow', lambda *a, **k: False)
+
+    common = dict(
+        transcript='Speaker 0: Send the budget. Speaker 1: It is late.',
+        started_at=_STARTED_AT,
+        language_code='en',
+        tz='UTC',
+    )
+
+    _result, structure_cls = _run_with_chain(
+        _poisoned_structured(), conv_proc.get_transcript_structure, uid='u1', **common
+    )
+    structure_text = _system_text(structure_cls)
+    assert 'when participant names are available' not in structure_text
+    assert 'whether or not' in structure_text
+    assert 'SPEAKER_00' in structure_text
+
+    _result, reprocess_cls = _run_with_chain(
+        _poisoned_structured(), conv_proc.get_reprocess_transcript_structure, **common
+    )
+    assert 'transcript machinery, not names' in _system_text(reprocess_cls)
+
+    from models.structured_extraction import ActionItemsExtraction
+
+    _result, actions_cls = _run_with_chain(
+        ActionItemsExtraction(action_items=[]), conv_proc.extract_action_items, **common
+    )
+    actions_text = _system_text(actions_cls)
+    assert 'when participant names are available' not in actions_text
+    assert 'with or without calendar context' in actions_text

--- a/backend/tests/unit/test_conversation_structure_timezone.py
+++ b/backend/tests/unit/test_conversation_structure_timezone.py
@@ -237,8 +237,9 @@ def _capture_structure(fn, **kwargs):
 
     Returns {'invoke': <dict passed to chain.invoke>, 'system_text': <joined system prompt text>}.
     """
-    mock_response = MagicMock()
-    mock_response.events = []
+    # The writers now sanitize the returned Structured (#12503 follow-up), so the
+    # mocked chain response must be a real model, not a bare MagicMock.
+    mock_response = conv_proc.Structured()
 
     mock_chain = MagicMock()
     mock_chain.invoke.return_value = mock_response
@@ -389,7 +390,8 @@ def test_unique_prompt_routes_drop_legacy_cache_key_whenever_gateway_mode_is_on(
             return self
 
         def invoke(self, *_args, **_kwargs):
-            return MagicMock(events=[])
+            # Reprocess sanitizes the returned Structured; return a real model, not a MagicMock.
+            return conv_proc.Structured()
 
     class _LLM:
         def __or__(self, _parser):

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -825,7 +825,10 @@ def extract_action_items(
 
     CRITICAL: If CALENDAR MEETING CONTEXT is provided with participant names, you MUST use those names:
     - The conversation DEFINITELY happened between the named participants
-    - NEVER use "Speaker 0", "Speaker 1", "Speaker 2", etc. when participant names are available
+    - Diarization placeholders ("Speaker 0", "Speaker 1", "Speaker 2", "SPEAKER_00", etc.) are NEVER
+      names. Do not emit them in any action item, whether or not participant names are available. Use
+      a real name only when it comes from meeting-identity metadata or a non-placeholder transcript
+      label; otherwise describe the action without a speaker label. Do not invent names.
     - Match transcript speakers to participant names by analyzing the conversation context
     - Use participant names in ALL action items (e.g., "Follow up with Sarah" NOT "Follow up with Speaker 0")
     - Reference the meeting title/context when relevant to the action item
@@ -886,7 +889,7 @@ def extract_action_items(
          * Use the actual participant names in ALL action items
          * ABSOLUTELY NEVER use "Speaker 0", "Speaker 1", "Speaker 2", etc.
          * Example: "Follow up with Sarah about budget" NOT "Follow up with Speaker 0 about budget"
-       - If no calendar context: NEVER use "Speaker 0", "Speaker 1", etc. in the final action item description
+       - Never emit "Speaker 0", "Speaker 1", "SPEAKER_00", etc. anywhere in an action item, with or without calendar context
        - If unsure about names, use natural phrasing like "Follow up on...", "Ensure...", etc.
 
     2. **Concrete Action**: The task describes a specific, actionable next step (not vague intentions)
@@ -1077,6 +1080,10 @@ def extract_action_items(
         if _should_run_conversation_action_items_shadow('conversation_action_items', started_at, conversation_context):
             _submit_conversation_action_items_shadow(prompt, prompt_values, action_items, user_tz, now)
 
+        # Speaker N is a diarization placeholder, not a person. The legacy action-item list rides the
+        # same summary card as the notes, so it gets the same scrub the v2 note path already applies
+        # (sanitize mutates the ActionItem instances in place).
+        sanitize_structured_speaker_placeholders(Structured(action_items=action_items))
         return action_items
 
     except Exception as e:
@@ -1325,7 +1332,11 @@ def get_transcript_structure(
 
     CRITICAL: If CALENDAR MEETING CONTEXT is provided with participant names, you MUST use those names:
     - The conversation DEFINITELY happened between the named participants
-    - NEVER use "Speaker 0", "Speaker 1", "Speaker 2", etc. when participant names are available
+    - Diarization placeholders ("Speaker 0", "Speaker 1", "Speaker 2", "SPEAKER_00", etc.) are NEVER
+      names. Do not emit them in the title, overview, or any generated content, whether or not
+      calendar context exists. Use a real name only when it comes from meeting-identity metadata or
+      a non-placeholder transcript label; otherwise state the fact without a speaker label. Do not
+      invent names.
     - Match transcript speakers to participant names by carefully analyzing the conversation context
     - Use participant names throughout the title, overview, and all generated content
     - Use the meeting title as a strong signal for the conversation title (but you can refine it based on the actual discussion)
@@ -1334,7 +1345,7 @@ def get_transcript_structure(
     - If there are 2-3 participants with known names, naturally mention them in the title (e.g., "Sarah and John Discuss Q2 Budget", "Team Meeting with Alex, Maria, and Chris")
 
     For the title, Write a clear, compelling headline (≤ 10 words) that captures the central topic and outcome. Use Title Case, avoid filler words, and include a key noun + verb where possible (e.g., "Team Finalizes Q2 Budget" or "Family Plans Weekend Road Trip"). If calendar context provides participant names (2-3 people), naturally include them when relevant (e.g., "John and Sarah Plan Marketing Campaign").
-    For the overview, condense the content into a summary with the main topics discussed or scenes observed, making sure to capture the key points and important details. When calendar context provides participant names, you MUST use their actual names instead of "Speaker 0" or "Speaker 1" to make the summary readable and personal. Analyze the transcript to understand who said what and match speakers to participant names.
+    For the overview, condense the content into a summary with the main topics discussed or scenes observed, making sure to capture the key points and important details. When calendar context provides participant names, you MUST use their actual names to make the summary readable and personal. Analyze the transcript to understand who said what and match speakers to participant names. Never write "Speaker 0", "Speaker 1", "SPEAKER_00", etc. in the title or overview; if a speaker's identity is unknown, state the fact without a speaker label. Do not invent names.
     For the emoji, select a single emoji that vividly reflects the core subject, mood, or outcome of the content. Strive for an emoji that is specific and evocative, rather than generic (e.g., prefer 🎉 for a celebration over 👍 for general agreement, or 💡 for a new idea over 🧠 for general thought).
 
     For the category, classify the content into one of the available categories.
@@ -1421,7 +1432,7 @@ def get_transcript_structure(
             event.duration = 180
         event.created = False
 
-    return response
+    return sanitize_structured_speaker_placeholders(response)
 
 
 def get_reprocess_transcript_structure(
@@ -1452,6 +1463,7 @@ def get_reprocess_transcript_structure(
 
     For the title, generate a concise title from the current content. Do not reuse a previous title.
     For the overview, condense the content into a summary with the main topics discussed or scenes observed, making sure to capture the key points and important details.
+    Never emit diarization placeholders ("Speaker 0", "Speaker 1", "SPEAKER_00", etc.) in the title or overview; they are transcript machinery, not names. Use a real person name only when it appears in meeting-identity metadata or a non-placeholder transcript label; otherwise state the fact without a speaker label. Do not invent names.
     For the emoji, select a single emoji that vividly reflects the core subject, mood, or outcome of the content. Strive for an emoji that is specific and evocative, rather than generic (e.g., prefer 🎉 for a celebration over 👍 for general agreement, or 💡 for a new idea over 🧠 for general thought).
 
     For the category, classify the content into one of the available categories.
@@ -1521,7 +1533,7 @@ def get_reprocess_transcript_structure(
             event.duration = 180
         event.created = False
 
-    return response
+    return sanitize_structured_speaker_placeholders(response)
 
 
 def get_app_result(


### PR DESCRIPTION
# fix(backend): sanitize Speaker N placeholders on legacy summary writers

## Why

`#12503` added `sanitize_structured_speaker_placeholders`, but it only runs inside `get_conversation_notes` (the v2 path). Prod GKE runs `CONVERSATION_NOTES_V2_ENABLED=false`, so most production summaries still come from the legacy writers:

- `get_transcript_structure` — workflow audio, first-pass desktop/mobile
- `get_reprocess_transcript_structure` — reprocess
- `extract_action_items` — the legacy action-item list attached to the same summary card

None of them sanitized their `Structured`, and their prompts only forbade `Speaker N` *when participant names were available* (or with calendar context) — exactly the conditional framing that let diarization placeholders persist as if they named a person. Speaker N is not a stable identity across conversations.

## What changed

- `get_transcript_structure` and `get_reprocess_transcript_structure` now return `sanitize_structured_speaker_placeholders(response)`; `extract_action_items` runs the same helper over its items via a `Structured(action_items=...)` carrier. One helper, one regex — no fork.
- The placeholder ban in all three prompts is now unconditional: never emit `Speaker 0/1/2` / `SPEAKER_00` in title, overview, sections, or action items, calendar or not. Use a real name only when identity metadata or a non-placeholder transcript label already has one; otherwise write the fact without a speaker label. Do not invent names.
- Transcript segment UI, backfills, flag flips, and memory L1 are untouched (out of scope).

## Tests

New `backend/tests/unit/test_conversation_speaker_placeholder_persistence.py` drives each writer end-to-end with a mocked LLM chain whose response carries `Speaker 1` / `SPEAKER_00` tokens with **no** calendar context, and asserts the returned model is clean while the underlying facts survive. All four tests fail on `origin/main` (`f463f3b728`) and pass with this PR. Also pins that the legacy prompts no longer gate the ban on calendar/participant availability.

`test_conversation_structure_timezone.py` mocks were updated to return a real `Structured` instead of a bare `MagicMock` (the writers now sanitize the return value).

## Verification

- `pytest tests/unit/test_conversation_speaker_placeholder_persistence.py` — 4 passed (4 failed on unmodified `origin/main` source)
- Standalone: `test_conversation_notes_v2.py` 7 passed, `test_conversation_structure_timezone.py` 16 passed, `test_action_item_date_validation.py` 26 passed, `test_conversation_structure_provider_timeout.py` 7 passed, `test_wake_word.py` 34 passed, `test_prompt_caching.py` 26 passed, `test_discard_calendar_override.py` 8 passed, `test_structured_extraction_partial_content.py` 14 passed, `test_screen_activity_identity.py` 27 passed
- `#12036` / Telegram identity tests unchanged and green

Failure-Class: FC-meeting-identity-catalog-split

Line-Count-Exception: backend/utils/llm/conversation_processing.py | 1805 -> 1817 | three sanitizer call sites (one per legacy writer) plus unconditional placeholder-ban prompt wording; no new logic volume


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

