### PR TITLE
fix(desktop): keep a mounted notch card whole through a voice turn

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift
@@ -330,6 +330,32 @@ enum FloatingControlBarGeometry {
     NSSize(width: max(a.width, b.width), height: max(a.height, b.height))
   }
 
+  /// A mounted notification card owns the closed surface. Every transient
+  /// island state — PTT listening, thinking, the too-short/mic-error status
+  /// banner — may only *grow* that surface, never replace it.
+  ///
+  /// The bug this exists to prevent: the card stays mounted while the user
+  /// holds the reply shortcut against it (Interject), so any resize that
+  /// substitutes the bare voice-island size crushes a 508pt card into a
+  /// ~270pt notch lobe and the copy re-wraps to three truncated words. Height
+  /// is the card's own plus `additionalHeight` — whatever the transient state
+  /// stacks alongside the card (the status banner row) — because the island's
+  /// chrome band is already counted inside the card size. `transientSize` is
+  /// the no-card surface and already carries that budget itself, so
+  /// `additionalHeight` applies only when a card is mounted.
+  static func notificationPreservingSurfaceSize(
+    transientSize: NSSize,
+    hasMountedNotification: Bool,
+    notificationSize: NSSize,
+    additionalHeight: CGFloat = 0
+  ) -> NSSize {
+    guard hasMountedNotification else { return transientSize }
+    return NSSize(
+      width: max(notificationSize.width, transientSize.width),
+      height: notificationSize.height + additionalHeight
+    )
+  }
+
   /// Closed-conversation chrome size. A mounted notification card wins over
   /// listening/thinking island sizes (or the union if listening is larger).
   static func collapsedSurfaceSize(

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -160,7 +160,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     .canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle,
   ]
   static let notchExpandedWidth: CGFloat = 382
-  private static let notificationWidth: CGFloat = 508
+  static let notificationWidth: CGFloat = 508
   private static let notificationHeight: CGFloat = 128
   private static let notificationSpacing: CGFloat = 8
   /// Vertical room for the readable PTT status banner under chrome/pill.
@@ -883,10 +883,8 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     if state.showingAIConversation {
       let height = max(inputPanelHeight, frame.height)
       size = NSSize(width: expandedContentWidth, height: height)
-    } else if !state.pttHintText.isEmpty {
-      size = pttHintSurfaceSize(usesNotchIsland: notchModeEnabled)
     } else {
-      size = collapsedChromeSurfaceSize(usesNotchIsland: notchModeEnabled)
+      size = closedSurfaceSize(usesNotchIsland: notchModeEnabled)
     }
     let windowSize = responseGlowWindowSizeForCurrentScreen(forSurfaceSize: size)
     return NSRect(origin: defaultTopCenteredOrigin(for: windowSize), size: windowSize)
@@ -907,31 +905,34 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       let contentHeight = max(panelHeight + statusBanner, frame.height - reservedGlowOutset)
       return NSSize(width: width, height: contentHeight)
     }
-    // Grow just enough to fit the readable PTT status banner under chrome/pill.
-    // (isVoiceListening is true during the hint, so this must precede it.)
-    if !state.pttHintText.isEmpty {
-      return pttHintSurfaceSize(usesNotchIsland: usesNotchIsland)
-    }
-    return collapsedChromeSurfaceSize(usesNotchIsland: usesNotchIsland)
+    return closedSurfaceSize(usesNotchIsland: usesNotchIsland)
   }
 
   private func currentSurfaceSizeForCurrentScreen(frameIncludesVoiceGlow: Bool? = nil) -> NSSize {
     currentSurfaceSize(usesNotchIsland: notchModeEnabled, frameIncludesVoiceGlow: frameIncludesVoiceGlow)
   }
 
-  /// Shared closed-conversation size: a mounted notification card wins over
-  /// the listening/thinking island so Interject PTT cannot crush the card.
-  private func collapsedChromeSurfaceSize(usesNotchIsland: Bool, screen: NSScreen? = nil) -> NSSize {
+  /// The mounted notification card's own surface: chrome band, the gap under
+  /// it, and the card body. Single authority — every caller that needs to know
+  /// how big a card is (sizing, resizing, PTT and status-banner unions) reads
+  /// it here rather than re-deriving `notificationWidth` locally.
+  private func notificationSurfaceSize(usesNotchIsland: Bool, screen: NSScreen? = nil) -> NSSize {
     let barHeight: CGFloat
     if usesNotchIsland {
       barHeight = screen.map { Self.notchChromeHeight(for: $0) } ?? notchChromeHeightForCurrentScreen
     } else {
       barHeight = state.isHoveringBar ? Self.expandedBarSize.height : Self.minBarSize.height
     }
-    let notificationSize = NSSize(
+    return NSSize(
       width: Self.notificationWidth,
       height: barHeight + Self.notificationSpacing + Self.notificationHeight
     )
+  }
+
+  /// Shared closed-conversation size: a mounted notification card wins over
+  /// the listening/thinking island so Interject PTT cannot crush the card.
+  private func collapsedChromeSurfaceSize(usesNotchIsland: Bool, screen: NSScreen? = nil) -> NSSize {
+    let notificationSize = notificationSurfaceSize(usesNotchIsland: usesNotchIsland, screen: screen)
     let listeningSize: NSSize
     if usesNotchIsland {
       listeningSize =
@@ -965,6 +966,23 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     )
   }
 
+  /// The whole closed-conversation surface: the notification card, the PTT
+  /// status banner, and the idle/listening/thinking island *composed*, never
+  /// substituted for one another. The banner stacks under the chrome and above
+  /// the card, so a card that is up while a "too short" hint fires needs both
+  /// budgets — returning the bare hint surface both narrowed the card to
+  /// `notchExpandedWidth` and clipped its body off the bottom.
+  func closedSurfaceSize(usesNotchIsland: Bool, screen: NSScreen? = nil) -> NSSize {
+    let collapsed = collapsedChromeSurfaceSize(usesNotchIsland: usesNotchIsland, screen: screen)
+    guard !state.pttHintText.isEmpty else { return collapsed }
+    return FloatingControlBarGeometry.notificationPreservingSurfaceSize(
+      transientSize: pttHintSurfaceSize(usesNotchIsland: usesNotchIsland, screen: screen),
+      hasMountedNotification: state.currentNotification != nil,
+      notificationSize: collapsed,
+      additionalHeight: Self.pttStatusBannerBudget
+    )
+  }
+
   private func frameForCurrentState(on screen: NSScreen, usesNotchIsland: Bool) -> NSRect {
     let size: NSSize
     if state.showingAIConversation {
@@ -977,10 +995,8 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         width: width,
         height: max(panelHeight + statusBanner, frame.height, chromeHeight + statusBanner)
       )
-    } else if !state.pttHintText.isEmpty {
-      size = pttHintSurfaceSize(usesNotchIsland: usesNotchIsland, screen: screen)
     } else {
-      size = collapsedChromeSurfaceSize(usesNotchIsland: usesNotchIsland, screen: screen)
+      size = closedSurfaceSize(usesNotchIsland: usesNotchIsland, screen: screen)
     }
     let windowSize = responseGlowWindowSize(forSurfaceSize: size, usesNotchIsland: usesNotchIsland)
     return NSRect(
@@ -2153,30 +2169,46 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   }
 
   /// Resize window for PTT state (expanded when listening, compact circle when idle)
+  ///
+  /// A mounted notification card outlives the voice turn on purpose: Interject
+  /// keeps it up so "hold fn to reply" has a referent while the user speaks and
+  /// while the answer is thinking. So the PTT surface is *unioned* with the
+  /// card rather than substituted for it — swapping in the bare voice island
+  /// crushed a 508pt card into the ~270pt notch lobe for the whole turn, which
+  /// is the scrunched notch users reported.
   func resizeForPTTState(expanded: Bool) {
     if expanded { cancelPendingRetraction() }
-    if notchModeEnabled {
-      if state.showingAIConversation {
-        return
-      }
-      let targetSize = expanded ? notchSize(active: true) : notchCollapsedSize
-      resizeSurfaceTransition(
-        .pushToTalk(expanded: expanded),
-        toSurfaceSize: targetSize,
-        animated: true,
-        animationDuration: Self.askOmiAnimationDuration
-      )
+    let usesNotchIsland = notchModeEnabled
+    if usesNotchIsland, state.showingAIConversation {
       return
     }
-    // On legacy displays, when the voice-response glow is still active
-    // (e.g. realtime audio received this turn), collapse to the glow-adjusted
-    // compact size so the white glow/stroke is not clipped until the idle
-    // timer clears it.
     resizeSurfaceTransition(
       .pushToTalk(expanded: expanded),
-      toSurfaceSize: expanded ? Self.voiceBarSize : Self.minBarSize,
+      toSurfaceSize: pushToTalkSurfaceSize(expanded: expanded),
       animated: true,
-      animationDuration: 0.18
+      animationDuration: usesNotchIsland ? Self.askOmiAnimationDuration : 0.18
+    )
+  }
+
+  /// The closed surface a Push-to-Talk transition should take: the bare voice
+  /// island, grown to keep any mounted notification card whole.
+  func pushToTalkSurfaceSize(expanded: Bool) -> NSSize {
+    let usesNotchIsland = notchModeEnabled
+    let voiceSize: NSSize
+    if usesNotchIsland {
+      voiceSize = expanded ? notchSize(active: true) : notchCollapsedSize
+    } else {
+      // On legacy displays, when the voice-response glow is still active
+      // (e.g. realtime audio received this turn), collapse to the glow-adjusted
+      // compact size so the white glow/stroke is not clipped until the idle
+      // timer clears it.
+      voiceSize = expanded ? Self.voiceBarSize : Self.minBarSize
+    }
+    return FloatingControlBarGeometry.notificationPreservingSurfaceSize(
+      transientSize: voiceSize,
+      hasMountedNotification: state.currentNotification != nil,
+      notificationSize: notificationSurfaceSize(usesNotchIsland: usesNotchIsland),
+      additionalHeight: state.pttHintText.isEmpty ? 0 : Self.pttStatusBannerBudget
     )
   }
   /// Size the notch to fit the "thinking" indicator (active width) while a PTT
@@ -2287,15 +2319,12 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     guard !state.showingAIConversation else { return }
     cancelPendingRetraction()
     state.currentNotification = notification
-    let barHeight =
-      notchModeEnabled
-      ? notchChromeHeightForCurrentScreen
-      : (state.isHoveringBar ? Self.expandedBarSize.height : Self.minBarSize.height)
-    let targetSize = NSSize(
-      width: Self.notificationWidth,
-      height: barHeight + Self.notificationSpacing + Self.notificationHeight
+    resizeAnchored(
+      to: closedSurfaceSize(usesNotchIsland: notchModeEnabled),
+      makeResizable: false,
+      animated: animated,
+      anchorTop: true
     )
-    resizeAnchored(to: targetSize, makeResizable: false, animated: animated, anchorTop: true)
   }
 
   func dismissNotification(animated: Bool = true) {
@@ -2303,12 +2332,16 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     state.currentNotification = nil
 
     let targetSize: NSSize
-    if state.isVoiceListening && !notchModeEnabled {
+    if notchModeEnabled {
+      // Dismissing the card hands the island back to whatever transient state
+      // is still running underneath it — listening, thinking, or a status
+      // banner. Collapsing straight to the idle lobe is the same substitution
+      // bug in the other direction.
+      targetSize = closedSurfaceSize(usesNotchIsland: true)
+    } else if state.isVoiceListening {
       targetSize = Self.voiceBarSize
-    } else if notchModeEnabled && !state.isVoiceListening {
-      targetSize = notchCollapsedSize
     } else {
-      targetSize = state.isHoveringBar && !notchModeEnabled ? Self.expandedBarSize : collapsedBarSize
+      targetSize = state.isHoveringBar ? Self.expandedBarSize : collapsedBarSize
     }
     resizeAnchored(to: targetSize, makeResizable: false, animated: animated, anchorTop: true)
   }
@@ -5635,6 +5668,13 @@ extension FloatingControlBarWindow {
   func savePreChatCenterIfNeeded() {
     guard preChatCenter == nil else { return }
     let size = collapsedBarSize
+    // The center is read back off `frame` below, so the canonical frame is
+    // normally established by snapping to it. A mounted notification card is
+    // the exception: it is still on screen and still the user's content, and
+    // snapping the panel down to the collapsed pill would crush the card into
+    // the notch lobe for as long as it stays up. Record the center from the
+    // computed frame instead of the window's.
+    var recordedFrame: NSRect?
     if !ShortcutSettings.shared.draggableBarEnabled || notchModeEnabled {
       // Non-draggable: always snap to the default pill position before saving.
       // This ensures preChatCenter is always the canonical default, not a
@@ -5647,9 +5687,12 @@ extension FloatingControlBarWindow {
       } else {
         snapFrame = NSRect(origin: defaultPillOrigin(), size: size)
       }
-      isResizingProgrammatically = true
-      setFrame(snapFrame, display: true, animate: false)
-      isResizingProgrammatically = false
+      recordedFrame = snapFrame
+      if state.currentNotification == nil {
+        isResizingProgrammatically = true
+        setFrame(snapFrame, display: true, animate: false)
+        isResizingProgrammatically = false
+      }
       pendingRestoreFrame = nil
     } else if let restoreFrame = pendingRestoreFrame {
       // Draggable: if a restore animation is running, snap to its target frame
@@ -5663,15 +5706,16 @@ extension FloatingControlBarWindow {
       isResizingProgrammatically = false
       pendingRestoreFrame = nil
     }
+    let reference = recordedFrame ?? frame
     if !notchModeEnabled, state.isNotchHoverMenuVisible {
       // Chat is opening from the taller pill agent list. The pill's true
       // center is the list's top-center minus half a pill — recording the
       // list frame's midpoint would drop the restored pill lower every
       // open/close cycle.
-      preChatCenter = NSPoint(x: frame.midX, y: frame.maxY - size.height / 2)
+      preChatCenter = NSPoint(x: reference.midX, y: reference.maxY - size.height / 2)
       return
     }
-    preChatCenter = NSPoint(x: frame.midX, y: frame.midY)
+    preChatCenter = NSPoint(x: reference.midX, y: reference.midY)
   }
 
   /// Invalidates any in-flight windowDidResignKey dismiss animation so a new PTT

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -678,7 +678,7 @@ import XCTest
     XCTAssertTrue(windowSource.contains("static let notchActiveSideWidth: CGFloat = 42"))
     XCTAssertTrue(windowSource.contains("func resizeForAgentSwitcher(visible: Bool)"))
     XCTAssertTrue(windowSource.contains("max(collapsedBarSize.width, Self.notchExpandedWidth)"))
-    XCTAssertTrue(windowSource.contains("      if state.showingAIConversation {\n        return\n      }"))
+    XCTAssertTrue(windowSource.contains("if usesNotchIsland, state.showingAIConversation {\n      return\n    }"))
   }
 
   func testSpacesTransitionPreservesUserResizedNotchChatFrame() {
@@ -1583,7 +1583,7 @@ import XCTest
 
     // Legacy PTT collapse supplies the bare compact surface to the shared
     // transition path, which applies the active response/agent glow exactly once.
-    XCTAssertTrue(source.contains("toSurfaceSize: expanded ? Self.voiceBarSize : Self.minBarSize"))
+    XCTAssertTrue(source.contains("voiceSize = expanded ? Self.voiceBarSize : Self.minBarSize"))
     XCTAssertTrue(source.contains("let windowSize = responseGlowWindowSizeForCurrentScreen(forSurfaceSize: size)"))
     XCTAssertTrue(source.contains("guard state.isVoiceResponseGlowActive || collapsedPillAgentGlowActive else"))
   }

--- a/desktop/macos/Desktop/Tests/FloatingBarNotchCardSizingTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarNotchCardSizingTests.swift
@@ -1,0 +1,244 @@
+import AppKit
+import XCTest
+
+@testable import Omi_Computer
+@testable import VoiceTurnDomain
+
+/// A mounted notification card owns the notch surface until it is dismissed.
+///
+/// The regression these tests exist for: `resizeForPTTState` substituted the
+/// bare voice island for whatever the surface was showing, checking only
+/// `showingAIConversation`. Interject deliberately keeps the card up while the
+/// user holds the reply shortcut against it ("hold fn to reply"), so holding
+/// fn on a card resized a 508pt panel down to the ~270pt notch lobe and kept
+/// it there for the whole turn — listening, thinking, and answering. The card
+/// stayed mounted inside it, so its copy re-wrapped into three truncated
+/// words: the "scrunched notch".
+///
+/// `FloatingControlBarGeometry.collapsedSurfaceSize` already encoded the right
+/// rule, and `FloatingBarGeometryTests` already asserted it. That is exactly
+/// why the bug shipped: the invariant was tested on the authority while the
+/// live PTT path never called it. These tests assert it on the paths that
+/// actually resize the window.
+@MainActor
+final class FloatingBarNotchCardSizingTests: XCTestCase {
+
+  private func withNotchMode(_ body: () -> Void) {
+    let previousForceNoNotch = getenv("OMI_FORCE_NO_NOTCH").map { String(cString: $0) }
+    let previousForceNotch = getenv("OMI_FORCE_NOTCH").map { String(cString: $0) }
+    unsetenv("OMI_FORCE_NO_NOTCH")
+    setenv("OMI_FORCE_NOTCH", "1", 1)
+    defer {
+      if let previousForceNoNotch {
+        setenv("OMI_FORCE_NO_NOTCH", previousForceNoNotch, 1)
+      } else {
+        unsetenv("OMI_FORCE_NO_NOTCH")
+      }
+      if let previousForceNotch {
+        setenv("OMI_FORCE_NOTCH", previousForceNotch, 1)
+      } else {
+        unsetenv("OMI_FORCE_NOTCH")
+      }
+    }
+    body()
+  }
+
+  private func makeWindow() -> FloatingControlBarWindow {
+    FloatingControlBarWindow(
+      contentRect: .zero,
+      styleMask: [.borderless, .nonactivatingPanel],
+      backing: .buffered,
+      defer: false
+    )
+  }
+
+  /// The projection a too-short hold publishes: a banner hint, no listening.
+  private static let hintProjection = VoiceTurnUIProjection(hint: "Hold longer to record")
+
+  private func card(_ title: String = "Memory") -> FloatingBarNotification {
+    FloatingBarNotification(
+      ownerID: "test-owner",
+      title: title,
+      message: "User is asked to find learned lessons in Claude Code sessions",
+      assistantId: "proactive_assistant"
+    )
+  }
+
+  // MARK: - The live PTT path
+
+  func testHoldingPushToTalkAgainstAMountedCardKeepsTheCardSurface() {
+    withNotchMode {
+      let window = makeWindow()
+      defer { window.close() }
+      window.makeKeyAndOrderFront(nil)
+
+      window.showNotification(card(), animated: false)
+      let mounted = window.frame
+      XCTAssertGreaterThan(mounted.width, 0)
+
+      // Listening and thinking are the two states Interject runs *while* the
+      // card is still on screen. Neither may shrink the panel under it.
+      for expanded in [true, false] {
+        let ptt = window.pushToTalkSurfaceSize(expanded: expanded)
+        XCTAssertGreaterThanOrEqual(
+          ptt.width + FloatingControlBarWindow.notchGlowOutsetX * 2, mounted.width,
+          "PTT (expanded=\(expanded)) must not narrow the panel under a mounted card")
+        XCTAssertGreaterThanOrEqual(
+          ptt.height + FloatingControlBarWindow.notchGlowOutsetBottom, mounted.height,
+          "PTT (expanded=\(expanded)) must not clip the card body")
+      }
+    }
+  }
+
+  /// End to end through the production trigger: the reducer projection that
+  /// `VoiceTurnCoordinator` publishes, applied by the real presenter, which is
+  /// what calls `resizeForPTTState`.
+  func testVoiceProjectionWhileACardIsMountedNeverTargetsTheBareIsland() {
+    withNotchMode {
+      let window = makeWindow()
+      defer { window.close() }
+      window.makeKeyAndOrderFront(nil)
+
+      window.showNotification(card(), animated: false)
+      let mounted = window.frame
+
+      let presenter = FloatingControlBarState.PTTBarPresenter(
+        barState: window.state,
+        resizeForPTT: { [weak window] in window?.resizeForPTTState(expanded: $0) }
+      )
+      presenter.apply(VoiceTurnUIProjection(isListening: true))
+
+      // The pre-fix code took the panel down to the listening lobe here.
+      XCTAssertGreaterThanOrEqual(window.frame.width, mounted.width)
+      XCTAssertGreaterThanOrEqual(window.frame.height, mounted.height)
+      XCTAssertNotNil(window.state.currentNotification, "the card must still be mounted")
+    }
+  }
+
+  func testPushToTalkWithoutACardStillUsesTheBareIsland() {
+    withNotchMode {
+      let window = makeWindow()
+      defer { window.close() }
+      window.makeKeyAndOrderFront(nil)
+
+      let listening = window.pushToTalkSurfaceSize(expanded: true)
+      let idle = window.pushToTalkSurfaceSize(expanded: false)
+
+      window.showNotification(card(), animated: false)
+      XCTAssertGreaterThan(
+        window.pushToTalkSurfaceSize(expanded: true).width, listening.width,
+        "the card must be what grows the surface — not a new unconditional minimum")
+      XCTAssertGreaterThan(window.pushToTalkSurfaceSize(expanded: false).width, idle.width)
+    }
+  }
+
+  // MARK: - The status-banner path
+
+  /// A too-short hold or a mic error draws a status banner under the chrome.
+  /// It used to *replace* the whole closed surface with `notchExpandedWidth`,
+  /// which both narrowed a mounted card and clipped its body off the bottom.
+  func testStatusBannerWhileACardIsMountedStacksInsteadOfReplacing() {
+    withNotchMode {
+      let window = makeWindow()
+      defer { window.close() }
+      window.makeKeyAndOrderFront(nil)
+
+      let presenter = FloatingControlBarState.PTTBarPresenter(
+        barState: window.state,
+        resizeForPTT: { [weak window] in window?.resizeForPTTState(expanded: $0) }
+      )
+
+      presenter.apply(Self.hintProjection)
+      let hintOnly = window.closedSurfaceSize(usesNotchIsland: true)
+      XCTAssertFalse(window.state.pttHintText.isEmpty, "the banner must actually be showing")
+
+      window.showNotification(card(), animated: false)
+      let cardPlusBanner = window.closedSurfaceSize(usesNotchIsland: true)
+
+      presenter.apply(.idle)
+      let cardOnly = window.closedSurfaceSize(usesNotchIsland: true)
+
+      XCTAssertEqual(
+        cardPlusBanner.width, FloatingControlBarWindow.notificationWidth, accuracy: 0.5,
+        "a mounted card keeps its own width, not the notch-expanded hint width")
+      XCTAssertGreaterThan(cardPlusBanner.width, hintOnly.width)
+      XCTAssertEqual(
+        cardPlusBanner.height, cardOnly.height + FloatingControlBarWindow.pttStatusBannerBudget,
+        accuracy: 0.5,
+        "the banner stacks on top of the card instead of replacing it")
+    }
+  }
+
+  // MARK: - Pre-chat center capture
+
+  func testSavingThePreChatCenterDoesNotCollapseAMountedCard() {
+    withNotchMode {
+      let previousDraggable = ShortcutSettings.shared.draggableBarEnabled
+      ShortcutSettings.shared.draggableBarEnabled = false
+      defer { ShortcutSettings.shared.draggableBarEnabled = previousDraggable }
+
+      let window = makeWindow()
+      defer { window.close() }
+      window.makeKeyAndOrderFront(nil)
+
+      window.showNotification(card(), animated: false)
+      let mounted = window.frame
+
+      // A prefilled query records the pre-chat pill center before the chat
+      // surface opens. Recording it must not snap the visible card down to the
+      // collapsed island.
+      window.savePreChatCenterIfNeeded()
+
+      XCTAssertEqual(window.frame, mounted)
+      XCTAssertNotNil(window.state.currentNotification)
+    }
+  }
+
+  // MARK: - The pure rule
+
+  func testNotificationPreservingSurfaceSizeKeepsTheCardWhole() {
+    let card = NSSize(width: 508, height: 194)
+    let island = NSSize(width: 290, height: 38)
+
+    let listening = FloatingControlBarGeometry.notificationPreservingSurfaceSize(
+      transientSize: island,
+      hasMountedNotification: true,
+      notificationSize: card
+    )
+    XCTAssertEqual(listening, card)
+
+    let withBanner = FloatingControlBarGeometry.notificationPreservingSurfaceSize(
+      transientSize: NSSize(width: 382, height: 76),
+      hasMountedNotification: true,
+      notificationSize: card,
+      additionalHeight: 38
+    )
+    XCTAssertEqual(withBanner.width, 508, accuracy: 0.001)
+    XCTAssertEqual(withBanner.height, 232, accuracy: 0.001, "the banner stacks with the card")
+  }
+
+  func testNotificationPreservingSurfaceSizeIsTransparentWithoutACard() {
+    let island = NSSize(width: 290, height: 38)
+    XCTAssertEqual(
+      FloatingControlBarGeometry.notificationPreservingSurfaceSize(
+        transientSize: island,
+        hasMountedNotification: false,
+        notificationSize: NSSize(width: 508, height: 194),
+        additionalHeight: 38
+      ),
+      island,
+      "the transient surface already carries its own budget when no card is up")
+  }
+
+  func testATransientSurfaceWiderThanTheCardStillWins() {
+    let card = NSSize(width: 508, height: 194)
+    let wide = NSSize(width: 640, height: 38)
+    let size = FloatingControlBarGeometry.notificationPreservingSurfaceSize(
+      transientSize: wide,
+      hasMountedNotification: true,
+      notificationSize: card
+    )
+    XCTAssertEqual(size.width, 640, accuracy: 0.001)
+    XCTAssertEqual(size.height, 194, accuracy: 0.001)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260902-notch-card-ptt-width.json
+++ b/desktop/macos/changelog/unreleased/20260902-notch-card-ptt-width.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "Notification cards in the notch no longer shrink to a narrow strip when you hold the push-to-talk shortcut to reply to them."
+  ]
+}


### PR DESCRIPTION
## The bug

Holding the reply shortcut on a notch notification card crushed it into the notch lobe for the whole voice turn — the copy re-wrapped into three truncated words:

| Before (386pt window) | After (556pt window) |
| --- | --- |
| card squeezed into the listening island | card keeps its own frame |

## Root cause

A notification card deliberately outlives the voice turn started against it: Interject keeps it mounted so **"hold fn to reply"** has a referent while the user speaks, while the query is thinking, and while the answer plays.

`resizeForPTTState` did not know that. It substituted the bare voice island for whatever the surface was showing, gated only on `showingAIConversation`, so holding the shortcut on a card resized the panel from the card's 508pt surface down to the ~270pt notch lobe and left it there for the whole turn.

`FloatingControlBarGeometry.collapsedSurfaceSize` already encoded the right rule — *"a mounted notification card wins over the listening/thinking island"* — and `FloatingBarGeometryTests` already asserted it. **That is exactly why this shipped: the invariant was tested on the authority while the live PTT path never called it.**

This is a recurrence of `FC-generic-deadline-revokes-in-flight-owner`, whose definition already names this exact case ("a mounted Interject notification card must keep notification chrome while PTT listening is also true") and whose canonical prevention is "size collapsed chrome from the mounted notification (unioned with listening) rather than the listening island". The earlier fix landed that on `collapsedSurfaceSize`. It did not reach the resize path the user's hold actually goes through, so the class recurred at a sibling call site. This change closes the remaining ones by making the union the only way to compute a closed surface.

## The class, not just the instance

Three call sites had the same shape — a transient notch state *substituted* for the closed surface instead of *composed* with it:

1. **`resizeForPTTState`** swapped in the listening/idle island. This is the reported bug, on every PTT hold against a card.
2. **`currentSurfaceSize` / `frameForCurrentState` / `defaultFrameForCurrentState`** returned `pttHintSurfaceSize` whenever a status banner was up ("Hold longer to record", "Microphone unavailable"), which both narrowed a mounted card to `notchExpandedWidth` and clipped its body off the bottom.
3. **`savePreChatCenterIfNeeded`** snapped the panel to the collapsed island purely to read a center back off `frame`, crushing a visible card on the way.

## The fix

- One pure home for the rule: `FloatingControlBarGeometry.notificationPreservingSurfaceSize`.
- Two authorities in the window that every closed-surface size now routes through: `notificationSurfaceSize` (how big the card itself is — previously re-derived in three places) and `closedSurfaceSize` (card, status banner and island *composed*).
- `showNotification` / `dismissNotification` use them too, which fixes the mirror case: dismissing a card mid-turn collapsed a listening island straight to the idle lobe.
- `savePreChatCenterIfNeeded` records the canonical center from the frame it computes rather than requiring a physical snap, so it leaves a mounted card alone.

## Verification

`FloatingBarNotchCardSizingTests` (8 tests, new). Every behavioural test fails on the pre-fix behaviour with the exact reported geometry and passes after:

```
XCTAssertGreaterThanOrEqual failed: ("386.0") is less than ("556.0")
  - PTT (expanded=true) must not narrow the panel under a mounted card
XCTAssertGreaterThanOrEqual failed: ("62.0") is less than ("198.0")
  - PTT (expanded=true) must not clip the card body
```

The end-to-end test drives the real production trigger: a `VoiceTurnUIProjection` applied by the real `FloatingControlBarState.PTTBarPresenter`, which is what calls `resizeForPTTState`.

Also run: full desktop Swift suite (one pre-existing unrelated failure, `ChatDiscoverabilityTests/testDesktopCapabilitiesExistInAgentToolDeclarations`, reproduced on clean `origin/main` — stale local agent-runtime dist), pinned swift-format lint, SwiftLint (0 violations), `check_desktop_test_quality.py` (at baseline).

Not run locally: the Xcode 16.4 strict-concurrency lane — this machine only has Xcode 26.6, so CI owns that check.

## Product invariants affected

- INV-CHAT-1 — touched only as window geometry. This change adds no store, no per-surface continuity ring, and no session/model/run identity in Swift; it moves NSPanel frame sizing behind two existing pure authorities. Transcript ownership and conversation state are untouched.

Failure-Class: FC-generic-deadline-revokes-in-flight-owner

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift | 5689 -> 5733 | +44 for the two extracted sizing authorities (notificationSurfaceSize, closedSurfaceSize), the pushToTalkSurfaceSize split, and the comments recording why a card outlives a voice turn. Splitting the file here would require loosening ~8 private notch-geometry members to internal, which is a larger change than the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

