### PR TITLE
fix(macos): do not request Bluetooth at launch

### DIFF
--- a/react-native/App.test.tsx
+++ b/react-native/App.test.tsx
@@ -47,19 +47,22 @@ test('macOS first paint and session probe do not require native devices or BLE',
   expect(onboarding).not.toContain(
     'setOnboardingRequired(!completed && !hasSession)',
   );
-  expect(onboarding).not.toContain('omiNative');
+  expect(onboarding).toContain("import {omiAuth} from '../omiNative'");
+  expect(onboarding).not.toMatch(/import \{[^}]*\bomiNative\b/);
   expect(onboarding).not.toContain('getSnapshot');
   expect(onboarding).not.toContain('useNativeDevices');
   expect(onboarding).not.toContain('CBCentral');
   expect(onboarding).not.toContain('startScan');
-  const sessionBlock = orchestrator.slice(
-    orchestrator.indexOf('session='),
-    orchestrator.indexOf('signingIn={signingIn}'),
+  const desktopMount = orchestrator.slice(
+    orchestrator.indexOf('<DesktopApp'),
+    orchestrator.indexOf('</PageShell>', orchestrator.indexOf('<DesktopApp')),
   );
-  expect(sessionBlock).toContain('onboardingRequired');
-  expect(sessionBlock).not.toContain('nativeSnapshot');
-  expect(sessionBlock).not.toContain('omiNative');
-  expect(sessionBlock).not.toContain('useNativeDevices');
+  expect(desktopMount).toContain('onboardingRequired');
+  expect(desktopMount).toContain("? 'probing'");
+  expect(desktopMount).toContain("'signed-out'");
+  expect(desktopMount).not.toContain('nativeSnapshot');
+  expect(desktopMount).not.toContain('omiNative');
+  expect(desktopMount).not.toContain('useNativeDevices');
 });
 
 test('DesktopApp owns sign-in inside the search-first shell', () => {

--- a/react-native/App.test.tsx
+++ b/react-native/App.test.tsx
@@ -32,6 +32,36 @@ test('macOS chrome is DesktopApp after first paint for every session state', () 
   expect(orchestrator).not.toContain('"Saved data unavailable"');
 });
 
+test('macOS first paint and session probe do not require native devices or BLE', () => {
+  const onboarding = readFileSync(
+    resolve(__dirname, 'src/app/useOnboarding.ts'),
+    'utf8',
+  );
+
+  expect(orchestrator).toMatch(
+    /useNativeDevices\(\{\s*enabled:\s*!macDesktop\s*\}\)/,
+  );
+  expect(orchestrator).not.toMatch(/useNativeDevices\(\)/);
+  expect(onboarding).toContain('hasCloudSession');
+  expect(onboarding).toContain('setOnboardingRequired(!hasSession)');
+  expect(onboarding).not.toContain(
+    'setOnboardingRequired(!completed && !hasSession)',
+  );
+  expect(onboarding).not.toContain('omiNative');
+  expect(onboarding).not.toContain('getSnapshot');
+  expect(onboarding).not.toContain('useNativeDevices');
+  expect(onboarding).not.toContain('CBCentral');
+  expect(onboarding).not.toContain('startScan');
+  const sessionBlock = orchestrator.slice(
+    orchestrator.indexOf('session='),
+    orchestrator.indexOf('signingIn={signingIn}'),
+  );
+  expect(sessionBlock).toContain('onboardingRequired');
+  expect(sessionBlock).not.toContain('nativeSnapshot');
+  expect(sessionBlock).not.toContain('omiNative');
+  expect(sessionBlock).not.toContain('useNativeDevices');
+});
+
 test('DesktopApp owns sign-in inside the search-first shell', () => {
   expect(desktopApp).toContain("Search what you've seen and heard");
   expect(desktopApp).toContain('signed-out');

--- a/react-native/__tests__/macOSNativeBoundary.test.ts
+++ b/react-native/__tests__/macOSNativeBoundary.test.ts
@@ -446,6 +446,55 @@ test('lets the host choose the glass radius so one panel can run full-bleed', ()
   );
 });
 
+test('does not construct CBCentralManager until an explicit scan or connect', () => {
+  const source = readNativeSource('OmiNativeModule.mm');
+  const initStart = source.indexOf('- (instancetype)init');
+  expect(initStart).toBeGreaterThan(-1);
+  const initSource = source.slice(
+    initStart,
+    source.indexOf('\n}\n', initStart),
+  );
+  expect(initSource).toContain('_lastEvent = @"Bluetooth adapter not checked"');
+  expect(initSource).not.toContain('CBCentralManager');
+  expect(initSource).not.toContain('initWithDelegate');
+
+  const snapshotStart = source.indexOf('RCT_REMAP_METHOD(getSnapshot');
+  const snapshotSource = source.slice(
+    snapshotStart,
+    source.indexOf('RCT_REMAP_METHOD(getBluetoothState', snapshotStart),
+  );
+  expect(snapshotSource).not.toContain('ensureCentral');
+  expect(snapshotSource).not.toContain('initWithDelegate');
+
+  const bluetoothStart = source.indexOf('RCT_REMAP_METHOD(getBluetoothState');
+  const bluetoothSource = source.slice(
+    bluetoothStart,
+    source.indexOf('RCT_REMAP_METHOD(requestPermissions', bluetoothStart),
+  );
+  expect(bluetoothSource).not.toContain('ensureCentral');
+  expect(bluetoothSource).not.toContain('initWithDelegate');
+
+  expect(source).toContain('- (void)ensureCentral');
+  expect(source).toContain(
+    'self.central = [[CBCentralManager alloc] initWithDelegate:self queue:dispatch_get_main_queue()]',
+  );
+  const scanStart = source.indexOf('RCT_REMAP_METHOD(startScan');
+  const scanSource = source.slice(
+    scanStart,
+    source.indexOf('RCT_REMAP_METHOD(stopScan', scanStart),
+  );
+  expect(scanSource).toContain('[self ensureCentral]');
+  const connectStart = source.indexOf('RCT_REMAP_METHOD(connectDevice');
+  const connectSource = source.slice(
+    connectStart,
+    source.indexOf('RCT_REMAP_METHOD(disconnectDevice', connectStart),
+  );
+  expect(connectSource).toContain('[self ensureCentral]');
+  expect(source).toMatch(
+    /bluetoothState \{[^]*if \(self\.central == nil\) \{[^]*return @"unknown"/,
+  );
+});
+
 test('exposes a real OmiNative CoreBluetooth module instead of a hardware stub', () => {
   const source = readNativeSource('OmiNativeModule.mm');
   const header = readNativeSource('OmiNativeModule.h');

--- a/react-native/__tests__/useNativeDevices.test.tsx
+++ b/react-native/__tests__/useNativeDevices.test.tsx
@@ -122,20 +122,23 @@ async function waitFor(predicate: () => boolean) {
 }
 
 function Harness({
+  enabled,
   onState,
 }: {
+  enabled?: boolean;
   onState: (state: ReturnType<typeof useNativeDevices>) => void;
 }) {
-  const state = useNativeDevices();
+  const state = useNativeDevices(enabled === undefined ? undefined : {enabled});
   onState(state);
   return null;
 }
 
-async function renderHook() {
+async function renderHook(enabled?: boolean) {
   let latest: ReturnType<typeof useNativeDevices> | null = null;
   await ReactTestRenderer.act(async () => {
     ReactTestRenderer.create(
       <Harness
+        enabled={enabled}
         onState={state => {
           latest = state;
         }}
@@ -165,6 +168,14 @@ beforeEach(() => {
     }
     return sessionResponse(201);
   });
+});
+
+test('does not probe native devices when the host disables them', async () => {
+  mockNative.getSnapshot.mockClear();
+  const hook = await renderHook(false);
+  expect(hook.latest().nativeSnapshot).toBeNull();
+  expect(mockNative.getSnapshot).not.toHaveBeenCalled();
+  expect(mockListeners).toHaveLength(0);
 });
 
 test('waits for startScan to resolve before clearing the busy flag', async () => {

--- a/react-native/__tests__/useOnboarding.test.tsx
+++ b/react-native/__tests__/useOnboarding.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+
+const mockAuth = {
+  hasCloudSession: jest.fn(),
+  hasCompletedOnboarding: jest.fn(),
+  markOnboardingComplete: jest.fn(async () => undefined),
+  signIn: jest.fn(),
+  signOut: jest.fn(),
+};
+
+jest.mock('../src/omiNative', () => ({
+  omiAuth: {
+    hasCloudSession: () => mockAuth.hasCloudSession(),
+    hasCompletedOnboarding: () => mockAuth.hasCompletedOnboarding(),
+    markOnboardingComplete: () => mockAuth.markOnboardingComplete(),
+    signIn: () => mockAuth.signIn(),
+    signOut: () => mockAuth.signOut(),
+  },
+}));
+
+import {useOnboarding} from '../src/app/useOnboarding';
+
+function Harness({
+  macDesktop,
+  refreshReads,
+  onState,
+}: {
+  macDesktop: boolean;
+  refreshReads: (initial: boolean) => Promise<void>;
+  onState: (state: ReturnType<typeof useOnboarding>) => void;
+}) {
+  const state = useOnboarding(macDesktop, refreshReads);
+  onState(state);
+  return null;
+}
+
+async function renderOnboarding(
+  macDesktop: boolean,
+  refreshReads: (initial: boolean) => Promise<void> = async () => undefined,
+) {
+  let latest: ReturnType<typeof useOnboarding> | null = null;
+  await ReactTestRenderer.act(async () => {
+    ReactTestRenderer.create(
+      <Harness
+        macDesktop={macDesktop}
+        onState={state => {
+          latest = state;
+        }}
+        refreshReads={refreshReads}
+      />,
+    );
+  });
+  return {
+    latest: () => latest!,
+  };
+}
+
+beforeEach(() => {
+  mockAuth.hasCloudSession.mockReset();
+  mockAuth.hasCompletedOnboarding.mockReset();
+  mockAuth.markOnboardingComplete.mockReset();
+  mockAuth.signIn.mockReset();
+  mockAuth.signOut.mockReset();
+  mockAuth.markOnboardingComplete.mockResolvedValue(undefined);
+});
+
+test('completed onboarding without a cloud session still requires Sign in', async () => {
+  mockAuth.hasCompletedOnboarding.mockResolvedValue(true);
+  mockAuth.hasCloudSession.mockResolvedValue(false);
+
+  const hook = await renderOnboarding(true);
+
+  expect(hook.latest().onboardingRequired).toBe(true);
+  expect(mockAuth.markOnboardingComplete).not.toHaveBeenCalled();
+});
+
+test('a live cloud session leaves DesktopApp ready even before onboarding is marked', async () => {
+  mockAuth.hasCompletedOnboarding.mockResolvedValue(false);
+  mockAuth.hasCloudSession.mockResolvedValue(true);
+
+  const hook = await renderOnboarding(true);
+
+  expect(hook.latest().onboardingRequired).toBe(false);
+  expect(mockAuth.markOnboardingComplete).toHaveBeenCalled();
+});
+
+test('session probe settles from auth alone when native devices are unavailable', async () => {
+  mockAuth.hasCompletedOnboarding.mockResolvedValue(true);
+  mockAuth.hasCloudSession.mockResolvedValue(true);
+
+  const hook = await renderOnboarding(true);
+
+  expect(hook.latest().onboardingRequired).toBe(false);
+  expect(hook.latest().onboardingRequired).not.toBeNull();
+});

--- a/react-native/macos/RnRuntime-macOS/OmiNativeModule.mm
+++ b/react-native/macos/RnRuntime-macOS/OmiNativeModule.mm
@@ -29,6 +29,9 @@ static NSString *const OmiBatteryLevelUUID = @"2A19";
 @property(nonatomic, copy) RCTPromiseResolveBlock connectResolve;
 @property(nonatomic, copy) RCTPromiseRejectBlock connectReject;
 @property(nonatomic) NSInteger scanGeneration;
+@property(nonatomic) BOOL awaitingAdapterForScan;
+@property(nonatomic, strong) NSNumber *pendingScanTimeoutSeconds;
+@property(nonatomic, copy) NSArray<NSString *> *pendingScanServiceUuids;
 @end
 
 @implementation OmiNativeModule
@@ -59,9 +62,15 @@ RCT_EXPORT_MODULE(OmiNative)
     _batteries = [NSMutableDictionary dictionary];
     _connectionState = @"disconnected";
     _lastEvent = @"Bluetooth adapter not checked";
-    _central = [[CBCentralManager alloc] initWithDelegate:self queue:dispatch_get_main_queue()];
   }
   return self;
+}
+
+- (void)ensureCentral {
+  if (self.central != nil) {
+    return;
+  }
+  self.central = [[CBCentralManager alloc] initWithDelegate:self queue:dispatch_get_main_queue()];
 }
 
 RCT_REMAP_METHOD(getSnapshot,
@@ -113,7 +122,16 @@ RCT_REMAP_METHOD(startScan,
     self.scanResolve([self deviceList]);
     self.scanResolve = nil;
   }
+  self.awaitingAdapterForScan = NO;
+  [self ensureCentral];
   if (self.central.state != CBManagerStatePoweredOn) {
+    if (self.central.state == CBManagerStateUnknown || self.central.state == CBManagerStateResetting) {
+      self.awaitingAdapterForScan = YES;
+      self.pendingScanTimeoutSeconds = timeoutSeconds;
+      self.pendingScanServiceUuids = serviceUuids;
+      self.scanResolve = resolve;
+      return;
+    }
     self.lastEvent = @"Bluetooth is not powered on";
     resolve(@[]);
     return;
@@ -156,7 +174,12 @@ RCT_REMAP_METHOD(startScan,
 RCT_REMAP_METHOD(stopScan,
                  stopScanWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-  [self.central stopScan];
+  self.awaitingAdapterForScan = NO;
+  self.pendingScanTimeoutSeconds = nil;
+  self.pendingScanServiceUuids = nil;
+  if (self.central != nil) {
+    [self.central stopScan];
+  }
   self.scanning = NO;
   self.lastEvent = @"Omi scan stopped";
   if (self.scanResolve != nil) {
@@ -170,6 +193,7 @@ RCT_REMAP_METHOD(connectDevice,
                  connectDeviceWithId:(NSString *)identifier
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
+  [self ensureCentral];
   CBPeripheral *peripheral = self.peripherals[identifier];
   if (peripheral == nil) {
     reject(@"OMI_DEVICE_UNAVAILABLE", @"Omi device is unavailable", nil);
@@ -202,7 +226,7 @@ RCT_REMAP_METHOD(disconnectDevice,
                  disconnectDeviceWithId:(NSString *)identifier
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-  if ([self.connectedPeripheral.identifier.UUIDString isEqualToString:identifier]) {
+  if (self.central != nil && [self.connectedPeripheral.identifier.UUIDString isEqualToString:identifier]) {
     [self.central cancelPeripheralConnection:self.connectedPeripheral];
   }
   resolve(nil);
@@ -211,6 +235,22 @@ RCT_REMAP_METHOD(disconnectDevice,
 - (void)centralManagerDidUpdateState:(CBCentralManager *)central {
   self.lastEvent = [NSString stringWithFormat:@"Bluetooth is %@", [self bluetoothState]];
   [self emitSnapshot];
+  if (!self.awaitingAdapterForScan || self.scanResolve == nil) {
+    return;
+  }
+  self.awaitingAdapterForScan = NO;
+  RCTPromiseResolveBlock pending = self.scanResolve;
+  NSNumber *timeoutSeconds = self.pendingScanTimeoutSeconds;
+  NSArray<NSString *> *serviceUuids = self.pendingScanServiceUuids;
+  self.scanResolve = nil;
+  self.pendingScanTimeoutSeconds = nil;
+  self.pendingScanServiceUuids = nil;
+  if (central.state == CBManagerStatePoweredOn) {
+    [self startScanWithTimeout:timeoutSeconds serviceUuids:serviceUuids resolver:pending rejecter:nil];
+    return;
+  }
+  self.lastEvent = @"Bluetooth is not powered on";
+  pending(@[]);
 }
 
 - (void)centralManager:(CBCentralManager *)central
@@ -429,6 +469,9 @@ didUpdateNotificationStateForCharacteristic:(CBCharacteristic *)characteristic
 }
 
 - (NSString *)bluetoothState {
+  if (self.central == nil) {
+    return @"unknown";
+  }
   switch (self.central.state) {
     case CBManagerStatePoweredOn: return @"poweredOn";
     case CBManagerStatePoweredOff: return @"poweredOff";

--- a/react-native/src/app/AppOrchestrator.tsx
+++ b/react-native/src/app/AppOrchestrator.tsx
@@ -128,7 +128,7 @@ function App({initialRoute}: AppProps): React.JSX.Element {
     nativeSnapshot,
     scanForOmi,
     toggleDevice,
-  } = useNativeDevices();
+  } = useNativeDevices({enabled: !macDesktop});
   const searchRef = useRef<TextInput>(null);
   useEffect(() => {
     let active = true;

--- a/react-native/src/app/useNativeDevices.ts
+++ b/react-native/src/app/useNativeDevices.ts
@@ -51,7 +51,8 @@ function mergeBattery(
   };
 }
 
-export function useNativeDevices() {
+export function useNativeDevices(options?: {enabled?: boolean}) {
+  const enabled = options?.enabled ?? true;
   const [nativeSnapshot, setNativeSnapshot] =
     useState<PlatformNativeSnapshot | null>(null);
   const [deviceBusy, setDeviceBusy] = useState(false);
@@ -190,7 +191,7 @@ export function useNativeDevices() {
 
   useEffect(() => {
     let active = true;
-    if (omiNative === undefined || omiNative === null) {
+    if (!enabled || omiNative === undefined || omiNative === null) {
       return () => undefined;
     }
     omiNative
@@ -240,7 +241,7 @@ export function useNativeDevices() {
       active = false;
       unsubscribe();
     };
-  }, [persistAudio]);
+  }, [enabled, persistAudio]);
 
   useEffect(() => {
     if (

--- a/react-native/src/app/useOnboarding.ts
+++ b/react-native/src/app/useOnboarding.ts
@@ -25,7 +25,7 @@ export function useOnboarding(
           await auth.markOnboardingComplete();
         }
         if (active) {
-          setOnboardingRequired(!completed && !hasSession);
+          setOnboardingRequired(!hasSession);
         }
       })
       .catch(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Software-only Omi V5 macOS launch showed **Allow 'RnRuntime' to use Bluetooth?** over DesktopApp. Session restore stayed on **Restoring your session…** until the dialog was dismissed. There is no necklace; first paint of Chat / Memories / Tasks / Apps / Settings must not request Bluetooth.

A second, related bug: `useOnboarding` treated `omi.onboarding.completed=1` plus a missing/expired session as `ready`, which hid Sign in inside DesktopApp.

## Cause

Verified against current `v5` sources:

1. `macos/RnRuntime-macOS/OmiNativeModule.mm` `-init` constructed `CBCentralManager` on the main queue. That triggers `NSBluetoothAlwaysUsageDescription` at process launch. The permission alert blocks the main queue. `OmiAuth.hasCloudSession` is also main-queue, so `useOnboarding` never left `probing`.
2. `AppOrchestrator` always called `useNativeDevices()`, which snapshots CoreBluetooth on mount even though DesktopApp never shows Devices.
3. `setOnboardingRequired(!completed && !hasSession)` mapped a completed-but-signed-out user to `ready`.

## Fix

- Defer `CBCentralManager` until an explicit `startScan` / `connectDevice`. `getSnapshot` / `getBluetoothState` / first paint do not start BLE. Adapter-unknown scans wait for `centralManagerDidUpdateState` instead of resolving empty.
- macOS DesktopApp first paint calls `useNativeDevices({enabled: !macDesktop})`, so the session probe does not touch native devices.
- Session required is `!hasSession`. Completed onboarding without a live cloud session shows Sign in inside DesktopApp.

No device UX added. Chat / memories / tasks still do not hit the staging worker. Settings stay on api.omi.me. No workers.dev URL baked into source.

## Verification

```
bun run --cwd react-native test -- --runInBand
bun run --cwd react-native typecheck
```

Result on this cloud agent:

- Jest: **14 suites, 124 tests passed** (includes existing DesktopApp session-state tests plus new BLE-deferral / session-probe / signed-out Sign in coverage)
- `tsc --noEmit`: clean

This Linux cloud agent cannot launch the macOS `RnRuntime` binary. The BLE-at-init and session-probe contracts are covered by Jest; Max should confirm a necklace-free launch no longer shows the Bluetooth dialog before session restore.

Base is `v5`, not `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a53dc805-6c7e-4501-9dd7-4a9870e8826a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a53dc805-6c7e-4501-9dd7-4a9870e8826a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

