### PR TITLE
fix(app): remove Today/This week chat scope chips

### DIFF
--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -3191,8 +3191,6 @@
     "accountCutoverMigrationInProgressMessage": "حسابك قيد الترحيل. ميزات المنتج متوقفة مؤقتًا حتى انتهاء الترحيل.",
     "accountCutoverMigrationRollbackMessage": "حسابك قيد الصيانة بعد التراجع عن الترحيل. قد تُعزل بعض البيانات الأحدث.",
     "accountCutoverOpenStore": "فتح المتجر",
-    "chatScopeToday": "اليوم",
-    "chatScopeThisWeek": "هذا الأسبوع",
     "chatScopeAbout": "عن: {title}",
     "askAboutThisConversation": "اسأل عن هذا",
     "sendRawAudioToOmi": "إرسال الصوت الخام إلى Omi",

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -10781,8 +10781,6 @@
     "accountCutoverMigrationInProgressMessage": "Ваш аккаунт мигрирует. Функции продукта приостановлены до завершения миграции.",
     "accountCutoverMigrationRollbackMessage": "Ваш аккаунт на обслуживании после отката миграции. Часть более новых данных может быть изолирована.",
     "accountCutoverOpenStore": "Открыть магазин",
-    "chatScopeToday": "Сёння",
-    "chatScopeThisWeek": "Гэты тыдзень",
     "chatScopeAbout": "Пра: {title}",
     "askAboutThisConversation": "Спытаць пра гэта",
     "sendRawAudioToOmi": "Адпраўляць неапрацаванае аўдыя ў Omi",

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -3193,8 +3193,6 @@
     "accountCutoverMigrationInProgressMessage": "Ваш аккаунт мигрирует. Функции продукта приостановлены до завершения миграции.",
     "accountCutoverMigrationRollbackMessage": "Ваш аккаунт на обслуживании после отката миграции. Часть более новых данных может быть изолирована.",
     "accountCutoverOpenStore": "Открыть магазин",
-    "chatScopeToday": "Днес",
-    "chatScopeThisWeek": "Тази седмица",
     "chatScopeAbout": "За: {title}",
     "askAboutThisConversation": "Попитай за това",
     "sendRawAudioToOmi": "Изпращане на необработен звук към Omi",

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -10781,8 +10781,6 @@
     "accountCutoverMigrationInProgressMessage": "आपका खाता माइग्रेट हो रहा है। माइग्रेशन पूरा होने तक उत्पाद सुविधाएँ रुकी रहेंगी।",
     "accountCutoverMigrationRollbackMessage": "माइग्रेशन रोलबैक के बाद आपका खाता रखरखाव में है। कुछ नए डेटा अलग रह सकते हैं।",
     "accountCutoverOpenStore": "स्टोर खोलें",
-    "chatScopeToday": "আজ",
-    "chatScopeThisWeek": "এই সপ্তাহ",
     "chatScopeAbout": "{title} সম্পর্কে",
     "askAboutThisConversation": "এটি সম্পর্কে জিজ্ঞাসা করুন",
     "sendRawAudioToOmi": "Omi-তে কাঁচা অডিও পাঠান",

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -10781,8 +10781,6 @@
     "accountCutoverMigrationInProgressMessage": "Váš účet se migrací. Produktové funkce jsou pozastaveny až do dokončení migrace.",
     "accountCutoverMigrationRollbackMessage": "Váš účet je po vrácení migrace v režimu údržby. Novější data mohou být izolována.",
     "accountCutoverOpenStore": "Otevřít obchod",
-    "chatScopeToday": "Danas",
-    "chatScopeThisWeek": "Ove sedmice",
     "chatScopeAbout": "O: {title}",
     "askAboutThisConversation": "Pitaj o ovome",
     "sendRawAudioToOmi": "Šalji sirovi zvuk u Omi",

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -3193,8 +3193,6 @@
     "accountCutoverMigrationInProgressMessage": "Tu cuenta se está migrando. Las funciones del producto están en pausa hasta que termine la migración.",
     "accountCutoverMigrationRollbackMessage": "Tu cuenta está en mantenimiento tras una reversión de migración. Algunos datos más recientes pueden quedar retenidos.",
     "accountCutoverOpenStore": "Abrir tienda",
-    "chatScopeToday": "Avui",
-    "chatScopeThisWeek": "Aquesta setmana",
     "chatScopeAbout": "Sobre: {title}",
     "askAboutThisConversation": "Pregunta sobre això",
     "sendRawAudioToOmi": "Envia l'àudio sense processar a Omi",

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -3193,8 +3193,6 @@
     "accountCutoverMigrationInProgressMessage": "Váš účet se migrací. Produktové funkce jsou pozastaveny až do dokončení migrace.",
     "accountCutoverMigrationRollbackMessage": "Váš účet je po vrácení migrace v režimu údržby. Novější data mohou být izolována.",
     "accountCutoverOpenStore": "Otevřít obchod",
-    "chatScopeToday": "Dnes",
-    "chatScopeThisWeek": "Tento týden",
     "chatScopeAbout": "O: {title}",
     "askAboutThisConversation": "Zeptat se na toto",
     "sendRawAudioToOmi": "Odesílat nezpracovaný zvuk do Omi",

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -3233,8 +3233,6 @@
     "accountCutoverMigrationInProgressMessage": "Din konto migreres. Produktfunktioner er sat på pause, indtil migreringen er færdig.",
     "accountCutoverMigrationRollbackMessage": "Din konto er under vedligeholdelse efter en migrerings-rollback. Nyere data kan være isoleret.",
     "accountCutoverOpenStore": "Åbn butik",
-    "chatScopeToday": "I dag",
-    "chatScopeThisWeek": "Denne uge",
     "chatScopeAbout": "Om: {title}",
     "askAboutThisConversation": "Spørg om dette",
     "sendRawAudioToOmi": "Send rå lyd til Omi",

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -3192,8 +3192,6 @@
     "accountCutoverMigrationInProgressMessage": "Dein Konto wird migriert. Produktfunktionen sind pausiert, bis die Migration abgeschlossen ist.",
     "accountCutoverMigrationRollbackMessage": "Dein Konto ist nach einem Migrations-Rollback in Wartung. Neuere Daten können isoliert sein.",
     "accountCutoverOpenStore": "Store öffnen",
-    "chatScopeToday": "Heute",
-    "chatScopeThisWeek": "Diese Woche",
     "chatScopeAbout": "Über: {title}",
     "askAboutThisConversation": "Dazu fragen",
     "sendRawAudioToOmi": "Roh-Audio an Omi senden",

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -3215,8 +3215,6 @@
     "accountCutoverMigrationInProgressMessage": "Ο λογαριασμός σας μεταφέρεται. Οι λειτουργίες προϊόντος είναι σε παύση μέχρι να ολοκληρωθεί η μετεγκατάσταση.",
     "accountCutoverMigrationRollbackMessage": "Ο λογαριασμός σας είναι σε συντήρηση μετά από επαναφορά μετεγκατάστασης. Νεότερα δεδομένα ενδέχεται να έχουν απομονωθεί.",
     "accountCutoverOpenStore": "Άνοιγμα καταστήματος",
-    "chatScopeToday": "Σήμερα",
-    "chatScopeThisWeek": "Αυτή την εβδομάδα",
     "chatScopeAbout": "Σχετικά με: {title}",
     "askAboutThisConversation": "Ρώτησε γι' αυτό",
     "sendRawAudioToOmi": "Αποστολή ακατέργαστου ήχου στο Omi",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -11639,14 +11639,6 @@
     "@accountCutoverOpenStore": {
         "description": "Button that opens the app store for a required cutover upgrade"
     },
-    "chatScopeToday": "Today",
-    "@chatScopeToday": {
-        "description": "Chat timeframe scope chip for today"
-    },
-    "chatScopeThisWeek": "This week",
-    "@chatScopeThisWeek": {
-        "description": "Chat timeframe scope chip for this week"
-    },
     "chatScopeAbout": "About: {title}",
     "@chatScopeAbout": {
         "description": "Chat scope chip when asking about a specific conversation",

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -3216,8 +3216,6 @@
     "accountCutoverMigrationInProgressMessage": "Tu cuenta se está migrando. Las funciones del producto están en pausa hasta que termine la migración.",
     "accountCutoverMigrationRollbackMessage": "Tu cuenta está en mantenimiento tras una reversión de migración. Algunos datos más recientes pueden quedar retenidos.",
     "accountCutoverOpenStore": "Abrir tienda",
-    "chatScopeToday": "Hoy",
-    "chatScopeThisWeek": "Esta semana",
     "chatScopeAbout": "Sobre: {title}",
     "askAboutThisConversation": "Preguntar sobre esto",
     "sendRawAudioToOmi": "Enviar audio sin procesar a Omi",

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -3215,8 +3215,6 @@
     "accountCutoverMigrationInProgressMessage": "Tiliäsi siirretään. Tuoteominaisuudet on keskeytetty, kunnes siirto valmistuu.",
     "accountCutoverMigrationRollbackMessage": "Tilisi on huollossa siirron peruutuksen jälkeen. Uudempaa dataa voi olla eristettynä.",
     "accountCutoverOpenStore": "Avaa kauppa",
-    "chatScopeToday": "Täna",
-    "chatScopeThisWeek": "Sel nädalal",
     "chatScopeAbout": "Teave: {title}",
     "askAboutThisConversation": "Küsi selle kohta",
     "sendRawAudioToOmi": "Saada töötlemata heli Omisse",

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -10781,8 +10781,6 @@
     "accountCutoverMigrationInProgressMessage": "حسابك قيد الترحيل. ميزات المنتج متوقفة مؤقتًا حتى انتهاء الترحيل.",
     "accountCutoverMigrationRollbackMessage": "حسابك قيد الصيانة بعد التراجع عن الترحيل. قد تُعزل بعض البيانات الأحدث.",
     "accountCutoverOpenStore": "فتح المتجر",
-    "chatScopeToday": "امروز",
-    "chatScopeThisWeek": "این هفته",
     "chatScopeAbout": "درباره: {title}",
     "askAboutThisConversation": "درباره این بپرسید",
     "sendRawAudioToOmi": "ارسال صدای خام به Omi",

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -3215,8 +3215,6 @@
     "accountCutoverMigrationInProgressMessage": "Tiliäsi siirretään. Tuoteominaisuudet on keskeytetty, kunnes siirto valmistuu.",
     "accountCutoverMigrationRollbackMessage": "Tilisi on huollossa siirron peruutuksen jälkeen. Uudempaa dataa voi olla eristettynä.",
     "accountCutoverOpenStore": "Avaa kauppa",
-    "chatScopeToday": "Tänään",
-    "chatScopeThisWeek": "Tällä viikolla",
     "chatScopeAbout": "Aihe: {title}",
     "askAboutThisConversation": "Kysy tästä",
     "sendRawAudioToOmi": "Lähetä käsittelemätön ääni Omille",

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -3250,8 +3250,6 @@
     "accountCutoverMigrationInProgressMessage": "Votre compte est en cours de migration. Les fonctionnalités produit sont en pause jusqu'à la fin de la migration.",
     "accountCutoverMigrationRollbackMessage": "Votre compte est en maintenance après un retour arrière de migration. Certaines données plus récentes peuvent être isolées.",
     "accountCutoverOpenStore": "Ouvrir le store",
-    "chatScopeToday": "Aujourd’hui",
-    "chatScopeThisWeek": "Cette semaine",
     "chatScopeAbout": "À propos de : {title}",
     "askAboutThisConversation": "Demander à ce sujet",
     "sendRawAudioToOmi": "Envoyer l'audio brut à Omi",

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -10781,8 +10781,6 @@
     "accountCutoverMigrationInProgressMessage": "החשבון שלכם בהעברה. תכונות המוצר מושהות עד לסיום ההעברה.",
     "accountCutoverMigrationRollbackMessage": "החשבון שלכם בתחזוקה לאחר ביטול העברה. ייתכן שנתונים חדשים יותר נותרו מבודדים.",
     "accountCutoverOpenStore": "פתחו חנות",
-    "chatScopeToday": "היום",
-    "chatScopeThisWeek": "השבוע הזה",
     "chatScopeAbout": "אודות: {title}",
     "askAboutThisConversation": "שאל על זה",
     "sendRawAudioToOmi": "שליחת שמע גולמי ל-Omi",

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -3216,8 +3216,6 @@
     "accountCutoverMigrationInProgressMessage": "आपका खाता माइग्रेट हो रहा है। माइग्रेशन पूरा होने तक उत्पाद सुविधाएँ रुकी रहेंगी।",
     "accountCutoverMigrationRollbackMessage": "माइग्रेशन रोलबैक के बाद आपका खाता रखरखाव में है। कुछ नए डेटा अलग रह सकते हैं।",
     "accountCutoverOpenStore": "स्टोर खोलें",
-    "chatScopeToday": "आज",
-    "chatScopeThisWeek": "इस सप्ताह",
     "chatScopeAbout": "इसके बारे में: {title}",
     "askAboutThisConversation": "इसके बारे में पूछें",
     "sendRawAudioToOmi": "Omi को कच्चा ऑडियो भेजें",

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -10781,8 +10781,6 @@
     "accountCutoverMigrationInProgressMessage": "Váš účet se migrací. Produktové funkce jsou pozastaveny až do dokončení migrace.",
     "accountCutoverMigrationRollbackMessage": "Váš účet je po vrácení migrace v režimu údržby. Novější data mohou být izolována.",
     "accountCutoverOpenStore": "Otevřít obchod",
-    "chatScopeToday": "Danas",
-    "chatScopeThisWeek": "Ovaj tjedan",
     "chatScopeAbout": "O: {title}",
     "askAboutThisConversation": "Pitaj o ovome",
     "sendRawAudioToOmi": "Šalji neobrađeni zvuk u Omi",

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -3311,8 +3311,6 @@
     "accountCutoverMigrationInProgressMessage": "A fiókja migrálás alatt áll. A termékfunkciók szünetelnek a migráció befejezéséig.",
     "accountCutoverMigrationRollbackMessage": "A fiókja karbantartás alatt áll a migráció visszavonása után. Egyes újabb adatok elkülönítve maradhatnak.",
     "accountCutoverOpenStore": "Áruház megnyitása",
-    "chatScopeToday": "Ma",
-    "chatScopeThisWeek": "Ezen a héten",
     "chatScopeAbout": "Erről: {title}",
     "askAboutThisConversation": "Kérdezz erről",
     "sendRawAudioToOmi": "Nyers hang küldése az Ominak",

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -3257,8 +3257,6 @@
     "accountCutoverMigrationInProgressMessage": "Akun Anda sedang dimigrasi. Fitur produk dijeda hingga migrasi selesai.",
     "accountCutoverMigrationRollbackMessage": "Akun Anda dalam pemeliharaan setelah rollback migrasi. Beberapa data yang lebih baru mungkin terisolasi.",
     "accountCutoverOpenStore": "Buka toko",
-    "chatScopeToday": "Hari ini",
-    "chatScopeThisWeek": "Minggu ini",
     "chatScopeAbout": "Tentang: {title}",
     "askAboutThisConversation": "Tanyakan tentang ini",
     "sendRawAudioToOmi": "Kirim audio mentah ke Omi",

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -3215,8 +3215,6 @@
     "accountCutoverMigrationInProgressMessage": "Il tuo account è in migrazione. Le funzioni del prodotto sono in pausa fino al termine della migrazione.",
     "accountCutoverMigrationRollbackMessage": "Il tuo account è in manutenzione dopo un rollback della migrazione. Alcuni dati più recenti potrebbero essere isolati.",
     "accountCutoverOpenStore": "Apri store",
-    "chatScopeToday": "Oggi",
-    "chatScopeThisWeek": "Questa settimana",
     "chatScopeAbout": "Informazioni su: {title}",
     "askAboutThisConversation": "Chiedi informazioni",
     "sendRawAudioToOmi": "Invia l'audio grezzo a Omi",

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -3191,8 +3191,6 @@
     "accountCutoverMigrationInProgressMessage": "アカウントを移行中です。移行が完了するまでプロダクト機能は一時停止されます。",
     "accountCutoverMigrationRollbackMessage": "移行のロールバック後、アカウントはメンテナンス中です。新しいデータの一部が孤立している可能性があります。",
     "accountCutoverOpenStore": "ストアを開く",
-    "chatScopeToday": "今日",
-    "chatScopeThisWeek": "今週",
     "chatScopeAbout": "{title}について",
     "askAboutThisConversation": "これについて尋ねる",
     "sendRawAudioToOmi": "未処理の音声を Omi に送信",

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -10781,8 +10781,6 @@
     "accountCutoverMigrationInProgressMessage": "आपका खाता माइग्रेट हो रहा है। माइग्रेशन पूरा होने तक उत्पाद सुविधाएँ रुकी रहेंगी।",
     "accountCutoverMigrationRollbackMessage": "माइग्रेशन रोलबैक के बाद आपका खाता रखरखाव में है। कुछ नए डेटा अलग रह सकते हैं।",
     "accountCutoverOpenStore": "स्टोर खोलें",
-    "chatScopeToday": "ಇಂದು",
-    "chatScopeThisWeek": "ಈ ವಾರ",
     "chatScopeAbout": "{title} ಕುರಿತು",
     "askAboutThisConversation": "ಇದರ ಕುರಿತು ಕೇಳಿ",
     "sendRawAudioToOmi": "Omi ಗೆ ಕಚ್ಚಾ ಆಡಿಯೊ ಕಳುಹಿಸಿ",

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -3215,8 +3215,6 @@
     "accountCutoverMigrationInProgressMessage": "계정을 마이그레이션하는 중입니다. 마이그레이션이 끝날 때까지 제품 기능이 일시 중지됩니다.",
     "accountCutoverMigrationRollbackMessage": "마이그레이션 롤백 후 계정이 유지보수 상태입니다. 일부 최신 데이터가 고립될 수 있습니다.",
     "accountCutoverOpenStore": "스토어 열기",
-    "chatScopeToday": "오늘",
-    "chatScopeThisWeek": "이번 주",
     "chatScopeAbout": "{title}에 대해",
     "askAboutThisConversation": "이에 대해 질문",
     "sendRawAudioToOmi": "원본 오디오를 Omi로 보내기",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -18339,18 +18339,6 @@ abstract class AppLocalizations {
   /// **'Open store'**
   String get accountCutoverOpenStore;
 
-  /// Chat timeframe scope chip for today
-  ///
-  /// In en, this message translates to:
-  /// **'Today'**
-  String get chatScopeToday;
-
-  /// Chat timeframe scope chip for this week
-  ///
-  /// In en, this message translates to:
-  /// **'This week'**
-  String get chatScopeThisWeek;
-
   /// Chat scope chip when asking about a specific conversation
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -9787,12 +9787,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get accountCutoverOpenStore => 'فتح المتجر';
 
   @override
-  String get chatScopeToday => 'اليوم';
-
-  @override
-  String get chatScopeThisWeek => 'هذا الأسبوع';
-
-  @override
   String chatScopeAbout(String title) {
     return 'عن: $title';
   }

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -9877,12 +9877,6 @@ class AppLocalizationsBe extends AppLocalizations {
   String get accountCutoverOpenStore => 'Открыть магазин';
 
   @override
-  String get chatScopeToday => 'Сёння';
-
-  @override
-  String get chatScopeThisWeek => 'Гэты тыдзень';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Пра: $title';
   }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9882,12 +9882,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get accountCutoverOpenStore => 'Открыть магазин';
 
   @override
-  String get chatScopeToday => 'Днес';
-
-  @override
-  String get chatScopeThisWeek => 'Тази седмица';
-
-  @override
   String chatScopeAbout(String title) {
     return 'За: $title';
   }

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -9850,12 +9850,6 @@ class AppLocalizationsBn extends AppLocalizations {
   String get accountCutoverOpenStore => 'स्टोर खोलें';
 
   @override
-  String get chatScopeToday => 'আজ';
-
-  @override
-  String get chatScopeThisWeek => 'এই সপ্তাহ';
-
-  @override
   String chatScopeAbout(String title) {
     return '$title সম্পর্কে';
   }

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -9873,12 +9873,6 @@ class AppLocalizationsBs extends AppLocalizations {
   String get accountCutoverOpenStore => 'Otevřít obchod';
 
   @override
-  String get chatScopeToday => 'Danas';
-
-  @override
-  String get chatScopeThisWeek => 'Ove sedmice';
-
-  @override
   String chatScopeAbout(String title) {
     return 'O: $title';
   }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9901,12 +9901,6 @@ class AppLocalizationsCa extends AppLocalizations {
   String get accountCutoverOpenStore => 'Abrir tienda';
 
   @override
-  String get chatScopeToday => 'Avui';
-
-  @override
-  String get chatScopeThisWeek => 'Aquesta setmana';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Sobre: $title';
   }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9846,12 +9846,6 @@ class AppLocalizationsCs extends AppLocalizations {
   String get accountCutoverOpenStore => 'Otevřít obchod';
 
   @override
-  String get chatScopeToday => 'Dnes';
-
-  @override
-  String get chatScopeThisWeek => 'Tento týden';
-
-  @override
   String chatScopeAbout(String title) {
     return 'O: $title';
   }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -9830,12 +9830,6 @@ class AppLocalizationsDa extends AppLocalizations {
   String get accountCutoverOpenStore => 'Åbn butik';
 
   @override
-  String get chatScopeToday => 'I dag';
-
-  @override
-  String get chatScopeThisWeek => 'Denne uge';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Om: $title';
   }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9927,12 +9927,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get accountCutoverOpenStore => 'Store öffnen';
 
   @override
-  String get chatScopeToday => 'Heute';
-
-  @override
-  String get chatScopeThisWeek => 'Diese Woche';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Über: $title';
   }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9914,12 +9914,6 @@ class AppLocalizationsEl extends AppLocalizations {
   String get accountCutoverOpenStore => 'Άνοιγμα καταστήματος';
 
   @override
-  String get chatScopeToday => 'Σήμερα';
-
-  @override
-  String get chatScopeThisWeek => 'Αυτή την εβδομάδα';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Σχετικά με: $title';
   }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -9837,12 +9837,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get accountCutoverOpenStore => 'Open store';
 
   @override
-  String get chatScopeToday => 'Today';
-
-  @override
-  String get chatScopeThisWeek => 'This week';
-
-  @override
   String chatScopeAbout(String title) {
     return 'About: $title';
   }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9868,12 +9868,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get accountCutoverOpenStore => 'Abrir tienda';
 
   @override
-  String get chatScopeToday => 'Hoy';
-
-  @override
-  String get chatScopeThisWeek => 'Esta semana';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Sobre: $title';
   }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9839,12 +9839,6 @@ class AppLocalizationsEt extends AppLocalizations {
   String get accountCutoverOpenStore => 'Avaa kauppa';
 
   @override
-  String get chatScopeToday => 'Täna';
-
-  @override
-  String get chatScopeThisWeek => 'Sel nädalal';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Teave: $title';
   }

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -9845,12 +9845,6 @@ class AppLocalizationsFa extends AppLocalizations {
   String get accountCutoverOpenStore => 'فتح المتجر';
 
   @override
-  String get chatScopeToday => 'امروز';
-
-  @override
-  String get chatScopeThisWeek => 'این هفته';
-
-  @override
   String chatScopeAbout(String title) {
     return 'درباره: $title';
   }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9845,12 +9845,6 @@ class AppLocalizationsFi extends AppLocalizations {
   String get accountCutoverOpenStore => 'Avaa kauppa';
 
   @override
-  String get chatScopeToday => 'Tänään';
-
-  @override
-  String get chatScopeThisWeek => 'Tällä viikolla';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Aihe: $title';
   }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9932,12 +9932,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get accountCutoverOpenStore => 'Ouvrir le store';
 
   @override
-  String get chatScopeToday => 'Aujourd’hui';
-
-  @override
-  String get chatScopeThisWeek => 'Cette semaine';
-
-  @override
   String chatScopeAbout(String title) {
     return 'À propos de : $title';
   }

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -9767,12 +9767,6 @@ class AppLocalizationsHe extends AppLocalizations {
   String get accountCutoverOpenStore => 'פתחו חנות';
 
   @override
-  String get chatScopeToday => 'היום';
-
-  @override
-  String get chatScopeThisWeek => 'השבוע הזה';
-
-  @override
   String chatScopeAbout(String title) {
     return 'אודות: $title';
   }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -9824,12 +9824,6 @@ class AppLocalizationsHi extends AppLocalizations {
   String get accountCutoverOpenStore => 'स्टोर खोलें';
 
   @override
-  String get chatScopeToday => 'आज';
-
-  @override
-  String get chatScopeThisWeek => 'इस सप्ताह';
-
-  @override
   String chatScopeAbout(String title) {
     return 'इसके बारे में: $title';
   }

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -9880,12 +9880,6 @@ class AppLocalizationsHr extends AppLocalizations {
   String get accountCutoverOpenStore => 'Otevřít obchod';
 
   @override
-  String get chatScopeToday => 'Danas';
-
-  @override
-  String get chatScopeThisWeek => 'Ovaj tjedan';
-
-  @override
   String chatScopeAbout(String title) {
     return 'O: $title';
   }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9885,12 +9885,6 @@ class AppLocalizationsHu extends AppLocalizations {
   String get accountCutoverOpenStore => 'Áruház megnyitása';
 
   @override
-  String get chatScopeToday => 'Ma';
-
-  @override
-  String get chatScopeThisWeek => 'Ezen a héten';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Erről: $title';
   }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9855,12 +9855,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get accountCutoverOpenStore => 'Buka toko';
 
   @override
-  String get chatScopeToday => 'Hari ini';
-
-  @override
-  String get chatScopeThisWeek => 'Minggu ini';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Tentang: $title';
   }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9902,12 +9902,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get accountCutoverOpenStore => 'Apri store';
 
   @override
-  String get chatScopeToday => 'Oggi';
-
-  @override
-  String get chatScopeThisWeek => 'Questa settimana';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Informazioni su: $title';
   }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -9679,12 +9679,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get accountCutoverOpenStore => 'ストアを開く';
 
   @override
-  String get chatScopeToday => '今日';
-
-  @override
-  String get chatScopeThisWeek => '今週';
-
-  @override
   String chatScopeAbout(String title) {
     return '$titleについて';
   }

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -9876,12 +9876,6 @@ class AppLocalizationsKn extends AppLocalizations {
   String get accountCutoverOpenStore => 'स्टोर खोलें';
 
   @override
-  String get chatScopeToday => 'ಇಂದು';
-
-  @override
-  String get chatScopeThisWeek => 'ಈ ವಾರ';
-
-  @override
   String chatScopeAbout(String title) {
     return '$title ಕುರಿತು';
   }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -9680,12 +9680,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get accountCutoverOpenStore => '스토어 열기';
 
   @override
-  String get chatScopeToday => '오늘';
-
-  @override
-  String get chatScopeThisWeek => '이번 주';
-
-  @override
   String chatScopeAbout(String title) {
     return '$title에 대해';
   }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9864,12 +9864,6 @@ class AppLocalizationsLt extends AppLocalizations {
   String get accountCutoverOpenStore => 'Otwórz sklep';
 
   @override
-  String get chatScopeToday => 'Šiandien';
-
-  @override
-  String get chatScopeThisWeek => 'Šią savaitę';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Apie: $title';
   }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9868,12 +9868,6 @@ class AppLocalizationsLv extends AppLocalizations {
   String get accountCutoverOpenStore => 'Otwórz sklep';
 
   @override
-  String get chatScopeToday => 'Šodien';
-
-  @override
-  String get chatScopeThisWeek => 'Šonedēļ';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Par: $title';
   }

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -9897,12 +9897,6 @@ class AppLocalizationsMk extends AppLocalizations {
   String get accountCutoverOpenStore => 'Otevřít obchod';
 
   @override
-  String get chatScopeToday => 'Денес';
-
-  @override
-  String get chatScopeThisWeek => 'Оваа недела';
-
-  @override
   String chatScopeAbout(String title) {
     return 'За: $title';
   }

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -9854,12 +9854,6 @@ class AppLocalizationsMr extends AppLocalizations {
   String get accountCutoverOpenStore => 'स्टोर खोलें';
 
   @override
-  String get chatScopeToday => 'आज';
-
-  @override
-  String get chatScopeThisWeek => 'या आठवड्यात';
-
-  @override
   String chatScopeAbout(String title) {
     return '$title विषयी';
   }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9870,12 +9870,6 @@ class AppLocalizationsMs extends AppLocalizations {
   String get accountCutoverOpenStore => 'Buka toko';
 
   @override
-  String get chatScopeToday => 'Hari ini';
-
-  @override
-  String get chatScopeThisWeek => 'Minggu ini';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Perihal: $title';
   }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9872,12 +9872,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get accountCutoverOpenStore => 'Store openen';
 
   @override
-  String get chatScopeToday => 'Vandaag';
-
-  @override
-  String get chatScopeThisWeek => 'Deze week';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Over: $title';
   }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9844,12 +9844,6 @@ class AppLocalizationsNo extends AppLocalizations {
   String get accountCutoverOpenStore => 'Öppna butik';
 
   @override
-  String get chatScopeToday => 'I dag';
-
-  @override
-  String get chatScopeThisWeek => 'Denne uken';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Om: $title';
   }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9874,12 +9874,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get accountCutoverOpenStore => 'Otwórz sklep';
 
   @override
-  String get chatScopeToday => 'Dzisiaj';
-
-  @override
-  String get chatScopeThisWeek => 'W tym tygodniu';
-
-  @override
   String chatScopeAbout(String title) {
     return 'O: $title';
   }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9853,12 +9853,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get accountCutoverOpenStore => 'Abrir loja';
 
   @override
-  String get chatScopeToday => 'Hoje';
-
-  @override
-  String get chatScopeThisWeek => 'Esta semana';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Sobre: $title';
   }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9892,12 +9892,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get accountCutoverOpenStore => 'Deschide magazinul';
 
   @override
-  String get chatScopeToday => 'Astăzi';
-
-  @override
-  String get chatScopeThisWeek => 'Săptămâna aceasta';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Despre: $title';
   }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9882,12 +9882,6 @@ class AppLocalizationsRu extends AppLocalizations {
   String get accountCutoverOpenStore => 'Открыть магазин';
 
   @override
-  String get chatScopeToday => 'Сегодня';
-
-  @override
-  String get chatScopeThisWeek => 'На этой неделе';
-
-  @override
   String chatScopeAbout(String title) {
     return 'О: $title';
   }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -9838,12 +9838,6 @@ class AppLocalizationsSk extends AppLocalizations {
   String get accountCutoverOpenStore => 'Otevřít obchod';
 
   @override
-  String get chatScopeToday => 'Dnes';
-
-  @override
-  String get chatScopeThisWeek => 'Tento týždeň';
-
-  @override
   String chatScopeAbout(String title) {
     return 'O: $title';
   }

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -9875,12 +9875,6 @@ class AppLocalizationsSl extends AppLocalizations {
   String get accountCutoverOpenStore => 'Otevřít obchod';
 
   @override
-  String get chatScopeToday => 'Danes';
-
-  @override
-  String get chatScopeThisWeek => 'Ta teden';
-
-  @override
   String chatScopeAbout(String title) {
     return 'O: $title';
   }

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -9860,12 +9860,6 @@ class AppLocalizationsSr extends AppLocalizations {
   String get accountCutoverOpenStore => 'Otevřít obchod';
 
   @override
-  String get chatScopeToday => 'Данас';
-
-  @override
-  String get chatScopeThisWeek => 'Ове недеље';
-
-  @override
   String chatScopeAbout(String title) {
     return 'О: $title';
   }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9849,12 +9849,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get accountCutoverOpenStore => 'Öppna butik';
 
   @override
-  String get chatScopeToday => 'Idag';
-
-  @override
-  String get chatScopeThisWeek => 'Den här veckan';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Om: $title';
   }

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -9914,12 +9914,6 @@ class AppLocalizationsTa extends AppLocalizations {
   String get accountCutoverOpenStore => 'स्टोर खोलें';
 
   @override
-  String get chatScopeToday => 'இன்று';
-
-  @override
-  String get chatScopeThisWeek => 'இந்த வாரம்';
-
-  @override
   String chatScopeAbout(String title) {
     return '$title பற்றி';
   }

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -9893,12 +9893,6 @@ class AppLocalizationsTe extends AppLocalizations {
   String get accountCutoverOpenStore => 'स्टोर खोलें';
 
   @override
-  String get chatScopeToday => 'ఈ రోజు';
-
-  @override
-  String get chatScopeThisWeek => 'ఈ వారం';
-
-  @override
   String chatScopeAbout(String title) {
     return '$title గురించి';
   }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -9789,12 +9789,6 @@ class AppLocalizationsTh extends AppLocalizations {
   String get accountCutoverOpenStore => 'เปิดสโตร์';
 
   @override
-  String get chatScopeToday => 'วันนี้';
-
-  @override
-  String get chatScopeThisWeek => 'สัปดาห์นี้';
-
-  @override
   String chatScopeAbout(String title) {
     return 'เกี่ยวกับ: $title';
   }

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -9935,12 +9935,6 @@ class AppLocalizationsTl extends AppLocalizations {
   String get accountCutoverOpenStore => 'Buka toko';
 
   @override
-  String get chatScopeToday => 'Ngayon';
-
-  @override
-  String get chatScopeThisWeek => 'Ngayong linggo';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Tungkol sa: $title';
   }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9856,12 +9856,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get accountCutoverOpenStore => 'Mağazayı aç';
 
   @override
-  String get chatScopeToday => 'Bugün';
-
-  @override
-  String get chatScopeThisWeek => 'Bu hafta';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Hakkında: $title';
   }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9867,12 +9867,6 @@ class AppLocalizationsUk extends AppLocalizations {
   String get accountCutoverOpenStore => 'Відкрити магазин';
 
   @override
-  String get chatScopeToday => 'Сьогодні';
-
-  @override
-  String get chatScopeThisWeek => 'Цього тижня';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Про: $title';
   }

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -9857,12 +9857,6 @@ class AppLocalizationsUr extends AppLocalizations {
   String get accountCutoverOpenStore => 'فتح المتجر';
 
   @override
-  String get chatScopeToday => 'آج';
-
-  @override
-  String get chatScopeThisWeek => 'اس ہفتے';
-
-  @override
   String chatScopeAbout(String title) {
     return '$title کے بارے میں';
   }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9841,12 +9841,6 @@ class AppLocalizationsVi extends AppLocalizations {
   String get accountCutoverOpenStore => 'Mở cửa hàng';
 
   @override
-  String get chatScopeToday => 'Hôm nay';
-
-  @override
-  String get chatScopeThisWeek => 'Tuần này';
-
-  @override
   String chatScopeAbout(String title) {
     return 'Về: $title';
   }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -9661,12 +9661,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get accountCutoverOpenStore => '打开应用商店';
 
   @override
-  String get chatScopeToday => '今天';
-
-  @override
-  String get chatScopeThisWeek => '本周';
-
-  @override
   String chatScopeAbout(String title) {
     return '关于：$title';
   }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -3215,8 +3215,6 @@
     "accountCutoverMigrationInProgressMessage": "Twoje konto jest migrowane. Funkcje produktu są wstrzymane do końca migracji.",
     "accountCutoverMigrationRollbackMessage": "Twoje konto jest w trybie konserwacji po cofnięciu migracji. Nowsze dane mogą zostać odizolowane.",
     "accountCutoverOpenStore": "Otwórz sklep",
-    "chatScopeToday": "Šiandien",
-    "chatScopeThisWeek": "Šią savaitę",
     "chatScopeAbout": "Apie: {title}",
     "askAboutThisConversation": "Paklausti apie tai",
     "sendRawAudioToOmi": "Siųsti neapdorotą garsą į Omi",

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -3215,8 +3215,6 @@
     "accountCutoverMigrationInProgressMessage": "Twoje konto jest migrowane. Funkcje produktu są wstrzymane do końca migracji.",
     "accountCutoverMigrationRollbackMessage": "Twoje konto jest w trybie konserwacji po cofnięciu migracji. Nowsze dane mogą zostać odizolowane.",
     "accountCutoverOpenStore": "Otwórz sklep",
-    "chatScopeToday": "Šodien",
-    "chatScopeThisWeek": "Šonedēļ",
     "chatScopeAbout": "Par: {title}",
     "askAboutThisConversation": "Jautāt par šo",
     "sendRawAudioToOmi": "Sūtīt neapstrādātu audio uz Omi",

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -10781,8 +10781,6 @@
     "accountCutoverMigrationInProgressMessage": "Váš účet se migrací. Produktové funkce jsou pozastaveny až do dokončení migrace.",
     "accountCutoverMigrationRollbackMessage": "Váš účet je po vrácení migrace v režimu údržby. Novější data mohou být izolována.",
     "accountCutoverOpenStore": "Otevřít obchod",
-    "chatScopeToday": "Денес",
-    "chatScopeThisWeek": "Оваа недела",
     "chatScopeAbout": "За: {title}",
     "askAboutThisConversation": "Прашај за ова",
     "sendRawAudioToOmi": "Испраќај необработено аудио до Omi",

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -10781,8 +10781,6 @@
     "accountCutoverMigrationInProgressMessage": "आपका खाता माइग्रेट हो रहा है। माइग्रेशन पूरा होने तक उत्पाद सुविधाएँ रुकी रहेंगी।",
     "accountCutoverMigrationRollbackMessage": "माइग्रेशन रोलबैक के बाद आपका खाता रखरखाव में है। कुछ नए डेटा अलग रह सकते हैं।",
     "accountCutoverOpenStore": "स्टोर खोलें",
-    "chatScopeToday": "आज",
-    "chatScopeThisWeek": "या आठवड्यात",
     "chatScopeAbout": "{title} विषयी",
     "askAboutThisConversation": "याबद्दल विचारा",
     "sendRawAudioToOmi": "Omi ला कच्चा ऑडिओ पाठवा",

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -3215,8 +3215,6 @@
     "accountCutoverMigrationInProgressMessage": "Akun Anda sedang dimigrasi. Fitur produk dijeda hingga migrasi selesai.",
     "accountCutoverMigrationRollbackMessage": "Akun Anda dalam pemeliharaan setelah rollback migrasi. Beberapa data yang lebih baru mungkin terisolasi.",
     "accountCutoverOpenStore": "Buka toko",
-    "chatScopeToday": "Hari ini",
-    "chatScopeThisWeek": "Minggu ini",
     "chatScopeAbout": "Perihal: {title}",
     "askAboutThisConversation": "Tanya tentang ini",
     "sendRawAudioToOmi": "Hantar audio mentah ke Omi",

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -3215,8 +3215,6 @@
     "accountCutoverMigrationInProgressMessage": "Je account wordt gemigreerd. Productfuncties zijn gepauzeerd tot de migratie klaar is.",
     "accountCutoverMigrationRollbackMessage": "Je account is in onderhoud na een migratie-rollback. Nieuwere data kan geïsoleerd zijn.",
     "accountCutoverOpenStore": "Store openen",
-    "chatScopeToday": "Vandaag",
-    "chatScopeThisWeek": "Deze week",
     "chatScopeAbout": "Over: {title}",
     "askAboutThisConversation": "Hiernaar vragen",
     "sendRawAudioToOmi": "Onbewerkte audio naar Omi sturen",

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -3215,8 +3215,6 @@
     "accountCutoverMigrationInProgressMessage": "Ditt konto migreras. Produktfunktioner pausas tills migreringen är klar.",
     "accountCutoverMigrationRollbackMessage": "Ditt konto är under underhåll efter en migreringsåterställning. Nyare data kan vara isolerad.",
     "accountCutoverOpenStore": "Öppna butik",
-    "chatScopeToday": "I dag",
-    "chatScopeThisWeek": "Denne uken",
     "chatScopeAbout": "Om: {title}",
     "askAboutThisConversation": "Spør om dette",
     "sendRawAudioToOmi": "Send rå lyd til Omi",

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -3250,8 +3250,6 @@
     "accountCutoverMigrationInProgressMessage": "Twoje konto jest migrowane. Funkcje produktu są wstrzymane do końca migracji.",
     "accountCutoverMigrationRollbackMessage": "Twoje konto jest w trybie konserwacji po cofnięciu migracji. Nowsze dane mogą zostać odizolowane.",
     "accountCutoverOpenStore": "Otwórz sklep",
-    "chatScopeToday": "Dzisiaj",
-    "chatScopeThisWeek": "W tym tygodniu",
     "chatScopeAbout": "O: {title}",
     "askAboutThisConversation": "Zapytaj o to",
     "sendRawAudioToOmi": "Wysyłaj surowy dźwięk do Omi",

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -3251,8 +3251,6 @@
     "accountCutoverMigrationInProgressMessage": "Sua conta está migrando. Os recursos do produto ficam pausados até a migração terminar.",
     "accountCutoverMigrationRollbackMessage": "Sua conta está em manutenção após um rollback de migração. Alguns dados mais recentes podem ficar isolados.",
     "accountCutoverOpenStore": "Abrir loja",
-    "chatScopeToday": "Hoje",
-    "chatScopeThisWeek": "Esta semana",
     "chatScopeAbout": "Sobre: {title}",
     "askAboutThisConversation": "Perguntar sobre isto",
     "sendRawAudioToOmi": "Enviar áudio em bruto para o Omi",

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -3215,8 +3215,6 @@
     "accountCutoverMigrationInProgressMessage": "Contul tău este în curs de migrare. Funcțiile produsului sunt întrerupte până la finalizarea migrării.",
     "accountCutoverMigrationRollbackMessage": "Contul tău este în mentenanță după un rollback al migrării. Unele date mai noi pot fi izolate.",
     "accountCutoverOpenStore": "Deschide magazinul",
-    "chatScopeToday": "Astăzi",
-    "chatScopeThisWeek": "Săptămâna aceasta",
     "chatScopeAbout": "Despre: {title}",
     "askAboutThisConversation": "Întreabă despre asta",
     "sendRawAudioToOmi": "Trimite sunetul brut către Omi",

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -3250,8 +3250,6 @@
     "accountCutoverMigrationInProgressMessage": "Ваш аккаунт мигрирует. Функции продукта приостановлены до завершения миграции.",
     "accountCutoverMigrationRollbackMessage": "Ваш аккаунт на обслуживании после отката миграции. Часть более новых данных может быть изолирована.",
     "accountCutoverOpenStore": "Открыть магазин",
-    "chatScopeToday": "Сегодня",
-    "chatScopeThisWeek": "На этой неделе",
     "chatScopeAbout": "О: {title}",
     "askAboutThisConversation": "Спросить об этом",
     "sendRawAudioToOmi": "Отправлять необработанный звук в Omi",

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -3220,8 +3220,6 @@
     "accountCutoverMigrationInProgressMessage": "Váš účet se migrací. Produktové funkce jsou pozastaveny až do dokončení migrace.",
     "accountCutoverMigrationRollbackMessage": "Váš účet je po vrácení migrace v režimu údržby. Novější data mohou být izolována.",
     "accountCutoverOpenStore": "Otevřít obchod",
-    "chatScopeToday": "Dnes",
-    "chatScopeThisWeek": "Tento týždeň",
     "chatScopeAbout": "O: {title}",
     "askAboutThisConversation": "Opýtať sa na to",
     "sendRawAudioToOmi": "Odosielať nespracovaný zvuk do Omi",

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -10781,8 +10781,6 @@
     "accountCutoverMigrationInProgressMessage": "Váš účet se migrací. Produktové funkce jsou pozastaveny až do dokončení migrace.",
     "accountCutoverMigrationRollbackMessage": "Váš účet je po vrácení migrace v režimu údržby. Novější data mohou být izolována.",
     "accountCutoverOpenStore": "Otevřít obchod",
-    "chatScopeToday": "Danes",
-    "chatScopeThisWeek": "Ta teden",
     "chatScopeAbout": "O: {title}",
     "askAboutThisConversation": "Vprašaj o tem",
     "sendRawAudioToOmi": "Pošiljaj neobdelan zvok v Omi",

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -10781,8 +10781,6 @@
     "accountCutoverMigrationInProgressMessage": "Váš účet se migrací. Produktové funkce jsou pozastaveny až do dokončení migrace.",
     "accountCutoverMigrationRollbackMessage": "Váš účet je po vrácení migrace v režimu údržby. Novější data mohou být izolována.",
     "accountCutoverOpenStore": "Otevřít obchod",
-    "chatScopeToday": "Данас",
-    "chatScopeThisWeek": "Ове недеље",
     "chatScopeAbout": "О: {title}",
     "askAboutThisConversation": "Питај о овоме",
     "sendRawAudioToOmi": "Шаљи необрађени звук у Omi",

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -3215,8 +3215,6 @@
     "accountCutoverMigrationInProgressMessage": "Ditt konto migreras. Produktfunktioner pausas tills migreringen är klar.",
     "accountCutoverMigrationRollbackMessage": "Ditt konto är under underhåll efter en migreringsåterställning. Nyare data kan vara isolerad.",
     "accountCutoverOpenStore": "Öppna butik",
-    "chatScopeToday": "Idag",
-    "chatScopeThisWeek": "Den här veckan",
     "chatScopeAbout": "Om: {title}",
     "askAboutThisConversation": "Fråga om detta",
     "sendRawAudioToOmi": "Skicka rått ljud till Omi",

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -10781,8 +10781,6 @@
     "accountCutoverMigrationInProgressMessage": "आपका खाता माइग्रेट हो रहा है। माइग्रेशन पूरा होने तक उत्पाद सुविधाएँ रुकी रहेंगी।",
     "accountCutoverMigrationRollbackMessage": "माइग्रेशन रोलबैक के बाद आपका खाता रखरखाव में है। कुछ नए डेटा अलग रह सकते हैं।",
     "accountCutoverOpenStore": "स्टोर खोलें",
-    "chatScopeToday": "இன்று",
-    "chatScopeThisWeek": "இந்த வாரம்",
     "chatScopeAbout": "{title} பற்றி",
     "askAboutThisConversation": "இதைப் பற்றி கேள்",
     "sendRawAudioToOmi": "மூல ஆடியோவை Omi-க்கு அனுப்பவும்",

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -10781,8 +10781,6 @@
     "accountCutoverMigrationInProgressMessage": "आपका खाता माइग्रेट हो रहा है। माइग्रेशन पूरा होने तक उत्पाद सुविधाएँ रुकी रहेंगी।",
     "accountCutoverMigrationRollbackMessage": "माइग्रेशन रोलबैक के बाद आपका खाता रखरखाव में है। कुछ नए डेटा अलग रह सकते हैं।",
     "accountCutoverOpenStore": "स्टोर खोलें",
-    "chatScopeToday": "ఈ రోజు",
-    "chatScopeThisWeek": "ఈ వారం",
     "chatScopeAbout": "{title} గురించి",
     "askAboutThisConversation": "దీని గురించి అడగండి",
     "sendRawAudioToOmi": "ముడి ఆడియోను Omiకి పంపండి",

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -3215,8 +3215,6 @@
     "accountCutoverMigrationInProgressMessage": "บัญชีของคุณกำลังย้าย ฟีเจอร์ผลิตภัณฑ์จะหยุดชั่วคราวจนกว่าการย้ายจะเสร็จ",
     "accountCutoverMigrationRollbackMessage": "บัญชีของคุณอยู่ในโหมดบำรุงรักษาหลังการย้อนกลับการย้าย ข้อมูลที่ใหม่กว่าบางส่วนอาจถูกแยกไว้",
     "accountCutoverOpenStore": "เปิดสโตร์",
-    "chatScopeToday": "วันนี้",
-    "chatScopeThisWeek": "สัปดาห์นี้",
     "chatScopeAbout": "เกี่ยวกับ: {title}",
     "askAboutThisConversation": "ถามเกี่ยวกับสิ่งนี้",
     "sendRawAudioToOmi": "ส่งเสียงดิบไปยัง Omi",

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -10781,8 +10781,6 @@
     "accountCutoverMigrationInProgressMessage": "Akun Anda sedang dimigrasi. Fitur produk dijeda hingga migrasi selesai.",
     "accountCutoverMigrationRollbackMessage": "Akun Anda dalam pemeliharaan setelah rollback migrasi. Beberapa data yang lebih baru mungkin terisolasi.",
     "accountCutoverOpenStore": "Buka toko",
-    "chatScopeToday": "Ngayon",
-    "chatScopeThisWeek": "Ngayong linggo",
     "chatScopeAbout": "Tungkol sa: {title}",
     "askAboutThisConversation": "Itanong tungkol dito",
     "sendRawAudioToOmi": "Ipadala ang raw na audio sa Omi",

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -3250,8 +3250,6 @@
     "accountCutoverMigrationInProgressMessage": "Hesabınız taşınıyor. Taşıma bitene kadar ürün özellikleri duraklatılır.",
     "accountCutoverMigrationRollbackMessage": "Taşıma geri alınmasından sonra hesabınız bakımda. Daha yeni bazı veriler izole kalabilir.",
     "accountCutoverOpenStore": "Mağazayı aç",
-    "chatScopeToday": "Bugün",
-    "chatScopeThisWeek": "Bu hafta",
     "chatScopeAbout": "Hakkında: {title}",
     "askAboutThisConversation": "Bunu sor",
     "sendRawAudioToOmi": "Ham sesi Omi'ye gönder",

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -3215,8 +3215,6 @@
     "accountCutoverMigrationInProgressMessage": "Ваш обліковий запис мігрує. Функції продукту призупинено до завершення міграції.",
     "accountCutoverMigrationRollbackMessage": "Ваш обліковий запис на обслуговуванні після відкату міграції. Частина новіших даних може бути ізольована.",
     "accountCutoverOpenStore": "Відкрити магазин",
-    "chatScopeToday": "Сьогодні",
-    "chatScopeThisWeek": "Цього тижня",
     "chatScopeAbout": "Про: {title}",
     "askAboutThisConversation": "Запитати про це",
     "sendRawAudioToOmi": "Надсилати необроблений звук до Omi",

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -10781,8 +10781,6 @@
     "accountCutoverMigrationInProgressMessage": "حسابك قيد الترحيل. ميزات المنتج متوقفة مؤقتًا حتى انتهاء الترحيل.",
     "accountCutoverMigrationRollbackMessage": "حسابك قيد الصيانة بعد التراجع عن الترحيل. قد تُعزل بعض البيانات الأحدث.",
     "accountCutoverOpenStore": "فتح المتجر",
-    "chatScopeToday": "آج",
-    "chatScopeThisWeek": "اس ہفتے",
     "chatScopeAbout": "{title} کے بارے میں",
     "askAboutThisConversation": "اس کے بارے میں پوچھیں",
     "sendRawAudioToOmi": "خام آڈیو Omi کو بھیجیں",

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -3220,8 +3220,6 @@
     "accountCutoverMigrationInProgressMessage": "Tài khoản của bạn đang được di chuyển. Các tính năng sản phẩm tạm dừng cho đến khi hoàn tất.",
     "accountCutoverMigrationRollbackMessage": "Tài khoản của bạn đang bảo trì sau khi hoàn tác di chuyển. Một số dữ liệu mới hơn có thể bị cô lập.",
     "accountCutoverOpenStore": "Mở cửa hàng",
-    "chatScopeToday": "Hôm nay",
-    "chatScopeThisWeek": "Tuần này",
     "chatScopeAbout": "Về: {title}",
     "askAboutThisConversation": "Hỏi về điều này",
     "sendRawAudioToOmi": "Gửi âm thanh thô đến Omi",

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -3237,8 +3237,6 @@
     "accountCutoverMigrationInProgressMessage": "您的账户正在迁移。产品功能将暂停，直到迁移完成。",
     "accountCutoverMigrationRollbackMessage": "账户迁移回滚后处于维护状态。部分较新的数据可能被隔离。",
     "accountCutoverOpenStore": "打开应用商店",
-    "chatScopeToday": "今天",
-    "chatScopeThisWeek": "本周",
     "chatScopeAbout": "关于：{title}",
     "askAboutThisConversation": "询问此内容",
     "sendRawAudioToOmi": "向 Omi 发送原始音频",

--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -85,7 +85,6 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
   String? _pendingDeleteAppId;
   String? _selectedContext;
   bool _quotaSheetShown = false;
-  String? _timeframePreset; // 'today' | 'week' | null
   ChatPageContext? _chatScope;
 
   @override
@@ -458,11 +457,12 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                               }
                             },
                           ),
-                          // Scope chips (#4515) — conversation and/or Today / This week
+                          // Scope chip (#4515) — clears an active conversation scope (Ask about this)
                           Builder(
                             builder: (context) {
                               final scope = _chatScope;
                               final hasConversation = scope?.type == 'conversation' && (scope?.id?.isNotEmpty ?? false);
+                              if (!hasConversation) return const SizedBox.shrink();
                               final l10n = context.l10n;
                               return Padding(
                                 padding: const EdgeInsets.fromLTRB(16, 4, 16, 0),
@@ -470,29 +470,10 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                                   scrollDirection: Axis.horizontal,
                                   child: Row(
                                     children: [
-                                      if (hasConversation) ...[
-                                        _scopeChip(
-                                          label: l10n.chatScopeAbout(scope!.title ?? l10n.conversationTab),
-                                          selected: true,
-                                          onTap: () {
-                                            setState(() {
-                                              _timeframePreset = null;
-                                              _chatScope = null;
-                                            });
-                                          },
-                                        ),
-                                        const SizedBox(width: 8),
-                                      ],
                                       _scopeChip(
-                                        label: l10n.chatScopeToday,
-                                        selected: _timeframePreset == 'today',
-                                        onTap: () => _toggleTimeframe('today'),
-                                      ),
-                                      const SizedBox(width: 8),
-                                      _scopeChip(
-                                        label: l10n.chatScopeThisWeek,
-                                        selected: _timeframePreset == 'week',
-                                        onTap: () => _toggleTimeframe('week'),
+                                        label: l10n.chatScopeAbout(scope!.title ?? l10n.conversationTab),
+                                        selected: true,
+                                        onTap: () => setState(() => _chatScope = null),
                                       ),
                                     ],
                                   ),
@@ -1008,47 +989,6 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
         ),
       ),
     );
-  }
-
-  void _toggleTimeframe(String preset) {
-    if (_timeframePreset == preset) {
-      setState(() {
-        _timeframePreset = null;
-        final existing = _chatScope;
-        if (existing != null && existing.type == 'conversation') {
-          _chatScope = existing.copyWith(clearDates: true);
-        } else {
-          _chatScope = null;
-        }
-      });
-      return;
-    }
-
-    final now = DateTime.now();
-    final end = DateTime(now.year, now.month, now.day + 1).subtract(const Duration(microseconds: 1));
-    late DateTime start;
-    if (preset == 'today') {
-      start = DateTime(now.year, now.month, now.day);
-    } else {
-      final mondayOffset = now.weekday == DateTime.sunday ? -6 : 1 - now.weekday;
-      final monday = now.add(Duration(days: mondayOffset));
-      start = DateTime(monday.year, monday.month, monday.day);
-    }
-
-    final existing = _chatScope;
-    final l10n = context.l10n;
-    final next = (existing != null && existing.type == 'conversation')
-        ? existing.copyWith(startDate: start.toUtc().toIso8601String(), endDate: end.toUtc().toIso8601String())
-        : ChatPageContext(
-            type: 'recap',
-            title: preset == 'today' ? l10n.chatScopeToday : l10n.chatScopeThisWeek,
-            startDate: start.toUtc().toIso8601String(),
-            endDate: end.toUtc().toIso8601String(),
-          );
-    setState(() {
-      _timeframePreset = preset;
-      _chatScope = next;
-    });
   }
 
   void _showPlansSheetOnQuotaExceeded() {

--- a/web/app/src/components/chat/ChatPanel.tsx
+++ b/web/app/src/components/chat/ChatPanel.tsx
@@ -50,15 +50,8 @@ function getQuickPrompts(contextType: string | undefined): string[] {
 }
 
 export function ChatPanel() {
-  const {
-    isOpen,
-    closeChat,
-    currentContext,
-    setContext,
-    selectedAppId,
-    chat,
-    clearAppContext,
-  } = useChatContext();
+  const { isOpen, closeChat, currentContext, selectedAppId, chat, clearAppContext } =
+    useChatContext();
   const {
     messages,
     isLoading,
@@ -115,88 +108,6 @@ export function ChatPanel() {
   }, [isOpen]);
 
   const quickPrompts = getQuickPrompts(currentContext?.type);
-
-  const activeTimeframePreset = (() => {
-    if (!currentContext?.start_date || !currentContext?.end_date) return null;
-    const start = new Date(currentContext.start_date);
-    const end = new Date(currentContext.end_date);
-    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return null;
-    const now = new Date();
-    const todayStart = new Date(now);
-    todayStart.setHours(0, 0, 0, 0);
-    const todayEnd = new Date(now);
-    todayEnd.setHours(23, 59, 59, 999);
-    const sameDay =
-      Math.abs(start.getTime() - todayStart.getTime()) < 60_000 &&
-      Math.abs(end.getTime() - todayEnd.getTime()) < 60_000;
-    if (sameDay) return 'today' as const;
-    const day = now.getDay();
-    const mondayOffset = day === 0 ? -6 : 1 - day;
-    const weekStart = new Date(now);
-    weekStart.setDate(weekStart.getDate() + mondayOffset);
-    weekStart.setHours(0, 0, 0, 0);
-    const weekMatch =
-      Math.abs(start.getTime() - weekStart.getTime()) < 60_000 &&
-      Math.abs(end.getTime() - todayEnd.getTime()) < 60_000;
-    return weekMatch ? ('week' as const) : null;
-  })();
-
-  const applyTimeframePreset = (preset: 'today' | 'week' | null) => {
-    if (!preset) {
-      if (!currentContext) return;
-      const { start_date: _s, end_date: _e, ...rest } = currentContext;
-      // Keep conversation/task/memory context; drop only the date window.
-      if (
-        rest.type === 'recap' &&
-        !rest.id &&
-        (rest.title === 'Today' || rest.title === 'This week')
-      ) {
-        setContext(null);
-      } else {
-        setContext({ ...rest });
-      }
-      return;
-    }
-
-    const now = new Date();
-    const end = new Date(now);
-    end.setHours(23, 59, 59, 999);
-    const start = new Date(now);
-    if (preset === 'today') {
-      start.setHours(0, 0, 0, 0);
-    } else {
-      // Monday-start week in local time
-      const day = start.getDay();
-      const mondayOffset = day === 0 ? -6 : 1 - day;
-      start.setDate(start.getDate() + mondayOffset);
-      start.setHours(0, 0, 0, 0);
-    }
-
-    const base =
-      currentContext && currentContext.type !== 'general'
-        ? currentContext
-        : { type: 'recap' as const, title: preset === 'today' ? 'Today' : 'This week' };
-
-    const preserveTitle =
-      currentContext &&
-      (currentContext.type === 'conversation' ||
-        currentContext.type === 'task' ||
-        currentContext.type === 'memory') &&
-      currentContext.title;
-
-    setContext({
-      ...base,
-      title: preserveTitle
-        ? currentContext!.title
-        : base.type === 'recap'
-          ? preset === 'today'
-            ? 'Today'
-            : 'This week'
-          : base.title,
-      start_date: start.toISOString(),
-      end_date: end.toISOString(),
-    });
-  };
 
   // Handle file selection
   const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -366,7 +277,6 @@ export function ChatPanel() {
                     {currentContext?.title && !selectedAppId && (
                       <p className="text-xs text-text-tertiary truncate max-w-[250px]">
                         Context: {currentContext.title}
-                        {currentContext.start_date ? ' · timed' : ''}
                       </p>
                     )}
                   </div>
@@ -391,53 +301,6 @@ export function ChatPanel() {
                   </button>
                 </div>
               </div>
-
-              {!selectedAppId && (
-                <div className="flex items-center gap-2 px-4 py-2 border-b border-bg-tertiary">
-                  <span className="text-xs text-text-quaternary">Scope</span>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      applyTimeframePreset(
-                        activeTimeframePreset === 'today' ? null : 'today',
-                      )
-                    }
-                    className={cn(
-                      'text-xs px-2.5 py-1 rounded-full border transition-colors',
-                      activeTimeframePreset === 'today'
-                        ? 'border-text-secondary bg-bg-tertiary text-text-primary'
-                        : 'border-bg-tertiary text-text-tertiary hover:text-text-secondary',
-                    )}
-                  >
-                    Today
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      applyTimeframePreset(
-                        activeTimeframePreset === 'week' ? null : 'week',
-                      )
-                    }
-                    className={cn(
-                      'text-xs px-2.5 py-1 rounded-full border transition-colors',
-                      activeTimeframePreset === 'week'
-                        ? 'border-text-secondary bg-bg-tertiary text-text-primary'
-                        : 'border-bg-tertiary text-text-tertiary hover:text-text-secondary',
-                    )}
-                  >
-                    This week
-                  </button>
-                  {currentContext?.start_date && (
-                    <button
-                      type="button"
-                      onClick={() => applyTimeframePreset(null)}
-                      className="text-xs text-text-quaternary hover:text-text-secondary ml-auto"
-                    >
-                      Clear
-                    </button>
-                  )}
-                </div>
-              )}
 
               {/* Error banner */}
               {error && (


### PR DESCRIPTION
## Summary

- Removes the always-on **Today** / **This week** composer chips from the Flutter `ChatPage` (`app/lib/pages/chat/page.dart`) and the **Scope** row (Today / This week / Clear) from the web `ChatPanel` (`web/app/src/components/chat/ChatPanel.tsx`).
- Keeps everything the chips fed: backend `chat_scope` / `PageContext` fail-closed retrieval, `ChatPageContext` + `sendMessageStreamToServer(..., context:)`, conversation-detail **Ask about this** (`initialChatContext`), the conversation **About: {title}** chip that clears an active scope, and the web `currentContext` plumbing (header `Context: {title}` + context on Ask).
- Drops the now-unreferenced `chatScopeToday` / `chatScopeThisWeek` keys from `app_en.arb` plus the 48 translations and regenerates the checked-in gen-l10n output. `chatScopeAbout` and `askAboutThisConversation` stay (still referenced).

Follow-up to #11206 / #4515: this strips only the timeframe preset UI; #4515's backend hard-scope capability is untouched. Not a revert of #11206.

Why: dogfooding showed the chips look tappable but only preset `_chatScope` for the next typed Ask — selected vs unselected are near-identical dark pills, PTT/voice never sends the scope, and no visible Scope label makes the state discoverable.

## Verification

Flutter (`app/`):

- `dart format --line-length 120 lib/pages/chat/page.dart` → 0 changed
- `flutter analyze lib/pages/chat/page.dart` → No issues found
- `bash scripts/analyze_ratchet.sh` → passed
- `flutter gen-l10n` → checked-in output changes only drop the two chatScope keys
- `bash test.sh` → 1656 passed, 5 skipped, 1 failed: `conversation_location_capture_test` "shares one deadline between capture and compatibility upload" fails only under full-suite load on this machine and passes in isolation (`flutter test test/unit/conversation_location_capture_test.dart` → 10/10). Timing flake unrelated to this diff (chat page + l10n only).

Web (`web/app/`):

- `bun run lint` → zero findings for ChatPanel.tsx
- `bun run typecheck` → clean
- `bunx vitest run src/components/chat` → 8 files / 30 tests passed

No device smoke run; the composer change is verified via analyzer, widget suite, and web tests only.

Failure-Class: none

Closes SCA-396


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

