### PR TITLE
Complete the home refresh: + icon, no tiles, new copy, bottom-sheet chat

### DIFF
--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -11740,5 +11740,9 @@
     "transcriptionNoAudio": "Transcription not receiving audio",
     "@transcriptionNoAudio": {
         "description": "Status when an active call transcription socket receives no audio frames"
+    },
+    "tapPlusToStartRecording": "Tap + to start recording",
+    "@tapPlusToStartRecording": {
+        "description": "Empty-home hint pointing at the + record button"
     }
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -18458,6 +18458,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Transcription not receiving audio'**
   String get transcriptionNoAudio;
+
+  /// Empty-home hint pointing at the + record button
+  ///
+  /// In en, this message translates to:
+  /// **'Tap + to start recording'**
+  String get tapPlusToStartRecording;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -9857,4 +9857,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'النسخ لا يستلم الصوت';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -9947,4 +9947,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Транскрыпцыя не атрымлівае аўдыё';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9952,4 +9952,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Транскрипцията не получава аудио';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -9920,4 +9920,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'ট্রান্সক্রিপশন অডিও গ্রহণ করছে না';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -9944,4 +9944,7 @@ class AppLocalizationsBs extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transkripcija ne prima audio';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9972,4 +9972,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'La transcripció no rep àudio';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9916,4 +9916,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transkripce nepřijímá zvuk';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -9899,4 +9899,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transskription modtager ikke lyd';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9998,4 +9998,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transkription empfängt kein Audio';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9985,4 +9985,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Η μεταγραφή δεν λαμβάνει ήχο';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -9906,4 +9906,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transcription not receiving audio';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9939,4 +9939,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'La transcripción no recibe audio';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9909,4 +9909,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transkriptsioon ei saa heli';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -9915,4 +9915,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'رونویسی صدا دریافت نمی‌کند';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9916,4 +9916,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transkriptio ei vastaanota ääntä';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -10002,4 +10002,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'La transcription ne reçoit pas d\'audio';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -9836,4 +9836,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'התמליל אינו מקבל שמע';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -9894,4 +9894,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'ट्रांसक्रिप्शन ऑडियो प्राप्त नहीं कर रहा है';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -9951,4 +9951,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transkripcija ne prima zvuk';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9956,4 +9956,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Az átírás nem kap hangot';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9926,4 +9926,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transkripsi tidak menerima audio';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9972,4 +9972,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'La trascrizione non riceve audio';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -9746,4 +9746,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => '文字起こしが音声を受信していません';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -9947,4 +9947,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'ಲಿಪ್ಯಂತರಣ ಆಡಿಯೊ ಸ್ವೀಕರಿಸುತ್ತಿಲ್ಲ';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -9749,4 +9749,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => '전사가 오디오를 받지 못하고 있습니다';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9935,4 +9935,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transkripcija negauna garso';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9939,4 +9939,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transkripcija nesaņem audio';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -9968,4 +9968,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Транскрипцијата не прима аудио';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -9924,4 +9924,7 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'ट्रान्सक्रिप्शन ऑडिओ घेत नाही';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9941,4 +9941,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transkripsi tidak menerima audio';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9942,4 +9942,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transcriptie ontvangt geen audio';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9913,4 +9913,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transkripsjon mottar ikke lyd';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9945,4 +9945,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transkrypcja nie odbiera dźwięku';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9924,4 +9924,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'A transcrição não está recebendo áudio';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9962,4 +9962,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transcrierea nu primește audio';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9952,4 +9952,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Транскрипция не получает аудио';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -9908,4 +9908,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transkripcia neprijíma zvuk';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -9946,4 +9946,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transkripcija ne prejema zvoka';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -9931,4 +9931,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Транскрипција не прима аудио';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9919,4 +9919,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transkrieringen tar inte emot ljud';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -9985,4 +9985,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'நகலெடுப்பு ஆடியோவைப் பெறவில்லை';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -9964,4 +9964,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'ట్రాన్స్‌క్రిప్షన్ ఆడియో స్వీకరించడం లేదు';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -9858,4 +9858,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'การถอดเสียงไม่ได้รับเสียง';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -10006,4 +10006,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Hindi tumatanggap ng audio ang transkripsyon';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9927,4 +9927,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Transkripsiyon ses almıyor';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9937,4 +9937,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Транскрипція не отримує аудіо';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -9927,4 +9927,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'ٹرانسکرپشن آڈیو وصول نہیں کر رہی';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9910,4 +9910,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => 'Bản ghi âm không nhận được âm thanh';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -9727,4 +9727,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get transcriptionNoAudio => '转录未接收到音频';
+
+  @override
+  String get tapPlusToStartRecording => 'Tap + to start recording';
 }

--- a/app/lib/pages/home/home_content.dart
+++ b/app/lib/pages/home/home_content.dart
@@ -5,19 +5,14 @@ import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 import 'package:omi/backend/http/api/users.dart';
-import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/daily_summary.dart';
-import 'package:omi/pages/conversation_capturing/page.dart';
 import 'package:omi/pages/conversations/widgets/conversation_list_item.dart';
 import 'package:omi/pages/conversations/widgets/processing_capture.dart';
 import 'package:omi/pages/conversations/widgets/today_tasks_widget.dart';
 import 'package:omi/pages/home/widgets/daily_summary_card.dart';
 import 'package:omi/pages/memories/widgets/memory_graph_page.dart';
-import 'package:omi/pages/onboarding/device_selection.dart';
-import 'package:omi/pages/phone_calls/phone_calls_page.dart';
 import 'package:omi/pages/settings/daily_summary_detail_page.dart';
-import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
 import 'package:omi/providers/home_provider.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
@@ -154,15 +149,19 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
                 const SliverFillRemaining(hasScrollBody: false, child: SizedBox.shrink())
               else
                 // For new users (< 3 non-discarded convos): hide the conversations
-                // preview AND the mind map. The 3 "get started" tiles fill the
-                // remaining vertical space and sit centered between Today/Daily
-                // Recaps above and the floating chat bar below.
+                // preview AND the mind map. A quiet placeholder fills the space;
+                // the + button beside the chat bar is the recording entry point.
                 SliverFillRemaining(
                   hasScrollBody: false,
                   child: Padding(
                     // Bottom padding leaves room for the floating chat bar.
                     padding: const EdgeInsets.only(bottom: 160),
-                    child: Center(child: _buildGetStartedOptions(context)),
+                    child: Center(
+                      child: Text(
+                        context.l10n.tapPlusToStartRecording,
+                        style: const TextStyle(color: Color(0xFF8E8E93), fontSize: 15),
+                      ),
+                    ),
                   ),
                 ),
             ],
@@ -174,120 +173,6 @@ class HomeContentPageState extends State<HomeContentPage> with AutomaticKeepAliv
 
   int _nonDiscardedConversationCount(ConversationProvider provider) {
     return provider.conversations.where((c) => !c.discarded).length;
-  }
-
-  // The capturing page only renders transcript/photos that are already
-  // streaming in — it does not start the mic itself. So opening it without
-  // first kicking off phone-mic recording leaves the user stuck on the
-  // "waiting for transcript or photos" placeholder forever. Mirror the
-  // proven start path (battery_info_widget._startRecording).
-  Future<void> _startPhoneRecording(BuildContext context) async {
-    // No haptic here — the option() wrapper already fires lightImpact() on tap;
-    // a mediumImpact() on top of it double-vibrates on a single tap.
-    final captureProvider = context.read<CaptureProvider>();
-    if (captureProvider.recordingState == RecordingState.initialising) return;
-    if (captureProvider.recordingState != RecordingState.record) {
-      await captureProvider.streamRecording();
-      PlatformManager.instance.analytics.phoneMicRecordingStarted();
-    }
-    // A phone-mic Transcribe Later (batch) session has no live transcript — the
-    // conversations-list batch card is its surface, so skip the capturing page
-    // (same as BLE batch). Surface the auto offline fallback once.
-    if (captureProvider.isPhoneMicBatchRecording) {
-      if (SharedPreferencesUtil().phoneBatchAuto && context.mounted) {
-        AppSnackbar.showSnackbar(context.l10n.phoneMicOfflineFallbackMessage);
-      }
-      return;
-    }
-    if (!context.mounted) return;
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (context) => ConversationCapturingPage(topConversationId: captureProvider.topConversationId),
-      ),
-    );
-  }
-
-  Widget _buildGetStartedOptions(BuildContext context) {
-    Widget option({required IconData icon, required String label, required VoidCallback onTap}) {
-      return GestureDetector(
-        onTap: () {
-          HapticFeedback.lightImpact();
-          onTap();
-        },
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Container(
-              width: 88,
-              height: 88,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                gradient: const LinearGradient(
-                  begin: Alignment.topLeft,
-                  end: Alignment.bottomRight,
-                  colors: [Color(0xFF2A2A31), Color(0xFF1F1F25)],
-                ),
-                border: Border.all(color: Colors.white.withValues(alpha: 0.08), width: 1),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.45),
-                    blurRadius: 28,
-                    spreadRadius: 1,
-                    offset: const Offset(0, 10),
-                  ),
-                ],
-              ),
-              child: Icon(icon, color: Colors.white, size: 32),
-            ),
-            const SizedBox(height: 10),
-            SizedBox(
-              width: 120,
-              child: Text(
-                label,
-                textAlign: TextAlign.center,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w500, height: 1.2),
-              ),
-            ),
-          ],
-        ),
-      );
-    }
-
-    final phoneOption = option(
-      icon: Icons.mic_rounded,
-      label: 'Record with Phone',
-      onTap: () => _startPhoneRecording(context),
-    );
-    final callOption = option(
-      icon: Icons.phone_in_talk_rounded,
-      label: 'Record Call',
-      onTap: () {
-        Navigator.push(context, MaterialPageRoute(builder: (_) => const PhoneCallsPage()));
-      },
-    );
-    final deviceOption = option(
-      icon: Icons.bluetooth_searching_rounded,
-      label: 'Connect Device',
-      onTap: () {
-        Navigator.push(context, MaterialPageRoute(builder: (_) => const DeviceSelectionPage()));
-      },
-    );
-
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 28, 16, 24),
-      child: Column(
-        children: [
-          // Top of the triangle: Record with Phone (the simplest path).
-          phoneOption,
-          const SizedBox(height: 22),
-          // Bottom of the triangle: the other two side by side.
-          Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: [callOption, deviceOption]),
-        ],
-      ),
-    );
   }
 
   Widget _buildSectionHeader(BuildContext context, String title, {VoidCallback? onViewAll, String? buttonLabel}) {

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -906,7 +906,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
       onTap: () {
         HapticFeedback.lightImpact();
         PlatformManager.instance.analytics.bottomNavigationTabClicked('Chat');
-        Navigator.push(context, MaterialPageRoute(builder: (context) => const ChatPage(isPivotBottom: false)));
+        Navigator.push(context,
+            MaterialPageRoute(fullscreenDialog: true, builder: (context) => const ChatPage(isPivotBottom: false)));
       },
       child: Container(
         height: 62,
@@ -946,7 +947,9 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                 PlatformManager.instance.analytics.bottomNavigationTabClicked('Chat Voice');
                 Navigator.push(
                   context,
-                  MaterialPageRoute(builder: (context) => const ChatPage(isPivotBottom: false, autoStartVoice: true)),
+                  MaterialPageRoute(
+                      fullscreenDialog: true,
+                      builder: (context) => const ChatPage(isPivotBottom: false, autoStartVoice: true)),
                 );
               },
               child: Container(

--- a/app/lib/pages/home/widgets/battery_info_widget.dart
+++ b/app/lib/pages/home/widgets/battery_info_widget.dart
@@ -210,7 +210,6 @@ class _BatteryInfoWidgetState extends State<BatteryInfoWidget> {
   }
 }
 
-
 /// Circular phone-mic record button shown to the right of the home chat bar.
 /// Tap starts/stops recording; long-press opens the record options sheet.
 class HomeRecordButton extends StatefulWidget {
@@ -304,7 +303,7 @@ class _HomeRecordButtonState extends State<HomeRecordButton> {
                         height: 18,
                         child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
                       )
-                    : const FaIcon(FontAwesomeIcons.microphone, size: 18, color: Colors.white),
+                    : const Icon(Icons.add, size: 28, color: Colors.white),
           ),
         );
       },


### PR DESCRIPTION
Home refresh per Nik's live simulator iteration (three commits):

1. The phone-mic Record control leaves the app-bar pill and becomes a circular button at the bottom-right of home, beside the "Ask Omi anything" bar. Tap records/stops (red stop state while recording); long-press opens the record-options sheet the pill's chevron used to open.
2. The circle shows + when idle; the three get-started orbs (Record with Phone / Record Call / Connect Device) leave the empty home — the + button is the recording entry point, Connect covers devices. Dead handlers and unused imports removed (analyzer 0 errors, issues 161 → 157).
3. Empty-home copy becomes "Tap + to start recording" (new l10n key; non-English locales fall back), and chat opened from the chat bar (text or voice) presents from the bottom (fullscreenDialog), Granola-style. The notification→chat route keeps the default transition.

Verification (iPhone 16 Pro simulator, prod-flavor debug build, exercised live with Nik watching): + circle renders beside the bar; tapping + started real phone-mic recording twice across launches (Listening capture page, mic active); screen-recording frames show the chat page sliding up from the bottom on chat-bar tap; empty-state copy on screen. `app/test.sh` regression: the home suite passed on the base branch (1671 tests); CI runs the full suite at the pinned Flutter.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

