### PR TITLE
fix(backend): keep existing memories when a reprocess extracts nothing

### DIFF
--- a/backend/tests/unit/test_conversation_replacement_backoff.py
+++ b/backend/tests/unit/test_conversation_replacement_backoff.py
@@ -232,3 +232,62 @@ def test_empty_replacement_over_existing_rows_still_demands_the_gate(monkeypatch
 
     # Fail-closed: the row survives the refused deletion.
     assert db.docs[f"users/{UID}/memory_items/{items[0]['id']}"]["status"] == MemoryItemStatus.active.value
+
+
+def test_extraction_intent_empty_over_existing_rows_is_a_noop_that_keeps_them(monkeypatch):
+    """Reprocess extracting nothing must keep the rows, not 500 or delete them.
+
+    Residual prod regression after #12410: conversation *reprocess*
+    (``routers/conversations.py -> process_conversation``) over a conversation
+    that already has canonical rows, where the new extraction is empty. The
+    empty replacement genuinely would retract rows, so it kept demanding the
+    ``explicit_memory_deletion`` gate the extraction path never holds and died
+    with LegalHoldAuthorityUnavailable. Extraction emptiness is model variance,
+    not deletion intent (FC-destructive-gate-keyed-on-proxy-for-intent), so the
+    extraction caller now declares its intent and the existing rows survive as
+    a successful no-op.
+    """
+
+    db = _extraction_db()
+    items = _extracted_items()
+    replace_conversation_sourced_memories(UID, CONVERSATION_ID, items, db_client=db)
+    assert db.docs[f"users/{UID}/memory_items/{items[0]['id']}"]["status"] == MemoryItemStatus.active.value
+    injector = _install_injector(monkeypatch, conflicts=0)
+
+    result = replace_conversation_sourced_memories(
+        UID,
+        CONVERSATION_ID,
+        [],
+        db_client=db,
+        empty_set_intent="extraction",
+    )
+
+    assert result["retracted_memory_ids"] == []
+    assert result["committed_memory_ids"] == []
+    assert result["reactivated_memory_ids"] == []
+    # The rows survive and the destructive boundary was never entered.
+    assert db.docs[f"users/{UID}/memory_items/{items[0]['id']}"]["status"] == MemoryItemStatus.active.value
+    assert injector.calls == 0
+    assert db.docs[f"users/{UID}/memory_state/apply_control"]["source_generation"] == 2
+
+
+def test_default_intent_still_treats_empty_over_existing_rows_as_a_retraction():
+    """The extraction shortcut must not relax the deletion callers' contract."""
+
+    from database.legal_holds import LegalHoldAuthorityUnavailable
+
+    db = _extraction_db()
+    items = _extracted_items()
+    replace_conversation_sourced_memories(UID, CONVERSATION_ID, items, db_client=db)
+
+    with pytest.raises(LegalHoldAuthorityUnavailable):
+        replace_conversation_sourced_memories(UID, CONVERSATION_ID, [], db_client=db)
+
+    assert db.docs[f"users/{UID}/memory_items/{items[0]['id']}"]["status"] == MemoryItemStatus.active.value
+
+
+def test_unknown_empty_set_intent_is_rejected():
+    with pytest.raises(ValueError, match="empty_set_intent"):
+        replace_conversation_sourced_memories(
+            UID, CONVERSATION_ID, [], db_client=_extraction_db(), empty_set_intent="oops"
+        )

--- a/backend/utils/memory/canonical_memory_adapter.py
+++ b/backend/utils/memory/canonical_memory_adapter.py
@@ -1921,6 +1921,7 @@ def replace_conversation_sourced_memories(
     *,
     db_client: Any = None,
     conflict_backoff_seconds: Sequence[float] = _REPLACEMENT_CONFLICT_BACKOFF_SECONDS,
+    empty_set_intent: str = "retraction",
 ) -> Dict[str, Any]:
     """Atomically replace one conversation's complete canonical memory set.
 
@@ -1928,7 +1929,19 @@ def replace_conversation_sourced_memories(
     a conflicted round must re-plan against the control the peer left behind.
     ``conflict_backoff_seconds`` bounds those rounds: one entry per retry, and
     the number of attempts is ``len(...) + 1``.
+
+    ``empty_set_intent`` states what an empty ``items`` means for this caller
+    (FC-destructive-gate-keyed-on-proxy-for-intent: emptiness alone cannot
+    carry intent). ``"retraction"`` — the default, and the only meaning before
+    this parameter existed — treats it as "remove this conversation's rows",
+    which demands ``explicit_memory_deletion`` authority whenever rows exist.
+    ``"extraction"`` declares the empty set an extraction outcome: when the
+    conversation already has rows and no deletion gate is held, the existing
+    rows are kept and the call resolves as a no-op instead of failing —
+    extraction variance is not permission to destroy knowledge.
     """
+    if empty_set_intent not in {"retraction", "extraction"}:
+        raise ValueError(f"unknown empty_set_intent: {empty_set_intent!r}")
     client = db_client if db_client is not None else default_db_client
     replacement_digest = _conversation_replacement_digest(uid, conversation_id, items)
     replacement_id = f"replace_{replacement_digest[:32]}"
@@ -1988,6 +2001,34 @@ def replace_conversation_sourced_memories(
             try:
                 current_destructive_operation_token(uid, kind="explicit_memory_deletion")
             except LegalHoldAuthorityUnavailable:
+                return {
+                    "retracted_memory_ids": [],
+                    "committed_memory_ids": [],
+                    "reactivated_memory_ids": [],
+                    "vector_delete_ids": [],
+                    "tombstoned_evidence_ids": [],
+                    "source_generation": observed_control.source_generation,
+                }
+        if not items and expected_source_items and empty_set_intent == "extraction":
+            # An extraction that produced nothing over a conversation that
+            # already has canonical rows. Falling through would retract those
+            # rows, and the retraction branch rightly demands an
+            # ``explicit_memory_deletion`` token the extraction path never
+            # holds — the residual LegalHoldAuthorityUnavailable 500s on
+            # conversation reprocess after #12410. Extraction emptiness is
+            # model variance, not deletion intent: keep the rows and resolve
+            # as a no-op. A caller that genuinely holds the deletion gate is
+            # performing a deliberate deletion and still falls through so the
+            # retraction is recorded.
+            try:
+                current_destructive_operation_token(uid, kind="explicit_memory_deletion")
+            except LegalHoldAuthorityUnavailable:
+                logger.info(
+                    "conversation extraction was empty; keeping %d existing canonical rows uid=%s conversation_id=%s",
+                    len(expected_source_items),
+                    uid,
+                    conversation_id,
+                )
                 return {
                     "retracted_memory_ids": [],
                     "committed_memory_ids": [],

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -3845,7 +3845,17 @@ class MemoryService:
         items: List[Dict[str, Any]],
     ) -> Dict[str, Any]:
         self.ensure_canonical_mutation_ready(uid)
-        result = replace_conversation_sourced_memories(uid, conversation_id, items, db_client=self.db_client)
+        # This wrapper is the conversation-extraction entry (finalize and
+        # reprocess). An empty extraction here is model variance, not deletion
+        # intent, so it keeps any existing rows instead of demanding the
+        # destructive gate the extraction path never holds.
+        result = replace_conversation_sourced_memories(
+            uid,
+            conversation_id,
+            items,
+            db_client=self.db_client,
+            empty_set_intent="extraction",
+        )
         retracted = list(result.get("retracted_memory_ids") or [])
         if retracted:
             self._write_historical_overrides(uid, retracted, MemoryItemStatus.tombstoned)


### PR DESCRIPTION
## What changed and why

Residual production 500s after #12410: conversation **reprocess** (`routers/conversations.py::reprocess_conversation` → `process_conversation` → `replace_conversation_memories`) still dies with `LegalHoldAuthorityUnavailable: destructive operation gate is not active in this context` whenever a reprocess extracts zero memories over a conversation that already has canonical rows (~3/day on prod `backend`).

#12410 fixed the empty-and-no-existing-rows case but deliberately kept an empty replacement over existing rows demanding the `explicit_memory_deletion` gate — right for deletion callers, wrong for the extraction entry, which never holds that gate. Extraction emptiness is model variance, not deletion intent.

Following the failure class's own prescription ("take intent as an explicit argument"), `replace_conversation_sourced_memories` grows `empty_set_intent`: the conversation-extraction wrapper declares `"extraction"`, so an empty extraction over existing rows keeps them and resolves as a successful no-op. Deletion callers keep the default `"retraction"` semantics unchanged, and a caller genuinely holding the gate still falls through so the retraction is recorded.

## Product invariants affected

- INV-MEM-1
- INV-MEM-2
- INV-MEM-3
- INV-MEM-4
- INV-MEM-5
- INV-MEM-6

## How it was verified

- `backend/.venv/bin/python -m pytest tests/unit/test_conversation_replacement_backoff.py` — 8 passed (includes both #12410 guards unchanged).
- `backend/.venv/bin/python -m pytest tests/unit/test_ws_j_delete_privacy.py tests/unit/test_conversation_jit_processing.py` — passed.
- Prod log evidence: `gcloud logging read` on `based-hardware` shows the traceback entering through `routers/conversations.py:491 reprocess_conversation` on 2026-08-31 and 2026-09-01.

## Tests

- `test_extraction_intent_empty_over_existing_rows_is_a_noop_that_keeps_them` — the regression: reprocess extracting nothing keeps the rows, never enters the destructive boundary.
- `test_default_intent_still_treats_empty_over_existing_rows_as_a_retraction` — the deletion callers' contract is not relaxed.
- `test_unknown_empty_set_intent_is_rejected` — intent is a closed enum.

## Failure class (fixes)

Failure-Class: FC-destructive-gate-keyed-on-proxy-for-intent

## Line-count exceptions

Oversized files grew by the minimal intent-argument patch; splitting them is out of scope for this production-regression fix.

Line-Count-Exception: backend/utils/memory/canonical_memory_adapter.py | 3496 -> 3537 | take empty-set intent as an explicit argument at the shared replacement boundary
Line-Count-Exception: backend/utils/memory/memory_service.py | 3939 -> 3949 | declare extraction intent at the conversation-extraction wrapper


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

