### PR TITLE
Onboarding: demote the permission "Skip for now" to a text link

### DIFF
--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -513,39 +513,8 @@ struct SBOnboardingView: View {
     .frame(maxWidth: 380, alignment: .leading)
   }
 
-  /// A hit target no smaller than this, whatever the type is set at. `statusLabel` is 12 pt, and 12 pt
-  /// of glyph is not a control — the padding is what keeps the de-emphasis a *visual* one rather than
-  /// a usability tax on the person who genuinely wants out.
-  private static let skipLinkMinHeight: CGFloat = 28
-
-  /// The one way past a permission step.
-  ///
-  /// Deliberately the quietest actionable thing on the card: `statusLabel` in `Ink.secondary` — never
-  /// `Ink.tertiary`, which measures under AA on glass and is banned on first-run surfaces — underlined
-  /// so it still reads as pressable rather than as a caption, and centred under the primary action so
-  /// it is where the eye already is. It never becomes a capsule: a capsule beside a capsule is a fork
-  /// in the road, and this is a side door.
   private func skipLink(_ title: String, action: @escaping () -> Void) -> some View {
-    HStack {
-      Spacer(minLength: 0)
-      Button(action: action) {
-        Text(title)
-          .inkStyle(InkType.statusLabel, color: Ink.secondary)
-          .underline()
-          .fixedSize(horizontal: false, vertical: true)
-          .multilineTextAlignment(.center)
-          .padding(.horizontal, 12)
-          .frame(minHeight: Self.skipLinkMinHeight)
-          // The label is the hit test, and a run of 12 pt type is a thin one. Without this the
-          // padding above is decoration: SwiftUI hit-tests what `.plain` actually renders.
-          .contentShape(Rectangle())
-      }
-      .buttonStyle(.plain)
-      .onHover { inside in
-        if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-      }
-      Spacer(minLength: 0)
-    }
+    SBSkipLink(title: title, action: action)
   }
 
   @ViewBuilder private var filesWidget: some View {
@@ -1045,6 +1014,70 @@ private struct ChipFlowLayout: Layout {
       sub.place(at: CGPoint(x: x, y: y), anchor: .topLeading, proposal: ProposedViewSize(size))
       x += size.width + spacing
       rowHeight = max(rowHeight, size.height)
+    }
+  }
+}
+
+/// The one way past a permission step.
+///
+/// Deliberately the quietest actionable thing on the card: `statusLabel` in `Ink.secondary` — never
+/// `Ink.tertiary`, which measures under AA on glass and is banned on first-run surfaces — underlined
+/// so it still reads as pressable rather than as a caption, and centred under the primary action so
+/// it is where the eye already is. It never becomes a capsule: a capsule beside a capsule is a fork
+/// in the road, and this is a side door.
+///
+/// A `View` rather than a `@ViewBuilder` method on `SBOnboardingView` for one reason: it owns
+/// `didPushCursor`, and that state has to be *per link*. Hung off the parent it would be one flag
+/// shared by every escape the flow draws.
+private struct SBSkipLink: View {
+  let title: String
+  let action: () -> Void
+
+  /// A hit target no smaller than this, whatever the type is set at. `statusLabel` is 12 pt, and 12 pt
+  /// of glyph is not a control — the padding is what keeps the de-emphasis a *visual* one rather than
+  /// a usability tax on the person who genuinely wants out.
+  static let skipLinkMinHeight: CGFloat = 28
+
+  /// `NSCursor` push/pop is a **stack**, so every push owes exactly one pop. SwiftUI does not deliver
+  /// `onHover(false)` to a view that leaves the hierarchy, and pressing this link is precisely that
+  /// case: `action()` advances the step and unmounts the card with the pointer still over it. Without
+  /// the flag the pointing-hand outlives the view and rides along over the next step's controls.
+  /// Same idiom, and the same reason, as `LiveTranscriptExpandTap`.
+  @State private var didPushCursor = false
+
+  private func setHovered(_ hovering: Bool) {
+    if hovering, !didPushCursor {
+      NSCursor.pointingHand.push()
+      didPushCursor = true
+    } else if !hovering, didPushCursor {
+      NSCursor.pop()
+      didPushCursor = false
+    }
+  }
+
+  var body: some View {
+    HStack {
+      Spacer(minLength: 0)
+      Button {
+        // Pop before the step swaps this card away; `onDisappear` is the belt to this braces.
+        setHovered(false)
+        action()
+      } label: {
+        Text(title)
+          .inkStyle(InkType.statusLabel, color: Ink.secondary)
+          .underline()
+          .fixedSize(horizontal: false, vertical: true)
+          .multilineTextAlignment(.center)
+          .padding(.horizontal, 12)
+          .frame(minHeight: Self.skipLinkMinHeight)
+          // The label is the hit test, and a run of 12 pt type is a thin one. Without this the
+          // padding above is decoration: SwiftUI hit-tests what `.plain` actually renders.
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .onHover { setHovered($0) }
+      .onDisappear { setHovered(false) }
+      Spacer(minLength: 0)
     }
   }
 }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -470,16 +470,9 @@ struct SBOnboardingView: View {
         }
         .buttonStyle(InkButtonStyle(kind: .primary))
         // The escape, with the consequence spelled out — never gate a step on something macOS cannot
-        // grant from a dialog. `secondary`, because on glass there is no fainter rung to hide it in,
-        // and an escape nobody can read is an escape nobody takes.
-        Button {
-          onContinue()
-        } label: {
-          Text("Later — \(name) stays off until you reopen")
-            .inkStyle(InkType.statusLabel, color: Ink.secondary)
-            .fixedSize(horizontal: false, vertical: true)
-        }
-        .buttonStyle(.plain)
+        // grant from a dialog. Same object as every other escape on this card: `skipLink`, so the way
+        // past a permission always looks the same and never outranks the way through it.
+        skipLink("Later — \(name) stays off until you reopen", action: onContinue)
       } else if action == .proceed {
         Button {
           onContinue()
@@ -507,20 +500,52 @@ struct SBOnboardingView: View {
             .frame(maxWidth: .infinity)
         }
         .buttonStyle(InkButtonStyle(kind: action == .recheck ? .secondary : .primary))
-        // The escape is a *control*, not a caption. As a bare `.plain` run of `statusLabel` this was
-        // an 11 pt grey line sitting 10 pt under a full-width filled pill — the shape of a footnote,
-        // on the one screen where the user most needs to know they are not trapped. `screenDemoWidget`
-        // already learned this ("it used to be a tiny, easily-missed text link") and shipped the
-        // secondary capsule; every skip in this flow is that same object now.
-        Button {
-          onContinue()
-        } label: {
-          Text("Skip for now").frame(maxWidth: .infinity)
-        }
-        .buttonStyle(InkButtonStyle(kind: .secondary))
+        // The escape is a **link, not a capsule**. Two full-width pills stacked read as a choice
+        // between equals, and this choice is not between equals: every permission on this card is
+        // something Omi cannot work without, and the skip is the exit, not the alternative. The
+        // capsule this replaces was itself a correction of a bare `.plain` caption that people
+        // missed — so the link keeps what that correction was actually buying: an underline and a
+        // pointing-hand cursor, so it still reads as pressable, and `skipLinkMinHeight` of target so
+        // it is still comfortably hittable. Faint but unmistakable, which is the whole ask.
+        skipLink("Skip for now", action: onContinue)
       }
     }
     .frame(maxWidth: 380, alignment: .leading)
+  }
+
+  /// A hit target no smaller than this, whatever the type is set at. `statusLabel` is 12 pt, and 12 pt
+  /// of glyph is not a control — the padding is what keeps the de-emphasis a *visual* one rather than
+  /// a usability tax on the person who genuinely wants out.
+  private static let skipLinkMinHeight: CGFloat = 28
+
+  /// The one way past a permission step.
+  ///
+  /// Deliberately the quietest actionable thing on the card: `statusLabel` in `Ink.secondary` — never
+  /// `Ink.tertiary`, which measures under AA on glass and is banned on first-run surfaces — underlined
+  /// so it still reads as pressable rather than as a caption, and centred under the primary action so
+  /// it is where the eye already is. It never becomes a capsule: a capsule beside a capsule is a fork
+  /// in the road, and this is a side door.
+  private func skipLink(_ title: String, action: @escaping () -> Void) -> some View {
+    HStack {
+      Spacer(minLength: 0)
+      Button(action: action) {
+        Text(title)
+          .inkStyle(InkType.statusLabel, color: Ink.secondary)
+          .underline()
+          .fixedSize(horizontal: false, vertical: true)
+          .multilineTextAlignment(.center)
+          .padding(.horizontal, 12)
+          .frame(minHeight: Self.skipLinkMinHeight)
+          // The label is the hit test, and a run of 12 pt type is a thin one. Without this the
+          // padding above is decoration: SwiftUI hit-tests what `.plain` actually renders.
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .onHover { inside in
+        if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+      }
+      Spacer(minLength: 0)
+    }
   }
 
   @ViewBuilder private var filesWidget: some View {

--- a/desktop/macos/Desktop/Tests/OnboardingGlassChromeTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingGlassChromeTests.swift
@@ -254,7 +254,83 @@ final class OnboardingGlassChromeTests: XCTestCase {
     }
   }
 
+  /// **The permission escape is a link, not a second capsule.**
+  ///
+  /// Two full-width pills stacked — "Allow Screen Recording" over "Skip for now" — is the shape of a
+  /// choice between equals, and on a permission card it is not one: the skip is the exit, not the
+  /// alternative. This asserts the rank rather than the pixels, by reading `permStepWidget`'s own body:
+  /// every branch's way-past must be the shared `skipLink`, and no branch may spend a capsule on it.
+  ///
+  /// Scoped to that one function on purpose. `InkButtonStyle(kind: .secondary)` is correct elsewhere in
+  /// this file (a retry, a re-check, the screen-demo skip, which is not a permission), so a file-wide
+  /// ban would be a rule about the wrong thing.
+  func testStaticCheckerPermissionEscapesAreLinksRatherThanASecondCapsule() throws {
+    let body = try code(Self.liveOnboardingSource)
+    let widget = try XCTUnwrap(
+      permStepWidgetBody(in: body),
+      "permStepWidget no longer parses; this checker is reading the wrong function")
+
+    XCTAssertTrue(
+      widget.contains("skipLink(\"Skip for now\", action: onContinue)"),
+      "the way past a permission must be the shared skip link")
+    XCTAssertTrue(
+      widget.contains("skipLink(\"Later —"),
+      "the reopen branch's escape must be that same object, not a bespoke run of caption type")
+    // The ask branch's own control is `InkButtonStyle(kind: action == .recheck ? .secondary : .primary)`
+    // — a different string, and a legitimate one. It is the *unconditional* secondary capsule that
+    // could only be the escape.
+    XCTAssertFalse(
+      widget.contains("InkButtonStyle(kind: .secondary)"),
+      """
+      permStepWidget spends a secondary capsule on something. The only thing on this card that is not \
+      the Allow action is the escape, and a capsule under the Allow pill reads as the equal-ranked \
+      other half of a choice rather than as the side door it is.
+      """)
+    XCTAssertEqual(
+      widget.components(separatedBy: "skipLink(").count - 1, 2,
+      "exactly two escapes — the reopen branch's and the ask branch's; a new one must join skipLink")
+  }
+
+  /// The de-emphasis is visual only. A 12 pt run of type is a 12 pt hit target unless something says
+  /// otherwise, and an escape people cannot land on is worse than a loud one.
+  func testStaticCheckerTheSkipLinkStaysAComfortableTarget() throws {
+    let body = try code(Self.liveOnboardingSource)
+    XCTAssertTrue(
+      body.contains("skipLinkMinHeight: CGFloat = 28"),
+      "the skip link must reserve a real target height, not just set small type")
+    XCTAssertTrue(
+      body.contains(".frame(minHeight: Self.skipLinkMinHeight)")
+        && body.contains(".contentShape(Rectangle())"),
+      "the reserved height must be hit-tested; a .plain button hit-tests only what it renders")
+    XCTAssertTrue(
+      body.contains(".underline()"),
+      "without the underline the link is a caption, which is the failure the capsule was fixing")
+    XCTAssertTrue(
+      body.contains("NSCursor.pointingHand.push()"),
+      "the pointer must change over the skip link so it still reads as pressable")
+  }
+
   // MARK: - Helpers
+
+  /// `permStepWidget`'s body, brace-matched from its signature. Slicing by function is what keeps the
+  /// checker above a rule about the permission card rather than about the whole file.
+  private func permStepWidgetBody(in source: String) -> String? {
+    guard let start = source.range(of: "private func permStepWidget("),
+      let open = source.range(of: "{", range: start.upperBound..<source.endIndex)
+    else { return nil }
+    var depth = 0
+    var index = open.lowerBound
+    while index < source.endIndex {
+      let character = source[index]
+      if character == "{" { depth += 1 }
+      if character == "}" {
+        depth -= 1
+        if depth == 0 { return String(source[open.upperBound..<index]) }
+      }
+      index = source.index(after: index)
+    }
+    return nil
+  }
 
   /// Source with `//` comments stripped.
   ///

--- a/desktop/macos/Desktop/Tests/OnboardingGlassChromeTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingGlassChromeTests.swift
@@ -293,29 +293,70 @@ final class OnboardingGlassChromeTests: XCTestCase {
 
   /// The de-emphasis is visual only. A 12 pt run of type is a 12 pt hit target unless something says
   /// otherwise, and an escape people cannot land on is worse than a loud one.
+  ///
+  /// Sliced to `SBSkipLink`'s own body, not the file. Scanned file-wide these tokens are all satisfied
+  /// by unrelated call sites — `.underline()` by the GitHub link in `promiseWidget`, `.contentShape`
+  /// by two disclosure rows — so a file-wide scan would stay green through exactly the regression it
+  /// names. That is the bug this test had on its first draft.
   func testStaticCheckerTheSkipLinkStaysAComfortableTarget() throws {
-    let body = try code(Self.liveOnboardingSource)
+    let source = try code(Self.liveOnboardingSource)
+    let link = try XCTUnwrap(
+      declarationBody("private struct SBSkipLink", in: source),
+      "SBSkipLink no longer parses; this checker is reading the wrong declaration")
+
     XCTAssertTrue(
-      body.contains("skipLinkMinHeight: CGFloat = 28"),
+      link.contains("skipLinkMinHeight: CGFloat = 28"),
       "the skip link must reserve a real target height, not just set small type")
     XCTAssertTrue(
-      body.contains(".frame(minHeight: Self.skipLinkMinHeight)")
-        && body.contains(".contentShape(Rectangle())"),
+      link.contains(".frame(minHeight: Self.skipLinkMinHeight)")
+        && link.contains(".contentShape(Rectangle())"),
       "the reserved height must be hit-tested; a .plain button hit-tests only what it renders")
     XCTAssertTrue(
-      body.contains(".underline()"),
+      link.contains(".underline()"),
       "without the underline the link is a caption, which is the failure the capsule was fixing")
     XCTAssertTrue(
-      body.contains("NSCursor.pointingHand.push()"),
+      link.contains("NSCursor.pointingHand.push()"),
       "the pointer must change over the skip link so it still reads as pressable")
+  }
+
+  /// **Every `NSCursor` push owes exactly one pop.**
+  ///
+  /// `push`/`pop` is a stack, and SwiftUI delivers no `onHover(false)` to a view leaving the
+  /// hierarchy — which is what pressing this link does. An unbalanced push leaves the pointing-hand
+  /// riding over the next step's controls. The guard is the `didPushCursor` flag plus both exit
+  /// paths, so this asserts all three rather than the presence of a `pop` somewhere.
+  func testStaticCheckerTheSkipLinkBalancesItsCursorPushes() throws {
+    let source = try code(Self.liveOnboardingSource)
+    let link = try XCTUnwrap(declarationBody("private struct SBSkipLink", in: source))
+
+    XCTAssertTrue(
+      link.contains("@State private var didPushCursor = false"),
+      "the link must track whether it holds a pushed cursor; an unguarded push double-pushes on rehover")
+    XCTAssertTrue(
+      link.contains("if hovering, !didPushCursor") && link.contains("else if !hovering, didPushCursor"),
+      "push and pop must both be gated on the flag, which is what makes them balanced")
+    XCTAssertTrue(
+      link.contains(".onDisappear { setHovered(false) }"),
+      "unmounting while hovered is the path that strands the cursor; onDisappear is the only hook for it")
+    XCTAssertTrue(
+      link.contains("setHovered(false)\n        action()"),
+      "the tap must pop before it advances the step, since advancing unmounts this view")
   }
 
   // MARK: - Helpers
 
-  /// `permStepWidget`'s body, brace-matched from its signature. Slicing by function is what keeps the
-  /// checker above a rule about the permission card rather than about the whole file.
+  /// `permStepWidget`'s body. See `declarationBody`.
   private func permStepWidgetBody(in source: String) -> String? {
-    guard let start = source.range(of: "private func permStepWidget("),
+    declarationBody("private func permStepWidget(", in: source)
+  }
+
+  /// The brace-matched body of the declaration introduced by `signature`.
+  ///
+  /// **Slicing is the point.** A checker for one control that scans the whole file asserts only that
+  /// the tokens exist *somewhere*, and in a 1,000-line view they always do — so it passes through the
+  /// regression it was written to catch. Both checkers above slice first for that reason.
+  private func declarationBody(_ signature: String, in source: String) -> String? {
+    guard let start = source.range(of: signature),
       let open = source.range(of: "{", range: start.upperBound..<source.endIndex)
     else { return nil }
     var depth = 0

--- a/desktop/macos/changelog/unreleased/20260902-onboarding-skip-link.json
+++ b/desktop/macos/changelog/unreleased/20260902-onboarding-skip-link.json
@@ -1,0 +1,3 @@
+{
+  "change": "Onboarding permission steps now lead with the Allow action; the way past a permission is a quieter text link beneath it rather than a second button of equal weight"
+}


### PR DESCRIPTION
## What changed and why

Every permission step in the second-brain onboarding drew its escape as a **full-width secondary capsule directly under the full-width "Allow …" pill**. Two stacked capsules is the shape of a choice between equals, and on a permission card it is not one — the microphone, system audio, Screen Recording and the rest are what Omi runs on, and the skip is the exit, not the alternative. We want the default path to be granting.

`permStepWidget` now routes both of its escapes — the ask branch's "Skip for now" and the reopen branch's "Later — X stays off until you reopen" — through one new `skipLink`: `InkType.statusLabel` in `Ink.secondary`, underlined, centred under the primary action.

Because every permission step is a `permStepWidget` call, the one change covers all seven: Microphone, System audio, Screen Recording, Accessibility, Automation, Notifications, Full Disk Access.

**The de-emphasis is visual only.** The capsule this replaces was itself a correction of a bare `.plain` caption that people missed (the comment it replaces says so), so the link keeps what that correction was actually buying:

- an `.underline()` and a pointing-hand cursor, so it still reads as pressable rather than as a footnote;
- a 28 pt `skipLinkMinHeight` with `.contentShape(Rectangle())`, because a `.plain` button hit-tests only what it renders and 12 pt of glyph is not a control.

`Ink.secondary`, never `Ink.tertiary` — glass carries two rungs and the third rung is banned on first-run surfaces by `testStaticCheckerFirstRunSurfacesNeverSetTheThirdTypeRungOnGlass`.

**Deliberately out of scope:** the screen-demo step's "Skip for now". That step is not a permission grant, so it keeps its secondary capsule; the new checker is scoped to `permStepWidget` rather than to the file for exactly that reason.

## Product invariants affected

None. `INV-UI-1` is untouched — no colour token changes, and `product/invariants/brand-ui.md` explicitly says not to cite it in routine UI PRs.

## How it was verified

Local `swift test` in a clean worktree at `origin/main`:

```
swift test --filter OnboardingGlassChromeTests
  → Executed 17 tests, with 0 failures

swift test --filter "OnboardingFlowTests|SBOnboardingNotificationsStepTests"
  → Executed 40 tests, with 0 failures
```

Gates run locally, all clean:

- `scripts/swift-format-wrapper.sh lint` on both changed files — no diagnostics
- `scripts/swiftlint-wrapper.sh lint` on `SBOnboardingView.swift` — no violations
- `scripts/check_desktop_test_quality.py` — at or below baseline
- `.github/scripts/check-desktop-changelog.py` — fragment found

A named QA bundle (`omi-skip-qa`, bundle id `com.omi.omi-skip-qa`) was built and installed from this branch for hands-on review. It launches signed-out with no TCC grants, so signing in walks the onboarding from step 0 with every permission card in its ungranted `Allow …` state — the state this PR changes. Production Omi and Omi Beta are untouched.

**Not verified by me:** the rendered result. Screen capture on the build machine is stale, and this repo's own note on desktop UI verification is that window capture drops CALayer filters and cannot see system panels — so the visual check is a human pass on that bundle, not something I am claiming here. What is asserted below is the view-tree contract, not the pixels.

**Also not verified locally:** the pinned Xcode 16.4 strict-concurrency build. This machine has only Xcode 26.6, so `scripts/run-swift-ci.sh --test` cannot select the CI toolchain. The change adds no concurrency-relevant code (one `@escaping () -> Void` view helper on an already-`@MainActor` view), but CI is the authority here.

## Tests

Two source-inspection checkers added to `OnboardingGlassChromeTests`, alongside the existing first-run static contracts:

- `testStaticCheckerPermissionEscapesAreLinksRatherThanASecondCapsule` — brace-matches `permStepWidget`'s own body and asserts both escapes go through `skipLink` and that no branch spends an unconditional secondary capsule. Scoped to that one function, since `InkButtonStyle(kind: .secondary)` stays correct elsewhere in the file (a retry, a re-check, the screen-demo skip).
- `testStaticCheckerTheSkipLinkStaysAComfortableTarget` — the underline, the pointing-hand cursor, the 28 pt reserved height, and the `contentShape` that makes that height hit-testable. This is the guard against the de-emphasis quietly becoming an unhittable caption on some later edit.

Source inspection rather than behaviour for the same reason the surrounding checkers give: which token a call site names has no runtime signal without a window server.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

