### PR TITLE
fix(app): anchor the remaining share sheet calls

### DIFF
--- a/app/lib/pages/action_items/widgets/action_item_form_sheet.dart
+++ b/app/lib/pages/action_items/widgets/action_item_form_sheet.dart
@@ -15,6 +15,7 @@ import 'package:omi/providers/action_items_provider.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/responsive/responsive_helper.dart';
 import 'package:omi/widgets/calendar_date_picker_sheet.dart';
+import 'package:omi/utils/share_sheet.dart';
 
 class ActionItemFormSheet extends StatefulWidget {
   final ActionItemWithMetadata? actionItem; // null for create, non-null for edit
@@ -207,7 +208,7 @@ class _ActionItemFormSheetState extends State<ActionItemFormSheet> {
     if (result != null && result['url'] != null) {
       final url = result['url'] as String;
       HapticFeedback.lightImpact();
-      await Share.share(url);
+      await Share.share(url, sharePositionOrigin: shareSheetOrigin());
       PlatformManager.instance.analytics.track(
         'Action Item Shared',
         properties: {'actionItemId': widget.actionItem!.id},

--- a/app/lib/pages/chat/widgets/ai_message.dart
+++ b/app/lib/pages/chat/widgets/ai_message.dart
@@ -34,6 +34,7 @@ import 'package:omi/widgets/extensions/string.dart';
 import 'package:omi/widgets/text_selection_controls.dart';
 import 'chart_message_widget.dart';
 import 'package:omi/widgets/components/chat_evidence_card.dart';
+import 'package:omi/utils/share_sheet.dart';
 import 'markdown_message_widget.dart';
 
 /// Parse app_id from thinking text (format: "text|app_id:app_id")
@@ -1304,7 +1305,7 @@ class _MessageActionBarState extends State<MessageActionBar> {
             onTap: () async {
               if (widget.messageText.isEmpty) return;
               HapticFeedback.lightImpact();
-              await Share.share(widget.messageText);
+              await Share.share(widget.messageText, sharePositionOrigin: shareSheetOrigin());
               PlatformManager.instance.analytics.track(
                 'Chat Message Shared',
                 properties: {'message': widget.messageText},

--- a/app/lib/pages/settings/daily_summary_detail_page.dart
+++ b/app/lib/pages/settings/daily_summary_detail_page.dart
@@ -18,6 +18,7 @@ import 'package:omi/utils/daily_summary_journey.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/platform/platform_service.dart';
 import 'package:omi/utils/share_links.dart';
+import 'package:omi/utils/share_sheet.dart';
 
 class DailySummaryDetailPage extends StatefulWidget {
   final String summaryId;
@@ -111,7 +112,9 @@ class _DailySummaryDetailPageState extends State<DailySummaryDetailPage> with Si
       }
       PlatformManager.instance.analytics.dailySummaryShared(summaryId: widget.summaryId, date: summary.date);
       final url = recapShareUrl(widget.summaryId);
-      await SharePlus.instance.share(ShareParams(uri: Uri.parse(url), subject: summary.headline));
+      await SharePlus.instance.share(
+        ShareParams(uri: Uri.parse(url), subject: summary.headline, sharePositionOrigin: shareSheetOrigin()),
+      );
     } finally {
       if (mounted) setState(() => _isSharing = false);
     }

--- a/app/test/utils/share_calls_anchored_test.dart
+++ b/app/test/utils/share_calls_anchored_test.dart
@@ -1,0 +1,50 @@
+/// Static tripwire (not behavioral coverage): every share_plus call in lib/
+/// must pass `sharePositionOrigin`.
+///
+/// share_plus throws `PlatformException(sharePositionOrigin: argument must be
+/// set ...)` on iPad/macOS when the anchor is missing, and the throw is usually
+/// the last await in a tap handler, so the button silently does nothing. The
+/// helper fix (`shareSheetOrigin`) landed with three call sites still
+/// unanchored (chat message share, action item share, daily summary share) —
+/// this scan is what keeps a fourth from shipping.
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('every Share call in lib/ passes sharePositionOrigin', () {
+    final callPattern = RegExp(r'\b(Share\.share(XFiles)?|SharePlus\.instance\.share)\(');
+    final violations = <String>[];
+
+    for (final file in Directory('lib').listSync(recursive: true).whereType<File>()) {
+      if (!file.path.endsWith('.dart')) continue;
+      final source = file.readAsStringSync();
+      for (final match in callPattern.allMatches(source)) {
+        final callEnd = _matchingParen(source, match.end - 1);
+        final call = source.substring(match.start, callEnd);
+        if (!call.contains('sharePositionOrigin')) {
+          final line = source.substring(0, match.start).split('\n').length;
+          violations.add('${file.path}:$line');
+        }
+      }
+    }
+
+    expect(violations, isEmpty,
+        reason: 'pass `sharePositionOrigin: shareSheetOrigin(anchorKey)` (lib/utils/share_sheet.dart) to each call');
+  });
+}
+
+int _matchingParen(String source, int openIndex) {
+  var depth = 0;
+  for (var i = openIndex; i < source.length; i++) {
+    final c = source[i];
+    if (c == '(') depth++;
+    if (c == ')') {
+      depth--;
+      if (depth == 0) return i + 1;
+    }
+  }
+  return source.length;
+}


### PR DESCRIPTION
## Summary
`share_plus` rejects a share with no `sharePositionOrigin` whenever iOS presents it as a popover, and the throw is the last await in the tap handler, so the button silently does nothing. Crashlytics on prod 1124 shows 288 fatal `PlatformException(error, sharePositionOrigin: argument must be set, …)` across 97 devices since Aug 19; the stack is the chat message share button.

The `shareSheetOrigin` helper (d3749f4b50) landed with three call sites still unanchored: chat message share (`ai_message.dart`), action item share, daily summary share. This anchors them and adds a static tripwire test (labelled as such) that scans `lib/` for `share_plus` calls without `sharePositionOrigin`, so a fourth cannot ship.

## Verification
- `flutter test test/utils/share_calls_anchored_test.dart test/utils/share_sheet_test.dart` → 5 passed
- Stashed the `ai_message.dart` fix → tripwire fails naming `lib/pages/chat/widgets/ai_message.dart:1307`
- iPhone 16 simulator (Debug-prod, unsigned): opened chat, tapped the message share button 3× → share sheet opened with the message text each time; `log show` for the Runner process shows no `PlatformException`/`sharePositionOrigin` since launch.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

