### PR TITLE
feat(desktop): give processing conversations an identity, a bounded wait, and an exit

### DIFF
--- a/desktop/macos/Desktop/Sources/AnalyticsManager+ConversationProcessing.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager+ConversationProcessing.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Processing-row telemetry. The 2/10-minute thresholds on the row are a
+/// guess until these two events give them a measured distribution.
+extension AnalyticsManager {
+  /// Elapsed time from recording end to a terminal status, observed by the
+  /// client. This is the number the processing-row thresholds are tuned from.
+  func conversationProcessingCompleted(conversationId: String, elapsedSeconds: Int, outcome: String) {
+    PostHogManager.shared.conversationProcessingCompleted(
+      conversationId: conversationId, elapsedSeconds: elapsedSeconds, outcome: outcome)
+  }
+
+  /// Fired once per conversation when the row crosses the stalled threshold.
+  func conversationProcessingStalled(conversationId: String, elapsedSeconds: Int) {
+    PostHogManager.shared.conversationProcessingStalled(
+      conversationId: conversationId, elapsedSeconds: elapsedSeconds)
+  }
+}

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -329,6 +329,15 @@ class AppState: ObservableObject {
   /// Used to prevent asynchronous work from mutating a newer recording decision.
   var recordingGeneration: UInt64 = 0
   @Published var isSavingConversation = false
+  /// True from the moment a capture stops until its conversation has been
+  /// loaded into the list. Keeps the Live card's slot occupied so the meeting
+  /// visibly lands as a row instead of vanishing and reappearing.
+  @Published var isFinalizingCapture = false
+  /// Follows visible processing rows to a terminal state (see the type).
+  lazy var processingWatcher = ProcessingConversationWatcher.live(
+    fetch: ProcessingConversationWatcher.fetchDetail,
+    onResolved: { [weak self] refreshed in self?.conversationRepository.replace(refreshed) }
+  )
   // currentTranscript is internal-only (not observed by views), so no @Published needed
   var currentTranscript: String = ""
   @Published var hasMicrophonePermission = false
@@ -678,6 +687,7 @@ class AppState: ObservableObject {
     conversationRepository.onSnapshot = { [weak self] snapshot in
       guard let self else { return }
       self.conversations = snapshot.conversations
+      self.processingWatcher.sync(with: snapshot.conversations)
       self.isLoadingConversations = snapshot.isLoading
       self.conversationsError = snapshot.error
       if self.hasActiveConversationFilters {

--- a/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
@@ -17,6 +17,9 @@ extension AppState {
   /// the cached projection immediately and quietly replaces it with server truth.
   func loadConversations() async {
     await conversationRepository.load(query: currentConversationQuery)
+    // Every capture-stop path ends here; the Saving card has held the Live
+    // card's slot until this load could show the conversation as a row.
+    isFinalizingCapture = false
     NotificationCenter.default.post(name: .conversationsPageDidLoad, object: nil)
   }
 

--- a/desktop/macos/Desktop/Sources/AppState/AppState+FinishedRecordingLifecycle.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+FinishedRecordingLifecycle.swift
@@ -28,6 +28,9 @@ extension AppState {
   }
 
   func captureCurrentFinishedRecordingForLifecycle() {
+    // A finished recording is on its way to the list. Hold the Live card's
+    // slot with the Saving card until the next conversations load lands.
+    isFinalizingCapture = currentSessionId != nil
     captureFinishedRecordingForLifecycle(
       sessionId: currentSessionId,
       clientConversationId: currentClientConversationId

--- a/desktop/macos/Desktop/Sources/ConversationProcessingProgress.swift
+++ b/desktop/macos/Desktop/Sources/ConversationProcessingProgress.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Where a still-processing conversation sits on the clock. The pipeline has
+/// no honest denominator for a percentage, so the UI communicates the only
+/// thing it can observe: how long the wait has already lasted.
+enum ConversationProcessingPhase: Equatable {
+  /// Within the expected window — the backend is writing the title and summary.
+  case summarizing
+  /// Past the expected window. Still plausibly running; no action offered yet.
+  case slow
+  /// Long enough that a live processor is unlikely. Offer Reprocess inline.
+  case stalled
+}
+
+/// Pure, clock-injected rules for the processing row. Thresholds are a
+/// starting point; `Conversation Processing Completed` telemetry records the
+/// measured elapsed time so they can be re-set from a real p95.
+enum ConversationProcessingProgress {
+  /// After this the pill stops promising "shortly".
+  static let slowAfter: TimeInterval = 120
+  /// After this the row offers Reprocess. Matches the backend's stale-orphan
+  /// floor (300s lease) with headroom for a slow but live LLM call.
+  static let stalledAfter: TimeInterval = 600
+  /// How long after status flips to completed the backend's derived effects
+  /// (memories, action items, embeddings) are typically still landing.
+  static let derivedSettleGrace: TimeInterval = 45
+
+  /// Processing starts when the recording ends, not when the row was created —
+  /// a 40-minute meeting created 40 minutes ago is not 40 minutes stalled.
+  static func processingStart(for conversation: ServerConversation) -> Date {
+    conversation.finishedAt ?? conversation.createdAt
+  }
+
+  static func elapsed(for conversation: ServerConversation, now: Date) -> TimeInterval {
+    max(0, now.timeIntervalSince(processingStart(for: conversation)))
+  }
+
+  static func phase(elapsed: TimeInterval) -> ConversationProcessingPhase {
+    if elapsed >= stalledAfter { return .stalled }
+    if elapsed >= slowAfter { return .slow }
+    return .summarizing
+  }
+
+  static func phase(for conversation: ServerConversation, now: Date = Date()) -> ConversationProcessingPhase {
+    phase(elapsed: elapsed(for: conversation, now: now))
+  }
+
+  /// Minimum words for a segment to be worth quoting as an identity.
+  static let provisionalTitleMinimumWords = 5
+  /// Character budget for a provisional title so it fits a single row line.
+  static let provisionalTitleMaxLength = 64
+
+  /// A row identity derived from the captured transcript so a processing
+  /// conversation is never introduced to the user as "Processing…". Takes the
+  /// first substantive segment, trims it to one line at a word boundary, and
+  /// capitalises the first letter. Returns nil when no segment is substantive.
+  static func provisionalTitle(from segments: [TranscriptSegment]) -> String? {
+    for segment in segments {
+      let words = segment.text.split(whereSeparator: { $0.isWhitespace })
+      guard words.count >= provisionalTitleMinimumWords else { continue }
+      var kept: [Substring] = []
+      var length = 0
+      for word in words {
+        let next = length + word.count + (kept.isEmpty ? 0 : 1)
+        if next > provisionalTitleMaxLength { break }
+        kept.append(word)
+        length = next
+      }
+      // A title budget that cannot fit the minimum words is not a title.
+      guard kept.count >= provisionalTitleMinimumWords else { continue }
+      var text = kept.joined(separator: " ")
+      if kept.count < words.count {
+        text = text.trimmingCharacters(in: CharacterSet(charactersIn: ".,;:!?-–—")) + "…"
+      }
+      return text.prefix(1).uppercased() + text.dropFirst()
+    }
+    return nil
+  }
+}

--- a/desktop/macos/Desktop/Sources/ConversationReconciliationPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ConversationReconciliationPolicy.swift
@@ -125,8 +125,12 @@ enum ConversationReconciliationPolicy {
       }
     }
 
+    let currentByID = Dictionary(current.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
     var merged = server.map { serverConversation in
-      apply(mutation: nextPending[serverConversation.id], to: serverConversation)
+      apply(
+        mutation: nextPending[serverConversation.id],
+        to: retainingLoadedTranscript(server: serverConversation, current: currentByID[serverConversation.id])
+      )
     }
 
     // Preserve genuinely local in-progress rows that have not reached the
@@ -141,6 +145,23 @@ enum ConversationReconciliationPolicy {
       conversations: merged,
       pendingMutations: nextPending
     )
+  }
+
+  /// List responses omit `transcript_segments`; that means "not loaded", not
+  /// "empty". A row that already holds a loaded transcript (local capture
+  /// cache, or a detail fetch) keeps it so a processing row's provisional
+  /// title does not flicker back to the clock on every list refresh.
+  static func retainingLoadedTranscript(
+    server: ServerConversation,
+    current: ServerConversation?
+  ) -> ServerConversation {
+    guard !server.transcriptSegmentsIncluded, let current, !current.transcriptSegments.isEmpty else {
+      return server
+    }
+    var retained = server
+    retained.transcriptSegments = current.transcriptSegments
+    retained.transcriptSegmentsIncluded = true
+    return retained
   }
 
   static func apply(

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationListView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationListView.swift
@@ -195,6 +195,9 @@ struct ConversationListView: View {
     .padding(.horizontal, PagePanelVerticalRhythm.horizontalPadding)
     .padding(.top, PagePanelVerticalRhythm.contentGap)
     .padding(.bottom, PagePanelVerticalRhythm.contentBottomPadding)
+    // Keyed on identity only: a finished capture slides into the list as one
+    // row change rather than a repaint, and field updates stay animation-free.
+    .omiAnimation(.easeInOut(duration: 0.25), value: conversations.map(\.id))
   }
 
   private var conversationList: some View {

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationProcessingBanner.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationProcessingBanner.swift
@@ -1,0 +1,93 @@
+import OmiTheme
+import SwiftUI
+
+/// Banner above a conversation's details while its summary is still being
+/// written. Wording follows the same clock as the list row's pill, and a
+/// stalled pipeline gets its exit here too. A deferred (free-tier) row is
+/// not on a clock: opening it is what started the work.
+struct ConversationProcessingBanner: View {
+  let conversation: ServerConversation
+  /// Adopts the reprocessed conversation in the presenting view.
+  let onReprocessed: (ServerConversation) -> Void
+
+  @State private var isReprocessing = false
+
+  static func title(phase: ConversationProcessingPhase, deferred: Bool) -> String {
+    if deferred { return "Summarizing now…" }
+    switch phase {
+    case .summarizing: return "Summarizing…"
+    case .slow: return "Taking longer than usual"
+    case .stalled: return "Processing looks stuck"
+    }
+  }
+
+  static func detail(phase: ConversationProcessingPhase, deferred: Bool) -> String {
+    if deferred { return "Opening this conversation started its title, summary and action items" }
+    switch phase {
+    case .summarizing: return "Title, summary and action items usually land within two minutes"
+    case .slow: return "Long conversations and busy periods can take a few minutes. The transcript is below."
+    case .stalled: return "It has been over ten minutes. Reprocess runs the title and summary again."
+    }
+  }
+
+  var body: some View {
+    TimelineView(.periodic(from: .now, by: 15)) { timeline in
+      let phase = ConversationProcessingProgress.phase(for: conversation, now: timeline.date)
+      let deferred = conversation.deferred
+      let offersReprocess = phase == .stalled && !deferred
+      HStack(spacing: OmiSpacing.md) {
+        if offersReprocess {
+          Image(systemName: "exclamationmark.triangle.fill")
+            .scaledFont(size: OmiType.body)
+            .foregroundColor(Ink.errorRed)
+        } else {
+          ProgressView()
+            .controlSize(.small)
+        }
+        VStack(alignment: .leading, spacing: OmiSpacing.hairline) {
+          Text(Self.title(phase: phase, deferred: deferred))
+            .scaledFont(size: OmiType.body, weight: .semibold)
+            .foregroundColor(Ink.primary)
+          Text(Self.detail(phase: phase, deferred: deferred))
+            .scaledFont(size: OmiType.caption)
+            .foregroundColor(Ink.secondary)
+        }
+        Spacer()
+        if offersReprocess {
+          Button {
+            Task { await reprocess() }
+          } label: {
+            Text(isReprocessing ? "Reprocessing…" : "Reprocess")
+              .scaledFont(size: OmiType.caption, weight: .semibold)
+              .foregroundColor(Ink.primary)
+              .padding(.horizontal, OmiSpacing.md)
+              .frame(height: 26)
+              .glassChip()
+          }
+          .buttonStyle(.plain)
+          .disabled(isReprocessing)
+          .accessibilityIdentifier("conversation-detail-reprocess-stalled")
+        }
+      }
+      .padding(OmiSpacing.lg)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(Ink.rowFillHover.opacity(0.5))
+      .cornerRadius(OmiChrome.smallControlRadius)
+    }
+  }
+
+  /// Default-app reprocess: the same call the row's inline button makes.
+  private func reprocess() async {
+    guard !isReprocessing else { return }
+    isReprocessing = true
+    defer { isReprocessing = false }
+    AnalyticsManager.shared.conversationReprocessedDefault(conversationId: conversation.id)
+    do {
+      let updated = try await APIClient.shared.reprocessConversation(conversationId: conversation.id)
+      AppState.current?.replaceConversation(updated)
+      onReprocessed(updated)
+    } catch {
+      logError("Failed to reprocess stalled conversation", error: error)
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
@@ -85,14 +85,110 @@ struct ConversationRowView: View {
     return folders.first(where: { $0.id == folderId })?.name
   }
 
-  /// Title color — dim non-titled placeholders (Processing / Locked /
-  /// Untitled) so they visually read as secondary text, not as the real
-  /// title of the conversation.
+  /// Title color — dim placeholders (Locked / Untitled / clock-only
+  /// provisional titles) so they read as secondary text. A provisional title
+  /// quoted from the transcript is real content and reads as primary.
   private var titleColor: Color {
     switch conversation.displayState {
     case .titled: return Ink.primary
+    case .processing, .awaitingFirstOpen:
+      return conversation.hasTranscriptProvisionalTitle ? Ink.primary : Ink.secondary
     default: return Ink.secondary
     }
+  }
+
+  /// A live pipeline row re-evaluates its phase on a slow clock; every other
+  /// row is static and must not pay for a timeline.
+  private var isLivePipelineRow: Bool {
+    conversation.displayState == .processing
+  }
+
+  private var isSettlingDerived: Bool {
+    conversation.status == .completed && appState.processingWatcher.isSettlingDerived(conversation.id)
+  }
+
+  private func processingPhase(now: Date) -> ConversationProcessingPhase {
+    ConversationProcessingProgress.phase(for: conversation, now: now)
+  }
+
+  /// Emoji tile, or a waveform while the conversation has no emoji of its
+  /// own. A fallback 💬 would claim an identity the pipeline has not produced.
+  @ViewBuilder
+  private func leadingTile(size: CGFloat, fontSize: CGFloat, cornerRadius: CGFloat) -> some View {
+    let tile = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous).fill(Ink.rowFill)
+    if conversation.structured.emoji.isEmpty {
+      Image(systemName: "waveform")
+        .scaledFont(size: fontSize * 0.8, weight: .medium)
+        .foregroundColor(Ink.secondary)
+        .frame(width: size, height: size)
+        .background(tile)
+    } else {
+      Text(conversation.structured.emoji)
+        .scaledFont(size: fontSize)
+        .frame(width: size, height: size)
+        .background(tile)
+    }
+  }
+
+  /// Status pill plus, once stalled, the way out — inline, not hidden behind
+  /// a hover menu.
+  @ViewBuilder
+  private func statusCluster(phase: ConversationProcessingPhase) -> some View {
+    ConversationStatusBadge(state: conversation.displayState, phase: phase)
+    if isLivePipelineRow && phase == .stalled {
+      Button {
+        Task { await reprocessConversation() }
+      } label: {
+        HStack(spacing: 4) {
+          Image(systemName: isReprocessing ? "arrow.triangle.2.circlepath" : "wand.and.stars")
+            .scaledFont(size: 9, weight: .semibold)
+          Text(isReprocessing ? "Reprocessing…" : "Reprocess")
+            .scaledFont(size: 10, weight: .semibold)
+        }
+        .foregroundColor(Ink.primary)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(Capsule(style: .continuous).fill(Ink.rowFillHover))
+      }
+      .buttonStyle(.plain)
+      .disabled(isReprocessing)
+      .help("Run the title and summary again")
+      .accessibilityIdentifier("conversation-row-reprocess-\(conversation.id)")
+    }
+  }
+
+  /// Second line: time · duration, plus the second wave of processing when
+  /// the title has landed but memories and tasks are still being added.
+  private var metadataLine: some View {
+    HStack(spacing: OmiSpacing.xs) {
+      Text(formattedTimestamp)
+        .scaledFont(size: OmiType.caption)
+        .foregroundColor(Ink.secondary)
+
+      Text("·")
+        .scaledFont(size: OmiType.caption)
+        .foregroundColor(Ink.secondary)
+
+      Text(conversation.formattedDuration)
+        .scaledFont(size: OmiType.caption)
+        .foregroundColor(Ink.secondary)
+
+      if isSettlingDerived {
+        Text("·")
+          .scaledFont(size: OmiType.caption)
+          .foregroundColor(Ink.secondary)
+        Text("Adding memories & tasks…")
+          .scaledFont(size: OmiType.caption)
+          .foregroundColor(Ink.secondary)
+          .transition(.opacity)
+      }
+    }
+  }
+
+  /// Whether the actions menu should offer Reprocess. `canReprocess` covers
+  /// failed/untitled rows; a stalled pipeline is the third case.
+  private func offersReprocess(now: Date) -> Bool {
+    conversation.canReprocess || (isLivePipelineRow && processingPhase(now: now) == .stalled)
   }
 
   /// Label for the conversation source
@@ -214,7 +310,7 @@ struct ConversationRowView: View {
 
   private var inlineActionMenu: some View {
     Menu {
-      if conversation.canReprocess {
+      if offersReprocess(now: Date()) {
         Button {
           Task { await reprocessConversation() }
         } label: {
@@ -313,7 +409,7 @@ struct ConversationRowView: View {
 
   // MARK: - Compact Row (single line)
 
-  private var compactRowContent: some View {
+  private func compactRowContent(phase: ConversationProcessingPhase) -> some View {
     HStack(spacing: OmiSpacing.sm) {
       // Checkbox for multi-select mode
       if isMultiSelectMode {
@@ -322,13 +418,7 @@ struct ConversationRowView: View {
           .foregroundColor(isSelected ? Ink.primary : Ink.secondary)
       }
 
-      // Emoji
-      Text(conversation.structured.emoji.isEmpty ? "💬" : conversation.structured.emoji)
-        .scaledFont(size: OmiType.subheading)
-        .frame(width: 36, height: 36)
-        .background(
-          RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius, style: .continuous).fill(
-            Ink.rowFill))
+      leadingTile(size: 36, fontSize: OmiType.subheading, cornerRadius: OmiChrome.smallControlRadius)
 
       // Title + metadata below
       VStack(alignment: .leading, spacing: OmiSpacing.hairline) {
@@ -338,7 +428,7 @@ struct ConversationRowView: View {
             .foregroundColor(titleColor)
             .lineLimit(1)
 
-          ConversationStatusBadge(state: conversation.displayState)
+          statusCluster(phase: phase)
 
           if isNewlyCreated {
             NewBadge()
@@ -346,19 +436,7 @@ struct ConversationRowView: View {
 
         }
 
-        HStack(spacing: OmiSpacing.xs) {
-          Text(formattedTimestamp)
-            .scaledFont(size: OmiType.caption)
-            .foregroundColor(Ink.secondary)
-
-          Text("·")
-            .scaledFont(size: OmiType.caption)
-            .foregroundColor(Ink.secondary)
-
-          Text(conversation.formattedDuration)
-            .scaledFont(size: OmiType.caption)
-            .foregroundColor(Ink.secondary)
-        }
+        metadataLine
       }
 
       Spacer()
@@ -376,7 +454,7 @@ struct ConversationRowView: View {
 
   // MARK: - Expanded Row (title + time/duration)
 
-  private var expandedRowContent: some View {
+  private func expandedRowContent(phase: ConversationProcessingPhase) -> some View {
     HStack(spacing: OmiSpacing.md) {
       // Checkbox for multi-select mode
       if isMultiSelectMode {
@@ -385,12 +463,7 @@ struct ConversationRowView: View {
           .foregroundColor(isSelected ? Ink.primary : Ink.secondary)
       }
 
-      // Emoji
-      Text(conversation.structured.emoji.isEmpty ? "💬" : conversation.structured.emoji)
-        .scaledFont(size: OmiType.heading)
-        .frame(width: 40, height: 40)
-        .background(
-          RoundedRectangle(cornerRadius: OmiChrome.chipRadius, style: .continuous).fill(Ink.rowFill))
+      leadingTile(size: 40, fontSize: OmiType.heading, cornerRadius: OmiChrome.chipRadius)
 
       // Title + time/duration below
       VStack(alignment: .leading, spacing: OmiSpacing.hairline) {
@@ -400,7 +473,7 @@ struct ConversationRowView: View {
             .foregroundColor(titleColor)
             .lineLimit(1)
 
-          ConversationStatusBadge(state: conversation.displayState)
+          statusCluster(phase: phase)
 
           if isNewlyCreated {
             NewBadge()
@@ -408,19 +481,7 @@ struct ConversationRowView: View {
 
         }
 
-        HStack(spacing: OmiSpacing.xs) {
-          Text(formattedTimestamp)
-            .scaledFont(size: OmiType.caption)
-            .foregroundColor(Ink.secondary)
-
-          Text("·")
-            .scaledFont(size: OmiType.caption)
-            .foregroundColor(Ink.secondary)
-
-          Text(conversation.formattedDuration)
-            .scaledFont(size: OmiType.caption)
-            .foregroundColor(Ink.secondary)
-        }
+        metadataLine
       }
 
       Spacer()
@@ -435,6 +496,17 @@ struct ConversationRowView: View {
       cornerRadius: PageGlass.cardRadius)
   }
 
+  @ViewBuilder
+  private func rowContent(phase: ConversationProcessingPhase) -> some View {
+    if isCompactView {
+      // Compact mode: single line with all info
+      compactRowContent(phase: phase)
+    } else {
+      // Expanded mode: title + overview with metadata below
+      expandedRowContent(phase: phase)
+    }
+  }
+
   var body: some View {
     ZStack(alignment: .trailing) {
       Button(action: {
@@ -445,12 +517,15 @@ struct ConversationRowView: View {
         }
       }) {
         Group {
-          if isCompactView {
-            // Compact mode: single line with all info
-            compactRowContent
+          if isLivePipelineRow {
+            // Bound the wait: the phase moves on a 15s clock so "Summarizing"
+            // becomes "Taking longer than usual" and then "Stuck" without any
+            // network event, and the Reprocess exit appears when it should.
+            TimelineView(.periodic(from: .now, by: 15)) { timeline in
+              rowContent(phase: processingPhase(now: timeline.date))
+            }
           } else {
-            // Expanded mode: title + overview with metadata below
-            expandedRowContent
+            rowContent(phase: .summarizing)
           }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -501,8 +576,8 @@ struct ConversationRowView: View {
 
       // Reprocess — surfaced in the menu (in addition to the inline hover
       // button) so it's discoverable even without hovering. Only enabled when
-      // there's something to recover (canReprocess).
-      if conversation.canReprocess {
+      // there's something to recover (canReprocess) or the pipeline stalled.
+      if offersReprocess(now: Date()) {
         Button(action: { Task { await reprocessConversation() } }) {
           Label(
             isReprocessing ? "Reprocessing…" : "Reprocess Title & Summary",

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationStatusBadge.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationStatusBadge.swift
@@ -7,11 +7,20 @@ import SwiftUI
 /// in its normal titled state.
 struct ConversationStatusBadge: View {
   let state: ConversationDisplayState
+  /// Only read for `.processing`; the row derives it from the clock.
+  var phase: ConversationProcessingPhase = .summarizing
 
   var body: some View {
     switch state {
     case .processing:
-      ProcessingPill()
+      ProcessingPill(phase: phase)
+    case .awaitingFirstOpen:
+      Pill(
+        icon: "sparkles",
+        text: "Tap to summarize",
+        color: Ink.accent,
+        help: "The transcript is saved. Open the conversation to generate its title and summary."
+      )
     case .locked:
       Pill(
         icon: "lock.fill",
@@ -66,31 +75,61 @@ private struct Pill: View {
   }
 }
 
-/// Animated "Processing…" pill with a subtle pulsing dot.
+/// Pill for a live pipeline. The wording and colour track how long the wait
+/// has lasted, so the row never promises "shortly" without a bound.
 private struct ProcessingPill: View {
+  let phase: ConversationProcessingPhase
   @State private var pulse = false
+
+  static func label(for phase: ConversationProcessingPhase) -> String {
+    switch phase {
+    case .summarizing: return "Summarizing"
+    case .slow: return "Taking longer than usual"
+    case .stalled: return "Stuck"
+    }
+  }
+
+  static func help(for phase: ConversationProcessingPhase) -> String {
+    switch phase {
+    case .summarizing:
+      return "Omi is writing the title and summary. This usually takes under two minutes."
+    case .slow:
+      return "Still processing. Longer conversations and busy periods can take a few minutes."
+    case .stalled:
+      return "This has been processing for over ten minutes. Reprocess to run it again."
+    }
+  }
+
+  private var color: Color {
+    switch phase {
+    case .summarizing: return Ink.accent
+    case .slow: return PageGlass.warning
+    case .stalled: return Ink.errorRed
+    }
+  }
 
   var body: some View {
     HStack(spacing: 4) {
       Circle()
-        .fill(Ink.accent)
+        .fill(color)
         .frame(width: 6, height: 6)
-        .opacity(pulse ? 0.4 : 1.0)
+        .opacity(pulse && phase != .stalled ? 0.4 : 1.0)
         .animation(
-          .easeInOut(duration: 0.9).repeatForever(autoreverses: true),
+          phase == .stalled ? nil : .easeInOut(duration: 0.9).repeatForever(autoreverses: true),
           value: pulse
         )
-      Text("Processing")
+      Text(Self.label(for: phase))
         .scaledFont(size: 10, weight: .semibold)
-        .foregroundColor(Ink.accent)
+        .foregroundColor(color)
     }
     .padding(.horizontal, 7)
     .padding(.vertical, 3)
     .background(
       Capsule(style: .continuous)
-        .fill(Ink.accent.opacity(0.16))
+        .fill(color.opacity(0.16))
     )
     .onAppear { pulse = true }
-    .help("This conversation is still being processed. Title and summary will appear shortly.")
+    .help(Self.help(for: phase))
+    .accessibilityLabel(Self.label(for: phase))
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/LiveTranscriptView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/LiveTranscriptView.swift
@@ -158,6 +158,53 @@ struct ConversationsLiveTranscript: View {
   }
 }
 
+/// Replaces the Live card between "capture stopped" and "row in the list".
+/// Same slot, same shape, same last line of transcript — the capture the
+/// user was watching is what is being saved.
+struct ConversationsSavingCaptureCard: View {
+  @ObservedObject private var monitor = LiveTranscriptMonitor.shared
+  @State private var pulse = false
+
+  private var lastLine: String? {
+    monitor.savedSegments.last?.text ?? monitor.latestText
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+      HStack(spacing: OmiSpacing.xs) {
+        Circle()
+          .fill(Ink.accent)
+          .frame(width: 7, height: 7)
+          .opacity(pulse ? 0.4 : 1.0)
+          .animation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true), value: pulse)
+        Text("Saving").scaledFont(size: OmiType.caption, weight: .semibold)
+          .foregroundColor(Ink.secondary)
+        Spacer()
+      }
+      if let lastLine, !lastLine.isEmpty {
+        Text(lastLine)
+          .scaledFont(size: OmiType.body)
+          .foregroundColor(Ink.secondary)
+          .lineLimit(2)
+          .padding(.vertical, OmiSpacing.sm)
+      } else {
+        Text("Adding to your conversations…").scaledFont(size: OmiType.body).foregroundColor(Ink.secondary)
+          .padding(.vertical, OmiSpacing.sm)
+      }
+    }
+    .padding(OmiSpacing.lg)
+    .background(
+      RoundedRectangle(cornerRadius: OmiChrome.cardRadius, style: .continuous)
+        .fill(Ink.rowFill)
+        .overlay(
+          RoundedRectangle(cornerRadius: OmiChrome.cardRadius, style: .continuous)
+            .stroke(Ink.separator.opacity(0.3), lineWidth: 1))
+    )
+    .onAppear { pulse = true }
+    .accessibilityIdentifier("conversations-saving-capture")
+  }
+}
+
 /// Adds the click-to-expand behavior only when an `onExpand` handler is present,
 /// so the card stays inert (no pointer cursor, no tap) when expansion is
 /// unavailable.

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -271,7 +271,6 @@ struct ConversationDetailView: View {
 
               ConversationDetailProcessingLayout(isProcessing: isEnrichingDeferred) {
                 deferredProcessingSection
-                  .allowsHitTesting(false)
               } content: {
                 summaryContent
               }
@@ -350,8 +349,11 @@ struct ConversationDetailView: View {
       // cached detail immediately, but always revalidates server-owned fields.
       if requestedConversation.deferred || requestedConversation.status == .processing {
         isEnrichingDeferred = true
+        // Keep following the row for as long as it is open. A bounded loop
+        // that silently stops leaves the banner promising a summary that no
+        // fetch will ever deliver; the backoff caps the cost instead.
         var attempts = 0
-        while attempts < 15 {
+        while true {
           guard isCurrentDetailRequest(requestGeneration), let appState = AppState.current else { break }
           let fetched = await appState.loadConversationDetail(requestedConversation) { cached in
             guard isCurrentDetailRequest(requestGeneration) else { return }
@@ -360,8 +362,9 @@ struct ConversationDetailView: View {
           guard isCurrentDetailRequest(requestGeneration) else { return }
           loadedConversation = fetched
           if fetched.status != .processing { break }
+          let delay = ProcessingConversationWatcher.pollDelay(attempt: attempts)
           attempts += 1
-          try? await Task.sleep(nanoseconds: 2_000_000_000)
+          try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
         }
         guard isCurrentDetailRequest(requestGeneration) else { return }
         isEnrichingDeferred = false
@@ -1169,23 +1172,10 @@ struct ConversationDetailView: View {
   /// Overlaid while a lazily-deferred conversation is enriched, preserving the
   /// position of details that may already be available from the local cache.
   private var deferredProcessingSection: some View {
-    HStack(spacing: OmiSpacing.md) {
-      ProgressView()
-        .controlSize(.small)
-      VStack(alignment: .leading, spacing: OmiSpacing.hairline) {
-        Text("Processing conversation…")
-          .scaledFont(size: OmiType.body, weight: .semibold)
-          .foregroundColor(Ink.primary)
-        Text("Generating summary and action items")
-          .scaledFont(size: OmiType.caption)
-          .foregroundColor(Ink.secondary)
-      }
-      Spacer()
+    ConversationProcessingBanner(conversation: displayConversation) { updated in
+      loadedConversation = updated
+      isEnrichingDeferred = false
     }
-    .padding(OmiSpacing.lg)
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .background(Ink.rowFillHover.opacity(0.5))
-    .cornerRadius(OmiChrome.smallControlRadius)
   }
 
   // MARK: - Overview Section

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -326,10 +326,22 @@ struct ConversationsPage: View {
         .padding(.horizontal, OmiSpacing.xxl)
         .padding(.top, OmiSpacing.md)
         .padding(.bottom, OmiSpacing.md)
+        .transition(.opacity)
+      } else if appState.isFinalizingCapture {
+        // The Live card's slot stays occupied while the capture becomes a
+        // row, so the meeting lands in place instead of vanishing and
+        // reappearing further down.
+        ConversationsSavingCaptureCard()
+          .padding(.horizontal, OmiSpacing.xxl)
+          .padding(.top, OmiSpacing.md)
+          .padding(.bottom, OmiSpacing.md)
+          .transition(.opacity)
       }
 
       conversationListSection
     }
+    .omiAnimation(.easeInOut(duration: 0.25), value: appState.isLiveCapturing)
+    .omiAnimation(.easeInOut(duration: 0.25), value: appState.isFinalizingCapture)
 
     if embedded {
       content

--- a/desktop/macos/Desktop/Sources/PostHogManager.swift
+++ b/desktop/macos/Desktop/Sources/PostHogManager.swift
@@ -519,6 +519,28 @@ extension PostHogManager {
     )
   }
 
+  static func conversationProcessingProperties(elapsedSeconds: Int, outcome: String?) -> [String: Any] {
+    var properties: [String: Any] = ["elapsed_seconds": max(0, elapsedSeconds)]
+    if let outcome {
+      properties["outcome"] = outcome
+    }
+    return properties
+  }
+
+  func conversationProcessingCompleted(conversationId _: String, elapsedSeconds: Int, outcome: String) {
+    track(
+      "Conversation Processing Completed",
+      properties: Self.conversationProcessingProperties(elapsedSeconds: elapsedSeconds, outcome: outcome)
+    )
+  }
+
+  func conversationProcessingStalled(conversationId _: String, elapsedSeconds: Int) {
+    track(
+      "Conversation Processing Stalled",
+      properties: Self.conversationProcessingProperties(elapsedSeconds: elapsedSeconds, outcome: nil)
+    )
+  }
+
   func memoryDeleted(conversationId: String) {
     track(
       "Memory Deleted",

--- a/desktop/macos/Desktop/Sources/ProcessingConversationWatcher.swift
+++ b/desktop/macos/Desktop/Sources/ProcessingConversationWatcher.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+/// Keeps every visible processing row honest until it reaches a terminal
+/// state. The list itself never polls — the only completion signal is the
+/// live-listen `memory_created` event, which cloud finalization does not
+/// always deliver — so without this a row could sit on "Processing" forever
+/// with the UI none the wiser (the 2026-08-30 finalization outage ran six
+/// hours that way).
+///
+/// Polling never gives up while the row is visible; it backs off to the last
+/// delay and stays there. The watcher also owns the two telemetry facts the
+/// row cannot: how long processing actually took, and when it crossed the
+/// stalled threshold.
+@MainActor
+final class ProcessingConversationWatcher: ObservableObject {
+  typealias Fetch = @Sendable (String) async throws -> ServerConversation
+  typealias Sleeper = @Sendable (UInt64) async throws -> Void
+
+  /// Backoff in seconds; the final entry repeats indefinitely.
+  static let pollDelaysSeconds: [Double] = [3, 5, 10, 15, 30, 60]
+
+  static func pollDelay(attempt: Int) -> Double {
+    pollDelaysSeconds[min(max(attempt, 0), pollDelaysSeconds.count - 1)]
+  }
+
+  /// Rows that just reached `completed` and whose memories/action items are
+  /// still landing server-side. The row shows a quiet hint until the grace
+  /// refetch clears it.
+  @Published private(set) var settlingDerivedIDs: Set<String> = []
+
+  private let fetch: Fetch
+  private let sleeper: Sleeper
+  private let now: () -> Date
+  private let onResolved: @MainActor (ServerConversation) -> Void
+  private let onCompleted: @MainActor (_ conversationID: String, _ elapsedSeconds: Int, _ outcome: String) -> Void
+  private let onStalled: @MainActor (_ conversationID: String, _ elapsedSeconds: Int) -> Void
+
+  private var tasks: [String: Task<Void, Never>] = [:]
+  private var stalledReported: Set<String> = []
+
+  init(
+    fetch: @escaping Fetch,
+    sleeper: @escaping Sleeper = { try await Task.sleep(nanoseconds: $0) },
+    now: @escaping () -> Date = Date.init,
+    onResolved: @escaping @MainActor (ServerConversation) -> Void,
+    onCompleted: @escaping @MainActor (String, Int, String) -> Void,
+    onStalled: @escaping @MainActor (String, Int) -> Void
+  ) {
+    self.fetch = fetch
+    self.sleeper = sleeper
+    self.now = now
+    self.onResolved = onResolved
+    self.onCompleted = onCompleted
+    self.onStalled = onStalled
+  }
+
+  /// Detail fetch used by production wiring. Kept as a named function so the
+  /// call site can reference it without an actor hop in a default-argument
+  /// position.
+  static func fetchDetail(id: String) async throws -> ServerConversation {
+    try await APIClient.shared.getConversation(id: id)
+  }
+
+  /// Production wiring: real clock, real sleeper, PostHog telemetry.
+  static func live(
+    fetch: @escaping Fetch,
+    onResolved: @escaping @MainActor (ServerConversation) -> Void
+  ) -> ProcessingConversationWatcher {
+    ProcessingConversationWatcher(
+      fetch: fetch,
+      onResolved: onResolved,
+      onCompleted: { id, elapsed, outcome in
+        AnalyticsManager.shared.conversationProcessingCompleted(
+          conversationId: id, elapsedSeconds: elapsed, outcome: outcome)
+      },
+      onStalled: { id, elapsed in
+        AnalyticsManager.shared.conversationProcessingStalled(conversationId: id, elapsedSeconds: elapsed)
+      }
+    )
+  }
+
+  /// Which rows the watcher should be following.
+  static func shouldWatch(_ conversation: ServerConversation) -> Bool {
+    conversation.displayState == .processing
+  }
+
+  var watchedIDs: Set<String> { Set(tasks.keys) }
+
+  func isSettlingDerived(_ conversationID: String) -> Bool {
+    settlingDerivedIDs.contains(conversationID)
+  }
+
+  /// Reconcile with the currently visible list: start following new
+  /// processing rows, stop following rows that left the list or resolved
+  /// through another path (a `memory_created` refresh, a reprocess).
+  func sync(with conversations: [ServerConversation]) {
+    let wanted = conversations.filter(Self.shouldWatch)
+    let wantedIDs = Set(wanted.map(\.id))
+    for (id, task) in tasks where !wantedIDs.contains(id) {
+      task.cancel()
+      tasks.removeValue(forKey: id)
+    }
+    for conversation in wanted where tasks[conversation.id] == nil {
+      tasks[conversation.id] = Task { [weak self] in
+        await self?.follow(conversation)
+      }
+    }
+  }
+
+  func stopAll() {
+    for task in tasks.values { task.cancel() }
+    tasks.removeAll()
+    settlingDerivedIDs.removeAll()
+  }
+
+  private func follow(_ initial: ServerConversation) async {
+    let id = initial.id
+    var attempt = 0
+    reportStalledIfNeeded(initial)
+    while !Task.isCancelled {
+      let delay = Self.pollDelay(attempt: attempt)
+      attempt += 1
+      guard (try? await sleeper(UInt64(delay * 1_000_000_000))) != nil, !Task.isCancelled else { return }
+      guard let fetched = try? await fetch(id), !Task.isCancelled else {
+        reportStalledIfNeeded(initial)
+        continue
+      }
+      if Self.shouldWatch(fetched) {
+        // Still processing. Detail responses carry transcript segments the
+        // list omitted, so publishing keeps the provisional title current.
+        onResolved(fetched)
+        reportStalledIfNeeded(fetched)
+        continue
+      }
+      resolve(fetched)
+      return
+    }
+  }
+
+  private func resolve(_ fetched: ServerConversation) {
+    let id = fetched.id
+    let elapsed = Int(ConversationProcessingProgress.elapsed(for: fetched, now: now()))
+    let outcome = fetched.status == .failed ? "failed" : "completed"
+    tasks.removeValue(forKey: id)
+    if fetched.status == .completed {
+      settlingDerivedIDs.insert(id)
+    }
+    onResolved(fetched)
+    onCompleted(id, elapsed, outcome)
+    guard fetched.status == .completed else { return }
+    Task { [weak self] in
+      guard let self else { return }
+      let grace = UInt64(ConversationProcessingProgress.derivedSettleGrace * 1_000_000_000)
+      if (try? await self.sleeper(grace)) != nil, let settled = try? await self.fetch(id) {
+        self.onResolved(settled)
+      }
+      self.settlingDerivedIDs.remove(id)
+    }
+  }
+
+  private func reportStalledIfNeeded(_ conversation: ServerConversation) {
+    let elapsed = ConversationProcessingProgress.elapsed(for: conversation, now: now())
+    guard ConversationProcessingProgress.phase(elapsed: elapsed) == .stalled,
+      stalledReported.insert(conversation.id).inserted
+    else { return }
+    onStalled(conversation.id, Int(elapsed))
+  }
+}

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+ConversationModels.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+ConversationModels.swift
@@ -20,6 +20,9 @@ enum ConversationDisplayState: Equatable {
   case titled(String)
   /// Pipeline is still running. Title will arrive soon.
   case processing
+  /// Stored with the raw transcript only; the backend enriches it the first
+  /// time it is opened (free-tier desktop capture). Nothing is running.
+  case awaitingFirstOpen
   /// Conversation is locked (subscription gating). Title intentionally hidden.
   case locked
   /// Processing finished but the title slot is empty AND the transcript has
@@ -337,7 +340,10 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     }
     switch status {
     case .inProgress, .processing, .merging:
-      return .processing
+      // A deferred row wears `processing` on the wire only so the client
+      // re-fetches on open. Nothing is running for it, so it must not look
+      // like — or be timed like — a live pipeline.
+      return deferred ? .awaitingFirstOpen : .processing
     case .failed:
       return .failed
     case .completed:
@@ -354,11 +360,30 @@ struct ServerConversation: Codable, Identifiable, Equatable {
     }
   }
 
+  /// Identity for a row that has no LLM title yet: the first substantive
+  /// transcript line, or the recording time when the transcript is not loaded.
+  /// Never the pipeline status — that belongs in the badge.
+  var provisionalTitle: String {
+    ConversationProcessingProgress.provisionalTitle(from: transcriptSegments)
+      ?? "Recording at \(Self.provisionalTimeFormatter.string(from: startedAt ?? createdAt))"
+  }
+
+  /// True when `provisionalTitle` quotes the transcript rather than the clock.
+  var hasTranscriptProvisionalTitle: Bool {
+    ConversationProcessingProgress.provisionalTitle(from: transcriptSegments) != nil
+  }
+
+  private static let provisionalTimeFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.dateFormat = "h:mm a"
+    return f
+  }()
+
   /// The string a row/header should display in the title slot.
   var displayTitle: String {
     switch displayState {
     case .titled(let title): return title
-    case .processing: return "Processing…"
+    case .processing, .awaitingFirstOpen: return provisionalTitle
     case .locked: return "Locked"
     case .failed: return "Failed to process"
     case .untitledRecoverable, .untitledEmpty: return "Untitled"

--- a/desktop/macos/Desktop/Tests/ConversationDisplayStateTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationDisplayStateTests.swift
@@ -17,13 +17,15 @@ final class ConversationDisplayStateTests: XCTestCase {
     title: String = "",
     status: ConversationStatus = .completed,
     isLocked: Bool = false,
-    segments: [TranscriptSegment] = []
+    segments: [TranscriptSegment] = [],
+    deferred: Bool = false,
+    startedAt: Date? = nil
   ) -> ServerConversation {
     ServerConversation(
       id: "id",
       createdAt: Date(),
       updatedAt: nil,
-      startedAt: nil,
+      startedAt: startedAt,
       finishedAt: nil,
       structured: Structured(
         title: title,
@@ -46,7 +48,8 @@ final class ConversationDisplayStateTests: XCTestCase {
       isLocked: isLocked,
       starred: false,
       folderId: nil,
-      inputDeviceName: nil
+      inputDeviceName: nil,
+      deferred: deferred
     )
   }
 
@@ -96,8 +99,49 @@ final class ConversationDisplayStateTests: XCTestCase {
   func test_inProgressStatus_returnsProcessing() {
     let conv = makeConversation(status: .inProgress)
     XCTAssertEqual(conv.displayState, .processing)
-    XCTAssertEqual(conv.displayTitle, "Processing…")
     XCTAssertFalse(conv.canReprocess)
+  }
+
+  func test_processingTitle_isNeverTheStatusWord() {
+    // Status belongs in the badge. The title slot carries identity: the
+    // recording time when no transcript is loaded yet.
+    guard let started = Calendar.current.date(bySettingHour: 23, minute: 12, second: 0, of: Date()) else {
+      return XCTFail("Calendar could not build the fixture date")
+    }
+    let conv = makeConversation(status: .processing, startedAt: started)
+    XCTAssertEqual(conv.displayTitle, "Recording at 11:12 PM")
+    XCTAssertFalse(conv.hasTranscriptProvisionalTitle)
+    XCTAssertFalse(conv.displayTitle.localizedCaseInsensitiveContains("processing"))
+  }
+
+  func test_processingTitle_quotesFirstSubstantiveTranscriptLine() {
+    let conv = makeConversation(
+      status: .processing,
+      segments: [segment("yeah"), segment("let's go over the launch timeline for next week")]
+    )
+    XCTAssertEqual(conv.displayTitle, "Let's go over the launch timeline for next week")
+    XCTAssertTrue(conv.hasTranscriptProvisionalTitle)
+    XCTAssertEqual(conv.displayState, .processing)
+  }
+
+  // MARK: - Deferred (awaiting first open)
+
+  func test_deferredProcessingRow_isAwaitingFirstOpen_notProcessing() {
+    // Free-tier desktop capture: stored with the raw transcript, `processing`
+    // on the wire, enriched on first open. Nothing is running for it.
+    let conv = makeConversation(
+      status: .processing,
+      segments: [segment("we talked about the budget for the offsite")],
+      deferred: true
+    )
+    XCTAssertEqual(conv.displayState, .awaitingFirstOpen)
+    XCTAssertEqual(conv.displayTitle, "We talked about the budget for the offsite")
+    XCTAssertFalse(conv.canReprocess)
+  }
+
+  func test_deferredFlagIgnored_onceCompleted() {
+    let conv = makeConversation(title: "Real title", status: .completed, deferred: true)
+    XCTAssertEqual(conv.displayState, .titled("Real title"))
   }
 
   func test_processingStatus_returnsProcessing() {

--- a/desktop/macos/Desktop/Tests/ConversationProcessingProgressTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationProcessingProgressTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Clock rules and provisional-title derivation for a processing row.
+final class ConversationProcessingProgressTests: XCTestCase {
+  private let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+  private func conversation(
+    createdAt: Date,
+    finishedAt: Date?,
+    segments: [TranscriptSegment] = []
+  ) -> ServerConversation {
+    ServerConversation(
+      id: "c",
+      createdAt: createdAt,
+      updatedAt: nil,
+      startedAt: nil,
+      finishedAt: finishedAt,
+      structured: Structured(title: "", overview: "", emoji: "", category: "", actionItems: [], events: []),
+      transcriptSegments: segments,
+      transcriptSegmentsIncluded: !segments.isEmpty,
+      geolocation: nil,
+      photos: [],
+      appsResults: [],
+      source: .desktop,
+      language: nil,
+      status: .processing,
+      discarded: false,
+      deleted: false,
+      isLocked: false,
+      starred: false,
+      folderId: nil,
+      inputDeviceName: nil
+    )
+  }
+
+  private func segment(_ text: String) -> TranscriptSegment {
+    TranscriptSegment(
+      id: UUID().uuidString, text: text, speaker: "SPEAKER_00", isUser: false, personId: nil, start: 0, end: 1)
+  }
+
+  // MARK: - Phase thresholds
+
+  func test_phaseBoundaries() {
+    XCTAssertEqual(ConversationProcessingProgress.phase(elapsed: 0), .summarizing)
+    XCTAssertEqual(ConversationProcessingProgress.phase(elapsed: 119), .summarizing)
+    XCTAssertEqual(ConversationProcessingProgress.phase(elapsed: 120), .slow)
+    XCTAssertEqual(ConversationProcessingProgress.phase(elapsed: 599), .slow)
+    XCTAssertEqual(ConversationProcessingProgress.phase(elapsed: 600), .stalled)
+  }
+
+  func test_elapsedCountsFromRecordingEnd_notRowCreation() {
+    // A 40-minute meeting: created when it started, finished 40 minutes later.
+    let created = base
+    let finished = base.addingTimeInterval(40 * 60)
+    let conv = conversation(createdAt: created, finishedAt: finished)
+    let now = finished.addingTimeInterval(30)
+    XCTAssertEqual(ConversationProcessingProgress.elapsed(for: conv, now: now), 30)
+    XCTAssertEqual(ConversationProcessingProgress.phase(for: conv, now: now), .summarizing)
+  }
+
+  func test_elapsedFallsBackToCreatedAt_whenNoFinishedAt() {
+    let conv = conversation(createdAt: base, finishedAt: nil)
+    XCTAssertEqual(ConversationProcessingProgress.phase(for: conv, now: base.addingTimeInterval(700)), .stalled)
+  }
+
+  func test_elapsedNeverNegative() {
+    let conv = conversation(createdAt: base, finishedAt: base.addingTimeInterval(60))
+    XCTAssertEqual(ConversationProcessingProgress.elapsed(for: conv, now: base), 0)
+  }
+
+  // MARK: - Provisional title
+
+  func test_provisionalTitle_skipsShortSegments_capitalises() {
+    let title = ConversationProcessingProgress.provisionalTitle(from: [
+      segment("um"),
+      segment("ok yeah"),
+      segment("so the plan for the launch is to ship on friday"),
+    ])
+    XCTAssertEqual(title, "So the plan for the launch is to ship on friday")
+  }
+
+  func test_provisionalTitle_truncatesAtWordBoundary_withEllipsis() {
+    let long = "we should talk about the quarterly numbers before the board meeting on thursday afternoon"
+    guard let title = ConversationProcessingProgress.provisionalTitle(from: [segment(long)]) else {
+      return XCTFail("Expected a provisional title")
+    }
+    XCTAssertTrue(title.hasSuffix("…"))
+    XCTAssertLessThanOrEqual(title.count, ConversationProcessingProgress.provisionalTitleMaxLength + 1)
+    XCTAssertFalse(title.dropLast().hasSuffix(" "), "Truncation must end on a whole word")
+    XCTAssertTrue(long.hasPrefix(String(title.dropLast()).lowercased()))
+  }
+
+  func test_provisionalTitle_stripsTrailingPunctuationBeforeEllipsis() {
+    let text = "alright, let us start with the first item on the agenda, which is hiring, and then budget"
+    let title = ConversationProcessingProgress.provisionalTitle(from: [segment(text)]) ?? ""
+    XCTAssertFalse(title.isEmpty)
+    XCTAssertFalse(title.contains(",…"))
+  }
+
+  func test_provisionalTitle_nilWhenNothingSubstantive() {
+    XCTAssertNil(ConversationProcessingProgress.provisionalTitle(from: []))
+    XCTAssertNil(ConversationProcessingProgress.provisionalTitle(from: [segment("hi there"), segment("yes")]))
+  }
+}

--- a/desktop/macos/Desktop/Tests/ConversationProcessingTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationProcessingTelemetryTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class ConversationProcessingTelemetryTests: XCTestCase {
+  func testCompletedPayloadCarriesElapsedAndOutcome() {
+    let properties = PostHogManager.conversationProcessingProperties(elapsedSeconds: 87, outcome: "completed")
+    XCTAssertEqual(properties["elapsed_seconds"] as? Int, 87)
+    XCTAssertEqual(properties["outcome"] as? String, "completed")
+    XCTAssertEqual(Set(properties.keys), ["elapsed_seconds", "outcome"])
+  }
+
+  func testStalledPayloadOmitsOutcome_andClampsNegativeElapsed() {
+    let properties = PostHogManager.conversationProcessingProperties(elapsedSeconds: -3, outcome: nil)
+    XCTAssertEqual(properties["elapsed_seconds"] as? Int, 0)
+    XCTAssertEqual(Set(properties.keys), ["elapsed_seconds"])
+  }
+}

--- a/desktop/macos/Desktop/Tests/ConversationReconciliationPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationReconciliationPolicyTests.swift
@@ -26,6 +26,37 @@ final class ConversationReconciliationPolicyTests: XCTestCase {
     XCTAssertTrue(result.pendingMutations.isEmpty)
   }
 
+  func testServerListWithoutTranscriptKeepsLoadedLocalTranscript() {
+    let segment = TranscriptSegment(
+      id: "s1", text: "the first line of the meeting transcript", speaker: "SPEAKER_00", isUser: false,
+      personId: nil, start: 0, end: 1)
+    var local = makeConversation(id: "c1", title: "", status: .processing)
+    local.transcriptSegments = [segment]
+    local.transcriptSegmentsIncluded = true
+    var server = makeConversation(id: "c1", title: "", status: .processing)
+    server.transcriptSegmentsIncluded = false
+
+    let result = ConversationReconciliationPolicy.mergeList(server: [server], current: [local])
+
+    XCTAssertEqual(result.conversations[0].transcriptSegments.map(\.id), ["s1"])
+    XCTAssertTrue(result.conversations[0].transcriptSegmentsIncluded)
+    XCTAssertEqual(result.conversations[0].displayTitle, "The first line of the meeting transcript")
+  }
+
+  func testServerListWithTranscriptWinsOverLocal() {
+    var local = makeConversation(id: "c1", status: .processing)
+    local.transcriptSegments = [
+      TranscriptSegment(
+        id: "old", text: "old words", speaker: nil, isUser: false, personId: nil, start: 0, end: 1)
+    ]
+    var server = makeConversation(id: "c1", status: .completed)
+    server.transcriptSegmentsIncluded = true
+    server.transcriptSegments = []
+
+    let result = ConversationReconciliationPolicy.mergeList(server: [server], current: [local])
+    XCTAssertTrue(result.conversations[0].transcriptSegments.isEmpty, "An included empty transcript is authoritative")
+  }
+
   func testStaleLocalTitleDoesNotMaskServerWithoutPendingMutation() {
     let local = makeConversation(id: "c1", title: "Local stale")
     let server = makeConversation(id: "c1", title: "Server fresh")

--- a/desktop/macos/Desktop/Tests/ProcessingConversationWatcherTests.swift
+++ b/desktop/macos/Desktop/Tests/ProcessingConversationWatcherTests.swift
@@ -1,0 +1,217 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// The watcher follows a processing row to a terminal state with injected
+/// clock and sleeper, publishes the resolved row, and emits telemetry.
+@MainActor
+final class ProcessingConversationWatcherTests: XCTestCase {
+  nonisolated private static let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+  nonisolated private static func conversation(
+    id: String = "c1",
+    status: ConversationStatus,
+    deferred: Bool = false,
+    title: String = ""
+  ) -> ServerConversation {
+    ServerConversation(
+      id: id,
+      createdAt: base,
+      updatedAt: nil,
+      startedAt: nil,
+      finishedAt: base,
+      structured: Structured(title: title, overview: "", emoji: "", category: "", actionItems: [], events: []),
+      transcriptSegments: [],
+      transcriptSegmentsIncluded: false,
+      geolocation: nil,
+      photos: [],
+      appsResults: [],
+      source: .desktop,
+      language: nil,
+      status: status,
+      discarded: false,
+      deleted: false,
+      isLocked: false,
+      starred: false,
+      folderId: nil,
+      inputDeviceName: nil,
+      deferred: deferred
+    )
+  }
+
+  /// Serialises the watcher's sleeps so a test can step it deterministically.
+  private actor StepClock {
+    private var waiters: [CheckedContinuation<Void, Error>] = []
+    private(set) var requestedDelays: [UInt64] = []
+
+    func sleep(_ nanoseconds: UInt64) async throws {
+      try await withCheckedThrowingContinuation { continuation in
+        requestedDelays.append(nanoseconds)
+        waiters.append(continuation)
+      }
+    }
+
+    /// Release one pending sleep. Yields until a sleeper is actually waiting.
+    func step() async {
+      while waiters.isEmpty {
+        await Task.yield()
+      }
+      waiters.removeFirst().resume()
+    }
+  }
+
+  /// Scripted detail responses; the last entry repeats.
+  private actor FetchScript {
+    private var responses: [Result<ServerConversation, Error>]
+    private(set) var calls = 0
+
+    init(_ responses: [Result<ServerConversation, Error>]) {
+      self.responses = responses
+    }
+
+    func next() throws -> ServerConversation {
+      calls += 1
+      let result = responses.count > 1 ? responses.removeFirst() : responses[0]
+      return try result.get()
+    }
+  }
+
+  private struct Boom: Error {}
+
+  private func settle() async {
+    for _ in 0..<40 { await Task.yield() }
+  }
+
+  func test_pollDelays_backOffThenRepeatLast() {
+    XCTAssertEqual(ProcessingConversationWatcher.pollDelay(attempt: 0), 3)
+    XCTAssertEqual(ProcessingConversationWatcher.pollDelay(attempt: 5), 60)
+    XCTAssertEqual(ProcessingConversationWatcher.pollDelay(attempt: 50), 60)
+  }
+
+  func test_shouldWatch_onlyLivePipelineRows() {
+    XCTAssertTrue(ProcessingConversationWatcher.shouldWatch(Self.conversation(status: .processing)))
+    XCTAssertTrue(ProcessingConversationWatcher.shouldWatch(Self.conversation(status: .inProgress)))
+    XCTAssertFalse(ProcessingConversationWatcher.shouldWatch(Self.conversation(status: .completed, title: "T")))
+    XCTAssertFalse(ProcessingConversationWatcher.shouldWatch(Self.conversation(status: .failed)))
+    XCTAssertFalse(
+      ProcessingConversationWatcher.shouldWatch(Self.conversation(status: .processing, deferred: true)),
+      "Nothing is running for a deferred row; polling it would only burn requests")
+  }
+
+  func test_resolvesProcessingRow_publishesAndEmitsElapsed() async {
+    let clock = StepClock()
+    let script = FetchScript([
+      .success(Self.conversation(status: .processing)),
+      .success(Self.conversation(status: .completed, title: "Done")),
+    ])
+    var now = Self.base.addingTimeInterval(10)
+    var resolved: [ServerConversation] = []
+    var completedEvents: [(String, Int, String)] = []
+    var stalledEvents: [(String, Int)] = []
+
+    let watcher = ProcessingConversationWatcher(
+      fetch: { _ in try await script.next() },
+      sleeper: { try await clock.sleep($0) },
+      now: { now },
+      onResolved: { resolved.append($0) },
+      onCompleted: { completedEvents.append(($0, $1, $2)) },
+      onStalled: { stalledEvents.append(($0, $1)) }
+    )
+
+    watcher.sync(with: [Self.conversation(status: .processing)])
+    XCTAssertEqual(watcher.watchedIDs, ["c1"])
+
+    await clock.step()  // first poll → still processing
+    await settle()
+    XCTAssertEqual(resolved.map(\.status), [.processing], "Interim detail is published for the provisional title")
+    XCTAssertEqual(completedEvents.count, 0)
+
+    now = Self.base.addingTimeInterval(42)
+    await clock.step()  // second poll → completed
+    await settle()
+
+    XCTAssertEqual(resolved.last?.structured.title, "Done")
+    XCTAssertEqual(completedEvents.count, 1)
+    XCTAssertEqual(completedEvents.first?.1, 42)
+    XCTAssertEqual(completedEvents.first?.2, "completed")
+    XCTAssertTrue(stalledEvents.isEmpty)
+    XCTAssertTrue(watcher.watchedIDs.isEmpty)
+    XCTAssertTrue(watcher.isSettlingDerived("c1"), "Derived effects are still landing after status flips")
+    let delays = await clock.requestedDelays
+    XCTAssertEqual(Array(delays.prefix(2)), [3_000_000_000, 5_000_000_000])
+
+    await clock.step()  // grace sleep → refetch → settled
+    await settle()
+    XCTAssertFalse(watcher.isSettlingDerived("c1"))
+    XCTAssertEqual(resolved.count, 3, "Grace refetch republishes the row with its derived fields")
+  }
+
+  func test_failedOutcome_doesNotEnterSettling() async {
+    let clock = StepClock()
+    let script = FetchScript([.success(Self.conversation(status: .failed))])
+    var completedEvents: [String] = []
+    let watcher = ProcessingConversationWatcher(
+      fetch: { _ in try await script.next() },
+      sleeper: { try await clock.sleep($0) },
+      now: { Self.base.addingTimeInterval(5) },
+      onResolved: { _ in },
+      onCompleted: { completedEvents.append($2) },
+      onStalled: { _, _ in }
+    )
+    watcher.sync(with: [Self.conversation(status: .processing)])
+    await clock.step()
+    await settle()
+    XCTAssertEqual(completedEvents, ["failed"])
+    XCTAssertFalse(watcher.isSettlingDerived("c1"))
+  }
+
+  func test_stalledReportedOnce_evenWhileFetchesFail() async {
+    let clock = StepClock()
+    let script = FetchScript([.failure(Boom())])
+    var stalledEvents: [(String, Int)] = []
+    var resolvedCount = 0
+    var completedCount = 0
+    let watcher = ProcessingConversationWatcher(
+      fetch: { _ in try await script.next() },
+      sleeper: { try await clock.sleep($0) },
+      now: { Self.base.addingTimeInterval(ConversationProcessingProgress.stalledAfter + 5) },
+      onResolved: { _ in resolvedCount += 1 },
+      onCompleted: { _, _, _ in completedCount += 1 },
+      onStalled: { stalledEvents.append(($0, $1)) }
+    )
+    watcher.sync(with: [Self.conversation(status: .processing)])
+    await settle()
+    XCTAssertEqual(stalledEvents.count, 1, "Stalled is reported from the first observation")
+    XCTAssertEqual(stalledEvents.first?.1, Int(ConversationProcessingProgress.stalledAfter + 5))
+    await clock.step()
+    await settle()
+    await clock.step()
+    await settle()
+    XCTAssertEqual(stalledEvents.count, 1, "Later polls must not re-report")
+    XCTAssertEqual(resolvedCount, 0, "Nothing to publish while fetches fail")
+    XCTAssertEqual(completedCount, 0)
+    XCTAssertEqual(watcher.watchedIDs, ["c1"], "The watcher never gives up while the row is visible")
+    watcher.stopAll()
+  }
+
+  func test_syncStopsFollowingRowsThatLeftTheList() async {
+    let clock = StepClock()
+    let script = FetchScript([.success(Self.conversation(status: .processing))])
+    let watcher = ProcessingConversationWatcher(
+      fetch: { _ in try await script.next() },
+      sleeper: { try await clock.sleep($0) },
+      now: { Self.base },
+      onResolved: { _ in },
+      onCompleted: { _, _, _ in },
+      onStalled: { _, _ in }
+    )
+    watcher.sync(with: [
+      Self.conversation(id: "a", status: .processing), Self.conversation(id: "b", status: .processing),
+    ])
+    XCTAssertEqual(watcher.watchedIDs, ["a", "b"])
+    watcher.sync(with: [Self.conversation(id: "b", status: .processing)])
+    XCTAssertEqual(watcher.watchedIDs, ["b"])
+    watcher.sync(with: [Self.conversation(id: "b", status: .completed, title: "T")])
+    XCTAssertTrue(watcher.watchedIDs.isEmpty, "A row resolved by another path is dropped")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260902-processing-row-identity.json
+++ b/desktop/macos/changelog/unreleased/20260902-processing-row-identity.json
@@ -1,0 +1,3 @@
+{
+  "change": "Conversations that are still being summarized now show their first transcript line instead of \"Processing…\", tell you when processing is taking longer than usual or looks stuck, offer Reprocess right on the row, and land in place when a recording ends"
+}

--- a/desktop/macos/e2e/flows/conversation-detail.yaml
+++ b/desktop/macos/e2e/flows/conversation-detail.yaml
@@ -4,6 +4,8 @@ tier: 2
 description: Hermetic conversation detail open, dark screenshot prototype, and full-width transcript pane
 app: non-prod
 covers:
+  - desktop/macos/Desktop/Sources/MainWindow/Components/ConversationStatusBadge.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Components/ConversationProcessingBanner.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationAppSelectorSheet.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationSummarySelection.swift

--- a/desktop/macos/e2e/flows/recording-finalization.yaml
+++ b/desktop/macos/e2e/flows/recording-finalization.yaml
@@ -4,6 +4,9 @@ tier: manual
 description: Desktop recording finalization flow - verify a granted microphone recording stops into one durable backend conversation and opens in detail view
 app: com.omi.computer-macos
 covers:
+  - desktop/macos/Desktop/Sources/ConversationProcessingProgress.swift
+  - desktop/macos/Desktop/Sources/ProcessingConversationWatcher.swift
+  - desktop/macos/Desktop/Sources/AnalyticsManager+ConversationProcessing.swift
   - desktop/Desktop/Sources/AppState.swift
   - desktop/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
   - desktop/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift


### PR DESCRIPTION
## Why

A conversation that is still being summarized renders as **"Processing…"** with a fallback 💬, a pulsing pill that promises "shortly" without a bound, and a client that silently stops checking after ~230 s. Meanwhile the transcript is already in the local cache and on the detail endpoint, the backend flips `completed` before memories/action items run, `/reprocess` works from a `processing` row, and free-tier desktop rows sit on `processing` forever by design (`deferred=true`, nothing running). None of that reached the UI. "Pending/zombie conversations" is a top user-complaint cluster, and the 2026‑08‑30 finalization outage ran six hours with every row looking like this screenshot.

## What changes (macOS only, no backend changes)

**1. Status is never the title.** The title slot shows the first substantive transcript line (`Let's go over the launch timeline for next week`), or `Recording at 11:12 PM` when no transcript is loaded. The pill carries status. No fake 💬: a waveform tile until the pipeline produces an emoji. List refreshes keep an already-loaded transcript when the server list omits `transcript_segments` (omitted = not loaded, not empty).

**2. Bounded wait with an exit.** Pill reads `Summarizing` → `Taking longer than usual` (2 min, orange) → `Stuck` (10 min, red) on a 15 s `TimelineView` that only live-pipeline rows pay for. Stuck rows show **Reprocess** inline on the row and in the detail banner. A new `ProcessingConversationWatcher` follows every visible processing row to a terminal state with 3→60 s backoff and never gives up while the row is visible; the detail view's poll uses the same backoff instead of 15×2 s.

**3. Two waves.** When status flips to `completed` the row gets its real title and shows `· Adding memories & tasks…` for a 45 s grace, then refetches once so action items land without a manual refresh.

**4. Deferred ≠ processing.** Free-tier desktop rows now read **Tap to summarize**, are not timed, and are not polled. The detail banner says "Summarizing now…" for them, which is what opening actually does.

**5. Continuity.** When a capture stops, the Live card's slot is held by a "Saving" card (last transcript line) until the next conversations load lands the row; row insertion animates. The flag is set where a finished recording enters the lifecycle and cleared in `loadConversations`, so every stop path (user stop, automation stop, max-duration rotation) shares one clear.

**6. Telemetry to tune the thresholds.** `Conversation Processing Completed {elapsed_seconds, outcome}` and `Conversation Processing Stalled {elapsed_seconds}`, emitted once per conversation by the watcher. Nothing measures processing latency today; the 2/10 min thresholds are a starting point to be re-set from the measured p95.

## Product invariants affected

- INV-NAV-1 — touched by path only (`ConversationRowView.swift`, `ConversationsPage.swift`). The Conversations page keeps every control and destination; this adds row states and a transient card above the list, it does not introduce a reduced copy or occlude top-navigation controls.

## Not in scope
Percentage progress (no honest denominator), streaming partial summaries, and the `merging` state for overlapping phone + desktop captures.

## Verification
- `xcrun swift build -c debug` green on the rebased tree.
- New behavioral tests (injected clock/sleeper, no wall-clock waits): `ConversationProcessingProgressTests`, `ProcessingConversationWatcherTests`, `ConversationProcessingTelemetryTests`; extended `ConversationDisplayStateTests`, `ConversationReconciliationPolicyTests`. 88 tests across the touched suites + `ShellGlassChromeTests` pass.
- swift-format and SwiftLint clean. Oversized-file ratchet satisfied by splitting: the detail banner is its own component (`ConversationProcessingBanner`), the two analytics methods live in `AnalyticsManager+ConversationProcessing`, and `AppState+Transcription.swift` is untouched. `check_desktop_test_quality.py` reports the same pre-existing baseline drift (55/149 vs 54/147) with this branch stashed, so it is not introduced here.
- **Not dogfooded in a named bundle yet.** The row/badge/banner/saving-card states are unit-tested at the model layer and compile, but I have not watched a live capture land through the new flow. Reviewer or I should run `OMI_APP_NAME=omi-processing-row ./run.sh`, stop a recording, and confirm: Saving card → row with transcript-line title and `Summarizing` pill → real title → `Adding memories & tasks…` → clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
