### PR TITLE
ci(public-build): declare the frontend DD_API_KEY secret binding

### DIFF
--- a/config/public-build-contract.json
+++ b/config/public-build-contract.json
@@ -261,6 +261,7 @@
           "--ingress=internal-and-cloud-load-balancing"
         ],
         "runtime_secrets": {
+          "DD_API_KEY": "DD_API_KEY:latest",
           "PUBLIC_SHARED_CONVERSATION_CHAT_IP_HMAC_KEY": "PUBLIC_SHARED_CONVERSATION_CHAT_IP_HMAC_KEY:latest"
         },
         "remove_runtime_secrets": [


### PR DESCRIPTION
Declare the frontend's `DD_API_KEY` Secret Manager binding in the public-build contract.

Failure-Class: none

## Why

On 2026-09-02 the live `frontend` Cloud Run service was cleaned up by hand: the plaintext `DD_API_KEY` env var was replaced with a Secret Manager binding (`DD_API_KEY:latest`) and the dead plaintext `OPENAI_API_KEY` was removed. The runtime preflight fails closed when the live service carries a secret binding the contract does not declare, so the very next prod deploy (run 33584066466, for #12578) stopped at:

```
public-build runtime preflight failed:
- frontend: secret binding DD_API_KEY is missing from the deployment contract
```

h.omi.me is unaffected (still serving the cleanup revision), but no frontend deploy can land until the contract agrees with the live service. This is the one-line reconciliation. The broader pipeline hardening (plain env-var removal, per-environment flags, invoker identity validation) is a separate PR in progress.

## Product invariants affected

none

## Verification

- `python3 -m pytest .github/scripts/test_check_public_build_contract.py -q` — 47 passed
- `python3 .github/scripts/check_public_build_contract.py` — public-build contract check passed
- Live service confirmed via `gcloud run services describe frontend`: `DD_API_KEY` is `valueFrom.secretKeyRef{DD_API_KEY:latest}`; runtime SA `208440318997-compute@` has `secretmanager.secretAccessor` on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

