### PR TITLE
fix(backend): resolve duplicate memory adds to the existing identical row

### DIFF
--- a/.github/failure-classes/FC-replay-idempotency-keyed-on-advancing-state.json
+++ b/.github/failure-classes/FC-replay-idempotency-keyed-on-advancing-state.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-replay-idempotency-keyed-on-advancing-state",
+  "violated_contract": "A write that promises duplicate-submission idempotency must derive its idempotency identity only from the logical request, never from ambient state that advances with unrelated writes. Folding the observed head commit into the operation id makes duplicate handling correct only while the account is otherwise idle: the same submission after any other write proposes a fresh operation, and when row ids are content-deterministic its add collides with the existing row instead of resolving as already-done.",
+  "canonical_prevention": "When deterministic row identity makes duplicates collide by construction, resolve the collision at the write boundary by proving the existing row is the same logical write (identical content, still active) and reporting the write complete with the existing id; keep different-content and non-active collisions failing. Keep a regression test that resubmits the identical payload after the account head has advanced, and one that a reused id with different content still fails.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_ws_j_delete_privacy.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/utils/memory/canonical_memory_adapter.py",
+    "backend/database/memory_apply_store.py",
+    "backend/models/memory_operations.py"
+  ],
+  "status": "open"
+}

--- a/backend/tests/unit/test_ws_j_delete_privacy.py
+++ b/backend/tests/unit/test_ws_j_delete_privacy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import copy
 import hashlib
 import importlib
 import os
@@ -971,6 +972,63 @@ def test_readding_a_deleted_manual_memory_lands_on_a_fresh_evidence_identity(mon
     # The deleted submission's evidence identity stays retired: the re-add is a
     # new source artifact, not a resurrection of the deleted one.
     assert retired_evidence == []
+
+
+def test_resubmitting_an_identical_manual_memory_resolves_to_the_existing_row(monkeypatch, canonical_db):
+    """Prod regression (#12084 deploy, 2026-08-28 onward): duplicate POST /v3/memories 500s.
+
+    Manual/API memory ids derive deterministically from content, but operation
+    identity folds the observed head commit into the operation id — so a
+    duplicate submission is replay-idempotent only while the account head has
+    not moved. Any other canonical write in between makes the duplicate propose
+    a fresh operation whose add collides with the existing row id, which
+    surfaced as ``canonical write failed: ApplyStatus.invalid_patch (add patch
+    new_memory_id already exists)`` at over a thousand requests per day. An
+    identical resubmission carries no new information: it must resolve to the
+    existing row and leave it untouched.
+    """
+    uid = "uid-canonical-ws-j"
+    _stub_delete_side_effects(monkeypatch)
+
+    first_id = write_canonical_external_memory(
+        uid, _external_memory_payload(uid, "I drink oat milk"), db_client=canonical_db
+    )
+    # An unrelated write advances the account head, so the resubmission below
+    # can never be recognized as a replay of the first operation.
+    write_canonical_external_memory(uid, _external_memory_payload(uid, "I bike to work"), db_client=canonical_db)
+    before = copy.deepcopy(canonical_db.docs[f"users/{uid}/memory_items/{first_id}"])
+
+    resubmitted_id = write_canonical_external_memory(
+        uid, _external_memory_payload(uid, "I drink oat milk"), db_client=canonical_db
+    )
+
+    assert resubmitted_id == first_id
+    assert canonical_db.docs[f"users/{uid}/memory_items/{first_id}"] == before
+
+
+def test_reusing_a_row_id_for_different_content_still_fails(monkeypatch, canonical_db):
+    """The duplicate resolution must never quietly swallow a genuine conflict.
+
+    A collision is benign only when the existing row carries the same content.
+    A client-supplied id reused for different text is a real conflict and keeps
+    failing, with the stored row left exactly as it was.
+    """
+    uid = "uid-canonical-ws-j"
+    _stub_delete_side_effects(monkeypatch)
+
+    first_id = write_canonical_external_memory(
+        uid, _external_memory_payload(uid, "I drink oat milk"), db_client=canonical_db
+    )
+    write_canonical_external_memory(uid, _external_memory_payload(uid, "I bike to work"), db_client=canonical_db)
+    before = copy.deepcopy(canonical_db.docs[f"users/{uid}/memory_items/{first_id}"])
+
+    conflicting = _external_memory_payload(uid, "I drink almond milk")
+    conflicting["id"] = first_id
+
+    with pytest.raises(RuntimeError, match="already exists"):
+        write_canonical_external_memory(uid, conflicting, db_client=canonical_db)
+
+    assert canonical_db.docs[f"users/{uid}/memory_items/{first_id}"] == before
 
 
 def test_conversation_sourced_evidence_is_never_reissued_after_delete(monkeypatch, canonical_db):

--- a/backend/utils/memory/canonical_memory_adapter.py
+++ b/backend/utils/memory/canonical_memory_adapter.py
@@ -65,6 +65,7 @@ from models.memory_evidence import (
 )
 from models.memories import Evidence, MemoryDB, MemoryCategory, SubjectAttribution, decide_initial_memory_tier
 from models.memory_apply import (
+    ApplyResult,
     ApplyStatus,
     MemoryControlState,
     MemoryWriterClass,
@@ -1401,6 +1402,42 @@ def _canonical_extraction_apply_write(
     )
 
 
+_DUPLICATE_ADD_ROW_REASON = "add patch new_memory_id already exists"
+
+
+def _existing_identical_add_row(
+    uid: str,
+    *,
+    result: ApplyResult,
+    memory_id: str,
+    data: Dict[str, Any],
+    db_client: Any,
+) -> Optional[MemoryItem]:
+    """Resolve an add collision against an already-committed identical row.
+
+    Operation identity folds the observed head commit into the operation id, so
+    a duplicate submission is only replay-idempotent while the account head has
+    not moved. Re-sending the same memory after any other ledger write proposes
+    a fresh operation whose add then collides with the deterministically derived
+    row id. The requested row already exists with the same content, so the write
+    is complete rather than failed. A collision with different content — a
+    client-supplied id reused for new text — is still an error, and a row that
+    is no longer active keeps failing so a resurrected id can never masquerade
+    as a fresh create.
+    """
+    if result.status != ApplyStatus.invalid_patch or result.reason != _DUPLICATE_ADD_ROW_REASON:
+        return None
+    snapshot = db_client.document(f"{MemoryCollections(uid=uid).memory_items}/{memory_id}").get()
+    if not getattr(snapshot, "exists", False):
+        return None
+    item = MemoryItem(**_snapshot_payload(snapshot))
+    if item.status != MemoryItemStatus.active:
+        return None
+    if (item.content or "").strip() != (data.get("content") or "").strip():
+        return None
+    return item
+
+
 def write_canonical_extraction_memory(
     uid: str,
     data: Dict[str, Any],
@@ -1455,7 +1492,26 @@ def write_canonical_extraction_memory(
             break
     assert result is not None
     if result.status not in {ApplyStatus.committed, ApplyStatus.idempotent_skip}:
-        raise RuntimeError(f"canonical write failed: {result.status} ({result.reason})")
+        duplicate_row = _existing_identical_add_row(
+            uid,
+            result=result,
+            memory_id=memory_id,
+            data=data,
+            db_client=client,
+        )
+        if duplicate_row is None:
+            raise RuntimeError(f"canonical write failed: {result.status} ({result.reason})")
+        logger.info(
+            "canonical duplicate add resolved to existing row uid=%s memory_id=%s",
+            uid,
+            duplicate_row.memory_id,
+        )
+        assert_legal_state(
+            DomainMemoryLayer(duplicate_row.tier.value),
+            physical_status_to_record_status(duplicate_row.status.value),
+            MemoryProcessingState(duplicate_row.processing_state.value),
+        )
+        return duplicate_row.memory_id
 
     committed_id = memory_id
     if result.memory_items:


### PR DESCRIPTION
## What changed and why

POST /v3/memories has 500'd at over a thousand requests per day in production since the #12084 deploy (2026-08-28): `canonical write failed: ApplyStatus.invalid_patch (add patch new_memory_id already exists)` from `create_memory` → `write_canonical_extraction_memory`. This is gate 1 of the JIT rollout follow-ups ("trace, fix, deploy, and verify the separate /v3/memories idempotency failure").

Root cause: manual/API memory ids derive deterministically from content (`document_id_from_seed(content)`), but operation identity folds the observed head commit into the operation id (`build_operation_id(... observed_head_commit_id ...)`). A duplicate submission is therefore replay-idempotent only while the account head has not moved. Any other canonical write in between makes the duplicate propose a fresh operation whose add collides with the existing row id — so a client re-sending the same memory (retry, sync replay, re-import) gets a 500 for a write that is already complete.

The fix resolves the collision at the write boundary: when the add's target row exists with identical content and is still active, the write is reported complete with the existing id and the row is left untouched. A collision with different content (a client-supplied id reused for new text) or against a non-active row keeps failing, and the privacy-deleted receipt branch is unchanged and still refuses.

## Product invariants affected

- INV-MEM-1
- INV-MEM-2
- INV-MEM-3
- INV-MEM-4
- INV-MEM-5
- INV-MEM-6

## How it was verified

- `backend/.venv/bin/python -m pytest tests/unit/test_ws_j_delete_privacy.py tests/unit/test_memory_apply_store.py tests/unit/test_conversation_replacement_backoff.py tests/unit/test_knowledge_ledger.py tests/unit/test_ws_i_hardening.py` — 120 passed.
- The new regression test fails on unmodified `origin/main` (verified by stashing the adapter change) and passes with the fix.
- Prod log evidence: `gcloud logging read` on `based-hardware` shows the exact traceback (routers/memories.py:366 → canonical_memory_adapter.py:1458) hitting the 1000-entry query cap every day 2026-08-28 → 2026-09-01.

## Tests

- `test_resubmitting_an_identical_manual_memory_resolves_to_the_existing_row` — the regression: identical resubmission after the head advances resolves to the existing row and leaves it byte-identical.
- `test_reusing_a_row_id_for_different_content_still_fails` — the guard that duplicate resolution never swallows a genuine conflict.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative

No existing class covers this: the registry has destructive-gate, CAS-retry, and delivery-retry classes, but nothing about idempotency identity derived from ambient advancing state. The new class `FC-replay-idempotency-keyed-on-advancing-state` names the contract (duplicate-handling identity must derive from the logical request only, never from state that advances with unrelated writes) and its canonical prevention (resolve deterministic-id collisions at the write boundary by proving the existing row is the same logical write; keep a resubmit-after-head-advance regression test). Prevention artifact: `backend/tests/unit/test_ws_j_delete_privacy.py`.

## Line-count exceptions

Oversized files grew by the minimal duplicate-resolution patch; splitting them is out of scope for this production-regression fix.

Line-Count-Exception: backend/utils/memory/canonical_memory_adapter.py | 3496 -> 3552 | resolve add collisions to the existing identical row at the shared write boundary


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

