### PR TITLE
fix(llm): route leftover desktop Haiku aliases through structured gateway

### DIFF
--- a/backend/routers/desktop_chat.py
+++ b/backend/routers/desktop_chat.py
@@ -254,9 +254,15 @@ _MANAGED_CHAT_ALIASES = {
 # Non-conversational desktop callers (the automation planner and the local-agent
 # loop) ask for a single-shot structured completion, not a chat turn. They select
 # the structured lane explicitly so they never inherit chat-agent routing.
+# Legacy Haiku specialist aliases used the company Anthropic key on this
+# router; remap them onto the same structured lane so leftover fielded clients
+# stop billing direct Haiku. Kill-switch / BYOK still resolve Haiku via
+# _MODEL_ROUTES when gateway_mode is off.
 _MANAGED_STRUCTURED_ALIASES = {
     'omi-structured',
     CHAT_STRUCTURED_AUTO_LANE_ID,
+    'claude-haiku-4-5-20251001',
+    'claude-haiku-4-5',
 }
 WEB_SEARCH_AUTO_LANE_ID = feature_auto_lane_id('web_search')
 _MAX_TOKENS = 16_384
@@ -278,14 +284,14 @@ def _managed_lane_id(body: Mapping[str, object]) -> str:
 
 
 def _uses_managed_chat_agent(body: Mapping[str, object]) -> bool:
-    """Route managed conversational traffic to Luna, but preserve specialist calls.
+    """Route managed desktop traffic onto gateway lanes.
 
     Desktop conversational traffic uses the managed Luna chat agent for Sonnet
-    and leftover Opus aliases plus explicit auto/Luna lane ids. Extraction jobs
-    still use Haiku; those legacy Anthropic calls must not inherit the chat-agent
-    personality/system prompt or have their requested model rewritten to Luna.
-    An omitted model uses the managed chat-agent default; an explicit unknown
-    model fails closed in the normal request validation path.
+    and leftover Opus aliases plus explicit auto/Luna lane ids. Legacy Haiku
+    extraction aliases join the structured lane so they do not inherit the
+    chat-agent personality or keep using the company Anthropic key. An omitted
+    model uses the managed chat-agent default; an explicit unknown model fails
+    closed in the normal request validation path.
     """
     if 'model' not in body:
         return True

--- a/backend/scripts/firestore_query_coverage_baseline.json
+++ b/backend/scripts/firestore_query_coverage_baseline.json
@@ -1,5 +1,5 @@
 {
-  "eligible_serving": 102,
+  "eligible_serving": 113,
   "raw_unregistered": [
     "05fdb282df637274",
     "0c75b579eb9f7f04",
@@ -39,7 +39,7 @@
     "fbf6a1e1fdc6920e",
     "fcb4a9e8a36ebd5e"
   ],
-  "registered_serving": 62,
+  "registered_serving": 73,
   "schema_version": 1,
   "unsupported": [
     "4a1b611f6580fc78",

--- a/backend/tests/unit/test_desktop_chat.py
+++ b/backend/tests/unit/test_desktop_chat.py
@@ -1401,8 +1401,9 @@ def test_gateway_body_rejects_unsupported_image_url_instead_of_dropping_it():
         )
 
 
-def test_specialist_haiku_requests_bypass_managed_chat_agent():
-    assert not desktop_chat._uses_managed_chat_agent({'model': 'claude-haiku-4-5-20251001'})
+def test_legacy_haiku_aliases_use_structured_lane_not_chat_agent():
+    assert desktop_chat._uses_managed_chat_agent({'model': 'claude-haiku-4-5-20251001'})
+    assert desktop_chat._managed_lane_id({'model': 'claude-haiku-4-5-20251001'}) == 'omi:auto:chat-structured'
     assert desktop_chat._uses_managed_chat_agent({'model': 'omi-opus'})
     assert desktop_chat._uses_managed_chat_agent({'model': 'claude-opus-4-6'})
     assert desktop_chat._uses_managed_chat_agent({'model': 'claude-sonnet-4-6'})
@@ -1414,7 +1415,13 @@ def test_specialist_haiku_requests_bypass_managed_chat_agent():
 
 
 def test_structured_aliases_route_to_the_structured_lane_not_chat():
-    for alias in ('omi-structured', 'OMI-Structured', 'omi:auto:chat-structured'):
+    for alias in (
+        'omi-structured',
+        'OMI-Structured',
+        'omi:auto:chat-structured',
+        'claude-haiku-4-5',
+        'claude-haiku-4-5-20251001',
+    ):
         assert desktop_chat._uses_managed_chat_agent({'model': alias})
         assert desktop_chat._managed_lane_id({'model': alias}) == 'omi:auto:chat-structured'
 
@@ -1639,7 +1646,7 @@ async def test_chat_completions_gateway_mode_disabled_for_byok(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_chat_completions_specialist_haiku_bypasses_managed_gateway(monkeypatch):
+async def test_chat_completions_legacy_haiku_alias_uses_structured_gateway(monkeypatch):
     monkeypatch.setattr(desktop_chat, 'llm_stub_enabled', lambda: False)
     monkeypatch.setattr(desktop_chat, 'enforce_desktop_chat_quota', lambda *_args, **_kwargs: None)
     monkeypatch.setattr(desktop_chat, '_meter_server_request', lambda *_args, **_kwargs: _done())
@@ -1647,36 +1654,37 @@ async def test_chat_completions_specialist_haiku_bypasses_managed_gateway(monkey
     monkeypatch.setattr(desktop_chat, 'should_route_chat_agent_through_gateway', lambda: True)
     monkeypatch.setattr(desktop_chat, 'get_byok_key', lambda _: None)
     monkeypatch.setattr(desktop_chat, '_record_usage', lambda *_args, **_kwargs: _done())
-
-    class Messages:
-        async def create(self, **payload):
-            assert payload['model'] == 'claude-haiku-4-5'
-            return SimpleNamespace(
-                id='msg_haiku',
-                content=[SimpleNamespace(type='text', text='specialist')],
-                stop_reason='end_turn',
-                usage=SimpleNamespace(
-                    input_tokens=1, cache_creation_input_tokens=0, cache_read_input_tokens=0, output_tokens=1
-                ),
-            )
-
+    monkeypatch.setattr(desktop_chat, 'get_llm_gateway_base_url', lambda: 'http://gateway.test')
     monkeypatch.setattr(
         desktop_chat,
         'get_direct_anthropic_client',
-        lambda **_: SimpleNamespace(messages=Messages()),
+        _fail_direct_anthropic('legacy Haiku aliases must not construct a direct Anthropic client'),
     )
 
     class GatewayClient:
-        async def post(self, *args, **kwargs):
-            raise AssertionError('specialist Haiku requests must not use managed gateway lane')
+        def __init__(self):
+            self.calls = []
 
-    monkeypatch.setattr(desktop_chat, 'get_llm_gateway_client', lambda: GatewayClient())
+        async def post(self, url, *, headers, json):
+            self.calls.append(json)
+            return httpx.Response(
+                200,
+                json={
+                    'id': 'chat-haiku',
+                    'choices': [{'message': {'content': 'structured'}}],
+                    'usage': {'prompt_tokens': 3, 'completion_tokens': 2, 'total_tokens': 5},
+                },
+                request=httpx.Request('POST', url),
+            )
 
+    client = GatewayClient()
+    monkeypatch.setattr(desktop_chat, 'get_llm_gateway_client', lambda: client)
     response = await desktop_chat.chat_completions(
         {
             'model': 'claude-haiku-4-5-20251001',
             'messages': [{'role': 'user', 'content': 'extract this'}],
             'max_tokens': 16,
+            'omi_web_search': True,
         },
         uid='user-1',
         x_app_platform=None,
@@ -1684,7 +1692,8 @@ async def test_chat_completions_specialist_haiku_bypasses_managed_gateway(monkey
         x_omi_request_id=None,
     )
 
-    assert b'"content":"specialist"' in response.body
+    assert b'structured' in response.body
+    assert client.calls[0]['model'] == 'omi:auto:chat-structured'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Route leftover desktop `claude-haiku-4-5*` `/v2/chat/completions` requests onto the managed structured gateway lane instead of the company Anthropic key.

Fielded older Mac builds still send Haiku specialist aliases. That is the remaining prod 001 ~$6–7/day 24/7 Haiku bill (1h cache writes on `desktop_chat.py`). Current main clients already use `omi-structured`; this closes the server hole.

Haiku does **not** inherit chat-agent. Kill-switch / BYOK still resolve Haiku via `_MODEL_ROUTES` when gateway mode is off.

## Test plan
- [x] Unit: Haiku aliases → `omi:auto:chat-structured`, no direct Anthropic client
- [x] Unit: leftover `omi_web_search` on Haiku stays off the web-search lane
- [x] Sabotage: tests fail if Haiku is removed from structured aliases
- [ ] Dev desktop-backend + backend bake, then Anthropic admin usage on prod 001 Haiku → 0 before key archive

## Failure-Class
Failure-Class: none

Line-Count-Exception: backend/routers/desktop_chat.py | 1798 -> 1804 | remap leftover Haiku aliases onto structured lane


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

