### PR TITLE
fix(backend): make repeat GET /v1/action-items polls read-free

### DIFF
--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -11,6 +11,7 @@ from google.api_core.exceptions import (
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
+from database.action_items_cache import bump_action_items_list_version
 from database.firestore_transaction_retry import run_with_transaction_contention_retry
 from database.firestore_read_metrics import FirestoreReadFamily, FirestoreReadMode, record_firestore_read
 from database.firestore_index_registry import (
@@ -371,7 +372,7 @@ def create_action_item(
         write_transaction.set(doc_ref, payload)
         return doc_ref.id
 
-    return cast(
+    created_id = cast(
         str,
         run_with_transaction_contention_retry(
             db.transaction,
@@ -379,6 +380,8 @@ def create_action_item(
             operation_name="action_item_create",
         ),
     )
+    bump_action_items_list_version(uid)
+    return created_id
 
 
 def create_action_items_batch(
@@ -454,7 +457,7 @@ def create_action_items_batch(
             write_transaction.set(doc_ref, {**item, 'account_generation': account_generation})
         return doc_refs
 
-    return cast(
+    created_ids = cast(
         List[str],
         run_with_transaction_contention_retry(
             db.transaction,
@@ -462,6 +465,8 @@ def create_action_items_batch(
             operation_name="action_item_batch_create",
         ),
     )
+    bump_action_items_list_version(uid)
+    return created_ids
 
 
 # *****************************
@@ -1066,13 +1071,16 @@ def update_action_item(uid: str, action_item_id: str, update_data: Dict[str, Any
             write_transaction.update(action_item_ref, {**update_data, 'updated_at': now})
             return True
 
-        return bool(
+        updated = bool(
             run_with_transaction_contention_retry(
                 db.transaction,
                 update_linked,
                 operation_name="action_item_linked_update",
             )
         )
+        if updated:
+            bump_action_items_list_version(uid)
+        return updated
 
     # Check if exists
     if not action_item_ref.get().exists:
@@ -1083,6 +1091,7 @@ def update_action_item(uid: str, action_item_id: str, update_data: Dict[str, Any
 
     # Update the document
     action_item_ref.update(update_data)
+    bump_action_items_list_version(uid)
 
     return True
 
@@ -1121,6 +1130,8 @@ def batch_update_action_items(uid: str, items: Iterable[_BatchUpdateEntry]) -> B
             continue
         result.updated_ids.append(item.id)
 
+    if result.updated_ids:
+        bump_action_items_list_version(uid)
     return result
 
 
@@ -1168,6 +1179,7 @@ def delete_action_item(uid: str, action_item_id: str) -> bool:
 
     # Delete the document
     action_item_ref.delete()
+    bump_action_items_list_version(uid)
 
     return True
 
@@ -1200,6 +1212,7 @@ def delete_action_items_batch(uid: str, action_item_ids: List[str]) -> List[str]
     if count > 0:
         batch.commit()
 
+    bump_action_items_list_version(uid)
     return list(action_item_ids)
 
 
@@ -1229,6 +1242,7 @@ def delete_action_items_for_conversation(uid: str, conversation_id: str) -> int:
 
     if count > 0:
         batch.commit()
+        bump_action_items_list_version(uid)
 
     return count
 
@@ -1270,6 +1284,7 @@ def retire_action_items_for_conversation(
         count += 1
     if count:
         batch.commit()
+        bump_action_items_list_version(uid)
     return count
 
 
@@ -1293,6 +1308,7 @@ def batch_set_sync_requested(uid: str, item_ids: List[str]) -> None:
         batch.update(doc_ref, {'sync_requested': True, 'updated_at': now})
 
     batch.commit()
+    bump_action_items_list_version(uid)
 
 
 def get_pending_apple_reminders_sync(uid: str) -> Dict[str, Any]:
@@ -1366,6 +1382,8 @@ def batch_sync_update_action_items(uid: str, updates: List[Dict[str, Any]]) -> B
             continue
         result.updated_ids.append(entry['id'])
 
+    if result.updated_ids:
+        bump_action_items_list_version(uid)
     return result
 
 
@@ -1388,6 +1406,7 @@ def unlock_all_action_items(uid: str) -> None:
             count = 0
     if count > 0:
         batch.commit()
+    bump_action_items_list_version(uid)
     logger.info(f"Unlocked all action items for user {uid}")
 
 

--- a/backend/database/action_items_cache.py
+++ b/backend/database/action_items_cache.py
@@ -1,0 +1,179 @@
+"""Read-free repeat polls for ``GET /v1/action-items``.
+
+Why this module exists
+----------------------
+``action_items_list`` was 48.8% of every billable Firestore document read in the
+project (~$328/day) before #12258 exempted the ``action_items:list`` policy from
+``RATE_LIMIT_BOOST`` and restored its 12/min per-uid cap. That cut the *frequency*
+of the stale ``omi-windows`` hot loop from ~97 req/min to 12 and took the family
+from ~6,600 docs/sec to ~690 docs/sec (24h mean, 2026-09-02).
+
+What is left is not frequency, it is *fan-out*: the surviving traffic is a small
+number of large-backlog accounts, and documents-per-operation rose from 54.5 to
+~223 because the cheap requests are the ones the cap removed. Each remaining
+allowed poll re-reads a whole backlog that did not change. A per-uid response
+cache keyed on a write-bumped version turns those repeats into zero Firestore
+reads, which is the only thing that moves this line further without asking a
+client fleet we cannot observe to update.
+
+Design
+------
+* **Key** — ``ail:{uid}:{version}:{query fingerprint}``. The version is a per-uid
+  counter bumped by every action-item write, so a write invalidates every cached
+  page for that user in one ``INCR`` with no key enumeration and no per-mutation
+  invalidation list to keep in sync.
+* **TTL is the safety net, not the mechanism.** If a writer is ever added that
+  forgets to bump the version, the worst case is bounded staleness of
+  ``ACTION_ITEMS_LIST_CACHE_TTL_SECONDS`` (default 30s), not a permanently wrong
+  list. The version key's own TTL is deliberately far longer than any response
+  TTL so a version cannot expire back onto a live cached entry.
+* **Fail-open.** Redis is fail-open for first-party paths (backend/AGENTS.md).
+  Every helper here swallows Redis errors and reports "no cache", which degrades
+  to today's behaviour — a Firestore read — never to a wrong answer.
+* **ETag** is derived from the cached body, so a client that sends
+  ``If-None-Match`` gets a 304 with no body and no Firestore read.
+
+Rollback: ``ACTION_ITEMS_LIST_CACHE_TTL_SECONDS=0`` disables the cache entirely
+(reads go straight to Firestore) without a deploy of new code.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from typing import Any, Dict, Optional
+
+import redis as redis_pkg
+
+from database import redis_db
+
+logger = logging.getLogger(__name__)
+
+# Response TTL. 0 disables the cache (the documented rollback). Capped so a
+# misconfigured value cannot make the list arbitrarily stale.
+_TTL_MAX_SECONDS = 300
+_TTL_DEFAULT_SECONDS = 30
+
+# The version counter must outlive any response entry by a wide margin: if it
+# expired while a cached page was still live, the counter would restart at 1 and
+# could re-address that stale page. Seven days against a <=300s response TTL.
+_VERSION_TTL_SECONDS = 7 * 24 * 3600
+
+_VERSION_KEY_PREFIX = 'ail:ver'
+_ENTRY_KEY_PREFIX = 'ail'
+
+
+def list_cache_ttl_seconds() -> int:
+    """Read the TTL at call time so the env var is a live operational knob."""
+    raw = os.getenv('ACTION_ITEMS_LIST_CACHE_TTL_SECONDS', str(_TTL_DEFAULT_SECONDS)).strip()
+    try:
+        ttl = int(raw)
+    except ValueError:
+        logger.warning('ACTION_ITEMS_LIST_CACHE_TTL_SECONDS=%r is not an integer; using default', raw)
+        return _TTL_DEFAULT_SECONDS
+    if ttl <= 0:
+        return 0
+    return min(ttl, _TTL_MAX_SECONDS)
+
+
+def _version_key(uid: str) -> str:
+    return f'{_VERSION_KEY_PREFIX}:{uid}'
+
+
+def bump_action_items_list_version(uid: str) -> None:
+    """Invalidate every cached list page for ``uid``.
+
+    Called from the write paths in ``database.action_items`` after the Firestore
+    mutation has committed. Fail-open: a Redis outage means the cache simply
+    keeps serving until its short TTL expires.
+    """
+    if not uid:
+        return
+    try:
+        key = _version_key(uid)
+        pipe = redis_db.r.pipeline()
+        pipe.incr(key)
+        pipe.expire(key, _VERSION_TTL_SECONDS)
+        pipe.execute()
+    except redis_pkg.exceptions.RedisError as e:  # type: ignore[attr-defined]
+        logger.warning('action-items list cache: version bump failed uid=%s: %s', uid, e)
+
+
+def get_action_items_list_version(uid: str) -> Optional[int]:
+    """Current invalidation version, or ``None`` when Redis cannot answer.
+
+    ``None`` means "do not use the cache for this request" — it is not the same
+    as version 0, which is a legitimate never-written-yet user.
+    """
+    try:
+        raw = redis_db.r.get(_version_key(uid))
+    except redis_pkg.exceptions.RedisError as e:  # type: ignore[attr-defined]
+        logger.warning('action-items list cache: version read failed uid=%s: %s', uid, e)
+        return None
+    if raw is None:
+        return 0
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
+
+
+def list_cache_key(uid: str, version: int, params: Dict[str, Any]) -> str:
+    """Address one list page. Params are hashed so the key length is bounded."""
+    fingerprint = hashlib.sha256(
+        json.dumps(params, sort_keys=True, separators=(',', ':'), default=str).encode('utf-8')
+    ).hexdigest()[:16]
+    return f'{_ENTRY_KEY_PREFIX}:{uid}:{version}:{fingerprint}'
+
+
+def compute_etag(body: Dict[str, Any]) -> str:
+    """Weak ETag over the exact bytes the route would return."""
+    digest = hashlib.sha256(json.dumps(body, sort_keys=True, separators=(',', ':'), default=str).encode('utf-8'))
+    return f'W/"{digest.hexdigest()[:32]}"'
+
+
+def read_cached_list(key: str) -> Optional[Dict[str, Any]]:
+    """Return ``{"etag": str, "body": dict}`` or ``None``. Never raises."""
+    try:
+        raw = redis_db.r.get(key)
+    except redis_pkg.exceptions.RedisError as e:  # type: ignore[attr-defined]
+        logger.warning('action-items list cache: read failed: %s', e)
+        return None
+    if not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict) or 'body' not in payload or 'etag' not in payload:
+        return None
+    return payload
+
+
+def write_cached_list(key: str, *, body: Dict[str, Any], etag: str, ttl: int) -> None:
+    """Store one list page. Never raises; a failed write just means a later miss."""
+    if ttl <= 0:
+        return
+    try:
+        redis_db.r.set(key, json.dumps({'etag': etag, 'body': body}, default=str), ex=ttl)
+    except redis_pkg.exceptions.RedisError as e:  # type: ignore[attr-defined]
+        logger.warning('action-items list cache: write failed: %s', e)
+    except (TypeError, ValueError) as e:
+        logger.warning('action-items list cache: body not serializable: %s', e)
+
+
+def if_none_match_matches(header_value: Optional[str], etag: str) -> bool:
+    """RFC 9110 If-None-Match comparison (weak comparison, ``*`` matches)."""
+    if not header_value:
+        return False
+    candidates = [c.strip() for c in header_value.split(',')]
+    if '*' in candidates:
+        return True
+    normalized = etag[2:] if etag.startswith('W/') else etag
+    for candidate in candidates:
+        stripped = candidate[2:] if candidate.startswith('W/') else candidate
+        if stripped == normalized:
+            return True
+    return False

--- a/backend/database/goals.py
+++ b/backend/database/goals.py
@@ -13,6 +13,7 @@ from google.cloud.firestore_v1 import FieldFilter
 from pydantic import ValidationError
 
 from database import _client
+from database.action_items_cache import bump_action_items_list_version
 from database.account_deletion_policy import account_deletion_blocks_access, normalize_account_deletion_status
 from database.read_boundary import parse_snapshot_strict, parse_snapshots
 from models.goal import (
@@ -774,7 +775,12 @@ def transition_goal_lifecycle(
         )
         return result
 
-    return apply(transaction)
+    lifecycle_result = apply(transaction)
+    # A `detach` disposition clears goal_id on up to 450 action items, which
+    # changes what GET /v1/action-items returns. Invalidate the list cache here
+    # because this write does not go through database.action_items.
+    bump_action_items_list_version(uid)
+    return lifecycle_result
 
 
 def _append_goal_progress_event(

--- a/backend/database/staged_tasks.py
+++ b/backend/database/staged_tasks.py
@@ -13,6 +13,7 @@ from google.cloud import firestore
 from google.cloud.firestore_v1.base_query import FieldFilter
 
 from ._client import db, get_firestore_client
+from .action_items_cache import bump_action_items_list_version
 from .firestore_index_registry import LEGACY_CONVERSATION_RECOVERY_QUERY
 import database.action_items as action_items_db
 
@@ -472,6 +473,11 @@ def restore_legacy_conversation_items(
             else:
                 restored += 1
                 break
+
+    if restored:
+        # Recovery creates action items directly (not through
+        # database.action_items), so the list cache is invalidated here too.
+        bump_action_items_list_version(uid)
 
     return {
         'restored': restored,

--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -6,6 +6,7 @@ import uuid
 from utils.executors import postprocess_executor, submit_with_context
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from fastapi.responses import JSONResponse
 from typing import Optional, List
 from datetime import datetime, timezone
 
@@ -20,6 +21,17 @@ from database.vector_db import (
     delete_action_item_vectors_batch,
     search_action_items_by_vector,
 )
+from database.action_items_cache import (
+    compute_etag,
+    get_action_items_list_version,
+    if_none_match_matches,
+    list_cache_key,
+    list_cache_ttl_seconds,
+    read_cached_list,
+    write_cached_list,
+)
+from utils.action_items_list_guard import enforce_hot_client_list_ceiling
+from utils.metrics import record_action_items_list_cache
 from utils.users import get_user_display_name
 from utils.share_links import build_share_url
 from utils.other import endpoints as auth
@@ -347,6 +359,128 @@ def _ensure_aware(value: datetime) -> datetime:
     return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
 
 
+def _action_items_list_cache_params(
+    *,
+    limit: int,
+    offset: int,
+    completed: Optional[bool],
+    conversation_id: Optional[str],
+    start_date: Optional[datetime],
+    end_date: Optional[datetime],
+    due_start_date: Optional[datetime],
+    due_end_date: Optional[datetime],
+) -> Optional[dict]:
+    """Cacheable request shape, or None when this request must not be cached.
+
+    Only the unfiltered listing is cached. That is the whole hot path (98.6% of
+    the measured traffic is ``limit=500&offset=0&completed=true|false``) and it
+    keeps the key space per user to a handful of entries; date- and
+    conversation-scoped reads are rare, high-cardinality, and stay uncached.
+    """
+    if (
+        conversation_id is not None
+        or start_date is not None
+        or end_date is not None
+        or due_start_date is not None
+        or due_end_date is not None
+    ):
+        return None
+    return {"limit": limit, "offset": offset, "completed": completed}
+
+
+def _serve_action_items_list_from_cache(
+    uid: str,
+    *,
+    request: Optional[Request],
+    limit: int,
+    offset: int,
+    completed: Optional[bool],
+    conversation_id: Optional[str],
+    start_date: Optional[datetime],
+    end_date: Optional[datetime],
+    due_start_date: Optional[datetime],
+    due_end_date: Optional[datetime],
+):
+    """Return a 304 or a cached 200 when one is available, else None.
+
+    Both return paths read **zero** Firestore documents — that is the entire
+    point of this function and what the ``omi_action_items_list_cache_total``
+    counter proves after a deploy.
+    """
+    ttl = list_cache_ttl_seconds()
+    if ttl <= 0:
+        return None
+    params = _action_items_list_cache_params(
+        limit=limit,
+        offset=offset,
+        completed=completed,
+        conversation_id=conversation_id,
+        start_date=start_date,
+        end_date=end_date,
+        due_start_date=due_start_date,
+        due_end_date=due_end_date,
+    )
+    if params is None:
+        record_action_items_list_cache('bypass')
+        return None
+    version = get_action_items_list_version(uid)
+    if version is None:
+        # Redis could not answer. Fail open to a real read rather than risk
+        # serving a page addressed by an unknown invalidation version.
+        record_action_items_list_cache('unavailable')
+        return None
+    entry = read_cached_list(list_cache_key(uid, version, params))
+    if entry is None:
+        record_action_items_list_cache('miss')
+        return None
+
+    etag = entry['etag']
+    inm = request.headers.get('if-none-match') if request is not None else None
+    if if_none_match_matches(inm, etag):
+        record_action_items_list_cache('not_modified')
+        return Response(status_code=304, headers={"ETag": etag, "Cache-Control": "private, no-cache"})
+    record_action_items_list_cache('hit')
+    return JSONResponse(
+        content=entry['body'],
+        headers={"ETag": etag, "Cache-Control": "private, no-cache"},
+    )
+
+
+def _store_action_items_list_in_cache(
+    uid: str,
+    body: dict,
+    *,
+    etag: str,
+    limit: int,
+    offset: int,
+    completed: Optional[bool],
+    conversation_id: Optional[str],
+    start_date: Optional[datetime],
+    end_date: Optional[datetime],
+    due_start_date: Optional[datetime],
+    due_end_date: Optional[datetime],
+) -> None:
+    ttl = list_cache_ttl_seconds()
+    if ttl <= 0:
+        return
+    params = _action_items_list_cache_params(
+        limit=limit,
+        offset=offset,
+        completed=completed,
+        conversation_id=conversation_id,
+        start_date=start_date,
+        end_date=end_date,
+        due_start_date=due_start_date,
+        due_end_date=due_end_date,
+    )
+    if params is None:
+        return
+    version = get_action_items_list_version(uid)
+    if version is None:
+        return
+    write_cached_list(list_cache_key(uid, version, params), body=body, etag=etag, ttl=ttl)
+
+
 @router.get("/v1/action-items", response_model=ActionItemsResponse, tags=['action-items'])
 def get_action_items(
     request: Request = None,  # type: ignore[assignment]
@@ -376,6 +510,27 @@ def get_action_items(
         and _ensure_aware(due_start_date) > _ensure_aware(due_end_date)
     ):
         raise HTTPException(status_code=400, detail="due_start_date must be earlier than or equal to due_end_date")
+
+    # Second ceiling for the known hot-loop client class. Raises 429 before any
+    # Firestore work, so a refused poll costs zero document reads. The 12/min
+    # action_items:list bucket has already been charged in the auth dependency;
+    # these two limits compose (both must admit), they do not replace each other.
+    enforce_hot_client_list_ceiling(uid, request)
+
+    cached_response = _serve_action_items_list_from_cache(
+        uid,
+        request=request,
+        limit=limit,
+        offset=offset,
+        completed=completed,
+        conversation_id=conversation_id,
+        start_date=start_date,
+        end_date=end_date,
+        due_start_date=due_start_date,
+        due_end_date=due_end_date,
+    )
+    if cached_response is not None:
+        return cached_response
 
     budget = list_read_budget_for_request(request, route='action-items')
     action_items = action_items_db.get_action_items(
@@ -407,7 +562,36 @@ def get_action_items(
         response.headers[OMI_LIST_TRUNCATED_HEADER] = OMI_LIST_TRUNCATED_VALUE
     budget.observe('truncated' if truncated else 'complete')
 
-    return {"action_items": response_items, "has_more": has_more, "truncated": truncated}
+    result = {"action_items": response_items, "has_more": has_more, "truncated": truncated}
+
+    # A truncated page is not a complete answer for this (uid, version, params);
+    # caching it would pin a budget-exhaustion artifact for the whole TTL, and a
+    # client that retried would keep getting the partial page for free.
+    if not truncated:
+        body = {
+            "action_items": [item.model_dump(mode='json') for item in response_items],
+            "has_more": has_more,
+            "truncated": truncated,
+        }
+        etag = compute_etag(body)
+        if response is not None:
+            response.headers["ETag"] = etag
+            response.headers["Cache-Control"] = "private, no-cache"
+        _store_action_items_list_in_cache(
+            uid,
+            body,
+            etag=etag,
+            limit=limit,
+            offset=offset,
+            completed=completed,
+            conversation_id=conversation_id,
+            start_date=start_date,
+            end_date=end_date,
+            due_start_date=due_start_date,
+            due_end_date=due_end_date,
+        )
+
+    return result
 
 
 @router.get("/v1/action-items/search", response_model=ActionItemsSearchResponse, tags=['action-items'])

--- a/backend/tests/unit/test_action_items_conversation_list_malformed.py
+++ b/backend/tests/unit/test_action_items_conversation_list_malformed.py
@@ -128,7 +128,14 @@ def test_conversation_list_skips_malformed_not_500():
 def test_main_list_skips_malformed_not_500():
     bad = {'id': 'a2', 'description': 'missing completed'}  # missing required 'completed' -> ValidationError
     page = [_valid('a1'), bad]
-    with patch.object(ai_mod.action_items_db, 'get_action_items', return_value=page):
+    # This module imports routers.action_items under a stub finder that replaces the
+    # whole `database`/`utils` packages, so the list-cache TTL helper would return a
+    # MagicMock. Pin it to 0 (cache disabled) — this test is about malformed-item
+    # skipping, and the cache path has its own suite in
+    # tests/unit/test_action_items_list_read_cost.py.
+    with patch.object(ai_mod.action_items_db, 'get_action_items', return_value=page), patch.object(
+        ai_mod, 'list_cache_ttl_seconds', return_value=0
+    ), patch.object(ai_mod, 'enforce_hot_client_list_ceiling', return_value=None):
         # Pass params explicitly: calling the handler directly leaves Query() defaults unresolved.
         resp = ai_mod.get_action_items(
             limit=50,

--- a/backend/tests/unit/test_action_items_list_read_cost.py
+++ b/backend/tests/unit/test_action_items_list_read_cost.py
@@ -1,0 +1,325 @@
+"""GET /v1/action-items must not read Firestore for a repeat poll.
+
+`action_items_list` was 48.8% of every billable Firestore document read
+(~$328/day) before #12258 restored its 12/min per-uid cap by exempting the
+policy from RATE_LIMIT_BOOST. That removed ~90% of the volume by cutting the
+*frequency* of the stale `omi-windows` hot loop. The residual is fan-out:
+documents-per-operation rose 54.5 -> ~223 because the cheap requests are the
+ones the cap removed, so each remaining allowed poll re-reads a whole unchanged
+backlog.
+
+These tests pin the two properties that make the residual go away:
+
+* a cache hit and a 304 both perform **zero** Firestore reads (asserted as zero
+  calls to `action_items_db.get_action_items`, the one function that streams
+  documents), and
+* a refused hot-loop poll is refused *before* any Firestore call.
+
+A test that only asserted "returns the right body" would pass on a design that
+reads Firestore and throws the result away, which is exactly the failure this
+change exists to prevent.
+"""
+
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import database.action_items_cache as ai_cache
+import routers.action_items as action_items_router
+import utils.action_items_list_guard as guard
+
+
+class _FakeRedis:
+    """Minimal Redis stand-in: get/set/incr/expire plus a pipeline."""
+
+    def __init__(self):
+        self.store = {}
+
+    def get(self, key):
+        value = self.store.get(key)
+        return value.encode() if isinstance(value, str) else value
+
+    def set(self, key, value, ex=None):
+        self.store[key] = value
+
+    def incr(self, key):
+        self.store[key] = str(int(self.store.get(key, 0)) + 1)
+        return int(self.store[key])
+
+    def expire(self, key, ttl):
+        return True
+
+    def pipeline(self):
+        outer = self
+
+        class _Pipe:
+            def __init__(self):
+                self.ops = []
+
+            def incr(self, key):
+                self.ops.append(('incr', key))
+                return self
+
+            def expire(self, key, ttl):
+                self.ops.append(('expire', key, ttl))
+                return self
+
+            def execute(self):
+                for op in self.ops:
+                    if op[0] == 'incr':
+                        outer.incr(op[1])
+                self.ops = []
+
+        return _Pipe()
+
+
+class _Headers(dict):
+    def get(self, key, default=None):
+        return super().get(key.lower(), default)
+
+
+def _request(headers=None):
+    return SimpleNamespace(headers=_Headers({k.lower(): v for k, v in (headers or {}).items()}))
+
+
+class _Response:
+    def __init__(self):
+        self.headers = {}
+
+
+def _item(item_id: str) -> dict:
+    return {'id': item_id, 'description': 'Do a thing', 'completed': False, 'is_locked': False}
+
+
+def _call(*, request=None, response=None, uid='user-1', limit=50, offset=0, completed=None, **kwargs):
+    return action_items_router.get_action_items(
+        request=request,
+        response=response,
+        limit=limit,
+        offset=offset,
+        completed=completed,
+        conversation_id=kwargs.get('conversation_id'),
+        start_date=kwargs.get('start_date'),
+        end_date=kwargs.get('end_date'),
+        due_start_date=kwargs.get('due_start_date'),
+        due_end_date=kwargs.get('due_end_date'),
+        uid=uid,
+    )
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    fake = _FakeRedis()
+    monkeypatch.setattr(ai_cache.redis_db, 'r', fake)
+    monkeypatch.setenv('ACTION_ITEMS_LIST_CACHE_TTL_SECONDS', '30')
+    return fake
+
+
+class _Budget:
+    truncated = False
+
+    def observe(self, _outcome):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _stub_budget(monkeypatch):
+    monkeypatch.setattr(action_items_router, 'list_read_budget_for_request', lambda *a, **k: _Budget())
+
+
+def test_repeat_poll_reads_zero_firestore_documents(fake_redis):
+    with patch.object(action_items_router.action_items_db, 'get_action_items', return_value=[_item('one')]) as db_call:
+        first = _call(request=_request(), response=_Response())
+        assert db_call.call_count == 1
+
+        second = _call(request=_request(), response=_Response())
+        # The whole point: the second identical poll never reaches Firestore.
+        assert db_call.call_count == 1
+
+    assert [i['id'] for i in json.loads(second.body)['action_items']] == ['one']
+    assert [i.id for i in first['action_items']] == ['one']
+
+
+def test_if_none_match_returns_304_without_reading_firestore(fake_redis):
+    resp = _Response()
+    with patch.object(action_items_router.action_items_db, 'get_action_items', return_value=[_item('one')]) as db_call:
+        _call(request=_request(), response=resp)
+        etag = resp.headers['ETag']
+        not_modified = _call(request=_request({'If-None-Match': etag}), response=_Response())
+        assert db_call.call_count == 1
+
+    assert not_modified.status_code == 304
+    assert not_modified.headers['etag'] == etag
+
+
+def test_a_write_invalidates_the_cached_page(fake_redis):
+    with patch.object(action_items_router.action_items_db, 'get_action_items', return_value=[_item('one')]) as db_call:
+        _call(request=_request(), response=_Response())
+        ai_cache.bump_action_items_list_version('user-1')
+        _call(request=_request(), response=_Response())
+
+    assert db_call.call_count == 2
+
+
+def test_date_filtered_reads_are_not_cached(fake_redis):
+    from datetime import datetime, timezone
+
+    start = datetime(2026, 9, 1, tzinfo=timezone.utc)
+    with patch.object(action_items_router.action_items_db, 'get_action_items', return_value=[_item('one')]) as db_call:
+        _call(request=_request(), response=_Response(), start_date=start)
+        _call(request=_request(), response=_Response(), start_date=start)
+
+    assert db_call.call_count == 2
+
+
+def test_truncated_pages_are_never_cached(fake_redis):
+    class _Truncated(_Budget):
+        truncated = True
+
+    with patch.object(action_items_router, 'list_read_budget_for_request', lambda *a, **k: _Truncated()):
+        with patch.object(
+            action_items_router.action_items_db, 'get_action_items', return_value=[_item('one')]
+        ) as db_call:
+            _call(request=_request(), response=_Response())
+            _call(request=_request(), response=_Response())
+
+    assert db_call.call_count == 2
+
+
+def test_redis_outage_falls_open_to_a_real_read(monkeypatch):
+    import redis as redis_pkg
+
+    class _Broken:
+        def get(self, *_a, **_k):
+            raise redis_pkg.exceptions.ConnectionError('down')
+
+        def set(self, *_a, **_k):
+            raise redis_pkg.exceptions.ConnectionError('down')
+
+    monkeypatch.setattr(ai_cache.redis_db, 'r', _Broken())
+    monkeypatch.setenv('ACTION_ITEMS_LIST_CACHE_TTL_SECONDS', '30')
+    with patch.object(action_items_router.action_items_db, 'get_action_items', return_value=[_item('one')]) as db_call:
+        result = _call(request=_request(), response=_Response())
+    assert db_call.call_count == 1
+    assert [i.id for i in result['action_items']] == ['one']
+
+
+def test_ttl_zero_disables_the_cache(monkeypatch, fake_redis):
+    monkeypatch.setenv('ACTION_ITEMS_LIST_CACHE_TTL_SECONDS', '0')
+    with patch.object(action_items_router.action_items_db, 'get_action_items', return_value=[_item('one')]) as db_call:
+        _call(request=_request(), response=_Response())
+        _call(request=_request(), response=_Response())
+    assert db_call.call_count == 2
+
+
+def test_ttl_is_clamped_and_typo_tolerant(monkeypatch):
+    monkeypatch.setenv('ACTION_ITEMS_LIST_CACHE_TTL_SECONDS', '99999')
+    assert ai_cache.list_cache_ttl_seconds() == 300
+    monkeypatch.setenv('ACTION_ITEMS_LIST_CACHE_TTL_SECONDS', 'thirty')
+    assert ai_cache.list_cache_ttl_seconds() == 30
+
+
+@pytest.mark.parametrize(
+    ('user_agent', 'expected'),
+    [
+        (
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 omi-windows/1.0.0 '
+            'Chrome/142.0.7444.265 Electron/39.8.10 Safari/537.36',
+            'stale_windows',
+        ),
+        ('Mozilla/5.0 omi-windows/1.0.36 Electron/39.8.10', 'windows'),
+        ('Omi/12264 CFNetwork/3826.500.111.2.2 Darwin/24.6.0', 'other'),
+        ('Dart/3.11 (dart:io)', 'other'),
+        (None, 'other'),
+        # A UA that merely mentions windows is not the hot-loop build.
+        ('Mozilla/5.0 (Windows NT 10.0) Chrome/142', 'other'),
+    ],
+)
+def test_client_classification(user_agent, expected):
+    assert guard.classify_list_client(user_agent) == expected
+
+
+def test_hot_client_ceiling_refuses_before_any_firestore_call(fake_redis, monkeypatch):
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(guard, 'ACTION_ITEMS_LIST_HOT_CLIENT_MAX', 2)
+    monkeypatch.setattr(guard, 'get_effective_limit', lambda _p: (2, 60))
+    calls = {'n': 0}
+
+    def _check(key, policy, max_requests, window):
+        calls['n'] += 1
+        return (calls['n'] <= max_requests, 0, 17)
+
+    monkeypatch.setattr(guard, 'check_rate_limit', _check)
+    hot = _request({'User-Agent': 'omi-windows/1.0.0 Electron/39.8.10'})
+
+    with patch.object(action_items_router.action_items_db, 'get_action_items', return_value=[_item('one')]) as db_call:
+        _call(request=hot, response=_Response())
+        _call(request=hot, response=_Response(), uid='user-2')
+        with pytest.raises(HTTPException) as excinfo:
+            _call(request=hot, response=_Response(), uid='user-3')
+        refused_at = db_call.call_count
+
+    assert excinfo.value.status_code == 429
+    assert excinfo.value.headers['Retry-After'] == '17'
+    # The refusal happened before the database call for that request.
+    assert refused_at == 2
+
+
+def test_hot_client_ceiling_ignores_other_clients(fake_redis, monkeypatch):
+    monkeypatch.setattr(guard, 'ACTION_ITEMS_LIST_HOT_CLIENT_MAX', 1)
+
+    def _never_allowed(*_a, **_k):
+        raise AssertionError('non-hot clients must not touch the second bucket')
+
+    monkeypatch.setattr(guard, 'check_rate_limit', _never_allowed)
+    mac = _request({'User-Agent': 'Omi/12264 CFNetwork/3826.500.111.2.2 Darwin/24.6.0'})
+
+    with patch.object(action_items_router.action_items_db, 'get_action_items', return_value=[_item('one')]):
+        _call(request=mac, response=_Response())
+
+
+def test_hot_client_ceiling_is_disabled_at_zero(fake_redis, monkeypatch):
+    monkeypatch.setattr(guard, 'ACTION_ITEMS_LIST_HOT_CLIENT_MAX', 0)
+
+    def _never_allowed(*_a, **_k):
+        raise AssertionError('the ceiling must be inert when the env knob is 0')
+
+    monkeypatch.setattr(guard, 'check_rate_limit', _never_allowed)
+    hot = _request({'User-Agent': 'omi-windows/1.0.0'})
+    with patch.object(action_items_router.action_items_db, 'get_action_items', return_value=[_item('one')]):
+        _call(request=hot, response=_Response())
+
+
+def test_hot_client_ceiling_fails_open_when_redis_is_down(fake_redis, monkeypatch):
+    import redis as redis_pkg
+
+    monkeypatch.setattr(guard, 'ACTION_ITEMS_LIST_HOT_CLIENT_MAX', 1)
+
+    def _down(*_a, **_k):
+        raise redis_pkg.exceptions.ConnectionError('down')
+
+    monkeypatch.setattr(guard, 'check_rate_limit', _down)
+    hot = _request({'User-Agent': 'omi-windows/1.0.0'})
+    with patch.object(action_items_router.action_items_db, 'get_action_items', return_value=[_item('one')]) as db_call:
+        _call(request=hot, response=_Response())
+    assert db_call.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ('header', 'etag', 'expected'),
+    [
+        ('W/"abc"', 'W/"abc"', True),
+        ('"abc"', 'W/"abc"', True),
+        ('*', 'W/"abc"', True),
+        ('W/"abc", W/"def"', 'W/"def"', True),
+        ('W/"zzz"', 'W/"abc"', False),
+        (None, 'W/"abc"', False),
+        ('', 'W/"abc"', False),
+    ],
+)
+def test_if_none_match_matching(header, etag, expected):
+    assert ai_cache.if_none_match_matches(header, etag) is expected

--- a/backend/tests/unit/test_task_sharing.py
+++ b/backend/tests/unit/test_task_sharing.py
@@ -42,6 +42,7 @@ for sub in [
     "tasks",
     "trends",
     "action_items",
+    "action_items_cache",
     "folders",
     "calendar_meetings",
     "vector_db",
@@ -68,6 +69,18 @@ sys.modules["database.firestore_transaction_retry"].FirestoreContentionExhausted
     {},
 )
 sys.modules["database.task_intelligence_control"].get_task_workflow_control = MagicMock()
+
+# The action-items router imports the list-cache seams at module scope. Keep
+# this sharing test's database package stubbed and provide inert implementations
+# for the unrelated list endpoint cache.
+action_items_cache_mod = sys.modules["database.action_items_cache"]
+action_items_cache_mod.compute_etag = MagicMock()
+action_items_cache_mod.get_action_items_list_version = MagicMock(return_value=None)
+action_items_cache_mod.if_none_match_matches = MagicMock(return_value=False)
+action_items_cache_mod.list_cache_key = MagicMock()
+action_items_cache_mod.list_cache_ttl_seconds = MagicMock(return_value=0)
+action_items_cache_mod.read_cached_list = MagicMock(return_value=None)
+action_items_cache_mod.write_cached_list = MagicMock()
 
 # Stub vector_db functions used by routers.action_items
 vector_db_mod = sys.modules["database.vector_db"]
@@ -102,6 +115,7 @@ sys.modules["utils.task_sync"].auto_sync_action_item = MagicMock()
 # Stub redis_db.r so Redis helper tests can patch it
 redis_mod = sys.modules["database.redis_db"]
 redis_mod.r = MagicMock()
+redis_mod.check_rate_limit = MagicMock(return_value=(True, 0, 0))
 redis_mod.try_catch_decorator = lambda f: f
 redis_mod.TASK_SHARE_TTL = 60 * 60 * 24 * 30
 redis_mod.json = __import__("json")

--- a/backend/utils/action_items_list_guard.py
+++ b/backend/utils/action_items_list_guard.py
@@ -1,0 +1,112 @@
+"""Client classification and the extra hot-loop ceiling for GET /v1/action-items.
+
+Context
+-------
+``GET /v1/action-items`` was 65.6% of all backend requests and 48.8% of every
+billable Firestore document read (~$328/day) because ~82 stale ``omi-windows``
+Electron binaries issued a ``completed=false`` + ``completed=true`` pair every
+~1.2 seconds. #12258 made the ``action_items:list`` policy immune to
+``RATE_LIMIT_BOOST`` and restored its 12/min per-uid cap, which removed ~90% of
+that volume. A fixed-window prod capture on 2026-09-02 shows the route at
+3.0 req/s with 11.7% 429s and **90% of the surviving traffic still coming from
+``omi-windows/1.0.0`` asking for ``limit=500``** — the pre-fix build, two weeks
+after its fix merged. That fleet is not updating on any schedule we can observe.
+
+What this adds
+--------------
+A **second** ceiling that composes with the first rather than replacing it.
+Every caller keeps the 12/min ``action_items:list`` bucket, checked in the auth
+dependency before this runs. A caller additionally classified as the hot-loop
+build is charged a second, independent Redis bucket
+(``action_items:list_hot_client``, default 4/min) and is refused with 429 +
+``Retry-After`` above it. Two buckets, two keys, no shared state: the tighter one
+binds for a stale poller and nothing changes for anyone else.
+
+Classification is deliberately narrow. Only the exact stale product build string
+is treated as hot; an unrecognised or absent user agent is *not*, because a
+misclassification here degrades a real client, and the 12/min policy already
+covers the general case.
+
+Rollback: ``ACTION_ITEMS_LIST_HOT_CLIENT_MAX=0`` disables the extra ceiling
+without a code deploy.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+import redis as redis_pkg
+from fastapi import HTTPException, Request
+
+from database.redis_db import check_rate_limit
+from utils.metrics import record_action_items_list_throttled
+from utils.rate_limit_config import ACTION_ITEMS_LIST_HOT_CLIENT_MAX, get_effective_limit
+
+HOT_CLIENT_POLICY = "action_items:list_hot_client"
+
+# The known hot-loop build. `omi-windows/1.0.0` is what the pre-fix Electron main
+# process reports (repo package.json is already at 1.0.35, so the shipped
+# binaries producing this string are the ones whose sync engine predates
+# 65249902cb). Anchored on the product token so an unrelated UA containing the
+# word "windows" is never classified.
+_STALE_WINDOWS_UA = re.compile(r"\bomi-windows/1\.0\.0\b")
+
+
+def classify_list_client(user_agent: Optional[str]) -> str:
+    """Return a low-cardinality client class for metrics and the hot ceiling.
+
+    Values: ``stale_windows`` (the known hot-loop build), ``windows`` (any other
+    omi-windows build), ``other``. Kept to a closed set — this label goes on a
+    Prometheus counter.
+    """
+    ua = user_agent or ""
+    if _STALE_WINDOWS_UA.search(ua):
+        return "stale_windows"
+    if "omi-windows/" in ua:
+        return "windows"
+    return "other"
+
+
+def is_hot_loop_client(client_class: str) -> bool:
+    return client_class == "stale_windows"
+
+
+def enforce_hot_client_list_ceiling(uid: str, request: Optional[Request]) -> None:
+    """Charge the second ceiling for a hot-loop client; raise 429 when exceeded.
+
+    Runs *before* any Firestore work, so a refused poll costs zero document
+    reads. Fail-open on Redis errors, matching the first-party rate-limit
+    contract in ``utils.other.endpoints._enforce_rate_limit``: a Redis outage
+    must not take the list endpoint down.
+    """
+    if ACTION_ITEMS_LIST_HOT_CLIENT_MAX <= 0 or request is None:
+        return
+    client_class = classify_list_client(request.headers.get("user-agent"))
+    if not is_hot_loop_client(client_class):
+        return
+
+    max_requests, window = get_effective_limit(HOT_CLIENT_POLICY)
+    if max_requests <= 0:
+        return
+    try:
+        allowed, _remaining, retry_after = check_rate_limit(
+            f"{uid}:{client_class}", HOT_CLIENT_POLICY, max_requests, window
+        )
+    except redis_pkg.exceptions.RedisError:  # type: ignore[attr-defined]
+        # Fail-open, exactly like the parent policy: the 12/min bucket already
+        # bounds this route, and a Redis outage must not 503 a read path.
+        return
+    if allowed:
+        return
+
+    record_action_items_list_throttled(client=client_class, policy=HOT_CLIENT_POLICY)
+    raise HTTPException(
+        status_code=429,
+        detail=f"Rate limit exceeded. Try again in {retry_after}s.",
+        headers={
+            "X-RateLimit-Limit": str(max_requests),
+            "X-RateLimit-Remaining": "0",
+            "Retry-After": str(max(1, retry_after)),
+        },
+    )

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -543,6 +543,34 @@ PUSHER_READY.set(1)
 PUSHER_DRAIN_IN_PROGRESS.set(0)
 
 
+# GET /v1/action-items read-cost controls (see database/action_items_cache.py).
+# `action_items_list` was 48.8% of every billable Firestore document read before
+# the 12/min per-uid cap shipped (#12258); the residual cost is a small number of
+# large-backlog accounts re-reading a full backlog on every allowed poll. These
+# two counters are how a deploy proves the remaining reads went away, rather than
+# inferring it from the billing export a week later.
+OMI_ACTION_ITEMS_LIST_THROTTLED_TOTAL = Counter(
+    'omi_action_items_list_throttled_total',
+    'GET /v1/action-items requests rejected with 429 by a list ceiling',
+    ['client', 'policy'],
+)
+
+OMI_ACTION_ITEMS_LIST_CACHE_TOTAL = Counter(
+    'omi_action_items_list_cache_total',
+    'GET /v1/action-items list responses by cache outcome (a hit or not_modified reads zero Firestore documents)',
+    ['outcome'],
+)
+
+
+def record_action_items_list_throttled(*, client: str, policy: str) -> None:
+    OMI_ACTION_ITEMS_LIST_THROTTLED_TOTAL.labels(client=client, policy=policy).inc()
+
+
+def record_action_items_list_cache(outcome: str) -> None:
+    """outcome: hit | not_modified | miss | bypass | unavailable."""
+    OMI_ACTION_ITEMS_LIST_CACHE_TOTAL.labels(outcome=outcome).inc()
+
+
 def metrics_response() -> Response:
     return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
 

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -20,10 +20,18 @@ Tuning knobs:
         event boost should widen 100x. Those policies are listed here and always
         serve their base limit.
 
-        Default: "action_items:list". Read from env at startup, so the exemption
-        is operator-escapable without a code change: set
-        RATE_LIMIT_BOOST_EXEMPT="" to put every policy back under the boost.
+        Default: "action_items:list,action_items:list_hot_client". Read from env
+        at startup, so the exemption is operator-escapable without a code change:
+        set RATE_LIMIT_BOOST_EXEMPT="" to put every policy back under the boost.
         Unknown names are ignored (a typo must not take the process down).
+
+    ACTION_ITEMS_LIST_HOT_CLIENT_MAX: requests per 60s that one uid may make to
+        GET /v1/action-items *from a hot-loop client class* (see
+        utils/action_items_list_guard.py). This is a second, stricter ceiling
+        that composes with action_items:list rather than replacing it: every
+        client keeps the 12/min cap, and a client identified as the stale
+        polling build additionally may not exceed this number. Default 4.
+        Set to 0 to disable the extra ceiling (the rollback).
 
 Redis efficiency:
     Each check = 1 Lua script call (atomic INCR + TTL check).
@@ -39,9 +47,27 @@ import os
 RATE_LIMIT_BOOST: float = float(os.getenv("RATE_LIMIT_BOOST", "1.0"))
 RATE_LIMIT_SHADOW: bool = os.getenv("RATE_LIMIT_SHADOW_MODE", "false").lower() == "true"
 
+
+def _hot_client_max() -> int:
+    """Base per-minute ceiling for the hot-loop list client class.
+
+    Read once at import like every other policy number. Invalid input falls back
+    to the default rather than raising: a typo in an env var must not refuse to
+    start the process, and this is a cost control, not a correctness control.
+    """
+    raw = os.getenv("ACTION_ITEMS_LIST_HOT_CLIENT_MAX", "4").strip()
+    try:
+        value = int(raw)
+    except ValueError:
+        return 4
+    return max(0, value)
+
+
+ACTION_ITEMS_LIST_HOT_CLIENT_MAX: int = _hot_client_max()
+
 # Policies the boost must not touch. Env-overridable (see module docstring);
 # resolved against RATE_POLICIES below so a typo is dropped, not enforced.
-_BOOST_EXEMPT_DEFAULT = "action_items:list"
+_BOOST_EXEMPT_DEFAULT = "action_items:list,action_items:list_hot_client"
 _RATE_LIMIT_BOOST_EXEMPT_RAW: str = os.getenv("RATE_LIMIT_BOOST_EXEMPT", _BOOST_EXEMPT_DEFAULT)
 
 # ---------------------------------------------------------------------------
@@ -103,6 +129,13 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     # prod this cap resolved to 1,200/60s and never fired once, while the loop
     # ran at ~97/min — 48.8% of all billable Firestore document reads.
     "action_items:list": (12, 60),
+    # Second, stricter ceiling for the hot-loop client class only. It does not
+    # replace action_items:list — both buckets are checked, so the tighter one
+    # binds for a stale poller while every other client is governed solely by
+    # the 12/min policy above. Base max is env-tunable
+    # (ACTION_ITEMS_LIST_HOT_CLIENT_MAX, 0 disables); boost-exempt for the same
+    # reason as its parent policy.
+    "action_items:list_hot_client": (ACTION_ITEMS_LIST_HOT_CLIENT_MAX, 60),
     "action_items:write": (120, 3600),
     # Memories — single LLM call each
     "memories:create": (60, 3600),


### PR DESCRIPTION
## What exists today (measured, not assumed)

`GET /v1/action-items` was **65.6% of all backend requests** and
**48.8% of every billable Firestore document read** (~$328/day) until #12258 made the
`action_items:list` policy immune to `RATE_LIMIT_BOOST`, so its 12/min per-uid cap
finally started firing. That fix worked, and it is not undone here.

I re-measured the route this afternoon before writing any code.

**Prometheus, 24h means (2026-09-02):**

| | before #12258 | now |
| --- | ---: | ---: |
| `action_items_list` docs/sec | 6,600 | **692** |
| `action_items_list` ops/sec | 121 | **3.11** |
| **docs per operation** | 54.5 | **~223** |
| `action_items_list` share of `stackdriver_..._document_read_count` | 48.8% | **~13%** |

**Cloud Run, untruncated fixed window 2026-09-02T17:46–17:49Z (545 requests, read-only capture):**

- **3.03 req/s** (was 128–132), **97 distinct remote IPs** — the drop came from each
  client polling less, not from clients disappearing.
- **480 × 200, 64 × 429 (11.7%), 1 × 401.** 63 of the 64 429s are `omi-windows`.
- Client mix: **490 `omi-windows`, 31 `Dart`, 23 macOS `CFNetwork`, 1 `Bun`.**
- Query mix: `limit=500&offset=0&completed=false` 223, `...&completed=true` 194,
  `limit=50` 37, `limit=100` 31, `offset=500` 28.

Two things follow, and they are the whole design rationale:

1. **The remaining problem is fan-out, not frequency.** Documents-per-operation went
   *up*, 54.5 → ~223, because the cheap requests are exactly the ones the cap removed.
   What survives is large-backlog accounts re-reading an unchanged backlog on every
   allowed poll — 12 full backlog reads per minute per uid, forever.
2. **The stale fleet is still the traffic.** 90% of surviving requests are the pre-fix
   `omi-windows/1.0.0` build asking for `limit=500`, two weeks after its client-side fix
   (`65249902cb`, `SYNC_THROTTLE_MS = 5 min`, `PAGE_LIMIT = 100`) merged. Its rollout is
   still unobservable, so the backstop has to be server-side.

**Honest scoping, stated up front:** at 692 docs/sec this route is now ~**$32/day**
(marginal $0.05395/100k) out of a `App Engine | Cloud Firestore Read Ops` line running
**$376.71/day** (mean of the six complete post-ship days 08-27…09-01). *This route is no
longer what dominates that line.* This PR takes the rest of it and caps the regression
path; it does not claim the other ~$340/day, which is uninstrumented read volume and
needs its own attribution work.

## What changes

Three things, each independently disableable by one env var.

### 1. Repeat polls read zero Firestore documents (`database/action_items_cache.py`)

A per-uid Redis response cache for the **unfiltered** listing (98.6% of measured
traffic), plus an `ETag` / `If-None-Match` → **304** path.

- **Key** is `ail:{uid}:{version}:{param fingerprint}`. The version is a per-uid counter
  that **every action-item write bumps** — one `INCR`, no key enumeration, no
  per-mutation invalidation list to drift out of sync. Invalidation is hooked into all
  12 mutating helpers in `database/action_items.py`, plus the two writers that touch the
  collection from outside that module (`goals.transition_goal_lifecycle`'s `detach`
  disposition and `staged_tasks.restore_legacy_conversation_items`).
- **The TTL is the safety net, not the mechanism.** If a future writer forgets to bump,
  the worst case is bounded staleness of `ACTION_ITEMS_LIST_CACHE_TTL_SECONDS`
  (default **30s**, clamped to 300), never a permanently wrong list. The version key's
  own TTL is 7 days so a version can never expire back onto a live cached entry.
- **Truncated pages are never cached** — caching a budget-exhaustion artifact would pin
  a partial page for the whole TTL and make a client's retry free.
- Date- and conversation-scoped reads bypass the cache entirely (rare, high cardinality).
- Redis is **fail-open**, matching `_enforce_rate_limit`'s first-party contract: an
  outage degrades to today's behaviour (a real read), never to a wrong answer.

**Why zero UX impact for an up-to-date client:** any write by that user — from any
device, including the server-side conversation pipeline — bumps the version and the next
read is fresh. The only staleness window is a write that does not go through the hooked
paths, bounded at 30s. macOS and Flutter already reconcile at a 5-minute cadence.

### 2. A second, stricter ceiling for the hot-loop client class (`utils/action_items_list_guard.py`)

`action_items:list_hot_client`, default **4/60s per uid**, env-tunable via
`ACTION_ITEMS_LIST_HOT_CLIENT_MAX` (0 disables). Returns 429 with `Retry-After`.

**It composes with the existing limiter rather than conflicting with it.** Two
independent Redis buckets: every client is still governed by `action_items:list`
(12/min), charged in the auth `Depends()` before the route body; a client *additionally*
classified as the hot-loop build is charged this second bucket inside the route, before
any Firestore work. Both must admit. Nothing about the existing policy's key, window, or
value changes, and the new policy is added to `RATE_LIMIT_BOOST_EXEMPT`'s default for
the same reason as its parent — a cap chosen to stop a hot loop is not something an
event boost should widen 100×.

Classification is deliberately narrow: only the exact `omi-windows/1.0.0` product token
counts as `stale_windows`. An unrecognised or absent user agent is **not** classified,
because a misclassification here degrades a real client and the 12/min policy already
covers the general case. (The stale build sends no `X-App-Platform`/`X-App-Version` on
this route, so the UA token is the only available discriminator.)

Blast radius: the ~90 hot-loop clients see a refresh every ~15s instead of every ~5s.
Their data stays correct, and that build already has 429-storm handling
(`53d5b9e54a`, `observability/backendDegraded.ts`).

### 3. Metrics that prove it (`utils/metrics.py`)

- `omi_action_items_list_cache_total{outcome}` — `hit | not_modified | miss | bypass | unavailable`.
- `omi_action_items_list_throttled_total{client,policy}` — 429s by client class.

These exist because the last three mitigations on this route were all *merged and inert*
in production, and nobody could tell for a week. `hit`/`not_modified` are, by
construction, the requests that performed **zero** Firestore reads.

### What I did not build: the minimum-client-version gate

**The backend has no client-version gate pattern to reuse**, so per the brief I am
proposing rather than inventing one. What exists is `routers/firmware.py`'s `min_version`
(device firmware, not API clients) and `routers/desktop_chat.py:1592`'s `426 Upgrade
Required` for a *chat contract* version — neither is a general client gate, and there is
no `X-App-Version` header on this route to gate on. A proper version gate would need
(a) the Windows client to send `X-App-Platform`/`X-App-Version` on `apiFetch` as it
already does for JIT and listen, (b) a shared `utils/client_version_gate.py` reading a
per-platform minimum from env, and (c) a client that renders "update required" instead
of retrying. That is a cross-tree change with a client release in it; it should be its
own PR, and it is strictly worse than this one as a *first* move because it depends on
the same unobservable auto-update reach that made the server-side backstop necessary.

### Can `completed=false` and `completed=true` be served from one read?

Not for these callers, and I would not change it here. The `completed=None` path already
reads both buckets in one request (active-first, then completed, product-sorted) — but
that returns one merged page, not the two bucket-scoped pages the Windows client asks
for, and swapping them changes pagination semantics for every client. The realistic wins,
both taken or already present: both buckets now share **one** invalidation version, so a
single write invalidates the pair and a paired poll costs at most one read per bucket per
TTL instead of two per cycle; and `GET /v1/action-items/ids?completed=` already exists as
the projection-only reconciliation path (`action_items_visible_ids`, 67 docs/sec in prod)
for clients that only need the id census.

## Expected saving, and its basis

Basis: `avg_over_time(sum(rate(omi_firestore_documents_per_operation_sum{family="action_items_list"}[1h]))[24h:10m])`
= **691.9 docs/sec** = 5.98e7 reads/day; marginal price **$0.05395/100k** (OLS on 14
complete billing-export days, r = 1.00000, `evidence/2026-08-26-c006-falsification.md`)
→ **$32.3/day** is the entire remaining prize for this family.

At a 30s TTL the cache bounds an idle user's polls to **2 Firestore reads/min** instead of
12 — an 83% ceiling reduction — and the docs/op histogram says the hit rate will be high
(25.7% of these requests read zero documents even before caching). Discounting for
write-driven misses and the uncached filtered reads:

> **Expected: $20–27/day (~$7–10k/year)**, taking the line from a $376.71/day six-day
> mean to roughly **$350–357/day**. Not a headline number — the headline was already
> taken by #12258 (−$172.73/day, −31.4%, holding six days).

## Kill-check — the metric that decides this within 24h of deploy

Measured 24h after the revision is confirmed *serving* (revision env / release SHA, never
merge status). Drop the newest two Cloud Monitoring buckets.

**Primary (mechanism, decides it):**

1. `sum(rate(omi_action_items_list_cache_total{outcome=~"hit|not_modified"}[1h])) / sum(rate(omi_action_items_list_cache_total[1h]))`
   ≥ **0.5**. Below 0.3 → the cache is not being hit and the change did not work; roll back.
2. `avg_over_time(sum(rate(omi_firestore_documents_per_operation_sum{family="action_items_list"}[1h]))[24h:10m])`
   < **250 docs/sec** (from 691.9). ≥ 500 → not supported.
3. `avg_over_time(sum(rate(omi_firestore_read_operations_total{family="action_items_list"}[1h]))[24h:10m])`
   < **1.2 ops/sec** (from 3.11).

**Void conditions (re-run, do not record a result):**

- Distinct `remoteIp` on `/v1/action-items` in a 60s window drops below **60** (from 97) —
  a drop that comes from clients disappearing is churn or an outage, not a saving.
- `omi_action_items_list_throttled_total` rises for any `client` other than
  `stale_windows` — that is a misclassification, and the ceiling should be zeroed.
- `/v1/action-items` non-200/429 rate above 1%.

**Money (confirmatory, 7 days):** `App Engine | Cloud Firestore Read Ops` net $/day,
complete days only (verify `MAX(usage_end_time)`), against the 08-27…09-01 mean of
$376.71/day. Expect **$350–357/day**. This line is no longer dominated by this route, so
it cannot decide the change on its own — that is what the mechanism checks are for.

## Rollback

Both levers are env vars on the serving revision; neither needs a code deploy:

- `ACTION_ITEMS_LIST_CACHE_TTL_SECONDS=0` — disables the cache and the 304 path entirely;
  every read goes straight to Firestore, exactly as today.
- `ACTION_ITEMS_LIST_HOT_CLIENT_MAX=0` — disables the second ceiling; the 12/min
  `action_items:list` policy is untouched and keeps enforcing.
- `RATE_LIMIT_BOOST_EXEMPT` still accepts an explicit list if the new policy needs to go
  back under the global boost.

## Tests

`backend/tests/unit/test_action_items_list_read_cost.py` — 25 tests. They assert the
*cost* property, not just the body: a cache hit and a 304 are pinned to **zero calls to
`action_items_db.get_action_items`**, the one function that streams documents. A test
that only checked the response would pass on a design that reads Firestore and throws the
result away — which is exactly the failure this change exists to prevent. Also covered:
write-driven invalidation, truncated pages never cached, filtered reads bypassing,
TTL clamping and typo tolerance, Redis-outage fail-open on both the cache and the ceiling,
the ceiling refusing *before* the database call, non-hot clients never touching the second
bucket, the `0` kill switch, UA classification (including "a UA that merely mentions
Windows is not the hot-loop build"), and RFC 9110 `If-None-Match` weak comparison.

## Self-test — the real HTTP path, not the function

Unit tests call the handler directly, which does not exercise FastAPI's response
handling. I also drove the router over HTTP with `TestClient` (fake Firestore rows, fake
Redis, `ACTION_ITEMS_LIST_CACHE_TTL_SECONDS=30`, `ACTION_ITEMS_LIST_HOT_CLIENT_MAX=2`),
counting calls to `action_items_db.get_action_items` across the sequence:

```
1  first        200 db_calls= 1 etag= W/"c000909dde9858350f2836fa6d929047"
2  repeat       200 db_calls= 1 same_body= True
3  If-None-Match 304 db_calls= 1 len(body)= 0
4  after write  200 db_calls= 2
5  hot 1/2/3 -> 200 200 429  retry_after= 11  db_calls= 4
6  mac after hot refusals -> 200

omi_action_items_list_cache_total{outcome="hit"} 1.0
omi_action_items_list_cache_total{outcome="not_modified"} 1.0
omi_action_items_list_cache_total{outcome="miss"} 5.0
omi_action_items_list_throttled_total{client="stale_windows",policy="action_items:list_hot_client"} 1.0
```

Line 2 and line 3 are the change: the repeat poll and the conditional request both return
without `db_calls` moving. Line 4 shows a write invalidating. Line 5 shows the hot-loop
ceiling refusing the third request with `Retry-After` and no database call, and line 6
shows a macOS client is unaffected by those refusals (separate bucket, separate key).

**Gates run locally:** `make preflight` — **28/28 pass**. `scripts/typecheck.sh` — 0
errors. `scripts/scan_async_blockers.py --dirs routers utils` — 0 blocking findings.
Backend unit suites (run per file; batching these files has a pre-existing cross-module
import-pollution artifact on `main` as well): `test_action_items_list_read_cost` 25
passed, `test_rate_limiting` 84 passed/1 skipped, `test_action_items_pagination_order` 11
passed, `test_action_items_router_pagination` 4 passed, `test_action_item_ids_endpoint` 13
passed, `test_action_items_conversation_list_malformed` 3 passed,
`test_action_item_canonical_contract` 18 passed, `test_mcp_action_item_writes` 43 passed,
plus `test_rate_limit_cache_cap`, `test_rate_limit_json_failopen`,
`test_action_item_dedup`, `test_action_item_date_validation`,
`test_action_items_date_coercion`, `test_action_items_due_range_index_contract`,
`test_conversation_action_items_count`, `test_action_items_timezone`,
`test_action_items_date_range_validation`, `test_action_item_reminder_cancel_on_complete`,
`test_action_item_vector_best_effort` — all green.

Failure-Class: none

This is a cost control on a route that is behaving as designed, not a repair of a
semantic defect. `scripts/failure-class prepare` found no definition whose scope hints
overlap the change. (The nearest historical class, `FC-alert-never-provably-fired`,
belongs to #12258 — a limiter that shipped and never fired — and is already fixed; the
two new counters here exist so this change cannot repeat it.)

Line-Count-Exception: backend/database/action_items.py | 1543 -> 1562 | one `bump_action_items_list_version(uid)` call after each of the module's committed writes, plus the import; the module is the canonical mutation owner for this collection, so splitting it to add cache invalidation would move the invalidation away from the writes it must follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

