### PR TITLE
fix(app): drop the drop shadows around the home chat bar and record button

### DIFF
--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -915,21 +915,6 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
           color: const Color(0xFF1F1F25),
           borderRadius: BorderRadius.circular(32),
           border: Border.all(color: const Color(0xFF35343B), width: 1),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: 0.65),
-              blurRadius: 60,
-              spreadRadius: 14,
-              offset: const Offset(0, -16),
-            ),
-            BoxShadow(
-              color: Colors.black.withValues(alpha: 0.45),
-              blurRadius: 32,
-              spreadRadius: 6,
-              offset: const Offset(0, -8),
-            ),
-            BoxShadow(color: Colors.black.withValues(alpha: 0.25), blurRadius: 10, offset: const Offset(0, 2)),
-          ],
         ),
         child: Row(
           children: [

--- a/app/lib/pages/home/widgets/battery_info_widget.dart
+++ b/app/lib/pages/home/widgets/battery_info_widget.dart
@@ -291,9 +291,6 @@ class _HomeRecordButtonState extends State<HomeRecordButton> {
             decoration: BoxDecoration(
               color: isRecording ? Colors.red.shade700 : Colors.deepPurple,
               shape: BoxShape.circle,
-              boxShadow: [
-                BoxShadow(color: Colors.black.withValues(alpha: 0.35), blurRadius: 18, offset: const Offset(0, 6)),
-              ],
             ),
             child: isRecording
                 ? const Icon(Icons.stop_rounded, size: 24, color: Colors.white)


### PR DESCRIPTION
Removes the drop shadows on the home chat bar (three stacked black shadows, 60/32/10px blur, offset upward) and on the circular record button (one 18px shadow). On the black home background they render as a gray haze between and around the two controls — Nik flagged it as a redundant "gray gradient". Pure deletion: no layout, color, or behavior change.

Verified on an iPhone 16 simulator: the band between the ask bar and the + circle is gone; bar, mic, + and their taps unchanged. Before/after: https://claude.ai/code/artifact/a03b5f4e-a87b-4f68-8667-ee21ed58771a

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

