### PR TITLE
fix(backend): expose pending MCP memory writes to readers

### DIFF
--- a/.github/failure-classes/FC-accepted-write-hidden-by-reader-filter.json
+++ b/.github/failure-classes/FC-accepted-write-hidden-by-reader-filter.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "id": "FC-accepted-write-hidden-by-reader-filter",
+  "violated_contract": "When a create endpoint returns an accepted record and its identifier, the same authenticated surface must provide an immediate read path to that record. A default reader that filters out the write's initial lifecycle state turns a committed asynchronous submission into an apparent silent write failure: the caller receives success but cannot verify, inspect, or distinguish the record from a dropped mutation.",
+  "canonical_prevention": "Keep create and list lifecycle exposure in one surface contract. If explicit submissions enter a pending-processing state, the corresponding list includes that state by default to preserve historical read-after-write behavior and exposes an explicit opt-out for processed-only consumers. Pin the default and opt-out behavior across every transport that projects the same MCP memory list.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_mcp_data_endpoints.py",
+    "backend/tests/unit/test_mcp_memory_filters.py",
+    "mcp/tests/test_get_memories.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/routers/mcp.py",
+    "backend/routers/mcp_sse.py",
+    "backend/utils/mcp_memories.py",
+    "backend/utils/memory/required_promotion.py",
+    "mcp/src/mcp_server_omi/server.py"
+  ],
+  "status": "open"
+}

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -59,6 +59,7 @@ from utils.mcp_memories import (
     parse_mcp_datetime,
     parse_mcp_int,
     parse_optional_mcp_bool,
+    resolve_mcp_pending_visibility,
 )
 import database.mcp_oauth as mcp_oauth_db
 import logging
@@ -70,6 +71,16 @@ router = APIRouter()
 
 class McpStatusResponse(BaseModel):
     status: str
+
+
+class McpCreatedMemory(Memory):
+    """Public create response: stable identity without internal user metadata."""
+
+    id: str
+    created_at: datetime
+    updated_at: datetime
+    memory_tier: Optional[str] = None
+    layer: Optional[str] = None
 
 
 class McpOauthGrantsResponse(BaseModel):
@@ -108,7 +119,7 @@ def revoke_oauth_grant(grant_id: str, uid: str = Depends(get_current_user_id)):
     return
 
 
-@router.post("/v1/mcp/memories", tags=["mcp"], response_model=Memory)
+@router.post("/v1/mcp/memories", tags=["mcp"], response_model=McpCreatedMemory)
 def create_memory(
     memory: Memory,
     auth_context: ProductAuthorizationContext = Depends(
@@ -299,6 +310,7 @@ def get_memories(
     updated_after: Optional[str] = None,
     include_activity: bool = False,
     include_sensitive: bool = True,
+    include_pending_processing: bool = True,
 ):
     uid = auth_context.uid
     try:
@@ -308,6 +320,11 @@ def get_memories(
         manually_added = parse_optional_mcp_bool(manually_added, "manually_added")
         include_activity = parse_mcp_bool(include_activity, "include_activity", default=False)
         include_sensitive = parse_mcp_bool(include_sensitive, "include_sensitive", default=True)
+        include_pending_processing = parse_mcp_bool(
+            include_pending_processing,
+            "include_pending_processing",
+            default=True,
+        )
         parsed_updated_after = parse_mcp_datetime(updated_after, "updated_after")
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
@@ -330,10 +347,19 @@ def get_memories(
             detail=app_key_grant.observability,
         )
 
+    read_pending_processing = resolve_mcp_pending_visibility(
+        include_pending_processing=include_pending_processing,
+        include_sensitive=include_sensitive,
+    )
     result = collect_filtered_memories(
         lambda batch_offset, batch_limit: [
             memory.model_dump(mode='json')
-            for memory in MemoryService(db_client=db).read(uid, limit=batch_limit, offset=batch_offset)
+            for memory in MemoryService(db_client=db).read(
+                uid,
+                limit=batch_limit,
+                offset=batch_offset,
+                include_pending_processing=read_pending_processing,
+            )
         ],
         limit=limit,
         offset=offset,

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -75,6 +75,7 @@ from utils.mcp_memories import (
     parse_mcp_datetime,
     parse_mcp_int,
     parse_optional_mcp_bool,
+    resolve_mcp_pending_visibility,
 )
 from utils.mcp_scopes import MCP_FULL_ACCESS_SCOPES
 from utils.mcp_analytics import (
@@ -336,8 +337,10 @@ MCP_TOOLS: List[Dict[str, Any]] = [
     {
         "name": "get_memories",
         "description": (
-            "Retrieve durable facts known about the user across domains. This is not recent conversation history; "
-            "for today, yesterday, last week, or another time window use date-bounded get_conversations instead."
+            "Retrieve memory records known about the user across domains. Explicit create_memory submissions that "
+            "are still being processed are included by default so callers can verify a write immediately. This is "
+            "not recent conversation history; for today, yesterday, last week, or another time window use "
+            "date-bounded get_conversations instead."
         ),
         "annotations": READ_ONLY_ANNOTATIONS,
         "securitySchemes": MEMORIES_READ_SECURITY,
@@ -352,7 +355,7 @@ MCP_TOOLS: List[Dict[str, Any]] = [
                 },
                 "limit": {
                     "type": "integer",
-                    "description": "Number of durable memories to retrieve",
+                    "description": "Number of memory records to retrieve",
                     "default": MCP_MEMORY_LIST_DEFAULT_LIMIT,
                     "minimum": 1,
                     "maximum": MCP_MEMORY_LIST_MAX_LIMIT,
@@ -380,12 +383,25 @@ MCP_TOOLS: List[Dict[str, Any]] = [
                     "description": "Include memories marked above standard data protection. Defaults to true for backward compatibility.",
                     "default": True,
                 },
+                "include_pending_processing": {
+                    "type": "boolean",
+                    "description": (
+                        "Include explicit user submissions that are still being processed. Defaults to true for "
+                        "read-after-write visibility; set false to return only processed memories. Pending "
+                        "submissions are also excluded when include_sensitive is false because their sensitivity "
+                        "classification is not complete."
+                    ),
+                    "default": True,
+                },
             },
         },
     },
     {
         "name": "create_memory",
-        "description": "Create a new memory. A memory is a known fact about the user across multiple domains.",
+        "description": (
+            "Create a new memory submission. The returned record can remain short-term while required processing "
+            "runs; get_memories includes pending submissions by default for immediate readback."
+        ),
         "annotations": WRITE_ANNOTATIONS,
         "securitySchemes": MEMORIES_WRITE_SECURITY,
         "inputSchema": {
@@ -968,6 +984,11 @@ def execute_tool(
             manually_added = parse_optional_mcp_bool(arguments.get("manually_added"), "manually_added")
             include_activity = parse_mcp_bool(arguments.get("include_activity"), "include_activity", default=False)
             include_sensitive = parse_mcp_bool(arguments.get("include_sensitive"), "include_sensitive", default=True)
+            include_pending_processing = parse_mcp_bool(
+                arguments.get("include_pending_processing"),
+                "include_pending_processing",
+                default=True,
+            )
             updated_after = parse_mcp_datetime(arguments.get("updated_after"), "updated_after")
         except ValueError as e:
             raise ToolExecutionError(str(e), code=-32602)
@@ -992,10 +1013,19 @@ def execute_tool(
         if not app_key_grant.allowed:
             raise _authorization_denied_error(str(app_key_grant.observability))
 
+        read_pending_processing = resolve_mcp_pending_visibility(
+            include_pending_processing=include_pending_processing,
+            include_sensitive=include_sensitive,
+        )
         result = collect_filtered_memories(
             lambda batch_offset, batch_limit: [
                 memory.model_dump(mode='json')
-                for memory in MemoryService(db_client=db).read(user_id, limit=batch_limit, offset=batch_offset)
+                for memory in MemoryService(db_client=db).read(
+                    user_id,
+                    limit=batch_limit,
+                    offset=batch_offset,
+                    include_pending_processing=read_pending_processing,
+                )
             ],
             limit=limit,
             offset=offset,

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -7,6 +7,7 @@ stubbing pattern in test_mcp_search_memories.py.
 """
 
 from datetime import datetime, timezone
+from inspect import signature
 import json
 from unittest.mock import patch, MagicMock
 import os
@@ -189,7 +190,50 @@ def test_memory_list_has_one_auth_dependency_and_uses_its_authorized_uid():
         assert rest.get_memories(auth_context=auth_context) == []
 
     authorize.assert_called_once_with(auth_context, db_client=rest.db)
-    memory_service.read.assert_called_once_with("auth-user", limit=100, offset=0)
+    memory_service.read.assert_called_once_with(
+        "auth-user",
+        limit=100,
+        offset=0,
+        include_pending_processing=True,
+    )
+
+
+def test_memory_list_can_exclude_pending_processing_submissions():
+    auth_context = SimpleNamespace(uid="auth-user")
+    authorization = SimpleNamespace(allowed=True)
+    memory_service = MagicMock()
+    memory_service.read.return_value = []
+    with (
+        patch.object(rest, "authorize_memory_external_default_memory_read", return_value=authorization),
+        patch.object(rest, "MemoryService", return_value=memory_service),
+    ):
+        assert rest.get_memories(auth_context=auth_context, include_pending_processing=False) == []
+
+    memory_service.read.assert_called_once_with(
+        "auth-user",
+        limit=100,
+        offset=0,
+        include_pending_processing=False,
+    )
+
+
+def test_memory_list_excludes_unclassified_pending_submissions_when_sensitive_data_is_excluded():
+    auth_context = SimpleNamespace(uid="auth-user")
+    authorization = SimpleNamespace(allowed=True)
+    memory_service = MagicMock()
+    memory_service.read.return_value = []
+    with (
+        patch.object(rest, "authorize_memory_external_default_memory_read", return_value=authorization),
+        patch.object(rest, "MemoryService", return_value=memory_service),
+    ):
+        assert rest.get_memories(auth_context=auth_context, include_sensitive=False) == []
+
+    assert memory_service.read.call_args.kwargs['include_pending_processing'] is False
+
+
+def test_memory_service_read_supports_the_pending_visibility_contract():
+    parameter = signature(rest.MemoryService.read).parameters['include_pending_processing']
+    assert parameter.default is False
 
 
 async def _run_blocking_inline(_executor, func, *args, **kwargs):
@@ -387,9 +431,10 @@ def test_sse_initialize_teaches_every_agent_to_retrieve_full_omi_context_safely(
     assert 'user clearly asked' in instructions
 
 
-def test_get_memories_advertises_and_executes_default_limit_20():
+def test_get_memories_advertises_and_executes_default_limit_20_with_pending_submissions():
     tool = next(tool for tool in sse.MCP_TOOLS if tool['name'] == 'get_memories')
     assert tool['inputSchema']['properties']['limit']['default'] == 20
+    assert tool['inputSchema']['properties']['include_pending_processing']['default'] is True
 
     service = MagicMock()
     service.read.return_value = []
@@ -401,12 +446,111 @@ def test_get_memories_advertises_and_executes_default_limit_20():
 
     assert result['limit'] == 20
     assert result['scanned_count'] == 0
+    assert service.read.call_args.kwargs['include_pending_processing'] is True
+
+
+def test_get_memories_can_exclude_pending_processing_submissions():
+    service = MagicMock()
+    service.read.return_value = []
+    with (
+        patch.object(sse, 'authorize_memory_external_default_memory_read', return_value=_allowed_empty_result()),
+        patch.object(sse, 'MemoryService', return_value=service),
+    ):
+        sse.execute_tool(
+            UID,
+            'get_memories',
+            {'include_pending_processing': False},
+            auth_context=_sse_auth_context(),
+        )
+
+    assert service.read.call_args.kwargs['include_pending_processing'] is False
+
+
+def test_get_memories_excludes_unclassified_pending_submissions_when_sensitive_data_is_excluded():
+    service = MagicMock()
+    service.read.return_value = []
+    with (
+        patch.object(sse, 'authorize_memory_external_default_memory_read', return_value=_allowed_empty_result()),
+        patch.object(sse, 'MemoryService', return_value=service),
+    ):
+        sse.execute_tool(
+            UID,
+            'get_memories',
+            {'include_sensitive': False},
+            auth_context=_sse_auth_context(),
+        )
+
+    assert service.read.call_args.kwargs['include_pending_processing'] is False
+
+
+def test_created_pending_memory_is_immediately_readable_by_id():
+    stored = []
+    service = MagicMock()
+
+    def _create(_uid, memory_db, **_kwargs):
+        stored.append(memory_db)
+        return memory_db
+
+    def _read(_uid, *, limit, offset, include_pending_processing):
+        if not include_pending_processing:
+            return []
+        return stored[offset : offset + limit]
+
+    service.create_external_memory.side_effect = _create
+    service.read.side_effect = _read
+    with (
+        patch.object(sse, 'authorize_memory_external_default_memory_write', return_value=_allowed_empty_result()),
+        patch.object(sse, 'authorize_memory_external_default_memory_read', return_value=_allowed_empty_result()),
+        patch.object(sse, 'MemoryService', return_value=service),
+        patch.object(sse, 'capture_memory_write'),
+    ):
+        created = sse.execute_tool(
+            UID,
+            'create_memory',
+            {'content': 'Read-after-write regression canary'},
+            auth_context=_sse_auth_context(),
+        )
+        listed = sse.execute_tool(UID, 'get_memories', {}, auth_context=_sse_auth_context())
+
+    created_id = created['memory']['id']
+    assert any(memory['id'] == created_id for memory in listed['memories'])
+
+
+@pytest.mark.asyncio
+async def test_rest_create_response_serializes_identity_and_excludes_internal_uid():
+    from fastapi.routing import APIRoute, serialize_response
+    from models.product_memory import MemoryTier
+
+    route = next(
+        route
+        for route in rest.router.routes
+        if isinstance(route, APIRoute) and route.path == "/v1/mcp/memories" and "POST" in route.methods
+    )
+    memory_db = rest.MemoryDB.from_memory(
+        rest.Memory(content="Read-after-write contract", category=rest.MemoryCategory.manual),
+        "internal-user-id",
+        None,
+        True,
+    )
+    memory_db.memory_tier = MemoryTier.short_term
+    payload = await serialize_response(
+        field=route.response_field,
+        response_content=memory_db,
+        is_coroutine=True,
+    )
+
+    assert route.response_model is rest.McpCreatedMemory
+    assert payload["id"] == memory_db.id
+    assert payload["memory_tier"] == "short_term"
+    assert payload["layer"] == "short_term"
+    assert "uid" not in payload
 
 
 def test_get_memories_created_desc_scan_is_capped_for_hosted_mcp():
     service = MagicMock()
 
-    def _read(_uid, *, limit, offset):
+    def _read(_uid, *, limit, offset, include_pending_processing):
+        assert include_pending_processing is True
         return [
             SimpleNamespace(
                 model_dump=lambda mode, memory_id=offset + index: {

--- a/backend/tests/unit/test_mcp_memory_filters.py
+++ b/backend/tests/unit/test_mcp_memory_filters.py
@@ -8,6 +8,7 @@ from utils.mcp_memories import (
     is_sensitive_memory,
     parse_mcp_bool,
     parse_mcp_int,
+    resolve_mcp_pending_visibility,
 )
 
 
@@ -22,6 +23,12 @@ def test_sensitive_memory_detection_uses_data_protection_level():
     assert is_sensitive_memory({"data_protection_level": "enhanced"})
     assert not is_sensitive_memory({"data_protection_level": "standard"})
     assert not is_sensitive_memory({})
+
+
+def test_pending_visibility_fails_closed_before_sensitivity_classification():
+    assert resolve_mcp_pending_visibility(include_pending_processing=True, include_sensitive=True)
+    assert not resolve_mcp_pending_visibility(include_pending_processing=True, include_sensitive=False)
+    assert not resolve_mcp_pending_visibility(include_pending_processing=False, include_sensitive=True)
 
 
 def test_filter_and_sort_memories_defaults_exclude_activity_but_keep_sensitive_for_compatibility():

--- a/backend/utils/mcp_memories.py
+++ b/backend/utils/mcp_memories.py
@@ -226,6 +226,16 @@ def is_sensitive_memory(memory: Dict[str, Any]) -> bool:
     return bool(level and level not in {'standard', 'none'})
 
 
+def resolve_mcp_pending_visibility(*, include_pending_processing: bool, include_sensitive: bool) -> bool:
+    """Keep pending submissions readable unless the caller requests classified-only data.
+
+    Required-processing submissions have not completed sensitivity classification.
+    A caller that excludes sensitive memories must therefore also exclude pending
+    submissions rather than treating an unclassified row as standard protection.
+    """
+    return include_pending_processing and include_sensitive
+
+
 def filter_and_sort_memories(
     memories: List[Dict[str, Any]],
     *,

--- a/docs/doc/developer/mcp/tools.mdx
+++ b/docs/doc/developer/mcp/tools.mdx
@@ -26,6 +26,7 @@ in the first two sections below; the additional tools are hosted-server tools.
     | `updated_after` | string | No | Only return memories updated after this ISO 8601 timestamp |
     | `include_activity` | boolean | No | Include focus/screen/activity memories, which are excluded by default |
     | `include_sensitive` | boolean | No | Include memories above standard data protection, default `true` for compatibility |
+    | `include_pending_processing` | boolean | No | Include explicit submissions still being processed, default `true` for immediate readback; pending rows are excluded when `include_sensitive` is `false` because classification is incomplete |
 
     **Returns:** `{ "memories": [...], "returned_count": 25, "has_more": true, "offset": 0, "limit": 25, "sort": "created_desc" }`
 
@@ -61,7 +62,9 @@ in the first two sections below; the additional tools are hosted-server tools.
   </Accordion>
 
   <Accordion title="create_memory" icon="plus">
-    Create a new memory. Category is auto-detected if not provided.
+    Create a new memory. Category is auto-detected if not provided. The returned record may remain
+    short-term while required processing runs; `get_memories` includes pending submissions by default
+    so the new ID can be read back immediately.
 
     **Parameters:**
     | Name | Type | Required | Description |

--- a/mcp/src/mcp_server_omi/server.py
+++ b/mcp/src/mcp_server_omi/server.py
@@ -86,6 +86,9 @@ class GetMemories(BaseModel):
     categories: List[MemoryCategory] = Field(description="The categories of memories to filter by.", default=[])
     limit: int = Field(description="The number of memories to retrieve.", default=100)
     offset: int = Field(description="The offset of the memories to retrieve.", default=0)
+    include_pending_processing: bool = Field(
+        description="Include accepted memories that are still in required processing.", default=True
+    )
 
 
 class CreateMemory(BaseModel):
@@ -139,9 +142,10 @@ def get_memories(
     offset: int = 0,
     limit: int = 100,
     categories: List[MemoryCategory] = [],
+    include_pending_processing: bool = True,
 ) -> List:
     logger.info(f"Getting memories with params: {offset}, {limit}, {categories}")
-    params = {"offset": offset, "limit": limit}
+    params = {"offset": offset, "limit": limit, "include_pending_processing": include_pending_processing}
     if categories:
         params["categories"] = ",".join([c.value for c in categories])
     logger.info(f"get_memories params: {params}")
@@ -344,6 +348,7 @@ async def serve(uid: str | None) -> None:
                 offset=arguments.get("offset", 0),
                 limit=arguments.get("limit", 100),
                 categories=categories_enum,
+                include_pending_processing=arguments.get("include_pending_processing", True),
             )
             return [TextContent(type="text", text=json.dumps(result, indent=2))]
 

--- a/mcp/tests/test_get_memories.py
+++ b/mcp/tests/test_get_memories.py
@@ -1,0 +1,97 @@
+"""Contract tests for standalone MCP memory listing."""
+
+import asyncio
+import logging
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import mcp_server_omi.server as server_module
+from mcp_server_omi.server import GetMemories, get_memories
+
+
+def test_get_memories_model_exposes_pending_processing_toggle():
+    model = GetMemories()
+    schema = GetMemories.model_json_schema()
+
+    assert model.include_pending_processing is True
+    assert schema["properties"]["include_pending_processing"]["default"] is True
+
+
+def test_get_memories_forwards_pending_processing_toggle():
+    response = MagicMock()
+    response.json.return_value = []
+
+    with patch("mcp_server_omi.server.requests.get", return_value=response) as request:
+        get_memories(
+            logging.getLogger("test"),
+            "omi_mcp_testkey",
+            include_pending_processing=False,
+        )
+
+    assert request.call_args.kwargs["params"]["include_pending_processing"] is False
+
+
+def test_get_memories_defaults_to_pending_visibility():
+    response = MagicMock()
+    response.json.return_value = []
+
+    with patch("mcp_server_omi.server.requests.get", return_value=response) as request:
+        get_memories(logging.getLogger("test"), "omi_mcp_testkey")
+
+    assert request.call_args.kwargs["params"]["include_pending_processing"] is True
+
+
+def test_call_tool_forwards_pending_processing_toggle():
+    servers = []
+
+    class FakeServer:
+        def __init__(self, _name):
+            self.call_tool_handler: Any = None
+            self.list_tools_handler: Any = None
+            servers.append(self)
+
+        def list_tools(self):
+            def decorator(handler):
+                self.list_tools_handler = handler
+                return handler
+
+            return decorator
+
+        def call_tool(self):
+            def decorator(handler):
+                self.call_tool_handler = handler
+                return handler
+
+            return decorator
+
+        def create_initialization_options(self):
+            return None
+
+        async def run(self, _read_stream, _write_stream, _options, **_kwargs):
+            return None
+
+    class FakeStdioContext:
+        async def __aenter__(self):
+            return object(), object()
+
+        async def __aexit__(self, _exc_type, _exc, _traceback):
+            return False
+
+    with (
+        patch.object(server_module, "Server", FakeServer),
+        patch.object(server_module, "stdio_server", return_value=FakeStdioContext()),
+        patch.object(server_module, "get_memories", return_value=[]) as list_memories,
+    ):
+        asyncio.run(server_module.serve(None))
+        result = asyncio.run(
+            servers[0].call_tool_handler(
+                "get_memories",
+                {
+                    "api_key": "omi_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "include_pending_processing": False,
+                },
+            )
+        )
+
+    assert result[0].text == "[]"
+    assert list_memories.call_args.kwargs["include_pending_processing"] is False


### PR DESCRIPTION
## Summary

- Restore immediate MCP read-after-write visibility for explicit `create_memory` submissions that are still in canonical required processing.
- Keep the REST MCP route and hosted SSE tool aligned, default pending visibility to `true`, and expose a processed-only opt-out.
- Forward the same option through the standalone MCP server and return a stable create ID from the REST bridge without exposing the internal user ID.
- Fail closed when `include_sensitive=false`: pending submissions remain hidden until sensitivity classification completes.
- Document the lifecycle behavior and register the failure class.

## Root cause

The required-processing rollout changed explicit memory submissions from immediately processed long-term rows to short-term pending canonical rows. `/v3/memories` includes those rows, but both MCP list surfaces called `MemoryService.read()` with its `include_pending_processing=False` default. `create_memory` therefore returned success and an ID that the same MCP client could not read until delayed promotion.

## Verification

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_mcp_data_endpoints.py backend/tests/unit/test_mcp_memory_adapter.py backend/tests/unit/test_mcp_memory_filters.py -q` - 99 passed.
- `uv run --project mcp pytest mcp/tests/test_get_memories.py -q` - 4 passed.
- Full standalone MCP suite: branch 15 passed / 2 errors; `origin/main` 11 passed / the same 2 errors (`mcp/tests/test_server.py` requests a missing `uid` fixture).
- Sabotage run against the pre-fix hosted SSE implementation: `test_created_pending_memory_is_immediately_readable_by_id` failed; restored fix: 1 passed.
- Sabotage run against the pre-fix REST create response and standalone MCP reader: 1 backend test and 3 standalone tests failed; all pass with the fixes restored.
- Sabotage proof for protocol dispatch: forced the standalone `call_tool` handler to ignore `include_pending_processing=false`; the handler-level test failed, then passed after restoring forwarding.
- `PYTHON=.venv/bin/python bash scripts/run-unit-ci.sh --changed-files /tmp/omi-changed-files.txt` - passed.
- `PATH="$PWD/backend/.venv/bin:$PATH" scripts/pr-preflight --pr-body-file /tmp/omi-pr-body.md` - 27 checks passed.

## Risk and rollback

The default restores pre-regression read-after-write behavior. Callers that only want processed memories can set `include_pending_processing=false`. Callers that set `include_sensitive=false` never receive unclassified pending submissions. The REST create response adds the canonical ID and lifecycle fields while continuing to exclude internal user metadata. Rollback is limited to the MCP read projections, standalone forwarding, the safe create response model, their shared visibility policy, and the additive tool argument.

Fixes #12569

## Product invariants affected

- INV-MEM-1
- INV-MEM-4

## Failure class (fixes)

Failure-Class: new

New class: `FC-accepted-write-hidden-by-reader-filter`

Line-Count-Exception: backend/routers/mcp_sse.py | 2024 -> 2054 | document and route pending-processing visibility through the hosted MCP memory reader
