### PR TITLE
fix(desktop): attach the key-down screen frame to every voice turn

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PTTContextVocabularyProvider.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PTTContextVocabularyProvider.swift
@@ -8,6 +8,9 @@ struct PTTContextSnapshot {
   /// hub's screen_now context and explicit screenshot tool.
   let keywords: [String]
   let sourceCount: Int
+  /// OCR text of the pre-overlay frame, bounded. Used only as the chat-lane fallback when the
+  /// realtime model escalates a turn without having grounded it on the screen image.
+  let visibleText: String?
 }
 
 enum PTTContextVocabularyProvider {
@@ -46,6 +49,8 @@ enum PTTContextVocabularyProvider {
     }
 
     let keywords = collector.values
+    let boundedVisibleText = visibleText.map { String($0.prefix(maxImmediateOCRLength)) }
+      .flatMap { $0.isEmpty ? nil : $0 }
     let sample = keywords.prefix(12).joined(separator: ", ")
     let immediateSourceCount = (visibleText?.isEmpty == false) ? 1 : 0
     log(
@@ -54,7 +59,8 @@ enum PTTContextVocabularyProvider {
     return PTTContextSnapshot(
       capturedAt: capturedAt,
       keywords: keywords,
-      sourceCount: immediateSourceCount
+      sourceCount: immediateSourceCount,
+      visibleText: boundedVisibleText
     )
   }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -279,6 +279,18 @@ class PushToTalkManager: ObservableObject {
   private var hasMicPermission: Bool = false
   private var isCurrentSessionFollowUp = false
   private var currentContextSnapshot: PTTContextSnapshot?
+
+  /// OCR text of this turn's pre-overlay frame, waiting briefly for the in-flight OCR when the
+  /// realtime model escalates before it finished. Nil when no turn is capturing.
+  func visibleScreenText(timeout: TimeInterval) async -> String? {
+    let deadline = Date().addingTimeInterval(timeout)
+    while currentVoiceTurnID != nil {
+      if let snapshot = currentContextSnapshot { return snapshot.visibleText }
+      if Date() >= deadline { return nil }
+      try? await Task.sleep(nanoseconds: 100_000_000)
+    }
+    return nil
+  }
   private var contextCaptureTask: Task<Void, Never>?
 
   // Batch mode: accumulate raw audio for post-recording transcription

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+AgentCompletionContext.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+AgentCompletionContext.swift
@@ -45,5 +45,6 @@ extension RealtimeHubController {
       interrupting: interrupting,
       trustedTurnInstruction: pendingTrustedTurnInstruction
     )
+    attachTurnScreenFrameIfNeeded(session: live)
   }
 }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+ScreenEvidence.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+ScreenEvidence.swift
@@ -25,7 +25,25 @@ extension RealtimeHubController {
       logScreenEvidence(
         stage: evidence.isReadyForProviderDelivery ? "encoded" : "encode_failed",
         evidence: evidence.descriptor)
+      attachTurnScreenFrameIfNeeded()
     }
+  }
+
+  /// Every Gemini turn carries the PTT-down frame as in-turn video, so the model sees the
+  /// current screen without first deciding to call `screenshot`. The frame rides the open
+  /// activity window (the session buffers it until activityStart and drops it at commit), and
+  /// is sent once per evidence per physical session so a barge-in replacement gets it again.
+  func attachTurnScreenFrameIfNeeded(session target: RealtimeHubSession? = nil) {
+    guard let live = target ?? session, sessionProvider == .gemini,
+      let evidence = screenEvidence, let jpeg = evidence.jpeg,
+      evidence.descriptor.canVerifyCurrentScreen,
+      VoiceTurnCoordinator.shared.activeTurnID == evidence.descriptor.turnID
+    else { return }
+    let key = "\(evidence.descriptor.evidenceID)|\(ObjectIdentifier(live).hashValue)"
+    guard attachedTurnScreenFrameKey != key else { return }
+    attachedTurnScreenFrameKey = key
+    live.sendVideoFrame(jpeg, mime: "image/jpeg", turnID: evidence.descriptor.turnID)
+    logScreenEvidence(stage: "turn_frame_attached", evidence: evidence.descriptor)
   }
 
   func startScreenEvidenceEncoding(_ evidence: RealtimeScreenEvidence) {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+Tools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+Tools.swift
@@ -18,7 +18,14 @@ extension RealtimeHubController {
   ) async -> AuthorizedRealtimeToolExecutionResult {
     // The chat lane cannot see the screen; hand it what this turn's screenshot showed so
     // "what's the answer to this riddle?" resolves to the riddle on screen, not an earlier one.
-    let screenContext = screenContextByContinuityKey[turnIdempotencyKey]
+    // When the realtime model escalated without grounding on the image, fall back to the OCR
+    // text of the same PTT-down frame so the escalation is never blind to the current screen.
+    var screenContext = screenContextByContinuityKey[turnIdempotencyKey]
+    if screenContext == nil,
+      let ocr = await PushToTalkManager.shared.visibleScreenText(timeout: 1.5)
+    {
+      screenContext = "OCR text of the screen at the moment they pressed the key:\n\(ocr)"
+    }
     return await queryChatLaneForVoice(
       prompt: RealtimeHubTools.escalationUserPrompt(
         query: query, toolContext: toolContext, screenContext: screenContext),

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -87,6 +87,8 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   /// image before the model can ask for it.
   var screenEvidenceSpeechEndedAt: Date?
   var screenEvidence: RealtimeScreenEvidence?
+  /// `evidenceID|session` of the PTT-down frame already attached to the live turn.
+  var attachedTurnScreenFrameKey: String?
   var screenEvidenceReadiness: RealtimeScreenEvidenceReadiness?
   var screenGroundingState: RealtimeScreenGroundingState = .inactive
   /// Latest safe protocol disposition, surfaced only through the non-production automation

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
@@ -140,7 +140,7 @@ final class RealtimeHubSession: NSObject, @unchecked Sendable {
   private var pendingAudio: [Data] = []
   /// Screen frames awaiting an open socket (base64, mime) — flushed into the turn in
   /// markReady. A cold first turn would otherwise drop the frame before connect.
-  private var pendingVideo: [(b64: String, mime: String)] = []
+  private var pendingVideo: [(b64: String, mime: String, turnID: VoiceTurnID?)] = []
   /// Headless-test text awaiting a provider-acceptable input window.
   private var pendingTextInputs: [(text: String, logLabel: String)] = []
   /// Per-turn Interject / trusted instruction. OpenAI applies it on the next
@@ -407,6 +407,9 @@ final class RealtimeHubSession: NSObject, @unchecked Sendable {
       }
     }
 
+    /// Base64 payloads of every screen frame actually written to the wire (test seam).
+    private(set) var sentVideoFramesForTesting: [String] = []
+
     func markReadyForTesting() {
       q.async { [weak self] in
         self?.acceptsTestingTransport = true
@@ -448,21 +451,25 @@ final class RealtimeHubSession: NSObject, @unchecked Sendable {
   /// a frame sent here becomes part of the user's speech turn, so the model has the screen
   /// when it answers. This is the ONLY image delivery this model accepts — a separate
   /// image-only turn (after the speech turn closed) is rejected with close 1007.
-  func sendVideoFrame(_ image: Data, mime: String, allowClosedActivityWindow: Bool = false) {
+  func sendVideoFrame(
+    _ image: Data, mime: String, turnID: VoiceTurnID? = nil, allowClosedActivityWindow: Bool = false
+  ) {
     guard provider == .gemini else { return }
     let b64 = image.base64EncodedString()
     q.async { [weak self] in
       guard let self else { return }
       // Buffer until the socket is open AND a turn is active, then flush in markReady.
       // A cold first turn dumps audio + this frame before connect (~300ms); without
-      // buffering the frame is dropped and the model answers blind.
+      // buffering the frame is dropped and the model answers blind. A buffered frame is
+      // tagged with its PTT turn so a later activityStart can only flush its own screen.
       guard self.isOpen, self.activityOpen || allowClosedActivityWindow else {
-        self.pendingVideo.append((b64, mime))
+        self.pendingVideo.append((b64, mime, turnID))
         log("\(self.tag): screen frame buffered until open (\(image.count) bytes)")
         return
       }
       let phase = self.activityOpen ? "in-turn" : "after-activity-end"
       log("\(self.tag): screen frame sent \(phase) (\(image.count) bytes)")
+      self.recordSentVideoFrame(b64)
       self.send(json: ["realtimeInput": ["video": ["data": b64, "mimeType": mime]]])
     }
   }
@@ -767,6 +774,7 @@ final class RealtimeHubSession: NSObject, @unchecked Sendable {
       if self.isOpen {
         self.send(json: ["realtimeInput": ["activityStart": [:]]])
         self.flushPendingAudioIfReady()
+        self.flushPendingVideoIntoTurn()
         self.flushPendingTextInputs()
         // Flush a parked trusted instruction inside this window, before a
         // pending commit can close it. Interject's MainActor retry is too late
@@ -800,10 +808,39 @@ final class RealtimeHubSession: NSObject, @unchecked Sendable {
     }
   }
 
+  /// A PTT-down frame is only meaningful inside the turn it was captured for. Send it while
+  /// the activity window is open; a frame that missed its window is dropped at commit so it
+  /// can never ride the next turn as a stale screen.
+  private func recordSentVideoFrame(_ b64: String) {
+    #if DEBUG
+      sentVideoFramesForTesting.append(b64)
+    #endif
+  }
+
+  private func flushPendingVideoIntoTurn() {
+    guard provider == .gemini, activityOpen else { return }
+    let currentTurn = activeEventIdentity?.turnID
+    for v in pendingVideo {
+      guard v.turnID == nil || currentTurn == nil || v.turnID == currentTurn else {
+        log("\(tag): dropped screen frame from an earlier turn")
+        continue
+      }
+      recordSentVideoFrame(v.b64)
+      send(json: ["realtimeInput": ["video": ["data": v.b64, "mimeType": v.mime]]])
+      log("\(tag): screen frame flushed into turn")
+    }
+    pendingVideo.removeAll()
+  }
+
   private func commitInputTurnNow() {
     flushPendingAudioIfReady()
+    flushPendingVideoIntoTurn()
     flushPendingTextInputs()
     flushTrustedTurnInstructionIfPossible()
+    if !pendingVideo.isEmpty {
+      log("\(tag): dropped \(pendingVideo.count) screen frame(s) that missed the turn window")
+      pendingVideo.removeAll()
+    }
     log("\(tag): turn committed")
     switch provider {
     case .openai:
@@ -1174,11 +1211,7 @@ final class RealtimeHubSession: NSObject, @unchecked Sendable {
     flushPendingTextInputs()
     flushPendingAudioIfReady()
     // Flush any screen frame INTO the turn (after activityStart + audio, before commit).
-    for v in pendingVideo {
-      send(json: ["realtimeInput": ["video": ["data": v.b64, "mimeType": v.mime]]])
-      log("\(tag): screen frame flushed into turn")
-    }
-    pendingVideo.removeAll()
+    flushPendingVideoIntoTurn()
     flushPendingTextInputs()
     if pendingCommit, provider == .openai || activityOpen {
       pendingCommit = false

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -96,8 +96,16 @@ enum RealtimeHubTools {
       tool call, and never read tool JSON or ids aloud. The think_deeper and web_search tool cards \
       are exceptions: call either one silently and immediately because the app speaks an instant \
       acknowledgement after the kernel accepts it. Do not repeat that acknowledgement when its \
-      result arrives. You cannot see the user's data or screen \
-      without calling a tool. When the screenshot tool succeeds for a current-screen question, the \
+      result arrives. You cannot see the user's data without calling a tool. \
+      Screen rule: every turn arrives with an image of the user's screen captured the instant \
+      they pressed the key. That image IS the current screen. Answer anything that could refer \
+      to it — "this", "that", "here", "it", "the page", "the answer", "the riddle", "the error", \
+      "what am I looking at" — directly from that image, before reaching for any other tool or \
+      for memory of earlier turns. Images from earlier turns are stale: the screen changes \
+      between turns, so never answer a current-screen question from an older image or an \
+      earlier answer. Call the screenshot tool only when no image arrived with this turn or \
+      the user says the screen changed since they pressed the key. When in doubt, look at \
+      this turn's image. When the screenshot tool succeeds for a current-screen question, the \
       attached image and, when present, its locally captured foreground-application context are \
       the only current visual source of truth. The foreground-application context is trustworthy \
       only for identifying the app active at capture time; it never replaces visual reasoning. \

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedRealtimeTools.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedRealtimeTools.swift
@@ -655,7 +655,7 @@ enum GeneratedRealtimeTools {
   {
     "type": "function",
     "name": "screenshot",
-    "description": "Capture the user's current screen so you can see what they're looking at.",
+    "description": "Take a fresh capture of the user's screen. Every turn already includes the screen as it was when the user pressed the key; call this only when no image arrived with this turn or the user says the screen changed since.",
     "parameters": {
       "type": "object",
       "properties": {},

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
@@ -54,8 +54,8 @@ enum GeneratedSwiftToolExecutor: String {
 
 enum GeneratedToolExecutors {
   static let manifestVersion = 1
-  static let manifestDigest = "sha256:d94dcf6184f3fa030e5352cdbd4ec4b5ff8432356bd424a8b2d369fd472b7c34"
-  static let chatFirstManifestDigest = "sha256:dfd93a44ff57c8e39f00316bf78c445385ec1dcbd6cad24398d5db160241449b"
+  static let manifestDigest = "sha256:6b23e8bfd2629b128b3b7b67cd3d1cc75fe64e2a59f49efa687915a0234f862e"
+  static let chatFirstManifestDigest = "sha256:693b02464ac7578eafdcd6d9c68b4e9925d3371a91c22781948682c49fed0d88"
 
   static let aliasToCanonical: [String: GeneratedSwiftTool] = [
     "search_screen_history": .semanticSearch,

--- a/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
+++ b/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
@@ -15,6 +15,21 @@ final class HubSystemInstructionTests: XCTestCase {
     XCTAssertEqual(RealtimeHubTools.escalationUserPrompt(query: "q", toolContext: ""), "q")
   }
 
+  func testVoiceInstructionTellsTheModelEveryTurnCarriesTheCurrentScreen() {
+    // Regression (Beta 0.12.257, two users): the model answered a current-screen question from a
+    // 13-second-old screenshot / an earlier answer without calling screenshot. Nothing in the
+    // prompt said when to look. The frame is now attached to every turn and the instruction
+    // must say so, mark earlier images stale, and keep screenshot for a fresh re-look only.
+    let instruction = RealtimeHubTools.systemInstruction(kernelContext: "ctx")
+    XCTAssertTrue(instruction.contains("every turn arrives with an image of the user's screen"))
+    XCTAssertTrue(instruction.contains("Images from earlier turns are stale"))
+    XCTAssertTrue(instruction.contains("Call the screenshot tool only when no image arrived with this turn"))
+    XCTAssertFalse(instruction.contains("You cannot see the user's data or screen without calling a tool"))
+    let tool = GeneratedRealtimeTools.baseOpenAITools(providerProperty: nil)
+      .first { ($0["name"] as? String) == HubTool.screenshot.rawValue }
+    XCTAssertTrue(((tool?["description"] as? String) ?? "").contains("Every turn already includes the screen"))
+  }
+
   func testOnboardingDemoNoteIsIncludedWhenPresentAndAbsentOtherwise() {
     let with = RealtimeHubTools.systemInstruction(
       kernelContext: "ctx", onboardingDemoContext: "Door 3 asks for the last word of the first riddle (answer: inside)."

--- a/desktop/macos/Desktop/Tests/RealtimeHubSessionInputLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubSessionInputLifecycleTests.swift
@@ -218,6 +218,48 @@ import XCTest
       XCTAssertEqual(buffered.pendingVideoFrameCount, 0)
     }
 
+    func testWarmGeminiFlushesBufferedScreenFrameWhenTheActivityWindowOpens() async {
+      // The PTT-down frame usually finishes encoding before activityStart. It must ride this
+      // turn (flushed at activityStart), not wait for a reconnect that never comes.
+      let delegate = RealtimeHubSessionDelegateSpy()
+      let session = makeSession(provider: .gemini, delegate: delegate)
+      session.markReadyForTesting()
+      _ = await session.inputLifecycleSnapshot()
+
+      session.sendVideoFrame(Data([9, 9]), mime: "image/jpeg")
+      let buffered = await session.inputLifecycleSnapshot()
+      XCTAssertEqual(buffered.pendingVideoFrameCount, 1, "no activity window yet: frame waits")
+
+      session.beginInputTurn()
+      let opened = await session.inputLifecycleSnapshot()
+      XCTAssertTrue(opened.activityOpen)
+      XCTAssertEqual(opened.pendingVideoFrameCount, 0, "activityStart flushes the frame into the turn")
+    }
+
+    func testGeminiCommitDropsAFrameThatMissedItsTurnWindow() async {
+      // A frame encoded after activityEnd belongs to a finished turn. It must never be
+      // carried into the next turn as a stale screen.
+      let delegate = RealtimeHubSessionDelegateSpy()
+      let session = makeSession(provider: .gemini, delegate: delegate)
+      session.markReadyForTesting()
+      session.beginInputTurn()
+      session.commitInputTurn()
+      _ = await session.inputLifecycleSnapshot()
+
+      let finishedTurn = VoiceTurnID()
+      session.sendVideoFrame(Data([7]), mime: "image/jpeg", turnID: finishedTurn)
+      let late = await session.inputLifecycleSnapshot()
+      XCTAssertEqual(late.pendingVideoFrameCount, 1)
+
+      session.beginInputTurn(turnID: VoiceTurnID(), responseID: VoiceResponseID("next"))
+      let next = await session.inputLifecycleSnapshot()
+      XCTAssertTrue(next.activityOpen)
+      XCTAssertEqual(next.pendingVideoFrameCount, 0, "a frame from a finished turn is dropped, not sent")
+      XCTAssertFalse(
+        session.sentVideoFramesForTesting.contains(Data([7]).base64EncodedString()),
+        "the earlier turn's screen never reaches the new turn")
+    }
+
     func testGeminiScreenshotToolResultCarriesPixelsInsideTheMatchingFunctionResponse() throws {
       let descriptor = RealtimeScreenEvidenceDescriptor(
         evidenceID: "evidence-1",

--- a/desktop/macos/Desktop/Tests/ScreenContextTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenContextTelemetryTests.swift
@@ -230,6 +230,12 @@ final class ScreenContextTelemetryTests: XCTestCase {
     XCTAssertTrue(snapshot.keywords.contains("Omi"))
     XCTAssertTrue(snapshot.keywords.contains("Codex"))
     XCTAssertFalse(snapshot.keywords.contains("Cursor"))
+    // The think_deeper fallback reads the same frame's text; an empty OCR result stays nil.
+    XCTAssertEqual(snapshot.visibleText, "Codex is open on the current screen")
+    XCTAssertNil(
+      PTTContextVocabularyProvider.snapshot(
+        capturedAt: Date(), settingsVocabulary: [], immediateOCRText: ""
+      ).visibleText)
   }
 
   func testPTTDoesNotCreateAnAmbientScreenContextSideChannel() throws {

--- a/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
@@ -766,7 +766,7 @@ const swiftToolSurfacePatches: Record<string, OmiToolSurfacePatch> = {
     ]),
     executor: { kind: "swiftTool", executorName: "realtimeHub" },
     voice: {
-      realtimeDescription: "Capture the user's current screen so you can see what they're looking at.",
+      realtimeDescription: "Take a fresh capture of the user's screen. Every turn already includes the screen as it was when the user pressed the key; call this only when no image arrived with this turn or the user says the screen changed since.",
     },
   },
   report_screen_observation: {

--- a/desktop/macos/agent/tests/fixtures/tool-manifest.json
+++ b/desktop/macos/agent/tests/fixtures/tool-manifest.json
@@ -5466,7 +5466,7 @@
       ]
     },
     "voice": {
-      "realtimeDescription": "Capture the user's current screen so you can see what they're looking at."
+      "realtimeDescription": "Take a fresh capture of the user's screen. Every turn already includes the screen as it was when the user pressed the key; call this only when no image arrived with this turn or the user says the screen changed since."
     }
   },
   {

--- a/desktop/macos/changelog/unreleased/20260902-voice-screen-every-turn.json
+++ b/desktop/macos/changelog/unreleased/20260902-voice-screen-every-turn.json
@@ -1,0 +1,3 @@
+{
+  "change": "Voice questions about what is on screen now always see the current screen: the frame captured when you press the key is attached to every turn, and think-deeper answers read its text too"
+}


### PR DESCRIPTION
## Summary
The voice model only saw the screen when it chose to call the `screenshot` tool. On Beta 0.12.256/257 it skipped that call on ~1 turn in 6 (stale in-session image, fresh barge-in session, short ambiguous audio routed to think_deeper) and answered a current-screen question ("what's the answer to this riddle?", "5+2?") from an earlier turn.

- The PTT-down frame is now sent as in-turn `realtimeInput.video` on every Gemini turn (`attachTurnScreenFrameIfNeeded`, called when the frame finishes encoding and on every `beginLiveInputTurn`, once per evidence per physical session so barge-in replacements get it too).
- Session: buffered frames are tagged with their turn and flushed at `activityStart` only for the matching turn; frames that miss their window are dropped at commit, never carried into the next turn.
- `think_deeper` falls back to the OCR text of the same PTT-down frame when no screen observation was accepted this turn.
- Voice instruction: the per-turn image IS the current screen; earlier images are stale; `screenshot` is for a fresh re-look only. Tool description updated in the manifest and regenerated.

Restores the turn-start frame delivery from 1d46c82ec9 (vendz, Jun 17) that was dropped in the #9597 refactor.

## Verification
Local `omi-doors` bundle built from this patch (2026-09-01 22:20). Nik exercised the real path: Notes with `5+5`/`5+2`, and the doors page. 8 PTT turns, every one shows `ptt_screen_evidence stage=turn_frame_attached` followed by `screen frame sent in-turn (~263 KB)`; answers followed the current screen, including the changed note. Regression tests added: `RealtimeHubSessionInputLifecycleTests` (frame flushed at activityStart; frame from a finished turn dropped), `HubSystemInstructionTests` (instruction + tool description), `ScreenContextTelemetryTests` (snapshot visibleText).

Invariants: INV-VOICE-1, INV-AGENT-1, INV-AGENT-2, INV-AGENT-3, INV-CHAT-1.
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

