### PR TITLE
fix(macos): restore visible desktop chrome

### DIFF
--- a/react-native/__tests__/macOSNativeBoundary.test.ts
+++ b/react-native/__tests__/macOSNativeBoundary.test.ts
@@ -472,33 +472,27 @@ test('uses HUD as the only shipping panel material', () => {
   );
 });
 
-test('never orphans contentHost and never hosts chrome in setContentView', () => {
+test('glass view does not override RCTView subview ownership', () => {
   const source = readNativeSource('OmiGlassPanelView.mm');
-  const attachStart = source.indexOf('- (void)omiAttachContentHost');
-  const layoutStart = source.indexOf('- (void)layout');
-  const layoutEnd = source.indexOf('\n}', layoutStart);
-  const layoutSource = source.slice(layoutStart, layoutEnd);
+  const desktop = readFileSync(
+    resolve(__dirname, '../src/desktop/DesktopApp.tsx'),
+    'utf8',
+  );
+  const chipRail = readFileSync(
+    resolve(__dirname, '../src/desktop/ChipRail.tsx'),
+    'utf8',
+  );
 
-  expect(source).toContain(
-    '@property (nonatomic, strong) NSView *contentHost;',
-  );
-  expect(source).toContain('[self addSubview:self.contentHost]');
-  expect(source).toContain('insertReactSubview');
-  expect(source).toContain('removeReactSubview');
-  expect(source).toContain('didUpdateReactSubviews');
-  expect(source).toContain('self.clipsToBounds = YES');
-  expect(source).toContain('self.layer.masksToBounds = YES');
-  expect(source).toContain('[self.contentHost addSubview:subview');
+  expect(source).not.toContain('contentHost');
+  expect(source).not.toContain('didUpdateReactSubviews');
+  expect(source).not.toContain('insertReactSubview');
+  expect(source).not.toContain('removeReactSubview');
   expect(source).not.toContain('setContentView:');
-  expect(layoutSource).toContain('self.contentHost.frame = self.bounds');
-  expect(layoutSource).toContain('self.contentHost.superview');
-  expect(attachStart).toBeGreaterThan(-1);
-  expect(source.slice(attachStart, attachStart + 400)).toContain(
-    '[self addSubview:self.contentHost]',
-  );
-  expect(source.slice(attachStart, attachStart + 400)).toContain(
-    'self.contentHost.superview != self',
-  );
+  expect(source).not.toContain('omiAttachContentHost');
+  expect(source).toContain('@implementation OmiGlassPanelView');
+  expect(source).toContain('[super layout]');
+  expect(desktop).not.toContain('GlassPanel');
+  expect(chipRail).not.toContain('GlassPanel');
 });
 
 test('lets the host choose the glass radius so one panel can run full-bleed', () => {

--- a/react-native/macos/RnRuntime-macOS/OmiGlassPanelView.mm
+++ b/react-native/macos/RnRuntime-macOS/OmiGlassPanelView.mm
@@ -21,8 +21,6 @@ static NSAppearance *OmiInkGlassAppearance(void)
 
 @property (nonatomic, strong) NSVisualEffectView *material;
 @property (nonatomic, strong) NSView *fallback;
-@property (nonatomic, strong) NSView *contentHost;
-@property (nonatomic, strong) NSView *finish;
 @property (nonatomic, strong) CALayer *scrim;
 @property (nonatomic, strong) CALayer *sheen;
 @property (nonatomic, strong, nullable) id accessibilityObserver;
@@ -39,8 +37,6 @@ static NSAppearance *OmiInkGlassAppearance(void)
   }
 
   self.wantsLayer = YES;
-  self.clipsToBounds = YES;
-  self.layer.masksToBounds = YES;
   self.appearance = OmiInkGlassAppearance();
   self.layer.borderWidth = 1;
 
@@ -51,29 +47,17 @@ static NSAppearance *OmiInkGlassAppearance(void)
   self.material.state = NSVisualEffectStateActive;
   self.material.wantsLayer = YES;
   self.material.layer.masksToBounds = YES;
-  self.material.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
   [self addSubview:self.material];
 
   self.fallback = [[NSView alloc] initWithFrame:self.bounds];
   self.fallback.wantsLayer = YES;
   self.fallback.layer.masksToBounds = YES;
-  self.fallback.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
   [self addSubview:self.fallback];
 
-  self.finish = [[NSView alloc] initWithFrame:self.bounds];
-  self.finish.wantsLayer = YES;
-  self.finish.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
-  [self addSubview:self.finish];
-
-  self.contentHost = [[NSView alloc] initWithFrame:self.bounds];
-  self.contentHost.wantsLayer = YES;
-  self.contentHost.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
-  [self addSubview:self.contentHost];
-
   self.scrim = [CALayer layer];
-  [self.finish.layer addSublayer:self.scrim];
+  [self.layer addSublayer:self.scrim];
   self.sheen = [CALayer layer];
-  [self.finish.layer addSublayer:self.sheen];
+  [self.layer addSublayer:self.sheen];
 
   __weak OmiGlassPanelView *weakSelf = self;
   self.accessibilityObserver =
@@ -105,8 +89,6 @@ static NSAppearance *OmiInkGlassAppearance(void)
   self.material.layer.cornerCurve = kCACornerCurveContinuous;
   self.fallback.layer.cornerRadius = _glassCornerRadius;
   self.fallback.layer.cornerCurve = kCACornerCurveContinuous;
-  self.finish.layer.cornerRadius = _glassCornerRadius;
-  self.finish.layer.cornerCurve = kCACornerCurveContinuous;
   self.scrim.cornerRadius = _glassCornerRadius;
   self.scrim.cornerCurve = kCACornerCurveContinuous;
 }
@@ -126,47 +108,9 @@ static NSAppearance *OmiInkGlassAppearance(void)
   [super layout];
   self.material.frame = self.bounds;
   self.fallback.frame = self.bounds;
-  self.finish.frame = self.bounds;
-  if (self.contentHost.superview != self) {
-    [self omiAttachContentHost];
-  }
-  self.contentHost.frame = self.bounds;
-  self.scrim.frame = self.finish.bounds;
+  self.scrim.frame = self.bounds;
   self.sheen.frame = NSMakeRect(0, NSMaxY(self.bounds) - OmiGlassSheenHeight, NSWidth(self.bounds),
       OmiGlassSheenHeight);
-}
-
-- (void)omiAttachContentHost
-{
-  if (self.contentHost.superview != nil && self.contentHost.superview != self) {
-    [self.contentHost removeFromSuperview];
-  }
-  if (self.contentHost.superview != self) {
-    [self addSubview:self.contentHost];
-  }
-}
-
-- (void)insertReactSubview:(RCTUIView *)subview atIndex:(NSInteger)atIndex
-{
-  [super insertReactSubview:subview atIndex:atIndex];
-  if (self.contentHost.superview != self) {
-    [self omiAttachContentHost];
-  }
-  NSArray<NSView *> *siblings = self.contentHost.subviews;
-  if (atIndex >= 0 && atIndex < (NSInteger)siblings.count) {
-    [self.contentHost addSubview:subview positioned:NSWindowBelow relativeTo:siblings[atIndex]];
-    return;
-  }
-  [self.contentHost addSubview:subview];
-}
-
-- (void)removeReactSubview:(RCTUIView *)subview
-{
-  [super removeReactSubview:subview];
-}
-
-- (void)didUpdateReactSubviews
-{
 }
 
 - (void)applyAccessibilityAppearance
@@ -183,7 +127,6 @@ static NSAppearance *OmiInkGlassAppearance(void)
     self.sheen.backgroundColor = [NSColor.whiteColor colorWithAlphaComponent:OmiGlassSheenAlpha].CGColor;
     self.layer.borderColor = [NSColor.labelColor colorWithAlphaComponent:OmiGlassEdgeAlpha].CGColor;
   }];
-  [self omiAttachContentHost];
 }
 
 @end

--- a/react-native/src/desktop/ChipRail.test.tsx
+++ b/react-native/src/desktop/ChipRail.test.tsx
@@ -1,3 +1,5 @@
+import {readFileSync} from 'node:fs';
+import {resolve} from 'node:path';
 import React from 'react';
 import {Animated, Text} from 'react-native';
 import ReactTestRenderer, {act} from 'react-test-renderer';
@@ -8,15 +10,6 @@ let mockReduceMotion = false;
 jest.mock('../app/useReduceMotion', () => ({
   useReduceMotion: () => mockReduceMotion,
 }));
-
-jest.mock('../ui/GlassPanel', () => {
-  const ReactModule = require('react');
-  const {View} = require('react-native');
-  return {
-    GlassPanel: (props: Record<string, unknown>) =>
-      ReactModule.createElement(View, props),
-  };
-});
 
 afterEach(() => {
   mockReduceMotion = false;
@@ -40,6 +33,14 @@ function layoutChip(
     });
   });
 }
+
+test('chip pill is a React Native View, not a native glass host', () => {
+  const source = readFileSync(resolve(__dirname, './ChipRail.tsx'), 'utf8');
+  expect(source).not.toContain('GlassPanel');
+  expect(source).not.toContain('OmiGlassPanel');
+  expect(source).toContain('token.color.glassStrong');
+  expect(source).toContain('Animated.View');
+});
 
 test('slides a glass pill behind the selected chip in 120ms ease-out', () => {
   const timing = jest.spyOn(Animated, 'timing');

--- a/react-native/src/desktop/ChipRail.tsx
+++ b/react-native/src/desktop/ChipRail.tsx
@@ -2,7 +2,6 @@ import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {Animated, StyleSheet, Text, View} from 'react-native';
 import {useReduceMotion} from '../app/useReduceMotion';
 import {FocusPressable} from '../ui/Pressable';
-import {GlassPanel} from '../ui/GlassPanel';
 import {chipMotionDuration, runShippingTiming} from './desktopMotion';
 import {desktopTokens as token} from './tokens';
 
@@ -59,13 +58,8 @@ export function ChipRail<Label extends string>({
           styles.pill,
           ready ? styles.pillReady : styles.pillHidden,
           {height, left, top, width},
-        ]}>
-        <GlassPanel
-          glassCornerRadius={token.radius.chip}
-          pointerEvents="none"
-          style={StyleSheet.absoluteFill}
-        />
-      </Animated.View>
+        ]}
+      />
       {labels.map(label => (
         <FocusPressable
           accessibilityRole="button"
@@ -92,6 +86,7 @@ export function ChipRail<Label extends string>({
 const styles = StyleSheet.create({
   rail: {flexDirection: 'row', flexWrap: 'wrap', gap: 6},
   pill: {
+    backgroundColor: token.color.glassStrong,
     borderRadius: token.radius.chip,
     overflow: 'hidden',
     position: 'absolute',

--- a/react-native/src/desktop/DesktopApp.test.tsx
+++ b/react-native/src/desktop/DesktopApp.test.tsx
@@ -3,8 +3,9 @@ import {resolve} from 'node:path';
 import React from 'react';
 import ReactTestRenderer, {act} from 'react-test-renderer';
 import {Text, TextInput} from 'react-native';
-import {DesktopApp} from './DesktopApp';
+import {DesktopApp, DesktopChromeGuard} from './DesktopApp';
 import type {TaskProjection} from '../desktopReadClient';
+import {desktopTokens as token} from './tokens';
 
 jest.mock('../app/useReduceMotion', () => ({
   useReduceMotion: () => true,
@@ -89,15 +90,6 @@ jest.mock('../desktopCloudClient', () => ({
   setPrivateCloudSync: jest.fn(),
   setStoreRecordingPermission: jest.fn(),
 }));
-
-jest.mock('../ui/GlassPanel', () => {
-  const ReactModule = require('react');
-  const {View} = require('react-native');
-  return {
-    GlassPanel: (props: Record<string, unknown>) =>
-      ReactModule.createElement(View, props),
-  };
-});
 
 const outcomes = {
   conversations: {
@@ -465,20 +457,19 @@ test('Apps page does not mount FlatList and still paints import cards', () => {
   expect(tree).toContain('Tasks');
 });
 
-test('paints shipping chrome in front of a background-only GlassPanel', () => {
+test('paints shipping chrome as yoga children of translucent Views', () => {
   const source = readFileSync(resolve(__dirname, './DesktopApp.tsx'), 'utf8');
   const start = source.indexOf('function GlassSurface');
-  const end = source.indexOf('function GlassHairline');
+  const end = source.indexOf('export class DesktopChromeGuard');
   const glassSurface = source.slice(start, end);
   expect(start).toBeGreaterThan(-1);
-  expect(glassSurface).toContain('pointerEvents="none"');
-  expect(glassSurface).toContain('StyleSheet.absoluteFill');
   expect(glassSurface).toContain('{children}');
-  expect(glassSurface).toMatch(/<GlassPanel[\s\S]*\/>\s*\{children\}/);
-  expect(glassSurface).not.toMatch(
-    /<GlassPanel[^>]*>\s*\{children\}\s*<\/GlassPanel>/,
-  );
+  expect(glassSurface).not.toContain('GlassPanel');
+  expect(glassSurface).not.toContain('OmiGlassPanel');
+  expect(source).not.toContain("from '../ui/GlassPanel'");
   expect(source).not.toContain('glassHost');
+  expect(source).toContain('token.color.glassStrong');
+  expect(source).toContain('token.color.glassQuiet');
 
   const renderer = renderDesktop();
   const tree = renderedText(renderer);
@@ -494,18 +485,56 @@ test('paints shipping chrome in front of a background-only GlassPanel', () => {
     .find(node => node.props.children === 'Home');
   expect(home).toBeDefined();
   let ancestor: ReactTestRenderer.ReactTestInstance | null = home!.parent;
+  let foundGlassSurface = false;
   while (ancestor != null) {
     expect(ancestor.props.glassCornerRadius).toBeUndefined();
+    const styles = ([] as unknown[]).concat(ancestor.props.style ?? []);
+    if (
+      styles.some(
+        entry =>
+          entry != null &&
+          typeof entry === 'object' &&
+          'backgroundColor' in entry &&
+          (entry as {backgroundColor?: string}).backgroundColor ===
+            token.color.glassStrong,
+      )
+    ) {
+      foundGlassSurface = true;
+    }
     ancestor = ancestor.parent;
   }
+  expect(foundGlassSurface).toBe(true);
 
-  const panels = renderer.root.findAll(
-    node => node.props.glassCornerRadius !== undefined,
-  );
-  expect(panels.length).toBeGreaterThanOrEqual(4);
-  expect(panels.every(panel => panel.props.pointerEvents === 'none')).toBe(
-    true,
-  );
+  expect(
+    renderer.root.findAll(node => node.props.glassCornerRadius !== undefined),
+  ).toHaveLength(0);
+});
+
+test('root chrome guard keeps nav labels when a child throws', () => {
+  function Boom(): React.JSX.Element {
+    throw new Error('chrome exploded');
+  }
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  let renderer: ReactTestRenderer.ReactTestRenderer;
+  act(() => {
+    renderer = ReactTestRenderer.create(
+      <DesktopChromeGuard>
+        <Boom />
+      </DesktopChromeGuard>,
+    );
+  });
+  const tree = renderedText(renderer!);
+  expect(tree).toContain('Home');
+  expect(tree).toContain('Library');
+  expect(tree).toContain('Tasks');
+  expect(tree).toContain('Rewind');
+  expect(tree).toContain('Apps');
+  expect(tree).toContain('chrome exploded');
+  expect(tree).not.toBe('');
+  act(() => {
+    renderer.unmount();
+  });
+  spy.mockRestore();
 });
 
 test('Home and Library chips share a sliding glass pill', () => {
@@ -517,9 +546,17 @@ test('Home and Library chips share a sliding glass pill', () => {
 
 test('uses discrete glass panels instead of one window material', () => {
   const renderer = renderDesktop();
-  const panels = renderer.root.findAll(
-    node => node.props.glassCornerRadius !== undefined,
-  );
+  const panels = renderer.root.findAll(node => {
+    const styles = ([] as unknown[]).concat(node.props.style ?? []);
+    return styles.some(
+      entry =>
+        entry != null &&
+        typeof entry === 'object' &&
+        'backgroundColor' in entry &&
+        (entry as {backgroundColor?: string}).backgroundColor ===
+          token.color.glassStrong,
+    );
+  });
   expect(panels.length).toBeGreaterThanOrEqual(4);
   expect(
     renderer.root.find(node => node.props.accessibilityLabel === 'Omi desktop')
@@ -534,6 +571,7 @@ test('uses discrete glass panels instead of one window material', () => {
   expect(source).not.toContain('UnderWindowBackground');
   expect(source.match(/<GlassSurface/g)?.length).toBeGreaterThanOrEqual(4);
   expect(source).toContain('token.color.onGlass');
+  expect(source).toContain('token.color.glassStrong');
 });
 
 test('searches real projections instead of a fake timeline', () => {

--- a/react-native/src/desktop/DesktopApp.tsx
+++ b/react-native/src/desktop/DesktopApp.tsx
@@ -36,7 +36,6 @@ import {
 } from '../desktopReadClient';
 import type {ReadsPhase} from '../app/useDesktopReads';
 import {FocusPressable} from '../ui/Pressable';
-import {GlassPanel} from '../ui/GlassPanel';
 import {
   desktopNavBarHeight,
   desktopNavItems,
@@ -105,14 +104,49 @@ function GlassSurface({
 }) {
   return (
     <ShippingGlassMount style={[styles.glassSurface, style]}>
-      <GlassPanel
-        glassCornerRadius={token.radius.panel}
-        pointerEvents="none"
-        style={StyleSheet.absoluteFill}
-      />
       {children}
     </ShippingGlassMount>
   );
+}
+
+export class DesktopChromeGuard extends React.Component<
+  {children: React.ReactNode},
+  {error: string | null}
+> {
+  state = {error: null as string | null};
+
+  static getDerivedStateFromError(error: unknown): {error: string} {
+    return {
+      error:
+        error instanceof Error
+          ? error.message
+          : 'Desktop chrome could not be shown.',
+    };
+  }
+
+  render(): React.ReactNode {
+    if (this.state.error !== null) {
+      return (
+        <View accessibilityLabel="Omi desktop" style={styles.root}>
+          <View style={[styles.glassSurface, styles.navbar]}>
+            <View
+              accessibilityLabel="Window controls"
+              style={styles.trafficLights}
+            />
+            <View style={styles.navItems}>
+              {desktopNavItems.map(label => (
+                <Text key={label} style={styles.navText}>
+                  {label}
+                </Text>
+              ))}
+            </View>
+          </View>
+          <Text style={styles.errorText}>{this.state.error}</Text>
+        </View>
+      );
+    }
+    return this.props.children;
+  }
 }
 
 function GlassHairline() {
@@ -634,88 +668,90 @@ export function DesktopApp({
   const [route, setRoute] = useState<DesktopRoute>('Home');
   const navigate = useCallback((next: DesktopRoute) => setRoute(next), []);
   return (
-    <View accessibilityLabel="Omi desktop" style={styles.root}>
-      <GlassSurface style={styles.navbar}>
-        <View
-          accessibilityLabel="Window controls"
-          style={styles.trafficLights}
-        />
-        <View style={styles.navItems}>
-          {desktopNavItems.map(label => {
-            const Icon = navIcons[label];
-            return (
-              <ShippingPressable
-                accessibilityRole="button"
-                accessibilityState={{selected: route === label}}
-                active={route === label}
-                key={label}
-                onPress={() => navigate(label)}
-                style={styles.navItem}>
-                <Icon color={token.color.onGlass} size={14} />
-                <Text
-                  style={[
-                    styles.navText,
-                    route === label && styles.navTextActive,
-                  ]}>
-                  {label}
-                </Text>
-              </ShippingPressable>
-            );
-          })}
-        </View>
-        <View style={styles.navUtilities}>
-          <Mic color={token.color.inkMuted} size={14} />
-          <Monitor color={token.color.inkMuted} size={14} />
-          <ShippingPressable
-            accessibilityLabel="Settings"
-            active={route === 'Settings'}
-            onPress={() => navigate('Settings')}
-            style={styles.utilityButton}>
-            <Settings color={token.color.onGlass} size={14} />
-          </ShippingPressable>
-        </View>
-      </GlassSurface>
-      <GlassHairline />
-      <ShippingStage stageKey={route} variant="page">
-        {route === 'Home' ? (
-          <ChatHome
-            chatBusy={chatBusy}
-            chatError={chatError}
-            draft={draft}
-            messages={messages}
-            onDraftChange={onDraftChange}
-            onRefresh={onRefresh}
-            onSend={onSend}
-            onSignIn={onSignIn}
-            onSignOut={onSignOut}
-            outcomes={outcomes}
-            reads={reads}
-            readsPhase={readsPhase}
-            session={session}
-            signingIn={signingIn}
+    <DesktopChromeGuard>
+      <View accessibilityLabel="Omi desktop" style={styles.root}>
+        <GlassSurface style={styles.navbar}>
+          <View
+            accessibilityLabel="Window controls"
+            style={styles.trafficLights}
           />
-        ) : route === 'Library' ? (
-          <LibraryPage outcomes={outcomes} />
-        ) : route === 'Tasks' ? (
-          <TasksPage outcomes={outcomes} />
-        ) : route === 'Rewind' ? (
-          <GlassSurface style={styles.singlePanel}>
-            <RewindState />
-          </GlassSurface>
-        ) : route === 'Apps' ? (
-          <AppsPage />
-        ) : (
-          <GlassSurface style={styles.singlePanel}>
-            <DesktopSettings
+          <View style={styles.navItems}>
+            {desktopNavItems.map(label => {
+              const Icon = navIcons[label];
+              return (
+                <ShippingPressable
+                  accessibilityRole="button"
+                  accessibilityState={{selected: route === label}}
+                  active={route === label}
+                  key={label}
+                  onPress={() => navigate(label)}
+                  style={styles.navItem}>
+                  <Icon color={token.color.onGlass} size={14} />
+                  <Text
+                    style={[
+                      styles.navText,
+                      route === label && styles.navTextActive,
+                    ]}>
+                    {label}
+                  </Text>
+                </ShippingPressable>
+              );
+            })}
+          </View>
+          <View style={styles.navUtilities}>
+            <Mic color={token.color.inkMuted} size={14} />
+            <Monitor color={token.color.inkMuted} size={14} />
+            <ShippingPressable
+              accessibilityLabel="Settings"
+              active={route === 'Settings'}
+              onPress={() => navigate('Settings')}
+              style={styles.utilityButton}>
+              <Settings color={token.color.onGlass} size={14} />
+            </ShippingPressable>
+          </View>
+        </GlassSurface>
+        <GlassHairline />
+        <ShippingStage stageKey={route} variant="page">
+          {route === 'Home' ? (
+            <ChatHome
+              chatBusy={chatBusy}
+              chatError={chatError}
+              draft={draft}
+              messages={messages}
+              onDraftChange={onDraftChange}
+              onRefresh={onRefresh}
+              onSend={onSend}
               onSignIn={onSignIn}
               onSignOut={onSignOut}
+              outcomes={outcomes}
+              reads={reads}
+              readsPhase={readsPhase}
               session={session}
               signingIn={signingIn}
             />
-          </GlassSurface>
-        )}
-      </ShippingStage>
-    </View>
+          ) : route === 'Library' ? (
+            <LibraryPage outcomes={outcomes} />
+          ) : route === 'Tasks' ? (
+            <TasksPage outcomes={outcomes} />
+          ) : route === 'Rewind' ? (
+            <GlassSurface style={styles.singlePanel}>
+              <RewindState />
+            </GlassSurface>
+          ) : route === 'Apps' ? (
+            <AppsPage />
+          ) : (
+            <GlassSurface style={styles.singlePanel}>
+              <DesktopSettings
+                onSignIn={onSignIn}
+                onSignOut={onSignOut}
+                session={session}
+                signingIn={signingIn}
+              />
+            </GlassSurface>
+          )}
+        </ShippingStage>
+      </View>
+    </DesktopChromeGuard>
   );
 }
 
@@ -729,7 +765,7 @@ const styles = StyleSheet.create({
     paddingTop: desktopNavTopInset,
   },
   glassSurface: {
-    backgroundColor: 'transparent',
+    backgroundColor: token.color.glassStrong,
     borderRadius: token.radius.panel,
     overflow: 'hidden',
     shadowColor: '#000000',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Three glass PRs after `b61992ec5a` left RnRuntime as an empty off-white rectangle. Chrome-in-front (`9f4341e660`) still mounted `OmiGlassPanel` as an `absoluteFill` native sibling. That native view overrode RCTView subview ownership (`contentHost`, empty `didUpdateReactSubviews`, `insertReactSubview`) and blanked the window on macOS 26 even after Keychain was dismissed.

## Cause

Visible UI is a React Native `View` tree. Hosting chrome in (or next to) a custom React subview host is what went blank. The last good paint (`b61992ec5a`) left RCTView's default subview path alone. Later commits made the native view a content host; that is the regression.

The Keychain sheet for `com.omi.rnruntime.firebase-rest-session` is not the blank-window cause. Reads already use `kSecUseAuthenticationUIFail` + `interactionNotAllowed`. This PR does not change that.

## Change

- **Desktop chrome** is a normal `View` with `token.color.glassStrong`. Nav labels are yoga children of that View. `GlassPanel` / `OmiGlassPanel` is no longer imported or mounted from `DesktopApp` or `ChipRail`.
- **ChipRail** sliding pill is an `Animated.View` with the same translucent fill.
- **`OmiGlassPanelView.mm`** is back to a simple unused RCTView: HUD material + reduce-transparency fallback, no `contentHost`, no empty `didUpdateReactSubviews`, no `setContentView:`, no `insertReactSubview` override.
- **`DesktopChromeGuard`** at the DesktopApp root keeps Home / Library / Tasks / Rewind / Apps plus error text if a child throws. Never an empty tree.
- Kept: Tasks `ScrollView`, Apps `ScrollView`, JS-driven stage fade, ChipRail sliding pill, stage error fallback, AppDelegate `UnderWindowBackground`, traffic lights on the Home row, 8pt inset.

## Verification

Ran on this agent (Linux, no RnRuntime binary):

```
bun run --cwd react-native test -- --runInBand
```

20 suites, 153 tests, 0 failures.

```
bun run --cwd react-native lint
```

0 errors (6 pre-existing warnings in `desktopReadClient.ts` / `OmiAvatar.tsx`).

```
bun run --cwd react-native typecheck
```

`tsc --noEmit` exit 0.

```
bun run format:check && bun run boundaries
```

Prettier clean. 1376 tracked files accepted.

This Linux agent cannot open the macOS 26 binary. A blank RnRuntime window is a failed PR. Please confirm on-device: Home, Library, Tasks, Rewind, Apps and a stage must paint before any Keychain sheet is answered.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bffaa6d-f492-4b50-9e16-deca46fdfe0b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bffaa6d-f492-4b50-9e16-deca46fdfe0b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

