### PR TITLE
fix(macos): even chrome inset, clickable traffic-light row, omnibar home

### DIFF
--- a/react-native/__tests__/macOSNativeBoundary.test.ts
+++ b/react-native/__tests__/macOSNativeBoundary.test.ts
@@ -47,6 +47,7 @@ test('puts traffic lights in the content chrome next to Home', () => {
   expect(source).toContain('positionOmiTrafficLights');
   expect(source).toContain('OmiTrafficLightLeading');
   expect(source).toMatch(/OmiTrafficLightLeading\s*=\s*16\.0/);
+  expect(source).toMatch(/OmiWindowInset\s*=\s*8\.0/);
   expect(source).toContain('NSWindowStyleMaskFullSizeContentView');
   expect(source).toContain('titlebarAppearsTransparent = YES');
   expect(source).toContain('NSTitlebarSeparatorStyleNone');
@@ -77,8 +78,35 @@ test('keeps every traffic light at its native standard size and moves only its o
   );
   expect(methodSource).toContain('frame.origin = NSMakePoint(x, y);');
   expect(methodSource).toContain('x += buttonWidth + OmiTrafficLightSpacing;');
+  expect(methodSource).toContain(
+    'CGFloat x = OmiWindowInset + OmiTrafficLightLeading;',
+  );
+  expect(methodSource).toContain(
+    'NSHeight(container.bounds) - OmiWindowInset - OmiTrafficLightChromeHeight',
+  );
   expect(methodSource).not.toContain('frame.size =');
   expect(methodSource).not.toMatch(/button\.frame\s*=\s*NSMakeRect/);
+});
+
+test('titlebar and drag monitor do not steal chrome clicks', () => {
+  const source = readNativeSource('AppDelegate.mm');
+  const header = readNativeSource('AppDelegate.h');
+
+  expect(source).toContain('OmiTitlebarPassthroughView');
+  expect(source).toContain('OmiTrafficLightChromeHeight + OmiWindowInset');
+  expect(source).toContain('installOmiTitlebarClickThrough');
+  expect(source).toContain('OmiSwizzleTitlebarHitTest');
+  expect(source).toContain('OmiViewBlocksWindowDrag');
+  expect(source).toContain('NSAccessibilityButtonRole');
+  expect(source).toContain('RCTText');
+  expect(source).toContain('return nil;');
+  expect(header).toContain('omiWindowDragMonitor');
+  const dragStart = source.indexOf('- (BOOL)omiWindowGroundDragEvent:');
+  expect(dragStart).toBeGreaterThan(-1);
+  const dragEnd = source.indexOf('\n}', dragStart);
+  const dragSource = source.slice(dragStart, dragEnd);
+  expect(dragSource).toContain('OmiViewBlocksWindowDrag(view)');
+  expect(dragSource).toContain('return NO;');
 });
 
 test('pairs the macOS backend origin and credentials in one validated policy', () => {

--- a/react-native/__tests__/macOSNativeBoundary.test.ts
+++ b/react-native/__tests__/macOSNativeBoundary.test.ts
@@ -48,6 +48,7 @@ test('puts traffic lights in the content chrome next to Home', () => {
   expect(source).toContain('OmiTrafficLightLeading');
   expect(source).toMatch(/OmiTrafficLightLeading\s*=\s*16\.0/);
   expect(source).toMatch(/OmiWindowInset\s*=\s*8\.0/);
+  expect(source).toMatch(/OmiWindowTopInset\s*=\s*12\.0/);
   expect(source).toContain('NSWindowStyleMaskFullSizeContentView');
   expect(source).toContain('titlebarAppearsTransparent = YES');
   expect(source).toContain('NSTitlebarSeparatorStyleNone');
@@ -76,12 +77,23 @@ test('keeps every traffic light at its native standard size and moves only its o
   expect(methodSource).toContain(
     'CGFloat buttonHeight = NSHeight(closeButton.frame);',
   );
-  expect(methodSource).toContain('frame.origin = NSMakePoint(x, y);');
-  expect(methodSource).toContain('x += buttonWidth + OmiTrafficLightSpacing;');
   expect(methodSource).toContain(
-    'CGFloat x = OmiWindowInset + OmiTrafficLightLeading;',
+    'NSView *frameView = window.contentView.superview',
   );
   expect(methodSource).toContain(
+    '[container convertPoint:inFrame fromView:frameView]',
+  );
+  expect(methodSource).toContain('frame.origin = inContainer;');
+  expect(methodSource).toContain(
+    'xInFrame += buttonWidth + OmiTrafficLightSpacing;',
+  );
+  expect(methodSource).toContain(
+    'CGFloat xInFrame = OmiWindowInset + OmiTrafficLightLeading;',
+  );
+  expect(methodSource).toContain(
+    'NSHeight(frameView.bounds) - OmiWindowTopInset - OmiTrafficLightChromeHeight',
+  );
+  expect(methodSource).not.toContain(
     'NSHeight(container.bounds) - OmiWindowInset - OmiTrafficLightChromeHeight',
   );
   expect(methodSource).not.toContain('frame.size =');
@@ -93,7 +105,11 @@ test('titlebar and drag monitor do not steal chrome clicks', () => {
   const header = readNativeSource('AppDelegate.h');
 
   expect(source).toContain('OmiTitlebarPassthroughView');
-  expect(source).toContain('OmiTrafficLightChromeHeight + OmiWindowInset');
+  expect(source).toContain('OmiTrafficLightChromeHeight + OmiWindowTopInset');
+  expect(
+    source.replaceAll('NSAccessibilitySearchFieldSubrole', ''),
+  ).not.toContain('NSAccessibilitySearchFieldRole');
+  expect(source).toContain('NSAccessibilitySearchFieldSubrole');
   expect(source).toContain('installOmiTitlebarClickThrough');
   expect(source).toContain('OmiSwizzleTitlebarHitTest');
   expect(source).toContain('OmiViewBlocksWindowDrag');

--- a/react-native/macos/RnRuntime-macOS/AppDelegate.mm
+++ b/react-native/macos/RnRuntime-macOS/AppDelegate.mm
@@ -5,10 +5,91 @@
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTUIKit.h>
 #import <ReactAppDependencyProvider/RCTAppDependencyProvider.h>
+#import <objc/runtime.h>
 
+static const CGFloat OmiWindowInset = 8.0;
 static const CGFloat OmiTrafficLightLeading = 16.0;
 static const CGFloat OmiTrafficLightSpacing = 8.0;
 static const CGFloat OmiTrafficLightChromeHeight = 52.0;
+
+@interface OmiTitlebarPassthroughView : NSView
+@end
+
+@implementation OmiTitlebarPassthroughView
+
+- (NSView *)hitTest:(NSPoint)point
+{
+  return nil;
+}
+
+@end
+
+static void OmiSwizzleTitlebarHitTest(Class cls)
+{
+  static NSMutableSet<NSString *> *swizzled;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    swizzled = [NSMutableSet new];
+  });
+  if (cls == Nil) {
+    return;
+  }
+  NSString *name = NSStringFromClass(cls);
+  if ([swizzled containsObject:name]) {
+    return;
+  }
+  [swizzled addObject:name];
+  SEL selector = @selector(hitTest:);
+  Method method = class_getInstanceMethod(cls, selector);
+  if (method == NULL) {
+    return;
+  }
+  NSView *(*original)(id, SEL, NSPoint) =
+      (NSView * (*)(id, SEL, NSPoint)) method_getImplementation(method);
+  IMP replacement = imp_implementationWithBlock(^NSView *(NSView *self, NSPoint point) {
+    NSView *hit = original(self, selector, point);
+    if (hit == nil) {
+      return nil;
+    }
+    for (NSView *view = hit; view != nil; view = view.superview) {
+      if ([view isKindOfClass:NSButton.class]) {
+        return hit;
+      }
+      if (view == self) {
+        break;
+      }
+    }
+    return nil;
+  });
+  method_setImplementation(method, replacement);
+}
+
+static BOOL OmiViewBlocksWindowDrag(NSView *view)
+{
+  if ([view isKindOfClass:NSControl.class] || [view isKindOfClass:NSText.class] ||
+      [view isKindOfClass:NSScrollView.class] || [view isKindOfClass:NSTextView.class]) {
+    return YES;
+  }
+  if (!view.mouseDownCanMoveWindow) {
+    return YES;
+  }
+  NSAccessibilityRole role = view.accessibilityRole;
+  if ([role isEqualToString:NSAccessibilityButtonRole] ||
+      [role isEqualToString:NSAccessibilityTextFieldRole] ||
+      [role isEqualToString:NSAccessibilityTextAreaRole] ||
+      [role isEqualToString:NSAccessibilityCheckBoxRole] ||
+      [role isEqualToString:NSAccessibilityLinkRole] ||
+      [role isEqualToString:NSAccessibilitySearchFieldRole] ||
+      [role isEqualToString:NSAccessibilityPopUpButtonRole]) {
+    return YES;
+  }
+  NSString *className = NSStringFromClass(view.class);
+  if ([className containsString:@"RCTText"] || [className containsString:@"RCTUIText"] ||
+      [className containsString:@"RCTScroll"]) {
+    return YES;
+  }
+  return NO;
+}
 
 @implementation AppDelegate
 
@@ -82,7 +163,8 @@ static const CGFloat OmiTrafficLightChromeHeight = 52.0;
   if (self.omiTitlebarAccessory != nil) {
     return;
   }
-  NSView *spacer = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 0, OmiTrafficLightChromeHeight)];
+  NSView *spacer = [[OmiTitlebarPassthroughView alloc]
+      initWithFrame:NSMakeRect(0, 0, 0, OmiTrafficLightChromeHeight + OmiWindowInset)];
   NSTitlebarAccessoryViewController *accessory = [[NSTitlebarAccessoryViewController alloc] init];
   accessory.view = spacer;
   accessory.layoutAttribute = NSLayoutAttributeTop;
@@ -128,6 +210,7 @@ static const CGFloat OmiTrafficLightChromeHeight = 52.0;
   [self installOmiWindowGlass:window];
   [self installOmiTitlebarAccessory:window];
   [self hideOmiTitlebarMaterial:window];
+  [self installOmiTitlebarClickThrough:window];
   [window standardWindowButton:NSWindowCloseButton].hidden = NO;
   [window standardWindowButton:NSWindowMiniaturizeButton].hidden = NO;
   [window standardWindowButton:NSWindowZoomButton].hidden = NO;
@@ -149,15 +232,26 @@ static const CGFloat OmiTrafficLightChromeHeight = 52.0;
   NSView *container = closeButton.superview;
   CGFloat buttonWidth = NSWidth(closeButton.frame);
   CGFloat buttonHeight = NSHeight(closeButton.frame);
-  CGFloat y = NSHeight(container.bounds) - OmiTrafficLightChromeHeight +
+  CGFloat y = NSHeight(container.bounds) - OmiWindowInset - OmiTrafficLightChromeHeight +
       floor((OmiTrafficLightChromeHeight - buttonHeight) / 2.0);
-  CGFloat x = OmiTrafficLightLeading;
+  CGFloat x = OmiWindowInset + OmiTrafficLightLeading;
   for (NSButton *button in @[ closeButton, miniaturizeButton, zoomButton ]) {
     NSRect frame = button.frame;
     frame.origin = NSMakePoint(x, y);
     button.frame = frame;
     x += buttonWidth + OmiTrafficLightSpacing;
   }
+}
+
+- (void)installOmiTitlebarClickThrough:(NSWindow *)window
+{
+  NSButton *closeButton = [window standardWindowButton:NSWindowCloseButton];
+  NSView *titlebar = closeButton.superview;
+  if (titlebar == nil) {
+    return;
+  }
+  OmiSwizzleTitlebarHitTest(titlebar.class);
+  OmiSwizzleTitlebarHitTest(titlebar.superview.class);
 }
 
 - (void)installOmiWindowDragMonitor
@@ -194,8 +288,7 @@ static const CGFloat OmiTrafficLightChromeHeight = 52.0;
     return NO;
   }
   for (NSView *view = hitView; view != nil; view = view.superview) {
-    if ([view isKindOfClass:NSControl.class] || [view isKindOfClass:NSText.class] ||
-        [view isKindOfClass:NSScrollView.class] || !view.mouseDownCanMoveWindow) {
+    if (OmiViewBlocksWindowDrag(view)) {
       return NO;
     }
     if (view == contentView) {

--- a/react-native/macos/RnRuntime-macOS/AppDelegate.mm
+++ b/react-native/macos/RnRuntime-macOS/AppDelegate.mm
@@ -8,6 +8,7 @@
 #import <objc/runtime.h>
 
 static const CGFloat OmiWindowInset = 8.0;
+static const CGFloat OmiWindowTopInset = 12.0;
 static const CGFloat OmiTrafficLightLeading = 16.0;
 static const CGFloat OmiTrafficLightSpacing = 8.0;
 static const CGFloat OmiTrafficLightChromeHeight = 52.0;
@@ -74,13 +75,14 @@ static BOOL OmiViewBlocksWindowDrag(NSView *view)
     return YES;
   }
   NSAccessibilityRole role = view.accessibilityRole;
+  NSAccessibilitySubrole subrole = view.accessibilitySubrole;
   if ([role isEqualToString:NSAccessibilityButtonRole] ||
       [role isEqualToString:NSAccessibilityTextFieldRole] ||
       [role isEqualToString:NSAccessibilityTextAreaRole] ||
       [role isEqualToString:NSAccessibilityCheckBoxRole] ||
       [role isEqualToString:NSAccessibilityLinkRole] ||
-      [role isEqualToString:NSAccessibilitySearchFieldRole] ||
-      [role isEqualToString:NSAccessibilityPopUpButtonRole]) {
+      [role isEqualToString:NSAccessibilityPopUpButtonRole] ||
+      [subrole isEqualToString:NSAccessibilitySearchFieldSubrole]) {
     return YES;
   }
   NSString *className = NSStringFromClass(view.class);
@@ -164,7 +166,7 @@ static BOOL OmiViewBlocksWindowDrag(NSView *view)
     return;
   }
   NSView *spacer = [[OmiTitlebarPassthroughView alloc]
-      initWithFrame:NSMakeRect(0, 0, 0, OmiTrafficLightChromeHeight + OmiWindowInset)];
+      initWithFrame:NSMakeRect(0, 0, 0, OmiTrafficLightChromeHeight + OmiWindowTopInset)];
   NSTitlebarAccessoryViewController *accessory = [[NSTitlebarAccessoryViewController alloc] init];
   accessory.view = spacer;
   accessory.layoutAttribute = NSLayoutAttributeTop;
@@ -230,16 +232,19 @@ static BOOL OmiViewBlocksWindowDrag(NSView *view)
   miniaturizeButton.hidden = NO;
   zoomButton.hidden = NO;
   NSView *container = closeButton.superview;
+  NSView *frameView = window.contentView.superview ?: container;
   CGFloat buttonWidth = NSWidth(closeButton.frame);
   CGFloat buttonHeight = NSHeight(closeButton.frame);
-  CGFloat y = NSHeight(container.bounds) - OmiWindowInset - OmiTrafficLightChromeHeight +
+  CGFloat yInFrame = NSHeight(frameView.bounds) - OmiWindowTopInset - OmiTrafficLightChromeHeight +
       floor((OmiTrafficLightChromeHeight - buttonHeight) / 2.0);
-  CGFloat x = OmiWindowInset + OmiTrafficLightLeading;
+  CGFloat xInFrame = OmiWindowInset + OmiTrafficLightLeading;
   for (NSButton *button in @[ closeButton, miniaturizeButton, zoomButton ]) {
+    NSPoint inFrame = NSMakePoint(xInFrame, yInFrame);
+    NSPoint inContainer = [container convertPoint:inFrame fromView:frameView];
     NSRect frame = button.frame;
-    frame.origin = NSMakePoint(x, y);
+    frame.origin = inContainer;
     button.frame = frame;
-    x += buttonWidth + OmiTrafficLightSpacing;
+    xInFrame += buttonWidth + OmiTrafficLightSpacing;
   }
 }
 

--- a/react-native/src/desktop/DesktopApp.test.tsx
+++ b/react-native/src/desktop/DesktopApp.test.tsx
@@ -1,6 +1,8 @@
+import {readFileSync} from 'node:fs';
+import {resolve} from 'node:path';
 import React from 'react';
 import ReactTestRenderer, {act} from 'react-test-renderer';
-import {Text, TextInput} from 'react-native';
+import {ScrollView, Text, TextInput} from 'react-native';
 import {DesktopApp} from './DesktopApp';
 
 jest.mock('../app/useReduceMotion', () => ({
@@ -147,7 +149,26 @@ const outcomes = {
   tasks: {
     status: 'success' as const,
     value: {
-      items: [],
+      items: [
+        {
+          kind: 'task' as const,
+          id: 'task-1',
+          title: 'Ship the desktop chrome',
+          summary: 'Finish the Home stage.',
+          searchableText: 'ship the desktop chrome finish the home stage',
+          completed: false,
+          completedAt: null,
+          dueAt: null,
+          owner: null,
+          source: 'desktop',
+          provenance: [],
+          sortOrder: 0,
+          indentLevel: 0,
+          createdAt: 1756540800,
+          updatedAt: 1756540800,
+          revision: null,
+        },
+      ],
       page: {
         windowStatus: 'complete' as const,
         complete: true,
@@ -200,7 +221,10 @@ function renderDesktop(
         onSignIn={jest.fn()}
         onSignOut={jest.fn()}
         outcomes={outcomes}
-        reads={outcomes.conversations.value.items}
+        reads={[
+          ...outcomes.conversations.value.items,
+          ...outcomes.tasks.value.items,
+        ]}
         readsPhase="ready"
         session="ready"
         signingIn={false}
@@ -215,22 +239,56 @@ function renderDesktop(
 test('renders the shipping search-first desktop hierarchy', () => {
   const renderer = renderDesktop();
   const tree = renderedText(renderer);
-  expect(
-    renderer.root.findAllByType(TextInput).map(node => node.props.placeholder),
-  ).toContain("Search what you've seen and heard…");
+  const placeholders = renderer.root
+    .findAllByType(TextInput)
+    .map(node => node.props.placeholder);
+  expect(placeholders).toContain("Search what you've seen and heard…");
+  expect(placeholders).not.toContain('Ask a follow-up…');
   expect(tree).toContain('Home');
   expect(tree).toContain('Library');
   expect(tree).toContain('Tasks');
   expect(tree).toContain('Rewind');
   expect(tree).toContain('Apps');
-  expect(tree).toContain("I'm ready.");
-  expect(
-    renderer.root.findAllByType(TextInput).map(node => node.props.placeholder),
-  ).toContain('Ask a follow-up…');
+  expect(tree).toContain('Currents');
+  expect(tree).toContain('Product review');
+  expect(tree).toContain('Ship the desktop chrome');
+  expect(tree).not.toContain("I'm ready.");
   expect(tree).not.toContain('Saved data unavailable');
   expect(tree).not.toContain('Omi disconnected');
   expect(tree).not.toContain('Devices');
   expect(tree).not.toContain('Your day is clear');
+  expect(renderer.root.findAllByType(ScrollView).length).toBeGreaterThan(0);
+});
+
+test('omnibar send uses the existing chat send path', () => {
+  const onSend = jest.fn();
+  const onDraftChange = jest.fn();
+  const renderer = renderDesktop({
+    draft: 'What did we decide?',
+    onDraftChange,
+    onSend,
+  });
+  const omnibar = renderer.root
+    .findAllByType(TextInput)
+    .find(
+      node => node.props.placeholder === "Search what you've seen and heard…",
+    );
+  expect(omnibar).toBeDefined();
+  expect(omnibar!.props.value).toBe('What did we decide?');
+  act(() => {
+    omnibar!.props.onChangeText('Follow up');
+  });
+  expect(onDraftChange).toHaveBeenCalledWith('Follow up');
+  act(() => {
+    omnibar!.props.onSubmitEditing();
+  });
+  expect(onSend).toHaveBeenCalled();
+  act(() => {
+    renderer.root
+      .find(node => node.props.accessibilityLabel === 'Send')
+      .props.onPress();
+  });
+  expect(onSend).toHaveBeenCalledTimes(2);
 });
 
 test('keeps signed-out users in the real desktop shell', () => {
@@ -341,19 +399,27 @@ test('Settings opens the shipping multi-pane IA including Advanced', async () =>
 
 test('searches real projections instead of a fake timeline', () => {
   const renderer = renderDesktop({
-    draft: '',
-  });
-  const search = renderer.root
-    .findAllByType(TextInput)
-    .find(
-      node => node.props.placeholder === "Search what you've seen and heard…",
-    );
-  act(() => {
-    search!.props.onChangeText('product');
+    draft: 'product',
   });
   const tree = renderedText(renderer);
   expect(tree).toContain('Product review');
+  expect(tree).not.toContain('Ship the desktop chrome');
   expect(tree).not.toContain('0 screen moments');
   expect(tree).not.toContain('💬');
   expect(tree).not.toContain('🧠');
+});
+
+test('Home stage lists never use FlatList', () => {
+  const source = readFileSync(resolve(__dirname, 'DesktopApp.tsx'), 'utf8');
+  expect(source).not.toMatch(/\bFlatList\b/);
+  expect(source).toContain('ScrollView');
+  expect(source).not.toContain('function GlassSurface');
+  expect(source).not.toContain("I'm ready.");
+  expect(source).not.toContain('Ask a follow-up');
+  expect(source).toMatch(/filterRow:\s*\{[^}]*flexDirection:\s*'row'/);
+  expect(source).not.toMatch(/chip:\s*\{[^}]*borderRadius:\s*14/);
+  expect(source).not.toMatch(/banner:\s*\{[^}]*borderRadius:/);
+  expect(source).not.toMatch(/composer:\s*\{/);
+  expect(source).toContain('accessibilityLabel="Home currents"');
+  expect(source).toContain('accessibilityLabel="Home tasks"');
 });

--- a/react-native/src/desktop/DesktopApp.test.tsx
+++ b/react-native/src/desktop/DesktopApp.test.tsx
@@ -367,6 +367,17 @@ test('signed-out first paint does not show a chat transport error', () => {
   expect(tree).not.toContain('Chat is temporarily unavailable.');
 });
 
+test('ready chat transport error is not painted on Home', () => {
+  const renderer = renderDesktop({
+    chatError: 'Chat is temporarily unavailable.',
+    session: 'ready',
+  });
+  expect(renderedText(renderer)).not.toContain(
+    'Chat is temporarily unavailable.',
+  );
+  expect(renderedText(renderer)).toContain('Currents');
+});
+
 test('Settings opens the shipping multi-pane IA including Advanced', async () => {
   const renderer = renderDesktop();
   await act(async () => {
@@ -422,4 +433,14 @@ test('Home stage lists never use FlatList', () => {
   expect(source).not.toMatch(/composer:\s*\{/);
   expect(source).toContain('accessibilityLabel="Home currents"');
   expect(source).toContain('accessibilityLabel="Home tasks"');
+  expect(source).toContain('visibleChatError');
+  expect(source).not.toContain('omnibarError');
+  expect(source).not.toMatch(/active=\{route === label\}/);
+  expect(source).not.toMatch(/navItem:\s*\{[^}]*borderRadius/);
+  expect(source).not.toMatch(
+    /sendButton:\s*\{[^}]*backgroundColor:\s*token\.color\.dark/,
+  );
+  expect(source).not.toMatch(/sendButton:\s*\{[^}]*borderRadius/);
+  expect(source).toMatch(/omnibarInput:\s*\{[^}]*minWidth:\s*0/);
+  expect(source).toMatch(/omnibar:\s*\{[^}]*minWidth:\s*220/);
 });

--- a/react-native/src/desktop/DesktopApp.tsx
+++ b/react-native/src/desktop/DesktopApp.tsx
@@ -585,7 +585,7 @@ export function DesktopApp({
 }: Props) {
   const [route, setRoute] = useState<DesktopRoute>('Home');
   const navigate = useCallback((next: DesktopRoute) => setRoute(next), []);
-  const error = visibleChatError(session, chatError);
+  const omittedChatError = visibleChatError(session, chatError);
   return (
     <View accessibilityLabel="Omi desktop" style={styles.root}>
       <View style={styles.navbar}>
@@ -600,7 +600,6 @@ export function DesktopApp({
               <ShippingPressable
                 accessibilityRole="button"
                 accessibilityState={{selected: route === label}}
-                active={route === label}
                 key={label}
                 onPress={() => navigate(label)}
                 style={styles.navItem}>
@@ -640,13 +639,12 @@ export function DesktopApp({
         </View>
         <ShippingPressable
           accessibilityLabel="Settings"
-          active={route === 'Settings'}
           onPress={() => navigate('Settings')}
           style={styles.utilityButton}>
           <Settings color={token.color.ink} size={14} />
         </ShippingPressable>
       </View>
-      {error !== null ? <Text style={styles.omnibarError}>{error}</Text> : null}
+      {omittedChatError}
       <ShippingStage stageKey={route} variant="page">
         {route === 'Home' ? (
           <HomeStage
@@ -710,26 +708,28 @@ const styles = StyleSheet.create({
     marginLeft: desktopTrafficLightLeading,
     width: desktopTrafficLightRowWidth,
   },
-  navItems: {alignItems: 'center', flexDirection: 'row', flexShrink: 0, gap: 4},
+  navItems: {alignItems: 'center', flexDirection: 'row', flexShrink: 1, gap: 2},
   navItem: {
     alignItems: 'center',
-    borderRadius: 15,
     flexDirection: 'row',
-    gap: 6,
+    gap: 5,
     height: 30,
     justifyContent: 'center',
-    paddingHorizontal: 12,
+    paddingHorizontal: 6,
   },
   navText: {
     color: token.color.inkMuted,
     fontFamily: token.font,
     fontSize: token.type.nav,
-    fontWeight: '600',
+    fontWeight: '500',
   },
-  navTextActive: {color: token.color.ink},
+  navTextActive: {
+    color: token.color.ink,
+    fontWeight: '700',
+    textDecorationLine: 'underline',
+  },
   utilityButton: {
     alignItems: 'center',
-    borderRadius: 16,
     height: 32,
     justifyContent: 'center',
     padding: 8,
@@ -740,23 +740,23 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flex: 1,
     flexDirection: 'row',
+    flexGrow: 1,
+    flexShrink: 1,
     gap: 8,
     minHeight: 32,
+    minWidth: 220,
     paddingHorizontal: 8,
   },
   omnibarInput: {
     color: token.color.ink,
     flex: 1,
+    flexGrow: 1,
+    flexShrink: 1,
     fontFamily: token.font,
     fontSize: token.type.search,
     fontWeight: '400',
+    minWidth: 0,
     paddingVertical: 6,
-  },
-  omnibarError: {
-    color: token.color.inkMuted,
-    fontFamily: token.font,
-    fontSize: token.type.meta,
-    paddingHorizontal: 12,
   },
   filterRow: {
     alignItems: 'center',
@@ -854,13 +854,14 @@ const styles = StyleSheet.create({
   },
   chatRow: {gap: 4, paddingVertical: 8},
   sendButton: {
-    backgroundColor: token.color.dark,
-    borderRadius: token.radius.control,
-    paddingHorizontal: 12,
-    paddingVertical: 7,
+    alignItems: 'center',
+    flexShrink: 0,
+    justifyContent: 'center',
+    paddingHorizontal: 4,
+    paddingVertical: 4,
   },
   sendText: {
-    color: token.color.white,
+    color: token.color.ink,
     fontFamily: token.font,
     fontSize: token.type.caption,
     fontWeight: '600',

--- a/react-native/src/desktop/DesktopApp.tsx
+++ b/react-native/src/desktop/DesktopApp.tsx
@@ -1,7 +1,7 @@
 import React, {memo, useCallback, useMemo, useState} from 'react';
 import {
   ActivityIndicator,
-  FlatList,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -18,7 +18,6 @@ import House from 'lucide-react-native/icons/house';
 import Library from 'lucide-react-native/icons/library';
 import ListFilter from 'lucide-react-native/icons/list-filter';
 import MessageCircle from 'lucide-react-native/icons/message-circle';
-import Mic from 'lucide-react-native/icons/mic';
 import Monitor from 'lucide-react-native/icons/monitor';
 import Puzzle from 'lucide-react-native/icons/puzzle';
 import Search from 'lucide-react-native/icons/search';
@@ -34,7 +33,6 @@ import type {
 } from '../desktopReadClient';
 import type {ReadsPhase} from '../app/useDesktopReads';
 import {FocusPressable} from '../ui/Pressable';
-import {GlassPanel} from '../ui/GlassPanel';
 import {
   desktopNavBarHeight,
   desktopNavItems,
@@ -52,12 +50,7 @@ import {
 export type {DesktopSession};
 import {DesktopSettings} from './DesktopSettings';
 import {ShippingPressable} from './ShippingPressable';
-import {
-  ShippingGlassMount,
-  ShippingListInsert,
-  ShippingSearchFocus,
-  ShippingStage,
-} from './ShippingStage';
+import {ShippingListInsert, ShippingStage} from './ShippingStage';
 import {desktopTokens as token} from './tokens';
 
 type DesktopRoute = DesktopNavItem | 'Settings';
@@ -93,33 +86,12 @@ const navIcons: Record<DesktopNavItem, typeof Search> = {
   Apps: Puzzle,
 };
 
-function GlassSurface({
-  children,
-  style,
-}: {
-  children: React.ReactNode;
-  style?: object;
-}) {
-  return (
-    <ShippingGlassMount style={[styles.glassSurface, style]}>
-      <GlassPanel
-        glassCornerRadius={token.radius.panel}
-        pointerEvents="none"
-        style={StyleSheet.absoluteFill}
-      />
-      {children}
-    </ShippingGlassMount>
-  );
-}
-
-function Chip({
+function FilterText({
   active = false,
-  Icon,
   label,
   onPress,
 }: {
   active?: boolean;
-  Icon?: typeof Search;
   label: string;
   onPress?: () => void;
 }) {
@@ -127,11 +99,9 @@ function Chip({
     <ShippingPressable
       accessibilityRole="button"
       accessibilityState={{selected: active}}
-      active={active}
       onPress={onPress}
-      style={styles.chip}>
-      {Icon === undefined ? null : <Icon color={token.color.ink} size={13} />}
-      <Text style={[styles.chipText, active && styles.chipTextActive]}>
+      style={styles.filterItem}>
+      <Text style={[styles.filterText, active && styles.filterTextActive]}>
         {label}
       </Text>
     </ShippingPressable>
@@ -300,152 +270,124 @@ function SessionBanner({
   return null;
 }
 
-function ChatHome({
+function HomeStage({
   chatBusy,
-  chatError,
   draft,
   messages,
-  onDraftChange,
-  onSend,
-  onSignIn,
   onRefresh,
+  onSignIn,
+  outcomes,
   reads,
   readsPhase,
   session,
   signingIn,
 }: Props) {
-  const [query, setQuery] = useState('');
-  const [searchFocused, setSearchFocused] = useState(false);
   const [filter, setFilter] = useState<
     'All' | 'Conversations' | 'Memories' | 'Tasks' | 'Rewind'
   >('All');
-  const searching = query.trim() !== '';
-  const filtered = useMemo(() => {
-    const normalized = query.trim().toLocaleLowerCase();
+  const query = draft.trim();
+  const normalized = query.toLocaleLowerCase();
+  const currentItems = useMemo(() => {
     return reads.filter(item => {
+      if (item.kind === 'task') {
+        return false;
+      }
       const kindMatches =
         filter === 'All' ||
         (filter === 'Conversations' && item.kind === 'conversation') ||
-        (filter === 'Memories' && item.kind === 'memory') ||
-        (filter === 'Tasks' && item.kind === 'task');
+        (filter === 'Memories' && item.kind === 'memory');
       return (
         kindMatches &&
         (normalized === '' ||
           item.searchableText.toLocaleLowerCase().includes(normalized))
       );
     });
-  }, [filter, query, reads]);
-  const error = visibleChatError(session, chatError);
+  }, [filter, normalized, reads]);
+  const tasks =
+    outcomes?.tasks.status === 'success' ? outcomes.tasks.value.items : [];
+  const visibleTasks = tasks.filter(
+    item =>
+      normalized === '' ||
+      item.searchableText.toLocaleLowerCase().includes(normalized),
+  );
+  const showCurrents = filter !== 'Tasks';
+  const showTasks = filter === 'All' || filter === 'Tasks';
   return (
     <View style={styles.page}>
-      <ShippingSearchFocus expanded={searchFocused || searching}>
-        <GlassSurface style={styles.omnisearch}>
-          <Search color={token.color.inkMuted} size={15} />
-          <TextInput
-            accessibilityLabel="Search what you have seen and heard"
-            onBlur={() => setSearchFocused(false)}
-            onChangeText={setQuery}
-            onFocus={() => setSearchFocused(true)}
-            placeholder={desktopSearchPlaceholder}
-            placeholderTextColor={token.color.inkMuted}
-            style={styles.omnisearchInput}
-            value={query}
-          />
-        </GlassSurface>
-      </ShippingSearchFocus>
-      <GlassSurface style={styles.homePanel}>
-        <View style={styles.filterBar}>
-          <Text style={styles.filterLabel}>Filter</Text>
-          <View style={styles.filterChips}>
-            {(
-              ['All', 'Conversations', 'Memories', 'Tasks', 'Rewind'] as const
-            ).map(label => (
-              <Chip
-                active={filter === label}
-                key={label}
-                label={label}
-                onPress={() => setFilter(label)}
-              />
+      <View style={styles.filterRow}>
+        {(['All', 'Conversations', 'Memories', 'Tasks', 'Rewind'] as const).map(
+          label => (
+            <FilterText
+              active={filter === label}
+              key={label}
+              label={label}
+              onPress={() => setFilter(label)}
+            />
+          ),
+        )}
+      </View>
+      <SessionBanner
+        onRefresh={onRefresh}
+        onSignIn={onSignIn}
+        readsPhase={readsPhase}
+        session={session}
+        signingIn={signingIn}
+      />
+      <ScrollView
+        contentContainerStyle={styles.list}
+        style={styles.stageScroll}>
+        {messages.length > 0 || chatBusy ? (
+          <View style={styles.conversation}>
+            {messages.map(item => (
+              <View key={item.id} style={styles.chatRow}>
+                <Text style={styles.rowMeta}>
+                  {item.sender === 'human' ? 'You' : 'Omi'}
+                </Text>
+                <Text style={styles.rowTitle}>{item.text}</Text>
+              </View>
             ))}
+            {chatBusy ? (
+              <ActivityIndicator color={token.color.inkMuted} size="small" />
+            ) : null}
           </View>
-        </View>
-        <SessionBanner
-          onRefresh={onRefresh}
-          onSignIn={onSignIn}
-          readsPhase={readsPhase}
-          session={session}
-          signingIn={signingIn}
-        />
-        <ShippingStage
-          stageKey={searching ? 'search' : 'chat'}
-          variant={searching ? 'search' : 'hub'}>
-          {searching ? (
-            <FlatList
-              contentContainerStyle={styles.list}
-              data={filtered}
-              keyExtractor={item => `${item.kind}-${item.id}`}
-              ListEmptyComponent={
-                readsPhase === 'ready' ? (
-                  <Text style={styles.emptyCopy}>
-                    Nothing captured matches this search.
-                  </Text>
-                ) : null
-              }
-              renderItem={({item}) => (
-                <ShippingListInsert itemKey={`${item.kind}-${item.id}`}>
+        ) : null}
+        {showCurrents ? (
+          <View accessibilityLabel="Home currents">
+            <Text style={styles.sectionTitle}>Currents</Text>
+            {currentItems.length > 0 ? (
+              currentItems.map(item => (
+                <ShippingListInsert
+                  itemKey={`${item.kind}-${item.id}`}
+                  key={`${item.kind}-${item.id}`}>
                   <ResultRow item={item} />
                 </ShippingListInsert>
-              )}
-            />
-          ) : (
-            <View style={styles.chatStage}>
-              {messages.length === 0 && !chatBusy ? (
-                <View style={styles.resting}>
-                  <Text style={styles.emptyTitle}>I'm ready.</Text>
-                </View>
-              ) : (
-                <FlatList
-                  contentContainerStyle={styles.list}
-                  data={messages}
-                  keyExtractor={item => item.id}
-                  renderItem={({item}) => (
-                    <View style={styles.chatRow}>
-                      <Text style={styles.rowMeta}>
-                        {item.sender === 'human' ? 'You' : 'Omi'}
-                      </Text>
-                      <Text style={styles.rowTitle}>{item.text}</Text>
-                    </View>
-                  )}
-                />
-              )}
-              {error !== null ? (
-                <Text style={styles.errorText}>{error}</Text>
-              ) : null}
-              <View style={styles.composer}>
-                <TextInput
-                  accessibilityLabel="Ask a follow-up"
-                  onChangeText={onDraftChange}
-                  onSubmitEditing={onSend}
-                  placeholder="Ask a follow-up…"
-                  placeholderTextColor={token.color.inkFaint}
-                  style={styles.composerInput}
-                  value={draft}
-                />
-                <FocusPressable
-                  accessibilityLabel="Send"
-                  accessibilityRole="button"
-                  onPress={onSend}
-                  style={({pressed}) => [
-                    styles.sendButton,
-                    pressed && styles.pressed,
-                  ]}>
-                  <Text style={styles.sendText}>Ask</Text>
-                </FocusPressable>
-              </View>
-            </View>
-          )}
-        </ShippingStage>
-      </GlassSurface>
+              ))
+            ) : (
+              <Text style={styles.emptyCopy}>
+                {readsPhase === 'ready'
+                  ? query !== ''
+                    ? 'Nothing captured matches this search.'
+                    : 'Nothing current right now.'
+                  : 'Currents will show here when your day is loaded.'}
+              </Text>
+            )}
+          </View>
+        ) : null}
+        {showTasks ? (
+          <View accessibilityLabel="Home tasks">
+            <Text style={styles.sectionTitle}>Tasks</Text>
+            {visibleTasks.length > 0 ? (
+              visibleTasks.map(item => (
+                <ShippingListInsert itemKey={item.id} key={item.id}>
+                  <TaskRow item={item} />
+                </ShippingListInsert>
+              ))
+            ) : (
+              <Text style={styles.emptyCopy}>No tasks yet</Text>
+            )}
+          </View>
+        ) : null}
+      </ScrollView>
     </View>
   );
 }
@@ -461,8 +403,8 @@ function LibraryPage({outcomes}: {outcomes: DesktopReadOutcomes | null}) {
       ? outcomes.memories.value.items
       : [];
   return (
-    <GlassSurface style={styles.singlePanel}>
-      <View style={styles.hubRow}>
+    <View style={styles.singlePanel}>
+      <View style={styles.filterRow}>
         {(
           [
             'Activity',
@@ -472,7 +414,7 @@ function LibraryPage({outcomes}: {outcomes: DesktopReadOutcomes | null}) {
             'Brain Map',
           ] as const
         ).map(label => (
-          <Chip
+          <FilterText
             active={hub === label}
             key={label}
             label={label}
@@ -481,37 +423,33 @@ function LibraryPage({outcomes}: {outcomes: DesktopReadOutcomes | null}) {
         ))}
       </View>
       {hub === 'Conversations' ? (
-        <FlatList
-          contentContainerStyle={styles.list}
-          data={conversations}
-          keyExtractor={item => item.id}
-          ListEmptyComponent={
+        <ScrollView contentContainerStyle={styles.list}>
+          {conversations.length > 0 ? (
+            conversations.map(item => (
+              <ShippingListInsert itemKey={item.id} key={item.id}>
+                <ConversationRow item={item} />
+              </ShippingListInsert>
+            ))
+          ) : (
             <Text style={styles.emptyCopy}>
               Nothing captured in this window yet.
             </Text>
-          }
-          renderItem={({item}) => (
-            <ShippingListInsert itemKey={item.id}>
-              <ConversationRow item={item} />
-            </ShippingListInsert>
           )}
-        />
+        </ScrollView>
       ) : hub === 'Memories' ? (
-        <FlatList
-          contentContainerStyle={styles.list}
-          data={memories}
-          keyExtractor={item => item.id}
-          ListEmptyComponent={
+        <ScrollView contentContainerStyle={styles.list}>
+          {memories.length > 0 ? (
+            memories.map(item => (
+              <ShippingListInsert itemKey={item.id} key={item.id}>
+                <MemoryRow item={item} />
+              </ShippingListInsert>
+            ))
+          ) : (
             <Text style={styles.emptyCopy}>
               Nothing captured in this window yet.
             </Text>
-          }
-          renderItem={({item}) => (
-            <ShippingListInsert itemKey={item.id}>
-              <MemoryRow item={item} />
-            </ShippingListInsert>
           )}
-        />
+        </ScrollView>
       ) : hub === 'Rewind' ? (
         <RewindState />
       ) : hub === 'Brain Map' ? (
@@ -520,26 +458,22 @@ function LibraryPage({outcomes}: {outcomes: DesktopReadOutcomes | null}) {
           <Text style={styles.emptyTitle}>No connections to show yet.</Text>
         </View>
       ) : (
-        <FlatList
-          contentContainerStyle={styles.list}
-          data={conversations}
-          keyExtractor={item => item.id}
-          ListEmptyComponent={
+        <ScrollView contentContainerStyle={styles.list}>
+          <Text style={styles.sectionTitle}>Activity</Text>
+          {conversations.length > 0 ? (
+            conversations.map(item => (
+              <ShippingListInsert itemKey={item.id} key={item.id}>
+                <ConversationRow item={item} />
+              </ShippingListInsert>
+            ))
+          ) : (
             <Text style={styles.emptyCopy}>
               Nothing captured in this window yet.
             </Text>
-          }
-          ListHeaderComponent={
-            <Text style={styles.sectionTitle}>Activity</Text>
-          }
-          renderItem={({item}) => (
-            <ShippingListInsert itemKey={item.id}>
-              <ConversationRow item={item} />
-            </ShippingListInsert>
           )}
-        />
+        </ScrollView>
       )}
-    </GlassSurface>
+    </View>
   );
 }
 
@@ -559,7 +493,6 @@ function RewindState() {
 
 function TasksPage({outcomes}: {outcomes: DesktopReadOutcomes | null}) {
   const [query, setQuery] = useState('');
-  const [searchFocused, setSearchFocused] = useState(false);
   const tasks =
     outcomes?.tasks.status === 'success' ? outcomes.tasks.value.items : [];
   const normalized = query.trim().toLocaleLowerCase();
@@ -569,38 +502,35 @@ function TasksPage({outcomes}: {outcomes: DesktopReadOutcomes | null}) {
       item.searchableText.toLocaleLowerCase().includes(normalized),
   );
   return (
-    <GlassSurface style={styles.singlePanel}>
+    <View style={styles.singlePanel}>
       <View style={styles.tasksHeader}>
         <Text style={styles.pageTitle}>Tasks</Text>
-        <ShippingSearchFocus
-          expanded={searchFocused || query.trim() !== ''}
-          radius={token.radius.control}
-          style={styles.searchControl}>
+        <View style={styles.searchControl}>
           <Search color={token.color.inkMuted} size={15} />
           <TextInput
-            onBlur={() => setSearchFocused(false)}
             onChangeText={setQuery}
-            onFocus={() => setSearchFocused(true)}
             placeholder="Search tasks…"
             placeholderTextColor={token.color.inkFaint}
             style={styles.searchInput}
             value={query}
           />
-        </ShippingSearchFocus>
+        </View>
       </View>
       <Text style={styles.sectionTitle}>Today</Text>
-      <FlatList
+      <ScrollView
         contentContainerStyle={styles.list}
-        data={visible}
-        keyExtractor={item => item.id}
-        ListEmptyComponent={<Text style={styles.emptyCopy}>No tasks yet</Text>}
-        renderItem={({item}) => (
-          <ShippingListInsert itemKey={item.id}>
-            <TaskRow item={item} />
-          </ShippingListInsert>
+        style={styles.stageScroll}>
+        {visible.length > 0 ? (
+          visible.map(item => (
+            <ShippingListInsert itemKey={item.id} key={item.id}>
+              <TaskRow item={item} />
+            </ShippingListInsert>
+          ))
+        ) : (
+          <Text style={styles.emptyCopy}>No tasks yet</Text>
         )}
-      />
-    </GlassSurface>
+      </ScrollView>
+    </View>
   );
 }
 
@@ -615,15 +545,11 @@ const imports = [
 
 function AppsPage() {
   return (
-    <GlassSurface style={styles.singlePanel}>
+    <View style={styles.singlePanel}>
       <Text style={styles.pageTitle}>Imports</Text>
-      <FlatList
-        contentContainerStyle={styles.appGrid}
-        data={imports}
-        keyExtractor={item => item[0]}
-        numColumns={3}
-        renderItem={({item: [name, source, Icon]}) => (
-          <View style={styles.appCard}>
+      <ScrollView contentContainerStyle={styles.appGrid}>
+        {imports.map(([name, source, Icon]) => (
+          <View key={name} style={styles.appCard}>
             <View style={styles.appCardHeader}>
               <View style={styles.appIcon}>
                 <Icon color={token.color.ink} size={18} />
@@ -635,9 +561,9 @@ function AppsPage() {
             </View>
             <Text style={styles.rowMeta}>Not connected</Text>
           </View>
-        )}
-      />
-    </GlassSurface>
+        ))}
+      </ScrollView>
+    </View>
   );
 }
 
@@ -659,9 +585,10 @@ export function DesktopApp({
 }: Props) {
   const [route, setRoute] = useState<DesktopRoute>('Home');
   const navigate = useCallback((next: DesktopRoute) => setRoute(next), []);
+  const error = visibleChatError(session, chatError);
   return (
     <View accessibilityLabel="Omi desktop" style={styles.root}>
-      <GlassSurface style={styles.navbar}>
+      <View style={styles.navbar}>
         <View
           accessibilityLabel="Window controls"
           style={styles.trafficLights}
@@ -689,21 +616,40 @@ export function DesktopApp({
             );
           })}
         </View>
-        <View style={styles.navUtilities}>
-          <Mic color={token.color.inkMuted} size={14} />
-          <Monitor color={token.color.inkMuted} size={14} />
-          <ShippingPressable
-            accessibilityLabel="Settings"
-            active={route === 'Settings'}
-            onPress={() => navigate('Settings')}
-            style={styles.utilityButton}>
-            <Settings color={token.color.ink} size={14} />
-          </ShippingPressable>
+        <View style={styles.omnibar}>
+          <Search color={token.color.inkMuted} size={15} />
+          <TextInput
+            accessibilityLabel="Search what you have seen and heard"
+            onChangeText={onDraftChange}
+            onSubmitEditing={onSend}
+            placeholder={desktopSearchPlaceholder}
+            placeholderTextColor={token.color.inkMuted}
+            style={styles.omnibarInput}
+            value={draft}
+          />
+          <FocusPressable
+            accessibilityLabel="Send"
+            accessibilityRole="button"
+            onPress={onSend}
+            style={({pressed}) => [
+              styles.sendButton,
+              pressed && styles.pressed,
+            ]}>
+            <Text style={styles.sendText}>Ask</Text>
+          </FocusPressable>
         </View>
-      </GlassSurface>
+        <ShippingPressable
+          accessibilityLabel="Settings"
+          active={route === 'Settings'}
+          onPress={() => navigate('Settings')}
+          style={styles.utilityButton}>
+          <Settings color={token.color.ink} size={14} />
+        </ShippingPressable>
+      </View>
+      {error !== null ? <Text style={styles.omnibarError}>{error}</Text> : null}
       <ShippingStage stageKey={route} variant="page">
         {route === 'Home' ? (
-          <ChatHome
+          <HomeStage
             chatBusy={chatBusy}
             chatError={chatError}
             draft={draft}
@@ -724,20 +670,20 @@ export function DesktopApp({
         ) : route === 'Tasks' ? (
           <TasksPage outcomes={outcomes} />
         ) : route === 'Rewind' ? (
-          <GlassSurface style={styles.singlePanel}>
+          <View style={styles.singlePanel}>
             <RewindState />
-          </GlassSurface>
+          </View>
         ) : route === 'Apps' ? (
           <AppsPage />
         ) : (
-          <GlassSurface style={styles.singlePanel}>
+          <View style={styles.singlePanel}>
             <DesktopSettings
               onSignIn={onSignIn}
               onSignOut={onSignOut}
               session={session}
               signingIn={signingIn}
             />
-          </GlassSurface>
+          </View>
         )}
       </ShippingStage>
     </View>
@@ -753,11 +699,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: desktopWindowInset,
     paddingTop: desktopNavTopInset,
   },
-  glassSurface: {
-    backgroundColor: 'transparent',
-    borderRadius: token.radius.panel,
-    overflow: 'hidden',
-  },
   navbar: {
     alignItems: 'center',
     flexDirection: 'row',
@@ -769,7 +710,7 @@ const styles = StyleSheet.create({
     marginLeft: desktopTrafficLightLeading,
     width: desktopTrafficLightRowWidth,
   },
-  navItems: {alignItems: 'center', flex: 1, flexDirection: 'row', gap: 4},
+  navItems: {alignItems: 'center', flexDirection: 'row', flexShrink: 0, gap: 4},
   navItem: {
     alignItems: 'center',
     borderRadius: 15,
@@ -786,7 +727,6 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   navTextActive: {color: token.color.ink},
-  navUtilities: {alignItems: 'center', flexDirection: 'row', gap: 12},
   utilityButton: {
     alignItems: 'center',
     borderRadius: 16,
@@ -796,55 +736,52 @@ const styles = StyleSheet.create({
     width: 32,
   },
   page: {flex: 1, gap: 8},
-  omnisearch: {
+  omnibar: {
     alignItems: 'center',
+    flex: 1,
     flexDirection: 'row',
-    gap: 10,
-    minHeight: 48,
-    paddingHorizontal: 14,
+    gap: 8,
+    minHeight: 32,
+    paddingHorizontal: 8,
   },
-  omnisearchInput: {
+  omnibarInput: {
     color: token.color.ink,
     flex: 1,
     fontFamily: token.font,
     fontSize: token.type.search,
     fontWeight: '400',
-    paddingVertical: 12,
+    paddingVertical: 6,
   },
-  homePanel: {flex: 1, padding: 14},
-  filterBar: {gap: 8},
-  filterLabel: {
+  omnibarError: {
     color: token.color.inkMuted,
     fontFamily: token.font,
-    fontSize: token.type.caption,
-    fontWeight: '600',
-  },
-  filterChips: {flexDirection: 'row', flexWrap: 'wrap', gap: 6},
-  chip: {
-    alignItems: 'center',
-    borderRadius: 14,
-    flexDirection: 'row',
-    gap: 6,
-    height: 28,
+    fontSize: token.type.meta,
     paddingHorizontal: 12,
   },
-  chipText: {
+  filterRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 16,
+  },
+  filterItem: {
+    alignItems: 'center',
+    height: 28,
+    justifyContent: 'center',
+  },
+  filterText: {
     color: token.color.inkMuted,
     fontFamily: token.font,
     fontSize: token.type.caption,
     fontWeight: '600',
   },
-  chipTextActive: {color: token.color.ink},
+  filterTextActive: {color: token.color.ink},
   pressed: {opacity: 0.78},
   banner: {
     alignItems: 'center',
-    backgroundColor: token.color.glassQuiet,
-    borderRadius: token.radius.control,
     flexDirection: 'row',
     gap: 10,
-    marginTop: 12,
-    minHeight: 40,
-    paddingHorizontal: 12,
+    minHeight: 28,
   },
   bannerText: {
     color: token.color.inkMuted,
@@ -870,6 +807,8 @@ const styles = StyleSheet.create({
     fontSize: token.type.caption,
     fontWeight: '600',
   },
+  stageScroll: {flex: 1},
+  conversation: {gap: 4, paddingBottom: 8},
   list: {paddingBottom: 24, paddingTop: 8},
   resultRow: {
     alignItems: 'center',
@@ -913,31 +852,7 @@ const styles = StyleSheet.create({
     marginTop: 6,
     textAlign: 'center',
   },
-  chatStage: {flex: 1, marginTop: 12},
-  resting: {alignItems: 'center', flex: 1, justifyContent: 'center'},
   chatRow: {gap: 4, paddingVertical: 8},
-  errorText: {
-    color: token.color.inkMuted,
-    fontFamily: token.font,
-    fontSize: token.type.meta,
-    marginTop: 8,
-  },
-  composer: {
-    alignItems: 'center',
-    backgroundColor: token.color.glassQuiet,
-    borderRadius: token.radius.control,
-    flexDirection: 'row',
-    gap: 10,
-    marginTop: 'auto',
-    minHeight: 48,
-    paddingHorizontal: 12,
-  },
-  composerInput: {
-    color: token.color.ink,
-    flex: 1,
-    fontFamily: token.font,
-    fontSize: token.type.body,
-  },
   sendButton: {
     backgroundColor: token.color.dark,
     borderRadius: token.radius.control,
@@ -950,8 +865,7 @@ const styles = StyleSheet.create({
     fontSize: token.type.caption,
     fontWeight: '600',
   },
-  singlePanel: {flex: 1, padding: 18},
-  hubRow: {flexDirection: 'row', flexWrap: 'wrap', gap: 6},
+  singlePanel: {flex: 1, paddingHorizontal: 4, paddingTop: 8},
   pageTitle: {
     color: token.color.ink,
     fontFamily: token.font,
@@ -967,13 +881,10 @@ const styles = StyleSheet.create({
   },
   searchControl: {
     alignItems: 'center',
-    backgroundColor: token.color.glassQuiet,
-    borderRadius: token.radius.control,
     flex: 1,
     flexDirection: 'row',
     gap: 8,
-    minHeight: 36,
-    paddingHorizontal: 10,
+    minHeight: 32,
   },
   searchInput: {
     color: token.color.ink,

--- a/react-native/src/desktop/DesktopApp.tsx
+++ b/react-native/src/desktop/DesktopApp.tsx
@@ -40,6 +40,8 @@ import {
   desktopNavItems,
   desktopNavTopInset,
   desktopSearchPlaceholder,
+  desktopTrafficLightButton,
+  desktopTrafficLightLeading,
   desktopTrafficLightRowWidth,
   desktopWindowInset,
   visibleChatError,
@@ -760,9 +762,13 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flexDirection: 'row',
     height: desktopNavBarHeight,
-    paddingHorizontal: desktopWindowInset,
+    paddingRight: desktopWindowInset,
   },
-  trafficLights: {height: 14, width: desktopTrafficLightRowWidth},
+  trafficLights: {
+    height: desktopTrafficLightButton,
+    marginLeft: desktopTrafficLightLeading,
+    width: desktopTrafficLightRowWidth,
+  },
   navItems: {alignItems: 'center', flex: 1, flexDirection: 'row', gap: 4},
   navItem: {
     alignItems: 'center',
@@ -770,6 +776,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     gap: 6,
     height: 30,
+    justifyContent: 'center',
     paddingHorizontal: 12,
   },
   navText: {
@@ -780,7 +787,14 @@ const styles = StyleSheet.create({
   },
   navTextActive: {color: token.color.ink},
   navUtilities: {alignItems: 'center', flexDirection: 'row', gap: 12},
-  utilityButton: {borderRadius: 16, height: 32, padding: 8, width: 32},
+  utilityButton: {
+    alignItems: 'center',
+    borderRadius: 16,
+    height: 32,
+    justifyContent: 'center',
+    padding: 8,
+    width: 32,
+  },
   page: {flex: 1, gap: 8},
   omnisearch: {
     alignItems: 'center',

--- a/react-native/src/desktop/desktopChrome.test.ts
+++ b/react-native/src/desktop/desktopChrome.test.ts
@@ -50,8 +50,8 @@ test('desktop chrome uses the shipping Home Library IA', () => {
   expect(desktopGlassCornerRadius).toBe(22);
   expect(desktopNavBarHeight).toBe(52);
   expect(desktopWindowInset).toBe(8);
-  expect(desktopNavTopInset).toBe(desktopWindowInset);
-  expect(desktopNavTopInset).not.toBe(0);
+  expect(desktopNavTopInset).toBeGreaterThan(desktopWindowInset);
+  expect(desktopNavTopInset).toBe(12);
   expect(desktopTrafficLightLeading).toBe(16);
   expect(desktopTrafficLightButton).toBe(14);
   expect(desktopTrafficLightSpacing).toBe(8);
@@ -108,9 +108,9 @@ test('signed-out and probing first paint hide chat transport errors', () => {
   expect(
     visibleChatError('probing', 'Chat is temporarily unavailable.'),
   ).toBeNull();
-  expect(visibleChatError('ready', 'Chat is temporarily unavailable.')).toBe(
-    'Chat is temporarily unavailable.',
-  );
+  expect(
+    visibleChatError('ready', 'Chat is temporarily unavailable.'),
+  ).toBeNull();
   expect(visibleChatError('ready', null)).toBeNull();
 });
 

--- a/react-native/src/desktop/desktopChrome.test.ts
+++ b/react-native/src/desktop/desktopChrome.test.ts
@@ -8,7 +8,12 @@ import {
   desktopSettingsPanes,
   desktopStageFade,
   desktopSystemFontFamily,
+  desktopTrafficLightButton,
+  desktopTrafficLightClusterWidth,
+  desktopTrafficLightLeading,
   desktopTrafficLightRowWidth,
+  desktopTrafficLightSpacing,
+  desktopWindowInset,
   isShippingDesktopNav,
   visibleChatError,
 } from './desktopChrome';
@@ -44,8 +49,18 @@ test('desktop chrome uses the shipping Home Library IA', () => {
   expect(desktopSystemFontFamily).toBe('System');
   expect(desktopGlassCornerRadius).toBe(22);
   expect(desktopNavBarHeight).toBe(52);
-  expect(desktopNavTopInset).toBe(0);
-  expect(desktopTrafficLightRowWidth).toBeGreaterThan(70);
+  expect(desktopWindowInset).toBe(8);
+  expect(desktopNavTopInset).toBe(desktopWindowInset);
+  expect(desktopNavTopInset).not.toBe(0);
+  expect(desktopTrafficLightLeading).toBe(16);
+  expect(desktopTrafficLightButton).toBe(14);
+  expect(desktopTrafficLightSpacing).toBe(8);
+  expect(desktopTrafficLightClusterWidth).toBe(
+    3 * desktopTrafficLightButton + 2 * desktopTrafficLightSpacing,
+  );
+  expect(desktopTrafficLightRowWidth).toBe(
+    desktopTrafficLightClusterWidth + desktopTrafficLightLeading,
+  );
   expect(desktopMotion.navMs).toBe(80);
   expect(desktopMotion.pressMs).toBe(90);
   expect(desktopMotion.stepMs).toBe(240);

--- a/react-native/src/desktop/desktopChrome.ts
+++ b/react-native/src/desktop/desktopChrome.ts
@@ -26,10 +26,15 @@ export type DesktopSettingsPane = (typeof desktopSettingsPanes)[number];
 export const desktopSearchPlaceholder = "Search what you've seen and heard…";
 
 export const desktopTrafficLightLeading = 16;
-export const desktopTrafficLightRowWidth = 78;
-export const desktopNavBarHeight = 52;
+export const desktopTrafficLightButton = 14;
+export const desktopTrafficLightSpacing = 8;
 export const desktopWindowInset = 8;
-export const desktopNavTopInset = 0;
+export const desktopTrafficLightClusterWidth =
+  3 * desktopTrafficLightButton + 2 * desktopTrafficLightSpacing;
+export const desktopTrafficLightRowWidth =
+  desktopTrafficLightClusterWidth + desktopTrafficLightLeading;
+export const desktopNavBarHeight = 52;
+export const desktopNavTopInset = desktopWindowInset;
 export const desktopGlassCornerRadius = 22;
 export const desktopSystemFontFamily = 'System';
 

--- a/react-native/src/desktop/desktopChrome.ts
+++ b/react-native/src/desktop/desktopChrome.ts
@@ -34,7 +34,7 @@ export const desktopTrafficLightClusterWidth =
 export const desktopTrafficLightRowWidth =
   desktopTrafficLightClusterWidth + desktopTrafficLightLeading;
 export const desktopNavBarHeight = 52;
-export const desktopNavTopInset = desktopWindowInset;
+export const desktopNavTopInset = 12;
 export const desktopGlassCornerRadius = 22;
 export const desktopSystemFontFamily = 'System';
 
@@ -60,12 +60,12 @@ export type DesktopSession = 'probing' | 'signed-out' | 'ready';
 
 export function visibleChatError(
   session: DesktopSession,
-  chatError: string | null,
+  _chatError: string | null,
 ): string | null {
   if (session !== 'ready') {
     return null;
   }
-  return chatError;
+  return null;
 }
 
 export function isShippingDesktopNav(label: string): boolean {

--- a/react-native/src/ui/PageShell.test.tsx
+++ b/react-native/src/ui/PageShell.test.tsx
@@ -30,4 +30,9 @@ test('DesktopApp keeps Home on the same row as the traffic-light spacer', () => 
   expect(desktopApp).toMatch(/navItem:\s*\{[^}]*justifyContent:\s*'center'/);
   expect(desktopApp).toContain('desktopSearchPlaceholder');
   expect(desktopApp).toMatch(/omnibar:\s*\{/);
+  expect(desktopApp).toMatch(/navbar:\s*\{[^}]*alignItems:\s*'center'/);
+  expect(desktopApp).not.toMatch(/navItem:\s*\{[^}]*borderRadius/);
+  expect(desktopApp).toMatch(
+    /navTextActive:[^}]*textDecorationLine:\s*'underline'/,
+  );
 });

--- a/react-native/src/ui/PageShell.test.tsx
+++ b/react-native/src/ui/PageShell.test.tsx
@@ -28,4 +28,6 @@ test('DesktopApp keeps Home on the same row as the traffic-light spacer', () => 
   expect(desktopApp).toMatch(/navbar:\s*\{[^}]*alignItems:\s*'center'/);
   expect(desktopApp).toMatch(/navItem:\s*\{[^}]*alignItems:\s*'center'/);
   expect(desktopApp).toMatch(/navItem:\s*\{[^}]*justifyContent:\s*'center'/);
+  expect(desktopApp).toContain('desktopSearchPlaceholder');
+  expect(desktopApp).toMatch(/omnibar:\s*\{/);
 });

--- a/react-native/src/ui/PageShell.test.tsx
+++ b/react-native/src/ui/PageShell.test.tsx
@@ -20,7 +20,12 @@ test('DesktopApp keeps Home on the same row as the traffic-light spacer', () => 
   expect(desktopApp).toContain('height: desktopNavBarHeight');
   expect(desktopApp).toContain('accessibilityLabel="Window controls"');
   expect(desktopApp).toContain('width: desktopTrafficLightRowWidth');
+  expect(desktopApp).toContain('marginLeft: desktopTrafficLightLeading');
+  expect(desktopApp).toContain('height: desktopTrafficLightButton');
   expect(desktopApp).toMatch(/root:\s*\{[^}]*paddingTop:\s*desktopNavTopInset/);
   expect(desktopApp).not.toMatch(/root:\s*\{[^}]*padding:\s*8/);
   expect(desktopApp).not.toMatch(/navbar:\s*\{[^}]*height:\s*52/);
+  expect(desktopApp).toMatch(/navbar:\s*\{[^}]*alignItems:\s*'center'/);
+  expect(desktopApp).toMatch(/navItem:\s*\{[^}]*alignItems:\s*'center'/);
+  expect(desktopApp).toMatch(/navItem:\s*\{[^}]*justifyContent:\s*'center'/);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
RN macOS only, against `v5` at `50d1d91063`. Does not target `main`.

## Problem
Max’s live 900×700 RnRuntime window after the first two commits:
- Traffic lights hugged the top; nav / omnibar / Ask sat on a lower baseline
- “Chat is temporarily unavailable.” still painted under the chrome
- Selected Home was a dark capsule; Ask was a black pill
- Omnibar placeholder clipped (“Search what you've seen and hea”)

Glass-as-yoga-parent blanked the window earlier. This PR does **not** remount `NSGlassEffectView` / `OmiGlassPanel` as a parent.

## Changes

### 1. `fix(macos): top inset, traffic-light alignment, clickable chrome`
Even 8pt inset, titlebar passthrough, drag monitor skips controls.

### 2. `feat(macos): omnibar and currents/tasks stage, no islands`
One top omnibar, currents + tasks stage, ScrollView lists, no floating glass chrome.

### 3. `fix(macos): align chrome row and drop leftover chat banner`
- Traffic lights are positioned in **window/frame** coordinates (`convertPoint:fromView:`) so they share one vertical center with icons, labels, search, Ask, and Settings.
- Top inset is **12pt** (sides/bottom stay 8) so the row is not flush.
- `visibleChatError` never paints “Chat is temporarily unavailable.” on Home (signed-out, probing, or ready).
- Selected nav is ink + underline, not a rounded pill. Ask is a text control in the omnibar row.
- Omnibar has `flex` + `minWidth: 220` and the field has `minWidth: 0` so the placeholder is not crushed.
- Drag monitor uses `NSAccessibilitySearchFieldSubrole` (not `NSAccessibilitySearchFieldRole`, which is missing in MacOSX27.0.sdk).
- Lists stay `ScrollView`. Window glass stays background-only.

## Verification
```
bun run --cwd react-native test -- --runInBand
# 19 suites, 143 tests, 0 failures
bun run --cwd react-native lint
# 0 errors (6 pre-existing warnings in untouched files)
bun run --cwd react-native typecheck
# clean
```

Please re-check the live 900×700 window. A split chrome row, leftover chat banner, or pill Home/Ask is still a failed PR.

## Out of scope
- No `workers.dev` written into source
- No necklace / pendant
- No mock product UI
- Not `main`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3b032ae-43d7-4a78-93e9-9055396e637f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3b032ae-43d7-4a78-93e9-9055396e637f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

