### PR TITLE
fix(backend): adopt the ledger keyword fields on a pre-ledger Typesense collection

### DIFF
--- a/.github/failure-classes/FC-schema-adopted-only-at-resource-creation.json
+++ b/.github/failure-classes/FC-schema-adopted-only-at-resource-creation.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "id": "FC-schema-adopted-only-at-resource-creation",
+  "violated_contract": "A schema requirement enforced by a fail-closed runtime check must have a migration path for resources that already exist. Attaching new required fields only to the resource-creation branch leaves every pre-existing resource permanently non-compliant: the check fails closed on each call, forever, and the failure reads as a transient provider error rather than the missing migration it is.",
+  "canonical_prevention": "When a fail-closed schema check gains new required fields, ship the idempotent adoption (additive alter) in the same change, keyed off the check's own missing-field computation, with the post-alter re-read as the authority — and share one field-definition table between the creation and adoption paths so they cannot drift. Keep tests for adoption, no-op on complete schemas, race-losing adoption, and a failed alter still failing closed.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_ws_m_atom_keyword_index.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/utils/memory/atom_keyword_index.py",
+    "backend/utils/conversations/search.py"
+  ],
+  "status": "open"
+}

--- a/backend/tests/unit/test_ws_m_atom_keyword_index.py
+++ b/backend/tests/unit/test_ws_m_atom_keyword_index.py
@@ -1172,3 +1172,96 @@ class TestDocumentShape:
         assert doc["predicate"] == "works_at"
         assert "ent_user" in doc["entity_terms"]
         assert "Omi" in doc["entity_terms"]
+
+
+class TestLedgerKeywordSchemaAdoption:
+    """A pre-ledger collection must adopt the ledger fields, not fail closed forever.
+
+    ``ensure_memories_collection`` includes the ledger fields only at creation,
+    so a collection created before they existed could never satisfy
+    ``ensure_ledger_keyword_schema``: every ledger keyword search failed closed,
+    permanently. Observed hourly in the dev daily-memory-sweep since 2026-08-30
+    (``ledger keyword search failed closed uid=... error_type=RuntimeError``).
+    """
+
+    @staticmethod
+    def _collection_with_fields(field_names):
+        from utils.memory.atom_keyword_index import _LEDGER_FIELD_DEFINITIONS
+
+        collection = MagicMock()
+        state = {"fields": [{"name": name} for name in field_names]}
+
+        def _retrieve():
+            return {"name": "canonical_memory_atoms", "fields": list(state["fields"])}
+
+        def _update(payload):
+            for field in payload["fields"]:
+                assert field == dict(_LEDGER_FIELD_DEFINITIONS[field["name"]])
+                state["fields"].append({"name": field["name"]})
+
+        collection.retrieve.side_effect = _retrieve
+        collection.update.side_effect = _update
+        return collection, state
+
+    @staticmethod
+    def _client_for(collection):
+        client = MagicMock()
+        client.collections.__getitem__.return_value = collection
+        return client
+
+    _PRE_LEDGER_FIELDS = [
+        "memory_id",
+        "userId",
+        "content",
+        "category",
+        "layer",
+        "status",
+        "schema_version",
+        "entity_terms",
+        "predicate",
+        "created_at",
+    ]
+
+    def test_pre_ledger_collection_adopts_the_missing_fields(self):
+        from utils.memory.atom_keyword_index import _LEDGER_SCHEMA_FIELDS, ensure_ledger_keyword_schema
+
+        collection, state = self._collection_with_fields(self._PRE_LEDGER_FIELDS)
+        with patch("utils.memory.atom_keyword_index._typesense_client", return_value=self._client_for(collection)):
+            ensure_ledger_keyword_schema()
+
+        adopted = {field["name"] for field in state["fields"]}
+        assert _LEDGER_SCHEMA_FIELDS <= adopted
+        collection.update.assert_called_once()
+
+    def test_complete_schema_is_never_altered(self):
+        from utils.memory.atom_keyword_index import _LEDGER_SCHEMA_FIELDS, ensure_ledger_keyword_schema
+
+        collection, _ = self._collection_with_fields(self._PRE_LEDGER_FIELDS + sorted(_LEDGER_SCHEMA_FIELDS))
+        with patch("utils.memory.atom_keyword_index._typesense_client", return_value=self._client_for(collection)):
+            ensure_ledger_keyword_schema()
+
+        collection.update.assert_not_called()
+
+    def test_failed_adoption_still_fails_closed(self):
+        from utils.memory.atom_keyword_index import ensure_ledger_keyword_schema
+
+        collection, _ = self._collection_with_fields(self._PRE_LEDGER_FIELDS)
+        collection.update.side_effect = Exception("alter refused")
+        with patch("utils.memory.atom_keyword_index._typesense_client", return_value=self._client_for(collection)):
+            with pytest.raises(RuntimeError, match="missing fields"):
+                ensure_ledger_keyword_schema()
+
+    def test_losing_the_adoption_race_is_success(self):
+        from utils.memory.atom_keyword_index import _LEDGER_SCHEMA_FIELDS, ensure_ledger_keyword_schema
+
+        collection, state = self._collection_with_fields(self._PRE_LEDGER_FIELDS)
+
+        def _racing_update(payload):
+            # A concurrent adopter already altered the collection; our alter
+            # is refused, but the fields are there on re-read.
+            state["fields"].extend({"name": name} for name in sorted(_LEDGER_SCHEMA_FIELDS))
+            raise Exception("alter conflict")
+
+        collection.update.side_effect = _racing_update
+        with patch("utils.memory.atom_keyword_index._typesense_client", return_value=self._client_for(collection)):
+            ensure_ledger_keyword_schema()

--- a/backend/utils/memory/atom_keyword_index.py
+++ b/backend/utils/memory/atom_keyword_index.py
@@ -54,14 +54,15 @@ _REQUIRED_SCHEMA_FIELDS = {
     "predicate",
     "created_at",
 }
-_LEDGER_SCHEMA_FIELDS = {
-    "ledger_index_version",
-    "ledger_schema_version",
-    "ledger_kind",
-    "ledger_row_state",
-    "ledger_has_slot",
-    "ledger_subject_scope",
+_LEDGER_FIELD_DEFINITIONS = {
+    "ledger_index_version": {"name": "ledger_index_version", "type": "int32", "facet": True, "optional": True},
+    "ledger_schema_version": {"name": "ledger_schema_version", "type": "string", "facet": True, "optional": True},
+    "ledger_kind": {"name": "ledger_kind", "type": "string", "facet": True, "optional": True},
+    "ledger_row_state": {"name": "ledger_row_state", "type": "string", "facet": True, "optional": True},
+    "ledger_has_slot": {"name": "ledger_has_slot", "type": "bool", "facet": True, "optional": True},
+    "ledger_subject_scope": {"name": "ledger_subject_scope", "type": "string", "facet": True, "optional": True},
 }
+_LEDGER_SCHEMA_FIELDS = set(_LEDGER_FIELD_DEFINITIONS)
 
 
 Payload = Dict[str, Any]
@@ -217,12 +218,7 @@ def ensure_memories_collection() -> None:
                 {"name": "schema_version", "type": "int32", "facet": True},
                 {"name": "entity_terms", "type": "string", "optional": True},
                 {"name": "predicate", "type": "string", "optional": True},
-                {"name": "ledger_index_version", "type": "int32", "facet": True, "optional": True},
-                {"name": "ledger_schema_version", "type": "string", "facet": True, "optional": True},
-                {"name": "ledger_kind", "type": "string", "facet": True, "optional": True},
-                {"name": "ledger_row_state", "type": "string", "facet": True, "optional": True},
-                {"name": "ledger_has_slot", "type": "bool", "facet": True, "optional": True},
-                {"name": "ledger_subject_scope", "type": "string", "facet": True, "optional": True},
+                *[dict(field) for field in _LEDGER_FIELD_DEFINITIONS.values()],
                 {"name": "created_at", "type": "int64"},
             ],
             "default_sorting_field": "created_at",
@@ -239,16 +235,45 @@ def ensure_memories_collection() -> None:
         )
 
 
+def _schema_field_names(schema: Payload) -> set[str]:
+    return {str(field.get("name")) for field in _payload_list(schema.get("fields")) if field.get("name")}
+
+
 def ensure_ledger_keyword_schema() -> None:
-    """Fail closed when the provider has not adopted the ledger index fields."""
+    """Adopt the ledger index fields on a pre-ledger collection; fail closed otherwise.
+
+    ``ensure_memories_collection`` includes the ledger fields only when it
+    creates the collection, so a collection created before those fields
+    existed could never pass this check: every ledger keyword search failed
+    closed, permanently (observed hourly in dev since 2026-08-30). The fields
+    are all optional and additive, so adopting them is a bounded idempotent
+    alter. A concurrent adopter can win the race; the post-alter re-read is
+    the authority, and a collection still missing fields after the attempt
+    keeps failing closed.
+    """
 
     collection_name = memories_collection_name()
+    collection = _typesense_client().collections[collection_name]
     try:
-        schema = _payload_or_empty(_typesense_client().collections[collection_name].retrieve())
+        schema = _payload_or_empty(collection.retrieve())
     except Exception as exc:
         raise RuntimeError("ledger keyword schema unavailable") from exc
-    actual_fields = {str(field.get("name")) for field in _payload_list(schema.get("fields")) if field.get("name")}
-    missing = sorted(_LEDGER_SCHEMA_FIELDS - actual_fields)
+    missing = sorted(_LEDGER_SCHEMA_FIELDS - _schema_field_names(schema))
+    if not missing:
+        return
+    try:
+        collection.update({"fields": [dict(_LEDGER_FIELD_DEFINITIONS[name]) for name in missing]})
+    except Exception:
+        logger.warning(
+            "ledger keyword schema adoption failed for collection=%s missing=%s",
+            collection_name,
+            missing,
+        )
+    try:
+        schema = _payload_or_empty(collection.retrieve())
+    except Exception as exc:
+        raise RuntimeError("ledger keyword schema unavailable") from exc
+    missing = sorted(_LEDGER_SCHEMA_FIELDS - _schema_field_names(schema))
     if missing:
         raise RuntimeError(f"Typesense ledger keyword schema is missing fields: {missing}")
 


### PR DESCRIPTION
## What changed and why

`ensure_memories_collection` includes the ledger index fields only when it *creates* the Typesense collection, so a collection created before those fields existed can never satisfy `ensure_ledger_keyword_schema` — every ledger keyword search fails closed, permanently. The dev `daily-memory-sweep-job` has logged `ledger keyword search failed closed uid=<allowlist-uid> error_type=RuntimeError` on every pass over a ledger-mode account since 2026-08-30, meaning the sweep agent runs without its prior-memory search seam. The same fate awaits prod the moment beta-enrolled accounts form ledger rows.

The ledger fields are all `optional: true` and additive, so adopting them is a bounded idempotent collection alter, keyed off the check's own missing-field computation. A concurrent adopter can win the race; the post-alter re-read is the authority, and a collection still missing fields after the attempt keeps failing closed. The create path now shares one field-definition table with the adopter so the two cannot drift.

## Product invariants affected

- INV-MEM-1
- INV-MEM-2
- INV-MEM-3
- INV-MEM-4
- INV-MEM-5
- INV-MEM-6

## How it was verified

- `backend/.venv/bin/python -m pytest tests/unit/test_ws_m_atom_keyword_index.py tests/unit/test_knowledge_ledger_search.py` — 63 passed (4 new).
- Dev log evidence: `gcloud logging read` on `based-hardware-dev` shows the fail-closed warning firing 4x per sweep pass over the ledger-mode account (e.g. 2026-09-01T07:03:05Z), every hour since 2026-08-30T10:03Z.

## Tests

- `test_pre_ledger_collection_adopts_the_missing_fields` — the regression.
- `test_complete_schema_is_never_altered` — no gratuitous alters.
- `test_failed_adoption_still_fails_closed` — the fail-closed rule survives the heal.
- `test_losing_the_adoption_race_is_success` — concurrent adopters converge.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative

No existing class covers a fail-closed schema check whose required fields are attached only to the resource-creation branch, leaving pre-existing resources permanently non-compliant. New class `FC-schema-adopted-only-at-resource-creation` names the contract (a fail-closed schema requirement must ship a migration path for resources that already exist) and the prevention (idempotent additive adoption keyed off the check's own missing-field computation, post-alter re-read as authority, one shared field-definition table). Prevention artifact: `backend/tests/unit/test_ws_m_atom_keyword_index.py`.

## Line-count exceptions

Line-Count-Exception: backend/utils/memory/atom_keyword_index.py | 504 -> 529 | adopt ledger fields on pre-ledger collections at the existing fail-closed check


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

