### PR TITLE
feat(desktop): first-use popup previews return to the drawn pages, site name larger

### DIFF
--- a/desktop/macos/Desktop/Sources/Onboarding/FirstUseCasePreview.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/FirstUseCasePreview.swift
@@ -1,4 +1,3 @@
-import AppKit
 import OmiTheme
 import SwiftUI
 
@@ -14,6 +13,7 @@ struct FirstUseCasePreview: View {
 
   private let block = Ink.primary.opacity(0.10)
   private let blockStrong = Ink.primary.opacity(0.22)
+  private let line = Ink.primary.opacity(0.16)
 
   var body: some View {
     ZStack(alignment: .bottom) {
@@ -50,11 +50,11 @@ struct FirstUseCasePreview: View {
           }
         }
         Spacer(minLength: OmiSpacing.sm)
-        Text(useCase.siteName.lowercased())
-          .font(.system(size: 10, weight: .medium, design: .rounded))
-          .foregroundColor(Ink.secondary)
-          .padding(.horizontal, OmiSpacing.md)
-          .padding(.vertical, 3)
+        Text(useCase.siteName)
+          .font(.system(size: 15, weight: .semibold, design: .rounded))
+          .foregroundColor(Ink.primary)
+          .padding(.horizontal, OmiSpacing.lg)
+          .padding(.vertical, 5)
           .background(Capsule().fill(block))
         Spacer(minLength: OmiSpacing.sm)
         Color.clear.frame(width: 34, height: 8)
@@ -64,13 +64,16 @@ struct FirstUseCasePreview: View {
 
       Rectangle().fill(Ink.separator).frame(height: 1)
 
-      // One big monochrome brand mark: the place, at a glance, in the panel's own ink.
-      GeometryReader { proxy in
-        let side = min(proxy.size.width, proxy.size.height) * 0.56
-        BrandMark(useCase: useCase)
-          .frame(width: side, height: side)
-          .position(x: proxy.size.width / 2, y: proxy.size.height / 2 - side * 0.08)
+      Group {
+        switch useCase.id {
+        case FirstUseCase.game.id: minecraftPage
+        case FirstUseCase.design.id: figmaPage
+        case FirstUseCase.post.id: composePage
+        default: shopPage
+        }
       }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .padding(OmiSpacing.md)
     }
     .background(
       RoundedRectangle(cornerRadius: 12, style: .continuous)
@@ -108,90 +111,51 @@ struct FirstUseCasePreview: View {
     .id(useCase.id)
     .transition(.opacity.combined(with: .move(edge: .bottom)))
   }
-}
 
-// MARK: - Brand marks
+  // MARK: - Page sketches
 
-/// The four marks, drawn in `Ink.primary` so they sit on the glass like the rest of the type and
-/// never carry a brand colour the panel has to answer for. Each is the shape people recognise
-/// from the icon alone: Figma's five tiles, the X, the creeper, the amazon smile.
-struct BrandMark: View {
-  let useCase: FirstUseCase
+  /// Minecraft, unmistakably: a square sun in a blue sky, a grass-and-dirt hill, an oak tree, a
+  /// creeper, and the hotbar. The one sketch that uses real colour, because the colours are the
+  /// recognition — a neutral voxel field reads as any block game.
+  private enum Voxel: Int {
+    case sky = 0
+    case grass = 1
+    case dirt = 2
+    case stone = 3
+    case leaves = 4
+    case wood = 5
+    case sun = 6
+    case cloud = 7
+  }
 
-  var body: some View {
-    switch useCase.id {
-    case FirstUseCase.design.id: FigmaMark()
-    case FirstUseCase.post.id: XMark()
-    case FirstUseCase.game.id: CreeperMark()
-    default: AmazonMark()
+  private static let world: [[Int]] = [
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 6],
+    [0, 7, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 6],
+    [0, 0, 0, 0, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [1, 1, 1, 1, 1, 5, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1],
+    [2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 2, 2, 2],
+    [2, 2, 3, 2, 2, 2, 3, 3, 2, 2, 2, 2, 2, 2, 3, 2],
+    [3, 3, 3, 3, 2, 3, 3, 3, 3, 3, 2, 3, 3, 3, 3, 3],
+  ]
+
+  private func voxelFill(_ raw: Int) -> Color {
+    switch Voxel(rawValue: raw) ?? .sky {
+    case .sky: return Color(red: 0.55, green: 0.75, blue: 0.98)
+    case .cloud: return Color.white.opacity(0.9)
+    case .grass: return Color(red: 0.36, green: 0.68, blue: 0.24)
+    case .dirt: return Color(red: 0.55, green: 0.36, blue: 0.20)
+    case .stone: return Color(red: 0.50, green: 0.50, blue: 0.50)
+    case .leaves: return Color(red: 0.22, green: 0.50, blue: 0.16)
+    case .wood: return Color(red: 0.42, green: 0.27, blue: 0.13)
+    case .sun: return Color(red: 0.99, green: 0.90, blue: 0.40)
     }
   }
-}
 
-/// Figma: a 2×3 grid of tiles; top row two half-pills, middle a half-pill and a circle, bottom a
-/// pill rounded on three corners.
-struct FigmaMark: View {
-  var body: some View {
-    GeometryReader { proxy in
-      let unit = min(proxy.size.width / 2, proxy.size.height / 3)
-      let gap = unit * 0.06
-      let tile = unit - gap
-      let x0 = (proxy.size.width - unit * 2) / 2
-      let y0 = (proxy.size.height - unit * 3) / 2
-      let r = tile / 2
-      ZStack(alignment: .topLeading) {
-        UnevenRoundedRectangle(cornerRadii: .init(topLeading: r, bottomLeading: r), style: .continuous)
-          .frame(width: tile, height: tile).offset(x: x0, y: y0)
-        UnevenRoundedRectangle(cornerRadii: .init(bottomTrailing: r, topTrailing: r), style: .continuous)
-          .frame(width: tile, height: tile).offset(x: x0 + unit, y: y0)
-        UnevenRoundedRectangle(cornerRadii: .init(topLeading: r, bottomLeading: r), style: .continuous)
-          .frame(width: tile, height: tile).offset(x: x0, y: y0 + unit)
-        Circle()
-          .frame(width: tile, height: tile).offset(x: x0 + unit, y: y0 + unit)
-        UnevenRoundedRectangle(
-          cornerRadii: .init(topLeading: r, bottomLeading: r, bottomTrailing: r), style: .continuous
-        )
-        .frame(width: tile, height: tile).offset(x: x0, y: y0 + unit * 2)
-      }
-      .foregroundColor(Ink.primary)
-    }
-  }
-}
-
-/// X: one heavy stroke corner to corner, a lighter one crossing it with the gap the mark is
-/// known for.
-struct XMark: View {
-  var body: some View {
-    GeometryReader { proxy in
-      let w = proxy.size.width
-      let h = proxy.size.height
-      Path { p in
-        // Heavy stroke: top-left → bottom-right.
-        p.move(to: CGPoint(x: w * 0.06, y: 0))
-        p.addLine(to: CGPoint(x: w * 0.30, y: 0))
-        p.addLine(to: CGPoint(x: w * 0.94, y: h))
-        p.addLine(to: CGPoint(x: w * 0.70, y: h))
-        p.closeSubpath()
-        // Light stroke: top-right → bottom-left, broken by the heavy one.
-        p.move(to: CGPoint(x: w * 0.80, y: 0))
-        p.addLine(to: CGPoint(x: w * 0.94, y: 0))
-        p.addLine(to: CGPoint(x: w * 0.56, y: h * 0.44))
-        p.addLine(to: CGPoint(x: w * 0.49, y: h * 0.36))
-        p.closeSubpath()
-        p.move(to: CGPoint(x: w * 0.44, y: h * 0.56))
-        p.addLine(to: CGPoint(x: w * 0.51, y: h * 0.64))
-        p.addLine(to: CGPoint(x: w * 0.20, y: h))
-        p.addLine(to: CGPoint(x: w * 0.06, y: h))
-        p.closeSubpath()
-      }
-      .fill(Ink.primary)
-    }
-  }
-}
-
-/// The creeper face on an 8×8 grid.
-struct CreeperMark: View {
-  private static let face: [[Int]] = [
+  /// The creeper face: 8×8, 1 = black.
+  private static let creeper: [[Int]] = [
+    [0, 0, 0, 0, 0, 0, 0, 0],
     [0, 0, 0, 0, 0, 0, 0, 0],
     [0, 1, 1, 0, 0, 1, 1, 0],
     [0, 1, 1, 0, 0, 1, 1, 0],
@@ -199,55 +163,193 @@ struct CreeperMark: View {
     [0, 0, 1, 1, 1, 1, 0, 0],
     [0, 0, 1, 1, 1, 1, 0, 0],
     [0, 0, 1, 0, 0, 1, 0, 0],
-    [0, 0, 0, 0, 0, 0, 0, 0],
   ]
 
-  var body: some View {
+  private var creeperFace: some View {
     VStack(spacing: 0) {
-      ForEach(Array(Self.face.enumerated()), id: \.offset) { _, row in
+      ForEach(Array(Self.creeper.enumerated()), id: \.offset) { _, row in
         HStack(spacing: 0) {
           ForEach(Array(row.enumerated()), id: \.offset) { _, on in
-            Rectangle().fill(on == 1 ? Ink.primary : Ink.primary.opacity(0.12))
+            Rectangle().fill(on == 1 ? Color.black.opacity(0.9) : Color(red: 0.36, green: 0.72, blue: 0.28))
           }
         }
       }
     }
     .aspectRatio(1, contentMode: .fit)
-    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
   }
-}
 
-/// amazon: the lowercase wordmark with the smile from a to z.
-struct AmazonMark: View {
-  var body: some View {
-    GeometryReader { proxy in
-      let w = proxy.size.width
-      VStack(spacing: w * 0.02) {
-        Text("amazon")
-          .font(.system(size: w * 0.24, weight: .bold, design: .rounded))
-          .tracking(-w * 0.012)
-          .lineLimit(1)
-          .fixedSize()
-          .foregroundColor(Ink.primary)
-        Path { p in
-          p.move(to: CGPoint(x: w * 0.06, y: 0))
-          p.addQuadCurve(to: CGPoint(x: w * 0.80, y: 0), control: CGPoint(x: w * 0.43, y: w * 0.22))
-        }
-        .stroke(Ink.primary, style: StrokeStyle(lineWidth: w * 0.05, lineCap: .round))
-        .frame(height: w * 0.12)
-        .overlay(alignment: .topTrailing) {
-          Path { p in
-            p.move(to: CGPoint(x: 0, y: -w * 0.05))
-            p.addLine(to: CGPoint(x: w * 0.09, y: 0))
-            p.addLine(to: CGPoint(x: -w * 0.01, y: w * 0.05))
+  private var minecraftPage: some View {
+    VStack(spacing: OmiSpacing.sm) {
+      GeometryReader { proxy in
+        let cell = proxy.size.width / CGFloat(Self.world[0].count)
+        ZStack(alignment: .topLeading) {
+          VStack(spacing: 0) {
+            ForEach(Array(Self.world.enumerated()), id: \.offset) { _, row in
+              HStack(spacing: 0) {
+                ForEach(Array(row.enumerated()), id: \.offset) { _, raw in
+                  Rectangle().fill(voxelFill(raw)).frame(height: cell)
+                }
+              }
+            }
           }
-          .stroke(Ink.primary, style: StrokeStyle(lineWidth: w * 0.05, lineCap: .round, lineJoin: .round))
-          .frame(width: w * 0.09, height: w * 0.1)
-          .offset(x: -w * 0.12, y: w * 0.0)
+          // The creeper stands on the low ground, two blocks tall.
+          creeperFace
+            .frame(width: cell * 1.6, height: cell * 1.6)
+            .offset(x: cell * 10.2, y: cell * 4.4)
+          Rectangle()
+            .fill(Color(red: 0.36, green: 0.72, blue: 0.28))
+            .frame(width: cell * 1.2, height: cell * 1.2)
+            .offset(x: cell * 10.4, y: cell * 5.9)
+          // Crosshair.
+          Image(systemName: "plus")
+            .font(.system(size: 12, weight: .regular))
+            .foregroundColor(.white.opacity(0.9))
+            .position(x: proxy.size.width / 2, y: cell * 4.5)
         }
       }
-      .frame(width: w)
-      .position(x: w / 2, y: proxy.size.height / 2)
+      .aspectRatio(16.0 / 9.0, contentMode: .fit)
+      .clipped()
+      .overlay(Rectangle().stroke(line, lineWidth: 1))
+
+      HStack(spacing: 2) {
+        ForEach(0..<9, id: \.self) { slot in
+          RoundedRectangle(cornerRadius: 2)
+            .fill(Color.black.opacity(0.55))
+            .overlay(
+              RoundedRectangle(cornerRadius: 2)
+                .stroke(slot == 0 ? Color.white : Color.white.opacity(0.35), lineWidth: slot == 0 ? 1.5 : 1)
+            )
+            .overlay(
+              Group {
+                switch slot {
+                case 0: RoundedRectangle(cornerRadius: 1).fill(voxelFill(Voxel.grass.rawValue)).padding(4)
+                case 1: RoundedRectangle(cornerRadius: 1).fill(voxelFill(Voxel.wood.rawValue)).padding(4)
+                case 2: RoundedRectangle(cornerRadius: 1).fill(voxelFill(Voxel.stone.rawValue)).padding(4)
+                default: EmptyView()
+                }
+              }
+            )
+            .aspectRatio(1, contentMode: .fit)
+        }
+      }
+      .frame(maxWidth: 200)
     }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  private var figmaPage: some View {
+    HStack(spacing: OmiSpacing.sm) {
+      VStack(alignment: .leading, spacing: OmiSpacing.xs) {
+        ForEach(0..<7, id: \.self) { index in
+          sketchLine(width: index == 0 ? 36 : (index.isMultiple(of: 3) ? 30 : 42))
+        }
+        Spacer(minLength: 0)
+      }
+      .frame(width: 52)
+
+      ZStack {
+        RoundedRectangle(cornerRadius: 4, style: .continuous).fill(block)
+        HStack(alignment: .top, spacing: OmiSpacing.md) {
+          VStack(spacing: OmiSpacing.xs) {
+            RoundedRectangle(cornerRadius: 3).fill(Ink.surface).frame(height: 18)
+            RoundedRectangle(cornerRadius: 3).fill(blockStrong).frame(height: 36)
+            RoundedRectangle(cornerRadius: 3).fill(Ink.surface).frame(height: 10)
+            RoundedRectangle(cornerRadius: 3).fill(Ink.surface).frame(height: 10)
+          }
+          .padding(OmiSpacing.xs)
+          .frame(width: 58)
+          .background(RoundedRectangle(cornerRadius: 6).fill(Ink.surface.opacity(0.7)))
+          .overlay(RoundedRectangle(cornerRadius: 6).stroke(Ink.accent, lineWidth: 1))
+
+          VStack(alignment: .leading, spacing: OmiSpacing.xs) {
+            RoundedRectangle(cornerRadius: 3).fill(blockStrong).frame(width: 60, height: 8)
+            RoundedRectangle(cornerRadius: 3).fill(Ink.surface).frame(height: 44)
+            Capsule().fill(Ink.primary.opacity(0.85)).frame(width: 40, height: 10)
+          }
+          .padding(OmiSpacing.xs)
+          .frame(maxWidth: .infinity)
+          .background(RoundedRectangle(cornerRadius: 6).fill(Ink.surface.opacity(0.7)))
+        }
+        .padding(OmiSpacing.md)
+      }
+
+      VStack(alignment: .leading, spacing: OmiSpacing.xs) {
+        ForEach(0..<6, id: \.self) { index in
+          HStack(spacing: OmiSpacing.xs) {
+            RoundedRectangle(cornerRadius: 2).fill(index == 2 ? Ink.accent : blockStrong)
+              .frame(width: 8, height: 8)
+            sketchLine(width: 30)
+          }
+        }
+        Spacer(minLength: 0)
+      }
+      .frame(width: 48)
+    }
+  }
+
+  private var composePage: some View {
+    VStack(alignment: .leading, spacing: OmiSpacing.md) {
+      HStack(alignment: .top, spacing: OmiSpacing.sm) {
+        Circle().fill(blockStrong).frame(width: 26, height: 26)
+        Text("What's happening?")
+          .font(.system(size: 15))
+          .foregroundColor(Ink.secondary)
+          .padding(.top, 3)
+        Spacer(minLength: 0)
+      }
+      Spacer(minLength: 0)
+      Rectangle().fill(Ink.separator).frame(height: 1)
+      HStack(spacing: OmiSpacing.md) {
+        ForEach(["photo", "chart.bar", "face.smiling", "calendar"], id: \.self) { symbol in
+          Image(systemName: symbol)
+            .font(.system(size: 12, weight: .medium))
+            .foregroundColor(Ink.accent)
+        }
+        Spacer(minLength: 0)
+        Text("Post")
+          .font(.system(size: 11, weight: .bold))
+          .foregroundColor(Ink.surface)
+          .padding(.horizontal, OmiSpacing.md)
+          .padding(.vertical, 5)
+          .background(Capsule().fill(Ink.primary.opacity(0.85)))
+      }
+    }
+  }
+
+  private var shopPage: some View {
+    VStack(spacing: OmiSpacing.sm) {
+      HStack(spacing: OmiSpacing.xs) {
+        RoundedRectangle(cornerRadius: 4).fill(block).frame(height: 16)
+        Image(systemName: "magnifyingglass")
+          .font(.system(size: 10, weight: .bold))
+          .foregroundColor(Ink.surface)
+          .frame(width: 22, height: 16)
+          .background(RoundedRectangle(cornerRadius: 4).fill(Ink.primary.opacity(0.85)))
+      }
+      LazyVGrid(
+        columns: [GridItem(.flexible(), spacing: OmiSpacing.sm), GridItem(.flexible(), spacing: OmiSpacing.sm)],
+        spacing: OmiSpacing.sm
+      ) {
+        ForEach(0..<4, id: \.self) { index in
+          VStack(alignment: .leading, spacing: 3) {
+            RoundedRectangle(cornerRadius: 3).fill(index == 1 ? blockStrong : block).frame(height: 26)
+            sketchLine(width: index.isMultiple(of: 2) ? 40 : 30)
+            Text("★★★★☆")
+              .font(.system(size: 7))
+              .foregroundColor(Ink.primary.opacity(0.7))
+            sketchLine(width: 18, strong: true)
+          }
+          .padding(OmiSpacing.xs)
+          .background(RoundedRectangle(cornerRadius: 5).stroke(Ink.separator, lineWidth: 1))
+        }
+      }
+      Spacer(minLength: 0)
+    }
+  }
+
+  private func sketchLine(width: CGFloat, strong: Bool = false) -> some View {
+    RoundedRectangle(cornerRadius: 2, style: .continuous)
+      .fill(strong ? blockStrong : block)
+      .frame(width: width, height: 5)
   }
 }

--- a/desktop/macos/changelog/unreleased/20260902-first-use-brand-marks.json
+++ b/desktop/macos/changelog/unreleased/20260902-first-use-brand-marks.json
@@ -1,3 +1,0 @@
-{
-  "change": "The first-use popup now shows each site as a big brand mark (Figma, X, Minecraft, Amazon) instead of a screenshot"
-}

--- a/desktop/macos/changelog/unreleased/20260902-first-use-sketches-back.json
+++ b/desktop/macos/changelog/unreleased/20260902-first-use-sketches-back.json
@@ -1,0 +1,3 @@
+{
+  "change": "The first-use popup previews are back to the drawn pages, with the site name larger at the top"
+}


### PR DESCRIPTION
## What

Reverts the first-use popup preview pane to the original drawn pages (as shipped in 0.12.261), undoing the site screenshots (#12596) and the brand marks (#12600), and makes the site name at the top of the mock larger (15pt semibold, proper case).

## Verification

`omi-first-use` named bundle: raised the popup over the bridge, selected the cases, captured the window — drawn pages with the larger name.

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

