### PR TITLE
test(desktop): repair onboarding door expectations

### DIFF
--- a/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
@@ -405,14 +405,14 @@ final class OnboardingFlowTests: XCTestCase {
       "the file-index onboarding Continue button must accept Return")
 
     let secondBrainSource = try desktopSourceFile("Onboarding/SecondBrain/SBOnboardingView.swift")
-    for title in ["Set up Omi →", "Continue"] {
+    for title in ["Set up Omi →", "Continue", "Open the doors"] {
       XCTAssertTrue(
         secondBrainSource.contains("SBInkButton(title: \"\(title)\", isDefaultAction: true)"),
         "the second-brain \(title) action must accept Return")
     }
     XCTAssertEqual(
       secondBrainSource.components(separatedBy: "isDefaultAction: true").count - 1,
-      8,
+      9,
       "every visible second-brain proceed action must register Return")
     XCTAssertTrue(
       secondBrainSource.contains("SBInkButton(title: \"Take me to Omi\", isDefaultAction: true)"),

--- a/desktop/macos/Desktop/Tests/ThreeDoorsDemoPageTests.swift
+++ b/desktop/macos/Desktop/Tests/ThreeDoorsDemoPageTests.swift
@@ -52,6 +52,7 @@ final class ThreeDoorsDemoPageTests: XCTestCase {
     let here = URL(fileURLWithPath: #filePath)
     let template = here.deletingLastPathComponent().deletingLastPathComponent()
       .appendingPathComponent("Sources/Resources/\(ThreeDoorsDemoPage.fileName)")
+    // omi-test-quality: source-inspection -- static contract: bundled riddle copy must match the model note
     let html = try String(contentsOf: template, encoding: .utf8)
     for phrase in [
       "I have keys but open no locks", "Which planet has a day longer than its year", "last word of the first riddle",
@@ -68,6 +69,7 @@ final class ThreeDoorsDemoPageTests: XCTestCase {
     let here = URL(fileURLWithPath: #filePath)
     let template = here.deletingLastPathComponent().deletingLastPathComponent()
       .appendingPathComponent("Sources/Resources/\(ThreeDoorsDemoPage.fileName)")
+    // omi-test-quality: source-inspection -- static contract: renderer replacement markers must remain bundled
     let html = try String(contentsOf: template, encoding: .utf8)
     XCTAssertTrue(html.contains(ThreeDoorsDemoPage.templateKeyMarkup))
     XCTAssertTrue(html.contains(ThreeDoorsDemoPage.templateReturnMarkup))


### PR DESCRIPTION
## What changed and why

Main's `OnboardingFlowTests` has been red since the three-doors onboarding merge: the flow now presents "Open the doors" and has nine default-action buttons, while the test still expected the earlier copy and count. This PR updates those expectations and classifies the two intentional source-inspection checks in `ThreeDoorsDemoPageTests`.

PR #12551 temporarily includes these same two commits to keep its Desktop Swift job green. After this PR merges, those commits will fall away when #12551 rebases onto `main`.

## How it was verified

- `desktop/macos/scripts/dev-feedback.py --once swift 'ThreeDoorsDemoPageTests|OnboardingFlowTests'` — 30 tests passed
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — passed

🤖 Generated with Codex


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

