### PR TITLE
fix(chat-first): prevent poison intents from stalling proactive delivery

### DIFF
--- a/.github/failure-classes/FC-batch-fault-domain-head-of-line-poison.json
+++ b/.github/failure-classes/FC-batch-fault-domain-head-of-line-poison.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-batch-fault-domain-head-of-line-poison",
+  "violated_contract": "One malformed, permanently conflicting, or repeatedly unacknowledged item in an ordered batch must not roll back later independent items or remain at the head forever. The pusher finalization discard-as-success outage, daily-summary hour-group abort (#12530), and daily-sweep page-cap stall (#12533) are sibling instances of the same unbounded batch fault domain.",
+  "canonical_prevention": "Give every independent item its own transaction and typed outcome, continue after rejection, and move poison to a reasoned terminal state within a bounded rejection or fetch budget. Reconcile already-satisfied stable identities, prioritize user-time-sensitive sources, and page on a durable stalled-queue event rather than relying on process-local queue age.",
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/agent/src/runtime/conversation-journal.ts",
+    "backend/database/chat_first_intents.py",
+    "backend/routers/chat_first.py"
+  ],
+  "canonical_prevention_artifact": [
+    "desktop/macos/agent/tests/conversation-journal.test.ts",
+    "backend/tests/unit/test_chat_first_proactive_intents.py",
+    "backend/charts/monitoring/alerts/resilience.json"
+  ],
+  "status": "open"
+}

--- a/backend/charts/monitoring/alert-rules.json
+++ b/backend/charts/monitoring/alert-rules.json
@@ -11608,5 +11608,44 @@
       "receiver": "Omi - Services Alerting (Telegram)"
     },
     "record": null
+  },
+  {
+    "uid": "omi-chat-first-proactive-stalled",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Chat-first proactive delivery - ready queue stalled",
+    "condition": "C",
+    "data": [
+      {"refId": "A", "queryType": "", "relativeTimeRange": {"from": 3600, "to": 0}, "datasourceUid": "prometheus", "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(rate(chat_first_proactive_total{event=\"stalled\"}[1h]))", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}},
+      {"refId": "B", "queryType": "", "relativeTimeRange": {"from": 0, "to": 0}, "datasourceUid": "__expr__", "model": {"conditions": [{"evaluator": {"params": [], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "intervalMs": 1000, "maxDataPoints": 43200, "reducer": "last", "refId": "B", "type": "reduce"}},
+      {"refId": "C", "queryType": "", "relativeTimeRange": {"from": 0, "to": 0}, "datasourceUid": "__expr__", "model": {"conditions": [{"evaluator": {"params": [0], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["C"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "B", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "C", "type": "threshold"}}
+    ],
+    "updated": "2026-09-01T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "summary": "A Chat-first proactive queue with an intent older than 24 hours was fetched during the last hour",
+      "threshold": "non-zero stalled event rate over 1h for 5m",
+      "user_impact": "Meeting notes and daily opener cards may be delayed behind an intent that is not reaching a terminal state.",
+      "scope": "The account-scoped Chat-first proactive fetch and acknowledgement path.",
+      "verification": "Break down chat_first_proactive_total by source and reason, then compare fetch, rejected, reconciled, and dead-letter events.",
+      "safe_next_action": "Inspect recent backend and desktop kernel errors; verify poison intents are reaching reconciled or dead-letter state before changing any retry budget.",
+      "runbook": "backend/docs/runbooks/real-traffic-journeys.md"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "ai-chat",
+      "alert_identity": "omi-chat-first-proactive-stalled",
+      "component": "ai-chat",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
   }
 ]

--- a/backend/charts/monitoring/alerts/resilience.json
+++ b/backend/charts/monitoring/alerts/resilience.json
@@ -2583,5 +2583,44 @@
       "receiver": "Omi - Services Alerting (Telegram)"
     },
     "record": null
+  },
+  {
+    "uid": "omi-chat-first-proactive-stalled",
+    "orgID": 1,
+    "folderUID": "betdycdziadc0e",
+    "ruleGroup": "Resilience",
+    "title": "Chat-first proactive delivery - ready queue stalled",
+    "condition": "C",
+    "data": [
+      {"refId": "A", "queryType": "", "relativeTimeRange": {"from": 3600, "to": 0}, "datasourceUid": "prometheus", "model": {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(rate(chat_first_proactive_total{event=\"stalled\"}[1h]))", "instant": true, "intervalMs": 1000, "maxDataPoints": 43200, "refId": "A"}},
+      {"refId": "B", "queryType": "", "relativeTimeRange": {"from": 0, "to": 0}, "datasourceUid": "__expr__", "model": {"conditions": [{"evaluator": {"params": [], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["B"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "A", "intervalMs": 1000, "maxDataPoints": 43200, "reducer": "last", "refId": "B", "type": "reduce"}},
+      {"refId": "C", "queryType": "", "relativeTimeRange": {"from": 0, "to": 0}, "datasourceUid": "__expr__", "model": {"conditions": [{"evaluator": {"params": [0], "type": "gt"}, "operator": {"type": "and"}, "query": {"params": ["C"]}, "reducer": {"params": [], "type": "last"}, "type": "query"}], "datasource": {"type": "__expr__", "uid": "__expr__"}, "expression": "B", "intervalMs": 1000, "maxDataPoints": 43200, "refId": "C", "type": "threshold"}}
+    ],
+    "updated": "2026-09-01T00:00:00Z",
+    "noDataState": "OK",
+    "execErrState": "Error",
+    "for": "5m",
+    "keep_firing_for": "0s",
+    "annotations": {
+      "summary": "A Chat-first proactive queue with an intent older than 24 hours was fetched during the last hour",
+      "threshold": "non-zero stalled event rate over 1h for 5m",
+      "user_impact": "Meeting notes and daily opener cards may be delayed behind an intent that is not reaching a terminal state.",
+      "scope": "The account-scoped Chat-first proactive fetch and acknowledgement path.",
+      "verification": "Break down chat_first_proactive_total by source and reason, then compare fetch, rejected, reconciled, and dead-letter events.",
+      "safe_next_action": "Inspect recent backend and desktop kernel errors; verify poison intents are reaching reconciled or dead-letter state before changing any retry budget.",
+      "runbook": "backend/docs/runbooks/real-traffic-journeys.md"
+    },
+    "labels": {
+      "severity": "critical",
+      "instatus_component": "ai-chat",
+      "alert_identity": "omi-chat-first-proactive-stalled",
+      "component": "ai-chat",
+      "impact": "user-experience"
+    },
+    "isPaused": false,
+    "notification_settings": {
+      "receiver": "Omi - Services Alerting (Telegram)"
+    },
+    "record": null
   }
 ]

--- a/backend/database/chat_first_delivery_attempts.py
+++ b/backend/database/chat_first_delivery_attempts.py
@@ -1,0 +1,265 @@
+"""Derived delivery attempts and terminal records for Chat-first intents."""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
+from google.api_core.exceptions import GoogleAPICallError
+from google.cloud import firestore
+from google.cloud.firestore_v1 import FieldFilter
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from database.firestore_index_registry import CHAT_FIRST_TRANSIENT_DEAD_LETTER_REPAIR_QUERY
+from database.read_boundary import MalformedDocError, parse_payload_strict, parse_snapshot_strict
+from models.chat_first import DeadLetteredProactiveIntent, ProactiveIntent
+
+INTENTS_COLLECTION = 'chat_first_proactive_intents'
+DELIVERY_ATTEMPTS_COLLECTION = 'chat_first_delivery_attempts'
+DEAD_LETTERS_COLLECTION = 'chat_first_dead_letters'
+TRANSIENT_DEAD_LETTER_REPAIR_AGE = timedelta(hours=6)
+UNACKNOWLEDGED_DEAD_LETTER_REASON = 'unacknowledged_after_fetch_budget'
+KERNEL_FAILURE_DEAD_LETTER_REASON = 'permanent_rejection:kernel_materialization_failed'
+TRANSIENT_DEAD_LETTER_REASONS = frozenset({UNACKNOWLEDGED_DEAD_LETTER_REASON, KERNEL_FAILURE_DEAD_LETTER_REASON})
+UNACKNOWLEDGED_FETCH_BUDGET = 20
+
+logger = logging.getLogger(__name__)
+
+
+class ChatFirstMalformedDeliveryAttempt(RuntimeError):
+    pass
+
+
+class DeliveryAttemptState(BaseModel):
+    """The bounded sibling schema; intent blocks never revalidate on a poll."""
+
+    model_config = ConfigDict(extra='ignore', frozen=True)
+
+    fetch_count: int = Field(default=0, ge=0)
+    last_fetched_at: datetime | None = None
+    requeue_count: int = Field(default=0, ge=0, le=1)
+    materialization_attempts: int = Field(default=0, ge=0)
+    last_rejection_code: str | None = Field(default=None, min_length=1, max_length=64, pattern=r'^[a-z0-9_]+$')
+    last_rejection_at: datetime | None = None
+    first_deferred_at: datetime | None = None
+    last_deferral_at: datetime | None = None
+
+
+def user_ref(uid: str, *, firestore_client: Any):
+    return firestore_client.collection('users').document(uid)
+
+
+def intent_ref(uid: str, intent_id: str, *, firestore_client: Any):
+    return user_ref(uid, firestore_client=firestore_client).collection(INTENTS_COLLECTION).document(intent_id)
+
+
+def delivery_attempt_ref(uid: str, intent_id: str, *, firestore_client: Any):
+    return user_ref(uid, firestore_client=firestore_client).collection(DELIVERY_ATTEMPTS_COLLECTION).document(intent_id)
+
+
+def dead_letter_ref(uid: str, intent_id: str, *, firestore_client: Any):
+    return user_ref(uid, firestore_client=firestore_client).collection(DEAD_LETTERS_COLLECTION).document(intent_id)
+
+
+def intent_with_delivery_attempt(intent: ProactiveIntent, snapshot: Any) -> ProactiveIntent:
+    if not snapshot.exists:
+        return intent
+    try:
+        attempt = parse_snapshot_strict(DeliveryAttemptState, snapshot)
+    except MalformedDocError as error:
+        raise ChatFirstMalformedDeliveryAttempt('chat-first delivery attempt state is malformed') from error
+    return intent.model_copy(update=attempt.model_dump(mode='python'))
+
+
+def valid_attempt_value(_intent: ProactiveIntent, field: str, value: Any) -> bool:
+    try:
+        DeliveryAttemptState.model_validate({field: value})
+    except ValidationError:
+        return False
+    return True
+
+
+def reset_malformed_delivery_attempt(intent: ProactiveIntent, raw: dict[str, Any], *, now: datetime) -> dict[str, Any]:
+    """Preserve every independently valid field and spend the next fetch."""
+
+    raw_requeue_count = raw.get('requeue_count', 0)
+    preserved_requeue_count = (
+        raw_requeue_count if valid_attempt_value(intent, 'requeue_count', raw_requeue_count) else 0
+    )
+    raw_fetch_count = raw.get('fetch_count', 0)
+    preserved_fetch_count = (
+        raw_fetch_count
+        if valid_attempt_value(intent, 'fetch_count', raw_fetch_count)
+        else (UNACKNOWLEDGED_FETCH_BUDGET - 1 if preserved_requeue_count > 0 else 0)
+    )
+    reset: dict[str, Any] = {'fetch_count': preserved_fetch_count + 1, 'last_fetched_at': now}
+    defaults = {
+        'requeue_count': preserved_requeue_count,
+        'materialization_attempts': 0,
+        'last_rejection_code': None,
+        'last_rejection_at': None,
+        'first_deferred_at': None,
+        'last_deferral_at': None,
+    }
+    for field, default in defaults.items():
+        value = raw.get(field, default)
+        reset[field] = value if valid_attempt_value(intent, field, value) else default
+    return reset
+
+
+def dead_letter_payload(intent: ProactiveIntent, *, terminal_at: datetime) -> dict[str, Any]:
+    """Keep the complete terminal record while ensuring repair ordering is non-null."""
+
+    terminal = parse_payload_strict(
+        DeadLetteredProactiveIntent,
+        intent.model_dump(mode='python'),
+        document_path='<derived-chat-first-dead-letter>',
+    )
+    payload = terminal.model_dump(mode='python')
+    if payload.get('last_fetched_at') is None:
+        payload['last_fetched_at'] = terminal_at
+    return payload
+
+
+def move_to_dead_letters(
+    write_transaction: Any,
+    *,
+    intent_ref_value: Any,
+    dead_letter_ref_value: Any,
+    intent: ProactiveIntent,
+    terminal_at: datetime,
+) -> None:
+    write_transaction.set(dead_letter_ref_value, dead_letter_payload(intent, terminal_at=terminal_at))
+    write_transaction.delete(intent_ref_value)
+
+
+def requeue_transient_dead_letter(
+    uid: str,
+    intent_id: str,
+    *,
+    account_generation: int,
+    now: datetime,
+    firestore_client: Any,
+) -> ProactiveIntent | None:
+    dead_ref = dead_letter_ref(uid, intent_id, firestore_client=firestore_client)
+    active_ref = intent_ref(uid, intent_id, firestore_client=firestore_client)
+    attempt_ref = delivery_attempt_ref(uid, intent_id, firestore_client=firestore_client)
+    transaction = firestore_client.transaction()
+
+    @firestore.transactional
+    def apply(write_transaction: Any) -> ProactiveIntent | None:
+        snapshot = dead_ref.get(transaction=write_transaction)
+        if not snapshot.exists:
+            return None
+        try:
+            intent = parse_snapshot_strict(DeadLetteredProactiveIntent, snapshot)
+        except MalformedDocError as error:
+            raise ChatFirstMalformedDeliveryAttempt('chat-first dead letter is malformed') from error
+        attempt_snapshot = attempt_ref.get(transaction=write_transaction)
+        intent = intent_with_delivery_attempt(intent, attempt_snapshot)
+        if (
+            intent.account_generation != account_generation
+            or intent.delivery_state != 'dead_letter'
+            or intent.dead_letter_reason not in TRANSIENT_DEAD_LETTER_REASONS
+            or intent.requeue_count != 0
+        ):
+            return None
+        terminal_at = intent.last_rejection_at or intent.last_fetched_at
+        if terminal_at is None or now - terminal_at < TRANSIENT_DEAD_LETTER_REPAIR_AGE:
+            return None
+        requeued = intent.model_copy(
+            update={
+                'delivery_state': 'ready',
+                'dead_letter_reason': None,
+                'fetch_count': 0,
+                'last_fetched_at': None,
+                'materialization_attempts': 0,
+                'last_rejection_code': None,
+                'last_rejection_at': None,
+                'requeue_count': 1,
+            }
+        )
+        active_payload = requeued.model_dump(
+            mode='python',
+            exclude={
+                'fetch_count',
+                'last_fetched_at',
+                'requeue_count',
+                'materialization_attempts',
+                'last_rejection_code',
+                'last_rejection_at',
+                'first_deferred_at',
+                'last_deferral_at',
+                'dead_letter_reason',
+            },
+        )
+        write_transaction.set(active_ref, active_payload)
+        write_transaction.set(
+            attempt_ref,
+            {
+                'fetch_count': 0,
+                'requeue_count': 1,
+                'materialization_attempts': 0,
+                'last_rejection_code': None,
+                'last_rejection_at': None,
+            },
+            merge=True,
+        )
+        write_transaction.delete(dead_ref)
+        return requeued
+
+    return apply(transaction)
+
+
+def repair_transient_dead_letters(
+    uid: str,
+    *,
+    account_generation: int,
+    limit: int,
+    now: datetime,
+    firestore_client: Any,
+    requeue: Any = requeue_transient_dead_letter,
+) -> bool:
+    """Repair a bounded terminal window; return whether the serving query failed."""
+
+    collection = user_ref(uid, firestore_client=firestore_client).collection(DEAD_LETTERS_COLLECTION)
+    try:
+        query = (
+            CHAT_FIRST_TRANSIENT_DEAD_LETTER_REPAIR_QUERY.build(
+                collection,
+                {
+                    'account_generation': account_generation,
+                    'requeue_count': 0,
+                    'dead_letter_reasons': list(TRANSIENT_DEAD_LETTER_REASONS),
+                    'last_fetched_at': None,
+                },
+                field_filter_factory=FieldFilter,
+            )
+            .order_by('last_fetched_at')
+            .limit(2 * limit)
+        )
+        repaired = 0
+        for snapshot in query.stream():
+            if repaired >= limit:
+                break
+            raw = snapshot.to_dict() or {}
+            terminal_at = raw.get('last_rejection_at') or raw.get('last_fetched_at')
+            if not isinstance(terminal_at, datetime) or now - terminal_at < TRANSIENT_DEAD_LETTER_REPAIR_AGE:
+                continue
+            try:
+                if (
+                    requeue(
+                        uid,
+                        snapshot.id,
+                        account_generation=account_generation,
+                        now=now,
+                        firestore_client=firestore_client,
+                    )
+                    is not None
+                ):
+                    repaired += 1
+            except ChatFirstMalformedDeliveryAttempt:
+                continue
+    except GoogleAPICallError:
+        logger.exception('Chat-first transient dead-letter repair scan failed')
+        return True
+    return False

--- a/backend/database/chat_first_intents.py
+++ b/backend/database/chat_first_intents.py
@@ -1,8 +1,9 @@
 """Durable Chat-first proactive intent state, separate from the chat journal."""
 
 import hashlib
+import json
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, Iterable
 
 from google.cloud import firestore
@@ -30,6 +31,28 @@ DEFERRALS_COLLECTION = 'chat_first_deferrals'
 STATE_COLLECTION = 'chat_first_proactive_state'
 BUDGET_DOCUMENT = 'budget'
 _DEFERRAL_DUE_AFTER = timedelta(hours=24)
+
+# A ready intent must reach a terminal state under bounded identical retries:
+# typed kernel failures park it after three reports, while fetch-only clients
+# cannot keep any head item live beyond twenty unacknowledged deliveries.
+MATERIALIZATION_REJECTION_BUDGET = 3
+UNACKNOWLEDGED_FETCH_BUDGET = 20
+STALLED_READY_AGE = timedelta(hours=24)
+PERMANENT_REJECTION_CODES = frozenset({'invalid_intent', 'identity_conflict'})
+
+
+@dataclass(frozen=True)
+class IntentLifecycleEvent:
+    event: str
+    source: ProactiveIntentSource
+    reason: str
+
+
+@dataclass(frozen=True)
+class ReadyIntentBatch:
+    intents: list[ProactiveIntent]
+    lifecycle_events: tuple[IntentLifecycleEvent, ...]
+    stalled_source: ProactiveIntentSource | None
 
 
 class ChatFirstIntentStoreError(RuntimeError):
@@ -528,17 +551,119 @@ def has_active_sparse_cold_start_sequence(
     return False
 
 
-def fetch_ready_intents(
+def _stable_chat_first_turn_id(intent_id: str) -> str:
+    return f'turn_cfi_{hashlib.sha256(intent_id.encode()).hexdigest()[:24]}'
+
+
+def _synthetic_reconciliation_receipt_id(intent_id: str) -> str:
+    return f'cfi_reconciled_{hashlib.sha256(intent_id.encode()).hexdigest()[:24]}'
+
+
+def _message_has_intent_identity(uid: str, intent_id: str, *, firestore_client: Any) -> bool:
+    """Point-read the stable chat row and verify its embedded intent identity."""
+
+    snapshot = (
+        _user_ref(uid, firestore_client=firestore_client)
+        .collection('messages')
+        .document(_stable_chat_first_turn_id(intent_id))
+        .get()
+    )
+    if not snapshot.exists:
+        return False
+    metadata = (snapshot.to_dict() or {}).get('metadata')
+    if isinstance(metadata, str):
+        try:
+            metadata = json.loads(metadata)
+        except (TypeError, ValueError):
+            return False
+    return isinstance(metadata, dict) and metadata.get('chatFirstIntentId') == intent_id
+
+
+def _fetch_priority(intent: ProactiveIntent) -> int:
+    if intent.source == 'daily_opener' or any(block.type == 'conversationLink' for block in intent.blocks):
+        return 0
+    if intent.source == 'capture_arrival' and all(block.type == 'captureLink' for block in intent.blocks):
+        return 2
+    return 1
+
+
+def _advance_fetched_intent(
+    uid: str,
+    intent_id: str,
+    *,
+    account_generation: int,
+    now: datetime,
+    reconcile: bool,
+    firestore_client: Any,
+) -> tuple[ProactiveIntent | None, IntentLifecycleEvent | None]:
+    intent_ref = _intent_ref(uid, intent_id, firestore_client=firestore_client)
+    transaction = firestore_client.transaction()
+
+    @firestore.transactional
+    def apply(write_transaction: Any) -> tuple[ProactiveIntent | None, IntentLifecycleEvent | None]:
+        control_snapshot = _control_ref(uid, firestore_client=firestore_client).get(transaction=write_transaction)
+        _require_control(control_snapshot, uid=uid, account_generation=account_generation)
+        snapshot = intent_ref.get(transaction=write_transaction)
+        if not snapshot.exists:
+            return None, None
+        intent = _intent_from_snapshot(snapshot)
+        if intent.account_generation != account_generation or intent.delivery_state not in {
+            'ready',
+            'pending_kernel_receipt',
+        }:
+            return None, None
+
+        fetch_count = intent.fetch_count + 1
+        common = {'fetch_count': fetch_count, 'last_fetched_at': now}
+        if reconcile:
+            budget_ref = _budget_ref(uid, firestore_client=firestore_client)
+            budget_snapshot = budget_ref.get(transaction=write_transaction) if intent.consumes_turn_budget else None
+            delivered = intent.model_copy(
+                update={
+                    **common,
+                    'delivery_state': 'delivered',
+                    'delivered_at': now,
+                    'materialization_receipt_id': _synthetic_reconciliation_receipt_id(intent.intent_id),
+                }
+            )
+            if intent.consumes_turn_budget:
+                assert budget_snapshot is not None
+                budget = _budget_from_snapshot(budget_snapshot, account_generation=account_generation, now=now)
+                write_transaction.set(
+                    budget_ref, account_materialization(budget, intent_id=intent_id, now=now).model_dump(mode='python')
+                )
+            write_transaction.set(intent_ref, _intent_payload(delivered))
+            return None, IntentLifecycleEvent('reconciled', intent.source, 'existing_chat_row')
+        if fetch_count > UNACKNOWLEDGED_FETCH_BUDGET:
+            dead_lettered = intent.model_copy(
+                update={
+                    **common,
+                    'delivery_state': 'dead_letter',
+                    'dead_letter_reason': 'unacknowledged_after_fetch_budget',
+                }
+            )
+            write_transaction.set(intent_ref, _intent_payload(dead_lettered))
+            return None, IntentLifecycleEvent('dead_letter', intent.source, 'unacknowledged_after_fetch_budget')
+        fetched = intent.model_copy(update=common)
+        write_transaction.set(intent_ref, _intent_payload(fetched))
+        return fetched, None
+
+    return apply(transaction)
+
+
+def fetch_ready_intent_batch(
     uid: str,
     *,
     account_generation: int,
     limit: int = 8,
     exclude_block_types: set[str] | frozenset[str] | None = None,
+    now: datetime | None = None,
     firestore_client: Any = None,
-) -> list[ProactiveIntent]:
-    """Return ready intents only; this never changes delivery or writes Chat."""
+) -> ReadyIntentBatch:
+    """Fetch a priority batch while bounding poison retries and reconciling stable rows."""
 
     client = _db(firestore_client)
+    fetched_at = now or datetime.now(timezone.utc)
     _require_current_control(uid, account_generation=account_generation, firestore_client=client)
     collection = _user_ref(uid, firestore_client=client).collection(INTENTS_COLLECTION)
     # Push the delivery-state filter to Firestore so delivered historical rows
@@ -546,7 +671,7 @@ def fetch_ready_intents(
     # ever needs ready or pending-receipt intents, which are bounded; the full
     # collection otherwise grows with account age.
     query = collection.where(filter=FieldFilter('delivery_state', 'in', ['ready', 'pending_kernel_receipt']))
-    ready: list[ProactiveIntent] = []
+    candidates: list[ProactiveIntent] = []
     for snapshot in query.stream():
         intent = _intent_from_snapshot(snapshot)
         if intent.account_generation != account_generation:
@@ -557,9 +682,110 @@ def fetch_ready_intents(
         # legacy-compatible intents behind them.
         if exclude_block_types and any(block.type in exclude_block_types for block in intent.blocks):
             continue
-        ready.append(intent)
-    ready.sort(key=lambda intent: (intent.created_at, intent.intent_id))
-    return ready[:limit]
+        candidates.append(intent)
+    candidates.sort(key=lambda intent: (_fetch_priority(intent), intent.created_at, intent.intent_id))
+    oldest_candidate = min(candidates, key=lambda intent: (intent.created_at, intent.intent_id), default=None)
+
+    ready: list[ProactiveIntent] = []
+    lifecycle_events: list[IntentLifecycleEvent] = []
+    # Process beyond the response limit when earlier candidates terminalize;
+    # the caller still receives up to eight live items in this same fetch.
+    for intent in candidates:
+        reconcile = intent.fetch_count > 0 and _message_has_intent_identity(
+            uid, intent.intent_id, firestore_client=client
+        )
+        advanced, event = _advance_fetched_intent(
+            uid,
+            intent.intent_id,
+            account_generation=account_generation,
+            now=fetched_at,
+            reconcile=reconcile,
+            firestore_client=client,
+        )
+        if event is not None:
+            lifecycle_events.append(event)
+        if advanced is not None and len(ready) < limit:
+            ready.append(advanced)
+        if len(ready) >= limit:
+            break
+
+    stalled_source = (
+        oldest_candidate.source
+        if oldest_candidate is not None and fetched_at - oldest_candidate.created_at > STALLED_READY_AGE
+        else None
+    )
+    return ReadyIntentBatch(ready, tuple(lifecycle_events), stalled_source)
+
+
+def fetch_ready_intents(
+    uid: str,
+    *,
+    account_generation: int,
+    limit: int = 8,
+    exclude_block_types: set[str] | frozenset[str] | None = None,
+    now: datetime | None = None,
+    firestore_client: Any = None,
+) -> list[ProactiveIntent]:
+    """Compatibility wrapper for callers that only consume the live intents."""
+
+    return fetch_ready_intent_batch(
+        uid,
+        account_generation=account_generation,
+        limit=limit,
+        exclude_block_types=exclude_block_types,
+        now=now,
+        firestore_client=firestore_client,
+    ).intents
+
+
+def record_materialization_rejection(
+    uid: str,
+    *,
+    intent_id: str,
+    code: str,
+    account_generation: int,
+    now: datetime,
+    firestore_client: Any = None,
+) -> tuple[ProactiveIntent, str | None]:
+    """Record a typed kernel rejection and park deterministic poison within budget."""
+
+    client = _db(firestore_client)
+    intent_ref = _intent_ref(uid, intent_id, firestore_client=client)
+    transaction = client.transaction()
+
+    @firestore.transactional
+    def apply(write_transaction: Any) -> tuple[ProactiveIntent, str | None]:
+        control_snapshot = _control_ref(uid, firestore_client=client).get(transaction=write_transaction)
+        _require_control(control_snapshot, uid=uid, account_generation=account_generation)
+        snapshot = intent_ref.get(transaction=write_transaction)
+        if not snapshot.exists:
+            raise ProactiveIntentNotReady('proactive intent is not ready')
+        intent = _intent_from_snapshot(snapshot)
+        if intent.account_generation != account_generation:
+            raise ChatFirstIntentGenerationMismatch('intent account generation changed')
+        if intent.delivery_state == 'dead_letter':
+            return intent, None
+        if intent.delivery_state not in {'ready', 'pending_kernel_receipt'}:
+            raise ProactiveIntentNotReady('proactive intent is not ready')
+
+        attempts = intent.materialization_attempts + 1
+        reason: str | None = None
+        if code in PERMANENT_REJECTION_CODES:
+            reason = f'permanent_rejection:{code}'
+        elif attempts >= MATERIALIZATION_REJECTION_BUDGET:
+            reason = 'rejection_budget_exhausted'
+        rejected = intent.model_copy(
+            update={
+                'materialization_attempts': attempts,
+                'last_rejection_code': code,
+                'last_rejection_at': now,
+                **({'delivery_state': 'dead_letter', 'dead_letter_reason': reason} if reason else {}),
+            }
+        )
+        write_transaction.set(intent_ref, _intent_payload(rejected))
+        return rejected, reason
+
+    return apply(transaction)
 
 
 def acknowledge_materialization(
@@ -814,6 +1040,7 @@ __all__ = [
     'acknowledge_sparse_cold_start_sequence_terminal',
     'has_active_sparse_cold_start_sequence',
     'fetch_ready_intents',
+    'fetch_ready_intent_batch',
     'get_budget_state',
     'iter_ready_intent_ids',
     'proactive_deferral_id',
@@ -821,4 +1048,5 @@ __all__ = [
     'release_agent_judgment_admission',
     'record_deferral',
     'release_due_deferrals',
+    'record_materialization_rejection',
 ]

--- a/backend/database/chat_first_intents.py
+++ b/backend/database/chat_first_intents.py
@@ -31,6 +31,8 @@ DEFERRALS_COLLECTION = 'chat_first_deferrals'
 STATE_COLLECTION = 'chat_first_proactive_state'
 BUDGET_DOCUMENT = 'budget'
 _DEFERRAL_DUE_AFTER = timedelta(hours=24)
+CONTINUOUS_DEFERRAL_BUDGET = timedelta(days=7)
+FETCH_CANDIDATE_SCAN_MULTIPLIER = 2
 
 # A ready intent must reach a terminal state under bounded identical retries:
 # typed kernel failures park it after three reports, while fetch-only clients
@@ -55,11 +57,25 @@ class ReadyIntentBatch:
     stalled_source: ProactiveIntentSource | None
 
 
+@dataclass(frozen=True)
+class DeferralReleaseBatch:
+    intents: list[ProactiveIntent]
+    malformed_count: int
+
+
 class ChatFirstIntentStoreError(RuntimeError):
     """Base class for closed intent-store failures."""
 
 
 class ChatFirstIntentGenerationMismatch(ChatFirstIntentStoreError):
+    pass
+
+
+class ChatFirstIntentDocumentGenerationMismatch(ChatFirstIntentStoreError):
+    pass
+
+
+class ChatFirstMalformedDocument(ChatFirstIntentStoreError):
     pass
 
 
@@ -153,7 +169,7 @@ def _budget_from_snapshot(snapshot: Any, *, account_generation: int, now: dateti
     try:
         state = parse_snapshot_strict(ProactiveBudgetState, snapshot)
     except MalformedDocError as error:
-        raise ChatFirstIntentGenerationMismatch('chat-first proactive budget state is malformed') from error
+        raise ChatFirstMalformedDocument('chat-first proactive budget state is malformed') from error
     if state.account_generation != account_generation:
         return ProactiveBudgetState(account_generation=account_generation)
     return normalized_budget_state(state, now=now)
@@ -165,7 +181,7 @@ def _intent_from_snapshot(snapshot: Any) -> ProactiveIntent:
     try:
         return parse_snapshot_strict(ProactiveIntent, snapshot)
     except MalformedDocError as error:
-        raise ChatFirstIntentGenerationMismatch('chat-first proactive intent is malformed') from error
+        raise ChatFirstMalformedDocument('chat-first proactive intent is malformed') from error
 
 
 def _deferral_from_snapshot(snapshot: Any) -> ProactiveDeferral:
@@ -174,7 +190,7 @@ def _deferral_from_snapshot(snapshot: Any) -> ProactiveDeferral:
     try:
         return parse_snapshot_strict(ProactiveDeferral, snapshot)
     except MalformedDocError as error:
-        raise ChatFirstIntentGenerationMismatch('chat-first deferral is malformed') from error
+        raise ChatFirstMalformedDocument('chat-first deferral is malformed') from error
 
 
 def _require_current_control(uid: str, *, account_generation: int, firestore_client: Any) -> None:
@@ -643,7 +659,7 @@ def _advance_fetched_intent(
             write_transaction.set(intent_ref, _intent_payload(dead_lettered))
             return None, IntentLifecycleEvent('dead_letter', intent.source, 'unacknowledged_after_fetch_budget')
         fetched = intent.model_copy(update=common)
-        write_transaction.set(intent_ref, _intent_payload(fetched))
+        write_transaction.set(intent_ref, common, merge=True)
         return fetched, None
 
     return apply(transaction)
@@ -674,7 +690,7 @@ def _dead_letter_malformed_intent(
             return
         try:
             _intent_from_snapshot(snapshot)
-        except ChatFirstIntentGenerationMismatch:
+        except ChatFirstMalformedDocument:
             write_transaction.set(
                 intent_ref,
                 {**raw, 'delivery_state': 'dead_letter', 'dead_letter_reason': 'malformed_document'},
@@ -709,7 +725,7 @@ def fetch_ready_intent_batch(
     for snapshot in query.stream():
         try:
             intent = _intent_from_snapshot(snapshot)
-        except ChatFirstIntentGenerationMismatch:
+        except ChatFirstMalformedDocument:
             raw = snapshot.to_dict() or {}
             malformed_intent_ids.append(getattr(snapshot, 'id', raw.get('intent_id', 'malformed')))
             continue
@@ -727,7 +743,9 @@ def fetch_ready_intent_batch(
 
     ready: list[ProactiveIntent] = []
     lifecycle_events: list[IntentLifecycleEvent] = []
-    for intent_id in malformed_intent_ids:
+    candidate_scan_limit = FETCH_CANDIDATE_SCAN_MULTIPLIER * limit
+    malformed_scan_count = min(len(malformed_intent_ids), candidate_scan_limit)
+    for intent_id in malformed_intent_ids[:malformed_scan_count]:
         try:
             _dead_letter_malformed_intent(
                 uid,
@@ -739,13 +757,14 @@ def fetch_ready_intent_batch(
             # A concurrently deleted or repaired malformed row is isolated from
             # every independent ready intent in this fetch.
             continue
-    # Process beyond the response limit when earlier candidates terminalize;
-    # the caller still receives up to eight live items in this same fetch.
-    for intent in candidates:
+    # Process beyond the response limit when earlier candidates terminalize,
+    # but never let a poison backlog amplify point reads and transactions
+    # without bound on every device poll.
+    remaining_scan_limit = candidate_scan_limit - malformed_scan_count
+    for intent in candidates[:remaining_scan_limit]:
         if deferred_intent_ids and intent.intent_id in deferred_intent_ids:
-            advanced, event = intent, None
             if len(ready) < limit:
-                ready.append(advanced)
+                ready.append(intent)
             if len(ready) >= limit:
                 break
             continue
@@ -825,7 +844,7 @@ def record_materialization_rejection(
             return None, None
         intent = _intent_from_snapshot(snapshot)
         if intent.account_generation != account_generation:
-            raise ChatFirstIntentGenerationMismatch('intent account generation changed')
+            raise ChatFirstIntentDocumentGenerationMismatch('intent account generation changed')
         if intent.delivery_state in {'dead_letter', 'delivered'}:
             return intent, None
         if intent.delivery_state not in {'ready', 'pending_kernel_receipt'}:
@@ -872,11 +891,27 @@ def record_materialization_deferral(
             return None
         intent = _intent_from_snapshot(snapshot)
         if intent.account_generation != account_generation:
-            raise ChatFirstIntentGenerationMismatch('intent account generation changed')
+            raise ChatFirstIntentDocumentGenerationMismatch('intent account generation changed')
         if intent.delivery_state not in {'ready', 'pending_kernel_receipt'}:
             return intent
-        write_transaction.set(intent_ref, {'last_deferral_at': now}, merge=True)
-        return intent
+        first_deferred_at = intent.first_deferred_at or now
+        if now - first_deferred_at >= CONTINUOUS_DEFERRAL_BUDGET:
+            dead_lettered = intent.model_copy(
+                update={
+                    'first_deferred_at': first_deferred_at,
+                    'last_deferral_at': now,
+                    'delivery_state': 'dead_letter',
+                    'dead_letter_reason': 'deferred_beyond_budget',
+                }
+            )
+            write_transaction.set(intent_ref, _intent_payload(dead_lettered))
+            return dead_lettered
+        write_transaction.set(
+            intent_ref,
+            {'first_deferred_at': first_deferred_at, 'last_deferral_at': now},
+            merge=True,
+        )
+        return intent.model_copy(update={'first_deferred_at': first_deferred_at, 'last_deferral_at': now})
 
     return apply(transaction)
 
@@ -907,8 +942,12 @@ def acknowledge_materialization(
         intent = _intent_from_snapshot(intent_snapshot)
         budget_snapshot = budget_ref.get(transaction=write_transaction) if intent.consumes_turn_budget else None
         if intent.account_generation != account_generation:
-            raise ChatFirstIntentGenerationMismatch('intent account generation changed')
-        if intent.delivery_state in {'delivered', 'dead_letter'}:
+            raise ChatFirstIntentDocumentGenerationMismatch('intent account generation changed')
+        if intent.delivery_state == 'delivered':
+            if intent.materialization_receipt_id != receipt_id:
+                raise ChatFirstIntentConflictError('intent was delivered with a different receipt')
+            return intent
+        if intent.delivery_state == 'dead_letter':
             return intent
         if intent.delivery_state not in {'ready', 'pending_kernel_receipt'}:
             raise ProactiveIntentNotReady('proactive intent is not ready')
@@ -992,7 +1031,7 @@ def release_due_deferrals(
     now: datetime,
     subject: ChatFirstSubject | None = None,
     firestore_client: Any = None,
-) -> list[ProactiveIntent]:
+) -> DeferralReleaseBatch:
     """Release due or meaningful-subject-change deferrals exactly once.
 
     Keep the pending/state and releaseability predicates in Firestore. A user's
@@ -1022,8 +1061,13 @@ def release_due_deferrals(
         )
     query = query.limit(32)
     candidates: list[ProactiveDeferral] = []
+    malformed_count = 0
     for snapshot in query.stream():
-        deferred = _deferral_from_snapshot(snapshot)
+        try:
+            deferred = _deferral_from_snapshot(snapshot)
+        except ChatFirstMalformedDocument:
+            malformed_count += 1
+            continue
         # Keep strict model validation and an exact subject check as the final
         # fence for old/malformed rows and for fake clients that do not fully
         # emulate Firestore's nested-field filtering.
@@ -1037,16 +1081,26 @@ def release_due_deferrals(
 
     released: list[ProactiveIntent] = []
     for deferred in candidates:
-        intent = _release_deferral_transaction(
-            uid,
-            deferred,
-            account_generation=account_generation,
-            now=now,
-            firestore_client=client,
-        )
+        try:
+            intent = _release_deferral_transaction(
+                uid,
+                deferred,
+                account_generation=account_generation,
+                now=now,
+                firestore_client=client,
+            )
+        except ChatFirstIntentGenerationMismatch:
+            raise
+        except ChatFirstMalformedDocument:
+            malformed_count += 1
+            continue
+        except Exception:
+            # One concurrently deleted, conflicting, or otherwise broken row
+            # cannot roll back independent due deferrals in this batch.
+            continue
         if intent is not None:
             released.append(intent)
-    return released
+    return DeferralReleaseBatch(released, malformed_count)
 
 
 def _release_deferral_transaction(
@@ -1117,7 +1171,9 @@ __all__ = [
     'AgentJudgmentAdmission',
     'BUDGET_DOCUMENT',
     'ChatFirstIntentConflictError',
+    'ChatFirstIntentDocumentGenerationMismatch',
     'ChatFirstIntentGenerationMismatch',
+    'ChatFirstMalformedDocument',
     'ChatFirstIntentStoreError',
     'DEFERRALS_COLLECTION',
     'INTENTS_COLLECTION',

--- a/backend/database/chat_first_intents.py
+++ b/backend/database/chat_first_intents.py
@@ -29,10 +29,13 @@ from models.task_intelligence import TaskWorkflowControl
 INTENTS_COLLECTION = 'chat_first_proactive_intents'
 DEFERRALS_COLLECTION = 'chat_first_deferrals'
 STATE_COLLECTION = 'chat_first_proactive_state'
+DELIVERY_ATTEMPTS_COLLECTION = 'chat_first_delivery_attempts'
 BUDGET_DOCUMENT = 'budget'
 _DEFERRAL_DUE_AFTER = timedelta(hours=24)
 CONTINUOUS_DEFERRAL_BUDGET = timedelta(days=7)
+TRANSIENT_DEAD_LETTER_REPAIR_AGE = timedelta(hours=6)
 FETCH_CANDIDATE_SCAN_MULTIPLIER = 2
+DEFERRAL_CANDIDATE_SCAN_LIMIT = 64
 
 # A ready intent must reach a terminal state under bounded identical retries:
 # typed kernel failures park it after three reports, while fetch-only clients
@@ -122,6 +125,12 @@ def _intent_ref(uid: str, intent_id: str, *, firestore_client: Any = None):
     return _user_ref(uid, firestore_client=firestore_client).collection(INTENTS_COLLECTION).document(intent_id)
 
 
+def _delivery_attempt_ref(uid: str, intent_id: str, *, firestore_client: Any = None):
+    return (
+        _user_ref(uid, firestore_client=firestore_client).collection(DELIVERY_ATTEMPTS_COLLECTION).document(intent_id)
+    )
+
+
 def _deferral_ref(uid: str, deferral_id: str, *, firestore_client: Any = None):
     return _user_ref(uid, firestore_client=firestore_client).collection(DEFERRALS_COLLECTION).document(deferral_id)
 
@@ -205,7 +214,39 @@ def _require_current_control(uid: str, *, account_generation: int, firestore_cli
 
 
 def _intent_payload(intent: ProactiveIntent) -> dict[str, Any]:
-    return intent.model_dump(mode='python')
+    # Rolling-deploy safety: pre-Round-7 readers reject these newer fetch and
+    # repair fields. They live in a sibling document keyed by intent ID, never
+    # on the intent document consumed by old revisions.
+    payload = intent.model_dump(mode='python', exclude={'fetch_count', 'last_fetched_at', 'requeue_count'})
+    optional_delivery_fields = {
+        'materialization_attempts': 0,
+        'last_rejection_code': None,
+        'last_rejection_at': None,
+        'first_deferred_at': None,
+        'last_deferral_at': None,
+        'dead_letter_reason': None,
+    }
+    for field, default in optional_delivery_fields.items():
+        if payload.get(field) == default:
+            payload.pop(field, None)
+    return payload
+
+
+def _intent_with_delivery_attempt(intent: ProactiveIntent, snapshot: Any) -> ProactiveIntent:
+    if not snapshot.exists:
+        return intent
+    raw = snapshot.to_dict() or {}
+    fetch_count = raw.get('fetch_count', 0)
+    requeue_count = raw.get('requeue_count', 0)
+    if not isinstance(fetch_count, int) or fetch_count < 0 or not isinstance(requeue_count, int):
+        raise ChatFirstMalformedDocument('chat-first delivery attempt state is malformed')
+    return intent.model_copy(
+        update={
+            'fetch_count': fetch_count,
+            'last_fetched_at': raw.get('last_fetched_at'),
+            'requeue_count': requeue_count,
+        }
+    )
 
 
 def get_budget_state(
@@ -614,6 +655,7 @@ def _advance_fetched_intent(
     firestore_client: Any,
 ) -> tuple[ProactiveIntent | None, IntentLifecycleEvent | None]:
     intent_ref = _intent_ref(uid, intent_id, firestore_client=firestore_client)
+    attempt_ref = _delivery_attempt_ref(uid, intent_id, firestore_client=firestore_client)
     transaction = firestore_client.transaction()
 
     @firestore.transactional
@@ -622,6 +664,8 @@ def _advance_fetched_intent(
         if not snapshot.exists:
             return None, None
         intent = _intent_from_snapshot(snapshot)
+        attempt_snapshot = attempt_ref.get(transaction=write_transaction)
+        intent = _intent_with_delivery_attempt(intent, attempt_snapshot)
         if intent.account_generation != account_generation or intent.delivery_state not in {
             'ready',
             'pending_kernel_receipt',
@@ -648,6 +692,7 @@ def _advance_fetched_intent(
                     budget_ref, account_materialization(budget, intent_id=intent_id, now=now).model_dump(mode='python')
                 )
             write_transaction.set(intent_ref, _intent_payload(delivered))
+            write_transaction.set(attempt_ref, common, merge=True)
             return None, IntentLifecycleEvent('reconciled', intent.source, 'existing_chat_row')
         if fetch_count > UNACKNOWLEDGED_FETCH_BUDGET:
             dead_lettered = intent.model_copy(
@@ -658,9 +703,10 @@ def _advance_fetched_intent(
                 }
             )
             write_transaction.set(intent_ref, _intent_payload(dead_lettered))
+            write_transaction.set(attempt_ref, common, merge=True)
             return None, IntentLifecycleEvent('dead_letter', intent.source, 'unacknowledged_after_fetch_budget')
         fetched = intent.model_copy(update=common)
-        write_transaction.set(intent_ref, common, merge=True)
+        write_transaction.set(attempt_ref, common, merge=True)
         return fetched, None
 
     return apply(transaction)
@@ -738,9 +784,17 @@ def fetch_ready_intent_batch(
         # legacy-compatible intents behind them.
         if exclude_block_types and any(block.type in exclude_block_types for block in intent.blocks):
             continue
+        try:
+            intent = _intent_with_delivery_attempt(
+                intent,
+                _delivery_attempt_ref(uid, intent.intent_id, firestore_client=client).get(),
+            )
+        except ChatFirstMalformedDocument:
+            continue
         candidates.append(intent)
     candidates.sort(key=lambda intent: (_fetch_priority(intent), intent.created_at, intent.intent_id))
-    oldest_candidate = min(candidates, key=lambda intent: (intent.created_at, intent.intent_id), default=None)
+    never_deferred = [intent for intent in candidates if intent.first_deferred_at is None]
+    oldest_candidate = min(never_deferred, key=lambda intent: (intent.created_at, intent.intent_id), default=None)
 
     ready: list[ProactiveIntent] = []
     lifecycle_events: list[IntentLifecycleEvent] = []
@@ -834,6 +888,7 @@ def record_materialization_rejection(
 
     client = _db(firestore_client)
     intent_ref = _intent_ref(uid, intent_id, firestore_client=client)
+    attempt_ref = _delivery_attempt_ref(uid, intent_id, firestore_client=client)
     transaction = client.transaction()
 
     @firestore.transactional
@@ -844,19 +899,41 @@ def record_materialization_rejection(
         if not snapshot.exists:
             return None, None
         intent = _intent_from_snapshot(snapshot)
+        attempt_snapshot = attempt_ref.get(transaction=write_transaction)
+        intent = _intent_with_delivery_attempt(intent, attempt_snapshot)
         if intent.account_generation != account_generation:
             raise ChatFirstIntentDocumentGenerationMismatch('intent account generation changed')
-        if intent.delivery_state in {'dead_letter', 'delivered'}:
+        if intent.delivery_state == 'dead_letter' and (
+            intent.dead_letter_reason == 'rejection_budget_exhausted'
+            and intent.last_rejection_code == 'kernel_materialization_failed'
+            and intent.requeue_count == 0
+            and intent.last_rejection_at is not None
+            and now - intent.last_rejection_at >= TRANSIENT_DEAD_LETTER_REPAIR_AGE
+        ):
+            intent = intent.model_copy(
+                update={
+                    'delivery_state': 'ready',
+                    'dead_letter_reason': None,
+                    'materialization_attempts': 0,
+                    'last_rejection_code': None,
+                    'last_rejection_at': None,
+                    'requeue_count': 1,
+                }
+            )
+            write_transaction.set(intent_ref, _intent_payload(intent))
+            write_transaction.set(attempt_ref, {'requeue_count': 1}, merge=True)
+        elif intent.delivery_state in {'dead_letter', 'delivered'}:
             return intent, None
         if intent.delivery_state not in {'ready', 'pending_kernel_receipt'}:
             raise ProactiveIntentNotReady('proactive intent is not ready')
 
+        if code not in PERMANENT_REJECTION_CODES:
+            # Transient kernel/SQLite failures consume only the independent
+            # fetch budget. Re-reporting them must never permanently destroy
+            # the queued intent.
+            return intent, None
         attempts = intent.materialization_attempts + 1
-        reason: str | None = None
-        if code in PERMANENT_REJECTION_CODES:
-            reason = f'permanent_rejection:{code}'
-        elif attempts >= MATERIALIZATION_REJECTION_BUDGET:
-            reason = 'rejection_budget_exhausted'
+        reason = f'permanent_rejection:{code}' if attempts >= MATERIALIZATION_REJECTION_BUDGET else None
         rejected = intent.model_copy(
             update={
                 'materialization_attempts': attempts,
@@ -887,6 +964,8 @@ def record_materialization_deferral(
 
     @firestore.transactional
     def apply(write_transaction: Any) -> ProactiveIntent | None:
+        control_snapshot = _control_ref(uid, firestore_client=client).get(transaction=write_transaction)
+        _require_control(control_snapshot, uid=uid, account_generation=account_generation)
         snapshot = intent_ref.get(transaction=write_transaction)
         if not snapshot.exists:
             return None
@@ -931,6 +1010,7 @@ def acknowledge_materialization(
     client = _db(firestore_client)
     intent_ref = _intent_ref(uid, intent_id, firestore_client=client)
     budget_ref = _budget_ref(uid, firestore_client=client)
+    attempt_ref = _delivery_attempt_ref(uid, intent_id, firestore_client=client)
     transaction = client.transaction()
 
     @firestore.transactional
@@ -941,6 +1021,8 @@ def acknowledge_materialization(
         if not intent_snapshot.exists:
             raise ProactiveIntentNotReady('proactive intent is not ready')
         intent = _intent_from_snapshot(intent_snapshot)
+        attempt_snapshot = attempt_ref.get(transaction=write_transaction)
+        intent = _intent_with_delivery_attempt(intent, attempt_snapshot)
         budget_snapshot = budget_ref.get(transaction=write_transaction) if intent.consumes_turn_budget else None
         if intent.account_generation != account_generation:
             raise ChatFirstIntentDocumentGenerationMismatch('intent account generation changed')
@@ -950,7 +1032,13 @@ def acknowledge_materialization(
             ).startswith(_SYNTHETIC_RECONCILIATION_RECEIPT_PREFIX):
                 raise ChatFirstIntentConflictError('intent was delivered with a different receipt')
             return intent
-        if intent.delivery_state == 'dead_letter':
+        repair_transient_dead_letter = (
+            intent.delivery_state == 'dead_letter'
+            and intent.dead_letter_reason == 'rejection_budget_exhausted'
+            and intent.last_rejection_code == 'kernel_materialization_failed'
+            and intent.requeue_count == 0
+        )
+        if intent.delivery_state == 'dead_letter' and not repair_transient_dead_letter:
             return intent
         if intent.delivery_state not in {'ready', 'pending_kernel_receipt'}:
             raise ProactiveIntentNotReady('proactive intent is not ready')
@@ -968,6 +1056,8 @@ def acknowledge_materialization(
             accounted = account_materialization(budget, intent_id=intent_id, now=now)
             write_transaction.set(budget_ref, accounted.model_dump(mode='python'))
         write_transaction.set(intent_ref, _intent_payload(delivered))
+        if repair_transient_dead_letter:
+            write_transaction.set(attempt_ref, {'requeue_count': 1}, merge=True)
         return delivered
 
     return apply(transaction)
@@ -1027,6 +1117,36 @@ def record_deferral(
     return apply(transaction)
 
 
+def _terminalize_malformed_deferral(
+    uid: str,
+    deferral_id: str,
+    *,
+    account_generation: int,
+    firestore_client: Any,
+) -> None:
+    """Remove one still-pending poison row from the bounded due-query head."""
+
+    if not deferral_id:
+        return
+    ref = _deferral_ref(uid, deferral_id, firestore_client=firestore_client)
+    transaction = firestore_client.transaction()
+
+    @firestore.transactional
+    def apply(write_transaction: Any) -> None:
+        snapshot = ref.get(transaction=write_transaction)
+        if not snapshot.exists:
+            return
+        raw = snapshot.to_dict() or {}
+        if raw.get('account_generation') != account_generation or raw.get('state') != 'pending':
+            return
+        try:
+            _deferral_from_snapshot(snapshot)
+        except ChatFirstMalformedDocument:
+            write_transaction.set(ref, {**raw, 'state': 'released'})
+
+    apply(transaction)
+
+
 def release_due_deferrals(
     uid: str,
     *,
@@ -1062,7 +1182,7 @@ def release_due_deferrals(
             },
             field_filter_factory=FieldFilter,
         )
-    query = query.limit(32)
+    query = query.limit(DEFERRAL_CANDIDATE_SCAN_LIMIT)
     candidates: list[ProactiveDeferral] = []
     malformed_count = 0
     for snapshot in query.stream():
@@ -1070,6 +1190,15 @@ def release_due_deferrals(
             deferred = _deferral_from_snapshot(snapshot)
         except ChatFirstMalformedDocument:
             malformed_count += 1
+            try:
+                _terminalize_malformed_deferral(
+                    uid,
+                    getattr(snapshot, 'id', ''),
+                    account_generation=account_generation,
+                    firestore_client=client,
+                )
+            except Exception:
+                pass
             continue
         # Keep strict model validation and an exact subject check as the final
         # fence for old/malformed rows and for fake clients that do not fully

--- a/backend/database/chat_first_intents.py
+++ b/backend/database/chat_first_intents.py
@@ -41,6 +41,7 @@ MATERIALIZATION_REJECTION_BUDGET = 3
 UNACKNOWLEDGED_FETCH_BUDGET = 20
 STALLED_READY_AGE = timedelta(hours=24)
 PERMANENT_REJECTION_CODES = frozenset({'invalid_intent', 'identity_conflict'})
+_SYNTHETIC_RECONCILIATION_RECEIPT_PREFIX = 'cfi_reconciled_'
 
 
 @dataclass(frozen=True)
@@ -572,7 +573,7 @@ def _stable_chat_first_turn_id(intent_id: str) -> str:
 
 
 def _synthetic_reconciliation_receipt_id(intent_id: str) -> str:
-    return f'cfi_reconciled_{hashlib.sha256(intent_id.encode()).hexdigest()[:24]}'
+    return f'{_SYNTHETIC_RECONCILIATION_RECEIPT_PREFIX}{hashlib.sha256(intent_id.encode()).hexdigest()[:24]}'
 
 
 def _message_has_intent_identity(uid: str, intent_id: str, *, firestore_client: Any) -> bool:
@@ -944,7 +945,9 @@ def acknowledge_materialization(
         if intent.account_generation != account_generation:
             raise ChatFirstIntentDocumentGenerationMismatch('intent account generation changed')
         if intent.delivery_state == 'delivered':
-            if intent.materialization_receipt_id != receipt_id:
+            if intent.materialization_receipt_id != receipt_id and not (
+                intent.materialization_receipt_id or ''
+            ).startswith(_SYNTHETIC_RECONCILIATION_RECEIPT_PREFIX):
                 raise ChatFirstIntentConflictError('intent was delivered with a different receipt')
             return intent
         if intent.delivery_state == 'dead_letter':

--- a/backend/database/chat_first_intents.py
+++ b/backend/database/chat_first_intents.py
@@ -601,8 +601,6 @@ def _advance_fetched_intent(
 
     @firestore.transactional
     def apply(write_transaction: Any) -> tuple[ProactiveIntent | None, IntentLifecycleEvent | None]:
-        control_snapshot = _control_ref(uid, firestore_client=firestore_client).get(transaction=write_transaction)
-        _require_control(control_snapshot, uid=uid, account_generation=account_generation)
         snapshot = intent_ref.get(transaction=write_transaction)
         if not snapshot.exists:
             return None, None
@@ -672,8 +670,21 @@ def fetch_ready_intent_batch(
     # collection otherwise grows with account age.
     query = collection.where(filter=FieldFilter('delivery_state', 'in', ['ready', 'pending_kernel_receipt']))
     candidates: list[ProactiveIntent] = []
+    malformed_refs: list[tuple[Any, dict[str, Any]]] = []
     for snapshot in query.stream():
-        intent = _intent_from_snapshot(snapshot)
+        try:
+            intent = _intent_from_snapshot(snapshot)
+        except ChatFirstIntentGenerationMismatch:
+            raw = snapshot.to_dict() or {}
+            malformed_refs.append(
+                (
+                    _intent_ref(
+                        uid, getattr(snapshot, 'id', raw.get('intent_id', 'malformed')), firestore_client=client
+                    ),
+                    {**raw, 'delivery_state': 'dead_letter', 'dead_letter_reason': 'malformed_document'},
+                )
+            )
+            continue
         if intent.account_generation != account_generation:
             continue
         # Apply compatibility filtering before the delivery window is bounded.
@@ -688,26 +699,67 @@ def fetch_ready_intent_batch(
 
     ready: list[ProactiveIntent] = []
     lifecycle_events: list[IntentLifecycleEvent] = []
+    write_batch = client.batch()
+    has_batched_writes = False
+    for ref, payload in malformed_refs:
+        write_batch.set(ref, payload)
+        has_batched_writes = True
     # Process beyond the response limit when earlier candidates terminalize;
     # the caller still receives up to eight live items in this same fetch.
     for intent in candidates:
-        reconcile = intent.fetch_count > 0 and _message_has_intent_identity(
+        reconcile = intent.fetch_count >= 2 and _message_has_intent_identity(
             uid, intent.intent_id, firestore_client=client
         )
-        advanced, event = _advance_fetched_intent(
-            uid,
-            intent.intent_id,
-            account_generation=account_generation,
-            now=fetched_at,
-            reconcile=reconcile,
-            firestore_client=client,
-        )
+        if reconcile:
+            try:
+                advanced, event = _advance_fetched_intent(
+                    uid,
+                    intent.intent_id,
+                    account_generation=account_generation,
+                    now=fetched_at,
+                    reconcile=True,
+                    firestore_client=client,
+                )
+            except Exception:
+                # One concurrently malformed or otherwise unadvanceable row is
+                # never allowed to block independent ready intents.
+                continue
+        else:
+            fetch_count = intent.fetch_count + 1
+            common = {'fetch_count': fetch_count, 'last_fetched_at': fetched_at}
+            if fetch_count > UNACKNOWLEDGED_FETCH_BUDGET:
+                advanced = None
+                event = IntentLifecycleEvent('dead_letter', intent.source, 'unacknowledged_after_fetch_budget')
+                updated = intent.model_copy(
+                    update={
+                        **common,
+                        'delivery_state': 'dead_letter',
+                        'dead_letter_reason': 'unacknowledged_after_fetch_budget',
+                    }
+                )
+            else:
+                updated = intent.model_copy(update=common)
+                advanced, event = updated, None
+            update = (
+                common
+                if advanced is not None
+                else {
+                    **common,
+                    'delivery_state': 'dead_letter',
+                    'dead_letter_reason': 'unacknowledged_after_fetch_budget',
+                }
+            )
+            write_batch.update(_intent_ref(uid, intent.intent_id, firestore_client=client), update)
+            has_batched_writes = True
         if event is not None:
             lifecycle_events.append(event)
         if advanced is not None and len(ready) < limit:
             ready.append(advanced)
         if len(ready) >= limit:
             break
+
+    if has_batched_writes:
+        write_batch.commit()
 
     stalled_source = (
         oldest_candidate.source
@@ -746,7 +798,7 @@ def record_materialization_rejection(
     account_generation: int,
     now: datetime,
     firestore_client: Any = None,
-) -> tuple[ProactiveIntent, str | None]:
+) -> tuple[ProactiveIntent | None, str | None]:
     """Record a typed kernel rejection and park deterministic poison within budget."""
 
     client = _db(firestore_client)
@@ -754,16 +806,16 @@ def record_materialization_rejection(
     transaction = client.transaction()
 
     @firestore.transactional
-    def apply(write_transaction: Any) -> tuple[ProactiveIntent, str | None]:
+    def apply(write_transaction: Any) -> tuple[ProactiveIntent | None, str | None]:
         control_snapshot = _control_ref(uid, firestore_client=client).get(transaction=write_transaction)
         _require_control(control_snapshot, uid=uid, account_generation=account_generation)
         snapshot = intent_ref.get(transaction=write_transaction)
         if not snapshot.exists:
-            raise ProactiveIntentNotReady('proactive intent is not ready')
+            return None, None
         intent = _intent_from_snapshot(snapshot)
         if intent.account_generation != account_generation:
             raise ChatFirstIntentGenerationMismatch('intent account generation changed')
-        if intent.delivery_state == 'dead_letter':
+        if intent.delivery_state in {'dead_letter', 'delivered'}:
             return intent, None
         if intent.delivery_state not in {'ready', 'pending_kernel_receipt'}:
             raise ProactiveIntentNotReady('proactive intent is not ready')
@@ -784,6 +836,49 @@ def record_materialization_rejection(
         )
         write_transaction.set(intent_ref, _intent_payload(rejected))
         return rejected, reason
+
+    return apply(transaction)
+
+
+def record_materialization_deferral(
+    uid: str,
+    *,
+    intent_id: str,
+    account_generation: int,
+    now: datetime,
+    firestore_client: Any = None,
+) -> ProactiveIntent | None:
+    """Exclude one explicitly suppressed delivery from the fetch backstop.
+
+    ``last_deferral_at`` makes replay idempotent when a response is lost after
+    the server committed this acknowledgement.
+    """
+
+    client = _db(firestore_client)
+    intent_ref = _intent_ref(uid, intent_id, firestore_client=client)
+    transaction = client.transaction()
+
+    @firestore.transactional
+    def apply(write_transaction: Any) -> ProactiveIntent | None:
+        snapshot = intent_ref.get(transaction=write_transaction)
+        if not snapshot.exists:
+            return None
+        intent = _intent_from_snapshot(snapshot)
+        if intent.account_generation != account_generation:
+            raise ChatFirstIntentGenerationMismatch('intent account generation changed')
+        if intent.delivery_state not in {'ready', 'pending_kernel_receipt'}:
+            return intent
+        raw = snapshot.to_dict() or {}
+        last_deferral_at = raw.get('last_deferral_at')
+        if intent.last_fetched_at is None or (
+            isinstance(last_deferral_at, datetime) and last_deferral_at >= intent.last_fetched_at
+        ):
+            return intent
+        adjusted = intent.model_copy(update={'fetch_count': max(0, intent.fetch_count - 1)})
+        payload = _intent_payload(adjusted)
+        payload['last_deferral_at'] = now
+        write_transaction.set(intent_ref, payload)
+        return adjusted
 
     return apply(transaction)
 
@@ -815,9 +910,7 @@ def acknowledge_materialization(
         budget_snapshot = budget_ref.get(transaction=write_transaction) if intent.consumes_turn_budget else None
         if intent.account_generation != account_generation:
             raise ChatFirstIntentGenerationMismatch('intent account generation changed')
-        if intent.delivery_state == 'delivered':
-            if intent.materialization_receipt_id != receipt_id:
-                raise ChatFirstIntentConflictError('intent was already acknowledged by a different receipt')
+        if intent.delivery_state in {'delivered', 'dead_letter'}:
             return intent
         if intent.delivery_state not in {'ready', 'pending_kernel_receipt'}:
             raise ProactiveIntentNotReady('proactive intent is not ready')

--- a/backend/database/chat_first_intents.py
+++ b/backend/database/chat_first_intents.py
@@ -649,12 +649,47 @@ def _advance_fetched_intent(
     return apply(transaction)
 
 
+def _dead_letter_malformed_intent(
+    uid: str,
+    intent_id: str,
+    *,
+    account_generation: int,
+    firestore_client: Any,
+) -> None:
+    """Terminalize one still-active malformed row without racing a newer writer."""
+
+    intent_ref = _intent_ref(uid, intent_id, firestore_client=firestore_client)
+    transaction = firestore_client.transaction()
+
+    @firestore.transactional
+    def apply(write_transaction: Any) -> None:
+        snapshot = intent_ref.get(transaction=write_transaction)
+        if not snapshot.exists:
+            return
+        raw = snapshot.to_dict() or {}
+        if raw.get('account_generation') != account_generation or raw.get('delivery_state') not in {
+            'ready',
+            'pending_kernel_receipt',
+        }:
+            return
+        try:
+            _intent_from_snapshot(snapshot)
+        except ChatFirstIntentGenerationMismatch:
+            write_transaction.set(
+                intent_ref,
+                {**raw, 'delivery_state': 'dead_letter', 'dead_letter_reason': 'malformed_document'},
+            )
+
+    apply(transaction)
+
+
 def fetch_ready_intent_batch(
     uid: str,
     *,
     account_generation: int,
     limit: int = 8,
     exclude_block_types: set[str] | frozenset[str] | None = None,
+    deferred_intent_ids: set[str] | frozenset[str] | None = None,
     now: datetime | None = None,
     firestore_client: Any = None,
 ) -> ReadyIntentBatch:
@@ -670,20 +705,13 @@ def fetch_ready_intent_batch(
     # collection otherwise grows with account age.
     query = collection.where(filter=FieldFilter('delivery_state', 'in', ['ready', 'pending_kernel_receipt']))
     candidates: list[ProactiveIntent] = []
-    malformed_refs: list[tuple[Any, dict[str, Any]]] = []
+    malformed_intent_ids: list[str] = []
     for snapshot in query.stream():
         try:
             intent = _intent_from_snapshot(snapshot)
         except ChatFirstIntentGenerationMismatch:
             raw = snapshot.to_dict() or {}
-            malformed_refs.append(
-                (
-                    _intent_ref(
-                        uid, getattr(snapshot, 'id', raw.get('intent_id', 'malformed')), firestore_client=client
-                    ),
-                    {**raw, 'delivery_state': 'dead_letter', 'dead_letter_reason': 'malformed_document'},
-                )
-            )
+            malformed_intent_ids.append(getattr(snapshot, 'id', raw.get('intent_id', 'malformed')))
             continue
         if intent.account_generation != account_generation:
             continue
@@ -699,67 +727,50 @@ def fetch_ready_intent_batch(
 
     ready: list[ProactiveIntent] = []
     lifecycle_events: list[IntentLifecycleEvent] = []
-    write_batch = client.batch()
-    has_batched_writes = False
-    for ref, payload in malformed_refs:
-        write_batch.set(ref, payload)
-        has_batched_writes = True
+    for intent_id in malformed_intent_ids:
+        try:
+            _dead_letter_malformed_intent(
+                uid,
+                intent_id,
+                account_generation=account_generation,
+                firestore_client=client,
+            )
+        except Exception:
+            # A concurrently deleted or repaired malformed row is isolated from
+            # every independent ready intent in this fetch.
+            continue
     # Process beyond the response limit when earlier candidates terminalize;
     # the caller still receives up to eight live items in this same fetch.
     for intent in candidates:
+        if deferred_intent_ids and intent.intent_id in deferred_intent_ids:
+            advanced, event = intent, None
+            if len(ready) < limit:
+                ready.append(advanced)
+            if len(ready) >= limit:
+                break
+            continue
         reconcile = intent.fetch_count >= 2 and _message_has_intent_identity(
             uid, intent.intent_id, firestore_client=client
         )
-        if reconcile:
-            try:
-                advanced, event = _advance_fetched_intent(
-                    uid,
-                    intent.intent_id,
-                    account_generation=account_generation,
-                    now=fetched_at,
-                    reconcile=True,
-                    firestore_client=client,
-                )
-            except Exception:
-                # One concurrently malformed or otherwise unadvanceable row is
-                # never allowed to block independent ready intents.
-                continue
-        else:
-            fetch_count = intent.fetch_count + 1
-            common = {'fetch_count': fetch_count, 'last_fetched_at': fetched_at}
-            if fetch_count > UNACKNOWLEDGED_FETCH_BUDGET:
-                advanced = None
-                event = IntentLifecycleEvent('dead_letter', intent.source, 'unacknowledged_after_fetch_budget')
-                updated = intent.model_copy(
-                    update={
-                        **common,
-                        'delivery_state': 'dead_letter',
-                        'dead_letter_reason': 'unacknowledged_after_fetch_budget',
-                    }
-                )
-            else:
-                updated = intent.model_copy(update=common)
-                advanced, event = updated, None
-            update = (
-                common
-                if advanced is not None
-                else {
-                    **common,
-                    'delivery_state': 'dead_letter',
-                    'dead_letter_reason': 'unacknowledged_after_fetch_budget',
-                }
+        try:
+            advanced, event = _advance_fetched_intent(
+                uid,
+                intent.intent_id,
+                account_generation=account_generation,
+                now=fetched_at,
+                reconcile=reconcile,
+                firestore_client=client,
             )
-            write_batch.update(_intent_ref(uid, intent.intent_id, firestore_client=client), update)
-            has_batched_writes = True
+        except Exception:
+            # One concurrently malformed or otherwise unadvanceable row is
+            # never allowed to block independent ready intents.
+            continue
         if event is not None:
             lifecycle_events.append(event)
         if advanced is not None and len(ready) < limit:
             ready.append(advanced)
         if len(ready) >= limit:
             break
-
-    if has_batched_writes:
-        write_batch.commit()
 
     stalled_source = (
         oldest_candidate.source
@@ -848,11 +859,7 @@ def record_materialization_deferral(
     now: datetime,
     firestore_client: Any = None,
 ) -> ProactiveIntent | None:
-    """Exclude one explicitly suppressed delivery from the fetch backstop.
-
-    ``last_deferral_at`` makes replay idempotent when a response is lost after
-    the server committed this acknowledgement.
-    """
+    """Record one explicit suppression without refunding an earlier fetch."""
 
     client = _db(firestore_client)
     intent_ref = _intent_ref(uid, intent_id, firestore_client=client)
@@ -868,17 +875,8 @@ def record_materialization_deferral(
             raise ChatFirstIntentGenerationMismatch('intent account generation changed')
         if intent.delivery_state not in {'ready', 'pending_kernel_receipt'}:
             return intent
-        raw = snapshot.to_dict() or {}
-        last_deferral_at = raw.get('last_deferral_at')
-        if intent.last_fetched_at is None or (
-            isinstance(last_deferral_at, datetime) and last_deferral_at >= intent.last_fetched_at
-        ):
-            return intent
-        adjusted = intent.model_copy(update={'fetch_count': max(0, intent.fetch_count - 1)})
-        payload = _intent_payload(adjusted)
-        payload['last_deferral_at'] = now
-        write_transaction.set(intent_ref, payload)
-        return adjusted
+        write_transaction.set(intent_ref, {'last_deferral_at': now}, merge=True)
+        return intent
 
     return apply(transaction)
 

--- a/backend/database/chat_first_intents.py
+++ b/backend/database/chat_first_intents.py
@@ -5,18 +5,18 @@ import json
 import logging
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
-from typing import Any, Iterable
+from typing import Any, Iterable, cast
 
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
 from database._client import get_firestore_client
+from database import chat_first_delivery_attempts as delivery_attempts
 from database.firestore_index_registry import (
     CHAT_FIRST_DEFERRALS_DUE_QUERY,
     CHAT_FIRST_DEFERRALS_SUBJECT_QUERY,
-    CHAT_FIRST_TRANSIENT_DEAD_LETTER_REPAIR_QUERY,
 )
-from database.read_boundary import MalformedDocError, parse_payload_strict, parse_snapshot_strict
+from database.read_boundary import MalformedDocError, parse_snapshot_strict
 from models.chat_first import (
     ChatFirstBlockSpec,
     ChatFirstSubject,
@@ -35,15 +35,16 @@ INTENTS_COLLECTION = 'chat_first_proactive_intents'
 DEFERRALS_COLLECTION = 'chat_first_deferrals'
 STATE_COLLECTION = 'chat_first_proactive_state'
 DELIVERY_ATTEMPTS_COLLECTION = 'chat_first_delivery_attempts'
+DEAD_LETTERS_COLLECTION = 'chat_first_dead_letters'
 BUDGET_DOCUMENT = 'budget'
 _DEFERRAL_DUE_AFTER = timedelta(hours=24)
 CONTINUOUS_DEFERRAL_BUDGET = timedelta(days=7)
-TRANSIENT_DEAD_LETTER_REPAIR_AGE = timedelta(hours=6)
+TRANSIENT_DEAD_LETTER_REPAIR_AGE = delivery_attempts.TRANSIENT_DEAD_LETTER_REPAIR_AGE
 FETCH_CANDIDATE_SCAN_MULTIPLIER = 2
 DEFERRAL_CANDIDATE_SCAN_LIMIT = 64
-UNACKNOWLEDGED_DEAD_LETTER_REASON = 'unacknowledged_after_fetch_budget'
-KERNEL_FAILURE_DEAD_LETTER_REASON = 'permanent_rejection:kernel_materialization_failed'
-TRANSIENT_DEAD_LETTER_REASONS = frozenset({UNACKNOWLEDGED_DEAD_LETTER_REASON, KERNEL_FAILURE_DEAD_LETTER_REASON})
+UNACKNOWLEDGED_DEAD_LETTER_REASON = delivery_attempts.UNACKNOWLEDGED_DEAD_LETTER_REASON
+KERNEL_FAILURE_DEAD_LETTER_REASON = delivery_attempts.KERNEL_FAILURE_DEAD_LETTER_REASON
+TRANSIENT_DEAD_LETTER_REASONS = delivery_attempts.TRANSIENT_DEAD_LETTER_REASONS
 TRANSIENT_DEATH_AFTER_REQUEUE_REASON = 'transient_death_after_requeue'
 
 logger = logging.getLogger(__name__)
@@ -61,7 +62,7 @@ _SYNTHETIC_RECONCILIATION_RECEIPT_PREFIX = 'cfi_reconciled_'
 @dataclass(frozen=True)
 class IntentLifecycleEvent:
     event: str
-    source: ProactiveIntentSource
+    source: str
     reason: str
 
 
@@ -140,6 +141,10 @@ def _delivery_attempt_ref(uid: str, intent_id: str, *, firestore_client: Any = N
     return (
         _user_ref(uid, firestore_client=firestore_client).collection(DELIVERY_ATTEMPTS_COLLECTION).document(intent_id)
     )
+
+
+def _dead_letter_ref(uid: str, intent_id: str, *, firestore_client: Any = None):
+    return _user_ref(uid, firestore_client=firestore_client).collection(DEAD_LETTERS_COLLECTION).document(intent_id)
 
 
 def _deferral_ref(uid: str, deferral_id: str, *, firestore_client: Any = None):
@@ -248,74 +253,14 @@ def _intent_payload(intent: ProactiveIntent) -> dict[str, Any]:
 
 
 def _intent_with_delivery_attempt(intent: ProactiveIntent, snapshot: Any) -> ProactiveIntent:
-    if not snapshot.exists:
-        return intent
-    raw = snapshot.to_dict() or {}
-    fetch_count = raw.get('fetch_count', 0)
-    requeue_count = raw.get('requeue_count', 0)
-    materialization_attempts = raw.get('materialization_attempts', 0)
-    if (
-        not isinstance(fetch_count, int)
-        or fetch_count < 0
-        or not isinstance(requeue_count, int)
-        or requeue_count < 0
-        or not isinstance(materialization_attempts, int)
-        or materialization_attempts < 0
-    ):
-        raise ChatFirstMalformedDocument('chat-first delivery attempt state is malformed')
-    hydrated = {
-        'fetch_count': fetch_count,
-        'last_fetched_at': raw.get('last_fetched_at'),
-        'requeue_count': requeue_count,
-        'materialization_attempts': materialization_attempts,
-        'last_rejection_code': raw.get('last_rejection_code'),
-        'last_rejection_at': raw.get('last_rejection_at'),
-        'first_deferred_at': raw.get('first_deferred_at'),
-        'last_deferral_at': raw.get('last_deferral_at'),
-    }
     try:
-        # ``model_copy(update=...)`` deliberately skips validation. Hydrated
-        # sibling state crosses a persistence boundary, so validate the merged
-        # model before it can reach the strict wire model.
-        return parse_payload_strict(
-            ProactiveIntent,
-            {**intent.model_dump(mode='python'), **hydrated},
-            document_path=f'{DELIVERY_ATTEMPTS_COLLECTION}/{intent.intent_id}',
-        )
-    except MalformedDocError as error:
+        return delivery_attempts.intent_with_delivery_attempt(intent, snapshot)
+    except delivery_attempts.ChatFirstMalformedDeliveryAttempt as error:
         raise ChatFirstMalformedDocument('chat-first delivery attempt state is malformed') from error
 
 
-def _valid_attempt_value(intent: ProactiveIntent, field: str, value: Any) -> bool:
-    try:
-        parse_payload_strict(
-            ProactiveIntent,
-            {**intent.model_dump(mode='python'), field: value},
-            document_path=f'{DELIVERY_ATTEMPTS_COLLECTION}/{intent.intent_id}',
-        )
-    except MalformedDocError:
-        return False
-    return True
-
-
-def _reset_malformed_delivery_attempt(
-    intent: ProactiveIntent, raw: dict[str, Any], *, fetch_count: int, now: datetime
-) -> dict[str, Any]:
-    """Reset corrupt derived fields without erasing independent valid history."""
-
-    reset: dict[str, Any] = {'fetch_count': fetch_count, 'last_fetched_at': now}
-    defaults = {
-        'requeue_count': 0,
-        'materialization_attempts': 0,
-        'last_rejection_code': None,
-        'last_rejection_at': None,
-        'first_deferred_at': None,
-        'last_deferral_at': None,
-    }
-    for field, default in defaults.items():
-        value = raw.get(field, default)
-        reset[field] = value if _valid_attempt_value(intent, field, value) else default
-    return reset
+def _reset_malformed_delivery_attempt(intent: ProactiveIntent, raw: dict[str, Any], *, now: datetime) -> dict[str, Any]:
+    return delivery_attempts.reset_malformed_delivery_attempt(intent, raw, now=now)
 
 
 def get_budget_state(
@@ -466,6 +411,7 @@ def create_intent(
         created_at=now,
     )
     intent_ref = _intent_ref(uid, intent_id, firestore_client=client)
+    dead_ref = _dead_letter_ref(uid, intent_id, firestore_client=client)
     budget_ref = _budget_ref(uid, firestore_client=client)
     transaction = client.transaction()
 
@@ -474,13 +420,25 @@ def create_intent(
         control_snapshot = _control_ref(uid, firestore_client=client).get(transaction=write_transaction)
         _require_control(control_snapshot, uid=uid, account_generation=account_generation)
         existing_snapshot = intent_ref.get(transaction=write_transaction)
+        dead_snapshot = dead_ref.get(transaction=write_transaction)
         budget_snapshot = (
             budget_ref.get(transaction=write_transaction)
-            if intent.consumes_turn_budget and not existing_snapshot.exists
+            if intent.consumes_turn_budget and not existing_snapshot.exists and not dead_snapshot.exists
             else None
         )
         if existing_snapshot.exists:
             existing = _intent_from_snapshot(existing_snapshot)
+            if (
+                existing.account_generation != account_generation
+                or existing.source != source
+                or existing.continuity_key != continuity_key
+                or existing.subject != subject
+                or existing.blocks != blocks
+            ):
+                raise ChatFirstIntentConflictError('intent continuity key was reused with different content')
+            return existing, False
+        if dead_snapshot.exists:
+            existing = _intent_from_snapshot(dead_snapshot)
             if (
                 existing.account_generation != account_generation
                 or existing.source != source
@@ -748,15 +706,14 @@ def _advance_fetched_intent(
         }:
             return None, None
 
-        fetch_count = intent.fetch_count + 1
-        common = {'fetch_count': fetch_count, 'last_fetched_at': now}
         attempt_update = (
-            _reset_malformed_delivery_attempt(
-                intent, attempt_snapshot.to_dict() or {}, fetch_count=fetch_count, now=now
-            )
+            _reset_malformed_delivery_attempt(intent, attempt_snapshot.to_dict() or {}, now=now)
             if malformed_attempt
-            else common
+            else {'fetch_count': intent.fetch_count + 1, 'last_fetched_at': now}
         )
+        fetch_count = cast(int, attempt_update['fetch_count'])
+        requeue_count = cast(int, attempt_update.get('requeue_count', intent.requeue_count))
+        common = {'fetch_count': fetch_count, 'last_fetched_at': now}
         if reconcile:
             budget_ref = _budget_ref(uid, firestore_client=firestore_client)
             budget_snapshot = budget_ref.get(transaction=write_transaction) if intent.consumes_turn_budget else None
@@ -777,19 +734,23 @@ def _advance_fetched_intent(
             write_transaction.set(intent_ref, _intent_payload(delivered))
             write_transaction.set(attempt_ref, attempt_update, merge=not malformed_attempt)
             return None, IntentLifecycleEvent('reconciled', intent.source, 'existing_chat_row')
-        if fetch_count > UNACKNOWLEDGED_FETCH_BUDGET:
+        if fetch_count >= UNACKNOWLEDGED_FETCH_BUDGET:
             dead_lettered = intent.model_copy(
                 update={
-                    **common,
+                    **attempt_update,
                     'delivery_state': 'dead_letter',
                     'dead_letter_reason': (
-                        TRANSIENT_DEATH_AFTER_REQUEUE_REASON
-                        if intent.requeue_count > 0
-                        else UNACKNOWLEDGED_DEAD_LETTER_REASON
+                        TRANSIENT_DEATH_AFTER_REQUEUE_REASON if requeue_count > 0 else UNACKNOWLEDGED_DEAD_LETTER_REASON
                     ),
                 }
             )
-            write_transaction.set(intent_ref, _intent_payload(dead_lettered))
+            delivery_attempts.move_to_dead_letters(
+                write_transaction,
+                intent_ref_value=intent_ref,
+                dead_letter_ref_value=_dead_letter_ref(uid, intent_id, firestore_client=firestore_client),
+                intent=dead_lettered,
+                terminal_at=now,
+            )
             write_transaction.set(attempt_ref, attempt_update, merge=not malformed_attempt)
             return None, IntentLifecycleEvent(
                 'dead_letter', intent.source, dead_lettered.dead_letter_reason or 'unknown'
@@ -832,10 +793,14 @@ def _dead_letter_malformed_intent(
         try:
             _intent_from_snapshot(snapshot)
         except ChatFirstMalformedDocument:
-            write_transaction.set(
-                intent_ref,
-                {**raw, 'delivery_state': 'dead_letter', 'dead_letter_reason': 'malformed_document'},
-            )
+            dead_payload = {
+                **raw,
+                'intent_id': raw.get('intent_id') or intent_id,
+                'delivery_state': 'dead_letter',
+                'dead_letter_reason': 'malformed_document',
+            }
+            write_transaction.set(_dead_letter_ref(uid, intent_id, firestore_client=firestore_client), dead_payload)
+            write_transaction.delete(intent_ref)
 
     apply(transaction)
 
@@ -848,58 +813,16 @@ def _requeue_transient_dead_letter(
     now: datetime,
     firestore_client: Any,
 ) -> ProactiveIntent | None:
-    intent_ref = _intent_ref(uid, intent_id, firestore_client=firestore_client)
-    attempt_ref = _delivery_attempt_ref(uid, intent_id, firestore_client=firestore_client)
-    transaction = firestore_client.transaction()
-
-    @firestore.transactional
-    def apply(write_transaction: Any) -> ProactiveIntent | None:
-        snapshot = intent_ref.get(transaction=write_transaction)
-        if not snapshot.exists:
-            return None
-        intent = _intent_from_snapshot(snapshot)
-        attempt_snapshot = attempt_ref.get(transaction=write_transaction)
-        intent = _intent_with_delivery_attempt(intent, attempt_snapshot)
-        if (
-            intent.account_generation != account_generation
-            or intent.delivery_state != 'dead_letter'
-            or intent.dead_letter_reason not in TRANSIENT_DEAD_LETTER_REASONS
-            or intent.requeue_count != 0
-        ):
-            return None
-        terminal_at = intent.last_rejection_at or intent.last_fetched_at
-        if terminal_at is None or now - terminal_at < TRANSIENT_DEAD_LETTER_REPAIR_AGE:
-            return None
-        requeued = intent.model_copy(
-            update={
-                'delivery_state': 'ready',
-                'dead_letter_reason': None,
-                'fetch_count': 0,
-                'last_fetched_at': None,
-                'materialization_attempts': 0,
-                'last_rejection_code': None,
-                'last_rejection_at': None,
-                'requeue_count': 1,
-            }
+    try:
+        return delivery_attempts.requeue_transient_dead_letter(
+            uid,
+            intent_id,
+            account_generation=account_generation,
+            now=now,
+            firestore_client=firestore_client,
         )
-        write_transaction.set(intent_ref, _intent_payload(requeued))
-        # Requeue owns only fetch/rejection accounting. Deferral history is an
-        # independent stall/budget clock and must survive this one-shot repair.
-        write_transaction.set(
-            attempt_ref,
-            {
-                'fetch_count': 0,
-                'last_fetched_at': None,
-                'requeue_count': 1,
-                'materialization_attempts': 0,
-                'last_rejection_code': None,
-                'last_rejection_at': None,
-            },
-            merge=True,
-        )
-        return requeued
-
-    return apply(transaction)
+    except delivery_attempts.ChatFirstMalformedDeliveryAttempt as error:
+        raise ChatFirstMalformedDocument('chat-first dead letter is malformed') from error
 
 
 def fetch_ready_intent_batch(
@@ -918,41 +841,16 @@ def fetch_ready_intent_batch(
     fetched_at = now or datetime.now(timezone.utc)
     _require_current_control(uid, account_generation=account_generation, firestore_client=client)
     collection = _user_ref(uid, firestore_client=client).collection(INTENTS_COLLECTION)
-    repair_query = (
-        CHAT_FIRST_TRANSIENT_DEAD_LETTER_REPAIR_QUERY.build(
-            collection,
-            {
-                'account_generation': account_generation,
-                'requeue_count': 0,
-                'dead_letter_reasons': list(TRANSIENT_DEAD_LETTER_REASONS),
-            },
-            field_filter_factory=FieldFilter,
-        )
-        .order_by('last_fetched_at')
-        .limit(FETCH_CANDIDATE_SCAN_MULTIPLIER * limit)
-    )
-    repaired = 0
-    for snapshot in repair_query.stream():
-        if repaired >= limit:
-            break
-        raw = snapshot.to_dict() or {}
-        terminal_at = raw.get('last_rejection_at') or raw.get('last_fetched_at')
-        if not isinstance(terminal_at, datetime) or fetched_at - terminal_at < TRANSIENT_DEAD_LETTER_REPAIR_AGE:
-            continue
-        try:
-            if (
-                _requeue_transient_dead_letter(
-                    uid,
-                    snapshot.id,
-                    account_generation=account_generation,
-                    now=fetched_at,
-                    firestore_client=client,
-                )
-                is not None
-            ):
-                repaired += 1
-        except ChatFirstMalformedDocument:
-            continue
+    lifecycle_events: list[IntentLifecycleEvent] = []
+    if delivery_attempts.repair_transient_dead_letters(
+        uid,
+        account_generation=account_generation,
+        limit=limit,
+        now=fetched_at,
+        firestore_client=client,
+        requeue=_requeue_transient_dead_letter,
+    ):
+        lifecycle_events.append(IntentLifecycleEvent('repair_scan_failed', 'materialization', 'google_api_error'))
     # Push the delivery-state filter to Firestore so delivered historical rows
     # are never transferred for a foreground materialization.  The caller only
     # ever needs ready or pending-receipt intents, which are bounded; the full
@@ -978,25 +876,30 @@ def fetch_ready_intent_batch(
     candidates.sort(key=lambda intent: (_fetch_priority(intent), intent.created_at, intent.intent_id))
 
     ready: list[ProactiveIntent] = []
-    lifecycle_events: list[IntentLifecycleEvent] = []
-    stall_candidates: list[ProactiveIntent] = []
+    candidate_scan_limit = FETCH_CANDIDATE_SCAN_MULTIPLIER * limit
     hydrated_attempts: dict[str, ProactiveIntent] = {}
-    # A row newer than the paging threshold cannot be stalled regardless of
-    # sibling state. Inspect every older candidate so a low-priority old row
-    # cannot disappear behind the response scan window.
-    for intent in candidates:
+    stall_age_candidates: list[tuple[datetime, ProactiveIntent]] = []
+    oldest_candidates = sorted(candidates, key=lambda intent: (intent.created_at, intent.intent_id))
+    oldest_hydration_ids = {intent.intent_id for intent in oldest_candidates[:candidate_scan_limit]}
+    # Hydrate only the bounded oldest window. For the rest, ``created_at`` is
+    # a conservative stall clock: it can page early after an unobserved recent
+    # deferral, but it cannot make per-poll point reads linear in the backlog.
+    for intent in oldest_candidates:
         if fetched_at - intent.created_at <= STALLED_READY_AGE:
             continue
-        try:
-            hydrated = _intent_with_delivery_attempt(
-                intent,
-                _delivery_attempt_ref(uid, intent.intent_id, firestore_client=client).get(),
-            )
-        except ChatFirstMalformedDocument:
-            continue
-        hydrated_attempts[intent.intent_id] = hydrated
-        stall_candidates.append(hydrated)
-    candidate_scan_limit = FETCH_CANDIDATE_SCAN_MULTIPLIER * limit
+        stall_age_from = intent.created_at
+        if intent.intent_id in oldest_hydration_ids:
+            try:
+                hydrated = _intent_with_delivery_attempt(
+                    intent,
+                    _delivery_attempt_ref(uid, intent.intent_id, firestore_client=client).get(),
+                )
+            except ChatFirstMalformedDocument:
+                hydrated = None
+            if hydrated is not None:
+                hydrated_attempts[intent.intent_id] = hydrated
+                stall_age_from = max(intent.created_at, hydrated.last_deferral_at or intent.created_at)
+        stall_age_candidates.append((stall_age_from, intent))
     malformed_scan_count = min(len(malformed_intent_ids), candidate_scan_limit)
     for intent_id in malformed_intent_ids[:malformed_scan_count]:
         try:
@@ -1052,16 +955,14 @@ def fetch_ready_intent_batch(
         if len(ready) >= limit:
             break
 
-    oldest_candidate = min(
-        stall_candidates,
-        key=lambda intent: (max(intent.created_at, intent.last_deferral_at or intent.created_at), intent.intent_id),
+    oldest_stall = min(
+        stall_age_candidates,
+        key=lambda item: (item[0], item[1].intent_id),
         default=None,
     )
     stalled_source = None
-    if oldest_candidate is not None:
-        stall_age_from = max(
-            oldest_candidate.created_at, oldest_candidate.last_deferral_at or oldest_candidate.created_at
-        )
+    if oldest_stall is not None:
+        stall_age_from, oldest_candidate = oldest_stall
         if fetched_at - stall_age_from > STALLED_READY_AGE:
             stalled_source = oldest_candidate.source
     return ReadyIntentBatch(ready, tuple(lifecycle_events), stalled_source)
@@ -1146,7 +1047,13 @@ def record_materialization_rejection(
             merge=True,
         )
         if reason:
-            write_transaction.set(intent_ref, _intent_payload(rejected))
+            delivery_attempts.move_to_dead_letters(
+                write_transaction,
+                intent_ref_value=intent_ref,
+                dead_letter_ref_value=_dead_letter_ref(uid, intent_id, firestore_client=client),
+                intent=rejected,
+                terminal_at=now,
+            )
         return rejected, reason
 
     return apply(transaction)
@@ -1191,7 +1098,13 @@ def record_materialization_deferral(
                     'dead_letter_reason': 'deferred_beyond_budget',
                 }
             )
-            write_transaction.set(intent_ref, _intent_payload(dead_lettered))
+            delivery_attempts.move_to_dead_letters(
+                write_transaction,
+                intent_ref_value=intent_ref,
+                dead_letter_ref_value=_dead_letter_ref(uid, intent_id, firestore_client=client),
+                intent=dead_lettered,
+                terminal_at=now,
+            )
             write_transaction.set(
                 attempt_ref, {'first_deferred_at': first_deferred_at, 'last_deferral_at': now}, merge=True
             )
@@ -1514,7 +1427,9 @@ __all__ = [
     'ChatFirstIntentGenerationMismatch',
     'ChatFirstMalformedDocument',
     'ChatFirstIntentStoreError',
+    'DEAD_LETTERS_COLLECTION',
     'DEFERRALS_COLLECTION',
+    'DELIVERY_ATTEMPTS_COLLECTION',
     'INTENTS_COLLECTION',
     'ProactiveBudgetExhausted',
     'ProactiveIntentNotReady',

--- a/backend/database/chat_first_intents.py
+++ b/backend/database/chat_first_intents.py
@@ -11,8 +11,12 @@ from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
 from database._client import get_firestore_client
-from database.firestore_index_registry import CHAT_FIRST_DEFERRALS_DUE_QUERY, CHAT_FIRST_DEFERRALS_SUBJECT_QUERY
-from database.read_boundary import MalformedDocError, parse_snapshot_strict
+from database.firestore_index_registry import (
+    CHAT_FIRST_DEFERRALS_DUE_QUERY,
+    CHAT_FIRST_DEFERRALS_SUBJECT_QUERY,
+    CHAT_FIRST_TRANSIENT_DEAD_LETTER_REPAIR_QUERY,
+)
+from database.read_boundary import MalformedDocError, parse_payload_strict, parse_snapshot_strict
 from models.chat_first import (
     ChatFirstBlockSpec,
     ChatFirstSubject,
@@ -40,6 +44,7 @@ DEFERRAL_CANDIDATE_SCAN_LIMIT = 64
 UNACKNOWLEDGED_DEAD_LETTER_REASON = 'unacknowledged_after_fetch_budget'
 KERNEL_FAILURE_DEAD_LETTER_REASON = 'permanent_rejection:kernel_materialization_failed'
 TRANSIENT_DEAD_LETTER_REASONS = frozenset({UNACKNOWLEDGED_DEAD_LETTER_REASON, KERNEL_FAILURE_DEAD_LETTER_REASON})
+TRANSIENT_DEATH_AFTER_REQUEUE_REASON = 'transient_death_after_requeue'
 
 logger = logging.getLogger(__name__)
 
@@ -234,9 +239,10 @@ def _intent_payload(intent: ProactiveIntent) -> dict[str, Any]:
         'last_deferral_at',
         'dead_letter_reason',
     }
-    # Old readers query only active states and use ``extra='forbid'``. Terminal
-    # rows are filtered out, so retaining diagnostics there is rollback-safe.
-    exclude = delivery_fields if intent.delivery_state in {'ready', 'pending_kernel_receipt'} else set()
+    # Old revisions also parse a receipt's intent by ID before checking whether
+    # it was already delivered. Keep every state they can read by ID strict-
+    # reader safe; dead letters alone retain queryable repair diagnostics.
+    exclude = delivery_fields if intent.delivery_state != 'dead_letter' else set()
     payload = intent.model_dump(mode='python', exclude=exclude)
     return payload
 
@@ -257,18 +263,59 @@ def _intent_with_delivery_attempt(intent: ProactiveIntent, snapshot: Any) -> Pro
         or materialization_attempts < 0
     ):
         raise ChatFirstMalformedDocument('chat-first delivery attempt state is malformed')
-    return intent.model_copy(
-        update={
-            'fetch_count': fetch_count,
-            'last_fetched_at': raw.get('last_fetched_at'),
-            'requeue_count': requeue_count,
-            'materialization_attempts': materialization_attempts,
-            'last_rejection_code': raw.get('last_rejection_code'),
-            'last_rejection_at': raw.get('last_rejection_at'),
-            'first_deferred_at': raw.get('first_deferred_at'),
-            'last_deferral_at': raw.get('last_deferral_at'),
-        }
-    )
+    hydrated = {
+        'fetch_count': fetch_count,
+        'last_fetched_at': raw.get('last_fetched_at'),
+        'requeue_count': requeue_count,
+        'materialization_attempts': materialization_attempts,
+        'last_rejection_code': raw.get('last_rejection_code'),
+        'last_rejection_at': raw.get('last_rejection_at'),
+        'first_deferred_at': raw.get('first_deferred_at'),
+        'last_deferral_at': raw.get('last_deferral_at'),
+    }
+    try:
+        # ``model_copy(update=...)`` deliberately skips validation. Hydrated
+        # sibling state crosses a persistence boundary, so validate the merged
+        # model before it can reach the strict wire model.
+        return parse_payload_strict(
+            ProactiveIntent,
+            {**intent.model_dump(mode='python'), **hydrated},
+            document_path=f'{DELIVERY_ATTEMPTS_COLLECTION}/{intent.intent_id}',
+        )
+    except MalformedDocError as error:
+        raise ChatFirstMalformedDocument('chat-first delivery attempt state is malformed') from error
+
+
+def _valid_attempt_value(intent: ProactiveIntent, field: str, value: Any) -> bool:
+    try:
+        parse_payload_strict(
+            ProactiveIntent,
+            {**intent.model_dump(mode='python'), field: value},
+            document_path=f'{DELIVERY_ATTEMPTS_COLLECTION}/{intent.intent_id}',
+        )
+    except MalformedDocError:
+        return False
+    return True
+
+
+def _reset_malformed_delivery_attempt(
+    intent: ProactiveIntent, raw: dict[str, Any], *, fetch_count: int, now: datetime
+) -> dict[str, Any]:
+    """Reset corrupt derived fields without erasing independent valid history."""
+
+    reset: dict[str, Any] = {'fetch_count': fetch_count, 'last_fetched_at': now}
+    defaults = {
+        'requeue_count': 0,
+        'materialization_attempts': 0,
+        'last_rejection_code': None,
+        'last_rejection_at': None,
+        'first_deferred_at': None,
+        'last_deferral_at': None,
+    }
+    for field, default in defaults.items():
+        value = raw.get(field, default)
+        reset[field] = value if _valid_attempt_value(intent, field, value) else default
+    return reset
 
 
 def get_budget_state(
@@ -703,7 +750,13 @@ def _advance_fetched_intent(
 
         fetch_count = intent.fetch_count + 1
         common = {'fetch_count': fetch_count, 'last_fetched_at': now}
-        attempt_update = {**({'requeue_count': 0} if malformed_attempt else {}), **common}
+        attempt_update = (
+            _reset_malformed_delivery_attempt(
+                intent, attempt_snapshot.to_dict() or {}, fetch_count=fetch_count, now=now
+            )
+            if malformed_attempt
+            else common
+        )
         if reconcile:
             budget_ref = _budget_ref(uid, firestore_client=firestore_client)
             budget_snapshot = budget_ref.get(transaction=write_transaction) if intent.consumes_turn_budget else None
@@ -729,12 +782,18 @@ def _advance_fetched_intent(
                 update={
                     **common,
                     'delivery_state': 'dead_letter',
-                    'dead_letter_reason': UNACKNOWLEDGED_DEAD_LETTER_REASON,
+                    'dead_letter_reason': (
+                        TRANSIENT_DEATH_AFTER_REQUEUE_REASON
+                        if intent.requeue_count > 0
+                        else UNACKNOWLEDGED_DEAD_LETTER_REASON
+                    ),
                 }
             )
             write_transaction.set(intent_ref, _intent_payload(dead_lettered))
             write_transaction.set(attempt_ref, attempt_update, merge=not malformed_attempt)
-            return None, IntentLifecycleEvent('dead_letter', intent.source, UNACKNOWLEDGED_DEAD_LETTER_REASON)
+            return None, IntentLifecycleEvent(
+                'dead_letter', intent.source, dead_lettered.dead_letter_reason or 'unknown'
+            )
         fetched = intent.model_copy(update=common)
         write_transaction.set(attempt_ref, attempt_update, merge=not malformed_attempt)
         event = (
@@ -824,15 +883,19 @@ def _requeue_transient_dead_letter(
             }
         )
         write_transaction.set(intent_ref, _intent_payload(requeued))
+        # Requeue owns only fetch/rejection accounting. Deferral history is an
+        # independent stall/budget clock and must survive this one-shot repair.
         write_transaction.set(
             attempt_ref,
             {
                 'fetch_count': 0,
+                'last_fetched_at': None,
                 'requeue_count': 1,
                 'materialization_attempts': 0,
                 'last_rejection_code': None,
                 'last_rejection_at': None,
             },
+            merge=True,
         )
         return requeued
 
@@ -855,13 +918,27 @@ def fetch_ready_intent_batch(
     fetched_at = now or datetime.now(timezone.utc)
     _require_current_control(uid, account_generation=account_generation, firestore_client=client)
     collection = _user_ref(uid, firestore_client=client).collection(INTENTS_COLLECTION)
-    repair_query = collection.where(
-        filter=FieldFilter('dead_letter_reason', 'in', list(TRANSIENT_DEAD_LETTER_REASONS))
-    ).limit(FETCH_CANDIDATE_SCAN_MULTIPLIER * limit)
+    repair_query = (
+        CHAT_FIRST_TRANSIENT_DEAD_LETTER_REPAIR_QUERY.build(
+            collection,
+            {
+                'account_generation': account_generation,
+                'requeue_count': 0,
+                'dead_letter_reasons': list(TRANSIENT_DEAD_LETTER_REASONS),
+            },
+            field_filter_factory=FieldFilter,
+        )
+        .order_by('last_fetched_at')
+        .limit(FETCH_CANDIDATE_SCAN_MULTIPLIER * limit)
+    )
     repaired = 0
     for snapshot in repair_query.stream():
         if repaired >= limit:
             break
+        raw = snapshot.to_dict() or {}
+        terminal_at = raw.get('last_rejection_at') or raw.get('last_fetched_at')
+        if not isinstance(terminal_at, datetime) or fetched_at - terminal_at < TRANSIENT_DEAD_LETTER_REPAIR_AGE:
+            continue
         try:
             if (
                 _requeue_transient_dead_letter(
@@ -903,6 +980,22 @@ def fetch_ready_intent_batch(
     ready: list[ProactiveIntent] = []
     lifecycle_events: list[IntentLifecycleEvent] = []
     stall_candidates: list[ProactiveIntent] = []
+    hydrated_attempts: dict[str, ProactiveIntent] = {}
+    # A row newer than the paging threshold cannot be stalled regardless of
+    # sibling state. Inspect every older candidate so a low-priority old row
+    # cannot disappear behind the response scan window.
+    for intent in candidates:
+        if fetched_at - intent.created_at <= STALLED_READY_AGE:
+            continue
+        try:
+            hydrated = _intent_with_delivery_attempt(
+                intent,
+                _delivery_attempt_ref(uid, intent.intent_id, firestore_client=client).get(),
+            )
+        except ChatFirstMalformedDocument:
+            continue
+        hydrated_attempts[intent.intent_id] = hydrated
+        stall_candidates.append(hydrated)
     candidate_scan_limit = FETCH_CANDIDATE_SCAN_MULTIPLIER * limit
     malformed_scan_count = min(len(malformed_intent_ids), candidate_scan_limit)
     for intent_id in malformed_intent_ids[:malformed_scan_count]:
@@ -923,15 +1016,13 @@ def fetch_ready_intent_batch(
     remaining_scan_limit = candidate_scan_limit - malformed_scan_count
     for intent in candidates[:remaining_scan_limit]:
         try:
-            intent = _intent_with_delivery_attempt(
-                intent,
-                _delivery_attempt_ref(uid, intent.intent_id, firestore_client=client).get(),
+            intent = hydrated_attempts.get(intent.intent_id) or _intent_with_delivery_attempt(
+                intent, _delivery_attempt_ref(uid, intent.intent_id, firestore_client=client).get()
             )
         except ChatFirstMalformedDocument:
             # Advancement repairs the derived sibling transactionally and
             # returns the valid intent on this same poll.
             pass
-        stall_candidates.append(intent)
         if deferred_intent_ids and intent.intent_id in deferred_intent_ids:
             if len(ready) < limit:
                 ready.append(intent)

--- a/backend/database/chat_first_intents.py
+++ b/backend/database/chat_first_intents.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+import logging
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, Iterable
@@ -36,6 +37,11 @@ CONTINUOUS_DEFERRAL_BUDGET = timedelta(days=7)
 TRANSIENT_DEAD_LETTER_REPAIR_AGE = timedelta(hours=6)
 FETCH_CANDIDATE_SCAN_MULTIPLIER = 2
 DEFERRAL_CANDIDATE_SCAN_LIMIT = 64
+UNACKNOWLEDGED_DEAD_LETTER_REASON = 'unacknowledged_after_fetch_budget'
+KERNEL_FAILURE_DEAD_LETTER_REASON = 'permanent_rejection:kernel_materialization_failed'
+TRANSIENT_DEAD_LETTER_REASONS = frozenset({UNACKNOWLEDGED_DEAD_LETTER_REASON, KERNEL_FAILURE_DEAD_LETTER_REASON})
+
+logger = logging.getLogger(__name__)
 
 # A ready intent must reach a terminal state under bounded identical retries:
 # typed kernel failures park it after three reports, while fetch-only clients
@@ -217,18 +223,21 @@ def _intent_payload(intent: ProactiveIntent) -> dict[str, Any]:
     # Rolling-deploy safety: pre-Round-7 readers reject these newer fetch and
     # repair fields. They live in a sibling document keyed by intent ID, never
     # on the intent document consumed by old revisions.
-    payload = intent.model_dump(mode='python', exclude={'fetch_count', 'last_fetched_at', 'requeue_count'})
-    optional_delivery_fields = {
-        'materialization_attempts': 0,
-        'last_rejection_code': None,
-        'last_rejection_at': None,
-        'first_deferred_at': None,
-        'last_deferral_at': None,
-        'dead_letter_reason': None,
+    delivery_fields = {
+        'fetch_count',
+        'last_fetched_at',
+        'requeue_count',
+        'materialization_attempts',
+        'last_rejection_code',
+        'last_rejection_at',
+        'first_deferred_at',
+        'last_deferral_at',
+        'dead_letter_reason',
     }
-    for field, default in optional_delivery_fields.items():
-        if payload.get(field) == default:
-            payload.pop(field, None)
+    # Old readers query only active states and use ``extra='forbid'``. Terminal
+    # rows are filtered out, so retaining diagnostics there is rollback-safe.
+    exclude = delivery_fields if intent.delivery_state in {'ready', 'pending_kernel_receipt'} else set()
+    payload = intent.model_dump(mode='python', exclude=exclude)
     return payload
 
 
@@ -238,13 +247,26 @@ def _intent_with_delivery_attempt(intent: ProactiveIntent, snapshot: Any) -> Pro
     raw = snapshot.to_dict() or {}
     fetch_count = raw.get('fetch_count', 0)
     requeue_count = raw.get('requeue_count', 0)
-    if not isinstance(fetch_count, int) or fetch_count < 0 or not isinstance(requeue_count, int):
+    materialization_attempts = raw.get('materialization_attempts', 0)
+    if (
+        not isinstance(fetch_count, int)
+        or fetch_count < 0
+        or not isinstance(requeue_count, int)
+        or requeue_count < 0
+        or not isinstance(materialization_attempts, int)
+        or materialization_attempts < 0
+    ):
         raise ChatFirstMalformedDocument('chat-first delivery attempt state is malformed')
     return intent.model_copy(
         update={
             'fetch_count': fetch_count,
             'last_fetched_at': raw.get('last_fetched_at'),
             'requeue_count': requeue_count,
+            'materialization_attempts': materialization_attempts,
+            'last_rejection_code': raw.get('last_rejection_code'),
+            'last_rejection_at': raw.get('last_rejection_at'),
+            'first_deferred_at': raw.get('first_deferred_at'),
+            'last_deferral_at': raw.get('last_deferral_at'),
         }
     )
 
@@ -665,7 +687,14 @@ def _advance_fetched_intent(
             return None, None
         intent = _intent_from_snapshot(snapshot)
         attempt_snapshot = attempt_ref.get(transaction=write_transaction)
-        intent = _intent_with_delivery_attempt(intent, attempt_snapshot)
+        malformed_attempt = False
+        try:
+            intent = _intent_with_delivery_attempt(intent, attempt_snapshot)
+        except ChatFirstMalformedDocument:
+            # The sibling is derived delivery bookkeeping. Repair it in this
+            # transaction instead of allowing corrupt derived state to hide a
+            # valid intent indefinitely.
+            malformed_attempt = True
         if intent.account_generation != account_generation or intent.delivery_state not in {
             'ready',
             'pending_kernel_receipt',
@@ -674,6 +703,7 @@ def _advance_fetched_intent(
 
         fetch_count = intent.fetch_count + 1
         common = {'fetch_count': fetch_count, 'last_fetched_at': now}
+        attempt_update = {**({'requeue_count': 0} if malformed_attempt else {}), **common}
         if reconcile:
             budget_ref = _budget_ref(uid, firestore_client=firestore_client)
             budget_snapshot = budget_ref.get(transaction=write_transaction) if intent.consumes_turn_budget else None
@@ -692,22 +722,27 @@ def _advance_fetched_intent(
                     budget_ref, account_materialization(budget, intent_id=intent_id, now=now).model_dump(mode='python')
                 )
             write_transaction.set(intent_ref, _intent_payload(delivered))
-            write_transaction.set(attempt_ref, common, merge=True)
+            write_transaction.set(attempt_ref, attempt_update, merge=not malformed_attempt)
             return None, IntentLifecycleEvent('reconciled', intent.source, 'existing_chat_row')
         if fetch_count > UNACKNOWLEDGED_FETCH_BUDGET:
             dead_lettered = intent.model_copy(
                 update={
                     **common,
                     'delivery_state': 'dead_letter',
-                    'dead_letter_reason': 'unacknowledged_after_fetch_budget',
+                    'dead_letter_reason': UNACKNOWLEDGED_DEAD_LETTER_REASON,
                 }
             )
             write_transaction.set(intent_ref, _intent_payload(dead_lettered))
-            write_transaction.set(attempt_ref, common, merge=True)
-            return None, IntentLifecycleEvent('dead_letter', intent.source, 'unacknowledged_after_fetch_budget')
+            write_transaction.set(attempt_ref, attempt_update, merge=not malformed_attempt)
+            return None, IntentLifecycleEvent('dead_letter', intent.source, UNACKNOWLEDGED_DEAD_LETTER_REASON)
         fetched = intent.model_copy(update=common)
-        write_transaction.set(attempt_ref, common, merge=True)
-        return fetched, None
+        write_transaction.set(attempt_ref, attempt_update, merge=not malformed_attempt)
+        event = (
+            IntentLifecycleEvent('malformed_attempt_reset', intent.source, 'malformed_document')
+            if malformed_attempt
+            else None
+        )
+        return fetched, event
 
     return apply(transaction)
 
@@ -746,6 +781,64 @@ def _dead_letter_malformed_intent(
     apply(transaction)
 
 
+def _requeue_transient_dead_letter(
+    uid: str,
+    intent_id: str,
+    *,
+    account_generation: int,
+    now: datetime,
+    firestore_client: Any,
+) -> ProactiveIntent | None:
+    intent_ref = _intent_ref(uid, intent_id, firestore_client=firestore_client)
+    attempt_ref = _delivery_attempt_ref(uid, intent_id, firestore_client=firestore_client)
+    transaction = firestore_client.transaction()
+
+    @firestore.transactional
+    def apply(write_transaction: Any) -> ProactiveIntent | None:
+        snapshot = intent_ref.get(transaction=write_transaction)
+        if not snapshot.exists:
+            return None
+        intent = _intent_from_snapshot(snapshot)
+        attempt_snapshot = attempt_ref.get(transaction=write_transaction)
+        intent = _intent_with_delivery_attempt(intent, attempt_snapshot)
+        if (
+            intent.account_generation != account_generation
+            or intent.delivery_state != 'dead_letter'
+            or intent.dead_letter_reason not in TRANSIENT_DEAD_LETTER_REASONS
+            or intent.requeue_count != 0
+        ):
+            return None
+        terminal_at = intent.last_rejection_at or intent.last_fetched_at
+        if terminal_at is None or now - terminal_at < TRANSIENT_DEAD_LETTER_REPAIR_AGE:
+            return None
+        requeued = intent.model_copy(
+            update={
+                'delivery_state': 'ready',
+                'dead_letter_reason': None,
+                'fetch_count': 0,
+                'last_fetched_at': None,
+                'materialization_attempts': 0,
+                'last_rejection_code': None,
+                'last_rejection_at': None,
+                'requeue_count': 1,
+            }
+        )
+        write_transaction.set(intent_ref, _intent_payload(requeued))
+        write_transaction.set(
+            attempt_ref,
+            {
+                'fetch_count': 0,
+                'requeue_count': 1,
+                'materialization_attempts': 0,
+                'last_rejection_code': None,
+                'last_rejection_at': None,
+            },
+        )
+        return requeued
+
+    return apply(transaction)
+
+
 def fetch_ready_intent_batch(
     uid: str,
     *,
@@ -762,6 +855,27 @@ def fetch_ready_intent_batch(
     fetched_at = now or datetime.now(timezone.utc)
     _require_current_control(uid, account_generation=account_generation, firestore_client=client)
     collection = _user_ref(uid, firestore_client=client).collection(INTENTS_COLLECTION)
+    repair_query = collection.where(
+        filter=FieldFilter('dead_letter_reason', 'in', list(TRANSIENT_DEAD_LETTER_REASONS))
+    ).limit(FETCH_CANDIDATE_SCAN_MULTIPLIER * limit)
+    repaired = 0
+    for snapshot in repair_query.stream():
+        if repaired >= limit:
+            break
+        try:
+            if (
+                _requeue_transient_dead_letter(
+                    uid,
+                    snapshot.id,
+                    account_generation=account_generation,
+                    now=fetched_at,
+                    firestore_client=client,
+                )
+                is not None
+            ):
+                repaired += 1
+        except ChatFirstMalformedDocument:
+            continue
     # Push the delivery-state filter to Firestore so delivered historical rows
     # are never transferred for a foreground materialization.  The caller only
     # ever needs ready or pending-receipt intents, which are bounded; the full
@@ -773,8 +887,7 @@ def fetch_ready_intent_batch(
         try:
             intent = _intent_from_snapshot(snapshot)
         except ChatFirstMalformedDocument:
-            raw = snapshot.to_dict() or {}
-            malformed_intent_ids.append(getattr(snapshot, 'id', raw.get('intent_id', 'malformed')))
+            malformed_intent_ids.append(snapshot.id)
             continue
         if intent.account_generation != account_generation:
             continue
@@ -784,20 +897,12 @@ def fetch_ready_intent_batch(
         # legacy-compatible intents behind them.
         if exclude_block_types and any(block.type in exclude_block_types for block in intent.blocks):
             continue
-        try:
-            intent = _intent_with_delivery_attempt(
-                intent,
-                _delivery_attempt_ref(uid, intent.intent_id, firestore_client=client).get(),
-            )
-        except ChatFirstMalformedDocument:
-            continue
         candidates.append(intent)
     candidates.sort(key=lambda intent: (_fetch_priority(intent), intent.created_at, intent.intent_id))
-    never_deferred = [intent for intent in candidates if intent.first_deferred_at is None]
-    oldest_candidate = min(never_deferred, key=lambda intent: (intent.created_at, intent.intent_id), default=None)
 
     ready: list[ProactiveIntent] = []
     lifecycle_events: list[IntentLifecycleEvent] = []
+    stall_candidates: list[ProactiveIntent] = []
     candidate_scan_limit = FETCH_CANDIDATE_SCAN_MULTIPLIER * limit
     malformed_scan_count = min(len(malformed_intent_ids), candidate_scan_limit)
     for intent_id in malformed_intent_ids[:malformed_scan_count]:
@@ -817,6 +922,16 @@ def fetch_ready_intent_batch(
     # without bound on every device poll.
     remaining_scan_limit = candidate_scan_limit - malformed_scan_count
     for intent in candidates[:remaining_scan_limit]:
+        try:
+            intent = _intent_with_delivery_attempt(
+                intent,
+                _delivery_attempt_ref(uid, intent.intent_id, firestore_client=client).get(),
+            )
+        except ChatFirstMalformedDocument:
+            # Advancement repairs the derived sibling transactionally and
+            # returns the valid intent on this same poll.
+            pass
+        stall_candidates.append(intent)
         if deferred_intent_ids and intent.intent_id in deferred_intent_ids:
             if len(ready) < limit:
                 ready.append(intent)
@@ -846,11 +961,18 @@ def fetch_ready_intent_batch(
         if len(ready) >= limit:
             break
 
-    stalled_source = (
-        oldest_candidate.source
-        if oldest_candidate is not None and fetched_at - oldest_candidate.created_at > STALLED_READY_AGE
-        else None
+    oldest_candidate = min(
+        stall_candidates,
+        key=lambda intent: (max(intent.created_at, intent.last_deferral_at or intent.created_at), intent.intent_id),
+        default=None,
     )
+    stalled_source = None
+    if oldest_candidate is not None:
+        stall_age_from = max(
+            oldest_candidate.created_at, oldest_candidate.last_deferral_at or oldest_candidate.created_at
+        )
+        if fetched_at - stall_age_from > STALLED_READY_AGE:
+            stalled_source = oldest_candidate.source
     return ReadyIntentBatch(ready, tuple(lifecycle_events), stalled_source)
 
 
@@ -903,26 +1025,7 @@ def record_materialization_rejection(
         intent = _intent_with_delivery_attempt(intent, attempt_snapshot)
         if intent.account_generation != account_generation:
             raise ChatFirstIntentDocumentGenerationMismatch('intent account generation changed')
-        if intent.delivery_state == 'dead_letter' and (
-            intent.dead_letter_reason == 'rejection_budget_exhausted'
-            and intent.last_rejection_code == 'kernel_materialization_failed'
-            and intent.requeue_count == 0
-            and intent.last_rejection_at is not None
-            and now - intent.last_rejection_at >= TRANSIENT_DEAD_LETTER_REPAIR_AGE
-        ):
-            intent = intent.model_copy(
-                update={
-                    'delivery_state': 'ready',
-                    'dead_letter_reason': None,
-                    'materialization_attempts': 0,
-                    'last_rejection_code': None,
-                    'last_rejection_at': None,
-                    'requeue_count': 1,
-                }
-            )
-            write_transaction.set(intent_ref, _intent_payload(intent))
-            write_transaction.set(attempt_ref, {'requeue_count': 1}, merge=True)
-        elif intent.delivery_state in {'dead_letter', 'delivered'}:
+        if intent.delivery_state in {'dead_letter', 'delivered'}:
             return intent, None
         if intent.delivery_state not in {'ready', 'pending_kernel_receipt'}:
             raise ProactiveIntentNotReady('proactive intent is not ready')
@@ -942,7 +1045,17 @@ def record_materialization_rejection(
                 **({'delivery_state': 'dead_letter', 'dead_letter_reason': reason} if reason else {}),
             }
         )
-        write_transaction.set(intent_ref, _intent_payload(rejected))
+        write_transaction.set(
+            attempt_ref,
+            {
+                'materialization_attempts': attempts,
+                'last_rejection_code': code,
+                'last_rejection_at': now,
+            },
+            merge=True,
+        )
+        if reason:
+            write_transaction.set(intent_ref, _intent_payload(rejected))
         return rejected, reason
 
     return apply(transaction)
@@ -960,6 +1073,7 @@ def record_materialization_deferral(
 
     client = _db(firestore_client)
     intent_ref = _intent_ref(uid, intent_id, firestore_client=client)
+    attempt_ref = _delivery_attempt_ref(uid, intent_id, firestore_client=client)
     transaction = client.transaction()
 
     @firestore.transactional
@@ -970,6 +1084,8 @@ def record_materialization_deferral(
         if not snapshot.exists:
             return None
         intent = _intent_from_snapshot(snapshot)
+        attempt_snapshot = attempt_ref.get(transaction=write_transaction)
+        intent = _intent_with_delivery_attempt(intent, attempt_snapshot)
         if intent.account_generation != account_generation:
             raise ChatFirstIntentDocumentGenerationMismatch('intent account generation changed')
         if intent.delivery_state not in {'ready', 'pending_kernel_receipt'}:
@@ -985,11 +1101,12 @@ def record_materialization_deferral(
                 }
             )
             write_transaction.set(intent_ref, _intent_payload(dead_lettered))
+            write_transaction.set(
+                attempt_ref, {'first_deferred_at': first_deferred_at, 'last_deferral_at': now}, merge=True
+            )
             return dead_lettered
         write_transaction.set(
-            intent_ref,
-            {'first_deferred_at': first_deferred_at, 'last_deferral_at': now},
-            merge=True,
+            attempt_ref, {'first_deferred_at': first_deferred_at, 'last_deferral_at': now}, merge=True
         )
         return intent.model_copy(update={'first_deferred_at': first_deferred_at, 'last_deferral_at': now})
 
@@ -1034,13 +1151,12 @@ def acknowledge_materialization(
             return intent
         repair_transient_dead_letter = (
             intent.delivery_state == 'dead_letter'
-            and intent.dead_letter_reason == 'rejection_budget_exhausted'
-            and intent.last_rejection_code == 'kernel_materialization_failed'
+            and intent.dead_letter_reason in TRANSIENT_DEAD_LETTER_REASONS
             and intent.requeue_count == 0
         )
         if intent.delivery_state == 'dead_letter' and not repair_transient_dead_letter:
             return intent
-        if intent.delivery_state not in {'ready', 'pending_kernel_receipt'}:
+        if intent.delivery_state not in {'ready', 'pending_kernel_receipt'} and not repair_transient_dead_letter:
             raise ProactiveIntentNotReady('proactive intent is not ready')
 
         delivered = intent.model_copy(
@@ -1193,12 +1309,12 @@ def release_due_deferrals(
             try:
                 _terminalize_malformed_deferral(
                     uid,
-                    getattr(snapshot, 'id', ''),
+                    snapshot.id,
                     account_generation=account_generation,
                     firestore_client=client,
                 )
             except Exception:
-                pass
+                logger.warning('Failed to terminalize malformed Chat-first deferral id=%s', snapshot.id)
             continue
         # Keep strict model validation and an exact subject check as the final
         # fence for old/malformed rows and for fake clients that do not fully

--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -1030,7 +1030,7 @@ CHAT_FIRST_DEFERRALS_SUBJECT_QUERY = FirestoreQuerySpec(
 
 CHAT_FIRST_TRANSIENT_DEAD_LETTER_REPAIR_QUERY = FirestoreQuerySpec(
     identifier='chat_first_transient_dead_letter_repair',
-    collection_group='chat_first_proactive_intents',
+    collection_group='chat_first_dead_letters',
     query_scope='COLLECTION',
     filters=(
         FirestoreQueryFilter('account_generation', '==', 'account_generation'),

--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -1028,6 +1028,24 @@ CHAT_FIRST_DEFERRALS_SUBJECT_QUERY = FirestoreQuerySpec(
     ),
 )
 
+CHAT_FIRST_TRANSIENT_DEAD_LETTER_REPAIR_QUERY = FirestoreQuerySpec(
+    identifier='chat_first_transient_dead_letter_repair',
+    collection_group='chat_first_proactive_intents',
+    query_scope='COLLECTION',
+    filters=(
+        FirestoreQueryFilter('account_generation', '==', 'account_generation'),
+        FirestoreQueryFilter('requeue_count', '==', 'requeue_count'),
+        FirestoreQueryFilter('dead_letter_reason', 'in', 'dead_letter_reasons'),
+    ),
+    index_fields=(
+        _asc('account_generation'),
+        _asc('requeue_count'),
+        _asc('dead_letter_reason'),
+        _asc('last_fetched_at'),
+        _asc('__name__'),
+    ),
+)
+
 CURRENT_CHAT_SESSION_QUERY = FirestoreQuerySpec(
     identifier='chat_sessions_current_by_app',
     collection_group='chat_sessions',
@@ -1277,6 +1295,7 @@ QUERY_SPECS = (
     ENTITY_TIMELINE_SCREEN_ACTIVITY_QUERY,
     CHAT_FIRST_DEFERRALS_DUE_QUERY,
     CHAT_FIRST_DEFERRALS_SUBJECT_QUERY,
+    CHAT_FIRST_TRANSIENT_DEAD_LETTER_REPAIR_QUERY,
     CURRENT_CHAT_SESSION_QUERY,
     CURRENT_CHAT_SESSION_ORDERED_QUERY,
     MEETING_RECEIPTS_DUE_QUERY,

--- a/backend/models/chat_first.py
+++ b/backend/models/chat_first.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from hashlib import sha256
 from typing import Annotated, Literal, Union
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from models.task_intelligence import StableId
 
@@ -134,7 +134,8 @@ ProactiveIntentSource = Literal[
     'cold_start_rich',
     'cold_start_sparse',
 ]
-ProactiveIntentDeliveryState = Literal['ready', 'pending_kernel_receipt', 'delivered']
+ProactiveIntentDeliveryState = Literal['ready', 'pending_kernel_receipt', 'delivered', 'dead_letter']
+MaterializableProactiveIntentDeliveryState = Literal['ready', 'pending_kernel_receipt', 'delivered']
 ColdStartSequenceTerminalState = Literal['completed', 'abandoned']
 
 
@@ -157,6 +158,12 @@ class ProactiveIntent(_StrictModel):
     created_at: datetime
     delivered_at: datetime | None = None
     materialization_receipt_id: StableId | None = None
+    materialization_attempts: int = Field(default=0, ge=0)
+    last_rejection_code: str | None = Field(default=None, min_length=1, max_length=64, pattern=r'^[a-z0-9_]+$')
+    last_rejection_at: datetime | None = None
+    fetch_count: int = Field(default=0, ge=0)
+    last_fetched_at: datetime | None = None
+    dead_letter_reason: str | None = Field(default=None, min_length=1, max_length=128, pattern=r'^[a-z0-9_:.-]+$')
     # This is a terminal local-journal receipt on the same sparse cold-start
     # intent, never an operator-owned completion switch. It is the bounded
     # server projection needed to stop suppressing agent-tier turns once the
@@ -182,6 +189,29 @@ class ProactiveIntent(_StrictModel):
         return self.source == 'agent_judgment'
 
 
+class MaterializableProactiveIntent(_StrictModel):
+    """Wire-safe intent state; terminal dead letters never leave the store."""
+
+    intent_id: StableId
+    continuity_key: StableId
+    account_generation: int = Field(ge=0)
+    source: ProactiveIntentSource
+    subject: ChatFirstSubject | None = None
+    blocks: list[ChatFirstBlockSpec] = Field(min_length=1, max_length=8)
+    delivery_state: MaterializableProactiveIntentDeliveryState = 'ready'
+    created_at: datetime
+    delivered_at: datetime | None = None
+    materialization_receipt_id: StableId | None = None
+    materialization_attempts: int = Field(default=0, ge=0)
+    last_rejection_code: str | None = Field(default=None, min_length=1, max_length=64, pattern=r'^[a-z0-9_]+$')
+    last_rejection_at: datetime | None = None
+    fetch_count: int = Field(default=0, ge=0)
+    last_fetched_at: datetime | None = None
+    dead_letter_reason: str | None = Field(default=None, min_length=1, max_length=128, pattern=r'^[a-z0-9_:.-]+$')
+    cold_start_sequence_terminal_state: ColdStartSequenceTerminalState | None = None
+    cold_start_sequence_terminal_receipt_id: StableId | None = None
+
+
 class ProactiveBudgetReservation(_StrictModel):
     intent_id: StableId
     expires_at: datetime
@@ -202,6 +232,14 @@ class ProactiveMaterializationReceipt(_StrictModel):
     receipt_id: StableId
 
 
+class ProactiveMaterializationRejection(_StrictModel):
+    """Content-free typed rejection emitted by the local kernel."""
+
+    intent_id: StableId
+    code: str = Field(min_length=1, max_length=64, pattern=r'^[a-z0-9_]+$')
+    message: str | None = Field(default=None, max_length=300)
+
+
 class ColdStartSequenceTerminalReceipt(_StrictModel):
     """A durable local-journal acknowledgement that sparse sequencing ended."""
 
@@ -217,6 +255,7 @@ class MaterializePromptsRequest(_StrictModel):
     window_foreground: bool = False
     initial_page_loaded: bool = False
     receipts: list[ProactiveMaterializationReceipt] = Field(default_factory=list, max_length=16)
+    rejections: list[ProactiveMaterializationRejection] = Field(default_factory=list, max_length=16)
     cold_start_sequence_terminal_receipts: list[ColdStartSequenceTerminalReceipt] = Field(
         default_factory=list, max_length=16
     )
@@ -226,6 +265,11 @@ class MaterializePromptsRequest(_StrictModel):
         intent_ids = [receipt.intent_id for receipt in self.receipts]
         if len(intent_ids) != len(set(intent_ids)):
             raise ValueError('materialization receipt intent IDs must be unique')
+        rejection_ids = [rejection.intent_id for rejection in self.rejections]
+        if len(rejection_ids) != len(set(rejection_ids)):
+            raise ValueError('materialization rejection intent IDs must be unique')
+        if set(intent_ids) & set(rejection_ids):
+            raise ValueError('an intent cannot be both acknowledged and rejected')
         sequence_ids = [receipt.sequence_id for receipt in self.cold_start_sequence_terminal_receipts]
         if len(sequence_ids) != len(set(sequence_ids)):
             raise ValueError('cold-start terminal receipt sequence IDs must be unique')
@@ -233,7 +277,12 @@ class MaterializePromptsRequest(_StrictModel):
 
 
 class MaterializePromptsResponse(_StrictModel):
-    intents: list[ProactiveIntent] = Field(default_factory=list)
+    intents: list[MaterializableProactiveIntent] = Field(default_factory=list)
+
+    @field_validator('intents', mode='before')
+    @classmethod
+    def narrow_internal_intents_for_wire(cls, intents):
+        return [intent.model_dump() if isinstance(intent, ProactiveIntent) else intent for intent in intents]
 
 
 class LegacyProactiveIntent(_StrictModel):
@@ -243,10 +292,16 @@ class LegacyProactiveIntent(_StrictModel):
     source: ProactiveIntentSource
     subject: ChatFirstSubject | None = None
     blocks: list[LegacyChatFirstBlockSpec] = Field(min_length=1, max_length=8)
-    delivery_state: ProactiveIntentDeliveryState = 'ready'
+    delivery_state: MaterializableProactiveIntentDeliveryState = 'ready'
     created_at: datetime
     delivered_at: datetime | None = None
     materialization_receipt_id: StableId | None = None
+    materialization_attempts: int = Field(default=0, ge=0)
+    last_rejection_code: str | None = None
+    last_rejection_at: datetime | None = None
+    fetch_count: int = Field(default=0, ge=0)
+    last_fetched_at: datetime | None = None
+    dead_letter_reason: str | None = None
     cold_start_sequence_terminal_state: ColdStartSequenceTerminalState | None = None
     cold_start_sequence_terminal_receipt_id: StableId | None = None
 
@@ -323,6 +378,7 @@ __all__ = [
     'ProactiveDeferral',
     'ProactiveIntent',
     'ProactiveMaterializationReceipt',
+    'ProactiveMaterializationRejection',
     'QuestionCardSpec',
     'QuestionOption',
     'TaskCardSpec',

--- a/backend/models/chat_first.py
+++ b/backend/models/chat_first.py
@@ -171,6 +171,16 @@ class ProactiveIntent(_StrictModel):
     cold_start_sequence_terminal_state: ColdStartSequenceTerminalState | None = None
     cold_start_sequence_terminal_receipt_id: StableId | None = None
 
+    # Firestore documents outlive individual backend revisions.  Stored-state
+    # readers must tolerate fields written by newer revisions during rolling
+    # deploys; request/response models remain strict.
+    model_config = ConfigDict(extra='ignore', frozen=True)
+
+    @field_validator('delivery_state', mode='before')
+    @classmethod
+    def unknown_delivery_states_are_terminal_on_read(cls, value):
+        return value if value in {'ready', 'pending_kernel_receipt', 'delivered', 'dead_letter'} else 'dead_letter'
+
     @model_validator(mode='after')
     def validate_cold_start_sequence_state(self):
         has_terminal_receipt = self.cold_start_sequence_terminal_receipt_id is not None
@@ -240,6 +250,18 @@ class ProactiveMaterializationRejection(_StrictModel):
     message: str | None = Field(default=None, max_length=300)
 
 
+class ProactiveMaterializationDeferral(_StrictModel):
+    """A fetched intent the kernel intentionally left behind a transcript tail."""
+
+    intent_id: StableId
+    code: Literal['tail_question', 'streaming_tail']
+
+
+class ProactiveMaterializationReceiptOutcome(_StrictModel):
+    intent_id: StableId
+    outcome: Literal['acknowledged', 'already_terminal', 'missing', 'conflict', 'generation_mismatch']
+
+
 class ColdStartSequenceTerminalReceipt(_StrictModel):
     """A durable local-journal acknowledgement that sparse sequencing ended."""
 
@@ -256,6 +278,7 @@ class MaterializePromptsRequest(_StrictModel):
     initial_page_loaded: bool = False
     receipts: list[ProactiveMaterializationReceipt] = Field(default_factory=list, max_length=16)
     rejections: list[ProactiveMaterializationRejection] = Field(default_factory=list, max_length=16)
+    deferrals: list[ProactiveMaterializationDeferral] = Field(default_factory=list, max_length=16)
     cold_start_sequence_terminal_receipts: list[ColdStartSequenceTerminalReceipt] = Field(
         default_factory=list, max_length=16
     )
@@ -270,6 +293,11 @@ class MaterializePromptsRequest(_StrictModel):
             raise ValueError('materialization rejection intent IDs must be unique')
         if set(intent_ids) & set(rejection_ids):
             raise ValueError('an intent cannot be both acknowledged and rejected')
+        deferral_ids = [deferral.intent_id for deferral in self.deferrals]
+        if len(deferral_ids) != len(set(deferral_ids)):
+            raise ValueError('materialization deferral intent IDs must be unique')
+        if set(intent_ids) & set(deferral_ids) or set(rejection_ids) & set(deferral_ids):
+            raise ValueError('an intent cannot have more than one materialization outcome')
         sequence_ids = [receipt.sequence_id for receipt in self.cold_start_sequence_terminal_receipts]
         if len(sequence_ids) != len(set(sequence_ids)):
             raise ValueError('cold-start terminal receipt sequence IDs must be unique')
@@ -278,6 +306,7 @@ class MaterializePromptsRequest(_StrictModel):
 
 class MaterializePromptsResponse(_StrictModel):
     intents: list[MaterializableProactiveIntent] = Field(default_factory=list)
+    receipt_outcomes: list[ProactiveMaterializationReceiptOutcome] = Field(default_factory=list)
 
     @field_validator('intents', mode='before')
     @classmethod

--- a/backend/models/chat_first.py
+++ b/backend/models/chat_first.py
@@ -163,6 +163,8 @@ class ProactiveIntent(_StrictModel):
     last_rejection_at: datetime | None = None
     fetch_count: int = Field(default=0, ge=0)
     last_fetched_at: datetime | None = None
+    first_deferred_at: datetime | None = None
+    last_deferral_at: datetime | None = None
     dead_letter_reason: str | None = Field(default=None, min_length=1, max_length=128, pattern=r'^[a-z0-9_:.-]+$')
     # This is a terminal local-journal receipt on the same sparse cold-start
     # intent, never an operator-owned completion switch. It is the bounded
@@ -262,6 +264,11 @@ class ProactiveMaterializationReceiptOutcome(_StrictModel):
     outcome: Literal['acknowledged', 'already_terminal', 'missing', 'conflict', 'generation_mismatch']
 
 
+class ProactiveMaterializationRejectionOutcome(_StrictModel):
+    intent_id: StableId
+    outcome: Literal['recorded', 'absorbed', 'generation_mismatch', 'malformed', 'missing']
+
+
 class ColdStartSequenceTerminalReceipt(_StrictModel):
     """A durable local-journal acknowledgement that sparse sequencing ended."""
 
@@ -307,11 +314,19 @@ class MaterializePromptsRequest(_StrictModel):
 class MaterializePromptsResponse(_StrictModel):
     intents: list[MaterializableProactiveIntent] = Field(default_factory=list)
     receipt_outcomes: list[ProactiveMaterializationReceiptOutcome] = Field(default_factory=list)
+    rejection_outcomes: list[ProactiveMaterializationRejectionOutcome] = Field(default_factory=list)
 
     @field_validator('intents', mode='before')
     @classmethod
     def narrow_internal_intents_for_wire(cls, intents):
-        return [intent.model_dump() if isinstance(intent, ProactiveIntent) else intent for intent in intents]
+        return [
+            (
+                intent.model_dump(exclude={'first_deferred_at', 'last_deferral_at'})
+                if isinstance(intent, ProactiveIntent)
+                else intent
+            )
+            for intent in intents
+        ]
 
 
 class LegacyProactiveIntent(_StrictModel):

--- a/backend/models/chat_first.py
+++ b/backend/models/chat_first.py
@@ -202,6 +202,15 @@ class ProactiveIntent(_StrictModel):
         return self.source == 'agent_judgment'
 
 
+class DeadLetteredProactiveIntent(ProactiveIntent):
+    """Full terminal record stored outside the rolling reader's collection."""
+
+    delivery_state: Literal['dead_letter'] = 'dead_letter'  # pyright: ignore[reportIncompatibleVariableOverride]
+    dead_letter_reason: str = Field(  # pyright: ignore[reportIncompatibleVariableOverride]
+        default='unknown', min_length=1, max_length=128, pattern=r'^[a-z0-9_:.-]+$'
+    )
+
+
 class MaterializableProactiveIntent(_StrictModel):
     """Wire-safe intent state; terminal dead letters never leave the store."""
 

--- a/backend/models/chat_first.py
+++ b/backend/models/chat_first.py
@@ -166,6 +166,7 @@ class ProactiveIntent(_StrictModel):
     first_deferred_at: datetime | None = None
     last_deferral_at: datetime | None = None
     dead_letter_reason: str | None = Field(default=None, min_length=1, max_length=128, pattern=r'^[a-z0-9_:.-]+$')
+    requeue_count: int = Field(default=0, ge=0, le=1)
     # This is a terminal local-journal receipt on the same sparse cold-start
     # intent, never an operator-owned completion switch. It is the bounded
     # server projection needed to stop suppressing agent-tier turns once the
@@ -215,6 +216,7 @@ class MaterializableProactiveIntent(_StrictModel):
     delivered_at: datetime | None = None
     materialization_receipt_id: StableId | None = None
     materialization_attempts: int = Field(default=0, ge=0)
+    requeue_count: int = Field(default=0, ge=0, le=1, exclude=True)
     last_rejection_code: str | None = Field(default=None, min_length=1, max_length=64, pattern=r'^[a-z0-9_]+$')
     last_rejection_at: datetime | None = None
     fetch_count: int = Field(default=0, ge=0)

--- a/backend/routers/chat_first.py
+++ b/backend/routers/chat_first.py
@@ -402,19 +402,26 @@ def _materialize_prompts(
 
     for deferral in request.deferrals:
         try:
-            chat_first_intents_db.record_materialization_deferral(
+            deferred_intent = chat_first_intents_db.record_materialization_deferral(
                 uid,
                 intent_id=deferral.intent_id,
                 account_generation=request.control_generation,
                 now=now,
             )
             deferred_intent_ids.add(deferral.intent_id)
+            if deferred_intent is not None and deferred_intent.dead_letter_reason == 'deferred_beyond_budget':
+                CHAT_FIRST_PROACTIVE_TOTAL.labels(
+                    event='dead_letter', source=deferred_intent.source, reason='deferred_beyond_budget'
+                ).inc()
         except (
             chat_first_intents_db.ChatFirstIntentDocumentGenerationMismatch,
             chat_first_intents_db.ChatFirstMalformedDocument,
             chat_first_intents_db.ProactiveIntentNotReady,
         ):
             # A stale device's explicit deferral must not poison the next batch.
+            continue
+        except Exception:
+            logger.exception('materialization deferral processing failed')
             continue
 
     for receipt in request.receipts:
@@ -489,7 +496,7 @@ def _materialize_prompts(
             account_generation=request.control_generation,
             now=now,
         )
-        released_intents = getattr(release_batch, 'intents', release_batch)
+        released_intents = release_batch if isinstance(release_batch, list) else release_batch.intents
         for _intent in released_intents:
             CHAT_FIRST_PROACTIVE_TOTAL.labels(event='deferral_released', source='deferral_reraise', reason='none').inc()
         for _ in range(getattr(release_batch, 'malformed_count', 0)):

--- a/backend/routers/chat_first.py
+++ b/backend/routers/chat_first.py
@@ -337,6 +337,7 @@ def _materialize_prompts(
         return MaterializePromptsResponse()
     now = datetime.now(timezone.utc)
     receipt_outcomes: list[ProactiveMaterializationReceiptOutcome] = []
+    deferred_intent_ids: set[str] = set()
     for rejection in request.rejections:
         try:
             rejected_intent, dead_letter_reason = chat_first_intents_db.record_materialization_rejection(
@@ -373,6 +374,7 @@ def _materialize_prompts(
                 account_generation=request.control_generation,
                 now=now,
             )
+            deferred_intent_ids.add(deferral.intent_id)
         except (chat_first_intents_db.ChatFirstIntentGenerationMismatch, chat_first_intents_db.ProactiveIntentNotReady):
             # A stale device's explicit deferral must not poison the next batch.
             continue
@@ -423,15 +425,19 @@ def _materialize_prompts(
                 account_generation=request.control_generation,
                 now=now,
             )
-        except chat_first_intents_db.ChatFirstIntentGenerationMismatch as exc:
-            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail='account generation mismatch') from exc
-        except (
-            chat_first_intents_db.ChatFirstIntentConflictError,
-            chat_first_intents_db.ProactiveIntentNotReady,
-        ) as exc:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT, detail='invalid cold-start terminal receipt'
-            ) from exc
+            outcome = 'acknowledged'
+        except chat_first_intents_db.ChatFirstIntentGenerationMismatch:
+            outcome = 'generation_mismatch'
+        except chat_first_intents_db.ChatFirstIntentConflictError:
+            outcome = 'conflict'
+        except chat_first_intents_db.ProactiveIntentNotReady:
+            outcome = 'missing'
+        except Exception:
+            logger.exception('cold-start terminal receipt processing failed')
+            outcome = 'conflict'
+        receipt_outcomes.append(
+            ProactiveMaterializationReceiptOutcome(intent_id=terminal_receipt.sequence_id, outcome=outcome)
+        )
         CHAT_FIRST_PROACTIVE_TOTAL.labels(
             event='cold_start_terminal_receipt', source='cold_start_sparse', reason='none'
         ).inc()
@@ -450,6 +456,7 @@ def _materialize_prompts(
             uid,
             account_generation=request.control_generation,
             exclude_block_types=exclude_block_types,
+            deferred_intent_ids=deferred_intent_ids,
             now=now,
         )
     except chat_first_intents_db.ChatFirstIntentGenerationMismatch as exc:

--- a/backend/routers/chat_first.py
+++ b/backend/routers/chat_first.py
@@ -33,6 +33,7 @@ from models.chat_first import (
     GoalLinkSpec,
     LegacyMaterializePromptsResponse,
     LegacyProactiveIntent,
+    MaterializableProactiveIntent,
     MaterializePromptsRequest,
     MaterializePromptsResponse,
     MemoryLinkSpec,
@@ -328,6 +329,27 @@ def _materialize_prompts(
     if not request.initial_page_loaded or not request.window_foreground:
         return MaterializePromptsResponse()
     now = datetime.now(timezone.utc)
+    for rejection in request.rejections:
+        try:
+            rejected_intent, dead_letter_reason = chat_first_intents_db.record_materialization_rejection(
+                uid,
+                intent_id=rejection.intent_id,
+                code=rejection.code,
+                account_generation=request.control_generation,
+                now=now,
+            )
+        except chat_first_intents_db.ChatFirstIntentGenerationMismatch as exc:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail='account generation mismatch') from exc
+        except chat_first_intents_db.ProactiveIntentNotReady as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT, detail='invalid materialization rejection'
+            ) from exc
+        CHAT_FIRST_PROACTIVE_TOTAL.labels(event='rejected', source=rejected_intent.source, reason=rejection.code).inc()
+        if dead_letter_reason is not None:
+            CHAT_FIRST_PROACTIVE_TOTAL.labels(
+                event='dead_letter', source=rejected_intent.source, reason=dead_letter_reason
+            ).inc()
+
     for receipt in request.receipts:
         try:
             delivered_intent = chat_first_intents_db.acknowledge_materialization(
@@ -355,7 +377,7 @@ def _materialize_prompts(
             chat_first_intents_db.ProactiveIntentNotReady,
         ) as exc:
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail='invalid materialization receipt') from exc
-        CHAT_FIRST_PROACTIVE_TOTAL.labels(event='kernel_receipt', source='materialization').inc()
+        CHAT_FIRST_PROACTIVE_TOTAL.labels(event='kernel_receipt', source='materialization', reason='none').inc()
 
     # The kernel can only emit this after it durably terminalizes the scripted
     # sequence in its canonical journal. This is an acknowledgement on the
@@ -379,7 +401,9 @@ def _materialize_prompts(
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT, detail='invalid cold-start terminal receipt'
             ) from exc
-        CHAT_FIRST_PROACTIVE_TOTAL.labels(event='cold_start_terminal_receipt', source='cold_start_sparse').inc()
+        CHAT_FIRST_PROACTIVE_TOTAL.labels(
+            event='cold_start_terminal_receipt', source='cold_start_sparse', reason='none'
+        ).inc()
 
     try:
         released = chat_first_intents_db.release_due_deferrals(
@@ -388,18 +412,31 @@ def _materialize_prompts(
             now=now,
         )
         for _intent in released:
-            CHAT_FIRST_PROACTIVE_TOTAL.labels(event='deferral_released', source='deferral_reraise').inc()
+            CHAT_FIRST_PROACTIVE_TOTAL.labels(event='deferral_released', source='deferral_reraise', reason='none').inc()
         _maybe_persist_cold_start(uid, control_generation=request.control_generation, now=now)
         _maybe_persist_daily_opener(uid, control_generation=request.control_generation, now=now)
-        intents = chat_first_intents_db.fetch_ready_intents(
+        batch = chat_first_intents_db.fetch_ready_intent_batch(
             uid,
             account_generation=request.control_generation,
             exclude_block_types=exclude_block_types,
+            now=now,
         )
     except chat_first_intents_db.ChatFirstIntentGenerationMismatch as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail='account generation mismatch') from exc
-    CHAT_FIRST_PROACTIVE_TOTAL.labels(event='fetch', source='materialization').inc()
-    return MaterializePromptsResponse(intents=intents)
+    for lifecycle_event in batch.lifecycle_events:
+        CHAT_FIRST_PROACTIVE_TOTAL.labels(
+            event=lifecycle_event.event,
+            source=lifecycle_event.source,
+            reason=lifecycle_event.reason,
+        ).inc()
+    if batch.stalled_source is not None:
+        CHAT_FIRST_PROACTIVE_TOTAL.labels(
+            event='stalled', source=batch.stalled_source, reason='ready_older_than_24h'
+        ).inc()
+    CHAT_FIRST_PROACTIVE_TOTAL.labels(event='fetch', source='materialization', reason='none').inc()
+    return MaterializePromptsResponse(
+        intents=[MaterializableProactiveIntent.model_validate(intent.model_dump()) for intent in batch.intents]
+    )
 
 
 @router.post(
@@ -432,5 +469,5 @@ def record_chat_deferral(
     except chat_first_intents_db.ChatFirstIntentConflictError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail='deferral continuity conflict') from exc
     if created:
-        CHAT_FIRST_PROACTIVE_TOTAL.labels(event='deferral_recorded', source='deferral_reraise').inc()
+        CHAT_FIRST_PROACTIVE_TOTAL.labels(event='deferral_recorded', source='deferral_reraise', reason='none').inc()
     return receipt

--- a/backend/routers/chat_first.py
+++ b/backend/routers/chat_first.py
@@ -36,6 +36,7 @@ from models.chat_first import (
     MaterializableProactiveIntent,
     MaterializePromptsRequest,
     MaterializePromptsResponse,
+    ProactiveMaterializationRejectionOutcome,
     ProactiveMaterializationReceiptOutcome,
     MemoryLinkSpec,
     TaskCardSpec,
@@ -337,6 +338,7 @@ def _materialize_prompts(
         return MaterializePromptsResponse()
     now = datetime.now(timezone.utc)
     receipt_outcomes: list[ProactiveMaterializationReceiptOutcome] = []
+    rejection_outcomes: list[ProactiveMaterializationRejectionOutcome] = []
     deferred_intent_ids: set[str] = set()
     for rejection in request.rejections:
         try:
@@ -349,10 +351,42 @@ def _materialize_prompts(
             )
         except chat_first_intents_db.ChatFirstIntentGenerationMismatch as exc:
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail='account generation mismatch') from exc
+        except chat_first_intents_db.ChatFirstIntentDocumentGenerationMismatch:
+            outcome = 'generation_mismatch'
+            rejection_outcomes.append(
+                ProactiveMaterializationRejectionOutcome(intent_id=rejection.intent_id, outcome=outcome)
+            )
+            continue
+        except chat_first_intents_db.ChatFirstMalformedDocument:
+            outcome = 'malformed'
+            rejection_outcomes.append(
+                ProactiveMaterializationRejectionOutcome(intent_id=rejection.intent_id, outcome=outcome)
+            )
+            continue
         except chat_first_intents_db.ProactiveIntentNotReady:
+            rejection_outcomes.append(
+                ProactiveMaterializationRejectionOutcome(intent_id=rejection.intent_id, outcome='absorbed')
+            )
+            continue
+        except Exception:
+            logger.exception('materialization rejection processing failed')
+            rejection_outcomes.append(
+                ProactiveMaterializationRejectionOutcome(intent_id=rejection.intent_id, outcome='malformed')
+            )
             continue
         if rejected_intent is None:
+            rejection_outcomes.append(
+                ProactiveMaterializationRejectionOutcome(intent_id=rejection.intent_id, outcome='missing')
+            )
             continue
+        outcome = (
+            'absorbed'
+            if rejected_intent.delivery_state in {'delivered', 'dead_letter'} and dead_letter_reason is None
+            else 'recorded'
+        )
+        rejection_outcomes.append(
+            ProactiveMaterializationRejectionOutcome(intent_id=rejection.intent_id, outcome=outcome)
+        )
         metric_code = _bounded_rejection_reason(rejection.code)
         CHAT_FIRST_PROACTIVE_TOTAL.labels(event='rejected', source=rejected_intent.source, reason=metric_code).inc()
         if dead_letter_reason is not None:
@@ -375,7 +409,11 @@ def _materialize_prompts(
                 now=now,
             )
             deferred_intent_ids.add(deferral.intent_id)
-        except (chat_first_intents_db.ChatFirstIntentGenerationMismatch, chat_first_intents_db.ProactiveIntentNotReady):
+        except (
+            chat_first_intents_db.ChatFirstIntentDocumentGenerationMismatch,
+            chat_first_intents_db.ChatFirstMalformedDocument,
+            chat_first_intents_db.ProactiveIntentNotReady,
+        ):
             # A stale device's explicit deferral must not poison the next batch.
             continue
 
@@ -400,7 +438,10 @@ def _materialize_prompts(
                     except Exception:
                         logger.exception('meeting receipt materialization projection failed')
             outcome = 'acknowledged' if delivered_intent.delivery_state == 'delivered' else 'already_terminal'
-        except chat_first_intents_db.ChatFirstIntentGenerationMismatch:
+        except (
+            chat_first_intents_db.ChatFirstIntentGenerationMismatch,
+            chat_first_intents_db.ChatFirstIntentDocumentGenerationMismatch,
+        ):
             outcome = 'generation_mismatch'
         except chat_first_intents_db.ChatFirstIntentConflictError:
             outcome = 'conflict'
@@ -443,13 +484,18 @@ def _materialize_prompts(
         ).inc()
 
     try:
-        released = chat_first_intents_db.release_due_deferrals(
+        release_batch = chat_first_intents_db.release_due_deferrals(
             uid,
             account_generation=request.control_generation,
             now=now,
         )
-        for _intent in released:
+        released_intents = getattr(release_batch, 'intents', release_batch)
+        for _intent in released_intents:
             CHAT_FIRST_PROACTIVE_TOTAL.labels(event='deferral_released', source='deferral_reraise', reason='none').inc()
+        for _ in range(getattr(release_batch, 'malformed_count', 0)):
+            CHAT_FIRST_PROACTIVE_TOTAL.labels(
+                event='deferral_malformed', source='deferral_reraise', reason='malformed_document'
+            ).inc()
         _maybe_persist_cold_start(uid, control_generation=request.control_generation, now=now)
         _maybe_persist_daily_opener(uid, control_generation=request.control_generation, now=now)
         batch = chat_first_intents_db.fetch_ready_intent_batch(
@@ -473,8 +519,14 @@ def _materialize_prompts(
         ).inc()
     CHAT_FIRST_PROACTIVE_TOTAL.labels(event='fetch', source='materialization', reason='none').inc()
     return MaterializePromptsResponse(
-        intents=[MaterializableProactiveIntent.model_validate(intent.model_dump()) for intent in batch.intents],
+        intents=[
+            MaterializableProactiveIntent.model_validate(
+                intent.model_dump(exclude={'first_deferred_at', 'last_deferral_at'})
+            )
+            for intent in batch.intents
+        ],
         receipt_outcomes=receipt_outcomes,
+        rejection_outcomes=rejection_outcomes,
     )
 
 

--- a/backend/routers/chat_first.py
+++ b/backend/routers/chat_first.py
@@ -36,6 +36,7 @@ from models.chat_first import (
     MaterializableProactiveIntent,
     MaterializePromptsRequest,
     MaterializePromptsResponse,
+    ProactiveMaterializationReceiptOutcome,
     MemoryLinkSpec,
     TaskCardSpec,
     stable_block_id,
@@ -54,6 +55,12 @@ from utils.task_intelligence.rollout import resolve_task_intelligence_for_user
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+_METRIC_REJECTION_CODES = frozenset({'invalid_intent', 'identity_conflict', 'kernel_materialization_failed'})
+
+
+def _bounded_rejection_reason(code: str) -> str:
+    return code if code in _METRIC_REJECTION_CODES else 'unknown'
 
 
 def _eligibility(uid: str):
@@ -329,6 +336,7 @@ def _materialize_prompts(
     if not request.initial_page_loaded or not request.window_foreground:
         return MaterializePromptsResponse()
     now = datetime.now(timezone.utc)
+    receipt_outcomes: list[ProactiveMaterializationReceiptOutcome] = []
     for rejection in request.rejections:
         try:
             rejected_intent, dead_letter_reason = chat_first_intents_db.record_materialization_rejection(
@@ -340,15 +348,34 @@ def _materialize_prompts(
             )
         except chat_first_intents_db.ChatFirstIntentGenerationMismatch as exc:
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail='account generation mismatch') from exc
-        except chat_first_intents_db.ProactiveIntentNotReady as exc:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT, detail='invalid materialization rejection'
-            ) from exc
-        CHAT_FIRST_PROACTIVE_TOTAL.labels(event='rejected', source=rejected_intent.source, reason=rejection.code).inc()
+        except chat_first_intents_db.ProactiveIntentNotReady:
+            continue
+        if rejected_intent is None:
+            continue
+        metric_code = _bounded_rejection_reason(rejection.code)
+        CHAT_FIRST_PROACTIVE_TOTAL.labels(event='rejected', source=rejected_intent.source, reason=metric_code).inc()
         if dead_letter_reason is not None:
             CHAT_FIRST_PROACTIVE_TOTAL.labels(
-                event='dead_letter', source=rejected_intent.source, reason=dead_letter_reason
+                event='dead_letter',
+                source=rejected_intent.source,
+                reason=(
+                    f'permanent_rejection:{metric_code}'
+                    if dead_letter_reason.startswith('permanent_rejection:')
+                    else dead_letter_reason
+                ),
             ).inc()
+
+    for deferral in request.deferrals:
+        try:
+            chat_first_intents_db.record_materialization_deferral(
+                uid,
+                intent_id=deferral.intent_id,
+                account_generation=request.control_generation,
+                now=now,
+            )
+        except (chat_first_intents_db.ChatFirstIntentGenerationMismatch, chat_first_intents_db.ProactiveIntentNotReady):
+            # A stale device's explicit deferral must not poison the next batch.
+            continue
 
     for receipt in request.receipts:
         try:
@@ -370,13 +397,17 @@ def _materialize_prompts(
                         )
                     except Exception:
                         logger.exception('meeting receipt materialization projection failed')
-        except chat_first_intents_db.ChatFirstIntentGenerationMismatch as exc:
-            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail='account generation mismatch') from exc
-        except (
-            chat_first_intents_db.ChatFirstIntentConflictError,
-            chat_first_intents_db.ProactiveIntentNotReady,
-        ) as exc:
-            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail='invalid materialization receipt') from exc
+            outcome = 'acknowledged' if delivered_intent.delivery_state == 'delivered' else 'already_terminal'
+        except chat_first_intents_db.ChatFirstIntentGenerationMismatch:
+            outcome = 'generation_mismatch'
+        except chat_first_intents_db.ChatFirstIntentConflictError:
+            outcome = 'conflict'
+        except chat_first_intents_db.ProactiveIntentNotReady:
+            outcome = 'missing'
+        except Exception:
+            logger.exception('materialization receipt processing failed')
+            outcome = 'conflict'
+        receipt_outcomes.append(ProactiveMaterializationReceiptOutcome(intent_id=receipt.intent_id, outcome=outcome))
         CHAT_FIRST_PROACTIVE_TOTAL.labels(event='kernel_receipt', source='materialization', reason='none').inc()
 
     # The kernel can only emit this after it durably terminalizes the scripted
@@ -435,7 +466,8 @@ def _materialize_prompts(
         ).inc()
     CHAT_FIRST_PROACTIVE_TOTAL.labels(event='fetch', source='materialization', reason='none').inc()
     return MaterializePromptsResponse(
-        intents=[MaterializableProactiveIntent.model_validate(intent.model_dump()) for intent in batch.intents]
+        intents=[MaterializableProactiveIntent.model_validate(intent.model_dump()) for intent in batch.intents],
+        receipt_outcomes=receipt_outcomes,
     )
 
 

--- a/backend/routers/chat_first.py
+++ b/backend/routers/chat_first.py
@@ -496,10 +496,9 @@ def _materialize_prompts(
             account_generation=request.control_generation,
             now=now,
         )
-        released_intents = release_batch if isinstance(release_batch, list) else release_batch.intents
-        for _intent in released_intents:
+        for _intent in release_batch.intents:
             CHAT_FIRST_PROACTIVE_TOTAL.labels(event='deferral_released', source='deferral_reraise', reason='none').inc()
-        for _ in range(getattr(release_batch, 'malformed_count', 0)):
+        for _ in range(release_batch.malformed_count):
             CHAT_FIRST_PROACTIVE_TOTAL.labels(
                 event='deferral_malformed', source='deferral_reraise', reason='malformed_document'
             ).inc()

--- a/backend/routers/chat_first.py
+++ b/backend/routers/chat_first.py
@@ -4,7 +4,6 @@ The local kernel owns its journal. This route validates capability and
 canonical references only; it never creates, updates, or syncs a chat row.
 """
 
-import inspect
 from typing import Annotated, Any
 
 from datetime import datetime, timezone
@@ -287,12 +286,7 @@ def materialize_prompts_v1(
 ) -> LegacyMaterializePromptsResponse:
     """Preserve the released block union; new receipt types remain pending for v2 clients."""
 
-    # Keep the narrow unit-test seam backwards-compatible with older callers
-    # that monkeypatch this helper with its original two-argument signature.
-    if 'exclude_block_types' in inspect.signature(_materialize_prompts).parameters:
-        response = _materialize_prompts(request, uid, exclude_block_types={'conversationLink'})
-    else:
-        response = _materialize_prompts(request, uid)
+    response = _materialize_prompts(request, uid, exclude_block_types={'conversationLink'})
     compatible = [
         LegacyProactiveIntent.model_validate(intent.model_dump())
         for intent in response.intents
@@ -458,7 +452,14 @@ def _materialize_prompts(
             logger.exception('materialization receipt processing failed')
             outcome = 'conflict'
         receipt_outcomes.append(ProactiveMaterializationReceiptOutcome(intent_id=receipt.intent_id, outcome=outcome))
-        CHAT_FIRST_PROACTIVE_TOTAL.labels(event='kernel_receipt', source='materialization', reason='none').inc()
+        CHAT_FIRST_PROACTIVE_TOTAL.labels(event='kernel_receipt', source='materialization', reason=outcome).inc()
+        if outcome in {'conflict', 'generation_mismatch'}:
+            logger.warning(
+                'materialization receipt outcome=%s intent_id=%s receipt_id=%s',
+                outcome,
+                receipt.intent_id,
+                receipt.receipt_id,
+            )
 
     # The kernel can only emit this after it durably terminalizes the scripted
     # sequence in its canonical journal. This is an acknowledgement on the
@@ -527,7 +528,7 @@ def _materialize_prompts(
     return MaterializePromptsResponse(
         intents=[
             MaterializableProactiveIntent.model_validate(
-                intent.model_dump(exclude={'first_deferred_at', 'last_deferral_at'})
+                intent.model_dump(exclude={'first_deferred_at', 'last_deferral_at', 'requeue_count'})
             )
             for intent in batch.intents
         ],

--- a/backend/services/users/data_export.py
+++ b/backend/services/users/data_export.py
@@ -38,6 +38,7 @@ TASK_EXPORT_COLLECTIONS = (
     'task_context_snapshots',
     'task_open_loop_snapshots',
     'chat_first_proactive_intents',
+    'chat_first_dead_letters',
     'chat_first_deferrals',
 )
 

--- a/backend/tests/unit/test_chat_first_blocks.py
+++ b/backend/tests/unit/test_chat_first_blocks.py
@@ -65,7 +65,11 @@ def test_materialization_v1_suppresses_conversation_links_while_v2_returns_them(
         }
     )
     response = MaterializePromptsResponse(intents=[intent])
-    monkeypatch.setattr(chat_first_router, '_materialize_prompts', lambda request, uid: response)
+    monkeypatch.setattr(
+        chat_first_router,
+        '_materialize_prompts',
+        lambda request, uid, *, exclude_block_types=None: response,
+    )
     request = MaterializePromptsRequest(
         source_surface='main_chat',
         control_generation=7,

--- a/backend/tests/unit/test_chat_first_blocks.py
+++ b/backend/tests/unit/test_chat_first_blocks.py
@@ -76,6 +76,19 @@ def test_materialization_v1_suppresses_conversation_links_while_v2_returns_them(
     assert chat_first_router.materialize_prompts(request, 'user-1') == response
 
 
+def test_v1_materialization_request_still_validates_without_rejections():
+    request = MaterializePromptsRequest.model_validate(
+        {
+            'source_surface': 'main_chat',
+            'control_generation': 7,
+            'owner_fence': 'user-1',
+        }
+    )
+
+    assert request.rejections == []
+    assert request.receipts == []
+
+
 def test_chat_first_validate_admits_canonical_blocks_with_retry_stable_ids(monkeypatch):
     _enable_chat_first(monkeypatch)
     monkeypatch.setattr(chat_first_router.action_items_db, 'get_action_item', lambda uid, task_id: {'id': task_id})

--- a/backend/tests/unit/test_chat_first_materialization_drop_rate.py
+++ b/backend/tests/unit/test_chat_first_materialization_drop_rate.py
@@ -227,12 +227,26 @@ class _FakeCollectionGroupQuery:
 
 
 class _FakeFirestoreClient:
-    def __init__(self, documents: list[dict[str, Any]]):
-        self._documents = documents
+    def __init__(self, documents: list[dict[str, Any]], dead_letters: list[dict[str, Any]] | None = None):
+        self._documents = {
+            report.INTENTS_COLLECTION: documents,
+            report.DEAD_LETTERS_COLLECTION: dead_letters or [],
+        }
 
     def collection_group(self, name: str) -> _FakeCollectionGroupQuery:
-        assert name == report.INTENTS_COLLECTION
-        return _FakeCollectionGroupQuery(self._documents)
+        return _FakeCollectionGroupQuery(self._documents[name])
+
+
+def test_collect_counts_terminal_records_from_dead_letter_collection():
+    delivered = _intent(delivery_state='delivered', created_at=NOW - timedelta(days=3))
+    dead_letter = _intent(delivery_state='dead_letter', created_at=NOW - timedelta(days=3))
+
+    result = report.collect(
+        None, None, 48, NOW, None, firestore_client=_FakeFirestoreClient([delivered], [dead_letter])
+    )
+
+    assert result['delivered'] == 1
+    assert result['dropped'] == 1
 
 
 def test_windowed_collect_excludes_a_drop_older_than_the_window():

--- a/backend/tests/unit/test_chat_first_proactive_engine.py
+++ b/backend/tests/unit/test_chat_first_proactive_engine.py
@@ -48,6 +48,10 @@ def _trigger():
     return engine.ProactiveWakeTrigger(kind='goal_changed', subject=SUBJECT, continuity_key='goal-1-complete')
 
 
+def _empty_release_batch(*args, **kwargs):
+    return engine.intent_db.DeferralReleaseBatch(intents=[], malformed_count=0)
+
+
 def _question():
     return QuestionCardSpec(
         type='questionCard',
@@ -66,7 +70,7 @@ def test_cold_start_decision_table_requires_both_canonical_facts():
 
 
 def test_sparse_cold_start_suppresses_agent_tier_without_calling_the_judge(monkeypatch):
-    monkeypatch.setattr(engine.intent_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(engine.intent_db, 'release_due_deferrals', _empty_release_batch)
     monkeypatch.setattr(engine.intent_db, 'has_active_sparse_cold_start_sequence', lambda *args, **kwargs: True)
     monkeypatch.setattr(
         engine.intent_db,
@@ -88,7 +92,7 @@ def test_sparse_cold_start_suppresses_agent_tier_without_calling_the_judge(monke
 
 
 def test_agent_judgment_cannot_mint_a_conversation_link(monkeypatch):
-    monkeypatch.setattr(engine.intent_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(engine.intent_db, 'release_due_deferrals', _empty_release_batch)
     monkeypatch.setattr(
         engine.intent_db,
         'admit_agent_judgment',
@@ -402,7 +406,7 @@ def test_capture_arrival_failure_logs_redact_authenticated_uid(monkeypatch, capl
 
 
 def test_exhausted_budget_short_circuits_before_judge(monkeypatch):
-    monkeypatch.setattr(engine.intent_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(engine.intent_db, 'release_due_deferrals', _empty_release_batch)
     monkeypatch.setattr(
         engine.intent_db,
         'admit_agent_judgment',
@@ -428,7 +432,7 @@ def test_exhausted_budget_short_circuits_before_judge(monkeypatch):
 
 
 def test_empty_judgment_declines_without_consuming_or_creating(monkeypatch):
-    monkeypatch.setattr(engine.intent_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(engine.intent_db, 'release_due_deferrals', _empty_release_batch)
     monkeypatch.setattr(
         engine.intent_db,
         'admit_agent_judgment',
@@ -462,7 +466,7 @@ def test_empty_judgment_declines_without_consuming_or_creating(monkeypatch):
 
 def test_agent_admission_happens_before_the_judge_and_duplicate_wake_stays_quiet(monkeypatch):
     events = []
-    monkeypatch.setattr(engine.intent_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(engine.intent_db, 'release_due_deferrals', _empty_release_batch)
     monkeypatch.setattr(
         engine.intent_db,
         'admit_agent_judgment',

--- a/backend/tests/unit/test_chat_first_proactive_intents.py
+++ b/backend/tests/unit/test_chat_first_proactive_intents.py
@@ -11,6 +11,7 @@ from models.chat_first import (
     CaptureLinkSpec,
     ChatFirstSubject,
     ColdStartSequence,
+    ConversationLinkSpec,
     QuestionCardSpec,
     QuestionOption,
 )
@@ -394,6 +395,169 @@ def test_capture_arrival_retry_creates_one_deterministic_receipt_intent(firestor
     assert retry.source == 'capture_arrival'
 
 
+def test_poison_item_contract_one_bad_item_never_blocks_rest_and_is_parked_with_reason_within_budget(firestore):
+    poison, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:poison',
+        subject=ChatFirstSubject(kind='capture', id='poison'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='poison', summary='Poison')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    healthy, _ = intents_db.create_intent(
+        UID,
+        source='daily_opener',
+        continuity_key='daily:healthy',
+        subject=None,
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='healthy', summary='Healthy')],
+        account_generation=GENERATION,
+        now=NOW + timedelta(seconds=1),
+        firestore_client=firestore,
+    )
+
+    for attempt in range(1, intents_db.MATERIALIZATION_REJECTION_BUDGET + 1):
+        rejected, reason = intents_db.record_materialization_rejection(
+            UID,
+            intent_id=poison.intent_id,
+            code='kernel_materialization_failed',
+            account_generation=GENERATION,
+            now=NOW + timedelta(minutes=attempt),
+            firestore_client=firestore,
+        )
+        assert rejected.materialization_attempts == attempt
+
+    assert reason == 'rejection_budget_exhausted'
+    assert rejected.delivery_state == 'dead_letter'
+    assert rejected.last_rejection_code == 'kernel_materialization_failed'
+    fetched = intents_db.fetch_ready_intents(
+        UID,
+        account_generation=GENERATION,
+        now=NOW + timedelta(minutes=10),
+        firestore_client=firestore,
+    )
+    assert [intent.intent_id for intent in fetched] == [healthy.intent_id]
+    assert poison.intent_id not in [intent.intent_id for intent in fetched]
+
+
+def test_fetch_budget_dead_letters_an_unacknowledged_intent(firestore):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:never-acknowledged',
+        subject=ChatFirstSubject(kind='capture', id='never-acknowledged'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='never-acknowledged', summary='Capture')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+
+    for fetch_index in range(intents_db.UNACKNOWLEDGED_FETCH_BUDGET):
+        assert intents_db.fetch_ready_intents(
+            UID,
+            account_generation=GENERATION,
+            now=NOW + timedelta(minutes=fetch_index),
+            firestore_client=firestore,
+        )
+    parked = intents_db.fetch_ready_intents(
+        UID,
+        account_generation=GENERATION,
+        now=NOW + timedelta(hours=1),
+        firestore_client=firestore,
+    )
+
+    assert parked == []
+    stored = intents_db._intent_from_snapshot(
+        intents_db._intent_ref(UID, intent.intent_id, firestore_client=firestore).get()
+    )
+    assert stored.delivery_state == 'dead_letter'
+    assert stored.fetch_count == intents_db.UNACKNOWLEDGED_FETCH_BUDGET + 1
+    assert stored.dead_letter_reason == 'unacknowledged_after_fetch_budget'
+
+
+def test_fetch_reconciles_a_stable_chat_row_after_an_earlier_delivery(firestore):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:reconciled',
+        subject=ChatFirstSubject(kind='capture', id='reconciled'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='reconciled', summary='Capture')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    first = intents_db.fetch_ready_intents(UID, account_generation=GENERATION, now=NOW, firestore_client=firestore)
+    turn_id = intents_db._stable_chat_first_turn_id(intent.intent_id)
+    firestore.rows[('users', UID, 'messages', turn_id)] = {
+        'metadata': '{"chatFirstIntentId":"' + intent.intent_id + '"}'
+    }
+
+    batch = intents_db.fetch_ready_intent_batch(
+        UID,
+        account_generation=GENERATION,
+        now=NOW + timedelta(minutes=1),
+        firestore_client=firestore,
+    )
+
+    assert [item.intent_id for item in first] == [intent.intent_id]
+    assert batch.intents == []
+    assert batch.lifecycle_events == (
+        intents_db.IntentLifecycleEvent('reconciled', 'capture_arrival', 'existing_chat_row'),
+    )
+    stored = intents_db._intent_from_snapshot(
+        intents_db._intent_ref(UID, intent.intent_id, firestore_client=firestore).get()
+    )
+    assert stored.delivery_state == 'delivered'
+    assert stored.materialization_receipt_id.startswith('cfi_reconciled_')
+
+
+def test_fetch_orders_daily_and_meeting_intents_ahead_of_capture_link_backlog(firestore):
+    for index in range(9):
+        intents_db.create_intent(
+            UID,
+            source='capture_arrival',
+            continuity_key=f'capture:backlog:{index}',
+            subject=ChatFirstSubject(kind='capture', id=f'backlog-{index}'),
+            blocks=[CaptureLinkSpec(type='captureLink', conversation_id=f'backlog-{index}', summary='Capture')],
+            account_generation=GENERATION,
+            now=NOW + timedelta(seconds=index),
+            firestore_client=firestore,
+        )
+    daily, _ = intents_db.create_intent(
+        UID,
+        source='daily_opener',
+        continuity_key='daily:priority',
+        subject=None,
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='daily-priority', summary='Daily')],
+        account_generation=GENERATION,
+        now=NOW + timedelta(minutes=10),
+        firestore_client=firestore,
+    )
+    meeting, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='meeting:priority',
+        subject=ChatFirstSubject(kind='capture', id='meeting-priority'),
+        blocks=[
+            ConversationLinkSpec(
+                type='conversationLink', conversation_id='meeting-priority', summary='Meeting notes ready'
+            )
+        ],
+        account_generation=GENERATION,
+        now=NOW + timedelta(minutes=11),
+        firestore_client=firestore,
+    )
+
+    batch = intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, now=NOW + timedelta(days=2), firestore_client=firestore
+    )
+
+    assert [intent.intent_id for intent in batch.intents[:2]] == [daily.intent_id, meeting.intent_id]
+    assert len(batch.intents) == 8
+    assert batch.stalled_source == 'capture_arrival'
+
+
 def test_cold_start_generation_retries_one_pending_intent_until_its_kernel_receipt(firestore):
     sequence_id = f'cold-start:{GENERATION}'
     question = QuestionCardSpec(
@@ -433,7 +597,8 @@ def test_cold_start_generation_retries_one_pending_intent_until_its_kernel_recei
         intents_db.has_active_sparse_cold_start_sequence(UID, account_generation=GENERATION, firestore_client=firestore)
         is True
     )
-    assert intents_db.fetch_ready_intents(UID, account_generation=GENERATION, firestore_client=firestore) == [first]
+    fetched = intents_db.fetch_ready_intents(UID, account_generation=GENERATION, now=NOW, firestore_client=firestore)
+    assert fetched == [first.model_copy(update={'fetch_count': 1, 'last_fetched_at': NOW})]
     delivered = intents_db.acknowledge_materialization(
         UID,
         intent_id=first.intent_id,

--- a/backend/tests/unit/test_chat_first_proactive_intents.py
+++ b/backend/tests/unit/test_chat_first_proactive_intents.py
@@ -71,6 +71,7 @@ class _Document:
     def get(self, transaction=None):
         if transaction is not None:
             transaction.read()
+            self._database.transaction_reads[self._path] = self._database.transaction_reads.get(self._path, 0) + 1
             hook = self._database.transaction_read_hooks.pop(self._path, None)
             if hook is not None:
                 hook()
@@ -158,10 +159,25 @@ class _FilteredCollection:
                 matched.append(snap)
             elif op == '<=' and actual is not None and actual <= value:
                 matched.append(snap)
+            elif op == 'in' and actual in value:
+                matched.append(snap)
         return _FilteredCollection(matched)
 
     def limit(self, count):
         return _FilteredCollection(self._snapshots[:count])
+
+    def order_by(self, field):
+        def value(snapshot):
+            actual = snapshot.to_dict() or {}
+            for component in field.split('.'):
+                if not isinstance(actual, dict):
+                    return None
+                actual = actual.get(component)
+            return actual
+
+        return _FilteredCollection(
+            sorted((snapshot for snapshot in self._snapshots if value(snapshot) is not None), key=value)
+        )
 
 
 class _Transaction:
@@ -183,6 +199,7 @@ class _Firestore:
         self.transaction_count = 0
         self.transaction_read_hooks = {}
         self.point_reads = {}
+        self.transaction_reads = {}
 
     def collection(self, name):
         return _Collection(self, (name,))
@@ -273,6 +290,19 @@ def test_agent_intent_reserves_then_receipt_accounts_one_turn_idempotently(fires
     assert replayed == delivered
     assert budget.reservations == []
     assert budget.materialized_at == [NOW]
+    delivered_path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+    parsed_by_old_reader = _OldStrictProactiveIntent.model_validate(firestore.rows[delivered_path])
+
+    # The merge-base acknowledged receipts by parsing first and branching on
+    # delivered state second. Preserve that exact rolling-reader shape.
+    def merge_base_acknowledgement_shape(payload):
+        parsed = _OldStrictProactiveIntent.model_validate(payload)
+        if parsed.delivery_state == 'delivered':
+            return parsed
+        raise AssertionError('expected the old idempotent delivered branch')
+
+    assert merge_base_acknowledgement_shape(firestore.rows[delivered_path]) == parsed_by_old_reader
+    assert set(firestore.rows[delivered_path]) == set(_OldStrictProactiveIntent.model_fields)
 
 
 def test_budget_gate_counts_reservations_before_a_provider_call(firestore):
@@ -510,6 +540,8 @@ def test_legacy_transient_dead_letter_requeues_once_from_next_fetch_after_repair
         materialization_attempts=3,
         last_rejection_code='kernel_materialization_failed',
         last_rejection_at=NOW,
+        last_fetched_at=NOW,
+        requeue_count=0,
     )
 
     repaired = intents_db.fetch_ready_intents(
@@ -905,12 +937,16 @@ def test_fetch_requeues_transient_dead_letter_once_but_never_deterministic_death
     firestore.rows[transient_path].update(
         delivery_state='dead_letter',
         dead_letter_reason='unacknowledged_after_fetch_budget',
+        last_fetched_at=NOW,
+        requeue_count=0,
     )
     transient_attempt_path = ('users', UID, intents_db.DELIVERY_ATTEMPTS_COLLECTION, transient.intent_id)
     firestore.rows[transient_attempt_path] = {
         'fetch_count': intents_db.UNACKNOWLEDGED_FETCH_BUDGET + 1,
         'last_fetched_at': NOW,
         'requeue_count': 0,
+        'first_deferred_at': NOW - timedelta(days=2),
+        'last_deferral_at': NOW - timedelta(days=1),
     }
     deterministic_path = ('users', UID, intents_db.INTENTS_COLLECTION, 'deterministic-death')
     deterministic = {**firestore.rows[transient_path], 'intent_id': 'deterministic-death'}
@@ -925,11 +961,15 @@ def test_fetch_requeues_transient_dead_letter_once_but_never_deterministic_death
     )
     assert [item.intent_id for item in fetched] == [transient.intent_id]
     assert fetched[0].requeue_count == 1
+    assert firestore.rows[transient_attempt_path]['first_deferred_at'] == NOW - timedelta(days=2)
+    assert firestore.rows[transient_attempt_path]['last_deferral_at'] == NOW - timedelta(days=1)
     assert firestore.rows[deterministic_path]['delivery_state'] == 'dead_letter'
 
     firestore.rows[transient_path].update(
         delivery_state='dead_letter',
-        dead_letter_reason='unacknowledged_after_fetch_budget',
+        dead_letter_reason=intents_db.TRANSIENT_DEATH_AFTER_REQUEUE_REASON,
+        last_fetched_at=NOW,
+        requeue_count=1,
     )
     firestore.rows[transient_attempt_path].update(last_fetched_at=NOW, requeue_count=1)
     assert (
@@ -956,13 +996,17 @@ def test_sibling_point_reads_are_bounded_by_candidate_scan_limit(firestore):
             firestore_client=firestore,
         )
 
+    non_transaction_reads_before = sum(firestore.point_reads.values())
+    transaction_reads_before = sum(firestore.transaction_reads.values())
     intents_db.fetch_ready_intent_batch(
         UID, account_generation=GENERATION, limit=8, now=NOW + timedelta(hours=1), firestore_client=firestore
     )
-    sibling_reads = sum(
-        count for path, count in firestore.point_reads.items() if intents_db.DELIVERY_ATTEMPTS_COLLECTION in path
-    )
-    assert sibling_reads <= intents_db.FETCH_CANDIDATE_SCAN_MULTIPLIER * 8
+    non_transaction_reads = sum(firestore.point_reads.values()) - non_transaction_reads_before
+    transaction_reads = sum(firestore.transaction_reads.values()) - transaction_reads_before
+    # One control read plus, for at most 2 * limit candidates, one sibling
+    # hydration read and two transactional point reads (intent + sibling).
+    read_bound = 1 + (intents_db.FETCH_CANDIDATE_SCAN_MULTIPLIER * 8 * 3)
+    assert non_transaction_reads + transaction_reads <= read_bound
 
 
 def test_transient_dead_letter_repair_scan_is_bounded(firestore, monkeypatch):
@@ -997,7 +1041,110 @@ def test_transient_dead_letter_repair_scan_is_bounded(firestore, monkeypatch):
     assert len(scanned) == intents_db.FETCH_CANDIDATE_SCAN_MULTIPLIER * 8
 
 
-def test_malformed_delivery_attempt_is_repaired_and_fetched_with_metric_event(firestore):
+def test_repair_query_does_not_starve_repairable_row_behind_requeued_deaths(firestore):
+    created = []
+    for index in range(20):
+        intent, _ = intents_db.create_intent(
+            UID,
+            source='capture_arrival',
+            continuity_key=f'capture:repair-starvation:{index}',
+            subject=ChatFirstSubject(kind='capture', id=f'repair-starvation-{index}'),
+            blocks=[CaptureLinkSpec(type='captureLink', conversation_id=f'repair-{index}', summary='Repair')],
+            account_generation=GENERATION,
+            now=NOW + timedelta(seconds=index),
+            firestore_client=firestore,
+        )
+        created.append(intent)
+    repairable = max(created, key=lambda intent: intent.intent_id)
+    for intent in created:
+        intent_path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+        attempt_path = ('users', UID, intents_db.DELIVERY_ATTEMPTS_COLLECTION, intent.intent_id)
+        requeue_count = 0 if intent == repairable else 1
+        firestore.rows[intent_path].update(
+            delivery_state='dead_letter',
+            dead_letter_reason='unacknowledged_after_fetch_budget',
+            last_fetched_at=NOW,
+            requeue_count=requeue_count,
+        )
+        firestore.rows[attempt_path] = {
+            'fetch_count': intents_db.UNACKNOWLEDGED_FETCH_BUDGET + 1,
+            'last_fetched_at': NOW,
+            'requeue_count': requeue_count,
+        }
+
+    fetched = intents_db.fetch_ready_intents(
+        UID, account_generation=GENERATION, now=NOW + timedelta(days=5), firestore_client=firestore
+    )
+
+    assert [intent.intent_id for intent in fetched] == [repairable.intent_id]
+
+
+def test_repair_scan_skips_young_rows_without_transactions(firestore):
+    for index in range(16):
+        intent, _ = intents_db.create_intent(
+            UID,
+            source='capture_arrival',
+            continuity_key=f'capture:young-death:{index}',
+            subject=ChatFirstSubject(kind='capture', id=f'young-death-{index}'),
+            blocks=[CaptureLinkSpec(type='captureLink', conversation_id=f'young-{index}', summary='Young')],
+            account_generation=GENERATION,
+            now=NOW,
+            firestore_client=firestore,
+        )
+        firestore.rows[('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)].update(
+            delivery_state='dead_letter',
+            dead_letter_reason='unacknowledged_after_fetch_budget',
+            last_fetched_at=NOW,
+            requeue_count=0,
+        )
+    transactions_before = firestore.transaction_count
+
+    batch = intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, now=NOW + timedelta(hours=1), firestore_client=firestore
+    )
+
+    assert batch.intents == []
+    assert firestore.transaction_count == transactions_before
+
+
+def test_twice_dead_intent_gets_terminal_reason_and_is_never_scanned_again(firestore):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:twice-dead',
+        subject=ChatFirstSubject(kind='capture', id='twice-dead'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='twice-dead', summary='Twice dead')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    intent_path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+    attempt_path = ('users', UID, intents_db.DELIVERY_ATTEMPTS_COLLECTION, intent.intent_id)
+    firestore.rows[attempt_path] = {
+        'fetch_count': intents_db.UNACKNOWLEDGED_FETCH_BUDGET,
+        'requeue_count': 1,
+    }
+
+    assert (
+        intents_db.fetch_ready_intents(
+            UID, account_generation=GENERATION, now=NOW + timedelta(hours=1), firestore_client=firestore
+        )
+        == []
+    )
+    assert firestore.rows[intent_path]['dead_letter_reason'] == intents_db.TRANSIENT_DEATH_AFTER_REQUEUE_REASON
+    assert firestore.rows[intent_path]['requeue_count'] == 1
+    transactions_before = firestore.transaction_count
+
+    assert (
+        intents_db.fetch_ready_intents(
+            UID, account_generation=GENERATION, now=NOW + timedelta(days=5), firestore_client=firestore
+        )
+        == []
+    )
+    assert firestore.transaction_count == transactions_before
+
+
+def test_invalid_rejection_code_is_repaired_and_fetched_with_metric_event(firestore):
     intent, _ = intents_db.create_intent(
         UID,
         source='capture_arrival',
@@ -1009,7 +1156,11 @@ def test_malformed_delivery_attempt_is_repaired_and_fetched_with_metric_event(fi
         firestore_client=firestore,
     )
     attempt_path = ('users', UID, intents_db.DELIVERY_ATTEMPTS_COLLECTION, intent.intent_id)
-    firestore.rows[attempt_path] = {'fetch_count': 'garbage', 'requeue_count': -1}
+    firestore.rows[attempt_path] = {
+        'fetch_count': 0,
+        'requeue_count': 0,
+        'last_rejection_code': 'Bad Code!',
+    }
 
     batch = intents_db.fetch_ready_intent_batch(
         UID, account_generation=GENERATION, now=NOW + timedelta(minutes=1), firestore_client=firestore
@@ -1018,6 +1169,31 @@ def test_malformed_delivery_attempt_is_repaired_and_fetched_with_metric_event(fi
     assert [item.intent_id for item in batch.intents] == [intent.intent_id]
     assert firestore.rows[attempt_path]['fetch_count'] == 1
     assert firestore.rows[attempt_path]['requeue_count'] == 0
+    assert firestore.rows[attempt_path]['last_rejection_code'] is None
+    assert [event.event for event in batch.lifecycle_events] == ['malformed_attempt_reset']
+
+
+def test_malformed_fetch_count_reset_preserves_valid_requeue_count(firestore):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:malformed-fetch-count',
+        subject=ChatFirstSubject(kind='capture', id='malformed-fetch-count'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='malformed-fetch-count', summary='Repair')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    attempt_path = ('users', UID, intents_db.DELIVERY_ATTEMPTS_COLLECTION, intent.intent_id)
+    firestore.rows[attempt_path] = {'fetch_count': 'garbage', 'requeue_count': 1}
+
+    batch = intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, now=NOW + timedelta(minutes=1), firestore_client=firestore
+    )
+
+    assert [item.intent_id for item in batch.intents] == [intent.intent_id]
+    assert firestore.rows[attempt_path]['fetch_count'] == 1
+    assert firestore.rows[attempt_path]['requeue_count'] == 1
     assert [event.event for event in batch.lifecycle_events] == ['malformed_attempt_reset']
 
 
@@ -1397,6 +1573,37 @@ def test_fetch_orders_daily_and_meeting_intents_ahead_of_capture_link_backlog(fi
 
     assert [intent.intent_id for intent in batch.intents[:2]] == [daily.intent_id, meeting.intent_id]
     assert len(batch.intents) == 8
+    assert batch.stalled_source == 'capture_arrival'
+
+
+def test_stall_scan_includes_old_low_priority_intent_below_response_window(firestore):
+    for index in range(20):
+        intents_db.create_intent(
+            UID,
+            source='daily_opener',
+            continuity_key=f'daily:fresh-priority:{index}',
+            subject=None,
+            blocks=[CaptureLinkSpec(type='captureLink', conversation_id=f'fresh-{index}', summary='Fresh')],
+            account_generation=GENERATION,
+            now=NOW + timedelta(seconds=index),
+            firestore_client=firestore,
+        )
+    old, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:old-low-priority',
+        subject=ChatFirstSubject(kind='capture', id='old-low-priority'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='old-low-priority', summary='Old')],
+        account_generation=GENERATION,
+        now=NOW - timedelta(days=30),
+        firestore_client=firestore,
+    )
+
+    batch = intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, limit=8, now=NOW + timedelta(minutes=1), firestore_client=firestore
+    )
+
+    assert old.intent_id not in {intent.intent_id for intent in batch.intents}
     assert batch.stalled_source == 'capture_arrival'
 
 

--- a/backend/tests/unit/test_chat_first_proactive_intents.py
+++ b/backend/tests/unit/test_chat_first_proactive_intents.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
+from pydantic import BaseModel, ConfigDict
 
 import database.chat_first_intents as intents_db
 from models.chat_first import (
@@ -22,6 +23,23 @@ from models.task_intelligence import TaskWorkflowControl, TaskWorkflowMode
 NOW = datetime(2026, 7, 15, 12, tzinfo=timezone.utc)
 UID = 'user-1'
 GENERATION = 7
+
+
+class _OldStrictProactiveIntent(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    intent_id: str
+    continuity_key: str
+    account_generation: int
+    source: str
+    subject: object | None = None
+    blocks: list[object]
+    delivery_state: str = 'ready'
+    created_at: datetime
+    delivered_at: datetime | None = None
+    materialization_receipt_id: str | None = None
+    cold_start_sequence_terminal_state: str | None = None
+    cold_start_sequence_terminal_receipt_id: str | None = None
 
 
 class _Snapshot:
@@ -157,41 +175,11 @@ class _Transaction:
         ref.set(payload, merge=merge)
 
 
-class _WriteBatch:
-    def __init__(self, database):
-        self.database = database
-        self.writes = []
-
-    def set(self, ref, payload):
-        self.writes.append((ref, payload))
-
-    def update(self, ref, payload):
-        self.writes.append(('update', ref, payload))
-
-    def commit(self):
-        self.database.batch_commit_count += 1
-        hook = self.database.batch_commit_hook
-        self.database.batch_commit_hook = None
-        if hook is not None:
-            hook()
-        for operation in self.writes:
-            if len(operation) == 2:
-                ref, payload = operation
-                ref.set(payload)
-                continue
-            _, ref, payload = operation
-            if ref._path not in self.database.rows:
-                raise KeyError('write batch update requires an existing document')
-            ref.set(payload, merge=True)
-
-
 class _Firestore:
     def __init__(self):
         self.rows = {}
         self.transaction_count = 0
-        self.batch_commit_count = 0
         self.transaction_read_hooks = {}
-        self.batch_commit_hook = None
 
     def collection(self, name):
         return _Collection(self, (name,))
@@ -199,9 +187,6 @@ class _Firestore:
     def transaction(self):
         self.transaction_count += 1
         return _Transaction()
-
-    def batch(self):
-        return _WriteBatch(self)
 
 
 @pytest.fixture
@@ -439,7 +424,7 @@ def test_capture_arrival_retry_creates_one_deterministic_receipt_intent(firestor
     assert retry.source == 'capture_arrival'
 
 
-def test_poison_item_contract_one_bad_item_never_blocks_rest_and_is_parked_with_reason_within_budget(firestore):
+def test_transient_kernel_error_three_times_does_not_dead_letter(firestore):
     poison, _ = intents_db.create_intent(
         UID,
         source='capture_arrival',
@@ -450,17 +435,6 @@ def test_poison_item_contract_one_bad_item_never_blocks_rest_and_is_parked_with_
         now=NOW,
         firestore_client=firestore,
     )
-    healthy, _ = intents_db.create_intent(
-        UID,
-        source='daily_opener',
-        continuity_key='daily:healthy',
-        subject=None,
-        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='healthy', summary='Healthy')],
-        account_generation=GENERATION,
-        now=NOW + timedelta(seconds=1),
-        firestore_client=firestore,
-    )
-
     for attempt in range(1, intents_db.MATERIALIZATION_REJECTION_BUDGET + 1):
         rejected, reason = intents_db.record_materialization_rejection(
             UID,
@@ -470,19 +444,83 @@ def test_poison_item_contract_one_bad_item_never_blocks_rest_and_is_parked_with_
             now=NOW + timedelta(minutes=attempt),
             firestore_client=firestore,
         )
-        assert rejected.materialization_attempts == attempt
+        assert rejected.materialization_attempts == 0
+        assert reason is None
 
-    assert reason == 'rejection_budget_exhausted'
-    assert rejected.delivery_state == 'dead_letter'
-    assert rejected.last_rejection_code == 'kernel_materialization_failed'
-    fetched = intents_db.fetch_ready_intents(
+    assert rejected.delivery_state == 'ready'
+
+
+def test_invalid_intent_three_times_dead_letters_and_requeued_poison_stays_terminal(firestore):
+    intent, _ = intents_db.create_intent(
         UID,
+        source='capture_arrival',
+        continuity_key='capture:deterministic-poison',
+        subject=ChatFirstSubject(kind='capture', id='deterministic-poison'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='deterministic-poison', summary='Poison')],
         account_generation=GENERATION,
-        now=NOW + timedelta(minutes=10),
+        now=NOW,
         firestore_client=firestore,
     )
-    assert [intent.intent_id for intent in fetched] == [healthy.intent_id]
-    assert poison.intent_id not in [intent.intent_id for intent in fetched]
+    path = ('users', UID, intents_db.DELIVERY_ATTEMPTS_COLLECTION, intent.intent_id)
+    firestore.rows[path] = {'requeue_count': 1}
+
+    for attempt in range(1, intents_db.MATERIALIZATION_REJECTION_BUDGET + 1):
+        rejected, reason = intents_db.record_materialization_rejection(
+            UID,
+            intent_id=intent.intent_id,
+            code='invalid_intent',
+            account_generation=GENERATION,
+            now=NOW + timedelta(minutes=attempt),
+            firestore_client=firestore,
+        )
+        assert rejected.materialization_attempts == attempt
+
+    assert reason == 'permanent_rejection:invalid_intent'
+    assert rejected.delivery_state == 'dead_letter'
+    replay, replay_reason = intents_db.record_materialization_rejection(
+        UID,
+        intent_id=intent.intent_id,
+        code='kernel_materialization_failed',
+        account_generation=GENERATION,
+        now=NOW + timedelta(days=1),
+        firestore_client=firestore,
+    )
+    assert replay.delivery_state == 'dead_letter'
+    assert replay_reason is None
+
+
+def test_legacy_transient_dead_letter_requeues_once_after_repair_age(firestore):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:legacy-transient-dead-letter',
+        subject=ChatFirstSubject(kind='capture', id='legacy-transient-dead-letter'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='legacy-transient', summary='Repair')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    intent_path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+    firestore.rows[intent_path].update(
+        delivery_state='dead_letter',
+        dead_letter_reason='rejection_budget_exhausted',
+        materialization_attempts=3,
+        last_rejection_code='kernel_materialization_failed',
+        last_rejection_at=NOW,
+    )
+
+    repaired, reason = intents_db.record_materialization_rejection(
+        UID,
+        intent_id=intent.intent_id,
+        code='kernel_materialization_failed',
+        account_generation=GENERATION,
+        now=NOW + intents_db.TRANSIENT_DEAD_LETTER_REPAIR_AGE,
+        firestore_client=firestore,
+    )
+
+    assert repaired.delivery_state == 'ready'
+    assert repaired.requeue_count == 1
+    assert reason is None
 
 
 def test_fetch_budget_dead_letters_an_unacknowledged_intent(firestore):
@@ -512,8 +550,11 @@ def test_fetch_budget_dead_letters_an_unacknowledged_intent(firestore):
     )
 
     assert parked == []
-    stored = intents_db._intent_from_snapshot(
-        intents_db._intent_ref(UID, intent.intent_id, firestore_client=firestore).get()
+    stored = intents_db._intent_with_delivery_attempt(
+        intents_db._intent_from_snapshot(
+            intents_db._intent_ref(UID, intent.intent_id, firestore_client=firestore).get()
+        ),
+        intents_db._delivery_attempt_ref(UID, intent.intent_id, firestore_client=firestore).get(),
     )
     assert stored.delivery_state == 'dead_letter'
     assert stored.fetch_count == intents_db.UNACKNOWLEDGED_FETCH_BUDGET + 1
@@ -565,14 +606,71 @@ def test_tail_deferral_never_spends_the_unacknowledged_fetch_budget(firestore):
     stored_deferred = intents_db._intent_from_snapshot(
         intents_db._intent_ref(UID, deferred.intent_id, firestore_client=firestore).get()
     )
-    stored_undeferred = intents_db._intent_from_snapshot(
-        intents_db._intent_ref(UID, undeferred.intent_id, firestore_client=firestore).get()
+    stored_undeferred = intents_db._intent_with_delivery_attempt(
+        intents_db._intent_from_snapshot(
+            intents_db._intent_ref(UID, undeferred.intent_id, firestore_client=firestore).get()
+        ),
+        intents_db._delivery_attempt_ref(UID, undeferred.intent_id, firestore_client=firestore).get(),
     )
     assert stored_deferred.delivery_state == 'ready'
     assert stored_deferred.fetch_count == 0
     assert stored_deferred.last_fetched_at is None
     assert stored_undeferred.delivery_state == 'dead_letter'
     assert stored_undeferred.fetch_count == intents_db.UNACKNOWLEDGED_FETCH_BUDGET + 1
+
+
+def test_deferred_old_intent_does_not_stall_but_never_fetched_old_intent_does(firestore):
+    deferred, _ = intents_db.create_intent(
+        UID,
+        source='daily_opener',
+        continuity_key='daily:old-deferred',
+        subject=None,
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='old-deferred', summary='Deferred')],
+        account_generation=GENERATION,
+        now=NOW - timedelta(hours=25),
+        firestore_client=firestore,
+    )
+    intents_db.record_materialization_deferral(
+        UID,
+        intent_id=deferred.intent_id,
+        account_generation=GENERATION,
+        now=NOW - timedelta(hours=1),
+        firestore_client=firestore,
+    )
+    intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:fresh',
+        subject=ChatFirstSubject(kind='capture', id='fresh'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='fresh', summary='Fresh')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+
+    without_stall = intents_db.fetch_ready_intent_batch(
+        UID,
+        account_generation=GENERATION,
+        deferred_intent_ids={deferred.intent_id},
+        now=NOW,
+        firestore_client=firestore,
+    )
+    assert without_stall.stalled_source is None
+
+    intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:old-never-fetched',
+        subject=ChatFirstSubject(kind='capture', id='old-never-fetched'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='old-never-fetched', summary='Old')],
+        account_generation=GENERATION,
+        now=NOW - timedelta(hours=25),
+        firestore_client=firestore,
+    )
+    stalled = intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, now=NOW, firestore_client=firestore
+    )
+    assert stalled.stalled_source == 'capture_arrival'
 
 
 def test_continuous_deferral_dead_letters_at_seven_days_but_not_six(firestore):
@@ -665,6 +763,30 @@ def test_fetch_advance_preserves_unknown_newer_revision_fields(firestore):
     assert firestore.rows[path]['newer_revision_field'] == {'keep': True}
 
 
+def test_fetch_bookkeeping_stays_in_sibling_doc_and_old_strict_reader_still_parses_intent(firestore):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:rolling-reader-safe',
+        subject=ChatFirstSubject(kind='capture', id='rolling-reader-safe'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='rolling-reader-safe', summary='Safe')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    intent_path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+
+    intents_db.fetch_ready_intents(
+        UID, account_generation=GENERATION, now=NOW + timedelta(minutes=1), firestore_client=firestore
+    )
+
+    assert 'fetch_count' not in firestore.rows[intent_path]
+    assert 'last_fetched_at' not in firestore.rows[intent_path]
+    _OldStrictProactiveIntent.model_validate(firestore.rows[intent_path])
+    attempt_path = ('users', UID, intents_db.DELIVERY_ATTEMPTS_COLLECTION, intent.intent_id)
+    assert firestore.rows[attempt_path]['fetch_count'] == 1
+
+
 def test_terminal_receipt_is_acknowledged_idempotently_after_fetch_budget_dead_letter(firestore):
     intent, _ = intents_db.create_intent(
         UID,
@@ -748,7 +870,6 @@ def test_fetch_isolates_malformed_documents_and_transactions_healthy_fetch_updat
     assert firestore.rows[malformed_path]['delivery_state'] == 'dead_letter'
     assert firestore.rows[malformed_path]['dead_letter_reason'] == 'malformed_document'
     assert firestore.transaction_count == transactions_before + 2
-    assert firestore.batch_commit_count == 0
 
 
 def test_concurrently_deleted_candidate_does_not_abort_fetch_or_other_writes(firestore):
@@ -778,14 +899,13 @@ def test_concurrently_deleted_candidate_does_not_abort_fetch_or_other_writes(fir
         firestore.rows.pop(deleted_path)
 
     firestore.transaction_read_hooks[deleted_path] = delete_during_write
-    firestore.batch_commit_hook = delete_during_write
 
     batch = intents_db.fetch_ready_intent_batch(
         UID, account_generation=GENERATION, now=NOW + timedelta(minutes=1), firestore_client=firestore
     )
 
     assert [item.intent_id for item in batch.intents] == [healthy.intent_id]
-    healthy_path = ('users', UID, intents_db.INTENTS_COLLECTION, healthy.intent_id)
+    healthy_path = ('users', UID, intents_db.DELIVERY_ATTEMPTS_COLLECTION, healthy.intent_id)
     assert firestore.rows[healthy_path]['fetch_count'] == 1
 
 
@@ -801,14 +921,14 @@ def test_dead_letter_transition_never_overwrites_a_concurrent_delivery(firestore
         firestore_client=firestore,
     )
     path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
-    firestore.rows[path]['fetch_count'] = intents_db.UNACKNOWLEDGED_FETCH_BUDGET
+    attempt_path = ('users', UID, intents_db.DELIVERY_ATTEMPTS_COLLECTION, intent.intent_id)
+    firestore.rows[attempt_path] = {'fetch_count': intents_db.UNACKNOWLEDGED_FETCH_BUDGET}
 
     def deliver_concurrently():
         firestore.rows[path]['delivery_state'] = 'delivered'
         firestore.rows[path]['materialization_receipt_id'] = 'other-device-receipt'
 
     firestore.transaction_read_hooks[path] = deliver_concurrently
-    firestore.batch_commit_hook = deliver_concurrently
 
     batch = intents_db.fetch_ready_intent_batch(
         UID, account_generation=GENERATION, now=NOW + timedelta(minutes=1), firestore_client=firestore
@@ -831,6 +951,7 @@ def test_two_interleaved_device_fetches_increment_fetch_count_twice(firestore):
         firestore_client=firestore,
     )
     path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+    attempt_path = ('users', UID, intents_db.DELIVERY_ATTEMPTS_COLLECTION, intent.intent_id)
 
     def second_device_fetch():
         intents_db.fetch_ready_intent_batch(
@@ -841,12 +962,11 @@ def test_two_interleaved_device_fetches_increment_fetch_count_twice(firestore):
         )
 
     firestore.transaction_read_hooks[path] = second_device_fetch
-    firestore.batch_commit_hook = second_device_fetch
     intents_db.fetch_ready_intent_batch(
         UID, account_generation=GENERATION, now=NOW + timedelta(seconds=2), firestore_client=firestore
     )
 
-    assert firestore.rows[path]['fetch_count'] == 2
+    assert firestore.rows[attempt_path]['fetch_count'] == 2
 
 
 def test_fetch_isolates_one_advance_failure_from_the_healthy_batch(firestore, monkeypatch):
@@ -949,8 +1069,11 @@ def test_fetch_reconciles_a_stable_chat_row_and_acknowledges_a_late_real_receipt
     assert batch.lifecycle_events == (
         intents_db.IntentLifecycleEvent('reconciled', 'capture_arrival', 'existing_chat_row'),
     )
-    stored = intents_db._intent_from_snapshot(
-        intents_db._intent_ref(UID, intent.intent_id, firestore_client=firestore).get()
+    stored = intents_db._intent_with_delivery_attempt(
+        intents_db._intent_from_snapshot(
+            intents_db._intent_ref(UID, intent.intent_id, firestore_client=firestore).get()
+        ),
+        intents_db._delivery_attempt_ref(UID, intent.intent_id, firestore_client=firestore).get(),
     )
     assert stored.delivery_state == 'delivered'
     assert stored.materialization_receipt_id.startswith('cfi_reconciled_')
@@ -1251,6 +1374,67 @@ def test_malformed_deferral_row_does_not_block_healthy_release_or_fetch(firestor
     assert released.malformed_count == 1
     assert len(released.intents) == 1
     assert [intent.intent_id for intent in fetched] == [released.intents[0].intent_id]
+
+
+def test_thirty_three_malformed_deferrals_ahead_of_valid_due_row_are_terminalized(firestore):
+    question = _question()
+    receipt, _ = intents_db.record_deferral(
+        UID,
+        continuity_key='valid-after-malformed-head',
+        subject=question.subject,
+        question=question,
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    malformed_paths = []
+    for index in range(33):
+        path = ('users', UID, intents_db.DEFERRALS_COLLECTION, f'000-malformed-{index:02d}')
+        malformed_paths.append(path)
+        firestore.rows[path] = {
+            'account_generation': GENERATION,
+            'state': 'pending',
+            'due_at': NOW,
+        }
+
+    released = intents_db.release_due_deferrals(
+        UID,
+        account_generation=GENERATION,
+        now=NOW + timedelta(days=1),
+        firestore_client=firestore,
+    )
+
+    assert released.malformed_count == 33
+    assert len(released.intents) == 1
+    assert all(firestore.rows[path]['state'] == 'released' for path in malformed_paths)
+    assert receipt.state == 'pending'
+
+
+def test_materialization_deferral_rejects_stale_generation_without_writing(firestore):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:stale-deferral-fence',
+        subject=ChatFirstSubject(kind='capture', id='stale-deferral-fence'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='stale-deferral-fence', summary='Fence')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+    before = deepcopy(firestore.rows[path])
+    firestore.rows[('users', UID, 'task_intelligence_control', 'state')]['account_generation'] = GENERATION + 1
+
+    with pytest.raises(intents_db.ChatFirstIntentGenerationMismatch):
+        intents_db.record_materialization_deferral(
+            UID,
+            intent_id=intent.intent_id,
+            account_generation=GENERATION,
+            now=NOW + timedelta(minutes=1),
+            firestore_client=firestore,
+        )
+
+    assert firestore.rows[path] == before
 
 
 def test_workflow_mode_cannot_suppress_intent_but_stale_generation_still_rejects(firestore):

--- a/backend/tests/unit/test_chat_first_proactive_intents.py
+++ b/backend/tests/unit/test_chat_first_proactive_intents.py
@@ -5,7 +5,9 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
+from google.api_core.exceptions import GoogleAPICallError
 from pydantic import BaseModel, ConfigDict
+from typing import Literal
 
 import database.chat_first_intents as intents_db
 from models.chat_first import (
@@ -13,6 +15,7 @@ from models.chat_first import (
     ChatFirstSubject,
     ColdStartSequence,
     ConversationLinkSpec,
+    DeadLetteredProactiveIntent,
     QuestionCardSpec,
     QuestionOption,
 )
@@ -34,7 +37,7 @@ class _OldStrictProactiveIntent(BaseModel):
     source: str
     subject: object | None = None
     blocks: list[object]
-    delivery_state: str = 'ready'
+    delivery_state: Literal['ready', 'pending_kernel_receipt', 'delivered'] = 'ready'
     created_at: datetime
     delivered_at: datetime | None = None
     materialization_receipt_id: str | None = None
@@ -170,18 +173,20 @@ class _FilteredCollection:
         def value(snapshot):
             actual = snapshot.to_dict() or {}
             for component in field.split('.'):
-                if not isinstance(actual, dict):
-                    return None
+                if not isinstance(actual, dict) or component not in actual:
+                    return False, None
                 actual = actual.get(component)
-            return actual
+            return True, actual
 
+        present = [snapshot for snapshot in self._snapshots if value(snapshot)[0]]
         return _FilteredCollection(
-            sorted((snapshot for snapshot in self._snapshots if value(snapshot) is not None), key=value)
+            sorted(present, key=lambda snapshot: (value(snapshot)[1] is not None, value(snapshot)[1]))
         )
 
 
 class _Transaction:
-    def __init__(self):
+    def __init__(self, database):
+        self._database = database
         self._wrote = False
 
     def read(self):
@@ -191,6 +196,10 @@ class _Transaction:
     def set(self, ref, payload, merge=False):
         self._wrote = True
         ref.set(payload, merge=merge)
+
+    def delete(self, ref):
+        self._wrote = True
+        self._database.rows.pop(ref._path, None)
 
 
 class _Firestore:
@@ -206,7 +215,7 @@ class _Firestore:
 
     def transaction(self):
         self.transaction_count += 1
-        return _Transaction()
+        return _Transaction(self)
 
 
 @pytest.fixture
@@ -518,8 +527,14 @@ def test_invalid_intent_three_times_dead_letters_and_requeued_poison_stays_termi
         now=NOW + timedelta(days=1),
         firestore_client=firestore,
     )
-    assert replay.delivery_state == 'dead_letter'
+    assert replay is None
     assert replay_reason is None
+    active_path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+    dead_path = ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, intent.intent_id)
+    assert active_path not in firestore.rows
+    terminal = DeadLetteredProactiveIntent.model_validate(firestore.rows[dead_path])
+    assert terminal.delivery_state == 'dead_letter'
+    assert terminal.last_fetched_at == NOW + timedelta(minutes=intents_db.MATERIALIZATION_REJECTION_BUDGET)
 
 
 def test_legacy_transient_dead_letter_requeues_once_from_next_fetch_after_repair_age(firestore):
@@ -534,7 +549,9 @@ def test_legacy_transient_dead_letter_requeues_once_from_next_fetch_after_repair
         firestore_client=firestore,
     )
     intent_path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
-    firestore.rows[intent_path].update(
+    dead_path = ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, intent.intent_id)
+    firestore.rows[dead_path] = firestore.rows.pop(intent_path)
+    firestore.rows[dead_path].update(
         delivery_state='dead_letter',
         dead_letter_reason='permanent_rejection:kernel_materialization_failed',
         materialization_attempts=3,
@@ -567,7 +584,7 @@ def test_fetch_budget_dead_letters_an_unacknowledged_intent(firestore):
         firestore_client=firestore,
     )
 
-    for fetch_index in range(intents_db.UNACKNOWLEDGED_FETCH_BUDGET):
+    for fetch_index in range(intents_db.UNACKNOWLEDGED_FETCH_BUDGET - 1):
         assert intents_db.fetch_ready_intents(
             UID,
             account_generation=GENERATION,
@@ -582,14 +599,12 @@ def test_fetch_budget_dead_letters_an_unacknowledged_intent(firestore):
     )
 
     assert parked == []
-    stored = intents_db._intent_with_delivery_attempt(
-        intents_db._intent_from_snapshot(
-            intents_db._intent_ref(UID, intent.intent_id, firestore_client=firestore).get()
-        ),
-        intents_db._delivery_attempt_ref(UID, intent.intent_id, firestore_client=firestore).get(),
-    )
+    active_path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+    dead_path = ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, intent.intent_id)
+    assert active_path not in firestore.rows
+    stored = DeadLetteredProactiveIntent.model_validate(firestore.rows[dead_path])
     assert stored.delivery_state == 'dead_letter'
-    assert stored.fetch_count == intents_db.UNACKNOWLEDGED_FETCH_BUDGET + 1
+    assert stored.fetch_count == intents_db.UNACKNOWLEDGED_FETCH_BUDGET
     assert stored.dead_letter_reason == 'unacknowledged_after_fetch_budget'
 
 
@@ -638,17 +653,14 @@ def test_tail_deferral_never_spends_the_unacknowledged_fetch_budget(firestore):
     stored_deferred = intents_db._intent_from_snapshot(
         intents_db._intent_ref(UID, deferred.intent_id, firestore_client=firestore).get()
     )
-    stored_undeferred = intents_db._intent_with_delivery_attempt(
-        intents_db._intent_from_snapshot(
-            intents_db._intent_ref(UID, undeferred.intent_id, firestore_client=firestore).get()
-        ),
-        intents_db._delivery_attempt_ref(UID, undeferred.intent_id, firestore_client=firestore).get(),
+    stored_undeferred = intents_db._intent_from_snapshot(
+        _Snapshot(firestore, ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, undeferred.intent_id))
     )
     assert stored_deferred.delivery_state == 'ready'
     assert stored_deferred.fetch_count == 0
     assert stored_deferred.last_fetched_at is None
     assert stored_undeferred.delivery_state == 'dead_letter'
-    assert stored_undeferred.fetch_count == intents_db.UNACKNOWLEDGED_FETCH_BUDGET + 1
+    assert stored_undeferred.fetch_count == intents_db.UNACKNOWLEDGED_FETCH_BUDGET
 
 
 def test_deferred_old_intent_does_not_stall_but_never_fetched_old_intent_does(firestore):
@@ -786,6 +798,12 @@ def test_continuous_deferral_dead_letters_at_seven_days_but_not_six(firestore):
     assert six_days.delivery_state == 'ready'
     assert seven_days.delivery_state == 'dead_letter'
     assert seven_days.dead_letter_reason == 'deferred_beyond_budget'
+    active_path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+    dead_path = ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, intent.intent_id)
+    assert active_path not in firestore.rows
+    assert DeadLetteredProactiveIntent.model_validate(firestore.rows[dead_path]).dead_letter_reason == (
+        'deferred_beyond_budget'
+    )
 
 
 def test_fetch_candidate_transactions_are_capped_at_twice_the_response_limit(firestore, monkeypatch):
@@ -906,7 +924,9 @@ def test_ready_intent_remains_old_reader_safe_after_deferrals_and_rejections(fir
         )
         _OldStrictProactiveIntent.model_validate(firestore.rows[intent_path])
 
-    firestore.rows[intent_path].update(
+    dead_path = ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, intent.intent_id)
+    firestore.rows[dead_path] = firestore.rows.pop(intent_path)
+    firestore.rows[dead_path].update(
         delivery_state='dead_letter',
         dead_letter_reason='unacknowledged_after_fetch_budget',
         last_fetched_at=NOW,
@@ -934,7 +954,9 @@ def test_fetch_requeues_transient_dead_letter_once_but_never_deterministic_death
         firestore_client=firestore,
     )
     transient_path = ('users', UID, intents_db.INTENTS_COLLECTION, transient.intent_id)
-    firestore.rows[transient_path].update(
+    transient_dead_path = ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, transient.intent_id)
+    firestore.rows[transient_dead_path] = firestore.rows.pop(transient_path)
+    firestore.rows[transient_dead_path].update(
         delivery_state='dead_letter',
         dead_letter_reason='unacknowledged_after_fetch_budget',
         last_fetched_at=NOW,
@@ -948,8 +970,8 @@ def test_fetch_requeues_transient_dead_letter_once_but_never_deterministic_death
         'first_deferred_at': NOW - timedelta(days=2),
         'last_deferral_at': NOW - timedelta(days=1),
     }
-    deterministic_path = ('users', UID, intents_db.INTENTS_COLLECTION, 'deterministic-death')
-    deterministic = {**firestore.rows[transient_path], 'intent_id': 'deterministic-death'}
+    deterministic_path = ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, 'deterministic-death')
+    deterministic = {**firestore.rows[transient_dead_path], 'intent_id': 'deterministic-death'}
     deterministic.update(dead_letter_reason='permanent_rejection:invalid_intent')
     firestore.rows[deterministic_path] = deterministic
 
@@ -965,7 +987,8 @@ def test_fetch_requeues_transient_dead_letter_once_but_never_deterministic_death
     assert firestore.rows[transient_attempt_path]['last_deferral_at'] == NOW - timedelta(days=1)
     assert firestore.rows[deterministic_path]['delivery_state'] == 'dead_letter'
 
-    firestore.rows[transient_path].update(
+    firestore.rows[transient_dead_path] = firestore.rows.pop(transient_path)
+    firestore.rows[transient_dead_path].update(
         delivery_state='dead_letter',
         dead_letter_reason=intents_db.TRANSIENT_DEATH_AFTER_REQUEUE_REASON,
         last_fetched_at=NOW,
@@ -999,7 +1022,7 @@ def test_sibling_point_reads_are_bounded_by_candidate_scan_limit(firestore):
     non_transaction_reads_before = sum(firestore.point_reads.values())
     transaction_reads_before = sum(firestore.transaction_reads.values())
     intents_db.fetch_ready_intent_batch(
-        UID, account_generation=GENERATION, limit=8, now=NOW + timedelta(hours=1), firestore_client=firestore
+        UID, account_generation=GENERATION, limit=8, now=NOW + timedelta(hours=25), firestore_client=firestore
     )
     non_transaction_reads = sum(firestore.point_reads.values()) - non_transaction_reads_before
     transaction_reads = sum(firestore.transaction_reads.values()) - transaction_reads_before
@@ -1021,7 +1044,10 @@ def test_transient_dead_letter_repair_scan_is_bounded(firestore, monkeypatch):
             now=NOW,
             firestore_client=firestore,
         )
-        firestore.rows[('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)].update(
+        active_path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+        dead_path = ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, intent.intent_id)
+        firestore.rows[dead_path] = firestore.rows.pop(active_path)
+        firestore.rows[dead_path].update(
             delivery_state='dead_letter',
             dead_letter_reason='unacknowledged_after_fetch_budget',
             last_fetched_at=NOW,
@@ -1058,9 +1084,11 @@ def test_repair_query_does_not_starve_repairable_row_behind_requeued_deaths(fire
     repairable = max(created, key=lambda intent: intent.intent_id)
     for intent in created:
         intent_path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+        dead_path = ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, intent.intent_id)
         attempt_path = ('users', UID, intents_db.DELIVERY_ATTEMPTS_COLLECTION, intent.intent_id)
         requeue_count = 0 if intent == repairable else 1
-        firestore.rows[intent_path].update(
+        firestore.rows[dead_path] = firestore.rows.pop(intent_path)
+        firestore.rows[dead_path].update(
             delivery_state='dead_letter',
             dead_letter_reason='unacknowledged_after_fetch_budget',
             last_fetched_at=NOW,
@@ -1091,7 +1119,10 @@ def test_repair_scan_skips_young_rows_without_transactions(firestore):
             now=NOW,
             firestore_client=firestore,
         )
-        firestore.rows[('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)].update(
+        active_path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+        dead_path = ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, intent.intent_id)
+        firestore.rows[dead_path] = firestore.rows.pop(active_path)
+        firestore.rows[dead_path].update(
             delivery_state='dead_letter',
             dead_letter_reason='unacknowledged_after_fetch_budget',
             last_fetched_at=NOW,
@@ -1105,6 +1136,86 @@ def test_repair_scan_skips_young_rows_without_transactions(firestore):
 
     assert batch.intents == []
     assert firestore.transaction_count == transactions_before
+
+
+def test_repair_query_failure_does_not_block_ready_delivery(firestore, monkeypatch):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:repair-query-failure',
+        subject=ChatFirstSubject(kind='capture', id='repair-query-failure'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='repair-query-failure', summary='Ready')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+
+    class FailingQuerySpec:
+        def build(self, *args, **kwargs):
+            raise GoogleAPICallError('index not ready')
+
+    monkeypatch.setattr(
+        intents_db.delivery_attempts, 'CHAT_FIRST_TRANSIENT_DEAD_LETTER_REPAIR_QUERY', FailingQuerySpec()
+    )
+    batch = intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, now=NOW + timedelta(minutes=1), firestore_client=firestore
+    )
+
+    assert [item.intent_id for item in batch.intents] == [intent.intent_id]
+    assert batch.lifecycle_events[0].event == 'repair_scan_failed'
+
+
+def test_null_ordered_dead_letters_do_not_hide_repairable_reason(firestore):
+    for index in range(2):
+        path = ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, f'null-terminal-{index}')
+        firestore.rows[path] = {
+            'account_generation': GENERATION,
+            'requeue_count': 0,
+            'dead_letter_reason': 'permanent_rejection:invalid_intent',
+            'last_fetched_at': None,
+        }
+    repairable, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:null-order-repairable',
+        subject=ChatFirstSubject(kind='capture', id='null-order-repairable'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='null-order-repairable', summary='Repair')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    active_path = ('users', UID, intents_db.INTENTS_COLLECTION, repairable.intent_id)
+    dead_path = ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, repairable.intent_id)
+    firestore.rows[dead_path] = firestore.rows.pop(active_path)
+    firestore.rows[dead_path].update(
+        delivery_state='dead_letter',
+        dead_letter_reason='unacknowledged_after_fetch_budget',
+        fetch_count=intents_db.UNACKNOWLEDGED_FETCH_BUDGET,
+        last_fetched_at=NOW,
+        requeue_count=0,
+    )
+
+    fetched = intents_db.fetch_ready_intents(
+        UID, account_generation=GENERATION, limit=1, now=NOW + timedelta(days=1), firestore_client=firestore
+    )
+    assert [intent.intent_id for intent in fetched] == [repairable.intent_id]
+
+
+def test_fake_order_by_sorts_explicit_nulls_first_and_drops_missing(firestore):
+    paths = [
+        ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, 'null-a'),
+        ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, 'null-b'),
+        ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, 'timestamped'),
+        ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, 'missing'),
+    ]
+    firestore.rows[paths[0]] = {'last_fetched_at': None}
+    firestore.rows[paths[1]] = {'last_fetched_at': None}
+    firestore.rows[paths[2]] = {'last_fetched_at': NOW}
+    firestore.rows[paths[3]] = {}
+
+    ordered = _FilteredCollection([_Snapshot(firestore, path) for path in paths]).order_by('last_fetched_at').stream()
+
+    assert [snapshot.id for snapshot in ordered] == ['null-a', 'null-b', 'timestamped']
 
 
 def test_twice_dead_intent_gets_terminal_reason_and_is_never_scanned_again(firestore):
@@ -1131,8 +1242,10 @@ def test_twice_dead_intent_gets_terminal_reason_and_is_never_scanned_again(fires
         )
         == []
     )
-    assert firestore.rows[intent_path]['dead_letter_reason'] == intents_db.TRANSIENT_DEATH_AFTER_REQUEUE_REASON
-    assert firestore.rows[intent_path]['requeue_count'] == 1
+    dead_path = ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, intent.intent_id)
+    assert intent_path not in firestore.rows
+    assert firestore.rows[dead_path]['dead_letter_reason'] == intents_db.TRANSIENT_DEATH_AFTER_REQUEUE_REASON
+    assert firestore.rows[dead_path]['requeue_count'] == 1
     transactions_before = firestore.transaction_count
 
     assert (
@@ -1173,7 +1286,65 @@ def test_invalid_rejection_code_is_repaired_and_fetched_with_metric_event(firest
     assert [event.event for event in batch.lifecycle_events] == ['malformed_attempt_reset']
 
 
-def test_malformed_fetch_count_reset_preserves_valid_requeue_count(firestore):
+def test_valid_fetch_budget_survives_other_malformed_sibling_field(firestore):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:malformed-at-budget',
+        subject=ChatFirstSubject(kind='capture', id='malformed-at-budget'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='malformed-at-budget', summary='Budget')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    active_path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+    attempt_path = ('users', UID, intents_db.DELIVERY_ATTEMPTS_COLLECTION, intent.intent_id)
+    firestore.rows[attempt_path] = {
+        'fetch_count': intents_db.UNACKNOWLEDGED_FETCH_BUDGET - 1,
+        'requeue_count': 1,
+        'last_rejection_code': 'Bad Code!',
+    }
+
+    assert (
+        intents_db.fetch_ready_intents(
+            UID, account_generation=GENERATION, now=NOW + timedelta(minutes=1), firestore_client=firestore
+        )
+        == []
+    )
+    dead_path = ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, intent.intent_id)
+    assert active_path not in firestore.rows
+    assert firestore.rows[dead_path]['fetch_count'] == intents_db.UNACKNOWLEDGED_FETCH_BUDGET
+    assert firestore.rows[dead_path]['requeue_count'] == 1
+
+
+def test_create_does_not_regenerate_dead_lettered_identity(firestore):
+    kwargs = {
+        'source': 'capture_arrival',
+        'continuity_key': 'capture:dead-letter-conflict',
+        'subject': ChatFirstSubject(kind='capture', id='dead-letter-conflict'),
+        'blocks': [CaptureLinkSpec(type='captureLink', conversation_id='dead-letter-conflict', summary='Terminal')],
+        'account_generation': GENERATION,
+        'now': NOW,
+        'firestore_client': firestore,
+    }
+    intent, _ = intents_db.create_intent(UID, **kwargs)
+    attempt_path = ('users', UID, intents_db.DELIVERY_ATTEMPTS_COLLECTION, intent.intent_id)
+    firestore.rows[attempt_path] = {'fetch_count': intents_db.UNACKNOWLEDGED_FETCH_BUDGET - 1}
+    assert (
+        intents_db.fetch_ready_intents(
+            UID, account_generation=GENERATION, now=NOW + timedelta(minutes=1), firestore_client=firestore
+        )
+        == []
+    )
+
+    existing, created = intents_db.create_intent(UID, **kwargs)
+
+    assert created is False
+    assert existing.delivery_state == 'dead_letter'
+    assert ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id) not in firestore.rows
+
+
+def test_malformed_fetch_count_on_requeued_intent_fails_closed_at_budget(firestore):
     intent, _ = intents_db.create_intent(
         UID,
         source='capture_arrival',
@@ -1191,13 +1362,14 @@ def test_malformed_fetch_count_reset_preserves_valid_requeue_count(firestore):
         UID, account_generation=GENERATION, now=NOW + timedelta(minutes=1), firestore_client=firestore
     )
 
-    assert [item.intent_id for item in batch.intents] == [intent.intent_id]
-    assert firestore.rows[attempt_path]['fetch_count'] == 1
-    assert firestore.rows[attempt_path]['requeue_count'] == 1
-    assert [event.event for event in batch.lifecycle_events] == ['malformed_attempt_reset']
+    assert batch.intents == []
+    dead_path = ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, intent.intent_id)
+    assert firestore.rows[dead_path]['fetch_count'] == intents_db.UNACKNOWLEDGED_FETCH_BUDGET
+    assert firestore.rows[dead_path]['requeue_count'] == 1
+    assert firestore.rows[dead_path]['dead_letter_reason'] == intents_db.TRANSIENT_DEATH_AFTER_REQUEUE_REASON
 
 
-def test_terminal_receipt_is_acknowledged_idempotently_after_fetch_budget_dead_letter(firestore):
+def test_receipt_for_dead_letter_removed_from_old_reader_collection_is_missing(firestore):
     intent, _ = intents_db.create_intent(
         UID,
         source='capture_arrival',
@@ -1208,20 +1380,22 @@ def test_terminal_receipt_is_acknowledged_idempotently_after_fetch_budget_dead_l
         now=NOW,
         firestore_client=firestore,
     )
-    path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
-    firestore.rows[path]['delivery_state'] = 'dead_letter'
-    firestore.rows[path]['dead_letter_reason'] = 'unacknowledged_after_fetch_budget'
-
-    acknowledged = intents_db.acknowledge_materialization(
-        UID,
-        intent_id=intent.intent_id,
-        receipt_id='late-kernel-receipt',
-        account_generation=GENERATION,
-        now=NOW + timedelta(hours=1),
-        firestore_client=firestore,
+    active_path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+    dead_path = ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, intent.intent_id)
+    firestore.rows[dead_path] = firestore.rows.pop(active_path)
+    firestore.rows[dead_path].update(
+        delivery_state='dead_letter', dead_letter_reason='unacknowledged_after_fetch_budget'
     )
 
-    assert acknowledged.delivery_state == 'delivered'
+    with pytest.raises(intents_db.ProactiveIntentNotReady):
+        intents_db.acknowledge_materialization(
+            UID,
+            intent_id=intent.intent_id,
+            receipt_id='late-kernel-receipt',
+            account_generation=GENERATION,
+            now=NOW + timedelta(hours=1),
+            firestore_client=firestore,
+        )
 
 
 def test_stale_rejection_is_absorbed_after_other_device_delivery_or_deletion(firestore):
@@ -1277,8 +1451,10 @@ def test_fetch_isolates_malformed_documents_and_transactions_healthy_fetch_updat
     batch = intents_db.fetch_ready_intent_batch(UID, account_generation=GENERATION, now=NOW, firestore_client=firestore)
 
     assert [item.intent_id for item in batch.intents] == [healthy.intent_id]
-    assert firestore.rows[malformed_path]['delivery_state'] == 'dead_letter'
-    assert firestore.rows[malformed_path]['dead_letter_reason'] == 'malformed_document'
+    malformed_dead_path = ('users', UID, intents_db.DEAD_LETTERS_COLLECTION, 'malformed-ready')
+    assert malformed_path not in firestore.rows
+    assert firestore.rows[malformed_dead_path]['delivery_state'] == 'dead_letter'
+    assert firestore.rows[malformed_dead_path]['dead_letter_reason'] == 'malformed_document'
     assert firestore.transaction_count == transactions_before + 2
 
 

--- a/backend/tests/unit/test_chat_first_proactive_intents.py
+++ b/backend/tests/unit/test_chat_first_proactive_intents.py
@@ -53,10 +53,14 @@ class _Document:
     def get(self, transaction=None):
         if transaction is not None:
             transaction.read()
+            hook = self._database.transaction_read_hooks.pop(self._path, None)
+            if hook is not None:
+                hook()
         return _Snapshot(self._database, self._path)
 
-    def set(self, payload):
-        self._database.rows[self._path] = deepcopy(payload)
+    def set(self, payload, merge=False):
+        existing = self._database.rows.get(self._path, {}) if merge else {}
+        self._database.rows[self._path] = {**deepcopy(existing), **deepcopy(payload)}
 
 
 class _Collection:
@@ -141,16 +145,17 @@ class _FilteredCollection:
 
 
 class _Transaction:
-    def __init__(self):
+    def __init__(self, database):
+        self.database = database
         self._wrote = False
 
     def read(self):
         if self._wrote:
             raise AssertionError('Firestore transactions must finish reads before writes')
 
-    def set(self, ref, payload):
+    def set(self, ref, payload, merge=False):
         self._wrote = True
-        ref.set(payload)
+        ref.set(payload, merge=merge)
 
 
 class _WriteBatch:
@@ -162,13 +167,23 @@ class _WriteBatch:
         self.writes.append((ref, payload))
 
     def update(self, ref, payload):
-        existing = ref.get().to_dict() or {}
-        self.writes.append((ref, {**existing, **payload}))
+        self.writes.append(('update', ref, payload))
 
     def commit(self):
         self.database.batch_commit_count += 1
-        for ref, payload in self.writes:
-            ref.set(payload)
+        hook = self.database.batch_commit_hook
+        self.database.batch_commit_hook = None
+        if hook is not None:
+            hook()
+        for operation in self.writes:
+            if len(operation) == 2:
+                ref, payload = operation
+                ref.set(payload)
+                continue
+            _, ref, payload = operation
+            if ref._path not in self.database.rows:
+                raise KeyError('write batch update requires an existing document')
+            ref.set(payload, merge=True)
 
 
 class _Firestore:
@@ -176,13 +191,15 @@ class _Firestore:
         self.rows = {}
         self.transaction_count = 0
         self.batch_commit_count = 0
+        self.transaction_read_hooks = {}
+        self.batch_commit_hook = None
 
     def collection(self, name):
         return _Collection(self, (name,))
 
     def transaction(self):
         self.transaction_count += 1
-        return _Transaction()
+        return _Transaction(self)
 
     def batch(self):
         return _WriteBatch(self)
@@ -505,7 +522,7 @@ def test_fetch_budget_dead_letters_an_unacknowledged_intent(firestore):
 
 
 def test_tail_deferral_never_spends_the_unacknowledged_fetch_budget(firestore):
-    intent, _ = intents_db.create_intent(
+    deferred, _ = intents_db.create_intent(
         UID,
         source='daily_opener',
         continuity_key='daily:tail-deferred',
@@ -515,25 +532,48 @@ def test_tail_deferral_never_spends_the_unacknowledged_fetch_budget(firestore):
         now=NOW,
         firestore_client=firestore,
     )
+    undeferred, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:undeferred-sibling',
+        subject=ChatFirstSubject(kind='capture', id='undeferred-sibling'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='undeferred-sibling', summary='Sibling')],
+        account_generation=GENERATION,
+        now=NOW + timedelta(seconds=1),
+        firestore_client=firestore,
+    )
 
-    for index in range(intents_db.UNACKNOWLEDGED_FETCH_BUDGET + 5):
-        fetched = intents_db.fetch_ready_intents(
-            UID, account_generation=GENERATION, now=NOW + timedelta(minutes=index), firestore_client=firestore
-        )
-        assert [item.intent_id for item in fetched] == [intent.intent_id]
+    for index in range(25):
+        request_now = NOW + timedelta(minutes=index)
+        # Match the router order exactly: record deferrals and then fetch with
+        # the same request timestamp and the current request's deferred IDs.
         intents_db.record_materialization_deferral(
             UID,
-            intent_id=intent.intent_id,
+            intent_id=deferred.intent_id,
             account_generation=GENERATION,
-            now=NOW + timedelta(minutes=index, seconds=1),
+            now=request_now,
             firestore_client=firestore,
         )
+        batch = intents_db.fetch_ready_intent_batch(
+            UID,
+            account_generation=GENERATION,
+            deferred_intent_ids={deferred.intent_id},
+            now=request_now,
+            firestore_client=firestore,
+        )
+        assert deferred.intent_id in [item.intent_id for item in batch.intents]
 
-    stored = intents_db._intent_from_snapshot(
-        intents_db._intent_ref(UID, intent.intent_id, firestore_client=firestore).get()
+    stored_deferred = intents_db._intent_from_snapshot(
+        intents_db._intent_ref(UID, deferred.intent_id, firestore_client=firestore).get()
     )
-    assert stored.delivery_state == 'ready'
-    assert stored.fetch_count == 0
+    stored_undeferred = intents_db._intent_from_snapshot(
+        intents_db._intent_ref(UID, undeferred.intent_id, firestore_client=firestore).get()
+    )
+    assert stored_deferred.delivery_state == 'ready'
+    assert stored_deferred.fetch_count == 0
+    assert stored_deferred.last_fetched_at is None
+    assert stored_undeferred.delivery_state == 'dead_letter'
+    assert stored_undeferred.fetch_count == intents_db.UNACKNOWLEDGED_FETCH_BUDGET + 1
 
 
 def test_terminal_receipt_is_acknowledged_idempotently_after_fetch_budget_dead_letter(firestore):
@@ -598,7 +638,7 @@ def test_stale_rejection_is_absorbed_after_other_device_delivery_or_deletion(fir
     assert missing is None and missing_reason is None
 
 
-def test_fetch_isolates_malformed_documents_and_batches_healthy_fetch_updates(firestore):
+def test_fetch_isolates_malformed_documents_and_transactions_healthy_fetch_updates(firestore):
     healthy, _ = intents_db.create_intent(
         UID,
         source='capture_arrival',
@@ -618,8 +658,106 @@ def test_fetch_isolates_malformed_documents_and_batches_healthy_fetch_updates(fi
     assert [item.intent_id for item in batch.intents] == [healthy.intent_id]
     assert firestore.rows[malformed_path]['delivery_state'] == 'dead_letter'
     assert firestore.rows[malformed_path]['dead_letter_reason'] == 'malformed_document'
-    assert firestore.transaction_count == transactions_before
-    assert firestore.batch_commit_count == 1
+    assert firestore.transaction_count == transactions_before + 2
+    assert firestore.batch_commit_count == 0
+
+
+def test_concurrently_deleted_candidate_does_not_abort_fetch_or_other_writes(firestore):
+    deleted, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:deleted-during-fetch',
+        subject=ChatFirstSubject(kind='capture', id='deleted-during-fetch'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='deleted-during-fetch', summary='Deleted')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    healthy, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:survives-peer-delete',
+        subject=ChatFirstSubject(kind='capture', id='survives-peer-delete'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='survives-peer-delete', summary='Healthy')],
+        account_generation=GENERATION,
+        now=NOW + timedelta(seconds=1),
+        firestore_client=firestore,
+    )
+    deleted_path = ('users', UID, intents_db.INTENTS_COLLECTION, deleted.intent_id)
+
+    def delete_during_write():
+        firestore.rows.pop(deleted_path)
+
+    firestore.transaction_read_hooks[deleted_path] = delete_during_write
+    firestore.batch_commit_hook = delete_during_write
+
+    batch = intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, now=NOW + timedelta(minutes=1), firestore_client=firestore
+    )
+
+    assert [item.intent_id for item in batch.intents] == [healthy.intent_id]
+    healthy_path = ('users', UID, intents_db.INTENTS_COLLECTION, healthy.intent_id)
+    assert firestore.rows[healthy_path]['fetch_count'] == 1
+
+
+def test_dead_letter_transition_never_overwrites_a_concurrent_delivery(firestore):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:delivered-before-dead-letter',
+        subject=ChatFirstSubject(kind='capture', id='delivered-before-dead-letter'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='delivered-before-dead-letter', summary='Race')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+    firestore.rows[path]['fetch_count'] = intents_db.UNACKNOWLEDGED_FETCH_BUDGET
+
+    def deliver_concurrently():
+        firestore.rows[path]['delivery_state'] = 'delivered'
+        firestore.rows[path]['materialization_receipt_id'] = 'other-device-receipt'
+
+    firestore.transaction_read_hooks[path] = deliver_concurrently
+    firestore.batch_commit_hook = deliver_concurrently
+
+    batch = intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, now=NOW + timedelta(minutes=1), firestore_client=firestore
+    )
+
+    assert batch.intents == []
+    assert firestore.rows[path]['delivery_state'] == 'delivered'
+    assert firestore.rows[path]['materialization_receipt_id'] == 'other-device-receipt'
+
+
+def test_two_interleaved_device_fetches_increment_fetch_count_twice(firestore):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:two-device-fetch',
+        subject=ChatFirstSubject(kind='capture', id='two-device-fetch'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='two-device-fetch', summary='Two devices')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+
+    def second_device_fetch():
+        intents_db.fetch_ready_intent_batch(
+            UID,
+            account_generation=GENERATION,
+            now=NOW + timedelta(seconds=1),
+            firestore_client=firestore,
+        )
+
+    firestore.transaction_read_hooks[path] = second_device_fetch
+    firestore.batch_commit_hook = second_device_fetch
+    intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, now=NOW + timedelta(seconds=2), firestore_client=firestore
+    )
+
+    assert firestore.rows[path]['fetch_count'] == 2
 
 
 def test_fetch_isolates_one_advance_failure_from_the_healthy_batch(firestore, monkeypatch):
@@ -648,11 +786,14 @@ def test_fetch_isolates_one_advance_failure_from_the_healthy_batch(firestore, mo
     firestore.rows[('users', UID, 'messages', intents_db._stable_chat_first_turn_id(failing.intent_id))] = {
         'metadata': '{"chatFirstIntentId":"' + failing.intent_id + '"}'
     }
-    monkeypatch.setattr(
-        intents_db,
-        '_advance_fetched_intent',
-        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError('isolated advance failure')),
-    )
+    advance = intents_db._advance_fetched_intent
+
+    def fail_one_advance(uid, intent_id, **kwargs):
+        if intent_id == failing.intent_id:
+            raise RuntimeError('isolated advance failure')
+        return advance(uid, intent_id, **kwargs)
+
+    monkeypatch.setattr(intents_db, '_advance_fetched_intent', fail_one_advance)
 
     batch = intents_db.fetch_ready_intent_batch(
         UID, account_generation=GENERATION, now=NOW + timedelta(minutes=1), firestore_client=firestore

--- a/backend/tests/unit/test_chat_first_proactive_intents.py
+++ b/backend/tests/unit/test_chat_first_proactive_intents.py
@@ -33,6 +33,10 @@ class _Snapshot:
     def to_dict(self):
         return deepcopy(self._database.rows.get(self._path))
 
+    @property
+    def id(self):
+        return self._path[-1]
+
 
 class _Document:
     def __init__(self, database, path):
@@ -149,15 +153,39 @@ class _Transaction:
         ref.set(payload)
 
 
+class _WriteBatch:
+    def __init__(self, database):
+        self.database = database
+        self.writes = []
+
+    def set(self, ref, payload):
+        self.writes.append((ref, payload))
+
+    def update(self, ref, payload):
+        existing = ref.get().to_dict() or {}
+        self.writes.append((ref, {**existing, **payload}))
+
+    def commit(self):
+        self.database.batch_commit_count += 1
+        for ref, payload in self.writes:
+            ref.set(payload)
+
+
 class _Firestore:
     def __init__(self):
         self.rows = {}
+        self.transaction_count = 0
+        self.batch_commit_count = 0
 
     def collection(self, name):
         return _Collection(self, (name,))
 
     def transaction(self):
+        self.transaction_count += 1
         return _Transaction()
+
+    def batch(self):
+        return _WriteBatch(self)
 
 
 @pytest.fixture
@@ -476,6 +504,185 @@ def test_fetch_budget_dead_letters_an_unacknowledged_intent(firestore):
     assert stored.dead_letter_reason == 'unacknowledged_after_fetch_budget'
 
 
+def test_tail_deferral_never_spends_the_unacknowledged_fetch_budget(firestore):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='daily_opener',
+        continuity_key='daily:tail-deferred',
+        subject=None,
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='tail-deferred', summary='Deferred')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+
+    for index in range(intents_db.UNACKNOWLEDGED_FETCH_BUDGET + 5):
+        fetched = intents_db.fetch_ready_intents(
+            UID, account_generation=GENERATION, now=NOW + timedelta(minutes=index), firestore_client=firestore
+        )
+        assert [item.intent_id for item in fetched] == [intent.intent_id]
+        intents_db.record_materialization_deferral(
+            UID,
+            intent_id=intent.intent_id,
+            account_generation=GENERATION,
+            now=NOW + timedelta(minutes=index, seconds=1),
+            firestore_client=firestore,
+        )
+
+    stored = intents_db._intent_from_snapshot(
+        intents_db._intent_ref(UID, intent.intent_id, firestore_client=firestore).get()
+    )
+    assert stored.delivery_state == 'ready'
+    assert stored.fetch_count == 0
+
+
+def test_terminal_receipt_is_acknowledged_idempotently_after_fetch_budget_dead_letter(firestore):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:late-receipt',
+        subject=ChatFirstSubject(kind='capture', id='late-receipt'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='late-receipt', summary='Late')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+    firestore.rows[path]['delivery_state'] = 'dead_letter'
+    firestore.rows[path]['dead_letter_reason'] = 'unacknowledged_after_fetch_budget'
+
+    acknowledged = intents_db.acknowledge_materialization(
+        UID,
+        intent_id=intent.intent_id,
+        receipt_id='late-kernel-receipt',
+        account_generation=GENERATION,
+        now=NOW + timedelta(hours=1),
+        firestore_client=firestore,
+    )
+
+    assert acknowledged.delivery_state == 'dead_letter'
+
+
+def test_stale_rejection_is_absorbed_after_other_device_delivery_or_deletion(firestore):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:stale-rejection',
+        subject=ChatFirstSubject(kind='capture', id='stale-rejection'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='stale-rejection', summary='Stale')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+    firestore.rows[path]['delivery_state'] = 'delivered'
+    delivered, reason = intents_db.record_materialization_rejection(
+        UID,
+        intent_id=intent.intent_id,
+        code='kernel_materialization_failed',
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    del firestore.rows[path]
+    missing, missing_reason = intents_db.record_materialization_rejection(
+        UID,
+        intent_id=intent.intent_id,
+        code='kernel_materialization_failed',
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+
+    assert delivered is not None and delivered.delivery_state == 'delivered' and reason is None
+    assert missing is None and missing_reason is None
+
+
+def test_fetch_isolates_malformed_documents_and_batches_healthy_fetch_updates(firestore):
+    healthy, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:healthy-batch',
+        subject=ChatFirstSubject(kind='capture', id='healthy-batch'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='healthy-batch', summary='Healthy')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    malformed_path = ('users', UID, intents_db.INTENTS_COLLECTION, 'malformed-ready')
+    firestore.rows[malformed_path] = {'delivery_state': 'ready', 'account_generation': GENERATION}
+    transactions_before = firestore.transaction_count
+
+    batch = intents_db.fetch_ready_intent_batch(UID, account_generation=GENERATION, now=NOW, firestore_client=firestore)
+
+    assert [item.intent_id for item in batch.intents] == [healthy.intent_id]
+    assert firestore.rows[malformed_path]['delivery_state'] == 'dead_letter'
+    assert firestore.rows[malformed_path]['dead_letter_reason'] == 'malformed_document'
+    assert firestore.transaction_count == transactions_before
+    assert firestore.batch_commit_count == 1
+
+
+def test_fetch_isolates_one_advance_failure_from_the_healthy_batch(firestore, monkeypatch):
+    failing, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:advance-failure',
+        subject=ChatFirstSubject(kind='capture', id='advance-failure'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='advance-failure', summary='Failing')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    healthy, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:after-advance-failure',
+        subject=ChatFirstSubject(kind='capture', id='after-advance-failure'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='after-advance-failure', summary='Healthy')],
+        account_generation=GENERATION,
+        now=NOW + timedelta(seconds=1),
+        firestore_client=firestore,
+    )
+    failing_path = ('users', UID, intents_db.INTENTS_COLLECTION, failing.intent_id)
+    firestore.rows[failing_path]['fetch_count'] = 2
+    firestore.rows[('users', UID, 'messages', intents_db._stable_chat_first_turn_id(failing.intent_id))] = {
+        'metadata': '{"chatFirstIntentId":"' + failing.intent_id + '"}'
+    }
+    monkeypatch.setattr(
+        intents_db,
+        '_advance_fetched_intent',
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError('isolated advance failure')),
+    )
+
+    batch = intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, now=NOW + timedelta(minutes=1), firestore_client=firestore
+    )
+
+    assert [item.intent_id for item in batch.intents] == [healthy.intent_id]
+
+
+def test_stored_intent_model_tolerates_new_fields_and_unknown_terminal_state():
+    payload = {
+        'intent_id': 'intent-rolling-deploy',
+        'continuity_key': 'rolling-deploy',
+        'account_generation': GENERATION,
+        'source': 'capture_arrival',
+        'blocks': [{'type': 'captureLink', 'conversation_id': 'capture-1', 'summary': 'Capture'}],
+        'delivery_state': 'future_terminal_state',
+        'created_at': NOW,
+        'last_deferral_at': NOW,
+        'newer_revision_field': True,
+    }
+
+    parsed = intents_db.ProactiveIntent.model_validate(payload)
+
+    assert parsed.delivery_state == 'dead_letter'
+
+
+def test_stable_chat_first_turn_identity_matches_the_kernel_shared_vector():
+    assert intents_db._stable_chat_first_turn_id('intent-shared-vector') == 'turn_cfi_df211fb1b31c4b849c6bb6b2'
+
+
 def test_fetch_reconciles_a_stable_chat_row_after_an_earlier_delivery(firestore):
     intent, _ = intents_db.create_intent(
         UID,
@@ -492,6 +699,13 @@ def test_fetch_reconciles_a_stable_chat_row_after_an_earlier_delivery(firestore)
     firestore.rows[('users', UID, 'messages', turn_id)] = {
         'metadata': '{"chatFirstIntentId":"' + intent.intent_id + '"}'
     }
+
+    # Reconciliation point reads begin only after the second unacknowledged
+    # delivery, avoiding a read on every ordinary poll.
+    second = intents_db.fetch_ready_intents(
+        UID, account_generation=GENERATION, now=NOW + timedelta(seconds=30), firestore_client=firestore
+    )
+    assert second
 
     batch = intents_db.fetch_ready_intent_batch(
         UID,
@@ -650,7 +864,7 @@ def test_cold_start_generation_retries_one_pending_intent_until_its_kernel_recei
             now=NOW + timedelta(seconds=3),
             firestore_client=firestore,
         )
-    with pytest.raises(intents_db.ChatFirstIntentConflictError):
+    assert (
         intents_db.acknowledge_materialization(
             UID,
             intent_id=first.intent_id,
@@ -658,7 +872,9 @@ def test_cold_start_generation_retries_one_pending_intent_until_its_kernel_recei
             account_generation=GENERATION,
             now=NOW + timedelta(seconds=1),
             firestore_client=firestore,
-        )
+        ).delivery_state
+        == 'delivered'
+    )
     assert intents_db.fetch_ready_intents(UID, account_generation=GENERATION, firestore_client=firestore) == []
 
 

--- a/backend/tests/unit/test_chat_first_proactive_intents.py
+++ b/backend/tests/unit/test_chat_first_proactive_intents.py
@@ -145,8 +145,7 @@ class _FilteredCollection:
 
 
 class _Transaction:
-    def __init__(self, database):
-        self.database = database
+    def __init__(self):
         self._wrote = False
 
     def read(self):
@@ -199,7 +198,7 @@ class _Firestore:
 
     def transaction(self):
         self.transaction_count += 1
-        return _Transaction(self)
+        return _Transaction()
 
     def batch(self):
         return _WriteBatch(self)
@@ -574,6 +573,96 @@ def test_tail_deferral_never_spends_the_unacknowledged_fetch_budget(firestore):
     assert stored_deferred.last_fetched_at is None
     assert stored_undeferred.delivery_state == 'dead_letter'
     assert stored_undeferred.fetch_count == intents_db.UNACKNOWLEDGED_FETCH_BUDGET + 1
+
+
+def test_continuous_deferral_dead_letters_at_seven_days_but_not_six(firestore):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='daily_opener',
+        continuity_key='daily:continuous-deferral',
+        subject=None,
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='continuous-deferral', summary='Deferred')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+
+    first = intents_db.record_materialization_deferral(
+        UID,
+        intent_id=intent.intent_id,
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    six_days = intents_db.record_materialization_deferral(
+        UID,
+        intent_id=intent.intent_id,
+        account_generation=GENERATION,
+        now=NOW + timedelta(days=6),
+        firestore_client=firestore,
+    )
+    seven_days = intents_db.record_materialization_deferral(
+        UID,
+        intent_id=intent.intent_id,
+        account_generation=GENERATION,
+        now=NOW + timedelta(days=7),
+        firestore_client=firestore,
+    )
+
+    assert first.first_deferred_at == NOW
+    assert six_days.delivery_state == 'ready'
+    assert seven_days.delivery_state == 'dead_letter'
+    assert seven_days.dead_letter_reason == 'deferred_beyond_budget'
+
+
+def test_fetch_candidate_transactions_are_capped_at_twice_the_response_limit(firestore, monkeypatch):
+    for index in range(7):
+        intents_db.create_intent(
+            UID,
+            source='capture_arrival',
+            continuity_key=f'capture:scan-cap-{index}',
+            subject=ChatFirstSubject(kind='capture', id=f'scan-cap-{index}'),
+            blocks=[CaptureLinkSpec(type='captureLink', conversation_id=f'scan-cap-{index}', summary='Candidate')],
+            account_generation=GENERATION,
+            now=NOW + timedelta(seconds=index),
+            firestore_client=firestore,
+        )
+    scanned = []
+
+    def absorb_candidate(uid, intent_id, **kwargs):
+        scanned.append(intent_id)
+        return None, None
+
+    monkeypatch.setattr(intents_db, '_advance_fetched_intent', absorb_candidate)
+
+    batch = intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, limit=2, now=NOW + timedelta(minutes=1), firestore_client=firestore
+    )
+
+    assert batch.intents == []
+    assert len(scanned) == intents_db.FETCH_CANDIDATE_SCAN_MULTIPLIER * 2
+
+
+def test_fetch_advance_preserves_unknown_newer_revision_fields(firestore):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:rolling-writer',
+        subject=ChatFirstSubject(kind='capture', id='rolling-writer'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='rolling-writer', summary='Rolling')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+    firestore.rows[path]['newer_revision_field'] = {'keep': True}
+
+    fetched = intents_db.fetch_ready_intents(
+        UID, account_generation=GENERATION, now=NOW + timedelta(minutes=1), firestore_client=firestore
+    )
+
+    assert fetched[0].fetch_count == 1
+    assert firestore.rows[path]['newer_revision_field'] == {'keep': True}
 
 
 def test_terminal_receipt_is_acknowledged_idempotently_after_fetch_budget_dead_letter(firestore):
@@ -1005,7 +1094,7 @@ def test_cold_start_generation_retries_one_pending_intent_until_its_kernel_recei
             now=NOW + timedelta(seconds=3),
             firestore_client=firestore,
         )
-    assert (
+    with pytest.raises(intents_db.ChatFirstIntentConflictError):
         intents_db.acknowledge_materialization(
             UID,
             intent_id=first.intent_id,
@@ -1013,9 +1102,7 @@ def test_cold_start_generation_retries_one_pending_intent_until_its_kernel_recei
             account_generation=GENERATION,
             now=NOW + timedelta(seconds=1),
             firestore_client=firestore,
-        ).delivery_state
-        == 'delivered'
-    )
+        )
     assert intents_db.fetch_ready_intents(UID, account_generation=GENERATION, firestore_client=firestore) == []
 
 
@@ -1039,7 +1126,7 @@ def test_deferral_releases_once_verbatim_when_due_or_subject_changes(firestore):
             account_generation=GENERATION,
             now=NOW + timedelta(hours=23, minutes=59),
             firestore_client=firestore,
-        )
+        ).intents
         == []
     )
 
@@ -1056,12 +1143,12 @@ def test_deferral_releases_once_verbatim_when_due_or_subject_changes(firestore):
         firestore_client=firestore,
     )
 
-    assert len(due) == 1
-    assert due[0].source == 'deferral_reraise'
-    released_question = due[0].blocks[0]
+    assert len(due.intents) == 1
+    assert due.intents[0].source == 'deferral_reraise'
+    released_question = due.intents[0].blocks[0]
     assert released_question.question_id != question.question_id
     assert released_question.model_copy(update={'question_id': question.question_id}) == question
-    assert replay == []
+    assert replay.intents == []
 
     task_subject = ChatFirstSubject(kind='task', id='task-1')
     task_question = _question(task_subject)
@@ -1082,9 +1169,47 @@ def test_deferral_releases_once_verbatim_when_due_or_subject_changes(firestore):
         firestore_client=firestore,
     )
 
-    assert len(subject_change) == 1
-    assert subject_change[0].blocks[0].model_copy(update={'question_id': task_question.question_id}) == task_question
-    assert subject_change[0].blocks[0].question_id != task_question.question_id
+    assert len(subject_change.intents) == 1
+    assert (
+        subject_change.intents[0].blocks[0].model_copy(update={'question_id': task_question.question_id})
+        == task_question
+    )
+    assert subject_change.intents[0].blocks[0].question_id != task_question.question_id
+
+
+def test_malformed_deferral_row_does_not_block_healthy_release_or_fetch(firestore):
+    question = _question()
+    intents_db.record_deferral(
+        UID,
+        continuity_key='healthy-due-deferral',
+        subject=question.subject,
+        question=question,
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    firestore.rows[('users', UID, intents_db.DEFERRALS_COLLECTION, 'malformed-due')] = {
+        'account_generation': GENERATION,
+        'state': 'pending',
+        'due_at': NOW,
+    }
+
+    released = intents_db.release_due_deferrals(
+        UID,
+        account_generation=GENERATION,
+        now=NOW + timedelta(days=1),
+        firestore_client=firestore,
+    )
+    fetched = intents_db.fetch_ready_intents(
+        UID,
+        account_generation=GENERATION,
+        now=NOW + timedelta(days=1),
+        firestore_client=firestore,
+    )
+
+    assert released.malformed_count == 1
+    assert len(released.intents) == 1
+    assert [intent.intent_id for intent in fetched] == [released.intents[0].intent_id]
 
 
 def test_workflow_mode_cannot_suppress_intent_but_stale_generation_still_rejects(firestore):
@@ -1158,7 +1283,7 @@ def test_malformed_intent_cannot_be_materialized_or_overwritten(firestore):
     original = deepcopy(firestore.rows[path])
 
     with patch('database.read_boundary.record_fallback') as fallback:
-        with pytest.raises(intents_db.ChatFirstIntentGenerationMismatch, match='proactive intent is malformed'):
+        with pytest.raises(intents_db.ChatFirstMalformedDocument, match='proactive intent is malformed'):
             intents_db.acknowledge_materialization(
                 UID,
                 intent_id='malformed-intent',
@@ -1184,7 +1309,7 @@ def test_malformed_deferral_cannot_be_accepted_or_overwritten(firestore):
     original = deepcopy(firestore.rows[path])
 
     with patch('database.read_boundary.record_fallback') as fallback:
-        with pytest.raises(intents_db.ChatFirstIntentGenerationMismatch, match='deferral is malformed'):
+        with pytest.raises(intents_db.ChatFirstMalformedDocument, match='deferral is malformed'):
             intents_db.record_deferral(
                 UID,
                 continuity_key=continuity_key,
@@ -1208,7 +1333,7 @@ def test_malformed_budget_state_cannot_be_reset_to_an_enabled_default(firestore)
     original = deepcopy(firestore.rows[path])
 
     with patch('database.read_boundary.record_fallback') as fallback:
-        with pytest.raises(intents_db.ChatFirstIntentGenerationMismatch, match='proactive budget state is malformed'):
+        with pytest.raises(intents_db.ChatFirstMalformedDocument, match='proactive budget state is malformed'):
             intents_db.get_budget_state(UID, account_generation=GENERATION, now=NOW, firestore_client=firestore)
 
     fallback.assert_not_called()

--- a/backend/tests/unit/test_chat_first_proactive_intents.py
+++ b/backend/tests/unit/test_chat_first_proactive_intents.py
@@ -913,7 +913,7 @@ def test_stable_chat_first_turn_identity_matches_the_kernel_shared_vector():
     assert intents_db._stable_chat_first_turn_id('intent-shared-vector') == 'turn_cfi_df211fb1b31c4b849c6bb6b2'
 
 
-def test_fetch_reconciles_a_stable_chat_row_after_an_earlier_delivery(firestore):
+def test_fetch_reconciles_a_stable_chat_row_and_acknowledges_a_late_real_receipt(firestore):
     intent, _ = intents_db.create_intent(
         UID,
         source='capture_arrival',
@@ -954,6 +954,47 @@ def test_fetch_reconciles_a_stable_chat_row_after_an_earlier_delivery(firestore)
     )
     assert stored.delivery_state == 'delivered'
     assert stored.materialization_receipt_id.startswith('cfi_reconciled_')
+
+    acknowledged = intents_db.acknowledge_materialization(
+        UID,
+        intent_id=intent.intent_id,
+        receipt_id='late-real-kernel-receipt',
+        account_generation=GENERATION,
+        now=NOW + timedelta(minutes=2),
+        firestore_client=firestore,
+    )
+    assert acknowledged == stored
+
+
+def test_two_distinct_real_materialization_receipts_conflict(firestore):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:real-receipt-conflict',
+        subject=ChatFirstSubject(kind='capture', id='real-receipt-conflict'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='real-receipt-conflict', summary='Capture')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    intents_db.acknowledge_materialization(
+        UID,
+        intent_id=intent.intent_id,
+        receipt_id='first-real-receipt',
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+
+    with pytest.raises(intents_db.ChatFirstIntentConflictError):
+        intents_db.acknowledge_materialization(
+            UID,
+            intent_id=intent.intent_id,
+            receipt_id='second-real-receipt',
+            account_generation=GENERATION,
+            now=NOW + timedelta(seconds=1),
+            firestore_client=firestore,
+        )
 
 
 def test_fetch_orders_daily_and_meeting_intents_ahead_of_capture_link_backlog(firestore):

--- a/backend/tests/unit/test_chat_first_proactive_intents.py
+++ b/backend/tests/unit/test_chat_first_proactive_intents.py
@@ -74,6 +74,8 @@ class _Document:
             hook = self._database.transaction_read_hooks.pop(self._path, None)
             if hook is not None:
                 hook()
+        else:
+            self._database.point_reads[self._path] = self._database.point_reads.get(self._path, 0) + 1
         return _Snapshot(self._database, self._path)
 
     def set(self, payload, merge=False):
@@ -180,6 +182,7 @@ class _Firestore:
         self.rows = {}
         self.transaction_count = 0
         self.transaction_read_hooks = {}
+        self.point_reads = {}
 
     def collection(self, name):
         return _Collection(self, (name,))
@@ -489,7 +492,7 @@ def test_invalid_intent_three_times_dead_letters_and_requeued_poison_stays_termi
     assert replay_reason is None
 
 
-def test_legacy_transient_dead_letter_requeues_once_after_repair_age(firestore):
+def test_legacy_transient_dead_letter_requeues_once_from_next_fetch_after_repair_age(firestore):
     intent, _ = intents_db.create_intent(
         UID,
         source='capture_arrival',
@@ -503,24 +506,21 @@ def test_legacy_transient_dead_letter_requeues_once_after_repair_age(firestore):
     intent_path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
     firestore.rows[intent_path].update(
         delivery_state='dead_letter',
-        dead_letter_reason='rejection_budget_exhausted',
+        dead_letter_reason='permanent_rejection:kernel_materialization_failed',
         materialization_attempts=3,
         last_rejection_code='kernel_materialization_failed',
         last_rejection_at=NOW,
     )
 
-    repaired, reason = intents_db.record_materialization_rejection(
+    repaired = intents_db.fetch_ready_intents(
         UID,
-        intent_id=intent.intent_id,
-        code='kernel_materialization_failed',
         account_generation=GENERATION,
-        now=NOW + intents_db.TRANSIENT_DEAD_LETTER_REPAIR_AGE,
+        now=NOW + intents_db.TRANSIENT_DEAD_LETTER_REPAIR_AGE + timedelta(minutes=10),
         firestore_client=firestore,
     )
 
-    assert repaired.delivery_state == 'ready'
-    assert repaired.requeue_count == 1
-    assert reason is None
+    assert repaired[0].delivery_state == 'ready'
+    assert repaired[0].requeue_count == 1
 
 
 def test_fetch_budget_dead_letters_an_unacknowledged_intent(firestore):
@@ -673,6 +673,49 @@ def test_deferred_old_intent_does_not_stall_but_never_fetched_old_intent_does(fi
     assert stalled.stalled_source == 'capture_arrival'
 
 
+def test_stall_age_restarts_at_last_deferral_but_eventually_pages(firestore):
+    recent, _ = intents_db.create_intent(
+        UID,
+        source='daily_opener',
+        continuity_key='daily:recently-deferred',
+        subject=None,
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='recently-deferred', summary='Recent')],
+        account_generation=GENERATION,
+        now=NOW - timedelta(days=30),
+        firestore_client=firestore,
+    )
+    intents_db.record_materialization_deferral(
+        UID,
+        intent_id=recent.intent_id,
+        account_generation=GENERATION,
+        now=NOW - timedelta(hours=1),
+        firestore_client=firestore,
+    )
+    assert (
+        intents_db.fetch_ready_intent_batch(
+            UID,
+            account_generation=GENERATION,
+            deferred_intent_ids={recent.intent_id},
+            now=NOW,
+            firestore_client=firestore,
+        ).stalled_source
+        is None
+    )
+
+    attempt_path = ('users', UID, intents_db.DELIVERY_ATTEMPTS_COLLECTION, recent.intent_id)
+    firestore.rows[attempt_path]['last_deferral_at'] = NOW - timedelta(days=30)
+    assert (
+        intents_db.fetch_ready_intent_batch(
+            UID,
+            account_generation=GENERATION,
+            deferred_intent_ids={recent.intent_id},
+            now=NOW,
+            firestore_client=firestore,
+        ).stalled_source
+        == 'daily_opener'
+    )
+
+
 def test_continuous_deferral_dead_letters_at_seven_days_but_not_six(firestore):
     intent, _ = intents_db.create_intent(
         UID,
@@ -787,6 +830,197 @@ def test_fetch_bookkeeping_stays_in_sibling_doc_and_old_strict_reader_still_pars
     assert firestore.rows[attempt_path]['fetch_count'] == 1
 
 
+def test_ready_intent_remains_old_reader_safe_after_deferrals_and_rejections(firestore):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:rolling-reader-all-active-writes',
+        subject=ChatFirstSubject(kind='capture', id='rolling-reader-all-active-writes'),
+        blocks=[
+            CaptureLinkSpec(type='captureLink', conversation_id='rolling-reader-all-active-writes', summary='Safe')
+        ],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    intent_path = ('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)
+
+    intents_db.fetch_ready_intents(
+        UID, account_generation=GENERATION, now=NOW + timedelta(minutes=1), firestore_client=firestore
+    )
+    intents_db.record_materialization_deferral(
+        UID,
+        intent_id=intent.intent_id,
+        account_generation=GENERATION,
+        now=NOW + timedelta(minutes=2),
+        firestore_client=firestore,
+    )
+    intents_db.record_materialization_rejection(
+        UID,
+        intent_id=intent.intent_id,
+        code='kernel_materialization_failed',
+        account_generation=GENERATION,
+        now=NOW + timedelta(minutes=2, seconds=30),
+        firestore_client=firestore,
+    )
+    for minute in (3, 4):
+        intents_db.record_materialization_rejection(
+            UID,
+            intent_id=intent.intent_id,
+            code='invalid_intent',
+            account_generation=GENERATION,
+            now=NOW + timedelta(minutes=minute),
+            firestore_client=firestore,
+        )
+        _OldStrictProactiveIntent.model_validate(firestore.rows[intent_path])
+
+    firestore.rows[intent_path].update(
+        delivery_state='dead_letter',
+        dead_letter_reason='unacknowledged_after_fetch_budget',
+        last_fetched_at=NOW,
+        requeue_count=0,
+    )
+    intents_db.fetch_ready_intents(
+        UID,
+        account_generation=GENERATION,
+        now=NOW + intents_db.TRANSIENT_DEAD_LETTER_REPAIR_AGE + timedelta(minutes=10),
+        firestore_client=firestore,
+    )
+    _OldStrictProactiveIntent.model_validate(firestore.rows[intent_path])
+    assert set(firestore.rows[intent_path]) == set(_OldStrictProactiveIntent.model_fields)
+
+
+def test_fetch_requeues_transient_dead_letter_once_but_never_deterministic_death(firestore):
+    transient, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:repair-on-fetch',
+        subject=ChatFirstSubject(kind='capture', id='repair-on-fetch'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='repair-on-fetch', summary='Repair')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    transient_path = ('users', UID, intents_db.INTENTS_COLLECTION, transient.intent_id)
+    firestore.rows[transient_path].update(
+        delivery_state='dead_letter',
+        dead_letter_reason='unacknowledged_after_fetch_budget',
+    )
+    transient_attempt_path = ('users', UID, intents_db.DELIVERY_ATTEMPTS_COLLECTION, transient.intent_id)
+    firestore.rows[transient_attempt_path] = {
+        'fetch_count': intents_db.UNACKNOWLEDGED_FETCH_BUDGET + 1,
+        'last_fetched_at': NOW,
+        'requeue_count': 0,
+    }
+    deterministic_path = ('users', UID, intents_db.INTENTS_COLLECTION, 'deterministic-death')
+    deterministic = {**firestore.rows[transient_path], 'intent_id': 'deterministic-death'}
+    deterministic.update(dead_letter_reason='permanent_rejection:invalid_intent')
+    firestore.rows[deterministic_path] = deterministic
+
+    fetched = intents_db.fetch_ready_intents(
+        UID,
+        account_generation=GENERATION,
+        now=NOW + intents_db.TRANSIENT_DEAD_LETTER_REPAIR_AGE,
+        firestore_client=firestore,
+    )
+    assert [item.intent_id for item in fetched] == [transient.intent_id]
+    assert fetched[0].requeue_count == 1
+    assert firestore.rows[deterministic_path]['delivery_state'] == 'dead_letter'
+
+    firestore.rows[transient_path].update(
+        delivery_state='dead_letter',
+        dead_letter_reason='unacknowledged_after_fetch_budget',
+    )
+    firestore.rows[transient_attempt_path].update(last_fetched_at=NOW, requeue_count=1)
+    assert (
+        intents_db.fetch_ready_intents(
+            UID,
+            account_generation=GENERATION,
+            now=NOW + timedelta(days=1),
+            firestore_client=firestore,
+        )
+        == []
+    )
+
+
+def test_sibling_point_reads_are_bounded_by_candidate_scan_limit(firestore):
+    for index in range(200):
+        intents_db.create_intent(
+            UID,
+            source='capture_arrival',
+            continuity_key=f'capture:read-bound:{index}',
+            subject=ChatFirstSubject(kind='capture', id=f'read-bound-{index}'),
+            blocks=[CaptureLinkSpec(type='captureLink', conversation_id=f'read-bound-{index}', summary='Bounded')],
+            account_generation=GENERATION,
+            now=NOW + timedelta(seconds=index),
+            firestore_client=firestore,
+        )
+
+    intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, limit=8, now=NOW + timedelta(hours=1), firestore_client=firestore
+    )
+    sibling_reads = sum(
+        count for path, count in firestore.point_reads.items() if intents_db.DELIVERY_ATTEMPTS_COLLECTION in path
+    )
+    assert sibling_reads <= intents_db.FETCH_CANDIDATE_SCAN_MULTIPLIER * 8
+
+
+def test_transient_dead_letter_repair_scan_is_bounded(firestore, monkeypatch):
+    for index in range(100):
+        intent, _ = intents_db.create_intent(
+            UID,
+            source='capture_arrival',
+            continuity_key=f'capture:repair-bound:{index}',
+            subject=ChatFirstSubject(kind='capture', id=f'repair-bound-{index}'),
+            blocks=[CaptureLinkSpec(type='captureLink', conversation_id=f'repair-bound-{index}', summary='Repair')],
+            account_generation=GENERATION,
+            now=NOW,
+            firestore_client=firestore,
+        )
+        firestore.rows[('users', UID, intents_db.INTENTS_COLLECTION, intent.intent_id)].update(
+            delivery_state='dead_letter',
+            dead_letter_reason='unacknowledged_after_fetch_budget',
+            last_fetched_at=NOW,
+            requeue_count=0,
+        )
+    scanned = []
+
+    def skip_repair(uid, intent_id, **kwargs):
+        scanned.append(intent_id)
+        return None
+
+    monkeypatch.setattr(intents_db, '_requeue_transient_dead_letter', skip_repair)
+    intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, limit=8, now=NOW + timedelta(days=1), firestore_client=firestore
+    )
+
+    assert len(scanned) == intents_db.FETCH_CANDIDATE_SCAN_MULTIPLIER * 8
+
+
+def test_malformed_delivery_attempt_is_repaired_and_fetched_with_metric_event(firestore):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key='capture:malformed-attempt',
+        subject=ChatFirstSubject(kind='capture', id='malformed-attempt'),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id='malformed-attempt', summary='Repair')],
+        account_generation=GENERATION,
+        now=NOW,
+        firestore_client=firestore,
+    )
+    attempt_path = ('users', UID, intents_db.DELIVERY_ATTEMPTS_COLLECTION, intent.intent_id)
+    firestore.rows[attempt_path] = {'fetch_count': 'garbage', 'requeue_count': -1}
+
+    batch = intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, now=NOW + timedelta(minutes=1), firestore_client=firestore
+    )
+
+    assert [item.intent_id for item in batch.intents] == [intent.intent_id]
+    assert firestore.rows[attempt_path]['fetch_count'] == 1
+    assert firestore.rows[attempt_path]['requeue_count'] == 0
+    assert [event.event for event in batch.lifecycle_events] == ['malformed_attempt_reset']
+
+
 def test_terminal_receipt_is_acknowledged_idempotently_after_fetch_budget_dead_letter(firestore):
     intent, _ = intents_db.create_intent(
         UID,
@@ -811,7 +1045,7 @@ def test_terminal_receipt_is_acknowledged_idempotently_after_fetch_budget_dead_l
         firestore_client=firestore,
     )
 
-    assert acknowledged.delivery_state == 'dead_letter'
+    assert acknowledged.delivery_state == 'delivered'
 
 
 def test_stale_rejection_is_absorbed_after_other_device_delivery_or_deletion(firestore):
@@ -1374,6 +1608,30 @@ def test_malformed_deferral_row_does_not_block_healthy_release_or_fetch(firestor
     assert released.malformed_count == 1
     assert len(released.intents) == 1
     assert [intent.intent_id for intent in fetched] == [released.intents[0].intent_id]
+
+
+def test_malformed_deferral_terminalization_failure_is_counted_and_logs_document_id(firestore, monkeypatch, caplog):
+    firestore.rows[('users', UID, intents_db.DEFERRALS_COLLECTION, 'malformed-warning-id')] = {
+        'account_generation': GENERATION,
+        'state': 'pending',
+        'due_at': NOW,
+    }
+
+    def fail_terminalization(*args, **kwargs):
+        raise RuntimeError('private failure detail')
+
+    monkeypatch.setattr(intents_db, '_terminalize_malformed_deferral', fail_terminalization)
+    with caplog.at_level('WARNING', logger=intents_db.__name__):
+        released = intents_db.release_due_deferrals(
+            UID,
+            account_generation=GENERATION,
+            now=NOW + timedelta(days=1),
+            firestore_client=firestore,
+        )
+
+    assert released.malformed_count == 1
+    assert 'id=malformed-warning-id' in caplog.text
+    assert 'private failure detail' not in caplog.text
 
 
 def test_thirty_three_malformed_deferrals_ahead_of_valid_due_row_are_terminalized(firestore):

--- a/backend/tests/unit/test_chat_first_proactive_router.py
+++ b/backend/tests/unit/test_chat_first_proactive_router.py
@@ -19,8 +19,8 @@ from models.task_intelligence import TaskWorkflowControl
 import routers.chat_first as chat_first_router
 
 
-def _batch(intents):
-    return chat_first_router.chat_first_intents_db.ReadyIntentBatch(intents, (), None)
+def _batch(intents, *, stalled_source=None):
+    return chat_first_router.chat_first_intents_db.ReadyIntentBatch(intents, (), stalled_source)
 
 
 def _empty_release_batch(*args, **kwargs):
@@ -338,6 +338,93 @@ def test_one_invalid_receipt_never_fails_the_materialization_batch(monkeypatch):
         {'intent_id': 'intent-terminal', 'outcome': 'missing'},
         {'intent_id': 'intent-good', 'outcome': 'acknowledged'},
     ]
+
+
+@pytest.mark.parametrize(
+    ('outcome', 'failure'),
+    [
+        ('acknowledged', None),
+        ('conflict', chat_first_router.chat_first_intents_db.ChatFirstIntentConflictError('conflict')),
+        ('missing', chat_first_router.chat_first_intents_db.ProactiveIntentNotReady('missing')),
+        (
+            'generation_mismatch',
+            chat_first_router.chat_first_intents_db.ChatFirstIntentDocumentGenerationMismatch('stale'),
+        ),
+    ],
+)
+def test_kernel_receipt_metric_labels_each_outcome_and_warns_only_for_conflicts(monkeypatch, outcome, failure):
+    _enable_chat_first(monkeypatch)
+    intent = ProactiveIntent(
+        intent_id='intent-receipt-observability',
+        continuity_key='receipt-observability',
+        account_generation=7,
+        source='capture_arrival',
+        subject=ChatFirstSubject(kind='capture', id='receipt-observability'),
+        blocks=[_question()],
+        created_at=datetime(2026, 7, 15, tzinfo=timezone.utc),
+        delivery_state='delivered',
+        materialization_receipt_id='receipt-observability',
+        delivered_at=datetime(2026, 7, 15, tzinfo=timezone.utc),
+    )
+    events = []
+    warnings = []
+
+    def acknowledge(*args, **kwargs):
+        if failure is not None:
+            raise failure
+        return intent
+
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'acknowledge_materialization', acknowledge)
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', _empty_release_batch)
+    monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
+    monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        chat_first_router.chat_first_intents_db, 'fetch_ready_intent_batch', lambda *args, **kwargs: _batch([])
+    )
+    monkeypatch.setattr(
+        chat_first_router,
+        'CHAT_FIRST_PROACTIVE_TOTAL',
+        SimpleNamespace(labels=lambda **kwargs: SimpleNamespace(inc=lambda: events.append(kwargs))),
+    )
+    monkeypatch.setattr(chat_first_router.logger, 'warning', lambda *args, **kwargs: warnings.append(args))
+
+    response = _client().post(
+        '/v2/chat/materialize-prompts',
+        json=_request(receipts=[{'intent_id': intent.intent_id, 'receipt_id': 'receipt-observability'}]),
+    )
+
+    assert response.status_code == 200
+    assert {'event': 'kernel_receipt', 'source': 'materialization', 'reason': outcome} in events
+    assert bool(warnings) is (outcome in {'conflict', 'generation_mismatch'})
+    if warnings:
+        assert warnings[0][2:] == (intent.intent_id, 'receipt-observability')
+
+
+@pytest.mark.parametrize(('stalled_source', 'expected'), [(None, False), ('capture_arrival', True)])
+def test_stalled_batch_metric_is_emitted_only_when_source_is_set(monkeypatch, stalled_source, expected):
+    _enable_chat_first(monkeypatch)
+    events = []
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', _empty_release_batch)
+    monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
+    monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        chat_first_router.chat_first_intents_db,
+        'fetch_ready_intent_batch',
+        lambda *args, **kwargs: _batch([], stalled_source=stalled_source),
+    )
+    monkeypatch.setattr(
+        chat_first_router,
+        'CHAT_FIRST_PROACTIVE_TOTAL',
+        SimpleNamespace(labels=lambda **kwargs: SimpleNamespace(inc=lambda: events.append(kwargs))),
+    )
+
+    response = _client().post('/v2/chat/materialize-prompts', json=_request())
+
+    assert response.status_code == 200
+    stalled = [event for event in events if event['event'] == 'stalled']
+    assert bool(stalled) is expected
+    if expected:
+        assert stalled == [{'event': 'stalled', 'source': 'capture_arrival', 'reason': 'ready_older_than_24h'}]
 
 
 def test_one_stale_cold_start_terminal_receipt_never_fails_the_materialization_batch(monkeypatch):

--- a/backend/tests/unit/test_chat_first_proactive_router.py
+++ b/backend/tests/unit/test_chat_first_proactive_router.py
@@ -290,6 +290,53 @@ def test_one_invalid_receipt_never_fails_the_materialization_batch(monkeypatch):
     ]
 
 
+def test_one_stale_cold_start_terminal_receipt_never_fails_the_materialization_batch(monkeypatch):
+    _enable_chat_first(monkeypatch)
+    calls = []
+
+    def acknowledge_terminal(*args, **kwargs):
+        calls.append(kwargs['sequence_id'])
+        if kwargs['sequence_id'] == 'cold-start:stale':
+            raise chat_first_router.chat_first_intents_db.ProactiveIntentNotReady('stale receipt')
+
+    monkeypatch.setattr(
+        chat_first_router.chat_first_intents_db,
+        'acknowledge_sparse_cold_start_sequence_terminal',
+        acknowledge_terminal,
+    )
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
+    monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        chat_first_router.chat_first_intents_db, 'fetch_ready_intent_batch', lambda *args, **kwargs: _batch([])
+    )
+
+    response = _client().post(
+        '/v2/chat/materialize-prompts',
+        json=_request(
+            terminal_receipts=[
+                {
+                    'sequence_id': 'cold-start:stale',
+                    'receipt_id': 'terminal-stale',
+                    'terminal_state': 'completed',
+                },
+                {
+                    'sequence_id': 'cold-start:7',
+                    'receipt_id': 'terminal-current',
+                    'terminal_state': 'completed',
+                },
+            ]
+        ),
+    )
+
+    assert response.status_code == 200
+    assert calls == ['cold-start:stale', 'cold-start:7']
+    assert response.json()['receipt_outcomes'] == [
+        {'intent_id': 'cold-start:stale', 'outcome': 'missing'},
+        {'intent_id': 'cold-start:7', 'outcome': 'acknowledged'},
+    ]
+
+
 def test_tail_deferral_is_reported_separately_from_rejection(monkeypatch):
     _enable_chat_first(monkeypatch)
     deferrals = []
@@ -301,8 +348,11 @@ def test_tail_deferral_is_reported_separately_from_rejection(monkeypatch):
     monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', lambda *args, **kwargs: [])
     monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
+    fetched = []
     monkeypatch.setattr(
-        chat_first_router.chat_first_intents_db, 'fetch_ready_intent_batch', lambda *args, **kwargs: _batch([])
+        chat_first_router.chat_first_intents_db,
+        'fetch_ready_intent_batch',
+        lambda *args, **kwargs: fetched.append(kwargs) or _batch([]),
     )
 
     response = _client().post(
@@ -312,6 +362,7 @@ def test_tail_deferral_is_reported_separately_from_rejection(monkeypatch):
 
     assert response.status_code == 200
     assert deferrals[0]['intent_id'] == 'intent-deferred'
+    assert fetched[0]['deferred_intent_ids'] == {'intent-deferred'}
 
 
 def test_client_rejection_codes_never_create_unbounded_metric_labels(monkeypatch):

--- a/backend/tests/unit/test_chat_first_proactive_router.py
+++ b/backend/tests/unit/test_chat_first_proactive_router.py
@@ -23,6 +23,10 @@ def _batch(intents):
     return chat_first_router.chat_first_intents_db.ReadyIntentBatch(intents, (), None)
 
 
+def _empty_release_batch(*args, **kwargs):
+    return chat_first_router.chat_first_intents_db.DeferralReleaseBatch(intents=[], malformed_count=0)
+
+
 def _client() -> TestClient:
     app = FastAPI()
     app.include_router(chat_first_router.router)
@@ -159,7 +163,7 @@ def test_materialize_returns_ready_intents_and_acknowledges_only_kernel_receipts
         'acknowledge_sparse_cold_start_sequence_terminal',
         lambda *args, **kwargs: terminal_acknowledgements.append(kwargs) or intent,
     )
-    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', _empty_release_batch)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
     monkeypatch.setattr(
@@ -213,7 +217,7 @@ def test_materialize_records_typed_rejections_and_dead_letter_metric(monkeypatch
         'record_materialization_rejection',
         lambda *args, **kwargs: recorded.append(kwargs) or (intent, 'permanent_rejection:invalid_intent'),
     )
-    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', _empty_release_batch)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
     monkeypatch.setattr(
@@ -266,7 +270,7 @@ def test_one_malformed_intent_with_pending_rejection_never_fails_batch_and_sibli
         return healthy, None
 
     monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'record_materialization_rejection', record_rejection)
-    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', _empty_release_batch)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
     monkeypatch.setattr(
@@ -311,7 +315,7 @@ def test_one_invalid_receipt_never_fails_the_materialization_batch(monkeypatch):
         return intent.model_copy(update={'delivery_state': 'delivered'})
 
     monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'acknowledge_materialization', acknowledge)
-    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', _empty_release_batch)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
     monkeypatch.setattr(
@@ -350,7 +354,7 @@ def test_one_stale_cold_start_terminal_receipt_never_fails_the_materialization_b
         'acknowledge_sparse_cold_start_sequence_terminal',
         acknowledge_terminal,
     )
-    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', _empty_release_batch)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
     monkeypatch.setattr(
@@ -397,7 +401,7 @@ def test_tail_deferral_is_reported_separately_from_rejection(monkeypatch):
         'record_materialization_deferral',
         record_deferral,
     )
-    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', _empty_release_batch)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
     fetched = []
@@ -441,7 +445,7 @@ def test_seven_day_deferral_records_deferred_beyond_budget_metric(monkeypatch):
         'record_materialization_deferral',
         lambda *args, **kwargs: dead_lettered,
     )
-    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', _empty_release_batch)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
     monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'fetch_ready_intent_batch', lambda *a, **k: _batch([]))
@@ -477,7 +481,7 @@ def test_client_rejection_codes_never_create_unbounded_metric_labels(monkeypatch
         'record_materialization_rejection',
         lambda *args, **kwargs: (intent, 'permanent_rejection:invented_client_code'),
     )
-    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', _empty_release_batch)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
     monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'fetch_ready_intent_batch', lambda *a, **k: _batch([]))
@@ -515,7 +519,7 @@ def test_v1_leaves_conversation_link_pending_and_v2_later_acknowledges_it(monkey
         created_at=datetime(2026, 8, 19, tzinfo=timezone.utc),
     )
     acknowledgements = []
-    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', _empty_release_batch)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
     monkeypatch.setattr(

--- a/backend/tests/unit/test_chat_first_proactive_router.py
+++ b/backend/tests/unit/test_chat_first_proactive_router.py
@@ -19,6 +19,10 @@ from models.task_intelligence import TaskWorkflowControl
 import routers.chat_first as chat_first_router
 
 
+def _batch(intents):
+    return chat_first_router.chat_first_intents_db.ReadyIntentBatch(intents, (), None)
+
+
 def _client() -> TestClient:
     app = FastAPI()
     app.include_router(chat_first_router.router)
@@ -35,7 +39,9 @@ def _client() -> TestClient:
     return TestClient(app)
 
 
-def _request(*, generation: int = 7, owner_fence: str = 'user-1', receipts=None, terminal_receipts=None) -> dict:
+def _request(
+    *, generation: int = 7, owner_fence: str = 'user-1', receipts=None, terminal_receipts=None, rejections=None
+) -> dict:
     return {
         'source_surface': 'main_chat',
         'control_generation': generation,
@@ -43,6 +49,7 @@ def _request(*, generation: int = 7, owner_fence: str = 'user-1', receipts=None,
         'window_foreground': True,
         'initial_page_loaded': True,
         'receipts': receipts or [],
+        'rejections': rejections or [],
         'cold_start_sequence_terminal_receipts': terminal_receipts or [],
     }
 
@@ -86,8 +93,9 @@ def test_materialize_capability_off_does_zero_feature_store_or_metric_work(monke
     for name in (
         'acknowledge_materialization',
         'acknowledge_sparse_cold_start_sequence_terminal',
+        'record_materialization_rejection',
         'release_due_deferrals',
-        'fetch_ready_intents',
+        'fetch_ready_intent_batch',
     ):
         monkeypatch.setattr(
             chat_first_router.chat_first_intents_db,
@@ -110,7 +118,7 @@ def test_materialize_rejects_wrong_owner_or_generation_before_feature_store_read
     _enable_chat_first(monkeypatch)
     monkeypatch.setattr(
         chat_first_router.chat_first_intents_db,
-        'fetch_ready_intents',
+        'fetch_ready_intent_batch',
         lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError('feature store must not run')),
     )
 
@@ -148,7 +156,7 @@ def test_materialize_returns_ready_intents_and_acknowledges_only_kernel_receipts
     monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
     monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
     monkeypatch.setattr(
-        chat_first_router.chat_first_intents_db, 'fetch_ready_intents', lambda *args, **kwargs: [intent]
+        chat_first_router.chat_first_intents_db, 'fetch_ready_intent_batch', lambda *args, **kwargs: _batch([intent])
     )
 
     response = _client().post(
@@ -180,6 +188,56 @@ def test_materialize_returns_ready_intents_and_acknowledges_only_kernel_receipts
     assert response.json()['intents'][0]['delivery_state'] == 'ready'
 
 
+def test_materialize_records_typed_rejections_and_dead_letter_metric(monkeypatch):
+    _enable_chat_first(monkeypatch)
+    intent = ProactiveIntent(
+        intent_id='intent-poison',
+        continuity_key='capture:poison',
+        account_generation=7,
+        source='capture_arrival',
+        subject=ChatFirstSubject(kind='capture', id='poison'),
+        blocks=[_question()],
+        created_at=datetime(2026, 7, 15, tzinfo=timezone.utc),
+    )
+    recorded = []
+    metric_events = []
+    monkeypatch.setattr(
+        chat_first_router.chat_first_intents_db,
+        'record_materialization_rejection',
+        lambda *args, **kwargs: recorded.append(kwargs) or (intent, 'permanent_rejection:invalid_intent'),
+    )
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
+    monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        chat_first_router.chat_first_intents_db,
+        'fetch_ready_intent_batch',
+        lambda *args, **kwargs: _batch([]),
+    )
+    monkeypatch.setattr(
+        chat_first_router,
+        'CHAT_FIRST_PROACTIVE_TOTAL',
+        SimpleNamespace(labels=lambda **kwargs: SimpleNamespace(inc=lambda: metric_events.append(kwargs))),
+    )
+
+    response = _client().post(
+        '/v2/chat/materialize-prompts',
+        json=_request(
+            rejections=[{'intent_id': intent.intent_id, 'code': 'invalid_intent', 'message': 'Invalid block'}]
+        ),
+    )
+
+    assert response.status_code == 200
+    assert recorded[0]['intent_id'] == intent.intent_id
+    assert recorded[0]['code'] == 'invalid_intent'
+    assert {'event': 'rejected', 'source': 'capture_arrival', 'reason': 'invalid_intent'} in metric_events
+    assert {
+        'event': 'dead_letter',
+        'source': 'capture_arrival',
+        'reason': 'permanent_rejection:invalid_intent',
+    } in metric_events
+
+
 def test_v1_leaves_conversation_link_pending_and_v2_later_acknowledges_it(monkeypatch):
     _enable_chat_first(monkeypatch)
     intent = ProactiveIntent(
@@ -203,8 +261,8 @@ def test_v1_leaves_conversation_link_pending_and_v2_later_acknowledges_it(monkey
     monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
     monkeypatch.setattr(
         chat_first_router.chat_first_intents_db,
-        'fetch_ready_intents',
-        lambda *args, **kwargs: [] if kwargs.get('exclude_block_types') else [intent],
+        'fetch_ready_intent_batch',
+        lambda *args, **kwargs: _batch([] if kwargs.get('exclude_block_types') else [intent]),
     )
     monkeypatch.setattr(
         chat_first_router.chat_first_intents_db,

--- a/backend/tests/unit/test_chat_first_proactive_router.py
+++ b/backend/tests/unit/test_chat_first_proactive_router.py
@@ -386,10 +386,16 @@ def test_one_stale_cold_start_terminal_receipt_never_fails_the_materialization_b
 def test_tail_deferral_is_reported_separately_from_rejection(monkeypatch):
     _enable_chat_first(monkeypatch)
     deferrals = []
+
+    def record_deferral(*args, **kwargs):
+        deferrals.append(kwargs)
+        if kwargs['intent_id'] == 'intent-broken':
+            raise RuntimeError('broken deferral')
+
     monkeypatch.setattr(
         chat_first_router.chat_first_intents_db,
         'record_materialization_deferral',
-        lambda *args, **kwargs: deferrals.append(kwargs),
+        record_deferral,
     )
     monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', lambda *args, **kwargs: [])
     monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
@@ -403,12 +409,55 @@ def test_tail_deferral_is_reported_separately_from_rejection(monkeypatch):
 
     response = _client().post(
         '/v2/chat/materialize-prompts',
-        json=_request(deferrals=[{'intent_id': 'intent-deferred', 'code': 'tail_question'}]),
+        json=_request(
+            deferrals=[
+                {'intent_id': 'intent-broken', 'code': 'tail_question'},
+                {'intent_id': 'intent-deferred', 'code': 'tail_question'},
+            ]
+        ),
     )
 
     assert response.status_code == 200
-    assert deferrals[0]['intent_id'] == 'intent-deferred'
+    assert [item['intent_id'] for item in deferrals] == ['intent-broken', 'intent-deferred']
     assert fetched[0]['deferred_intent_ids'] == {'intent-deferred'}
+
+
+def test_seven_day_deferral_records_deferred_beyond_budget_metric(monkeypatch):
+    _enable_chat_first(monkeypatch)
+    dead_lettered = ProactiveIntent(
+        intent_id='intent-deferred',
+        continuity_key='deferred-seven-days',
+        account_generation=7,
+        source='capture_arrival',
+        subject=ChatFirstSubject(kind='capture', id='deferred'),
+        blocks=[_question()],
+        created_at=datetime(2026, 7, 8, tzinfo=timezone.utc),
+        delivery_state='dead_letter',
+        dead_letter_reason='deferred_beyond_budget',
+    )
+    events = []
+    monkeypatch.setattr(
+        chat_first_router.chat_first_intents_db,
+        'record_materialization_deferral',
+        lambda *args, **kwargs: dead_lettered,
+    )
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
+    monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'fetch_ready_intent_batch', lambda *a, **k: _batch([]))
+    monkeypatch.setattr(
+        chat_first_router,
+        'CHAT_FIRST_PROACTIVE_TOTAL',
+        SimpleNamespace(labels=lambda **kwargs: SimpleNamespace(inc=lambda: events.append(kwargs))),
+    )
+
+    response = _client().post(
+        '/v2/chat/materialize-prompts',
+        json=_request(deferrals=[{'intent_id': dead_lettered.intent_id, 'code': 'tail_question'}]),
+    )
+
+    assert response.status_code == 200
+    assert {'event': 'dead_letter', 'source': 'capture_arrival', 'reason': 'deferred_beyond_budget'} in events
 
 
 def test_client_rejection_codes_never_create_unbounded_metric_labels(monkeypatch):

--- a/backend/tests/unit/test_chat_first_proactive_router.py
+++ b/backend/tests/unit/test_chat_first_proactive_router.py
@@ -40,7 +40,13 @@ def _client() -> TestClient:
 
 
 def _request(
-    *, generation: int = 7, owner_fence: str = 'user-1', receipts=None, terminal_receipts=None, rejections=None
+    *,
+    generation: int = 7,
+    owner_fence: str = 'user-1',
+    receipts=None,
+    terminal_receipts=None,
+    rejections=None,
+    deferrals=None,
 ) -> dict:
     return {
         'source_surface': 'main_chat',
@@ -50,6 +56,7 @@ def _request(
         'initial_page_loaded': True,
         'receipts': receipts or [],
         'rejections': rejections or [],
+        'deferrals': deferrals or [],
         'cold_start_sequence_terminal_receipts': terminal_receipts or [],
     }
 
@@ -236,6 +243,112 @@ def test_materialize_records_typed_rejections_and_dead_letter_metric(monkeypatch
         'source': 'capture_arrival',
         'reason': 'permanent_rejection:invalid_intent',
     } in metric_events
+
+
+def test_one_invalid_receipt_never_fails_the_materialization_batch(monkeypatch):
+    _enable_chat_first(monkeypatch)
+    intent = ProactiveIntent(
+        intent_id='intent-good',
+        continuity_key='good',
+        account_generation=7,
+        source='capture_arrival',
+        subject=ChatFirstSubject(kind='capture', id='good'),
+        blocks=[_question()],
+        created_at=datetime(2026, 7, 15, tzinfo=timezone.utc),
+    )
+    calls = []
+
+    def acknowledge(*args, **kwargs):
+        calls.append(kwargs['intent_id'])
+        if kwargs['intent_id'] == 'intent-terminal':
+            raise chat_first_router.chat_first_intents_db.ProactiveIntentNotReady('terminal')
+        return intent.model_copy(update={'delivery_state': 'delivered'})
+
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'acknowledge_materialization', acknowledge)
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
+    monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        chat_first_router.chat_first_intents_db, 'fetch_ready_intent_batch', lambda *args, **kwargs: _batch([])
+    )
+
+    response = _client().post(
+        '/v2/chat/materialize-prompts',
+        json=_request(
+            receipts=[
+                {'intent_id': 'intent-terminal', 'receipt_id': 'receipt-terminal'},
+                {'intent_id': 'intent-good', 'receipt_id': 'receipt-good'},
+            ]
+        ),
+    )
+
+    assert response.status_code == 200
+    assert calls == ['intent-terminal', 'intent-good']
+    assert response.json()['receipt_outcomes'] == [
+        {'intent_id': 'intent-terminal', 'outcome': 'missing'},
+        {'intent_id': 'intent-good', 'outcome': 'acknowledged'},
+    ]
+
+
+def test_tail_deferral_is_reported_separately_from_rejection(monkeypatch):
+    _enable_chat_first(monkeypatch)
+    deferrals = []
+    monkeypatch.setattr(
+        chat_first_router.chat_first_intents_db,
+        'record_materialization_deferral',
+        lambda *args, **kwargs: deferrals.append(kwargs),
+    )
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
+    monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        chat_first_router.chat_first_intents_db, 'fetch_ready_intent_batch', lambda *args, **kwargs: _batch([])
+    )
+
+    response = _client().post(
+        '/v2/chat/materialize-prompts',
+        json=_request(deferrals=[{'intent_id': 'intent-deferred', 'code': 'tail_question'}]),
+    )
+
+    assert response.status_code == 200
+    assert deferrals[0]['intent_id'] == 'intent-deferred'
+
+
+def test_client_rejection_codes_never_create_unbounded_metric_labels(monkeypatch):
+    _enable_chat_first(monkeypatch)
+    intent = ProactiveIntent(
+        intent_id='intent-client-code',
+        continuity_key='client-code',
+        account_generation=7,
+        source='capture_arrival',
+        subject=None,
+        blocks=[_question()],
+        created_at=datetime(2026, 7, 15, tzinfo=timezone.utc),
+    )
+    events = []
+    monkeypatch.setattr(
+        chat_first_router.chat_first_intents_db,
+        'record_materialization_rejection',
+        lambda *args, **kwargs: (intent, 'permanent_rejection:invented_client_code'),
+    )
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
+    monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'fetch_ready_intent_batch', lambda *a, **k: _batch([]))
+    monkeypatch.setattr(
+        chat_first_router,
+        'CHAT_FIRST_PROACTIVE_TOTAL',
+        SimpleNamespace(labels=lambda **kwargs: SimpleNamespace(inc=lambda: events.append(kwargs))),
+    )
+
+    response = _client().post(
+        '/v2/chat/materialize-prompts',
+        json=_request(rejections=[{'intent_id': intent.intent_id, 'code': 'invented_client_code'}]),
+    )
+
+    assert response.status_code == 200
+    assert {'event': 'rejected', 'source': 'capture_arrival', 'reason': 'unknown'} in events
+    assert {'event': 'dead_letter', 'source': 'capture_arrival', 'reason': 'permanent_rejection:unknown'} in events
 
 
 def test_v1_leaves_conversation_link_pending_and_v2_later_acknowledges_it(monkeypatch):

--- a/backend/tests/unit/test_chat_first_proactive_router.py
+++ b/backend/tests/unit/test_chat_first_proactive_router.py
@@ -243,6 +243,52 @@ def test_materialize_records_typed_rejections_and_dead_letter_metric(monkeypatch
         'source': 'capture_arrival',
         'reason': 'permanent_rejection:invalid_intent',
     } in metric_events
+    assert response.json()['rejection_outcomes'] == [{'intent_id': 'intent-poison', 'outcome': 'recorded'}]
+
+
+def test_one_malformed_intent_with_pending_rejection_never_fails_batch_and_sibling_is_recorded(monkeypatch):
+    _enable_chat_first(monkeypatch)
+    healthy = ProactiveIntent(
+        intent_id='intent-healthy-rejection',
+        continuity_key='healthy-rejection',
+        account_generation=7,
+        source='capture_arrival',
+        subject=ChatFirstSubject(kind='capture', id='healthy-rejection'),
+        blocks=[_question()],
+        created_at=datetime(2026, 7, 15, tzinfo=timezone.utc),
+    )
+    calls = []
+
+    def record_rejection(*args, **kwargs):
+        calls.append(kwargs['intent_id'])
+        if kwargs['intent_id'] == 'intent-malformed-rejection':
+            raise chat_first_router.chat_first_intents_db.ChatFirstMalformedDocument('malformed intent')
+        return healthy, None
+
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'record_materialization_rejection', record_rejection)
+    monkeypatch.setattr(chat_first_router.chat_first_intents_db, 'release_due_deferrals', lambda *args, **kwargs: [])
+    monkeypatch.setattr(chat_first_router, '_maybe_persist_cold_start', lambda *args, **kwargs: None)
+    monkeypatch.setattr(chat_first_router, '_maybe_persist_daily_opener', lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        chat_first_router.chat_first_intents_db, 'fetch_ready_intent_batch', lambda *args, **kwargs: _batch([])
+    )
+
+    response = _client().post(
+        '/v2/chat/materialize-prompts',
+        json=_request(
+            rejections=[
+                {'intent_id': 'intent-malformed-rejection', 'code': 'invalid_intent'},
+                {'intent_id': healthy.intent_id, 'code': 'kernel_materialization_failed'},
+            ]
+        ),
+    )
+
+    assert response.status_code == 200
+    assert calls == ['intent-malformed-rejection', healthy.intent_id]
+    assert response.json()['rejection_outcomes'] == [
+        {'intent_id': 'intent-malformed-rejection', 'outcome': 'malformed'},
+        {'intent_id': healthy.intent_id, 'outcome': 'recorded'},
+    ]
 
 
 def test_one_invalid_receipt_never_fails_the_materialization_batch(monkeypatch):

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -453,7 +453,7 @@ TASK_INTELLIGENCE_ATTRIBUTION_TOTAL = Counter(
 CHAT_FIRST_PROACTIVE_TOTAL = Counter(
     'chat_first_proactive_total',
     'Chat-first proactive engine activity with no user content',
-    ['event', 'source'],
+    ['event', 'source', 'reason'],
 )
 
 MEMORY_UNIVERSAL_READ_ORIGIN_TOTAL = Counter(

--- a/backend/utils/task_intelligence/chat_first_e2e_fixture.py
+++ b/backend/utils/task_intelligence/chat_first_e2e_fixture.py
@@ -128,7 +128,12 @@ def _existing_feature_refs(uid: str, *, firestore_client: Any) -> list[Any]:
 
     user_ref = _user_ref(uid, firestore_client=firestore_client)
     refs: list[Any] = []
-    for collection_name in (intents_db.INTENTS_COLLECTION, intents_db.DEFERRALS_COLLECTION):
+    for collection_name in (
+        intents_db.INTENTS_COLLECTION,
+        intents_db.DEAD_LETTERS_COLLECTION,
+        intents_db.DELIVERY_ATTEMPTS_COLLECTION,
+        intents_db.DEFERRALS_COLLECTION,
+    ):
         refs.extend(document.reference for document in user_ref.collection(collection_name).stream())
     return refs
 

--- a/backend/utils/task_intelligence/chat_first_materialization_health.py
+++ b/backend/utils/task_intelligence/chat_first_materialization_health.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, Iterable, Iterator, List, Literal, Typed
 from google.cloud.firestore_v1 import FieldFilter
 
 from database._client import get_firestore_client
-from database.chat_first_intents import INTENTS_COLLECTION
+from database.chat_first_intents import DEAD_LETTERS_COLLECTION, INTENTS_COLLECTION
 
 DEFAULT_STALE_AFTER_HOURS = 48
 SCHEDULED_WEEKDAY_UTC = 0  # Monday
@@ -89,18 +89,24 @@ def _documents(
     """
 
     client = firestore_client or get_firestore_client()
-    if uid:
-        query: Any = client.collection('users').document(uid).collection(INTENTS_COLLECTION)
-    else:
-        query = client.collection_group(INTENTS_COLLECTION)
-    if min_created_at is not None:
-        query = query.where(filter=FieldFilter('created_at', '>=', min_created_at))
-    if limit is not None:
-        query = query.limit(limit)
-    for snapshot in query.stream():
-        raw: object = snapshot.to_dict()
-        if isinstance(raw, dict):
-            yield cast(Dict[str, Any], raw)
+    remaining = limit
+    for collection_name in (INTENTS_COLLECTION, DEAD_LETTERS_COLLECTION):
+        if uid:
+            query: Any = client.collection('users').document(uid).collection(collection_name)
+        else:
+            query = client.collection_group(collection_name)
+        if min_created_at is not None:
+            query = query.where(filter=FieldFilter('created_at', '>=', min_created_at))
+        if remaining is not None:
+            query = query.limit(remaining)
+        for snapshot in query.stream():
+            raw: object = snapshot.to_dict()
+            if isinstance(raw, dict):
+                yield cast(Dict[str, Any], raw)
+                if remaining is not None:
+                    remaining -= 1
+                    if remaining == 0:
+                        return
 
 
 def _created_at(document: Dict[str, Any]) -> datetime | None:

--- a/backend/utils/task_intelligence/proactive_engine.py
+++ b/backend/utils/task_intelligence/proactive_engine.py
@@ -155,7 +155,7 @@ def wake_after_commit(
         now=resolved_now,
         subject=trigger.subject,
     )
-    for _intent in released:
+    for _intent in getattr(released, 'intents', released):
         _meter('deferral_released', 'deferral_reraise')
 
     if trigger.kind not in {'task_changed', 'goal_changed'}:

--- a/backend/utils/task_intelligence/proactive_engine.py
+++ b/backend/utils/task_intelligence/proactive_engine.py
@@ -466,7 +466,7 @@ def _deterministic_shortlist(trigger: ProactiveWakeTrigger) -> list[ProactiveCan
 def _meter(event: str, source: str) -> None:
     """Emit only bounded shape labels; never content, prompts, or subject IDs."""
 
-    CHAT_FIRST_PROACTIVE_TOTAL.labels(event=event, source=source).inc()
+    CHAT_FIRST_PROACTIVE_TOTAL.labels(event=event, source=source, reason='none').inc()
 
 
 __all__ = [

--- a/backend/utils/task_intelligence/proactive_engine.py
+++ b/backend/utils/task_intelligence/proactive_engine.py
@@ -155,7 +155,11 @@ def wake_after_commit(
         now=resolved_now,
         subject=trigger.subject,
     )
-    for _intent in getattr(released, 'intents', released):
+    malformed_count = getattr(released, 'malformed_count', 0)
+    if malformed_count:
+        logger.warning('Skipped malformed Chat-first deferrals during release: count=%d', malformed_count)
+    released_intents = released if isinstance(released, list) else released.intents
+    for _intent in released_intents:
         _meter('deferral_released', 'deferral_reraise')
 
     if trigger.kind not in {'task_changed', 'goal_changed'}:

--- a/backend/utils/task_intelligence/proactive_engine.py
+++ b/backend/utils/task_intelligence/proactive_engine.py
@@ -149,17 +149,15 @@ def wake_after_commit(
 
     # A due deferral is deterministic. Release it before agent judgment, but
     # never recurse into this wake path from the release/receipt operation.
-    released = intent_db.release_due_deferrals(
+    release_batch = intent_db.release_due_deferrals(
         uid,
         account_generation=generation,
         now=resolved_now,
         subject=trigger.subject,
     )
-    malformed_count = getattr(released, 'malformed_count', 0)
-    if malformed_count:
-        logger.warning('Skipped malformed Chat-first deferrals during release: count=%d', malformed_count)
-    released_intents = released if isinstance(released, list) else released.intents
-    for _intent in released_intents:
+    if release_batch.malformed_count:
+        logger.warning('Skipped malformed Chat-first deferrals during release: count=%d', release_batch.malformed_count)
+    for _intent in release_batch.intents:
         _meter('deferral_released', 'deferral_reraise')
 
     if trigger.kind not in {'task_changed', 'goal_changed'}:

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess+ChatFirstJournal.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess+ChatFirstJournal.swift
@@ -107,6 +107,7 @@ extension AgentRuntimeProcess {
     let suppressedByStreamingTail: Bool
     let materializationStoppedByTail: Bool
     let materializationReceipts: [ChatFirstMaterializationReceipt]
+    let materializationRejections: [ChatFirstMaterializationRejection]
     let coldStartSequenceTerminalReceipts: [ChatFirstColdStartSequenceTerminalReceipt]
     let acknowledgedReceiptCount: Int
 
@@ -126,6 +127,7 @@ extension AgentRuntimeProcess {
       suppressedByStreamingTail: Bool = false,
       materializationStoppedByTail: Bool = false,
       materializationReceipts: [ChatFirstMaterializationReceipt] = [],
+      materializationRejections: [ChatFirstMaterializationRejection] = [],
       coldStartSequenceTerminalReceipts: [ChatFirstColdStartSequenceTerminalReceipt] = [],
       acknowledgedReceiptCount: Int = 0
     ) {
@@ -144,6 +146,7 @@ extension AgentRuntimeProcess {
       self.suppressedByStreamingTail = suppressedByStreamingTail
       self.materializationStoppedByTail = materializationStoppedByTail
       self.materializationReceipts = materializationReceipts
+      self.materializationRejections = materializationRejections
       self.coldStartSequenceTerminalReceipts = coldStartSequenceTerminalReceipts
       self.acknowledgedReceiptCount = acknowledgedReceiptCount
     }
@@ -162,6 +165,7 @@ extension AgentRuntimeProcess {
     let accepted: Bool
     let stoppedByTail: Bool
     let receipts: [ChatFirstMaterializationReceipt]
+    let rejections: [ChatFirstMaterializationRejection]
   }
 
   /// Append server-validated structured blocks to exactly the assistant turn
@@ -362,7 +366,8 @@ extension AgentRuntimeProcess {
     return ChatFirstIntentsMaterialization(
       accepted: result.accepted == true,
       stoppedByTail: result.materializationStoppedByTail,
-      receipts: result.materializationReceipts
+      receipts: result.materializationReceipts,
+      rejections: result.materializationRejections
     )
   }
 
@@ -446,6 +451,31 @@ extension AgentRuntimeProcess {
       else { return nil }
       return ChatFirstMaterializationReceipt(intentID: intentID, receiptID: receiptID)
     }
+  }
+
+  nonisolated static func chatFirstRejections(
+    from payload: Any?
+  ) -> [ChatFirstMaterializationRejection] {
+    guard let values = payload as? [[String: Any]] else { return [] }
+    return values.compactMap { value in
+      guard let intentID = value["intentId"] as? String,
+        !intentID.isEmpty,
+        let code = value["code"] as? String,
+        !code.isEmpty
+      else { return nil }
+      return ChatFirstMaterializationRejection(
+        intentID: intentID,
+        code: code,
+        message: value["message"] as? String
+      )
+    }
+  }
+
+  nonisolated static func chatFirstJournalFailureLog(
+    failure: AgentRuntimeFailure?, payload: [String: Any], raw: String
+  ) -> String {
+    let code = failure?.code ?? payload["errorCode"] as? String ?? "journal_operation_failed"
+    return "AgentRuntimeProcess: journal operation failed code=\(code) message=\(raw)"
   }
 
   nonisolated static func chatFirstColdStartSequenceTerminalReceipts(

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess+ChatFirstJournal.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess+ChatFirstJournal.swift
@@ -108,6 +108,7 @@ extension AgentRuntimeProcess {
     let materializationStoppedByTail: Bool
     let materializationReceipts: [ChatFirstMaterializationReceipt]
     let materializationRejections: [ChatFirstMaterializationRejection]
+    let materializationDeferrals: [ChatFirstMaterializationDeferral]
     let coldStartSequenceTerminalReceipts: [ChatFirstColdStartSequenceTerminalReceipt]
     let acknowledgedReceiptCount: Int
 
@@ -128,6 +129,7 @@ extension AgentRuntimeProcess {
       materializationStoppedByTail: Bool = false,
       materializationReceipts: [ChatFirstMaterializationReceipt] = [],
       materializationRejections: [ChatFirstMaterializationRejection] = [],
+      materializationDeferrals: [ChatFirstMaterializationDeferral] = [],
       coldStartSequenceTerminalReceipts: [ChatFirstColdStartSequenceTerminalReceipt] = [],
       acknowledgedReceiptCount: Int = 0
     ) {
@@ -147,6 +149,7 @@ extension AgentRuntimeProcess {
       self.materializationStoppedByTail = materializationStoppedByTail
       self.materializationReceipts = materializationReceipts
       self.materializationRejections = materializationRejections
+      self.materializationDeferrals = materializationDeferrals
       self.coldStartSequenceTerminalReceipts = coldStartSequenceTerminalReceipts
       self.acknowledgedReceiptCount = acknowledgedReceiptCount
     }
@@ -166,6 +169,7 @@ extension AgentRuntimeProcess {
     let stoppedByTail: Bool
     let receipts: [ChatFirstMaterializationReceipt]
     let rejections: [ChatFirstMaterializationRejection]
+    let deferrals: [ChatFirstMaterializationDeferral]
   }
 
   /// Append server-validated structured blocks to exactly the assistant turn
@@ -367,7 +371,8 @@ extension AgentRuntimeProcess {
       accepted: result.accepted == true,
       stoppedByTail: result.materializationStoppedByTail,
       receipts: result.materializationReceipts,
-      rejections: result.materializationRejections
+      rejections: result.materializationRejections,
+      deferrals: result.materializationDeferrals
     )
   }
 
@@ -468,6 +473,16 @@ extension AgentRuntimeProcess {
         code: code,
         message: value["message"] as? String
       )
+    }
+  }
+
+  nonisolated static func chatFirstDeferrals(from payload: Any?) -> [ChatFirstMaterializationDeferral] {
+    guard let values = payload as? [[String: Any]] else { return [] }
+    return values.compactMap { value in
+      guard let intentID = value["intentId"] as? String, !intentID.isEmpty,
+        let code = value["code"] as? String, ["tail_question", "streaming_tail"].contains(code)
+      else { return nil }
+      return ChatFirstMaterializationDeferral(intentID: intentID, code: code)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -2,8 +2,7 @@ import Foundation
 import OmiSupport
 
 extension Notification.Name {
-  /// Posted on MainActor after the runtime handshake makes direct control
-  /// tools admissible. Carries no owner id or request content.
+  /// Posted on MainActor after the runtime handshake makes direct control tools admissible.
   static let agentRuntimeDidBecomeReady = Notification.Name("com.omi.desktop.agentRuntimeDidBecomeReady")
 }
 
@@ -3698,6 +3697,7 @@ actor AgentRuntimeProcess {
         materializationReceipts: Self.chatFirstMaterializationReceipts(
           from: message.payload["materializationReceipts"]),
         materializationRejections: Self.chatFirstRejections(from: message.payload["materializationRejections"]),
+        materializationDeferrals: Self.chatFirstDeferrals(from: message.payload["materializationDeferrals"]),
         coldStartSequenceTerminalReceipts: Self.chatFirstColdStartSequenceTerminalReceipts(
           from: message.payload["coldStartSequenceTerminalReceipts"]
         ),

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -3696,8 +3696,8 @@ actor AgentRuntimeProcess {
         suppressedByStreamingTail: message.payload["suppressedByStreamingTail"] as? Bool ?? false,
         materializationStoppedByTail: message.payload["materializationStoppedByTail"] as? Bool ?? false,
         materializationReceipts: Self.chatFirstMaterializationReceipts(
-          from: message.payload["materializationReceipts"]
-        ),
+          from: message.payload["materializationReceipts"]),
+        materializationRejections: Self.chatFirstRejections(from: message.payload["materializationRejections"]),
         coldStartSequenceTerminalReceipts: Self.chatFirstColdStartSequenceTerminalReceipts(
           from: message.payload["coldStartSequenceTerminalReceipts"]
         ),
@@ -3987,7 +3987,7 @@ actor AgentRuntimeProcess {
         journalRequest.continuation.resume(throwing: BridgeError.authMissing)
         return
       }
-      log("AgentRuntimeProcess: journal operation failed (code-only)")
+      log(Self.chatFirstJournalFailureLog(failure: failure, payload: message.payload, raw: raw))
       journalRequest.continuation.resume(
         throwing: failure.map(BridgeError.agentRuntimeFailure) ?? BridgeError.agentError(raw)
       )

--- a/desktop/macos/Desktop/Sources/Chat/ChatFirstPromptMaterializationDriver.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatFirstPromptMaterializationDriver.swift
@@ -236,7 +236,7 @@ final class APIChatFirstPromptMaterializationDriver: ChatFirstPromptMaterializat
   }
 }
 
-private struct ChatFirstMaterializePromptsRequest: Encodable {
+struct ChatFirstMaterializePromptsRequest: Encodable {
   struct Receipt: Encodable {
     let intentID: String
     let receiptID: String
@@ -286,8 +286,8 @@ private struct ChatFirstMaterializePromptsRequest: Encodable {
   let initialPageLoaded: Bool = true
   let receipts: [Receipt]
   let coldStartSequenceTerminalReceipts: [ColdStartSequenceTerminalReceipt]
-  let rejections: [Rejection]
-  let deferrals: [Deferral]
+  let rejections: [Rejection]?
+  let deferrals: [Deferral]?
 
   enum CodingKeys: String, CodingKey {
     case sourceSurface = "source_surface"
@@ -331,16 +331,20 @@ extension APIClient {
           terminalState: $0.terminalState
         )
       },
-      rejections: receipts.materializationRejections.map {
-        ChatFirstMaterializePromptsRequest.Rejection(
-          intentID: $0.intentID,
-          code: $0.code,
-          message: $0.message.map(ChatFirstMaterializationWire.rejectionMessage)
-        )
-      },
-      deferrals: receipts.materializationDeferrals.map {
-        ChatFirstMaterializePromptsRequest.Deferral(intentID: $0.intentID, code: $0.code)
-      }
+      rejections: receipts.materializationRejections.isEmpty
+        ? nil
+        : receipts.materializationRejections.map {
+          ChatFirstMaterializePromptsRequest.Rejection(
+            intentID: $0.intentID,
+            code: $0.code,
+            message: $0.message.map(ChatFirstMaterializationWire.rejectionMessage)
+          )
+        },
+      deferrals: receipts.materializationDeferrals.isEmpty
+        ? nil
+        : receipts.materializationDeferrals.map {
+          ChatFirstMaterializePromptsRequest.Deferral(intentID: $0.intentID, code: $0.code)
+        }
     )
     do {
       return try await post(

--- a/desktop/macos/Desktop/Sources/Chat/ChatFirstPromptMaterializationDriver.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatFirstPromptMaterializationDriver.swift
@@ -24,6 +24,22 @@ struct ChatFirstMaterializationRejection: Codable, Equatable, Sendable {
   }
 }
 
+struct ChatFirstMaterializationDeferral: Codable, Equatable, Sendable {
+  let intentID: String
+  let code: String
+
+  enum CodingKeys: String, CodingKey {
+    case intentID = "intent_id"
+    case code
+  }
+}
+
+enum ChatFirstMaterializationWire {
+  static func rejectionMessage(_ message: String) -> String {
+    String(message.prefix(300))
+  }
+}
+
 /// A terminal receipt is derived only from the local main-Chat journal after
 /// the fixed sparse script completes or the user explicitly abandons it. It
 /// is carried beside materialization receipts through the existing server
@@ -49,15 +65,18 @@ struct ChatFirstPromptReceiptBatch: Equatable, Sendable {
   let materializationReceipts: [ChatFirstMaterializationReceipt]
   let coldStartSequenceTerminalReceipts: [ChatFirstColdStartSequenceTerminalReceipt]
   let materializationRejections: [ChatFirstMaterializationRejection]
+  let materializationDeferrals: [ChatFirstMaterializationDeferral]
 
   init(
     materializationReceipts: [ChatFirstMaterializationReceipt],
     coldStartSequenceTerminalReceipts: [ChatFirstColdStartSequenceTerminalReceipt],
-    materializationRejections: [ChatFirstMaterializationRejection] = []
+    materializationRejections: [ChatFirstMaterializationRejection] = [],
+    materializationDeferrals: [ChatFirstMaterializationDeferral] = []
   ) {
     self.materializationReceipts = materializationReceipts
     self.coldStartSequenceTerminalReceipts = coldStartSequenceTerminalReceipts
     self.materializationRejections = materializationRejections
+    self.materializationDeferrals = materializationDeferrals
   }
 
   static let empty = Self(materializationReceipts: [], coldStartSequenceTerminalReceipts: [])
@@ -65,6 +84,7 @@ struct ChatFirstPromptReceiptBatch: Equatable, Sendable {
   var isEmpty: Bool {
     materializationReceipts.isEmpty && coldStartSequenceTerminalReceipts.isEmpty
       && materializationRejections.isEmpty
+      && materializationDeferrals.isEmpty
   }
 }
 
@@ -164,6 +184,7 @@ enum ChatFirstPromptMaterializationRunner {
 final class APIChatFirstPromptMaterializationDriver: ChatFirstPromptMaterializationDriving {
   private weak var chatProvider: ChatProvider?
   private var pendingRejections: [ChatFirstMaterializationRejection] = []
+  private var pendingDeferrals: [ChatFirstMaterializationDeferral] = []
 
   init(chatProvider: ChatProvider) {
     self.chatProvider = chatProvider
@@ -179,7 +200,8 @@ final class APIChatFirstPromptMaterializationDriver: ChatFirstPromptMaterializat
     return ChatFirstPromptReceiptBatch(
       materializationReceipts: receipts.materializationReceipts,
       coldStartSequenceTerminalReceipts: receipts.coldStartSequenceTerminalReceipts,
-      materializationRejections: pendingRejections
+      materializationRejections: pendingRejections,
+      materializationDeferrals: pendingDeferrals
     )
   }
 
@@ -200,12 +222,17 @@ final class APIChatFirstPromptMaterializationDriver: ChatFirstPromptMaterializat
   func acknowledge(_ receipts: ChatFirstPromptReceiptBatch) async throws {
     guard let chatProvider else { return }
     _ = try await chatProvider.acknowledgeChatFirstMaterializationReceipts(receipts)
-    pendingRejections.removeAll()
+    let sentRejections = Set(receipts.materializationRejections.map(\.intentID))
+    let sentDeferrals = Set(receipts.materializationDeferrals.map(\.intentID))
+    pendingRejections.removeAll { sentRejections.contains($0.intentID) }
+    pendingDeferrals.removeAll { sentDeferrals.contains($0.intentID) }
   }
 
   func materialize(_ intents: [ChatFirstPromptIntent]) async throws {
     guard let chatProvider else { return }
-    pendingRejections = try await chatProvider.materializeChatFirstIntents(intents)?.rejections ?? []
+    let result = try await chatProvider.materializeChatFirstIntents(intents)
+    pendingRejections.append(contentsOf: result?.rejections ?? [])
+    pendingDeferrals.append(contentsOf: result?.deferrals ?? [])
   }
 }
 
@@ -243,6 +270,15 @@ private struct ChatFirstMaterializePromptsRequest: Encodable {
     }
   }
 
+  struct Deferral: Encodable {
+    let intentID: String
+    let code: String
+    enum CodingKeys: String, CodingKey {
+      case intentID = "intent_id"
+      case code
+    }
+  }
+
   let sourceSurface: String = "main_chat"
   let controlGeneration: Int
   let ownerFence: String
@@ -251,6 +287,7 @@ private struct ChatFirstMaterializePromptsRequest: Encodable {
   let receipts: [Receipt]
   let coldStartSequenceTerminalReceipts: [ColdStartSequenceTerminalReceipt]
   let rejections: [Rejection]
+  let deferrals: [Deferral]
 
   enum CodingKeys: String, CodingKey {
     case sourceSurface = "source_surface"
@@ -261,6 +298,7 @@ private struct ChatFirstMaterializePromptsRequest: Encodable {
     case receipts
     case coldStartSequenceTerminalReceipts = "cold_start_sequence_terminal_receipts"
     case rejections
+    case deferrals
   }
 }
 
@@ -275,7 +313,7 @@ extension APIClient {
       controlGeneration >= 0,
       receipts.materializationReceipts.count <= 16,
       receipts.coldStartSequenceTerminalReceipts.count <= 16,
-      receipts.materializationRejections.count <= 16
+      receipts.materializationRejections.count <= 16, receipts.materializationDeferrals.count <= 16
     else {
       throw APIError.invalidResponse
     }
@@ -294,7 +332,14 @@ extension APIClient {
         )
       },
       rejections: receipts.materializationRejections.map {
-        ChatFirstMaterializePromptsRequest.Rejection(intentID: $0.intentID, code: $0.code, message: $0.message)
+        ChatFirstMaterializePromptsRequest.Rejection(
+          intentID: $0.intentID,
+          code: $0.code,
+          message: $0.message.map(ChatFirstMaterializationWire.rejectionMessage)
+        )
+      },
+      deferrals: receipts.materializationDeferrals.map {
+        ChatFirstMaterializePromptsRequest.Deferral(intentID: $0.intentID, code: $0.code)
       }
     )
     do {

--- a/desktop/macos/Desktop/Sources/Chat/ChatFirstPromptMaterializationDriver.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatFirstPromptMaterializationDriver.swift
@@ -38,6 +38,54 @@ enum ChatFirstMaterializationWire {
   static func rejectionMessage(_ message: String) -> String {
     String(message.prefix(300))
   }
+
+  static func encodedRequest(
+    ownerID: String,
+    controlGeneration: Int,
+    windowForeground: Bool,
+    receipts: ChatFirstPromptReceiptBatch
+  ) throws -> Data {
+    try JSONEncoder().encode(
+      request(
+        ownerID: ownerID,
+        controlGeneration: controlGeneration,
+        windowForeground: windowForeground,
+        receipts: receipts))
+  }
+
+  fileprivate static func request(
+    ownerID: String,
+    controlGeneration: Int,
+    windowForeground: Bool,
+    receipts: ChatFirstPromptReceiptBatch
+  ) -> ChatFirstMaterializePromptsRequest {
+    ChatFirstMaterializePromptsRequest(
+      controlGeneration: controlGeneration,
+      ownerFence: ownerID,
+      windowForeground: windowForeground,
+      receipts: receipts.materializationReceipts.map {
+        ChatFirstMaterializePromptsRequest.Receipt(intentID: $0.intentID, receiptID: $0.receiptID)
+      },
+      coldStartSequenceTerminalReceipts: receipts.coldStartSequenceTerminalReceipts.map {
+        ChatFirstMaterializePromptsRequest.ColdStartSequenceTerminalReceipt(
+          sequenceID: $0.sequenceID,
+          receiptID: $0.receiptID,
+          terminalState: $0.terminalState)
+      },
+      rejections: receipts.materializationRejections.isEmpty
+        ? nil
+        : receipts.materializationRejections.map {
+          ChatFirstMaterializePromptsRequest.Rejection(
+            intentID: $0.intentID,
+            code: $0.code,
+            message: $0.message.map(rejectionMessage))
+        },
+      deferrals: receipts.materializationDeferrals.isEmpty
+        ? nil
+        : receipts.materializationDeferrals.map {
+          ChatFirstMaterializePromptsRequest.Deferral(intentID: $0.intentID, code: $0.code)
+        })
+  }
 }
 
 /// A terminal receipt is derived only from the local main-Chat journal after
@@ -159,24 +207,31 @@ enum ChatFirstPromptMaterializationRunner {
     driver: any ChatFirstPromptMaterializationDriving,
     context: ChatFirstMaterializationContext,
     windowForeground: Bool,
-    isCurrent: @escaping @MainActor () -> Bool
+    isCurrent: @escaping @MainActor () -> Bool,
+    onFailure: (@MainActor (Error, ChatFirstPromptReceiptBatch) -> Void)? = nil
   ) async throws {
-    guard isCurrent() else { return }
-    let pendingReceipts = try await driver.pendingReceipts()
-    guard isCurrent() else { return }
-    let response = try await driver.fetchPrompts(
-      ownerID: context.ownerID,
-      controlGeneration: context.controlGeneration,
-      windowForeground: windowForeground,
-      receipts: pendingReceipts
-    )
-    guard isCurrent() else { return }
-    if !pendingReceipts.isEmpty {
-      try await driver.acknowledge(pendingReceipts)
+    var pendingReceipts = ChatFirstPromptReceiptBatch.empty
+    do {
       guard isCurrent() else { return }
+      pendingReceipts = try await driver.pendingReceipts()
+      guard isCurrent() else { return }
+      let response = try await driver.fetchPrompts(
+        ownerID: context.ownerID,
+        controlGeneration: context.controlGeneration,
+        windowForeground: windowForeground,
+        receipts: pendingReceipts
+      )
+      guard isCurrent() else { return }
+      if !pendingReceipts.isEmpty {
+        try await driver.acknowledge(pendingReceipts)
+        guard isCurrent() else { return }
+      }
+      guard response.intents.allSatisfy({ $0.accountGeneration == context.controlGeneration }) else { return }
+      try await driver.materialize(response.intents)
+    } catch {
+      onFailure?(error, pendingReceipts)
+      throw error
     }
-    guard response.intents.allSatisfy({ $0.accountGeneration == context.controlGeneration }) else { return }
-    try await driver.materialize(response.intents)
   }
 }
 
@@ -236,7 +291,7 @@ final class APIChatFirstPromptMaterializationDriver: ChatFirstPromptMaterializat
   }
 }
 
-struct ChatFirstMaterializePromptsRequest: Encodable {
+private struct ChatFirstMaterializePromptsRequest: Encodable {
   struct Receipt: Encodable {
     let intentID: String
     let receiptID: String
@@ -317,34 +372,11 @@ extension APIClient {
     else {
       throw APIError.invalidResponse
     }
-    let body = ChatFirstMaterializePromptsRequest(
+    let body = ChatFirstMaterializationWire.request(
+      ownerID: ownerID,
       controlGeneration: controlGeneration,
-      ownerFence: ownerID,
       windowForeground: windowForeground,
-      receipts: receipts.materializationReceipts.map {
-        ChatFirstMaterializePromptsRequest.Receipt(intentID: $0.intentID, receiptID: $0.receiptID)
-      },
-      coldStartSequenceTerminalReceipts: receipts.coldStartSequenceTerminalReceipts.map {
-        ChatFirstMaterializePromptsRequest.ColdStartSequenceTerminalReceipt(
-          sequenceID: $0.sequenceID,
-          receiptID: $0.receiptID,
-          terminalState: $0.terminalState
-        )
-      },
-      rejections: receipts.materializationRejections.isEmpty
-        ? nil
-        : receipts.materializationRejections.map {
-          ChatFirstMaterializePromptsRequest.Rejection(
-            intentID: $0.intentID,
-            code: $0.code,
-            message: $0.message.map(ChatFirstMaterializationWire.rejectionMessage)
-          )
-        },
-      deferrals: receipts.materializationDeferrals.isEmpty
-        ? nil
-        : receipts.materializationDeferrals.map {
-          ChatFirstMaterializePromptsRequest.Deferral(intentID: $0.intentID, code: $0.code)
-        }
+      receipts: receipts
     )
     do {
       return try await post(

--- a/desktop/macos/Desktop/Sources/Chat/ChatFirstPromptMaterializationDriver.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatFirstPromptMaterializationDriver.swift
@@ -13,6 +13,17 @@ struct ChatFirstMaterializationReceipt: Codable, Equatable, Sendable {
   }
 }
 
+struct ChatFirstMaterializationRejection: Codable, Equatable, Sendable {
+  let intentID: String
+  let code: String
+  let message: String?
+
+  enum CodingKeys: String, CodingKey {
+    case intentID = "intent_id"
+    case code, message
+  }
+}
+
 /// A terminal receipt is derived only from the local main-Chat journal after
 /// the fixed sparse script completes or the user explicitly abandons it. It
 /// is carried beside materialization receipts through the existing server
@@ -37,11 +48,23 @@ struct ChatFirstColdStartSequenceTerminalReceipt: Codable, Equatable, Sendable {
 struct ChatFirstPromptReceiptBatch: Equatable, Sendable {
   let materializationReceipts: [ChatFirstMaterializationReceipt]
   let coldStartSequenceTerminalReceipts: [ChatFirstColdStartSequenceTerminalReceipt]
+  let materializationRejections: [ChatFirstMaterializationRejection]
+
+  init(
+    materializationReceipts: [ChatFirstMaterializationReceipt],
+    coldStartSequenceTerminalReceipts: [ChatFirstColdStartSequenceTerminalReceipt],
+    materializationRejections: [ChatFirstMaterializationRejection] = []
+  ) {
+    self.materializationReceipts = materializationReceipts
+    self.coldStartSequenceTerminalReceipts = coldStartSequenceTerminalReceipts
+    self.materializationRejections = materializationRejections
+  }
 
   static let empty = Self(materializationReceipts: [], coldStartSequenceTerminalReceipts: [])
 
   var isEmpty: Bool {
     materializationReceipts.isEmpty && coldStartSequenceTerminalReceipts.isEmpty
+      && materializationRejections.isEmpty
   }
 }
 
@@ -140,6 +163,7 @@ enum ChatFirstPromptMaterializationRunner {
 @MainActor
 final class APIChatFirstPromptMaterializationDriver: ChatFirstPromptMaterializationDriving {
   private weak var chatProvider: ChatProvider?
+  private var pendingRejections: [ChatFirstMaterializationRejection] = []
 
   init(chatProvider: ChatProvider) {
     self.chatProvider = chatProvider
@@ -151,7 +175,12 @@ final class APIChatFirstPromptMaterializationDriver: ChatFirstPromptMaterializat
 
   func pendingReceipts() async throws -> ChatFirstPromptReceiptBatch {
     guard let chatProvider else { return .empty }
-    return try await chatProvider.pendingChatFirstMaterializationReceipts()
+    let receipts = try await chatProvider.pendingChatFirstMaterializationReceipts()
+    return ChatFirstPromptReceiptBatch(
+      materializationReceipts: receipts.materializationReceipts,
+      coldStartSequenceTerminalReceipts: receipts.coldStartSequenceTerminalReceipts,
+      materializationRejections: pendingRejections
+    )
   }
 
   func fetchPrompts(
@@ -171,11 +200,12 @@ final class APIChatFirstPromptMaterializationDriver: ChatFirstPromptMaterializat
   func acknowledge(_ receipts: ChatFirstPromptReceiptBatch) async throws {
     guard let chatProvider else { return }
     _ = try await chatProvider.acknowledgeChatFirstMaterializationReceipts(receipts)
+    pendingRejections.removeAll()
   }
 
   func materialize(_ intents: [ChatFirstPromptIntent]) async throws {
     guard let chatProvider else { return }
-    _ = try await chatProvider.materializeChatFirstIntents(intents)
+    pendingRejections = try await chatProvider.materializeChatFirstIntents(intents)?.rejections ?? []
   }
 }
 
@@ -202,6 +232,17 @@ private struct ChatFirstMaterializePromptsRequest: Encodable {
     }
   }
 
+  struct Rejection: Encodable {
+    let intentID: String
+    let code: String
+    let message: String?
+
+    enum CodingKeys: String, CodingKey {
+      case intentID = "intent_id"
+      case code, message
+    }
+  }
+
   let sourceSurface: String = "main_chat"
   let controlGeneration: Int
   let ownerFence: String
@@ -209,6 +250,7 @@ private struct ChatFirstMaterializePromptsRequest: Encodable {
   let initialPageLoaded: Bool = true
   let receipts: [Receipt]
   let coldStartSequenceTerminalReceipts: [ColdStartSequenceTerminalReceipt]
+  let rejections: [Rejection]
 
   enum CodingKeys: String, CodingKey {
     case sourceSurface = "source_surface"
@@ -218,6 +260,7 @@ private struct ChatFirstMaterializePromptsRequest: Encodable {
     case initialPageLoaded = "initial_page_loaded"
     case receipts
     case coldStartSequenceTerminalReceipts = "cold_start_sequence_terminal_receipts"
+    case rejections
   }
 }
 
@@ -231,7 +274,8 @@ extension APIClient {
     guard !ownerID.isEmpty,
       controlGeneration >= 0,
       receipts.materializationReceipts.count <= 16,
-      receipts.coldStartSequenceTerminalReceipts.count <= 16
+      receipts.coldStartSequenceTerminalReceipts.count <= 16,
+      receipts.materializationRejections.count <= 16
     else {
       throw APIError.invalidResponse
     }
@@ -248,6 +292,9 @@ extension APIClient {
           receiptID: $0.receiptID,
           terminalState: $0.terminalState
         )
+      },
+      rejections: receipts.materializationRejections.map {
+        ChatFirstMaterializePromptsRequest.Rejection(intentID: $0.intentID, code: $0.code, message: $0.message)
       }
     )
     do {

--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstPromptMaterializationCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstPromptMaterializationCoordinator.swift
@@ -169,8 +169,14 @@ final class ChatFirstPromptMaterializationCoordinator: ObservableObject {
           self?.isCurrentMaterialization(generation) ?? false
         },
         onFailure: { [weak self] error, batch in
+          let failure: String
+          if case APIError.httpError(let statusCode, _) = error {
+            failure = "status=\(statusCode)"
+          } else {
+            failure = "error_type=\(String(describing: type(of: error)))"
+          }
           self?.logger(
-            "Chat-first prompt materialization deferred: error=\(error.localizedDescription) "
+            "Chat-first prompt materialization deferred: \(failure) "
               + "receipts=\(batch.materializationReceipts.count) "
               + "rejections=\(batch.materializationRejections.count) "
               + "deferrals=\(batch.materializationDeferrals.count)")

--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstPromptMaterializationCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstPromptMaterializationCoordinator.swift
@@ -32,9 +32,11 @@ final class ChatFirstPromptMaterializationCoordinator: ObservableObject {
   private var pendingCompletionWindowForeground = false
   private var requestGeneration = 0
   private let now: () -> Date
+  private let logger: (String) -> Void
 
-  init(now: @escaping () -> Date = Date.init) {
+  init(now: @escaping () -> Date = Date.init, logger: @escaping (String) -> Void = log) {
     self.now = now
+    self.logger = logger
   }
 
   func activate(using chatProvider: ChatProvider) {
@@ -165,12 +167,18 @@ final class ChatFirstPromptMaterializationCoordinator: ObservableObject {
         windowForeground: windowForeground,
         isCurrent: { [weak self] in
           self?.isCurrentMaterialization(generation) ?? false
+        },
+        onFailure: { [weak self] error, batch in
+          self?.logger(
+            "Chat-first prompt materialization deferred: error=\(error.localizedDescription) "
+              + "receipts=\(batch.materializationReceipts.count) "
+              + "rejections=\(batch.materializationRejections.count) "
+              + "deferrals=\(batch.materializationDeferrals.count)")
         }
       )
     } catch {
       // Failure is intentionally quiet and retryable on the next debounced
       // foreground/open. Do not create a notification, badge, or Chat row.
-      log("Chat-first prompt materialization deferred")
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstPromptMaterializationCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstPromptMaterializationCoordinator.swift
@@ -172,6 +172,10 @@ final class ChatFirstPromptMaterializationCoordinator: ObservableObject {
           let failure: String
           if case APIError.httpError(let statusCode, _) = error {
             failure = "status=\(statusCode)"
+          } else if let urlError = error as? URLError {
+            failure =
+              "error_type=\(String(describing: type(of: error))) "
+              + "url_error_code=\(urlError.code.rawValue)"
           } else {
             failure = "error_type=\(String(describing: type(of: error)))"
           }

--- a/desktop/macos/Desktop/Tests/ChatFirstPromptMaterializationCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatFirstPromptMaterializationCoordinatorTests.swift
@@ -17,6 +17,19 @@ final class ChatFirstPromptMaterializationCoordinatorTests: XCTestCase {
     )
   }
 
+  func testKernelTailDeferralsDecodeSeparatelyFromPermanentRejections() {
+    XCTAssertEqual(
+      AgentRuntimeProcess.chatFirstDeferrals(
+        from: [["intentId": "intent-deferred", "code": "tail_question"]]
+      ),
+      [ChatFirstMaterializationDeferral(intentID: "intent-deferred", code: "tail_question")]
+    )
+  }
+
+  func testRejectionMessageIsTruncatedToTheWireLimit() {
+    XCTAssertEqual(ChatFirstMaterializationWire.rejectionMessage(String(repeating: "x", count: 500)).count, 300)
+  }
+
   func testMaterializationFallsBackOnlyWhenV2RouteIsMissing() {
     XCTAssertTrue(
       ChatFirstMaterializationEndpointPolicy.shouldFallbackToV1(

--- a/desktop/macos/Desktop/Tests/ChatFirstPromptMaterializationCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatFirstPromptMaterializationCoordinatorTests.swift
@@ -4,20 +4,36 @@ import XCTest
 
 final class ChatFirstPromptMaterializationCoordinatorTests: XCTestCase {
   func testEmptyMaterializationBatchOmitsNewOutcomeKeysForOldBackends() throws {
-    let request = ChatFirstMaterializePromptsRequest(
+    let data = try ChatFirstMaterializationWire.encodedRequest(
+      ownerID: "owner",
       controlGeneration: 7,
-      ownerFence: "owner",
       windowForeground: true,
-      receipts: [],
-      coldStartSequenceTerminalReceipts: [],
-      rejections: nil,
-      deferrals: nil
-    )
-
-    let object = try XCTUnwrap(JSONSerialization.jsonObject(with: JSONEncoder().encode(request)) as? [String: Any])
+      receipts: .empty)
+    let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
     XCTAssertNil(object["rejections"])
     XCTAssertNil(object["deferrals"])
+  }
+
+  func testNonEmptyMaterializationBatchIncludesBothOutcomeKeys() throws {
+    let batch = ChatFirstPromptReceiptBatch(
+      materializationReceipts: [],
+      coldStartSequenceTerminalReceipts: [],
+      materializationRejections: [
+        ChatFirstMaterializationRejection(intentID: "rejected", code: "invalid_intent", message: nil)
+      ],
+      materializationDeferrals: [
+        ChatFirstMaterializationDeferral(intentID: "deferred", code: "tail_question")
+      ])
+    let data = try ChatFirstMaterializationWire.encodedRequest(
+      ownerID: "owner",
+      controlGeneration: 7,
+      windowForeground: true,
+      receipts: batch)
+    let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+    XCTAssertEqual((object["rejections"] as? [[String: Any]])?.count, 1)
+    XCTAssertEqual((object["deferrals"] as? [[String: Any]])?.count, 1)
   }
 
   func testKernelMaterializationRejectionsDecodeWithTypedIdentityAndReason() {
@@ -292,6 +308,33 @@ final class ChatFirstPromptMaterializationCoordinatorTests: XCTestCase {
       .preserveReadingPosition
     )
   }
+
+  @MainActor
+  func testHTTP422FailureLogIncludesStatusAndBatchSizes() async {
+    let batch = ChatFirstPromptReceiptBatch(
+      materializationReceipts: [ChatFirstMaterializationReceipt(intentID: "receipt", receiptID: "r1")],
+      coldStartSequenceTerminalReceipts: [],
+      materializationRejections: [
+        ChatFirstMaterializationRejection(intentID: "rejected", code: "invalid_intent", message: nil)
+      ],
+      materializationDeferrals: [
+        ChatFirstMaterializationDeferral(intentID: "deferred", code: "tail_question")
+      ])
+    let driver = FakePromptMaterializationDriver(
+      context: ChatFirstMaterializationContext(ownerID: "owner", controlGeneration: 3),
+      pendingReceipts: batch,
+      response: ChatFirstMaterializePromptsResponse(intents: []))
+    driver.fetchError = APIError.httpError(statusCode: 422)
+    var messages: [String] = []
+    let coordinator = ChatFirstPromptMaterializationCoordinator(logger: { messages.append($0) })
+    coordinator.activate(driver: driver)
+
+    coordinator.chatTranscriptFirstPageDidLoad()
+    for _ in 0..<40 where messages.isEmpty { await Task.yield() }
+
+    XCTAssertTrue(messages.first?.contains("422") == true)
+    XCTAssertTrue(messages.first?.contains("receipts=1 rejections=1 deferrals=1") == true)
+  }
 }
 
 @MainActor
@@ -300,6 +343,7 @@ private final class FakePromptMaterializationDriver: ChatFirstPromptMaterializat
   private var storedPendingReceipts: ChatFirstPromptReceiptBatch
   private let response: ChatFirstMaterializePromptsResponse
   var acknowledgementError: Error?
+  var fetchError: Error?
   var suspendNextFetch = false
   private(set) var isFetchSuspended = false
   private var fetchContinuation: CheckedContinuation<Void, Never>?
@@ -341,6 +385,7 @@ private final class FakePromptMaterializationDriver: ChatFirstPromptMaterializat
         fetchContinuation = $0
       }
     }
+    if let fetchError { throw fetchError }
     return response
   }
 

--- a/desktop/macos/Desktop/Tests/ChatFirstPromptMaterializationCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatFirstPromptMaterializationCoordinatorTests.swift
@@ -337,6 +337,24 @@ final class ChatFirstPromptMaterializationCoordinatorTests: XCTestCase {
     XCTAssertFalse(messages.first?.contains(serverDetail) == true)
     XCTAssertTrue(messages.first?.contains("receipts=1 rejections=1 deferrals=1") == true)
   }
+
+  @MainActor
+  func testURLErrorFailureLogIncludesTypeAndCode() async {
+    let driver = FakePromptMaterializationDriver(
+      context: ChatFirstMaterializationContext(ownerID: "owner", controlGeneration: 3),
+      pendingReceipts: .empty,
+      response: ChatFirstMaterializePromptsResponse(intents: []))
+    driver.fetchError = URLError(.timedOut)
+    var messages: [String] = []
+    let coordinator = ChatFirstPromptMaterializationCoordinator(logger: { messages.append($0) })
+    coordinator.activate(driver: driver)
+
+    coordinator.chatTranscriptFirstPageDidLoad()
+    for _ in 0..<40 where messages.isEmpty { await Task.yield() }
+
+    XCTAssertTrue(messages.first?.contains("error_type=") == true)
+    XCTAssertTrue(messages.first?.contains("url_error_code=\(URLError.Code.timedOut.rawValue)") == true)
+  }
 }
 
 @MainActor

--- a/desktop/macos/Desktop/Tests/ChatFirstPromptMaterializationCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatFirstPromptMaterializationCoordinatorTests.swift
@@ -324,7 +324,8 @@ final class ChatFirstPromptMaterializationCoordinatorTests: XCTestCase {
       context: ChatFirstMaterializationContext(ownerID: "owner", controlGeneration: 3),
       pendingReceipts: batch,
       response: ChatFirstMaterializePromptsResponse(intents: []))
-    driver.fetchError = APIError.httpError(statusCode: 422)
+    let serverDetail = "raw pydantic validation body must stay private"
+    driver.fetchError = APIError.httpError(statusCode: 422, detail: serverDetail)
     var messages: [String] = []
     let coordinator = ChatFirstPromptMaterializationCoordinator(logger: { messages.append($0) })
     coordinator.activate(driver: driver)
@@ -332,7 +333,8 @@ final class ChatFirstPromptMaterializationCoordinatorTests: XCTestCase {
     coordinator.chatTranscriptFirstPageDidLoad()
     for _ in 0..<40 where messages.isEmpty { await Task.yield() }
 
-    XCTAssertTrue(messages.first?.contains("422") == true)
+    XCTAssertTrue(messages.first?.contains("status=422") == true)
+    XCTAssertFalse(messages.first?.contains(serverDetail) == true)
     XCTAssertTrue(messages.first?.contains("receipts=1 rejections=1 deferrals=1") == true)
   }
 }

--- a/desktop/macos/Desktop/Tests/ChatFirstPromptMaterializationCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatFirstPromptMaterializationCoordinatorTests.swift
@@ -3,6 +3,23 @@ import XCTest
 @testable import Omi_Computer
 
 final class ChatFirstPromptMaterializationCoordinatorTests: XCTestCase {
+  func testEmptyMaterializationBatchOmitsNewOutcomeKeysForOldBackends() throws {
+    let request = ChatFirstMaterializePromptsRequest(
+      controlGeneration: 7,
+      ownerFence: "owner",
+      windowForeground: true,
+      receipts: [],
+      coldStartSequenceTerminalReceipts: [],
+      rejections: nil,
+      deferrals: nil
+    )
+
+    let object = try XCTUnwrap(JSONSerialization.jsonObject(with: JSONEncoder().encode(request)) as? [String: Any])
+
+    XCTAssertNil(object["rejections"])
+    XCTAssertNil(object["deferrals"])
+  }
+
   func testKernelMaterializationRejectionsDecodeWithTypedIdentityAndReason() {
     let decoded = AgentRuntimeProcess.chatFirstRejections(
       from: [

--- a/desktop/macos/Desktop/Tests/ChatFirstPromptMaterializationCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatFirstPromptMaterializationCoordinatorTests.swift
@@ -3,6 +3,20 @@ import XCTest
 @testable import Omi_Computer
 
 final class ChatFirstPromptMaterializationCoordinatorTests: XCTestCase {
+  func testKernelMaterializationRejectionsDecodeWithTypedIdentityAndReason() {
+    let decoded = AgentRuntimeProcess.chatFirstRejections(
+      from: [
+        ["intentId": "intent-poison", "code": "invalid_intent", "message": "Invalid block"],
+        ["intentId": "", "code": "invalid_intent", "message": "Dropped malformed row"],
+      ]
+    )
+
+    XCTAssertEqual(
+      decoded,
+      [ChatFirstMaterializationRejection(intentID: "intent-poison", code: "invalid_intent", message: "Invalid block")]
+    )
+  }
+
   func testMaterializationFallsBackOnlyWhenV2RouteIsMissing() {
     XCTAssertTrue(
       ChatFirstMaterializationEndpointPolicy.shouldFallbackToV1(

--- a/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
@@ -405,14 +405,16 @@ final class OnboardingFlowTests: XCTestCase {
       "the file-index onboarding Continue button must accept Return")
 
     let secondBrainSource = try desktopSourceFile("Onboarding/SecondBrain/SBOnboardingView.swift")
-    for title in ["Set up Omi →", "Continue"] {
+    for title in ["Set up Omi →", "Continue", "Open the doors"] {
       XCTAssertTrue(
         secondBrainSource.contains("SBInkButton(title: \"\(title)\", isDefaultAction: true)"),
         "the second-brain \(title) action must accept Return")
     }
+    // Promise, language, files, screen-demo (Open the doors / Continue, mutually exclusive),
+    // agents, context, referral: nine sites, never two visible at once.
     XCTAssertEqual(
       secondBrainSource.components(separatedBy: "isDefaultAction: true").count - 1,
-      8,
+      9,
       "every visible second-brain proceed action must register Return")
     XCTAssertTrue(
       secondBrainSource.contains("SBInkButton(title: \"Take me to Omi\", isDefaultAction: true)"),

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -3104,6 +3104,12 @@ async function main(): Promise<void> {
               code: candidate.rejectionCode ?? "kernel_materialization_failed",
               message: candidate.rejectionMessage ?? "Chat-first intent materialization failed",
             }] : []),
+            materializationDeferrals: result.stoppedByTail ? intents.flatMap((intent, index) => {
+              const candidate = result.results[index];
+              if (candidate?.accepted || candidate?.rejected) return [];
+              const streaming = result.results.some((item) => item.suppressedByStreamingTail);
+              return [{ intentId: intent.intentId, code: streaming ? "streaming_tail" : "tail_question" }];
+            }) : [],
           });
           if (committedTurns.length > 0) {
             for (const turn of committedTurns) for (const wake of journalTurnChangedWakes(store, ownerId, turn)) {

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -3099,6 +3099,11 @@ async function main(): Promise<void> {
             suppressedByStreamingTail: result.results.some((candidate) => candidate.suppressedByStreamingTail),
             materializationStoppedByTail: result.stoppedByTail,
             materializationReceipts: result.results.flatMap((candidate) => candidate.receipt ? [candidate.receipt] : []),
+            materializationRejections: result.results.flatMap((candidate, index) => candidate.rejected ? [{
+              intentId: intents[index]!.intentId,
+              code: candidate.rejectionCode ?? "kernel_materialization_failed",
+              message: candidate.rejectionMessage ?? "Chat-first intent materialization failed",
+            }] : []),
           });
           if (committedTurns.length > 0) {
             for (const turn of committedTurns) for (const wake of journalTurnChangedWakes(store, ownerId, turn)) {

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -140,6 +140,7 @@ import {
   applyBackendReconcilePage,
   beginBackendReconcilesForOwner,
   clearJournalConversation,
+  chatFirstMaterializationDeferrals,
   classifyBackendTurnResultDisposition,
   drainBackendConversationDeleteOutbox,
   drainBackendTurnOutbox,
@@ -3104,12 +3105,7 @@ async function main(): Promise<void> {
               code: candidate.rejectionCode ?? "kernel_materialization_failed",
               message: candidate.rejectionMessage ?? "Chat-first intent materialization failed",
             }] : []),
-            materializationDeferrals: result.stoppedByTail ? intents.flatMap((intent, index) => {
-              const candidate = result.results[index];
-              if (candidate?.accepted || candidate?.rejected) return [];
-              const streaming = result.results.some((item) => item.suppressedByStreamingTail);
-              return [{ intentId: intent.intentId, code: streaming ? "streaming_tail" : "tail_question" }];
-            }) : [],
+            materializationDeferrals: chatFirstMaterializationDeferrals(intents, result),
           });
           if (committedTurns.length > 0) {
             for (const turn of committedTurns) for (const wake of journalTurnChangedWakes(store, ownerId, turn)) {

--- a/desktop/macos/agent/src/protocol.ts
+++ b/desktop/macos/agent/src/protocol.ts
@@ -1129,6 +1129,7 @@ export interface JournalOperationResultMessage extends OutboundEnvelope {
   materializationStoppedByTail?: boolean;
   materializationReceipts?: Array<{ intentId: string; receiptId: string }>;
   materializationRejections?: Array<{ intentId: string; code: string; message: string }>;
+  materializationDeferrals?: Array<{ intentId: string; code: "tail_question" | "streaming_tail" }>;
   coldStartSequenceTerminalReceipts?: Array<{
     sequenceId: string;
     receiptId: string;

--- a/desktop/macos/agent/src/protocol.ts
+++ b/desktop/macos/agent/src/protocol.ts
@@ -1128,6 +1128,7 @@ export interface JournalOperationResultMessage extends OutboundEnvelope {
   suppressedByStreamingTail?: boolean;
   materializationStoppedByTail?: boolean;
   materializationReceipts?: Array<{ intentId: string; receiptId: string }>;
+  materializationRejections?: Array<{ intentId: string; code: string; message: string }>;
   coldStartSequenceTerminalReceipts?: Array<{
     sequenceId: string;
     receiptId: string;

--- a/desktop/macos/agent/src/runtime/conversation-journal.ts
+++ b/desktop/macos/agent/src/runtime/conversation-journal.ts
@@ -191,6 +191,9 @@ export interface MaterializeChatFirstIntentInput {
 export interface ChatFirstIntentMaterializationResult {
   accepted: boolean;
   duplicate: boolean;
+  rejected: boolean;
+  rejectionCode: string | null;
+  rejectionMessage: string | null;
   suppressedByTailQuestion: boolean;
   suppressedByStreamingTail: boolean;
   turn: ConversationTurn | null;
@@ -198,9 +201,8 @@ export interface ChatFirstIntentMaterializationResult {
 }
 
 /**
- * One ordered server batch becomes one kernel transaction. The server owns
- * creation order; the kernel owns whether the current transcript tail admits
- * the next intent and records the only visible rows.
+ * The server owns creation order; the kernel gives each item its own fault
+ * domain while preserving tail suppression across the ordered batch.
  */
 export interface ChatFirstIntentsMaterializationResult {
   results: ChatFirstIntentMaterializationResult[];
@@ -1090,9 +1092,41 @@ function materializeChatFirstIntentInTransaction(
     return {
       accepted: true,
       duplicate: true,
+      rejected: false,
+      rejectionCode: null,
+      rejectionMessage: null,
       suppressedByTailQuestion: false,
       suppressedByStreamingTail: false,
       turn: requireJournalTurn(store, input.conversationId, turnId),
+      receipt: { intentId, receiptId },
+    };
+  }
+
+  // Chat-first identity is the stable turn ID, not the importing client's
+  // origin or producer. A second device may already have committed this turn
+  // and the backend reconciler may have imported it before its receipt landed.
+  // Adopt that canonical row without weakening ordinary producer/payload
+  // collision checks in recordJournalTurn.
+  const existingTurn = findJournalTurnById(store, turnId);
+  if (existingTurn) {
+    if (existingTurn.conversationId !== input.conversationId) {
+      throw new Error("Chat-first stable turn ID belongs to a different conversation");
+    }
+    store.execute(
+      `INSERT INTO chat_first_materialization_receipts(
+         intent_id, owner_id, conversation_id, control_generation, receipt_id, turn_id, created_at_ms
+       ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [intentId, input.ownerId, input.conversationId, input.controlGeneration, receiptId, turnId, now],
+    );
+    return {
+      accepted: true,
+      duplicate: true,
+      rejected: false,
+      rejectionCode: null,
+      rejectionMessage: null,
+      suppressedByTailQuestion: false,
+      suppressedByStreamingTail: false,
+      turn: existingTurn,
       receipt: { intentId, receiptId },
     };
   }
@@ -1102,6 +1136,9 @@ function materializeChatFirstIntentInTransaction(
     return {
       accepted: false,
       duplicate: false,
+      rejected: false,
+      rejectionCode: null,
+      rejectionMessage: null,
       suppressedByTailQuestion: tail.unansweredQuestion,
       suppressedByStreamingTail: tail.streaming,
       turn: null,
@@ -1138,6 +1175,9 @@ function materializeChatFirstIntentInTransaction(
   return {
     accepted: true,
     duplicate: recorded.duplicate,
+    rejected: false,
+    rejectionCode: null,
+    rejectionMessage: null,
     suppressedByTailQuestion: false,
     suppressedByStreamingTail: false,
     turn: recorded.turn,
@@ -1159,23 +1199,41 @@ export function materializeChatFirstIntents(
   if (inputs.length < 1 || inputs.length > 8) {
     throw new Error("Chat-first materialization batch requires one to eight intents");
   }
-  return store.withTransaction(() => {
-    const results: ChatFirstIntentMaterializationResult[] = [];
-    for (const input of inputs) {
-      const result = materializeChatFirstIntentInTransaction(store, input);
-      results.push(result);
-      // Do not submit an additional intent after a current tail suppresses the
-      // batch, or after this intent itself becomes the new unanswered tail.
-      if (
-        result.suppressedByTailQuestion
-        || result.suppressedByStreamingTail
-        || materializationTailState(store, input.conversationId).unansweredQuestion
-      ) {
-        return { results, stoppedByTail: true };
-      }
+  const results: ChatFirstIntentMaterializationResult[] = [];
+  for (const input of inputs) {
+    let result: ChatFirstIntentMaterializationResult;
+    try {
+      result = store.withTransaction(() => materializeChatFirstIntentInTransaction(store, input));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown chat-first materialization failure";
+      const identityConflict = /reused|different conversation/i.test(message);
+      const invalidIntent = /invalid|requires|unsupported/i.test(message);
+      result = {
+        accepted: false,
+        duplicate: false,
+        rejected: true,
+        rejectionCode: identityConflict
+          ? "identity_conflict"
+          : invalidIntent ? "invalid_intent" : "kernel_materialization_failed",
+        rejectionMessage: message,
+        suppressedByTailQuestion: false,
+        suppressedByStreamingTail: false,
+        turn: null,
+        receipt: null,
+      };
     }
-    return { results, stoppedByTail: false };
-  });
+    results.push(result);
+    // Rejections are parked independently and never stop later items. A real
+    // transcript tail remains an intentional batch deferral.
+    if (
+      result.suppressedByTailQuestion
+      || result.suppressedByStreamingTail
+      || (result.accepted && materializationTailState(store, input.conversationId).unansweredQuestion)
+    ) {
+      return { results, stoppedByTail: true };
+    }
+  }
+  return { results, stoppedByTail: false };
 }
 
 /** Receipts remain pending locally until Swift receives a successful server acknowledgement. */

--- a/desktop/macos/agent/src/runtime/conversation-journal.ts
+++ b/desktop/macos/agent/src/runtime/conversation-journal.ts
@@ -209,6 +209,17 @@ export interface ChatFirstIntentsMaterializationResult {
   stoppedByTail: boolean;
 }
 
+class ChatFirstMaterializationError extends Error {
+  constructor(readonly code: "invalid_intent" | "identity_conflict" | "kernel_materialization_failed", message: string) {
+    super(message);
+    this.name = "ChatFirstMaterializationError";
+  }
+}
+
+export function chatFirstWireRejectionMessage(error: unknown): string {
+  return (error instanceof Error ? error.message : "Unknown chat-first materialization failure").slice(0, 300);
+}
+
 export interface RepairOrphanedJournalTurnsInput {
   ownerId: string;
   turnIds: readonly string[];
@@ -1057,7 +1068,10 @@ function materializeChatFirstIntentInTransaction(
   const intentId = nonEmpty(input.intentId, "chat-first intent ID");
   const continuityKey = nonEmpty(input.continuityKey, "chat-first intent continuity key");
   if (!Number.isSafeInteger(input.controlGeneration) || input.controlGeneration < 0) {
-    throw new Error("Chat-first materialization requires a valid control generation");
+    throw new ChatFirstMaterializationError(
+      "kernel_materialization_failed",
+      "Chat-first materialization requires a valid control generation",
+    );
   }
   if (![
     "daily_opener",
@@ -1069,7 +1083,15 @@ function materializeChatFirstIntentInTransaction(
   ].includes(input.source)) {
     throw new Error("Chat-first materialization source is invalid");
   }
-  const blocks = chatFirstIntentBlocks(intentId, input.controlGeneration, input.source, input.blocks);
+  let blocks: ConversationContentBlock[];
+  try {
+    blocks = chatFirstIntentBlocks(intentId, input.controlGeneration, input.source, input.blocks);
+  } catch (error) {
+    throw new ChatFirstMaterializationError(
+      "invalid_intent",
+      error instanceof Error ? error.message : "Chat-first intent is invalid",
+    );
+  }
   const turnId = stableChatFirstIntentTurnID(intentId);
   const receiptId = stableChatFirstMaterializationReceiptID(intentId, continuityKey);
 
@@ -1087,7 +1109,9 @@ function materializeChatFirstIntentInTransaction(
       || String(existingReceipt.receipt_id) !== receiptId
       || String(existingReceipt.turn_id) !== turnId
     ) {
-      throw new Error("Chat-first intent ID was reused with different receipt identity");
+      throw new ChatFirstMaterializationError(
+        "identity_conflict", "Chat-first intent ID was reused with different receipt identity",
+      );
     }
     return {
       accepted: true,
@@ -1110,7 +1134,9 @@ function materializeChatFirstIntentInTransaction(
   const existingTurn = findJournalTurnById(store, turnId);
   if (existingTurn) {
     if (existingTurn.conversationId !== input.conversationId) {
-      throw new Error("Chat-first stable turn ID belongs to a different conversation");
+      throw new ChatFirstMaterializationError(
+        "identity_conflict", "Chat-first stable turn ID belongs to a different conversation",
+      );
     }
     store.execute(
       `INSERT INTO chat_first_materialization_receipts(
@@ -1205,16 +1231,14 @@ export function materializeChatFirstIntents(
     try {
       result = store.withTransaction(() => materializeChatFirstIntentInTransaction(store, input));
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Unknown chat-first materialization failure";
-      const identityConflict = /reused|different conversation/i.test(message);
-      const invalidIntent = /invalid|requires|unsupported/i.test(message);
+      const message = chatFirstWireRejectionMessage(error);
       result = {
         accepted: false,
         duplicate: false,
         rejected: true,
-        rejectionCode: identityConflict
-          ? "identity_conflict"
-          : invalidIntent ? "invalid_intent" : "kernel_materialization_failed",
+        rejectionCode: error instanceof ChatFirstMaterializationError
+          ? error.code
+          : "kernel_materialization_failed",
         rejectionMessage: message,
         suppressedByTailQuestion: false,
         suppressedByStreamingTail: false,

--- a/desktop/macos/agent/src/runtime/conversation-journal.ts
+++ b/desktop/macos/agent/src/runtime/conversation-journal.ts
@@ -209,6 +209,21 @@ export interface ChatFirstIntentsMaterializationResult {
   stoppedByTail: boolean;
 }
 
+export function chatFirstMaterializationDeferrals(
+  inputs: readonly Pick<MaterializeChatFirstIntentInput, "intentId">[],
+  result: ChatFirstIntentsMaterializationResult,
+): Array<{ intentId: string; code: "tail_question" | "streaming_tail" }> {
+  if (!result.stoppedByTail) return [];
+  return inputs.flatMap((input, index) => {
+    const candidate = result.results[index];
+    if (candidate?.accepted || candidate?.rejected) return [];
+    return [{
+      intentId: input.intentId,
+      code: candidate?.suppressedByStreamingTail ? "streaming_tail" : "tail_question",
+    }];
+  });
+}
+
 class ChatFirstMaterializationError extends Error {
   constructor(readonly code: "invalid_intent" | "identity_conflict" | "kernel_materialization_failed", message: string) {
     super(message);

--- a/desktop/macos/agent/tests/conversation-journal.test.ts
+++ b/desktop/macos/agent/tests/conversation-journal.test.ts
@@ -242,6 +242,71 @@ describe("kernel conversation journal", () => {
     fixture.store.close();
   });
 
+  it("poison item contract: one bad item never blocks the rest and returns a typed rejection", () => {
+    const fixture = newSurface("main_chat", "chat", "chat-first-poison-isolation");
+    const batch = materializeChatFirstIntents(fixture.store, [
+      {
+        ownerId: fixture.ownerId, conversationId: fixture.conversationId, controlGeneration: 9,
+        intentId: "intent-poison", continuityKey: "intent-poison", source: "capture_arrival",
+        blocks: [{ type: "notARealBlock" }], nowMs: 100,
+      },
+      {
+        ownerId: fixture.ownerId, conversationId: fixture.conversationId, controlGeneration: 9,
+        intentId: "intent-after-poison", continuityKey: "intent-after-poison", source: "capture_arrival",
+        blocks: [{ type: "captureLink", conversation_id: "capture-2", summary: "Capture" }], nowMs: 101,
+      },
+    ]);
+
+    expect(batch.stoppedByTail).toBe(false);
+    expect(batch.results[0]).toMatchObject({
+      accepted: false, rejected: true, rejectionCode: "invalid_intent", turn: null, receipt: null,
+    });
+    expect(batch.results[1]).toMatchObject({ accepted: true, rejected: false, turn: { role: "assistant" } });
+    expect(fixture.store.getRow("SELECT COUNT(*) AS count FROM conversation_turns").count).toBe(1);
+    expect(fixture.store.getRow("SELECT COUNT(*) AS count FROM chat_first_materialization_receipts").count).toBe(1);
+    fixture.store.close();
+  });
+
+  it("adopts an imported stable chat-first turn and records its receipt by identity", () => {
+    const fixture = newSurface("main_chat", "chat", "chat-first-import-adoption");
+    const intentId = "intent-imported-elsewhere";
+    const stableTurnId = `turn_cfi_${createHash("sha256").update(intentId).digest("hex").slice(0, 24)}`;
+    const imported = importRemoteJournalTurn(fixture.store, {
+      ownerId: fixture.ownerId,
+      conversationId: fixture.conversationId,
+      remoteId: "remote-imported-intent",
+      canonicalTurnId: stableTurnId,
+      role: "assistant",
+      surfaceKind: "main_chat",
+      content: "",
+      contentBlocks: [{ type: "captureLink", id: "remote-block", conversationId: "capture-1", summary: "Capture" }],
+      metadataJson: JSON.stringify({ chatFirstIntentId: intentId }),
+      createdAtMs: 90,
+      nowMs: 91,
+      source: "backend_reconcile",
+    });
+
+    const materialized = materializeChatFirstIntent(fixture.store, {
+      ownerId: fixture.ownerId,
+      conversationId: fixture.conversationId,
+      controlGeneration: 9,
+      intentId,
+      continuityKey: intentId,
+      source: "capture_arrival",
+      blocks: [{ type: "captureLink", conversation_id: "capture-1", summary: "Different local payload" }],
+      nowMs: 100,
+    });
+
+    expect(imported.turn).toMatchObject({ turnId: stableTurnId, origin: "backend_import" });
+    expect(materialized).toMatchObject({
+      accepted: true, duplicate: true, rejected: false,
+      turn: { turnId: stableTurnId, origin: "backend_import" },
+      receipt: { intentId },
+    });
+    expect(fixture.store.getRow("SELECT COUNT(*) AS count FROM conversation_turns").count).toBe(1);
+    fixture.store.close();
+  });
+
   it("suppresses a materialization batch behind a streaming assistant tail", () => {
     const fixture = newSurface("main_chat", "chat", "chat-first-streaming-tail");
     recordStreamingAssistantPlaceholder(fixture, "streaming-tail");
@@ -251,7 +316,7 @@ describe("kernel conversation journal", () => {
       blocks: [{ type: "captureLink", conversation_id: "capture-1", summary: "Capture" }], nowMs: 100,
     }]);
     expect(batch).toMatchObject({ stoppedByTail: true, results: [{
-      accepted: false, suppressedByStreamingTail: true, turn: null,
+      accepted: false, rejected: false, suppressedByStreamingTail: true, turn: null,
     }] });
     fixture.store.close();
   });

--- a/desktop/macos/agent/tests/conversation-journal.test.ts
+++ b/desktop/macos/agent/tests/conversation-journal.test.ts
@@ -14,6 +14,7 @@ import {
   beginBackendReconcile,
   beginBackendReconcilesForOwner,
   clearJournalConversation,
+  chatFirstMaterializationDeferrals,
   chatFirstWireRejectionMessage,
   classifyBackendTurnResultDisposition,
   drainBackendConversationDeleteOutbox,
@@ -350,6 +351,13 @@ describe("kernel conversation journal", () => {
     expect(batch).toMatchObject({ stoppedByTail: true, results: [{
       accepted: false, rejected: false, suppressedByStreamingTail: true, turn: null,
     }] });
+    expect(chatFirstMaterializationDeferrals(
+      [{ intentId: "intent-late" }, { intentId: "intent-after-streaming-item" }],
+      batch,
+    )).toEqual([
+      { intentId: "intent-late", code: "streaming_tail" },
+      { intentId: "intent-after-streaming-item", code: "tail_question" },
+    ]);
     fixture.store.close();
   });
 

--- a/desktop/macos/agent/tests/conversation-journal.test.ts
+++ b/desktop/macos/agent/tests/conversation-journal.test.ts
@@ -14,6 +14,7 @@ import {
   beginBackendReconcile,
   beginBackendReconcilesForOwner,
   clearJournalConversation,
+  chatFirstWireRejectionMessage,
   classifyBackendTurnResultDisposition,
   drainBackendConversationDeleteOutbox,
   drainBackendTurnOutbox,
@@ -264,6 +265,37 @@ describe("kernel conversation journal", () => {
     expect(batch.results[1]).toMatchObject({ accepted: true, rejected: false, turn: { role: "assistant" } });
     expect(fixture.store.getRow("SELECT COUNT(*) AS count FROM conversation_turns").count).toBe(1);
     expect(fixture.store.getRow("SELECT COUNT(*) AS count FROM chat_first_materialization_receipts").count).toBe(1);
+    fixture.store.close();
+  });
+
+  it("generation validation failures remain transient typed kernel rejections", () => {
+    const fixture = newSurface("main_chat", "chat", "chat-first-generation-transient");
+    const batch = materializeChatFirstIntents(fixture.store, [{
+      ownerId: fixture.ownerId, conversationId: fixture.conversationId, controlGeneration: -1,
+      intentId: "intent-stale-generation", continuityKey: "intent-stale-generation", source: "capture_arrival",
+      blocks: [{ type: "captureLink", conversation_id: "capture-1", summary: "Capture" }], nowMs: 100,
+    }]);
+
+    expect(batch.results[0]).toMatchObject({
+      rejected: true,
+      rejectionCode: "kernel_materialization_failed",
+      rejectionMessage: "Chat-first materialization requires a valid control generation",
+    });
+    fixture.store.close();
+  });
+
+  it("wire rejection messages are bounded before leaving the kernel", () => {
+    expect(chatFirstWireRejectionMessage(new Error("x".repeat(500)))).toHaveLength(300);
+  });
+
+  it("shares the stable chat-first turn identity vector with the backend", () => {
+    const fixture = newSurface("main_chat", "chat", "chat-first-shared-vector");
+    const result = materializeChatFirstIntent(fixture.store, {
+      ownerId: fixture.ownerId, conversationId: fixture.conversationId, controlGeneration: 7,
+      intentId: "intent-shared-vector", continuityKey: "shared-vector", source: "capture_arrival",
+      blocks: [{ type: "captureLink", conversation_id: "capture-1", summary: "Capture" }], nowMs: 100,
+    });
+    expect(result.turn?.turnId).toBe("turn_cfi_df211fb1b31c4b849c6bb6b2");
     fixture.store.close();
   });
 

--- a/desktop/macos/changelog/unreleased/20260901-chat-first-poison-isolation.json
+++ b/desktop/macos/changelog/unreleased/20260901-chat-first-poison-isolation.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed meeting notes and daily opener cards getting stuck behind an undeliverable Chat item"
+}

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -2664,6 +2664,7 @@ export interface MaterializableProactiveIntent {
 export interface MaterializePromptsRequest {
   cold_start_sequence_terminal_receipts?: Array<ColdStartSequenceTerminalReceipt>;
   control_generation: number;
+  deferrals?: Array<ProactiveMaterializationDeferral>;
   initial_page_loaded?: boolean;
   owner_fence: string;
   receipts?: Array<ProactiveMaterializationReceipt>;
@@ -2674,6 +2675,7 @@ export interface MaterializePromptsRequest {
 
 export interface MaterializePromptsResponse {
   intents?: Array<MaterializableProactiveIntent>;
+  receipt_outcomes?: Array<ProactiveMaterializationReceiptOutcome>;
 }
 
 export interface McpAddServerResponse {
@@ -3260,9 +3262,19 @@ export interface PrivateCloudSyncResponse {
   private_cloud_sync_enabled: boolean;
 }
 
+export interface ProactiveMaterializationDeferral {
+  code: "tail_question" | "streaming_tail";
+  intent_id: string;
+}
+
 export interface ProactiveMaterializationReceipt {
   intent_id: string;
   receipt_id: string;
+}
+
+export interface ProactiveMaterializationReceiptOutcome {
+  intent_id: string;
+  outcome: "acknowledged" | "already_terminal" | "missing" | "conflict" | "generation_mismatch";
 }
 
 export interface ProactiveMaterializationRejection {
@@ -5141,7 +5153,9 @@ export interface OmiApiSchemas {
   "PluginResult": PluginResult;
   "PricingOption": PricingOption;
   "PrivateCloudSyncResponse": PrivateCloudSyncResponse;
+  "ProactiveMaterializationDeferral": ProactiveMaterializationDeferral;
   "ProactiveMaterializationReceipt": ProactiveMaterializationReceipt;
+  "ProactiveMaterializationReceiptOutcome": ProactiveMaterializationReceiptOutcome;
   "ProactiveMaterializationRejection": ProactiveMaterializationRejection;
   "ProactiveNotification": ProactiveNotification;
   "ProcessConversationRequest": ProcessConversationRequest;

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -2588,9 +2588,15 @@ export interface LegacyProactiveIntent {
   cold_start_sequence_terminal_state?: "completed" | "abandoned" | null;
   continuity_key: string;
   created_at: string;
+  dead_letter_reason?: string | null;
   delivered_at?: string | null;
   delivery_state?: "ready" | "pending_kernel_receipt" | "delivered";
+  fetch_count?: number;
   intent_id: string;
+  last_fetched_at?: string | null;
+  last_rejection_at?: string | null;
+  last_rejection_code?: string | null;
+  materialization_attempts?: number;
   materialization_receipt_id?: string | null;
   source: "daily_opener" | "capture_arrival" | "deferral_reraise" | "agent_judgment" | "cold_start_rich" | "cold_start_sparse";
   subject?: ChatFirstSubject | null;
@@ -2634,18 +2640,40 @@ export interface LocationContextConsentUpdate {
   enabled: boolean;
 }
 
+export interface MaterializableProactiveIntent {
+  account_generation: number;
+  blocks: Array<QuestionCardSpec | TaskCardSpec | GoalLinkSpec | CaptureLinkSpec | ConversationLinkSpec | MemoryLinkSpec>;
+  cold_start_sequence_terminal_receipt_id?: string | null;
+  cold_start_sequence_terminal_state?: "completed" | "abandoned" | null;
+  continuity_key: string;
+  created_at: string;
+  dead_letter_reason?: string | null;
+  delivered_at?: string | null;
+  delivery_state?: "ready" | "pending_kernel_receipt" | "delivered";
+  fetch_count?: number;
+  intent_id: string;
+  last_fetched_at?: string | null;
+  last_rejection_at?: string | null;
+  last_rejection_code?: string | null;
+  materialization_attempts?: number;
+  materialization_receipt_id?: string | null;
+  source: "daily_opener" | "capture_arrival" | "deferral_reraise" | "agent_judgment" | "cold_start_rich" | "cold_start_sparse";
+  subject?: ChatFirstSubject | null;
+}
+
 export interface MaterializePromptsRequest {
   cold_start_sequence_terminal_receipts?: Array<ColdStartSequenceTerminalReceipt>;
   control_generation: number;
   initial_page_loaded?: boolean;
   owner_fence: string;
   receipts?: Array<ProactiveMaterializationReceipt>;
+  rejections?: Array<ProactiveMaterializationRejection>;
   source_surface: "main_chat";
   window_foreground?: boolean;
 }
 
 export interface MaterializePromptsResponse {
-  intents?: Array<ProactiveIntent>;
+  intents?: Array<MaterializableProactiveIntent>;
 }
 
 export interface McpAddServerResponse {
@@ -3232,24 +3260,15 @@ export interface PrivateCloudSyncResponse {
   private_cloud_sync_enabled: boolean;
 }
 
-export interface ProactiveIntent {
-  account_generation: number;
-  blocks: Array<QuestionCardSpec | TaskCardSpec | GoalLinkSpec | CaptureLinkSpec | ConversationLinkSpec | MemoryLinkSpec>;
-  cold_start_sequence_terminal_receipt_id?: string | null;
-  cold_start_sequence_terminal_state?: "completed" | "abandoned" | null;
-  continuity_key: string;
-  created_at: string;
-  delivered_at?: string | null;
-  delivery_state?: "ready" | "pending_kernel_receipt" | "delivered";
-  intent_id: string;
-  materialization_receipt_id?: string | null;
-  source: "daily_opener" | "capture_arrival" | "deferral_reraise" | "agent_judgment" | "cold_start_rich" | "cold_start_sparse";
-  subject?: ChatFirstSubject | null;
-}
-
 export interface ProactiveMaterializationReceipt {
   intent_id: string;
   receipt_id: string;
+}
+
+export interface ProactiveMaterializationRejection {
+  code: string;
+  intent_id: string;
+  message?: string | null;
 }
 
 export interface ProactiveNotification {
@@ -5034,6 +5053,7 @@ export interface OmiApiSchemas {
   "LlmUsageResponse": LlmUsageResponse;
   "LocationContextConsentResponse": LocationContextConsentResponse;
   "LocationContextConsentUpdate": LocationContextConsentUpdate;
+  "MaterializableProactiveIntent": MaterializableProactiveIntent;
   "MaterializePromptsRequest": MaterializePromptsRequest;
   "MaterializePromptsResponse": MaterializePromptsResponse;
   "McpAddServerResponse": McpAddServerResponse;
@@ -5121,8 +5141,8 @@ export interface OmiApiSchemas {
   "PluginResult": PluginResult;
   "PricingOption": PricingOption;
   "PrivateCloudSyncResponse": PrivateCloudSyncResponse;
-  "ProactiveIntent": ProactiveIntent;
   "ProactiveMaterializationReceipt": ProactiveMaterializationReceipt;
+  "ProactiveMaterializationRejection": ProactiveMaterializationRejection;
   "ProactiveNotification": ProactiveNotification;
   "ProcessConversationRequest": ProcessConversationRequest;
   "ProgressExtractRequest": ProgressExtractRequest;

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -2676,6 +2676,7 @@ export interface MaterializePromptsRequest {
 export interface MaterializePromptsResponse {
   intents?: Array<MaterializableProactiveIntent>;
   receipt_outcomes?: Array<ProactiveMaterializationReceiptOutcome>;
+  rejection_outcomes?: Array<ProactiveMaterializationRejectionOutcome>;
 }
 
 export interface McpAddServerResponse {
@@ -3281,6 +3282,11 @@ export interface ProactiveMaterializationRejection {
   code: string;
   intent_id: string;
   message?: string | null;
+}
+
+export interface ProactiveMaterializationRejectionOutcome {
+  intent_id: string;
+  outcome: "recorded" | "absorbed" | "generation_mismatch" | "malformed" | "missing";
 }
 
 export interface ProactiveNotification {
@@ -5157,6 +5163,7 @@ export interface OmiApiSchemas {
   "ProactiveMaterializationReceipt": ProactiveMaterializationReceipt;
   "ProactiveMaterializationReceiptOutcome": ProactiveMaterializationReceiptOutcome;
   "ProactiveMaterializationRejection": ProactiveMaterializationRejection;
+  "ProactiveMaterializationRejectionOutcome": ProactiveMaterializationRejectionOutcome;
   "ProactiveNotification": ProactiveNotification;
   "ProcessConversationRequest": ProcessConversationRequest;
   "ProgressExtractRequest": ProgressExtractRequest;

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -16755,6 +16755,13 @@
             },
             "title": "Receipt Outcomes",
             "type": "array"
+          },
+          "rejection_outcomes": {
+            "items": {
+              "$ref": "#/components/schemas/ProactiveMaterializationRejectionOutcome"
+            },
+            "title": "Rejection Outcomes",
+            "type": "array"
           }
         },
         "title": "MaterializePromptsResponse",
@@ -20268,6 +20275,35 @@
           "code"
         ],
         "title": "ProactiveMaterializationRejection",
+        "type": "object"
+      },
+      "ProactiveMaterializationRejectionOutcome": {
+        "additionalProperties": false,
+        "properties": {
+          "intent_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
+            "title": "Intent Id",
+            "type": "string"
+          },
+          "outcome": {
+            "enum": [
+              "recorded",
+              "absorbed",
+              "generation_mismatch",
+              "malformed",
+              "missing"
+            ],
+            "title": "Outcome",
+            "type": "string"
+          }
+        },
+        "required": [
+          "intent_id",
+          "outcome"
+        ],
+        "title": "ProactiveMaterializationRejectionOutcome",
         "type": "object"
       },
       "ProactiveNotification": {

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -16139,6 +16139,17 @@
             "title": "Created At",
             "type": "string"
           },
+          "dead_letter_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dead Letter Reason"
+          },
           "delivered_at": {
             "anyOf": [
               {
@@ -16161,12 +16172,59 @@
             "title": "Delivery State",
             "type": "string"
           },
+          "fetch_count": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Fetch Count",
+            "type": "integer"
+          },
           "intent_id": {
             "maxLength": 128,
             "minLength": 1,
             "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
             "title": "Intent Id",
             "type": "string"
+          },
+          "last_fetched_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Fetched At"
+          },
+          "last_rejection_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Rejection At"
+          },
+          "last_rejection_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Rejection Code"
+          },
+          "materialization_attempts": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Materialization Attempts",
+            "type": "integer"
           },
           "materialization_receipt_id": {
             "anyOf": [
@@ -16380,6 +16438,236 @@
         "title": "LocationContextConsentUpdate",
         "type": "object"
       },
+      "MaterializableProactiveIntent": {
+        "additionalProperties": false,
+        "description": "Wire-safe intent state; terminal dead letters never leave the store.",
+        "properties": {
+          "account_generation": {
+            "minimum": 0.0,
+            "title": "Account Generation",
+            "type": "integer"
+          },
+          "blocks": {
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "captureLink": "#/components/schemas/CaptureLinkSpec",
+                  "conversationLink": "#/components/schemas/ConversationLinkSpec",
+                  "goalLink": "#/components/schemas/GoalLinkSpec",
+                  "memoryLink": "#/components/schemas/MemoryLinkSpec",
+                  "questionCard": "#/components/schemas/QuestionCardSpec",
+                  "taskCard": "#/components/schemas/TaskCardSpec"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/QuestionCardSpec"
+                },
+                {
+                  "$ref": "#/components/schemas/TaskCardSpec"
+                },
+                {
+                  "$ref": "#/components/schemas/GoalLinkSpec"
+                },
+                {
+                  "$ref": "#/components/schemas/CaptureLinkSpec"
+                },
+                {
+                  "$ref": "#/components/schemas/ConversationLinkSpec"
+                },
+                {
+                  "$ref": "#/components/schemas/MemoryLinkSpec"
+                }
+              ]
+            },
+            "maxItems": 8,
+            "minItems": 1,
+            "title": "Blocks",
+            "type": "array"
+          },
+          "cold_start_sequence_terminal_receipt_id": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "minLength": 1,
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cold Start Sequence Terminal Receipt Id"
+          },
+          "cold_start_sequence_terminal_state": {
+            "anyOf": [
+              {
+                "enum": [
+                  "completed",
+                  "abandoned"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cold Start Sequence Terminal State"
+          },
+          "continuity_key": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
+            "title": "Continuity Key",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "dead_letter_reason": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "minLength": 1,
+                "pattern": "^[a-z0-9_:.-]+$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dead Letter Reason"
+          },
+          "delivered_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Delivered At"
+          },
+          "delivery_state": {
+            "default": "ready",
+            "enum": [
+              "ready",
+              "pending_kernel_receipt",
+              "delivered"
+            ],
+            "title": "Delivery State",
+            "type": "string"
+          },
+          "fetch_count": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Fetch Count",
+            "type": "integer"
+          },
+          "intent_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
+            "title": "Intent Id",
+            "type": "string"
+          },
+          "last_fetched_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Fetched At"
+          },
+          "last_rejection_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Rejection At"
+          },
+          "last_rejection_code": {
+            "anyOf": [
+              {
+                "maxLength": 64,
+                "minLength": 1,
+                "pattern": "^[a-z0-9_]+$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Rejection Code"
+          },
+          "materialization_attempts": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Materialization Attempts",
+            "type": "integer"
+          },
+          "materialization_receipt_id": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "minLength": 1,
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Materialization Receipt Id"
+          },
+          "source": {
+            "enum": [
+              "daily_opener",
+              "capture_arrival",
+              "deferral_reraise",
+              "agent_judgment",
+              "cold_start_rich",
+              "cold_start_sparse"
+            ],
+            "title": "Source",
+            "type": "string"
+          },
+          "subject": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ChatFirstSubject"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "intent_id",
+          "continuity_key",
+          "account_generation",
+          "source",
+          "blocks",
+          "created_at"
+        ],
+        "title": "MaterializableProactiveIntent",
+        "type": "object"
+      },
       "MaterializePromptsRequest": {
         "additionalProperties": false,
         "properties": {
@@ -16416,6 +16704,14 @@
             "title": "Receipts",
             "type": "array"
           },
+          "rejections": {
+            "items": {
+              "$ref": "#/components/schemas/ProactiveMaterializationRejection"
+            },
+            "maxItems": 16,
+            "title": "Rejections",
+            "type": "array"
+          },
           "source_surface": {
             "const": "main_chat",
             "title": "Source Surface",
@@ -16440,7 +16736,7 @@
         "properties": {
           "intents": {
             "items": {
-              "$ref": "#/components/schemas/ProactiveIntent"
+              "$ref": "#/components/schemas/MaterializableProactiveIntent"
             },
             "title": "Intents",
             "type": "array"
@@ -19839,172 +20135,6 @@
         "title": "PrivateCloudSyncResponse",
         "type": "object"
       },
-      "ProactiveIntent": {
-        "additionalProperties": false,
-        "description": "A server-side instruction, not a Chat transcript row.\n\nThe local desktop kernel is the sole writer of the visible assistant turn.\nThis record remains deliverable until that kernel has committed and\nacknowledged its stable ``intent_id``; cold-start intents make that\nexplicit as ``pending_kernel_receipt``.",
-        "properties": {
-          "account_generation": {
-            "minimum": 0.0,
-            "title": "Account Generation",
-            "type": "integer"
-          },
-          "blocks": {
-            "items": {
-              "discriminator": {
-                "mapping": {
-                  "captureLink": "#/components/schemas/CaptureLinkSpec",
-                  "conversationLink": "#/components/schemas/ConversationLinkSpec",
-                  "goalLink": "#/components/schemas/GoalLinkSpec",
-                  "memoryLink": "#/components/schemas/MemoryLinkSpec",
-                  "questionCard": "#/components/schemas/QuestionCardSpec",
-                  "taskCard": "#/components/schemas/TaskCardSpec"
-                },
-                "propertyName": "type"
-              },
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/QuestionCardSpec"
-                },
-                {
-                  "$ref": "#/components/schemas/TaskCardSpec"
-                },
-                {
-                  "$ref": "#/components/schemas/GoalLinkSpec"
-                },
-                {
-                  "$ref": "#/components/schemas/CaptureLinkSpec"
-                },
-                {
-                  "$ref": "#/components/schemas/ConversationLinkSpec"
-                },
-                {
-                  "$ref": "#/components/schemas/MemoryLinkSpec"
-                }
-              ]
-            },
-            "maxItems": 8,
-            "minItems": 1,
-            "title": "Blocks",
-            "type": "array"
-          },
-          "cold_start_sequence_terminal_receipt_id": {
-            "anyOf": [
-              {
-                "maxLength": 128,
-                "minLength": 1,
-                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cold Start Sequence Terminal Receipt Id"
-          },
-          "cold_start_sequence_terminal_state": {
-            "anyOf": [
-              {
-                "enum": [
-                  "completed",
-                  "abandoned"
-                ],
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cold Start Sequence Terminal State"
-          },
-          "continuity_key": {
-            "maxLength": 128,
-            "minLength": 1,
-            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
-            "title": "Continuity Key",
-            "type": "string"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "delivered_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Delivered At"
-          },
-          "delivery_state": {
-            "default": "ready",
-            "enum": [
-              "ready",
-              "pending_kernel_receipt",
-              "delivered"
-            ],
-            "title": "Delivery State",
-            "type": "string"
-          },
-          "intent_id": {
-            "maxLength": 128,
-            "minLength": 1,
-            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
-            "title": "Intent Id",
-            "type": "string"
-          },
-          "materialization_receipt_id": {
-            "anyOf": [
-              {
-                "maxLength": 128,
-                "minLength": 1,
-                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Materialization Receipt Id"
-          },
-          "source": {
-            "enum": [
-              "daily_opener",
-              "capture_arrival",
-              "deferral_reraise",
-              "agent_judgment",
-              "cold_start_rich",
-              "cold_start_sparse"
-            ],
-            "title": "Source",
-            "type": "string"
-          },
-          "subject": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ChatFirstSubject"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "required": [
-          "intent_id",
-          "continuity_key",
-          "account_generation",
-          "source",
-          "blocks",
-          "created_at"
-        ],
-        "title": "ProactiveIntent",
-        "type": "object"
-      },
       "ProactiveMaterializationReceipt": {
         "additionalProperties": false,
         "description": "Content-free receipt emitted only after the local journal commits.",
@@ -20029,6 +20159,44 @@
           "receipt_id"
         ],
         "title": "ProactiveMaterializationReceipt",
+        "type": "object"
+      },
+      "ProactiveMaterializationRejection": {
+        "additionalProperties": false,
+        "description": "Content-free typed rejection emitted by the local kernel.",
+        "properties": {
+          "code": {
+            "maxLength": 64,
+            "minLength": 1,
+            "pattern": "^[a-z0-9_]+$",
+            "title": "Code",
+            "type": "string"
+          },
+          "intent_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
+            "title": "Intent Id",
+            "type": "string"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "maxLength": 300,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message"
+          }
+        },
+        "required": [
+          "intent_id",
+          "code"
+        ],
+        "title": "ProactiveMaterializationRejection",
         "type": "object"
       },
       "ProactiveNotification": {

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -16684,6 +16684,14 @@
             "title": "Control Generation",
             "type": "integer"
           },
+          "deferrals": {
+            "items": {
+              "$ref": "#/components/schemas/ProactiveMaterializationDeferral"
+            },
+            "maxItems": 16,
+            "title": "Deferrals",
+            "type": "array"
+          },
           "initial_page_loaded": {
             "default": false,
             "title": "Initial Page Loaded",
@@ -16739,6 +16747,13 @@
               "$ref": "#/components/schemas/MaterializableProactiveIntent"
             },
             "title": "Intents",
+            "type": "array"
+          },
+          "receipt_outcomes": {
+            "items": {
+              "$ref": "#/components/schemas/ProactiveMaterializationReceiptOutcome"
+            },
+            "title": "Receipt Outcomes",
             "type": "array"
           }
         },
@@ -20135,6 +20150,33 @@
         "title": "PrivateCloudSyncResponse",
         "type": "object"
       },
+      "ProactiveMaterializationDeferral": {
+        "additionalProperties": false,
+        "description": "A fetched intent the kernel intentionally left behind a transcript tail.",
+        "properties": {
+          "code": {
+            "enum": [
+              "tail_question",
+              "streaming_tail"
+            ],
+            "title": "Code",
+            "type": "string"
+          },
+          "intent_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
+            "title": "Intent Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "intent_id",
+          "code"
+        ],
+        "title": "ProactiveMaterializationDeferral",
+        "type": "object"
+      },
       "ProactiveMaterializationReceipt": {
         "additionalProperties": false,
         "description": "Content-free receipt emitted only after the local journal commits.",
@@ -20159,6 +20201,35 @@
           "receipt_id"
         ],
         "title": "ProactiveMaterializationReceipt",
+        "type": "object"
+      },
+      "ProactiveMaterializationReceiptOutcome": {
+        "additionalProperties": false,
+        "properties": {
+          "intent_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
+            "title": "Intent Id",
+            "type": "string"
+          },
+          "outcome": {
+            "enum": [
+              "acknowledged",
+              "already_terminal",
+              "missing",
+              "conflict",
+              "generation_mismatch"
+            ],
+            "title": "Outcome",
+            "type": "string"
+          }
+        },
+        "required": [
+          "intent_id",
+          "outcome"
+        ],
+        "title": "ProactiveMaterializationReceiptOutcome",
         "type": "object"
       },
       "ProactiveMaterializationRejection": {

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1415,7 +1415,7 @@
       ]
     },
     {
-      "collectionGroup": "chat_first_proactive_intents",
+      "collectionGroup": "chat_first_dead_letters",
       "queryScope": "COLLECTION",
       "fields": [
         {

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1415,6 +1415,32 @@
       ]
     },
     {
+      "collectionGroup": "chat_first_proactive_intents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "account_generation",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "requeue_count",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dead_letter_reason",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "last_fetched_at",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "chat_sessions",
       "queryScope": "COLLECTION",
       "fields": [

--- a/scripts/test_failure_class.py
+++ b/scripts/test_failure_class.py
@@ -26,7 +26,16 @@ SEED_IDS = {path.stem for path in SEED_DIRECTORY.glob("*.json")}
 # pre-commit or pre-push hook, GIT_DIR and core.hooksPath point at the real
 # checkout, so an unisolated `git init`/`git config`/`git add .` in a temp
 # directory writes to the repository under test.
-GIT_ISOLATION = ["-c", "core.hooksPath=/dev/null", "-c", "commit.gpgsign=false"]
+GIT_ISOLATION = [
+    "-c",
+    "core.hooksPath=/dev/null",
+    "-c",
+    "commit.gpgsign=false",
+    "-c",
+    "maintenance.auto=false",
+    "-c",
+    "gc.auto=0",
+]
 
 
 def run(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -2664,6 +2664,7 @@ export interface MaterializableProactiveIntent {
 export interface MaterializePromptsRequest {
   cold_start_sequence_terminal_receipts?: Array<ColdStartSequenceTerminalReceipt>;
   control_generation: number;
+  deferrals?: Array<ProactiveMaterializationDeferral>;
   initial_page_loaded?: boolean;
   owner_fence: string;
   receipts?: Array<ProactiveMaterializationReceipt>;
@@ -2674,6 +2675,7 @@ export interface MaterializePromptsRequest {
 
 export interface MaterializePromptsResponse {
   intents?: Array<MaterializableProactiveIntent>;
+  receipt_outcomes?: Array<ProactiveMaterializationReceiptOutcome>;
 }
 
 export interface McpAddServerResponse {
@@ -3260,9 +3262,19 @@ export interface PrivateCloudSyncResponse {
   private_cloud_sync_enabled: boolean;
 }
 
+export interface ProactiveMaterializationDeferral {
+  code: "tail_question" | "streaming_tail";
+  intent_id: string;
+}
+
 export interface ProactiveMaterializationReceipt {
   intent_id: string;
   receipt_id: string;
+}
+
+export interface ProactiveMaterializationReceiptOutcome {
+  intent_id: string;
+  outcome: "acknowledged" | "already_terminal" | "missing" | "conflict" | "generation_mismatch";
 }
 
 export interface ProactiveMaterializationRejection {
@@ -5141,7 +5153,9 @@ export interface OmiApiSchemas {
   "PluginResult": PluginResult;
   "PricingOption": PricingOption;
   "PrivateCloudSyncResponse": PrivateCloudSyncResponse;
+  "ProactiveMaterializationDeferral": ProactiveMaterializationDeferral;
   "ProactiveMaterializationReceipt": ProactiveMaterializationReceipt;
+  "ProactiveMaterializationReceiptOutcome": ProactiveMaterializationReceiptOutcome;
   "ProactiveMaterializationRejection": ProactiveMaterializationRejection;
   "ProactiveNotification": ProactiveNotification;
   "ProcessConversationRequest": ProcessConversationRequest;

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -2588,9 +2588,15 @@ export interface LegacyProactiveIntent {
   cold_start_sequence_terminal_state?: "completed" | "abandoned" | null;
   continuity_key: string;
   created_at: string;
+  dead_letter_reason?: string | null;
   delivered_at?: string | null;
   delivery_state?: "ready" | "pending_kernel_receipt" | "delivered";
+  fetch_count?: number;
   intent_id: string;
+  last_fetched_at?: string | null;
+  last_rejection_at?: string | null;
+  last_rejection_code?: string | null;
+  materialization_attempts?: number;
   materialization_receipt_id?: string | null;
   source: "daily_opener" | "capture_arrival" | "deferral_reraise" | "agent_judgment" | "cold_start_rich" | "cold_start_sparse";
   subject?: ChatFirstSubject | null;
@@ -2634,18 +2640,40 @@ export interface LocationContextConsentUpdate {
   enabled: boolean;
 }
 
+export interface MaterializableProactiveIntent {
+  account_generation: number;
+  blocks: Array<QuestionCardSpec | TaskCardSpec | GoalLinkSpec | CaptureLinkSpec | ConversationLinkSpec | MemoryLinkSpec>;
+  cold_start_sequence_terminal_receipt_id?: string | null;
+  cold_start_sequence_terminal_state?: "completed" | "abandoned" | null;
+  continuity_key: string;
+  created_at: string;
+  dead_letter_reason?: string | null;
+  delivered_at?: string | null;
+  delivery_state?: "ready" | "pending_kernel_receipt" | "delivered";
+  fetch_count?: number;
+  intent_id: string;
+  last_fetched_at?: string | null;
+  last_rejection_at?: string | null;
+  last_rejection_code?: string | null;
+  materialization_attempts?: number;
+  materialization_receipt_id?: string | null;
+  source: "daily_opener" | "capture_arrival" | "deferral_reraise" | "agent_judgment" | "cold_start_rich" | "cold_start_sparse";
+  subject?: ChatFirstSubject | null;
+}
+
 export interface MaterializePromptsRequest {
   cold_start_sequence_terminal_receipts?: Array<ColdStartSequenceTerminalReceipt>;
   control_generation: number;
   initial_page_loaded?: boolean;
   owner_fence: string;
   receipts?: Array<ProactiveMaterializationReceipt>;
+  rejections?: Array<ProactiveMaterializationRejection>;
   source_surface: "main_chat";
   window_foreground?: boolean;
 }
 
 export interface MaterializePromptsResponse {
-  intents?: Array<ProactiveIntent>;
+  intents?: Array<MaterializableProactiveIntent>;
 }
 
 export interface McpAddServerResponse {
@@ -3232,24 +3260,15 @@ export interface PrivateCloudSyncResponse {
   private_cloud_sync_enabled: boolean;
 }
 
-export interface ProactiveIntent {
-  account_generation: number;
-  blocks: Array<QuestionCardSpec | TaskCardSpec | GoalLinkSpec | CaptureLinkSpec | ConversationLinkSpec | MemoryLinkSpec>;
-  cold_start_sequence_terminal_receipt_id?: string | null;
-  cold_start_sequence_terminal_state?: "completed" | "abandoned" | null;
-  continuity_key: string;
-  created_at: string;
-  delivered_at?: string | null;
-  delivery_state?: "ready" | "pending_kernel_receipt" | "delivered";
-  intent_id: string;
-  materialization_receipt_id?: string | null;
-  source: "daily_opener" | "capture_arrival" | "deferral_reraise" | "agent_judgment" | "cold_start_rich" | "cold_start_sparse";
-  subject?: ChatFirstSubject | null;
-}
-
 export interface ProactiveMaterializationReceipt {
   intent_id: string;
   receipt_id: string;
+}
+
+export interface ProactiveMaterializationRejection {
+  code: string;
+  intent_id: string;
+  message?: string | null;
 }
 
 export interface ProactiveNotification {
@@ -5034,6 +5053,7 @@ export interface OmiApiSchemas {
   "LlmUsageResponse": LlmUsageResponse;
   "LocationContextConsentResponse": LocationContextConsentResponse;
   "LocationContextConsentUpdate": LocationContextConsentUpdate;
+  "MaterializableProactiveIntent": MaterializableProactiveIntent;
   "MaterializePromptsRequest": MaterializePromptsRequest;
   "MaterializePromptsResponse": MaterializePromptsResponse;
   "McpAddServerResponse": McpAddServerResponse;
@@ -5121,8 +5141,8 @@ export interface OmiApiSchemas {
   "PluginResult": PluginResult;
   "PricingOption": PricingOption;
   "PrivateCloudSyncResponse": PrivateCloudSyncResponse;
-  "ProactiveIntent": ProactiveIntent;
   "ProactiveMaterializationReceipt": ProactiveMaterializationReceipt;
+  "ProactiveMaterializationRejection": ProactiveMaterializationRejection;
   "ProactiveNotification": ProactiveNotification;
   "ProcessConversationRequest": ProcessConversationRequest;
   "ProgressExtractRequest": ProgressExtractRequest;

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -2676,6 +2676,7 @@ export interface MaterializePromptsRequest {
 export interface MaterializePromptsResponse {
   intents?: Array<MaterializableProactiveIntent>;
   receipt_outcomes?: Array<ProactiveMaterializationReceiptOutcome>;
+  rejection_outcomes?: Array<ProactiveMaterializationRejectionOutcome>;
 }
 
 export interface McpAddServerResponse {
@@ -3281,6 +3282,11 @@ export interface ProactiveMaterializationRejection {
   code: string;
   intent_id: string;
   message?: string | null;
+}
+
+export interface ProactiveMaterializationRejectionOutcome {
+  intent_id: string;
+  outcome: "recorded" | "absorbed" | "generation_mismatch" | "malformed" | "missing";
 }
 
 export interface ProactiveNotification {
@@ -5157,6 +5163,7 @@ export interface OmiApiSchemas {
   "ProactiveMaterializationReceipt": ProactiveMaterializationReceipt;
   "ProactiveMaterializationReceiptOutcome": ProactiveMaterializationReceiptOutcome;
   "ProactiveMaterializationRejection": ProactiveMaterializationRejection;
+  "ProactiveMaterializationRejectionOutcome": ProactiveMaterializationRejectionOutcome;
   "ProactiveNotification": ProactiveNotification;
   "ProcessConversationRequest": ProcessConversationRequest;
   "ProgressExtractRequest": ProgressExtractRequest;

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -2664,6 +2664,7 @@ export interface MaterializableProactiveIntent {
 export interface MaterializePromptsRequest {
   cold_start_sequence_terminal_receipts?: Array<ColdStartSequenceTerminalReceipt>;
   control_generation: number;
+  deferrals?: Array<ProactiveMaterializationDeferral>;
   initial_page_loaded?: boolean;
   owner_fence: string;
   receipts?: Array<ProactiveMaterializationReceipt>;
@@ -2674,6 +2675,7 @@ export interface MaterializePromptsRequest {
 
 export interface MaterializePromptsResponse {
   intents?: Array<MaterializableProactiveIntent>;
+  receipt_outcomes?: Array<ProactiveMaterializationReceiptOutcome>;
 }
 
 export interface McpAddServerResponse {
@@ -3260,9 +3262,19 @@ export interface PrivateCloudSyncResponse {
   private_cloud_sync_enabled: boolean;
 }
 
+export interface ProactiveMaterializationDeferral {
+  code: "tail_question" | "streaming_tail";
+  intent_id: string;
+}
+
 export interface ProactiveMaterializationReceipt {
   intent_id: string;
   receipt_id: string;
+}
+
+export interface ProactiveMaterializationReceiptOutcome {
+  intent_id: string;
+  outcome: "acknowledged" | "already_terminal" | "missing" | "conflict" | "generation_mismatch";
 }
 
 export interface ProactiveMaterializationRejection {
@@ -5141,7 +5153,9 @@ export interface OmiApiSchemas {
   "PluginResult": PluginResult;
   "PricingOption": PricingOption;
   "PrivateCloudSyncResponse": PrivateCloudSyncResponse;
+  "ProactiveMaterializationDeferral": ProactiveMaterializationDeferral;
   "ProactiveMaterializationReceipt": ProactiveMaterializationReceipt;
+  "ProactiveMaterializationReceiptOutcome": ProactiveMaterializationReceiptOutcome;
   "ProactiveMaterializationRejection": ProactiveMaterializationRejection;
   "ProactiveNotification": ProactiveNotification;
   "ProcessConversationRequest": ProcessConversationRequest;

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -2588,9 +2588,15 @@ export interface LegacyProactiveIntent {
   cold_start_sequence_terminal_state?: "completed" | "abandoned" | null;
   continuity_key: string;
   created_at: string;
+  dead_letter_reason?: string | null;
   delivered_at?: string | null;
   delivery_state?: "ready" | "pending_kernel_receipt" | "delivered";
+  fetch_count?: number;
   intent_id: string;
+  last_fetched_at?: string | null;
+  last_rejection_at?: string | null;
+  last_rejection_code?: string | null;
+  materialization_attempts?: number;
   materialization_receipt_id?: string | null;
   source: "daily_opener" | "capture_arrival" | "deferral_reraise" | "agent_judgment" | "cold_start_rich" | "cold_start_sparse";
   subject?: ChatFirstSubject | null;
@@ -2634,18 +2640,40 @@ export interface LocationContextConsentUpdate {
   enabled: boolean;
 }
 
+export interface MaterializableProactiveIntent {
+  account_generation: number;
+  blocks: Array<QuestionCardSpec | TaskCardSpec | GoalLinkSpec | CaptureLinkSpec | ConversationLinkSpec | MemoryLinkSpec>;
+  cold_start_sequence_terminal_receipt_id?: string | null;
+  cold_start_sequence_terminal_state?: "completed" | "abandoned" | null;
+  continuity_key: string;
+  created_at: string;
+  dead_letter_reason?: string | null;
+  delivered_at?: string | null;
+  delivery_state?: "ready" | "pending_kernel_receipt" | "delivered";
+  fetch_count?: number;
+  intent_id: string;
+  last_fetched_at?: string | null;
+  last_rejection_at?: string | null;
+  last_rejection_code?: string | null;
+  materialization_attempts?: number;
+  materialization_receipt_id?: string | null;
+  source: "daily_opener" | "capture_arrival" | "deferral_reraise" | "agent_judgment" | "cold_start_rich" | "cold_start_sparse";
+  subject?: ChatFirstSubject | null;
+}
+
 export interface MaterializePromptsRequest {
   cold_start_sequence_terminal_receipts?: Array<ColdStartSequenceTerminalReceipt>;
   control_generation: number;
   initial_page_loaded?: boolean;
   owner_fence: string;
   receipts?: Array<ProactiveMaterializationReceipt>;
+  rejections?: Array<ProactiveMaterializationRejection>;
   source_surface: "main_chat";
   window_foreground?: boolean;
 }
 
 export interface MaterializePromptsResponse {
-  intents?: Array<ProactiveIntent>;
+  intents?: Array<MaterializableProactiveIntent>;
 }
 
 export interface McpAddServerResponse {
@@ -3232,24 +3260,15 @@ export interface PrivateCloudSyncResponse {
   private_cloud_sync_enabled: boolean;
 }
 
-export interface ProactiveIntent {
-  account_generation: number;
-  blocks: Array<QuestionCardSpec | TaskCardSpec | GoalLinkSpec | CaptureLinkSpec | ConversationLinkSpec | MemoryLinkSpec>;
-  cold_start_sequence_terminal_receipt_id?: string | null;
-  cold_start_sequence_terminal_state?: "completed" | "abandoned" | null;
-  continuity_key: string;
-  created_at: string;
-  delivered_at?: string | null;
-  delivery_state?: "ready" | "pending_kernel_receipt" | "delivered";
-  intent_id: string;
-  materialization_receipt_id?: string | null;
-  source: "daily_opener" | "capture_arrival" | "deferral_reraise" | "agent_judgment" | "cold_start_rich" | "cold_start_sparse";
-  subject?: ChatFirstSubject | null;
-}
-
 export interface ProactiveMaterializationReceipt {
   intent_id: string;
   receipt_id: string;
+}
+
+export interface ProactiveMaterializationRejection {
+  code: string;
+  intent_id: string;
+  message?: string | null;
 }
 
 export interface ProactiveNotification {
@@ -5034,6 +5053,7 @@ export interface OmiApiSchemas {
   "LlmUsageResponse": LlmUsageResponse;
   "LocationContextConsentResponse": LocationContextConsentResponse;
   "LocationContextConsentUpdate": LocationContextConsentUpdate;
+  "MaterializableProactiveIntent": MaterializableProactiveIntent;
   "MaterializePromptsRequest": MaterializePromptsRequest;
   "MaterializePromptsResponse": MaterializePromptsResponse;
   "McpAddServerResponse": McpAddServerResponse;
@@ -5121,8 +5141,8 @@ export interface OmiApiSchemas {
   "PluginResult": PluginResult;
   "PricingOption": PricingOption;
   "PrivateCloudSyncResponse": PrivateCloudSyncResponse;
-  "ProactiveIntent": ProactiveIntent;
   "ProactiveMaterializationReceipt": ProactiveMaterializationReceipt;
+  "ProactiveMaterializationRejection": ProactiveMaterializationRejection;
   "ProactiveNotification": ProactiveNotification;
   "ProcessConversationRequest": ProcessConversationRequest;
   "ProgressExtractRequest": ProgressExtractRequest;

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -2676,6 +2676,7 @@ export interface MaterializePromptsRequest {
 export interface MaterializePromptsResponse {
   intents?: Array<MaterializableProactiveIntent>;
   receipt_outcomes?: Array<ProactiveMaterializationReceiptOutcome>;
+  rejection_outcomes?: Array<ProactiveMaterializationRejectionOutcome>;
 }
 
 export interface McpAddServerResponse {
@@ -3281,6 +3282,11 @@ export interface ProactiveMaterializationRejection {
   code: string;
   intent_id: string;
   message?: string | null;
+}
+
+export interface ProactiveMaterializationRejectionOutcome {
+  intent_id: string;
+  outcome: "recorded" | "absorbed" | "generation_mismatch" | "malformed" | "missing";
 }
 
 export interface ProactiveNotification {
@@ -5157,6 +5163,7 @@ export interface OmiApiSchemas {
   "ProactiveMaterializationReceipt": ProactiveMaterializationReceipt;
   "ProactiveMaterializationReceiptOutcome": ProactiveMaterializationReceiptOutcome;
   "ProactiveMaterializationRejection": ProactiveMaterializationRejection;
+  "ProactiveMaterializationRejectionOutcome": ProactiveMaterializationRejectionOutcome;
   "ProactiveNotification": ProactiveNotification;
   "ProcessConversationRequest": ProcessConversationRequest;
   "ProgressExtractRequest": ProgressExtractRequest;

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -2664,6 +2664,7 @@ export interface MaterializableProactiveIntent {
 export interface MaterializePromptsRequest {
   cold_start_sequence_terminal_receipts?: Array<ColdStartSequenceTerminalReceipt>;
   control_generation: number;
+  deferrals?: Array<ProactiveMaterializationDeferral>;
   initial_page_loaded?: boolean;
   owner_fence: string;
   receipts?: Array<ProactiveMaterializationReceipt>;
@@ -2674,6 +2675,7 @@ export interface MaterializePromptsRequest {
 
 export interface MaterializePromptsResponse {
   intents?: Array<MaterializableProactiveIntent>;
+  receipt_outcomes?: Array<ProactiveMaterializationReceiptOutcome>;
 }
 
 export interface McpAddServerResponse {
@@ -3260,9 +3262,19 @@ export interface PrivateCloudSyncResponse {
   private_cloud_sync_enabled: boolean;
 }
 
+export interface ProactiveMaterializationDeferral {
+  code: "tail_question" | "streaming_tail";
+  intent_id: string;
+}
+
 export interface ProactiveMaterializationReceipt {
   intent_id: string;
   receipt_id: string;
+}
+
+export interface ProactiveMaterializationReceiptOutcome {
+  intent_id: string;
+  outcome: "acknowledged" | "already_terminal" | "missing" | "conflict" | "generation_mismatch";
 }
 
 export interface ProactiveMaterializationRejection {
@@ -5141,7 +5153,9 @@ export interface OmiApiSchemas {
   "PluginResult": PluginResult;
   "PricingOption": PricingOption;
   "PrivateCloudSyncResponse": PrivateCloudSyncResponse;
+  "ProactiveMaterializationDeferral": ProactiveMaterializationDeferral;
   "ProactiveMaterializationReceipt": ProactiveMaterializationReceipt;
+  "ProactiveMaterializationReceiptOutcome": ProactiveMaterializationReceiptOutcome;
   "ProactiveMaterializationRejection": ProactiveMaterializationRejection;
   "ProactiveNotification": ProactiveNotification;
   "ProcessConversationRequest": ProcessConversationRequest;

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -2588,9 +2588,15 @@ export interface LegacyProactiveIntent {
   cold_start_sequence_terminal_state?: "completed" | "abandoned" | null;
   continuity_key: string;
   created_at: string;
+  dead_letter_reason?: string | null;
   delivered_at?: string | null;
   delivery_state?: "ready" | "pending_kernel_receipt" | "delivered";
+  fetch_count?: number;
   intent_id: string;
+  last_fetched_at?: string | null;
+  last_rejection_at?: string | null;
+  last_rejection_code?: string | null;
+  materialization_attempts?: number;
   materialization_receipt_id?: string | null;
   source: "daily_opener" | "capture_arrival" | "deferral_reraise" | "agent_judgment" | "cold_start_rich" | "cold_start_sparse";
   subject?: ChatFirstSubject | null;
@@ -2634,18 +2640,40 @@ export interface LocationContextConsentUpdate {
   enabled: boolean;
 }
 
+export interface MaterializableProactiveIntent {
+  account_generation: number;
+  blocks: Array<QuestionCardSpec | TaskCardSpec | GoalLinkSpec | CaptureLinkSpec | ConversationLinkSpec | MemoryLinkSpec>;
+  cold_start_sequence_terminal_receipt_id?: string | null;
+  cold_start_sequence_terminal_state?: "completed" | "abandoned" | null;
+  continuity_key: string;
+  created_at: string;
+  dead_letter_reason?: string | null;
+  delivered_at?: string | null;
+  delivery_state?: "ready" | "pending_kernel_receipt" | "delivered";
+  fetch_count?: number;
+  intent_id: string;
+  last_fetched_at?: string | null;
+  last_rejection_at?: string | null;
+  last_rejection_code?: string | null;
+  materialization_attempts?: number;
+  materialization_receipt_id?: string | null;
+  source: "daily_opener" | "capture_arrival" | "deferral_reraise" | "agent_judgment" | "cold_start_rich" | "cold_start_sparse";
+  subject?: ChatFirstSubject | null;
+}
+
 export interface MaterializePromptsRequest {
   cold_start_sequence_terminal_receipts?: Array<ColdStartSequenceTerminalReceipt>;
   control_generation: number;
   initial_page_loaded?: boolean;
   owner_fence: string;
   receipts?: Array<ProactiveMaterializationReceipt>;
+  rejections?: Array<ProactiveMaterializationRejection>;
   source_surface: "main_chat";
   window_foreground?: boolean;
 }
 
 export interface MaterializePromptsResponse {
-  intents?: Array<ProactiveIntent>;
+  intents?: Array<MaterializableProactiveIntent>;
 }
 
 export interface McpAddServerResponse {
@@ -3232,24 +3260,15 @@ export interface PrivateCloudSyncResponse {
   private_cloud_sync_enabled: boolean;
 }
 
-export interface ProactiveIntent {
-  account_generation: number;
-  blocks: Array<QuestionCardSpec | TaskCardSpec | GoalLinkSpec | CaptureLinkSpec | ConversationLinkSpec | MemoryLinkSpec>;
-  cold_start_sequence_terminal_receipt_id?: string | null;
-  cold_start_sequence_terminal_state?: "completed" | "abandoned" | null;
-  continuity_key: string;
-  created_at: string;
-  delivered_at?: string | null;
-  delivery_state?: "ready" | "pending_kernel_receipt" | "delivered";
-  intent_id: string;
-  materialization_receipt_id?: string | null;
-  source: "daily_opener" | "capture_arrival" | "deferral_reraise" | "agent_judgment" | "cold_start_rich" | "cold_start_sparse";
-  subject?: ChatFirstSubject | null;
-}
-
 export interface ProactiveMaterializationReceipt {
   intent_id: string;
   receipt_id: string;
+}
+
+export interface ProactiveMaterializationRejection {
+  code: string;
+  intent_id: string;
+  message?: string | null;
 }
 
 export interface ProactiveNotification {
@@ -5034,6 +5053,7 @@ export interface OmiApiSchemas {
   "LlmUsageResponse": LlmUsageResponse;
   "LocationContextConsentResponse": LocationContextConsentResponse;
   "LocationContextConsentUpdate": LocationContextConsentUpdate;
+  "MaterializableProactiveIntent": MaterializableProactiveIntent;
   "MaterializePromptsRequest": MaterializePromptsRequest;
   "MaterializePromptsResponse": MaterializePromptsResponse;
   "McpAddServerResponse": McpAddServerResponse;
@@ -5121,8 +5141,8 @@ export interface OmiApiSchemas {
   "PluginResult": PluginResult;
   "PricingOption": PricingOption;
   "PrivateCloudSyncResponse": PrivateCloudSyncResponse;
-  "ProactiveIntent": ProactiveIntent;
   "ProactiveMaterializationReceipt": ProactiveMaterializationReceipt;
+  "ProactiveMaterializationRejection": ProactiveMaterializationRejection;
   "ProactiveNotification": ProactiveNotification;
   "ProcessConversationRequest": ProcessConversationRequest;
   "ProgressExtractRequest": ProgressExtractRequest;

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -2676,6 +2676,7 @@ export interface MaterializePromptsRequest {
 export interface MaterializePromptsResponse {
   intents?: Array<MaterializableProactiveIntent>;
   receipt_outcomes?: Array<ProactiveMaterializationReceiptOutcome>;
+  rejection_outcomes?: Array<ProactiveMaterializationRejectionOutcome>;
 }
 
 export interface McpAddServerResponse {
@@ -3281,6 +3282,11 @@ export interface ProactiveMaterializationRejection {
   code: string;
   intent_id: string;
   message?: string | null;
+}
+
+export interface ProactiveMaterializationRejectionOutcome {
+  intent_id: string;
+  outcome: "recorded" | "absorbed" | "generation_mismatch" | "malformed" | "missing";
 }
 
 export interface ProactiveNotification {
@@ -5157,6 +5163,7 @@ export interface OmiApiSchemas {
   "ProactiveMaterializationReceipt": ProactiveMaterializationReceipt;
   "ProactiveMaterializationReceiptOutcome": ProactiveMaterializationReceiptOutcome;
   "ProactiveMaterializationRejection": ProactiveMaterializationRejection;
+  "ProactiveMaterializationRejectionOutcome": ProactiveMaterializationRejectionOutcome;
   "ProactiveNotification": ProactiveNotification;
   "ProcessConversationRequest": ProcessConversationRequest;
   "ProgressExtractRequest": ProgressExtractRequest;


### PR DESCRIPTION
## Status for reviewers

**Ready for review.** Ten iterations with adversarial review between each; the sections below are the audit trail, in order. Read this section and "Root cause" / "What changed"; the round sections are for tracing why a given line exists.

**Deploy order: backend first, then desktop.** A desktop build from this branch sends `rejections` / `deferrals` only when non-empty, so it stays compatible with the current backend for empty batches; non-empty reports need the new backend contract. The backend change is independently safe against current desktop builds.

**Firestore index gate.** The transient-repair query needs the composite index added in `firestore.indexes.json` / `firestore_index_registry.py` (collection `chat_first_dead_letters`). The existing `firestore_readiness` step in `gcp_backend.yml` (`reconcile_firestore_indexes.py --check-only`) blocks the rollout until it is `READY`; if the query fails at runtime anyway, delivery continues and `repair_scan_failed` is emitted.

**Rolling / rollback contract.** Active intents (`ready`, `pending_kernel_receipt`, `delivered`) carry only the pre-PR field set; all new bookkeeping lives in `chat_first_delivery_attempts/{intent_id}` and terminal rows move to `chat_first_dead_letters/{intent_id}`. A pre-PR reader therefore parses every document it can still see, and a late receipt for a moved terminal row resolves as `missing`.

**Known follow-ups (not in this PR):** live firing proof for the `omi-chat-first-proactive-stalled` rule; Swift decoding of `receipt_outcomes` for client-side receipt telemetry; migrating the other outboxes onto the same per-item contract; product decision on `captureLink` card volume (~28/day/user since pusher finalization). The active ready query is intentionally unbounded (one document read per active row per poll); bounding it is a separate change.

**CI note.** `Desktop Swift Static & Test Contracts` fails on `main` in `OnboardingFlowTests` (stale default-action count); this branch carries the one-line test fix until #12577 merges.

## Root cause

Chat-first proactive delivery treated ordered batches as shared fault domains. A malformed or conflicting item could reject or roll back healthy siblings, while repeatedly deferred or unacknowledged rows could remain live or amplify per-poll Firestore work without a hard bound.

This is `FC-batch-fault-domain-head-of-line-poison`: one independent bad item must never roll back or reject the rest of a batch, and intentional deferral must remain distinct from failed delivery while still having a server-owned terminal budget.

## What changed

- The kernel gives each intent its own transaction, returns typed per-intent rejections, continues after poison items, and preserves unanswered-question/streaming-tail suppression as explicit per-item deferrals.
- Stable Chat-first turn identity adopts an existing matching turn, records the durable receipt, and is guarded by a shared backend/kernel test vector.
- Swift forwards typed rejections and tail deferrals, bounds rejection messages to the wire limit, and clears only outcomes actually sent.
- The backend processes receipt and rejection outcomes independently. Malformed, missing, stale-generation, conflicting, and absorbed items cannot reject healthy siblings; only the control-document fence may reject the request.
- Explicit tail deferrals do not spend the unacknowledged fetch budget, but seven days of continuous deferral dead-letters the intent as `deferred_beyond_budget`.
- Stored intent reads tolerate newer fields and unknown terminal states. Ordinary fetch bookkeeping uses a merge write so fields from a newer rolling writer survive.
- Candidate advancement is capped at `2 * limit` per poll, including malformed-row terminalization work.
- Due-deferral release skips and counts malformed rows while continuing to release healthy siblings.
- Receipt identity conflicts return a per-receipt `conflict` outcome, and kernel deferral reasons are labeled per item.
- Rejected, dead-letter, reconciled, malformed-deferral, and stalled events remain observable; the stalled-queue Grafana pager remains included.

## Product invariants affected

- INV-AGENT-*
- INV-CHAT-1
- INV-NAV-1

## Review fixes

Review-fix commits before rebase: `470bb1010e`, then `332c60ccc0`, on top of original fix `4f6c02f821`.

- Late receipts for terminal intents are acknowledged idempotently; receipt processing returns per-item outcomes and continues after conflicts.
- Transcript-tail suppression is reported as `deferrals` and excluded from the unacknowledged fetch budget.
- Rejections for delivered or missing intents are absorbed idempotently.
- Malformed fetch rows and reconciliation failures are isolated from healthy candidates.
- Stored Firestore intent documents ignore unknown fields and map unknown delivery states to terminal/not-ready.
- Client rejection codes are mapped to `invalid_intent`, `identity_conflict`, `kernel_materialization_failed`, or `unknown` before metric labeling.
- Kernel rejection classification uses typed errors, including a transient generation-validation code, with no regex over messages.
- Rejection messages are truncated to 300 characters in the kernel and defensively in Swift.
- Fetch count updates re-read state transactionally, the control document is read once, and reconciliation point reads start only after two unacknowledged fetches.

### Round 3

Round 3 commit before rebase: `332c60ccc0`.

- Current-request deferred intent IDs bypass both `fetch_count` and `last_fetched_at` advancement; an undeferred sibling still dead-letters on schedule.
- Fetch bookkeeping and delivery-state transitions advance in per-intent transactions that re-read current state. Concurrent deletion is isolated, concurrent delivery cannot be overwritten by dead-lettering, and two interleaved devices retain both increments.
- Stale cold-start terminal receipts produce per-item `missing`, `conflict`, or `generation_mismatch` outcomes and cannot 409 the rest of materialization.

N5–N9 status:

- N5 — addressed in Round 4: fetch bookkeeping now uses a merge write and preserves newer-revision fields.
- N6 — deferred: Swift still does not decode/log `receipt_outcomes`; the server response and generated DTOs retain the field for a focused client observability follow-up.
- N7 — addressed in Round 4: a delivered intent with a different receipt ID returns the existing per-receipt `conflict` outcome.
- N8 — addressed in Round 4: malformed persisted documents now raise `ChatFirstMalformedDocument`, distinct from control and per-intent generation mismatches.
- N9 — addressed in Round 4: `streaming_tail` is assigned only to the item that reports streaming suppression; later deferred items retain `tail_question`.

Round 3 verification:

- `backend/.venv/bin/pytest -q backend/tests/unit/test_chat_first_proactive_intents.py backend/tests/unit/test_chat_first_proactive_router.py` — pass: 40 tests in 0.79s.
- `OMI_PR_BODY_FILE=./pr-body.md make preflight` — pass: 43 selected checks.
- `cd backend && bash test.sh` — affected suites passed, but the repository-wide run was not green: the unrelated `test_byok_llm_logging.py` CPU-duration guard reported 0.39s, 0.38s, and 0.34s against its 0.30s limit; the remaining unrelated long-running partitions were stopped after more than eight minutes.

## Round 4

The branch was rebased cleanly onto `origin/main` at `706774f96c` before the Round 4 changes. Round 4 is commit `667d1b1fb1`.

Regression coverage:

- A — `test_one_malformed_intent_with_pending_rejection_never_fails_batch_and_sibling_is_recorded`
- B — `test_malformed_deferral_row_does_not_block_healthy_release_or_fetch`
- C — `test_continuous_deferral_dead_letters_at_seven_days_but_not_six`
- D — `test_fetch_candidate_transactions_are_capped_at_twice_the_response_limit`
- E — `test_fetch_advance_preserves_unknown_newer_revision_fields`

Round 4 verification on the rebased tree:

- `cd desktop/macos/agent && npm test` — pass: 59 files, 716 tests.
- `cd desktop/macos/agent && npm run build` — pass.
- `cd desktop/macos && ./scripts/agent-logic-harness.sh` — pass: all four stages, 157.34s total.
- `cd desktop/macos && xcrun swift build -c debug --package-path Desktop` — pass in 10.48s.
- `cd desktop/macos && xcrun swift test --package-path Desktop --filter ChatFirstPromptMaterializationCoordinatorTests` — pass: 12 tests, 0 failures.
- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_chat_first_proactive_intents.py backend/tests/unit/test_chat_first_proactive_router.py backend/tests/unit/test_chat_first_blocks.py backend/tests/unit/test_monitoring_alert_rule_contract.py backend/tests/unit/test_chat_first_proactive_engine.py` — pass: 102 tests in 3.37s.
- `cd backend && bash test.sh` — all chat-first and other partitions observed passed; the aggregate exited on the unrelated `tests/unit/test_app_review_score_clamp.py` partition. The repository-prescribed isolated rerun passed all 17 tests in 1.52s, confirming a transient partition failure.
- `OMI_PR_BODY_FILE=./pr-body.md make preflight` — all selected checks passed through the final desktop-quality gate; that gate reports the inherited baseline mismatch described below.
- `cd desktop/macos && python3 scripts/check_desktop_test_quality.py` — expected inherited failure: current `main` is 55 files / 149 sites against baselines 54 / 147 after `ff96bff7bb` added two production-source inspection sites in `ThreeDoorsDemoPageTests.swift`. This PR adds no Swift source-inspection sites; the baseline was not raised.

Explicit deferred list:

- N6: decode and log `receipt_outcomes` in Swift.
- Environment-level firing proof for the proactive stalled alert scrape path.

## Round 5

Round 5 is commit `0af6d9c948`.

- The seven-day `deferred_beyond_budget` transition now emits the same `dead_letter` metric family used by stalled-queue alerting, and unexpected per-deferral failures remain isolated to their item.
- Reconciliation's synthetic receipt is acknowledged idempotently when a late real kernel receipt arrives; two distinct real receipt identities still produce `conflict`.
- Proactive-engine deferral release now logs its bounded malformed-row count.

Operational-limit notes:

- When malformed ready rows are at least `2 * limit`, one poll can return zero cards while the malformed backlog drains; work remains bounded to about 16 candidates per default poll.
- Firestore `query.stream()` document reads are not capped by the transaction cap; only candidate advancement transactions are capped at `2 * limit`.

Round 5 verification:

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_chat_first_proactive_intents.py backend/tests/unit/test_chat_first_proactive_router.py backend/tests/unit/test_chat_first_blocks.py backend/tests/unit/test_monitoring_alert_rule_contract.py backend/tests/unit/test_chat_first_proactive_engine.py` — pass: 104 tests in 1.07s.
- `cd backend && PYRIGHT_PYTHON="$PWD/.venv/bin/python" bash scripts/typecheck.sh` — pass: 0 errors (repository baseline warnings only).
- `OMI_PR_BODY_FILE=./pr-body.md make preflight` — every selected check passed except the inherited desktop test-quality baseline mismatch: 55 files / 149 production-source inspection sites against baselines 54 / 147; Round 5 adds no Swift inspection sites.
- `cd backend && bash test.sh` — affected Chat-first suites passed; the aggregate hit the unrelated `test_byok_llm_logging.py` CPU-duration guard at 0.47s, 0.45s, and 0.40s against its 0.30s limit, after which the remaining unrelated partitions were stopped.

Final deferred list:

- N6: decode and log `receipt_outcomes` in Swift.
- Environment-level firing proof for the proactive stalled alert scrape path.
- Remove the dead test-only `_WriteBatch` / `batch_commit_hook` scaffolding and its inert assignments; this exceeds the optional ~20-line cleanup budget.

## Explicit follow-ups

- Migrate the other hand-rolled outboxes onto the same per-item typed-outcome and bounded-terminal contract.
- Decide how many capture-arrival cards per day a user should receive.
- Add an environment-level firing proof for the proactive stalled alert scrape path.

## Failure-class transition narrative

The violated contract is that one malformed, conflicting, terminal, or repeatedly unacknowledged item must not roll back later independent work or remain at the head forever. The canonical guard is per-item typed outcomes, stable-identity reconciliation, explicit but bounded deferral accounting, capped scan work, reasoned terminals, and durable stall alerting. Cross-layer poison-item, tail-deferral, rolling-reader, metric-cardinality, typed-error, truncation, shared-identity, scan-cap, and malformed-row tests defend that boundary.

Failure-Class: new

🤖 Generated with Codex via agentctl/Multica (gpt-5.6-sol on m5-mbp)


## Round 6

Round 6 is commit `762e53a61c363313df6a1bd85f6b25050ee7a641`.

- Both production callers now consume `DeferralReleaseBatch.intents` and `DeferralReleaseBatch.malformed_count` directly; the list/`getattr` test-compatibility fallbacks are gone.
- Router and proactive-engine test doubles return typed empty `DeferralReleaseBatch` values.

### Verification

- `cd backend && PYRIGHT_PYTHON=.venv/bin/python bash scripts/typecheck.sh`

  ```text
  0 errors, 5370 warnings, 0 informations
  ```

- `cd backend && .venv/bin/python -m pytest -q tests/unit/test_chat_first*.py`

  ```text
  108 passed in 6.90s
  ```

The locked Linux `pylock.toml` cannot install its Linux-only `onnxruntime==1.19.0` wheel on Apple Silicon, so local verification used the repository's `pylock.macos.toml`; the enforced Pyright command and pinned Pyright 1.1.403 were unchanged. The pre-push manifest again reached only the inherited desktop test-quality baseline mismatch (55 files / 149 sites versus 54 / 147); Round 6 changes no Swift.

## Round 7

Round 7 is commit `dd6b5ebd92`; the required desktop quality repair is `5516af7754`.

- H1 — empty desktop materialization batches omit `rejections` and `deferrals`, preserving compatibility with the strict pre-PR request model.
- H2 — fetch bookkeeping moved to sibling `chat_first_delivery_attempts/{intent_id}` documents. The intent document is unchanged by ordinary fetches, so a pre-PR strict reader can still parse it during a traffic split or rollback. This sibling-document design was chosen over a gated two-deploy writer because it preserves fetch budgets without leaving dormant production write scaffolding.
- H3 — deferred intents are excluded from the 24-hour stalled-ready calculation; only never-deferred ready work can page.
- H4 — only deterministic `invalid_intent` and `identity_conflict` reports spend the three-attempt rejection budget. Transient kernel failures spend only the fetch budget. Legacy transient-only dead letters have a six-hour, one-shot repair path and a later successful receipt can complete them; deterministic failure after requeue remains terminal.
- H5 — malformed pending deferrals are terminalized transactionally, and the bounded scan reaches a valid due row behind 33 malformed rows.
- H6 — router tests cover both presence and absence of the `event='stalled'` metric. The alert’s live firing proof remains deferred; the rule is not proven end to end.
- M7 — kernel receipt metrics use `reason=<outcome>`; conflict and generation-mismatch outcomes warn with only intent and receipt IDs.
- L8 — materialization deferrals read the control document inside the transaction before writing.
- L9 — the production signature-inspection compatibility branch is removed and tests patch the real helper signature.
- L10 — unused write-batch test scaffolding and inert hooks are removed.

### Deploy order

Deploy the backend before shipping the desktop build. Empty requests remain compatible with the pre-PR backend, but typed rejection/deferral reports require the new backend contract.

### Baseline regression proof on `762e53a61c`

- H1 — `xcrun swift test --package-path Desktop --filter ChatFirstPromptMaterializationCoordinatorTests.testEmptyMaterializationBatchOmitsNewOutcomeKeysForOldBackends` — FAIL: request type is private/unavailable and empty new keys cannot be omitted.
- H3 — `pytest -q backend/tests/unit/test_chat_first_proactive_intents.py::test_deferred_old_intent_does_not_stall_but_never_fetched_old_intent_does` — FAIL: old deferred intent reports `stalled_source='daily_opener'`.
- H4 — `pytest -q backend/tests/unit/test_chat_first_proactive_intents.py::test_transient_kernel_error_three_times_does_not_dead_letter` — FAIL: first transient report increments `materialization_attempts`.
- H5 — `pytest -q backend/tests/unit/test_chat_first_proactive_intents.py::test_thirty_three_malformed_deferrals_ahead_of_valid_due_row_are_terminalized` — FAIL: only 32 malformed rows are counted and the valid row is not released.

### Verification

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_chat_first*.py` — 120 passed.
- `cd backend && PYRIGHT_PYTHON=.venv/bin/python bash scripts/typecheck.sh` — 0 errors (repository baseline warnings only).
- `cd desktop/macos/agent && npx vitest run tests/conversation-journal.test.ts` — 69 passed.
- `cd desktop/macos && xcrun swift test --package-path Desktop --filter ChatFirstPromptMaterializationCoordinatorTests` — 13 passed.
- `cd desktop/macos && python3 scripts/check_desktop_test_quality.py` — OK at baseline (54 files / 147 sites).



## Round 8

Round 8 is commit `462835e39f`.

- D1 — active intent documents remain parseable by the pre-PR strict reader after fetches, deferrals, transient reports, deterministic rejections below budget, and one-shot requeue; all PR-new active-delivery fields live in `chat_first_delivery_attempts/{intent_id}`.
- D2 — fetch polls perform a bounded scan for six-hour-old transient dead letters with reasons `unacknowledged_after_fetch_budget` or `permanent_rejection:kernel_materialization_failed`, requeue each intent at most once, and never requeue deterministic deaths.
- D3 — sibling point reads occur only inside the bounded candidate window.
- D4 — malformed delivery-attempt siblings are reset transactionally, fetched on the same poll, and counted through the existing lifecycle metric stream.
- D5 — the Swift compatibility test now calls the production request mapping/encoder; the request type is file-private again.
- H1 residual — retry logs include the HTTP/error description and aggregate receipt/rejection/deferral counts; the 404-only v1 fallback is unchanged.
- D6 — stalled age is measured from `max(created_at, last_deferral_at)`, so a recent deferral suppresses paging without suppressing it forever.
- D7/D8 — malformed-deferral terminalization failures retain the malformed count and warn with `snapshot.id` only.

### Pre-PR strict-reader field list

`intent_id`, `continuity_key`, `account_generation`, `source`, `subject`, `blocks`, `delivery_state`, `created_at`, `delivered_at`, `materialization_receipt_id`, `cold_start_sequence_terminal_state`, `cold_start_sequence_terminal_receipt_id`.

Terminal `dead_letter` and `delivered` rows may retain newer diagnostic fields because the pre-PR ready-intent query filters them out.

### Baseline regression proof on `5516af7754`

- D1 — `test_ready_intent_remains_old_reader_safe_after_deferrals_and_rejections` fails with five `extra_forbidden` fields: `materialization_attempts`, `last_rejection_code`, `last_rejection_at`, `first_deferred_at`, and `last_deferral_at`.
- D2 — `test_fetch_requeues_transient_dead_letter_once_but_never_deterministic_death` fails because the six-hour fetch returns no intent.
- D3 — `test_sibling_point_reads_are_bounded_by_candidate_scan_limit` fails with 200 sibling reads versus the 16-read bound for `limit=8`.
- D5 — `ChatFirstPromptMaterializationCoordinatorTests.testEmptyMaterializationBatchOmitsNewOutcomeKeysForOldBackends` fails to compile because baseline production has no `ChatFirstMaterializationWire.encodedRequest` seam.

### Verification

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_chat_first*.py` — 127 passed.
- `cd backend && PYRIGHT_PYTHON=.venv/bin/python bash scripts/typecheck.sh` — 0 errors (5386 repository-baseline warnings).
- `cd desktop/macos/agent && npx vitest run tests/conversation-journal.test.ts` — 69 passed.
- `cd desktop/macos && python3 scripts/check_desktop_test_quality.py` — OK at baseline (54 source-reading files / 147 sites, 16 waits).
- `xcrun swift test --package-path desktop/macos/Desktop --filter ChatFirstPromptMaterializationCoordinatorTests` — 15 passed.



## Round 9

Round 9 production fix is commit `6a43036a53`; regression coverage is `110fd7ec57`. The requested test-only desktop patch is preserved by branch commit `63ca201fc6`.

Line-Count-Exception: backend/database/chat_first_intents.py | 824 -> 1538 | The existing PR owns this cohesive cross-version intent state machine; Round 9 adds narrow validation, query, and regression guards rather than splitting storage authority during hardening.

- N1 — transient-dead-letter repair now filters `account_generation` and `requeue_count == 0` in Firestore, orders by `last_fetched_at`, and gives a twice-dead requeued intent the terminal `transient_death_after_requeue` reason. Repair eligibility remains on dead-letter intent documents so the serving query can filter before opening transactions.
- N2 — ready, pending-receipt, and delivered intent documents omit all nine delivery-attempt fields. Only dead letters retain queryable repair diagnostics; the pre-PR parse-before-delivered-check reader can parse an acknowledged intent.
- N3 — the desktop retry log pattern-matches `APIError.httpError`, records `status=<code>` plus receipt/rejection/deferral counts, and never logs the server detail body.
- N4 — the repair scan rejects rows younger than six hours from their snapshots, before opening a transaction.
- N5 — every hydrated sibling field is validated through `ProactiveIntent.model_validate`; malformed values raise `ChatFirstMalformedDocument` and use the existing same-poll reset path.
- N6 — stall detection considers every ready candidate, hydrating sibling deferral state only for candidates whose `created_at` can already exceed the stall threshold.
- N7 — one-shot requeue merges its owned fetch/rejection reset fields and preserves deferral history.
- N8 — malformed-sibling reset preserves each independently valid field, including a valid `requeue_count == 1`.
- N9 — the fake Firestore tracks transactional and non-transactional point reads. The fetch-bound test asserts the total against `1 control + (2 * limit) * (1 sibling hydration + 2 transactional reads)` for fresh non-reconciling capture candidates.

### Firestore index

The N1 serving query adds this checked-in composite for collection-scoped `chat_first_proactive_intents`:

`account_generation ASC, requeue_count ASC, dead_letter_reason ASC, last_fetched_at ASC, __name__ ASC`

### Regression proof on `462835e39f`

- N1 — `test_repair_query_does_not_starve_repairable_row_behind_requeued_deaths` fails: the repairable twentieth row is starved and fetch returns `[]`.
- N2 — `test_agent_intent_reserves_then_receipt_accounts_one_turn_idempotently` fails: `_OldStrictProactiveIntent` rejects all nine delivery-attempt fields on the delivered document.
- N3 — `testHTTP422FailureLogIncludesStatusAndBatchSizes` fails: `status=422` is absent and the raw non-nil server detail is present.
- N5 — `test_invalid_rejection_code_is_repaired_and_fetched_with_metric_event` fails: `Bad Code!` survives in the sibling instead of entering the malformed reset path.
- N6 — `test_stall_scan_includes_old_low_priority_intent_below_response_window` fails: `stalled_source` remains nil for the 30-day-old row behind 20 fresh high-priority rows.

### Verification

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_chat_first*.py` — 132 passed.
- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_chat_first_proactive_intents.py backend/tests/unit/test_firestore_indexes.py backend/tests/unit/test_reconcile_firestore_indexes.py` — 84 passed.
- `cd backend && PYRIGHT_PYTHON=.venv/bin/python bash scripts/typecheck.sh` — 0 errors (5391 repository-baseline warnings).
- `cd desktop/macos/agent && npx vitest run tests/conversation-journal.test.ts` — 69 passed.
- `xcrun swift test --package-path desktop/macos/Desktop --filter ChatFirstPromptMaterializationCoordinatorTests` — 15 passed.
- `cd desktop/macos && python3 scripts/check_desktop_test_quality.py` — OK at baseline (54 source-reading files / 147 sites, 16 waits).
- `backend/.venv/bin/python backend/scripts/generate_firestore_indexes.py` — manifest matches the registry.

## Round 10

Round 10 is commit `ff2c8670f3`.

- D9-1 — stall hydration is bounded to the oldest `2 * limit` candidates. The ready-intent query still streams every matching active row by design so an old low-priority row remains visible; only sibling and transactional reads are bounded.
- D9-2 — terminal intents move transactionally to `chat_first_dead_letters/{intent_id}` and are deleted from `chat_first_proactive_intents`. Ready, pending-receipt, and delivered documents remain parseable by the pre-PR strict reader. Late receipts for moved terminal rows now return `missing`, which is the pre-PR behavior for an absent active intent.
- D9-3 — a `GoogleAPICallError` while building or streaming the repair query emits `repair_scan_failed` lifecycle telemetry and does not block ready delivery.
- D9-4 — malformed rows consume their real preserved counters. A requeued row with a corrupt fetch counter fails closed at the fetch budget instead of receiving another full budget.
- D9-5 — terminal writes always materialize a non-null `last_fetched_at` repair-order value. The Firestore fake now sorts explicit nulls first and excludes missing order fields, including the requested two-null-rows-ahead fixture.
- D9-6 — malformed sibling reset preserves every independently valid field. A valid fetch count of 19 plus another malformed field therefore dead-letters at the next unacknowledged fetch.
- D9-7 — delivery-attempt parsing and repair/dead-letter helpers moved to `backend/database/chat_first_delivery_attempts.py`; the active state-machine module is 85 lines smaller than its Round 9 version.
- N3 — non-HTTP desktop retry logs now include the raw `URLError` code and concrete error type while continuing to omit response bodies and secrets.

### Read bound in real Firestore terms

For response limit `L`:

- the active ready query uses an unbounded `query.stream()` and bills one document read per matching active row; this is intentionally separate from the bounded point/transaction formula;
- the repair query streams at most `2L` dead-letter documents and repairs at most `L`, with two transaction reads per repair;
- stall inspection performs at most `2L` sibling point reads;
- advancement considers at most `2L` candidates, each with at most one sibling point read, one optional reconciliation message point read, two intent/attempt transaction reads, and one optional agent-judgment budget transaction read;
- therefore the non-repair bounded hot path is at most `1 + 12L` document reads including the control read. Fresh non-reconciling candidates whose sibling hydration is reused use `1 + 6L` (49 reads for the default `L=8`), which the regression test asserts. Malformed rows substitute a single terminalization read for an advancement slot and do not increase the maximum;
- including the independently bounded repair scan and repair transactions gives at most another `4L` reads, while the active ready-query stream remains explicitly unbounded.

### Rolling-reader contract

The pre-PR strict reader continues to parse active `ready`, `pending_kernel_receipt`, and `delivered` documents because those rows contain only its original field set. Terminal rows are no longer visible in the active collection: they validate as `DeadLetteredProactiveIntent` in `chat_first_dead_letters`, and a pre-PR late-receipt lookup observes an absent active document and returns `missing`. This intentionally replaces Round 9's claim that terminal diagnostics could remain on active rows.

### Firestore index and deploy gate

The transient-repair composite now targets collection-scoped `chat_first_dead_letters`:

`account_generation ASC, requeue_count ASC, dead_letter_reason ASC, last_fetched_at ASC, __name__ ASC`

`.github/workflows/gcp_backend.yml` gates backend rollout in `firestore_readiness` by running `backend/scripts/reconcile_firestore_indexes.py --check-only`; the backend must not deploy until the composite is ready.

### Regression proof on `6a43036a53`

- D9-1 — `test_sibling_point_reads_are_bounded_by_candidate_scan_limit` at `NOW + 25h` fails with 217 bounded reads versus the asserted 49.
- D9-2 — `test_receipt_for_dead_letter_removed_from_old_reader_collection_is_missing` fails because the terminal document remains in the active collection and the old lookup does not return `missing`.
- D9-3 — `test_repair_query_failure_does_not_block_ready_delivery` raises the Firestore API error instead of returning the healthy ready intent.
- D9-4 — `test_malformed_fetch_count_on_requeued_intent_fails_closed_at_budget` resets the corrupt counter and grants the requeued intent another budget.
- D9-5 — `test_fake_order_by_sorts_explicit_nulls_first_and_drops_missing` fails because the Round 9 fake drops explicit nulls instead of sorting them ahead of timestamps; terminal-write assertions also show the production null-order hazard.
- D9-6 — `test_valid_fetch_budget_survives_other_malformed_sibling_field` loses fetch count 19 during reset instead of dead-lettering on the next fetch.
- D9-7 — the delivery-attempt state machine remains embedded in the oversized active-intent module.
- N3 — `testTransportFailureLogIncludesURLErrorCodeAndType` lacks both the raw transport code and concrete error type.

### Verification

- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_chat_first*.py backend/tests/unit/test_firestore_indexes.py backend/tests/unit/test_reconcile_firestore_indexes.py` — 172 passed.
- `cd backend && PYRIGHT_PYTHON=.venv/bin/python bash scripts/typecheck.sh` — 0 errors (repository-baseline warnings only).
- `backend/.venv/bin/python backend/scripts/generate_firestore_indexes.py` — manifest matches the registry.
- `xcrun swift test --package-path desktop/macos/Desktop --filter ChatFirstPromptMaterializationCoordinatorTests` — 16 passed.
- `cd desktop/macos && python3 scripts/check_desktop_test_quality.py` — OK at baseline (54 source-reading files / 147 sites, 16 waits).

## Product invariants affected

- INV-AGENT-*
- INV-CHAT-1
- INV-NAV-1
- INV-MEM-3
