### PR TITLE
fix(app): stop share and copy from rating the message

### DIFF
--- a/app/lib/pages/chat/widgets/ai_message.dart
+++ b/app/lib/pages/chat/widgets/ai_message.dart
@@ -1251,11 +1251,6 @@ class _MessageActionBarState extends State<MessageActionBar> {
                 properties: {'message': widget.messageText},
               );
 
-              // Implicit positive feedback - user copied the message (silent, no UI change)
-              if (_selectedNps == null) {
-                widget.setMessageNps?.call(1, reason: 'user_copied_message');
-              }
-
               if (context.mounted) {
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(
@@ -1310,11 +1305,6 @@ class _MessageActionBarState extends State<MessageActionBar> {
                 'Chat Message Shared',
                 properties: {'message': widget.messageText},
               );
-
-              // Implicit positive feedback - user shared the message (silent, no UI change)
-              if (_selectedNps == null) {
-                widget.setMessageNps?.call(1, reason: 'user_shared_message');
-              }
             },
           ),
         ],

--- a/app/test/pages/chat/message_action_bar_test.dart
+++ b/app/test/pages/chat/message_action_bar_test.dart
@@ -1,0 +1,77 @@
+/// Copy and share on a chat message must never rate the message.
+///
+/// Both actions used to call `setMessageNps(1)` as "implicit positive
+/// feedback". The provider writes the rating back onto the message, so the
+/// thumbs-up icon lit up as soon as share or copy ran — tapping share visibly
+/// pressed thumbs-up. Only the explicit thumbs buttons may rate.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/chat/widgets/ai_message.dart';
+
+Finder faIcon(FaIconData icon) => find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == icon.codePoint);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late List<int> ratings;
+
+  setUp(() {
+    ratings = [];
+    final messenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    // Clipboard and share_plus both go over platform channels that have no
+    // host in a widget test; answer them so the handlers run to completion.
+    messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async => null);
+    messenger.setMockMethodCallHandler(
+      const MethodChannel('dev.fluttercommunity.plus/share'),
+      (call) async => 'dev.fluttercommunity.plus/share/success',
+    );
+  });
+
+  Future<void> pumpBar(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: const [Locale('en')],
+        home: Scaffold(
+          body: MessageActionBar(
+            messageText: 'hello',
+            setMessageNps: (int value, {String? reason}) => ratings.add(value),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('tapping share does not rate the message', (tester) async {
+    await pumpBar(tester);
+
+    await tester.tap(faIcon(FontAwesomeIcons.share));
+    await tester.pumpAndSettle();
+
+    expect(ratings, isEmpty);
+  });
+
+  testWidgets('tapping copy does not rate the message', (tester) async {
+    await pumpBar(tester);
+
+    await tester.tap(faIcon(FontAwesomeIcons.copy));
+    await tester.pumpAndSettle();
+
+    expect(ratings, isEmpty);
+  });
+
+  testWidgets('thumbs up still rates the message explicitly', (tester) async {
+    await pumpBar(tester);
+
+    await tester.tap(faIcon(FontAwesomeIcons.thumbsUp));
+    await tester.pumpAndSettle();
+
+    expect(ratings, [1]);
+  });
+}


### PR DESCRIPTION
## Summary
Tapping share (or copy) on a chat message visibly pressed thumbs-up. Both handlers called `setMessageNps(1)` as "implicit positive feedback" (515bf763c2); the provider writes `message.rating = 1` and `MessageActionBar.didUpdateWidget` syncs it into `_selectedNps`, so the thumbs-up icon lit. Nobody saw it before because share threw on the missing anchor rect before reaching that line — #12617 fixed share and exposed this.

Only the explicit thumbs buttons rate now. The `Chat Message Shared` / `Chat Message Copied` analytics events are unchanged.

## Verification
- `flutter test test/pages/chat/message_action_bar_test.dart` → 3 passed; with the `ai_message.dart` change stashed, the share and copy tests fail with `Actual: [1]`.
- iPhone 16 simulator, Debug-prod build of this branch: opened chat, tapped share 3× and copy 1× on one message, dismissed the sheet → all four action glyphs remain unselected grey (pixel brightness 117; selected renders 255).

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

