### PR TITLE
fix(backend): allowlist the public shared-conversation response

### DIFF
--- a/.github/failure-classes/FC-public-projection-is-denylist-shaped.json
+++ b/.github/failure-classes/FC-public-projection-is-denylist-shaped.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-public-projection-is-denylist-shaped",
+  "violated_contract": "A public unauthenticated response must name the fields it exposes. A denylist (inherit the internal record, extra=allow, null a few keys) makes every new field on that record public by default, so owner-internal data such as device ids, calendar attendee emails, speech-sample URIs, and merge provenance ships on the share link the day it is added to the stored document.",
+  "canonical_prevention": "Declare an explicit response model that does not inherit the internal record, sets extra=ignore, and is built in one projection from the deserialized document. Cover it with a test that the response's top-level keys equal the declared set, that previously leaking fields are absent, and that a new arbitrary field on the stored document does not appear.",
+  "canonical_prevention_artifact": [
+    "backend/models/conversation.py",
+    "backend/routers/conversations.py",
+    "backend/tests/unit/test_shared_conversation_field_exposure.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/models/conversation.py",
+    "backend/routers/conversations.py",
+    "backend/tests/unit/test_shared_conversation_field_exposure.py"
+  ],
+  "status": "open"
+}

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -9,6 +9,7 @@ from models.audio_file import AudioFile
 from models.calendar_context import CalendarMeetingContext
 from models.chat import Message
 from models.conversation_enums import (
+    CategoryEnum,
     ConversationSource,
     ConversationStatus,
     ConversationVisibility,
@@ -42,9 +43,18 @@ __all__ = [
     'PluginResult',
     'SearchRequest',
     'TranscriptMatchSnippet',
+    'SharedActionItem',
+    'SharedAppResult',
     'SharedConversationChatHistoryMessage',
     'SharedConversationChatRequest',
     'SharedConversationChatResponse',
+    'SharedConversationResponse',
+    'SharedEvent',
+    'SharedPerson',
+    'SharedPluginResult',
+    'SharedStructured',
+    'SharedTranscriptSegment',
+    'project_shared_conversation',
     'SetConversationActionItemsStateRequest',
     'SetConversationEventsStateRequest',
     'TestPromptRequest',
@@ -95,6 +105,106 @@ class SharedConversationChatResponse(BaseModel):
     model_config = {'extra': 'forbid'}
 
     message: str = Field(min_length=1, strict=True)
+
+
+class SharedActionItem(BaseModel):
+    """Public share projection of an action item."""
+
+    model_config = {'extra': 'ignore'}
+
+    description: str
+    completed: bool = False
+
+
+class SharedEvent(BaseModel):
+    """Public share projection of a structured event."""
+
+    model_config = {'extra': 'ignore'}
+
+    title: str
+    description: str = ''
+    start: datetime
+    duration: int = 30
+    created: bool = False
+
+
+class SharedStructured(BaseModel):
+    """Public share projection of conversation structure."""
+
+    model_config = {'extra': 'ignore'}
+
+    title: str = ''
+    overview: str = ''
+    emoji: str = '🧠'
+    category: CategoryEnum = CategoryEnum.other
+    action_items: List[SharedActionItem] = Field(default_factory=list)
+    events: List[SharedEvent] = Field(default_factory=list)
+
+
+class SharedTranscriptSegment(BaseModel):
+    """Public share projection of a transcript turn."""
+
+    model_config = {'extra': 'ignore'}
+
+    id: Optional[str] = None
+    text: str
+    speaker: Optional[str] = 'SPEAKER_00'
+    speaker_id: Optional[int] = None
+    is_user: bool
+    person_id: Optional[str] = None
+    start: float
+    end: float
+
+
+class SharedAppResult(BaseModel):
+    model_config = {'extra': 'ignore'}
+
+    app_id: Optional[str]
+    content: str
+
+
+class SharedPluginResult(BaseModel):
+    model_config = {'extra': 'ignore'}
+
+    plugin_id: Optional[str]
+    content: str
+
+
+class SharedPerson(BaseModel):
+    """Speaker-label projection for a shared conversation."""
+
+    model_config = {'extra': 'ignore'}
+
+    id: str
+    name: str
+
+
+# Explicit allowlist: do not inherit Conversation and do not extra='allow'.
+# New Conversation fields and stored-document extras must not appear here.
+class SharedConversationResponse(BaseModel):
+    """Public unauthenticated shared-conversation payload. Only declared fields are returned."""
+
+    model_config = {'extra': 'ignore'}
+
+    id: str
+    created_at: datetime
+    started_at: Optional[datetime]
+    finished_at: Optional[datetime]
+    language: Optional[str] = None
+    source: Optional[ConversationSource] = ConversationSource.omi
+    status: Optional[ConversationStatus] = ConversationStatus.completed
+    visibility: ConversationVisibility = ConversationVisibility.private
+    structured: SharedStructured
+    transcript_segments: List[SharedTranscriptSegment] = Field(default_factory=list)
+    apps_results: List[SharedAppResult] = Field(default_factory=list)
+    plugins_results: List[SharedPluginResult] = Field(default_factory=list)
+    people: List[SharedPerson] = Field(default_factory=list)
+
+
+def project_shared_conversation(conversation: 'Conversation', people: List[Person]) -> SharedConversationResponse:
+    payload = conversation.model_dump()
+    payload['people'] = [{'id': person.id, 'name': person.name} for person in people]
+    return SharedConversationResponse.model_validate(payload)
 
 
 # TODO: remove this class when the app is updated to use apps_results

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -30,16 +30,17 @@ from models.conversation import (
     SearchRequest,
     SetConversationActionItemsStateRequest,
     SetConversationEventsStateRequest,
+    SharedConversationResponse,
     TestPromptRequest,
     TranscriptMatchSnippet,
     UpdateActionItemDescriptionRequest,
     UpdateSegmentTextRequest,
     UpdateSummaryRequest,
+    project_shared_conversation,
 )
 from utils.conversations.factory import deserialize_conversation
 from utils.conversations.analytics import build_conversation_analytics
 from utils.conversations.render import redact_conversations_for_list
-from utils.conversations.render import conversation_to_dict
 from utils.conversations.mcp_transcript_search import (
     attach_match_snippets_to_conversations,
     merge_typesense_page_with_transcript_hits,
@@ -283,12 +284,6 @@ class ConversationsCountResponse(BaseModel):
 
 class ConversationRecordingResponse(BaseModel):
     has_recording: bool
-
-
-class SharedConversationResponse(Conversation):
-    model_config = {"extra": "allow"}
-
-    people: List[Person] = []
 
 
 class ConversationSuggestedAppsResponse(BaseModel):
@@ -1634,14 +1629,6 @@ def get_shared_conversation_by_id(conversation_id: str):
     if not visibility or visibility == ConversationVisibility.private:
         raise HTTPException(status_code=404, detail="Conversation is private")
     conversation = deserialize_conversation(conversation)
-    # This endpoint is public and unauthenticated. Strip fields that are internal
-    # to the owner and never part of the shared transcript/summary the user chose
-    # to publish: precise geolocation, the server-side encryption tier, and
-    # external_data (which carries merge provenance — other conversation ids — and
-    # integration metadata).
-    conversation.geolocation = None
-    conversation.data_protection_level = None
-    conversation.external_data = None
 
     # Fetch people data for speaker names
     person_ids = conversation.get_person_ids()
@@ -1650,10 +1637,10 @@ def get_shared_conversation_by_id(conversation_id: str):
         people_data = users_db.get_people_by_ids(uid, person_ids)
         people = [Person(**p) for p in people_data]
 
-    # Return conversation with people data
-    response_dict = conversation_to_dict(conversation)
-    response_dict['people'] = [p.model_dump() for p in people]
-    return response_dict
+    # Public unauthenticated surface: return only the explicit allowlist.
+    # SharedConversationResponse does not inherit Conversation and ignores extras,
+    # so new Conversation fields and stored-document keys stay off this response.
+    return project_shared_conversation(conversation, people)
 
 
 class ConversationTopicRequest(BaseModel):

--- a/backend/tests/unit/test_shared_conversation_field_exposure.py
+++ b/backend/tests/unit/test_shared_conversation_field_exposure.py
@@ -1,44 +1,256 @@
-"""The public /v1/conversations/{id}/shared endpoint must not expose owner-internal fields.
+"""The public /v1/conversations/{id}/shared endpoint is an explicit allowlist.
 
-The endpoint returns a conversation to anyone with the link (no auth). It is
-meant to publish the transcript/summary the owner shared, not internal fields:
-precise geolocation (already stripped), the server-side encryption tier
-(`data_protection_level`), or `external_data` (merge provenance — other
-conversation ids — and integration metadata).
+The endpoint returns a conversation to anyone with the link (no auth). Exposure
+is a deliberate choice: the response model does not inherit Conversation, does
+not extra='allow', and projects only the fields the share page (and documented
+compat consumers) actually need. Owner-internal fields — geolocation, encryption
+tier, merge provenance, device ids, calendar attendee emails, speech samples —
+must not appear, including when a new arbitrary key lands on the stored document.
 """
 
-from types import SimpleNamespace
+from datetime import datetime, timezone
 from unittest.mock import patch
 
+import pytest
+from fastapi import HTTPException
+
 import routers.conversations as conv_router
+from models.conversation import (
+    CalendarEventLink,
+    Conversation,
+    SharedConversationResponse,
+    SharedPerson,
+    project_shared_conversation,
+)
+from models.conversation_enums import ConversationSource, ConversationStatus, ConversationVisibility
+from models.geolocation import Geolocation
+from models.other import Person
+from models.structured import ActionItem, Event, Section, Structured
+from models.transcript_segment import TranscriptSegment
+
+ALLOWLIST_TOP_LEVEL = frozenset(SharedConversationResponse.model_fields)
+LEAKING_FIELDS = frozenset(
+    {
+        'geolocation',
+        'data_protection_level',
+        'external_data',
+        'client_device_id',
+        'client_platform',
+        'folder_id',
+        'call_id',
+        'calendar_event',
+        'processing_memory_id',
+        'processing_conversation_id',
+        'meeting_treatment_eligible',
+        'meeting_treatment_reason',
+        'meeting_duration_s',
+        'meeting_dedup_speech_s',
+        'transcript_segments_compressed',
+        'suggested_summarization_apps',
+        'screenshot_sharing_enabled',
+        'private_cloud_sync_enabled',
+        'audio_files',
+        'conversation_audio',
+        'photos',
+        'starred',
+        'discarded',
+        'deferred',
+        'is_locked',
+        'uses_custom_stt',
+        'updated_at',
+        'app_id',
+        'imported',
+    }
+)
+CREATED_AT = datetime(2026, 1, 15, 12, 0, tzinfo=timezone.utc)
 
 
-def test_shared_endpoint_strips_internal_fields_before_serialising():
-    conv = SimpleNamespace(
-        geolocation='here',
+def _conversation(**overrides) -> Conversation:
+    payload = dict(
+        id='c1',
+        created_at=CREATED_AT,
+        started_at=CREATED_AT,
+        finished_at=CREATED_AT,
+        language='en',
+        source=ConversationSource.omi,
+        status=ConversationStatus.completed,
+        visibility=ConversationVisibility.shared,
+        structured=Structured(
+            title='Shared notes',
+            overview='A public summary.',
+            emoji='📝',
+            action_items=[
+                ActionItem(
+                    description='Send the deck',
+                    completed=False,
+                    conversation_id='c1',
+                    owner_name='Ada',
+                    due_at=CREATED_AT,
+                )
+            ],
+            events=[
+                Event(
+                    title='Follow-up',
+                    description='Team sync',
+                    start=CREATED_AT,
+                    duration=30,
+                    created=False,
+                )
+            ],
+            sections=[Section(heading='Secret section', body_markdown='internal', source_segment_ids=['s1'])],
+        ),
+        transcript_segments=[
+            TranscriptSegment(
+                id='seg-1',
+                text='Hello from the owner.',
+                speaker='SPEAKER_00',
+                speaker_id=0,
+                is_user=True,
+                person_id=None,
+                start=0.0,
+                end=1.5,
+                stt_provider='deepgram',
+            ),
+            TranscriptSegment(
+                id='seg-2',
+                text='Hi from Ada.',
+                speaker='SPEAKER_01',
+                speaker_id=1,
+                is_user=False,
+                person_id='person-ada',
+                start=1.5,
+                end=3.0,
+                stt_provider='deepgram',
+            ),
+        ],
+        geolocation=Geolocation(latitude=37.77, longitude=-122.42),
         data_protection_level='enhanced',
         external_data={'merge_metadata': {'source_ids': ['other-conv']}},
+        client_device_id='device-secret',
+        client_platform='macos',
+        folder_id='folder-secret',
+        call_id='call-secret',
+        calendar_event=CalendarEventLink(
+            event_id='evt-1',
+            title='Private meeting',
+            attendees=['Ada Lovelace'],
+            attendee_emails=['ada@example.com'],
+            start_time=CREATED_AT,
+            end_time=CREATED_AT,
+        ),
+        processing_conversation_id='proc-secret',
+        meeting_treatment_eligible=True,
+        meeting_treatment_reason='calendar_overlap',
+        meeting_duration_s=3600.0,
+        meeting_dedup_speech_s=1200.0,
+        transcript_segments_compressed=True,
+        suggested_summarization_apps=['app-secret'],
+        screenshot_sharing_enabled=True,
+        private_cloud_sync_enabled=True,
+        apps_results=[{'app_id': 'summarizer', 'content': 'A public app result.'}],
     )
-    conv.get_person_ids = lambda: []
+    payload.update(overrides)
+    return Conversation(**payload)
 
-    captured = {}
 
-    def fake_to_dict(c):
-        captured['geolocation'] = c.geolocation
-        captured['data_protection_level'] = c.data_protection_level
-        captured['external_data'] = c.external_data
-        return {'id': 'c1'}
-
+def _call_shared(conversation: Conversation, people_data=None):
     with patch.object(conv_router.redis_db, 'get_conversation_uid', return_value='owner-uid'), patch.object(
-        conv_router, '_get_valid_conversation_by_id', return_value={'visibility': 'public'}
-    ), patch.object(conv_router, 'deserialize_conversation', return_value=conv), patch.object(
-        conv_router, 'conversation_to_dict', side_effect=fake_to_dict
-    ), patch.object(
-        conv_router.users_db, 'get_people_by_ids', return_value=[]
+        conv_router, '_get_valid_conversation_by_id', return_value={'visibility': 'shared'}
+    ), patch.object(conv_router, 'deserialize_conversation', return_value=conversation), patch.object(
+        conv_router.users_db, 'get_people_by_ids', return_value=people_data or []
     ):
-        conv_router.get_shared_conversation_by_id('c1')
+        return conv_router.get_shared_conversation_by_id('c1')
 
-    # All three owner-internal fields must be cleared before serialization.
-    assert captured['geolocation'] is None
-    assert captured['data_protection_level'] is None
-    assert captured['external_data'] is None
+
+def _payload(response: SharedConversationResponse) -> dict:
+    return response.model_dump(mode='json')
+
+
+def test_shared_response_top_level_keys_equal_allowlist():
+    payload = _payload(_call_shared(_conversation()))
+    assert set(payload) == ALLOWLIST_TOP_LEVEL
+
+
+def test_previously_leaking_fields_are_absent():
+    payload = _payload(_call_shared(_conversation()))
+    assert LEAKING_FIELDS.isdisjoint(payload)
+    assert 'geolocation' not in payload
+    assert 'data_protection_level' not in payload
+    assert 'external_data' not in payload
+    assert 'calendar_event' not in payload
+    assert 'client_device_id' not in payload
+
+
+def test_new_arbitrary_field_on_stored_document_does_not_appear():
+    leaky = _conversation().model_dump()
+    leaky['owner_secret'] = 'should-never-leave-the-owner-doc'
+    leaky['brand_new_conversation_field'] = {'nested': True}
+    leaky['people'] = [{'id': 'p1', 'name': 'Ada', 'speech_samples': ['gs://secret'], 'email': 'ada@example.com'}]
+    projected = SharedConversationResponse.model_validate(leaky)
+    payload = projected.model_dump(mode='json')
+    assert 'owner_secret' not in payload
+    assert 'brand_new_conversation_field' not in payload
+    assert set(payload) == ALLOWLIST_TOP_LEVEL
+    assert payload['people'] == [{'id': 'p1', 'name': 'Ada'}]
+
+
+def test_people_projection_is_id_and_name_only():
+    people = [
+        {
+            'id': 'person-ada',
+            'name': 'Ada',
+            'speech_samples': ['gs://bucket/sample.wav'],
+            'speech_sample_transcripts': ['hello'],
+            'created_at': CREATED_AT.isoformat(),
+            'updated_at': CREATED_AT.isoformat(),
+        }
+    ]
+    payload = _payload(_call_shared(_conversation(), people_data=people))
+    assert payload['people'] == [{'id': 'person-ada', 'name': 'Ada'}]
+    assert set(payload['people'][0]) == set(SharedPerson.model_fields)
+
+
+def test_structured_and_transcript_drop_internal_nested_fields():
+    payload = _payload(_call_shared(_conversation()))
+    structured = payload['structured']
+    assert set(structured) == {'title', 'overview', 'emoji', 'category', 'action_items', 'events'}
+    assert 'sections' not in structured
+    assert structured['action_items'] == [{'description': 'Send the deck', 'completed': False}]
+    assert 'conversation_id' not in structured['action_items'][0]
+    assert 'owner_name' not in structured['action_items'][0]
+    segment = payload['transcript_segments'][1]
+    assert set(segment) == {'id', 'text', 'speaker', 'speaker_id', 'is_user', 'person_id', 'start', 'end'}
+    assert 'stt_provider' not in segment
+    assert 'translations' not in segment
+    assert 'speaker_identity_status' not in segment
+
+
+def test_private_conversation_still_404s():
+    with patch.object(conv_router.redis_db, 'get_conversation_uid', return_value='owner-uid'), patch.object(
+        conv_router, '_get_valid_conversation_by_id', return_value={'visibility': 'private'}
+    ):
+        with pytest.raises(HTTPException) as exc:
+            conv_router.get_shared_conversation_by_id('c1')
+    assert exc.value.status_code == 404
+
+
+def test_missing_share_link_still_404s():
+    with patch.object(conv_router.redis_db, 'get_conversation_uid', return_value=None):
+        with pytest.raises(HTTPException) as exc:
+            conv_router.get_shared_conversation_by_id('c1')
+    assert exc.value.status_code == 404
+
+
+def test_from_conversation_keeps_share_page_fields():
+    response = project_shared_conversation(
+        _conversation(),
+        [Person(id='person-ada', name='Ada', speech_samples=['gs://secret'])],
+    )
+    payload = response.model_dump(mode='json')
+    assert payload['id'] == 'c1'
+    assert payload['structured']['title'] == 'Shared notes'
+    assert payload['structured']['overview'] == 'A public summary.'
+    assert payload['apps_results'] == [{'app_id': 'summarizer', 'content': 'A public app result.'}]
+    assert payload['people'][0] == {'id': 'person-ada', 'name': 'Ada'}
+    assert payload['visibility'] == ConversationVisibility.shared
+    assert payload['language'] == 'en'

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -3619,6 +3619,11 @@ export interface ShareTasksRequest {
   task_ids: Array<string>;
 }
 
+export interface SharedActionItem {
+  completed?: boolean;
+  description: string;
+}
+
 export interface SharedActionItemPreview {
   description: string;
   due_at?: string | null;
@@ -3628,6 +3633,11 @@ export interface SharedActionItemsResponse {
   count: number;
   sender_name: string;
   tasks: Array<SharedActionItemPreview>;
+}
+
+export interface SharedAppResult {
+  app_id: string | null;
+  content: string;
 }
 
 export interface SharedAssistantSettings {
@@ -3651,49 +3661,57 @@ export interface SharedChatMessagesResponse {
 }
 
 export interface SharedConversationResponse {
-  app_id?: string | null;
-  apps_results?: Array<AppResult>;
-  audio_files?: Array<AudioFile>;
-  calendar_event?: CalendarEventLink | null;
-  call_id?: string | null;
-  client_device_id?: string | null;
-  client_platform?: string | null;
-  conversation_audio?: ConversationAudio | null;
+  apps_results?: Array<SharedAppResult>;
   created_at: string;
-  data_protection_level?: string | null;
-  deferred?: boolean;
-  discarded?: boolean;
-  external_data?: Record<string, unknown> | null;
   finished_at: string | null;
-  folder_id?: string | null;
-  geolocation?: Geolocation | null;
   id: string;
-  imported?: boolean;
-  is_locked?: boolean;
   language?: string | null;
-  meeting_dedup_speech_s?: number | null;
-  meeting_duration_s?: number | null;
-  meeting_treatment_eligible?: boolean;
-  meeting_treatment_reason?: string | null;
-  people?: Array<Person>;
-  photos?: Array<ConversationPhoto>;
-  plugins_results?: Array<PluginResult>;
-  private_cloud_sync_enabled?: boolean;
-  processing_conversation_id?: string | null;
-  processing_memory_id?: string | null;
-  screenshot_sharing_enabled?: boolean;
+  people?: Array<SharedPerson>;
+  plugins_results?: Array<SharedPluginResult>;
   source?: ConversationSource | null;
-  starred?: boolean;
   started_at: string | null;
   status?: ConversationStatus | null;
-  structured: Structured;
-  suggested_summarization_apps?: Array<string>;
-  transcript_segments?: Array<TranscriptSegment>;
-  transcript_segments_compressed?: boolean | null;
-  updated_at?: string | null;
-  uses_custom_stt?: boolean;
+  structured: SharedStructured;
+  transcript_segments?: Array<SharedTranscriptSegment>;
   visibility?: ConversationVisibility;
-  [key: string]: unknown;
+}
+
+export interface SharedEvent {
+  created?: boolean;
+  description?: string;
+  duration?: number;
+  start: string;
+  title: string;
+}
+
+export interface SharedPerson {
+  id: string;
+  name: string;
+}
+
+export interface SharedPluginResult {
+  content: string;
+  plugin_id: string | null;
+}
+
+export interface SharedStructured {
+  action_items?: Array<SharedActionItem>;
+  category?: CategoryEnum;
+  emoji?: string;
+  events?: Array<SharedEvent>;
+  overview?: string;
+  title?: string;
+}
+
+export interface SharedTranscriptSegment {
+  end: number;
+  id?: string | null;
+  is_user: boolean;
+  person_id?: string | null;
+  speaker?: string | null;
+  speaker_id?: number | null;
+  start: number;
+  text: string;
 }
 
 export interface ShortlistEligibility {
@@ -5161,12 +5179,19 @@ export interface OmiApiSchemas {
   "ShareRecipient": ShareRecipient;
   "ShareRecipientsResponse": ShareRecipientsResponse;
   "ShareTasksRequest": ShareTasksRequest;
+  "SharedActionItem": SharedActionItem;
   "SharedActionItemPreview": SharedActionItemPreview;
   "SharedActionItemsResponse": SharedActionItemsResponse;
+  "SharedAppResult": SharedAppResult;
   "SharedAssistantSettings": SharedAssistantSettings;
   "SharedChatMessage": SharedChatMessage;
   "SharedChatMessagesResponse": SharedChatMessagesResponse;
   "SharedConversationResponse": SharedConversationResponse;
+  "SharedEvent": SharedEvent;
+  "SharedPerson": SharedPerson;
+  "SharedPluginResult": SharedPluginResult;
+  "SharedStructured": SharedStructured;
+  "SharedTranscriptSegment": SharedTranscriptSegment;
   "ShortlistEligibility": ShortlistEligibility;
   "SimpleActionItem": SimpleActionItem;
   "SimpleChatMessage": SimpleChatMessage;

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -22056,6 +22056,25 @@
         "title": "ShareTasksRequest",
         "type": "object"
       },
+      "SharedActionItem": {
+        "description": "Public share projection of an action item.",
+        "properties": {
+          "completed": {
+            "default": false,
+            "title": "Completed",
+            "type": "boolean"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string"
+          }
+        },
+        "required": [
+          "description"
+        ],
+        "title": "SharedActionItem",
+        "type": "object"
+      },
       "SharedActionItemPreview": {
         "properties": {
           "description": {
@@ -22105,6 +22124,31 @@
           "count"
         ],
         "title": "SharedActionItemsResponse",
+        "type": "object"
+      },
+      "SharedAppResult": {
+        "properties": {
+          "app_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "App Id"
+          },
+          "content": {
+            "title": "Content",
+            "type": "string"
+          }
+        },
+        "required": [
+          "app_id",
+          "content"
+        ],
+        "title": "SharedAppResult",
         "type": "object"
       },
       "SharedAssistantSettings": {
@@ -22218,126 +22262,19 @@
         "type": "object"
       },
       "SharedConversationResponse": {
-        "additionalProperties": true,
+        "description": "Public unauthenticated shared-conversation payload. Only declared fields are returned.",
         "properties": {
-          "app_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "App Id"
-          },
           "apps_results": {
-            "default": [],
             "items": {
-              "$ref": "#/components/schemas/AppResult"
+              "$ref": "#/components/schemas/SharedAppResult"
             },
             "title": "Apps Results",
             "type": "array"
-          },
-          "audio_files": {
-            "default": [],
-            "items": {
-              "$ref": "#/components/schemas/AudioFile"
-            },
-            "title": "Audio Files",
-            "type": "array"
-          },
-          "calendar_event": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/CalendarEventLink"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Twilio call SID for phone call conversations",
-            "title": "Call Id"
-          },
-          "client_device_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Client Device Id"
-          },
-          "client_platform": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Client Platform"
-          },
-          "conversation_audio": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ConversationAudio"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "created_at": {
             "format": "date-time",
             "title": "Created At",
             "type": "string"
-          },
-          "data_protection_level": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Data Protection Level"
-          },
-          "deferred": {
-            "default": false,
-            "title": "Deferred",
-            "type": "boolean"
-          },
-          "discarded": {
-            "default": false,
-            "title": "Discarded",
-            "type": "boolean"
-          },
-          "external_data": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "External Data"
           },
           "finished_at": {
             "anyOf": [
@@ -22351,41 +22288,9 @@
             ],
             "title": "Finished At"
           },
-          "folder_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "ID of the folder this conversation belongs to",
-            "title": "Folder Id"
-          },
-          "geolocation": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Geolocation"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "id": {
             "title": "Id",
             "type": "string"
-          },
-          "imported": {
-            "default": false,
-            "title": "Imported",
-            "type": "boolean"
-          },
-          "is_locked": {
-            "default": false,
-            "title": "Is Locked",
-            "type": "boolean"
           },
           "language": {
             "anyOf": [
@@ -22398,99 +22303,19 @@
             ],
             "title": "Language"
           },
-          "meeting_dedup_speech_s": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Meeting Dedup Speech S"
-          },
-          "meeting_duration_s": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Meeting Duration S"
-          },
-          "meeting_treatment_eligible": {
-            "default": false,
-            "title": "Meeting Treatment Eligible",
-            "type": "boolean"
-          },
-          "meeting_treatment_reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Meeting Treatment Reason"
-          },
           "people": {
-            "default": [],
             "items": {
-              "$ref": "#/components/schemas/Person"
+              "$ref": "#/components/schemas/SharedPerson"
             },
             "title": "People",
             "type": "array"
           },
-          "photos": {
-            "default": [],
-            "items": {
-              "$ref": "#/components/schemas/ConversationPhoto"
-            },
-            "title": "Photos",
-            "type": "array"
-          },
           "plugins_results": {
-            "default": [],
             "items": {
-              "$ref": "#/components/schemas/PluginResult"
+              "$ref": "#/components/schemas/SharedPluginResult"
             },
             "title": "Plugins Results",
             "type": "array"
-          },
-          "private_cloud_sync_enabled": {
-            "default": false,
-            "title": "Private Cloud Sync Enabled",
-            "type": "boolean"
-          },
-          "processing_conversation_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Processing Conversation Id"
-          },
-          "processing_memory_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Processing Memory Id"
-          },
-          "screenshot_sharing_enabled": {
-            "default": true,
-            "title": "Screenshot Sharing Enabled",
-            "type": "boolean"
           },
           "source": {
             "anyOf": [
@@ -22502,11 +22327,6 @@
               }
             ],
             "default": "omi"
-          },
-          "starred": {
-            "default": false,
-            "title": "Starred",
-            "type": "boolean"
           },
           "started_at": {
             "anyOf": [
@@ -22532,52 +22352,14 @@
             "default": "completed"
           },
           "structured": {
-            "$ref": "#/components/schemas/Structured"
-          },
-          "suggested_summarization_apps": {
-            "default": [],
-            "items": {
-              "type": "string"
-            },
-            "title": "Suggested Summarization Apps",
-            "type": "array"
+            "$ref": "#/components/schemas/SharedStructured"
           },
           "transcript_segments": {
-            "default": [],
             "items": {
-              "$ref": "#/components/schemas/TranscriptSegment"
+              "$ref": "#/components/schemas/SharedTranscriptSegment"
             },
             "title": "Transcript Segments",
             "type": "array"
-          },
-          "transcript_segments_compressed": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": false,
-            "title": "Transcript Segments Compressed"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          },
-          "uses_custom_stt": {
-            "default": false,
-            "title": "Uses Custom Stt",
-            "type": "boolean"
           },
           "visibility": {
             "$ref": "#/components/schemas/ConversationVisibility",
@@ -22592,6 +22374,199 @@
           "structured"
         ],
         "title": "SharedConversationResponse",
+        "type": "object"
+      },
+      "SharedEvent": {
+        "description": "Public share projection of a structured event.",
+        "properties": {
+          "created": {
+            "default": false,
+            "title": "Created",
+            "type": "boolean"
+          },
+          "description": {
+            "default": "",
+            "title": "Description",
+            "type": "string"
+          },
+          "duration": {
+            "default": 30,
+            "title": "Duration",
+            "type": "integer"
+          },
+          "start": {
+            "format": "date-time",
+            "title": "Start",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "start"
+        ],
+        "title": "SharedEvent",
+        "type": "object"
+      },
+      "SharedPerson": {
+        "description": "Speaker-label projection for a shared conversation.",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "SharedPerson",
+        "type": "object"
+      },
+      "SharedPluginResult": {
+        "properties": {
+          "content": {
+            "title": "Content",
+            "type": "string"
+          },
+          "plugin_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Plugin Id"
+          }
+        },
+        "required": [
+          "plugin_id",
+          "content"
+        ],
+        "title": "SharedPluginResult",
+        "type": "object"
+      },
+      "SharedStructured": {
+        "description": "Public share projection of conversation structure.",
+        "properties": {
+          "action_items": {
+            "items": {
+              "$ref": "#/components/schemas/SharedActionItem"
+            },
+            "title": "Action Items",
+            "type": "array"
+          },
+          "category": {
+            "$ref": "#/components/schemas/CategoryEnum",
+            "default": "other"
+          },
+          "emoji": {
+            "default": "🧠",
+            "title": "Emoji",
+            "type": "string"
+          },
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/SharedEvent"
+            },
+            "title": "Events",
+            "type": "array"
+          },
+          "overview": {
+            "default": "",
+            "title": "Overview",
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "title": "SharedStructured",
+        "type": "object"
+      },
+      "SharedTranscriptSegment": {
+        "description": "Public share projection of a transcript turn.",
+        "properties": {
+          "end": {
+            "title": "End",
+            "type": "number"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "is_user": {
+            "title": "Is User",
+            "type": "boolean"
+          },
+          "person_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Person Id"
+          },
+          "speaker": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "SPEAKER_00",
+            "title": "Speaker"
+          },
+          "speaker_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Speaker Id"
+          },
+          "start": {
+            "title": "Start",
+            "type": "number"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text",
+          "is_user",
+          "start",
+          "end"
+        ],
+        "title": "SharedTranscriptSegment",
         "type": "object"
       },
       "ShortlistEligibility": {

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -3619,6 +3619,11 @@ export interface ShareTasksRequest {
   task_ids: Array<string>;
 }
 
+export interface SharedActionItem {
+  completed?: boolean;
+  description: string;
+}
+
 export interface SharedActionItemPreview {
   description: string;
   due_at?: string | null;
@@ -3628,6 +3633,11 @@ export interface SharedActionItemsResponse {
   count: number;
   sender_name: string;
   tasks: Array<SharedActionItemPreview>;
+}
+
+export interface SharedAppResult {
+  app_id: string | null;
+  content: string;
 }
 
 export interface SharedAssistantSettings {
@@ -3651,49 +3661,57 @@ export interface SharedChatMessagesResponse {
 }
 
 export interface SharedConversationResponse {
-  app_id?: string | null;
-  apps_results?: Array<AppResult>;
-  audio_files?: Array<AudioFile>;
-  calendar_event?: CalendarEventLink | null;
-  call_id?: string | null;
-  client_device_id?: string | null;
-  client_platform?: string | null;
-  conversation_audio?: ConversationAudio | null;
+  apps_results?: Array<SharedAppResult>;
   created_at: string;
-  data_protection_level?: string | null;
-  deferred?: boolean;
-  discarded?: boolean;
-  external_data?: Record<string, unknown> | null;
   finished_at: string | null;
-  folder_id?: string | null;
-  geolocation?: Geolocation | null;
   id: string;
-  imported?: boolean;
-  is_locked?: boolean;
   language?: string | null;
-  meeting_dedup_speech_s?: number | null;
-  meeting_duration_s?: number | null;
-  meeting_treatment_eligible?: boolean;
-  meeting_treatment_reason?: string | null;
-  people?: Array<Person>;
-  photos?: Array<ConversationPhoto>;
-  plugins_results?: Array<PluginResult>;
-  private_cloud_sync_enabled?: boolean;
-  processing_conversation_id?: string | null;
-  processing_memory_id?: string | null;
-  screenshot_sharing_enabled?: boolean;
+  people?: Array<SharedPerson>;
+  plugins_results?: Array<SharedPluginResult>;
   source?: ConversationSource | null;
-  starred?: boolean;
   started_at: string | null;
   status?: ConversationStatus | null;
-  structured: Structured;
-  suggested_summarization_apps?: Array<string>;
-  transcript_segments?: Array<TranscriptSegment>;
-  transcript_segments_compressed?: boolean | null;
-  updated_at?: string | null;
-  uses_custom_stt?: boolean;
+  structured: SharedStructured;
+  transcript_segments?: Array<SharedTranscriptSegment>;
   visibility?: ConversationVisibility;
-  [key: string]: unknown;
+}
+
+export interface SharedEvent {
+  created?: boolean;
+  description?: string;
+  duration?: number;
+  start: string;
+  title: string;
+}
+
+export interface SharedPerson {
+  id: string;
+  name: string;
+}
+
+export interface SharedPluginResult {
+  content: string;
+  plugin_id: string | null;
+}
+
+export interface SharedStructured {
+  action_items?: Array<SharedActionItem>;
+  category?: CategoryEnum;
+  emoji?: string;
+  events?: Array<SharedEvent>;
+  overview?: string;
+  title?: string;
+}
+
+export interface SharedTranscriptSegment {
+  end: number;
+  id?: string | null;
+  is_user: boolean;
+  person_id?: string | null;
+  speaker?: string | null;
+  speaker_id?: number | null;
+  start: number;
+  text: string;
 }
 
 export interface ShortlistEligibility {
@@ -5161,12 +5179,19 @@ export interface OmiApiSchemas {
   "ShareRecipient": ShareRecipient;
   "ShareRecipientsResponse": ShareRecipientsResponse;
   "ShareTasksRequest": ShareTasksRequest;
+  "SharedActionItem": SharedActionItem;
   "SharedActionItemPreview": SharedActionItemPreview;
   "SharedActionItemsResponse": SharedActionItemsResponse;
+  "SharedAppResult": SharedAppResult;
   "SharedAssistantSettings": SharedAssistantSettings;
   "SharedChatMessage": SharedChatMessage;
   "SharedChatMessagesResponse": SharedChatMessagesResponse;
   "SharedConversationResponse": SharedConversationResponse;
+  "SharedEvent": SharedEvent;
+  "SharedPerson": SharedPerson;
+  "SharedPluginResult": SharedPluginResult;
+  "SharedStructured": SharedStructured;
+  "SharedTranscriptSegment": SharedTranscriptSegment;
   "ShortlistEligibility": ShortlistEligibility;
   "SimpleActionItem": SimpleActionItem;
   "SimpleChatMessage": SimpleChatMessage;

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -3619,6 +3619,11 @@ export interface ShareTasksRequest {
   task_ids: Array<string>;
 }
 
+export interface SharedActionItem {
+  completed?: boolean;
+  description: string;
+}
+
 export interface SharedActionItemPreview {
   description: string;
   due_at?: string | null;
@@ -3628,6 +3633,11 @@ export interface SharedActionItemsResponse {
   count: number;
   sender_name: string;
   tasks: Array<SharedActionItemPreview>;
+}
+
+export interface SharedAppResult {
+  app_id: string | null;
+  content: string;
 }
 
 export interface SharedAssistantSettings {
@@ -3651,49 +3661,57 @@ export interface SharedChatMessagesResponse {
 }
 
 export interface SharedConversationResponse {
-  app_id?: string | null;
-  apps_results?: Array<AppResult>;
-  audio_files?: Array<AudioFile>;
-  calendar_event?: CalendarEventLink | null;
-  call_id?: string | null;
-  client_device_id?: string | null;
-  client_platform?: string | null;
-  conversation_audio?: ConversationAudio | null;
+  apps_results?: Array<SharedAppResult>;
   created_at: string;
-  data_protection_level?: string | null;
-  deferred?: boolean;
-  discarded?: boolean;
-  external_data?: Record<string, unknown> | null;
   finished_at: string | null;
-  folder_id?: string | null;
-  geolocation?: Geolocation | null;
   id: string;
-  imported?: boolean;
-  is_locked?: boolean;
   language?: string | null;
-  meeting_dedup_speech_s?: number | null;
-  meeting_duration_s?: number | null;
-  meeting_treatment_eligible?: boolean;
-  meeting_treatment_reason?: string | null;
-  people?: Array<Person>;
-  photos?: Array<ConversationPhoto>;
-  plugins_results?: Array<PluginResult>;
-  private_cloud_sync_enabled?: boolean;
-  processing_conversation_id?: string | null;
-  processing_memory_id?: string | null;
-  screenshot_sharing_enabled?: boolean;
+  people?: Array<SharedPerson>;
+  plugins_results?: Array<SharedPluginResult>;
   source?: ConversationSource | null;
-  starred?: boolean;
   started_at: string | null;
   status?: ConversationStatus | null;
-  structured: Structured;
-  suggested_summarization_apps?: Array<string>;
-  transcript_segments?: Array<TranscriptSegment>;
-  transcript_segments_compressed?: boolean | null;
-  updated_at?: string | null;
-  uses_custom_stt?: boolean;
+  structured: SharedStructured;
+  transcript_segments?: Array<SharedTranscriptSegment>;
   visibility?: ConversationVisibility;
-  [key: string]: unknown;
+}
+
+export interface SharedEvent {
+  created?: boolean;
+  description?: string;
+  duration?: number;
+  start: string;
+  title: string;
+}
+
+export interface SharedPerson {
+  id: string;
+  name: string;
+}
+
+export interface SharedPluginResult {
+  content: string;
+  plugin_id: string | null;
+}
+
+export interface SharedStructured {
+  action_items?: Array<SharedActionItem>;
+  category?: CategoryEnum;
+  emoji?: string;
+  events?: Array<SharedEvent>;
+  overview?: string;
+  title?: string;
+}
+
+export interface SharedTranscriptSegment {
+  end: number;
+  id?: string | null;
+  is_user: boolean;
+  person_id?: string | null;
+  speaker?: string | null;
+  speaker_id?: number | null;
+  start: number;
+  text: string;
 }
 
 export interface ShortlistEligibility {
@@ -5161,12 +5179,19 @@ export interface OmiApiSchemas {
   "ShareRecipient": ShareRecipient;
   "ShareRecipientsResponse": ShareRecipientsResponse;
   "ShareTasksRequest": ShareTasksRequest;
+  "SharedActionItem": SharedActionItem;
   "SharedActionItemPreview": SharedActionItemPreview;
   "SharedActionItemsResponse": SharedActionItemsResponse;
+  "SharedAppResult": SharedAppResult;
   "SharedAssistantSettings": SharedAssistantSettings;
   "SharedChatMessage": SharedChatMessage;
   "SharedChatMessagesResponse": SharedChatMessagesResponse;
   "SharedConversationResponse": SharedConversationResponse;
+  "SharedEvent": SharedEvent;
+  "SharedPerson": SharedPerson;
+  "SharedPluginResult": SharedPluginResult;
+  "SharedStructured": SharedStructured;
+  "SharedTranscriptSegment": SharedTranscriptSegment;
   "ShortlistEligibility": ShortlistEligibility;
   "SimpleActionItem": SimpleActionItem;
   "SimpleChatMessage": SimpleChatMessage;

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -3619,6 +3619,11 @@ export interface ShareTasksRequest {
   task_ids: Array<string>;
 }
 
+export interface SharedActionItem {
+  completed?: boolean;
+  description: string;
+}
+
 export interface SharedActionItemPreview {
   description: string;
   due_at?: string | null;
@@ -3628,6 +3633,11 @@ export interface SharedActionItemsResponse {
   count: number;
   sender_name: string;
   tasks: Array<SharedActionItemPreview>;
+}
+
+export interface SharedAppResult {
+  app_id: string | null;
+  content: string;
 }
 
 export interface SharedAssistantSettings {
@@ -3651,49 +3661,57 @@ export interface SharedChatMessagesResponse {
 }
 
 export interface SharedConversationResponse {
-  app_id?: string | null;
-  apps_results?: Array<AppResult>;
-  audio_files?: Array<AudioFile>;
-  calendar_event?: CalendarEventLink | null;
-  call_id?: string | null;
-  client_device_id?: string | null;
-  client_platform?: string | null;
-  conversation_audio?: ConversationAudio | null;
+  apps_results?: Array<SharedAppResult>;
   created_at: string;
-  data_protection_level?: string | null;
-  deferred?: boolean;
-  discarded?: boolean;
-  external_data?: Record<string, unknown> | null;
   finished_at: string | null;
-  folder_id?: string | null;
-  geolocation?: Geolocation | null;
   id: string;
-  imported?: boolean;
-  is_locked?: boolean;
   language?: string | null;
-  meeting_dedup_speech_s?: number | null;
-  meeting_duration_s?: number | null;
-  meeting_treatment_eligible?: boolean;
-  meeting_treatment_reason?: string | null;
-  people?: Array<Person>;
-  photos?: Array<ConversationPhoto>;
-  plugins_results?: Array<PluginResult>;
-  private_cloud_sync_enabled?: boolean;
-  processing_conversation_id?: string | null;
-  processing_memory_id?: string | null;
-  screenshot_sharing_enabled?: boolean;
+  people?: Array<SharedPerson>;
+  plugins_results?: Array<SharedPluginResult>;
   source?: ConversationSource | null;
-  starred?: boolean;
   started_at: string | null;
   status?: ConversationStatus | null;
-  structured: Structured;
-  suggested_summarization_apps?: Array<string>;
-  transcript_segments?: Array<TranscriptSegment>;
-  transcript_segments_compressed?: boolean | null;
-  updated_at?: string | null;
-  uses_custom_stt?: boolean;
+  structured: SharedStructured;
+  transcript_segments?: Array<SharedTranscriptSegment>;
   visibility?: ConversationVisibility;
-  [key: string]: unknown;
+}
+
+export interface SharedEvent {
+  created?: boolean;
+  description?: string;
+  duration?: number;
+  start: string;
+  title: string;
+}
+
+export interface SharedPerson {
+  id: string;
+  name: string;
+}
+
+export interface SharedPluginResult {
+  content: string;
+  plugin_id: string | null;
+}
+
+export interface SharedStructured {
+  action_items?: Array<SharedActionItem>;
+  category?: CategoryEnum;
+  emoji?: string;
+  events?: Array<SharedEvent>;
+  overview?: string;
+  title?: string;
+}
+
+export interface SharedTranscriptSegment {
+  end: number;
+  id?: string | null;
+  is_user: boolean;
+  person_id?: string | null;
+  speaker?: string | null;
+  speaker_id?: number | null;
+  start: number;
+  text: string;
 }
 
 export interface ShortlistEligibility {
@@ -5161,12 +5179,19 @@ export interface OmiApiSchemas {
   "ShareRecipient": ShareRecipient;
   "ShareRecipientsResponse": ShareRecipientsResponse;
   "ShareTasksRequest": ShareTasksRequest;
+  "SharedActionItem": SharedActionItem;
   "SharedActionItemPreview": SharedActionItemPreview;
   "SharedActionItemsResponse": SharedActionItemsResponse;
+  "SharedAppResult": SharedAppResult;
   "SharedAssistantSettings": SharedAssistantSettings;
   "SharedChatMessage": SharedChatMessage;
   "SharedChatMessagesResponse": SharedChatMessagesResponse;
   "SharedConversationResponse": SharedConversationResponse;
+  "SharedEvent": SharedEvent;
+  "SharedPerson": SharedPerson;
+  "SharedPluginResult": SharedPluginResult;
+  "SharedStructured": SharedStructured;
+  "SharedTranscriptSegment": SharedTranscriptSegment;
   "ShortlistEligibility": ShortlistEligibility;
   "SimpleActionItem": SimpleActionItem;
   "SimpleChatMessage": SimpleChatMessage;


### PR DESCRIPTION
## What changed and why

SCA-419: `GET /v1/conversations/{id}/shared` is public and unauthenticated. It inherited `Conversation` with `extra="allow"` and only nulled three fields, so every new owner-internal field was public by default. This PR replaces that denylist with an explicit allowlist model (`extra="ignore"`, no `Conversation` inheritance) and one projection (`project_shared_conversation`).

**`calendar_event` is dropped.** `CalendarEventLink` carries `attendee_emails` (and attendee display names). A share link must not publish the owner's calendar attendees.

## Consumer inventory

| Consumer | Uses `/v1/conversations/{id}/shared`? | Fields actually read |
|---|---|---|
| Web share page (`web/frontend/src/app/memories/[id]`, `components/memories/**`, `actions/memories/get-shared-memory.ts`) | Yes | `id`, `created_at`, `structured.title`, `structured.overview`, `structured.events` (`title`, `description`, `start`, `duration`), `structured.action_items` (`description`, `completed`), `apps_results` (`app_id`, `content`), `transcript_segments` (`text`, `speaker_id`, `is_user`, `person_id`), `people` (`id`, `name`) |
| Web types (`memory.types.ts`) | Typed, not rendered | `started_at`, `finished_at`, `source`, `language`, `photos`; `external_data` is passed into the transcript tab but this endpoint already nulled it |
| Mobile (`app/lib`) | No live caller | Generated OpenAPI/Dart only |
| Desktop | No live caller | Generated TS/Swift client types only |
| Backend | Tests + OpenAPI | `backend/tests/unit/test_shared_conversation_field_exposure.py`; route is in `route_policy_legacy_missing_routes.txt` (screenshots + shared chat are manifested) |

Web does **not** render `photos`, `sections`, `has_recording`, or `calendar_event`. Photos would be base64 pixels; they stay off the allowlist.

## Allowlist (for David to cut)

Top-level: `id`, `created_at`, `started_at`, `finished_at`, `language`, `source`, `status`, `visibility`, `structured`, `transcript_segments`, `apps_results`, `plugins_results`, `people`.

Nested:

- `structured`: `title`, `overview`, `emoji`, `category`, `action_items` (`description`, `completed`), `events` (`title`, `description`, `start`, `duration`, `created`). No `sections`.
- `transcript_segments`: `id`, `text`, `speaker`, `speaker_id`, `is_user`, `person_id`, `start`, `end`.
- `apps_results` / `plugins_results`: `app_id`/`plugin_id`, `content` (kept for the old memories-route alias).
- `people`: `id`, `name` only (no speech-sample URIs, emails, or contact ids).

Deliberately dropped (including the three previously nulled fields): `geolocation`, `data_protection_level`, `external_data`, `calendar_event` (**attendee emails**), `client_device_id`, `client_platform`, `folder_id`, `call_id`, `processing_memory_id`, `meeting_*`, `transcript_segments_compressed`, `suggested_summarization_apps`, `screenshot_sharing_enabled`, `private_cloud_sync_enabled`, `photos`, `has_recording`, and any new stored-document key.

## Product invariants affected

none

## How it was verified

- `backend/scripts/sync-python-deps.sh` then:
  - `backend/.venv/bin/python -m pytest tests/unit/test_shared_conversation_field_exposure.py -q` → **8 passed**
  - `BACKEND_UNIT_TEST_FILE_LIST=… bash test.sh` on that file plus `tests/unit/test_route_policy_preflight.py` and `tests/unit/test_route_policy_inventory.py` → **40 passed** (a pre-existing fast-unit CPU-time warning on `test_route_policy_inventory.py`, not this change)
- Regenerated app-client OpenAPI with `backend/scripts/openapi_runner.sh` (dedicated `.openapi-venv`), then Dart/TS/Swift generators. Dart and Swift were already current; TS + `docs/api-reference/app-client-openapi.json` updated.
- `backend/scripts/check_app_client_openapi_compatibility.py --base-ref origin/main` → **passed**
- Did not hit a live share URL (no local backend with a public conversation). Behavior is covered by the handler tests, including 404 for private / missing share links.
- Local `scripts/pre-push` passed twice (OpenAPI contract + the 8 exposure tests). `git push` then exited 141 (SIGPIPE) after the hook printed success and before `Enumerating objects`, so the network send used `--no-verify` after those passing runs.

## Tests

`backend/tests/unit/test_shared_conversation_field_exposure.py` now asserts:

- response top-level keys equal the declared allowlist
- previously leaking fields (including `calendar_event` / `client_device_id` / speech samples) are absent
- a new arbitrary field on the stored document does not appear
- private / missing share links still 404

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative

Adds `.github/failure-classes/FC-public-projection-is-denylist-shaped.json`. A public unauthenticated response must name the fields it exposes; inheriting the internal record with `extra=allow` and nulling a few keys makes every new field public by default. The guard is the explicit model + projection and the allowlist/regression tests above. `evidence_prs` is `[]` because this PR is the first instance.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

