### PR TITLE
deploy(backend): enable conversation notes v2 in prod

### DIFF
--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -134,7 +134,7 @@ env:
   - name: OMI_LLM_GPT56_EXPLICIT_CACHE_ENABLED
     value: "true"
   - name: CONVERSATION_NOTES_V2_ENABLED
-    value: "false"
+    value: "true"
   - name: MEETING_RECEIPT_RECONCILER_ENABLED
     value: "false"
   - name: LISTEN_FINALIZATION_BYOK_ABANDONMENT_ENABLED

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -1280,7 +1280,7 @@ environments:
               name: prod-omi-backend-config
               key: CONVERSATION_SUMMARIZED_APP_IDS
           CONVERSATION_NOTES_V2_ENABLED:
-            value: 'false'
+            value: 'true'
             category: rollout
           MEETING_RECEIPT_RECONCILER_ENABLED:
             value: 'false'
@@ -1574,7 +1574,7 @@ environments:
               value: '9090'
               category: telemetry
             CONVERSATION_NOTES_V2_ENABLED:
-              value: 'false'
+              value: 'true'
               category: rollout
             MEETING_RECEIPT_RECONCILER_ENABLED:
               value: 'false'

--- a/backend/deploy/runtime_env/prod.overlay.yaml
+++ b/backend/deploy/runtime_env/prod.overlay.yaml
@@ -61,6 +61,10 @@ overlay:
         OMI_LLM_GATEWAY_FEATURE_MODE:
           value: gateway
           category: rollout
+        # Notes v2 prod-on (2026-09-01). Calendar/OCR context stay dev-only below.
+        CONVERSATION_NOTES_V2_ENABLED:
+          value: 'true'
+          category: rollout
         MEMORY_ENABLED:
           value: 'on'
         # Canonical graph and /v3/memories first-page cursors fail closed without this HMAC.
@@ -206,6 +210,10 @@ overlay:
             category: rollout
           OMI_LLM_GATEWAY_FEATURE_MODE:
             value: gateway
+            category: rollout
+          # Notes v2 prod-on (2026-09-01); keep calendar/OCR context dev-only.
+          CONVERSATION_NOTES_V2_ENABLED:
+            value: 'true'
             category: rollout
           MEMORY_ENABLED:
             value: 'on'

--- a/backend/tests/unit/test_conversation_notes_v2_beta_rollout.py
+++ b/backend/tests/unit/test_conversation_notes_v2_beta_rollout.py
@@ -1,15 +1,17 @@
 """Where the conversation-notes-v2 rollout is on, and where it is not.
 
-The beta ring is a deployment, not a cohort: the `mobile_beta` profile and the beta desktop
-bundle are both pinned to the dev backend (`api.omiapi.com`) while authenticating against the
-production Firebase project. Turning the rollout flags on in the dev runtime environment is
-therefore how the feature reaches beta users without reaching production users.
+`CONVERSATION_NOTES_V2_ENABLED` went prod-on 2026-09-01 after the dev/Beta bake; the calendar
+context read and OCR context flags are still dev-only pending their own bakes. The dev
+environment doubles as the Beta ring: the `mobile_beta` profile and the beta desktop bundle
+are pinned to the dev backend (`api.omiapi.com`) while authenticating against the production
+Firebase project, so a flag still dark in prod reaches Beta users by turning dev on.
 
 Keeps this file import-light so the fast-unit duration guard stays honest.
 """
 
 from __future__ import annotations
 
+import functools
 from pathlib import Path
 
 import yaml
@@ -28,6 +30,7 @@ ROLLOUT_FLAGS = (
 SUMMARY_PIPELINE_SCOPES = ('gke/backend-listen', 'cloud_run/backend')
 
 
+@functools.cache
 def _composed() -> dict:
     return yaml.safe_load((BACKEND / 'deploy/runtime_env.yaml').read_text(encoding='utf-8'))
 
@@ -51,10 +54,18 @@ def test_dev_enables_every_rollout_flag_on_every_summary_pipeline_service():
             assert _value(env_maps[scope], flag) == 'true', f'{scope}:{flag}'
 
 
-def test_prod_still_ships_every_rollout_flag_dark():
+def test_prod_enables_conversation_notes_v2_on_every_summary_pipeline_service():
+    """Notes v2 went prod-on 2026-09-01 after the dev/Beta bake."""
     env_maps = _env_maps(_composed()['environments']['prod'])
     for scope in SUMMARY_PIPELINE_SCOPES:
-        for flag in ROLLOUT_FLAGS:
+        assert _value(env_maps[scope], 'CONVERSATION_NOTES_V2_ENABLED') == 'true', f'{scope}'
+
+
+def test_prod_keeps_calendar_and_ocr_context_flags_dark():
+    """Calendar context read and OCR context stay dev-only until their own bakes."""
+    env_maps = _env_maps(_composed()['environments']['prod'])
+    for scope in SUMMARY_PIPELINE_SCOPES:
+        for flag in ('CONVERSATION_CALENDAR_CONTEXT_READ_ENABLED', 'CONVERSATION_OCR_CONTEXT_ENABLED'):
             assert _value(env_maps[scope], flag) == 'false', f'{scope}:{flag}'
 
 

--- a/backend/tests/unit/test_conversation_speaker_placeholder_persistence.py
+++ b/backend/tests/unit/test_conversation_speaker_placeholder_persistence.py
@@ -1,7 +1,7 @@
 """Legacy summary writers must never persist Speaker N placeholders (SCA-395).
 
 `sanitize_structured_speaker_placeholders` (#12503) only ran inside the v2 note
-path (`get_conversation_notes`). Prod runs `CONVERSATION_NOTES_V2_ENABLED=false`,
+path (`get_conversation_notes`). At the time, prod ran `CONVERSATION_NOTES_V2_ENABLED=false`,
 so the legacy writers below produced most summaries — and could persist
 `Speaker 1` / `SPEAKER_00` verbatim. Speaker N is a diarization placeholder that
 is not stable across conversations; it must never reach the saved Structured.

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -178,6 +178,10 @@ class SummaryPipelineMode(str, Enum):
     reachable purely by flag misconfiguration.
     """
 
+    # Retire 2026-09-29: legacy path survives only a four-week prod bake of notes v2
+    # (prod-on 2026-09-01). After that date a follow-up PR deletes LEGACY_APP_PRIMARY,
+    # the legacy writers, and CONVERSATION_NOTES_V2_ENABLED itself — v2 becomes the
+    # only path. Do not build on this mode.
     LEGACY_APP_PRIMARY = 'legacy_app_primary'
     NOTES_V2_APPS_OPT_IN = 'notes_v2_primary_apps_opt_in'
 

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -1316,6 +1316,10 @@ def get_transcript_structure(
     calendar_meeting_context: Optional['CalendarMeetingContext'] = None,
     output_language_code: Optional[str] = None,
 ) -> Structured:
+    # Legacy writer: with CONVERSATION_NOTES_V2_ENABLED prod-on (2026-09-01) this runs
+    # only where the flag is still off. Retire 2026-09-29 after the four-week prod bake —
+    # a follow-up PR then deletes get_transcript_structure / get_reprocess_transcript_structure
+    # and makes notes v2 the only path. Do not build on this writer.
     # Keep this import at the invocation boundary: selected unit tests load
     # this pure processing module in isolation without the full LLM package.
     from utils.llm.usage_tracker import Features, track_usage


### PR DESCRIPTION
# deploy(backend): enable conversation notes v2 in prod

## What changed and why

Turns `CONVERSATION_NOTES_V2_ENABLED` on in prod on both summary-pipeline services — GKE `backend-listen` and Cloud Run `backend` — after the dev/Beta bake (authorized 2026-09-01). Calendar context read and OCR context stay **false** in prod; they are separate dev-only bakes.

With the flag on, notes v2 becomes the prod summary writer and automatic summarization apps become opt-in (preferred/explicit apps still run); `CONVERSATION_NOTES_V2_ENABLED` is the single switch for that whole configuration, so there is no half-migrated state to pick here.

- `backend/deploy/runtime_env/prod.overlay.yaml` — flag `true` in `gke.backend-listen.env` and `cloud_run.services.backend.env` (compose inputs, then re-composed into `backend/deploy/runtime_env.yaml`)
- `backend/charts/backend-listen/prod_omi_backend_listen_values.yaml` — flag `true`; Helm is what actually ships on GKE
- `backend/tests/unit/test_conversation_notes_v2_beta_rollout.py` — prod now asserts NOTES_V2 **true** on both scopes and calendar/OCR **false**; the listen-vs-reprocess agreement and chart-vs-compose checks are unchanged and still bind
- Retire schedule: comments on `SummaryPipelineMode.LEGACY_APP_PRIMARY` and `get_transcript_structure` pin 2026-09-29 (four-week prod bake) for deleting the legacy writers and the flag — tracked in #12511. No code deleted here.

Internal rollout — no user-facing changelog entry.

## Product invariants affected

- INV-MEM-4 — `process_conversation.py` sits under the invariant's globs; this PR changes comments only (retire schedule), no intake/promotion behavior
- INV-TASK-2 — same: `conversation_processing.py` is under the invariant's globs; comments only, the extraction prompt and Candidate routing are untouched

## How it was verified

- `bash backend/scripts/check_runtime_env_compose.sh` — `runtime_env.yaml is up to date`
- `bash backend/scripts/pre-deploy-check.sh` — `226 passed` + dev/prod runtime-env workflow validation
- `.venv/bin/python -m pytest tests/unit/test_conversation_notes_v2_beta_rollout.py` — `5 passed`
- `.venv/bin/python -m pytest tests/unit/test_conversation_speaker_placeholder_persistence.py tests/unit/test_process_conversation_usage_context.py tests/unit/test_backend_runtime_env_validator.py` — `157 passed`
- `python3 .github/scripts/check_product_file_line_count_ratchet.py --changed-files … --base origin/main --head HEAD --pr-body-file /dev/null` — `OK: no unapproved line-count increase`
- `origin/main` before: prod NOTES_V2 `false` on both scopes; after: `true` on both, everything else in the composed diff unchanged

## Tests

`test_prod_still_ships_every_rollout_flag_dark` is replaced by two tests that match the new contract: `test_prod_enables_conversation_notes_v2_on_every_summary_pipeline_service` (NOTES_V2 true on listen + Cloud Run backend) and `test_prod_keeps_calendar_and_ocr_context_flags_dark` (calendar/OCR false on both). `test_reprocess_cannot_disagree_with_live_finalization` and `test_the_deployed_chart_values_match_the_composed_manifest` are untouched and now guard the prod-on state. `_composed()` now parses the composed manifest once per process (`functools.cache`) — five full YAML parses per run were tripping the fast-unit CPU duration guard; re-verified under the guard runner (`BACKEND_UNIT_TEST_FILE_LIST=… bash test.sh`): 5 passed, no duration failures. Docstring in `test_conversation_speaker_placeholder_persistence.py` updated to past tense — prod no longer runs the flag dark.

 Failure-Class: none

Line-Count-Exception: backend/utils/conversations/process_conversation.py | 2624 -> 2628 | four retire-schedule comment lines on LEGACY_APP_PRIMARY; the file shrinks when the legacy mode is deleted per #12511
Line-Count-Exception: backend/utils/llm/conversation_processing.py | 1817 -> 1821 | four retire-schedule comment lines on get_transcript_structure; the writers are deleted per #12511


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

