### PR TITLE
fix(macos): one-row traffic lights and InkGlass / Liquid Glass

### DIFF
--- a/react-native/__tests__/macOSNativeBoundary.test.ts
+++ b/react-native/__tests__/macOSNativeBoundary.test.ts
@@ -20,9 +20,11 @@ test('keeps a transparent glass window over the desktop', () => {
   expect(source).toContain(
     'window.appearance = [NSAppearance appearanceNamed:NSAppearanceNameAqua];',
   );
-  expect(source).toContain('NSVisualEffectView');
-  expect(source).toContain('NSVisualEffectMaterialUnderWindowBackground');
-  expect(source).toContain('NSVisualEffectBlendingModeBehindWindow');
+  expect(source).toContain('OmiGlassPanelView');
+  expect(source).toContain('setGlassCornerRadius:0');
+  expect(source).toContain('hideOmiTitlebarMaterial');
+  expect(source).not.toContain('NSVisualEffectMaterialUnderWindowBackground');
+  expect(source).not.toContain('NSWindowToolbarStyleUnified');
   expect(source).not.toContain('OmiTitlebarFillColor');
   expect(source).not.toContain('NSAppearanceNameVibrantDark');
 });
@@ -52,6 +54,8 @@ test('puts traffic lights in the content chrome next to Home', () => {
   expect(source).toContain('installOmiTitlebarAccessory');
   expect(source).toContain('addTitlebarAccessoryViewController');
   expect(source).toMatch(/OmiTrafficLightChromeHeight\s*=\s*52\.0/);
+  expect(source).toContain('hideOmiTitlebarMaterial');
+  expect(source).not.toContain('NSWindowToolbarStyleUnified');
   expect(source).not.toContain('accessibilityLabel="Window drag handle"');
 });
 
@@ -418,7 +422,10 @@ test('keeps the glass reduce-transparency fallback intact', () => {
 
   expect(source).toContain('@property (nonatomic, strong) NSView *fallback;');
   expect(source).toContain('self.fallback.hidden = !reduceTransparency;');
-  expect(source).toContain('self.material.hidden = reduceTransparency;');
+  expect(source).toContain(
+    'self.material.hidden = reduceTransparency || hasLiquid;',
+  );
+  expect(source).toContain('self.sheen.hidden = reduceTransparency;');
   expect(source).toContain(
     'CGFloat alpha = reduceTransparency ? 1.0 : OmiGlassScrimAlpha;',
   );
@@ -428,25 +435,28 @@ test('keeps the shared HUD material translucent with a semantic opaque fallback'
   const source = readNativeSource('OmiGlassPanelView.mm');
 
   expect(source).toContain('static const CGFloat OmiGlassScrimAlpha = 0.46;');
+  expect(source).toContain('NSAppearanceNameAqua');
+  expect(source).toContain('NSClassFromString(@"NSGlassEffectView")');
+  expect(source).toContain('self.liquidGlass');
+  expect(source).toContain('self.sheen');
+  expect(source).toContain('NSMaxY(self.bounds) - OmiGlassSheenHeight');
+  expect(source).toContain(
+    '[NSColor.whiteColor colorWithAlphaComponent:OmiGlassSheenAlpha]',
+  );
   expect(source).toContain(
     'self.fallback.layer.backgroundColor = NSColor.controlBackgroundColor.CGColor;',
   );
   expect(source).toContain(
     'self.material.material = NSVisualEffectMaterialHUDWindow;',
   );
-  expect(source).toContain('self.appearance = nil;');
-  expect(source).toContain('self.layer.borderWidth = 0;');
-  expect(source).not.toContain('NSAppearanceNameAqua');
-  expect(source).not.toContain('self.sheen');
+  expect(source).not.toContain('self.appearance = nil;');
+  expect(source).not.toContain('NSVisualEffectMaterialUnderWindowBackground');
+  expect(source).not.toContain('NSAppearanceNameVibrantDark');
   expect(source).not.toContain('shadowColor');
   expect(source).not.toContain('shadowRadius');
   expect(source).not.toContain('shadowOpacity');
   expect(source).not.toContain('shadowOffset');
   expect(source).not.toContain('shadowPath');
-  expect(source).not.toContain('NSMaxY(self.bounds) - 1.0');
-  expect(source).not.toContain(
-    '[NSColor.whiteColor colorWithAlphaComponent:0.5]',
-  );
   expect(source).toContain(
     'self.scrim.backgroundColor = [NSColor.controlBackgroundColor colorWithAlphaComponent:alpha].CGColor;',
   );

--- a/react-native/macos/RnRuntime-macOS/AppDelegate.h
+++ b/react-native/macos/RnRuntime-macOS/AppDelegate.h
@@ -5,7 +5,7 @@
 
 @property (nonatomic, strong, nullable) id omiWindowUpdateObserver;
 @property (nonatomic, strong, nullable) id omiWindowDragMonitor;
-@property (nonatomic, strong, nullable) NSVisualEffectView *omiWindowGlass;
+@property (nonatomic, strong, nullable) NSView *omiWindowGlass;
 @property (nonatomic, strong, nullable) NSTitlebarAccessoryViewController *omiTitlebarAccessory;
 @property (nonatomic, assign) BOOL omiWindowGeometryApplied;
 

--- a/react-native/macos/RnRuntime-macOS/AppDelegate.mm
+++ b/react-native/macos/RnRuntime-macOS/AppDelegate.mm
@@ -1,5 +1,6 @@
 #import "AppDelegate.h"
 #import "OmiDesktopCommandsModule.h"
+#import "OmiGlassPanelView.h"
 
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTUIKit.h>
@@ -52,16 +53,28 @@ static const CGFloat OmiTrafficLightChromeHeight = 52.0;
 {
   RCTUIView *rootView = (RCTUIView *)window.contentViewController.view;
   if (self.omiWindowGlass == nil) {
-    self.omiWindowGlass = [[NSVisualEffectView alloc] initWithFrame:rootView.bounds];
-    self.omiWindowGlass.material = NSVisualEffectMaterialUnderWindowBackground;
-    self.omiWindowGlass.blendingMode = NSVisualEffectBlendingModeBehindWindow;
-    self.omiWindowGlass.state = NSVisualEffectStateActive;
-    self.omiWindowGlass.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+    OmiGlassPanelView *glass = [[OmiGlassPanelView alloc] initWithFrame:rootView.bounds];
+    [glass setGlassCornerRadius:0];
+    glass.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+    self.omiWindowGlass = glass;
   }
   self.omiWindowGlass.frame = rootView.bounds;
   if (self.omiWindowGlass.superview != rootView) {
     [rootView addSubview:self.omiWindowGlass positioned:NSWindowBelow relativeTo:nil];
   }
+}
+
+- (void)hideOmiTitlebarMaterial:(NSWindow *)window
+{
+  NSButton *closeButton = [window standardWindowButton:NSWindowCloseButton];
+  NSView *titlebar = closeButton.superview;
+  for (NSView *view in titlebar.subviews) {
+    if ([view isKindOfClass:NSVisualEffectView.class]) {
+      view.hidden = YES;
+    }
+  }
+  titlebar.wantsLayer = YES;
+  titlebar.layer.backgroundColor = NSColor.clearColor.CGColor;
 }
 
 - (void)installOmiTitlebarAccessory:(NSWindow *)window
@@ -97,7 +110,7 @@ static const CGFloat OmiTrafficLightChromeHeight = 52.0;
   window.titlebarAppearsTransparent = YES;
   window.titleVisibility = NSWindowTitleHidden;
   window.title = @"";
-  window.toolbarStyle = NSWindowToolbarStyleUnified;
+  window.toolbar = nil;
   window.titlebarSeparatorStyle = NSTitlebarSeparatorStyleNone;
   window.movableByWindowBackground = NO;
   window.level = NSNormalWindowLevel;
@@ -114,6 +127,7 @@ static const CGFloat OmiTrafficLightChromeHeight = 52.0;
   window.collectionBehavior = behavior;
   [self installOmiWindowGlass:window];
   [self installOmiTitlebarAccessory:window];
+  [self hideOmiTitlebarMaterial:window];
   [window standardWindowButton:NSWindowCloseButton].hidden = NO;
   [window standardWindowButton:NSWindowMiniaturizeButton].hidden = NO;
   [window standardWindowButton:NSWindowZoomButton].hidden = NO;

--- a/react-native/macos/RnRuntime-macOS/OmiGlassPanelView.mm
+++ b/react-native/macos/RnRuntime-macOS/OmiGlassPanelView.mm
@@ -1,11 +1,40 @@
 #import "OmiGlassPanelView.h"
 
 #import <React/RCTViewManager.h>
+#import <objc/message.h>
+#import <objc/runtime.h>
 
-// Default radius for floating panels; the host may override it per instance so a
-// single panel can run full-bleed inside the window's own rounded clip shape.
 static const CGFloat defaultCornerRadius = 22.0;
 static const CGFloat OmiGlassScrimAlpha = 0.46;
+static const CGFloat OmiGlassEdgeAlpha = 0.06;
+static const CGFloat OmiGlassSheenAlpha = 0.5;
+static const CGFloat OmiGlassSheenHeight = 1.0;
+
+static NSAppearance *OmiInkGlassAppearance(void)
+{
+  return [NSAppearance appearanceNamed:NSAppearanceNameAqua];
+}
+
+static NSView *OmiMakeLiquidGlass(NSRect frame, CGFloat radius)
+{
+  Class glassClass = NSClassFromString(@"NSGlassEffectView");
+  if (glassClass == Nil) {
+    return nil;
+  }
+  NSView *glass = [[glassClass alloc] initWithFrame:frame];
+  glass.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+  if ([glass respondsToSelector:@selector(setCornerRadius:)]) {
+    ((void (*)(id, SEL, CGFloat))objc_msgSend)(glass, @selector(setCornerRadius:), radius);
+  }
+  if ([glass respondsToSelector:@selector(setStyle:)]) {
+    ((void (*)(id, SEL, NSInteger))objc_msgSend)(glass, @selector(setStyle:), 0);
+  }
+  if ([glass respondsToSelector:@selector(setTintColor:)]) {
+    ((void (*)(id, SEL, id))objc_msgSend)(
+        glass, @selector(setTintColor:), [NSColor colorWithCalibratedWhite:1.0 alpha:OmiGlassScrimAlpha]);
+  }
+  return glass;
+}
 
 @interface OmiGlassPanelView ()
 
@@ -13,9 +42,11 @@ static const CGFloat OmiGlassScrimAlpha = 0.46;
   CGFloat _glassCornerRadius;
 }
 
+@property (nonatomic, strong) NSView *liquidGlass;
 @property (nonatomic, strong) NSVisualEffectView *material;
 @property (nonatomic, strong) NSView *fallback;
 @property (nonatomic, strong) CALayer *scrim;
+@property (nonatomic, strong) CALayer *sheen;
 @property (nonatomic, strong, nullable) id accessibilityObserver;
 
 @end
@@ -30,12 +61,16 @@ static const CGFloat OmiGlassScrimAlpha = 0.46;
   }
 
   self.wantsLayer = YES;
-  // Let the hosting window choose light or dark material; a panel must not
-  // pin Aqua over a transparent titlebar.
-  self.appearance = nil;
-  self.layer.borderWidth = 0;
+  self.appearance = OmiInkGlassAppearance();
+  self.layer.borderWidth = 1;
+
+  self.liquidGlass = OmiMakeLiquidGlass(self.bounds, defaultCornerRadius);
+  if (self.liquidGlass != nil) {
+    [self addSubview:self.liquidGlass];
+  }
 
   self.material = [[NSVisualEffectView alloc] initWithFrame:self.bounds];
+  self.material.appearance = OmiInkGlassAppearance();
   self.material.material = NSVisualEffectMaterialHUDWindow;
   self.material.blendingMode = NSVisualEffectBlendingModeBehindWindow;
   self.material.state = NSVisualEffectStateActive;
@@ -49,7 +84,9 @@ static const CGFloat OmiGlassScrimAlpha = 0.46;
   [self addSubview:self.fallback];
 
   self.scrim = [CALayer layer];
-  [self.material.layer addSublayer:self.scrim];
+  [self.layer addSublayer:self.scrim];
+  self.sheen = [CALayer layer];
+  [self.layer addSublayer:self.sheen];
 
   __weak OmiGlassPanelView *weakSelf = self;
   self.accessibilityObserver =
@@ -83,6 +120,10 @@ static const CGFloat OmiGlassScrimAlpha = 0.46;
   self.fallback.layer.cornerCurve = kCACornerCurveContinuous;
   self.scrim.cornerRadius = _glassCornerRadius;
   self.scrim.cornerCurve = kCACornerCurveContinuous;
+  if (self.liquidGlass != nil && [self.liquidGlass respondsToSelector:@selector(setCornerRadius:)]) {
+    ((void (*)(id, SEL, CGFloat))objc_msgSend)(
+        self.liquidGlass, @selector(setCornerRadius:), _glassCornerRadius);
+  }
 }
 
 - (BOOL)acceptsFirstMouse:(NSEvent *)event
@@ -98,19 +139,30 @@ static const CGFloat OmiGlassScrimAlpha = 0.46;
 - (void)layout
 {
   [super layout];
+  self.liquidGlass.frame = self.bounds;
   self.material.frame = self.bounds;
   self.fallback.frame = self.bounds;
   self.scrim.frame = self.bounds;
+  self.sheen.frame = NSMakeRect(0, NSMaxY(self.bounds) - OmiGlassSheenHeight, NSWidth(self.bounds),
+      OmiGlassSheenHeight);
 }
 
 - (void)applyAccessibilityAppearance
 {
   BOOL reduceTransparency = NSWorkspace.sharedWorkspace.accessibilityDisplayShouldReduceTransparency;
-  self.material.hidden = reduceTransparency;
+  BOOL hasLiquid = self.liquidGlass != nil;
+  self.liquidGlass.hidden = reduceTransparency || !hasLiquid;
+  self.material.hidden = reduceTransparency || hasLiquid;
   self.fallback.hidden = !reduceTransparency;
-  self.fallback.layer.backgroundColor = NSColor.controlBackgroundColor.CGColor;
-  CGFloat alpha = reduceTransparency ? 1.0 : OmiGlassScrimAlpha;
-  self.scrim.backgroundColor = [NSColor.controlBackgroundColor colorWithAlphaComponent:alpha].CGColor;
+  self.appearance = OmiInkGlassAppearance();
+  [self.appearance performAsCurrentDrawingAppearance:^{
+    self.fallback.layer.backgroundColor = NSColor.controlBackgroundColor.CGColor;
+    CGFloat alpha = reduceTransparency ? 1.0 : OmiGlassScrimAlpha;
+    self.scrim.backgroundColor = [NSColor.controlBackgroundColor colorWithAlphaComponent:alpha].CGColor;
+    self.sheen.hidden = reduceTransparency;
+    self.sheen.backgroundColor = [NSColor.whiteColor colorWithAlphaComponent:OmiGlassSheenAlpha].CGColor;
+    self.layer.borderColor = [NSColor.labelColor colorWithAlphaComponent:OmiGlassEdgeAlpha].CGColor;
+  }];
 }
 
 @end

--- a/react-native/src/desktop/DesktopApp.tsx
+++ b/react-native/src/desktop/DesktopApp.tsx
@@ -36,9 +36,12 @@ import type {ReadsPhase} from '../app/useDesktopReads';
 import {FocusPressable} from '../ui/Pressable';
 import {GlassPanel} from '../ui/GlassPanel';
 import {
+  desktopNavBarHeight,
   desktopNavItems,
+  desktopNavTopInset,
   desktopSearchPlaceholder,
   desktopTrafficLightRowWidth,
+  desktopWindowInset,
   visibleChatError,
   type DesktopNavItem,
   type DesktopSession,
@@ -743,8 +746,10 @@ const styles = StyleSheet.create({
   root: {
     backgroundColor: 'transparent',
     flex: 1,
-    gap: 8,
-    padding: 8,
+    gap: desktopWindowInset,
+    paddingBottom: desktopWindowInset,
+    paddingHorizontal: desktopWindowInset,
+    paddingTop: desktopNavTopInset,
   },
   glassSurface: {
     backgroundColor: 'transparent',
@@ -754,8 +759,8 @@ const styles = StyleSheet.create({
   navbar: {
     alignItems: 'center',
     flexDirection: 'row',
-    height: 52,
-    paddingHorizontal: 8,
+    height: desktopNavBarHeight,
+    paddingHorizontal: desktopWindowInset,
   },
   trafficLights: {height: 14, width: desktopTrafficLightRowWidth},
   navItems: {alignItems: 'center', flex: 1, flexDirection: 'row', gap: 4},

--- a/react-native/src/desktop/desktopChrome.test.ts
+++ b/react-native/src/desktop/desktopChrome.test.ts
@@ -1,7 +1,9 @@
 import {
   desktopGlassCornerRadius,
   desktopMotion,
+  desktopNavBarHeight,
   desktopNavItems,
+  desktopNavTopInset,
   desktopSearchPlaceholder,
   desktopSettingsPanes,
   desktopStageFade,
@@ -41,6 +43,8 @@ test('desktop chrome uses the shipping Home Library IA', () => {
   expect(desktopSearchPlaceholder).toBe("Search what you've seen and heard…");
   expect(desktopSystemFontFamily).toBe('System');
   expect(desktopGlassCornerRadius).toBe(22);
+  expect(desktopNavBarHeight).toBe(52);
+  expect(desktopNavTopInset).toBe(0);
   expect(desktopTrafficLightRowWidth).toBeGreaterThan(70);
   expect(desktopMotion.navMs).toBe(80);
   expect(desktopMotion.pressMs).toBe(90);

--- a/react-native/src/desktop/desktopChrome.ts
+++ b/react-native/src/desktop/desktopChrome.ts
@@ -28,6 +28,8 @@ export const desktopSearchPlaceholder = "Search what you've seen and heard…";
 export const desktopTrafficLightLeading = 16;
 export const desktopTrafficLightRowWidth = 78;
 export const desktopNavBarHeight = 52;
+export const desktopWindowInset = 8;
+export const desktopNavTopInset = 0;
 export const desktopGlassCornerRadius = 22;
 export const desktopSystemFontFamily = 'System';
 

--- a/react-native/src/ui/PageShell.test.tsx
+++ b/react-native/src/ui/PageShell.test.tsx
@@ -1,0 +1,26 @@
+import {readFileSync} from 'node:fs';
+import {resolve} from 'node:path';
+
+const pageShell = readFileSync(resolve(__dirname, 'PageShell.tsx'), 'utf8');
+const desktopApp = readFileSync(
+  resolve(__dirname, '../desktop/DesktopApp.tsx'),
+  'utf8',
+);
+
+test('macOS PageShell does not inset the nav below the titlebar', () => {
+  expect(pageShell).toContain('const content = macDesktop ? (');
+  expect(pageShell).toContain('<View style={[styles.safe, styles.macSafe]}>');
+  expect(pageShell).not.toMatch(
+    /macDesktop\s*\?\s*<SafeAreaView|SafeAreaView style=\{\[styles\.safe, macDesktop/,
+  );
+});
+
+test('DesktopApp keeps Home on the same row as the traffic-light spacer', () => {
+  expect(desktopApp).toContain('paddingTop: desktopNavTopInset');
+  expect(desktopApp).toContain('height: desktopNavBarHeight');
+  expect(desktopApp).toContain('accessibilityLabel="Window controls"');
+  expect(desktopApp).toContain('width: desktopTrafficLightRowWidth');
+  expect(desktopApp).toMatch(/root:\s*\{[^}]*paddingTop:\s*desktopNavTopInset/);
+  expect(desktopApp).not.toMatch(/root:\s*\{[^}]*padding:\s*8/);
+  expect(desktopApp).not.toMatch(/navbar:\s*\{[^}]*height:\s*52/);
+});

--- a/react-native/src/ui/PageShell.tsx
+++ b/react-native/src/ui/PageShell.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {StyleSheet, View} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
-import {GlassPanel} from './GlassPanel';
 import {tokens} from './tokens';
 
 export function PageShell({
@@ -15,10 +14,10 @@ export function PageShell({
   macDesktop: boolean;
   workspaceMaterial?: boolean;
 }) {
-  const content = (
-    <SafeAreaView style={[styles.safe, macDesktop && styles.macSafe]}>
-      {children}
-    </SafeAreaView>
+  const content = macDesktop ? (
+    <View style={[styles.safe, styles.macSafe]}>{children}</View>
+  ) : (
+    <SafeAreaView style={styles.safe}>{children}</SafeAreaView>
   );
   if (!macDesktop) {
     return content;
@@ -26,9 +25,8 @@ export function PageShell({
   return (
     <View pointerEvents="box-none" style={styles.macRoot}>
       {workspaceMaterial ? (
-        <GlassPanel
+        <View
           accessibilityLabel="Desktop workspace material"
-          glassCornerRadius={tokens.radius.none}
           pointerEvents="none"
           style={styles.glass}
         />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix the two chrome bugs Max rejected on the rebuilt v5 window. Base is lowercase `v5` (continues from `3d2c1b79`), one squash-ready commit, never `main`.

## Traffic lights on the same row as Home

The previous port reserved a 52pt titlebar accessory **and** let `SafeAreaView` plus `padding: 8` push the RN nav below that band. Result: lights on their own gray titlebar, Home / Library / Tasks / Rewind / Apps on a second line.

This change:
- Keeps `fullSizeContentView`, hidden title, transparent titlebar, and the 52pt accessory so the standard buttons stay native-sized
- Positions those buttons in that 52pt band
- Drops macOS `SafeAreaView` top inset so RN draws under the titlebar
- Sets `desktopNavTopInset = 0` so the nav is the window’s top edge
- Leaves the 78pt leading spacer so **Home sits immediately after the lights on one line**
- Hides the stock titlebar material and does not use Unified toolbar chrome

## Liquid / InkGlass (readable dark type)

The window was cheap `NSVisualEffectMaterialUnderWindowBackground` with unpinned panel appearance. Wallpaper blew through and type went medium-gray.

This change uses shipping **InkGlass** for panels and window chrome:
- Light-pinned Aqua
- `NSVisualEffectMaterialHUDWindow` + behindWindow (not dark NotchGlass, not UnderWindowBackground)
- 0.46 light `controlBackground` scrim, 1pt white sheen, 0.06 ink edge
- On macOS 26, `NSGlassEffectView` when the class exists; InkGlass fallback otherwise
- Reduce Transparency: hide material/liquid/sheen, opaque light panel
- Dark SF type stays `Ink.primary` / `Ink.secondary` on that light scrim

Unchanged: no necklace, no workers.dev default in source, session import, Advanced old (`api.omi.me`) vs new (`OMI_V5_BACKEND_URL`) toggle, motion tokens.

## Verification

```
bun run check
bun run --cwd react-native test -- --runInBand src/ui/PageShell.test.tsx src/desktop/desktopChrome.test.ts src/desktop/DesktopApp.test.tsx __tests__/macOSNativeBoundary.test.ts
```

This Linux VM cannot open the live RnRuntime window. Confirm on a Mac: one nav row (lights + Home … Apps) and readable dark type over wallpaper.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c58eb266-dd0f-436b-8376-c3f622d4638b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c58eb266-dd0f-436b-8376-c3f622d4638b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

