### PR TITLE
fix(app): stop AI chat messages collapsing to ~1 word per line on iOS

### DIFF
--- a/app/lib/pages/chat/widgets/ai_message.dart
+++ b/app/lib/pages/chat/widgets/ai_message.dart
@@ -624,7 +624,13 @@ class _NormalMessageWidgetState extends State<NormalMessageWidget> {
                           widget.onAskOmi?.call(text);
                         }, selectedText: selectedText);
                       },
-                      child: getMarkdownWidget(context, widget.messageText, onAskOmi: widget.onAskOmi),
+                      // Force full available width: SelectionArea + MarkdownBody
+                      // otherwise size to the text's minimum intrinsic width, which
+                      // collapses the message to ~1 word per line on iOS.
+                      child: SizedBox(
+                        width: double.infinity,
+                        child: getMarkdownWidget(context, widget.messageText, onAskOmi: widget.onAskOmi),
+                      ),
                     );
                   },
                 ),


### PR DESCRIPTION
AI chat replies wrapped at ~1 word per line (even mid-word) on iOS TestFlight — a width-collapse: SelectionArea + MarkdownBody size to the text's minimum intrinsic width. Fix forces full width via SizedBox(width: double.infinity) (parent list is bounded → safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

