### PR TITLE
feat(web-app): liquid-gooey FAB and transitions.dev chrome motion

### DIFF
--- a/.github/agent-docs/web-app-destinations.md
+++ b/.github/agent-docs/web-app-destinations.md
@@ -63,6 +63,15 @@ a backgrounded browser reads as permanently stuck at its initial frame —
 `transition: none` and read the resting value. This cost real time on this
 branch: a working menu was rewritten three times before the tab was the answer.
 
+## Chrome motion
+
+Page and chrome enter/leave use the copy-paste `t-*` snippets from
+[transitions.dev](https://transitions.dev) (`web/app/src/styles/transitions-dev*.css`).
+Do not invent easing curves — tune the semantic tokens. The ChatBubble on
+non-home routes is the liquid-gooey FAB: notifications fan out of the chat
+control. `framer-motion` stays for layout-id pills and existing springs; do
+not rip it out. Honor `prefers-reduced-motion` on anything new.
+
 ## Layout gotcha worth knowing
 
 The rail is a flex column whose nav takes the slack, so anything in the footer

--- a/web/app/bun.lock
+++ b/web/app/bun.lock
@@ -33,6 +33,7 @@
         "fuse.js": "^7.0.0",
         "idb": "^8.0.3",
         "leaflet": "^1.9.4",
+        "liquid-gooey": "^0.2.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.438.0",
         "mixpanel-browser": "^2.73.0",
@@ -868,6 +869,8 @@
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "liquid-gooey": ["liquid-gooey@0.2.1", "", { "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-BRb0Rscie4JCHFmk4bkWxM+p03c34sidLgNE8XFJGRGEyWM/Wf0FYztJH3CfMWwOVajd4dVurAFe+BTSj8Eeeg=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -43,6 +43,7 @@
     "fuse.js": "^7.0.0",
     "idb": "^8.0.3",
     "leaflet": "^1.9.4",
+    "liquid-gooey": "^0.2.1",
     "lodash": "^4.17.21",
     "lucide-react": "^0.438.0",
     "mixpanel-browser": "^2.73.0",

--- a/web/app/src/app/globals.css
+++ b/web/app/src/app/globals.css
@@ -1,4 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap');
+@import '../styles/transitions-dev-root.css';
+@import '../styles/transitions-dev.css';
 
 @tailwind base;
 @tailwind components;

--- a/web/app/src/app/login/LoginClient.tsx
+++ b/web/app/src/app/login/LoginClient.tsx
@@ -8,6 +8,8 @@ import { motion } from 'framer-motion';
 import { useAuth } from '@/components/auth/AuthProvider';
 import { cn } from '@/lib/utils';
 import { MixpanelManager } from '@/lib/analytics/mixpanel';
+import { TextSwap } from '@/components/ui/TextSwap';
+import { replayErrorShake } from '@/lib/transitionsDev';
 import { isFirebaseAuthConfigured } from '@/lib/firebase';
 import {
   claimReferralTrial,
@@ -64,6 +66,12 @@ export function LoginClient() {
   const statusMessage =
     error ??
     (signInUnavailable ? 'Sign-in is not configured in this local preview.' : null);
+  const authActionsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!statusMessage || !authActionsRef.current) return;
+    replayErrorShake(authActionsRef.current);
+  }, [statusMessage]);
 
   // Track page view
   useEffect(() => {
@@ -292,11 +300,13 @@ export function LoginClient() {
             <div aria-hidden="true" className="mb-16 hidden h-16 w-16 sm:block" />
 
             {/* Auth buttons */}
+            <div className={cn('t-input-wrap w-full', statusMessage && 'is-error')}>
             <motion.div
+              ref={authActionsRef}
               initial={{ opacity: 0, y: 18 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: 1.25, ease: 'easeOut' }}
-              className="w-full space-y-2"
+              className={cn('t-input w-full space-y-2', statusMessage && 'is-error')}
             >
               {/* Apple Sign In */}
               <button
@@ -319,9 +329,9 @@ export function LoginClient() {
                     <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
                   </svg>
                 )}
-                <span>
-                  {isSigningIn === 'apple' ? 'Connecting...' : 'Continue with Apple'}
-                </span>
+                <TextSwap
+                  text={isSigningIn === 'apple' ? 'Connecting...' : 'Continue with Apple'}
+                />
               </button>
 
               {/* Google Sign In */}
@@ -360,26 +370,22 @@ export function LoginClient() {
                     />
                   </svg>
                 )}
-                <span>
-                  {isSigningIn === 'google' ? 'Connecting...' : 'Continue with Google'}
-                </span>
+                <TextSwap
+                  text={
+                    isSigningIn === 'google' ? 'Connecting...' : 'Continue with Google'
+                  }
+                />
               </button>
             </motion.div>
-
             <div
               role="status"
               aria-live="polite"
               className="absolute inset-x-0 top-full mt-3 h-[72px] w-full"
             >
-              {statusMessage && (
-                <motion.p
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  className="w-full rounded-lg border border-red-300/20 bg-red-500/10 px-3 py-2 text-center text-sm text-error"
-                >
-                  {statusMessage}
-                </motion.p>
-              )}
+              <p className="t-error-msg w-full rounded-lg border border-red-300/20 bg-red-500/10 px-3 py-2 text-center text-sm text-error">
+                {statusMessage}
+              </p>
+            </div>
             </div>
           </div>
         </motion.div>

--- a/web/app/src/app/login/LoginClient.tsx
+++ b/web/app/src/app/login/LoginClient.tsx
@@ -70,7 +70,7 @@ export function LoginClient() {
 
   useEffect(() => {
     if (!statusMessage || !authActionsRef.current) return;
-    replayErrorShake(authActionsRef.current);
+    return replayErrorShake(authActionsRef.current);
   }, [statusMessage]);
 
   // Track page view

--- a/web/app/src/components/chat/ChatBubble.tsx
+++ b/web/app/src/components/chat/ChatBubble.tsx
@@ -22,7 +22,7 @@ function ChatIconButton({
     <button
       type="button"
       onClick={onClick}
-      className={fabClass}
+      className={cn(fabClass, 'pointer-events-auto')}
       aria-label={isOpen ? 'Close chat' : 'Open chat'}
     >
       <span className="t-icon-swap" data-state={isOpen ? 'b' : 'a'}>
@@ -77,7 +77,7 @@ export function ChatBubble() {
 
   return (
     <div
-      className="fixed bottom-20 right-6 z-50 h-[136px] w-14 lg:bottom-6"
+      className="pointer-events-none fixed bottom-20 right-6 z-50 h-[136px] w-14 lg:bottom-6"
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
@@ -93,10 +93,11 @@ export function ChatBubble() {
           <button
             type="button"
             onClick={toggleNotificationCenter}
-            className={fabClass}
+            className={cn(fabClass, fan ? 'pointer-events-auto' : 'pointer-events-none opacity-0')}
             aria-label="Notifications"
             tabIndex={fan ? 0 : -1}
             aria-hidden={!fan}
+            inert={!fan}
           >
             <span className="relative">
               <Bell className="h-6 w-6" />

--- a/web/app/src/components/chat/ChatBubble.tsx
+++ b/web/app/src/components/chat/ChatBubble.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Bell, MessageCircle, X } from 'lucide-react';
 import { Liquid } from 'liquid-gooey';
 import { useReducedMotion } from 'framer-motion';
@@ -43,6 +43,7 @@ export function ChatBubble() {
   const reduceMotion = useReducedMotion();
   const [hovered, setHovered] = useState(false);
   const [coarse, setCoarse] = useState(false);
+  const notifyRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     const media = window.matchMedia('(pointer: coarse)');
@@ -51,6 +52,16 @@ export function ChatBubble() {
     media.addEventListener('change', sync);
     return () => media.removeEventListener('change', sync);
   }, []);
+
+  const fan = coarse || hovered;
+
+  useEffect(() => {
+    if (fan) return;
+    const notify = notifyRef.current;
+    if (notify && document.activeElement === notify) {
+      notify.blur();
+    }
+  }, [fan]);
 
   if (reduceMotion) {
     return (
@@ -89,8 +100,6 @@ export function ChatBubble() {
     );
   }
 
-  const fan = coarse || hovered;
-
   return (
     <div
       className="pointer-events-none fixed bottom-20 right-6 z-50 h-[136px] w-14 lg:bottom-6"
@@ -107,6 +116,7 @@ export function ChatBubble() {
       >
         <Liquid.Item x={0} y={fan ? -72 : 0} transition="bouncy">
           <button
+            ref={notifyRef}
             type="button"
             onClick={toggleNotificationCenter}
             className={cn(fabClass, fan ? 'pointer-events-auto' : 'pointer-events-none opacity-0')}

--- a/web/app/src/components/chat/ChatBubble.tsx
+++ b/web/app/src/components/chat/ChatBubble.tsx
@@ -54,7 +54,23 @@ export function ChatBubble() {
 
   if (reduceMotion) {
     return (
-      <div className="fixed bottom-20 right-6 z-50 lg:bottom-6">
+      <div className="fixed bottom-20 right-6 z-50 flex flex-col items-center gap-3 lg:bottom-6">
+        <button
+          type="button"
+          onClick={toggleNotificationCenter}
+          className={cn(
+            'relative flex h-14 w-14 items-center justify-center rounded-full',
+            'bg-text-primary text-bg-primary shadow-lg shadow-black/40 hover:bg-text-primary/80',
+          )}
+          aria-label="Notifications"
+        >
+          <Bell className="h-6 w-6" />
+          <span className="t-badge" data-open={unreadCount > 0 ? 'true' : 'false'}>
+            <span className="t-badge-dot flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white">
+              {unreadCount > 99 ? '99+' : unreadCount}
+            </span>
+          </span>
+        </button>
         <button
           type="button"
           onClick={toggleChat}
@@ -83,11 +99,11 @@ export function ChatBubble() {
     >
       <Liquid
         className="h-full w-full"
-        blur={6}
-        contrast={18}
+        blur={fan ? 6 : 0}
+        contrast={fan ? 18 : 1}
         fill="#ffffff"
         shadow="0 10px 15px -3px rgba(0,0,0,0.4)"
-        filterPadding={80}
+        filterPadding={fan ? 80 : 0}
       >
         <Liquid.Item x={0} y={fan ? -72 : 0} transition="bouncy">
           <button

--- a/web/app/src/components/chat/ChatBubble.tsx
+++ b/web/app/src/components/chat/ChatBubble.tsx
@@ -1,34 +1,117 @@
 'use client';
 
-import { MessageCircle, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Bell, MessageCircle, X } from 'lucide-react';
+import { Liquid } from 'liquid-gooey';
+import { useReducedMotion } from 'framer-motion';
 import { useChat } from './ChatContext';
+import { useNotificationContext } from '@/components/notifications/NotificationContext';
 import { cn } from '@/lib/utils';
+
+const fabClass =
+  'flex h-14 w-14 items-center justify-center rounded-full bg-transparent text-bg-primary';
+
+function ChatIconButton({
+  isOpen,
+  onClick,
+}: {
+  isOpen: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={fabClass}
+      aria-label={isOpen ? 'Close chat' : 'Open chat'}
+    >
+      <span className="t-icon-swap" data-state={isOpen ? 'b' : 'a'}>
+        <span className="t-icon" data-icon="a">
+          <MessageCircle className="h-6 w-6" />
+        </span>
+        <span className="t-icon" data-icon="b">
+          <X className="h-6 w-6" />
+        </span>
+      </span>
+    </button>
+  );
+}
 
 export function ChatBubble() {
   const { isOpen, toggleChat } = useChat();
+  const { toggleNotificationCenter, unreadCount } = useNotificationContext();
+  const reduceMotion = useReducedMotion();
+  const [hovered, setHovered] = useState(false);
+  const [coarse, setCoarse] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia('(pointer: coarse)');
+    const sync = () => setCoarse(media.matches);
+    sync();
+    media.addEventListener('change', sync);
+    return () => media.removeEventListener('change', sync);
+  }, []);
+
+  if (reduceMotion) {
+    return (
+      <div className="fixed bottom-20 right-6 z-50 lg:bottom-6">
+        <button
+          type="button"
+          onClick={toggleChat}
+          className={cn(
+            'flex h-14 w-14 items-center justify-center rounded-full',
+            'shadow-lg shadow-black/40',
+            isOpen
+              ? 'bg-bg-tertiary text-text-primary hover:bg-bg-quaternary'
+              : 'bg-text-primary text-bg-primary hover:bg-text-primary/80',
+          )}
+          aria-label={isOpen ? 'Close chat' : 'Open chat'}
+        >
+          {isOpen ? <X className="h-6 w-6" /> : <MessageCircle className="h-6 w-6" />}
+        </button>
+      </div>
+    );
+  }
+
+  const fan = coarse || hovered;
 
   return (
-    <button
-      onClick={toggleChat}
-      className={cn(
-        'fixed bottom-20 lg:bottom-6 right-6 z-50',
-        'w-14 h-14 rounded-full',
-        'flex items-center justify-center',
-        'shadow-lg shadow-black/40',
-        'transition-colors duration-200',
-        isOpen
-          ? 'bg-bg-tertiary hover:bg-bg-quaternary'
-          : 'bg-text-primary text-bg-primary hover:bg-text-primary/80',
-      )}
-      aria-label={isOpen ? 'Close chat' : 'Open chat'}
+    <div
+      className="fixed bottom-20 right-6 z-50 h-[136px] w-14 lg:bottom-6"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
     >
-      {isOpen ? (
-        <X className="w-6 h-6 text-text-primary" />
-      ) : (
-        // The closed pill is white, so the icon has to be the dark token — a
-        // white icon on it is white on white.
-        <MessageCircle className="w-6 h-6 text-bg-primary" />
-      )}
-    </button>
+      <Liquid
+        className="h-full w-full"
+        blur={6}
+        contrast={18}
+        fill="#ffffff"
+        shadow="0 10px 15px -3px rgba(0,0,0,0.4)"
+        filterPadding={80}
+      >
+        <Liquid.Item x={0} y={fan ? -72 : 0} transition="bouncy">
+          <button
+            type="button"
+            onClick={toggleNotificationCenter}
+            className={fabClass}
+            aria-label="Notifications"
+            tabIndex={fan ? 0 : -1}
+            aria-hidden={!fan}
+          >
+            <span className="relative">
+              <Bell className="h-6 w-6" />
+              <span className="t-badge" data-open={unreadCount > 0 ? 'true' : 'false'}>
+                <span className="t-badge-dot flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white">
+                  {unreadCount > 99 ? '99+' : unreadCount}
+                </span>
+              </span>
+            </span>
+          </button>
+        </Liquid.Item>
+        <Liquid.Item>
+          <ChatIconButton isOpen={isOpen} onClick={toggleChat} />
+        </Liquid.Item>
+      </Liquid>
+    </div>
   );
 }

--- a/web/app/src/components/chat/ChatPanel.tsx
+++ b/web/app/src/components/chat/ChatPanel.tsx
@@ -15,6 +15,7 @@ import { shouldSubmitComposerKey } from '@/lib/chatComposerKey';
 import { parseChatEvidenceFromRecord } from '@/lib/chatEvidence';
 import { ChatMarkdown } from './ChatMarkdown';
 import { ChatEvidenceCard } from './ChatEvidenceCard';
+import { PanelReveal } from '@/components/ui/PanelReveal';
 
 interface FilePreviewItem {
   file: File;
@@ -252,7 +253,7 @@ export function ChatPanel() {
               'max-sm:fixed max-sm:inset-0 max-sm:z-50 max-sm:w-full',
             )}
           >
-            <div className={cn('w-[400px] h-full flex flex-col', 'max-sm:w-full')}>
+            <PanelReveal className={cn('w-[400px] h-full flex flex-col', 'max-sm:w-full')}>
               {/* Header */}
               <div className="flex items-center justify-between p-4 border-b border-bg-tertiary">
                 <div className="flex items-center gap-3">
@@ -531,7 +532,7 @@ export function ChatPanel() {
                   </div>
                 </div>
               </div>
-            </div>
+            </PanelReveal>
           </motion.div>
 
           {/* Clear chat confirmation dialog */}

--- a/web/app/src/components/chat/__tests__/ChatBubble.test.tsx
+++ b/web/app/src/components/chat/__tests__/ChatBubble.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  isOpen: false,
+  unreadCount: 2,
+  reduceMotion: false,
+  toggleChat: vi.fn(),
+  toggleNotificationCenter: vi.fn(),
+}));
+
+vi.mock('liquid-gooey', () => {
+  function Item({
+    children,
+    x,
+    y,
+  }: {
+    children: React.ReactNode;
+    x?: number;
+    y?: number;
+  }) {
+    return (
+      <div data-testid="liquid-item" data-x={x ?? 0} data-y={y ?? 0}>
+        {children}
+      </div>
+    );
+  }
+  function Liquid({ children }: { children: React.ReactNode }) {
+    return <div data-testid="liquid">{children}</div>;
+  }
+  Liquid.Item = Item;
+  return { Liquid };
+});
+
+vi.mock('framer-motion', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('framer-motion')>()),
+  useReducedMotion: () => state.reduceMotion,
+}));
+
+vi.mock('@/components/chat/ChatContext', () => ({
+  useChat: () => ({
+    isOpen: state.isOpen,
+    toggleChat: state.toggleChat,
+  }),
+}));
+
+vi.mock('@/components/notifications/NotificationContext', () => ({
+  useNotificationContext: () => ({
+    toggleNotificationCenter: state.toggleNotificationCenter,
+    unreadCount: state.unreadCount,
+  }),
+}));
+
+import { ChatBubble } from '@/components/chat/ChatBubble';
+
+describe('ChatBubble', () => {
+  beforeEach(() => {
+    state.isOpen = false;
+    state.unreadCount = 2;
+    state.reduceMotion = false;
+    state.toggleChat.mockClear();
+    state.toggleNotificationCenter.mockClear();
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query.includes('pointer: coarse') ? false : false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        onchange: null,
+      })),
+    });
+  });
+
+  it('fans the notifications control out of the chat FAB', () => {
+    const { container } = render(<ChatBubble />);
+    expect(screen.getByRole('button', { name: 'Open chat' })).toBeInTheDocument();
+    expect(container.querySelector('[data-testid="liquid"]')).not.toBeNull();
+
+    const items = screen.getAllByTestId('liquid-item');
+    expect(items[0]).toHaveAttribute('data-y', '0');
+
+    fireEvent.mouseEnter(container.firstChild as HTMLElement);
+    expect(screen.getAllByTestId('liquid-item')[0]).toHaveAttribute('data-y', '-72');
+    expect(screen.getByRole('button', { name: 'Notifications' })).toBeInTheDocument();
+    expect(container.querySelector('.t-badge')).toHaveAttribute('data-open', 'true');
+  });
+
+  it('skips the gooey fan when reduced motion is requested', () => {
+    state.reduceMotion = true;
+    render(<ChatBubble />);
+    expect(screen.queryByTestId('liquid')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Open chat' }));
+    expect(state.toggleChat).toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Notifications' })).toBeNull();
+  });
+});

--- a/web/app/src/components/chat/__tests__/ChatBubble.test.tsx
+++ b/web/app/src/components/chat/__tests__/ChatBubble.test.tsx
@@ -96,6 +96,7 @@ describe('ChatBubble', () => {
     expect(screen.queryByTestId('liquid')).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: 'Open chat' }));
     expect(state.toggleChat).toHaveBeenCalled();
-    expect(screen.queryByRole('button', { name: 'Notifications' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Notifications' }));
+    expect(state.toggleNotificationCenter).toHaveBeenCalled();
   });
 });

--- a/web/app/src/components/chat/__tests__/ChatBubble.test.tsx
+++ b/web/app/src/components/chat/__tests__/ChatBubble.test.tsx
@@ -90,6 +90,17 @@ describe('ChatBubble', () => {
     expect(container.querySelector('.t-badge')).toHaveAttribute('data-open', 'true');
   });
 
+  it('blurs the notifications control when the fan collapses', () => {
+    const { container } = render(<ChatBubble />);
+    fireEvent.mouseEnter(container.firstChild as HTMLElement);
+    const notify = screen.getByRole('button', { name: 'Notifications' });
+    notify.focus();
+    expect(document.activeElement).toBe(notify);
+
+    fireEvent.mouseLeave(container.firstChild as HTMLElement);
+    expect(document.activeElement).not.toBe(notify);
+  });
+
   it('skips the gooey fan when reduced motion is requested', () => {
     state.reduceMotion = true;
     render(<ChatBubble />);

--- a/web/app/src/components/chat/__tests__/ChatBubble.test.tsx
+++ b/web/app/src/components/chat/__tests__/ChatBubble.test.tsx
@@ -63,7 +63,7 @@ describe('ChatBubble', () => {
     Object.defineProperty(window, 'matchMedia', {
       configurable: true,
       value: vi.fn().mockImplementation((query: string) => ({
-        matches: query.includes('pointer: coarse') ? false : false,
+        matches: false,
         media: query,
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
@@ -82,6 +82,7 @@ describe('ChatBubble', () => {
 
     const items = screen.getAllByTestId('liquid-item');
     expect(items[0]).toHaveAttribute('data-y', '0');
+    expect(screen.queryByRole('button', { name: 'Notifications' })).toBeNull();
 
     fireEvent.mouseEnter(container.firstChild as HTMLElement);
     expect(screen.getAllByTestId('liquid-item')[0]).toHaveAttribute('data-y', '-72');

--- a/web/app/src/components/conversations/ConversationSplitView.tsx
+++ b/web/app/src/components/conversations/ConversationSplitView.tsx
@@ -33,6 +33,7 @@ import { ConversationGallery, ConversationGallerySkeleton } from './Conversation
 import { ResizeHandle } from '@/components/ui/ResizeHandle';
 import { PageToolbar } from '@/components/layout/PageToolbar';
 import { useToast } from '@/components/ui/Toast';
+import { TextSwap } from '@/components/ui/TextSwap';
 import {
   mergeConversations,
   getFolders,
@@ -707,17 +708,15 @@ export function ConversationSplitView() {
                   : 'text-text-secondary hover:text-text-primary hover:bg-bg-tertiary',
               )}
             >
-              {isSelectionMode ? (
-                <>
-                  <X className="w-4 h-4" />
-                  <span>Cancel</span>
-                </>
-              ) : (
-                <>
+              <span className="t-icon-swap" data-state={isSelectionMode ? 'b' : 'a'}>
+                <span className="t-icon" data-icon="a">
                   <CheckSquare className="w-4 h-4" />
-                  <span>Select</span>
-                </>
-              )}
+                </span>
+                <span className="t-icon" data-icon="b">
+                  <X className="w-4 h-4" />
+                </span>
+              </span>
+              <TextSwap text={isSelectionMode ? 'Cancel' : 'Select'} />
             </button>
           </>
         }
@@ -852,7 +851,7 @@ export function ConversationSplitView() {
             style={{
               width: `min(${panelWidth}px, calc(100% - ${MIN_CONVERSATION_GALLERY_WIDTH}px))`,
             }}
-            className="w-full lg:w-auto flex-shrink-0 flex flex-col h-full overflow-hidden bg-bg-pane border-l border-stroke"
+            className="t-resize w-full lg:w-auto flex-shrink-0 flex flex-col h-full overflow-hidden bg-bg-pane border-l border-stroke"
           >
             <AnimatePresence mode="wait">
               <motion.div

--- a/web/app/src/components/conversations/ConversationSplitView.tsx
+++ b/web/app/src/components/conversations/ConversationSplitView.tsx
@@ -105,6 +105,7 @@ export function ConversationSplitView() {
     DEFAULT_PANEL_WIDTH,
   );
   const splitViewRef = useRef<HTMLDivElement>(null);
+  const [detailResizing, setDetailResizing] = useState(false);
 
   // Selection mode state (for merge feature)
   const [isSelectionMode, setIsSelectionMode] = useState(false);
@@ -840,6 +841,8 @@ export function ConversationSplitView() {
         {selection && (
           <ResizeHandle
             onResize={handleResize}
+            onResizeStart={() => setDetailResizing(true)}
+            onResizeEnd={() => setDetailResizing(false)}
             onDoubleClick={handleResetWidth}
             className="hidden lg:flex"
           />
@@ -851,6 +854,7 @@ export function ConversationSplitView() {
             style={{
               width: `min(${panelWidth}px, calc(100% - ${MIN_CONVERSATION_GALLERY_WIDTH}px))`,
             }}
+            data-dragging={detailResizing ? 'true' : undefined}
             className="t-resize w-full lg:w-auto flex-shrink-0 flex flex-col h-full overflow-hidden bg-bg-pane border-l border-stroke"
           >
             <AnimatePresence mode="wait">

--- a/web/app/src/components/conversations/FolderTabs.tsx
+++ b/web/app/src/components/conversations/FolderTabs.tsx
@@ -35,13 +35,15 @@ export function FolderTabs({
     x: number;
     y: number;
   } | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   const handleContextMenu = (e: React.MouseEvent, folder: Folder) => {
     e.preventDefault();
     setContextMenu({ folder, x: e.clientX, y: e.clientY });
+    setMenuOpen(true);
   };
 
-  const closeContextMenu = () => setContextMenu(null);
+  const closeContextMenu = () => setMenuOpen(false);
 
   return (
     <div className="relative">
@@ -95,12 +97,13 @@ export function FolderTabs({
       </div>
 
       {/* Context menu for folder options */}
+      {contextMenu && menuOpen && (
+        <div className="fixed inset-0 z-50" onClick={closeContextMenu} />
+      )}
       {contextMenu && (
-        <>
-          {/* Backdrop */}
-          <div className="fixed inset-0 z-50" onClick={closeContextMenu} />
-          {/* Menu */}
           <OpenSurface
+            open={menuOpen}
+            onExited={() => setContextMenu(null)}
             data-origin="top-left"
             className={cn(
               't-dropdown',
@@ -139,7 +142,6 @@ export function FolderTabs({
               <span>Delete folder</span>
             </button>
           </OpenSurface>
-        </>
       )}
     </div>
   );

--- a/web/app/src/components/conversations/FolderTabs.tsx
+++ b/web/app/src/components/conversations/FolderTabs.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { useRef, useState } from 'react';
-import { motion } from 'framer-motion';
 import { Plus, Star, Pencil, Trash2, Inbox, Briefcase, Heart, Users } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { Folder } from '@/types/folder';
+import { OpenSurface } from '@/components/ui/OpenSurface';
 
 // Special folder IDs for built-in tabs
 export const FOLDER_ALL = 'all';
@@ -100,10 +100,10 @@ export function FolderTabs({
           {/* Backdrop */}
           <div className="fixed inset-0 z-50" onClick={closeContextMenu} />
           {/* Menu */}
-          <motion.div
-            initial={{ opacity: 0, scale: 0.95 }}
-            animate={{ opacity: 1, scale: 1 }}
+          <OpenSurface
+            data-origin="top-left"
             className={cn(
+              't-dropdown',
               'fixed z-50 py-1 rounded-lg',
               'bg-bg-secondary border border-bg-tertiary',
               'shadow-lg min-w-[140px]',
@@ -138,7 +138,7 @@ export function FolderTabs({
               <Trash2 className="w-4 h-4" />
               <span>Delete folder</span>
             </button>
-          </motion.div>
+          </OpenSurface>
         </>
       )}
     </div>

--- a/web/app/src/components/layout/MainLayout.tsx
+++ b/web/app/src/components/layout/MainLayout.tsx
@@ -2,9 +2,9 @@
 
 import { useState, useEffect } from 'react';
 import { usePathname, useSearchParams } from '@tschk/moonshine-next/navigation';
-import { motion } from 'framer-motion';
 import dynamic from '@tschk/moonshine-next/dynamic';
 import { Sidebar, MobileMenuButton } from './Sidebar';
+import { PageSlide } from '@/components/ui/PageSlide';
 import { ChatProvider, useChat as useChatContext } from '@/components/chat/ChatContext';
 import { BottomNavigation } from './BottomNavigation';
 import {
@@ -147,8 +147,7 @@ export function MainLayout({ children, title, hideHeader = false }: MainLayoutPr
                     'sm:shadow-[0_14px_26px_rgba(0,0,0,0.22)]',
                   )}
                 >
-                  {/* Keyed on the pathname so each destination fades and lifts
-                      in.
+                  {/* Keyed on the pathname so each destination enters.
 
                       Deliberately not wrapped in `AnimatePresence
                       initial={false}`: every route registers its own copy of
@@ -156,19 +155,14 @@ export function MainLayout({ children, title, hideHeader = false }: MainLayoutPr
                       makes each navigation look like a first render, and
                       `initial={false}` exists precisely to suppress the enter
                       animation on a first render — so the transition never
-                      played on any page. A plain keyed `initial` animates on
-                      both a remount and an in-place key change. There is no
-                      exit animation for the same reason: the outgoing tree is
-                      already gone by the time the new one mounts. */}
-                  <motion.div
-                    key={pathname}
-                    initial={{ opacity: 0, y: 8 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
-                    className="h-full"
-                  >
+                      played on any page. `PageSlide` flips `data-page` on
+                      mount so the incoming `.t-page` runs the enter slide.
+                      There is no exit animation for the same reason: the
+                      outgoing tree is already gone by the time the new one
+                      mounts. */}
+                  <PageSlide pageKey={pathname ?? ''} className="h-full">
                     {children}
-                  </motion.div>
+                  </PageSlide>
                 </div>
               </div>
             </main>

--- a/web/app/src/components/layout/MainLayout.tsx
+++ b/web/app/src/components/layout/MainLayout.tsx
@@ -15,7 +15,11 @@ import { HeaderRecordingIndicator } from '@/components/recording';
 import { getChatApps } from '@/lib/api';
 import { cn } from '@/lib/utils';
 import { MemoriesPrefetcher } from '@/components/memories/MemoriesPrefetcher';
-import { ChatBubble } from '@/components/chat/ChatBubble';
+
+const ChatBubble = dynamic(
+  () => import('@/components/chat/ChatBubble').then((mod) => ({ default: mod.ChatBubble })),
+  { ssr: false },
+);
 
 // Dynamic imports for panels - not visible on initial load
 const ChatPanel = dynamic(

--- a/web/app/src/components/layout/Sidebar.tsx
+++ b/web/app/src/components/layout/Sidebar.tsx
@@ -54,6 +54,7 @@ import { cn } from '@/lib/utils';
 import { SETTINGS_SECTIONS, type SettingsSectionId } from '@/lib/settingsSections';
 import { PROFILE_MENU_MAX_HEIGHT } from '@/lib/profileMenu';
 import { ConfettiBurst } from '@/components/ui/ConfettiBurst';
+import { OpenSurface } from '@/components/ui/OpenSurface';
 
 /** How long the banner takes to swell and pop, and the burst to clear it. */
 const BANNER_BURST_MS = 420;
@@ -461,10 +462,10 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
               >
                 <div className="relative">
                   <Bell className="w-5 h-5" />
-                  {unreadCount > 0 && (
+                  <span className="t-badge" data-open={unreadCount > 0 ? 'true' : 'false'}>
                     <span
                       className={cn(
-                        'absolute -top-2.5 -right-2.5',
+                        't-badge-dot',
                         'min-w-[18px] h-[18px] px-1',
                         'flex items-center justify-center',
                         'bg-red-500 text-white text-[10px] font-bold',
@@ -473,7 +474,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                     >
                       {unreadCount > 99 ? '99+' : unreadCount}
                     </span>
-                  )}
+                  </span>
                 </div>
               </button>
 
@@ -490,11 +491,14 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                   title={isExpanded ? 'Collapse sidebar' : 'Expand sidebar'}
                   aria-label={isExpanded ? 'Collapse sidebar' : 'Expand sidebar'}
                 >
-                  {isExpanded ? (
-                    <PanelLeftClose className="w-5 h-5" />
-                  ) : (
-                    <PanelLeft className="w-5 h-5" />
-                  )}
+                  <span className="t-icon-swap" data-state={isExpanded ? 'a' : 'b'}>
+                    <span className="t-icon" data-icon="a">
+                      <PanelLeftClose className="w-5 h-5" />
+                    </span>
+                    <span className="t-icon" data-icon="b">
+                      <PanelLeft className="w-5 h-5" />
+                    </span>
+                  </span>
                 </button>
               )}
 
@@ -784,16 +788,17 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
 
           {/* Collapsed: the menu is a popover beside the rail. */}
           {!showText && menuOpen && (
-            <div
+            <OpenSurface
+              data-origin="bottom-left"
               className={cn(
+                't-dropdown',
                 'absolute bottom-0 left-full z-[60] ml-2 w-64 origin-bottom-left',
                 'overflow-hidden rounded-card border border-stroke bg-bg-raised',
                 'shadow-[0_18px_40px_-12px_rgba(0,0,0,0.6)]',
-                'animate-slideUp',
               )}
             >
               <ProfileMenuRows onNavigate={closeUserMenu} onSignOut={handleSignOut} />
-            </div>
+            </OpenSurface>
           )}
         </div>
       </aside>

--- a/web/app/src/components/layout/Sidebar.tsx
+++ b/web/app/src/components/layout/Sidebar.tsx
@@ -787,8 +787,9 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
           </button>
 
           {/* Collapsed: the menu is a popover beside the rail. */}
-          {!showText && menuOpen && (
+          {!showText && (
             <OpenSurface
+              open={menuOpen}
               data-origin="bottom-left"
               className={cn(
                 't-dropdown',

--- a/web/app/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/web/app/src/components/layout/__tests__/Sidebar.test.tsx
@@ -153,4 +153,3 @@ describe('notification badge', () => {
     expect(container.querySelector('.t-badge')).toHaveAttribute('data-open', 'false');
   });
 });
-

--- a/web/app/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/web/app/src/components/layout/__tests__/Sidebar.test.tsx
@@ -25,13 +25,19 @@ vi.mock('@/components/auth/AuthProvider', () => ({
     signOut: vi.fn(),
   }),
 }));
+const notificationState = vi.hoisted(() => ({ unreadCount: 0 }));
+
 vi.mock('@/components/notifications/NotificationContext', () => ({
-  useNotificationContext: () => ({ toggleNotificationCenter: vi.fn(), unreadCount: 0 }),
+  useNotificationContext: () => ({
+    toggleNotificationCenter: vi.fn(),
+    unreadCount: notificationState.unreadCount,
+  }),
 }));
 
 beforeEach(() => {
   localStorage.clear();
   vi.clearAllMocks();
+  notificationState.unreadCount = 0;
   reducedMotion = false;
   Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1440 });
   Object.defineProperty(window, 'innerHeight', { configurable: true, value: 900 });
@@ -127,5 +133,16 @@ describe('macOS promotion dismissal', () => {
     await act(async () => {
       await new Promise((resolve) => window.setTimeout(resolve, 430));
     });
+  });
+});
+
+describe('notification badge', () => {
+  it('opens the t-badge when there is unread mail', async () => {
+    notificationState.unreadCount = 4;
+    const { container } = render(<Sidebar isOpen onClose={vi.fn()} />);
+    await screen.findByTitle('Home');
+    const badge = container.querySelector('.t-badge');
+    expect(badge).toHaveAttribute('data-open', 'true');
+    expect(container.querySelector('.t-badge-dot')).toHaveTextContent('4');
   });
 });

--- a/web/app/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/web/app/src/components/layout/__tests__/Sidebar.test.tsx
@@ -145,4 +145,12 @@ describe('notification badge', () => {
     expect(badge).toHaveAttribute('data-open', 'true');
     expect(container.querySelector('.t-badge-dot')).toHaveTextContent('4');
   });
+
+  it('keeps the t-badge closed when there is no unread mail', async () => {
+    notificationState.unreadCount = 0;
+    const { container } = render(<Sidebar isOpen onClose={vi.fn()} />);
+    await screen.findByTitle('Home');
+    expect(container.querySelector('.t-badge')).toHaveAttribute('data-open', 'false');
+  });
 });
+

--- a/web/app/src/components/notifications/NotificationCenter.tsx
+++ b/web/app/src/components/notifications/NotificationCenter.tsx
@@ -8,6 +8,7 @@ import { NotificationItem } from './NotificationItem';
 import { NotificationPermissionBanner } from './NotificationPermissionBanner';
 import { cn } from '@/lib/utils';
 import type { OmiNotification } from '@/types/notification';
+import { PanelReveal } from '@/components/ui/PanelReveal';
 
 /**
  * Group notifications by date (Today, Yesterday, Earlier)
@@ -94,7 +95,7 @@ export function NotificationCenter() {
               'max-sm:fixed max-sm:inset-0 max-sm:z-50 max-sm:w-full',
             )}
           >
-            <div className={cn('w-[400px] h-full flex flex-col', 'max-sm:w-full')}>
+            <PanelReveal className={cn('w-[400px] h-full flex flex-col', 'max-sm:w-full')}>
               {/* Header */}
               <div className="flex items-center justify-between p-4 border-b border-bg-tertiary">
                 <div className="flex items-center gap-3">
@@ -198,7 +199,7 @@ export function NotificationCenter() {
                   </div>
                 )}
               </div>
-            </div>
+            </PanelReveal>
           </motion.div>
         </>
       )}

--- a/web/app/src/components/tasks/TaskRow.tsx
+++ b/web/app/src/components/tasks/TaskRow.tsx
@@ -6,6 +6,7 @@ import { Check, Trash2, Clock, Calendar, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { formatDueBadge } from '@/lib/taskDue';
 import type { ActionItem } from '@/types/conversation';
+import { SuccessCheck } from '@/components/ui/SuccessCheck';
 
 interface TaskRowProps {
   task: ActionItem;
@@ -193,7 +194,9 @@ export function TaskRow({
           )}
         >
           {(task.completed || isCompleting) && (
-            <Check className="w-2.5 h-2.5 text-white" strokeWidth={3} />
+            <SuccessCheck active={task.completed || isCompleting}>
+              <Check className="w-2.5 h-2.5 text-white" strokeWidth={3} />
+            </SuccessCheck>
           )}
         </button>
       )}

--- a/web/app/src/components/tasks/__tests__/TaskRow.test.tsx
+++ b/web/app/src/components/tasks/__tests__/TaskRow.test.tsx
@@ -36,4 +36,19 @@ describe('TaskRow', () => {
     expect(onSnooze).toHaveBeenCalledWith('task-1', 1);
     expect(onEnterSelectionMode).not.toHaveBeenCalled();
   });
+
+  it('plays the success-check appear when a task is completed', () => {
+    const { container } = render(
+      <TaskRow
+        task={task({ completed: true })}
+        onToggleComplete={vi.fn()}
+        onSnooze={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    const check = container.querySelector('.t-success-check');
+    expect(check).not.toBeNull();
+    expect(check).toHaveAttribute('data-state', 'in');
+  });
 });

--- a/web/app/src/components/ui/ConfirmDialog.tsx
+++ b/web/app/src/components/ui/ConfirmDialog.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import * as Dialog from '@radix-ui/react-dialog';
-import { motion, AnimatePresence } from 'framer-motion';
 import { X, AlertTriangle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { OpenSurface } from '@/components/ui/OpenSurface';
@@ -38,113 +37,100 @@ export function ConfirmDialog({
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <AnimatePresence>
-        {open && (
-          <Dialog.Portal forceMount>
-            <Dialog.Overlay asChild>
-              <motion.div
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.15 }}
-                className="fixed inset-0 bg-black/50 z-[100]"
-              />
-            </Dialog.Overlay>
-            <Dialog.Content asChild>
-              <div
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[100] bg-black/50 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content
+          className={cn(
+            'fixed left-1/2 top-1/2 z-[101] w-[90vw] max-w-[400px] -translate-x-1/2 -translate-y-1/2',
+            'focus:outline-none',
+            'duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out',
+            'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+          )}
+        >
+          <OpenSurface
+            className={cn(
+              't-modal relative',
+              'bg-bg-secondary rounded-2xl',
+              'border border-bg-tertiary',
+              'shadow-2xl',
+              'p-6',
+            )}
+          >
+            {/* Close button */}
+            <Dialog.Close asChild>
+              <button
+                className="absolute top-4 right-4 p-1.5 rounded-lg hover:bg-bg-tertiary transition-colors"
+                aria-label="Close"
+              >
+                <X className="w-4 h-4 text-text-quaternary" />
+              </button>
+            </Dialog.Close>
+
+            {/* Icon */}
+            <div
+              className={cn(
+                'w-12 h-12 rounded-full flex items-center justify-center mb-4',
+                variant === 'danger' ? 'bg-error/10' : 'bg-white/[0.08]',
+              )}
+            >
+              <AlertTriangle
                 className={cn(
-                  'fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[101]',
-                  'w-[90vw] max-w-[400px]',
-                  'focus:outline-none',
+                  'w-6 h-6',
+                  variant === 'danger' ? 'text-error' : 'text-text-primary',
+                )}
+              />
+            </div>
+
+            {/* Title */}
+            <Dialog.Title className="text-lg font-semibold text-text-primary mb-2">
+              {title}
+            </Dialog.Title>
+
+            {/* Description */}
+            <Dialog.Description className="text-sm text-text-tertiary mb-6">
+              {description}
+            </Dialog.Description>
+
+            {/* Actions */}
+            <div className="flex gap-3">
+              <Dialog.Close asChild>
+                <button
+                  className={cn(
+                    'flex-1 px-4 py-2.5 rounded-xl',
+                    'bg-bg-tertiary hover:bg-bg-quaternary',
+                    'text-text-secondary text-sm font-medium',
+                    'transition-colors',
+                  )}
+                >
+                  {cancelLabel}
+                </button>
+              </Dialog.Close>
+              <button
+                onClick={handleConfirm}
+                disabled={isLoading}
+                className={cn(
+                  'flex-1 px-4 py-2.5 rounded-xl',
+                  'text-white text-sm font-medium',
+                  'transition-colors',
+                  'disabled:opacity-50 disabled:cursor-not-allowed',
+                  variant === 'danger'
+                    ? 'bg-error hover:bg-error/90'
+                    : 'bg-text-primary text-bg-primary hover:bg-text-primary/90',
                 )}
               >
-                <OpenSurface
-                  className={cn(
-                    't-modal relative',
-                    'bg-bg-secondary rounded-2xl',
-                    'border border-bg-tertiary',
-                    'shadow-2xl',
-                    'p-6',
-                  )}
-                >
-                {/* Close button */}
-                <Dialog.Close asChild>
-                  <button
-                    className="absolute top-4 right-4 p-1.5 rounded-lg hover:bg-bg-tertiary transition-colors"
-                    aria-label="Close"
-                  >
-                    <X className="w-4 h-4 text-text-quaternary" />
-                  </button>
-                </Dialog.Close>
-
-                {/* Icon */}
-                <div
-                  className={cn(
-                    'w-12 h-12 rounded-full flex items-center justify-center mb-4',
-                    variant === 'danger' ? 'bg-error/10' : 'bg-white/[0.08]',
-                  )}
-                >
-                  <AlertTriangle
-                    className={cn(
-                      'w-6 h-6',
-                      variant === 'danger' ? 'text-error' : 'text-text-primary',
-                    )}
-                  />
-                </div>
-
-                {/* Title */}
-                <Dialog.Title className="text-lg font-semibold text-text-primary mb-2">
-                  {title}
-                </Dialog.Title>
-
-                {/* Description */}
-                <Dialog.Description className="text-sm text-text-tertiary mb-6">
-                  {description}
-                </Dialog.Description>
-
-                {/* Actions */}
-                <div className="flex gap-3">
-                  <Dialog.Close asChild>
-                    <button
-                      className={cn(
-                        'flex-1 px-4 py-2.5 rounded-xl',
-                        'bg-bg-tertiary hover:bg-bg-quaternary',
-                        'text-text-secondary text-sm font-medium',
-                        'transition-colors',
-                      )}
-                    >
-                      {cancelLabel}
-                    </button>
-                  </Dialog.Close>
-                  <button
-                    onClick={handleConfirm}
-                    disabled={isLoading}
-                    className={cn(
-                      'flex-1 px-4 py-2.5 rounded-xl',
-                      'text-white text-sm font-medium',
-                      'transition-colors',
-                      'disabled:opacity-50 disabled:cursor-not-allowed',
-                      variant === 'danger'
-                        ? 'bg-error hover:bg-error/90'
-                        : 'bg-text-primary text-bg-primary hover:bg-text-primary/90',
-                    )}
-                  >
-                    {isLoading ? (
-                      <span className="flex items-center justify-center gap-2">
-                        <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                        <span>Clearing...</span>
-                      </span>
-                    ) : (
-                      confirmLabel
-                    )}
-                  </button>
-                </div>
-                </OpenSurface>
-              </div>
-            </Dialog.Content>
-          </Dialog.Portal>
-        )}
-      </AnimatePresence>
+                {isLoading ? (
+                  <span className="flex items-center justify-center gap-2">
+                    <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                    <span>Clearing...</span>
+                  </span>
+                ) : (
+                  confirmLabel
+                )}
+              </button>
+            </div>
+          </OpenSurface>
+        </Dialog.Content>
+      </Dialog.Portal>
     </Dialog.Root>
   );
 }

--- a/web/app/src/components/ui/ConfirmDialog.tsx
+++ b/web/app/src/components/ui/ConfirmDialog.tsx
@@ -4,6 +4,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X, AlertTriangle } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { OpenSurface } from '@/components/ui/OpenSurface';
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -50,21 +51,22 @@ export function ConfirmDialog({
               />
             </Dialog.Overlay>
             <Dialog.Content asChild>
-              <motion.div
-                initial={{ opacity: 0, scale: 0.95, y: 10 }}
-                animate={{ opacity: 1, scale: 1, y: 0 }}
-                exit={{ opacity: 0, scale: 0.95, y: 10 }}
-                transition={{ duration: 0.15, ease: 'easeOut' }}
+              <div
                 className={cn(
                   'fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[101]',
                   'w-[90vw] max-w-[400px]',
-                  'bg-bg-secondary rounded-2xl',
-                  'border border-bg-tertiary',
-                  'shadow-2xl',
-                  'p-6',
                   'focus:outline-none',
                 )}
               >
+                <OpenSurface
+                  className={cn(
+                    't-modal relative',
+                    'bg-bg-secondary rounded-2xl',
+                    'border border-bg-tertiary',
+                    'shadow-2xl',
+                    'p-6',
+                  )}
+                >
                 {/* Close button */}
                 <Dialog.Close asChild>
                   <button
@@ -137,7 +139,8 @@ export function ConfirmDialog({
                     )}
                   </button>
                 </div>
-              </motion.div>
+                </OpenSurface>
+              </div>
             </Dialog.Content>
           </Dialog.Portal>
         )}

--- a/web/app/src/components/ui/OpenSurface.tsx
+++ b/web/app/src/components/ui/OpenSurface.tsx
@@ -1,28 +1,119 @@
 'use client';
 
-import { useLayoutEffect, useRef, type HTMLAttributes, type ReactNode } from 'react';
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
 import { cn } from '@/lib/utils';
+import { prefersReducedMotion, readDurationToken } from '@/lib/transitionsDev';
+
+function closeMs(className?: string): number {
+  if (typeof className === 'string' && className.includes('t-modal')) {
+    return readDurationToken('--modal-close-dur', 150);
+  }
+  return readDurationToken('--dropdown-close-dur', 150);
+}
 
 export function OpenSurface({
+  open = true,
+  onExited,
   className,
   children,
   ...props
-}: HTMLAttributes<HTMLDivElement> & { children: ReactNode }) {
+}: HTMLAttributes<HTMLDivElement> & {
+  children: ReactNode;
+  open?: boolean;
+  onExited?: () => void;
+}) {
   const ref = useRef<HTMLDivElement>(null);
+  const onExitedRef = useRef(onExited);
+  onExitedRef.current = onExited;
+  const [mounted, setMounted] = useState(open);
+  const [phase, setPhase] = useState<'idle' | 'open' | 'closing'>('idle');
 
   useLayoutEffect(() => {
+    if (open) setMounted(true);
+  }, [open]);
+
+  useLayoutEffect(() => {
+    if (!mounted) return;
     const el = ref.current;
-    if (!el) return;
-    el.classList.remove('is-closing');
-    el.classList.add('is-open');
-    return () => {
-      el.classList.remove('is-open');
-      el.classList.add('is-closing');
+    const host = el?.parentElement?.closest('[data-state]');
+
+    if (host) {
+      let enterFrame = 0;
+      const sync = () => {
+        cancelAnimationFrame(enterFrame);
+        if (host.getAttribute('data-state') === 'closed') {
+          setPhase('closing');
+          return;
+        }
+        setPhase('idle');
+        enterFrame = requestAnimationFrame(() => setPhase('open'));
+      };
+      sync();
+      const observer = new MutationObserver(sync);
+      observer.observe(host, { attributes: true, attributeFilter: ['data-state'] });
+      return () => {
+        cancelAnimationFrame(enterFrame);
+        observer.disconnect();
+      };
+    }
+
+    if (!open) {
+      setPhase('closing');
+      return;
+    }
+
+    setPhase('idle');
+    const enterFrame = requestAnimationFrame(() => setPhase('open'));
+    return () => cancelAnimationFrame(enterFrame);
+  }, [mounted, open]);
+
+  useEffect(() => {
+    if (open || !mounted) return;
+    const finish = () => {
+      setMounted(false);
+      onExitedRef.current?.();
     };
-  }, []);
+    if (prefersReducedMotion()) {
+      finish();
+      return;
+    }
+    const el = ref.current;
+    let finished = false;
+    const once = () => {
+      if (finished) return;
+      finished = true;
+      finish();
+    };
+    const onEnd = (event: TransitionEvent) => {
+      if (event.target === el) once();
+    };
+    el?.addEventListener('transitionend', onEnd);
+    const timer = window.setTimeout(once, closeMs(className) + 50);
+    return () => {
+      el?.removeEventListener('transitionend', onEnd);
+      window.clearTimeout(timer);
+    };
+  }, [open, mounted, className]);
+
+  if (!mounted) return null;
 
   return (
-    <div ref={ref} className={cn(className)} {...props}>
+    <div
+      ref={ref}
+      className={cn(
+        className,
+        phase === 'open' && 'is-open',
+        phase === 'closing' && 'is-closing',
+      )}
+      {...props}
+    >
       {children}
     </div>
   );

--- a/web/app/src/components/ui/OpenSurface.tsx
+++ b/web/app/src/components/ui/OpenSurface.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useLayoutEffect, useRef, type HTMLAttributes, type ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export function OpenSurface({
+  className,
+  children,
+  ...props
+}: HTMLAttributes<HTMLDivElement> & { children: ReactNode }) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.classList.remove('is-closing');
+    el.classList.add('is-open');
+    return () => {
+      el.classList.remove('is-open');
+      el.classList.add('is-closing');
+    };
+  }, []);
+
+  return (
+    <div ref={ref} className={cn(className)} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/web/app/src/components/ui/OpenSurface.tsx
+++ b/web/app/src/components/ui/OpenSurface.tsx
@@ -45,33 +45,23 @@ export function OpenSurface({
     const host = el?.parentElement?.closest('[data-state]');
 
     if (host) {
-      let enterFrame = 0;
       const sync = () => {
-        cancelAnimationFrame(enterFrame);
-        if (host.getAttribute('data-state') === 'closed') {
-          setPhase('closing');
-          return;
-        }
-        setPhase('idle');
-        enterFrame = requestAnimationFrame(() => setPhase('open'));
+        setPhase(host.getAttribute('data-state') === 'closed' ? 'closing' : 'open');
       };
-      sync();
+      if (host.getAttribute('data-state') === 'closed') {
+        setPhase('closing');
+      }
       const observer = new MutationObserver(sync);
       observer.observe(host, { attributes: true, attributeFilter: ['data-state'] });
-      return () => {
-        cancelAnimationFrame(enterFrame);
-        observer.disconnect();
-      };
+      return () => observer.disconnect();
     }
 
-    if (!open) {
-      setPhase('closing');
-      return;
-    }
+    setPhase(open ? 'idle' : 'closing');
+  }, [mounted, open]);
 
-    setPhase('idle');
-    const enterFrame = requestAnimationFrame(() => setPhase('open'));
-    return () => cancelAnimationFrame(enterFrame);
+  useEffect(() => {
+    if (!mounted || !open) return;
+    setPhase((current) => (current === 'closing' ? current : 'open'));
   }, [mounted, open]);
 
   useEffect(() => {

--- a/web/app/src/components/ui/OpenSurface.tsx
+++ b/web/app/src/components/ui/OpenSurface.tsx
@@ -42,7 +42,8 @@ export function OpenSurface({
   useLayoutEffect(() => {
     if (!mounted) return;
     const el = ref.current;
-    const host = el?.parentElement?.closest('[data-state]');
+    const parent = el?.parentElement;
+    const host = parent?.hasAttribute('data-state') ? parent : null;
 
     if (host) {
       const sync = () => {

--- a/web/app/src/components/ui/PageSlide.tsx
+++ b/web/app/src/components/ui/PageSlide.tsx
@@ -14,6 +14,7 @@ export function PageSlide({
   className?: string;
 }) {
   const ref = useRef<HTMLDivElement>(null);
+  const pageRef = useRef<HTMLElement>(null);
 
   useLayoutEffect(() => {
     const el = ref.current;
@@ -28,7 +29,7 @@ export function PageSlide({
       return;
     }
 
-    const page = el.querySelector('.t-page');
+    const page = pageRef.current;
     const settle = () => el.setAttribute('data-settled', '');
     page?.addEventListener('transitionend', settle);
     const timer = window.setTimeout(settle, readDurationToken('--page-slide-dur', 250) + 80);
@@ -40,7 +41,7 @@ export function PageSlide({
 
   return (
     <div ref={ref} className={cn('t-page-slide h-full', className)} data-page="1">
-      <section className="t-page" data-page-id="2">
+      <section ref={pageRef} className="t-page" data-page-id="2">
         {children}
       </section>
     </div>

--- a/web/app/src/components/ui/PageSlide.tsx
+++ b/web/app/src/components/ui/PageSlide.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useLayoutEffect, useRef, type ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export function PageSlide({
+  pageKey,
+  children,
+  className,
+}: {
+  pageKey: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.setAttribute('data-page', '1');
+    void el.offsetWidth;
+    el.setAttribute('data-page', '2');
+  }, [pageKey]);
+
+  return (
+    <div ref={ref} className={cn('t-page-slide h-full', className)} data-page="1">
+      <section className="t-page" data-page-id="2">
+        {children}
+      </section>
+    </div>
+  );
+}

--- a/web/app/src/components/ui/PageSlide.tsx
+++ b/web/app/src/components/ui/PageSlide.tsx
@@ -2,6 +2,7 @@
 
 import { useLayoutEffect, useRef, type ReactNode } from 'react';
 import { cn } from '@/lib/utils';
+import { prefersReducedMotion, readDurationToken } from '@/lib/transitionsDev';
 
 export function PageSlide({
   pageKey,
@@ -17,9 +18,24 @@ export function PageSlide({
   useLayoutEffect(() => {
     const el = ref.current;
     if (!el) return;
+    el.removeAttribute('data-settled');
     el.setAttribute('data-page', '1');
     void el.offsetWidth;
     el.setAttribute('data-page', '2');
+
+    if (prefersReducedMotion()) {
+      el.setAttribute('data-settled', '');
+      return;
+    }
+
+    const page = el.querySelector('.t-page');
+    const settle = () => el.setAttribute('data-settled', '');
+    page?.addEventListener('transitionend', settle);
+    const timer = window.setTimeout(settle, readDurationToken('--page-slide-dur', 250) + 80);
+    return () => {
+      page?.removeEventListener('transitionend', settle);
+      window.clearTimeout(timer);
+    };
   }, [pageKey]);
 
   return (

--- a/web/app/src/components/ui/PanelReveal.tsx
+++ b/web/app/src/components/ui/PanelReveal.tsx
@@ -17,7 +17,14 @@ export function PanelReveal({
   useLayoutEffect(() => {
     const el = ref.current;
     if (!el) return;
-    el.setAttribute('data-open', open ? 'true' : 'false');
+    if (!open) {
+      el.setAttribute('data-open', 'false');
+      return;
+    }
+    const frame = requestAnimationFrame(() => {
+      el.setAttribute('data-open', 'true');
+    });
+    return () => cancelAnimationFrame(frame);
   }, [open]);
 
   return (

--- a/web/app/src/components/ui/PanelReveal.tsx
+++ b/web/app/src/components/ui/PanelReveal.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useLayoutEffect, useRef, type CSSProperties, type ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export function PanelReveal({
+  children,
+  className,
+  open = true,
+}: {
+  children: ReactNode;
+  className?: string;
+  open?: boolean;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.setAttribute('data-open', open ? 'true' : 'false');
+  }, [open]);
+
+  return (
+    <div
+      ref={ref}
+      className={cn('t-panel-slide', className)}
+      data-open="false"
+      style={{ '--panel-translate-y': '16px' } as CSSProperties}
+    >
+      {children}
+    </div>
+  );
+}

--- a/web/app/src/components/ui/PanelReveal.tsx
+++ b/web/app/src/components/ui/PanelReveal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useLayoutEffect, useRef, type CSSProperties, type ReactNode } from 'react';
+import { useEffect, useLayoutEffect, useRef, type CSSProperties, type ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 
 export function PanelReveal({
@@ -17,14 +17,13 @@ export function PanelReveal({
   useLayoutEffect(() => {
     const el = ref.current;
     if (!el) return;
-    if (!open) {
-      el.setAttribute('data-open', 'false');
-      return;
-    }
-    const frame = requestAnimationFrame(() => {
-      el.setAttribute('data-open', 'true');
-    });
-    return () => cancelAnimationFrame(frame);
+    if (!open) el.setAttribute('data-open', 'false');
+  }, [open]);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.setAttribute('data-open', open ? 'true' : 'false');
   }, [open]);
 
   return (

--- a/web/app/src/components/ui/ResizeHandle.tsx
+++ b/web/app/src/components/ui/ResizeHandle.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils';
 
 interface ResizeHandleProps {
   onResize: (delta: number) => void;
+  onResizeStart?: () => void;
   onResizeEnd?: () => void;
   onDoubleClick?: () => void;
   className?: string;
@@ -12,6 +13,7 @@ interface ResizeHandleProps {
 
 export function ResizeHandle({
   onResize,
+  onResizeStart,
   onResizeEnd,
   onDoubleClick,
   className,
@@ -24,7 +26,8 @@ export function ResizeHandle({
     e.preventDefault();
     setIsDragging(true);
     startXRef.current = e.clientX;
-  }, []);
+    onResizeStart?.();
+  }, [onResizeStart]);
 
   const handleMouseMove = useCallback(
     (e: MouseEvent) => {

--- a/web/app/src/components/ui/SuccessCheck.tsx
+++ b/web/app/src/components/ui/SuccessCheck.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useLayoutEffect, useRef, type CSSProperties, type ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export function SuccessCheck({
+  active,
+  children,
+  className,
+}: {
+  active: boolean;
+  children: ReactNode;
+  className?: string;
+}) {
+  const ref = useRef<HTMLSpanElement>(null);
+
+  useLayoutEffect(() => {
+    const path = ref.current?.querySelector('path');
+    if (!path || typeof path.getTotalLength !== 'function') return;
+    try {
+      const len = Math.ceil(path.getTotalLength());
+      path.style.strokeDasharray = String(len);
+      path.style.strokeDashoffset = String(len);
+    } catch {
+      return;
+    }
+  }, [children]);
+
+  return (
+    <span
+      ref={ref}
+      className={cn('t-success-check', className)}
+      data-state={active ? 'in' : 'out'}
+      aria-hidden="true"
+      style={
+        {
+          '--check-y-amount': '3px',
+          '--check-blur-from': '2px',
+          '--check-rotate-from': '25deg',
+        } as CSSProperties
+      }
+    >
+      {children}
+    </span>
+  );
+}

--- a/web/app/src/components/ui/TextSwap.tsx
+++ b/web/app/src/components/ui/TextSwap.tsx
@@ -15,7 +15,10 @@ export function TextSwap({
   const [phase, setPhase] = useState<'idle' | 'exit' | 'enter-start'>('idle');
 
   useEffect(() => {
-    if (text === display) return;
+    if (text === display) {
+      if (phase !== 'idle') setPhase('idle');
+      return;
+    }
     if (prefersReducedMotion()) {
       setDisplay(text);
       setPhase('idle');
@@ -28,7 +31,7 @@ export function TextSwap({
       setPhase('enter-start');
     }, dur);
     return () => window.clearTimeout(timer);
-  }, [text, display]);
+  }, [text, display, phase]);
 
   useLayoutEffect(() => {
     if (phase !== 'enter-start') return;

--- a/web/app/src/components/ui/TextSwap.tsx
+++ b/web/app/src/components/ui/TextSwap.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect, useLayoutEffect, useState } from 'react';
+import { cn } from '@/lib/utils';
+import { prefersReducedMotion, readDurationToken } from '@/lib/transitionsDev';
+
+export function TextSwap({
+  text,
+  className,
+}: {
+  text: string;
+  className?: string;
+}) {
+  const [display, setDisplay] = useState(text);
+  const [phase, setPhase] = useState<'idle' | 'exit' | 'enter-start'>('idle');
+
+  useEffect(() => {
+    if (text === display) return;
+    if (prefersReducedMotion()) {
+      setDisplay(text);
+      setPhase('idle');
+      return;
+    }
+    setPhase('exit');
+    const dur = readDurationToken('--text-swap-dur', 150);
+    const timer = window.setTimeout(() => {
+      setDisplay(text);
+      setPhase('enter-start');
+    }, dur);
+    return () => window.clearTimeout(timer);
+  }, [text, display]);
+
+  useLayoutEffect(() => {
+    if (phase !== 'enter-start') return;
+    void document.body.offsetHeight;
+    setPhase('idle');
+  }, [phase]);
+
+  return (
+    <span
+      className={cn(
+        't-text-swap',
+        phase === 'exit' && 'is-exit',
+        phase === 'enter-start' && 'is-enter-start',
+        className,
+      )}
+    >
+      {display}
+    </span>
+  );
+}

--- a/web/app/src/components/ui/__tests__/OpenSurface.test.tsx
+++ b/web/app/src/components/ui/__tests__/OpenSurface.test.tsx
@@ -1,0 +1,61 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OpenSurface } from '@/components/ui/OpenSurface';
+
+describe('OpenSurface', () => {
+  beforeEach(() => {
+    document.documentElement.style.setProperty('--dropdown-close-dur', '150ms');
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({
+        matches: false,
+        media: '(prefers-reduced-motion: reduce)',
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        onchange: null,
+      })),
+    );
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (cb: FrameRequestCallback) => window.setTimeout(() => cb(0), 0),
+    );
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('stays mounted through the close transition', () => {
+    vi.useFakeTimers();
+    const onExited = vi.fn();
+    const { rerender } = render(
+      <OpenSurface open className="t-dropdown" onExited={onExited}>
+        Menu
+      </OpenSurface>,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(screen.getByText('Menu')).toHaveClass('is-open');
+
+    rerender(
+      <OpenSurface open={false} className="t-dropdown" onExited={onExited}>
+        Menu
+      </OpenSurface>,
+    );
+    expect(screen.getByText('Menu')).toHaveClass('is-closing');
+    expect(onExited).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(screen.queryByText('Menu')).toBeNull();
+    expect(onExited).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/app/src/components/ui/__tests__/OpenSurface.test.tsx
+++ b/web/app/src/components/ui/__tests__/OpenSurface.test.tsx
@@ -50,4 +50,18 @@ describe('OpenSurface', () => {
     expect(screen.queryByText('Menu')).toBeNull();
     expect(onExited).toHaveBeenCalledTimes(1);
   });
+
+  it('does not treat a distant data-state ancestor as the close host', () => {
+    render(
+      <div data-state="closed">
+        <div>
+          <OpenSurface open className="t-dropdown">
+            Menu
+          </OpenSurface>
+        </div>
+      </div>,
+    );
+    expect(screen.getByText('Menu')).toHaveClass('is-open');
+    expect(screen.getByText('Menu')).not.toHaveClass('is-closing');
+  });
 });

--- a/web/app/src/components/ui/__tests__/OpenSurface.test.tsx
+++ b/web/app/src/components/ui/__tests__/OpenSurface.test.tsx
@@ -18,11 +18,6 @@ describe('OpenSurface', () => {
         onchange: null,
       })),
     );
-    vi.stubGlobal(
-      'requestAnimationFrame',
-      (cb: FrameRequestCallback) => window.setTimeout(() => cb(0), 0),
-    );
-    vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id));
   });
 
   afterEach(() => {
@@ -39,9 +34,6 @@ describe('OpenSurface', () => {
       </OpenSurface>,
     );
 
-    act(() => {
-      vi.advanceTimersByTime(0);
-    });
     expect(screen.getByText('Menu')).toHaveClass('is-open');
 
     rerender(

--- a/web/app/src/components/ui/__tests__/PageSlide.test.tsx
+++ b/web/app/src/components/ui/__tests__/PageSlide.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { PageSlide } from '@/components/ui/PageSlide';
+
+describe('PageSlide', () => {
+  it('flips data-page so the incoming t-page can enter', () => {
+    const { container, rerender } = render(
+      <PageSlide pageKey="/home">
+        <p>Home</p>
+      </PageSlide>,
+    );
+
+    const slider = container.querySelector('.t-page-slide');
+    expect(slider).not.toBeNull();
+    expect(slider).toHaveAttribute('data-page', '2');
+    expect(container.querySelector('.t-page')).toHaveAttribute('data-page-id', '2');
+
+    rerender(
+      <PageSlide pageKey="/conversations">
+        <p>Conversations</p>
+      </PageSlide>,
+    );
+    expect(container.querySelector('.t-page-slide')).toHaveAttribute('data-page', '2');
+  });
+});

--- a/web/app/src/components/ui/__tests__/PageSlide.test.tsx
+++ b/web/app/src/components/ui/__tests__/PageSlide.test.tsx
@@ -1,8 +1,30 @@
-import { render } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PageSlide } from '@/components/ui/PageSlide';
 
 describe('PageSlide', () => {
+  beforeEach(() => {
+    document.documentElement.style.setProperty('--page-slide-dur', '250ms');
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({
+        matches: false,
+        media: '(prefers-reduced-motion: reduce)',
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        onchange: null,
+      })),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
   it('flips data-page so the incoming t-page can enter', () => {
     const { container, rerender } = render(
       <PageSlide pageKey="/home">
@@ -21,5 +43,20 @@ describe('PageSlide', () => {
       </PageSlide>,
     );
     expect(container.querySelector('.t-page-slide')).toHaveAttribute('data-page', '2');
+  });
+
+  it('clears the page transform after the enter transition settles', () => {
+    const { container } = render(
+      <PageSlide pageKey="/home">
+        <p>Home</p>
+      </PageSlide>,
+    );
+    const slider = container.querySelector('.t-page-slide');
+    expect(slider).not.toHaveAttribute('data-settled');
+
+    act(() => {
+      container.querySelector('.t-page')?.dispatchEvent(new Event('transitionend'));
+    });
+    expect(slider).toHaveAttribute('data-settled');
   });
 });

--- a/web/app/src/components/ui/__tests__/PanelReveal.test.tsx
+++ b/web/app/src/components/ui/__tests__/PanelReveal.test.tsx
@@ -1,0 +1,34 @@
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PanelReveal } from '@/components/ui/PanelReveal';
+
+describe('PanelReveal', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (cb: FrameRequestCallback) => window.setTimeout(() => cb(0), 0),
+    );
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('paints closed before opening so the CSS transition can run', () => {
+    vi.useFakeTimers();
+    const { container } = render(
+      <PanelReveal>
+        <p>Panel</p>
+      </PanelReveal>,
+    );
+    const el = container.querySelector('.t-panel-slide');
+    expect(el).toHaveAttribute('data-open', 'false');
+
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(el).toHaveAttribute('data-open', 'true');
+  });
+});

--- a/web/app/src/components/ui/__tests__/PanelReveal.test.tsx
+++ b/web/app/src/components/ui/__tests__/PanelReveal.test.tsx
@@ -1,34 +1,27 @@
-import { act, render } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { useLayoutEffect, useRef } from 'react';
+import { describe, expect, it } from 'vitest';
 import { PanelReveal } from '@/components/ui/PanelReveal';
 
 describe('PanelReveal', () => {
-  beforeEach(() => {
-    vi.stubGlobal(
-      'requestAnimationFrame',
-      (cb: FrameRequestCallback) => window.setTimeout(() => cb(0), 0),
-    );
-    vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id));
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    vi.useRealTimers();
-  });
-
   it('paints closed before opening so the CSS transition can run', () => {
-    vi.useFakeTimers();
+    const firstLayout: string[] = [];
+
+    function Probe() {
+      const ref = useRef<HTMLSpanElement>(null);
+      useLayoutEffect(() => {
+        firstLayout.push(ref.current?.parentElement?.getAttribute('data-open') ?? '');
+      }, []);
+      return <span ref={ref}>Panel</span>;
+    }
+
     const { container } = render(
       <PanelReveal>
-        <p>Panel</p>
+        <Probe />
       </PanelReveal>,
     );
-    const el = container.querySelector('.t-panel-slide');
-    expect(el).toHaveAttribute('data-open', 'false');
 
-    act(() => {
-      vi.advanceTimersByTime(0);
-    });
-    expect(el).toHaveAttribute('data-open', 'true');
+    expect(firstLayout[0]).toBe('false');
+    expect(container.querySelector('.t-panel-slide')).toHaveAttribute('data-open', 'true');
   });
 });

--- a/web/app/src/components/ui/__tests__/TextSwap.test.tsx
+++ b/web/app/src/components/ui/__tests__/TextSwap.test.tsx
@@ -73,4 +73,3 @@ describe('TextSwap', () => {
     expect(el).not.toHaveClass('is-exit');
   });
 });
-

--- a/web/app/src/components/ui/__tests__/TextSwap.test.tsx
+++ b/web/app/src/components/ui/__tests__/TextSwap.test.tsx
@@ -1,0 +1,42 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TextSwap } from '@/components/ui/TextSwap';
+
+describe('TextSwap', () => {
+  beforeEach(() => {
+    document.documentElement.style.setProperty('--text-swap-dur', '150ms');
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({
+        matches: false,
+        media: '(prefers-reduced-motion: reduce)',
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        onchange: null,
+      })),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('swaps text through the t-text-swap exit/enter classes', () => {
+    vi.useFakeTimers();
+    const { rerender } = render(<TextSwap text="Select" />);
+    const el = screen.getByText('Select');
+    expect(el).toHaveClass('t-text-swap');
+
+    rerender(<TextSwap text="Cancel" />);
+    expect(el).toHaveClass('is-exit');
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+  });
+});

--- a/web/app/src/components/ui/__tests__/TextSwap.test.tsx
+++ b/web/app/src/components/ui/__tests__/TextSwap.test.tsx
@@ -39,4 +39,38 @@ describe('TextSwap', () => {
     });
     expect(screen.getByText('Cancel')).toBeInTheDocument();
   });
+
+  it('returns to idle when the text reverses before the exit finishes', () => {
+    vi.useFakeTimers();
+    const { rerender } = render(<TextSwap text="Select" />);
+    const el = screen.getByText('Select');
+
+    rerender(<TextSwap text="Cancel" />);
+    expect(el).toHaveClass('is-exit');
+
+    rerender(<TextSwap text="Select" />);
+    expect(el).not.toHaveClass('is-exit');
+    expect(el).toHaveTextContent('Select');
+  });
+
+  it('swaps immediately when reduced motion is requested', () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({
+        matches: true,
+        media: '(prefers-reduced-motion: reduce)',
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        onchange: null,
+      })),
+    );
+    const { rerender } = render(<TextSwap text="Select" />);
+    rerender(<TextSwap text="Cancel" />);
+    const el = screen.getByText('Cancel');
+    expect(el).not.toHaveClass('is-exit');
+  });
 });
+

--- a/web/app/src/components/ui/dialog.tsx
+++ b/web/app/src/components/ui/dialog.tsx
@@ -40,6 +40,8 @@ const DialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         'fixed left-[50%] top-[50%] z-50 w-full max-w-lg translate-x-[-50%] translate-y-[-50%]',
+        'duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
         className,
       )}
       {...props}

--- a/web/app/src/components/ui/dialog.tsx
+++ b/web/app/src/components/ui/dialog.tsx
@@ -5,6 +5,7 @@ import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
+import { OpenSurface } from '@/components/ui/OpenSurface';
 
 const Dialog = DialogPrimitive.Root;
 
@@ -38,16 +39,23 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-card border border-stroke bg-bg-secondary p-6 text-text-primary shadow-strong duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        'fixed left-[50%] top-[50%] z-50 w-full max-w-lg translate-x-[-50%] translate-y-[-50%]',
         className,
       )}
       {...props}
     >
-      {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-element p-1 text-text-tertiary opacity-70 transition-opacity hover:bg-bg-tertiary hover:text-text-primary hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-white/40 disabled:pointer-events-none">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      <OpenSurface
+        className={cn(
+          't-modal relative grid gap-4 rounded-card border border-stroke bg-bg-secondary p-6 text-text-primary shadow-strong',
+          className,
+        )}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-element p-1 text-text-tertiary opacity-70 transition-opacity hover:bg-bg-tertiary hover:text-text-primary hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-white/40 disabled:pointer-events-none">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </OpenSurface>
     </DialogPrimitive.Content>
   </DialogPortal>
 ));

--- a/web/app/src/components/ui/dropdown-menu.tsx
+++ b/web/app/src/components/ui/dropdown-menu.tsx
@@ -43,8 +43,9 @@ const DropdownMenuSubContent = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.SubContent
     ref={ref}
+    data-origin="top-left"
     className={cn(
-      'z-50 min-w-[8rem] overflow-hidden rounded-section border border-stroke bg-bg-raised p-1 text-text-primary shadow-strong data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+      't-dropdown is-open z-50 min-w-[8rem] overflow-hidden rounded-section border border-stroke bg-bg-raised p-1 text-text-primary shadow-strong',
       className,
     )}
     {...props}
@@ -55,20 +56,41 @@ DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayNam
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <DropdownMenuPrimitive.Portal>
-    <DropdownMenuPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
-      className={cn(
-        'z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-section border border-stroke bg-bg-raised p-1 text-text-primary shadow-strong',
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-        className,
-      )}
-      {...props}
-    />
-  </DropdownMenuPrimitive.Portal>
-));
+>(({ className, sideOffset = 4, ...props }, ref) => {
+  const localRef = React.useRef<HTMLDivElement>(null);
+  React.useLayoutEffect(() => {
+    const el = localRef.current;
+    if (!el) return;
+    el.classList.remove('is-closing');
+    el.classList.add('is-open');
+    return () => {
+      el.classList.remove('is-open');
+      el.classList.add('is-closing');
+    };
+  }, []);
+  const setRefs = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      localRef.current = node;
+      if (typeof ref === 'function') ref(node);
+      else if (ref) (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+    },
+    [ref],
+  );
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        ref={setRefs}
+        sideOffset={sideOffset}
+        data-origin="top-left"
+        className={cn(
+          't-dropdown z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-section border border-stroke bg-bg-raised p-1 text-text-primary shadow-strong',
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+});
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
 const DropdownMenuItem = React.forwardRef<

--- a/web/app/src/components/ui/dropdown-menu.tsx
+++ b/web/app/src/components/ui/dropdown-menu.tsx
@@ -43,9 +43,8 @@ const DropdownMenuSubContent = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.SubContent
     ref={ref}
-    data-origin="top-left"
     className={cn(
-      't-dropdown is-open z-50 min-w-[8rem] overflow-hidden rounded-section border border-stroke bg-bg-raised p-1 text-text-primary shadow-strong',
+      't-dropdown z-50 min-w-[8rem] overflow-hidden rounded-section border border-stroke bg-bg-raised p-1 text-text-primary shadow-strong',
       className,
     )}
     {...props}
@@ -56,41 +55,19 @@ DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayNam
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => {
-  const localRef = React.useRef<HTMLDivElement>(null);
-  React.useLayoutEffect(() => {
-    const el = localRef.current;
-    if (!el) return;
-    el.classList.remove('is-closing');
-    el.classList.add('is-open');
-    return () => {
-      el.classList.remove('is-open');
-      el.classList.add('is-closing');
-    };
-  }, []);
-  const setRefs = React.useCallback(
-    (node: HTMLDivElement | null) => {
-      localRef.current = node;
-      if (typeof ref === 'function') ref(node);
-      else if (ref) (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
-    },
-    [ref],
-  );
-  return (
-    <DropdownMenuPrimitive.Portal>
-      <DropdownMenuPrimitive.Content
-        ref={setRefs}
-        sideOffset={sideOffset}
-        data-origin="top-left"
-        className={cn(
-          't-dropdown z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-section border border-stroke bg-bg-raised p-1 text-text-primary shadow-strong',
-          className,
-        )}
-        {...props}
-      />
-    </DropdownMenuPrimitive.Portal>
-  );
-});
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        't-dropdown z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-section border border-stroke bg-bg-raised p-1 text-text-primary shadow-strong',
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
 const DropdownMenuItem = React.forwardRef<

--- a/web/app/src/lib/__tests__/transitionsDev.test.ts
+++ b/web/app/src/lib/__tests__/transitionsDev.test.ts
@@ -93,4 +93,3 @@ describe('transitionsDev helpers', () => {
     expect(input.classList.contains('is-shaking')).toBe(false);
   });
 });
-

--- a/web/app/src/lib/__tests__/transitionsDev.test.ts
+++ b/web/app/src/lib/__tests__/transitionsDev.test.ts
@@ -6,6 +6,19 @@ describe('transitionsDev helpers', () => {
     document.documentElement.style.setProperty('--text-swap-dur', '150ms');
     document.documentElement.style.setProperty('--shake-dur-a', '80ms');
     document.documentElement.style.setProperty('--shake-dur-b', '60ms');
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({
+        matches: false,
+        media: '(prefers-reduced-motion: reduce)',
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        onchange: null,
+      })),
+    );
   });
 
   afterEach(() => {
@@ -14,7 +27,8 @@ describe('transitionsDev helpers', () => {
   });
 
   it('reads duration tokens from :root', () => {
-    expect(readDurationToken('--text-swap-dur', 200)).toBe(150);
+    document.documentElement.style.setProperty('--text-swap-dur', '180ms');
+    expect(readDurationToken('--text-swap-dur', 200)).toBe(180);
     expect(readDurationToken('--missing-token', 42)).toBe(42);
   });
 
@@ -46,6 +60,29 @@ describe('transitionsDev helpers', () => {
 
     vi.advanceTimersByTime(300);
     expect(input.classList.contains('is-shaking')).toBe(false);
+
+    replayErrorShake(input);
+    expect(input.classList.contains('is-shaking')).toBe(true);
     input.remove();
   });
+
+  it('skips the error shake when reduced motion is requested', () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn((query: string) => ({
+        matches: query.includes('prefers-reduced-motion'),
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        onchange: null,
+      })),
+    );
+    const input = document.createElement('div');
+    replayErrorShake(input);
+    expect(input.classList.contains('is-shaking')).toBe(false);
+  });
 });
+

--- a/web/app/src/lib/__tests__/transitionsDev.test.ts
+++ b/web/app/src/lib/__tests__/transitionsDev.test.ts
@@ -66,6 +66,14 @@ describe('transitionsDev helpers', () => {
     input.remove();
   });
 
+  it('cancels an in-flight error shake', () => {
+    const input = document.createElement('div');
+    const stop = replayErrorShake(input);
+    expect(input.classList.contains('is-shaking')).toBe(true);
+    stop();
+    expect(input.classList.contains('is-shaking')).toBe(false);
+  });
+
   it('skips the error shake when reduced motion is requested', () => {
     vi.stubGlobal(
       'matchMedia',

--- a/web/app/src/lib/__tests__/transitionsDev.test.ts
+++ b/web/app/src/lib/__tests__/transitionsDev.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { prefersReducedMotion, readDurationToken, replayErrorShake } from '@/lib/transitionsDev';
+
+describe('transitionsDev helpers', () => {
+  beforeEach(() => {
+    document.documentElement.style.setProperty('--text-swap-dur', '150ms');
+    document.documentElement.style.setProperty('--shake-dur-a', '80ms');
+    document.documentElement.style.setProperty('--shake-dur-b', '60ms');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('reads duration tokens from :root', () => {
+    expect(readDurationToken('--text-swap-dur', 200)).toBe(150);
+    expect(readDurationToken('--missing-token', 42)).toBe(42);
+  });
+
+  it('detects prefers-reduced-motion', () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn((query: string) => ({
+        matches: query.includes('prefers-reduced-motion'),
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        onchange: null,
+      })),
+    );
+    expect(prefersReducedMotion()).toBe(true);
+  });
+
+  it('replays the error shake class through a reflow', () => {
+    vi.useFakeTimers();
+    const input = document.createElement('div');
+    input.classList.add('t-input');
+    document.body.appendChild(input);
+
+    replayErrorShake(input);
+    expect(input.classList.contains('is-shaking')).toBe(true);
+
+    vi.advanceTimersByTime(300);
+    expect(input.classList.contains('is-shaking')).toBe(false);
+    input.remove();
+  });
+});

--- a/web/app/src/lib/transitionsDev.ts
+++ b/web/app/src/lib/transitionsDev.ts
@@ -11,6 +11,7 @@ export function prefersReducedMotion(): boolean {
 }
 
 export function replayErrorShake(input: HTMLElement): void {
+  if (prefersReducedMotion()) return;
   input.classList.remove('is-shaking');
   void input.offsetWidth;
   input.classList.add('is-shaking');

--- a/web/app/src/lib/transitionsDev.ts
+++ b/web/app/src/lib/transitionsDev.ts
@@ -1,0 +1,20 @@
+export function readDurationToken(name: string, fallbackMs: number): number {
+  if (typeof document === 'undefined') return fallbackMs;
+  const raw = getComputedStyle(document.documentElement).getPropertyValue(name);
+  const parsed = parseFloat(raw);
+  return Number.isFinite(parsed) ? parsed : fallbackMs;
+}
+
+export function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+export function replayErrorShake(input: HTMLElement): void {
+  input.classList.remove('is-shaking');
+  void input.offsetWidth;
+  input.classList.add('is-shaking');
+  const shakeMs =
+    readDurationToken('--shake-dur-a', 80) * 2 + readDurationToken('--shake-dur-b', 60) * 2;
+  window.setTimeout(() => input.classList.remove('is-shaking'), shakeMs + 20);
+}

--- a/web/app/src/lib/transitionsDev.ts
+++ b/web/app/src/lib/transitionsDev.ts
@@ -10,12 +10,16 @@ export function prefersReducedMotion(): boolean {
   return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
-export function replayErrorShake(input: HTMLElement): void {
-  if (prefersReducedMotion()) return;
+export function replayErrorShake(input: HTMLElement): () => void {
+  if (prefersReducedMotion()) return () => {};
   input.classList.remove('is-shaking');
   void input.offsetWidth;
   input.classList.add('is-shaking');
   const shakeMs =
     readDurationToken('--shake-dur-a', 80) * 2 + readDurationToken('--shake-dur-b', 60) * 2;
-  window.setTimeout(() => input.classList.remove('is-shaking'), shakeMs + 20);
+  const timer = window.setTimeout(() => input.classList.remove('is-shaking'), shakeMs + 20);
+  return () => {
+    window.clearTimeout(timer);
+    input.classList.remove('is-shaking');
+  };
 }

--- a/web/app/src/styles/transitions-dev-root.css
+++ b/web/app/src/styles/transitions-dev-root.css
@@ -1,0 +1,282 @@
+/* transitions-dev — copy this :root block into your project once.
+   Every transition snippet reads from these semantic names. */
+:root {
+  /* ── Motion tokens — shared scale ──────────────────────────────
+     Reference these with var(--…) anywhere in your project. The
+     transitions below ship literal values so each snippet works on
+     its own; `transitions refine` maps hardcoded values back to
+     these tokens. */
+  /* Durations */
+  --duration-stagger: 40ms;  /* per-item stagger offset */
+  --duration-micro: 80ms;  /* tooltip/path delay, shake segment, large stagger */
+  --duration-quick: 150ms;  /* modal/dropdown close, text swap, tooltip appear */
+  --duration-fast: 250ms;  /* icon swap, dropdown/modal open, tabs sliding, page slide */
+  --duration-medium: 350ms;  /* panel close, toast close */
+  --duration-slow: 400ms;  /* panel open, skeleton content reveal, input clear */
+  --duration-very-slow: 500ms;  /* emphasis moments, badge appear, text reveal, success check */
+  /* Easings */
+  --ease-smooth-out: cubic-bezier(0.22, 1, 0.36, 1);  /* modal/dropdown/panel open + close, page slide, resize, position change */
+  --ease-in-out: ease-in-out;  /* icon swap, text swap, text reveal, skeleton reveal */
+  --ease-out: ease-out;  /* tooltip open / close */
+  --ease-linear: linear;  /* shimmer, skeleton pulse, spinner */
+  --ease-bounce: cubic-bezier(0.34, 1.36, 0.64, 1);  /* badge pop open */
+  --ease-bounce-strong: cubic-bezier(0.34, 3.85, 0.64, 1);  /* bouncy hover-out (avatar return) */
+  /* Distances */
+  --distance-micro: 4px;  /* text swap */
+  --distance-small: 6px;  /* error shake (small segment) */
+  --distance-base: 8px;  /* badge diagonal reveal, page slide, error shake (large segment) */
+  --distance-medium: 12px;  /* text reveal */
+  --distance-large: 30px;  /* check badge appear */
+  /* Scales */
+  --scale-large: 0.96;  /* modal open / close */
+  --scale-medium: 0.97;  /* dropdown open */
+  --scale-small: 0.98;  /* tooltip open */
+  --scale-tiny: 0.99;  /* dropdown close */
+  /* Blur */
+  --blur-small: 2px;  /* panel reveal, icon swap, text swap, skeleton reveal, number pop-in */
+  --blur-medium: 3px;  /* page slide, text reveal */
+  --blur-large: 8px;  /* success check open */
+
+  /* Card resize */
+  --resize-dur: 300ms;
+  --resize-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  /* Number pop-in */
+  --digit-dur: 500ms;
+  --digit-distance: 8px;
+  --digit-stagger: 70ms;
+  --digit-blur: 2px;
+  --digit-ease: cubic-bezier(0.34, 1.45, 0.64, 1);
+  --digit-dir-x: 0;
+  --digit-dir-y: 1;
+  /* Notification badge */
+  --badge-slide-dur: 260ms;
+  --badge-pop-dur: 500ms;
+  --badge-pop-close-dur: 180ms;
+  --badge-fade-dur: 400ms;
+  --badge-fade-close-dur: 180ms;
+  --badge-blur: 2px;
+  --badge-offset-x: -8.2px;
+  --badge-offset-y: 12.4px;
+  --badge-slide-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --badge-pop-ease: cubic-bezier(0.34, 1.36, 0.64, 1);
+  --badge-close-ease: cubic-bezier(0.4, 0, 0.2, 1);
+  /* Text states swap */
+  --text-swap-dur: 150ms;
+  --text-swap-translate-y: 4px;
+  --text-swap-blur: 2px;
+  --text-swap-ease: ease-in-out;
+  /* Menu dropdown */
+  --dropdown-open-dur: 250ms;
+  --dropdown-close-dur: 150ms;
+  --dropdown-pre-scale: 0.97;
+  --dropdown-closing-scale: 0.99;
+  --dropdown-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  /* Modal open / close */
+  --modal-open-dur: 250ms;
+  --modal-close-dur: 150ms;
+  --modal-scale: 0.96;
+  --modal-scale-close: 0.96;
+  --modal-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  /* Panel reveal */
+  --panel-open-dur: 400ms;
+  --panel-close-dur: 350ms;
+  --panel-translate-y: 100px;
+  --panel-blur: 2px;
+  --panel-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  /* Page side-by-side */
+  --page-slide-dur: 250ms;
+  --page-fade-dur: 250ms;
+  --page-slide-distance: 8px;
+  --page-blur: 3px;
+  --page-stagger: 0ms;
+  --page-exit-enabled: 1;
+  --page-slide-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --page-fade-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  /* Icon swap */
+  --icon-swap-dur: 250ms;
+  --icon-swap-blur: 2px;
+  --icon-swap-start-scale: 0.25;
+  --icon-swap-ease: ease-in-out;
+  /* Success check */
+  --check-opacity-dur: 500ms;
+  --check-rotate-dur: 500ms;
+  --check-rotate-from: 80deg;
+  --check-bob-dur: 500ms;
+  --check-y-amount: 40px;
+  --check-blur-dur: 500ms;
+  --check-blur-from: 10px;
+  --check-path-dur: 500ms;
+  --check-path-delay: 80ms;
+  --check-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --check-ease-opacity: cubic-bezier(0.22, 1, 0.36, 1);
+  --check-ease-rotate: cubic-bezier(0.22, 1, 0.36, 1);
+  --check-ease-bob: cubic-bezier(0.34, 1.35, 0.64, 1);
+  --check-ease-path: cubic-bezier(0.22, 1, 0.36, 1);
+  /* Avatar group hover */
+  --avatar-lift: -4px;
+  --avatar-dur: 320ms;
+  --avatar-scale: 1.05;
+  --avatar-falloff: 0.45;
+  --avatar-ease-in: cubic-bezier(0.22, 1, 0.36, 1);
+  --avatar-ease-out: cubic-bezier(0.34, 3.85, 0.64, 1);
+  /* Error state shake */
+  --shake-distance: 6px;
+  --shake-overshoot: 4px;
+  --shake-dur-a: 80ms;
+  --shake-dur-b: 60ms;
+  --shake-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --revert-hold: 3000ms;
+  --revert-dur: 280ms;
+  /* Input clear with dissolve */
+  --clear-dur: 1000ms;
+  --clear-out-dur: 400ms;
+  --clear-in-dur: 400ms;
+  --clear-out-fly: 12px;
+  --clear-in-fly: 12px;
+  --clear-out-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --clear-in-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --clear-blur: 2px;
+  --glow-delay: 50ms;
+  --glow-peak-at: 0.15;
+  --glow-opacity: 0.42;
+  --glow-spread: 1.5;
+  /* Skeleton loader and reveal */
+  --pulse-dur: 1000ms;
+  --pulse-count: 1;
+  --pulse-min: 0.5;
+  --reveal-dur: 400ms;
+  --reveal-blur: 2px;
+  --reveal-ease: ease-in-out;
+  /* Shimmer text */
+  --shimmer-dur: 2000ms;
+  --shimmer-base: #7c7c7c;
+  --shimmer-highlight: #0d0d0d;
+  --shimmer-band: 400%;
+  --shimmer-ease: linear;
+  /* Tabs sliding */
+  --tabs-dur: 250ms;
+  --tabs-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --tabs-text-muted: rgba(15, 15, 15, 0.8);
+  --tabs-text-active: #0f0f0f;
+  --tabs-bar-bg: #f1f1f1;
+  --tabs-pill-bg: #ffffff;
+  /* Tooltip open/close */
+  --tt-in-dur: 150ms;
+  --tt-out-dur: 50ms;
+  --tt-scale: 0.98;
+  --tt-delay: 80ms;
+  --tt-in-ease: ease-out;
+  --tt-out-ease: ease-out;
+  --tt-bg: #ffffff;
+  --tt-fg: #2f2f2f;
+  /* Texts reveal */
+  --stagger-dur: 500ms;
+  --stagger-distance: 12px;
+  --stagger-stagger: 40ms;
+  --stagger-blur: 3px;
+  --stagger-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  /* Card hover tilt */
+  --tilt-perspective: 1000px;
+  --tilt-return: 1000ms;
+  --tilt-return-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --tilt-follow: 400ms;
+  --tilt-follow-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --tilt-glare-opacity: 0.32;
+  --tilt-glare-fade: 300ms;
+  --tilt-glare-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  /* Plus to menu morph */
+  --morph-open-dur: 350ms;
+  --morph-close-dur: 250ms;
+  --morph-ease: cubic-bezier(0.34, 1.25, 0.64, 1);
+  --morph-close-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --morph-r-closed: 40px;
+  --morph-r-open: 20px;
+  --morph-fade-dur: 200ms;
+  --morph-slide: 40px;
+  --morph-rotate: 45deg;
+  --morph-scale: 0.97;
+  --morph-blur: 2px;
+  /* Accordion expand */
+  --acc-expand: 250ms;
+  --acc-collapse: 250ms;
+  --acc-chevron: 250ms;
+  --acc-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  /* Toast open / close */
+  --toast-open: 350ms;
+  --toast-close: 250ms;
+  --toast-distance: 16px;
+  --toast-blur: 2px;
+  --toast-scale: 0.97;
+  --toast-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  /* Like button */
+  --like-color: #f40051;
+  --like-fill: 150ms;
+  --like-pop: 350ms;
+  --like-pop-ease: cubic-bezier(0.34, 1.96, 0.64, 1);
+  --like-particle-dur: 600ms;
+  --like-particle-dist: 20px;
+  --like-particle-size: 2.5px;
+  --like-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  /* Learn more hover */
+  --learn-shift: 2px;
+  --learn-spread: 8deg;
+  --learn-in: 350ms;
+  --learn-out: 350ms;
+  --learn-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  /* Checkbox check */
+  --check-box: 150ms;
+  --check-draw: 350ms;
+  --check-delay: 0ms;
+  --check-uncheck: 150ms;
+  --check-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  /* Spinning counter */
+  --reel-dur: 1400ms;
+  --reel-cell: 30px;
+  --reel-spin-blur: 3px;
+  --reel-stagger: 90ms;
+  --reel-ease: cubic-bezier(0.16, 1, 0.3, 1);
+  /* Toggle */
+  --toggle-dur: 350ms;
+  --toggle-travel: 14.66px;
+  --toggle-ov1: 1px;
+  --toggle-ov2: 0px;
+  --toggle-track: 0ms;
+  --toggle-ease: cubic-bezier(0.34, 1.35, 0.64, 1);
+  /* Thinking states */
+  --think-hold: 2000ms;
+  --think-swap: 150ms;
+  --think-gap: 50ms;
+  --think-distance: 8px;
+  --think-blur: 2px;
+  --think-shimmer: 2000ms;
+  --think-base: #7c7c7c;
+  --think-highlight: #0d0d0d;
+  --think-ease: ease-in-out;
+  /* Reasoning stream */
+  --reason-hold: 840ms;
+  --reason-step: 500ms;
+  --reason-lines: 2;
+  --reason-fade: 28px;
+  --reason-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  /* Streaming text */
+  --stream-gap: 60ms;
+  --stream-fade: 350ms;
+  --stream-blur: 1px;
+  --stream-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  /* Matrix dot loader */
+  --matrix-cycle: 1200ms;
+  --matrix-base: #d9d9d9;
+  --matrix-active: #85858f;
+  --matrix-ease: ease-in-out;
+  /* Banner stacking */
+  --stack-open: 350ms;
+  --stack-close: 250ms;
+  --stack-rise: 80px;
+  --stack-blur: 2px;
+  --stack-scale: 0.97;
+  --stack-peek: 12px;
+  --stack-spread-gap: 8px;
+  --stack-depth-scale: 0.06;
+  --stack-depth-fade: 0.4;
+  --stack-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}

--- a/web/app/src/styles/transitions-dev.css
+++ b/web/app/src/styles/transitions-dev.css
@@ -1,0 +1,362 @@
+/* transitions.dev t-* snippets — pasted verbatim from
+   https://github.com/Jakubantalik/transitions.dev/tree/main/skills/transitions-dev
+   :root tokens live in transitions-dev-root.css; do not duplicate them here. */
+
+/* 01-card-resize.md */
+.t-resize {
+  transition:
+    width  var(--resize-dur) var(--resize-ease),
+    height var(--resize-dur) var(--resize-ease);
+  will-change: width, height;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-resize { transition: none !important; }
+}
+
+
+/* 03-notification-badge.md */
+@keyframes t-badge-slide-in {
+  from { transform: translate(var(--badge-offset-x), var(--badge-offset-y)); }
+  to   { transform: translate(0, 0); }
+}
+
+/* .t-badge is the absolutely-positioned wrapper for the dot.
+   Adjust top/right (or left/bottom) to anchor it on your trigger. */
+.t-badge {
+  position: absolute;
+  top: -6px;
+  right: -8px;
+  pointer-events: none;
+  will-change: transform;
+}
+.t-badge[data-open="true"] {
+  animation: t-badge-slide-in var(--badge-slide-dur) var(--badge-slide-ease);
+}
+
+.t-badge-dot {
+  display: block;
+  transform-origin: center;
+  transform: scale(1);
+  opacity: 1;
+  filter: blur(0);
+  transition:
+    transform var(--badge-pop-dur)  var(--badge-pop-ease),
+    opacity   var(--badge-fade-dur) var(--badge-pop-ease),
+    filter    var(--badge-pop-dur)  var(--badge-pop-ease);
+  will-change: transform, opacity, filter;
+}
+.t-badge[data-open="false"] .t-badge-dot {
+  transform: scale(0);
+  opacity: 0;
+  filter: blur(var(--badge-blur));
+  transition:
+    transform var(--badge-pop-close-dur)  var(--badge-close-ease),
+    opacity   var(--badge-fade-close-dur) var(--badge-close-ease),
+    filter    var(--badge-pop-close-dur)  var(--badge-close-ease);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-badge, .t-badge-dot { animation: none !important; transition: none !important; }
+}
+
+
+/* 04-text-states-swap.md */
+.t-text-swap {
+  display: inline-block;
+  transform: translateY(0);
+  filter: blur(0);
+  opacity: 1;
+  transition:
+    transform var(--text-swap-dur) var(--text-swap-ease),
+    filter    var(--text-swap-dur) var(--text-swap-ease),
+    opacity   var(--text-swap-dur) var(--text-swap-ease);
+  will-change: transform, filter, opacity;
+}
+.t-text-swap.is-exit {
+  transform: translateY(calc(var(--text-swap-translate-y) * -1));
+  filter: blur(var(--text-swap-blur));
+  opacity: 0;
+}
+.t-text-swap.is-enter-start {
+  transform: translateY(var(--text-swap-translate-y));
+  filter: blur(var(--text-swap-blur));
+  opacity: 0;
+  transition: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-text-swap { transition: none !important; }
+}
+
+
+/* 05-menu-dropdown.md */
+.t-dropdown {
+  transform-origin: top left;
+  transform: scale(var(--dropdown-pre-scale));
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    transform var(--dropdown-open-dur) var(--dropdown-ease),
+    opacity   var(--dropdown-open-dur) var(--dropdown-ease);
+  will-change: transform, opacity;
+}
+.t-dropdown[data-origin="top-right"]     { transform-origin: top right; }
+.t-dropdown[data-origin="top-center"]    { transform-origin: top center; }
+.t-dropdown[data-origin="bottom-left"]   { transform-origin: bottom left; }
+.t-dropdown[data-origin="bottom-center"] { transform-origin: bottom center; }
+.t-dropdown[data-origin="bottom-right"]  { transform-origin: bottom right; }
+
+.t-dropdown.is-open {
+  transform: scale(1);
+  opacity: 1;
+  pointer-events: auto;
+}
+.t-dropdown.is-closing {
+  transform: scale(var(--dropdown-closing-scale));
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    transform var(--dropdown-close-dur) var(--dropdown-ease),
+    opacity   var(--dropdown-close-dur) var(--dropdown-ease);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-dropdown { transition: none !important; }
+}
+
+
+/* 06-modal.md */
+.t-modal {
+  transform-origin: center;
+  transform: scale(var(--modal-scale));
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    transform var(--modal-open-dur) var(--modal-ease),
+    opacity   var(--modal-open-dur) var(--modal-ease);
+  will-change: transform, opacity;
+}
+.t-modal.is-open {
+  transform: scale(1);
+  opacity: 1;
+  pointer-events: auto;
+}
+.t-modal.is-closing {
+  transform: scale(var(--modal-scale-close));
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    transform var(--modal-close-dur) var(--modal-ease),
+    opacity   var(--modal-close-dur) var(--modal-ease);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-modal { transition: none !important; }
+}
+
+
+/* 07-panel-reveal.md */
+.t-panel-slide {
+  transform: translateY(var(--panel-translate-y));
+  opacity: 0;
+  filter: blur(var(--panel-blur));
+  pointer-events: none;
+  transition:
+    transform var(--panel-close-dur) var(--panel-ease),
+    opacity   var(--panel-close-dur) var(--panel-ease),
+    filter    var(--panel-close-dur) var(--panel-ease);
+  will-change: transform, opacity, filter;
+}
+.t-panel-slide[data-open="true"] {
+  transform: translateY(0);
+  opacity: 1;
+  filter: blur(0);
+  pointer-events: auto;
+  transition:
+    transform var(--panel-open-dur) var(--panel-ease),
+    opacity   var(--panel-open-dur) var(--panel-ease),
+    filter    var(--panel-open-dur) var(--panel-ease);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-panel-slide { transition: none !important; }
+}
+
+
+/* 08-page-side-by-side.md */
+.t-page-slide {
+  position: relative;
+}
+.t-page-slide .t-page[data-page-id="1"] {
+  --t-page-from-x: calc(var(--page-slide-distance) * -1);
+}
+.t-page-slide .t-page[data-page-id="2"] {
+  --t-page-from-x: var(--page-slide-distance);
+}
+.t-page-slide .t-page {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(calc(var(--t-page-from-x, 0px) * var(--page-exit-enabled)));
+  filter: blur(calc(var(--page-blur) * var(--page-exit-enabled)));
+  transition:
+    opacity   var(--page-fade-dur)  var(--page-fade-ease),
+    transform var(--page-slide-dur) var(--page-slide-ease),
+    filter    var(--page-slide-dur) var(--page-slide-ease);
+  will-change: opacity, transform, filter;
+}
+.t-page-slide[data-page="1"] .t-page[data-page-id="1"],
+.t-page-slide[data-page="2"] .t-page[data-page-id="2"] {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(0);
+  filter: blur(0);
+  transition-delay: var(--page-stagger);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-page-slide .t-page { transition: none !important; }
+}
+
+
+/* 09-icon-swap.md */
+.t-icon-swap {
+  position: relative;
+  display: inline-grid;
+}
+.t-icon-swap .t-icon {
+  grid-area: 1 / 1;
+  transition:
+    opacity   var(--icon-swap-dur) var(--icon-swap-ease),
+    filter    var(--icon-swap-dur) var(--icon-swap-ease),
+    transform var(--icon-swap-dur) var(--icon-swap-ease);
+  will-change: opacity, filter, transform;
+}
+.t-icon-swap[data-state="a"] .t-icon[data-icon="a"],
+.t-icon-swap[data-state="b"] .t-icon[data-icon="b"] {
+  opacity: 1;
+  filter: blur(0);
+  transform: scale(1);
+}
+.t-icon-swap[data-state="a"] .t-icon[data-icon="b"],
+.t-icon-swap[data-state="b"] .t-icon[data-icon="a"] {
+  opacity: 0;
+  filter: blur(var(--icon-swap-blur));
+  transform: scale(var(--icon-swap-start-scale));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-icon-swap .t-icon { transition: none !important; }
+}
+
+
+/* 10-success-check.md */
+/* Wrapper drives the appear animation; it doesn't own any
+   sizing or color so you can drop in any icon. */
+.t-success-check {
+  display: inline-block;
+  transform-origin: center;
+  opacity: 0;
+  will-change: transform, opacity, filter;
+}
+/* overflow: visible keeps the stroke from clipping while it
+   draws; display: block kills the inline whitespace under SVGs. */
+.t-success-check svg { display: block; overflow: visible; }
+/* Stroke-draw setup. Replace 20 with the result of
+   path.getTotalLength() for your path; round caps mean any
+   sub-pixel overshoot is invisible. */
+.t-success-check svg path {
+  stroke-dasharray: 20;
+  stroke-dashoffset: 20;
+}
+
+.t-success-check[data-state="in"] {
+  animation:
+    t-check-fade   var(--check-opacity-dur) var(--check-ease-opacity) forwards,
+    t-check-rotate var(--check-rotate-dur)  var(--check-ease-rotate)  forwards,
+    t-check-blur   var(--check-blur-dur)    var(--check-ease-out)     forwards,
+    t-check-bob    var(--check-bob-dur)     var(--check-ease-bob)     forwards;
+}
+.t-success-check[data-state="in"] svg path {
+  animation: t-check-draw var(--check-path-dur) var(--check-ease-path) var(--check-path-delay, 0ms) forwards;
+}
+
+@keyframes t-check-fade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes t-check-rotate {
+  from { transform: rotate(var(--check-rotate-from)); }
+  to   { transform: rotate(0deg); }
+}
+@keyframes t-check-blur {
+  from { filter: blur(var(--check-blur-from)); }
+  to   { filter: blur(0); }
+}
+@keyframes t-check-bob {
+  from { translate: 0 var(--check-y-amount); }
+  to   { translate: 0 0; }
+}
+@keyframes t-check-draw { to { stroke-dashoffset: 0; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .t-success-check { animation: none !important; opacity: 1; }
+  .t-success-check svg path { animation: none !important; stroke-dashoffset: 0 !important; }
+}
+
+
+/* 12-error-state-shake.md */
+/* Border-color tween. Define your input's default / focused
+   / error border-color in your own component CSS — this rule
+   only owns the interpolation. Use a constant border-width
+   across states so the tween never shifts inner content. */
+.t-input {
+  transition: border-color 150ms ease-out;
+  will-change: transform;
+}
+.t-input.is-error {
+  /* Error border auto-reverts on the hold timer, so the
+     fade-out uses the slower revert duration (matches the
+     message fade). */
+  transition: border-color var(--revert-dur, 280ms) ease-out;
+}
+
+/* Error message reveal. Visibility is delayed by --revert-dur
+   on hide so the message stays painted for the full opacity
+   fade-out. Entering .is-error drops the delay to 0 so the
+   message becomes visible immediately. */
+.t-error-msg {
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    opacity    var(--revert-dur, 280ms) ease-out,
+    visibility 0s linear var(--revert-dur, 280ms);
+}
+.t-input-wrap.is-error .t-error-msg {
+  opacity: 1;
+  visibility: visible;
+  transition:
+    opacity    var(--revert-dur, 280ms) ease-out,
+    visibility 0s linear 0s;
+}
+
+/* Multi-segment keyframe with per-stop easing so each leg
+   of the shake follows its own cubic-bezier independently.
+   %-stops are cumulative durations as a fraction of the
+   total (80, 60, 80, 60 = 280ms): 28.57%, 57.14%, 78.57%,
+   100%. Recompute if any segment duration changes. */
+.t-input.is-shaking {
+  animation: t-input-shake calc(
+      var(--shake-dur-a) * 2 + var(--shake-dur-b) * 2
+    ) linear;
+}
+@keyframes t-input-shake {
+  0%      { transform: translateX(0);                                 animation-timing-function: var(--shake-ease); }
+  28.57%  { transform: translateX(var(--shake-distance));             animation-timing-function: var(--shake-ease); }
+  57.14%  { transform: translateX(calc(var(--shake-distance) * -1)); animation-timing-function: var(--shake-ease); }
+  78.57%  { transform: translateX(var(--shake-overshoot));            animation-timing-function: var(--shake-ease); }
+  100%    { transform: translateX(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-input { animation: none !important; transform: none !important; }
+}

--- a/web/app/src/styles/transitions-dev.css
+++ b/web/app/src/styles/transitions-dev.css
@@ -400,3 +400,9 @@
 @media (prefers-reduced-motion: reduce) {
   .t-input { animation: none !important; transform: none !important; }
 }
+
+.t-input:not(.is-shaking),
+.t-text-swap:not(.is-exit):not(.is-enter-start),
+.t-badge:not([data-open="true"]) {
+  will-change: auto;
+}

--- a/web/app/src/styles/transitions-dev.css
+++ b/web/app/src/styles/transitions-dev.css
@@ -113,6 +113,7 @@
 .t-dropdown[data-side="top"][data-align="end"] { transform-origin: bottom right; }
 .t-dropdown[data-side="right"] { transform-origin: left center; }
 .t-dropdown[data-side="left"] { transform-origin: right center; }
+.t-dropdown[data-origin="top-left"]      { transform-origin: top left; }
 .t-dropdown[data-origin="top-right"]     { transform-origin: top right; }
 .t-dropdown[data-origin="top-center"]    { transform-origin: top center; }
 .t-dropdown[data-origin="bottom-left"]   { transform-origin: bottom left; }

--- a/web/app/src/styles/transitions-dev.css
+++ b/web/app/src/styles/transitions-dev.css
@@ -10,6 +10,10 @@
   will-change: width, height;
 }
 
+.t-resize[data-dragging="true"] {
+  transition: none;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .t-resize { transition: none !important; }
 }
@@ -101,11 +105,36 @@
     opacity   var(--dropdown-open-dur) var(--dropdown-ease);
   will-change: transform, opacity;
 }
+.t-dropdown[data-side="bottom"] { transform-origin: top center; }
+.t-dropdown[data-side="bottom"][data-align="start"] { transform-origin: top left; }
+.t-dropdown[data-side="bottom"][data-align="end"] { transform-origin: top right; }
+.t-dropdown[data-side="top"] { transform-origin: bottom center; }
+.t-dropdown[data-side="top"][data-align="start"] { transform-origin: bottom left; }
+.t-dropdown[data-side="top"][data-align="end"] { transform-origin: bottom right; }
+.t-dropdown[data-side="right"] { transform-origin: left center; }
+.t-dropdown[data-side="left"] { transform-origin: right center; }
 .t-dropdown[data-origin="top-right"]     { transform-origin: top right; }
 .t-dropdown[data-origin="top-center"]    { transform-origin: top center; }
 .t-dropdown[data-origin="bottom-left"]   { transform-origin: bottom left; }
 .t-dropdown[data-origin="bottom-center"] { transform-origin: bottom center; }
 .t-dropdown[data-origin="bottom-right"]  { transform-origin: bottom right; }
+
+@keyframes t-dropdown-in {
+  from { transform: scale(var(--dropdown-pre-scale)); opacity: 0; }
+  to   { transform: scale(1); opacity: 1; }
+}
+@keyframes t-dropdown-out {
+  from { transform: scale(1); opacity: 1; }
+  to   { transform: scale(var(--dropdown-closing-scale)); opacity: 0; }
+}
+.t-dropdown[data-state="open"] {
+  animation: t-dropdown-in var(--dropdown-open-dur) var(--dropdown-ease) both;
+  pointer-events: auto;
+}
+.t-dropdown[data-state="closed"] {
+  animation: t-dropdown-out var(--dropdown-close-dur) var(--dropdown-ease) both;
+  pointer-events: none;
+}
 
 .t-dropdown.is-open {
   transform: scale(1);
@@ -122,7 +151,13 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .t-dropdown { transition: none !important; }
+  .t-dropdown { transition: none !important; animation: none !important; }
+  .t-dropdown[data-state="open"],
+  .t-dropdown.is-open {
+    transform: scale(1);
+    opacity: 1;
+    pointer-events: auto;
+  }
 }
 
 
@@ -214,6 +249,11 @@
   transform: translateX(0);
   filter: blur(0);
   transition-delay: var(--page-stagger);
+}
+.t-page-slide[data-settled] .t-page {
+  transform: none;
+  filter: none;
+  will-change: auto;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

Add nicer motion to the signed-in web client (`web/app`, `omi-web-app`) using the two sources Max named. No demo route — everything is wired into chrome users already hit.

1. **[liquid-gooey](https://gooey.jakubantalik.com)** (`liquid-gooey@0.2.1`) on the existing **ChatBubble** FAB (conversations / memories / tasks / settings — hidden on `/home`). Hover (desktop) or a coarse pointer (touch) fans notifications out of the chat control. Composer attach/voice stay first-class in the pill; they do not fan.

2. **[transitions.dev](https://transitions.dev)** copy-paste CSS from [`skills/transitions-dev/`](https://github.com/Jakubantalik/transitions.dev/tree/main/skills/transitions-dev) (`_root.css` + free `t-*` snippets). No Pro recipes, no `transitions-pro login`.

`framer-motion` stays (sidebar active pill, existing springs). New motion honors `prefers-reduced-motion` (library snaps + snippet guards + ChatBubble skips the fan but keeps both controls).

## Maintainer review follow-up

Against the code at this head:

- **Radix close:** Dialog/ConfirmDialog Content already has Presence-waited `animate-out` fade; dropdown Content uses `t-dropdown` keyframes on the same node Radix Presence watches. Nested `.t-modal` scale is extra visual, not the exit Presence waits for. Collapsed profile and folder menus use delayed-unmount `OpenSurface` (`open={menuOpen}`), not `{cond && <menu>}`.
- **Folder `data-origin`:** default `.t-dropdown` origin is already `top left`; `[data-origin="top-left"]` is now an explicit matching rule.
- **PageSlide containing block:** enter still uses transform/filter; `data-settled` clears them after `transitionend` (or the duration timeout).
- **FAB focus:** collapsing the fan while Notifications is focused now blurs that control before `inert`/`aria-hidden` apply.
- **CI tests:** `web-app-checks` in `.github/checks-manifest.yaml` already runs `web/app/test.sh` → `bun run check` on `web/app/src/**` in Repo Checks. `web-checks.yml` Build is compile-only; duplicating vitest there would double-run the suite.

Human product/dependency sign-off still needed before merge.

## Security review

Scoped to this motion stack (no new endpoints, webhooks, or auth paths).

| Area | Finding | Action |
|---|---|---|
| Authz | FAB / menus / dialogs sit inside the existing signed-in layout. No new API or principal check. | None needed |
| XSS | Login errors are mapped to fixed strings (`getAuthErrorMessage`), never `error.message`. Badge counts and menu coords are numbers. `liquid-gooey` has no `innerHTML` / `eval`; fill/shadow are constants we pass. | None needed |
| Secrets | No new tokens, env vars, or logging of auth material. | None needed |
| Webhooks | None in this stack. | None needed |
| DOM host confusion | `OpenSurface` used `closest('[data-state]')`, so a distant `data-state` (icon-swap, tabs) could force `is-closing`. | Now binds only the immediate parent |

## Performance review

| Area | Finding | Action |
|---|---|---|
| Bundle | `liquid-gooey` is ~95KB ESM and was a static import through `MainLayout` on every signed-in route, including `/home` where the FAB is hidden. | `ChatBubble` is now `dynamic(..., { ssr: false })` like the chat/notification panels |
| Queries | No new network or list queries. | None |
| Motion cost | SVG gooey (`blur`/`contrast`/`filterPadding`) ran while collapsed. Idle `will-change` on text/badge/input kept extra layers. Page `transform`/`filter` re-anchored `position: fixed`. | Filter work is off until fan-out; idle `will-change` reset; page settles after enter |

## Screens / primitives

| Pattern | Where |
|---|---|
| Page side-by-side enter | `MainLayout` route remount (`PageSlide` / `.t-page-slide`) — enter only; the shell remounts so there is no exit tree. After enter, transform/filter/will-change are cleared so `position: fixed` descendants stay viewport-anchored. |
| Modal open/close | `dialog.tsx`, `ConfirmDialog` (`.t-modal` + Radix fade Presence on the content node) |
| Menu dropdown | `dropdown-menu.tsx` (keyframes on `data-state`, origin from `data-side`/`data-align`), collapsed sidebar profile menu, folder context menu (`.t-dropdown` via delayed-unmount `OpenSurface`) |
| Panel reveal | Chat panel + notification center inner column (`.t-panel-slide`, closed frame paints first) |
| Card resize | Conversations detail pane width (`.t-resize`, transition disabled while dragging) |
| Notification badge | Sidebar bell + ChatBubble satellite (`.t-badge`) |
| Icon swap | Chat open/close, sidebar collapse, conversations Select/Cancel (`.t-icon-swap`) |
| Text states swap | Login Apple/Google labels, Select/Cancel (`.t-text-swap`; rapid reversal returns to idle) |
| Success check | Task row completion (`.t-success-check`) |
| Error shake | Login auth error / unconfigured sign-in (`.t-input` / `.t-error-msg`) |

## Product invariants affected

none

## How it was verified

```
cd web/app && bun run check
git diff --check origin/main
```

- `bunx tsc --noEmit` — clean
- `bun test scripts/moonshine-smoke.test.ts` — 5 pass
- `bunx vitest run --config vitest.config.mts` — **80 files, 436 tests, 0 fail**

Could not exercise a signed-in browser session on this VM (no web-app auth / live backend).

## Tests

- `ChatBubble.test.tsx` — gooey fan vs reduced-motion; notifications stay available without gooey; focus leaves the satellite when the fan collapses
- `PageSlide.test.tsx` — `data-page` enter flip + `data-settled` after transitionend
- `TextSwap.test.tsx` — exit/enter class sequence, rapid reversal, reduced motion
- `OpenSurface.test.tsx` — close delay; distant `data-state` ancestor is ignored
- `PanelReveal.test.tsx` — first layout is `data-open=false`
- `transitionsDev.test.ts` — token read, reduced-motion skip, shake replay + cancel
- Sidebar unread `.t-badge` open and closed

## Failure class (fixes)

Failure-Class: none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fc86d56-f549-4eb3-af44-8022e45d3127?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fc86d56-f549-4eb3-af44-8022e45d3127&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

