### PR TITLE
fix(app): stop the chat transcript collapsing to a character-wide column

### DIFF
--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -270,78 +270,85 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                                           selectionHandleColor: Colors.blue,
                                         ),
                                       ),
-                                      child: Stack(
-                                        alignment: Alignment.bottomCenter,
-                                        children: [
-                                          Positioned.fill(
-                                            child: NotificationListener<ScrollNotification>(
-                                              onNotification: _handleScrollNotification,
-                                              child: ListView.builder(
-                                                shrinkWrap: false,
-                                                reverse: false,
-                                                controller: scrollController,
-                                                padding: const EdgeInsets.fromLTRB(
-                                                  18,
-                                                  16,
-                                                  18,
-                                                  ChatScrollPolicy.transcriptBottomPadding,
+                                      // Tight width: under the Column's loose constraints this Stack
+                                      // otherwise shrink-wraps to its only non-positioned child (the
+                                      // jump-to-latest chip, ~100pt), and every message collapses to a
+                                      // character-wide column whenever that chip is visible.
+                                      child: SizedBox(
+                                        width: constraints.maxWidth,
+                                        child: Stack(
+                                          alignment: Alignment.bottomCenter,
+                                          children: [
+                                            Positioned.fill(
+                                              child: NotificationListener<ScrollNotification>(
+                                                onNotification: _handleScrollNotification,
+                                                child: ListView.builder(
+                                                  shrinkWrap: false,
+                                                  reverse: false,
+                                                  controller: scrollController,
+                                                  padding: const EdgeInsets.fromLTRB(
+                                                    18,
+                                                    16,
+                                                    18,
+                                                    ChatScrollPolicy.transcriptBottomPadding,
+                                                  ),
+                                                  itemCount: provider.messages.length,
+                                                  itemBuilder: (context, chatIndex) {
+                                                    if (!_hasInitialScrolled && provider.messages.isNotEmpty) {
+                                                      _hasInitialScrolled = true;
+                                                      _schedulePostFrameModeAwareScroll();
+                                                    }
+
+                                                    final message = provider.messages[chatIndex];
+                                                    double topPadding =
+                                                        chatIndex == provider.messages.length - 1 ? 8 : 16;
+                                                    double bottomPadding = chatIndex == 0 ? 16 : 0;
+
+                                                    return Padding(
+                                                      key: ValueKey(message.id),
+                                                      padding: EdgeInsets.only(bottom: bottomPadding, top: topPadding),
+                                                      child: message.sender == MessageSender.ai
+                                                          ? AIMessage(
+                                                              showTypingIndicator: provider.showTypingIndicator &&
+                                                                  chatIndex == provider.messages.length - 1,
+                                                              showThinkingAfterText: provider.agentThinkingAfterText,
+                                                              message: message,
+                                                              sendMessage: _sendMessageUtil,
+                                                              onAskOmi: (text) {
+                                                                setState(() {
+                                                                  _selectedContext = text;
+                                                                });
+                                                                textFieldFocusNode.requestFocus();
+                                                              },
+                                                              displayOptions: provider.messages.length <= 1,
+                                                              appSender: provider.messageSenderApp(message.appId),
+                                                              updateConversation: (ServerConversation conversation) {
+                                                                context.read<ConversationProvider>().updateConversation(
+                                                                      conversation,
+                                                                    );
+                                                              },
+                                                              setMessageNps: (int value, {String? reason}) {
+                                                                provider.setMessageNps(message, value, reason: reason);
+                                                              },
+                                                            )
+                                                          : HumanMessage(
+                                                              message: message,
+                                                              onAskOmi: (text) {
+                                                                setState(() {
+                                                                  _selectedContext = text;
+                                                                });
+                                                                textFieldFocusNode.requestFocus();
+                                                              },
+                                                            ),
+                                                    );
+                                                  },
                                                 ),
-                                                itemCount: provider.messages.length,
-                                                itemBuilder: (context, chatIndex) {
-                                                  if (!_hasInitialScrolled && provider.messages.isNotEmpty) {
-                                                    _hasInitialScrolled = true;
-                                                    _schedulePostFrameModeAwareScroll();
-                                                  }
-
-                                                  final message = provider.messages[chatIndex];
-                                                  double topPadding =
-                                                      chatIndex == provider.messages.length - 1 ? 8 : 16;
-                                                  double bottomPadding = chatIndex == 0 ? 16 : 0;
-
-                                                  return Padding(
-                                                    key: ValueKey(message.id),
-                                                    padding: EdgeInsets.only(bottom: bottomPadding, top: topPadding),
-                                                    child: message.sender == MessageSender.ai
-                                                        ? AIMessage(
-                                                            showTypingIndicator: provider.showTypingIndicator &&
-                                                                chatIndex == provider.messages.length - 1,
-                                                            showThinkingAfterText: provider.agentThinkingAfterText,
-                                                            message: message,
-                                                            sendMessage: _sendMessageUtil,
-                                                            onAskOmi: (text) {
-                                                              setState(() {
-                                                                _selectedContext = text;
-                                                              });
-                                                              textFieldFocusNode.requestFocus();
-                                                            },
-                                                            displayOptions: provider.messages.length <= 1,
-                                                            appSender: provider.messageSenderApp(message.appId),
-                                                            updateConversation: (ServerConversation conversation) {
-                                                              context.read<ConversationProvider>().updateConversation(
-                                                                    conversation,
-                                                                  );
-                                                            },
-                                                            setMessageNps: (int value, {String? reason}) {
-                                                              provider.setMessageNps(message, value, reason: reason);
-                                                            },
-                                                          )
-                                                        : HumanMessage(
-                                                            message: message,
-                                                            onAskOmi: (text) {
-                                                              setState(() {
-                                                                _selectedContext = text;
-                                                              });
-                                                              textFieldFocusNode.requestFocus();
-                                                            },
-                                                          ),
-                                                  );
-                                                },
                                               ),
                                             ),
-                                          ),
-                                          if (_chatScrollMode == ChatScrollMode.freeScrolling)
-                                            _buildJumpToLatestButton(),
-                                        ],
+                                            if (_chatScrollMode == ChatScrollMode.freeScrolling)
+                                              _buildJumpToLatestButton(),
+                                          ],
+                                        ),
                                       ),
                                     );
                                   },


### PR DESCRIPTION
Fixes the chat transcript collapsing to a one-character-per-line column (user and AI messages) whenever the jump-to-latest chip is visible.

Root cause (from the render tree on the iPhone 16 Pro simulator): the message `Stack` in `ChatPage` sits in a `Column` that hands it loose width, so with the chip — its only non-positioned child — showing, the Stack shrink-wraps to ~100pt (`SliverConstraints crossAxisExtent 65.1`, Stack `101.1`) and every bubble wraps at one character. #12568 forced the AI bubble to `width: double.infinity`, which only masked the symptom for one sender. Fix: give the Stack the LayoutBuilder's full width.

Verified on the simulator (Nik watching): with the chip visible, multi-line and long user messages render at full transcript width; short messages still hug.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

