### PR TITLE
harden(app): fail fast on mobile build profile drift

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -6,7 +6,7 @@ Inherits all rules from the root [`../AGENTS.md`](../AGENTS.md). This file adds 
 
 ### Flavors
 - **dev**: Android `com.friend.ios.dev`, iOS `com.friend-app-with-wearable.ios12.development` — uses `.dev.env`, Firebase project `based-hardware-dev`
-- **prod**: Android `com.friend.ios`, iOS `com.friend-app-with-wearable.ios12` — uses `.prod.env`, Firebase project `based-hardware-prod`
+- **prod**: Android `com.friend.ios`, iOS `com.friend-app-with-wearable.ios12` — uses `.env`, Firebase project `based-hardware-prod`
 - **raybanDat**: camera-capable iOS target with the same iOS development identity; use `scripts/rayban_dat.sh`, which excludes mcumgr only for that transaction and restores the default graph.
 
 ### Generated Files (never edit manually)
@@ -23,6 +23,11 @@ Inherits all rules from the root [`../AGENTS.md`](../AGENTS.md). This file adds 
 bash setup.sh ios    # or: bash setup.sh android
 ```
 This handles: pub get, build_runner, gen-l10n, and flavor configuration.
+
+For physical-device builds, use the wrapper: it owns `dev + local_dev` and
+`prod + mobile_beta` pairing plus auth env setup. Direct builds must first run
+`scripts/validate_mobile_build_config.sh --flavor <dev|prod> --profile <profile>`
+with the matching `OMI_APP_PROFILE`; release/profile helpers do this too.
 
 ### Firebase Config
 Never run `flutterfire configure` — it overwrites prod credentials. Config files:

--- a/app/README.md
+++ b/app/README.md
@@ -93,7 +93,14 @@ To build and deploy the app to an iPhone so it can run independently from your l
 
 1. Build the iOS app with release mode and specific flavor:
    ```bash
-   flutter build ios --flavor dev --release
+   # After the normal setup has seeded the iOS/Firebase files:
+   source setup.sh
+   setup_app_env local_dev "$LOCAL_API_BASE_URL"
+   scripts/validate_mobile_build_config.sh --flavor dev --profile local_dev
+   flutter build ios --flavor dev --release \
+     --dart-define=OMI_APP_PROFILE=local_dev \
+     --dart-define=OMI_API_BASE_URL="$LOCAL_API_BASE_URL" \
+     --dart-define=OMI_FIREBASE_AUTH_EMULATOR_HOST="$LOCAL_DEV_HOST"
    ```
    This produces an .app bundle at:
    ```

--- a/app/release.sh
+++ b/app/release.sh
@@ -1,4 +1,20 @@
-flutter clean; dart run build_runner build; echo "1"
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$APP_DIR"
+
+# Keep this legacy release helper on the same profile/auth contract as the
+# setup wrapper. Only setup-owned keys are updated; developer-owned .env values
+# remain intact.
+source setup.sh >/dev/null
+setup_app_env mobile_beta "$BETA_API_BASE_URL"
+scripts/validate_mobile_build_config.sh --flavor prod --profile mobile_beta
+
+flutter clean
 flutter pub get
-flutter build appbundle --release --flavor prod -t lib/main_prod.dart
-flutter build apk --release --flavor prod -t lib/main_prod.dart
+dart run build_runner build --delete-conflicting-outputs
+flutter build appbundle --release --flavor prod -t lib/main_prod.dart \
+  --dart-define=OMI_APP_PROFILE=mobile_beta
+flutter build apk --release --flavor prod -t lib/main_prod.dart \
+  --dart-define=OMI_APP_PROFILE=mobile_beta

--- a/app/scripts/mobile_build_wrapper_test.sh
+++ b/app/scripts/mobile_build_wrapper_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture_dir="$(mktemp -d "${TMPDIR:-/tmp}/omi-mobile-wrapper.XXXXXX")"
+trap 'rm -rf "$fixture_dir"' EXIT
+
+mkdir -p "$fixture_dir/scripts" "$fixture_dir/ios"
+cp "$ROOT_DIR/setup.sh" "$fixture_dir/setup.sh"
+cp "$ROOT_DIR/scripts/validate_mobile_build_config.sh" "$fixture_dir/scripts/validate_mobile_build_config.sh"
+chmod +x "$fixture_dir/scripts/validate_mobile_build_config.sh"
+
+log_file="$fixture_dir/flutter.log"
+(
+  cd "$fixture_dir"
+  source ./setup.sh >/dev/null
+
+  flutter() {
+    {
+      printf 'flutter'
+      printf ' %s' "$@"
+      printf '\n'
+    } >>"$log_file"
+  }
+  pod() {
+    {
+      printf 'pod'
+      printf ' %s' "$@"
+      printf '\n'
+    } >>"$log_file"
+  }
+  dart() {
+    {
+      printf 'dart'
+      printf ' %s' "$@"
+      printf '\n'
+    } >>"$log_file"
+  }
+  check_ios_prerequisites() { :; }
+  select_ios_device() { printf 'TEST-DEVICE\n'; }
+
+  run_build_ios prod
+  grep -F 'flutter run --flavor prod -d TEST-DEVICE --dart-define=OMI_APP_PROFILE=mobile_beta' "$log_file" >/dev/null
+  [[ "$(grep -F 'OMI_APP_PROFILE=mobile_beta' "$log_file" | tr ' ' '\n' | grep -c '^--dart-define=')" == 1 ]]
+
+  if run_build_ios prod --dart-define=OMI_APP_PROFILE=production; then
+    echo 'FAIL: wrapper accepted a conflicting profile define' >&2
+    exit 1
+  fi
+)
+
+echo 'mobile build wrapper injects one required profile and rejects conflicts'

--- a/app/scripts/profile_flutter_android.sh
+++ b/app/scripts/profile_flutter_android.sh
@@ -110,7 +110,37 @@ if [[ "$DO_BUILD" == true ]]; then
   echo ""
   echo "=== Building profile APK ==="
   pushd "$APP_DIR" > /dev/null
-  flutter build apk --flavor "$FLAVOR" --profile
+  case "$FLAVOR" in
+    dev)
+      PROFILE='local_dev'
+      ENV_FILE='.dev.env'
+      ANDROID_DEV_HOST="${OMI_ANDROID_DEV_HOST:-${OMI_DEV_HOST:-10.0.2.2}}"
+      ;;
+    prod)
+      PROFILE='mobile_beta'
+      ENV_FILE='.env'
+      ANDROID_DEV_HOST=''
+      ;;
+    *)
+      echo "Error: unsupported mobile flavor '$FLAVOR' (expected dev or prod)" >&2
+      exit 1
+      ;;
+  esac
+  scripts/validate_mobile_build_config.sh \
+    --flavor "$FLAVOR" \
+    --profile "$PROFILE" \
+    --env-file "$ENV_FILE"
+  API_BASE_URL="$(awk -F= '$1 == "API_BASE_URL" { value = $2 } END { print value }' "$ENV_FILE")"
+  flutter_args=(
+    --flavor "$FLAVOR"
+    --profile
+    "--dart-define=OMI_APP_PROFILE=$PROFILE"
+    "--dart-define=OMI_API_BASE_URL=$API_BASE_URL"
+  )
+  if [[ -n "$ANDROID_DEV_HOST" ]]; then
+    flutter_args+=("--dart-define=OMI_FIREBASE_AUTH_EMULATOR_HOST=$ANDROID_DEV_HOST")
+  fi
+  flutter build apk "${flutter_args[@]}"
   popd > /dev/null
 fi
 

--- a/app/scripts/setup_app_env_test.sh
+++ b/app/scripts/setup_app_env_test.sh
@@ -34,3 +34,20 @@ grep -Fx 'USE_AUTH_CUSTOM_TOKEN=true' "$fixture_dir/.env" >/dev/null
 [[ "$(grep -c '^USE_AUTH_CUSTOM_TOKEN=' "$fixture_dir/.env")" == 1 ]]
 
 echo "setup_app_env preserves unrelated keys and updates beta-owned keys"
+
+printf '%s\n' \
+  '# developer-owned setting' \
+  'API_BASE_URL=https://old.example.test/' \
+  'USE_WEB_AUTH=false' \
+  'USE_AUTH_CUSTOM_TOKEN=false' >"$fixture_dir/.dev.env"
+
+(
+  cd "$fixture_dir"
+  setup_app_env local_dev 'http://192.168.1.212:8000/'
+)
+
+grep -Fx '# developer-owned setting' "$fixture_dir/.dev.env" >/dev/null
+grep -Fx 'API_BASE_URL=http://192.168.1.212:8000/' "$fixture_dir/.dev.env" >/dev/null
+grep -Fx 'USE_WEB_AUTH=true' "$fixture_dir/.dev.env" >/dev/null
+grep -Fx 'USE_AUTH_CUSTOM_TOKEN=true' "$fixture_dir/.dev.env" >/dev/null
+echo "setup_app_env enables web OAuth and custom-token exchange for local device builds"

--- a/app/scripts/test.sh
+++ b/app/scripts/test.sh
@@ -34,6 +34,8 @@ done
 if $RUN_UNIT; then
     echo "🧪 Running unit & widget tests..."
     cd "$APP_DIR"
+    bash scripts/validate_mobile_build_config_test.sh
+    bash scripts/mobile_build_wrapper_test.sh
     flutter test
     echo ""
 fi

--- a/app/scripts/validate_mobile_build_config.sh
+++ b/app/scripts/validate_mobile_build_config.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 --flavor <dev|prod> [--profile <profile>] [--env-file <path>]" >&2
+}
+
+flavor=''
+profile=''
+env_file=''
+while (($#)); do
+  case "$1" in
+    --flavor)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      flavor="$2"
+      shift 2
+      ;;
+    --profile)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      profile="$2"
+      shift 2
+      ;;
+    --env-file)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      env_file="$2"
+      shift 2
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+case "$flavor" in
+  dev)
+    expected_profile='local_dev'
+    default_env_file='.dev.env'
+    ;;
+  prod)
+    expected_profile='mobile_beta'
+    default_env_file='.env'
+    ;;
+  *)
+    echo "ERROR: unsupported mobile flavor '${flavor:-<missing>}' (expected dev or prod)." >&2
+    exit 1
+    ;;
+esac
+
+if [[ -n "$profile" && "$profile" != "$expected_profile" ]]; then
+  echo "ERROR: mobile flavor '$flavor' requires OMI_APP_PROFILE=$expected_profile, got '$profile'." >&2
+  exit 1
+fi
+
+env_file="${env_file:-$default_env_file}"
+if [[ ! -f "$env_file" ]]; then
+  echo "ERROR: missing $env_file; run setup_app_env $expected_profile before building." >&2
+  exit 1
+fi
+
+read_setting() {
+  local key="$1"
+  awk -F= -v key="$key" '$1 == key { value = $2 } END { print value }' "$env_file"
+}
+
+for key in USE_WEB_AUTH USE_AUTH_CUSTOM_TOKEN; do
+  if [[ "$(read_setting "$key")" != 'true' ]]; then
+    echo "ERROR: $env_file must contain $key=true for the supported $flavor/$expected_profile mobile build." >&2
+    exit 1
+  fi
+done
+
+echo "mobile build config valid: flavor=$flavor profile=$expected_profile env=$env_file"

--- a/app/scripts/validate_mobile_build_config_test.sh
+++ b/app/scripts/validate_mobile_build_config_test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VALIDATOR="$ROOT_DIR/scripts/validate_mobile_build_config.sh"
+fixture_dir="$(mktemp -d "${TMPDIR:-/tmp}/omi-mobile-build-config.XXXXXX")"
+trap 'find "$fixture_dir" -type f -delete; rmdir "$fixture_dir"' EXIT
+
+printf '%s\n' \
+  'API_BASE_URL=http://192.168.1.212:8000/' \
+  'USE_WEB_AUTH=true' \
+  'USE_AUTH_CUSTOM_TOKEN=true' >"$fixture_dir/.dev.env"
+
+valid_output="$(
+  cd "$fixture_dir"
+  "$VALIDATOR" --flavor dev --profile local_dev
+)"
+[[ "$valid_output" == *'flavor=dev profile=local_dev'* ]]
+
+if (
+  cd "$fixture_dir"
+  "$VALIDATOR" --flavor prod --profile local_dev
+) 2>"$fixture_dir/mismatch.err"; then
+  echo 'FAIL: accepted prod/local_dev pairing' >&2
+  exit 1
+fi
+grep -F "requires OMI_APP_PROFILE=mobile_beta" "$fixture_dir/mismatch.err" >/dev/null
+
+printf '%s\n' \
+  'API_BASE_URL=http://192.168.1.212:8000/' \
+  'USE_WEB_AUTH=false' \
+  'USE_AUTH_CUSTOM_TOKEN=true' >"$fixture_dir/.dev.env"
+if (
+  cd "$fixture_dir"
+  "$VALIDATOR" --flavor dev
+) 2>"$fixture_dir/flags.err"; then
+  echo 'FAIL: accepted native-auth local build without web auth' >&2
+  exit 1
+fi
+grep -F 'USE_WEB_AUTH=true' "$fixture_dir/flags.err" >/dev/null
+
+printf '%s\n' \
+  'API_BASE_URL=https://api.omiapi.com/' \
+  'USE_WEB_AUTH=true' \
+  'USE_AUTH_CUSTOM_TOKEN=true' >"$fixture_dir/.env"
+prod_output="$(
+  cd "$fixture_dir"
+  "$VALIDATOR" --flavor prod --profile mobile_beta
+)"
+[[ "$prod_output" == *'flavor=prod profile=mobile_beta'* ]]
+
+rm "$fixture_dir/.env"
+if (
+  cd "$fixture_dir"
+  "$VALIDATOR" --flavor prod --profile mobile_beta
+) 2>"$fixture_dir/missing.err"; then
+  echo 'FAIL: accepted a production build without its env file' >&2
+  exit 1
+fi
+grep -F 'missing .env' "$fixture_dir/missing.err" >/dev/null
+
+printf '%s\n' \
+  'API_BASE_URL=https://api.omiapi.com/' \
+  'USE_WEB_AUTH=true' \
+  'USE_AUTH_CUSTOM_TOKEN=false' >"$fixture_dir/.env"
+if (
+  cd "$fixture_dir"
+  "$VALIDATOR" --flavor prod
+) 2>"$fixture_dir/custom-token.err"; then
+  echo 'FAIL: accepted a build without custom-token auth' >&2
+  exit 1
+fi
+grep -F 'USE_AUTH_CUSTOM_TOKEN=true' "$fixture_dir/custom-token.err" >/dev/null
+
+source "$ROOT_DIR/setup.sh" >/dev/null
+if validate_flutter_profile_arg mobile_beta --dart-define=OMI_APP_PROFILE=production 2>"$fixture_dir/wrapper.err"; then
+  echo 'FAIL: wrapper accepted a conflicting profile define' >&2
+  exit 1
+fi
+grep -F "requires OMI_APP_PROFILE=mobile_beta" "$fixture_dir/wrapper.err" >/dev/null
+
+if validate_flutter_profile_arg mobile_beta \
+  --dart-define=OMI_APP_PROFILE=mobile_beta \
+  --dart-define=OMI_APP_PROFILE=mobile_beta 2>"$fixture_dir/duplicate.err"; then
+  echo 'FAIL: wrapper accepted duplicate profile defines' >&2
+  exit 1
+fi
+grep -F 'pass OMI_APP_PROFILE only once' "$fixture_dir/duplicate.err" >/dev/null
+
+echo 'validate_mobile_build_config rejects invalid flavor/profile and auth settings'

--- a/app/setup.sh
+++ b/app/setup.sh
@@ -202,6 +202,51 @@ function setup_app_env() {
   fi
 }
 
+function validate_flutter_profile_arg() {
+  local expected_profile="$1"
+  shift
+  local arg requested_profile profile_arg_count=0
+  for arg in "$@"; do
+    if [[ "$arg" == --dart-define=OMI_APP_PROFILE=* ]]; then
+      profile_arg_count=$((profile_arg_count + 1))
+      requested_profile="${arg#--dart-define=OMI_APP_PROFILE=}"
+      if [[ "$requested_profile" != "$expected_profile" ]]; then
+        echo "ERROR: this flavor requires OMI_APP_PROFILE=$expected_profile, got '$requested_profile'." >&2
+        return 1
+      fi
+    fi
+  done
+  if [[ "$profile_arg_count" -gt 1 ]]; then
+    echo "ERROR: pass OMI_APP_PROFILE only once; the wrapper supplies the required value." >&2
+    return 1
+  fi
+}
+
+function prepare_mobile_build_env() {
+  local flavor="$1"
+  local configured_api_base_url="${2:-}"
+  local profile api_base_url
+  case "$flavor" in
+    dev)
+      profile='local_dev'
+      api_base_url="$LOCAL_API_BASE_URL"
+      ;;
+    prod)
+      profile='mobile_beta'
+      api_base_url="$BETA_API_BASE_URL"
+      ;;
+    *)
+      echo "ERROR: unsupported mobile flavor '$flavor' (expected dev or prod)." >&2
+      return 1
+      ;;
+  esac
+  if [[ "$flavor" == 'dev' && -n "$configured_api_base_url" ]]; then
+    api_base_url="$configured_api_base_url"
+  fi
+  setup_app_env "$profile" "$api_base_url" || return 1
+  scripts/validate_mobile_build_config.sh --flavor "$flavor" --profile "$profile" || return 1
+}
+
 # #######################
 # Set up Android Keystore
 # #######################
@@ -217,11 +262,19 @@ function run_build_android() {
   local profile='local_dev'
   local api_base_url="$ANDROID_LOCAL_API_BASE_URL"
   local emulator_host="$ANDROID_DEV_HOST"
-  if [[ "$flavor" == "prod" ]]; then
-    profile='mobile_beta'
-    api_base_url="$BETA_API_BASE_URL"
-    emulator_host=''
-  fi
+  case "$flavor" in
+    dev) ;;
+    prod)
+      profile='mobile_beta'
+      api_base_url="$BETA_API_BASE_URL"
+      emulator_host=''
+      ;;
+    *)
+      echo "ERROR: unsupported mobile flavor '$flavor' (expected dev or prod)." >&2
+      return 1
+      ;;
+  esac
+  prepare_mobile_build_env "$flavor" "$api_base_url"
   local flutter_args=(
     --flavor "$flavor"
     "--dart-define=OMI_APP_PROFILE=$profile"
@@ -372,6 +425,30 @@ function _ios_device_is_physical() {
 function run_build_ios() {
   local flavor="${1:-dev}"
   shift || true
+  local profile='local_dev'
+  local api_base_url="$LOCAL_API_BASE_URL"
+  case "$flavor" in
+    dev) ;;
+    prod)
+      profile='mobile_beta'
+      api_base_url="$BETA_API_BASE_URL"
+      ;;
+    *)
+      echo "ERROR: unsupported mobile flavor '$flavor' (expected dev or prod)." >&2
+      return 1
+      ;;
+  esac
+  validate_flutter_profile_arg "$profile" "$@" || return 1
+  prepare_mobile_build_env "$flavor" "$api_base_url" || return 1
+  local flutter_args=("--dart-define=OMI_APP_PROFILE=$profile")
+  local arg
+  for arg in "$@"; do
+    # The wrapper owns this invariant and injects exactly one profile define.
+    if [[ "$arg" == --dart-define=OMI_APP_PROFILE=* ]]; then
+      continue
+    fi
+    flutter_args+=("$arg")
+  done
   check_ios_prerequisites || return 1
   local device_id
   device_id=$(select_ios_device) || return 1
@@ -385,7 +462,7 @@ function run_build_ios() {
   flutter pub get \
     && pushd ios && pod install --repo-update && popd \
     && dart run build_runner build \
-    && flutter run --flavor "$flavor" -d "$device_id" "$@"
+    && flutter run --flavor "$flavor" -d "$device_id" "${flutter_args[@]}"
 }
 
 
@@ -397,18 +474,17 @@ case "${1}" in
         echo "ios beta requires FIREBASE_SERVICE_ACCOUNT_KEY so the production Firebase app config can be generated." >&2
         exit 1
       fi
-      setup_firebase \
+      prepare_mobile_build_env prod \
+        && setup_firebase \
         && setup_firebase_with_service_account_ios \
         && generate_ios_custom_config Prod omi-beta \
-        && setup_app_env mobile_beta \
         && run_build_ios prod --dart-define=OMI_APP_PROFILE=mobile_beta
     else
-      setup_firebase \
+      prepare_mobile_build_env dev \
+        && setup_firebase \
         && bash scripts/generate_ios_dev_info_plist.sh \
         && generate_ios_custom_config Dev omi-dev \
-        && setup_app_env local_dev \
         && run_build_ios dev \
-          --dart-define=OMI_APP_PROFILE=local_dev \
           --dart-define=OMI_API_BASE_URL="$LOCAL_API_BASE_URL" \
           --dart-define=OMI_FIREBASE_AUTH_EMULATOR_HOST="$LOCAL_DEV_HOST"
     fi
@@ -419,15 +495,15 @@ case "${1}" in
         echo "android beta requires FIREBASE_SERVICE_ACCOUNT_KEY so the production Firebase app config can be generated." >&2
         exit 1
       fi
-      setup_keystore_android \
+      prepare_mobile_build_env prod \
+        && setup_keystore_android \
         && setup_firebase \
         && setup_firebase_with_service_account_android \
-        && setup_app_env mobile_beta "$BETA_API_BASE_URL" \
         && run_build_android prod
     else
-      setup_keystore_android \
+      prepare_mobile_build_env dev \
+        && setup_keystore_android \
         && setup_firebase \
-        && setup_app_env local_dev "$ANDROID_LOCAL_API_BASE_URL" \
         && run_build_android dev
     fi
     ;;

--- a/app/setup/scripts/release.ps1
+++ b/app/setup/scripts/release.ps1
@@ -1,4 +1,29 @@
-flutter clean; dart run build_runner build; Write-Host "1"
+$ErrorActionPreference = "Stop"
+
+$AppDir = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+Set-Location $AppDir
+
+$EnvFile = Join-Path $AppDir ".env"
+if (-not (Test-Path $EnvFile)) {
+    throw "Missing .env; prepare the mobile beta environment before releasing."
+}
+$EnvSettings = @{}
+Get-Content $EnvFile | ForEach-Object {
+    if ($_ -match '^([^#][^=]*)=(.*)$') {
+        $EnvSettings[$Matches[1]] = $Matches[2]
+    }
+}
+foreach ($Key in @("USE_WEB_AUTH", "USE_AUTH_CUSTOM_TOKEN")) {
+    if ($EnvSettings[$Key] -ne "true") {
+        throw ".env must contain $Key=true for the prod/mobile_beta release."
+    }
+}
+
+$Profile = "mobile_beta"
+flutter clean
 flutter pub get
-flutter build appbundle --release --flavor prod -t lib/main_prod.dart
-flutter build apk --release --flavor prod -t lib/main_prod.dart 
+dart run build_runner build --delete-conflicting-outputs
+flutter build appbundle --release --flavor prod -t lib/main_prod.dart `
+  --dart-define=OMI_APP_PROFILE=$Profile
+flutter build apk --release --flavor prod -t lib/main_prod.dart `
+  --dart-define=OMI_APP_PROFILE=$Profile

--- a/app/test.sh
+++ b/app/test.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts/validate_mobile_build_config_test.sh"
+"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts/mobile_build_wrapper_test.sh"
+
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$ROOT_DIR"
 


### PR DESCRIPTION
## Summary

- Make setup.sh own mobile flavor/profile pairing and auth environment preparation.
- Fail before Flutter/Xcode on invalid, missing, or conflicting mobile build configuration.
- Apply the same preflight to release and Android profiling helpers, and document the safe physical-device path.
- Add shell regression coverage to the normal app test entry points.

## Verification

- bash scripts/validate_mobile_build_config_test.sh
- bash scripts/mobile_build_wrapper_test.sh
- bash scripts/setup_app_env_test.sh
- bash test/shell/ios_device_selection_test.sh
- bash scripts/generate_ios_custom_config_bundle_id_test.sh
- bash test/shell/ios_dev_ats_config_test.sh
- bash -n on all changed shell scripts
- git diff --check
- bounded pre-push gate: 14 checks passed

The unrelated local iOS signing/Xcode edits from the device test remain uncommitted and are not included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



Failure-Class: none
