### PR TITLE
SCA-411: remove unused imports that #12563 landed on main

### DIFF
--- a/.github/failure-classes/FC-merged-past-red-analyzer-ratchet.json
+++ b/.github/failure-classes/FC-merged-past-red-analyzer-ratchet.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "id": "FC-merged-past-red-analyzer-ratchet",
+  "violated_contract": "A PR whose Dart Analyze & Tests job is red must not merge to main. The analyzer ratchet fails closed on unused_import above a baseline of 0; merging past that red check lands new unused imports on main and blocks every later PR that runs the mobile job.",
+  "canonical_prevention": "Keep unused_import at baseline 0. Delete the unused import lines; never raise the baseline to clear a red Dart Analyze & Tests check, and never merge while that check is red.",
+  "canonical_prevention_artifact": [
+    "app/scripts/analyze_ratchet.sh",
+    "app/analysis_baseline.json",
+    ".github/workflows/mobile-app-checks.yml"
+  ],
+  "evidence_prs": [12563],
+  "scope_hints": [
+    "app/lib/",
+    "app/scripts/analyze_ratchet.sh",
+    "app/analysis_baseline.json",
+    ".github/workflows/mobile-app-checks.yml"
+  ],
+  "status": "open"
+}

--- a/app/lib/pages/home/home_content.dart
+++ b/app/lib/pages/home/home_content.dart
@@ -15,8 +15,6 @@ import 'package:omi/pages/memories/widgets/memory_graph_page.dart';
 import 'package:omi/pages/settings/daily_summary_detail_page.dart';
 import 'package:omi/providers/conversation_provider.dart';
 import 'package:omi/providers/home_provider.dart';
-import 'package:omi/utils/alerts/app_snackbar.dart';
-import 'package:omi/utils/enums.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/ui_guidelines.dart';
 import 'package:omi/widgets/shimmer_with_timeout.dart';


### PR DESCRIPTION
## What changed and why

`main` is red on the Flutter analyzer ratchet because PR #12563 ("Complete the home refresh") merged at 2026-09-01T21:46:43Z with its `Dart Analyze & Tests` check **failing**. That landed two `unused_import` violations onto `main` (`unused_import: 2 found, baseline 0`) and is blocking PRs that run the mobile job, including #12564.

Both leftovers are in `app/lib/pages/home/home_content.dart`: after #12563 deleted the get-started orbs / `_startPhoneRecording`, the `app_snackbar.dart` and `enums.dart` imports were unused. This PR deletes those two import lines and leaves the `unused_import` baseline at 0.

Closes SCA-411

## Product invariants affected

none

## How it was verified

Local `bash app/scripts/analyze_ratchet.sh` at this branch head (Flutter 3.44.5 / Dart 3.12.2):

```
Running: dart analyze --format=machine .
avoid_print: improved (26 found, baseline 29) — consider running --update-baseline to lock in
curly_braces_in_flow_control_structures: improved (0 found, baseline 6) — consider running --update-baseline to lock in
sort_child_properties_last: improved (1 found, baseline 2) — consider running --update-baseline to lock in
use_super_parameters: improved (5 found, baseline 6) — consider running --update-baseline to lock in
Analyzer ratchet passed.
```

Baselines for the improved categories were left alone. `unused_import` is back to 0.

## Tests

No new Dart test. The analyzer ratchet (`unused_import` baseline 0) is the regression guard for this class of failure; a unit test that the import lines are absent would be a static tripwire, not behavioral coverage.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative (only when needed)

Registering `FC-merged-past-red-analyzer-ratchet`. Violated contract: a PR whose Dart Analyze & Tests job is red must not merge to `main`; #12563 did, and the two unused imports it left blocked later mobile PRs. Canonical prevention is already in-tree: `app/scripts/analyze_ratchet.sh` with `unused_import` baseline 0, run by `.github/workflows/mobile-app-checks.yml`. Do not raise that baseline to clear a red check, and do not merge while it is red. `evidence_prs` cites #12563 as the merged incident; this PR is the first instance fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

