### PR TITLE
fix(web): render the shared-conversation overview as markdown

### DIFF
--- a/web/frontend/src/components/memories/summary/sumary.tsx
+++ b/web/frontend/src/components/memories/summary/sumary.tsx
@@ -2,6 +2,7 @@ import { Memory } from '@/src/types/memory.types';
 import ActionItems from './action-items';
 import MemoryEvents from '../events/memory-events';
 import Plugins from '../plugins/plugins';
+import Markdown from 'markdown-to-jsx';
 
 interface SummaryProps {
   memory: Memory;
@@ -14,9 +15,12 @@ export default function Summary({ memory }: SummaryProps) {
     <div className="flex flex-col gap-12">
       {overview && (
         <div className="mt-8 md:mt-10">
-          <p className="whitespace-pre-wrap text-base leading-7 text-zinc-200 md:text-lg">
+          <Markdown
+            className="font-system-ui prose prose-base max-w-none text-zinc-200 md:prose-lg prose-headings:mb-3 prose-headings:mt-8 prose-headings:text-lg prose-headings:font-semibold prose-headings:text-white first:prose-headings:mt-0 prose-h1:text-xl prose-h2:text-lg prose-h3:text-base prose-p:leading-7 prose-p:text-zinc-200 prose-a:text-zinc-100 prose-a:underline prose-strong:text-white prose-ol:my-3 prose-ol:text-zinc-200 prose-ul:my-3 prose-ul:text-zinc-200 prose-li:my-1 prose-li:text-zinc-200 prose-li:marker:text-zinc-500 md:prose-h1:text-2xl md:prose-h2:text-xl md:prose-h3:text-lg"
+            options={{ forceBlock: true }}
+          >
             {overview}
-          </p>
+          </Markdown>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- The public shared-conversation page (`h.omi.me/conversations/<id>`) shows only Action Items today. The overview text (the sectioned summary the desktop app shows) is missing.
- #11203 (merged 2026-08-15) added overview rendering, but as a plain `<p>` with `whitespace-pre-wrap`. `structured.overview` is markdown (`## Riddle Answers`, `- …` bullets), so that would print raw markers. It also never reached prod: every `Deploy Frontend to Cloud Run` run since May has been cancelled or stuck on the prod gate, and the one released today failed its runtime preflight because the `PUBLIC_SHARED_CONVERSATION_CHAT_IP_HMAC_KEY` secret did not exist in prod Secret Manager (now created, runtime SA granted accessor).
- This PR renders the overview with `markdown-to-jsx` using the same prose styling the app-result cards already use, so the web share matches the desktop summary.

## Product invariants affected

- INV-MEM-1 — presentation-only change to the shared summary; no memory tier, collection, or access-policy change.

Failure-Class: none

(One-off consumer format mismatch: the web share kept rendering `structured.overview` as plain text after the field became markdown. The missing prod runtime secret that blocked every frontend deploy since May is infra, not code in this PR.)

## Test plan
- [x] `npm run lint`, `npm test` in `web/frontend`
- [x] Local `next dev` against `https://api.omi.me` renders the sectioned summary for conversation `99b4e759-…`
- [ ] Prod deploy via `gcp_frontend.yml`, then verify https://h.omi.me/conversations/99b4e759-3982-5c33-87ea-ece573af9a05

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

