### PR TITLE
feat: daily+weekly thumbs positive % (macOS, text vs voice)

### DIFF
--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -916,9 +916,13 @@ class AnalyticsManager {
     PostHogManager.shared.track("chat_session_deleted", properties: [:])
   }
 
-  func messageRated(rating: Int) {
+  func messageRated(rating: Int, surface: String = "text") {
     let ratingString = rating == 1 ? "thumbs_up" : "thumbs_down"
-    PostHogManager.shared.track("message_rated", properties: ["rating": ratingString])
+    // `source` splits the admin thumbs-ratio chart: "text" = main-window
+    // chat, "voice" = floating-bar responses. Events before this dimension
+    // existed chart as the combined series only.
+    PostHogManager.shared.track(
+      "message_rated", properties: ["rating": ratingString, "source": surface])
   }
 
   func initialMessageGenerated(hasApp: Bool) {

--- a/desktop/macos/Desktop/Sources/Chat/ChatMessageRatingPersistence.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatMessageRatingPersistence.swift
@@ -22,12 +22,20 @@ enum ChatMessageRatingPersistence: Equatable {
 
 /// Last-write-wins queue of ratings that must wait for journal sync.
 struct ChatMessageRatingQueue: Equatable {
-  private var pending: [String: Int?] = [:]
+  struct Entry: Equatable {
+    let rating: Int?
+    /// Telemetry dimension carried with the rating so a queued floating-bar
+    /// thumb still reports source=voice after sync (it must never silently
+    /// default back to text at flush time).
+    let surface: String
+  }
+
+  private var pending: [String: Entry] = [:]
 
   var isEmpty: Bool { pending.isEmpty }
 
-  mutating func enqueue(messageId: String, rating: Int?) {
-    pending.updateValue(rating, forKey: messageId)
+  mutating func enqueue(messageId: String, rating: Int?, surface: String = "text") {
+    pending.updateValue(Entry(rating: rating, surface: surface), forKey: messageId)
   }
 
   mutating func cancel(messageId: String) {
@@ -52,10 +60,12 @@ struct ChatMessageRatingQueue: Equatable {
   /// message whose `id` is the kernel `turnId`, while the original id survives
   /// only as `clientTurnId`. Match on either so the rating survives the remap,
   /// and PATCH with the projected (remote) id so the backend row is found.
-  mutating func drain(using messages: [ChatMessage]) -> [(messageId: String, rating: Int?)] {
-    var persist: [(messageId: String, rating: Int?)] = []
+  mutating func drain(
+    using messages: [ChatMessage]
+  ) -> [(messageId: String, rating: Int?, surface: String)] {
+    var persist: [(messageId: String, rating: Int?, surface: String)] = []
     let snapshot = pending
-    for (messageId, rating) in snapshot {
+    for (messageId, entry) in snapshot {
       guard let message = messages.first(where: { $0.id == messageId || $0.clientTurnId == messageId }) else {
         pending.removeValue(forKey: messageId)
         continue
@@ -63,7 +73,7 @@ struct ChatMessageRatingQueue: Equatable {
       switch ChatMessageRatingPersistence.of(message) {
       case .persistNow:
         pending.removeValue(forKey: messageId)
-        persist.append((message.id, rating))
+        persist.append((message.id, entry.rating, entry.surface))
       case .localOnly:
         pending.removeValue(forKey: messageId)
       case .waitForSync:

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -3106,7 +3106,7 @@ class FloatingControlBarManager {
     barWindow.onRate = { [weak chatProvider] messageId, rating in
       guard let provider = chatProvider else { return }
       Task { @MainActor in
-        await provider.rateMessage(messageId, rating: rating)
+        await provider.rateMessage(messageId, rating: rating, surface: "voice")
       }
     }
 

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+MessageRating.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+MessageRating.swift
@@ -8,7 +8,7 @@ extension ChatProvider {
   ///   - surface: which response surface was rated — "text" (main-window
   ///     chat) or "voice" (floating-bar responses). Telemetry-only dimension.
   func rateMessage(_ messageId: String, rating: Int?, surface: String = "text") async {
-    switch queueMessageRating(messageId, rating: rating) {
+    switch queueMessageRating(messageId, rating: rating, surface: surface) {
     case .persistNow:
       await persistMessageRating(messageId, rating: rating, surface: surface)
     case .waitForSync, .localOnly, nil:
@@ -18,7 +18,9 @@ extension ChatProvider {
 
   /// Apply the rating locally and decide whether a backend PATCH can run yet.
   @discardableResult
-  func queueMessageRating(_ messageId: String, rating: Int?) -> ChatMessageRatingPersistence? {
+  func queueMessageRating(
+    _ messageId: String, rating: Int?, surface: String = "text"
+  ) -> ChatMessageRatingPersistence? {
     guard let index = messages.firstIndex(where: { $0.id == messageId }) else { return nil }
     messages[index].rating = rating
     let decision = ChatMessageRatingPersistence.of(messages[index])
@@ -26,7 +28,7 @@ extension ChatProvider {
     case .persistNow:
       pendingMessageRatings.cancel(messageId: messageId)
     case .waitForSync:
-      pendingMessageRatings.enqueue(messageId: messageId, rating: rating)
+      pendingMessageRatings.enqueue(messageId: messageId, rating: rating, surface: surface)
     case .localOnly:
       pendingMessageRatings.cancel(messageId: messageId)
     }
@@ -44,7 +46,7 @@ extension ChatProvider {
     for item in ready {
       Task { [weak self] in
         await self?.persistMessageRating(
-          item.messageId, rating: item.rating, expectedOwner: ownerAtFlush)
+          item.messageId, rating: item.rating, surface: item.surface, expectedOwner: ownerAtFlush)
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+MessageRating.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+MessageRating.swift
@@ -5,10 +5,12 @@ extension ChatProvider {
   /// - Parameters:
   ///   - messageId: The message ID to rate
   ///   - rating: 1 for thumbs up, -1 for thumbs down, nil to clear rating
-  func rateMessage(_ messageId: String, rating: Int?) async {
+  ///   - surface: which response surface was rated — "text" (main-window
+  ///     chat) or "voice" (floating-bar responses). Telemetry-only dimension.
+  func rateMessage(_ messageId: String, rating: Int?, surface: String = "text") async {
     switch queueMessageRating(messageId, rating: rating) {
     case .persistNow:
-      await persistMessageRating(messageId, rating: rating)
+      await persistMessageRating(messageId, rating: rating, surface: surface)
     case .waitForSync, .localOnly, nil:
       break
     }
@@ -47,7 +49,9 @@ extension ChatProvider {
     }
   }
 
-  func persistMessageRating(_ messageId: String, rating: Int?, expectedOwner: String? = nil) async {
+  func persistMessageRating(
+    _ messageId: String, rating: Int?, surface: String = "text", expectedOwner: String? = nil
+  ) async {
     // Owner fence: if an auth change happened between the flush drain and this
     // call, the rating belongs to the previous account and must not be written
     // under the new session.
@@ -60,7 +64,7 @@ extension ChatProvider {
       }
       log("Rated message \(messageId) with rating: \(String(describing: rating))")
       if let rating {
-        AnalyticsManager.shared.messageRated(rating: rating)
+        AnalyticsManager.shared.messageRated(rating: rating, surface: surface)
       }
     } catch {
       logError("Failed to rate message", error: error)

--- a/desktop/macos/Desktop/Tests/ChatMessageRatingPersistenceTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatMessageRatingPersistenceTests.swift
@@ -61,6 +61,30 @@ final class ChatMessageRatingPersistenceTests: XCTestCase {
     XCTAssertTrue(queue.isEmpty)
   }
 
+  func testQueuedVoiceRatingKeepsItsSurfaceThroughSync() {
+    // A floating-bar thumb on an unsynced reply waits in the queue; when it
+    // drains after sync it must still identify as a voice rating — silently
+    // defaulting to text at flush time corrupts the text/voice ratio split.
+    var queue = ChatMessageRatingQueue()
+    queue.enqueue(messageId: "m1", rating: 1, surface: "voice")
+
+    let unsynced = ChatMessage(id: "m1", text: "Done.", sender: .ai, isSynced: false)
+    XCTAssertTrue(queue.drain(using: [unsynced]).isEmpty)
+
+    let synced = ChatMessage(id: "m1", text: "Done.", sender: .ai, isSynced: true)
+    let ready = queue.drain(using: [synced])
+    XCTAssertEqual(ready.count, 1)
+    XCTAssertEqual(ready.first?.surface, "voice")
+    XCTAssertEqual(ready.first?.rating, 1)
+  }
+
+  func testQueueDefaultsToTextSurface() {
+    var queue = ChatMessageRatingQueue()
+    queue.enqueue(messageId: "m1", rating: -1)
+    let synced = ChatMessage(id: "m1", text: "Done.", sender: .ai, isSynced: true)
+    XCTAssertEqual(queue.drain(using: [synced]).first?.surface, "text")
+  }
+
   func testQueueDrainsClearedRatingAfterSync() {
     var queue = ChatMessageRatingQueue()
     queue.enqueue(messageId: "m1", rating: 1)

--- a/desktop/macos/changelog/unreleased/20260901-thumbs-source.json
+++ b/desktop/macos/changelog/unreleased/20260901-thumbs-source.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Thumbs up/down on responses now records whether it was a chat or a voice reply, powering the team quality dashboards."
+  ]
+}

--- a/web/admin/app/api/omi/stats/message-ratings/route.ts
+++ b/web/admin/app/api/omi/stats/message-ratings/route.ts
@@ -1,84 +1,135 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
-import { cachedPosthogFetch } from "@/lib/posthog";
+import { posthogResults } from "@/lib/posthog";
 
 export const dynamic = "force-dynamic";
 
-// Module-level cache (30 min TTL)
-let cache: { data: { date: string; thumbs_up: number; thumbs_down: number; ratio: number | null }[]; days: number; timestamp: number } | null = null;
-const CACHE_TTL = 30 * 60 * 1000;
+// macOS thumbs up/down on assistant responses (`message_rated`, always
+// filtered to $os_name = 'macOS'). The positive share is ONE number per
+// bucket: thumbs_up / (thumbs_up + thumbs_down) * 100.
+//
+// `source` splits text (main-window chat) from voice (floating-bar
+// responses); events recorded before the dimension shipped count only toward
+// the combined "all" series.
+type RatioPoint = {
+  date: string;
+  all: number | null;
+  text: number | null;
+  voice: number | null;
+  upAll: number;
+  downAll: number;
+};
+
+function ratio(up: number, down: number): number | null {
+  const total = up + down;
+  return total > 0 ? Math.round((1000 * up) / total) / 10 : null;
+}
+
+function mondayKey(ymd: string): string {
+  const d = new Date(ymd + "T12:00:00Z");
+  d.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7));
+  return d.toISOString().slice(0, 10);
+}
+
+export async function computeMessageRatings(days: number) {
+  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  const projectId = process.env.POSTHOG_PROJECT_ID;
+  const host = (process.env.POSTHOG_HOST || "https://us.posthog.com").replace(
+    /\/$/,
+    "",
+  );
+  if (!apiKey || !projectId) {
+    throw new Error("PostHog credentials not configured");
+  }
+
+  const rows = (await posthogResults(
+    host,
+    projectId,
+    apiKey,
+    `
+      SELECT
+        toDate(toTimeZone(timestamp, 'America/New_York')) AS day,
+        coalesce(toString(properties.source), 'legacy') AS src,
+        countIf(properties.rating = 'thumbs_up') AS up,
+        countIf(properties.rating = 'thumbs_down') AS down
+      FROM events
+      WHERE event = 'message_rated'
+        AND properties.$os_name = 'macOS'
+        AND timestamp >= now() - INTERVAL ${days} DAY
+      GROUP BY day, src
+      ORDER BY day
+    `,
+  )) as any[];
+
+  type Bucket = { up: Record<string, number>; down: Record<string, number> };
+  const byDay = new Map<string, Bucket>();
+  for (const [day, src, up, down] of rows ?? []) {
+    const key = String(day).slice(0, 10);
+    const bucket = byDay.get(key) ?? { up: {}, down: {} };
+    bucket.up[src] = (bucket.up[src] ?? 0) + Number(up);
+    bucket.down[src] = (bucket.down[src] ?? 0) + Number(down);
+    byDay.set(key, bucket);
+  }
+
+  const sum = (rec: Record<string, number>, keys?: string[]) =>
+    Object.entries(rec)
+      .filter(([k]) => !keys || keys.includes(k))
+      .reduce((a, [, v]) => a + v, 0);
+
+  const toPoint = (date: string, b: Bucket): RatioPoint => ({
+    date,
+    all: ratio(sum(b.up), sum(b.down)),
+    text: ratio(sum(b.up, ["text"]), sum(b.down, ["text"])),
+    voice: ratio(sum(b.up, ["voice"]), sum(b.down, ["voice"])),
+    upAll: sum(b.up),
+    downAll: sum(b.down),
+  });
+
+  const daily = Array.from(byDay.entries())
+    .map(([date, bucket]) => toPoint(date, bucket))
+    .sort((a, b) => (a.date < b.date ? -1 : 1));
+
+  const byWeek = new Map<string, Bucket>();
+  byDay.forEach((bucket, day) => {
+    const week = mondayKey(day);
+    const acc = byWeek.get(week) ?? { up: {}, down: {} };
+    for (const [k, v] of Object.entries(bucket.up))
+      acc.up[k] = (acc.up[k] ?? 0) + (v as number);
+    for (const [k, v] of Object.entries(bucket.down))
+      acc.down[k] = (acc.down[k] ?? 0) + (v as number);
+    byWeek.set(week, acc);
+  });
+  const weekly = Array.from(byWeek.entries())
+    .map(([week, bucket]) => ({ ...toPoint(week, bucket), week }))
+    .sort((a, b) => (a.week < b.week ? -1 : 1));
+
+  // Legacy shape kept for the existing "Message ratings" volumes panel and
+  // /dashboard/classic.
+  const data = daily.map((p) => ({
+    date: p.date,
+    thumbs_up: p.upAll,
+    thumbs_down: p.downAll,
+    ratio: p.all,
+  }));
+
+  return { days, data, daily, weekly };
+}
 
 export async function GET(request: NextRequest) {
   const authResult = await verifyAdmin(request);
   if (authResult instanceof NextResponse) return authResult;
 
   try {
-    const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
-    const projectId = process.env.POSTHOG_PROJECT_ID;
-    const host = process.env.POSTHOG_HOST || "https://us.posthog.com";
-
-    if (!apiKey || !projectId) {
-      return NextResponse.json(
-        { error: "PostHog credentials not configured" },
-        { status: 500 }
-      );
-    }
-
-    const searchParams = request.nextUrl.searchParams;
-    const days = Math.min(parseInt(searchParams.get("days") || "30", 10), 90);
-
-    if (cache && cache.days === days && Date.now() - cache.timestamp < CACHE_TTL) {
-      return NextResponse.json({ data: cache.data, days });
-    }
-
-    // Query PostHog for message_rated events from macOS desktop app
-    const hogql = `
-      SELECT
-        toDate(timestamp) as day,
-        countIf(properties.rating = 'thumbs_up') as thumbs_up,
-        countIf(properties.rating = 'thumbs_down') as thumbs_down
-      FROM events
-      WHERE event = 'message_rated'
-        AND properties.$os_name = 'macOS'
-        AND timestamp >= now() - interval ${days} day
-      GROUP BY day
-      ORDER BY day
-    `;
-
-    const response = await cachedPosthogFetch(host, projectId, apiKey, hogql);
-
-    if (!response.ok) {
-      const text = await response.text();
-      console.error("PostHog query error:", response.status, text);
-      return NextResponse.json(
-        { error: `PostHog API error: ${response.status}` },
-        { status: 502 }
-      );
-    }
-
-    const result = await response.json();
-    const rows: [string, number, number][] = result?.results ?? [];
-
-    const data = rows.map(([date, thumbs_up, thumbs_down]) => {
-      const total = thumbs_up + thumbs_down;
-      return {
-        date: date.slice(0, 10),
-        thumbs_up,
-        thumbs_down,
-        // null, not 0: a day with no ratings has no ratio. Reporting 0 made it
-        // indistinguishable from a day that was rated all-thumbs-down.
-        ratio: total > 0 ? Math.round((thumbs_up / total) * 100) : null,
-      };
-    });
-
-    cache = { data, days, timestamp: Date.now() };
-
-    return NextResponse.json({ data, days });
-  } catch (error) {
+    const days = Math.min(
+      parseInt(request.nextUrl.searchParams.get("days") || "30", 10) || 30,
+      180,
+    );
+    return NextResponse.json(await computeMessageRatings(days));
+  } catch (error: any) {
     console.error("Message ratings error:", error);
     return NextResponse.json(
-      { error: "Failed to fetch message ratings" },
-      { status: 500 }
+      { error: error.message || "Failed to fetch message ratings" },
+      { status: 502 },
     );
   }
 }

--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -4391,6 +4391,292 @@
       "timeFrom": "60d",
       "title": "Activation rate \u2014 daily",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. Last bucket is the current partial day.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "decimals": 1
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "All %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#94a3b8",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Text %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3b82f6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Voice %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#22c55e",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 102,
+        "w": 12,
+        "h": 7
+      },
+      "id": 997,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/message-ratings?days=60&_tzdates=date",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "daily",
+          "columns": [
+            {
+              "selector": "date",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "all",
+              "text": "All %",
+              "type": "number"
+            },
+            {
+              "selector": "text",
+              "text": "Text %",
+              "type": "number"
+            },
+            {
+              "selector": "voice",
+              "text": "Voice %",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "60d",
+      "title": "Thumbs positive % \u2014 daily",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. NYC Monday weeks; last bucket is the partial current week.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "decimals": 1
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "All %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#94a3b8",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Text %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3b82f6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Voice %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#22c55e",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 102,
+        "w": 12,
+        "h": 7
+      },
+      "id": 998,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/message-ratings?days=60&_tzdates=week",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "weekly",
+          "columns": [
+            {
+              "selector": "week",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "all",
+              "text": "All %",
+              "type": "number"
+            },
+            {
+              "selector": "text",
+              "text": "Text %",
+              "type": "number"
+            },
+            {
+              "selector": "voice",
+              "text": "Voice %",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "60d",
+      "title": "Thumbs positive % \u2014 weekly",
+      "type": "timeseries"
     }
   ],
   "refresh": "1h",

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -3747,6 +3747,292 @@
       "timeFrom": "60d",
       "title": "Activation rate \u2014 daily",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. Last bucket is the current partial day.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "decimals": 1
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "All %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#94a3b8",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Text %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3b82f6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Voice %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#22c55e",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 102,
+        "w": 12,
+        "h": 7
+      },
+      "id": 997,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/message-ratings?days=60&_tzdates=date",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "daily",
+          "columns": [
+            {
+              "selector": "date",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "all",
+              "text": "All %",
+              "type": "number"
+            },
+            {
+              "selector": "text",
+              "text": "Text %",
+              "type": "number"
+            },
+            {
+              "selector": "voice",
+              "text": "Voice %",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "60d",
+      "title": "Thumbs positive % \u2014 daily",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. NYC Monday weeks; last bucket is the partial current week.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "decimals": 1
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "All %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#94a3b8",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Text %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3b82f6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Voice %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#22c55e",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 102,
+        "w": 12,
+        "h": 7
+      },
+      "id": 998,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/message-ratings?days=60&_tzdates=week",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "weekly",
+          "columns": [
+            {
+              "selector": "week",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "all",
+              "text": "All %",
+              "type": "number"
+            },
+            {
+              "selector": "text",
+              "text": "Text %",
+              "type": "number"
+            },
+            {
+              "selector": "voice",
+              "text": "Voice %",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "60d",
+      "title": "Thumbs positive % \u2014 weekly",
+      "type": "timeseries"
     }
   ],
   "refresh": "1h",

--- a/web/admin/grafana/dashboards/omi-tv.json
+++ b/web/admin/grafana/dashboards/omi-tv.json
@@ -5794,6 +5794,292 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. Last bucket is the current partial day.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "decimals": 1
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "All %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#94a3b8",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Text %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3b82f6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Voice %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#22c55e",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 994
+      },
+      "id": 997,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/message-ratings?days=60&_tzdates=date",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "daily",
+          "columns": [
+            {
+              "selector": "date",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "all",
+              "text": "All %",
+              "type": "number"
+            },
+            {
+              "selector": "text",
+              "text": "Text %",
+              "type": "number"
+            },
+            {
+              "selector": "voice",
+              "text": "Voice %",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "60d",
+      "title": "Thumbs positive % \u2014 daily",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. NYC Monday weeks; last bucket is the partial current week.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "decimals": 1
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "All %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#94a3b8",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Text %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3b82f6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Voice %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#22c55e",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 994
+      },
+      "id": 998,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/message-ratings?days=60&_tzdates=week",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "weekly",
+          "columns": [
+            {
+              "selector": "week",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "all",
+              "text": "All %",
+              "type": "number"
+            },
+            {
+              "selector": "text",
+              "text": "Text %",
+              "type": "number"
+            },
+            {
+              "selector": "voice",
+              "text": "Voice %",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "60d",
+      "title": "Thumbs positive % \u2014 weekly",
+      "type": "timeseries"
+    },
+    {
       "id": 991,
       "type": "timeseries",
       "title": "Releases / day \u2014 macOS vs iOS",

--- a/web/admin/lib/__tests__/message-ratings.test.ts
+++ b/web/admin/lib/__tests__/message-ratings.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const posthogResults = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/posthog", () => ({ posthogResults }));
+vi.mock("@/lib/auth", () => ({ verifyAdmin: vi.fn() }));
+
+import { computeMessageRatings } from "@/app/api/omi/stats/message-ratings/route";
+
+const ENV_KEYS = ["POSTHOG_PERSONAL_API_KEY", "POSTHOG_PROJECT_ID"] as const;
+const originalEnv = Object.fromEntries(
+  ENV_KEYS.map((k) => [k, process.env[k]]),
+);
+
+afterEach(() => {
+  posthogResults.mockReset();
+  for (const key of ENV_KEYS) {
+    if (originalEnv[key] == null) delete process.env[key];
+    else process.env[key] = originalEnv[key];
+  }
+});
+
+describe("computeMessageRatings (macOS thumbs positive share)", () => {
+  it("splits text/voice, folds legacy into All only, and rolls NYC weeks", async () => {
+    process.env.POSTHOG_PERSONAL_API_KEY = "phx";
+    process.env.POSTHOG_PROJECT_ID = "1";
+    // Monday 2026-08-24: text 3↑1↓, voice 1↑1↓; Tuesday: legacy 2↑0↓.
+    posthogResults.mockResolvedValue([
+      ["2026-08-24", "text", 3, 1],
+      ["2026-08-24", "voice", 1, 1],
+      ["2026-08-25", "legacy", 2, 0],
+    ]);
+    const payload = await computeMessageRatings(30);
+
+    const query = posthogResults.mock.calls[0][3] as string;
+    expect(query).toContain("properties.$os_name = 'macOS'");
+    expect(query).toContain("America/New_York");
+
+    const monday = payload.daily.find((p) => p.date === "2026-08-24")!;
+    expect(monday.text).toBe(75); // one number %: up / rated
+    expect(monday.voice).toBe(50);
+    expect(monday.all).toBeCloseTo(66.7);
+    const tuesday = payload.daily.find((p) => p.date === "2026-08-25")!;
+    expect(tuesday.text).toBeNull(); // legacy events never fake a split series
+    expect(tuesday.voice).toBeNull();
+    expect(tuesday.all).toBe(100);
+
+    // Weekly: both days share the 2026-08-24 NYC Monday bucket.
+    expect(payload.weekly).toHaveLength(1);
+    expect(payload.weekly[0].week).toBe("2026-08-24");
+    expect(payload.weekly[0].all).toBe(75); // (3+1+2)↑ / 8 rated
+    expect(payload.weekly[0].text).toBe(75);
+    expect(payload.weekly[0].voice).toBe(50);
+
+    // Legacy shape stays for the volumes panel and /dashboard/classic.
+    expect(payload.data[0]).toEqual({
+      date: "2026-08-24",
+      thumbs_up: 4,
+      thumbs_down: 2,
+      ratio: expect.closeTo(66.7, 1),
+    });
+  });
+});

--- a/web/admin/lib/__tests__/stats-staleness-honesty.test.ts
+++ b/web/admin/lib/__tests__/stats-staleness-honesty.test.ts
@@ -11,7 +11,7 @@ vi.mock("@/lib/auth", () => ({
 }));
 
 const fetchMock = vi.fn();
-const posthogResultsMock = vi.hoisted(() => vi.fn(async () => []));
+const posthogResultsMock = vi.hoisted(() => vi.fn(async (): Promise<any[]> => []));
 vi.mock("@/lib/posthog", () => ({
   cachedPosthogFetch: (...args: unknown[]) => fetchMock(...args),
   posthogResults: posthogResultsMock,

--- a/web/admin/lib/__tests__/stats-staleness-honesty.test.ts
+++ b/web/admin/lib/__tests__/stats-staleness-honesty.test.ts
@@ -6,12 +6,15 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
  * date key must be computed in the same timezone the upstream bucketed in.
  */
 
-vi.mock("@/lib/auth", () => ({ verifyAdmin: vi.fn(async () => ({ uid: "t" })) }));
+vi.mock("@/lib/auth", () => ({
+  verifyAdmin: vi.fn(async () => ({ uid: "t" })),
+}));
 
 const fetchMock = vi.fn();
+const posthogResultsMock = vi.hoisted(() => vi.fn(async () => []));
 vi.mock("@/lib/posthog", () => ({
   cachedPosthogFetch: (...args: unknown[]) => fetchMock(...args),
-  posthogResults: vi.fn(async () => []),
+  posthogResults: posthogResultsMock,
   POSTHOG_SERVED_MAX_ROWS: 50_000,
 }));
 
@@ -104,21 +107,17 @@ describe("crash-rate date keys", () => {
 describe("message-ratings ratio", () => {
   beforeEach(() => {
     fetchMock.mockReset();
+    posthogResultsMock.mockReset();
     process.env.POSTHOG_PERSONAL_API_KEY = "k";
     process.env.POSTHOG_PROJECT_ID = "1";
   });
 
   it("reports null, not 0, on a day with no ratings at all", async () => {
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        results: [
-          ["2026-08-01", 0, 0],
-          ["2026-08-02", 0, 4],
-          ["2026-08-03", 3, 1],
-        ],
-      }),
-    });
+    posthogResultsMock.mockResolvedValue([
+      ["2026-08-01", "legacy", 0, 0],
+      ["2026-08-02", "legacy", 0, 4],
+      ["2026-08-03", "legacy", 3, 1],
+    ]);
 
     const { GET } = await import("@/app/api/omi/stats/message-ratings/route");
     const url = "https://admin.omi.me/api/omi/stats/message-ratings?days=7";


### PR DESCRIPTION
## Why

Nik wants the thumbs up/down ratio as **one number (% positive)** charted **daily and weekly** on admin.omi.me, macOS-only, split by **text vs voice** responses.

## What

- **Desktop**: `message_rated` now carries `source=text` (main-window chat) / `voice` (floating-bar responses), threaded through the single rating chain (`rateMessage → persistMessageRating → messageRated`). Telemetry-only dimension.
- **Admin**: `/api/omi/stats/message-ratings` recomputed — NYC day buckets, per-source split, weekly Monday buckets; positive share = up/(up+down)·100. Legacy `data[]` shape preserved for the existing volumes panel and `/dashboard/classic`. Pre-dimension events count only toward the All series (never faked into a split); zero-rating buckets stay `null`, not 0 (honesty test updated to the new seam and still enforced).
- **Boards**: "Thumbs positive % — daily" and "— weekly" panels (All/Text/Voice lines; macOS-filtered route).

## Verification

- vitest 208/208 (new contract test: split math, legacy fold, NYC week rollup; null-vs-0 honesty preserved); `test_build_dashboards.py` + admin-deploy-scope contracts OK; swift build clean.
- Live through the real route against prod PostHog: daily All% tail 100 / 66.7 / 40; weekly 47.3% (26↑/29↓) and 50%. Text/Voice series begin accruing with the next desktop release.

Failure-Class: none

Line-Count-Exception: desktop/macos/Desktop/Sources/AnalyticsManager.swift | 1667 -> 1671 | the messageRated source dimension + its constraint comment; splitting the analytics facade is out of scope

Product invariants affected: INV-CHAT-1 — the rating chain change only adds a telemetry `surface` parameter with a default; queueing, owner fences, and PATCH semantics are untouched.
