### PR TITLE
fix(desktop): route screen-read recall to screen history, not conversations

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/DesktopCapabilityRegistry.swift
+++ b/desktop/macos/Desktop/Sources/Chat/DesktopCapabilityRegistry.swift
@@ -47,6 +47,7 @@ enum DesktopCapabilityRegistry {
     """
     Omi capability model:
     - You can read Omi data quickly with fast tools: tasks, memories, conversations, daily recaps, and screen history.
+    - Anything the user saw or read on screen earlier (a page, riddle, message, document, error, "the first X", "what did it say") lives in screen history, not conversations: use search_screen_history. Conversations are spoken audio. If a conversation search finds nothing for a "do you remember" question, search screen history before saying it was never mentioned.
     - You can create a straightforward calendar event with create_calendar_event when the user gives the event details.
     - You can propose macOS permission checks or requests with check_permission_status and request_permission; the kernel authorizes the native action. Treat "screen share", "screen sharing", and "screen-share" as the Screen Recording permission type, screen_recording.
     - When screen access is unavailable, explicitly say that Omi needs Screen Recording permission so a next-turn request such as "request it" has one unambiguous permission referent. If the user then asks to request it, propose request_permission with type screen_recording immediately.
@@ -176,6 +177,10 @@ enum DesktopCapabilityRegistry {
         : " Raw screenshots.ocrText projections are refused; use only bounded OCR previews for exact inspection."
       append("Counts, aggregates, date ranges, or exact structured local stats -> execute_sql.\(boundary)", when: true)
     }
+    append(
+      "Something the user saw or read on screen earlier (a page, riddle, message, document, error; \"the first X\", \"what did it say\") -> semantic_search over screen history, not conversation tools. Conversations are spoken audio. If a conversation search finds nothing for a \"do you remember\" question, search screen history before saying it was never mentioned.",
+      when: has("semantic_search")
+    )
     append("Fuzzy screen-history questions -> semantic_search.", when: has("semantic_search"))
     append("Find tasks by meaning -> search_tasks.", when: has("search_tasks"))
     let taskWriteTools = ["create_action_item", "update_action_item", "execute_sql"]

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedRealtimeTools.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedRealtimeTools.swift
@@ -35,7 +35,7 @@ enum GeneratedRealtimeTools {
   {
     "type": "function",
     "name": "search_screen_history",
-    "description": "Search the user's on-screen history — what they saw, read, or worked on — by meaning. Use for 'when was I looking at X', 'find where I read about Y', 'what was I doing in app Z'. Returns matching moments with the app and context. Fast synchronous read. Speak the result.",
+    "description": "Search the user's on-screen history — what they saw, read, or worked on — by meaning. Use for 'when was I looking at X', 'find where I read about Y', 'what was I doing in app Z', and for text they read on screen earlier ('the riddle on the first page', 'what did that message say'). Anything displayed rather than spoken lives here, not in conversations. Returns matching moments with the app, context, and an OCR text preview. Fast synchronous read. Speak the result.",
     "parameters": {
       "type": "object",
       "properties": {
@@ -355,7 +355,7 @@ enum GeneratedRealtimeTools {
   {
     "type": "function",
     "name": "search_conversations",
-    "description": "Search the user's past conversations for what they discussed ('what did I say about X', 'what did we decide', 'summarize my last meeting'), or pass a canonical conversation UUID/share link for an exact lookup. Returns titles + summaries only (no full transcripts). Fast synchronous read. Speak the result.",
+    "description": "Search the user's past spoken conversations (meetings, calls, things said aloud) for what they discussed ('what did I say about X', 'what did we decide', 'summarize my last meeting'), or pass a canonical conversation UUID/share link for an exact lookup. Not for things the user read on screen; use search_screen_history for those. Returns titles + summaries only (no full transcripts). Fast synchronous read. Speak the result.",
     "parameters": {
       "type": "object",
       "properties": {

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
@@ -88,7 +88,8 @@ enum GeneratedToolCapabilities {
       surfaces: Set([.realtimeHub]),
       summary: "Search the user's on-screen history by meaning.",
       bullets: [
-      "Use for what the user saw, read, or worked on. Speak a short summary of the result."
+      "Use for what the user saw, read, or worked on, including text they read on a page earlier (a riddle, a message, a document). Speak a short summary of the result.",
+      "Prefer this over conversation tools for anything that was displayed rather than spoken."
     ]
     ),
     Capability(

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
@@ -54,8 +54,8 @@ enum GeneratedSwiftToolExecutor: String {
 
 enum GeneratedToolExecutors {
   static let manifestVersion = 1
-  static let manifestDigest = "sha256:9cd462c76d7eeb7ea2655ccd7bb6ac40557f853383a7f11f1072f9b32213d5e5"
-  static let chatFirstManifestDigest = "sha256:17988ae5508eade38e4ad536194ca7d51ccd6cfc182f523f3a95a048abcc5d0b"
+  static let manifestDigest = "sha256:d94dcf6184f3fa030e5352cdbd4ec4b5ff8432356bd424a8b2d369fd472b7c34"
+  static let chatFirstManifestDigest = "sha256:dfd93a44ff57c8e39f00316bf78c445385ec1dcbd6cad24398d5db160241449b"
 
   static let aliasToCanonical: [String: GeneratedSwiftTool] = [
     "search_screen_history": .semanticSearch,

--- a/desktop/macos/Desktop/Tests/ChatPromptsTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatPromptsTests.swift
@@ -88,6 +88,17 @@ final class ChatPromptsTests: XCTestCase {
     )
   }
 
+  func testScreenReadRecallRoutesToScreenHistoryNotConversations() {
+    // Regression: a voice turn asking about a riddle the user had only *read* on screen
+    // called search_conversations, found nothing, and answered "no riddles mentioned".
+    let voice = DesktopCapabilityRegistry.realtimeSelfModelPrompt
+    XCTAssertTrue(voice.contains("lives in screen history, not conversations: use search_screen_history"))
+    XCTAssertTrue(voice.contains("search screen history before saying it was never mentioned"))
+
+    let desktopPrompt = ChatPromptBuilder.buildDesktopChat(userName: "Taylor")
+    XCTAssertTrue(desktopPrompt.contains("-> semantic_search over screen history, not conversation tools"))
+  }
+
   func testOnboardingDefersWebResearchUntilAfterFileScanAndEmailAttempt() throws {
     let prompt = ChatPromptBuilder.buildOnboardingChat(
       userName: "Taylor Swift",

--- a/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
@@ -267,14 +267,17 @@ const swiftToolSurfacePatches: Record<string, OmiToolSurfacePatch> = {
         ...doc(
           "Search Screen History",
           "Search the user's on-screen history by meaning.",
-          ["Use for what the user saw, read, or worked on. Speak a short summary of the result."],
+          [
+            "Use for what the user saw, read, or worked on, including text they read on a page earlier (a riddle, a message, a document). Speak a short summary of the result.",
+            "Prefer this over conversation tools for anything that was displayed rather than spoken.",
+          ],
         ),
         surfaces: ["realtime_voice"],
       },
     },
     voice: {
       realtimeDescription:
-        "Search the user's on-screen history — what they saw, read, or worked on — by meaning. Use for 'when was I looking at X', 'find where I read about Y', 'what was I doing in app Z'. Returns matching moments with the app and context. Fast synchronous read. Speak the result.",
+        "Search the user's on-screen history — what they saw, read, or worked on — by meaning. Use for 'when was I looking at X', 'find where I read about Y', 'what was I doing in app Z', and for text they read on screen earlier ('the riddle on the first page', 'what did that message say'). Anything displayed rather than spoken lives here, not in conversations. Returns matching moments with the app, context, and an OCR text preview. Fast synchronous read. Speak the result.",
     },
   },
   get_daily_recap: {
@@ -401,7 +404,7 @@ const swiftToolSurfacePatches: Record<string, OmiToolSurfacePatch> = {
     ),
     voice: {
       realtimeDescription:
-        "Search the user's past conversations for what they discussed ('what did I say about X', 'what did we decide', 'summarize my last meeting'), or pass a canonical conversation UUID/share link for an exact lookup. Returns titles + summaries only (no full transcripts). Fast synchronous read. Speak the result.",
+        "Search the user's past spoken conversations (meetings, calls, things said aloud) for what they discussed ('what did I say about X', 'what did we decide', 'summarize my last meeting'), or pass a canonical conversation UUID/share link for an exact lookup. Not for things the user read on screen; use search_screen_history for those. Returns titles + summaries only (no full transcripts). Fast synchronous read. Speak the result.",
     },
   },
   get_memories: {

--- a/desktop/macos/agent/tests/fixtures/tool-manifest.json
+++ b/desktop/macos/agent/tests/fixtures/tool-manifest.json
@@ -221,7 +221,8 @@
         "title": "Search Screen History",
         "summary": "Search the user's on-screen history by meaning.",
         "bullets": [
-          "Use for what the user saw, read, or worked on. Speak a short summary of the result."
+          "Use for what the user saw, read, or worked on, including text they read on a page earlier (a riddle, a message, a document). Speak a short summary of the result.",
+          "Prefer this over conversation tools for anything that was displayed rather than spoken."
         ],
         "surfaces": [
           "realtime_voice"
@@ -229,7 +230,7 @@
       }
     },
     "voice": {
-      "realtimeDescription": "Search the user's on-screen history — what they saw, read, or worked on — by meaning. Use for 'when was I looking at X', 'find where I read about Y', 'what was I doing in app Z'. Returns matching moments with the app and context. Fast synchronous read. Speak the result."
+      "realtimeDescription": "Search the user's on-screen history — what they saw, read, or worked on — by meaning. Use for 'when was I looking at X', 'find where I read about Y', 'what was I doing in app Z', and for text they read on screen earlier ('the riddle on the first page', 'what did that message say'). Anything displayed rather than spoken lives here, not in conversations. Returns matching moments with the app, context, and an OCR text preview. Fast synchronous read. Speak the result."
     }
   },
   {
@@ -3792,7 +3793,7 @@
       ]
     },
     "voice": {
-      "realtimeDescription": "Search the user's past conversations for what they discussed ('what did I say about X', 'what did we decide', 'summarize my last meeting'), or pass a canonical conversation UUID/share link for an exact lookup. Returns titles + summaries only (no full transcripts). Fast synchronous read. Speak the result."
+      "realtimeDescription": "Search the user's past spoken conversations (meetings, calls, things said aloud) for what they discussed ('what did I say about X', 'what did we decide', 'summarize my last meeting'), or pass a canonical conversation UUID/share link for an exact lookup. Not for things the user read on screen; use search_screen_history for those. Returns titles + summaries only (no full transcripts). Fast synchronous read. Speak the result."
     }
   },
   {

--- a/desktop/macos/changelog/unreleased/20260901-voice-recall-screen-history.json
+++ b/desktop/macos/changelog/unreleased/20260901-voice-recall-screen-history.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Omi answering \"that was never mentioned\" when you ask about something you read on screen earlier; voice and chat now check your screen history, not just conversations"
+}


### PR DESCRIPTION
## Summary

A voice turn asking about a riddle the user had only *read* on screen ("what was the last word of the first riddle?") called `search_conversations`, found nothing, and answered that no riddle was ever mentioned (Beta, Sep 1 2026 16:40, log turn with `search_conversations({"query":"riddle"})`). Neither the realtime self-model prompt nor the chat-lane routing rules said that displayed text lives in screen history; only spoken conversations were routed.

- Voice self-model prompt: anything the user saw or read on screen earlier -> `search_screen_history`; conversations are spoken audio; never say "never mentioned" without checking screen history.
- Chat lane routing (`scopedDesktopToolPrompt`): same rule for `semantic_search`.
- Tool manifest: `search_screen_history` description now covers text read on screen; `search_conversations` scoped to spoken conversations. Surfaces regenerated.
- Regression test `testScreenReadRecallRoutesToScreenHistoryNotConversations` pins both prompts.

## Verification

- `swift test --filter 'ChatPromptsTests|HubSystemInstructionTests|ScreenContextTelemetryTests'`: 59 passed, 0 failed.
- `bash desktop/macos/scripts/test-tool-surfaces.sh`: passed after regeneration.
- Real voice path: UNVERIFIED in this PR (needs a spoken turn on a build containing this change); the failing turn was reproduced from the Beta log, not synthetically.

Failure-Class: none

## Product invariants affected

- INV-AGENT-*
- INV-CHAT-1


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

