### PR TITLE
Home: circular + record button, cleaner empty state, bottom-sheet chat

### DIFF
--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -869,7 +869,18 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                               },
                             ),
                             if (home.selectedIndex == 0)
-                              Positioned(left: 16, right: 16, bottom: 78, child: _buildChatBar(context)),
+                              Positioned(
+                                left: 16,
+                                right: 16,
+                                bottom: 78,
+                                child: Row(
+                                  children: [
+                                    Expanded(child: _buildChatBar(context)),
+                                    const SizedBox(width: 10),
+                                    const HomeRecordButton(),
+                                  ],
+                                ),
+                              ),
                           ],
                         );
                       },

--- a/app/lib/pages/home/widgets/battery_info_widget.dart
+++ b/app/lib/pages/home/widgets/battery_info_widget.dart
@@ -29,59 +29,6 @@ class BatteryInfoWidget extends StatefulWidget {
 }
 
 class _BatteryInfoWidgetState extends State<BatteryInfoWidget> {
-  void _showRecordOptions(BuildContext context) {
-    HapticFeedback.lightImpact();
-    showModalBottomSheet(
-      context: context,
-      backgroundColor: Colors.transparent,
-      isScrollControlled: true,
-      builder: (sheetContext) => RecordOptionsSheet(
-        onPickPhoneMic: () {
-          Navigator.pop(sheetContext);
-          _startRecording(context);
-        },
-        onPickPhoneCall: () {
-          Navigator.pop(sheetContext);
-          if (!context.mounted) return;
-          Navigator.push(context, MaterialPageRoute(builder: (_) => const PhoneCallsPage()));
-        },
-      ),
-    );
-  }
-
-  Future<void> _startRecording(BuildContext context) async {
-    HapticFeedback.mediumImpact();
-    final captureProvider = context.read<CaptureProvider>();
-    if (captureProvider.recordingState == RecordingState.initialising) return;
-    if (captureProvider.recordingState == RecordingState.record) {
-      // Batch reports RecordingState.record too, but has no in-progress conversation
-      // to force-process — stopStreamRecording finalizes the local .bin on its own.
-      final wasBatch = captureProvider.isPhoneMicBatchRecording;
-      await captureProvider.stopStreamRecording();
-      if (!wasBatch) captureProvider.forceProcessingCurrentConversation();
-      PlatformManager.instance.analytics.phoneMicRecordingStopped();
-      return;
-    }
-    await captureProvider.streamRecording();
-    PlatformManager.instance.analytics.phoneMicRecordingStarted();
-    // Phone-mic Transcribe Later (batch) has no live transcript — its surface is the
-    // conversations-list batch card, so skip the capturing page (same as BLE batch).
-    if (captureProvider.isPhoneMicBatchRecording) {
-      if (SharedPreferencesUtil().phoneBatchAuto && context.mounted) {
-        AppSnackbar.showSnackbar(context.l10n.phoneMicOfflineFallbackMessage);
-      }
-      return;
-    }
-    if (context.mounted) {
-      Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (context) => ConversationCapturingPage(topConversationId: captureProvider.topConversationId),
-        ),
-      );
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     return Selector<HomeProvider, bool>(
@@ -253,90 +200,112 @@ class _BatteryInfoWidgetState extends State<BatteryInfoWidget> {
                       ),
                     ),
                   ),
-                  if (isMemoriesPage)
-                    Consumer<CaptureProvider>(
-                      builder: (context, captureProvider, _) {
-                        final isRecording = captureProvider.recordingState == RecordingState.record;
-                        final isInitialising = captureProvider.recordingState == RecordingState.initialising;
-                        final showChevron = !isRecording && !isInitialising;
-                        return Padding(
-                          padding: const EdgeInsets.only(left: 8),
-                          child: AnimatedContainer(
-                            duration: const Duration(milliseconds: 200),
-                            height: 36,
-                            decoration: BoxDecoration(
-                              color: isRecording ? Colors.red.shade700 : Colors.deepPurple,
-                              borderRadius: BorderRadius.circular(18),
-                            ),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              crossAxisAlignment: CrossAxisAlignment.center,
-                              children: [
-                                GestureDetector(
-                                  behavior: HitTestBehavior.opaque,
-                                  onTap: () => _startRecording(context),
-                                  child: Container(
-                                    height: 36,
-                                    alignment: Alignment.center,
-                                    padding: EdgeInsets.fromLTRB(12, 0, showChevron ? 10 : 12, 0),
-                                    child: Row(
-                                      mainAxisSize: MainAxisSize.min,
-                                      crossAxisAlignment: CrossAxisAlignment.center,
-                                      children: [
-                                        if (isRecording)
-                                          const Icon(Icons.stop_rounded, size: 14, color: Colors.white)
-                                        else if (isInitialising)
-                                          const SizedBox(
-                                            width: 12,
-                                            height: 12,
-                                            child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
-                                          )
-                                        else
-                                          const FaIcon(FontAwesomeIcons.microphone, size: 12, color: Colors.white),
-                                        const SizedBox(width: 6),
-                                        Text(
-                                          isRecording
-                                              ? context.l10n.stop
-                                              : isInitialising
-                                                  ? '...'
-                                                  : context.l10n.record,
-                                          style: const TextStyle(
-                                            color: Colors.white,
-                                            fontSize: 12,
-                                            fontWeight: FontWeight.w600,
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                ),
-                                if (showChevron) ...[
-                                  Container(width: 1, height: 18, color: Colors.white.withValues(alpha: 0.25)),
-                                  GestureDetector(
-                                    behavior: HitTestBehavior.opaque,
-                                    onTap: () => _showRecordOptions(context),
-                                    child: Container(
-                                      height: 36,
-                                      alignment: Alignment.center,
-                                      padding: const EdgeInsets.symmetric(horizontal: 8),
-                                      child: const Icon(
-                                        Icons.keyboard_arrow_down_rounded,
-                                        size: 18,
-                                        color: Colors.white,
-                                      ),
-                                    ),
-                                  ),
-                                ],
-                              ],
-                            ),
-                          ),
-                        );
-                      },
-                    ),
                 ],
               );
             }
           },
+        );
+      },
+    );
+  }
+}
+
+
+/// Circular phone-mic record button shown to the right of the home chat bar.
+/// Tap starts/stops recording; long-press opens the record options sheet.
+class HomeRecordButton extends StatefulWidget {
+  const HomeRecordButton({super.key});
+
+  @override
+  State<HomeRecordButton> createState() => _HomeRecordButtonState();
+}
+
+class _HomeRecordButtonState extends State<HomeRecordButton> {
+  void _showRecordOptions(BuildContext context) {
+    HapticFeedback.lightImpact();
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (sheetContext) => RecordOptionsSheet(
+        onPickPhoneMic: () {
+          Navigator.pop(sheetContext);
+          _startRecording(context);
+        },
+        onPickPhoneCall: () {
+          Navigator.pop(sheetContext);
+          if (!context.mounted) return;
+          Navigator.push(context, MaterialPageRoute(builder: (_) => const PhoneCallsPage()));
+        },
+      ),
+    );
+  }
+
+  Future<void> _startRecording(BuildContext context) async {
+    HapticFeedback.mediumImpact();
+    final captureProvider = context.read<CaptureProvider>();
+    if (captureProvider.recordingState == RecordingState.initialising) return;
+    if (captureProvider.recordingState == RecordingState.record) {
+      // Batch reports RecordingState.record too, but has no in-progress conversation
+      // to force-process — stopStreamRecording finalizes the local .bin on its own.
+      final wasBatch = captureProvider.isPhoneMicBatchRecording;
+      await captureProvider.stopStreamRecording();
+      if (!wasBatch) captureProvider.forceProcessingCurrentConversation();
+      PlatformManager.instance.analytics.phoneMicRecordingStopped();
+      return;
+    }
+    await captureProvider.streamRecording();
+    PlatformManager.instance.analytics.phoneMicRecordingStarted();
+    // Phone-mic Transcribe Later (batch) has no live transcript — its surface is the
+    // conversations-list batch card, so skip the capturing page (same as BLE batch).
+    if (captureProvider.isPhoneMicBatchRecording) {
+      if (SharedPreferencesUtil().phoneBatchAuto && context.mounted) {
+        AppSnackbar.showSnackbar(context.l10n.phoneMicOfflineFallbackMessage);
+      }
+      return;
+    }
+    if (context.mounted) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => ConversationCapturingPage(topConversationId: captureProvider.topConversationId),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<CaptureProvider>(
+      builder: (context, captureProvider, _) {
+        final isRecording = captureProvider.recordingState == RecordingState.record;
+        final isInitialising = captureProvider.recordingState == RecordingState.initialising;
+        return GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: () => _startRecording(context),
+          onLongPress: isRecording || isInitialising ? null : () => _showRecordOptions(context),
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            width: 62,
+            height: 62,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: isRecording ? Colors.red.shade700 : Colors.deepPurple,
+              shape: BoxShape.circle,
+              boxShadow: [
+                BoxShadow(color: Colors.black.withValues(alpha: 0.35), blurRadius: 18, offset: const Offset(0, 6)),
+              ],
+            ),
+            child: isRecording
+                ? const Icon(Icons.stop_rounded, size: 24, color: Colors.white)
+                : isInitialising
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                      )
+                    : const FaIcon(FontAwesomeIcons.microphone, size: 18, color: Colors.white),
+          ),
         );
       },
     );


### PR DESCRIPTION
Home refresh per Nik's live simulator iteration (three commits):

1. The phone-mic Record control leaves the app-bar pill and becomes a circular button at the bottom-right of home, beside the "Ask Omi anything" bar. Tap records/stops (red stop state while recording); long-press opens the record-options sheet the pill's chevron used to open.
2. The circle shows + when idle; the three get-started orbs (Record with Phone / Record Call / Connect Device) leave the empty home — the + button is the recording entry point, Connect covers devices. Dead handlers and unused imports removed (analyzer 0 errors, issues 161 → 157).
3. Empty-home copy becomes "Tap + to start recording" (new l10n key; non-English locales fall back), and chat opened from the chat bar (text or voice) presents from the bottom (fullscreenDialog), Granola-style. The notification→chat route keeps the default transition.

Verification (iPhone 16 Pro simulator, prod-flavor debug build, exercised live with Nik watching): + circle renders beside the bar; tapping + started real phone-mic recording twice across launches (Listening capture page, mic active); screen-recording frames show the chat page sliding up from the bottom on chat-bar tap; empty-state copy on screen. `app/test.sh` regression: the home suite passed on the base branch (1671 tests); CI runs the full suite at the pinned Flutter.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

