### PR TITLE
fix(desktop): door 3 hint asks the question directly

### DIFF
--- a/desktop/macos/Desktop/Sources/Resources/three-doors.html
+++ b/desktop/macos/Desktop/Sources/Resources/three-doors.html
@@ -100,7 +100,7 @@
     { kind:'type', planks:4, keystone:'', say:"Yo, what's the answer to this riddle?", timed:20,
       r:'Which planet has a day longer than its year?',
       a:['venus','planet venus'] },
-    { kind:'type', planks:5, keystone:'', say:'Yo, check my screen history: what was the last word of the first riddle?',
+    { kind:'type', planks:5, keystone:'', say:'Yo, what was the last word of the first riddle?',
       r:'What was the last word of the first riddle? There is no way back.',
       a:['inside','go inside','never go inside'], placeholder:'type the word' },
   ];

--- a/desktop/macos/changelog/unreleased/20260902-door3-hint.json
+++ b/desktop/macos/changelog/unreleased/20260902-door3-hint.json
@@ -1,0 +1,3 @@
+{
+  "change": "Onboarding door 3 hint asks the question directly instead of telling Omi to check screen history, which is not searchable yet that early in onboarding"
+}


### PR DESCRIPTION
## Summary
On Beta 0.12.259 the door-3 hint ("Yo, check my screen history: what was the last word of the first riddle?") made the voice model call `search_screen_history("first riddle")`, which returned 0 vector and 0 text-fallback results (Rewind capture started ~95 s earlier; OCR is not searchable for ~156 s), and it then answered from the demo note anyway. The hint now asks the question directly: "Yo, what was the last word of the first riddle?" so the demo does not stage a search that cannot succeed yet.

## Verification
Log (Beta 0.12.259, 23:10:40): `tool_call search_screen_history({"query":"first riddle"})` → `vector returned 0 results` → `text fallback returned 0 results` → answer spoken from the note. Rendered the updated template headlessly at door 3 and confirmed the new hint text (screenshot attached to the review). One-string change in `three-doors.html`; no test asserted the old wording.

Invariants: none matched.
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

