### PR TITLE
feat: activation = 2+ chat questions within the first 48 hours (+ daily rate chart)

### DIFF
--- a/web/admin/app/api/omi/stats/activation/route.ts
+++ b/web/admin/app/api/omi/stats/activation/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
-import { getDb } from "@/lib/firebase/admin";
 import { getPayload, setPayload, withFreshness } from "@/lib/payload-cache";
 import { toGrafanaActivationPayload } from "@/lib/activation-compat";
+import { posthogResults } from "@/lib/posthog";
 import {
   rollUpActivationCohort,
   type ActivationCohortMember,
@@ -12,112 +12,111 @@ import {
 export const dynamic = "force-dynamic";
 export const maxDuration = 3600;
 
-const DAY_MS = 86_400_000;
-const MATURITY_DAYS = 7;
-const PAGE = 500;
-const CONCURRENCY = 16;
-
-// `created_at` is null on user documents written by the current signup path;
-// `signup_platform_at` is the field that is actually populated. Cohorting on
-// `created_at` silently returns almost nobody.
-const SIGNUP_FIELD = "signup_platform_at";
+// Activation (Nik, 2026-08-28): a macOS signup counts as activated when they
+// ask 2+ chat questions within their first 48 hours. Signup = first-seen
+// macOS actor in PostHog (the same person-deduped anchor every other board
+// cohort uses); question = the `Chat Message Sent` event every main-window
+// chat surface funnels through. Signups younger than the 48h window are not
+// yet matured and are excluded so the rate is never depressed by users whose
+// window is still open. Replaces the older Firestore definition (>=1
+// conversation within 7 days).
+export const ACTIVATION_QUESTIONS = 2;
+export const ACTIVATION_WINDOW_HOURS = 48;
 
 export function activationCacheKey(days: number): string {
-  return `activation:v1:macos:${days}`;
+  return `activation:v2:macos-2q48h:${days}`;
 }
 
-/**
- * macOS activation measured from conversation records rather than telemetry.
- *
- * The PostHog series counts the desktop `Memory Created` event, which older
- * builds cannot emit at all, so it reports build age rather than behaviour.
- * A conversation document exists whether or not the client managed to report
- * it, which makes this the only source that can answer the question today.
- */
+export type ActivationDailyPoint = {
+  date: string;
+  signups: number;
+  activated: number;
+  rate: number;
+};
+
+function nycDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-CA", {
+    timeZone: "America/New_York",
+  });
+}
+
+export function rollUpDaily(
+  members: readonly ActivationCohortMember[],
+): ActivationDailyPoint[] {
+  const byDay = new Map<string, { signups: number; activated: number }>();
+  for (const member of members) {
+    const day = nycDate(member.signupAt);
+    const entry = byDay.get(day) ?? { signups: 0, activated: 0 };
+    entry.signups += 1;
+    if (member.activated) entry.activated += 1;
+    byDay.set(day, entry);
+  }
+  return Array.from(byDay.entries())
+    .map(([date, { signups, activated }]) => ({
+      date,
+      signups,
+      activated,
+      rate: signups > 0 ? Math.round((1000 * activated) / signups) / 10 : 0,
+    }))
+    .sort((a, b) => (a.date < b.date ? -1 : 1));
+}
+
 export async function computeActivation(
   days: number,
-): Promise<ActivationSeries & { erroredUsers: number }> {
-  const db = getDb();
-  const now = Date.now();
-  const windowStart = new Date(now - days * DAY_MS);
-  const maturedBefore = new Date(now - MATURITY_DAYS * DAY_MS);
-
-  // Filtering on signup_os alongside a signup_platform_at range needs a
-  // composite index that does not exist on this project, so the range is the
-  // query and the platform is filtered here.
-  const cohort: { uid: string; signupAt: Date }[] = [];
-  let cursor: FirebaseFirestore.QueryDocumentSnapshot | null = null;
-  for (;;) {
-    let query = db
-      .collection("users")
-      .where(SIGNUP_FIELD, ">", windowStart)
-      .orderBy(SIGNUP_FIELD, "asc")
-      .limit(PAGE);
-    if (cursor) query = query.startAfter(cursor);
-
-    const snap = await query.get();
-    if (snap.empty) break;
-
-    for (const doc of snap.docs) {
-      const data = doc.data();
-      if (data.signup_os !== "macos") continue;
-      const signupAt: Date | undefined = data[SIGNUP_FIELD]?.toDate?.();
-      // Signups inside the maturity window have not had their full 7 days, so
-      // counting them would pit a guaranteed-zero numerator against a real
-      // denominator.
-      if (!signupAt || signupAt > maturedBefore) continue;
-      cohort.push({ uid: doc.id, signupAt });
-    }
-
-    if (snap.size < PAGE) break;
-    cursor = snap.docs[snap.docs.length - 1];
+): Promise<
+  ActivationSeries & { daily: ActivationDailyPoint[]; erroredUsers: number }
+> {
+  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  const projectId = process.env.POSTHOG_PROJECT_ID;
+  const host = (process.env.POSTHOG_HOST || "https://us.posthog.com").replace(
+    /\/$/,
+    "",
+  );
+  if (!apiKey || !projectId) {
+    throw new Error("PostHog credentials not configured");
   }
 
-  // `null` means the read failed. It must stay distinct from `false`: scoring an
-  // unreadable user as "did not activate" is the same mistake this whole metric
-  // exists to undo, just one layer down.
-  const activated = new Array<boolean | null>(cohort.length).fill(null);
-  let next = 0;
+  // One query: each first-seen macOS actor in the window (matured only) with
+  // their question count inside the first ACTIVATION_WINDOW_HOURS.
+  const rows = (await posthogResults(
+    host,
+    projectId,
+    apiKey,
+    `
+      WITH firsts AS (
+        SELECT COALESCE(person_id, distinct_id) AS actor, min(timestamp) AS first_ts
+        FROM events
+        WHERE properties.$os_name = 'macOS'
+        GROUP BY actor
+        HAVING first_ts >= now() - INTERVAL ${days} DAY
+          AND first_ts <= now() - INTERVAL ${ACTIVATION_WINDOW_HOURS} HOUR
+      )
+      SELECT toString(any(f.first_ts)) AS first_ts,
+             countIf(
+               e.event = 'Chat Message Sent'
+               AND e.timestamp >= f.first_ts
+               AND e.timestamp <= f.first_ts + INTERVAL ${ACTIVATION_WINDOW_HOURS} HOUR
+             ) AS questions
+      FROM firsts f
+      LEFT JOIN events e
+        ON COALESCE(e.person_id, e.distinct_id) = f.actor
+        AND e.timestamp >= now() - INTERVAL ${days + 2} DAY
+      GROUP BY f.actor
+    `,
+  )) as any[];
 
-  async function worker(): Promise<void> {
-    for (;;) {
-      const i = next++;
-      if (i >= cohort.length) return;
-      const { uid, signupAt } = cohort[i];
-      const windowEnd = new Date(signupAt.getTime() + MATURITY_DAYS * DAY_MS);
-      try {
-        const agg = await db
-          .collection("users")
-          .doc(uid)
-          .collection("conversations")
-          .where("created_at", ">=", signupAt)
-          .where("created_at", "<=", windowEnd)
-          .count()
-          .get();
-        activated[i] = agg.data().count > 0;
-      } catch {
-        // Left null: reported via erroredUsers and dropped from the cohort, so
-        // a partial read shrinks the sample instead of depressing the rate.
-      }
-    }
-  }
-
-  await Promise.all(
-    Array.from({ length: Math.min(CONCURRENCY, cohort.length) }, worker),
+  const members: ActivationCohortMember[] = (rows ?? []).map(
+    ([firstTs, questions]) => ({
+      signupAt: new Date(String(firstTs).replace(" ", "T") + "Z").toISOString(),
+      activated: Number(questions) >= ACTIVATION_QUESTIONS,
+    }),
   );
 
-  const members: ActivationCohortMember[] = [];
-  let erroredUsers = 0;
-  cohort.forEach((m, i) => {
-    const result = activated[i];
-    if (result === null) {
-      erroredUsers += 1;
-      return;
-    }
-    members.push({ signupAt: m.signupAt.toISOString(), activated: result });
-  });
-
-  return { ...rollUpActivationCohort(members), erroredUsers };
+  return {
+    ...rollUpActivationCohort(members),
+    daily: rollUpDaily(members),
+    erroredUsers: 0,
+  };
 }
 
 export async function GET(request: NextRequest) {
@@ -125,8 +124,7 @@ export async function GET(request: NextRequest) {
   if (authResult instanceof NextResponse) return authResult;
 
   try {
-    // A non-numeric `days` would otherwise reach Firestore as NaN date
-    // arithmetic and 500 the route.
+    // A non-numeric `days` would otherwise reach the query as NaN.
     const requestedDays = parseInt(
       request.nextUrl.searchParams.get("days") || "60",
       10,

--- a/web/admin/grafana/build_dashboards.py
+++ b/web/admin/grafana/build_dashboards.py
@@ -474,8 +474,9 @@ def build_platform_board(base, scope: str) -> dict:
         # The stat tile is already platform-neutral ("Activation"); board
         # context makes the All board's "macOS only" marker redundant here.
         panel_by_title(dash, "Activation")["description"] = (
-            "Firestore: % of signups with a conversation within 7 days — the aha "
-            "moment. Biggest controllable lever — first-5-minutes work."
+            "% of first-seen macOS users who asked 2+ chat questions within their "
+            "first 48 hours (PostHog; matured signups only). The aha moment — "
+            "biggest controllable lever, first-5-minutes work."
         )
         chart = panel_by_title(dash, "Activation (signup → activated, macOS)")
         chart["title"] = "Activation (signup → activated)" + (
@@ -504,6 +505,16 @@ def build_platform_board(base, scope: str) -> dict:
             "All and macOS boards use."
         )
         set_stat_query(rate, viral_mobile, "summary", "activationRate", "Activation")
+        # Mobile daily activation: viral-metrics' daily telemetry series (its
+        # own definition, Memory Created <=7d) — honest, not the macOS 2q/48h.
+        daily_chart = panel_by_title(dash, "Activation rate — daily")
+        daily_chart["description"] = (
+            "PostHog telemetry: daily % of first-seen mobile users with a Memory "
+            "Created within 7 days (not the macOS 2-questions/48h definition)."
+        )
+        dtarget = daily_chart["targets"][0]
+        dtarget["url"] = add_query_param(f"{PROXY}{viral_mobile}", "_tzdates", "date")
+        dtarget["root_selector"] = "activationDaily"
         chart = panel_by_title(dash, "Activation (signup → activated, macOS)")
         chart["title"] = "Activation (signup → activated)  ·  ${d_act}"
         target = chart["targets"][0]

--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -322,7 +322,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Firestore: % of signups with a conversation within 7 days \u2014 the aha moment. Biggest controllable lever \u2014 first-5-minutes work.",
+      "description": "% of first-seen macOS users who asked 2+ chat questions within their first 48 hours (PostHog; matured signups only). The aha moment \u2014 biggest controllable lever, first-5-minutes work.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4303,6 +4303,93 @@
       ],
       "timeFrom": "60d",
       "title": "Omi Desktop rating \u2014 daily",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "Daily activation rate: % of that day's first-seen macOS users who asked 2+ questions within 48h. Only matured days (older than 48h) appear.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#22c55e"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "percent",
+          "min": 0,
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 95,
+        "w": 24,
+        "h": 7
+      },
+      "id": 996,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/activation?days=60&_tzdates=date",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "daily",
+          "columns": [
+            {
+              "selector": "date",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "rate",
+              "text": "Activation rate",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "60d",
+      "title": "Activation rate \u2014 daily",
       "type": "timeseries"
     }
   ],

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -3660,6 +3660,93 @@
         "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
       },
       "targets": []
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "PostHog telemetry: daily % of first-seen mobile users with a Memory Created within 7 days (not the macOS 2-questions/48h definition).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#22c55e"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "percent",
+          "min": 0,
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 95,
+        "w": 24,
+        "h": 7
+      },
+      "id": 996,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=mobile&_tzdates=date",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "activationDaily",
+          "columns": [
+            {
+              "selector": "date",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "rate",
+              "text": "Activation rate",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "60d",
+      "title": "Activation rate \u2014 daily",
+      "type": "timeseries"
     }
   ],
   "refresh": "1h",

--- a/web/admin/grafana/dashboards/omi-tv.json
+++ b/web/admin/grafana/dashboards/omi-tv.json
@@ -405,7 +405,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "% of first-seen macOS users who asked 2+ chat questions within their first 48 hours (PostHog; matured signups only). The aha moment \u2014 biggest controllable lever, first-5-minutes work.",
+      "description": "% of first-seen macOS users (macOS only) who asked 2+ chat questions within their first 48 hours (PostHog; matured signups only). The aha moment \u2014 first-5-minutes work.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/web/admin/grafana/dashboards/omi-tv.json
+++ b/web/admin/grafana/dashboards/omi-tv.json
@@ -405,7 +405,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "macOS only (Firestore): % of signups with a conversation within 7 days \u2014 the aha moment. Biggest controllable lever \u2014 first-5-minutes work.",
+      "description": "% of first-seen macOS users who asked 2+ chat questions within their first 48 hours (PostHog; matured signups only). The aha moment \u2014 biggest controllable lever, first-5-minutes work.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -5704,6 +5704,93 @@
       ],
       "timeFrom": "60d",
       "title": "Omi Desktop rating \u2014 daily",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "Daily activation rate: % of that day's first-seen macOS users who asked 2+ questions within 48h. Only matured days (older than 48h) appear.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#22c55e"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "percent",
+          "min": 0,
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 993
+      },
+      "id": 996,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/activation?days=60&_tzdates=date",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "daily",
+          "columns": [
+            {
+              "selector": "date",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "rate",
+              "text": "Activation rate",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "60d",
+      "title": "Activation rate \u2014 daily",
       "type": "timeseries"
     },
     {

--- a/web/admin/lib/__tests__/activation-route.test.ts
+++ b/web/admin/lib/__tests__/activation-route.test.ts
@@ -1,239 +1,105 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-// The route reaches Firestore through getDb(); faking it here exercises the
-// real cohort/pagination/maturity logic without a service account.
-const getDb = vi.fn();
-vi.mock("@/lib/firebase/admin", () => ({ getDb: () => getDb() }));
+const posthogResults = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/posthog", () => ({ posthogResults }));
 vi.mock("@/lib/auth", () => ({ verifyAdmin: vi.fn() }));
 vi.mock("@/lib/payload-cache", () => ({
   getPayload: vi.fn(),
   setPayload: vi.fn(),
+  withFreshness: (data: object, freshAt: number) => ({ ...data, freshAt }),
 }));
 
-import { computeActivation } from "@/app/api/omi/stats/activation/route";
+import {
+  ACTIVATION_QUESTIONS,
+  ACTIVATION_WINDOW_HOURS,
+  computeActivation,
+  rollUpDaily,
+} from "@/app/api/omi/stats/activation/route";
 
-const DAY = 86_400_000;
+const ENV_KEYS = ["POSTHOG_PERSONAL_API_KEY", "POSTHOG_PROJECT_ID"] as const;
+const originalEnv = Object.fromEntries(
+  ENV_KEYS.map((key) => [key, process.env[key]]),
+);
 
-type UserSeed = {
-  uid: string;
-  signupOs: string;
-  signupDaysAgo: number;
-  conversationOffsetsDays?: number[];
-  throwOnRead?: boolean;
-};
-
-function fakeDb(users: UserSeed[]) {
-  const now = Date.now();
-  const docs = users.map((u) => ({
-    id: u.uid,
-    seed: u,
-    signupAt: new Date(now - u.signupDaysAgo * DAY),
-  }));
-  docs.sort((a, b) => a.signupAt.getTime() - b.signupAt.getTime());
-
-  // The route's own predicates decide the count. If it filtered the wrong
-  // field, or shifted either bound, the returned count changes -- so the
-  // 7-day window is a real contract here rather than something the fake
-  // re-implements and always agrees with.
-  const conversationsFor = (uid: string) => {
-    const seed = users.find((u) => u.uid === uid)!;
-    const signupAt = new Date(now - seed.signupDaysAgo * DAY);
-    const timestamps = (seed.conversationOffsetsDays ?? []).map(
-      (off) => signupAt.getTime() + off * DAY,
-    );
-    const bounds: { field: string; op: string; value: Date }[] = [];
-    const api = {
-      where(field: string, op: string, value: Date) {
-        bounds.push({ field, op, value });
-        return api;
-      },
-      count() {
-        return {
-          async get() {
-            if (seed.throwOnRead) throw new Error("permission denied");
-            for (const b of bounds) {
-              if (b.field !== "created_at") {
-                throw new Error(`unexpected filter field: ${b.field}`);
-              }
-            }
-            const n = timestamps.filter((t) =>
-              bounds.every((b) =>
-                b.op === ">="
-                  ? t >= b.value.getTime()
-                  : b.op === "<="
-                    ? t <= b.value.getTime()
-                    : true,
-              ),
-            ).length;
-            return { data: () => ({ count: n }) };
-          },
-        };
-      },
-    };
-    return api;
-  };
-
-  // Honours the caller's limit(), so the route's own PAGE size drives paging.
-  function usersQuery(after = 0, pageSize = docs.length) {
-    return {
-      where: () => usersQuery(after, pageSize),
-      orderBy: () => usersQuery(after, pageSize),
-      limit: (n: number) => usersQuery(after, n),
-      startAfter(cursorDoc: any) {
-        return usersQuery(
-          docs.findIndex((d) => d.id === cursorDoc.id) + 1,
-          pageSize,
-        );
-      },
-      async get() {
-        const slice = docs.slice(after, after + pageSize);
-        return {
-          empty: slice.length === 0,
-          size: slice.length,
-          docs: slice.map((d) => ({
-            id: d.id,
-            data: () => ({
-              signup_os: d.seed.signupOs,
-              signup_platform_at: { toDate: () => d.signupAt },
-            }),
-          })),
-        };
-      },
-    };
+afterEach(() => {
+  posthogResults.mockReset();
+  for (const key of ENV_KEYS) {
+    if (originalEnv[key] == null) delete process.env[key];
+    else process.env[key] = originalEnv[key];
   }
+});
 
-  return {
-    collection(name: string) {
-      if (name !== "users") throw new Error("unexpected collection " + name);
-      return {
-        ...usersQuery(),
-        doc: (uid: string) => ({
-          collection: (sub: string) => {
-            if (sub !== "conversations") throw new Error("unexpected sub " + sub);
-            return conversationsFor(uid);
-          },
-        }),
-      };
-    },
-  };
+function configure() {
+  process.env.POSTHOG_PERSONAL_API_KEY = "phx_test";
+  process.env.POSTHOG_PROJECT_ID = "1";
 }
 
-beforeEach(() => getDb.mockReset());
+// PostHog returns "YYYY-MM-DD HH:MM:SS" strings (UTC) for toString(ts).
+function ph(daysAgo: number): string {
+  return new Date(Date.now() - daysAgo * 86_400_000)
+    .toISOString()
+    .slice(0, 19)
+    .replace("T", " ");
+}
 
-describe("computeActivation", () => {
-  it("counts a macOS signup as activated only on a conversation inside its 7-day window", async () => {
-    getDb.mockReturnValue(
-      fakeDb([
-        { uid: "in-window", signupOs: "macos", signupDaysAgo: 30, conversationOffsetsDays: [3] },
-        { uid: "too-late", signupOs: "macos", signupDaysAgo: 30, conversationOffsetsDays: [9] },
-        { uid: "none", signupOs: "macos", signupDaysAgo: 30 },
-      ]),
-    );
+describe("computeActivation (2+ questions within 48h)", () => {
+  it("activation = questions >= threshold; rate over the matured cohort", async () => {
+    configure();
+    // 4 matured signups: 2 activated (>=2 questions in window), 2 not.
+    posthogResults.mockResolvedValue([
+      [ph(10), 5],
+      [ph(9), 2],
+      [ph(8), 1],
+      [ph(7), 0],
+    ]);
+    const series = await computeActivation(60);
 
-    const result = await computeActivation(60);
-
-    expect(result.signups).toBe(3);
-    expect(result.activated).toBe(1);
-    expect(result.rate).toBe(33.3);
+    expect(series.signups).toBe(4);
+    expect(series.activated).toBe(2);
+    expect(series.rate).toBeCloseTo(50);
+    expect(series.erroredUsers).toBe(0);
+    // Weekly rollup preserved for the existing signup→activated chart.
+    expect(series.weeks.length).toBeGreaterThan(0);
+    // Daily series for the new daily-rate chart.
+    expect(series.daily.reduce((a, d) => a + d.signups, 0)).toBe(4);
+    expect(series.daily.every((d) => d.rate >= 0 && d.rate <= 100)).toBe(true);
   });
 
-  it("treats the 7-day window as closed at both ends", async () => {
-    getDb.mockReturnValue(
-      fakeDb([
-        { uid: "at-signup", signupOs: "macos", signupDaysAgo: 30, conversationOffsetsDays: [0] },
-        { uid: "at-day-seven", signupOs: "macos", signupDaysAgo: 30, conversationOffsetsDays: [7] },
-        { uid: "just-after", signupOs: "macos", signupDaysAgo: 30, conversationOffsetsDays: [7.001] },
-        { uid: "just-before", signupOs: "macos", signupDaysAgo: 30, conversationOffsetsDays: [-0.001] },
-      ]),
+  it("sends the definition to PostHog: macOS cohort, maturity, Chat Message Sent window", async () => {
+    configure();
+    posthogResults.mockResolvedValue([]);
+    await computeActivation(30);
+    const query = posthogResults.mock.calls[0][3] as string;
+    expect(query).toContain("properties.$os_name = 'macOS'");
+    expect(query).toContain(
+      `first_ts <= now() - INTERVAL ${ACTIVATION_WINDOW_HOURS} HOUR`,
     );
-
-    const result = await computeActivation(60);
-
-    // Inclusive at signup and at signup+7d; anything outside is not activation.
-    expect(result.signups).toBe(4);
-    expect(result.activated).toBe(2);
+    expect(query).toContain("Chat Message Sent");
+    expect(query).toContain(
+      `f.first_ts + INTERVAL ${ACTIVATION_WINDOW_HOURS} HOUR`,
+    );
+    expect(ACTIVATION_QUESTIONS).toBe(2);
   });
 
-  it("excludes non-macOS signups", async () => {
-    getDb.mockReturnValue(
-      fakeDb([
-        { uid: "mac", signupOs: "macos", signupDaysAgo: 20, conversationOffsetsDays: [1] },
-        { uid: "ios", signupOs: "ios", signupDaysAgo: 20, conversationOffsetsDays: [1] },
-        { uid: "web", signupOs: "web", signupDaysAgo: 20 },
-      ]),
+  it("throws without PostHog credentials so the caller returns an honest 500", async () => {
+    delete process.env.POSTHOG_PERSONAL_API_KEY;
+    delete process.env.POSTHOG_PROJECT_ID;
+    await expect(computeActivation(60)).rejects.toThrow(
+      "PostHog credentials not configured",
     );
-
-    const result = await computeActivation(60);
-
-    expect(result.signups).toBe(1);
-    expect(result.activated).toBe(1);
   });
+});
 
-  it("excludes signups whose 7-day window has not elapsed", async () => {
-    getDb.mockReturnValue(
-      fakeDb([
-        { uid: "matured", signupOs: "macos", signupDaysAgo: 10, conversationOffsetsDays: [1] },
-        { uid: "yesterday", signupOs: "macos", signupDaysAgo: 1 },
-        { uid: "day-six", signupOs: "macos", signupDaysAgo: 6 },
-      ]),
-    );
-
-    const result = await computeActivation(60);
-
-    expect(result.signups).toBe(1);
-    expect(result.rate).toBe(100);
-  });
-
-  it("paginates past the 500-doc page instead of stopping at the first page", async () => {
-    // 1,200 > 2 full pages, so a missing cursor advance truncates the cohort --
-    // the exact shape that would silently undercount a real 10k-signup window.
-    const many: UserSeed[] = Array.from({ length: 1200 }, (_, i) => ({
-      uid: `u${i}`,
-      signupOs: "macos",
-      signupDaysAgo: 10 + (i % 40),
-      conversationOffsetsDays: i % 2 === 0 ? [1] : [],
-    }));
-    getDb.mockReturnValue(fakeDb(many));
-
-    const result = await computeActivation(60);
-
-    expect(result.signups).toBe(1200);
-    expect(result.activated).toBe(600);
-  });
-
-  it("drops unreadable users from the denominator instead of scoring them as not activated", async () => {
-    getDb.mockReturnValue(
-      fakeDb([
-        { uid: "ok", signupOs: "macos", signupDaysAgo: 30, conversationOffsetsDays: [1] },
-        { uid: "broken", signupOs: "macos", signupDaysAgo: 30, throwOnRead: true },
-      ]),
-    );
-
-    const result = await computeActivation(60);
-
-    // Counting the unreadable user would report 50% -- the same "absence of
-    // evidence read as evidence of absence" mistake this metric exists to undo.
-    expect(result.erroredUsers).toBe(1);
-    expect(result.signups).toBe(1);
-    expect(result.activated).toBe(1);
-    expect(result.rate).toBe(100);
-  });
-
-  it("keeps a week's rate honest when only some of its users are unreadable", async () => {
-    getDb.mockReturnValue(
-      fakeDb([
-        { uid: "a", signupOs: "macos", signupDaysAgo: 30, conversationOffsetsDays: [1] },
-        { uid: "b", signupOs: "macos", signupDaysAgo: 30 },
-        { uid: "c", signupOs: "macos", signupDaysAgo: 30, throwOnRead: true },
-        { uid: "d", signupOs: "macos", signupDaysAgo: 30, throwOnRead: true },
-      ]),
-    );
-
-    const result = await computeActivation(60);
-
-    expect(result.erroredUsers).toBe(2);
-    expect(result.weeks).toHaveLength(1);
-    expect(result.weeks[0].signups).toBe(2);
-    expect(result.weeks[0].rate).toBe(50);
+describe("rollUpDaily", () => {
+  it("groups by NYC day and rounds rate to one decimal", () => {
+    const day = "2026-08-20T15:00:00.000Z";
+    const daily = rollUpDaily([
+      { signupAt: day, activated: true },
+      { signupAt: day, activated: true },
+      { signupAt: day, activated: false },
+    ]);
+    expect(daily).toEqual([
+      { date: "2026-08-20", signups: 3, activated: 2, rate: 66.7 },
+    ]);
   });
 });


### PR DESCRIPTION
## Why

Nik redefined macOS activation: **2+ chat questions within the first 48 hours** (was: >=1 Firestore conversation within 7 days). Also adds the daily activation-rate chart he asked for.

## What

- `/api/omi/stats/activation` recomputed from PostHog: cohort = first-seen macOS actors (matured >= 48h), activated = >=2 `Chat Message Sent` within 48h of first-seen. Response keeps `rate`/`weeks[]` (existing tile + weekly chart keep working) and adds `daily[]`.
- Boards: updated tile/chart descriptions to the new definition; new **"Activation rate — daily"** panel on All + macOS; the mobile board's daily panel charts viral-metrics' own `activationDaily` (its Memory-Created definition, honestly labeled).
- Cache key bumped (`activation:v2:macos-2q48h`) so stale Firestore-definition payloads never serve.

## Verification

- vitest 207/207 (route contract: threshold, maturity fence, query definition pinned, NYC daily rollup); `test_build_dashboards.py` 23/23.
- Live against prod PostHog through the real route (local admin + real admin token): **rate 23.4% (364/1556 matured signups, 60d)**, daily tail 36-39% — consistent with the 24.4%/14d ad-hoc query that motivated the change.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

