### PR TITLE
fix(macos): stop glass from blanking the window

### DIFF
--- a/react-native/__tests__/macOSNativeBoundary.test.ts
+++ b/react-native/__tests__/macOSNativeBoundary.test.ts
@@ -475,6 +475,21 @@ test('uses NSGlassEffectView per panel and HUD only as InkGlass fallback', () =>
   );
 });
 
+test('hosts React children in NSGlassEffectView contentView and clips to the panel', () => {
+  const source = readNativeSource('OmiGlassPanelView.mm');
+
+  expect(source).toContain(
+    '@property (nonatomic, strong) NSView *contentHost;',
+  );
+  expect(source).toContain('setContentView:');
+  expect(source).toContain('insertReactSubview');
+  expect(source).toContain('removeReactSubview');
+  expect(source).toContain('didUpdateReactSubviews');
+  expect(source).toContain('self.clipsToBounds = YES');
+  expect(source).toContain('self.layer.masksToBounds = YES');
+  expect(source).toContain('[self.contentHost addSubview:subview');
+});
+
 test('lets the host choose the glass radius so one panel can run full-bleed', () => {
   const source = readNativeSource('OmiGlassPanelView.mm');
 

--- a/react-native/macos/RnRuntime-macOS/OmiGlassPanelView.mm
+++ b/react-native/macos/RnRuntime-macOS/OmiGlassPanelView.mm
@@ -45,6 +45,8 @@ static NSView *OmiMakeLiquidGlass(NSRect frame, CGFloat radius)
 @property (nonatomic, strong) NSView *liquidGlass;
 @property (nonatomic, strong) NSVisualEffectView *material;
 @property (nonatomic, strong) NSView *fallback;
+@property (nonatomic, strong) NSView *contentHost;
+@property (nonatomic, strong) NSView *finish;
 @property (nonatomic, strong) CALayer *scrim;
 @property (nonatomic, strong) CALayer *sheen;
 @property (nonatomic, strong, nullable) id accessibilityObserver;
@@ -61,8 +63,18 @@ static NSView *OmiMakeLiquidGlass(NSRect frame, CGFloat radius)
   }
 
   self.wantsLayer = YES;
+  self.clipsToBounds = YES;
+  self.layer.masksToBounds = YES;
   self.appearance = OmiInkGlassAppearance();
   self.layer.borderWidth = 1;
+
+  self.contentHost = [[NSView alloc] initWithFrame:self.bounds];
+  self.contentHost.wantsLayer = YES;
+  self.contentHost.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+  self.finish = [[NSView alloc] initWithFrame:self.bounds];
+  self.finish.wantsLayer = YES;
+  self.finish.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+  [self.contentHost addSubview:self.finish];
 
   self.liquidGlass = OmiMakeLiquidGlass(self.bounds, defaultCornerRadius);
   if (self.liquidGlass != nil) {
@@ -85,9 +97,9 @@ static NSView *OmiMakeLiquidGlass(NSRect frame, CGFloat radius)
   [self addSubview:self.fallback];
 
   self.scrim = [CALayer layer];
-  [self.layer addSublayer:self.scrim];
+  [self.finish.layer addSublayer:self.scrim];
   self.sheen = [CALayer layer];
-  [self.layer addSublayer:self.sheen];
+  [self.finish.layer addSublayer:self.sheen];
 
   __weak OmiGlassPanelView *weakSelf = self;
   self.accessibilityObserver =
@@ -119,6 +131,8 @@ static NSView *OmiMakeLiquidGlass(NSRect frame, CGFloat radius)
   self.material.layer.cornerCurve = kCACornerCurveContinuous;
   self.fallback.layer.cornerRadius = _glassCornerRadius;
   self.fallback.layer.cornerCurve = kCACornerCurveContinuous;
+  self.finish.layer.cornerRadius = _glassCornerRadius;
+  self.finish.layer.cornerCurve = kCACornerCurveContinuous;
   self.scrim.cornerRadius = _glassCornerRadius;
   self.scrim.cornerCurve = kCACornerCurveContinuous;
   if (self.liquidGlass != nil && [self.liquidGlass respondsToSelector:@selector(setCornerRadius:)]) {
@@ -134,7 +148,19 @@ static NSView *OmiMakeLiquidGlass(NSRect frame, CGFloat radius)
 
 - (NSView *)hitTest:(NSPoint)point
 {
-  return nil;
+  NSPoint local = [self convertPoint:point fromView:self.superview];
+  if (self.isHidden || ![self mouse:local inRect:self.bounds] || self.contentHost == nil) {
+    return nil;
+  }
+  NSView *hostSuperview = self.contentHost.superview;
+  if (hostSuperview == nil) {
+    return nil;
+  }
+  NSView *hit = [self.contentHost hitTest:[hostSuperview convertPoint:local fromView:self]];
+  if (hit == nil || hit == self.contentHost || hit == self.finish) {
+    return nil;
+  }
+  return hit;
 }
 
 - (void)layout
@@ -143,9 +169,57 @@ static NSView *OmiMakeLiquidGlass(NSRect frame, CGFloat radius)
   self.liquidGlass.frame = self.bounds;
   self.material.frame = self.bounds;
   self.fallback.frame = self.bounds;
-  self.scrim.frame = self.bounds;
+  if (self.contentHost.superview == self) {
+    self.contentHost.frame = self.bounds;
+  } else if (self.contentHost.superview != nil) {
+    self.contentHost.frame = self.contentHost.superview.bounds;
+  }
+  self.finish.frame = self.contentHost.bounds;
+  self.scrim.frame = self.finish.bounds;
   self.sheen.frame = NSMakeRect(0, NSMaxY(self.bounds) - OmiGlassSheenHeight, NSWidth(self.bounds),
       OmiGlassSheenHeight);
+}
+
+- (void)omiAttachContentHost
+{
+  BOOL reduceTransparency = NSWorkspace.sharedWorkspace.accessibilityDisplayShouldReduceTransparency;
+  BOOL useGlassContent = self.liquidGlass != nil && !self.liquidGlass.hidden && !reduceTransparency &&
+      [self.liquidGlass respondsToSelector:@selector(setContentView:)];
+  if (useGlassContent) {
+    ((void (*)(id, SEL, id))objc_msgSend)(
+        self.liquidGlass, @selector(setContentView:), self.contentHost);
+    return;
+  }
+  if ([self.liquidGlass respondsToSelector:@selector(setContentView:)]) {
+    id current = ((id (*)(id, SEL))objc_msgSend)(self.liquidGlass, @selector(contentView));
+    if (current == self.contentHost) {
+      ((void (*)(id, SEL, id))objc_msgSend)(self.liquidGlass, @selector(setContentView:), nil);
+    }
+  }
+  if (self.contentHost.superview != self) {
+    [self addSubview:self.contentHost];
+  }
+}
+
+- (void)insertReactSubview:(RCTUIView *)subview atIndex:(NSInteger)atIndex
+{
+  [super insertReactSubview:subview atIndex:atIndex];
+  NSArray<NSView *> *siblings = self.contentHost.subviews;
+  NSInteger hostIndex = atIndex + 1;
+  if (hostIndex >= 0 && hostIndex < (NSInteger)siblings.count) {
+    [self.contentHost addSubview:subview positioned:NSWindowBelow relativeTo:siblings[hostIndex]];
+    return;
+  }
+  [self.contentHost addSubview:subview];
+}
+
+- (void)removeReactSubview:(RCTUIView *)subview
+{
+  [super removeReactSubview:subview];
+}
+
+- (void)didUpdateReactSubviews
+{
 }
 
 - (void)applyAccessibilityAppearance
@@ -166,6 +240,7 @@ static NSView *OmiMakeLiquidGlass(NSRect frame, CGFloat radius)
     self.sheen.backgroundColor = [NSColor.whiteColor colorWithAlphaComponent:OmiGlassSheenAlpha].CGColor;
     self.layer.borderColor = [NSColor.labelColor colorWithAlphaComponent:OmiGlassEdgeAlpha].CGColor;
   }];
+  [self omiAttachContentHost];
 }
 
 @end

--- a/react-native/src/desktop/DesktopApp.test.tsx
+++ b/react-native/src/desktop/DesktopApp.test.tsx
@@ -424,6 +424,16 @@ test('Home Tasks Library Rewind Apps never throw for empty outcomes', () => {
   for (const label of ['Tasks', 'Library', 'Rewind', 'Apps', 'Home'] as const) {
     expect(() => pressLabeledButton(renderer, label)).not.toThrow();
   }
+  pressLabeledButton(renderer, 'Library');
+  expect(renderedText(renderer)).toContain('Activity');
+  pressLabeledButton(renderer, 'Rewind');
+  expect(renderedText(renderer)).toContain(
+    'Screen history is ready when capture is on',
+  );
+  pressLabeledButton(renderer, 'Apps');
+  expect(renderedText(renderer)).toContain('Imports');
+  pressLabeledButton(renderer, 'Home');
+  expect(renderedText(renderer)).toContain("I'm ready.");
 });
 
 test('Tasks page does not mount FlatList inside the shipping stage', () => {
@@ -434,6 +444,51 @@ test('Tasks page does not mount FlatList inside the shipping stage', () => {
   expect(start).toBeGreaterThan(-1);
   expect(tasksPage).not.toContain('FlatList');
   expect(tasksPage).toContain('ScrollView');
+});
+
+test('Apps page does not mount FlatList and still paints import cards', () => {
+  const source = readFileSync(resolve(__dirname, './DesktopApp.tsx'), 'utf8');
+  const start = source.indexOf('function AppsPage');
+  const end = source.indexOf('export function DesktopApp');
+  const appsPage = source.slice(start, end);
+  expect(start).toBeGreaterThan(-1);
+  expect(appsPage).not.toContain('FlatList');
+  expect(appsPage).toContain('ScrollView');
+
+  const renderer = renderDesktop();
+  pressLabeledButton(renderer, 'Apps');
+  const tree = renderedText(renderer);
+  expect(tree).toContain('Imports');
+  expect(tree).toContain('Google Calendar');
+  expect(tree).toContain('This Mac');
+  expect(tree).toContain('Home');
+  expect(tree).toContain('Tasks');
+});
+
+test('puts shipping chrome inside GlassPanel instead of stacking it on top', () => {
+  const source = readFileSync(resolve(__dirname, './DesktopApp.tsx'), 'utf8');
+  const start = source.indexOf('function GlassSurface');
+  const end = source.indexOf('function GlassHairline');
+  const glassSurface = source.slice(start, end);
+  expect(start).toBeGreaterThan(-1);
+  expect(glassSurface).toContain('{children}');
+  expect(glassSurface).not.toContain('pointerEvents="none"');
+  expect(glassSurface).not.toContain('StyleSheet.absoluteFill');
+
+  const renderer = renderDesktop();
+  const panels = renderer.root.findAll(
+    node => node.props.glassCornerRadius !== undefined,
+  );
+  const navbar = panels.find(panel =>
+    panel.findAllByType(Text).some(text => text.props.children === 'Home'),
+  );
+  expect(navbar).toBeDefined();
+  expect(
+    navbar!
+      .findAllByType(Text)
+      .map(text => text.props.children)
+      .join(' '),
+  ).toContain('Tasks');
 });
 
 test('Home and Library chips share a sliding glass pill', () => {

--- a/react-native/src/desktop/DesktopApp.tsx
+++ b/react-native/src/desktop/DesktopApp.tsx
@@ -107,10 +107,9 @@ function GlassSurface({
     <ShippingGlassMount style={[styles.glassSurface, style]}>
       <GlassPanel
         glassCornerRadius={token.radius.panel}
-        pointerEvents="none"
-        style={StyleSheet.absoluteFill}
-      />
-      {children}
+        style={[styles.glassHost, style]}>
+        {children}
+      </GlassPanel>
     </ShippingGlassMount>
   );
 }
@@ -593,13 +592,11 @@ function AppsPage() {
   return (
     <GlassSurface style={styles.singlePanel}>
       <Text style={styles.pageTitle}>Imports</Text>
-      <FlatList
+      <ScrollView
         contentContainerStyle={styles.appGrid}
-        data={imports}
-        keyExtractor={item => item[0]}
-        numColumns={3}
-        renderItem={({item: [name, source, Icon]}) => (
-          <View style={styles.appCard}>
+        style={styles.taskList}>
+        {imports.map(([name, source, Icon]) => (
+          <View key={name} style={styles.appCard}>
             <View style={styles.appCardHeader}>
               <View style={styles.appIcon}>
                 <Icon color={token.color.onGlass} size={18} />
@@ -611,8 +608,8 @@ function AppsPage() {
             </View>
             <Text style={styles.rowMeta}>Not connected</Text>
           </View>
-        )}
-      />
+        ))}
+      </ScrollView>
     </GlassSurface>
   );
 }
@@ -738,6 +735,13 @@ const styles = StyleSheet.create({
     shadowOffset: {height: 3, width: 0},
     shadowOpacity: 0.1,
     shadowRadius: 10,
+  },
+  glassHost: {
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
   },
   glassHairline: {
     backgroundColor: token.color.sheen,
@@ -985,11 +989,16 @@ const styles = StyleSheet.create({
     color: token.color.inkFaint,
     textDecorationLine: 'line-through',
   },
-  appGrid: {paddingTop: 14},
+  appGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    paddingTop: 14,
+  },
   appCard: {
     backgroundColor: token.color.glassQuiet,
     borderRadius: 16,
-    flex: 1,
+    flexBasis: '30%',
+    flexGrow: 1,
     margin: 6,
     minHeight: 108,
     padding: 12,

--- a/react-native/src/desktop/ShippingStage.test.tsx
+++ b/react-native/src/desktop/ShippingStage.test.tsx
@@ -36,6 +36,9 @@ test('page stage uses 80ms ease-out on route change and never springs', () => {
   expect(timing).toHaveBeenCalled();
   const durations = timing.mock.calls.map(call => call[1]?.duration);
   expect(durations).toContain(80);
+  expect(
+    timing.mock.calls.every(call => call[1]?.useNativeDriver === false),
+  ).toBe(true);
   act(() => {
     renderer.unmount();
   });
@@ -66,6 +69,30 @@ test('search stage uses the 240ms hub-to-results step', () => {
     renderer.unmount();
   });
   timing.mockRestore();
+});
+
+test('keeps a visible fallback when the stage child throws', () => {
+  function Boom(): React.JSX.Element {
+    throw new Error('stage exploded');
+  }
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  let renderer: ReactTestRenderer.ReactTestRenderer;
+  act(() => {
+    renderer = ReactTestRenderer.create(
+      <ShippingStage stageKey="Tasks" variant="page">
+        <Boom />
+      </ShippingStage>,
+    );
+  });
+  expect(
+    renderer!.root
+      .findAllByType(Text)
+      .some(node => node.props.children === 'This page could not be shown.'),
+  ).toBe(true);
+  act(() => {
+    renderer.unmount();
+  });
+  spy.mockRestore();
 });
 
 test('reduce-motion keeps stage and list insert instant', () => {

--- a/react-native/src/desktop/ShippingStage.tsx
+++ b/react-native/src/desktop/ShippingStage.tsx
@@ -2,12 +2,14 @@ import React, {useEffect, useRef} from 'react';
 import {
   Animated,
   StyleSheet,
+  Text,
   View,
   type StyleProp,
   type ViewStyle,
 } from 'react-native';
 import {useReduceMotion} from '../app/useReduceMotion';
 import {desktopStageFade} from './desktopChrome';
+import {desktopTokens as token} from './tokens';
 import {
   glassMotionDuration,
   listInsertMotionDuration,
@@ -36,6 +38,32 @@ function stageDuration(
   return variant === 'page'
     ? navMotionDuration(reduceMotion)
     : stepMotionDuration(reduceMotion);
+}
+
+class ShippingStageGuard extends React.Component<
+  {children: React.ReactNode},
+  {failed: boolean}
+> {
+  state = {failed: false};
+
+  static getDerivedStateFromError(): {failed: boolean} {
+    return {failed: true};
+  }
+
+  render(): React.ReactNode {
+    if (this.state.failed) {
+      return (
+        <View
+          accessibilityLabel="Desktop stage unavailable"
+          style={styles.stageFallback}>
+          <Text style={styles.stageFallbackCopy}>
+            This page could not be shown.
+          </Text>
+        </View>
+      );
+    }
+    return this.props.children;
+  }
 }
 
 export function ShippingStage({
@@ -69,8 +97,8 @@ export function ShippingStage({
     translateY.setValue(fromY);
     const animation = Animated.parallel(
       [
-        runShippingTiming(opacity, 1, duration, true),
-        runShippingTiming(translateY, 0, duration, true),
+        runShippingTiming(opacity, 1, duration, false),
+        runShippingTiming(translateY, 0, duration, false),
       ].filter((item): item is Animated.CompositeAnimation => item !== null),
     );
     animation.start();
@@ -79,7 +107,7 @@ export function ShippingStage({
   return (
     <Animated.View
       style={[styles.stage, style, {opacity, transform: [{translateY}]}]}>
-      {children}
+      <ShippingStageGuard key={stageKey}>{children}</ShippingStageGuard>
     </Animated.View>
   );
 }
@@ -195,4 +223,6 @@ const styles = StyleSheet.create({
     top: 0,
   },
   stage: {flex: 1},
+  stageFallback: {alignItems: 'center', flex: 1, justifyContent: 'center'},
+  stageFallbackCopy: {color: token.color.inkMuted, textAlign: 'center'},
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After Always Allow on the Keychain sheet (`com.omi.rnruntime.firebase-rest-session`) and clicking Tasks, RnRuntime stayed alive but painted a blank white rectangle with traffic lights only. Home could look the same: a large liquid-glass slab and no nav labels.

Apple documents that `NSGlassEffectView` only guarantees z-order for its `contentView`. Shipping chrome was a sibling stacked on top of `OmiGlassPanelView`, so the material could composite over React Native children. A secondary risk: `ShippingStage` faded with `useNativeDriver: true`, which can leave opacity at 0 on react-native-macos when the tree includes native glass / `ScrollView`. Apps still used `FlatList` (same crash class as Tasks).

## Change

1. **Glass host** — React children go through `insertReactSubview` into a `contentHost` assigned as `NSGlassEffectView.contentView`. Each panel clips to its own bounds (`clipsToBounds` + `masksToBounds`). Hits pass through to content; the material itself still returns `nil`. HUD `NSVisualEffectView` is still only the no-`NSGlassEffectView` fallback. Reduce-transparency reparents the host onto the panel so content does not disappear with the hidden glass.
2. **Stage + Apps** — `GlassSurface` mounts children *inside* `GlassPanel`. Page fades use the JS driver. Apps is a `ScrollView` grid, not `FlatList`. `ShippingStage` keeps a visible fallback if a page throws so session restore cannot unmount chrome into a blank window.

Distinct glass pieces (nav / search / chips / stage), traffic lights on the Home row, and the 8pt inset are unchanged.

## Verification

```
bun run --cwd react-native test -- --runInBand
# 20 suites, 151 tests, pass

bun run --cwd react-native lint
# 0 errors (6 pre-existing warnings in desktopReadClient / OmiAvatar)

bun run --cwd react-native typecheck
# tsc --noEmit, pass
```

This Linux VM cannot launch RnRuntime. Please confirm on macOS 26: Home chrome visible at launch, Tasks empty state ("No tasks yet"), Library / Rewind / Apps paint.

## Notes

- Base is `v5`, not `main`.
- No `workers.dev` in source.
- No necklace / BLE work.

Failure-Class: none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee9bbfb7-3aad-4272-8ddf-b750c49905d8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee9bbfb7-3aad-4272-8ddf-b750c49905d8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

