### PR TITLE
fix(backend): accept speech-profile uploads up to 180s

### DIFF
--- a/.github/failure-classes/FC-server-bound-excludes-client-design-range.json
+++ b/.github/failure-classes/FC-server-bound-excludes-client-design-range.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "id": "FC-server-bound-excludes-client-design-range",
+  "violated_contract": "A server-side validation bound on first-party client input must cover the full range that client is designed to produce. The onboarding recorder buffers up to its own 150s cap while the upload endpoint rejected anything over 120s, so a legitimately produced recording was refused as invalid input; the two constants lived on opposite sides of the wire with nothing tying them together, and the client then mapped the rejection to a misleading 'too short' message.",
+  "canonical_prevention": "When a server validates a quantity a first-party client caps independently, set the server bound from the client's designed maximum plus headroom, name the client constant at the server check site, and land a regression test that drives the validated path at the client's maximum. Watch the rejection rate of the endpoint after changing either constant.",
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/routers/speech_profile.py",
+    "app/lib/providers/speech_profile_provider.dart"
+  ],
+  "status": "open"
+}

--- a/backend/routers/speech_profile.py
+++ b/backend/routers/speech_profile.py
@@ -105,8 +105,11 @@ def upload_profile(file: UploadFile, uid: str = Depends(auth.get_current_user_ui
     if aseg.frame_rate != 16000:
         raise HTTPException(status_code=400, detail="Invalid codec, must be opus 16khz.")
 
-    if aseg.duration_seconds < 5 or aseg.duration_seconds > 120:
-        raise HTTPException(status_code=400, detail="Audio duration is invalid (must be 5-120 seconds)")
+    # Upper bound must stay >= the app's onboarding recording cap (maxDuration = 150 in
+    # app/lib/providers/speech_profile_provider.dart) plus headroom: a 120s cap rejected
+    # ~28% of prod onboarding uploads (users whose Q&A ran past 2 minutes).
+    if aseg.duration_seconds < 5 or aseg.duration_seconds > 180:
+        raise HTTPException(status_code=400, detail="Audio duration is invalid (must be 5-180 seconds)")
 
     try:
         apply_vad_for_speech_profile(file_path)

--- a/backend/scripts/stt/j_apply_vad_to_speech_profiles.py
+++ b/backend/scripts/stt/j_apply_vad_to_speech_profiles.py
@@ -35,7 +35,7 @@ def execute():
         aseg = cast(
             Any, AudioSegment.from_wav(file_path)
         )  # pyright: ignore[reportUnknownMemberType]  # pydub has no type stubs
-        if aseg.duration_seconds < 5 or aseg.duration_seconds > 120:
+        if aseg.duration_seconds < 5 or aseg.duration_seconds > 180:
             print('Invalid duration for', uid)
             return
         upload_profile_audio(file_path, uid)

--- a/backend/tests/unit/test_speech_profile_wav_decode.py
+++ b/backend/tests/unit/test_speech_profile_wav_decode.py
@@ -151,6 +151,48 @@ class TestUploadProfileWavDecodeGuard:
         mock_vad.assert_called_once_with("_temp/test-uid/speech_profile.wav", return_segments=True)
         mock_upload.assert_not_called()
 
+    def test_onboarding_length_recording_accepted(self):
+        """Regression: the app's onboarding recorder buffers up to 150s of audio
+        (maxDuration in app/lib/providers/speech_profile_provider.dart). The old
+        120s server cap rejected ~28% of prod speech-profile uploads with
+        'Audio duration is invalid'. Durations up to 180s must be accepted."""
+        for duration in (121, 150, 180):
+            fake_file = _fake_upload_file(b"long recording")
+
+            with patch.object(mod, "os") as mock_os, patch("builtins.open", MagicMock()), patch.object(
+                mod, "AudioSegment"
+            ) as mock_aseg, patch.object(mod, "apply_vad_for_speech_profile"), patch.object(
+                mod, "av"
+            ) as mock_av, patch.object(
+                mod, "upload_profile_audio", return_value="https://example.com/profile.wav"
+            ) as mock_upload, patch.object(
+                mod, "extract_embedding"
+            ):
+                mock_os.makedirs.return_value = None
+                mock_aseg.from_wav.return_value = MagicMock(frame_rate=16000, duration_seconds=duration)
+                mock_av.open.return_value.__enter__.return_value.duration = None
+
+                result = mod.upload_profile(fake_file, uid="test-uid")
+
+            assert result == {"url": "https://example.com/profile.wav"}, f"{duration}s upload was rejected"
+            mock_upload.assert_called_once()
+
+    def test_over_180s_recording_still_rejected(self):
+        fake_file = _fake_upload_file(b"way too long")
+
+        with patch.object(mod, "os") as mock_os, patch("builtins.open", MagicMock()), patch.object(
+            mod, "AudioSegment"
+        ) as mock_aseg, patch.object(mod, "upload_profile_audio") as mock_upload:
+            mock_os.makedirs.return_value = None
+            mock_aseg.from_wav.return_value = MagicMock(frame_rate=16000, duration_seconds=181)
+
+            with pytest.raises(HTTPException) as exc_info:
+                mod.upload_profile(fake_file, uid="test-uid")
+
+        assert exc_info.value.status_code == 400
+        assert "duration is invalid" in exc_info.value.detail
+        mock_upload.assert_not_called()
+
     def test_batch_skips_empty_vad_without_uploading(self):
         class ImmediateThread:
             def __init__(self, target, args):


### PR DESCRIPTION
## Summary
Mobile onboarding 'teach Omi your voice' failed for ~28% of users: the app records up to 150s (maxDuration in app/lib/providers/speech_profile_provider.dart) but POST /v3/upload-audio rejected anything over 120s with 400 'Audio duration is invalid'. 189 of 679 uploads failed in the 7 days to Aug 31 (prod Cloud Run logs: all 400s are 3.85-4.8MB WAVs = 120-150s; all 200s <=3.82MB).

## Approach
Raise the server duration cap to 180s (150s client cap + headroom) in routers/speech_profile.py; the batch VAD script's copy of the bound moves with it. Server-side fix lands for all existing app versions with no app release.

## Verification
- Reproduced pre-fix on live prod: real 130s 16kHz WAV -> 400 'Audio duration is invalid (must be 5-120 seconds)'.
- Regression test: 121/150/180s accepted through upload_profile; 181s still rejected; backend/test.sh tests/unit/test_speech_profile_wav_decode.py green.
- Post-deploy: same 130s WAV upload against prod api.omi.me -> 200 (will attach).

## Product invariants affected

none

## Failure-Class
Failure-Class: new

## Risk
Low: widens one validation bound; VAD/storage path unchanged. Revert = restore the 120s constant.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

