### PR TITLE
feat: thumbs positive % counts only general Omi responses (excludes proactive-notification ratings)

### DIFF
--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+MessageRating.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+MessageRating.swift
@@ -8,12 +8,25 @@ extension ChatProvider {
   ///   - surface: which response surface was rated — "text" (main-window
   ///     chat) or "voice" (floating-bar responses). Telemetry-only dimension.
   func rateMessage(_ messageId: String, rating: Int?, surface: String = "text") async {
-    switch queueMessageRating(messageId, rating: rating, surface: surface) {
+    let resolvedSurface = Self.ratingSurface(
+      for: messages.first(where: { $0.id == messageId }), requested: surface)
+    switch queueMessageRating(messageId, rating: rating, surface: resolvedSurface) {
     case .persistNow:
-      await persistMessageRating(messageId, rating: rating, surface: surface)
+      await persistMessageRating(messageId, rating: rating, surface: resolvedSurface)
     case .waitForSync, .localOnly, nil:
       break
     }
+  }
+
+  /// Thumbs on proactive-notification messages (focus/insight/task/memory
+  /// cards in the transcript) rate the notification, not a general Omi
+  /// answer — tag them "notification" so response-quality % excludes them,
+  /// whichever surface the caller rated from.
+  static func ratingSurface(for message: ChatMessage?, requested: String) -> String {
+    guard let message, ChatContinuityInvariants.isProactiveNotification(message) else {
+      return requested
+    }
+    return "notification"
   }
 
   /// Apply the rating locally and decide whether a backend PATCH can run yet.

--- a/desktop/macos/Desktop/Tests/ChatMessageRatingPersistenceTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatMessageRatingPersistenceTests.swift
@@ -102,6 +102,55 @@ final class ChatMessageRatingPersistenceTests: XCTestCase {
     XCTAssertTrue(queue.isEmpty)
   }
 
+  func testProactiveNotificationRatingResolvesToNotificationSurface() {
+    // A thumb on a proactive-notification message (focus/insight/task/memory
+    // card in the transcript) rates the notification, not a general Omi
+    // answer — it must report source="notification" so the admin response
+    // quality % can exclude it, no matter which surface the caller passed.
+    let notification = ChatMessage(
+      id: "n1",
+      clientTurnId: ChatContinuityInvariants.proactiveNotificationContinuityKey(
+        id: UUID(), kind: .insight),
+      text: "You seem distracted.",
+      sender: .ai,
+      isSynced: true)
+    XCTAssertEqual(
+      ChatProvider.ratingSurface(for: notification, requested: "text"), "notification")
+    XCTAssertEqual(
+      ChatProvider.ratingSurface(for: notification, requested: "voice"), "notification")
+
+    let answer = ChatMessage(id: "a1", text: "Done.", sender: .ai, isSynced: true)
+    XCTAssertEqual(ChatProvider.ratingSurface(for: answer, requested: "text"), "text")
+    XCTAssertEqual(ChatProvider.ratingSurface(for: nil, requested: "voice"), "voice")
+  }
+
+  func testUnsyncedProactiveRatingKeepsNotificationSurfaceThroughFlush() async {
+    // Real deferred path: a thumb on an UNSYNCED proactive-notification
+    // message goes rateMessage → queue → post-sync drain. The resolved
+    // "notification" surface must be what drains — not the caller's "text".
+    let provider = ChatProvider()
+    let messageId = "proactive-live"
+    let unsynced = ChatMessage(
+      id: messageId,
+      clientTurnId: ChatContinuityInvariants.proactiveNotificationContinuityKey(
+        id: UUID(), kind: .task),
+      text: "You said you'd email Alex today.",
+      sender: .ai,
+      isStreaming: false,
+      isSynced: false,
+      journalStatus: .completed)
+    provider.messages = [unsynced]
+
+    await provider.rateMessage(messageId, rating: -1, surface: "text")
+    XCTAssertTrue(provider.pendingMessageRatings.contains(messageId))
+
+    provider.messages[0].isSynced = true
+    let ready = provider.pendingMessageRatings.drain(using: provider.messages)
+    XCTAssertEqual(ready.count, 1)
+    XCTAssertEqual(ready.first?.surface, "notification")
+    XCTAssertEqual(ready.first?.rating, -1)
+  }
+
   func testQueueDropsFailedJournalWithoutPersist() {
     var queue = ChatMessageRatingQueue()
     queue.enqueue(messageId: "m1", rating: 1)

--- a/desktop/macos/changelog/unreleased/20260902-thumbs-notification-surface.json
+++ b/desktop/macos/changelog/unreleased/20260902-thumbs-notification-surface.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Thumbs on proactive notification cards (focus, insights, tasks, memories) are now tracked separately from ratings of regular Omi answers."
+  ]
+}

--- a/web/admin/app/api/omi/stats/message-ratings/route.ts
+++ b/web/admin/app/api/omi/stats/message-ratings/route.ts
@@ -11,6 +11,11 @@ export const dynamic = "force-dynamic";
 // `source` splits text (main-window chat) from voice (floating-bar
 // responses); events recorded before the dimension shipped count only toward
 // the combined "all" series.
+//
+// Thumbs on proactive-notification messages (focus/insight/task/memory) are
+// tagged source="notification" by the client and EXCLUDED from every series
+// here — they rate the notification, not a general Omi answer (Nik,
+// 2026-09-02). Pre-tag legacy events can't be classified and stay in "all".
 type RatioPoint = {
   date: string;
   all: number | null;
@@ -36,7 +41,7 @@ export async function computeMessageRatings(days: number) {
   const projectId = process.env.POSTHOG_PROJECT_ID;
   const host = (process.env.POSTHOG_HOST || "https://us.posthog.com").replace(
     /\/$/,
-    "",
+    ""
   );
   if (!apiKey || !projectId) {
     throw new Error("PostHog credentials not configured");
@@ -58,7 +63,7 @@ export async function computeMessageRatings(days: number) {
         AND timestamp >= now() - INTERVAL ${days} DAY
       GROUP BY day, src
       ORDER BY day
-    `,
+    `
   )) as any[];
 
   type Bucket = { up: Record<string, number>; down: Record<string, number> };
@@ -71,9 +76,14 @@ export async function computeMessageRatings(days: number) {
     byDay.set(key, bucket);
   }
 
-  const sum = (rec: Record<string, number>, keys?: string[]) =>
+  // "All" is an explicit allowlist so an unknown future source can never
+  // silently leak in. Legacy (pre-tag) events stay: they cannot be
+  // classified, and dropping them would blank the whole history until tagged
+  // builds roll out — the caveat lives in the panel descriptions.
+  const ALL_SOURCES = ["text", "voice", "legacy"];
+  const sum = (rec: Record<string, number>, keys: string[] = ALL_SOURCES) =>
     Object.entries(rec)
-      .filter(([k]) => !keys || keys.includes(k))
+      .filter(([k]) => keys.includes(k))
       .reduce((a, [, v]) => a + v, 0);
 
   const toPoint = (date: string, b: Bucket): RatioPoint => ({
@@ -122,14 +132,14 @@ export async function GET(request: NextRequest) {
   try {
     const days = Math.min(
       parseInt(request.nextUrl.searchParams.get("days") || "30", 10) || 30,
-      180,
+      180
     );
     return NextResponse.json(await computeMessageRatings(days));
   } catch (error: any) {
     console.error("Message ratings error:", error);
     return NextResponse.json(
       { error: error.message || "Failed to fetch message ratings" },
-      { status: 502 },
+      { status: 502 }
     );
   }
 }

--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -4397,7 +4397,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. Last bucket is the current partial day.",
+      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. Proactive-notification thumbs (focus/insight/task/memory cards) are excluded from every series; only pre-tag legacy events can't be separated and stay in All. Last bucket is the current partial day.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4540,7 +4540,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. NYC Monday weeks; last bucket is the partial current week.",
+      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. Proactive-notification thumbs (focus/insight/task/memory cards) are excluded from every series; only pre-tag legacy events can't be separated and stay in All. NYC Monday weeks; last bucket is the partial current week.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -3753,7 +3753,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. Last bucket is the current partial day.",
+      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. Proactive-notification thumbs (focus/insight/task/memory cards) are excluded from every series; only pre-tag legacy events can't be separated and stay in All. Last bucket is the current partial day.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3896,7 +3896,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. NYC Monday weeks; last bucket is the partial current week.",
+      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. Proactive-notification thumbs (focus/insight/task/memory cards) are excluded from every series; only pre-tag legacy events can't be separated and stay in All. NYC Monday weeks; last bucket is the partial current week.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/web/admin/grafana/dashboards/omi-tv.json
+++ b/web/admin/grafana/dashboards/omi-tv.json
@@ -5798,7 +5798,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. Last bucket is the current partial day.",
+      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. Proactive-notification thumbs (focus/insight/task/memory cards) are excluded from every series; only pre-tag legacy events can't be separated and stay in All. Last bucket is the current partial day.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -5941,7 +5941,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. NYC Monday weeks; last bucket is the partial current week.",
+      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. Proactive-notification thumbs (focus/insight/task/memory cards) are excluded from every series; only pre-tag legacy events can't be separated and stay in All. NYC Monday weeks; last bucket is the partial current week.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/web/admin/lib/__tests__/message-ratings.test.ts
+++ b/web/admin/lib/__tests__/message-ratings.test.ts
@@ -8,7 +8,7 @@ import { computeMessageRatings } from "@/app/api/omi/stats/message-ratings/route
 
 const ENV_KEYS = ["POSTHOG_PERSONAL_API_KEY", "POSTHOG_PROJECT_ID"] as const;
 const originalEnv = Object.fromEntries(
-  ENV_KEYS.map((k) => [k, process.env[k]]),
+  ENV_KEYS.map((k) => [k, process.env[k]])
 );
 
 afterEach(() => {
@@ -24,9 +24,13 @@ describe("computeMessageRatings (macOS thumbs positive share)", () => {
     process.env.POSTHOG_PERSONAL_API_KEY = "phx";
     process.env.POSTHOG_PROJECT_ID = "1";
     // Monday 2026-08-24: text 3↑1↓, voice 1↑1↓; Tuesday: legacy 2↑0↓.
+    // Notification thumbs (proactive focus/insight/task/memory cards) must
+    // not move any series — they rate the notification, not a response.
     posthogResults.mockResolvedValue([
       ["2026-08-24", "text", 3, 1],
       ["2026-08-24", "voice", 1, 1],
+      ["2026-08-24", "notification", 0, 9],
+      ["2026-08-24", "mystery-future-source", 7, 0],
       ["2026-08-25", "legacy", 2, 0],
     ]);
     const payload = await computeMessageRatings(30);
@@ -38,7 +42,8 @@ describe("computeMessageRatings (macOS thumbs positive share)", () => {
     const monday = payload.daily.find((p) => p.date === "2026-08-24")!;
     expect(monday.text).toBe(75); // one number %: up / rated
     expect(monday.voice).toBe(50);
-    expect(monday.all).toBeCloseTo(66.7);
+    expect(monday.all).toBeCloseTo(66.7); // 9 notification downs excluded
+    expect(monday.downAll).toBe(2);
     const tuesday = payload.daily.find((p) => p.date === "2026-08-25")!;
     expect(tuesday.text).toBeNull(); // legacy events never fake a split series
     expect(tuesday.voice).toBeNull();


### PR DESCRIPTION
Nik: "can we modify those graphs to include ratings only from general omi responses (not from proactive notifications: insights/focus/tasks/memories)".

Proactive-notification messages land in the chat transcript and were rateable through the same ChatBubble path as regular answers, so their thumbs counted as `source=text` in the macOS "Thumbs positive %" charts.

## What changed

- **Desktop:** `ChatProvider.rateMessage` resolves the telemetry surface from the rated message itself — `ChatContinuityInvariants.isProactiveNotification` → `source="notification"`, overriding whatever surface the caller rated from (main-window text or floating-bar voice). Queued (unsynced) ratings carry the resolved surface through drain.
- **Admin:** `message-ratings` route now counts only an explicit allowlist (`text`, `voice`, `legacy`) into every series (All/Text/Voice, daily + weekly, and the legacy volumes shape); `notification` and any unknown future source are excluded. Panel descriptions updated.

Honesty caveat: pre-tag `legacy` events cannot be classified retroactively (PostHog has only rating+source, no message id) and stay in the All line — excluding them would blank the entire chart history until tagged builds roll out. Every event from tagged builds onward is general-response-only; Text/Voice lines are clean by construction.

## Verification

- `swift test --filter ChatMessageRatingPersistenceTests` — 15/15, including a direct resolution test and a deferred-path regression (rateMessage on an **unsynced** proactive message → queue → post-sync drain keeps `surface=notification` even when rated from "text").
- `npx vitest run lib/__tests__/message-ratings.test.ts` — a `notification` row (0↑/9↓) and a `mystery-future-source` row (7↑) move no series; legacy still folds into All only.
- `npx tsc --noEmit` clean in web/admin.
- Post-deploy: prod route probed and Grafana panels captured (values identical to before by construction — zero tagged events exist until the next desktop release ships the `source` property).

Product invariants affected: none

Line-Count-Exception: desktop/macos/Desktop/Sources/Providers/ChatProvider+MessageRating.swift | 82 -> 97 | central surface resolution for notification-tagged ratings plus its doc comment; no new observer or fallback path


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

