### PR TITLE
fix(app): remove the conversation detail page header title

### DIFF
--- a/app/lib/pages/conversation_detail/page.dart
+++ b/app/lib/pages/conversation_detail/page.dart
@@ -291,7 +291,10 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
       case ConversationTab.transcript:
         return context.l10n.transcriptTab;
       case ConversationTab.summary:
-        return context.l10n.conversationTab;
+        // The summary tab is this page's default view, so a "Conversation"
+        // label restates the screen the user is already on and crowds a header
+        // that already carries the back button and three actions.
+        return '';
       case ConversationTab.actionItems:
         return context.l10n.actionItemsTab;
     }
@@ -701,16 +704,19 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
                 icon: const FaIcon(FontAwesomeIcons.arrowLeft, size: 16.0, color: Colors.white),
               ),
             ),
-            title: Align(
-              alignment: Alignment.centerLeft,
-              child: Padding(
-                padding: const EdgeInsets.only(left: 8.0),
-                child: Text(
-                  _getTabTitle(context, selectedTab),
-                  style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w600),
+            title: switch (_getTabTitle(context, selectedTab)) {
+              '' => null,
+              final tabTitle => Align(
+                  alignment: Alignment.centerLeft,
+                  child: Padding(
+                    padding: const EdgeInsets.only(left: 8.0),
+                    child: Text(
+                      tabTitle,
+                      style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w600),
+                    ),
+                  ),
                 ),
-              ),
-            ),
+            },
             titleSpacing: 0,
             actions: [
               Consumer<ConversationDetailProvider>(

--- a/app/lib/pages/conversation_detail/page.dart
+++ b/app/lib/pages/conversation_detail/page.dart
@@ -291,10 +291,7 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
       case ConversationTab.transcript:
         return context.l10n.transcriptTab;
       case ConversationTab.summary:
-        // The summary tab is this page's default view, so a "Conversation"
-        // label restates the screen the user is already on and crowds a header
-        // that already carries the back button and three actions.
-        return '';
+        return context.l10n.conversationTab;
       case ConversationTab.actionItems:
         return context.l10n.actionItemsTab;
     }
@@ -704,19 +701,9 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
                 icon: const FaIcon(FontAwesomeIcons.arrowLeft, size: 16.0, color: Colors.white),
               ),
             ),
-            title: switch (_getTabTitle(context, selectedTab)) {
-              '' => null,
-              final tabTitle => Align(
-                  alignment: Alignment.centerLeft,
-                  child: Padding(
-                    padding: const EdgeInsets.only(left: 8.0),
-                    child: Text(
-                      tabTitle,
-                      style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w600),
-                    ),
-                  ),
-                ),
-            },
+            // No title: the tab bar below already names the active view, so a
+            // header label only crowds the row with the back button and actions.
+            // _getTabTitle still backs the `active_tab` search analytics property.
             titleSpacing: 0,
             actions: [
               Consumer<ConversationDetailProvider>(


### PR DESCRIPTION
## What

The conversation detail page — the screen that opens when you tap a conversation in the list — carried a title in its app bar. It's removed entirely, on all three tabs.

```dart
-  title: Align(
-    alignment: Alignment.centerLeft,
-    child: Padding(
-      padding: const EdgeInsets.only(left: 8.0),
-      child: Text(_getTabTitle(context, selectedTab), ...),
-    ),
-  ),
```

Net against main: **4 insertions, 17 deletions.**

## Why

The app bar titled itself from the selected tab — "Conversation" on summary, "Transcript", "Action Items". The tab bar sits directly below the header and already names the active view, so the title duplicated it while crowding the row that holds the back button and three action buttons.

Note this removes the label on **all three** tabs, not just the summary one. Nothing becomes unidentifiable — the tab bar is the wayfinding.

## The analytics trap in here

`_getTabTitle` is not only the header. It also supplies the `active_tab` property on search analytics:

```dart
PlatformManager.instance.analytics.conversationDetailSearchQueryEntered(
  ..., activeTab: _getTabTitle(context, selectedTab),
);
```

The first commit on this branch blanked the summary tab by returning `''` from that helper, which would have logged `active_tab: ""` for every search on the summary tab — nothing failing, the dimension just quietly going empty. The second commit reverts that: the helper keeps returning real labels and now serves analytics alone, while the header simply omits `title:`.

Left alone but worth knowing: `active_tab` is sent as a *localized* string, so a French client reports `"Transcription"` where an English one reports `"Transcript"`, splitting that dimension by locale. Pre-existing, out of scope here.

## Verification

- `flutter analyze lib/pages/conversation_detail/page.dart` — **0 errors**. The 5 infos (`unnecessary_import`, `prefer_final_fields`, deprecated `Share`/`shareXFiles`, `sized_box_for_whitespace`) are pre-existing on this file and untouched.
- `app/test.sh` — **1683 passed**.
- `dart format --line-length 120` — no change.
- Grepped `app/lib/pages/conversation_detail/` — no rendered title text remains.

**Not verified: the rendered header.** `adb` is broken on this host (x86_64 emulator binaries on an arm64 machine) and `agent-flutter` is not installed, so the Edit → Verify → Evidence loop in `app/AGENTS.md` could not run. This is a widget removal with no other layout logic, but it has not been seen on a device — worth a glance from anyone with a simulator before merge.

## No test

A header widget removal. Asserting the absence of a string in source would be a static tripwire rather than behavioural coverage, which `AGENTS.md` warns against, so none was added. The analyzer covers compilation and the existing suite covers the surrounding page behaviour — including the analytics call whose regression is described above.

Failure-Class: none
