### PR TITLE
fix: activation questions include push-to-talk, not just typed chat

### DIFF
--- a/web/admin/app/api/omi/stats/activation/route.ts
+++ b/web/admin/app/api/omi/stats/activation/route.ts
@@ -13,10 +13,12 @@ export const dynamic = "force-dynamic";
 export const maxDuration = 3600;
 
 // Activation (Nik, 2026-08-28): a macOS signup counts as activated when they
-// ask 2+ chat questions within their first 48 hours. Signup = first-seen
+// ask 2+ questions within their first 48 hours. Signup = first-seen
 // macOS actor in PostHog (the same person-deduped anchor every other board
-// cohort uses); question = the `Chat Message Sent` event every main-window
-// chat surface funnels through. Signups younger than the 48h window are not
+// cohort uses); question = typed chat (`Chat Message Sent`, every main-window
+// chat surface) PLUS floating-bar/push-to-talk queries
+// (`floating_bar_query_sent`) — PTT is ~a third of question volume and must
+// count (Nik, 2026-09-01). Signups younger than the 48h window are not
 // yet matured and are excluded so the rate is never depressed by users whose
 // window is still open. Replaces the older Firestore definition (>=1
 // conversation within 7 days).
@@ -24,7 +26,7 @@ export const ACTIVATION_QUESTIONS = 2;
 export const ACTIVATION_WINDOW_HOURS = 48;
 
 export function activationCacheKey(days: number): string {
-  return `activation:v2:macos-2q48h:${days}`;
+  return `activation:v3:macos-2q48h-ptt:${days}`;
 }
 
 export type ActivationDailyPoint = {
@@ -93,7 +95,7 @@ export async function computeActivation(
       )
       SELECT toString(any(f.first_ts)) AS first_ts,
              countIf(
-               e.event = 'Chat Message Sent'
+               e.event IN ('Chat Message Sent', 'floating_bar_query_sent')
                AND e.timestamp >= f.first_ts
                AND e.timestamp <= f.first_ts + INTERVAL ${ACTIVATION_WINDOW_HOURS} HOUR
              ) AS questions

--- a/web/admin/app/api/omi/stats/activation/route.ts
+++ b/web/admin/app/api/omi/stats/activation/route.ts
@@ -18,7 +18,10 @@ export const maxDuration = 3600;
 // cohort uses); question = typed chat (`Chat Message Sent`, every main-window
 // chat surface) PLUS floating-bar/push-to-talk queries
 // (`floating_bar_query_sent`) — PTT is ~a third of question volume and must
-// count (Nik, 2026-09-01). Signups younger than the 48h window are not
+// count (Nik, 2026-09-01). Only questions asked AFTER `Onboarding Completed`
+// count: the onboarding chat itself sends questions, and finishing onboarding
+// is part of being activated — a user who never completed it is not
+// activated regardless of onboarding-chat activity (Nik, 2026-09-01). Signups younger than the 48h window are not
 // yet matured and are excluded so the rate is never depressed by users whose
 // window is still open. Replaces the older Firestore definition (>=1
 // conversation within 7 days).
@@ -26,7 +29,7 @@ export const ACTIVATION_QUESTIONS = 2;
 export const ACTIVATION_WINDOW_HOURS = 48;
 
 export function activationCacheKey(days: number): string {
-  return `activation:v3:macos-2q48h-ptt:${days}`;
+  return `activation:v4:macos-2q48h-ptt-postonb:${days}`;
 }
 
 export type ActivationDailyPoint = {
@@ -92,14 +95,24 @@ export async function computeActivation(
         GROUP BY actor
         HAVING first_ts >= now() - INTERVAL ${days} DAY
           AND first_ts <= now() - INTERVAL ${ACTIVATION_WINDOW_HOURS} HOUR
+      ),
+      onboarded AS (
+        SELECT COALESCE(person_id, distinct_id) AS actor, min(timestamp) AS onb_ts
+        FROM events
+        WHERE event = 'Onboarding Completed' AND properties.$os_name = 'macOS'
+          AND timestamp >= now() - INTERVAL ${days + 2} DAY
+        GROUP BY actor
       )
       SELECT toString(any(f.first_ts)) AS first_ts,
              countIf(
                e.event IN ('Chat Message Sent', 'floating_bar_query_sent')
+               AND o.onb_ts > toDateTime(0)
+               AND e.timestamp >= o.onb_ts
                AND e.timestamp >= f.first_ts
                AND e.timestamp <= f.first_ts + INTERVAL ${ACTIVATION_WINDOW_HOURS} HOUR
              ) AS questions
       FROM firsts f
+      LEFT JOIN onboarded o ON o.actor = f.actor
       LEFT JOIN events e
         ON COALESCE(e.person_id, e.distinct_id) = f.actor
         AND e.timestamp >= now() - INTERVAL ${days + 2} DAY

--- a/web/admin/grafana/build_dashboards.py
+++ b/web/admin/grafana/build_dashboards.py
@@ -475,7 +475,7 @@ def build_platform_board(base, scope: str) -> dict:
         # context makes the All board's "macOS only" marker redundant here.
         panel_by_title(dash, "Activation")["description"] = (
             "% of first-seen macOS users who asked 2+ questions (typed chat or "
-            "push-to-talk) within their "
+            "push-to-talk) after completing onboarding, within their "
             "first 48 hours (PostHog; matured signups only). The aha moment — "
             "biggest controllable lever, first-5-minutes work."
         )

--- a/web/admin/grafana/build_dashboards.py
+++ b/web/admin/grafana/build_dashboards.py
@@ -474,7 +474,8 @@ def build_platform_board(base, scope: str) -> dict:
         # The stat tile is already platform-neutral ("Activation"); board
         # context makes the All board's "macOS only" marker redundant here.
         panel_by_title(dash, "Activation")["description"] = (
-            "% of first-seen macOS users who asked 2+ chat questions within their "
+            "% of first-seen macOS users who asked 2+ questions (typed chat or "
+            "push-to-talk) within their "
             "first 48 hours (PostHog; matured signups only). The aha moment — "
             "biggest controllable lever, first-5-minutes work."
         )

--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -322,7 +322,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "% of first-seen macOS users who asked 2+ chat questions within their first 48 hours (PostHog; matured signups only). The aha moment \u2014 biggest controllable lever, first-5-minutes work.",
+      "description": "% of first-seen macOS users who asked 2+ questions (typed chat or push-to-talk) within their first 48 hours (PostHog; matured signups only). The aha moment \u2014 biggest controllable lever, first-5-minutes work.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4310,7 +4310,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Daily activation rate: % of that day's first-seen macOS users who asked 2+ questions within 48h. Only matured days (older than 48h) appear.",
+      "description": "Daily activation rate: % of that day's first-seen macOS users who asked 2+ questions (typed or PTT) within 48h. Only matured days (older than 48h) appear.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -322,7 +322,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "% of first-seen macOS users who asked 2+ questions (typed chat or push-to-talk) within their first 48 hours (PostHog; matured signups only). The aha moment \u2014 biggest controllable lever, first-5-minutes work.",
+      "description": "% of first-seen macOS users who asked 2+ questions (typed chat or push-to-talk) after completing onboarding, within their first 48 hours (PostHog; matured signups only). The aha moment \u2014 biggest controllable lever, first-5-minutes work.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4310,7 +4310,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Daily activation rate: % of that day's first-seen macOS users who asked 2+ questions (typed or PTT) within 48h. Only matured days (older than 48h) appear.",
+      "description": "Daily activation rate: % of that day's first-seen macOS users who asked 2+ questions (typed or PTT) after onboarding, within 48h. Only matured days (older than 48h) appear.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/web/admin/grafana/dashboards/omi-tv.json
+++ b/web/admin/grafana/dashboards/omi-tv.json
@@ -405,7 +405,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "% of first-seen macOS users (macOS only) who asked 2+ questions (typed chat or push-to-talk) within their first 48 hours (PostHog; matured signups only). The aha moment \u2014 first-5-minutes work.",
+      "description": "% of first-seen macOS users (macOS only) who asked 2+ questions (typed chat or push-to-talk) after completing onboarding, within their first 48 hours (PostHog; matured signups only). The aha moment \u2014 first-5-minutes work.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -5711,7 +5711,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Daily activation rate: % of that day's first-seen macOS users who asked 2+ questions (typed or PTT) within 48h. Only matured days (older than 48h) appear.",
+      "description": "Daily activation rate: % of that day's first-seen macOS users who asked 2+ questions (typed or PTT) after onboarding, within 48h. Only matured days (older than 48h) appear.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/web/admin/grafana/dashboards/omi-tv.json
+++ b/web/admin/grafana/dashboards/omi-tv.json
@@ -405,7 +405,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "% of first-seen macOS users (macOS only) who asked 2+ chat questions within their first 48 hours (PostHog; matured signups only). The aha moment \u2014 first-5-minutes work.",
+      "description": "% of first-seen macOS users (macOS only) who asked 2+ questions (typed chat or push-to-talk) within their first 48 hours (PostHog; matured signups only). The aha moment \u2014 first-5-minutes work.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -5711,7 +5711,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Daily activation rate: % of that day's first-seen macOS users who asked 2+ questions within 48h. Only matured days (older than 48h) appear.",
+      "description": "Daily activation rate: % of that day's first-seen macOS users who asked 2+ questions (typed or PTT) within 48h. Only matured days (older than 48h) appear.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/web/admin/lib/__tests__/activation-route.test.ts
+++ b/web/admin/lib/__tests__/activation-route.test.ts
@@ -74,7 +74,9 @@ describe("computeActivation (2+ questions within 48h)", () => {
     expect(query).toContain(
       `first_ts <= now() - INTERVAL ${ACTIVATION_WINDOW_HOURS} HOUR`,
     );
-    expect(query).toContain("Chat Message Sent");
+    // Questions = typed chat AND floating-bar/PTT queries — counting only
+    // one of them undercounts activation by ~a third (user-reported).
+    expect(query).toContain("'Chat Message Sent', 'floating_bar_query_sent'");
     expect(query).toContain(
       `f.first_ts + INTERVAL ${ACTIVATION_WINDOW_HOURS} HOUR`,
     );

--- a/web/admin/lib/__tests__/activation-route.test.ts
+++ b/web/admin/lib/__tests__/activation-route.test.ts
@@ -77,6 +77,12 @@ describe("computeActivation (2+ questions within 48h)", () => {
     // Questions = typed chat AND floating-bar/PTT queries — counting only
     // one of them undercounts activation by ~a third (user-reported).
     expect(query).toContain("'Chat Message Sent', 'floating_bar_query_sent'");
+    // Only post-onboarding questions count; a user who never completed
+    // onboarding cannot activate (onboarding-chat questions are not product
+    // usage).
+    expect(query).toContain("Onboarding Completed");
+    expect(query).toContain("e.timestamp >= o.onb_ts");
+    expect(query).toContain("o.onb_ts > toDateTime(0)");
     expect(query).toContain(
       `f.first_ts + INTERVAL ${ACTIVATION_WINDOW_HOURS} HOUR`,
     );


### PR DESCRIPTION
Two refinements to the 2-questions-in-48h activation definition (both user-requested):

1. **Questions = typed chat + push-to-talk**: counting only `Chat Message Sent` missed `floating_bar_query_sent` (~a third of macOS question volume; 7d: 1241 typed vs 723 PTT/bar).
2. **Only post-onboarding questions count**: the onboarding chat itself sends questions; activation counts questions after `Onboarding Completed`, and a user who never completed onboarding cannot activate (74.4% of the matured 60d cohort has the event). 

Cache key bumped to v4 so older-definition payloads never serve.

## Verification
vitest 4/4 pins the two-event set + the onboarding fence in the query; test_build_dashboards 23/23; admin-deploy-scope contract OK. Live through the real route against prod PostHog: **30.5%** (474/1556 matured signups, 60d) — vs 36.2% without the onboarding fence and 23.4% chat-only.

Failure-Class: none