### PR TITLE
fix(backend): page the sweep's compatibility occupant proof past one page

### DIFF
--- a/.github/failure-classes/FC-single-page-cap-mistaken-for-complete-proof.json
+++ b/.github/failure-classes/FC-single-page-cap-mistaken-for-complete-proof.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-single-page-cap-mistaken-for-complete-proof",
+  "violated_contract": "A completeness proof over stored data must be complete for every realistic account, not just for accounts smaller than one page. Implementing 'prove the whole cohort' as a single bounded page with a fail-closed overflow makes the check's own cap the failure: any account whose cohort outgrows the page fails closed deterministically and forever, and the failure grows with exactly the accounts that use the product most.",
+  "canonical_prevention": "When a proof requires reading a complete cohort, drain a cursor in bounded pages and fail closed only at a ceiling sized for pathology, not for normal use. Size the ceiling from measured real-account data, keep the fail-closed overflow behavior, and keep regression tests for a cohort larger than one page (found and not-found) plus the above-ceiling refusal.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_daily_memory_sweep.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/utils/memory/daily_memory_sweep.py",
+    "backend/utils/memory/canonical_memory_adapter.py",
+    "backend/database/memory_apply_store.py"
+  ],
+  "status": "open"
+}

--- a/backend/tests/unit/test_daily_memory_sweep.py
+++ b/backend/tests/unit/test_daily_memory_sweep.py
@@ -1822,3 +1822,115 @@ def test_unstructured_fallback_marker_matches_the_prompt_rule():
     assert UNSTRUCTURED_SUMMARY_MARKER in prompts._DAILY_SWEEP_SHARED_RULES
     rule = next(line for line in prompts._DAILY_SWEEP_SHARED_RULES.splitlines() if UNSTRUCTURED_SUMMARY_MARKER in line)
     assert "NEVER set a slot" in rule
+
+
+def _legacy_row_payload(index: int, content: str):
+    from models.product_memory import MemoryItemStatus, MemoryTier, ProcessingState
+    from models.memory_evidence import SourceState
+
+    now = datetime(2026, 8, 24, tzinfo=timezone.utc)
+    return {
+        "memory_id": f"memory-{index:05d}",
+        "uid": "user-1",
+        "version": 1,
+        "tier": MemoryTier.long_term.value,
+        "status": MemoryItemStatus.active.value,
+        "processing_state": ProcessingState.processed.value,
+        "content": content,
+        "source_state": SourceState.active.value,
+        "sensitivity_labels": [],
+        "visibility": "private",
+        "user_asserted": True,
+        "captured_at": now,
+        "updated_at": now,
+        "ledger_commit_id": f"commit-{index}",
+        "ledger_sequence": index + 1,
+    }
+
+
+class _PaginatedLegacyDb:
+    """A fake whose legacy query obeys limit + start_after over sorted rows."""
+
+    def __init__(self, rows):
+        self._rows = sorted(rows, key=lambda snapshot: snapshot.id)
+
+    def collection(self, _path):
+        rows = self._rows
+
+        class Query:
+            def __init__(self, normalized=False, after_id=None, count=None):
+                self.normalized = normalized
+                self.after_id = after_id
+                self.count = count
+
+            def where(self, *, filter):
+                return Query(
+                    self.normalized or filter.field_path == "normalized_content_key", self.after_id, self.count
+                )
+
+            def limit(self, count):
+                return Query(self.normalized, self.after_id, count)
+
+            def start_after(self, snapshot):
+                return Query(self.normalized, snapshot.id, self.count)
+
+            def stream(self):
+                if self.normalized:
+                    return []
+                selected = [row for row in rows if self.after_id is None or row.id > self.after_id]
+                return selected[: self.count] if self.count is not None else selected
+
+        class Collection:
+            def where(self, *, filter):
+                return Query(filter.field_path == "normalized_content_key")
+
+        return Collection()
+
+
+class _LegacySnapshot:
+    def __init__(self, payload, row_id):
+        self._payload = payload
+        self.id = row_id
+
+    def to_dict(self):
+        return self._payload
+
+
+def test_legacy_compatibility_proof_survives_a_real_accounts_cohort():
+    """Regression: dev sweep stuck since 2026-08-30 (canonical_occupant_query_unavailable).
+
+    The compatibility occupant proof capped the whole cohort at one 64-row
+    page, so an account with more active unslotted facts than that — the
+    owner's dogfood account holds ~196 — could never complete a sweep day:
+    every hourly run failed closed with "exceeded proof budget". Completeness
+    now comes from draining the cursor; the duplicate is still found even
+    when it sits past the old cap.
+    """
+
+    rows = [_legacy_row_payload(index, f"legacy fact {index}") for index in range(700)]
+    rows[650]["content"] = "Alice owns release review"
+    db = _PaginatedLegacyDb([_LegacySnapshot(payload, payload["memory_id"]) for payload in rows])
+
+    occupant = _find_active_slot_or_subject("user-1", _candidate(slot=None), db_client=db)
+
+    assert occupant is not None and occupant.memory_id == "memory-00650"
+
+
+def test_legacy_compatibility_proof_completes_with_no_duplicate_past_the_old_cap():
+    rows = [_legacy_row_payload(index, f"legacy fact {index}") for index in range(100)]
+    db = _PaginatedLegacyDb([_LegacySnapshot(payload, payload["memory_id"]) for payload in rows])
+
+    occupant = _find_active_slot_or_subject("user-1", _candidate(slot=None), db_client=db)
+
+    assert occupant is None
+
+
+def test_legacy_compatibility_proof_still_fails_closed_above_the_scan_ceiling():
+    from utils.memory.daily_memory_sweep import MAX_LEGACY_COMPAT_OCCUPANT_SCAN, SweepAuthoritativeQueryUnavailable
+
+    total = MAX_LEGACY_COMPAT_OCCUPANT_SCAN + 1
+    rows = [_legacy_row_payload(index, f"legacy fact {index}") for index in range(total)]
+    db = _PaginatedLegacyDb([_LegacySnapshot(payload, payload["memory_id"]) for payload in rows])
+
+    with pytest.raises(SweepAuthoritativeQueryUnavailable):
+        _find_active_slot_or_subject("user-1", _candidate(slot=None), db_client=db)

--- a/backend/utils/memory/daily_memory_sweep.py
+++ b/backend/utils/memory/daily_memory_sweep.py
@@ -105,6 +105,12 @@ MAX_ONBOARDING_SCAN_PAGES = 16
 MAX_ONBOARDING_INPUT_CHARACTERS = 24_000
 MAX_ONBOARDING_RECEIPT_KEYS = 4_096
 MAX_LEGACY_COMPAT_OCCUPANTS = 64
+# The compatibility occupant proof pages through the complete cohort; a real
+# long-tenured account holds hundreds of active unslotted facts per subject,
+# so completeness must come from draining a cursor, not from one bounded page.
+# The ceiling still fails closed on a pathological cohort.
+LEGACY_COMPAT_OCCUPANT_PAGE_SIZE = 300
+MAX_LEGACY_COMPAT_OCCUPANT_SCAN = 5000
 MODEL_COST_PER_1K_INPUT_CHARACTERS_USD = 0.002
 ONBOARDING_CONSUMED_STATE_PATH = "memory_control/daily_memory_sweep_onboarding"
 ONBOARDING_PERMANENT_RECEIPT_PREFIX = "onboarding_source_"
@@ -2606,13 +2612,26 @@ def _find_active_slot_or_subject(
                 field_filter_factory=FieldFilter,
             )
             # Legacy rows predate ``normalized_content_key``.  Prove the
-            # complete bounded compatibility cohort before deciding that no
-            # duplicate exists; two rows is not a safe global cap for a user
-            # who accumulated several historical unslotted facts.
-            snapshots = list(legacy_query.limit(MAX_LEGACY_COMPAT_OCCUPANTS + 1).stream())
+            # complete compatibility cohort before deciding that no duplicate
+            # exists. One bounded page is not that proof: a long-tenured
+            # account holds far more than 64 active unslotted facts per
+            # subject, and the old single-page cap made every such account's
+            # sweep day fail closed forever (dev, hourly, since 2026-08-30).
+            # Drain the cursor in bounded pages instead; the scan ceiling
+            # below still fails closed on a pathological cohort.
+            snapshots = []
+            cursor_query = legacy_query
+            while True:
+                page = list(cursor_query.limit(LEGACY_COMPAT_OCCUPANT_PAGE_SIZE).stream())
+                snapshots.extend(page)
+                if len(snapshots) > MAX_LEGACY_COMPAT_OCCUPANT_SCAN:
+                    break
+                if len(page) < LEGACY_COMPAT_OCCUPANT_PAGE_SIZE:
+                    break
+                cursor_query = legacy_query.start_after(page[-1])
     except Exception as exc:
         raise SweepAuthoritativeQueryUnavailable("canonical occupant query failed") from exc
-    proof_limit = MAX_LEGACY_COMPAT_OCCUPANTS if used_legacy_compatibility else MAX_AUTHORITATIVE_OCCUPANTS
+    proof_limit = MAX_LEGACY_COMPAT_OCCUPANT_SCAN if used_legacy_compatibility else MAX_AUTHORITATIVE_OCCUPANTS
     if len(snapshots) > proof_limit:
         raise SweepAuthoritativeQueryUnavailable("canonical occupant query exceeded proof budget")
     items: List[MemoryItem] = []


### PR DESCRIPTION
## What changed and why

The dev `daily-memory-sweep-job` has failed 31/32+ hourly executions since 2026-08-30T10:03Z, stuck on one enrolled account whose day claims hourly and never commits. Once #12527 named the errors, the cause surfaced: `uid=<uid>:canonical_occupant_query_unavailable` on the first attempt each hour, then `uid=<uid>:source_idempotency_conflict` on Cloud Run's task retries (blocked by the 10-minute receipt lease the first attempt left behind — a shadow, not a second bug).

Root cause: `_find_active_slot_or_subject`'s legacy-compatibility fallback implements "prove the complete cohort" as a single 64-row page (`MAX_LEGACY_COMPAT_OCCUPANTS`) with fail-closed overflow. The stuck account holds **196 active `primary_user` fact rows** (verified read-only against the data plane), so the proof exceeded its budget deterministically, every hour, forever. The accounts that fail are exactly the most engaged ones — which is what the beta cohort is made of, making this a JIT beta-rollout blocker.

Completeness now comes from draining the cursor in bounded pages (300/page); the scan ceiling (5000) still fails closed on a pathological cohort. The primary keyed query keeps its two-row proof budget. Composite indexes for all occupant query shapes were verified present in both dev and prod Firestore.

## Product invariants affected

- INV-MEM-1
- INV-MEM-2
- INV-MEM-3
- INV-MEM-4
- INV-MEM-5
- INV-MEM-6

## How it was verified

- `backend/.venv/bin/python -m pytest tests/unit/test_daily_memory_sweep.py` — 55 passed (3 new).
- Without the source change, all 3 new tests fail (verified by stashing the source file): the >64-row cohort raises `exceeded proof budget`.
- Dev log evidence: named error lines from the 2026-09-01T09:00Z execution; the stuck day's receipt (`receipt_state=pending`, re-claimed hourly) read via read-only Firestore REST.

## Tests

- `test_legacy_compatibility_proof_survives_a_real_accounts_cohort` — 700-row cohort, duplicate at index 650, found across pages.
- `test_legacy_compatibility_proof_completes_with_no_duplicate_past_the_old_cap` — 100-row cohort (over the old 64 cap) resolves to no occupant instead of failing closed.
- `test_legacy_compatibility_proof_still_fails_closed_above_the_scan_ceiling` — the ceiling refusal survives.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative

No existing class covers a completeness proof implemented as one bounded page whose own cap becomes the deterministic failure for every account larger than the page. New class `FC-single-page-cap-mistaken-for-complete-proof` names the contract (a completeness proof must be complete for realistic accounts; drain a cursor, fail closed only at a pathology-sized ceiling) and prevention artifacts in `backend/tests/unit/test_daily_memory_sweep.py`.

## Line-count exceptions

Line-Count-Exception: backend/utils/memory/daily_memory_sweep.py | 5008 -> 5027 | page the compatibility occupant proof instead of failing closed at one page


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

