### PR TITLE
feat: thumbs positive % from chat-DB join — full history classified as general answers only

### DIFF
--- a/web/admin/app/api/omi/stats/message-ratings/route.ts
+++ b/web/admin/app/api/omi/stats/message-ratings/route.ts
@@ -1,21 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
-import { posthogResults } from "@/lib/posthog";
+import { getDb } from "@/lib/firebase/admin";
 
 export const dynamic = "force-dynamic";
 
-// macOS thumbs up/down on assistant responses (`message_rated`, always
-// filtered to $os_name = 'macOS'). The positive share is ONE number per
-// bucket: thumbs_up / (thumbs_up + thumbs_down) * 100.
+// macOS thumbs positive share, computed from the chat DB itself: every rated
+// message doc (users/*/messages, rating in {1,-1}) joined to its own journal
+// metadata. This replaces the earlier PostHog-event version because events
+// carry no message id — the DB join classifies ALL history, not just events
+// from tagged builds (Nik, 2026-09-02).
 //
-// `source` splits text (main-window chat) from voice (floating-bar
-// responses); events recorded before the dimension shipped count only toward
-// the combined "all" series.
-//
-// Thumbs on proactive-notification messages (focus/insight/task/memory) are
-// tagged source="notification" by the client and EXCLUDED from every series
-// here — they rate the notification, not a general Omi answer (Nik,
-// 2026-09-02). Pre-tag legacy events can't be classified and stay in "all".
+// Desktop messages are the ones with a `message_source` of desktop_chat
+// (text) or realtime_voice (voice); mobile ratings (message_source null) are
+// excluded — this board is macOS. Thumbs on proactive-notification cards
+// (journal continuityKey prefixed "notification:" — memory/insight/
+// suggestion/task/goal/etc.) rate the notification, not a general Omi
+// answer, and are excluded from every series.
 type RatioPoint = {
   date: string;
   all: number | null;
@@ -23,6 +23,13 @@ type RatioPoint = {
   voice: number | null;
   upAll: number;
   downAll: number;
+};
+
+export type RatedMessageRow = {
+  createdAt: string; // ISO
+  rating: 1 | -1;
+  messageSource: string | null;
+  continuityKey: string | null;
 };
 
 function ratio(up: number, down: number): number | null {
@@ -36,54 +43,41 @@ function mondayKey(ymd: string): string {
   return d.toISOString().slice(0, 10);
 }
 
-export async function computeMessageRatings(days: number) {
-  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
-  const projectId = process.env.POSTHOG_PROJECT_ID;
-  const host = (process.env.POSTHOG_HOST || "https://us.posthog.com").replace(
-    /\/$/,
-    ""
-  );
-  if (!apiKey || !projectId) {
-    throw new Error("PostHog credentials not configured");
-  }
+function nycDay(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-CA", {
+    timeZone: "America/New_York",
+  });
+}
 
-  const rows = (await posthogResults(
-    host,
-    projectId,
-    apiKey,
-    `
-      SELECT
-        toDate(toTimeZone(timestamp, 'America/New_York')) AS day,
-        coalesce(toString(properties.source), 'legacy') AS src,
-        countIf(properties.rating = 'thumbs_up') AS up,
-        countIf(properties.rating = 'thumbs_down') AS down
-      FROM events
-      WHERE event = 'message_rated'
-        AND properties.$os_name = 'macOS'
-        AND timestamp >= now() - INTERVAL ${days} DAY
-      GROUP BY day, src
-      ORDER BY day
-    `
-  )) as any[];
+const DESKTOP_SOURCES: Record<string, "text" | "voice"> = {
+  desktop_chat: "text",
+  realtime_voice: "voice",
+};
 
+export function classifyRatedMessage(
+  row: RatedMessageRow
+): "text" | "voice" | "notification" | "mobile" {
+  if (row.continuityKey?.startsWith("notification:")) return "notification";
+  const lane = row.messageSource ? DESKTOP_SOURCES[row.messageSource] : null;
+  return lane ?? "mobile";
+}
+
+export function aggregateRatedMessages(rows: RatedMessageRow[]) {
   type Bucket = { up: Record<string, number>; down: Record<string, number> };
   const byDay = new Map<string, Bucket>();
-  for (const [day, src, up, down] of rows ?? []) {
-    const key = String(day).slice(0, 10);
+  for (const row of rows) {
+    const lane = classifyRatedMessage(row);
+    if (lane === "notification" || lane === "mobile") continue;
+    const key = nycDay(row.createdAt);
     const bucket = byDay.get(key) ?? { up: {}, down: {} };
-    bucket.up[src] = (bucket.up[src] ?? 0) + Number(up);
-    bucket.down[src] = (bucket.down[src] ?? 0) + Number(down);
+    const side = row.rating === 1 ? bucket.up : bucket.down;
+    side[lane] = (side[lane] ?? 0) + 1;
     byDay.set(key, bucket);
   }
 
-  // "All" is an explicit allowlist so an unknown future source can never
-  // silently leak in. Legacy (pre-tag) events stay: they cannot be
-  // classified, and dropping them would blank the whole history until tagged
-  // builds roll out — the caveat lives in the panel descriptions.
-  const ALL_SOURCES = ["text", "voice", "legacy"];
-  const sum = (rec: Record<string, number>, keys: string[] = ALL_SOURCES) =>
+  const sum = (rec: Record<string, number>, keys?: string[]) =>
     Object.entries(rec)
-      .filter(([k]) => keys.includes(k))
+      .filter(([k]) => !keys || keys.includes(k))
       .reduce((a, [, v]) => a + v, 0);
 
   const toPoint = (date: string, b: Bucket): RatioPoint => ({
@@ -104,9 +98,9 @@ export async function computeMessageRatings(days: number) {
     const week = mondayKey(day);
     const acc = byWeek.get(week) ?? { up: {}, down: {} };
     for (const [k, v] of Object.entries(bucket.up))
-      acc.up[k] = (acc.up[k] ?? 0) + (v as number);
+      acc.up[k] = (acc.up[k] ?? 0) + v;
     for (const [k, v] of Object.entries(bucket.down))
-      acc.down[k] = (acc.down[k] ?? 0) + (v as number);
+      acc.down[k] = (acc.down[k] ?? 0) + v;
     byWeek.set(week, acc);
   });
   const weekly = Array.from(byWeek.entries())
@@ -122,7 +116,45 @@ export async function computeMessageRatings(days: number) {
     ratio: p.all,
   }));
 
-  return { days, data, daily, weekly };
+  return { data, daily, weekly };
+}
+
+async function fetchRatedMessages(days: number): Promise<RatedMessageRow[]> {
+  const db = getDb();
+  const since = new Date(Date.now() - days * 86_400_000);
+  // Needs the collection-group composite index on (rating, created_at) —
+  // created 2026-09-02 on prod.
+  const snap = await db
+    .collectionGroup("messages")
+    .where("rating", "in", [1, -1])
+    .where("created_at", ">=", since)
+    .get();
+  return snap.docs.map((doc) => {
+    const d = doc.data();
+    let continuityKey: string | null = null;
+    if (typeof d.metadata === "string" && d.metadata) {
+      try {
+        continuityKey = JSON.parse(d.metadata)?.continuityKey ?? null;
+      } catch {
+        // unreadable journal metadata → treated as a plain message
+      }
+    }
+    const createdAt =
+      typeof d.created_at?.toDate === "function"
+        ? d.created_at.toDate().toISOString()
+        : new Date(d.created_at).toISOString();
+    return {
+      createdAt,
+      rating: d.rating,
+      messageSource: d.message_source ?? null,
+      continuityKey,
+    };
+  });
+}
+
+export async function computeMessageRatings(days: number) {
+  const rows = await fetchRatedMessages(days);
+  return { days, ...aggregateRatedMessages(rows) };
 }
 
 export async function GET(request: NextRequest) {

--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -4397,7 +4397,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. Proactive-notification thumbs (focus/insight/task/memory cards) are excluded from every series; only pre-tag legacy events can't be separated and stay in All. Last bucket is the current partial day.",
+      "description": "Positive share of thumbs on general Omi answers (up / rated, macOS only) \u2014 computed from the chat DB, so ALL history is classified. Text = main-window chat, Voice = floating-bar responses. Excluded: proactive-notification cards (memory/insight/suggestion/task/goal) and mobile ratings. Last bucket is the current partial day.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4540,7 +4540,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. Proactive-notification thumbs (focus/insight/task/memory cards) are excluded from every series; only pre-tag legacy events can't be separated and stay in All. NYC Monday weeks; last bucket is the partial current week.",
+      "description": "Positive share of thumbs on general Omi answers (up / rated, macOS only) \u2014 computed from the chat DB, so ALL history is classified. Text = main-window chat, Voice = floating-bar responses. Excluded: proactive-notification cards (memory/insight/suggestion/task/goal) and mobile ratings. NYC Monday weeks; last bucket is the partial current week.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -3753,7 +3753,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. Proactive-notification thumbs (focus/insight/task/memory cards) are excluded from every series; only pre-tag legacy events can't be separated and stay in All. Last bucket is the current partial day.",
+      "description": "Positive share of thumbs on general Omi answers (up / rated, macOS only) \u2014 computed from the chat DB, so ALL history is classified. Text = main-window chat, Voice = floating-bar responses. Excluded: proactive-notification cards (memory/insight/suggestion/task/goal) and mobile ratings. Last bucket is the current partial day.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3896,7 +3896,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. Proactive-notification thumbs (focus/insight/task/memory cards) are excluded from every series; only pre-tag legacy events can't be separated and stay in All. NYC Monday weeks; last bucket is the partial current week.",
+      "description": "Positive share of thumbs on general Omi answers (up / rated, macOS only) \u2014 computed from the chat DB, so ALL history is classified. Text = main-window chat, Voice = floating-bar responses. Excluded: proactive-notification cards (memory/insight/suggestion/task/goal) and mobile ratings. NYC Monday weeks; last bucket is the partial current week.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/web/admin/grafana/dashboards/omi-tv.json
+++ b/web/admin/grafana/dashboards/omi-tv.json
@@ -5798,7 +5798,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. Proactive-notification thumbs (focus/insight/task/memory cards) are excluded from every series; only pre-tag legacy events can't be separated and stay in All. Last bucket is the current partial day.",
+      "description": "Positive share of thumbs on general Omi answers (up / rated, macOS only) \u2014 computed from the chat DB, so ALL history is classified. Text = main-window chat, Voice = floating-bar responses. Excluded: proactive-notification cards (memory/insight/suggestion/task/goal) and mobile ratings. Last bucket is the current partial day.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -5941,7 +5941,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Positive share of thumbs on assistant responses (up / rated, macOS only). Text = main-window chat, Voice = floating-bar responses; ratings from builds before the split count only toward All. Proactive-notification thumbs (focus/insight/task/memory cards) are excluded from every series; only pre-tag legacy events can't be separated and stay in All. NYC Monday weeks; last bucket is the partial current week.",
+      "description": "Positive share of thumbs on general Omi answers (up / rated, macOS only) \u2014 computed from the chat DB, so ALL history is classified. Text = main-window chat, Voice = floating-bar responses. Excluded: proactive-notification cards (memory/insight/suggestion/task/goal) and mobile ratings. NYC Monday weeks; last bucket is the partial current week.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/web/admin/lib/__tests__/message-ratings.test.ts
+++ b/web/admin/lib/__tests__/message-ratings.test.ts
@@ -1,67 +1,149 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const posthogResults = vi.hoisted(() => vi.fn());
-vi.mock("@/lib/posthog", () => ({ posthogResults }));
+const docsMock = vi.hoisted(() => ({ docs: [] as any[] }));
+vi.mock("@/lib/firebase/admin", () => ({
+  getDb: () => ({
+    collectionGroup: () => ({
+      where: () => ({
+        where: () => ({ get: async () => ({ docs: docsMock.docs }) }),
+      }),
+    }),
+  }),
+}));
 vi.mock("@/lib/auth", () => ({ verifyAdmin: vi.fn() }));
 
-import { computeMessageRatings } from "@/app/api/omi/stats/message-ratings/route";
+import {
+  aggregateRatedMessages,
+  classifyRatedMessage,
+  computeMessageRatings,
+} from "@/app/api/omi/stats/message-ratings/route";
 
-const ENV_KEYS = ["POSTHOG_PERSONAL_API_KEY", "POSTHOG_PROJECT_ID"] as const;
-const originalEnv = Object.fromEntries(
-  ENV_KEYS.map((k) => [k, process.env[k]])
-);
+// Noon UTC = same NYC calendar day.
+const at = (ymd: string) => `${ymd}T12:00:00.000Z`;
+const row = (
+  ymd: string,
+  rating: 1 | -1,
+  messageSource: string | null,
+  continuityKey: string | null = null
+) => ({ createdAt: at(ymd), rating, messageSource, continuityKey });
 
-afterEach(() => {
-  posthogResults.mockReset();
-  for (const key of ENV_KEYS) {
-    if (originalEnv[key] == null) delete process.env[key];
-    else process.env[key] = originalEnv[key];
-  }
+describe("classifyRatedMessage", () => {
+  it("routes notification cards, desktop lanes, and mobile correctly", () => {
+    expect(
+      classifyRatedMessage(
+        row("2026-08-24", 1, "desktop_chat", "notification:memory:abc")
+      )
+    ).toBe("notification");
+    expect(classifyRatedMessage(row("2026-08-24", 1, "desktop_chat"))).toBe(
+      "text"
+    );
+    expect(classifyRatedMessage(row("2026-08-24", 1, "realtime_voice"))).toBe(
+      "voice"
+    );
+    // Mobile ratings have no desktop message_source — they must never count
+    // on the macOS board (522 of 633 rated docs in the 28d verification scan
+    // were mobile, at a very different positive rate).
+    expect(classifyRatedMessage(row("2026-08-24", 1, null))).toBe("mobile");
+    expect(
+      classifyRatedMessage(row("2026-08-24", 1, "some_future_source"))
+    ).toBe("mobile");
+  });
 });
 
-describe("computeMessageRatings (macOS thumbs positive share)", () => {
-  it("splits text/voice, folds legacy into All only, and rolls NYC weeks", async () => {
-    process.env.POSTHOG_PERSONAL_API_KEY = "phx";
-    process.env.POSTHOG_PROJECT_ID = "1";
-    // Monday 2026-08-24: text 3↑1↓, voice 1↑1↓; Tuesday: legacy 2↑0↓.
-    // Notification thumbs (proactive focus/insight/task/memory cards) must
-    // not move any series — they rate the notification, not a response.
-    posthogResults.mockResolvedValue([
-      ["2026-08-24", "text", 3, 1],
-      ["2026-08-24", "voice", 1, 1],
-      ["2026-08-24", "notification", 0, 9],
-      ["2026-08-24", "mystery-future-source", 7, 0],
-      ["2026-08-25", "legacy", 2, 0],
+describe("aggregateRatedMessages (general Omi answers only)", () => {
+  it("excludes notification and mobile ratings from every series", () => {
+    // Monday 2026-08-24: text 3↑1↓, voice 1↑1↓, plus noise that must move
+    // nothing: notification thumbs and mobile thumbs.
+    const { daily, weekly, data } = aggregateRatedMessages([
+      row("2026-08-24", 1, "desktop_chat"),
+      row("2026-08-24", 1, "desktop_chat"),
+      row("2026-08-24", 1, "desktop_chat"),
+      row("2026-08-24", -1, "desktop_chat"),
+      row("2026-08-24", 1, "realtime_voice"),
+      row("2026-08-24", -1, "realtime_voice"),
+      row("2026-08-24", -1, "desktop_chat", "notification:memory:x"),
+      row("2026-08-24", -1, "desktop_chat", "notification:suggestion:y"),
+      row("2026-08-24", 1, null),
+      row("2026-08-24", 1, null),
+      // Tuesday: all-downvote day is a real 0, not null.
+      row("2026-08-25", -1, "desktop_chat"),
     ]);
-    const payload = await computeMessageRatings(30);
 
-    const query = posthogResults.mock.calls[0][3] as string;
-    expect(query).toContain("properties.$os_name = 'macOS'");
-    expect(query).toContain("America/New_York");
-
-    const monday = payload.daily.find((p) => p.date === "2026-08-24")!;
-    expect(monday.text).toBe(75); // one number %: up / rated
+    const monday = daily.find((p) => p.date === "2026-08-24")!;
+    expect(monday.text).toBe(75);
     expect(monday.voice).toBe(50);
-    expect(monday.all).toBeCloseTo(66.7); // 9 notification downs excluded
+    expect(monday.all).toBeCloseTo(66.7);
+    expect(monday.upAll).toBe(4);
     expect(monday.downAll).toBe(2);
-    const tuesday = payload.daily.find((p) => p.date === "2026-08-25")!;
-    expect(tuesday.text).toBeNull(); // legacy events never fake a split series
-    expect(tuesday.voice).toBeNull();
-    expect(tuesday.all).toBe(100);
+
+    const tuesday = daily.find((p) => p.date === "2026-08-25")!;
+    expect(tuesday.all).toBe(0); // all-down day: real 0
+    expect(tuesday.voice).toBeNull(); // no voice ratings: unmeasurable
+
+    // A day with no desktop-answer ratings yields no point at all — absence,
+    // never a fake 0 (honesty rule).
+    expect(daily).toHaveLength(2);
 
     // Weekly: both days share the 2026-08-24 NYC Monday bucket.
-    expect(payload.weekly).toHaveLength(1);
-    expect(payload.weekly[0].week).toBe("2026-08-24");
-    expect(payload.weekly[0].all).toBe(75); // (3+1+2)↑ / 8 rated
-    expect(payload.weekly[0].text).toBe(75);
-    expect(payload.weekly[0].voice).toBe(50);
+    expect(weekly).toHaveLength(1);
+    expect(weekly[0].week).toBe("2026-08-24");
+    expect(weekly[0].all).toBeCloseTo(57.1); // 4↑ / 7 rated
+    expect(weekly[0].text).toBe(60);
 
     // Legacy shape stays for the volumes panel and /dashboard/classic.
-    expect(payload.data[0]).toEqual({
+    expect(data[0]).toEqual({
       date: "2026-08-24",
       thumbs_up: 4,
       thumbs_down: 2,
       ratio: expect.closeTo(66.7, 1),
+    });
+  });
+});
+
+describe("computeMessageRatings (Firestore join)", () => {
+  beforeEach(() => {
+    docsMock.docs = [];
+  });
+
+  it("decodes Firestore docs: timestamp, message_source, journal continuityKey", async () => {
+    docsMock.docs = [
+      {
+        data: () => ({
+          rating: 1,
+          created_at: { toDate: () => new Date(at("2026-08-24")) },
+          message_source: "desktop_chat",
+          metadata: JSON.stringify({ continuityKey: "turn-1" }),
+        }),
+      },
+      {
+        data: () => ({
+          rating: -1,
+          created_at: { toDate: () => new Date(at("2026-08-24")) },
+          message_source: "desktop_chat",
+          metadata: JSON.stringify({ continuityKey: "notification:insight:z" }),
+        }),
+      },
+      {
+        data: () => ({
+          rating: -1,
+          created_at: { toDate: () => new Date(at("2026-08-24")) },
+          message_source: null,
+          metadata: "not json {",
+        }),
+      },
+    ];
+    const payload = await computeMessageRatings(30);
+    expect(payload.days).toBe(30);
+    // Only the desktop answer counts: notification and mobile (bad-metadata,
+    // no source) rows are excluded.
+    expect(payload.daily).toHaveLength(1);
+    expect(payload.daily[0]).toMatchObject({
+      date: "2026-08-24",
+      all: 100,
+      text: 100,
+      voice: null,
+      upAll: 1,
+      downAll: 0,
     });
   });
 });

--- a/web/admin/lib/__tests__/stats-staleness-honesty.test.ts
+++ b/web/admin/lib/__tests__/stats-staleness-honesty.test.ts
@@ -11,7 +11,9 @@ vi.mock("@/lib/auth", () => ({
 }));
 
 const fetchMock = vi.fn();
-const posthogResultsMock = vi.hoisted(() => vi.fn(async (): Promise<any[]> => []));
+const posthogResultsMock = vi.hoisted(() =>
+  vi.fn(async (): Promise<any[]> => [])
+);
 vi.mock("@/lib/posthog", () => ({
   cachedPosthogFetch: (...args: unknown[]) => fetchMock(...args),
   posthogResults: posthogResultsMock,
@@ -105,31 +107,31 @@ describe("crash-rate date keys", () => {
 });
 
 describe("message-ratings ratio", () => {
-  beforeEach(() => {
-    fetchMock.mockReset();
-    posthogResultsMock.mockReset();
-    process.env.POSTHOG_PERSONAL_API_KEY = "k";
-    process.env.POSTHOG_PROJECT_ID = "1";
-  });
-
-  it("reports null, not 0, on a day with no ratings at all", async () => {
-    posthogResultsMock.mockResolvedValue([
-      ["2026-08-01", "legacy", 0, 0],
-      ["2026-08-02", "legacy", 0, 4],
-      ["2026-08-03", "legacy", 3, 1],
+  it("distinguishes a real all-downvote 0 from an unmeasurable day", async () => {
+    const { aggregateRatedMessages } = await import(
+      "@/app/api/omi/stats/message-ratings/route"
+    );
+    const { data, daily } = aggregateRatedMessages([
+      {
+        createdAt: "2026-08-02T12:00:00.000Z",
+        rating: -1,
+        messageSource: "desktop_chat",
+        continuityKey: null,
+      },
+      {
+        createdAt: "2026-08-03T12:00:00.000Z",
+        rating: 1,
+        messageSource: "desktop_chat",
+        continuityKey: null,
+      },
     ]);
 
-    const { GET } = await import("@/app/api/omi/stats/message-ratings/route");
-    const url = "https://admin.omi.me/api/omi/stats/message-ratings?days=7";
-    const res = await GET({
-      url,
-      nextUrl: new URL(url),
-    } as never);
-    const body = await res.json();
-
-    // No ratings -> unmeasurable. All-downvotes -> a real 0. These must differ.
-    expect(body.data[0].ratio).toBeNull();
-    expect(body.data[1].ratio).toBe(0);
-    expect(body.data[2].ratio).toBe(75);
+    // All-downvotes -> a real 0. A day with no ratings at all produces no
+    // point (absence), never a fake 0. These must differ.
+    expect(data.find((p) => p.date === "2026-08-02")!.ratio).toBe(0);
+    expect(data.find((p) => p.date === "2026-08-03")!.ratio).toBe(100);
+    expect(daily.find((p) => p.date === "2026-08-01")).toBeUndefined();
+    // Lanes with no observations stay null, not 0.
+    expect(daily.find((p) => p.date === "2026-08-03")!.voice).toBeNull();
   });
 });


### PR DESCRIPTION
Nik compared the board's blended weekly thumbs % (~36-47%) with a message-level analysis showing real answers score far higher, and asked why. Root cause: PostHog rating events carry no message id, so history could not be classified — the chart blended proactive-card thumbs into every historic bucket.

## What changed

`/api/omi/stats/message-ratings` now computes from the chat DB itself instead of PostHog: rated message docs (`rating in {1,-1}`, `created_at >= now-N`) joined to their own journal metadata.

- **Classification:** `continuityKey` prefixed `notification:` → proactive card (memory/insight/suggestion/task/goal), excluded. `message_source` `desktop_chat` → Text lane, `realtime_voice` → Voice lane. No desktop `message_source` → mobile, excluded (macOS board).
- Every series (All/Text/Voice, daily+weekly, legacy volumes shape) is now general-Omi-answers-only **for the entire history**, and the Text/Voice split works historically too.
- Requires the `(rating, created_at)` collection-group composite index — created on prod 2026-09-02 (READY, verified).
- Panel descriptions updated; boards regenerated via `build_dashboards.py`.

## Verification

- Independent Python scan of prod Firestore (28d): 633 rated docs — 522 mobile (92.3% positive, would have poisoned the macOS metric), desktop answers 16↑/6↓ = 72.7%, memory cards 29.6%, suggestion 34.3%, insight 40%. 
- Local admin (`next dev`, prod Firestore creds) probed with a real admin token: weekly 2026-08-24 = 100% (9↑/0↓), 2026-08-31 = 80% — consistent with the scan.
- `npx vitest run` — 12/12 (classification, exclusion of notification/mobile/unknown, Firestore doc decoding incl. malformed metadata, all-down-0 vs absent-day honesty).
- `npx tsc --noEmit` clean; `test_build_dashboards` 25/25.
- Post-deploy: prod route probed and board captured.

Product invariants affected: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

