### PR TITLE
fix(dev-harness): validate Node version against pinned firebase-tools

### DIFF
--- a/scripts/dev-harness/dev_harness/cli.py
+++ b/scripts/dev-harness/dev_harness/cli.py
@@ -7,6 +7,7 @@ import functools
 import hashlib
 import json
 import os
+import re
 import shutil
 import signal
 import socket
@@ -312,11 +313,50 @@ def _java_runtime_present() -> bool:
         return False
 
 
+def _node_major_version() -> int | None:
+    try:
+        result = subprocess.run(
+            ["node", "--version"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=10, text=True
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    match = re.match(r"v(\d+)", result.stdout.strip())
+    return int(match.group(1)) if match else None
+
+
+def _minimum_node_major_for_firebase_tools(repo_root: Path) -> int | None:
+    """Read the minimum Node major version pinned firebase-tools declares via `engines.node`.
+
+    package-lock.json is the source of truth for the resolved firebase-tools version (see
+    package.json); its `engines.node` range (e.g. ">=20.0.0 || >=22.0.0 || >=24.0.0") lists
+    the lowest major first, so the lowest `>=N` bound is the minimum this repo requires.
+    """
+    try:
+        data = json.loads((repo_root / "package-lock.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    node_range = data.get("packages", {}).get("node_modules/firebase-tools", {}).get("engines", {}).get("node")
+    if not node_range:
+        return None
+    majors = [int(major) for major in re.findall(r">=\s*(\d+)", node_range)]
+    return min(majors) if majors else None
+
+
 def prerequisite_report(cfg: config.HarnessConfig) -> tuple[list[str], list[str]]:
     missing: list[str] = []
     warnings: list[str] = []
     if not _which("node"):
         missing.append("node (required by Firebase emulator CLI)")
+    else:
+        node_major = _node_major_version()
+        min_major = _minimum_node_major_for_firebase_tools(cfg.repo_root)
+        if node_major is not None and min_major is not None and node_major < min_major:
+            missing.append(
+                f"node >= {min_major} (found v{node_major}; required by the pinned firebase-tools "
+                "version in package-lock.json)"
+            )
     if not (_which("firebase") or _which("npx")):
         missing.append(
             "firebase-tools CLI or npx (install with npm install, npm install -g firebase-tools, or use npx)"

--- a/scripts/dev-harness/tests/test_cli.py
+++ b/scripts/dev-harness/tests/test_cli.py
@@ -99,6 +99,49 @@ def test_missing_java_runtime_is_reported_as_a_prerequisite(
     assert any("java runtime" in item for item in missing)
 
 
+def test_minimum_node_major_reads_the_pinned_firebase_tools_engines_range() -> None:
+    assert cli._minimum_node_major_for_firebase_tools(REPO_ROOT) == 20
+
+
+def test_node_major_version_parses_the_node_version_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        cli.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, stdout="v18.19.0\n"),
+    )
+
+    assert cli._node_major_version() == 18
+
+
+def test_old_node_on_path_is_reported_as_a_prerequisite(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A contributor with Node 16/18 on PATH passes the bare `_which("node")` check today,
+
+    then only hits an opaque failure once the Firestore emulator tries to start under
+    npx-launched firebase-tools, which requires Node >= 20.
+    """
+    monkeypatch.setenv("PROVIDER_MODE", "offline")
+    monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
+    monkeypatch.setattr(cli, "_which", lambda _name: "/usr/bin/node")
+    monkeypatch.setattr(cli, "_node_major_version", lambda: 18)
+    cfg = config.load_config(REPO_ROOT)
+
+    missing, _warnings = cli.prerequisite_report(cfg)
+
+    assert any("node >= 20" in item and "v18" in item for item in missing)
+
+
+def test_current_node_on_path_is_not_reported_as_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PROVIDER_MODE", "offline")
+    monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
+    monkeypatch.setattr(cli, "_which", lambda _name: "/usr/bin/node")
+    monkeypatch.setattr(cli, "_node_major_version", lambda: 22)
+    cfg = config.load_config(REPO_ROOT)
+
+    missing, _warnings = cli.prerequisite_report(cfg)
+
+    assert not any(item.startswith("node >=") for item in missing)
+
+
 def test_npx_firebase_tools_does_not_wait_on_an_install_prompt(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## What

`prerequisite_report()` in `scripts/dev-harness/dev_harness/cli.py` only checked that a `node` binary exists on PATH, never which version. The repo pins `firebase-tools` (`package.json`), which declares `engines.node: ">=20.0.0 || >=22.0.0 || >=24.0.0"` in `package-lock.json`. A contributor with an older Node (16/18) on PATH passed the prereq check and only hit an opaque failure — or an npm `EBADENGINE` warning — once the Firestore emulator actually tried to start, the same "present but unusable" class #11569 fixed for the Java stub.

Adds `_node_major_version()` (parses `node --version`) and `_minimum_node_major_for_firebase_tools()` (reads the minimum major out of the pinned `firebase-tools` `engines.node` range in `package-lock.json`), and reports `node >= N (found vM; ...)` as a missing prerequisite when the installed major is below the pin, instead of letting it fail downstream.

## Why

Closes #12394.

## Testing

- Added 4 regression tests in `scripts/dev-harness/tests/test_cli.py`: real parse of the repo's pinned `engines.node` range, `node --version` output parsing, an old-Node-on-PATH case reported as missing, and a current-Node-on-PATH case that stays clean.
- `backend/.venv/bin/python -m pytest scripts/dev-harness/tests/test_cli.py` — 25 passed.
- `make preflight` (local lane) — green after fixing an unrelated environment gap (`lsof` missing from PATH on this machine; symlinked `/usr/sbin/lsof` into `~/.local/bin`, not a repo change).

## Failure class

Failure-Class: none

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

