### PR TITLE
fix(app): make chat message Share button work (share_plus 11)

### DIFF
--- a/app/lib/pages/chat/widgets/ai_message.dart
+++ b/app/lib/pages/chat/widgets/ai_message.dart
@@ -1305,7 +1305,9 @@ class _MessageActionBarState extends State<MessageActionBar> {
             onTap: () async {
               if (widget.messageText.isEmpty) return;
               HapticFeedback.lightImpact();
-              await Share.share(widget.messageText, sharePositionOrigin: shareSheetOrigin());
+              await SharePlus.instance.share(
+                ShareParams(text: widget.messageText, sharePositionOrigin: shareSheetOrigin()),
+              );
               PlatformManager.instance.analytics.track(
                 'Chat Message Shared',
                 properties: {'message': widget.messageText},


### PR DESCRIPTION
Clicking Share on a chat message did nothing. share_plus 11 deprecated `Share.share()`; migrated the chat-message share to `SharePlus.instance.share(ShareParams(...))` — the same pattern that already fixed the other share buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

