### PR TITLE
feat(desktop): remote-triggered onboarding rerun for users who never got going

### DIFF
--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -478,6 +478,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
 
     // Initialize analytics (PostHog)
     AnalyticsManager.shared.initialize()
+    OnboardingRerunFlag.install()
     AnalyticsManager.shared.detectAndReportCrash()
     AnalyticsManager.shared.recoverMonitoringSessionIfNeeded()
     if let attempt = pendingUpdateRelaunch?.attempt {

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingRerunPolicy.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingRerunPolicy.swift
@@ -1,0 +1,224 @@
+import Combine
+import CoreGraphics
+import FirebaseAuth
+import FirebaseCore
+import Foundation
+import OmiSupport
+
+/// Remote-triggered onboarding rerun.
+///
+/// The PostHog flag `desktop-onboarding-rerun` is rolled out to everyone and carries a payload
+/// such as `{"generation": 1, "min_account_age_days": 7, "active_questions_30d": 8}`. Each
+/// client evaluates the rule locally, so every install that launches again is covered, not
+/// only the users PostHog saw recently. A client reruns onboarding at most once per
+/// generation: the generation is recorded before the reset, so a flag left on never loops.
+///
+/// Eligible: signed in, onboarding completed, account older than `min_account_age_days`, and
+/// NOT active. Active means at least `active_questions_30d` questions in the last 30 days
+/// with both Screen Recording and Microphone granted.
+enum OnboardingRerunPolicy {
+  static let flagName = "desktop-onboarding-rerun"
+  static let appliedGenerationKey = "onboardingRerunAppliedGeneration"
+
+  struct Rule: Equatable {
+    var generation: Int
+    var minAccountAgeDays: Int = 7
+    var activeQuestions30d: Int = 8
+
+    /// Accepts the payload as a JSON object, a JSON string, or a bare generation number.
+    static func parse(_ payload: Any?) -> Rule? {
+      switch payload {
+      case let n as Int: return Rule(generation: n)
+      case let d as Double: return Rule(generation: Int(d))
+      case let s as String:
+        if let n = Int(s.trimmingCharacters(in: .whitespacesAndNewlines)) { return Rule(generation: n) }
+        guard let data = s.data(using: .utf8),
+          let obj = try? JSONSerialization.jsonObject(with: data)
+        else { return nil }
+        return parse(obj)
+      case let dict as [String: Any]:
+        guard let generation = intValue(dict["generation"]) else { return nil }
+        var rule = Rule(generation: generation)
+        if let v = intValue(dict["min_account_age_days"]) { rule.minAccountAgeDays = v }
+        if let v = intValue(dict["active_questions_30d"]) { rule.activeQuestions30d = v }
+        return rule
+      default: return nil
+      }
+    }
+
+    private static func intValue(_ any: Any?) -> Int? {
+      switch any {
+      case let n as Int: return n
+      case let d as Double: return Int(d)
+      case let s as String: return Int(s)
+      default: return nil
+      }
+    }
+  }
+
+  struct Profile: Equatable {
+    var accountAgeDays: Int?
+    var questionsLast30Days: Int
+    var screenRecordingGranted: Bool
+    var microphoneGranted: Bool
+  }
+
+  /// The generation to apply now, or nil (flag off, already applied, too new, or active).
+  static func generationToApply(
+    enabled: Bool, payload: Any?, appliedGeneration: Int, profile: Profile
+  ) -> Int? {
+    guard enabled, let rule = Rule.parse(payload), rule.generation > appliedGeneration else {
+      return nil
+    }
+    // Unknown age counts as brand new: a rule with a minimum age never fires on it.
+    guard (profile.accountAgeDays ?? 0) >= rule.minAccountAgeDays else { return nil }
+    let active =
+      profile.questionsLast30Days >= rule.activeQuestions30d
+      && profile.screenRecordingGranted && profile.microphoneGranted
+    return active ? nil : rule.generation
+  }
+
+  static func questionsInLast30Days(_ messages: [ChatMessageDB], now: Date = Date()) -> Int {
+    let cutoff = now.addingTimeInterval(-30 * 24 * 3600)
+    return messages.filter { $0.createdAt >= cutoff && $0.sender.lowercased() != "ai" }.count
+  }
+}
+
+/// Launch-time glue: observes PostHog flag delivery and applies the policy once per generation.
+@MainActor enum OnboardingRerunFlag {
+  private static var observer: NSObjectProtocol?
+  private static var sessionObserver: AnyCancellable?
+  private static var evaluating = false
+
+  @MainActor static func install() {
+    guard observer == nil else { return }
+    observer = NotificationCenter.default.addObserver(
+      forName: PostHogManager.featureFlagsDidLoad, object: nil, queue: .main
+    ) { _ in
+      Task { @MainActor in await evaluate() }
+    }
+    // Flags usually arrive before the stored session is restored; re-evaluate once the user
+    // is authenticated so the decision is made with the real signed-in state.
+    sessionObserver = AuthState.shared.$sessionPhase
+      .removeDuplicates()
+      .sink { phase in
+        guard phase == .authenticated else { return }
+        Task { @MainActor in await evaluate() }
+      }
+    Task { @MainActor in await evaluate() }
+  }
+
+  /// Flag delivery as the app sees it. DEBUG builds accept `OMI_ONBOARDING_RERUN_PAYLOAD` (the
+  /// JSON the flag would carry) so the rerun path can be exercised on a dev bundle without a
+  /// live PostHog flag; release builds only ever read PostHog.
+  static func deliveredRule() -> OnboardingRerunPolicy.Rule? {
+    #if DEBUG
+      // getenv, not ProcessInfo: BundleEnvironment applies the bundle's .env with setenv after
+      // launch, and ProcessInfo.environment is a snapshot taken at first access.
+      if let c = getenv("OMI_ONBOARDING_RERUN_PAYLOAD"), let raw = String(validatingCString: c),
+        !raw.isEmpty
+      {
+        return OnboardingRerunPolicy.Rule.parse(raw)
+      }
+    #endif
+    guard PostHogManager.shared.isFeatureEnabled(OnboardingRerunPolicy.flagName) else { return nil }
+    return OnboardingRerunPolicy.Rule.parse(
+      PostHogManager.shared.getFeatureFlagPayload(OnboardingRerunPolicy.flagName))
+  }
+
+  @MainActor static func evaluate(defaults: UserDefaults = .standard) async {
+    guard !evaluating else { return }
+    let applied = defaults.integer(forKey: OnboardingRerunPolicy.appliedGenerationKey)
+    guard let rule = deliveredRule(), rule.generation > applied else { return }
+    // Signed out (or the session is not restored yet): decide later, record nothing.
+    guard AuthState.shared.isSignedIn else { return }
+    // Signed in but never finished onboarding: record the generation so their first, fresh
+    // onboarding is not followed by a second one.
+    guard defaults.bool(forKey: .hasCompletedOnboarding) else {
+      defaults.set(rule.generation, forKey: OnboardingRerunPolicy.appliedGenerationKey)
+      log("OnboardingRerun: generation \(rule.generation) recorded without rerun (not onboarded)")
+      return
+    }
+    evaluating = true
+    defer { evaluating = false }
+    let profile = await currentProfile()
+    guard
+      let generation = OnboardingRerunPolicy.generationToApply(
+        enabled: true,
+        payload: [
+          "generation": rule.generation,
+          "min_account_age_days": rule.minAccountAgeDays,
+          "active_questions_30d": rule.activeQuestions30d,
+        ],
+        appliedGeneration: applied, profile: profile)
+    else {
+      // Active or too new: this generation does not apply to them; keep it pending so a later
+      // drop in usage does not matter either (the decision is per generation, made once).
+      defaults.set(rule.generation, forKey: OnboardingRerunPolicy.appliedGenerationKey)
+      log("OnboardingRerun: generation \(rule.generation) skipped, profile=\(profile)")
+      PostHogManager.shared.track(
+        "Onboarding Rerun Skipped",
+        properties: [
+          "generation": rule.generation, "questions_30d": profile.questionsLast30Days,
+          "account_age_days": profile.accountAgeDays ?? -1,
+        ])
+      return
+    }
+    defaults.set(generation, forKey: OnboardingRerunPolicy.appliedGenerationKey)
+    log("OnboardingRerun: generation \(generation) — rerunning onboarding, profile=\(profile)")
+    PostHogManager.shared.track(
+      "Onboarding Rerun Triggered",
+      properties: [
+        "generation": generation, "questions_30d": profile.questionsLast30Days,
+        "account_age_days": profile.accountAgeDays ?? -1,
+      ])
+    // Same steps as the manual Reset Onboarding action, minus the relaunch: the home view
+    // drops `hasCompletedOnboarding` on this notification and mounts onboarding in place.
+    NotificationCenter.default.post(name: .resetOnboardingRequested, object: nil)
+    OnboardingFlow.clearPersistedState(in: defaults)
+    defaults.removeObject(forKey: .hasCompletedOnboarding)
+    OnboardingChatPersistence.clear()
+  }
+
+  /// Backend timestamps arrive with or without fractional seconds.
+  private static func parseBackendDate(_ raw: String) -> Date? {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let d = f.date(from: raw) { return d }
+    f.formatOptions = [.withInternetDateTime]
+    return f.date(from: raw)
+  }
+
+  private static func localDataDirectoryCreationDate() -> Date? {
+    let dir = DesktopLocalProfile.applicationSupportURL()
+    return (try? dir.resourceValues(forKeys: [.creationDateKey]))?.creationDate
+  }
+
+  @MainActor private static func currentProfile() async -> OnboardingRerunPolicy.Profile {
+    var ageDays: Int?
+    if FirebaseApp.app() != nil, let created = Auth.auth().currentUser?.metadata.creationDate {
+      ageDays = Int(Date().timeIntervalSince(created) / 86_400)
+    } else if let created = try? await APIClient.shared.getUserProfile().createdAt,
+      let date = parseBackendDate(created)
+    {
+      ageDays = Int(Date().timeIntervalSince(date) / 86_400)
+    } else if let created = localDataDirectoryCreationDate() {
+      // No account timestamp reachable: the local data folder is at least as old as this
+      // install's onboarding, which is a lower bound on the account's age.
+      ageDays = Int(Date().timeIntervalSince(created) / 86_400)
+      log("OnboardingRerun: account age from local data folder (\(ageDays ?? -1)d)")
+    }
+    var questions = 0
+    if let messages = try? await APIClient.shared.getMessages(limit: 200) {
+      questions = OnboardingRerunPolicy.questionsInLast30Days(messages)
+    } else {
+      // Backend unavailable: fall back to the local lifetime question counter.
+      questions = RatingPromptManager.shared.questionCount
+    }
+    return OnboardingRerunPolicy.Profile(
+      accountAgeDays: ageDays,
+      questionsLast30Days: questions,
+      screenRecordingGranted: CGPreflightScreenCaptureAccess(),
+      microphoneGranted: AudioCaptureService.checkPermission())
+  }
+}

--- a/desktop/macos/Desktop/Sources/PostHogManager.swift
+++ b/desktop/macos/Desktop/Sources/PostHogManager.swift
@@ -207,6 +207,12 @@ class PostHogManager {
     return PostHogSDK.shared.getFeatureFlag(flag)
   }
 
+  /// Get the JSON payload configured on a feature flag
+  func getFeatureFlagPayload(_ flag: String) -> Any? {
+    guard isInitialized else { return nil }
+    return PostHogSDK.shared.getFeatureFlagResult(flag)?.payload
+  }
+
   /// The SDK's own flag-delivery signal (posted on the main queue after the
   /// initial preload and after every reload) — re-exported so observers get a
   /// compile-checked symbol instead of a raw notification-name string.

--- a/desktop/macos/Desktop/Tests/OnboardingRerunPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingRerunPolicyTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class OnboardingRerunPolicyTests: XCTestCase {
+  private let payload: [String: Any] = [
+    "generation": 1, "min_account_age_days": 7, "active_questions_30d": 8,
+  ]
+  private func profile(
+    age: Int? = 30, questions: Int = 0, screen: Bool = true, mic: Bool = true
+  ) -> OnboardingRerunPolicy.Profile {
+    .init(
+      accountAgeDays: age, questionsLast30Days: questions, screenRecordingGranted: screen,
+      microphoneGranted: mic)
+  }
+
+  func testLowUsageOldAccountReruns() {
+    XCTAssertEqual(
+      OnboardingRerunPolicy.generationToApply(
+        enabled: true, payload: payload, appliedGeneration: 0, profile: profile(questions: 3)), 1)
+  }
+
+  func testActiveUserWithBothPermissionsIsLeftAlone() {
+    XCTAssertNil(
+      OnboardingRerunPolicy.generationToApply(
+        enabled: true, payload: payload, appliedGeneration: 0, profile: profile(questions: 8)))
+  }
+
+  func testHeavyUserMissingAPermissionStillReruns() {
+    XCTAssertEqual(
+      OnboardingRerunPolicy.generationToApply(
+        enabled: true, payload: payload, appliedGeneration: 0,
+        profile: profile(questions: 40, screen: false)), 1)
+  }
+
+  func testAccountsYoungerThanAWeekOrUnknownAgeAreSkipped() {
+    // Unknown age counts as brand new, so only a rule with no minimum age fires on it.
+    XCTAssertEqual(
+      OnboardingRerunPolicy.generationToApply(
+        enabled: true, payload: ["generation": 1, "min_account_age_days": 0],
+        appliedGeneration: 0, profile: profile(age: nil)), 1)
+    XCTAssertNil(
+      OnboardingRerunPolicy.generationToApply(
+        enabled: true, payload: payload, appliedGeneration: 0, profile: profile(age: 3)))
+    XCTAssertNil(
+      OnboardingRerunPolicy.generationToApply(
+        enabled: true, payload: payload, appliedGeneration: 0, profile: profile(age: nil)))
+  }
+
+  func testAppliesAtMostOncePerGenerationAndNeverWhenOff() {
+    XCTAssertNil(
+      OnboardingRerunPolicy.generationToApply(
+        enabled: true, payload: payload, appliedGeneration: 1, profile: profile()))
+    XCTAssertNil(
+      OnboardingRerunPolicy.generationToApply(
+        enabled: false, payload: payload, appliedGeneration: 0, profile: profile()))
+    XCTAssertEqual(
+      OnboardingRerunPolicy.generationToApply(
+        enabled: true, payload: ["generation": 2], appliedGeneration: 1, profile: profile()), 2)
+  }
+
+  func testPayloadParsingAcceptsJSONStringObjectAndBareNumber() {
+    XCTAssertEqual(
+      OnboardingRerunPolicy.Rule.parse(#"{"generation": 3, "active_questions_30d": 4}"#),
+      .init(generation: 3, minAccountAgeDays: 7, activeQuestions30d: 4))
+    XCTAssertEqual(OnboardingRerunPolicy.Rule.parse(5), .init(generation: 5))
+    XCTAssertNil(OnboardingRerunPolicy.Rule.parse("nope"))
+    XCTAssertNil(OnboardingRerunPolicy.Rule.parse(nil))
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260902-onboarding-rerun-flag.json
+++ b/desktop/macos/changelog/unreleased/20260902-onboarding-rerun-flag.json
@@ -1,0 +1,3 @@
+{
+  "change": "Omi can ask users who never got going to walk through onboarding again on their next launch"
+}


### PR DESCRIPTION
## Summary
Remote-triggered onboarding rerun for users who never got going. The PostHog flag `desktop-onboarding-rerun` carries a rule payload:

```
{"generation":1,"min_account_age_days":7,"active_questions_30d":8}
```

Each client evaluates the rule locally when flags arrive and again when the session becomes authenticated (flags usually land before the stored session is restored). Eligible = signed in, onboarding completed, account older than `min_account_age_days`, and NOT active, where active = at least `active_questions_30d` questions in the last 30 days (backend chat history; local lifetime counter as fallback) with both Screen Recording and Microphone granted. Eligible clients rerun onboarding in place (same steps as Reset Onboarding, no relaunch), once per generation; the generation is recorded before the reset so a flag left on never loops. Account age comes from Firebase auth metadata, then the backend profile `created_at`, then the local data folder's creation date (a lower bound). Because the rule lives on the client, every install that launches again after updating is covered (39k macOS users all-time), not only the ~4k PostHog saw this month.

DEBUG builds accept `OMI_ONBOARDING_RERUN_PAYLOAD` (the JSON the flag would carry) so the path can be exercised on a dev bundle without a live flag; release builds only read PostHog.

## Verification
`omi-doors` dev bundle (previously onboarded, signed in as Nik) with the payload in the bundle `.env`:
- First attempt exposed a real race: flags arrived before auth restored → "recorded without rerun (not onboarded)" burned the generation. Fixed: signed-out evaluations record nothing, and a session observer re-evaluates on authentication.
- After the fix: log shows `OnboardingRerun: generation 2 — rerunning onboarding, profile=Profile(accountAgeDays: 0, questionsLast30Days: 26, screenRecordingGranted: true, microphoneGranted: true)` followed by `DesktopHomeView: resetOnboardingRequested`; `hasCompletedOnboarding` cleared; `omi-ctl state` reports `appState: onboarding`; the window shows the first onboarding step (screenshot attached to the review).
- Relaunched the bundle: no second rerun (generation already applied), app stays in onboarding.
- Unit tests: `OnboardingRerunPolicyTests` (low-usage reruns; active with both permissions skipped; heavy user missing a permission reruns; young/unknown age skipped unless the rule has no minimum; once per generation; payload parsing).

Invariants: none matched.
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

