### PR TITLE
fix(web): plain-text OpenGraph description for shared conversations

### DIFF
--- a/web/frontend/src/__tests__/markdown-to-plain-text.test.mjs
+++ b/web/frontend/src/__tests__/markdown-to-plain-text.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { markdownToPlainText } from '../lib/markdown-to-plain-text.mjs';
+
+describe('markdownToPlainText', () => {
+  it('returns an empty string for undefined, null, and blank input', () => {
+    assert.equal(markdownToPlainText(undefined), '');
+    assert.equal(markdownToPlainText(null), '');
+    assert.equal(markdownToPlainText(''), '');
+    assert.equal(markdownToPlainText('   \n\t  '), '');
+  });
+
+  it('drops heading markers', () => {
+    assert.equal(markdownToPlainText('## Riddle Answers'), 'Riddle Answers');
+    assert.equal(markdownToPlainText('# Title\n### Nested'), 'Title Nested');
+  });
+
+  it('drops bold and italics markers', () => {
+    assert.equal(markdownToPlainText('**Yes**: a fact'), 'Yes: a fact');
+    assert.equal(markdownToPlainText('*italic* and __bold__'), 'italic and bold');
+    assert.equal(markdownToPlainText('keep snake_case names'), 'keep snake_case names');
+  });
+
+  it('keeps link text and drops the URL', () => {
+    assert.equal(
+      markdownToPlainText('See [the docs](https://example.com/path) please'),
+      'See the docs please',
+    );
+  });
+
+  it('flattens nested lists into a single line', () => {
+    const markdown = `## Riddle Answers
+- Keyboard: keys without locks
+  - nested detail
+    1. numbered
+- Venus: day lasts longer`;
+    assert.equal(
+      markdownToPlainText(markdown),
+      'Riddle Answers Keyboard: keys without locks nested detail numbered Venus: day lasts longer',
+    );
+  });
+
+  it('drops code fences and inline backticks, keeping the inner text', () => {
+    const markdown = 'Use `npm test` then\n```js\nconst x = 1;\n```\ndone';
+    assert.equal(markdownToPlainText(markdown), 'Use npm test then const x = 1; done');
+  });
+
+  it('collapses whitespace to single spaces', () => {
+    assert.equal(markdownToPlainText('hello\n\n\t  world'), 'hello world');
+  });
+
+  it('truncates to about 200 characters at a word boundary with an ellipsis', () => {
+    const words = Array.from({ length: 50 }, (_, i) => `word${i}`).join(' ');
+    const result = markdownToPlainText(words);
+    assert.ok(result.endsWith('...'));
+    assert.ok(!result.includes('word49'));
+    const withoutEllipsis = result.slice(0, -3);
+    assert.ok(withoutEllipsis.length <= 200);
+    assert.ok(!withoutEllipsis.endsWith(' '));
+    assert.match(withoutEllipsis, /^word0(?: word\d+)*$/);
+  });
+
+  it('does not truncate short input', () => {
+    assert.equal(markdownToPlainText('Short overview.'), 'Short overview.');
+  });
+
+  it('strips HTML tags and blockquote markers', () => {
+    assert.equal(markdownToPlainText('> quoted <b>bold</b> text'), 'quoted bold text');
+  });
+});

--- a/web/frontend/src/app/memories/[id]/page.tsx
+++ b/web/frontend/src/app/memories/[id]/page.tsx
@@ -6,6 +6,7 @@ import SharedConversationInstallCta, {
 } from '@/src/components/memories/shared-conversation-install-cta';
 import envConfig from '@/src/constants/envConfig';
 import { DEFAULT_TITLE_MEMORY } from '@/src/constants/memory';
+import { markdownToPlainText } from '@/src/lib/markdown-to-plain-text.mjs';
 import { ParamsTypes, SearchParamsTypes } from '@/src/types/params.types';
 import { Metadata, ResolvingMetadata } from 'next';
 import { headers } from 'next/headers';
@@ -49,7 +50,7 @@ export async function generateMetadata(
     : memory?.structured?.title || DEFAULT_TITLE_MEMORY;
   const description = !memory
     ? 'This shared conversation is private or no longer available. Open Omi to capture your own.'
-    : memory?.structured?.overview ||
+    : markdownToPlainText(memory?.structured?.overview) ||
       'A conversation shared from Omi — open it in the app.';
 
   const ogUrl = prevData.metadataBase

--- a/web/frontend/src/app/recaps/[id]/page.tsx
+++ b/web/frontend/src/app/recaps/[id]/page.tsx
@@ -1,4 +1,5 @@
 import envConfig from '@/src/constants/envConfig';
+import { markdownToPlainText } from '@/src/lib/markdown-to-plain-text.mjs';
 import { Metadata, ResolvingMetadata } from 'next';
 import { notFound } from 'next/navigation';
 import { ParamsTypes } from '@/src/types/params.types';
@@ -81,7 +82,7 @@ export async function generateMetadata(
   const recap = await getSharedRecap(params.id);
 
   const title = recap ? `${recap.day_emoji} ${recap.headline}` : 'Daily Recap';
-  const description = recap?.overview ?? 'A daily recap from Omi.';
+  const description = markdownToPlainText(recap?.overview) || 'A daily recap from Omi.';
 
   return {
     title,

--- a/web/frontend/src/lib/markdown-to-plain-text.mjs
+++ b/web/frontend/src/lib/markdown-to-plain-text.mjs
@@ -1,0 +1,54 @@
+/**
+ * Turn markdown into a one-line plain-text excerpt for meta / OpenGraph
+ * descriptions. Kept as plain JS so node:test can import it without a TS loader.
+ */
+
+const DEFAULT_MAX_LENGTH = 200;
+
+/**
+ * @param {unknown} input
+ * @param {number} [maxLength]
+ * @returns {string}
+ */
+export function markdownToPlainText(input, maxLength = DEFAULT_MAX_LENGTH) {
+  if (input == null) return '';
+  let text = String(input);
+  if (!text.trim()) return '';
+
+  // Fenced code: drop the fences, keep the inner text.
+  text = text.replace(/```[\w+-]*\n?([\s\S]*?)```/g, '$1');
+  text = text.replace(/```+/g, '');
+
+  // Inline code backticks.
+  text = text.replace(/`([^`]+)`/g, '$1');
+  text = text.replace(/`+/g, '');
+
+  // Images then links: keep alt / link text, drop the URL.
+  text = text.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1');
+  text = text.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1');
+  text = text.replace(/\[([^\]]+)\]\[[^\]]*\]/g, '$1');
+
+  text = text.replace(/<\/?[^>]+>/g, ' ');
+
+  // Line-oriented markers: headings, blockquotes, bullets, numbered lists.
+  text = text.replace(/^#{1,6}\s+/gm, '');
+  text = text.replace(/^>\s?/gm, '');
+  text = text.replace(/^\s*[-*+]\s+/gm, '');
+  text = text.replace(/^\s*\d+\.\s+/gm, '');
+
+  // Emphasis. Underscores only when they are not inside a word (snake_case).
+  text = text.replace(/\*\*([^*]+)\*\*/g, '$1');
+  text = text.replace(/__([^_]+)__/g, '$1');
+  text = text.replace(/\*([^*]+)\*/g, '$1');
+  text = text.replace(/(?<!\w)_([^_]+)_(?!\w)/g, '$1');
+
+  text = text.replace(/\s+/g, ' ').trim();
+  if (!text) return '';
+
+  if (text.length <= maxLength) return text;
+
+  const slice = text.slice(0, maxLength);
+  const lastSpace = slice.lastIndexOf(' ');
+  const head = (lastSpace > 0 ? slice.slice(0, lastSpace) : slice).trimEnd();
+  return `${head}...`;
+}


### PR DESCRIPTION
Shared conversation (and recap) OpenGraph / meta descriptions were dumping raw markdown from `structured.overview` into link previews. This strips that markdown to a one-line plain-text excerpt before it is used as `description`.

Closes SCA-418

Failure-Class: none

No existing consumer/producer format-drift class matched this (checked `.github/failure-classes/`; `scripts/failure-class` has no `list` subcommand). The producer now returns markdown overviews; the HTML meta consumer needs plain text. The helper is the consumer-side strip, not a new class.

## Product invariants affected

none

`scripts/pr-preflight --suggest` reported none. This does not touch `web/frontend/src/components/memories/**` (INV-MEM-1 glob). Rendered conversation/recap page content is unchanged.

## What changed

- New helper `web/frontend/src/lib/markdown-to-plain-text.mjs` (plain JS, no new dependency) so `node --test` can import it without a TS loader — same pattern as `share-base-url.mjs`. JSDoc types + `allowJs`; no `.d.ts`.
- `generateMetadata` in `web/frontend/src/app/memories/[id]/page.tsx` runs the overview through the helper for `description` and `openGraph.description` (Twitter description is derived from `description`). Empty overview still uses the existing fallbacks.
- Same helper applied to `web/frontend/src/app/recaps/[id]/page.tsx`, the only other `generateMetadata` in `web/frontend/src/app/**` that put `overview` into a description. Chat/apps/tasks descriptions are already constructed plain strings. Page body still renders `{recap.overview}` as before.
- Tests: `web/frontend/src/__tests__/markdown-to-plain-text.test.mjs`.

## Before (production `https://h.omi.me/conversations/99b4e759-3982-5c33-87ea-ece573af9a05`)

```
<meta name="description" content="## Riddle Answers

- Keyboard: keys without locks, space bar without room, enter key without physical entry
- Venus: day lasts longer than its orbit around the Sun
- First riddle’s final word: “inside”
- Answer-entry testing failed repeatedly, including after approximately ten attempts

## Product Experience

- Push to talk: strong feature demonstration and generally good experience
- Personalization: insufficient for current preferences
- Performance: potentially “very shitty” when operating only through the tested mode
- Testing flow: keyboard answer followed by a second step; Venus answer tested separately

## Identity Recall

- David Zhang: identified as “Stabley” and currently a co founder
- Riddle recall: keyboard answer reproduced after explicit memory prompt
- Conversation included repeated prompts: “Do you remember?”

## Browser Onboarding

- Browser workflow: separate HTML experience from onboarding
- App launch: required before opening the browser-based flow
- Onboarding: candidate for shortening before returning users to the main process
- Detection and population: expected for the browser experience"/>
<meta property="og:description" content="## Riddle Answers

- Keyboard: keys without locks, space bar without room, enter key without physical entry
- Venus: day lasts longer than its orbit around the Sun
- First riddle’s final word: “inside”
- Answer-entry testing failed repeatedly, including after approximately ten attempts

## Product Experience

- Push to talk: strong feature demonstration and generally good experience
- Personalization: insufficient for current preferences
- Performance: potentially “very shitty” when operating only through the tested mode
- Testing flow: keyboard answer followed by a second step; Venus answer tested separately

## Identity Recall

- David Zhang: identified as “Stabley” and currently a co founder
- Riddle recall: keyboard answer reproduced after explicit memory prompt
- Conversation included repeated prompts: “Do you remember?”

## Browser Onboarding

- Browser workflow: separate HTML experience from onboarding
- App launch: required before opening the browser-based flow
- Onboarding: candidate for shortening before returning users to the main process
- Detection and population: expected for the browser experience"/>
<meta name="twitter:description" content="## Riddle Answers

- Keyboard: keys without locks, space bar without room, enter key without physical entry
- Venus: day lasts longer than its orbit around the Sun
- First riddle’s final word: “inside”
- Answer-entry testing failed repeatedly, including after approximately ten attempts

## Product Experience

- Push to talk: strong feature demonstration and generally good experience
- Personalization: insufficient for current preferences
- Performance: potentially “very shitty” when operating only through the tested mode
- Testing flow: keyboard answer followed by a second step; Venus answer tested separately

## Identity Recall

- David Zhang: identified as “Stabley” and currently a co founder
- Riddle recall: keyboard answer reproduced after explicit memory prompt
- Conversation included repeated prompts: “Do you remember?”

## Browser Onboarding

- Browser workflow: separate HTML experience from onboarding
- App launch: required before opening the browser-based flow
- Onboarding: candidate for shortening before returning users to the main process
- Detection and population: expected for the browser experience"/>
```

## After (`npm run dev` with `API_URL=https://api.omi.me`, `http://localhost:3000/conversations/99b4e759-3982-5c33-87ea-ece573af9a05`)

```
<meta name="description" content="Riddle Answers Keyboard: keys without locks, space bar without room, enter key without physical entry Venus: day lasts longer than its orbit around the Sun First riddle’s final word: “inside”..."/>
<meta property="og:description" content="Riddle Answers Keyboard: keys without locks, space bar without room, enter key without physical entry Venus: day lasts longer than its orbit around the Sun First riddle’s final word: “inside”..."/>
<meta name="twitter:description" content="Riddle Answers Keyboard: keys without locks, space bar without room, enter key without physical entry Venus: day lasts longer than its orbit around the Sun First riddle’s final word: “inside”..."/>
```

## Verification

- `npm ci` in `web/frontend`
- `npm run lint` — pass
- `npm test` — 77 pass, including 10 new `markdownToPlainText` cases
- `npm run build` with `NEXT_PUBLIC_FIREBASE_*` and `API_URL` from `config/public-build-values.json` `environments.prod.values` — pass
- Local `npm run dev` + curl of the shared conversation URL — after tags above


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

