### PR TITLE
fix(backend): skip not-yet-drained accounts in the daily sweep scheduler

### DIFF
--- a/backend/tests/unit/test_daily_memory_sweep.py
+++ b/backend/tests/unit/test_daily_memory_sweep.py
@@ -9,7 +9,7 @@ from zoneinfo import ZoneInfo
 from google.cloud import firestore
 import pytest
 
-from models.memory_apply import MemoryControlState
+from models.memory_apply import MemoryControlState, WriterMode
 from models.memory_contracts import deterministic_contract_id
 from services.users import data_export
 from utils.memory.daily_memory_sweep import (
@@ -1934,3 +1934,88 @@ def test_legacy_compatibility_proof_still_fails_closed_above_the_scan_ceiling():
 
     with pytest.raises(SweepAuthoritativeQueryUnavailable):
         _find_active_slot_or_subject("user-1", _candidate(slot=None), db_client=db)
+
+
+def test_scheduler_skips_predrain_accounts_without_error_or_claims(monkeypatch):
+    """Regression: enrolled-but-undrained accounts failed the job hourly.
+
+    Every beta account starts in ``compatibility`` writer mode until the
+    maintenance drain publishes its ledger cutover, and ordinary ledger writes
+    are refused there (``require_writer_admitted``). The scheduler used to
+    claim the day anyway: the write died with WriterAdmissionError, the burned
+    receipt lease shadowed the retries as ``source_idempotency_conflict``, and
+    the hourly job exited 1 — observed continuously in dev on the dogfood
+    account (still compatibility at epoch 0). Pre-drain is an expected rollout
+    state: skip quietly, advance the fair page, and leave the account's day
+    cursor untouched so pending days catch up after the drain.
+    """
+
+    from models.memory_apply import MemoryControlState
+
+    control = MemoryControlState(
+        uid="user-1",
+        head_commit_id="head0",
+        account_generation=4,
+        source_generation=7,
+    )
+    assert control.writer_mode is not WriterMode.ledger
+    monkeypatch.setattr(
+        "utils.memory.daily_memory_sweep.ensure_canonical_apply_control_state",
+        lambda _uid, db_client: control,
+    )
+    db = _Db()
+    source_calls = []
+
+    summary = run_daily_memory_sweep_scheduler(
+        db_client=db,
+        now=datetime(2026, 8, 24, 12, tzinfo=timezone.utc),
+        uid_inventory=("user-1",),
+        source_provider=lambda *_args, **_kwargs: source_calls.append(True),
+        timezone_resolver=lambda _uid: "UTC",
+        authority=SweepAuthorityState(enabled=True),
+        cohort_authority=DailySweepCohortAuthority(enabled=True, cohort_name="memory-sweep"),
+        cohort_authorizer=lambda *_args: True,
+    )
+
+    assert summary.errors == ()
+    assert summary.completed_uids == ("user-1",)
+    assert summary.failed_uids == ()
+    assert summary.blocked_users == 1
+    assert source_calls == []
+    # No receipt claim, cursor write, or any other document was touched.
+    assert db.store == {}
+
+
+def test_scheduler_proceeds_for_ledger_mode_accounts(monkeypatch):
+    from models.memory_apply import MemoryControlState
+
+    control = MemoryControlState(
+        uid="user-1",
+        head_commit_id="head0",
+        account_generation=4,
+        source_generation=7,
+        writer_mode=WriterMode.ledger,
+        writer_epoch=1,
+    )
+    monkeypatch.setattr(
+        "utils.memory.daily_memory_sweep.ensure_canonical_apply_control_state",
+        lambda _uid, db_client: control,
+    )
+    db = _Db()
+    source_calls = []
+
+    run_daily_memory_sweep_scheduler(
+        db_client=db,
+        now=datetime(2026, 8, 24, 12, tzinfo=timezone.utc),
+        uid_inventory=("user-1",),
+        source_provider=lambda *_args, **_kwargs: source_calls.append(True) or None,
+        timezone_resolver=lambda _uid: "UTC",
+        authority=SweepAuthorityState(enabled=True),
+        cohort_authority=DailySweepCohortAuthority(enabled=True, cohort_name="memory-sweep"),
+        cohort_authorizer=lambda *_args: True,
+    )
+
+    # The gate is passed: the scheduler advanced beyond writer-mode admission
+    # into ordinary day planning for this account (which asks the source
+    # provider for the pending day's packet).
+    assert source_calls != []

--- a/backend/utils/memory/daily_memory_sweep.py
+++ b/backend/utils/memory/daily_memory_sweep.py
@@ -34,12 +34,15 @@ from enum import Enum
 from dataclasses import dataclass, field
 import atexit
 import importlib
+import logging
 import os
 import re
 import threading
 from typing import Any, Dict, Iterable, List, Literal, Mapping, Optional, Sequence, Tuple, cast
 from uuid import uuid4
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+logger = logging.getLogger(__name__)
 
 from google.cloud.firestore_v1 import FieldFilter
 from google.cloud import firestore
@@ -58,7 +61,7 @@ from database.firestore_index_registry import (
 )
 from database.memory_collections import MemoryCollections
 from database.memory_apply_store import cleanup_expired_memory_deletion_receipts
-from models.memory_apply import MemoryControlState
+from models.memory_apply import MemoryControlState, WriterMode
 from models.memory_contracts import deterministic_contract_id
 from models.product_memory import (
     LedgerWriteReason,
@@ -4881,6 +4884,24 @@ def run_daily_memory_sweep_scheduler(
                 errors.append(f"uid={uid}:cohort_unavailable")
                 continue
             control = ensure_canonical_apply_control_state(uid, db_client=db_client)
+            if control.writer_mode is not WriterMode.ledger:
+                # An enrolled account that has not completed ledger cutover
+                # cannot commit ordinary ledger writes (require_writer_admitted
+                # refuses them in compatibility mode), so claiming its day only
+                # burns receipt leases and fails the whole hourly job with
+                # WriterAdmissionError. Pre-drain is an expected rollout state:
+                # skip quietly and retry after the maintenance drain moves the
+                # account to ledger mode. The account's day cursor does not
+                # advance, so no day is lost — pending days catch up in
+                # bounded windows once the account drains.
+                logger.info(
+                    "daily-memory-sweep skipping uid=%s: writer_mode=%s awaits ledger cutover",
+                    uid,
+                    control.writer_mode.value,
+                )
+                blocked_users += 1
+                completed_uids.append(uid)
+                continue
             timezone_name = str(timezone_resolver(uid) or "UTC")
             cursor = _read_cursor(db_client, uid, control)
             if cursor.last_completed_local_date is not None and cursor.timezone_name != timezone_name:


### PR DESCRIPTION
## What changed and why

With #12533 deployed, the dev hourly sweep named its next failure: `uid=<uid>:WriterAdmissionError` on the first attempt, then lease-shadowed `source_idempotency_conflict` retries. Root cause: every enrolled account starts in `compatibility` writer mode until the maintenance drain publishes its ledger cutover, and the sweep's ordinary ledger-class writes are refused there by `require_writer_admitted`. **No account has ever drained** — both dogfood accounts sit at `compatibility`/epoch 0, because the drain rides the tail of the hourly `memory-maintenance-job`, which is killed at its 3600s timeout every run (#12535).

Pre-drain is an expected rollout state, not an error. The scheduler now checks `control.writer_mode` before claiming anything: a not-yet-drained account is skipped quietly (blocked count only), the fair inventory page advances, and the account's day cursor is untouched so pending days catch up in bounded windows once the drain moves it to `ledger`. Without this, flipping the beta cohort would put ~146 permanently-failing accounts into the hourly job.

## Product invariants affected

- INV-MEM-1
- INV-MEM-2
- INV-MEM-3
- INV-MEM-4
- INV-MEM-5
- INV-MEM-6

## How it was verified

- `backend/.venv/bin/python -m pytest tests/unit/test_daily_memory_sweep.py tests/unit/test_daily_memory_sweep_job.py tests/unit/test_daily_memory_sweep_inventory.py` — 74 passed (2 new).
- Dev log evidence: 11:00Z execution on the #12533 image named `WriterAdmissionError`; both dogfood accounts' `memory_state/apply_control` read via read-only Firestore REST show `writer_mode=compatibility`, `writer_epoch=0`.

## Tests

- `test_scheduler_skips_predrain_accounts_without_error_or_claims` — the regression: no errors, no source-provider call, no document writes, page advances.
- `test_scheduler_proceeds_for_ledger_mode_accounts` — drained accounts still sweep.

## Failure class (fixes)

Failure-Class: FC-destructive-gate-keyed-on-proxy-for-intent

## Line-count exceptions

Line-Count-Exception: backend/utils/memory/daily_memory_sweep.py | 5027 -> 5048 | return before the writer-admission boundary for the known pre-drain state


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

