### PR TITLE
test(desktop): expect the screen-demo "Open the doors" default action

### DIFF
--- a/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
@@ -405,14 +405,16 @@ final class OnboardingFlowTests: XCTestCase {
       "the file-index onboarding Continue button must accept Return")
 
     let secondBrainSource = try desktopSourceFile("Onboarding/SecondBrain/SBOnboardingView.swift")
-    for title in ["Set up Omi →", "Continue"] {
+    for title in ["Set up Omi →", "Continue", "Open the doors"] {
       XCTAssertTrue(
         secondBrainSource.contains("SBInkButton(title: \"\(title)\", isDefaultAction: true)"),
         "the second-brain \(title) action must accept Return")
     }
+    // Promise, language, files, screen-demo (Open the doors / Continue, mutually exclusive),
+    // agents, context, referral: nine sites, never two visible at once.
     XCTAssertEqual(
       secondBrainSource.components(separatedBy: "isDefaultAction: true").count - 1,
-      8,
+      9,
       "every visible second-brain proceed action must register Return")
     XCTAssertTrue(
       secondBrainSource.contains("SBInkButton(title: \"Take me to Omi\", isDefaultAction: true)"),


### PR DESCRIPTION
## Why

`Desktop Swift Static & Test Contracts` fails on `main` in `OnboardingFlowTests.testOnboardingProceedActionsUseDefaultActionKeyboardShortcut`: it expects 8 `isDefaultAction: true` sites in `SBOnboardingView.swift`, and e4316bd9bf added a ninth ("Open the doors", the screen-demo step's proceed action before the doors are opened, mutually exclusive with that step's Continue). Every PR rebased onto main inherits the red; main's own push CI skips the Swift jobs for non-desktop commits, so it reads green there.

This was masked until now by the test-quality ratchet failure that ran first in the same job (fixed on main by af3ffd7f7e).

## What

Expect nine sites and assert the "Open the doors" title explicitly, with a comment listing the steps. Test-only; no production change.

## Proof

- `xcrun swift test --package-path Desktop --filter OnboardingFlowTests/` → 25 tests, 0 failures
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` → OK at baseline
- Previous head of this PR (before rebase) ran the full Swift job green in CI with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
