### PR TITLE
fix(macos): paint chrome in front of glass

### DIFF
--- a/react-native/__tests__/macOSNativeBoundary.test.ts
+++ b/react-native/__tests__/macOSNativeBoundary.test.ts
@@ -435,13 +435,16 @@ test('keeps the glass reduce-transparency fallback intact', () => {
   );
 });
 
-test('uses NSGlassEffectView per panel and HUD only as InkGlass fallback', () => {
+test('uses HUD as the only shipping panel material', () => {
   const source = readNativeSource('OmiGlassPanelView.mm');
 
   expect(source).toContain('static const CGFloat OmiGlassScrimAlpha = 0.46;');
   expect(source).toContain('NSAppearanceNameAqua');
-  expect(source).toContain('NSClassFromString(@"NSGlassEffectView")');
-  expect(source).toContain('self.liquidGlass');
+  expect(source).toContain(
+    'self.material.material = NSVisualEffectMaterialHUDWindow;',
+  );
+  expect(source).toContain('self.material = [[NSVisualEffectView alloc]');
+  expect(source).toContain('[self addSubview:self.material]');
   expect(source).toContain('self.sheen');
   expect(source).toContain('NSMaxY(self.bounds) - OmiGlassSheenHeight');
   expect(source).toContain(
@@ -450,15 +453,9 @@ test('uses NSGlassEffectView per panel and HUD only as InkGlass fallback', () =>
   expect(source).toContain(
     'self.fallback.layer.backgroundColor = NSColor.controlBackgroundColor.CGColor;',
   );
-  expect(source).toContain(
-    'self.material.material = NSVisualEffectMaterialHUDWindow;',
-  );
-  expect(source).toMatch(
-    /if \(self\.liquidGlass != nil\) \{\s*\[self addSubview:self\.liquidGlass\];/,
-  );
-  expect(source).toMatch(
-    /if \(self\.liquidGlass == nil\) \{\s*self\.material = \[\[NSVisualEffectView alloc\]/,
-  );
+  expect(source).not.toContain('NSGlassEffectView');
+  expect(source).not.toContain('liquidGlass');
+  expect(source).not.toContain('OmiMakeLiquidGlass');
   expect(source).not.toContain(
     'self.material.hidden = reduceTransparency || hasLiquid;',
   );
@@ -475,19 +472,33 @@ test('uses NSGlassEffectView per panel and HUD only as InkGlass fallback', () =>
   );
 });
 
-test('hosts React children in NSGlassEffectView contentView and clips to the panel', () => {
+test('never orphans contentHost and never hosts chrome in setContentView', () => {
   const source = readNativeSource('OmiGlassPanelView.mm');
+  const attachStart = source.indexOf('- (void)omiAttachContentHost');
+  const layoutStart = source.indexOf('- (void)layout');
+  const layoutEnd = source.indexOf('\n}', layoutStart);
+  const layoutSource = source.slice(layoutStart, layoutEnd);
 
   expect(source).toContain(
     '@property (nonatomic, strong) NSView *contentHost;',
   );
-  expect(source).toContain('setContentView:');
+  expect(source).toContain('[self addSubview:self.contentHost]');
   expect(source).toContain('insertReactSubview');
   expect(source).toContain('removeReactSubview');
   expect(source).toContain('didUpdateReactSubviews');
   expect(source).toContain('self.clipsToBounds = YES');
   expect(source).toContain('self.layer.masksToBounds = YES');
   expect(source).toContain('[self.contentHost addSubview:subview');
+  expect(source).not.toContain('setContentView:');
+  expect(layoutSource).toContain('self.contentHost.frame = self.bounds');
+  expect(layoutSource).toContain('self.contentHost.superview');
+  expect(attachStart).toBeGreaterThan(-1);
+  expect(source.slice(attachStart, attachStart + 400)).toContain(
+    '[self addSubview:self.contentHost]',
+  );
+  expect(source.slice(attachStart, attachStart + 400)).toContain(
+    'self.contentHost.superview != self',
+  );
 });
 
 test('lets the host choose the glass radius so one panel can run full-bleed', () => {

--- a/react-native/macos/RnRuntime-macOS/OmiGlassPanelView.mm
+++ b/react-native/macos/RnRuntime-macOS/OmiGlassPanelView.mm
@@ -1,8 +1,6 @@
 #import "OmiGlassPanelView.h"
 
 #import <React/RCTViewManager.h>
-#import <objc/message.h>
-#import <objc/runtime.h>
 
 static const CGFloat defaultCornerRadius = 22.0;
 static const CGFloat OmiGlassScrimAlpha = 0.46;
@@ -15,34 +13,12 @@ static NSAppearance *OmiInkGlassAppearance(void)
   return [NSAppearance appearanceNamed:NSAppearanceNameAqua];
 }
 
-static NSView *OmiMakeLiquidGlass(NSRect frame, CGFloat radius)
-{
-  Class glassClass = NSClassFromString(@"NSGlassEffectView");
-  if (glassClass == Nil) {
-    return nil;
-  }
-  NSView *glass = [[glassClass alloc] initWithFrame:frame];
-  glass.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
-  if ([glass respondsToSelector:@selector(setCornerRadius:)]) {
-    ((void (*)(id, SEL, CGFloat))objc_msgSend)(glass, @selector(setCornerRadius:), radius);
-  }
-  if ([glass respondsToSelector:@selector(setStyle:)]) {
-    ((void (*)(id, SEL, NSInteger))objc_msgSend)(glass, @selector(setStyle:), 0);
-  }
-  if ([glass respondsToSelector:@selector(setTintColor:)]) {
-    ((void (*)(id, SEL, id))objc_msgSend)(
-        glass, @selector(setTintColor:), [NSColor colorWithCalibratedWhite:1.0 alpha:OmiGlassScrimAlpha]);
-  }
-  return glass;
-}
-
 @interface OmiGlassPanelView ()
 
 {
   CGFloat _glassCornerRadius;
 }
 
-@property (nonatomic, strong) NSView *liquidGlass;
 @property (nonatomic, strong) NSVisualEffectView *material;
 @property (nonatomic, strong) NSView *fallback;
 @property (nonatomic, strong) NSView *contentHost;
@@ -68,33 +44,31 @@ static NSView *OmiMakeLiquidGlass(NSRect frame, CGFloat radius)
   self.appearance = OmiInkGlassAppearance();
   self.layer.borderWidth = 1;
 
-  self.contentHost = [[NSView alloc] initWithFrame:self.bounds];
-  self.contentHost.wantsLayer = YES;
-  self.contentHost.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
-  self.finish = [[NSView alloc] initWithFrame:self.bounds];
-  self.finish.wantsLayer = YES;
-  self.finish.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
-  [self.contentHost addSubview:self.finish];
-
-  self.liquidGlass = OmiMakeLiquidGlass(self.bounds, defaultCornerRadius);
-  if (self.liquidGlass != nil) {
-    [self addSubview:self.liquidGlass];
-  }
-  if (self.liquidGlass == nil) {
-    self.material = [[NSVisualEffectView alloc] initWithFrame:self.bounds];
-    self.material.appearance = OmiInkGlassAppearance();
-    self.material.material = NSVisualEffectMaterialHUDWindow;
-    self.material.blendingMode = NSVisualEffectBlendingModeBehindWindow;
-    self.material.state = NSVisualEffectStateActive;
-    self.material.wantsLayer = YES;
-    self.material.layer.masksToBounds = YES;
-    [self addSubview:self.material];
-  }
+  self.material = [[NSVisualEffectView alloc] initWithFrame:self.bounds];
+  self.material.appearance = OmiInkGlassAppearance();
+  self.material.material = NSVisualEffectMaterialHUDWindow;
+  self.material.blendingMode = NSVisualEffectBlendingModeBehindWindow;
+  self.material.state = NSVisualEffectStateActive;
+  self.material.wantsLayer = YES;
+  self.material.layer.masksToBounds = YES;
+  self.material.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+  [self addSubview:self.material];
 
   self.fallback = [[NSView alloc] initWithFrame:self.bounds];
   self.fallback.wantsLayer = YES;
   self.fallback.layer.masksToBounds = YES;
+  self.fallback.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
   [self addSubview:self.fallback];
+
+  self.finish = [[NSView alloc] initWithFrame:self.bounds];
+  self.finish.wantsLayer = YES;
+  self.finish.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+  [self addSubview:self.finish];
+
+  self.contentHost = [[NSView alloc] initWithFrame:self.bounds];
+  self.contentHost.wantsLayer = YES;
+  self.contentHost.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+  [self addSubview:self.contentHost];
 
   self.scrim = [CALayer layer];
   [self.finish.layer addSublayer:self.scrim];
@@ -135,10 +109,6 @@ static NSView *OmiMakeLiquidGlass(NSRect frame, CGFloat radius)
   self.finish.layer.cornerCurve = kCACornerCurveContinuous;
   self.scrim.cornerRadius = _glassCornerRadius;
   self.scrim.cornerCurve = kCACornerCurveContinuous;
-  if (self.liquidGlass != nil && [self.liquidGlass respondsToSelector:@selector(setCornerRadius:)]) {
-    ((void (*)(id, SEL, CGFloat))objc_msgSend)(
-        self.liquidGlass, @selector(setCornerRadius:), _glassCornerRadius);
-  }
 }
 
 - (BOOL)acceptsFirstMouse:(NSEvent *)event
@@ -148,33 +118,19 @@ static NSView *OmiMakeLiquidGlass(NSRect frame, CGFloat radius)
 
 - (NSView *)hitTest:(NSPoint)point
 {
-  NSPoint local = [self convertPoint:point fromView:self.superview];
-  if (self.isHidden || ![self mouse:local inRect:self.bounds] || self.contentHost == nil) {
-    return nil;
-  }
-  NSView *hostSuperview = self.contentHost.superview;
-  if (hostSuperview == nil) {
-    return nil;
-  }
-  NSView *hit = [self.contentHost hitTest:[hostSuperview convertPoint:local fromView:self]];
-  if (hit == nil || hit == self.contentHost || hit == self.finish) {
-    return nil;
-  }
-  return hit;
+  return nil;
 }
 
 - (void)layout
 {
   [super layout];
-  self.liquidGlass.frame = self.bounds;
   self.material.frame = self.bounds;
   self.fallback.frame = self.bounds;
-  if (self.contentHost.superview == self) {
-    self.contentHost.frame = self.bounds;
-  } else if (self.contentHost.superview != nil) {
-    self.contentHost.frame = self.contentHost.superview.bounds;
+  self.finish.frame = self.bounds;
+  if (self.contentHost.superview != self) {
+    [self omiAttachContentHost];
   }
-  self.finish.frame = self.contentHost.bounds;
+  self.contentHost.frame = self.bounds;
   self.scrim.frame = self.finish.bounds;
   self.sheen.frame = NSMakeRect(0, NSMaxY(self.bounds) - OmiGlassSheenHeight, NSWidth(self.bounds),
       OmiGlassSheenHeight);
@@ -182,19 +138,8 @@ static NSView *OmiMakeLiquidGlass(NSRect frame, CGFloat radius)
 
 - (void)omiAttachContentHost
 {
-  BOOL reduceTransparency = NSWorkspace.sharedWorkspace.accessibilityDisplayShouldReduceTransparency;
-  BOOL useGlassContent = self.liquidGlass != nil && !self.liquidGlass.hidden && !reduceTransparency &&
-      [self.liquidGlass respondsToSelector:@selector(setContentView:)];
-  if (useGlassContent) {
-    ((void (*)(id, SEL, id))objc_msgSend)(
-        self.liquidGlass, @selector(setContentView:), self.contentHost);
-    return;
-  }
-  if ([self.liquidGlass respondsToSelector:@selector(setContentView:)]) {
-    id current = ((id (*)(id, SEL))objc_msgSend)(self.liquidGlass, @selector(contentView));
-    if (current == self.contentHost) {
-      ((void (*)(id, SEL, id))objc_msgSend)(self.liquidGlass, @selector(setContentView:), nil);
-    }
+  if (self.contentHost.superview != nil && self.contentHost.superview != self) {
+    [self.contentHost removeFromSuperview];
   }
   if (self.contentHost.superview != self) {
     [self addSubview:self.contentHost];
@@ -204,10 +149,12 @@ static NSView *OmiMakeLiquidGlass(NSRect frame, CGFloat radius)
 - (void)insertReactSubview:(RCTUIView *)subview atIndex:(NSInteger)atIndex
 {
   [super insertReactSubview:subview atIndex:atIndex];
+  if (self.contentHost.superview != self) {
+    [self omiAttachContentHost];
+  }
   NSArray<NSView *> *siblings = self.contentHost.subviews;
-  NSInteger hostIndex = atIndex + 1;
-  if (hostIndex >= 0 && hostIndex < (NSInteger)siblings.count) {
-    [self.contentHost addSubview:subview positioned:NSWindowBelow relativeTo:siblings[hostIndex]];
+  if (atIndex >= 0 && atIndex < (NSInteger)siblings.count) {
+    [self.contentHost addSubview:subview positioned:NSWindowBelow relativeTo:siblings[atIndex]];
     return;
   }
   [self.contentHost addSubview:subview];
@@ -225,11 +172,7 @@ static NSView *OmiMakeLiquidGlass(NSRect frame, CGFloat radius)
 - (void)applyAccessibilityAppearance
 {
   BOOL reduceTransparency = NSWorkspace.sharedWorkspace.accessibilityDisplayShouldReduceTransparency;
-  BOOL hasLiquid = self.liquidGlass != nil;
-  self.liquidGlass.hidden = reduceTransparency || !hasLiquid;
-  if (self.material != nil) {
-    self.material.hidden = reduceTransparency;
-  }
+  self.material.hidden = reduceTransparency;
   self.fallback.hidden = !reduceTransparency;
   self.appearance = OmiInkGlassAppearance();
   [self.appearance performAsCurrentDrawingAppearance:^{

--- a/react-native/src/desktop/DesktopApp.test.tsx
+++ b/react-native/src/desktop/DesktopApp.test.tsx
@@ -465,30 +465,47 @@ test('Apps page does not mount FlatList and still paints import cards', () => {
   expect(tree).toContain('Tasks');
 });
 
-test('puts shipping chrome inside GlassPanel instead of stacking it on top', () => {
+test('paints shipping chrome in front of a background-only GlassPanel', () => {
   const source = readFileSync(resolve(__dirname, './DesktopApp.tsx'), 'utf8');
   const start = source.indexOf('function GlassSurface');
   const end = source.indexOf('function GlassHairline');
   const glassSurface = source.slice(start, end);
   expect(start).toBeGreaterThan(-1);
+  expect(glassSurface).toContain('pointerEvents="none"');
+  expect(glassSurface).toContain('StyleSheet.absoluteFill');
   expect(glassSurface).toContain('{children}');
-  expect(glassSurface).not.toContain('pointerEvents="none"');
-  expect(glassSurface).not.toContain('StyleSheet.absoluteFill');
+  expect(glassSurface).toMatch(/<GlassPanel[\s\S]*\/>\s*\{children\}/);
+  expect(glassSurface).not.toMatch(
+    /<GlassPanel[^>]*>\s*\{children\}\s*<\/GlassPanel>/,
+  );
+  expect(source).not.toContain('glassHost');
 
   const renderer = renderDesktop();
+  const tree = renderedText(renderer);
+  expect(tree).toContain('Home');
+  expect(tree).toContain('Library');
+  expect(tree).toContain('Tasks');
+  expect(tree).toContain('Rewind');
+  expect(tree).toContain('Apps');
+  expect(tree).toContain("I'm ready.");
+
+  const home = renderer.root
+    .findAllByType(Text)
+    .find(node => node.props.children === 'Home');
+  expect(home).toBeDefined();
+  let ancestor: ReactTestRenderer.ReactTestInstance | null = home!.parent;
+  while (ancestor != null) {
+    expect(ancestor.props.glassCornerRadius).toBeUndefined();
+    ancestor = ancestor.parent;
+  }
+
   const panels = renderer.root.findAll(
     node => node.props.glassCornerRadius !== undefined,
   );
-  const navbar = panels.find(panel =>
-    panel.findAllByType(Text).some(text => text.props.children === 'Home'),
+  expect(panels.length).toBeGreaterThanOrEqual(4);
+  expect(panels.every(panel => panel.props.pointerEvents === 'none')).toBe(
+    true,
   );
-  expect(navbar).toBeDefined();
-  expect(
-    navbar!
-      .findAllByType(Text)
-      .map(text => text.props.children)
-      .join(' '),
-  ).toContain('Tasks');
 });
 
 test('Home and Library chips share a sliding glass pill', () => {

--- a/react-native/src/desktop/DesktopApp.tsx
+++ b/react-native/src/desktop/DesktopApp.tsx
@@ -107,9 +107,10 @@ function GlassSurface({
     <ShippingGlassMount style={[styles.glassSurface, style]}>
       <GlassPanel
         glassCornerRadius={token.radius.panel}
-        style={[styles.glassHost, style]}>
-        {children}
-      </GlassPanel>
+        pointerEvents="none"
+        style={StyleSheet.absoluteFill}
+      />
+      {children}
     </ShippingGlassMount>
   );
 }
@@ -735,13 +736,6 @@ const styles = StyleSheet.create({
     shadowOffset: {height: 3, width: 0},
     shadowOpacity: 0.1,
     shadowRadius: 10,
-  },
-  glassHost: {
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
-    right: 0,
-    top: 0,
   },
   glassHairline: {
     backgroundColor: token.color.sheen,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`360411e9bb` already merged and still blanks. After the Keychain bypass, RnRuntime on macOS 26 is an off-white rounded rectangle with traffic lights and no Home / Tasks / Library / Rewind / Apps chrome. The process stays alive.

The previous host put every React child inside `NSGlassEffectView` via `setContentView:` and returned without checking `contentHost.superview`. When that selector exists but does not parent the view, `contentHost` is orphaned and the window shows only AppDelegate's Aqua `UnderWindowBackground`. `GlassSurface` also made `GlassPanel` the yoga parent of an absolute-fill host, so nav/stage styles could zero-size or hide labels.

`NSGlassEffectView` cannot host RN views and previously composited over siblings. Visible chrome outranks matching Liquid Glass APIs.

## Change

1. **GlassSurface** — outer layout view (flex/height from the caller) → background `GlassPanel` (`absoluteFill`, `pointerEvents="none"`) → children in a normal RN view. `GlassPanel` is not the yoga parent of labels.
2. **OmiGlassPanelView** — stop using `NSGlassEffectView`. One HUD `NSVisualEffectView` per panel as background only. `contentHost` is always a subview of the panel with a non-zero frame matching the panel. Never call `setContentView:`. Hits still return `nil` so the material does not swallow clicks.

Unchanged: traffic lights on the Home row, 8pt even inset, JS-driver stage fade, Apps as `ScrollView`, stage error fallback, dark ink on glass, no full-window white scrim, no necklace, no `workers.dev` in source.

## Verification

```
bun run --cwd react-native test -- src/desktop/DesktopApp.test.tsx __tests__/macOSNativeBoundary.test.ts --runInBand
# 37 tests pass after the host change

bun run --cwd react-native test -- --runInBand
# full suite pending in this revision

bun run --cwd react-native lint
bun run --cwd react-native typecheck
```

This Linux VM cannot launch RnRuntime. Acceptance is a macOS 26 screenshot with visible Home / Tasks / Library / Rewind / Apps chrome, not a blank rectangle.

## Notes

- Base is `v5` at `360411e9bb`, not `main`.
- Failure-Class: none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94f5374a-885f-4426-92fa-72c1c3456c68?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94f5374a-885f-4426-92fa-72c1c3456c68&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

