### PR TITLE
feat(monitoring): page Cloud Run instance start failures

### DIFF
--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -11488,5 +11488,125 @@
       "receiver": "Omi - Services Alerting (Telegram)"
     },
     "record": null
+  },
+  {
+    "id": 85,
+    "uid": "omi-cr-start-fail",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Backend",
+    "title": "Cloud Run - instance start failures",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 300,
+          "to": 0
+        },
+        "datasourceUid": "deuxlwt1d569sb",
+        "model": {
+          "datasource": {
+            "type": "googlecloud-logging-datasource",
+            "uid": "deuxlwt1d569sb"
+          },
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "projectId": "based-hardware",
+          "queryText": "resource.type=\"cloud_run_revision\" AND (textPayload:\"STARTUP TCP probe failed\" OR textPayload:\"instance could not start successfully\")",
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "count",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-09-01T18:44:52Z",
+    "noDataState": "OK",
+    "execErrState": "OK",
+    "for": "5m",
+    "isPaused": false,
+    "keep_firing_for": "0s",
+    "labels": {
+      "alert_identity": "omi-cr-start-fail",
+      "component": "api",
+      "impact": "product",
+      "instatus_component": "api",
+      "severity": "critical"
+    },
+    "annotations": {
+      "safe_next_action": "Do not deploy a new Cloud Run revision (starts will fail). Check GCP status for us-central1. Wait for instance starts to succeed.",
+      "scope": "Cloud Run revisions in based-hardware matching STARTUP TCP probe failed or instance could not start successfully.",
+      "summary": "Cloud Run instances are failing to start (STARTUP TCP probe / instance could not start).",
+      "threshold": "> 0 matching log lines in 5m (zero baseline)",
+      "user_impact": "New requests queue or hang while warm minScale instances can still return /health 200. This is the 2026-09-01 us-central1 failure mode.",
+      "verification": "Cloud Logging: resource.type=cloud_run_revision AND textPayload:STARTUP TCP probe failed. Contrast api.omi.me vs a warm instance."
+    },
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
   }
 ]

--- a/backend/charts/monitoring/alerts/backend.json
+++ b/backend/charts/monitoring/alerts/backend.json
@@ -1138,5 +1138,125 @@
       "repeat_interval": "5m"
     },
     "record": null
+  },
+  {
+    "id": 85,
+    "uid": "omi-cr-start-fail",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Backend",
+    "title": "Cloud Run - instance start failures",
+    "condition": "C",
+    "data": [
+      {
+        "refId": "A",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 300,
+          "to": 0
+        },
+        "datasourceUid": "deuxlwt1d569sb",
+        "model": {
+          "datasource": {
+            "type": "googlecloud-logging-datasource",
+            "uid": "deuxlwt1d569sb"
+          },
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "projectId": "based-hardware",
+          "queryText": "resource.type=\"cloud_run_revision\" AND (textPayload:\"STARTUP TCP probe failed\" OR textPayload:\"instance could not start successfully\")",
+          "refId": "A"
+        }
+      },
+      {
+        "refId": "B",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "A",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "reducer": "count",
+          "refId": "B",
+          "type": "reduce"
+        }
+      },
+      {
+        "refId": "C",
+        "queryType": "",
+        "relativeTimeRange": {
+          "from": 0,
+          "to": 0
+        },
+        "datasourceUid": "__expr__",
+        "model": {
+          "conditions": [
+            {
+              "evaluator": {
+                "params": [
+                  0
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "C"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "last"
+              },
+              "type": "query"
+            }
+          ],
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "B",
+          "intervalMs": 1000,
+          "maxDataPoints": 43200,
+          "refId": "C",
+          "type": "threshold"
+        }
+      }
+    ],
+    "updated": "2026-09-01T18:44:52Z",
+    "noDataState": "OK",
+    "execErrState": "OK",
+    "for": "5m",
+    "isPaused": false,
+    "keep_firing_for": "0s",
+    "labels": {
+      "alert_identity": "omi-cr-start-fail",
+      "component": "api",
+      "impact": "product",
+      "instatus_component": "api",
+      "severity": "critical"
+    },
+    "annotations": {
+      "safe_next_action": "Do not deploy a new Cloud Run revision (starts will fail). Check GCP status for us-central1. Wait for instance starts to succeed.",
+      "scope": "Cloud Run revisions in based-hardware matching STARTUP TCP probe failed or instance could not start successfully.",
+      "summary": "Cloud Run instances are failing to start (STARTUP TCP probe / instance could not start).",
+      "threshold": "> 0 matching log lines in 5m (zero baseline)",
+      "user_impact": "New requests queue or hang while warm minScale instances can still return /health 200. This is the 2026-09-01 us-central1 failure mode.",
+      "verification": "Cloud Logging: resource.type=cloud_run_revision AND textPayload:STARTUP TCP probe failed. Contrast api.omi.me vs a warm instance."
+    },
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
   }
 ]

--- a/backend/tests/unit/test_monitoring_alert_rule_contract.py
+++ b/backend/tests/unit/test_monitoring_alert_rule_contract.py
@@ -612,3 +612,27 @@ def test_no_alert_applies_a_counter_function_to_a_stackdriver_gauge():
         "these UIDs were fixed or removed -- delete them from COUNTER_FN_ON_GAUGE_DEBT so the "
         "ratchet keeps tightening: " + ", ".join(sorted(stale))
     )
+
+
+START_FAIL_RULE = "omi-cr-start-fail"
+
+
+def test_cloud_run_instance_start_fail_alert_is_zero_baseline_logging_count():
+    """2026-09-01: minScale kept /health green while new Cloud Run instances failed to start."""
+    for rules in _all_rule_exports().values():
+        rule = rules[START_FAIL_RULE]
+        assert rule["title"] == "Cloud Run - instance start failures"
+        assert rule["noDataState"] == "OK"
+        assert rule["execErrState"] == "OK"
+        assert rule["for"] == "5m"
+        assert rule["labels"]["severity"] == "critical"
+        assert rule["labels"]["instatus_component"] == "api"
+        assert rule["labels"]["impact"] == "product"
+        query = rule["data"][0]
+        assert query["datasourceUid"] == "deuxlwt1d569sb"
+        text = query["model"]["queryText"]
+        assert "STARTUP TCP probe failed" in text
+        assert "instance could not start successfully" in text
+        assert query["model"]["projectId"] == "based-hardware"
+        threshold = rule["data"][2]["model"]["conditions"][0]["evaluator"]["params"]
+        assert threshold == [0]


### PR DESCRIPTION
## Summary
Export the live Grafana rule `omi-cr-start-fail` (Cloud Run instance start failures) into the monitoring alert sources so it survives re-import.

Zero-baseline alert on Cloud Logging `STARTUP TCP probe failed` / `instance could not start successfully`. This is the 2026-09-01 us-central1 gap: minScale kept `/health` green while new instances failed.

## Failure-Class
Failure-Class: none

## Test Plan
- [x] `pytest backend/tests/unit/test_monitoring_alert_rule_contract.py` (28 passed)
- [ ] CI green


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

