### PR TITLE
fix(backend): stop replaying the capture-receipt backlog into Chat

### DIFF
--- a/.github/failure-classes/FC-presence-gated-notice-without-retirement.json
+++ b/.github/failure-classes/FC-presence-gated-notice-without-retirement.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-presence-gated-notice-without-retirement",
+  "violated_contract": "A per-event notice whose delivery is gated on the consumer being present must carry a rule that retires it when it stops being worth delivering. Without one the producer writes a row per event and nothing ever removes it, so the queue grows for exactly as long as the consumer is absent and the eventual arrival replays the whole backlog in one batch -- stamped with the consumer's own clock, which makes a week of late notices read as a burst sent just now rather than as late ones. The defect is invisible to everyone who is watching: a present consumer drains each notice before a second can accumulate, so every test, demo, and dogfood session sees the correct one-notice-per-event behaviour, and only an account that stepped away ever meets the failure. A staleness threshold that is measured and reported but never acted on is not a retirement rule; it makes the backlog observable without bounding it.",
+  "canonical_prevention": "Decide retirement in the one place that decides deliverability, and express it as two bounds on the notice itself: superseded -- an older notice about the same subject class has been overtaken by a newer one -- and expired -- the notice is older than the window in which a consumer could still have acted on it. Retire transactionally, re-reading the row so a notice another consumer already claimed is never taken from under it, bound the retirement writes per pass so a long backlog cannot make one fetch linear in its size, and emit a lifecycle metric for each retirement so the drop is reported rather than silent. Pin it with a test that a backlog collapses to one deliverable notice and a test that the live one-at-a-time path is unchanged.",
+  "canonical_prevention_artifact": [
+    "backend/database/chat_first_intents.py",
+    "backend/tests/unit/test_chat_first_proactive_intents.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/database/chat_first_intents.py",
+    "backend/routers/chat_first.py",
+    "backend/utils/task_intelligence/proactive_engine.py"
+  ],
+  "status": "open"
+}

--- a/backend/database/chat_first_intents.py
+++ b/backend/database/chat_first_intents.py
@@ -859,15 +859,23 @@ def _retire_capture_receipt(
     now: datetime,
     firestore_client: Any,
 ) -> bool:
-    """Terminalize one undelivered capture receipt.
+    """Terminalize one capture receipt that was never handed to a kernel.
 
-    Re-reads inside the transaction and refuses anything that is no longer a
-    ready capture receipt, so a row a concurrent poll already advanced into
-    ``pending_kernel_receipt`` is never retired from under the kernel that is
-    about to acknowledge it.
+    Returns whether the row was retired. Everything is decided from a re-read
+    inside the transaction, because the caller's copy comes from a collection
+    scan that cannot see the sibling delivery-attempt document:
+
+    * A fetch does not change ``delivery_state`` for a normal intent -- it only
+      increments ``fetch_count`` on that sibling -- so ``ready`` alone does not
+      mean undelivered. A receipt some kernel is already holding is refused
+      here and left to the unacknowledged-fetch budget, which is the existing
+      owner of a delivery that never came back.
+    * The terminal record is written from the hydrated intent, so the dead
+      letter keeps the fetch and deferral history rather than defaults.
     """
 
     intent_ref = _intent_ref(uid, intent_id, firestore_client=firestore_client)
+    attempt_ref = _delivery_attempt_ref(uid, intent_id, firestore_client=firestore_client)
     transaction = firestore_client.transaction()
 
     @firestore.transactional
@@ -876,7 +884,9 @@ def _retire_capture_receipt(
         if not snapshot.exists:
             return False
         try:
-            intent = _intent_from_snapshot(snapshot)
+            intent = _intent_with_delivery_attempt(
+                _intent_from_snapshot(snapshot), attempt_ref.get(transaction=write_transaction)
+            )
         except ChatFirstMalformedDocument:
             # The malformed sweep in this same fetch owns that row.
             return False
@@ -884,6 +894,7 @@ def _retire_capture_receipt(
             intent.account_generation != account_generation
             or intent.delivery_state != 'ready'
             or not _is_capture_receipt(intent)
+            or intent.fetch_count > 0
         ):
             return False
         delivery_attempts.move_to_dead_letters(
@@ -957,26 +968,24 @@ def fetch_ready_intent_batch(
             continue
         candidates.append(intent)
 
-    # Keep at most the newest live receipt; retire the rest. Removing them here
-    # is what stops the backlog replay -- the bounded writes further down only
-    # stop the same rows being re-scanned on every later poll.
+    # Keep at most the newest live receipt and retire the rest.
     capture_receipts.sort(key=lambda intent: (intent.created_at, intent.intent_id))
     retiring_captures: list[tuple[ProactiveIntent, str]] = [
         (intent, SUPERSEDED_CAPTURE_DEAD_LETTER_REASON) for intent in capture_receipts[:-1]
     ]
+    deliverable_capture: ProactiveIntent | None = None
     if capture_receipts:
         newest = capture_receipts[-1]
         if fetched_at - newest.created_at > CAPTURE_RECEIPT_DELIVERY_WINDOW:
             retiring_captures.append((newest, STALE_CAPTURE_DEAD_LETTER_REASON))
         else:
-            candidates.append(newest)
-    candidates.sort(key=lambda intent: (_fetch_priority(intent), intent.created_at, intent.intent_id))
+            deliverable_capture = newest
 
     ready: list[ProactiveIntent] = []
     candidate_scan_limit = FETCH_CANDIDATE_SCAN_MULTIPLIER * limit
     # Bounded per poll so a long backlog can never make one fetch linear in its
-    # size. Whatever is left over is already excluded from this response, so it
-    # costs nothing to retire it on a later poll instead.
+    # size. Whatever is left over is excluded from this response either way, so
+    # it costs nothing to retire it on a later poll instead.
     for intent, reason in retiring_captures[:candidate_scan_limit]:
         try:
             retired = _retire_capture_receipt(
@@ -992,6 +1001,18 @@ def fetch_ready_intent_batch(
             continue
         if retired:
             lifecycle_events.append(IntentLifecycleEvent('retired', intent.source, reason))
+        else:
+            # A receipt a kernel is already holding, or one another poll changed
+            # underneath this scan. Put it back in play rather than leaving it
+            # out of every future response: its own delivery path -- the
+            # unacknowledged-fetch budget -- is what terminalizes it, and the
+            # kernel keys the row on a stable turn ID, so re-offering it cannot
+            # produce a second card.
+            candidates.append(intent)
+    if deliverable_capture is not None:
+        candidates.append(deliverable_capture)
+    candidates.sort(key=lambda intent: (_fetch_priority(intent), intent.created_at, intent.intent_id))
+
     hydrated_attempts: dict[str, ProactiveIntent] = {}
     stall_age_candidates: list[tuple[datetime, ProactiveIntent]] = []
     oldest_candidates = sorted(candidates, key=lambda intent: (intent.created_at, intent.intent_id))

--- a/backend/database/chat_first_intents.py
+++ b/backend/database/chat_first_intents.py
@@ -55,6 +55,20 @@ logger = logging.getLogger(__name__)
 MATERIALIZATION_REJECTION_BUDGET = 3
 UNACKNOWLEDGED_FETCH_BUDGET = 20
 STALLED_READY_AGE = timedelta(hours=24)
+# A capture receipt announces one conversation that just finished processing.
+# It is only ever delivered while the rich Chat transcript is foregrounded, and
+# until now nothing retired one that was never delivered -- so an account that
+# was not looking at Chat accrued one ready intent per finalized conversation,
+# and the next foreground poll handed the kernel a whole batch of them at once.
+# The kernel stamps every row it writes with its own clock, so that backlog
+# lands as a run of conversation cards sharing one timestamp, days after the
+# conversations they announce.  Two bounds keep a receipt a live notice: an
+# older receipt has been superseded by a newer one, and a receipt past the
+# delivery window has no reader left.  Neither loses anything, because the
+# conversation itself is in the conversation list either way.
+CAPTURE_RECEIPT_DELIVERY_WINDOW = STALLED_READY_AGE
+STALE_CAPTURE_DEAD_LETTER_REASON = 'stale_capture_receipt'
+SUPERSEDED_CAPTURE_DEAD_LETTER_REASON = 'superseded_capture_receipt'
 PERMANENT_REJECTION_CODES = frozenset({'invalid_intent', 'identity_conflict'})
 _SYNTHETIC_RECONCILIATION_RECEIPT_PREFIX = 'cfi_reconciled_'
 
@@ -664,10 +678,21 @@ def _message_has_intent_identity(uid: str, intent_id: str, *, firestore_client: 
     return isinstance(metadata, dict) and metadata.get('chatFirstIntentId') == intent_id
 
 
+def _is_capture_receipt(intent: ProactiveIntent) -> bool:
+    """The plain "your conversation is ready" receipt, not a meeting-notes intent.
+
+    A desktop meeting carries a ``conversationLink`` under the same source and
+    keeps its own delivery contract; only the bare ``captureLink`` receipt is
+    the per-conversation notice that collapses.
+    """
+
+    return intent.source == 'capture_arrival' and all(block.type == 'captureLink' for block in intent.blocks)
+
+
 def _fetch_priority(intent: ProactiveIntent) -> int:
     if intent.source == 'daily_opener' or any(block.type == 'conversationLink' for block in intent.blocks):
         return 0
-    if intent.source == 'capture_arrival' and all(block.type == 'captureLink' for block in intent.blocks):
+    if _is_capture_receipt(intent):
         return 2
     return 1
 
@@ -825,6 +850,54 @@ def _requeue_transient_dead_letter(
         raise ChatFirstMalformedDocument('chat-first dead letter is malformed') from error
 
 
+def _retire_capture_receipt(
+    uid: str,
+    intent_id: str,
+    *,
+    account_generation: int,
+    reason: str,
+    now: datetime,
+    firestore_client: Any,
+) -> bool:
+    """Terminalize one undelivered capture receipt.
+
+    Re-reads inside the transaction and refuses anything that is no longer a
+    ready capture receipt, so a row a concurrent poll already advanced into
+    ``pending_kernel_receipt`` is never retired from under the kernel that is
+    about to acknowledge it.
+    """
+
+    intent_ref = _intent_ref(uid, intent_id, firestore_client=firestore_client)
+    transaction = firestore_client.transaction()
+
+    @firestore.transactional
+    def apply(write_transaction: Any) -> bool:
+        snapshot = intent_ref.get(transaction=write_transaction)
+        if not snapshot.exists:
+            return False
+        try:
+            intent = _intent_from_snapshot(snapshot)
+        except ChatFirstMalformedDocument:
+            # The malformed sweep in this same fetch owns that row.
+            return False
+        if (
+            intent.account_generation != account_generation
+            or intent.delivery_state != 'ready'
+            or not _is_capture_receipt(intent)
+        ):
+            return False
+        delivery_attempts.move_to_dead_letters(
+            write_transaction,
+            intent_ref_value=intent_ref,
+            dead_letter_ref_value=_dead_letter_ref(uid, intent_id, firestore_client=firestore_client),
+            intent=intent.model_copy(update={'delivery_state': 'dead_letter', 'dead_letter_reason': reason}),
+            terminal_at=now,
+        )
+        return True
+
+    return apply(transaction)
+
+
 def fetch_ready_intent_batch(
     uid: str,
     *,
@@ -858,6 +931,7 @@ def fetch_ready_intent_batch(
     query = collection.where(filter=FieldFilter('delivery_state', 'in', ['ready', 'pending_kernel_receipt']))
     candidates: list[ProactiveIntent] = []
     malformed_intent_ids: list[str] = []
+    capture_receipts: list[ProactiveIntent] = []
     for snapshot in query.stream():
         try:
             intent = _intent_from_snapshot(snapshot)
@@ -872,11 +946,52 @@ def fetch_ready_intent_batch(
         # legacy-compatible intents behind them.
         if exclude_block_types and any(block.type in exclude_block_types for block in intent.blocks):
             continue
+        # A receipt this device explicitly deferred keeps its own contract and
+        # is re-offered below rather than collapsed against its siblings.
+        if (
+            intent.delivery_state == 'ready'
+            and _is_capture_receipt(intent)
+            and not (deferred_intent_ids and intent.intent_id in deferred_intent_ids)
+        ):
+            capture_receipts.append(intent)
+            continue
         candidates.append(intent)
+
+    # Keep at most the newest live receipt; retire the rest. Removing them here
+    # is what stops the backlog replay -- the bounded writes further down only
+    # stop the same rows being re-scanned on every later poll.
+    capture_receipts.sort(key=lambda intent: (intent.created_at, intent.intent_id))
+    retiring_captures: list[tuple[ProactiveIntent, str]] = [
+        (intent, SUPERSEDED_CAPTURE_DEAD_LETTER_REASON) for intent in capture_receipts[:-1]
+    ]
+    if capture_receipts:
+        newest = capture_receipts[-1]
+        if fetched_at - newest.created_at > CAPTURE_RECEIPT_DELIVERY_WINDOW:
+            retiring_captures.append((newest, STALE_CAPTURE_DEAD_LETTER_REASON))
+        else:
+            candidates.append(newest)
     candidates.sort(key=lambda intent: (_fetch_priority(intent), intent.created_at, intent.intent_id))
 
     ready: list[ProactiveIntent] = []
     candidate_scan_limit = FETCH_CANDIDATE_SCAN_MULTIPLIER * limit
+    # Bounded per poll so a long backlog can never make one fetch linear in its
+    # size. Whatever is left over is already excluded from this response, so it
+    # costs nothing to retire it on a later poll instead.
+    for intent, reason in retiring_captures[:candidate_scan_limit]:
+        try:
+            retired = _retire_capture_receipt(
+                uid,
+                intent.intent_id,
+                account_generation=account_generation,
+                reason=reason,
+                now=fetched_at,
+                firestore_client=client,
+            )
+        except Exception:
+            # One unretirable row never blocks an independent ready intent.
+            continue
+        if retired:
+            lifecycle_events.append(IntentLifecycleEvent('retired', intent.source, reason))
     hydrated_attempts: dict[str, ProactiveIntent] = {}
     stall_age_candidates: list[tuple[datetime, ProactiveIntent]] = []
     oldest_candidates = sorted(candidates, key=lambda intent: (intent.created_at, intent.intent_id))

--- a/backend/tests/unit/test_chat_first_proactive_intents.py
+++ b/backend/tests/unit/test_chat_first_proactive_intents.py
@@ -1875,6 +1875,59 @@ def test_a_capture_receipt_awaiting_its_kernel_receipt_is_never_retired(firestor
     assert {intent.intent_id for intent in batch.intents} == {pending.intent_id, newer.intent_id}
 
 
+def test_a_capture_receipt_a_kernel_already_holds_is_not_superseded(firestore):
+    """A fetch leaves a normal intent ``ready`` -- only the sibling attempt row moves.
+
+    So ``ready`` alone does not mean undelivered, and superseding on it would
+    delete a row out from under the kernel that is about to acknowledge it.
+    """
+
+    in_flight = _capture_receipt(firestore, 'in-flight', created_at=NOW)
+    first = intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, now=NOW + timedelta(minutes=1), firestore_client=firestore
+    )
+    assert [intent.intent_id for intent in first.intents] == [in_flight.intent_id]
+    assert (
+        firestore.rows[('users', UID, intents_db.INTENTS_COLLECTION, in_flight.intent_id)]['delivery_state'] == 'ready'
+    )
+
+    newer = _capture_receipt(firestore, 'newer', created_at=NOW + timedelta(minutes=2))
+    second = intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, now=NOW + timedelta(minutes=3), firestore_client=firestore
+    )
+
+    assert _dead_letter_reason(firestore, in_flight.intent_id) is None
+    assert {intent.intent_id for intent in second.intents} == {in_flight.intent_id, newer.intent_id}
+    # The unacknowledged-fetch budget, not this rule, is what terminalizes it.
+    assert (
+        firestore.rows[('users', UID, intents_db.DELIVERY_ATTEMPTS_COLLECTION, in_flight.intent_id)]['fetch_count'] == 2
+    )
+
+
+def test_a_retired_receipt_keeps_its_delivery_attempt_history(firestore):
+    """The terminal record is written from the hydrated intent, not the bare row."""
+
+    superseded = _capture_receipt(firestore, 'superseded', created_at=NOW)
+    _capture_receipt(firestore, 'newest', created_at=NOW + timedelta(minutes=1))
+    deferred_at = NOW - timedelta(hours=2)
+    firestore.rows[('users', UID, intents_db.DELIVERY_ATTEMPTS_COLLECTION, superseded.intent_id)] = {
+        'fetch_count': 0,
+        'first_deferred_at': deferred_at,
+        'last_deferral_at': deferred_at,
+    }
+
+    intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, now=NOW + timedelta(minutes=2), firestore_client=firestore
+    )
+
+    dead = DeadLetteredProactiveIntent.model_validate(
+        firestore.rows[('users', UID, intents_db.DEAD_LETTERS_COLLECTION, superseded.intent_id)]
+    )
+    assert dead.dead_letter_reason == intents_db.SUPERSEDED_CAPTURE_DEAD_LETTER_REASON
+    assert dead.first_deferred_at == deferred_at
+    assert dead.last_deferral_at == deferred_at
+
+
 def test_capture_retirement_writes_stay_bounded_on_one_poll(firestore):
     limit = 2
     for index in range(4 * intents_db.FETCH_CANDIDATE_SCAN_MULTIPLIER * limit):

--- a/backend/tests/unit/test_chat_first_proactive_intents.py
+++ b/backend/tests/unit/test_chat_first_proactive_intents.py
@@ -701,9 +701,11 @@ def test_deferred_old_intent_does_not_stall_but_never_fetched_old_intent_does(fi
     )
     assert without_stall.stalled_source is None
 
+    # Not a capture receipt: one this old is retired rather than left to
+    # stall, so the stall clock is shown on a source that still waits.
     intents_db.create_intent(
         UID,
-        source='capture_arrival',
+        source='deferral_reraise',
         continuity_key='capture:old-never-fetched',
         subject=ChatFirstSubject(kind='capture', id='old-never-fetched'),
         blocks=[CaptureLinkSpec(type='captureLink', conversation_id='old-never-fetched', summary='Old')],
@@ -714,7 +716,7 @@ def test_deferred_old_intent_does_not_stall_but_never_fetched_old_intent_does(fi
     stalled = intents_db.fetch_ready_intent_batch(
         UID, account_generation=GENERATION, now=NOW, firestore_client=firestore
     )
-    assert stalled.stalled_source == 'capture_arrival'
+    assert stalled.stalled_source == 'deferral_reraise'
 
 
 def test_stall_age_restarts_at_last_deferral_but_eventually_pages(firestore):
@@ -810,7 +812,9 @@ def test_fetch_candidate_transactions_are_capped_at_twice_the_response_limit(fir
     for index in range(7):
         intents_db.create_intent(
             UID,
-            source='capture_arrival',
+            # Not a capture receipt: those collapse to the newest one, and this
+            # bound is about the candidate scan rather than that rule.
+            source='deferral_reraise',
             continuity_key=f'capture:scan-cap-{index}',
             subject=ChatFirstSubject(kind='capture', id=f'scan-cap-{index}'),
             blocks=[CaptureLinkSpec(type='captureLink', conversation_id=f'scan-cap-{index}', summary='Candidate')],
@@ -1072,7 +1076,9 @@ def test_repair_query_does_not_starve_repairable_row_behind_requeued_deaths(fire
     for index in range(20):
         intent, _ = intents_db.create_intent(
             UID,
-            source='capture_arrival',
+            # Not a capture receipt: a requeued one past its delivery window is
+            # retired, which is a different rule than the one under test here.
+            source='deferral_reraise',
             continuity_key=f'capture:repair-starvation:{index}',
             subject=ChatFirstSubject(kind='capture', id=f'repair-starvation-{index}'),
             blocks=[CaptureLinkSpec(type='captureLink', conversation_id=f'repair-{index}', summary='Repair')],
@@ -1747,9 +1753,148 @@ def test_fetch_orders_daily_and_meeting_intents_ahead_of_capture_link_backlog(fi
         UID, account_generation=GENERATION, now=NOW + timedelta(days=2), firestore_client=firestore
     )
 
-    assert [intent.intent_id for intent in batch.intents[:2]] == [daily.intent_id, meeting.intent_id]
-    assert len(batch.intents) == 8
-    assert batch.stalled_source == 'capture_arrival'
+    # The daily opener and the meeting-notes intent keep their priority, and the
+    # nine-deep capture backlog no longer follows them into the transcript: the
+    # newest receipt is two days old, so every one of them is retired.
+    assert [intent.intent_id for intent in batch.intents] == [daily.intent_id, meeting.intent_id]
+    # The stall clock now pages on the opener, which is the one row still
+    # waiting past the boundary rather than being retired at it.
+    assert batch.stalled_source == 'daily_opener'
+    dead_reasons = {
+        row['dead_letter_reason']
+        for path, row in firestore.rows.items()
+        if path[2] == intents_db.DEAD_LETTERS_COLLECTION
+    }
+    assert dead_reasons == {
+        intents_db.SUPERSEDED_CAPTURE_DEAD_LETTER_REASON,
+        intents_db.STALE_CAPTURE_DEAD_LETTER_REASON,
+    }
+
+
+def _capture_receipt(firestore, key: str, *, created_at):
+    intent, _ = intents_db.create_intent(
+        UID,
+        source='capture_arrival',
+        continuity_key=f'capture:{key}',
+        subject=ChatFirstSubject(kind='capture', id=key),
+        blocks=[CaptureLinkSpec(type='captureLink', conversation_id=key, summary=f'Conversation {key}')],
+        account_generation=GENERATION,
+        now=created_at,
+        firestore_client=firestore,
+    )
+    return intent
+
+
+def _dead_letter_reason(firestore, intent_id: str) -> str | None:
+    row = firestore.rows.get(('users', UID, intents_db.DEAD_LETTERS_COLLECTION, intent_id))
+    return None if row is None else row['dead_letter_reason']
+
+
+def test_capture_receipt_backlog_collapses_to_the_newest_live_receipt(firestore):
+    """One conversation card, not the run of them a closed Chat used to accrue."""
+
+    receipts = [
+        _capture_receipt(firestore, f'backlog-{index}', created_at=NOW + timedelta(minutes=index)) for index in range(5)
+    ]
+
+    batch = intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, now=NOW + timedelta(minutes=10), firestore_client=firestore
+    )
+
+    assert [intent.intent_id for intent in batch.intents] == [receipts[-1].intent_id]
+    assert {_dead_letter_reason(firestore, intent.intent_id) for intent in receipts[:-1]} == {
+        intents_db.SUPERSEDED_CAPTURE_DEAD_LETTER_REASON
+    }
+    assert [event.event for event in batch.lifecycle_events] == ['retired'] * 4
+    # The surviving receipt is delivered, not parked for a later poll.
+    assert ('users', UID, intents_db.INTENTS_COLLECTION, receipts[-1].intent_id) in firestore.rows
+
+
+def test_capture_receipt_past_its_delivery_window_is_retired_rather_than_delivered(firestore):
+    stale = _capture_receipt(
+        firestore, 'stale', created_at=NOW - intents_db.CAPTURE_RECEIPT_DELIVERY_WINDOW - timedelta(minutes=1)
+    )
+
+    assert (
+        intents_db.fetch_ready_intent_batch(
+            UID, account_generation=GENERATION, now=NOW, firestore_client=firestore
+        ).intents
+        == []
+    )
+    assert _dead_letter_reason(firestore, stale.intent_id) == intents_db.STALE_CAPTURE_DEAD_LETTER_REASON
+
+    live = _capture_receipt(
+        firestore, 'live', created_at=NOW - intents_db.CAPTURE_RECEIPT_DELIVERY_WINDOW + timedelta(minutes=1)
+    )
+    delivered = intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, now=NOW, firestore_client=firestore
+    )
+    assert [intent.intent_id for intent in delivered.intents] == [live.intent_id]
+
+
+def test_meeting_notes_intents_keep_their_own_delivery_contract(firestore):
+    """``conversationLink`` shares the source but is not a per-conversation receipt."""
+
+    meetings = []
+    for index in range(2):
+        intent, _ = intents_db.create_intent(
+            UID,
+            source='capture_arrival',
+            continuity_key=f'meeting:{index}',
+            subject=ChatFirstSubject(kind='capture', id=f'meeting-{index}'),
+            blocks=[
+                ConversationLinkSpec(
+                    type='conversationLink', conversation_id=f'meeting-{index}', summary='Meeting notes ready'
+                )
+            ],
+            account_generation=GENERATION,
+            now=NOW + timedelta(minutes=index),
+            firestore_client=firestore,
+        )
+        meetings.append(intent)
+
+    batch = intents_db.fetch_ready_intent_batch(
+        UID, account_generation=GENERATION, now=NOW + timedelta(days=30), firestore_client=firestore
+    )
+
+    assert {intent.intent_id for intent in batch.intents} == {intent.intent_id for intent in meetings}
+
+
+def test_a_capture_receipt_awaiting_its_kernel_receipt_is_never_retired(firestore):
+    """The kernel already wrote that row; retiring it would strand its receipt."""
+
+    pending = _capture_receipt(firestore, 'pending', created_at=NOW - timedelta(days=30))
+    newer = _capture_receipt(firestore, 'newer', created_at=NOW)
+    firestore.rows[('users', UID, intents_db.INTENTS_COLLECTION, pending.intent_id)][
+        'delivery_state'
+    ] = 'pending_kernel_receipt'
+
+    batch = intents_db.fetch_ready_intent_batch(UID, account_generation=GENERATION, now=NOW, firestore_client=firestore)
+
+    assert _dead_letter_reason(firestore, pending.intent_id) is None
+    assert {intent.intent_id for intent in batch.intents} == {pending.intent_id, newer.intent_id}
+
+
+def test_capture_retirement_writes_stay_bounded_on_one_poll(firestore):
+    limit = 2
+    for index in range(4 * intents_db.FETCH_CANDIDATE_SCAN_MULTIPLIER * limit):
+        _capture_receipt(firestore, f'flood-{index:03d}', created_at=NOW + timedelta(seconds=index))
+    transactions_before = firestore.transaction_count
+
+    batch = intents_db.fetch_ready_intent_batch(
+        UID,
+        account_generation=GENERATION,
+        limit=limit,
+        now=NOW + timedelta(minutes=1),
+        firestore_client=firestore,
+    )
+
+    # Everything but the newest is excluded from the response on this poll even
+    # though only a bounded number of them can be retired by it.
+    assert len(batch.intents) == 1
+    retired = sum(1 for event in batch.lifecycle_events if event.event == 'retired')
+    assert retired == intents_db.FETCH_CANDIDATE_SCAN_MULTIPLIER * limit
+    assert firestore.transaction_count - transactions_before <= 2 * intents_db.FETCH_CANDIDATE_SCAN_MULTIPLIER * limit
 
 
 def test_stall_scan_includes_old_low_priority_intent_below_response_window(firestore):
@@ -1764,9 +1909,10 @@ def test_stall_scan_includes_old_low_priority_intent_below_response_window(fires
             now=NOW + timedelta(seconds=index),
             firestore_client=firestore,
         )
+    # Not a capture receipt: one this old is retired instead of stalling.
     old, _ = intents_db.create_intent(
         UID,
-        source='capture_arrival',
+        source='deferral_reraise',
         continuity_key='capture:old-low-priority',
         subject=ChatFirstSubject(kind='capture', id='old-low-priority'),
         blocks=[CaptureLinkSpec(type='captureLink', conversation_id='old-low-priority', summary='Old')],
@@ -1780,7 +1926,7 @@ def test_stall_scan_includes_old_low_priority_intent_below_response_window(fires
     )
 
     assert old.intent_id not in {intent.intent_id for intent in batch.intents}
-    assert batch.stalled_source == 'capture_arrival'
+    assert batch.stalled_source == 'deferral_reraise'
 
 
 def test_cold_start_generation_retries_one_pending_intent_until_its_kernel_receipt(firestore):


### PR DESCRIPTION
## What you see

Open Chat after being away and a run of conversation cards appears at once —
one per conversation, each with the "Conversation" eyebrow and an
**Open conversation** button, all sharing a single timestamp, for conversations
that happened days ago. It reads as if they were sent retroactively.

## Why

Each of those cards is a **capture receipt**: a `capture_arrival` proactive
intent carrying a `captureLink` block, queued by
`backend/utils/conversations/finalizer.py` for every finalized Omi conversation.

Three properties combine into the symptom:

1. A receipt is only ever delivered while the rich Chat transcript is
   **foregrounded** — `_materialize_prompts` returns nothing unless
   `window_foreground and initial_page_loaded`. Being away means nothing drains.
2. **Nothing retired an undelivered receipt.** `capture_arrival` does not
   consume the proactive turn budget and had no expiry, so the queue grew by one
   ready intent per conversation, without bound, for as long as Chat stayed
   closed. `STALLED_READY_AGE` (24h) already named the staleness boundary but
   only ever incremented a metric.
3. The next foreground poll fetched a **batch of 8** and the desktop kernel
   materialized all of them, stamping each row with its own clock
   (`createdAtMs: now` in `conversation-journal.ts`). Hence one timestamp for a
   week of conversations — the timestamp is honest about when the card was
   inserted, which is exactly what makes the backlog look retroactive.

So the same-timestamp run is a symptom; the defect is that a live per-conversation
notice had no retirement rule.

## The fix

Bound the receipt to being a live notice, in the one place that decides what is
deliverable (`fetch_ready_intent_batch`):

- **Only the newest ready receipt is offered.** Older siblings have been
  superseded by it and are retired as `superseded_capture_receipt`.
- **A receipt past `CAPTURE_RECEIPT_DELIVERY_WINDOW`** — the module's existing
  24h boundary, now enforced rather than only counted — has no reader left and is
  retired as `stale_capture_receipt`.

Nothing is lost either way: the conversation itself is in the conversation list.
In the live case there is only ever one ready receipt at a time, so supersession
never fires and the card still arrives within a poll of the conversation
finishing — the collapse only engages on the backlog that is the bug.

Safety properties held:

- Retirement is transactional and re-reads the row, so a receipt a concurrent
  poll already advanced into `pending_kernel_receipt` is never taken from under
  the kernel that is about to acknowledge it.
- Retirement writes are bounded per poll by the existing candidate scan limit, so
  a long backlog cannot make one fetch linear in its size. Rows past the bound are
  already excluded from the response and are retired on a later poll.
- Meeting-notes intents share the `capture_arrival` source but carry a
  `conversationLink`; `_is_capture_receipt` excludes them and they keep their own
  delivery contract.
- Both retirements emit an `IntentLifecycleEvent`, so `CHAT_FIRST_PROACTIVE_TOTAL`
  now reports what was dropped and why.

## Review findings addressed (cubic, both valid)

**P1 — a fetched receipt could be superseded out from under its kernel.** Correct,
and it invalidated my first guard: for a normal intent `_advance_fetched_intent`
never changes `delivery_state`, it only increments `fetch_count` on the sibling
delivery-attempt document. `ready` therefore does not mean undelivered. Retirement
now hydrates that sibling inside its transaction and refuses any receipt with a
non-zero fetch count, leaving it to the unacknowledged-fetch budget that already
owns an undelivered fetch. A refused row goes back into the candidate set rather
than being dropped from every future response; the kernel keys its row on a stable
turn ID, so re-offering cannot produce a second card.

**P2 — retirement dropped the delivery-attempt history from the terminal record.**
Also correct; the same hydration fixes it. The dead letter is now written from the
hydrated intent, so a retired receipt keeps its fetch and deferral history instead
of reporting defaults.

## Tests

`backend/tests/unit/test_chat_first_proactive_intents.py` — seven new cases:
backlog collapses to the newest live receipt; a receipt past the window is retired
rather than delivered while one inside it is delivered; meeting-notes intents are
not collapsed; a receipt awaiting its kernel receipt is never retired; retirement
writes stay bounded on one poll; a receipt a kernel already holds is not superseded
by a newer one; a retired receipt keeps its delivery-attempt history. Five of the
seven fail without the change they pin.

Three existing tests used a stack of capture receipts as generic filler for
scan-bound and stall-clock invariants; they now use a source that still waits, so
those invariants are unchanged. `test_fetch_orders_daily_and_meeting_intents_ahead_of_capture_link_backlog`
stated the old contract and now states the new one.

```
pytest tests/unit/test_chat_first_*.py \
       tests/services/test_conversation_finalization.py  ->  154 passed
pytest tests/routers/test_conversation_first_open_dispatch.py  ->  passed
scripts/typecheck.sh  ->  0 errors
```

Failure-Class: new

New class, added in this PR as
`.github/failure-classes/FC-presence-gated-notice-without-retirement.json`: a
per-event notice whose delivery is gated on the consumer being present must carry
a rule that retires it when it stops being worth delivering. Without one the queue
grows by one row per event for as long as the consumer is absent, and its eventual
arrival replays the whole backlog in one batch — stamped with the consumer's own
clock, so it reads as a burst sent just now rather than as late notices. It is
invisible to everyone who is watching, because a present consumer drains each
notice before a second can accumulate.

Line-Count-Exception: backend/database/chat_first_intents.py | 1453 -> 1589 | The retirement rule belongs in `fetch_ready_intent_batch`, which is the single place that decides what is deliverable; splitting the intent store to add one predicate and one transactional writer would move the delivery decision away from the fetch that makes it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
