### PR TITLE
fix(firmware): keep DevKit 2 BLE alive when SD init fails

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -6,9 +6,9 @@
 checks:
   - id: devkit-offline-storage-startup-tests
     command: ["bash", "omi/firmware/devkit/tests/offline_storage/run.sh"]
-    triggers: ["omi/firmware/devkit/src/main.c", "omi/firmware/devkit/src/startup.c", "omi/firmware/devkit/src/startup.h", "omi/firmware/devkit/src/transport.c", "omi/firmware/devkit/src/transport.h", "omi/firmware/devkit/tests/offline_storage/**", "omi/firmware/devkit/CMakeLists.txt", ".github/checks-manifest.yaml"]
+    triggers: ["omi/firmware/devkit/src/startup.c", "omi/firmware/devkit/src/startup.h", "omi/firmware/devkit/tests/offline_storage/**", "omi/firmware/devkit/CMakeLists.txt", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
-    reason: "#9771: a DevKit 2 SD mount failure returned from main before BLE transport startup; the optional-storage boundary must remain non-fatal and pass an unavailable state to transport"
+    reason: "#9771: a DevKit 2 SD mount failure returned from main before BLE transport startup; this hermetic test links the real startup.c and asserts the optional-storage boundary stays non-fatal and reports an unavailable state via transport_start()'s argument (main.c and transport.c's own use of that argument are not exercised by this check)"
   - id: dev-harness-unit-tests
     command: ["bash", "scripts/dev-harness/run-tests.sh"]
     triggers: ["Makefile", "scripts/dev-harness/**", "desktop/macos/scripts/omi-fault-inject.sh", ".github/checks-manifest.yaml"]

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -4,6 +4,11 @@
 # Checks that consume PR metadata declare `requires_pr_body: true`; post-merge
 # push runs exclude only that category because no authoritative PR body is available.
 checks:
+  - id: devkit-offline-storage-startup-tests
+    command: ["bash", "omi/firmware/devkit/tests/offline_storage/run.sh"]
+    triggers: ["omi/firmware/devkit/src/main.c", "omi/firmware/devkit/src/startup.c", "omi/firmware/devkit/src/startup.h", "omi/firmware/devkit/src/transport.c", "omi/firmware/devkit/src/transport.h", "omi/firmware/devkit/tests/offline_storage/**", "omi/firmware/devkit/CMakeLists.txt", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#9771: a DevKit 2 SD mount failure returned from main before BLE transport startup; the optional-storage boundary must remain non-fatal and pass an unavailable state to transport"
   - id: dev-harness-unit-tests
     command: ["bash", "scripts/dev-harness/run-tests.sh"]
     triggers: ["Makefile", "scripts/dev-harness/**", "desktop/macos/scripts/omi-fault-inject.sh", ".github/checks-manifest.yaml"]

--- a/omi/firmware/AGENTS.md
+++ b/omi/firmware/AGENTS.md
@@ -12,6 +12,12 @@ Firmware releases are manual via `.github/workflows/firmware_release.yml`:
 
 Build logic lives in `omi/firmware/scripts/ci/`.
 
+## DevKit Tests
+
+Run the hermetic DevKit optional-storage startup regression test from the repository root:
+
+`bash omi/firmware/devkit/tests/offline_storage/run.sh`
+
 ## Formatting
 
 C/C++ files: `clang-format -i <files>` (the repo pre-commit hook covers this).

--- a/omi/firmware/devkit/CMakeLists.txt
+++ b/omi/firmware/devkit/CMakeLists.txt
@@ -7,6 +7,7 @@ enable_language(C ASM)
 
 target_sources(app PRIVATE
     src/main.c
+    src/startup.c
     src/transport.c
     src/mic.c
     src/led.c

--- a/omi/firmware/devkit/src/main.c
+++ b/omi/firmware/devkit/src/main.c
@@ -7,9 +7,8 @@
 #include "config.h"
 #include "led.h"
 #include "mic.h"
-#include "sdcard.h"
 #include "speaker.h"
-#include "storage.h"
+#include "startup.h"
 #include "transport.h"
 #include "usb.h"
 #include "utils.h"
@@ -220,25 +219,9 @@ int main(void)
     LOG_INF("Speaker initialized");
 #endif
 
-    // Enable sdcard
+    // Enable offline storage when available
 #ifdef CONFIG_OMI_ENABLE_OFFLINE_STORAGE
-    LOG_PRINTK("\n");
-    LOG_INF("Mount SD card...\n");
-
-    err = mount_sd_card();
-    if (err) {
-        LOG_ERR("Failed to mount SD card (err %d)", err);
-        return err;
-    }
-    k_msleep(500);
-
-    LOG_PRINTK("\n");
-    LOG_INF("Initializing storage...\n");
-
-    err = storage_init();
-    if (err) {
-        LOG_ERR("Failed to initialize storage (err %d)", err);
-    }
+    startup_init_optional_storage();
 #endif
 
     // Enable haptic
@@ -275,7 +258,7 @@ int main(void)
 
     // Start transport
     int transportErr;
-    transportErr = transport_start();
+    transportErr = startup_start_transport();
     if (transportErr) {
         LOG_ERR("Failed to start transport (err %d)", transportErr);
         // TODO: Detect the current core is app core or net core

--- a/omi/firmware/devkit/src/startup.c
+++ b/omi/firmware/devkit/src/startup.c
@@ -1,0 +1,41 @@
+#include "startup.h"
+
+#include <stdbool.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+#include "sdcard.h"
+#include "storage.h"
+#include "transport.h"
+
+LOG_MODULE_REGISTER(startup, CONFIG_LOG_DEFAULT_LEVEL);
+
+static bool offline_storage_available;
+
+void startup_init_optional_storage(void)
+{
+    offline_storage_available = false;
+
+    LOG_INF("Mounting SD card");
+    int err = mount_sd_card();
+    if (err) {
+        LOG_WRN("SD mount failed (err %d); continuing without offline storage", err);
+        return;
+    }
+
+    k_msleep(500);
+
+    LOG_INF("Initializing offline storage");
+    err = storage_init();
+    if (err) {
+        LOG_WRN("Offline storage init failed (err %d); continuing without offline storage", err);
+        return;
+    }
+
+    offline_storage_available = true;
+}
+
+int startup_start_transport(void)
+{
+    return transport_start(offline_storage_available);
+}

--- a/omi/firmware/devkit/src/startup.c
+++ b/omi/firmware/devkit/src/startup.c
@@ -20,6 +20,9 @@ void startup_init_optional_storage(void)
     int err = mount_sd_card();
     if (err) {
         LOG_WRN("SD mount failed (err %d); continuing without offline storage", err);
+        if (is_sd_on()) {
+            sd_off();
+        }
         return;
     }
 
@@ -29,6 +32,7 @@ void startup_init_optional_storage(void)
     err = storage_init();
     if (err) {
         LOG_WRN("Offline storage init failed (err %d); continuing without offline storage", err);
+        sd_off();
         return;
     }
 

--- a/omi/firmware/devkit/src/startup.h
+++ b/omi/firmware/devkit/src/startup.h
@@ -1,0 +1,16 @@
+#ifndef STARTUP_H
+#define STARTUP_H
+
+/**
+ * @brief Initializes optional offline storage without aborting device startup.
+ */
+void startup_init_optional_storage(void);
+
+/**
+ * @brief Starts BLE transport with the offline storage availability determined at startup.
+ *
+ * @return 0 if successful, negative errno code if transport startup fails
+ */
+int startup_start_transport(void);
+
+#endif

--- a/omi/firmware/devkit/src/transport.c
+++ b/omi/firmware/devkit/src/transport.c
@@ -698,14 +698,16 @@ static bool offline_storage_is_available(void)
 
 void update_file_size()
 {
-    k_mutex_lock(&write_sdcard_mutex, K_FOREVER);
     if (!offline_storage_is_available()) {
-        k_mutex_unlock(&write_sdcard_mutex);
         return;
     }
 
-    file_num_array[0] = get_file_size(1);
-    file_num_array[1] = get_offset();
+    int size = get_file_size(1);
+    int offset = get_offset();
+
+    k_mutex_lock(&write_sdcard_mutex, K_FOREVER);
+    file_num_array[0] = size;
+    file_num_array[1] = offset;
     k_mutex_unlock(&write_sdcard_mutex);
     // LOG_PRINTK("file size for file count %d %d\n",file_count,file_num_array[0]);
     // LOG_PRINTK("offset for file count %d %d\n",file_count,file_num_array[1]);

--- a/omi/firmware/devkit/src/transport.c
+++ b/omi/firmware/devkit/src/transport.c
@@ -782,6 +782,14 @@ void pusher(void)
     }
 }
 extern struct bt_gatt_service storage_service;
+
+static void register_storage_service_if_available(void)
+{
+    if (use_storage) {
+        bt_gatt_service_register(&storage_service);
+    }
+}
+
 //
 // Public functions
 //
@@ -823,7 +831,7 @@ int bt_on()
 {
     int err = bt_enable(NULL);
     bt_le_adv_start(BT_LE_ADV_CONN, bt_ad, ARRAY_SIZE(bt_ad), bt_sd, ARRAY_SIZE(bt_sd));
-    bt_gatt_service_register(&storage_service);
+    register_storage_service_if_available();
     if (use_storage) {
         k_mutex_lock(&write_sdcard_mutex, K_FOREVER);
         sd_on();
@@ -862,7 +870,7 @@ int transport_start(bool offline_storage_available)
 
     // Start advertising
     memset(storage_temp_data, 0, OPUS_PADDED_LENGTH * 4);
-    bt_gatt_service_register(&storage_service);
+    register_storage_service_if_available();
     bt_gatt_service_register(&audio_service);
     bt_gatt_service_register(&dfu_service);
     err = bt_le_adv_start(BT_LE_ADV_CONN, bt_ad, ARRAY_SIZE(bt_ad), bt_sd, ARRAY_SIZE(bt_sd));

--- a/omi/firmware/devkit/src/transport.c
+++ b/omi/firmware/devkit/src/transport.c
@@ -38,6 +38,15 @@ uint16_t current_package_index = 0;
 // Internal
 //
 
+struct sensors {
+    struct sensor_value a_x;
+    struct sensor_value a_y;
+    struct sensor_value a_z;
+    struct sensor_value g_x;
+    struct sensor_value g_y;
+    struct sensor_value g_z;
+};
+
 struct k_mutex write_sdcard_mutex;
 
 static ssize_t audio_data_write_handler(struct bt_conn *conn,
@@ -677,15 +686,27 @@ bool write_to_storage(void)
     return true;
 }
 
-static bool use_storage = true;
+static bool use_storage;
 #define MAX_FILES 10
 #define MAX_AUDIO_FILE_SIZE 300000
 static int recent_file_size_updated = 0;
 static uint8_t heartbeat_count = 0;
+static bool offline_storage_is_available(void)
+{
+    return use_storage && is_sd_on();
+}
+
 void update_file_size()
 {
+    k_mutex_lock(&write_sdcard_mutex, K_FOREVER);
+    if (!offline_storage_is_available()) {
+        k_mutex_unlock(&write_sdcard_mutex);
+        return;
+    }
+
     file_num_array[0] = get_file_size(1);
     file_num_array[1] = get_offset();
+    k_mutex_unlock(&write_sdcard_mutex);
     // LOG_PRINTK("file size for file count %d %d\n",file_count,file_num_array[0]);
     // LOG_PRINTK("offset for file count %d %d\n",file_count,file_num_array[1]);
 }
@@ -726,11 +747,11 @@ void pusher(void)
             valid = bt_gatt_is_subscribed(conn, &audio_service.attrs[1], BT_GATT_CCC_NOTIFY); // Check if subscribed
         }
 
-        if (!valid && !storage_is_on) {
+        if (!valid && !storage_is_on && use_storage) {
             bool result = false;
             if (file_num_array[1] < MAX_STORAGE_BYTES) {
                 k_mutex_lock(&write_sdcard_mutex, K_FOREVER);
-                if (is_sd_on()) {
+                if (offline_storage_is_available()) {
                     result = write_to_storage();
                 }
                 k_mutex_unlock(&write_sdcard_mutex);
@@ -801,15 +822,20 @@ int bt_on()
     int err = bt_enable(NULL);
     bt_le_adv_start(BT_LE_ADV_CONN, bt_ad, ARRAY_SIZE(bt_ad), bt_sd, ARRAY_SIZE(bt_sd));
     bt_gatt_service_register(&storage_service);
-    sd_on();
+    if (use_storage) {
+        k_mutex_lock(&write_sdcard_mutex, K_FOREVER);
+        sd_on();
+        k_mutex_unlock(&write_sdcard_mutex);
+    }
     mic_on();
 
     return 0;
 }
 
 // periodic advertising
-int transport_start()
+int transport_start(bool offline_storage_available)
 {
+    use_storage = offline_storage_available;
     k_mutex_init(&write_sdcard_mutex);
 
     // Configure callbacks

--- a/omi/firmware/devkit/src/transport.h
+++ b/omi/firmware/devkit/src/transport.h
@@ -1,16 +1,11 @@
 #ifndef TRANSPORT_H
 #define TRANSPORT_H
 
-#include <zephyr/drivers/sensor.h>
-typedef struct sensors {
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
-    struct sensor_value a_x;
-    struct sensor_value a_y;
-    struct sensor_value a_z;
-    struct sensor_value g_x;
-    struct sensor_value g_y;
-    struct sensor_value g_z;
-};
+struct bt_conn;
 /**
  * @brief Initialize the BLE transport logic
  *
@@ -18,7 +13,7 @@ typedef struct sensors {
  *
  * @return 0 if successful, negative errno code if error
  */
-int transport_start();
+int transport_start(bool offline_storage_available);
 int broadcast_audio_packets(uint8_t *buffer, size_t size);
 struct bt_conn *get_current_connection();
 int bt_on();

--- a/omi/firmware/devkit/tests/offline_storage/run.sh
+++ b/omi/firmware/devkit/tests/offline_storage/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+test_dir="$repo_root/omi/firmware/devkit/tests/offline_storage"
+build_dir="$(mktemp -d "${TMPDIR:-/tmp}/omi-devkit-storage-test.XXXXXX")"
+trap 'rm -rf -- "$build_dir"' EXIT
+
+"${CC:-cc}" \
+  -std=c11 \
+  -Wall \
+  -Wextra \
+  -Werror \
+  -I"$test_dir/stubs" \
+  -I"$repo_root/omi/firmware/devkit/src" \
+  "$repo_root/omi/firmware/devkit/src/startup.c" \
+  "$test_dir/test_startup.c" \
+  -o "$build_dir/test_startup"
+
+"$build_dir/test_startup"

--- a/omi/firmware/devkit/tests/offline_storage/run.sh
+++ b/omi/firmware/devkit/tests/offline_storage/run.sh
@@ -6,10 +6,25 @@ test_dir="$repo_root/omi/firmware/devkit/tests/offline_storage"
 build_dir="$(mktemp -d "${TMPDIR:-/tmp}/omi-devkit-storage-test.XXXXXX")"
 trap 'rm -rf -- "$build_dir"' EXIT
 
-"${CC:-cc}" \
+cc="${CC:-}"
+if [ -z "$cc" ]; then
+    for candidate in cc gcc clang; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            cc="$candidate"
+            break
+        fi
+    done
+fi
+if [ -z "$cc" ]; then
+    echo "error: no C compiler found (looked for cc, gcc, clang; set \$CC to override)" >&2
+    exit 1
+fi
+
+"$cc" \
   -std=c11 \
   -Wall \
   -Wextra \
+  -Wno-strict-prototypes \
   -Werror \
   -I"$test_dir/stubs" \
   -I"$repo_root/omi/firmware/devkit/src" \

--- a/omi/firmware/devkit/tests/offline_storage/stubs/zephyr/kernel.h
+++ b/omi/firmware/devkit/tests/offline_storage/stubs/zephyr/kernel.h
@@ -1,0 +1,8 @@
+#ifndef TEST_ZEPHYR_KERNEL_H
+#define TEST_ZEPHYR_KERNEL_H
+
+#include <stdint.h>
+
+int32_t k_msleep(int32_t ms);
+
+#endif

--- a/omi/firmware/devkit/tests/offline_storage/stubs/zephyr/logging/log.h
+++ b/omi/firmware/devkit/tests/offline_storage/stubs/zephyr/logging/log.h
@@ -1,0 +1,8 @@
+#ifndef TEST_ZEPHYR_LOGGING_LOG_H
+#define TEST_ZEPHYR_LOGGING_LOG_H
+
+#define LOG_MODULE_REGISTER(...)
+#define LOG_INF(...)
+#define LOG_WRN(...)
+
+#endif

--- a/omi/firmware/devkit/tests/offline_storage/test_startup.c
+++ b/omi/firmware/devkit/tests/offline_storage/test_startup.c
@@ -1,0 +1,139 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "startup.h"
+
+static int mount_result;
+static int storage_result;
+static int transport_result;
+static int mount_calls;
+static int storage_calls;
+static int transport_calls;
+static int sleep_calls;
+static int32_t last_sleep_ms;
+static bool last_transport_storage_available;
+
+static void reset_fakes(void)
+{
+    mount_result = 0;
+    storage_result = 0;
+    transport_result = 0;
+    mount_calls = 0;
+    storage_calls = 0;
+    transport_calls = 0;
+    sleep_calls = 0;
+    last_sleep_ms = 0;
+    last_transport_storage_available = false;
+}
+
+int mount_sd_card(void)
+{
+    mount_calls++;
+    return mount_result;
+}
+
+int storage_init(void)
+{
+    storage_calls++;
+    return storage_result;
+}
+
+int transport_start(bool offline_storage_available)
+{
+    transport_calls++;
+    last_transport_storage_available = offline_storage_available;
+    return transport_result;
+}
+
+int32_t k_msleep(int32_t ms)
+{
+    sleep_calls++;
+    last_sleep_ms = ms;
+    return 0;
+}
+
+static void test_storage_success(void)
+{
+    reset_fakes();
+
+    startup_init_optional_storage();
+    int result = startup_start_transport();
+
+    assert(result == 0);
+    assert(mount_calls == 1);
+    assert(storage_calls == 1);
+    assert(sleep_calls == 1);
+    assert(last_sleep_ms == 500);
+    assert(transport_calls == 1);
+    assert(last_transport_storage_available);
+}
+
+static void test_mount_failure_still_starts_transport(void)
+{
+    reset_fakes();
+    mount_result = -EIO;
+
+    startup_init_optional_storage();
+    int result = startup_start_transport();
+
+    assert(result == 0);
+    assert(mount_calls == 1);
+    assert(storage_calls == 0);
+    assert(sleep_calls == 0);
+    assert(transport_calls == 1);
+    assert(!last_transport_storage_available);
+}
+
+static void test_storage_failure_still_starts_transport(void)
+{
+    reset_fakes();
+    storage_result = -ENOMEM;
+
+    startup_init_optional_storage();
+    int result = startup_start_transport();
+
+    assert(result == 0);
+    assert(mount_calls == 1);
+    assert(storage_calls == 1);
+    assert(sleep_calls == 1);
+    assert(last_sleep_ms == 500);
+    assert(transport_calls == 1);
+    assert(!last_transport_storage_available);
+}
+
+static void test_transport_failure_is_propagated(void)
+{
+    reset_fakes();
+    transport_result = -ENETDOWN;
+
+    startup_init_optional_storage();
+    int result = startup_start_transport();
+
+    assert(result == -ENETDOWN);
+    assert(transport_calls == 1);
+    assert(last_transport_storage_available);
+
+    reset_fakes();
+    mount_result = -EIO;
+    transport_result = -ENETDOWN;
+
+    startup_init_optional_storage();
+    result = startup_start_transport();
+
+    assert(result == -ENETDOWN);
+    assert(transport_calls == 1);
+    assert(!last_transport_storage_available);
+}
+
+int main(void)
+{
+    test_storage_success();
+    test_mount_failure_still_starts_transport();
+    test_storage_failure_still_starts_transport();
+    test_transport_failure_is_propagated();
+    puts("DevKit offline storage startup tests passed");
+    return 0;
+}

--- a/omi/firmware/devkit/tests/offline_storage/test_startup.c
+++ b/omi/firmware/devkit/tests/offline_storage/test_startup.c
@@ -15,6 +15,8 @@ static int transport_calls;
 static int sleep_calls;
 static int32_t last_sleep_ms;
 static bool last_transport_storage_available;
+static bool sd_on;
+static int sd_off_calls;
 
 static void reset_fakes(void)
 {
@@ -27,12 +29,28 @@ static void reset_fakes(void)
     sleep_calls = 0;
     last_sleep_ms = 0;
     last_transport_storage_available = false;
+    sd_on = false;
+    sd_off_calls = 0;
 }
 
 int mount_sd_card(void)
 {
     mount_calls++;
+    if (mount_result == 0) {
+        sd_on = true;
+    }
     return mount_result;
+}
+
+bool is_sd_on(void)
+{
+    return sd_on;
+}
+
+void sd_off(void)
+{
+    sd_off_calls++;
+    sd_on = false;
 }
 
 int storage_init(void)
@@ -69,6 +87,8 @@ static void test_storage_success(void)
     assert(last_sleep_ms == 500);
     assert(transport_calls == 1);
     assert(last_transport_storage_available);
+    assert(sd_off_calls == 0);
+    assert(sd_on);
 }
 
 static void test_mount_failure_still_starts_transport(void)
@@ -85,6 +105,7 @@ static void test_mount_failure_still_starts_transport(void)
     assert(sleep_calls == 0);
     assert(transport_calls == 1);
     assert(!last_transport_storage_available);
+    assert(!sd_on);
 }
 
 static void test_storage_failure_still_starts_transport(void)
@@ -102,6 +123,8 @@ static void test_storage_failure_still_starts_transport(void)
     assert(last_sleep_ms == 500);
     assert(transport_calls == 1);
     assert(!last_transport_storage_available);
+    assert(sd_off_calls == 1);
+    assert(!sd_on);
 }
 
 static void test_transport_failure_is_propagated(void)

--- a/omi/firmware/devkit/tests/offline_storage/test_startup.c
+++ b/omi/firmware/devkit/tests/offline_storage/test_startup.c
@@ -17,6 +17,9 @@ static int32_t last_sleep_ms;
 static bool last_transport_storage_available;
 static bool sd_on;
 static int sd_off_calls;
+// mount_sd_card() powers the card before the steps that can fail, so a failed
+// mount normally leaves it on; only the early GPIO-not-ready exit does not.
+static bool mount_powers_sd;
 
 static void reset_fakes(void)
 {
@@ -31,12 +34,13 @@ static void reset_fakes(void)
     last_transport_storage_available = false;
     sd_on = false;
     sd_off_calls = 0;
+    mount_powers_sd = true;
 }
 
 int mount_sd_card(void)
 {
     mount_calls++;
-    if (mount_result == 0) {
+    if (mount_powers_sd) {
         sd_on = true;
     }
     return mount_result;
@@ -105,7 +109,23 @@ static void test_mount_failure_still_starts_transport(void)
     assert(sleep_calls == 0);
     assert(transport_calls == 1);
     assert(!last_transport_storage_available);
+    assert(sd_off_calls == 1);
     assert(!sd_on);
+}
+
+static void test_mount_failure_before_power_on_skips_sd_off(void)
+{
+    reset_fakes();
+    mount_result = -EIO;
+    mount_powers_sd = false;
+
+    startup_init_optional_storage();
+    int result = startup_start_transport();
+
+    assert(result == 0);
+    assert(sd_off_calls == 0);
+    assert(transport_calls == 1);
+    assert(!last_transport_storage_available);
 }
 
 static void test_storage_failure_still_starts_transport(void)
@@ -155,6 +175,7 @@ int main(void)
 {
     test_storage_success();
     test_mount_failure_still_starts_transport();
+    test_mount_failure_before_power_on_skips_sd_off();
     test_storage_failure_still_starts_transport();
     test_transport_failure_is_propagated();
     puts("DevKit offline storage startup tests passed");


### PR DESCRIPTION
Fixes #9771

> **Hardware verification is required before merge.** The production-linked host regression and a clean DevKit v2 NCS v2.7.0 target build pass. I do not have a DevKit 2 connected, so this PR does not claim physical-device verification. The requested procedure is listed below.

## Problem

DevKit 2 treated offline storage as a mandatory boot dependency. When `mount_sd_card()` failed, `main()` returned before USB, BLE transport, codec, and microphone startup. A missing or unreadable SD card therefore disabled live BLE audio even though live transport does not require offline recording.

The original degraded-mode fix also left a capability mismatch: transport correctly avoided storage I/O, but still registered the storage GATT service. The app could then see an eight-byte zero response and incorrectly present storage as supported.

## Root cause

The boot sequence did not preserve the ownership boundary between optional storage and required transport. Transport also used the SD power flag as its only storage guard, even though `mount_sd_card()` can set that flag before a later mount step fails. Finally, GATT registration did not use the availability state passed into transport, so the advertised capability could disagree with the initialized subsystem.

## Fix

- Add a small DevKit startup boundary that owns offline-storage availability.
- Treat SD mount and storage-thread initialization failures as degraded startup: log the stage and error, power the card back down when necessary, and continue to transport.
- Pass the resulting availability into `transport_start()` and keep transport's own failures fatal.
- Require both successful startup initialization and current SD power before transport updates file metadata or writes queued audio.
- Prevent `bt_on()` from re-enabling an SD card whose startup initialization did not complete.
- Register the storage GATT service only when startup marked offline storage available. Initial transport startup and Bluetooth restart use the same private guard. Audio, DFU, button, and speaker services keep their existing registration and advertising flow.
- Keep blocking `get_file_size()` / `get_offset()` reads outside `write_sdcard_mutex`; `bt_off()` takes that mutex from the button thread, so a hung card must not stall the BLE path this PR protects.
- Register a hermetic host regression in the shared local/CI check manifest and document its component entrypoint.

With a healthy SD card, the existing storage, BLE, codec, and microphone order remains unchanged and the storage service is registered. With unavailable storage, BLE, USB, and live audio startup continue while the storage service is absent and transport cannot call `get_file_size()`, `get_offset()`, or `write_to_storage()`.

The app already treats an absent storage characteristic as an empty response and enters its existing no-storage UX. No app API, GATT UUID, characteristic payload, advertising data, wire protocol, or Kconfig change is needed.

## State and concurrency details

A late `mount_sd_card()` failure can leave the legacy `file_count` value populated. This PR intentionally does not introduce another SD-state API or infer availability from that value. In degraded mode it is unreachable from storage behavior because `use_storage` is false, the storage thread was not started, and the storage GATT service is not registered.

Metadata reads check `use_storage && is_sd_on()` immediately before each blocking filesystem call. They remain outside `write_sdcard_mutex` so Bluetooth shutdown is not blocked by a faulty card. Offline writes re-check the same availability condition while holding the existing mutex before entering `write_to_storage()`.

## Prior attempt

#9920 proposed removing the same `return err`. It was closed for process reasons rather than on the merits, with a request that any later version be tested before landing. This PR repairs the same boundary and adds behavioral coverage, degraded-mode I/O guards, SD power-down behavior, and conditional storage capability registration that #9920 did not include.

## Scope

This fixes only the failure boundary reported in #9771. It does not guess at or alter SD power pin P0.19, SPI wiring, card-slot hardware, SDHC/SDXC support, exFAT support, or individual board/card faults. The low-level cause remains a separate investigation; this PR makes an optional-storage failure stop costing the user BLE and live audio.

The new check is intentionally DevKit-specific rather than a shared firmware primitive. This legacy DevKit alone owns the `mount_sd_card()` / `storage_init()` / `transport_start()` startup contract, while CV1 firmware has a different lifecycle and toolchain. The real instance it would have caught is #9771: a shipped DevKit 2 that advertised nothing over BLE because optional-storage failure returned from `main()`; #9920 also shows this boundary being patched without a regression check.

## Regression coverage

The host test links production `startup.c` and replaces only `mount_sd_card()`, `storage_init()`, `transport_start()`, `k_msleep()`, `is_sd_on()`, and `sd_off()` with deterministic fakes. The mount fake mirrors production by powering the card before returning its result, so degraded power-down behavior is executed rather than asserted vacuously. It covers:

- healthy storage: one 500 ms wait, one storage initialization, one `transport_start(true)` call, and no `sd_off()`;
- SD mount failure after power-on: no wait or storage initialization, exactly one `sd_off()`, then one `transport_start(false)` call;
- SD mount failure before power-on: no `sd_off()`, still one `transport_start(false)` call;
- storage-thread initialization failure: exactly one `sd_off()` and a degraded `transport_start(false)` without marking storage available;
- transport failure: the exact transport error propagates with both healthy and degraded storage.

Mutation-checking confirmed that deleting either degraded `sd_off()` call aborts the test on its `sd_off_calls == 1` assertion.

No test-only Zephyr/Bluetooth injection framework was added for the two conditional registration calls. The production-linked startup test proves the false availability value reaches `transport_start()`, the private helper gives initial startup and Bluetooth restart one registration rule, and the clean real-target build verifies that integration against Zephyr's GATT API.

## Verification

The branch is rebased onto `origin/main` at `bd945adb3f`.

The final base-only rebase added one desktop test commit after the clean firmware build. `git diff --quiet f29d15fe4c..bd945adb3f -- omi/firmware .github/checks-manifest.yaml` confirmed that the firmware and manifest inputs were identical; the host regression, formatting, diff check, and both preflight modes were then rerun on final head `5ce5f08535`.

- `bash omi/firmware/devkit/tests/offline_storage/run.sh` — passed after rebase and after the review fix.
- `clang-format --dry-run --Werror <changed C/H files>` — passed with LLVM clang-format 22.1.8.
- `git diff --check` — passed.
- `scripts/pr-preflight --suggest` — no locked product invariant and no matching existing failure class.
- `make preflight` with this PR body — passed, including `devkit-offline-storage-startup-tests` in the local manifest lane.
- `scripts/pr-preflight --pr-body-file /tmp/pr-body-12512.md` — passed.
- Clean NCS v2.7.0 DevKit v2 Adafruit BFF build — passed after the firmware-changing rebase in the official Nordic toolchain image below with the synchronized NCS workspace mounted read-only and `--network none`; the final base-only rebase preserved the exact firmware inputs as noted above:

  `ghcr.io/nrfconnect/sdk-nrf-toolchain@sha256:b481467f39ed524a2cb23fed8b9dcdc1e4f60972988b913c386538953c929247`

  Target inputs: `BOARD=xiao_ble_sense`, `CONF_FILE=prj_xiao_ble_sense_devkitv2-adafruit.conf`, and `DTC_OVERLAY_FILE=overlay/xiao_ble_sense_devkitv2-adafruit.overlay`, using the existing configured build directory followed by `cmake --build build/build_xiao_ble_sense_devkitv2-adafruit --clean-first --parallel 2`.

  Generated artifacts: `zephyr.elf`, `zephyr.bin`, `zephyr.hex`, and `zephyr.uf2`. Flash: 302,460 B / 788 KB (37.48%). RAM: 192,600 B / 256 KB (73.47%). UF2: 605,184 B. UF2 SHA-256: `358f17f2ec069458e77f23c655b8f1e3ff8f2f57503254e7a46161da913bbbdf`.

## Hardware verification required

No DevKit 2, UF2 boot volume, or matching USB serial device is connected to the development Mac. A maintainer or issue reporter should verify:

1. Boot with a healthy FAT32 SD card and confirm BLE advertising and connection, live audio, storage-service discovery, and offline recording.
2. Remove the SD card or force a mount failure and confirm BLE advertising, app connection, and live audio remain available while the storage GATT service and characteristics are absent.
3. In degraded mode, confirm no reboot, crash, or card write occurs from storage access.
4. Restore a valid SD card, reboot, and confirm offline storage and its GATT service recover.

## Product invariants affected

none

Failure-Class: none
