### PR TITLE
harden(backend): name the accounts that failed the daily sweep

### DIFF
--- a/backend/modal/daily_memory_sweep_job.py
+++ b/backend/modal/daily_memory_sweep_job.py
@@ -109,6 +109,12 @@ def run_daily_memory_sweep_job() -> None:
         advance_page=summary.attempted_users > 0,
     )
     if summary.errors:
+        # The summary already bounds this tuple to 16 entries of
+        # `uid=<uid>:<reason-or-exception-type>` (or a scheduler-level token),
+        # with no memory, transcript, or prompt content. Without this line the
+        # job reports only a count, and a single account failing every hourly
+        # run is undiagnosable from logs.
+        logger.error("daily-memory-sweep errors: %s", ", ".join(summary.errors))
         raise RuntimeError(f"daily-memory-sweep completed with {len(summary.errors)} error(s)")
 
 


### PR DESCRIPTION
## What changed and why

The hourly `daily-memory-sweep-job` has exited 1 on 31 of its last 32 dev executions, and the only diagnostic it emits is `daily-memory-sweep completed with 1 error(s)` — the scheduler's bounded errors tuple (`uid=<uid>:<reason-or-exception-type>`) is discarded. One stuck account retried every hour is indistinguishable from a fleet-wide outage. Log the bounded tuple before raising.

## Product invariants affected

none

## How it was verified

- The tuple is already bounded to 16 entries by `DailySweepSchedulerSummary` and contains only uid + reason/exception-type tokens — no memory, transcript, or prompt content (the JIT telemetry boundary applies to decision logs; sweep logs already carry uid in existing warnings).
- `backend/.venv/bin/python -m pytest tests/unit/test_daily_memory_sweep*.py` (see CI) — behavior-neutral: the raise is unchanged.

## Tests

No test change: the change adds one log line before an unchanged raise; no branch or contract changes.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

