### PR TITLE
feat(app): show Transcribe Later captures on the home day timeline

### DIFF
--- a/app/lib/pages/home/day_snapshot.dart
+++ b/app/lib/pages/home/day_snapshot.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/foundation.dart';
 
 import 'package:omi/backend/schema/schema.dart';
+import 'package:omi/models/local_recording.dart';
+import 'package:omi/pages/conversations/widgets/conversations_group_widget.dart';
 import 'package:omi/providers/conversation_provider.dart';
 
 /// Everything the home day view renders for one day, plus a fingerprint of the
@@ -14,7 +16,8 @@ import 'package:omi/providers/conversation_provider.dart';
 class HomeDaySnapshot {
   const HomeDaySnapshot({
     required this.conversations,
-    required this.highlights,
+    required this.recordings,
+    required this.entries,
     required this.shortOnes,
     required this.tasksByConversation,
     required this.isNewUser,
@@ -25,8 +28,16 @@ class HomeDaySnapshot {
   /// discarded ones included — they still carry the day's map locations.
   final List<ServerConversation> conversations;
 
-  /// The day's real conversations, and the ones folded behind the short line.
-  final List<ServerConversation> highlights;
+  /// The day's Transcribe Later captures, still on the phone. They carry their
+  /// own start-location snapshot, so they belong to the header's map too.
+  final List<LocalRecording> recordings;
+
+  /// The day as it is rendered, in the order it happened: its conversations
+  /// interleaved with recordings still waiting to be transcribed.
+  final List<ConversationGroupEntry> entries;
+
+  /// Conversations folded behind the short-conversations line. Recordings are
+  /// never folded away — an untranscribed one is asking the user for something.
   final List<ServerConversation> shortOnes;
 
   final Map<String, List<ActionItemWithMetadata>> tasksByConversation;
@@ -36,7 +47,7 @@ class HomeDaySnapshot {
   /// same pixels, so the page can skip the rebuild.
   final String fingerprint;
 
-  bool get isEmpty => conversations.isEmpty;
+  bool get isEmpty => entries.isEmpty;
 
   @override
   bool operator ==(Object other) => other is HomeDaySnapshot && other.fingerprint == fingerprint;
@@ -49,12 +60,18 @@ class HomeDaySnapshot {
 ///
 /// Only tasks belonging to the day's own conversations are carried, so a task
 /// edited on another day cannot force the timeline to rebuild.
+///
+/// [recordings] are Transcribe Later captures still on the phone. They belong
+/// on the day they were recorded even though no conversation exists for them
+/// yet — without them a day spent recording offline reads as empty until the
+/// files upload and transcribe.
 HomeDaySnapshot buildHomeDaySnapshot({
   required DateTime day,
   required List<ServerConversation> conversations,
   required List<ActionItemWithMetadata> tasks,
   required int shortThreshold,
   required bool isNewUser,
+  List<LocalRecording> recordings = const [],
   DateTime? now,
 }) {
   final current = now ?? DateTime.now();
@@ -63,6 +80,8 @@ HomeDaySnapshot buildHomeDaySnapshot({
       .toList()
     // The day reads top to bottom the way it was lived.
     ..sort((a, b) => (a.startedAt ?? a.createdAt).compareTo(b.startedAt ?? b.createdAt));
+
+  final dayRecordings = recordings.where((recording) => conversationLocalDayKey(recording.startedAt) == day).toList();
 
   final highlights = <ServerConversation>[];
   final shortOnes = <ServerConversation>[];
@@ -110,9 +129,23 @@ HomeDaySnapshot buildHomeDaySnapshot({
       ..write(task.dueAt?.millisecondsSinceEpoch);
   }
 
+  for (final recording in dayRecordings) {
+    fingerprint
+      ..write('|r:')
+      ..write(recording.id)
+      ..write(recording.state.name)
+      ..write(recording.seconds)
+      ..write(recording.geolocation?.latitude)
+      ..write(recording.geolocation?.longitude);
+  }
+
   return HomeDaySnapshot(
     conversations: dayConversations,
-    highlights: highlights,
+    recordings: dayRecordings,
+    // The conversations page already defines what "everything that happened
+    // that day, in order" means; reusing it keeps home from drifting into a
+    // second answer. That helper orders newest first, home reads forwards.
+    entries: buildConversationGroupEntries(conversations: highlights, recordings: dayRecordings).reversed.toList(),
     shortOnes: shortOnes,
     tasksByConversation: tasksByConversation,
     isNewUser: isNewUser,

--- a/app/lib/pages/home/day_snapshot.dart
+++ b/app/lib/pages/home/day_snapshot.dart
@@ -47,7 +47,10 @@ class HomeDaySnapshot {
   /// same pixels, so the page can skip the rebuild.
   final String fingerprint;
 
-  bool get isEmpty => entries.isEmpty;
+  /// Nothing happened that day at all. Deliberately not `entries.isEmpty`: a
+  /// day of only short conversations has empty entries but is not an empty day,
+  /// and saying so under its own "N short conversations" line contradicts it.
+  bool get isEmpty => conversations.isEmpty && recordings.isEmpty;
 
   @override
   bool operator ==(Object other) => other is HomeDaySnapshot && other.fingerprint == fingerprint;

--- a/app/lib/pages/home/day_snapshot.dart
+++ b/app/lib/pages/home/day_snapshot.dart
@@ -78,8 +78,9 @@ HomeDaySnapshot buildHomeDaySnapshot({
   final dayConversations = conversations
       .where((conversation) => conversationLocalDayKey(conversation.startedAt ?? conversation.createdAt) == day)
       .toList()
-    // The day reads top to bottom the way it was lived.
-    ..sort((a, b) => (a.startedAt ?? a.createdAt).compareTo(b.startedAt ?? b.createdAt));
+    // Newest first: opening home should land on what just happened, and the
+    // conversations list orders the same way.
+    ..sort((a, b) => (b.startedAt ?? b.createdAt).compareTo(a.startedAt ?? a.createdAt));
 
   final dayRecordings = recordings.where((recording) => conversationLocalDayKey(recording.startedAt) == day).toList();
 
@@ -143,9 +144,9 @@ HomeDaySnapshot buildHomeDaySnapshot({
     conversations: dayConversations,
     recordings: dayRecordings,
     // The conversations page already defines what "everything that happened
-    // that day, in order" means; reusing it keeps home from drifting into a
-    // second answer. That helper orders newest first, home reads forwards.
-    entries: buildConversationGroupEntries(conversations: highlights, recordings: dayRecordings).reversed.toList(),
+    // that day, in order" means — newest first — and reusing it keeps home from
+    // drifting into a second answer.
+    entries: buildConversationGroupEntries(conversations: highlights, recordings: dayRecordings),
     shortOnes: shortOnes,
     tasksByConversation: tasksByConversation,
     isNewUser: isNewUser,

--- a/app/lib/pages/home/home_content.dart
+++ b/app/lib/pages/home/home_content.dart
@@ -13,15 +13,18 @@ import 'package:omi/backend/schema/schema.dart';
 import 'package:omi/pages/conversation_capturing/page.dart';
 import 'package:omi/pages/conversation_detail/page.dart';
 import 'package:omi/pages/conversations/widgets/processing_capture.dart';
+import 'package:omi/pages/conversations/widgets/conversations_group_widget.dart';
 import 'package:omi/pages/home/day_snapshot.dart';
 import 'package:omi/pages/home/widgets/day_header.dart';
 import 'package:omi/pages/home/widgets/day_timeline_entry.dart';
+import 'package:omi/pages/home/widgets/day_timeline_recording.dart';
 import 'package:omi/pages/onboarding/device_selection.dart';
 import 'package:omi/pages/phone_calls/phone_calls_page.dart';
 import 'package:omi/pages/settings/daily_summary_detail_page.dart';
 import 'package:omi/providers/action_items_provider.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
+import 'package:omi/providers/local_recordings_provider.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/enums.dart';
 import 'package:omi/utils/l10n_extensions.dart';
@@ -191,16 +194,21 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    return Selector2<ConversationProvider, ActionItemsProvider, HomeDaySnapshot>(
-      selector: (_, convoProvider, tasksProvider) => buildHomeDaySnapshot(
+    return Selector3<ConversationProvider, ActionItemsProvider, LocalRecordingsProvider, HomeDaySnapshot>(
+      selector: (_, convoProvider, tasksProvider, recordingsProvider) => buildHomeDaySnapshot(
         day: _selectedDay,
         conversations: convoProvider.conversations,
         tasks: tasksProvider.actionItems,
+        recordings: recordingsProvider.recordings,
         shortThreshold: homeShortConversationThreshold(
           showShortConversations: convoProvider.showShortConversations,
           userThreshold: convoProvider.shortConversationThreshold,
         ),
+        // Someone who only ever used Transcribe Later has recorded plenty; the
+        // audio just has not become conversations yet. Telling them to start
+        // recording would be wrong, so recordings count as having started.
         isNewUser: convoProvider.conversations.isEmpty &&
+            recordingsProvider.recordings.isEmpty &&
             !convoProvider.isLoadingConversations &&
             !convoProvider.isFetchingConversations &&
             !convoProvider.isAwaitingInitialFetchRetry,
@@ -241,6 +249,7 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
                   day: day,
                   topInset: topInset,
                   conversations: snapshot.conversations,
+                  recordings: snapshot.recordings,
                   summaryAddresses: summary?.locations.map((location) => location.address).toList() ?? const [],
                   headline: summary?.headline,
                   canGoForward: day.isBefore(_startOfToday()),
@@ -263,8 +272,8 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
               else ...[
                 SliverList(
                   delegate: SliverChildBuilderDelegate(
-                    childCount: snapshot.highlights.length,
-                    (context, index) => _buildEntry(context, snapshot.highlights[index], snapshot),
+                    childCount: snapshot.entries.length,
+                    (context, index) => _buildTimelineRow(context, snapshot.entries[index], snapshot),
                   ),
                 ),
                 if (snapshot.shortOnes.isNotEmpty)
@@ -301,6 +310,16 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
         );
       },
     );
+  }
+
+  /// A day is a sequence of things that happened, some of them conversations
+  /// and some of them audio still waiting to become one.
+  Widget _buildTimelineRow(BuildContext context, ConversationGroupEntry entry, HomeDaySnapshot snapshot) {
+    final recording = entry.recording;
+    if (recording != null) {
+      return DayTimelineRecording(key: ValueKey('recording-${recording.id}'), recording: recording);
+    }
+    return _buildEntry(context, entry.conversation!, snapshot);
   }
 
   Widget _buildEntry(

--- a/app/lib/pages/home/widgets/day_header.dart
+++ b/app/lib/pages/home/widgets/day_header.dart
@@ -7,6 +7,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/models/local_recording.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/widgets/extensions/string.dart';
 
@@ -18,6 +19,7 @@ class DayHeader extends StatelessWidget {
     required this.day,
     required this.conversations,
     required this.canGoForward,
+    this.recordings = const [],
     this.summaryAddresses = const [],
     this.topInset = 0,
     required this.onPreviousDay,
@@ -34,6 +36,10 @@ class DayHeader extends StatelessWidget {
   /// Every conversation of the day, short and discarded ones included — they
   /// still carry the locations that make up the day's map.
   final List<ServerConversation> conversations;
+
+  /// Transcribe Later captures for the day. They carry a start-location
+  /// snapshot of their own, so a day spent recording offline still has a map.
+  final List<LocalRecording> recordings;
 
   /// Addresses the daily summary recorded for the day. Conversations often
   /// carry coordinates without an address, so the summary is the only place a
@@ -63,8 +69,8 @@ class DayHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final points = dayLocationPoints(conversations);
-    final place = dayPlaceLabel(conversations, summaryAddresses: summaryAddresses);
+    final points = dayLocationPoints(conversations, recordings: recordings);
+    final place = dayPlaceLabel(conversations, summaryAddresses: summaryAddresses, recordings: recordings);
     final summary = headline?.trim();
 
     final content = Padding(
@@ -191,27 +197,42 @@ String dayLabel(BuildContext context, DateTime day) {
   return MaterialLocalizations.of(context).formatMediumDate(day);
 }
 
-/// Map pins for the day. Conversations without a usable fix are skipped.
-List<LatLng> dayLocationPoints(List<ServerConversation> conversations) {
+/// Map pins for the day, from its conversations and from any Transcribe Later
+/// captures still waiting to be uploaded. Anything without a usable fix is
+/// skipped.
+List<LatLng> dayLocationPoints(
+  List<ServerConversation> conversations, {
+  List<LocalRecording> recordings = const [],
+}) {
   final points = <LatLng>[];
   for (final conversation in conversations) {
-    final latitude = conversation.geolocation?.latitude;
-    final longitude = conversation.geolocation?.longitude;
-    if (latitude == null || longitude == null) continue;
-    if (!latitude.isFinite || !longitude.isFinite) continue;
-    if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) continue;
-    if (latitude == 0 && longitude == 0) continue;
-    points.add(LatLng(latitude, longitude));
+    _addPoint(points, conversation.geolocation?.latitude, conversation.geolocation?.longitude);
+  }
+  for (final recording in recordings) {
+    _addPoint(points, recording.geolocation?.latitude, recording.geolocation?.longitude);
   }
   return points;
+}
+
+void _addPoint(List<LatLng> points, double? latitude, double? longitude) {
+  if (latitude == null || longitude == null) return;
+  if (!latitude.isFinite || !longitude.isFinite) return;
+  if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) return;
+  if (latitude == 0 && longitude == 0) return;
+  points.add(LatLng(latitude, longitude));
 }
 
 /// Where the day happened: the place that shows up in the most conversations,
 /// falling back to the day summary's own pins when the conversations only
 /// carried coordinates.
-String? dayPlaceLabel(List<ServerConversation> conversations, {List<String?> summaryAddresses = const []}) {
-  final fromConversations = _mostCommonPlace(conversations.map((c) => c.geolocation?.address));
-  return fromConversations ?? _mostCommonPlace(summaryAddresses);
+String? dayPlaceLabel(
+  List<ServerConversation> conversations, {
+  List<String?> summaryAddresses = const [],
+  List<LocalRecording> recordings = const [],
+}) {
+  return _mostCommonPlace(conversations.map((c) => c.geolocation?.address)) ??
+      _mostCommonPlace(recordings.map((r) => r.geolocation?.address)) ??
+      _mostCommonPlace(summaryAddresses);
 }
 
 String? _mostCommonPlace(Iterable<String?> addresses) {

--- a/app/lib/pages/home/widgets/day_timeline_recording.dart
+++ b/app/lib/pages/home/widgets/day_timeline_recording.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:omi/models/local_recording.dart';
+import 'package:omi/pages/conversations/recording_detail/recording_detail_sheet.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/pages/home/widgets/day_timeline_entry.dart';
+
+/// A Transcribe Later capture on the home day timeline.
+///
+/// It sits in the same shape as a conversation — time, what it is, how long it
+/// ran — because on the day it happened that is what it is. It has no title
+/// yet, so the second line carries what the user actually needs to know: that
+/// the audio is still on the phone, on its way, or that sending it failed.
+class DayTimelineRecording extends StatelessWidget {
+  const DayTimelineRecording({super.key, required this.recording});
+
+  final LocalRecording recording;
+
+  static const double _timeColumnWidth = 58;
+
+  (Color, String) _status(BuildContext context) {
+    final l10n = context.l10n;
+    switch (recording.state) {
+      case LocalRecordingState.uploading:
+        return (Colors.white.withValues(alpha: 0.55), l10n.syncStatusBackingUp);
+      case LocalRecordingState.processing:
+        return (Colors.white.withValues(alpha: 0.55), l10n.syncStatusUploaded);
+      case LocalRecordingState.failed:
+        return (const Color(0xFFFF5C47), l10n.failedStatus);
+      case LocalRecordingState.pending:
+        return (Colors.white.withValues(alpha: 0.45), l10n.privateAndSecureOnDevice);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final (statusColor, statusLabel) = _status(context);
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () {
+        HapticFeedback.selectionClick();
+        showRecordingDetailSheet(context, recording);
+      },
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 14, 24, 14),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              width: _timeColumnWidth,
+              child: Padding(
+                padding: const EdgeInsets.only(top: 1, right: 8),
+                child: Text(
+                  timelineTimeLabel(context, recording.startedAt),
+                  maxLines: 1,
+                  overflow: TextOverflow.clip,
+                  style: TextStyle(color: Colors.white.withValues(alpha: 0.45), fontSize: 13),
+                ),
+              ),
+            ),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: Text(
+                          context.l10n.recording,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            color: Colors.white.withValues(alpha: 0.95),
+                            fontSize: 16,
+                            fontWeight: FontWeight.w500,
+                            height: 1.3,
+                            letterSpacing: -0.1,
+                          ),
+                        ),
+                      ),
+                      if (recording.seconds > 0) ...[
+                        const SizedBox(width: 10),
+                        Padding(
+                          padding: const EdgeInsets.only(top: 2),
+                          child: Text(
+                            timelineDurationLabel(context, recording.seconds),
+                            style: TextStyle(color: Colors.white.withValues(alpha: 0.4), fontSize: 13),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    statusLabel,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(color: statusColor, fontSize: 14, height: 1.3),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/test/unit/home_day_snapshot_test.dart
+++ b/app/test/unit/home_day_snapshot_test.dart
@@ -56,7 +56,7 @@ void main() {
       expect(snapshot(conversations: plain), isNot(snapshot(conversations: located)));
     });
 
-    test('splits the day on the short threshold and keeps it in order', () {
+    test('splits the day on the short threshold and orders it newest first', () {
       final result = snapshot(
         conversations: [
           _conversation('late', 'Roadmap sync', day.add(const Duration(hours: 13)), 600),
@@ -65,9 +65,9 @@ void main() {
         ],
       );
 
-      expect(result.entries.map((e) => e.conversation?.id), ['early', 'late']);
+      expect(result.entries.map((e) => e.conversation?.id), ['late', 'early']);
       expect(result.shortOnes.map((c) => c.id), ['blip']);
-      expect(result.conversations.map((c) => c.id), ['early', 'blip', 'late']);
+      expect(result.conversations.map((c) => c.id), ['late', 'blip', 'early']);
     });
 
     test('changes when the short-conversation threshold changes', () {
@@ -101,8 +101,8 @@ void main() {
       );
 
       expect(result.entries, hasLength(2));
-      expect(result.entries.first.conversation?.id, 'convo');
-      expect(result.entries.last.recording?.id, 'rec', reason: 'the day reads forwards, 9am before 11am');
+      expect(result.entries.first.recording?.id, 'rec', reason: 'newest first, so 11am leads');
+      expect(result.entries.last.conversation?.id, 'convo');
       expect(result.isEmpty, isFalse);
     });
 

--- a/app/test/unit/home_day_snapshot_test.dart
+++ b/app/test/unit/home_day_snapshot_test.dart
@@ -131,6 +131,18 @@ void main() {
       expect(result.recordings, isEmpty);
     });
 
+    test('a day of only short conversations is not an empty day', () {
+      // Its entries are empty because everything folded into shortOnes, but the
+      // day still happened — calling it empty contradicts the line counting it.
+      final result = snapshot(
+        conversations: [_conversation('blip', 'yeah ok', day.add(const Duration(hours: 9)), 6)],
+      );
+
+      expect(result.entries, isEmpty);
+      expect(result.shortOnes, hasLength(1));
+      expect(result.isEmpty, isFalse);
+    });
+
     test('keeps only the selected day', () {
       final result = snapshot(
         conversations: [

--- a/app/test/unit/home_day_snapshot_test.dart
+++ b/app/test/unit/home_day_snapshot_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:omi/backend/schema/schema.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/models/local_recording.dart';
 import 'package:omi/pages/home/day_snapshot.dart';
 
 void main() {
@@ -10,6 +12,7 @@ void main() {
   HomeDaySnapshot snapshot({
     List<ServerConversation>? conversations,
     List<ActionItemWithMetadata> tasks = const [],
+    List<LocalRecording> recordings = const [],
     DateTime? on,
     int shortThreshold = 120,
     DateTime? now,
@@ -18,6 +21,7 @@ void main() {
       day: on ?? day,
       conversations: conversations ?? [_conversation('a', 'Standup', day, 600)],
       tasks: tasks,
+      recordings: recordings,
       shortThreshold: shortThreshold,
       isNewUser: false,
       now: now ?? DateTime(2026, 7, 15, 12),
@@ -61,7 +65,7 @@ void main() {
         ],
       );
 
-      expect(result.highlights.map((c) => c.id), ['early', 'late']);
+      expect(result.entries.map((e) => e.conversation?.id), ['early', 'late']);
       expect(result.shortOnes.map((c) => c.id), ['blip']);
       expect(result.conversations.map((c) => c.id), ['early', 'blip', 'late']);
     });
@@ -86,6 +90,45 @@ void main() {
       final after = [_conversation('a', 'Standup', day.add(const Duration(hours: 10)), 600)];
 
       expect(snapshot(conversations: before), isNot(snapshot(conversations: after)));
+    });
+
+    test('places a recording waiting to be transcribed in the day it happened', () {
+      // Without this a day spent recording offline reads as empty on home until
+      // the files upload, while the conversations tab shows them sitting there.
+      final result = snapshot(
+        conversations: [_conversation('convo', 'Standup', day.add(const Duration(hours: 9)), 600)],
+        recordings: [_recording('rec', day.add(const Duration(hours: 11)))],
+      );
+
+      expect(result.entries, hasLength(2));
+      expect(result.entries.first.conversation?.id, 'convo');
+      expect(result.entries.last.recording?.id, 'rec', reason: 'the day reads forwards, 9am before 11am');
+      expect(result.isEmpty, isFalse);
+    });
+
+    test('keeps a recording out of the collapsed short group', () {
+      // A short conversation is noise; an untranscribed recording is a thing
+      // the user still has to act on, so it is never folded away.
+      final result = snapshot(
+        conversations: const [],
+        recordings: [_recording('blip', day.add(const Duration(hours: 9)), seconds: 6)],
+      );
+
+      expect(result.entries.single.recording?.id, 'blip');
+      expect(result.shortOnes, isEmpty);
+    });
+
+    test('changes when a recording finishes uploading', () {
+      final pending = [_recording('rec', day, state: LocalRecordingState.pending)];
+      final processing = [_recording('rec', day, state: LocalRecordingState.processing)];
+
+      expect(snapshot(recordings: pending), isNot(snapshot(recordings: processing)));
+    });
+
+    test('ignores recordings from another day', () {
+      final result = snapshot(recordings: [_recording('elsewhere', other)]);
+
+      expect(result.recordings, isEmpty);
     });
 
     test('keeps only the selected day', () {
@@ -127,6 +170,24 @@ ServerConversation _conversation(
         translations: const [],
       ),
     ],
+  );
+}
+
+LocalRecording _recording(
+  String id,
+  DateTime startedAt, {
+  int seconds = 600,
+  LocalRecordingState state = LocalRecordingState.pending,
+}) {
+  return LocalRecording(
+    fileName: id,
+    filePath: '/tmp/$id',
+    timerStart: startedAt.millisecondsSinceEpoch ~/ 1000,
+    codec: BleAudioCodec.opus,
+    frameSize: 160,
+    sizeBytes: 1024,
+    seconds: seconds,
+    state: state,
   );
 }
 

--- a/app/test/widgets/day_header_test.dart
+++ b/app/test/widgets/day_header_test.dart
@@ -6,7 +6,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_map/flutter_map.dart';
 
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/geolocation.dart';
+import 'package:omi/models/local_recording.dart';
 import 'package:omi/backend/schema/structured.dart';
 import 'package:omi/l10n/app_localizations.dart';
 import 'package:omi/pages/home/widgets/day_header.dart';
@@ -127,6 +129,21 @@ void main() {
     expect(identical(first, second), isTrue);
   });
 
+  testWidgets('draws the map from a day that only has untranscribed recordings', (tester) async {
+    // Transcribe Later captures carry their own start-location snapshot, so a
+    // day with nothing uploaded yet still knows where it happened.
+    await _pumpHeader(
+      tester,
+      const [],
+      recordings: [
+        _recording(latitude: 37.7749, longitude: -122.4194, address: '1 Mission St, San Francisco, CA, USA')
+      ],
+    );
+
+    expect(find.byType(FlutterMap), findsOneWidget);
+    expect(find.text('San Francisco'), findsOneWidget);
+  });
+
   test('collapses a full address to its neighbourhood component', () {
     expect(shortPlaceLabel('1234 Mission St, San Francisco, CA 94110, USA'), 'San Francisco');
     expect(shortPlaceLabel('Mission District, San Francisco, USA'), 'Mission District');
@@ -141,6 +158,7 @@ Future<void> _pumpHeader(
   WidgetTester tester,
   List<ServerConversation> conversations, {
   List<String?> summaryAddresses = const [],
+  List<LocalRecording> recordings = const [],
   VoidCallback? onPickDay,
   bool navigable = true,
   DateTime? day,
@@ -159,6 +177,7 @@ Future<void> _pumpHeader(
           day: day ?? DateTime(2026, 7, 15),
           conversations: conversations,
           summaryAddresses: summaryAddresses,
+          recordings: recordings,
           headline: 'A day worth remembering',
           canGoForward: true,
           onPreviousDay: () {},
@@ -181,6 +200,20 @@ ServerConversation _conversation(String id, {double? latitude, double? longitude
     createdAt: DateTime(2026, 7, 15, 9),
     structured: Structured('Title', 'Overview', emoji: '🧠'),
     geolocation: latitude == null ? null : Geolocation(latitude: latitude, longitude: longitude, address: address),
+  );
+}
+
+LocalRecording _recording({required double latitude, required double longitude, String? address}) {
+  return LocalRecording(
+    fileName: 'rec.bin',
+    filePath: '/tmp/rec.bin',
+    timerStart: DateTime(2026, 7, 15, 9).millisecondsSinceEpoch ~/ 1000,
+    codec: BleAudioCodec.opus,
+    frameSize: 160,
+    sizeBytes: 1024,
+    seconds: 600,
+    state: LocalRecordingState.pending,
+    geolocation: Geolocation(latitude: latitude, longitude: longitude, address: address),
   );
 }
 


### PR DESCRIPTION
The day timeline shipped in #12474 renders server conversations only. Transcribe Later captures audio to the phone and turns it into a conversation later, so between stopping a recording and the upload finishing, that audio existed on the device and nowhere on home.

## What was wrong

- **A day spent recording offline read as empty.** Home showed *"No conversations yet"* while the Conversations tab listed the very same recordings — it already interleaves them into its day groups.
- **A first-run user was told to start recording after doing exactly that.** `isNewUser` tested `conversations.isEmpty` alone, so somebody who had only ever used Transcribe Later got the get-started tiles. The conversations page has always guarded this case with `!hasRecordings`; home did not. This is the part I'd call a bug rather than a gap — it actively misinforms.
- **The map ignored locations it had.** `LocalRecording` carries a start-location snapshot, so an unsynced day *does* know where it happened.

The path after sync was already correct: an uploaded recording becomes a conversation with its original `startedAt`, so it lands on the right day retroactively.

## What changed

The day snapshot carries the day's recordings and interleaves them with its conversations by start time, **reusing the conversations page's own `buildConversationGroupEntries`** rather than defining a second answer to "what happened that day, in order" — two implementations of that would drift.

A recording renders in the same shape as a conversation, because on the day it happened that is what it is: time, what it is, how long it ran. Having no title yet, its second line carries what the user actually needs — audio still on the phone, on its way, or failed to send — using the same localized status strings the conversations list uses, so no new strings. Tapping it opens the same detail sheet (transcribe / share / delete).

Two deliberate calls:

- **Recordings are never folded into the short-conversations group.** A short conversation is noise; an untranscribed recording is asking the user for something.
- **Conversation addresses still win for the place name**, with recordings as the fallback, so a synced day reads the same as before.

## Verification

- `app/test.sh` → **1683 passed** (+5: a recording placed in its day and ordered against a conversation, kept out of the short group, the fingerprint moving when an upload progresses, other days ignored, and a header map drawn from a recording's location alone).
- `app/scripts/analyze_ratchet.sh` → passed.

**Not visually verified.** As with #12537, none of this has been seen running — reproducing it needs a Transcribe Later recording captured and left unsynced. The snapshot and map behaviour are covered by tests; the row's appearance is not.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

