### PR TITLE
Put private-cloud-sync bucket lifecycle under version control + Coldline@30d on chunks/

### DIFF
--- a/.github/workflows/gcp_storage_lifecycle.yml
+++ b/.github/workflows/gcp_storage_lifecycle.yml
@@ -139,6 +139,15 @@ jobs:
           test -f "$file"
           bucket="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['bucket'])" "$file")"
           project="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['project'])" "$file")"
+          case "$RESOLVED_ENVIRONMENT" in
+            development) expected_bucket='omi-dev-private-cloud-sync' ;;
+            prod) expected_bucket='omi-private-cloud-sync' ;;
+            *) echo "Invalid environment: $RESOLVED_ENVIRONMENT."; exit 1 ;;
+          esac
+          if [[ "$bucket" != "$expected_bucket" ]]; then
+            echo "Lifecycle file bucket $bucket does not match the expected $RESOLVED_ENVIRONMENT bucket $expected_bucket."
+            exit 1
+          fi
           if [[ "$project" != "${{ vars.GCP_PROJECT_ID }}" ]]; then
             echo "Lifecycle file project $project does not match the environment project ${{ vars.GCP_PROJECT_ID }}."
             exit 1
@@ -160,7 +169,7 @@ jobs:
         run: |
           set -euo pipefail
           gcloud storage buckets describe "gs://${{ steps.select.outputs.bucket }}" \
-            --project="${{ steps.select.outputs.project }}" --format=json > before.json
+            --project="${{ steps.select.outputs.project }}" --raw --format=json > before.json
           gcloud storage buckets notifications list "gs://${{ steps.select.outputs.bucket }}" \
             --project="${{ steps.select.outputs.project }}" --format=json > notifications.json
           python3 -c "import json;print(json.dumps(json.load(open('before.json')).get('lifecycle', {}), indent=2))"
@@ -169,7 +178,13 @@ jobs:
         run: |
           set -euo pipefail
           extra=()
-          if [[ "$LIFECYCLE_VARIANT" == "rollback" ]]; then extra+=(--allow-rule-removal); fi
+          if [[ "$LIFECYCLE_VARIANT" == "rollback" ]]; then
+            # Scoped removal: only rules the apply variant declared (the Coldline
+            # rule) may be dropped; a later live rule still blocks the rollback.
+            apply_file="backend/deploy/storage-lifecycle/${RESOLVED_ENVIRONMENT}.json"
+            test -f "$apply_file"
+            extra+=(--allow-rule-removal-of "$apply_file")
+          fi
           python3 backend/scripts/validate_storage_lifecycle.py \
             --desired "${{ steps.select.outputs.file }}" \
             --live before.json \
@@ -188,7 +203,7 @@ jobs:
         run: |
           set -euo pipefail
           gcloud storage buckets describe "gs://${{ steps.select.outputs.bucket }}" \
-            --project="${{ steps.select.outputs.project }}" --format=json > after.json
+            --project="${{ steps.select.outputs.project }}" --raw --format=json > after.json
           python3 backend/scripts/validate_storage_lifecycle.py \
             --desired "${{ steps.select.outputs.file }}" --live after.json --expect-applied
 

--- a/.github/workflows/gcp_storage_lifecycle.yml
+++ b/.github/workflows/gcp_storage_lifecycle.yml
@@ -1,0 +1,210 @@
+name: Apply Cloud Storage lifecycle (private-cloud-sync)
+
+# The private-cloud-sync bucket's lifecycle was managed by nothing: console and
+# gsutil only. This workflow is the single writer. `gcloud storage buckets
+# update --lifecycle-file` REPLACES the whole lifecycle config, so the apply is
+# fenced by a describe -> superset validation -> apply -> describe -> assert
+# sequence, and every artifact is uploaded.
+#
+# push  -> development only. prod is dispatch-only, typed-confirmation gated,
+#          and additionally gated by the `prod` GitHub Environment reviewer.
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'backend/deploy/storage-lifecycle/**'
+      - 'backend/scripts/validate_storage_lifecycle.py'
+      - '.github/workflows/gcp_storage_lifecycle.yml'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Bucket environment to reconcile'
+        required: true
+        default: 'development'
+        type: choice
+        options:
+          - development
+          - prod
+      lifecycle_variant:
+        description: 'apply = checked-in lifecycle; rollback = pre-change rules only'
+        required: true
+        default: 'apply'
+        type: choice
+        options:
+          - apply
+          - rollback
+      confirmation:
+        description: 'Type APPLY_STORAGE_LIFECYCLE_PROD for prod'
+        required: false
+        default: ''
+        type: string
+      release_sha:
+        description: 'Exact current main SHA (prod only)'
+        required: false
+        default: ''
+        type: string
+
+# Deliberately NOT the backend-stack lock: this workflow builds and deploys no
+# code, and must not queue behind or block a backend release.
+concurrency:
+  group: storage-lifecycle-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || 'development' }}
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    environment: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || 'development' }}
+    permissions:
+      contents: read
+      actions: read
+    runs-on: ubuntu-latest
+    env:
+      RESOLVED_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment || 'development' }}
+      LIFECYCLE_VARIANT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.lifecycle_variant || 'apply' }}
+    steps:
+      - name: Validate storage lifecycle input
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CONFIRMATION: ${{ github.event.inputs.confirmation }}
+          DEPLOY_SHA: ${{ github.event.inputs.release_sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$RESOLVED_ENVIRONMENT" != "development" && "$RESOLVED_ENVIRONMENT" != "prod" ]]; then
+            echo "Invalid environment: $RESOLVED_ENVIRONMENT."
+            exit 1
+          fi
+          if [[ "$LIFECYCLE_VARIANT" != "apply" && "$LIFECYCLE_VARIANT" != "rollback" ]]; then
+            echo "Invalid lifecycle_variant: $LIFECYCLE_VARIANT."
+            exit 1
+          fi
+          # A push never reaches prod: the resolved environment is hardcoded to
+          # development on that trigger. prod requires a dispatch, the typed
+          # confirmation, an exact main SHA, and the prod environment reviewer.
+          if [[ "$RESOLVED_ENVIRONMENT" == "prod" ]]; then
+            if [[ "$EVENT_NAME" != "workflow_dispatch" ]]; then
+              echo "prod is dispatch-only."
+              exit 1
+            fi
+            if [[ "$CONFIRMATION" != "APPLY_STORAGE_LIFECYCLE_PROD" ]]; then
+              echo "Refusing prod lifecycle mutation without APPLY_STORAGE_LIFECYCLE_PROD confirmation."
+              exit 1
+            fi
+            if [[ ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "prod requires release_sha to be an exact 40-character main SHA."
+              exit 1
+            fi
+          fi
+          echo "Reconciling $RESOLVED_ENVIRONMENT lifecycle (variant $LIFECYCLE_VARIANT) via $EVENT_NAME."
+
+      - name: Checkout lifecycle control plane
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Admit exact proven main source
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DEPLOY_SHA: ${{ github.event.inputs.release_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          if [[ "$RESOLVED_ENVIRONMENT" == "prod" ]]; then
+            test "$DEPLOY_SHA" = "$(git rev-parse 'origin/main^{commit}')"
+            proof_path="${RUNNER_TEMP}/release-eligibility-${DEPLOY_SHA}.json"
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/release-eligibility.yml/runs?event=push&branch=main&status=completed&head_sha=${DEPLOY_SHA}&per_page=100" \
+              > "$proof_path"
+            python3 .github/scripts/verify_backend_release_admission.py \
+              --sha "$DEPLOY_SHA" --repository "$GITHUB_REPOSITORY" \
+              --workflow-runs "$proof_path" --require-first-attempt
+            git checkout --detach "$DEPLOY_SHA"
+            test "$(git rev-parse HEAD)" = "$DEPLOY_SHA"
+          else
+            git checkout --detach "$GITHUB_SHA"
+            test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          fi
+          echo "Applying lifecycle from $(git rev-parse HEAD)."
+
+      - name: Select and source-validate the lifecycle document
+        id: select
+        run: |
+          set -euo pipefail
+          suffix=''
+          if [[ "$LIFECYCLE_VARIANT" == "rollback" ]]; then suffix='.rollback'; fi
+          file="backend/deploy/storage-lifecycle/${RESOLVED_ENVIRONMENT}${suffix}.json"
+          test -f "$file"
+          bucket="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['bucket'])" "$file")"
+          project="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['project'])" "$file")"
+          if [[ "$project" != "${{ vars.GCP_PROJECT_ID }}" ]]; then
+            echo "Lifecycle file project $project does not match the environment project ${{ vars.GCP_PROJECT_ID }}."
+            exit 1
+          fi
+          python3 backend/scripts/validate_storage_lifecycle.py --desired "$file" --source-only
+          {
+            echo "file=$file"
+            echo "bucket=$bucket"
+            echo "project=$project"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - uses: google-github-actions/setup-gcloud@v3
+
+      - name: Capture live bucket state before apply
+        run: |
+          set -euo pipefail
+          gcloud storage buckets describe "gs://${{ steps.select.outputs.bucket }}" \
+            --project="${{ steps.select.outputs.project }}" --format=json > before.json
+          gcloud storage buckets notifications list "gs://${{ steps.select.outputs.bucket }}" \
+            --project="${{ steps.select.outputs.project }}" --format=json > notifications.json
+          python3 -c "import json;print(json.dumps(json.load(open('before.json')).get('lifecycle', {}), indent=2))"
+
+      - name: Refuse to drop any live rule
+        run: |
+          set -euo pipefail
+          extra=()
+          if [[ "$LIFECYCLE_VARIANT" == "rollback" ]]; then extra+=(--allow-rule-removal); fi
+          python3 backend/scripts/validate_storage_lifecycle.py \
+            --desired "${{ steps.select.outputs.file }}" \
+            --live before.json \
+            --notifications notifications.json \
+            "${extra[@]}"
+
+      - name: Apply lifecycle
+        run: |
+          set -euo pipefail
+          python3 -c "import json,sys;json.dump(json.load(open(sys.argv[1]))['lifecycle'],open('apply.json','w'))" \
+            "${{ steps.select.outputs.file }}"
+          gcloud storage buckets update "gs://${{ steps.select.outputs.bucket }}" \
+            --project="${{ steps.select.outputs.project }}" --lifecycle-file=apply.json
+
+      - name: Assert the applied lifecycle equals the checked-in document
+        run: |
+          set -euo pipefail
+          gcloud storage buckets describe "gs://${{ steps.select.outputs.bucket }}" \
+            --project="${{ steps.select.outputs.project }}" --format=json > after.json
+          python3 backend/scripts/validate_storage_lifecycle.py \
+            --desired "${{ steps.select.outputs.file }}" --live after.json --expect-applied
+
+      - name: Upload lifecycle evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: storage-lifecycle-${{ env.RESOLVED_ENVIRONMENT }}-${{ github.run_id }}
+          path: |
+            before.json
+            after.json
+            notifications.json
+            apply.json
+          retention-days: 90
+          if-no-files-found: warn
+
+      - name: Print apply receipt
+        run: |
+          echo "storage-lifecycle-receipt bucket=${{ steps.select.outputs.bucket }} project=${{ steps.select.outputs.project }} variant=$LIFECYCLE_VARIANT sha=$(git rev-parse HEAD) applied_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/backend/deploy/storage-lifecycle/README.md
+++ b/backend/deploy/storage-lifecycle/README.md
@@ -13,6 +13,7 @@ noncurrent-version (`isLive: false`) rule.
 
 Rollback: dispatch the workflow with `lifecycle_variant=rollback`. That stops
 further transitions; objects already moved stay Coldline (reverting the class
-needs a rewrite job).
+needs a rewrite job). Rollback may drop only the rules the apply variant
+declared — any other live rule blocks it until re-declared.
 
 Plan and evidence: `omi-knowledge-base/projects/gcp-cost-efficiency/evidence/2026-09-02-coldline-rollout-plan.md`.

--- a/backend/deploy/storage-lifecycle/README.md
+++ b/backend/deploy/storage-lifecycle/README.md
@@ -1,0 +1,18 @@
+# `private-cloud-sync` bucket lifecycle
+
+Checked-in lifecycle configuration for `omi-private-cloud-sync` (prod) and
+`omi-dev-private-cloud-sync` (dev). Applied only by
+`.github/workflows/gcp_storage_lifecycle.yml` — never by hand.
+
+`gcloud storage buckets update --lifecycle-file` **replaces the whole lifecycle
+config**, so every legacy rule must be re-declared verbatim in these files.
+`backend/scripts/validate_storage_lifecycle.py` refuses any file that drops a
+rule present in the live bucket, lets a `Delete` rule reach `chunks/`, adds a
+`SetStorageClass` rule not scoped to exactly `chunks/`, or adds a
+noncurrent-version (`isLive: false`) rule.
+
+Rollback: dispatch the workflow with `lifecycle_variant=rollback`. That stops
+further transitions; objects already moved stay Coldline (reverting the class
+needs a rewrite job).
+
+Plan and evidence: `omi-knowledge-base/projects/gcp-cost-efficiency/evidence/2026-09-02-coldline-rollout-plan.md`.

--- a/backend/deploy/storage-lifecycle/development.json
+++ b/backend/deploy/storage-lifecycle/development.json
@@ -1,0 +1,18 @@
+{
+  "bucket": "omi-dev-private-cloud-sync",
+  "project": "based-hardware-dev",
+  "lifecycle": {
+    "rule": [
+      {"action": {"type": "Delete"}, "condition": {"age": 3, "matchesPrefix": ["merged/"]}},
+      {"action": {"type": "Delete"}, "condition": {"age": 30, "matchesPrefix": ["playback/"]}},
+      {
+        "action": {"type": "SetStorageClass", "storageClass": "COLDLINE"},
+        "condition": {
+          "age": 30,
+          "matchesPrefix": ["chunks/"],
+          "matchesStorageClass": ["STANDARD", "MULTI_REGIONAL"]
+        }
+      }
+    ]
+  }
+}

--- a/backend/deploy/storage-lifecycle/development.rollback.json
+++ b/backend/deploy/storage-lifecycle/development.rollback.json
@@ -1,0 +1,10 @@
+{
+  "bucket": "omi-dev-private-cloud-sync",
+  "project": "based-hardware-dev",
+  "lifecycle": {
+    "rule": [
+      {"action": {"type": "Delete"}, "condition": {"age": 3, "matchesPrefix": ["merged/"]}},
+      {"action": {"type": "Delete"}, "condition": {"age": 30, "matchesPrefix": ["playback/"]}}
+    ]
+  }
+}

--- a/backend/deploy/storage-lifecycle/prod.json
+++ b/backend/deploy/storage-lifecycle/prod.json
@@ -1,0 +1,18 @@
+{
+  "bucket": "omi-private-cloud-sync",
+  "project": "based-hardware",
+  "lifecycle": {
+    "rule": [
+      {"action": {"type": "Delete"}, "condition": {"age": 3, "matchesPrefix": ["merged/"]}},
+      {"action": {"type": "Delete"}, "condition": {"age": 30, "matchesPrefix": ["playback/"]}},
+      {
+        "action": {"type": "SetStorageClass", "storageClass": "COLDLINE"},
+        "condition": {
+          "age": 30,
+          "matchesPrefix": ["chunks/"],
+          "matchesStorageClass": ["STANDARD", "MULTI_REGIONAL"]
+        }
+      }
+    ]
+  }
+}

--- a/backend/deploy/storage-lifecycle/prod.rollback.json
+++ b/backend/deploy/storage-lifecycle/prod.rollback.json
@@ -1,0 +1,10 @@
+{
+  "bucket": "omi-private-cloud-sync",
+  "project": "based-hardware",
+  "lifecycle": {
+    "rule": [
+      {"action": {"type": "Delete"}, "condition": {"age": 3, "matchesPrefix": ["merged/"]}},
+      {"action": {"type": "Delete"}, "condition": {"age": 30, "matchesPrefix": ["playback/"]}}
+    ]
+  }
+}

--- a/backend/scripts/validate_storage_lifecycle.py
+++ b/backend/scripts/validate_storage_lifecycle.py
@@ -10,7 +10,10 @@ The load-bearing facts this guards:
 * ``gcloud storage buckets update --lifecycle-file`` **replaces** the whole
   lifecycle config, so a desired file that forgets a live rule silently deletes
   that rule. Without ``--allow-rule-removal`` this validator refuses any desired
-  file that drops a rule present in the live describe.
+  file that drops a rule present in the live describe. Rollback is narrower:
+  ``--allow-rule-removal-of <apply document>`` permits dropping only rules that
+  the apply variant declared (the Coldline rule); any other live rule still
+  blocks. ``--allow-rule-removal`` remains as an explicit operator override.
 * No ``Delete`` action may ever reach ``chunks/``. An unscoped Delete rule counts
   as reaching it.
 * Every ``SetStorageClass`` rule must be prefix-scoped to exactly ``chunks/``.
@@ -75,7 +78,7 @@ def validate_desired_document(document: Mapping[str, Any]) -> list[str]:
         action = rule.get("action") if isinstance(rule.get("action"), Mapping) else {}
         condition = rule.get("condition") if isinstance(rule.get("condition"), Mapping) else {}
         action_type = action.get("type")
-        if action_type not in ALLOWED_ACTIONS:
+        if not isinstance(action_type, str) or action_type not in ALLOWED_ACTIONS:
             errors.append(f"desired rule {index} has unsupported action {action_type!r}")
             continue
         if condition.get("isLive") is False or any(key in condition for key in NONCURRENT_CONDITION_KEYS):
@@ -118,9 +121,14 @@ def validate_desired_document(document: Mapping[str, Any]) -> list[str]:
                     f"got {prefixes!r}"
                 )
             source_classes = condition.get("matchesStorageClass")
-            if source_classes is not None and not set(source_classes).issubset(ALLOWED_SOURCE_CLASSES):
+            classes_ok = (
+                isinstance(source_classes, list)
+                and all(isinstance(c, str) for c in source_classes)
+                and sorted(source_classes) == sorted(ALLOWED_SOURCE_CLASSES)
+            )
+            if not classes_ok:
                 errors.append(
-                    f"desired rule {index} matchesStorageClass must be a subset of "
+                    f"desired rule {index} matchesStorageClass must be exactly "
                     f"{sorted(ALLOWED_SOURCE_CLASSES)}, got {source_classes!r}"
                 )
 
@@ -138,6 +146,7 @@ def validate_against_live(
     live: Mapping[str, Any],
     allow_rule_removal: bool = False,
     expect_applied: bool = False,
+    allow_rule_removal_of: Sequence[Mapping[str, Any]] | None = None,
 ) -> list[str]:
     errors: list[str] = []
     live_name = str(live.get("name") or "").strip()
@@ -152,13 +161,24 @@ def validate_against_live(
     desired_rules = _rules(desired)
     live_rules = _rules(live)
     if not allow_rule_removal:
+        # Scoped removal (rollback): only rules the apply variant declared may
+        # be dropped; a later live rule the apply never contained still blocks.
+        droppable: Sequence[Any] = (
+            desired_rules if allow_rule_removal_of is None else desired_rules + list(allow_rule_removal_of)
+        )
         for rule in live_rules:
-            if rule not in desired_rules:
-                errors.append(
-                    "desired document drops a rule that is live on the bucket "
-                    f"({json.dumps(rule, sort_keys=True)}); --lifecycle-file replaces the whole config, "
-                    "so this would delete it. Re-declare it or pass --allow-rule-removal."
-                )
+            if rule in droppable:
+                continue
+            hint = (
+                "Re-declare it or pass --allow-rule-removal."
+                if allow_rule_removal_of is None
+                else "Re-declare it, or restrict removal to rules the apply variant declared."
+            )
+            errors.append(
+                "desired document drops a rule that is live on the bucket "
+                f"({json.dumps(rule, sort_keys=True)}); --lifecycle-file replaces the whole config, "
+                f"so this would delete it. {hint}"
+            )
     if expect_applied:
         missing = [r for r in desired_rules if r not in live_rules]
         extra = [r for r in live_rules if r not in desired_rules]
@@ -190,10 +210,18 @@ def main() -> int:
     parser.add_argument("--notifications", type=Path, default=None)
     parser.add_argument("--expect-applied", action="store_true")
     parser.add_argument("--allow-rule-removal", action="store_true")
+    parser.add_argument(
+        "--allow-rule-removal-of",
+        type=Path,
+        default=None,
+        help="Scoped removal (rollback): allow dropping only rules declared in this apply document",
+    )
     parser.add_argument("--source-only", action="store_true")
     args = parser.parse_args()
 
     errors: list[str] = []
+    if args.allow_rule_removal and args.allow_rule_removal_of is not None:
+        errors.append("--allow-rule-removal and --allow-rule-removal-of are mutually exclusive")
     try:
         desired = _read_json(args.desired)
     except (OSError, json.JSONDecodeError) as exc:
@@ -205,9 +233,26 @@ def main() -> int:
     errors.extend(validate_desired_document(desired))
 
     if args.source_only:
-        if args.live or args.notifications or args.expect_applied:
+        if (
+            args.live
+            or args.notifications
+            or args.expect_applied
+            or args.allow_rule_removal
+            or args.allow_rule_removal_of is not None
+        ):
             errors.append("--source-only cannot claim live bucket validation")
     else:
+        allow_rule_removal_of: Sequence[Mapping[str, Any]] | None = None
+        if args.allow_rule_removal_of is not None:
+            try:
+                apply_document = _read_json(args.allow_rule_removal_of)
+            except (OSError, json.JSONDecodeError) as exc:
+                errors.append(f"could not read allow-rule-removal-of document: {exc}")
+            else:
+                if isinstance(apply_document, Mapping):
+                    allow_rule_removal_of = _rules(apply_document)
+                else:
+                    errors.append("allow-rule-removal-of document must be a JSON object")
         if args.live is None:
             errors.append("a live describe document is required outside --source-only mode")
         else:
@@ -223,6 +268,7 @@ def main() -> int:
                             live,
                             allow_rule_removal=args.allow_rule_removal,
                             expect_applied=args.expect_applied,
+                            allow_rule_removal_of=allow_rule_removal_of,
                         )
                     )
                 else:

--- a/backend/scripts/validate_storage_lifecycle.py
+++ b/backend/scripts/validate_storage_lifecycle.py
@@ -1,0 +1,247 @@
+"""Validate the checked-in Cloud Storage lifecycle contract for private-cloud-sync.
+
+Offline validator, in the shape of ``validate_frame_request_bucket_contract.py``:
+it reads a checked-in desired document and, optionally, a
+``gcloud storage buckets describe --format=json`` fixture. It never creates or
+mutates a bucket.
+
+The load-bearing facts this guards:
+
+* ``gcloud storage buckets update --lifecycle-file`` **replaces** the whole
+  lifecycle config, so a desired file that forgets a live rule silently deletes
+  that rule. Without ``--allow-rule-removal`` this validator refuses any desired
+  file that drops a rule present in the live describe.
+* No ``Delete`` action may ever reach ``chunks/``. An unscoped Delete rule counts
+  as reaching it.
+* Every ``SetStorageClass`` rule must be prefix-scoped to exactly ``chunks/``.
+* Noncurrent-version rules (``isLive: false`` and friends) are forbidden: a
+  bucket-wide noncurrent rule would move ``playback/`` noncurrent versions to
+  Coldline, which the 30-day Delete rule then early-deletes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+CHUNKS_PREFIX = "chunks/"
+ALLOWED_ACTIONS = {"Delete", "SetStorageClass"}
+ALLOWED_SOURCE_CLASSES = {"STANDARD", "MULTI_REGIONAL"}
+NONCURRENT_CONDITION_KEYS = ("daysSinceNoncurrentTime", "noncurrentTimeBefore", "numNewerVersions")
+
+PROD_BUCKET = "omi-private-cloud-sync"
+LEGACY_DELETE_RULES: tuple[dict[str, Any], ...] = (
+    {"action": {"type": "Delete"}, "condition": {"age": 3, "matchesPrefix": ["merged/"]}},
+    {"action": {"type": "Delete"}, "condition": {"age": 30, "matchesPrefix": ["playback/"]}},
+)
+
+
+def _rules(document: Mapping[str, Any] | None) -> list[Any]:
+    if not isinstance(document, Mapping):
+        return []
+    lifecycle = document.get("lifecycle")
+    if not isinstance(lifecycle, Mapping):
+        return []
+    rules = lifecycle.get("rule")
+    return list(rules) if isinstance(rules, list) else []
+
+
+def _prefix_touches_chunks(prefix: str) -> bool:
+    """True when a lifecycle prefix can select an object under ``chunks/``."""
+    return prefix.startswith(CHUNKS_PREFIX) or CHUNKS_PREFIX.startswith(prefix)
+
+
+def validate_desired_document(document: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    bucket = str(document.get("bucket") or "").strip()
+    project = str(document.get("project") or "").strip()
+    if not bucket:
+        errors.append("desired document must name a bucket")
+    if not project:
+        errors.append("desired document must name a project")
+    lifecycle = document.get("lifecycle")
+    if not isinstance(lifecycle, Mapping) or not isinstance(lifecycle.get("rule"), list):
+        errors.append("desired document must contain lifecycle.rule as a list")
+        return errors
+
+    set_class_rules = 0
+    for index, rule in enumerate(lifecycle["rule"]):
+        if not isinstance(rule, Mapping):
+            errors.append(f"desired rule {index} is not an object")
+            continue
+        action = rule.get("action") if isinstance(rule.get("action"), Mapping) else {}
+        condition = rule.get("condition") if isinstance(rule.get("condition"), Mapping) else {}
+        action_type = action.get("type")
+        if action_type not in ALLOWED_ACTIONS:
+            errors.append(f"desired rule {index} has unsupported action {action_type!r}")
+            continue
+        if condition.get("isLive") is False or any(key in condition for key in NONCURRENT_CONDITION_KEYS):
+            errors.append(
+                f"desired rule {index} targets noncurrent versions; noncurrent-version rules are forbidden "
+                "(they would Coldline playback/ noncurrent versions that the 30-day Delete rule early-deletes)"
+            )
+        prefixes = condition.get("matchesPrefix")
+        if prefixes is not None and (
+            not isinstance(prefixes, Sequence)
+            or isinstance(prefixes, (str, bytes))
+            or not all(isinstance(p, str) for p in prefixes)
+        ):
+            errors.append(f"desired rule {index} matchesPrefix must be a list of strings")
+            continue
+
+        if action_type == "Delete":
+            if not prefixes:
+                errors.append(
+                    f"desired rule {index} is an unscoped Delete; a Delete rule must never be able to match {CHUNKS_PREFIX!r}"
+                )
+            else:
+                for prefix in prefixes:
+                    if _prefix_touches_chunks(prefix):
+                        errors.append(
+                            f"desired rule {index} is a Delete rule whose prefix {prefix!r} can match {CHUNKS_PREFIX!r}"
+                        )
+        else:  # SetStorageClass
+            set_class_rules += 1
+            if action.get("storageClass") != "COLDLINE":
+                errors.append(
+                    f"desired rule {index} must set storageClass COLDLINE, got {action.get('storageClass')!r}"
+                )
+            age = condition.get("age")
+            if not isinstance(age, int) or isinstance(age, bool) or age < 30:
+                errors.append(f"desired rule {index} must carry an integer age >= 30, got {age!r}")
+            if list(prefixes or []) != [CHUNKS_PREFIX]:
+                errors.append(
+                    f"desired rule {index} SetStorageClass must be prefix-scoped to exactly ['{CHUNKS_PREFIX}'], "
+                    f"got {prefixes!r}"
+                )
+            source_classes = condition.get("matchesStorageClass")
+            if source_classes is not None and not set(source_classes).issubset(ALLOWED_SOURCE_CLASSES):
+                errors.append(
+                    f"desired rule {index} matchesStorageClass must be a subset of "
+                    f"{sorted(ALLOWED_SOURCE_CLASSES)}, got {source_classes!r}"
+                )
+
+    if set_class_rules > 1:
+        errors.append(f"desired document declares {set_class_rules} SetStorageClass rules; exactly one is expected")
+    if bucket == PROD_BUCKET:
+        for legacy in LEGACY_DELETE_RULES:
+            if legacy not in lifecycle["rule"]:
+                errors.append(f"desired document is missing the legacy prod rule {json.dumps(legacy, sort_keys=True)}")
+    return errors
+
+
+def validate_against_live(
+    desired: Mapping[str, Any],
+    live: Mapping[str, Any],
+    allow_rule_removal: bool = False,
+    expect_applied: bool = False,
+) -> list[str]:
+    errors: list[str] = []
+    live_name = str(live.get("name") or "").strip()
+    bucket = str(desired.get("bucket") or "").strip()
+    if live_name and bucket and live_name != bucket:
+        errors.append(f"live bucket name {live_name!r} does not match desired bucket {bucket!r}")
+    versioning = live.get("versioning")
+    enabled = versioning.get("enabled") if isinstance(versioning, Mapping) else None
+    if enabled is not True:
+        errors.append("live bucket versioning must be enabled; it is the only undo for a mass-delete bug")
+
+    desired_rules = _rules(desired)
+    live_rules = _rules(live)
+    if not allow_rule_removal:
+        for rule in live_rules:
+            if rule not in desired_rules:
+                errors.append(
+                    "desired document drops a rule that is live on the bucket "
+                    f"({json.dumps(rule, sort_keys=True)}); --lifecycle-file replaces the whole config, "
+                    "so this would delete it. Re-declare it or pass --allow-rule-removal."
+                )
+    if expect_applied:
+        missing = [r for r in desired_rules if r not in live_rules]
+        extra = [r for r in live_rules if r not in desired_rules]
+        if missing or extra:
+            errors.append(
+                "applied lifecycle does not equal the desired lifecycle; "
+                f"missing={json.dumps(missing, sort_keys=True)} unexpected={json.dumps(extra, sort_keys=True)}"
+            )
+    return errors
+
+
+def validate_notifications(notifications: Any) -> list[str]:
+    if isinstance(notifications, list) and not notifications:
+        return []
+    return [
+        "bucket has notification configs; lifecycle transitions would fan out metadata events — review first "
+        f"({json.dumps(notifications, sort_keys=True)})"
+    ]
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--desired", type=Path, required=True)
+    parser.add_argument("--live", type=Path, default=None, help="gcloud storage buckets describe --format=json")
+    parser.add_argument("--notifications", type=Path, default=None)
+    parser.add_argument("--expect-applied", action="store_true")
+    parser.add_argument("--allow-rule-removal", action="store_true")
+    parser.add_argument("--source-only", action="store_true")
+    args = parser.parse_args()
+
+    errors: list[str] = []
+    try:
+        desired = _read_json(args.desired)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: could not read desired lifecycle document: {exc}")
+        return 1
+    if not isinstance(desired, Mapping):
+        print("ERROR: desired lifecycle document must be a JSON object")
+        return 1
+    errors.extend(validate_desired_document(desired))
+
+    if args.source_only:
+        if args.live or args.notifications or args.expect_applied:
+            errors.append("--source-only cannot claim live bucket validation")
+    else:
+        if args.live is None:
+            errors.append("a live describe document is required outside --source-only mode")
+        else:
+            try:
+                live = _read_json(args.live)
+            except (OSError, json.JSONDecodeError) as exc:
+                errors.append(f"could not read live describe document: {exc}")
+            else:
+                if isinstance(live, Mapping):
+                    errors.extend(
+                        validate_against_live(
+                            desired,
+                            live,
+                            allow_rule_removal=args.allow_rule_removal,
+                            expect_applied=args.expect_applied,
+                        )
+                    )
+                else:
+                    errors.append("live describe document must be a JSON object")
+        if args.notifications is not None:
+            try:
+                notifications = _read_json(args.notifications)
+            except (OSError, json.JSONDecodeError) as exc:
+                errors.append(f"could not read notifications document: {exc}")
+            else:
+                errors.extend(validate_notifications(notifications))
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+    print(f"storage lifecycle contract passed for {desired.get('bucket')}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/unit/test_storage_lifecycle_contract.py
+++ b/backend/tests/unit/test_storage_lifecycle_contract.py
@@ -1,0 +1,150 @@
+import json
+from pathlib import Path
+
+from scripts.validate_storage_lifecycle import (
+    LEGACY_DELETE_RULES,
+    validate_against_live,
+    validate_desired_document,
+    validate_notifications,
+)
+
+DEPLOY_DIR = Path(__file__).resolve().parents[2] / "deploy" / "storage-lifecycle"
+APPLY_FILES = ("prod.json", "development.json")
+ROLLBACK_FILES = ("prod.rollback.json", "development.rollback.json")
+
+
+def _load(name: str) -> dict:
+    return json.loads((DEPLOY_DIR / name).read_text(encoding="utf-8"))
+
+
+def _rules(document: dict) -> list:
+    return document["lifecycle"]["rule"]
+
+
+def test_checked_in_documents_pass_the_source_contract():
+    for name in APPLY_FILES + ROLLBACK_FILES:
+        assert validate_desired_document(_load(name)) == [], name
+
+
+def test_no_delete_rule_can_reach_chunks():
+    for name in APPLY_FILES + ROLLBACK_FILES:
+        for rule in _rules(_load(name)):
+            if rule["action"]["type"] != "Delete":
+                continue
+            prefixes = rule["condition"].get("matchesPrefix")
+            assert prefixes, f"{name}: unscoped Delete rule"
+            for prefix in prefixes:
+                assert not prefix.startswith("chunks/"), f"{name}: {prefix}"
+                assert not "chunks/".startswith(prefix), f"{name}: {prefix}"
+
+
+def test_apply_files_declare_exactly_one_coldline_rule_scoped_to_chunks():
+    for name in APPLY_FILES:
+        set_class = [r for r in _rules(_load(name)) if r["action"]["type"] == "SetStorageClass"]
+        assert len(set_class) == 1, name
+        rule = set_class[0]
+        assert rule["action"]["storageClass"] == "COLDLINE"
+        assert rule["condition"]["age"] == 30
+        assert rule["condition"]["matchesPrefix"] == ["chunks/"]
+
+
+def test_prod_re_declares_the_two_legacy_delete_rules_verbatim():
+    for name in ("prod.json", "prod.rollback.json"):
+        rules = _rules(_load(name))
+        assert {"action": {"type": "Delete"}, "condition": {"age": 3, "matchesPrefix": ["merged/"]}} in rules, name
+        assert {"action": {"type": "Delete"}, "condition": {"age": 30, "matchesPrefix": ["playback/"]}} in rules, name
+        for legacy in LEGACY_DELETE_RULES:
+            assert legacy in rules, name
+
+
+def test_rollback_files_only_drop_the_set_storage_class_rule():
+    for apply_name, rollback_name in zip(APPLY_FILES, ROLLBACK_FILES):
+        apply_rules = _rules(_load(apply_name))
+        rollback_rules = _rules(_load(rollback_name))
+        assert all(rule["action"]["type"] == "Delete" for rule in rollback_rules)
+        assert all(rule in apply_rules for rule in rollback_rules)
+        dropped = [rule for rule in apply_rules if rule not in rollback_rules]
+        assert [rule["action"]["type"] for rule in dropped] == ["SetStorageClass"]
+        assert _load(apply_name)["bucket"] == _load(rollback_name)["bucket"]
+
+
+def test_bucket_wide_set_storage_class_rule_is_rejected():
+    errors = validate_desired_document(
+        {
+            "bucket": "omi-dev-private-cloud-sync",
+            "project": "based-hardware-dev",
+            "lifecycle": {
+                "rule": [
+                    {
+                        "action": {"type": "SetStorageClass", "storageClass": "COLDLINE"},
+                        "condition": {"age": 30},
+                    }
+                ]
+            },
+        }
+    )
+    assert any("prefix-scoped to exactly" in error for error in errors)
+
+
+def test_unscoped_delete_rule_is_rejected():
+    errors = validate_desired_document(
+        {
+            "bucket": "omi-dev-private-cloud-sync",
+            "project": "based-hardware-dev",
+            "lifecycle": {"rule": [{"action": {"type": "Delete"}, "condition": {"age": 365}}]},
+        }
+    )
+    assert any("unscoped Delete" in error for error in errors)
+
+
+def test_delete_rule_on_chunks_is_rejected():
+    errors = validate_desired_document(
+        {
+            "bucket": "omi-dev-private-cloud-sync",
+            "project": "based-hardware-dev",
+            "lifecycle": {
+                "rule": [{"action": {"type": "Delete"}, "condition": {"age": 365, "matchesPrefix": ["chunks/"]}}]
+            },
+        }
+    )
+    assert any("can match 'chunks/'" in error for error in errors)
+
+
+def test_noncurrent_version_rule_is_rejected():
+    document = _load("development.json")
+    document["lifecycle"]["rule"].append(
+        {
+            "action": {"type": "SetStorageClass", "storageClass": "COLDLINE"},
+            "condition": {"isLive": False, "daysSinceNoncurrentTime": 30},
+        }
+    )
+    errors = validate_desired_document(document)
+    assert any("noncurrent" in error for error in errors)
+
+
+def test_live_rule_not_present_in_desired_fails_without_allow_rule_removal():
+    desired = _load("development.json")
+    live = {
+        "name": "omi-dev-private-cloud-sync",
+        "versioning": {"enabled": True},
+        "lifecycle": {
+            "rule": _rules(desired)[:1]
+            + [{"action": {"type": "Delete"}, "condition": {"age": 7, "matchesPrefix": ["scratch/"]}}]
+        },
+    }
+    errors = validate_against_live(desired, live)
+    assert any("drops a rule that is live" in error for error in errors)
+    assert validate_against_live(desired, live, allow_rule_removal=True) == []
+
+
+def test_expect_applied_requires_equality_and_versioning_stays_on():
+    desired = _load("prod.json")
+    live = {"name": "omi-private-cloud-sync", "versioning": {"enabled": True}, "lifecycle": {"rule": _rules(desired)}}
+    assert validate_against_live(desired, live, expect_applied=True) == []
+    live["versioning"] = {"enabled": False}
+    assert any("versioning must be enabled" in error for error in validate_against_live(desired, live))
+
+
+def test_notification_configs_block_the_apply():
+    assert validate_notifications([]) == []
+    assert validate_notifications([{"id": "1", "topic": "projects/x/topics/y"}])

--- a/backend/tests/unit/test_storage_lifecycle_contract.py
+++ b/backend/tests/unit/test_storage_lifecycle_contract.py
@@ -148,3 +148,55 @@ def test_expect_applied_requires_equality_and_versioning_stays_on():
 def test_notification_configs_block_the_apply():
     assert validate_notifications([]) == []
     assert validate_notifications([{"id": "1", "topic": "projects/x/topics/y"}])
+
+
+def test_non_string_action_type_is_rejected_not_crashed():
+    document = _load("development.json")
+    document["lifecycle"]["rule"].append(
+        {"action": {"type": ["Delete", "SetStorageClass"]}, "condition": {"age": 30, "matchesPrefix": ["chunks/"]}}
+    )
+    errors = validate_desired_document(document)
+    assert any("unsupported action" in error for error in errors)
+
+
+def test_missing_or_malformed_matches_storage_class_is_rejected():
+    document = _load("development.json")
+    document["lifecycle"]["rule"] = [
+        {
+            "action": {"type": "SetStorageClass", "storageClass": "COLDLINE"},
+            "condition": {"age": 30, "matchesPrefix": ["chunks/"]},
+        }
+    ]
+    errors = validate_desired_document(document)
+    assert any("matchesStorageClass must be exactly" in error for error in errors), "omitted matchesStorageClass"
+
+    document["lifecycle"]["rule"][0]["condition"]["matchesStorageClass"] = ["STANDARD"]
+    errors = validate_desired_document(document)
+    assert any("matchesStorageClass must be exactly" in error for error in errors), "subset is no longer accepted"
+
+    document["lifecycle"]["rule"][0]["condition"]["matchesStorageClass"] = ["STANDARD", 7]
+    errors = validate_desired_document(document)
+    assert any("matchesStorageClass must be exactly" in error for error in errors), "malformed element"
+
+
+def test_scoped_rule_removal_blocks_rules_the_apply_never_declared():
+    desired = _load("development.rollback.json")
+    apply_rules = _rules(_load("development.json"))
+    later_rule = {"action": {"type": "Delete"}, "condition": {"age": 7, "matchesPrefix": ["scratch/"]}}
+    live = {
+        "name": "omi-dev-private-cloud-sync",
+        "versioning": {"enabled": True},
+        "lifecycle": {"rule": _rules(desired) + [later_rule]},
+    }
+    # The Coldline rule (declared by the apply variant) is droppable...
+    coldline_live = {
+        "name": "omi-dev-private-cloud-sync",
+        "versioning": {"enabled": True},
+        "lifecycle": {"rule": apply_rules},
+    }
+    assert validate_against_live(desired, coldline_live, allow_rule_removal_of=apply_rules) == []
+    # ...but a later live rule the apply never contained still blocks.
+    errors = validate_against_live(desired, live, allow_rule_removal_of=apply_rules)
+    assert any("drops a rule that is live" in error for error in errors)
+    # And the blanket override still exists for operators.
+    assert validate_against_live(desired, live, allow_rule_removal=True) == []

--- a/backend/tests/unit/test_storage_lifecycle_workflow.py
+++ b/backend/tests/unit/test_storage_lifecycle_workflow.py
@@ -1,0 +1,46 @@
+"""Structural contract for the storage lifecycle workflow.
+
+Pins the guards that keep the automatic development run honest: the bucket is
+asserted per environment before any gcloud command runs, live-state describes
+use the raw API representation, and rollback removal is scoped to the rules the
+apply variant declared. Static tripwire by design: it mirrors the workflow YAML,
+the behavioral contract lives in test_storage_lifecycle_contract.py.
+"""
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = ROOT / '.github/workflows/gcp_storage_lifecycle.yml'
+
+
+def _workflow() -> dict:
+    loaded = yaml.load(WORKFLOW.read_text(encoding='utf-8'), Loader=yaml.BaseLoader)
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def _step_text(workflow: dict) -> str:
+    steps = workflow['jobs']['apply']['steps']
+    return '\n'.join(str(step.get('run', '')) for step in steps)
+
+
+def test_environment_select_step_asserts_the_expected_bucket_per_environment() -> None:
+    text = _step_text(_workflow())
+    assert "development) expected_bucket='omi-dev-private-cloud-sync'" in text
+    assert "prod) expected_bucket='omi-private-cloud-sync'" in text
+    assert 'Lifecycle file bucket $bucket does not match' in text
+
+
+def test_live_state_describes_use_the_raw_api_representation() -> None:
+    text = _step_text(_workflow())
+    assert text.count('--raw --format=json') == 2, 'both describe fixtures must use --raw'
+
+
+def test_rollback_rule_removal_is_scoped_to_the_apply_variant_rules() -> None:
+    text = _step_text(_workflow())
+    assert '--allow-rule-removal-of' in text
+    assert '--allow-rule-removal)' not in text.replace(
+        '--allow-rule-removal-of', ''
+    ), 'blanket --allow-rule-removal must not be wired into the automatic rollback path'


### PR DESCRIPTION
## What this changes

Puts the `omi-private-cloud-sync` bucket lifecycle under version control (it was managed by nothing — console/`gsutil` only) and adds one rule:

```json
{
  "action": {"type": "SetStorageClass", "storageClass": "COLDLINE"},
  "condition": {"age": 30, "matchesPrefix": ["chunks/"], "matchesStorageClass": ["STANDARD", "MULTI_REGIONAL"]}
}
```

Applied to **dev on merge**. **Prod is dispatch-only** behind a typed confirmation, an exact-main-SHA admission, and the `prod` GitHub Environment reviewer — David approves that gate; subagents never do.

Files added:

- `backend/deploy/storage-lifecycle/{prod,development,prod.rollback,development.rollback}.json` + `README.md`
- `backend/scripts/validate_storage_lifecycle.py` — offline validator, same shape as `validate_frame_request_bucket_contract.py`
- `backend/tests/unit/test_storage_lifecycle_contract.py`
- `.github/workflows/gcp_storage_lifecycle.yml` — describe → validate superset → apply → describe → assert-equal, artifacts uploaded (90 d)

No application code changes. `runtime_env.yaml`, `runtime_images.json` and the Helm values are untouched; the bucket-name binding already lives there.

Exact prod lifecycle applied (`backend/deploy/storage-lifecycle/prod.json`):

```json
{
  "bucket": "omi-private-cloud-sync",
  "project": "based-hardware",
  "lifecycle": {
    "rule": [
      {"action": {"type": "Delete"}, "condition": {"age": 3, "matchesPrefix": ["merged/"]}},
      {"action": {"type": "Delete"}, "condition": {"age": 30, "matchesPrefix": ["playback/"]}},
      {
        "action": {"type": "SetStorageClass", "storageClass": "COLDLINE"},
        "condition": {"age": 30, "matchesPrefix": ["chunks/"], "matchesStorageClass": ["STANDARD", "MULTI_REGIONAL"]}
      }
    ]
  }
}
```

## Why

Plan: `omi-knowledge-base/projects/gcp-cost-efficiency/evidence/2026-09-02-coldline-rollout-plan.md`
Scoping report: `omi-knowledge-base/projects/gcp-cost-efficiency/evidence/2026-09-02-sync-bucket-tiering-scope.md`

`chunks/` is 97.4% of a 154 TB bucket, append-only, and 91.8% of its bytes are older than 30 days. Expected prod effect (MODELLED from a MEASURED $108.97/day storage line): storage falls to ~$38/day, plus ~$0.8/day retrieval (ceiling $7.9/day) and ≤$1.5/day Coldline Class B — **net ≈ −$70/day, ≈ −$2.1k/month**. One-time transition cost ~**$6.9k** (≈346 M objects × $0.020/1,000, billed at the destination class). Payback ≈ 3.3 months. Nothing is deleted, in either direction.

**Compatibility, in one line:** no reader can observe storage class — every `chunks/` reader is `list_blobs` → `download_as_bytes` → in-memory concat; **no chunk is ever signed-URL'd** (only `merged/*.wav` and `playback/*.mp3` are); and **`compose`/`rewrite` are not used anywhere** in `backend/`. The full 16-row audit is §2 of the plan.

## The one thing to know before reviewing

**`gcloud storage buckets update --lifecycle-file` REPLACES the whole lifecycle config.** A desired file that forgets a live rule silently deletes that rule. That is why:

- the two legacy Delete rules (`merged/` age 3, `playback/` age 30) are re-declared **verbatim** in every environment file;
- the workflow captures `before.json` with the deploy identity and the validator runs as a **superset check against that live document**, not against an assumed file — it fails closed if `before.json` contains a rule the desired file lacks (override is the explicit `--allow-rule-removal`, used only for the rollback variant);
- the validator refuses any Delete rule that could reach `chunks/` (an **unscoped** Delete counts), any `SetStorageClass` rule not prefix-scoped to exactly `["chunks/"]`, and any `isLive: false` / noncurrent-version rule — a bucket-wide noncurrent rule would Coldline `playback/` noncurrent versions that the 30-day Delete rule then early-deletes.

`matchesPrefix: ["chunks/"]` is the load-bearing line of the whole change: because no `merged/`/`playback/` object ever becomes Coldline, those Delete rules never trigger an early-delete fee.

## Two things the read-only bot could not verify, and how the workflow closes them

1. **Bucket notification configs** (bot lacks `serviceusage.services.use`). The workflow runs `gcloud storage buckets notifications list` with the deploy identity and the validator **fails the run** if the list is non-empty — a stray config would fan out ~346 M `OBJECT_METADATA_UPDATE` events.
2. **The dev bucket's current lifecycle** (bot lacks `storage.buckets.get` on `omi-dev-private-cloud-sync`). `development.json` is built from the same two legacy Delete rules plus the Coldline rule; the workflow's `before.json` superset check is what actually proves nothing is dropped, and it fails closed if dev holds a rule this file does not.

**Do not merge until the dev deploy identity has been confirmed to hold `storage.buckets.update` on `omi-dev-private-cloud-sync`** (and the prod SA the same on `omi-private-cloud-sync` before the prod dispatch). If it does not, the push-trigger run fails loudly — acceptable but noisy, and it is an IAM change for David, not for this PR.

## Rollout

**1. Merge** → the `push` trigger applies `development.json` to `omi-dev-private-cloud-sync` (GitHub environment `development`, no approval). `before.json` / `after.json` / `notifications.json` upload as run artifacts. Resume the Hermes watch cron the same day (below).

**2. Dev bake: 48 h from the `after.json` timestamp.** Pass = **all** of:

- **Config integrity** — `after.json` lifecycle == the checked-in file (workflow step, hard fail).
- **Transition happens** — Cloud Monitoring `storage.googleapis.com/storage/v2/total_bytes` for `omi-dev-private-cloud-sync` shows a `storage_class=COLDLINE` series with **≥ 50% of live bytes by T+48 h** (dev is 1.95 TB, essentially all >30 d; expect >90%).
- **Billing rows appear with the SKU strings** — billing export `based-hardware.gcp_billing_export.gcp_billing_export_resource_v1_01B287_9348DC_02D256`, `resource.name = "omi-dev-private-cloud-sync"`, new `sku.description LIKE "%Coldline%"` rows (storage + Class A). Today the export contains **no** Coldline/Nearline/Retrieval/Early-Delete SKU for this billing account (MEASURED, 90 d), so the cron filters on `%Coldline%`, `%Retrieval%`, `%Early Delete%` until dev pins the literal names.
- **One-time price sanity** — dev Coldline Class A ÷ objects transitioned ≈ **$0.020/1,000 (±25%)**. **> $0.03/1,000 → stop and reconcile before prod** (contract pricing differs).
- **No early-delete row** for the dev bucket (proves the prefix scoping did not touch a Delete-ruled prefix).
- **No new reader errors** — Cloud Logging, project `based-hardware-dev`, services `backend`/`backend-sync`/`pusher`, filter on `audio_merge cache_upload_failed`, `Failed to decode/decrypt`, `Error downloading audio file`, `conversation_artifact:`, `Chunk not found for timestamp`: count over the bake **≤** count over the preceding 48 h. Dev has ~0 reads, so this is 0 = 0; it is included so the same filter is proven before prod.

What dev does **not** prove: retrieval share (the dev bucket had **zero** `ReadObject` calls in 7 days). Do not wait for it — reader compatibility is a code property, not a traffic property, which is also why the prod partition canary was dropped.

**3. Prod go-live** (David dispatches; the `prod` environment reviewer is the second gate):

```bash
gh workflow run gcp_storage_lifecycle.yml --ref main \
  -f environment=prod \
  -f lifecycle_variant=apply \
  -f confirmation=APPLY_STORAGE_LIFECYCLE_PROD \
  -f release_sha=<exact merged main SHA>
```

**4. Prod watch** — daily Hermes cron (below): lifecycle drift, per-bucket billing SKUs, Coldline byte share, and the reader-error log filter. Alarms: Early Delete > $2/day, Retrieval > $10/day, cumulative Coldline Class A > $9,000, reader errors > 2× the 7-day pre-apply mean **and** > 20/day. Progress expectation: Coldline share ≥ 50% by T+3 d, ≥ 85% by T+7 d.

## Rollback

Dispatch `gcp_storage_lifecycle.yml` with `lifecycle_variant=rollback` for the environment. This re-applies the pre-change rules and stops further transitions within ≤24 h. **Objects already moved stay Coldline** — a lifecycle rule cannot move them back. Moving them back is a rewrite job (`gcloud storage objects update gs://omi-private-cloud-sync/chunks/** --storage-class=STANDARD`, or a rewrite loop), which costs Class A at the Standard rate (~$1.7k for 346 M objects) **and, unlike the lifecycle-driven forward transition, is a deletion of the Coldline copy: objects that have not yet reached 90 days total age are charged the remainder as early-delete.** There is no data-loss path in either direction.

```bash
gh workflow run gcp_storage_lifecycle.yml --ref main \
  -f environment=prod \
  -f lifecycle_variant=rollback \
  -f confirmation=APPLY_STORAGE_LIFECYCLE_PROD \
  -f release_sha=<exact merged main SHA>
```

## Hermes watch cron

`Omi PCS Coldline rollout watch` — job **`7ee554b17e07`**, daily `20 10 * * *` America/New_York, `no_agent`, `expect_output`, whitelisted `critical: true`, delivering to `telegram:-1004448164123:2232`, quiet-when-healthy via `{"wakeAgent": false}`. Script: `~/.hermes/scripts/omi-pcs-coldline-watch.sh`.

It is registered **paused** so it arms only when this PR merges and dev is live. On merge:

```bash
hermes cron resume 7ee554b17e07
```

## Verification

- `actionlint .github/workflows/gcp_storage_lifecycle.yml` → clean
- `pytest backend/tests/unit/test_storage_lifecycle_contract.py` → 12 passed
- Validator dry-runs: `prod.json`, `development.json` and both rollback files pass; a fixture that drops a legacy rule, a fixture with a `Delete` on `chunks/`, a fixture with `isLive: false`, and a non-empty notifications list each exit 1 with a specific error.
- `black --line-length 120 --skip-string-normalization` applied to the new script and test.

## Follow-ons deliberately NOT in this PR

Realtime writer PCM16 → Opus (the only lever that bends the +16 TB/month slope); single-region migration; Archive@365 (decide at T+14/T+30 d from the cron's measured old-read share); versioning-off + soft-delete-7 d (the validator currently *requires* versioning on, so that must be a deliberate edit).

## Product invariants affected

- INV-DATA-1

This workflow matches the `.github/workflows/gcp_*.yml` glob but changes no routing
authority: it deploys no code and touches no serving endpoint, auth project, or
Firebase/Firestore binding. It reads and writes exactly one bucket property —
`lifecycle` — on the bucket named by the environment's own checked-in file, and
refuses to run when that file's `project` does not equal `vars.GCP_PROJECT_ID`, so
a development dispatch can never reach the production bucket and vice versa. The
`push` trigger resolves to `development` unconditionally; prod requires a dispatch,
a typed confirmation, an exact main SHA, and the `prod` environment reviewer.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

