### PR TITLE
fix(app): open chat on the last message when the keyboard comes up

### DIFF
--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -59,13 +59,14 @@ class ChatPage extends StatefulWidget {
   State<ChatPage> createState() => ChatPageState();
 }
 
-class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
+class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin, WidgetsBindingObserver {
   TextEditingController textController = TextEditingController();
   late ScrollController scrollController;
   late FocusNode textFieldFocusNode;
 
   bool _isInitialLoad = true;
   bool _hasInitialScrolled = false;
+  double _lastBottomInset = 0;
   MessageProvider? _messageProvider;
 
   ChatScrollMode _chatScrollMode = ChatScrollMode.followingBottom;
@@ -92,6 +93,7 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
 
   @override
   void initState() {
+    WidgetsBinding.instance.addObserver(this);
     apps = prefs.appsList;
     scrollController = ScrollController();
     textFieldFocusNode = FocusNode();
@@ -177,8 +179,24 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
     }
   }
 
+  /// The keyboard shrinks the viewport after the initial jump to the bottom,
+  /// which leaves the transcript parked mid-way (the list keeps its pixel offset
+  /// while maxScrollExtent grows). Re-pin to the live edge on every inset change
+  /// while the reader is following, so opening chat always lands on the last
+  /// message regardless of keyboard animation timing.
+  @override
+  void didChangeMetrics() {
+    final view = View.of(context);
+    final bottomInset = view.viewInsets.bottom / view.devicePixelRatio;
+    if ((bottomInset - _lastBottomInset).abs() < 1) return;
+    _lastBottomInset = bottomInset;
+    if (_chatScrollMode != ChatScrollMode.followingBottom) return;
+    _schedulePostFrameModeAwareScroll();
+  }
+
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _messageProvider?.removeListener(_onMessageProviderChanged);
     _cancelPendingScrolls();
     textController.dispose();


### PR DESCRIPTION
Opening chat (from the home chat bar, which auto-focuses the input) landed mid-transcript on device; the reader had to scroll to see the last message.

Cause: ChatPage jumps to the bottom on first layout, then the input auto-focuses ~300ms later and the keyboard shrinks the viewport. The list keeps its pixel offset while `maxScrollExtent` grows, and the single delayed follow-scroll fires mid-keyboard-animation, so the transcript ends up parked above the live edge. Fix: observe viewport-inset changes via `WidgetsBindingObserver.didChangeMetrics` and re-pin to the bottom after the frame while the reader is in follow mode (a manual scroll-up still opts out via the existing scroll policy).

Verified on an iPhone 16 simulator with the software keyboard enabled and a 14-message seeded transcript: opening chat lands on the last message above the keyboard, three consecutive opens.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

