### PR TITLE
test(desktop): regression tests for the door-on-screen escalation fix

### DIFF
--- a/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
+++ b/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
@@ -3,6 +3,18 @@ import XCTest
 @testable import Omi_Computer
 
 final class HubSystemInstructionTests: XCTestCase {
+  func testEscalationPromptCarriesThisTurnsScreenContext() {
+    // Regression (Beta 0.12.256): think_deeper was called with only "What is the answer to this
+    // riddle?" and no screen info, so the chat lane answered the previous door. The escalation
+    // prompt must carry what this turn's screenshot showed.
+    let prompt = RealtimeHubTools.escalationUserPrompt(
+      query: "What is the answer to this riddle?", toolContext: "",
+      screenContext: "Door 2 of 3: Which planet has a day longer than its year?")
+    XCTAssertTrue(prompt.contains("this turn's screenshot"))
+    XCTAssertTrue(prompt.contains("Door 2 of 3"))
+    XCTAssertEqual(RealtimeHubTools.escalationUserPrompt(query: "q", toolContext: ""), "q")
+  }
+
   func testOnboardingDemoNoteIsIncludedWhenPresentAndAbsentOtherwise() {
     let with = RealtimeHubTools.systemInstruction(
       kernelContext: "ctx", onboardingDemoContext: "Door 3 asks for the last word of the first riddle (answer: inside)."

--- a/desktop/macos/Desktop/Tests/ThreeDoorsDemoPageTests.swift
+++ b/desktop/macos/Desktop/Tests/ThreeDoorsDemoPageTests.swift
@@ -60,6 +60,7 @@ final class ThreeDoorsDemoPageTests: XCTestCase {
       XCTAssertTrue(ThreeDoorsDemoPage.modelNote.contains(phrase), phrase)
     }
     XCTAssertTrue(ThreeDoorsDemoPage.modelNote.contains("(answer: inside)"))
+    XCTAssertTrue(ThreeDoorsDemoPage.modelNote.contains("Never assume it is door 1"))
   }
 
   func testBundledTemplateContainsTheReplaceableKeyMarkup() throws {


### PR DESCRIPTION
## Summary
Regression tests that should have shipped with #12570 (the door-2 ask answered door 1): the escalation prompt carries this turn's screen observation, and the demo note requires identifying "Door N of 3" on screen first.

## Verification
- `swift test --filter 'HubSystemInstructionTests|ThreeDoorsDemoPageTests'`: 33 passed.

## Product invariants affected

- INV-VOICE-1


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

