### PR TITLE
fix(app): give chat message actions a finger-sized hit area

### DIFF
--- a/app/lib/pages/chat/widgets/ai_message.dart
+++ b/app/lib/pages/chat/widgets/ai_message.dart
@@ -1235,7 +1235,7 @@ class _MessageActionBarState extends State<MessageActionBar> {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(top: 8, left: 4),
+      padding: const EdgeInsets.only(left: 4),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -1268,7 +1268,6 @@ class _MessageActionBarState extends State<MessageActionBar> {
               }
             },
           ),
-          const SizedBox(width: 20),
           // Thumbs up button
           _buildActionButton(
             icon: _selectedNps == 1 ? FontAwesomeIcons.solidThumbsUp : FontAwesomeIcons.thumbsUp,
@@ -1281,7 +1280,6 @@ class _MessageActionBarState extends State<MessageActionBar> {
               widget.setMessageNps?.call(_selectedNps ?? 0);
             },
           ),
-          const SizedBox(width: 20),
           // Thumbs down button
           _buildActionButton(
             icon: _selectedNps == -1 ? FontAwesomeIcons.solidThumbsDown : FontAwesomeIcons.thumbsDown,
@@ -1300,7 +1298,6 @@ class _MessageActionBarState extends State<MessageActionBar> {
               }
             },
           ),
-          const SizedBox(width: 20),
           // Share button
           _buildActionButton(
             icon: FontAwesomeIcons.share,
@@ -1325,13 +1322,19 @@ class _MessageActionBarState extends State<MessageActionBar> {
   }
 
   Widget _buildActionButton({required FaIconData icon, required VoidCallback onTap, bool isSelected = false}) {
+    // The 14pt glyph alone is far below the 44pt tap minimum; pad the hit area
+    // (34x38) so finger taps on copy/share actually land. Visual pitch is kept
+    // by dropping the 20pt gaps between buttons in favour of this padding.
     return InkWell(
       splashColor: Colors.transparent,
       focusColor: Colors.transparent,
       hoverColor: Colors.transparent,
       highlightColor: Colors.transparent,
       onTap: onTap,
-      child: FaIcon(icon, color: isSelected ? Colors.white : Colors.grey.shade600, size: 14),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 12),
+        child: FaIcon(icon, color: isSelected ? Colors.white : Colors.grey.shade600, size: 14),
+      ),
     );
   }
 }


### PR DESCRIPTION
The copy / like / dislike / share actions under AI chat messages were bare 14pt `InkWell`s — a finger tap that lands a few points off the glyph does nothing, which is why they read as "share doesn't work" and "copy is hard to click / broken" on TestFlight. The handlers themselves are fine (a dead-center tap opens the share sheet and copies the text).

Fix: pad each action's hit area to 34×38pt. The 20pt inter-button gaps become the padding, so the glyph positions and row look are unchanged.

Verified on an iPhone 16 simulator: taps 4-5pt off the glyph now open the iOS share sheet and copy the message to the clipboard (read back with `simctl pbpaste`); dead-center taps still work. Before/after hit boxes measured from the widget tree: 14×14 → 34×38.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

