### PR TITLE
ci(public-build): env-var removal, per-environment flags, real invoker identity checks

### DIFF
--- a/.github/actions/deploy-public-build/action.yml
+++ b/.github/actions/deploy-public-build/action.yml
@@ -56,6 +56,7 @@ runs:
         set -euo pipefail
         contract=config/public-build-contract.json
         target='${{ inputs.target }}'
+        environment='${{ inputs.environment }}'
         target_json="$(jq -ce --arg target "$target" '.targets[$target]' "$contract")"
         output_string() {
           local key="$1"
@@ -70,7 +71,14 @@ runs:
           echo 'platforms<<EOF'
           jq -er '.deployment.platforms[]' <<<"$target_json"
           echo EOF
-          printf 'flags=%s\n' "$(jq -r '[.deployment.flags[]?] | join(" ")' <<<"$target_json")"
+          printf 'flags=%s\n' "$(
+            jq -r --arg env "$environment" '
+              .deployment.flags as $flags
+              | if ($flags | type) == "object" then [($flags[$env] // [])[]?] | join(" ")
+                else [$flags[]?] | join(" ")
+                end
+            ' <<<"$target_json"
+          )"
           echo 'runtime_secrets<<EOF'
           jq -r '.deployment.runtime_secrets | to_entries[]? | "\(.key)=\(.value)"' <<<"$target_json"
           echo EOF
@@ -79,6 +87,10 @@ runs:
           echo EOF
           printf 'remove_runtime_secrets=%s\n' "$(
             jq -r '(.deployment.remove_runtime_secrets // []) | if length == 0 then "" else "--remove-secrets=" + join(",") end' \
+              <<<"$target_json"
+          )"
+          printf 'remove_runtime_env_vars=%s\n' "$(
+            jq -r '(.deployment.remove_runtime_env_vars // []) | if length == 0 then "" else "--remove-env-vars=" + join(",") end' \
               <<<"$target_json"
           )"
           # preserve_runtime_secrets are validated by the runtime preflight. The
@@ -117,7 +129,8 @@ runs:
         python3 .github/scripts/preflight_public_build_runtime.py \
           --target "${{ inputs.target }}" \
           --project-id "${{ inputs.project_id }}" \
-          --github-output "$GITHUB_OUTPUT"
+          --github-output "$GITHUB_OUTPUT" \
+          --service-account "${{ inputs.service_account }}"
 
     - name: Fail closed for a production first create
       shell: bash
@@ -180,6 +193,7 @@ runs:
           ${{ inputs.subnet != '' && format('--subnet={0}', inputs.subnet) || '' }}
           ${{ inputs.network != '' && inputs.subnet != '' && '--vpc-egress=private-ranges-only' || '' }}
           ${{ steps.contract.outputs.remove_runtime_secrets }}
+          ${{ steps.contract.outputs.remove_runtime_env_vars }}
           ${{ steps.contract.outputs.flags }}
         env_vars: |-
           ${{ steps.contract.outputs.runtime_env_vars }}

--- a/.github/failure-classes/FC-placeholder-value-passes-presence-check.json
+++ b/.github/failure-classes/FC-placeholder-value-passes-presence-check.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-placeholder-value-passes-presence-check",
+  "violated_contract": "A required identity or audience must be a real, usable value, not merely a non-empty string. A presence check admits placeholders such as TBD_feature_disabled, which then reach gcloud run deploy --service-account= and fail with iam.serviceAccounts.actAs denied.",
+  "canonical_prevention": "Shape-check service-account emails and origin-only HTTPS audiences before deploy, print the offending variable name without its value, and in runtime preflight prove the service account exists and the deployer has iam.serviceAccounts.actAs via testIamPermissions.",
+  "canonical_prevention_artifact": [
+    ".github/workflows/gcp_frontend.yml",
+    ".github/scripts/preflight_public_build_runtime.py",
+    ".github/scripts/test_check_public_build_contract.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    ".github/workflows/gcp_frontend.yml",
+    ".github/scripts/preflight_public_build_runtime.py",
+    ".github/actions/deploy-public-build/**"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/check_public_build_contract.py
+++ b/.github/scripts/check_public_build_contract.py
@@ -147,12 +147,18 @@ class Deployment:
     region: str
     build_context: str
     platforms: tuple[str, ...]
-    flags: tuple[str, ...]
+    flags_by_environment: dict[str, tuple[str, ...]]
     runtime_secrets: dict[str, str]
     preserve_runtime_secrets: tuple[str, ...]
     fallback_runtime_secrets: dict[str, str]
     runtime_env_vars: dict[str, str]
     remove_runtime_secrets: tuple[str, ...]
+    remove_runtime_env_vars: tuple[str, ...]
+
+    def flags_for(self, environment: str) -> tuple[str, ...]:
+        """Return the gcloud flags that apply to one declared environment."""
+
+        return self.flags_by_environment.get(environment, ())
 
 
 @dataclass(frozen=True)
@@ -203,7 +209,44 @@ def _parse_input(raw_input: Any, *, target_name: str) -> PublicInput:
     return PublicInput(name=name, required=required, source=source, allowed_scopes=tuple(raw_scopes))
 
 
-def _parse_deployment(raw_deployment: Any, *, target_name: str) -> Deployment:
+def _parse_flag_list(raw_flags: Any, *, target_name: str, where: str) -> tuple[str, ...]:
+    if not isinstance(raw_flags, list) or not all(
+        isinstance(flag, str) and flag.startswith("--") and "\n" not in flag and "\r" not in flag for flag in raw_flags
+    ):
+        raise ValueError(f"target {target_name} {where} must be safe gcloud flags")
+    return tuple(raw_flags)
+
+
+def _parse_flags(raw_flags: Any, *, target_name: str, environments: tuple[str, ...]) -> dict[str, tuple[str, ...]]:
+    """Accept a shared flag list or an object keyed by declared environment."""
+
+    if isinstance(raw_flags, list):
+        flags = _parse_flag_list(raw_flags, target_name=target_name, where="deployment flags")
+        return {environment: flags for environment in environments}
+    if isinstance(raw_flags, Mapping):
+        unknown = sorted(str(environment) for environment in raw_flags if environment not in environments)
+        if unknown:
+            raise ValueError(f"target {target_name} deployment flags names unknown environment {unknown[0]!r}")
+        parsed = {environment: () for environment in environments}
+        for environment, env_flags in raw_flags.items():
+            if not isinstance(environment, str) or not environment:
+                raise ValueError(f"target {target_name} deployment flags must be keyed by environment name")
+            parsed[environment] = _parse_flag_list(
+                env_flags, target_name=target_name, where=f"deployment flags[{environment!r}]"
+            )
+        return parsed
+    raise ValueError(f"target {target_name} deployment flags must be a list or an object keyed by environment")
+
+
+def _parse_env_name_list(raw_names: Any, *, target_name: str, field: str) -> tuple[str, ...]:
+    if not isinstance(raw_names, list) or not all(isinstance(name, str) and NAME.fullmatch(name) for name in raw_names):
+        raise ValueError(f"target {target_name} deployment {field} must be environment names")
+    if len(set(raw_names)) != len(raw_names):
+        raise ValueError(f"target {target_name} deployment {field} must be unique")
+    return tuple(raw_names)
+
+
+def _parse_deployment(raw_deployment: Any, *, target_name: str, environments: tuple[str, ...]) -> Deployment:
     if not isinstance(raw_deployment, Mapping):
         raise ValueError(f"target {target_name} must declare deployment")
     region = _require_string(raw_deployment.get("region"), field=f"target {target_name} deployment region")
@@ -217,11 +260,7 @@ def _parse_deployment(raw_deployment: Any, *, target_name: str) -> Deployment:
         or not all(isinstance(platform, str) and platform for platform in raw_platforms)
     ):
         raise ValueError(f"target {target_name} deployment platforms must be non-empty strings")
-    raw_flags = raw_deployment.get("flags")
-    if not isinstance(raw_flags, list) or not all(
-        isinstance(flag, str) and flag.startswith("--") and "\n" not in flag and "\r" not in flag for flag in raw_flags
-    ):
-        raise ValueError(f"target {target_name} deployment flags must be safe gcloud flags")
+    flags_by_environment = _parse_flags(raw_deployment.get("flags"), target_name=target_name, environments=environments)
     raw_runtime_secrets = raw_deployment.get("runtime_secrets")
     if not isinstance(raw_runtime_secrets, Mapping) or not all(
         isinstance(name, str)
@@ -272,13 +311,22 @@ def _parse_deployment(raw_deployment: Any, *, target_name: str) -> Deployment:
             f"target {target_name} deployment runtime_env_vars must map environment names to non-empty deploy-safe values"
         )
 
-    raw_remove_runtime_secrets = raw_deployment.get("remove_runtime_secrets", [])
-    if not isinstance(raw_remove_runtime_secrets, list) or not all(
-        isinstance(name, str) and NAME.fullmatch(name) for name in raw_remove_runtime_secrets
-    ):
-        raise ValueError(f"target {target_name} deployment remove_runtime_secrets must be environment names")
-    if len(set(raw_remove_runtime_secrets)) != len(raw_remove_runtime_secrets):
-        raise ValueError(f"target {target_name} deployment remove_runtime_secrets must be unique")
+    raw_remove_runtime_secrets = _parse_env_name_list(
+        raw_deployment.get("remove_runtime_secrets", []),
+        target_name=target_name,
+        field="remove_runtime_secrets",
+    )
+    raw_remove_runtime_env_vars = _parse_env_name_list(
+        raw_deployment.get("remove_runtime_env_vars", []),
+        target_name=target_name,
+        field="remove_runtime_env_vars",
+    )
+    env_var_removal_overlaps = set(raw_remove_runtime_env_vars) & (set(raw_runtime_secrets) | set(raw_runtime_env_vars))
+    if env_var_removal_overlaps:
+        raise ValueError(
+            f"target {target_name} deployment remove_runtime_env_vars cannot overlap runtime_secrets or "
+            f"runtime_env_vars: {', '.join(sorted(env_var_removal_overlaps))}"
+        )
 
     binding_groups = {
         "runtime_secrets": set(raw_runtime_secrets),
@@ -310,12 +358,13 @@ def _parse_deployment(raw_deployment: Any, *, target_name: str) -> Deployment:
         region=region,
         build_context=build_context,
         platforms=tuple(raw_platforms),
-        flags=tuple(raw_flags),
+        flags_by_environment=flags_by_environment,
         runtime_secrets=dict(raw_runtime_secrets),
         preserve_runtime_secrets=tuple(raw_preserve_runtime_secrets),
         fallback_runtime_secrets=dict(raw_fallback_runtime_secrets),
         runtime_env_vars=dict(raw_runtime_env_vars),
-        remove_runtime_secrets=tuple(raw_remove_runtime_secrets),
+        remove_runtime_secrets=raw_remove_runtime_secrets,
+        remove_runtime_env_vars=raw_remove_runtime_env_vars,
     )
 
 
@@ -371,7 +420,9 @@ def load_contract(path: Path) -> Contract:
             dockerfile=_require_string(raw_target.get("dockerfile"), field=f"target {target_name} dockerfile"),
             workflow=_require_string(raw_target.get("workflow"), field=f"target {target_name} workflow"),
             gateway_required=gateway_required,
-            deployment=_parse_deployment(raw_target.get("deployment"), target_name=target_name),
+            deployment=_parse_deployment(
+                raw_target.get("deployment"), target_name=target_name, environments=environments
+            ),
             canary_component=_require_string(
                 raw_target.get("canary_component"), field=f"target {target_name} canary_component"
             ),
@@ -638,6 +689,9 @@ def validate_shared_actions(root: Path) -> list[str]:
             "fallback_runtime_secrets",
             ".deployment.runtime_env_vars",
             ".deployment.remove_runtime_secrets",
+            ".deployment.remove_runtime_env_vars",
+            "($flags[$env] // [])",
+            "--service-account",
             PREPARE_ACTION,
             "google-github-actions/auth@",
             "preflight_public_build_runtime.py",
@@ -653,6 +707,7 @@ def validate_shared_actions(root: Path) -> list[str]:
             "--tag=",
             "inputs.environment == 'development' && '--allow-unauthenticated' || ''",
             "--remove-secrets=",
+            "--remove-env-vars=",
             "require_gateway_url",
             "OMI_LLM_GATEWAY_URL must be a non-empty HTTP(S) URL",
             "env_vars_update_strategy: merge",

--- a/.github/scripts/check_public_build_contract.py
+++ b/.github/scripts/check_public_build_contract.py
@@ -321,11 +321,21 @@ def _parse_deployment(raw_deployment: Any, *, target_name: str, environments: tu
         target_name=target_name,
         field="remove_runtime_env_vars",
     )
-    env_var_removal_overlaps = set(raw_remove_runtime_env_vars) & (set(raw_runtime_secrets) | set(raw_runtime_env_vars))
+    # preserve_runtime_secrets are retained by the merge update strategies, so a
+    # removal emitted for the same runtime name would strip the preserved
+    # binding (env-var names and secret bindings share one runtime namespace).
+    # fallback_runtime_secrets is validated to mirror preserve_runtime_secrets.
+    env_var_removal_overlaps = set(raw_remove_runtime_env_vars) & (
+        set(raw_runtime_secrets)
+        | set(raw_runtime_env_vars)
+        | set(raw_preserve_runtime_secrets)
+        | set(raw_fallback_runtime_secrets)
+    )
     if env_var_removal_overlaps:
         raise ValueError(
-            f"target {target_name} deployment remove_runtime_env_vars cannot overlap runtime_secrets or "
-            f"runtime_env_vars: {', '.join(sorted(env_var_removal_overlaps))}"
+            f"target {target_name} deployment remove_runtime_env_vars cannot overlap runtime_secrets, "
+            f"runtime_env_vars, preserve_runtime_secrets, or fallback_runtime_secrets: "
+            f"{', '.join(sorted(env_var_removal_overlaps))}"
         )
 
     binding_groups = {

--- a/.github/scripts/preflight_public_build_runtime.py
+++ b/.github/scripts/preflight_public_build_runtime.py
@@ -8,6 +8,9 @@ import json
 import re
 import subprocess
 import sys
+import urllib.error
+import urllib.parse
+import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -203,6 +206,82 @@ def _gcloud_json(arguments: Sequence[str]) -> Mapping[str, Any]:
     return result
 
 
+def _gcloud_access_token() -> str:
+    """Return the current gcloud access token. Never log or print it."""
+
+    try:
+        completed = subprocess.run(
+            ["gcloud", "auth", "print-access-token"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        # stdout is the bearer token on success; never include it in diagnostics.
+        raise RuntimePreflightError(
+            "gcloud auth print-access-token failed",
+            category="unauthenticated",
+        ) from exc
+    token = ""
+    for line in completed.stdout.splitlines():
+        if line.strip():
+            token = line.strip()
+    if not token:
+        raise RuntimePreflightError(
+            "gcloud auth print-access-token returned no token",
+            category="unauthenticated",
+        )
+    return token
+
+
+def _test_service_account_iam_permissions(
+    *,
+    service_account: str,
+    project_id: str,
+    permissions: Sequence[str],
+) -> Mapping[str, Any]:
+    """POST IAM testIamPermissions. Fake this in tests; never log the token."""
+
+    token = _gcloud_access_token()
+    quoted_project = urllib.parse.quote(project_id, safe=".-")
+    quoted_account = urllib.parse.quote(service_account, safe=".-")
+    url = (
+        f"https://iam.googleapis.com/v1/projects/{quoted_project}"
+        f"/serviceAccounts/{quoted_account}:testIamPermissions"
+    )
+    request = urllib.request.Request(
+        url,
+        data=json.dumps({"permissions": list(permissions)}).encode("utf-8"),
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            raw = response.read()
+    except urllib.error.HTTPError as exc:
+        try:
+            exc.close()
+        except Exception:
+            pass
+        raise RuntimePreflightError(
+            f"IAM testIamPermissions HTTP {exc.code}",
+            category="unknown",
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise RuntimePreflightError("IAM testIamPermissions request failed", category="unknown") from exc
+    try:
+        result = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimePreflightError("IAM testIamPermissions returned invalid JSON") from exc
+    if not isinstance(result, Mapping):
+        raise RuntimePreflightError("IAM testIamPermissions returned an unexpected JSON document")
+    return result
+
+
 def _cloud_run_service_exists(*, target: Target, project_id: str) -> bool:
     """Use an authenticated, name-filtered list to classify a first create."""
 
@@ -312,15 +391,10 @@ def validate_service_account(*, service_account: str, project_id: str) -> list[s
     except RuntimePreflightError as exc:
         return [f"{identity}: Cloud Run runtime identity does not exist or cannot be described ({exc})"]
     try:
-        result = _gcloud_json(
-            [
-                "iam",
-                "service-accounts",
-                "test-iam-permissions",
-                identity,
-                "--permissions=iam.serviceAccounts.actAs",
-                f"--project={project_id}",
-            ]
+        result = _test_service_account_iam_permissions(
+            service_account=identity,
+            project_id=project_id,
+            permissions=("iam.serviceAccounts.actAs",),
         )
     except RuntimePreflightError as exc:
         return [f"{identity}: cannot test iam.serviceAccounts.actAs ({exc})"]

--- a/.github/scripts/preflight_public_build_runtime.py
+++ b/.github/scripts/preflight_public_build_runtime.py
@@ -301,10 +301,42 @@ def validate_secret_references(*, service_name: str, references: Mapping[str, st
     return errors
 
 
-def preflight_deployment_result(*, target: Target, project_id: str) -> tuple[list[str], dict[str, str], bool]:
+def validate_service_account(*, service_account: str, project_id: str) -> list[str]:
+    """Prove a Cloud Run runtime identity exists and the deployer can act as it."""
+
+    identity = service_account.strip()
+    if not identity:
+        return []
+    try:
+        _gcloud_json(["iam", "service-accounts", "describe", identity, f"--project={project_id}"])
+    except RuntimePreflightError as exc:
+        return [f"{identity}: Cloud Run runtime identity does not exist or cannot be described ({exc})"]
+    try:
+        result = _gcloud_json(
+            [
+                "iam",
+                "service-accounts",
+                "test-iam-permissions",
+                identity,
+                "--permissions=iam.serviceAccounts.actAs",
+                f"--project={project_id}",
+            ]
+        )
+    except RuntimePreflightError as exc:
+        return [f"{identity}: cannot test iam.serviceAccounts.actAs ({exc})"]
+    granted = result.get("permissions")
+    if not isinstance(granted, list) or "iam.serviceAccounts.actAs" not in granted:
+        return [f"{identity}: deployer is missing permission iam.serviceAccounts.actAs"]
+    return []
+
+
+def preflight_deployment_result(
+    *, target: Target, project_id: str, service_account: str = ""
+) -> tuple[list[str], dict[str, str], bool]:
     """Validate the runtime and report whether the Cloud Run service exists."""
 
     errors = validate_secret_versions(target=target, project_id=project_id)
+    errors.extend(validate_service_account(service_account=service_account, project_id=project_id))
     fallback_runtime_secrets: dict[str, str] = {}
     service_exists = False
     try:
@@ -322,23 +354,24 @@ def preflight_deployment_result(*, target: Target, project_id: str) -> tuple[lis
     return errors, fallback_runtime_secrets, service_exists
 
 
-def preflight_result(*, target: Target, project_id: str) -> tuple[list[str], dict[str, str]]:
+def preflight_result(*, target: Target, project_id: str, service_account: str = "") -> tuple[list[str], dict[str, str]]:
     """Validate the runtime for callers that do not need deployment metadata."""
 
     errors, fallback_runtime_secrets, _service_exists = preflight_deployment_result(
-        target=target, project_id=project_id
+        target=target, project_id=project_id, service_account=service_account
     )
     return errors, fallback_runtime_secrets
 
 
-def preflight(*, target: Target, project_id: str) -> list[str]:
-    return preflight_result(target=target, project_id=project_id)[0]
+def preflight(*, target: Target, project_id: str, service_account: str = "") -> list[str]:
+    return preflight_result(target=target, project_id=project_id, service_account=service_account)[0]
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--target", required=True)
     parser.add_argument("--project-id", required=True)
+    parser.add_argument("--service-account", default="")
     parser.add_argument("--contract", type=Path, default=ROOT / "config" / "public-build-contract.json")
     parser.add_argument("--github-output", type=Path)
     args = parser.parse_args(argv)
@@ -350,7 +383,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
 
     errors, fallback_runtime_secrets, service_exists = preflight_deployment_result(
-        target=target, project_id=args.project_id
+        target=target, project_id=args.project_id, service_account=args.service_account
     )
     if errors:
         print("public-build runtime preflight failed:", file=sys.stderr)

--- a/.github/scripts/test_check_public_build_contract.py
+++ b/.github/scripts/test_check_public_build_contract.py
@@ -272,6 +272,19 @@ jobs:
         with self.assertRaisesRegex(ValueError, "remove_runtime_env_vars cannot overlap"):
             self.target()
 
+    def test_rejects_remove_runtime_env_vars_overlap_with_preserve_runtime_secrets(self) -> None:
+        contract = fixture_contract()
+        deployment = contract["targets"]["fake"]["deployment"]
+        deployment["preserve_runtime_secrets"] = ["FAKE_PRESERVED_SECRET"]
+        deployment["fallback_runtime_secrets"] = {"FAKE_PRESERVED_SECRET": "fallback-fake-preserved-secret:latest"}
+        deployment["remove_runtime_env_vars"] = ["FAKE_PRESERVED_SECRET"]
+        self.write_json("config/public-build-contract.json", contract)
+
+        with self.assertRaisesRegex(
+            ValueError, "remove_runtime_env_vars cannot overlap.*preserve_runtime_secrets"
+        ):
+            self.target()
+
     def test_shared_flags_list_applies_to_every_environment(self) -> None:
         contract = fixture_contract()
         contract["targets"]["fake"]["deployment"]["flags"] = ["--memory=2Gi"]

--- a/.github/scripts/test_check_public_build_contract.py
+++ b/.github/scripts/test_check_public_build_contract.py
@@ -248,6 +248,59 @@ jobs:
                     with self.assertRaisesRegex(ValueError, "runtime binding groups cannot overlap"):
                         self.target()
 
+    def test_parses_remove_runtime_env_vars(self) -> None:
+        contract = fixture_contract()
+        contract["targets"]["fake"]["deployment"]["remove_runtime_env_vars"] = ["STALE_PLAINTEXT"]
+        self.write_json("config/public-build-contract.json", contract)
+
+        self.assertEqual(self.target().deployment.remove_runtime_env_vars, ("STALE_PLAINTEXT",))
+
+    def test_rejects_remove_runtime_env_vars_overlap_with_runtime_secrets(self) -> None:
+        contract = fixture_contract()
+        contract["targets"]["fake"]["deployment"]["remove_runtime_env_vars"] = ["FAKE_RUNTIME_SECRET"]
+        self.write_json("config/public-build-contract.json", contract)
+
+        with self.assertRaisesRegex(ValueError, "remove_runtime_env_vars cannot overlap"):
+            self.target()
+
+    def test_rejects_remove_runtime_env_vars_overlap_with_runtime_env_vars(self) -> None:
+        contract = fixture_contract()
+        contract["targets"]["fake"]["deployment"]["runtime_env_vars"] = {"FAKE_RUNTIME_CONFIG": "reviewed.example"}
+        contract["targets"]["fake"]["deployment"]["remove_runtime_env_vars"] = ["FAKE_RUNTIME_CONFIG"]
+        self.write_json("config/public-build-contract.json", contract)
+
+        with self.assertRaisesRegex(ValueError, "remove_runtime_env_vars cannot overlap"):
+            self.target()
+
+    def test_shared_flags_list_applies_to_every_environment(self) -> None:
+        contract = fixture_contract()
+        contract["targets"]["fake"]["deployment"]["flags"] = ["--memory=2Gi"]
+        self.write_json("config/public-build-contract.json", contract)
+        deployment = self.target().deployment
+
+        self.assertEqual(deployment.flags_for("development"), ("--memory=2Gi",))
+        self.assertEqual(deployment.flags_for("prod"), ("--memory=2Gi",))
+
+    def test_per_environment_flags_object_resolves_for_the_requested_environment(self) -> None:
+        contract = fixture_contract()
+        contract["targets"]["fake"]["deployment"]["flags"] = {
+            "prod": ["--ingress=internal-and-cloud-load-balancing"],
+            "development": [],
+        }
+        self.write_json("config/public-build-contract.json", contract)
+        deployment = self.target().deployment
+
+        self.assertEqual(deployment.flags_for("prod"), ("--ingress=internal-and-cloud-load-balancing",))
+        self.assertEqual(deployment.flags_for("development"), ())
+
+    def test_rejects_flags_for_an_unknown_environment(self) -> None:
+        contract = fixture_contract()
+        contract["targets"]["fake"]["deployment"]["flags"] = {"staging": ["--memory=2Gi"]}
+        self.write_json("config/public-build-contract.json", contract)
+
+        with self.assertRaisesRegex(ValueError, "unknown environment 'staging'"):
+            self.target()
+
     def test_rejects_runtime_env_values_that_cannot_be_rendered_as_action_input(self) -> None:
         contract = fixture_contract()
         contract["targets"]["fake"]["deployment"]["runtime_env_vars"] = {"FAKE_RUNTIME_CONFIG": "one,two"}
@@ -1219,7 +1272,13 @@ class AcceptanceRouteFixture(unittest.TestCase):
         # h.omi.me fronts the `frontend` service, whose contract restricts ingress
         # to the balancer; without this URL no prod frontend candidate can ever be accepted.
         target = STATIC.load_contract(STATIC.DEFAULT_CONTRACT).targets["frontend"]
-        self.assertIn("--ingress=internal-and-cloud-load-balancing", target.deployment.flags)
+        self.assertEqual(
+            target.deployment.flags_for("prod"),
+            ("--ingress=internal-and-cloud-load-balancing",),
+        )
+        self.assertEqual(target.deployment.flags_for("development"), ())
+        self.assertEqual(target.deployment.remove_runtime_env_vars, ("OPENAI_API_KEY",))
+        self.assertEqual(target.deployment.runtime_secrets["DD_API_KEY"], "DD_API_KEY:latest")
         self.assertEqual(target.candidate_acceptance.public_urls.get("prod"), "https://h.omi.me")
 
     def test_shipped_frontend_contract_declares_expect_sha(self) -> None:
@@ -1233,6 +1292,86 @@ class AcceptanceRouteFixture(unittest.TestCase):
                 sha="0123456789abcdef0123456789abcdef01234567",
             )[-2:],
             ("--expect-sha", "0123456789abcdef0123456789abcdef01234567"),
+        )
+
+
+class RuntimeServiceAccountPreflightTests(unittest.TestCase):
+    SA = "frontend-invoker@fake-project.iam.gserviceaccount.com"
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory(prefix="omi-public-build-sa-")
+        self.root = Path(self.temp_dir.name)
+        contract_path = self.root / "config/public-build-contract.json"
+        contract_path.parent.mkdir(parents=True)
+        contract_path.write_text(json.dumps(fixture_contract()), encoding="utf-8")
+        self.target = STATIC.load_contract(contract_path).targets["fake"]
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_skips_service_account_checks_when_none_is_supplied(self) -> None:
+        self.assertEqual(RUNTIME_PREFLIGHT.validate_service_account(service_account="", project_id="fake-project"), [])
+
+    def test_runtime_preflight_accepts_an_existing_service_account_the_deployer_can_act_as(self) -> None:
+        calls: list[list[str]] = []
+        original = RUNTIME_PREFLIGHT._gcloud_json
+
+        def fake_gcloud(arguments):
+            calls.append(list(arguments))
+            if arguments[:3] == ["iam", "service-accounts", "describe"]:
+                return {"email": self.SA}
+            if arguments[:3] == ["iam", "service-accounts", "test-iam-permissions"]:
+                return {"permissions": ["iam.serviceAccounts.actAs"]}
+            raise AssertionError(arguments)
+
+        RUNTIME_PREFLIGHT._gcloud_json = fake_gcloud
+        try:
+            self.assertEqual(
+                RUNTIME_PREFLIGHT.validate_service_account(service_account=self.SA, project_id="fake-project"),
+                [],
+            )
+        finally:
+            RUNTIME_PREFLIGHT._gcloud_json = original
+
+        self.assertEqual(calls[0][:4], ["iam", "service-accounts", "describe", self.SA])
+        self.assertEqual(calls[1][:4], ["iam", "service-accounts", "test-iam-permissions", self.SA])
+        self.assertIn("--permissions=iam.serviceAccounts.actAs", calls[1])
+
+    def test_runtime_preflight_rejects_a_missing_service_account(self) -> None:
+        original = RUNTIME_PREFLIGHT._gcloud_json
+
+        def missing(_arguments):
+            raise RUNTIME_PREFLIGHT.RuntimePreflightError("resource not found", category="not_found")
+
+        RUNTIME_PREFLIGHT._gcloud_json = missing
+        try:
+            errors = RUNTIME_PREFLIGHT.validate_service_account(service_account=self.SA, project_id="fake-project")
+        finally:
+            RUNTIME_PREFLIGHT._gcloud_json = original
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn(self.SA, errors[0])
+        self.assertIn("does not exist", errors[0])
+
+    def test_runtime_preflight_rejects_missing_act_as_permission(self) -> None:
+        original = RUNTIME_PREFLIGHT._gcloud_json
+
+        def fake_gcloud(arguments):
+            if arguments[:3] == ["iam", "service-accounts", "describe"]:
+                return {"email": self.SA}
+            if arguments[:3] == ["iam", "service-accounts", "test-iam-permissions"]:
+                return {"permissions": []}
+            raise AssertionError(arguments)
+
+        RUNTIME_PREFLIGHT._gcloud_json = fake_gcloud
+        try:
+            errors = RUNTIME_PREFLIGHT.validate_service_account(service_account=self.SA, project_id="fake-project")
+        finally:
+            RUNTIME_PREFLIGHT._gcloud_json = original
+
+        self.assertEqual(
+            errors,
+            [f"{self.SA}: deployer is missing permission iam.serviceAccounts.actAs"],
         )
 
 

--- a/.github/scripts/test_check_public_build_contract.py
+++ b/.github/scripts/test_check_public_build_contract.py
@@ -1309,70 +1309,190 @@ class RuntimeServiceAccountPreflightTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.temp_dir.cleanup()
 
+    def _stub_describe(self, *, describe):
+        original = RUNTIME_PREFLIGHT._gcloud_json
+
+        def fake_gcloud(arguments):
+            if arguments[:3] == ["iam", "service-accounts", "describe"]:
+                return describe(arguments)
+            raise AssertionError(arguments)
+
+        RUNTIME_PREFLIGHT._gcloud_json = fake_gcloud
+        return original
+
     def test_skips_service_account_checks_when_none_is_supplied(self) -> None:
         self.assertEqual(RUNTIME_PREFLIGHT.validate_service_account(service_account="", project_id="fake-project"), [])
 
     def test_runtime_preflight_accepts_an_existing_service_account_the_deployer_can_act_as(self) -> None:
-        calls: list[list[str]] = []
-        original = RUNTIME_PREFLIGHT._gcloud_json
+        describe_calls: list[list[str]] = []
+        iam_calls: list[dict] = []
+        original_gcloud = self._stub_describe(
+            describe=lambda arguments: describe_calls.append(list(arguments)) or {"email": self.SA}
+        )
+        original_iam = RUNTIME_PREFLIGHT._test_service_account_iam_permissions
 
-        def fake_gcloud(arguments):
-            calls.append(list(arguments))
-            if arguments[:3] == ["iam", "service-accounts", "describe"]:
-                return {"email": self.SA}
-            if arguments[:3] == ["iam", "service-accounts", "test-iam-permissions"]:
-                return {"permissions": ["iam.serviceAccounts.actAs"]}
-            raise AssertionError(arguments)
+        def fake_iam(**kwargs):
+            iam_calls.append(kwargs)
+            return {"permissions": ["iam.serviceAccounts.actAs"]}
 
-        RUNTIME_PREFLIGHT._gcloud_json = fake_gcloud
+        RUNTIME_PREFLIGHT._test_service_account_iam_permissions = fake_iam
         try:
             self.assertEqual(
                 RUNTIME_PREFLIGHT.validate_service_account(service_account=self.SA, project_id="fake-project"),
                 [],
             )
         finally:
-            RUNTIME_PREFLIGHT._gcloud_json = original
+            RUNTIME_PREFLIGHT._gcloud_json = original_gcloud
+            RUNTIME_PREFLIGHT._test_service_account_iam_permissions = original_iam
 
-        self.assertEqual(calls[0][:4], ["iam", "service-accounts", "describe", self.SA])
-        self.assertEqual(calls[1][:4], ["iam", "service-accounts", "test-iam-permissions", self.SA])
-        self.assertIn("--permissions=iam.serviceAccounts.actAs", calls[1])
+        self.assertEqual(describe_calls[0][:4], ["iam", "service-accounts", "describe", self.SA])
+        self.assertEqual(iam_calls[0]["service_account"], self.SA)
+        self.assertEqual(iam_calls[0]["project_id"], "fake-project")
+        self.assertEqual(iam_calls[0]["permissions"], ("iam.serviceAccounts.actAs",))
 
     def test_runtime_preflight_rejects_a_missing_service_account(self) -> None:
-        original = RUNTIME_PREFLIGHT._gcloud_json
+        original_gcloud = RUNTIME_PREFLIGHT._gcloud_json
+        original_iam = RUNTIME_PREFLIGHT._test_service_account_iam_permissions
+        iam_called = False
 
         def missing(_arguments):
             raise RUNTIME_PREFLIGHT.RuntimePreflightError("resource not found", category="not_found")
 
+        def fake_iam(**_kwargs):
+            nonlocal iam_called
+            iam_called = True
+            raise AssertionError("testIamPermissions must not run when describe fails")
+
         RUNTIME_PREFLIGHT._gcloud_json = missing
+        RUNTIME_PREFLIGHT._test_service_account_iam_permissions = fake_iam
         try:
             errors = RUNTIME_PREFLIGHT.validate_service_account(service_account=self.SA, project_id="fake-project")
         finally:
-            RUNTIME_PREFLIGHT._gcloud_json = original
+            RUNTIME_PREFLIGHT._gcloud_json = original_gcloud
+            RUNTIME_PREFLIGHT._test_service_account_iam_permissions = original_iam
 
+        self.assertFalse(iam_called)
         self.assertEqual(len(errors), 1)
         self.assertIn(self.SA, errors[0])
         self.assertIn("does not exist", errors[0])
 
     def test_runtime_preflight_rejects_missing_act_as_permission(self) -> None:
-        original = RUNTIME_PREFLIGHT._gcloud_json
+        original_gcloud = self._stub_describe(describe=lambda _arguments: {"email": self.SA})
+        original_iam = RUNTIME_PREFLIGHT._test_service_account_iam_permissions
 
-        def fake_gcloud(arguments):
-            if arguments[:3] == ["iam", "service-accounts", "describe"]:
-                return {"email": self.SA}
-            if arguments[:3] == ["iam", "service-accounts", "test-iam-permissions"]:
-                return {"permissions": []}
-            raise AssertionError(arguments)
+        def fake_iam(**_kwargs):
+            return {}
 
-        RUNTIME_PREFLIGHT._gcloud_json = fake_gcloud
+        RUNTIME_PREFLIGHT._test_service_account_iam_permissions = fake_iam
         try:
             errors = RUNTIME_PREFLIGHT.validate_service_account(service_account=self.SA, project_id="fake-project")
         finally:
-            RUNTIME_PREFLIGHT._gcloud_json = original
+            RUNTIME_PREFLIGHT._gcloud_json = original_gcloud
+            RUNTIME_PREFLIGHT._test_service_account_iam_permissions = original_iam
 
         self.assertEqual(
             errors,
             [f"{self.SA}: deployer is missing permission iam.serviceAccounts.actAs"],
         )
+
+    def test_runtime_preflight_rejects_act_as_probe_http_failure(self) -> None:
+        original_gcloud = self._stub_describe(describe=lambda _arguments: {"email": self.SA})
+        original_iam = RUNTIME_PREFLIGHT._test_service_account_iam_permissions
+
+        def fake_iam(**_kwargs):
+            raise RUNTIME_PREFLIGHT.RuntimePreflightError("IAM testIamPermissions HTTP 401", category="unknown")
+
+        RUNTIME_PREFLIGHT._test_service_account_iam_permissions = fake_iam
+        try:
+            errors = RUNTIME_PREFLIGHT.validate_service_account(service_account=self.SA, project_id="fake-project")
+        finally:
+            RUNTIME_PREFLIGHT._gcloud_json = original_gcloud
+            RUNTIME_PREFLIGHT._test_service_account_iam_permissions = original_iam
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn(self.SA, errors[0])
+        self.assertIn("cannot test iam.serviceAccounts.actAs", errors[0])
+        self.assertIn("HTTP 401", errors[0])
+
+    def test_test_iam_permissions_posts_to_iam_rest_without_exposing_the_token(self) -> None:
+        token = "super-secret-token-value"
+        captured: dict[str, object] = {}
+        original_token = RUNTIME_PREFLIGHT._gcloud_access_token
+        original_urlopen = RUNTIME_PREFLIGHT.urllib.request.urlopen
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return b'{"permissions":["iam.serviceAccounts.actAs"]}'
+
+        def fake_urlopen(request, timeout=None):
+            captured["url"] = request.full_url
+            captured["method"] = request.get_method()
+            captured["body"] = request.data
+            captured["authorization"] = request.get_header("Authorization")
+            captured["timeout"] = timeout
+            return FakeResponse()
+
+        RUNTIME_PREFLIGHT._gcloud_access_token = lambda: token
+        RUNTIME_PREFLIGHT.urllib.request.urlopen = fake_urlopen
+        try:
+            result = RUNTIME_PREFLIGHT._test_service_account_iam_permissions(
+                service_account=self.SA,
+                project_id="fake-project",
+                permissions=("iam.serviceAccounts.actAs",),
+            )
+        finally:
+            RUNTIME_PREFLIGHT._gcloud_access_token = original_token
+            RUNTIME_PREFLIGHT.urllib.request.urlopen = original_urlopen
+
+        self.assertEqual(result, {"permissions": ["iam.serviceAccounts.actAs"]})
+        self.assertEqual(captured["method"], "POST")
+        self.assertEqual(captured["timeout"], 30)
+        self.assertEqual(
+            captured["url"],
+            "https://iam.googleapis.com/v1/projects/fake-project/serviceAccounts/"
+            "frontend-invoker%40fake-project.iam.gserviceaccount.com:testIamPermissions",
+        )
+        self.assertEqual(json.loads(captured["body"]), {"permissions": ["iam.serviceAccounts.actAs"]})
+        self.assertEqual(captured["authorization"], f"Bearer {token}")
+        self.assertNotIn(token, captured["url"])
+
+    def test_test_iam_permissions_token_failure_does_not_call_http(self) -> None:
+        original_token = RUNTIME_PREFLIGHT._gcloud_access_token
+        original_urlopen = RUNTIME_PREFLIGHT.urllib.request.urlopen
+        http_called = False
+
+        def fake_token():
+            raise RUNTIME_PREFLIGHT.RuntimePreflightError(
+                "gcloud auth print-access-token failed",
+                category="unauthenticated",
+            )
+
+        def fake_urlopen(*_args, **_kwargs):
+            nonlocal http_called
+            http_called = True
+            raise AssertionError("must not HTTP after token failure")
+
+        RUNTIME_PREFLIGHT._gcloud_access_token = fake_token
+        RUNTIME_PREFLIGHT.urllib.request.urlopen = fake_urlopen
+        try:
+            with self.assertRaises(RUNTIME_PREFLIGHT.RuntimePreflightError) as caught:
+                RUNTIME_PREFLIGHT._test_service_account_iam_permissions(
+                    service_account=self.SA,
+                    project_id="fake-project",
+                    permissions=("iam.serviceAccounts.actAs",),
+                )
+        finally:
+            RUNTIME_PREFLIGHT._gcloud_access_token = original_token
+            RUNTIME_PREFLIGHT.urllib.request.urlopen = original_urlopen
+
+        self.assertFalse(http_called)
+        self.assertIn("print-access-token failed", str(caught.exception))
 
 
 if __name__ == "__main__":

--- a/.github/workflows/gcp_frontend.yml
+++ b/.github/workflows/gcp_frontend.yml
@@ -46,8 +46,19 @@ jobs:
           PUBLIC_SHARED_CONVERSATION_CHAT_FRONTEND_INVOKER_SA: ${{ vars.PUBLIC_SHARED_CONVERSATION_CHAT_FRONTEND_INVOKER_SA }}
           PUBLIC_SHARED_CONVERSATION_CHAT_FRONTEND_AUDIENCE: ${{ vars.PUBLIC_SHARED_CONVERSATION_CHAT_FRONTEND_AUDIENCE }}
         run: |
-          test -n "$PUBLIC_SHARED_CONVERSATION_CHAT_FRONTEND_INVOKER_SA"
-          test -n "$PUBLIC_SHARED_CONVERSATION_CHAT_FRONTEND_AUDIENCE"
+          set -euo pipefail
+          user_sa='^[a-z][a-z0-9-]{4,28}[a-z0-9]@[a-z][a-z0-9-]+\.iam\.gserviceaccount\.com$'
+          compute_sa='^[0-9]+-compute@developer\.gserviceaccount\.com$'
+          audience='^https://[A-Za-z0-9.-]+$'
+          if [[ ! "$PUBLIC_SHARED_CONVERSATION_CHAT_FRONTEND_INVOKER_SA" =~ $user_sa &&
+                ! "$PUBLIC_SHARED_CONVERSATION_CHAT_FRONTEND_INVOKER_SA" =~ $compute_sa ]]; then
+            echo "PUBLIC_SHARED_CONVERSATION_CHAT_FRONTEND_INVOKER_SA is not a Cloud Run service-account identity" >&2
+            exit 1
+          fi
+          if [[ ! "$PUBLIC_SHARED_CONVERSATION_CHAT_FRONTEND_AUDIENCE" =~ $audience ]]; then
+            echo "PUBLIC_SHARED_CONVERSATION_CHAT_FRONTEND_AUDIENCE is not an origin-only HTTPS audience" >&2
+            exit 1
+          fi
 
       - name: Deploy checked public-build candidate
         id: public-build-deploy

--- a/config/public-build-contract.json
+++ b/config/public-build-contract.json
@@ -257,14 +257,20 @@
         "platforms": [
           "linux/amd64"
         ],
-        "flags": [
-          "--ingress=internal-and-cloud-load-balancing"
-        ],
+        "flags": {
+          "prod": [
+            "--ingress=internal-and-cloud-load-balancing"
+          ],
+          "development": []
+        },
         "runtime_secrets": {
           "DD_API_KEY": "DD_API_KEY:latest",
           "PUBLIC_SHARED_CONVERSATION_CHAT_IP_HMAC_KEY": "PUBLIC_SHARED_CONVERSATION_CHAT_IP_HMAC_KEY:latest"
         },
         "remove_runtime_secrets": [
+          "OPENAI_API_KEY"
+        ],
+        "remove_runtime_env_vars": [
           "OPENAI_API_KEY"
         ]
       },

--- a/web/frontend/src/__tests__/shared-conversation-chat-contract.test.mjs
+++ b/web/frontend/src/__tests__/shared-conversation-chat-contract.test.mjs
@@ -78,14 +78,21 @@ describe('public shared conversation chat frontend safety contract', () => {
 
   it('owns the Cloud Run ingress, identity, and frontend-only HMAC deployment contract', () => {
     const frontend = publicBuildContract.targets.frontend;
-    assert.ok(
-      frontend.deployment.flags.includes('--ingress=internal-and-cloud-load-balancing'),
+    const flags = frontend.deployment.flags;
+    const prodFlags = Array.isArray(flags) ? flags : (flags.prod || []);
+    const developmentFlags = Array.isArray(flags) ? flags : (flags.development || []);
+    assert.ok(prodFlags.includes('--ingress=internal-and-cloud-load-balancing'));
+    assert.equal(
+      developmentFlags.includes('--ingress=internal-and-cloud-load-balancing'),
+      false,
     );
     assert.equal(
       frontend.deployment.runtime_secrets.PUBLIC_SHARED_CONVERSATION_CHAT_IP_HMAC_KEY,
       'PUBLIC_SHARED_CONVERSATION_CHAT_IP_HMAC_KEY:latest',
     );
     assert.equal(frontend.deployment.runtime_secrets.OPENAI_API_KEY, undefined);
+    assert.ok(frontend.deployment.remove_runtime_env_vars.includes('OPENAI_API_KEY'));
+    assert.equal(frontend.deployment.runtime_secrets.DD_API_KEY, 'DD_API_KEY:latest');
     assert.match(deployActionSource, /service_account/);
     assert.match(deployActionSource, /runtime_env_vars/);
     assert.match(
@@ -96,6 +103,11 @@ describe('public shared conversation chat frontend safety contract', () => {
       frontendWorkflowSource,
       /PUBLIC_SHARED_CONVERSATION_CHAT_FRONTEND_AUDIENCE/,
     );
+    assert.doesNotMatch(
+      frontendWorkflowSource,
+      /test -n "\$PUBLIC_SHARED_CONVERSATION_CHAT_FRONTEND_INVOKER_SA"/,
+    );
+    assert.match(frontendWorkflowSource, /iam\\.gserviceaccount\\.com/);
   });
 
   it('passes only conversation id, bounded history, and the current question to the action', () => {


### PR DESCRIPTION
## Summary

Hardens the public-build pipeline against three defects found while unblocking the h.omi.me deploy:

1. **Plain env-var removal.** `--remove-secrets=` only drops Secret Manager bindings. The frontend still carried `OPENAI_API_KEY` (and previously `DD_API_KEY`) as plaintext env vars, and `env_vars_update_strategy: merge` preserved them. The contract now has `remove_runtime_env_vars`, and the deploy action emits `--remove-env-vars=` next to `--remove-secrets=`. Frontend removes `OPENAI_API_KEY` as an env var and binds `DD_API_KEY` to Secret Manager `DD_API_KEY:latest`.
2. **Per-environment flags.** `deployment.flags` may be a shared list (unchanged) or an object keyed by environment. Frontend keeps `--ingress=internal-and-cloud-load-balancing` on **prod only**; development has no ingress flag so the tagged candidate URL stays reachable. This is the same contract as `FC-acceptance-probe-unreachable-by-own-ingress-policy`.
3. **Invoker identity.** `gcp_frontend.yml` no longer treats `PUBLIC_SHARED_CONVERSATION_CHAT_FRONTEND_INVOKER_SA` / `_AUDIENCE` as "non-empty is enough" (`TBD_feature_disabled` used to reach `gcloud run deploy --service-account=`). Shape-check the SA email and origin-only HTTPS audience, print the offending **name** on failure, then have runtime preflight `describe` the SA and `testIamPermissions` for `iam.serviceAccounts.actAs`.

Closes SCA-420.

## `secrets:` vs `--remove-env-vars` for a key that used to be plaintext

`google-github-actions/deploy-cloudrun@v3` passes `secrets:` as `--update-secrets` (merge) and extra `flags` through to `gcloud run deploy`. gcloud will not convert a plaintext env var into a secret binding in one command (`Cannot update environment variable [NAME] to secret because it has already been set with a different type`). The contract also forbids listing the same name in both `remove_runtime_env_vars` and `runtime_secrets`.

`DD_API_KEY` is therefore **only** declared as `runtime_secrets: DD_API_KEY=DD_API_KEY:latest`. The 2026-09-02 ops cleanup already moved the live serving revision (`frontend-00141-r85`) to that Secret Manager binding, so the next merge deploy is an update-secrets of an existing secret, not a type conversion. If a retired revision still has plaintext `DD_API_KEY`, do not expect this PR to convert it; that one-time step is already done on the serving revision.

`OPENAI_API_KEY` stays in `remove_runtime_secrets` **and** `remove_runtime_env_vars` so either leftover shape is stripped. gcloud applies `--remove-env-vars` before `--update-env-vars` when both are present.

Failure-Class: new

## Product invariants affected

- INV-DATA-1

`gcp_frontend.yml` is in the INV-DATA-1 path glob. This PR does not change production-family data-plane routing, OAuth, Firebase, or Firestore project selection; it only shape-checks the frontend Cloud Run invoker identity and audience before deploy.

## Test plan

- [x] `python3 -m pytest .github/scripts/test_check_public_build_contract.py -q` (57 passed)
- [x] `python3 .github/scripts/check_public_build_contract.py`
- [x] YAML load of `deploy-public-build/action.yml` and `gcp_frontend.yml`
- [x] `actionlint .github/workflows/gcp_frontend.yml`
- [x] `node --test web/frontend/src/__tests__/shared-conversation-chat-contract.test.mjs`
- [ ] CI green on this PR


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

