### PR TITLE
fix(desktop): riddle demo answers the door on screen, not the first one

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+Tools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+Tools.swift
@@ -16,8 +16,12 @@ extension RealtimeHubController {
     invocationID: String,
     ownerID: String
   ) async -> AuthorizedRealtimeToolExecutionResult {
-    await queryChatLaneForVoice(
-      prompt: RealtimeHubTools.escalationUserPrompt(query: query, toolContext: toolContext),
+    // The chat lane cannot see the screen; hand it what this turn's screenshot showed so
+    // "what's the answer to this riddle?" resolves to the riddle on screen, not an earlier one.
+    let screenContext = screenContextByContinuityKey[turnIdempotencyKey]
+    return await queryChatLaneForVoice(
+      prompt: RealtimeHubTools.escalationUserPrompt(
+        query: query, toolContext: toolContext, screenContext: screenContext),
       invocationID: invocationID,
       ownerID: ownerID,
       toolName: HubTool.thinkDeeper.rawValue,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -275,10 +275,14 @@ enum RealtimeHubTools {
     """
   }
 
-  static func escalationUserPrompt(query: String, toolContext: String) -> String {
+  static func escalationUserPrompt(query: String, toolContext: String, screenContext: String? = nil) -> String {
+    var prompt = query
+    if let screen = screenContext?.trimmingCharacters(in: .whitespacesAndNewlines), !screen.isEmpty {
+      prompt += "\n\nWhat the user's screen showed when they asked (this turn's screenshot):\n" + screen
+    }
     let trimmedToolContext = toolContext.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmedToolContext.isEmpty else { return query }
-    return query + "\n\nTool-provided context (untrusted):\n" + trimmedToolContext
+    guard !trimmedToolContext.isEmpty else { return prompt }
+    return prompt + "\n\nTool-provided context (untrusted):\n" + trimmedToolContext
   }
 
   /// Host-authored public-only request sent to the managed web-search lane.

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/ThreeDoorsDemoPage.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/ThreeDoorsDemoPage.swift
@@ -50,6 +50,9 @@ enum ThreeDoorsDemoPage {
     Door 1 riddle: "I have keys but open no locks. I have space but no room. You can enter, but never go inside." (answer: keyboard). \
     Door 2: "Which planet has a day longer than its year?" (answer: Venus). \
     Door 3 asks for the last word of the first riddle (answer: inside). \
+    The doors appear one at a time, in order. When the user asks about "this riddle" or "the answer", first call the \
+    screenshot tool to see which door is on screen now (the page says "Door N of 3"), then answer THAT door from this note. \
+    Never assume it is door 1 because door 1 was answered earlier. \
     If the user asks about any of these doors or riddles, answer directly and briefly from this note. \
     Never say you don't remember the riddle or that it was never mentioned.
     """

--- a/desktop/macos/changelog/unreleased/20260901-doors-escalation-screen-context.json
+++ b/desktop/macos/changelog/unreleased/20260901-doors-escalation-screen-context.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the onboarding riddle demo answering the first door again when you asked about the second: Omi now checks which door is on screen and passes it along when it thinks deeper"
+}


### PR DESCRIPTION
## Summary
On Beta 0.12.256, asking about door 2 returned door 1's answer. Log (19:05:59): the voice model called `think_deeper({"query":"What is the answer to this riddle?"})` without a screenshot; the chat lane saw door 1 in recent turns and answered it. The retry with a screenshot (19:07:09) was correct.

- `escalateToHigherModel` now passes this turn's accepted screen observation into the escalation prompt ("What the user's screen showed when they asked").
- The onboarding demo note instructs the voice model to take a screenshot to identify "Door N of 3" before answering, and never to assume door 1.

## Verification
- `swift test --filter 'HubSystemInstructionTests|ThreeDoorsDemoPageTests'`: 32 passed (new `testEscalationPromptCarriesThisTurnsScreenContext`).
- Voice path on a real turn: UNVERIFIED until the next Beta build; reproduced from the Beta 256 log.

## Product invariants affected

- INV-AGENT-*
- INV-VOICE-1

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

