### PR TITLE
feat: follow-up chips, learned-memory review card, daily-summary tail fix, knows-list rotation

### DIFF
--- a/app/lib/backend/schema/daily_summary.dart
+++ b/app/lib/backend/schema/daily_summary.dart
@@ -1,4 +1,5 @@
 import 'package:omi/backend/schema/gen/users_wire.g.dart' as wire;
+import 'package:omi/backend/schema/memory_review.dart';
 // Phase 4.1 — none of these classes typedef to their GeneratedDailySummary* types.
 // The generated fields are all nullable (String?/bool?/int?/double?) while these
 // classes coerce them to non-null with defaults (?? '', ?? 'medium', ?? false,
@@ -173,6 +174,11 @@ class DailySummary {
   final List<DecisionMade> decisionsMade; // Max 3
   final List<KnowledgeNugget> knowledgeNuggets; // Max 3
 
+  /// Memories this day actually produced, with identity so the owner can
+  /// confirm, drop, or correct them. Unlike [knowledgeNuggets] (LLM prose),
+  /// each entry points at a real memory row. Max 3.
+  final List<MemoryReviewItem> memoriesLearned;
+
   // Locations
   final List<LocationPin> locations;
 
@@ -189,6 +195,7 @@ class DailySummary {
     this.unresolvedQuestions = const [],
     this.decisionsMade = const [],
     this.knowledgeNuggets = const [],
+    this.memoriesLearned = const [],
     this.locations = const [],
   });
 
@@ -224,6 +231,12 @@ class DailySummary {
       unresolvedQuestions: generated.unresolvedQuestions?.map(UnresolvedQuestion.fromGenerated).toList() ?? [],
       decisionsMade: generated.decisionsMade?.map(DecisionMade.fromGenerated).toList() ?? [],
       knowledgeNuggets: generated.knowledgeNuggets?.map(KnowledgeNugget.fromGenerated).toList() ?? [],
+      memoriesLearned: generated.memoriesLearned
+              ?.map(MemoryReviewItem.fromGenerated)
+              .where((item) => item.memoryId.isNotEmpty && item.content.trim().isNotEmpty)
+              .take(MemoryReviewCardBlock.maxItems)
+              .toList() ??
+          [],
       locations: generated.locations?.map(LocationPin.fromGenerated).toList() ?? [],
     );
   }

--- a/app/lib/backend/schema/gen/users_wire.g.dart
+++ b/app/lib/backend/schema/gen/users_wire.g.dart
@@ -558,6 +558,38 @@ class GeneratedDailySummaryKnowledgeNugget {
   }
 }
 
+class GeneratedLearnedMemoryRef {
+  final DateTime? capturedAt;
+  final String category;
+  final String content;
+  final String memoryId;
+
+  const GeneratedLearnedMemoryRef({
+    this.capturedAt,
+    this.category = "",
+    required this.content,
+    required this.memoryId,
+  });
+
+  factory GeneratedLearnedMemoryRef.fromJson(Map<String, dynamic> json) {
+    return GeneratedLearnedMemoryRef(
+      capturedAt: _readFieldValue<DateTime>(_readField(json, const ["captured_at"]), "captured_at", _readDateTime, requiredField: false, nullable: true),
+      category: _required(_readFieldValue<String>(_readField(json, const ["category"]), "category", _readString, requiredField: false, nullable: false, defaultValue: ""), "category"),
+      content: _required(_readFieldValue<String>(_readField(json, const ["content"]), "content", _readString, requiredField: true, nullable: false), "content"),
+      memoryId: _required(_readFieldValue<String>(_readField(json, const ["memory_id"]), "memory_id", _readString, requiredField: true, nullable: false), "memory_id"),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'captured_at': capturedAt?.toUtc().toIso8601String(),
+      'category': category,
+      'content': content,
+      'memory_id': memoryId,
+    };
+  }
+}
+
 class GeneratedDailySummaryDayStats {
   final int? actionItemsCount;
   final int? totalConversations;
@@ -633,6 +665,7 @@ class GeneratedDailySummaryResponse {
   final String? id;
   final List<GeneratedDailySummaryKnowledgeNugget>? knowledgeNuggets;
   final List<GeneratedDailySummaryLocationPin>? locations;
+  final List<GeneratedLearnedMemoryRef>? memoriesLearned;
   final String? overview;
   final GeneratedDailySummaryDayStats? stats;
   final List<GeneratedDailySummaryUnresolvedQuestion>? unresolvedQuestions;
@@ -648,6 +681,7 @@ class GeneratedDailySummaryResponse {
     this.id,
     this.knowledgeNuggets,
     this.locations,
+    this.memoriesLearned,
     this.overview,
     this.stats,
     this.unresolvedQuestions,
@@ -665,6 +699,7 @@ class GeneratedDailySummaryResponse {
       id: _readFieldValue<String>(_readField(json, const ["id"]), "id", _readString, requiredField: false, nullable: true),
       knowledgeNuggets: _readFieldValue<List<GeneratedDailySummaryKnowledgeNugget>>(_readField(json, const ["knowledge_nuggets"]), "knowledge_nuggets", (value) => _readObjectList(value, GeneratedDailySummaryKnowledgeNugget.fromJson), requiredField: false, nullable: true),
       locations: _readFieldValue<List<GeneratedDailySummaryLocationPin>>(_readField(json, const ["locations"]), "locations", (value) => _readObjectList(value, GeneratedDailySummaryLocationPin.fromJson), requiredField: false, nullable: true),
+      memoriesLearned: _readFieldValue<List<GeneratedLearnedMemoryRef>>(_readField(json, const ["memories_learned"]), "memories_learned", (value) => _readObjectList(value, GeneratedLearnedMemoryRef.fromJson), requiredField: false, nullable: true),
       overview: _readFieldValue<String>(_readField(json, const ["overview"]), "overview", _readString, requiredField: false, nullable: true),
       stats: _readFieldValue<GeneratedDailySummaryDayStats>(_readField(json, const ["stats"]), "stats", (value) => _readObject(value, GeneratedDailySummaryDayStats.fromJson), requiredField: false, nullable: true),
       unresolvedQuestions: _readFieldValue<List<GeneratedDailySummaryUnresolvedQuestion>>(_readField(json, const ["unresolved_questions"]), "unresolved_questions", (value) => _readObjectList(value, GeneratedDailySummaryUnresolvedQuestion.fromJson), requiredField: false, nullable: true),
@@ -683,6 +718,7 @@ class GeneratedDailySummaryResponse {
       'id': id,
       'knowledge_nuggets': knowledgeNuggets?.map((value) => value.toJson()).toList(),
       'locations': locations?.map((value) => value.toJson()).toList(),
+      'memories_learned': memoriesLearned?.map((value) => value.toJson()).toList(),
       'overview': overview,
       'stats': stats?.toJson(),
       'unresolved_questions': unresolvedQuestions?.map((value) => value.toJson()).toList(),

--- a/app/lib/backend/schema/memory_review.dart
+++ b/app/lib/backend/schema/memory_review.dart
@@ -1,0 +1,101 @@
+import 'package:omi/backend/schema/gen/users_wire.g.dart' as wire;
+
+/// One memory Omi says it learned, as referenced by the daily summary.
+///
+/// Deliberately carries no review verdict: `user_review`/`edited` are read live
+/// from the memory itself (`MemoriesProvider`), so a vote cast on one device is
+/// visible on the other. A reference that has gone stale still renders its
+/// content; only the controls depend on the live row.
+class MemoryReviewItem {
+  final String memoryId;
+  final String content;
+  final String category;
+  final DateTime? capturedAt;
+
+  const MemoryReviewItem({
+    required this.memoryId,
+    required this.content,
+    this.category = '',
+    this.capturedAt,
+  });
+
+  factory MemoryReviewItem.fromGenerated(wire.GeneratedLearnedMemoryRef generated) {
+    return MemoryReviewItem(
+      memoryId: generated.memoryId,
+      content: generated.content,
+      category: generated.category,
+      capturedAt: generated.capturedAt,
+    );
+  }
+
+  /// Decode one `memoryReviewCard.items[]` entry. Returns null for anything
+  /// without an id or content: an unusable row must not become a blank control.
+  static MemoryReviewItem? tryFromBlockItem(Object? value) {
+    if (value is! Map) return null;
+    final map = Map<String, dynamic>.from(value);
+    String read(String camel, String snake) {
+      final raw = map[camel] ?? map[snake];
+      return raw is String ? raw.trim() : '';
+    }
+
+    final memoryId = read('memoryId', 'memory_id');
+    final content = read('content', 'content');
+    if (memoryId.isEmpty || content.isEmpty) return null;
+    return MemoryReviewItem(memoryId: memoryId, content: content, category: read('category', 'category'));
+  }
+
+  /// Human label for the small category tag. Empty when the backend sent none.
+  String get categoryLabel {
+    final trimmed = category.trim();
+    if (trimmed.isEmpty) return '';
+    final normalized = trimmed.replaceAll('_', ' ');
+    return normalized[0].toUpperCase() + normalized.substring(1);
+  }
+}
+
+/// The `memoryReviewCard` chat content block.
+///
+/// Built by `backend/utils/memory/learned_today.py`; the block never carries
+/// review state, only identity plus the paraphrase to show.
+class MemoryReviewCardBlock {
+  final String id;
+  final String summaryId;
+  final String date;
+  final List<MemoryReviewItem> items;
+
+  const MemoryReviewCardBlock({
+    required this.id,
+    required this.summaryId,
+    required this.date,
+    required this.items,
+  });
+
+  static const int maxItems = 3;
+
+  static const Set<String> blockTypes = {'memoryReviewCard', 'memory_review_card'};
+
+  /// Fail-soft: an unknown, malformed, or item-less block decodes to null so the
+  /// day summary text renders exactly as it did before this block existed.
+  static MemoryReviewCardBlock? tryFromBlock(Map<String, dynamic> block) {
+    if (!blockTypes.contains(block['type'])) return null;
+    final rawItems = block['items'];
+    if (rawItems is! List) return null;
+    final items = rawItems
+        .map(MemoryReviewItem.tryFromBlockItem)
+        .whereType<MemoryReviewItem>()
+        .take(maxItems)
+        .toList(growable: false);
+    if (items.isEmpty) return null;
+    String read(String camel, String snake) {
+      final raw = block[camel] ?? block[snake];
+      return raw is String ? raw : '';
+    }
+
+    return MemoryReviewCardBlock(
+      id: read('id', 'id'),
+      summaryId: read('summaryId', 'summary_id'),
+      date: read('date', 'date'),
+      items: items,
+    );
+  }
+}

--- a/app/lib/backend/schema/message.dart
+++ b/app/lib/backend/schema/message.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:collection/collection.dart';
 import 'package:omi/backend/schema/gen/messages_wire.g.dart' as wire;
+import 'package:omi/backend/schema/memory_review.dart';
 import 'package:omi/models/chat_evidence_reference.dart';
 import 'package:uuid/uuid.dart';
 
@@ -275,10 +276,14 @@ class ServerMessage {
   }
 
   static ServerMessage fromGeneratedWireJson(Map<String, dynamic> json) {
-    // Evidence is deliberately fail-soft UI chrome. Decode it through the
-    // bounded compatibility parser below instead of letting the strict
-    // generated DTO reject an otherwise valid text answer.
-    final generatedJson = Map<String, dynamic>.from(json)..remove('evidence');
+    // Evidence and content blocks are deliberately fail-soft UI chrome. Decode
+    // them through the bounded compatibility parsers below instead of letting
+    // the strict generated DTO reject an otherwise valid text answer — an FCM
+    // push carries `content_blocks` as JSON text, which the generated
+    // `List<Map>` reader rejects outright.
+    final generatedJson = Map<String, dynamic>.from(json)
+      ..remove('evidence')
+      ..remove('content_blocks');
     final generated = wire.GeneratedMessage.fromJson(generatedJson);
     final fromIntegration = (json['from_integration'] as bool?) ?? generated.fromExternalIntegration;
     return ServerMessage.fromGenerated(
@@ -290,7 +295,9 @@ class ServerMessage {
   }
 
   static ServerMessage fromResponseJson(Map<String, dynamic> json) {
-    final generatedJson = Map<String, dynamic>.from(json)..remove('evidence');
+    final generatedJson = Map<String, dynamic>.from(json)
+      ..remove('evidence')
+      ..remove('content_blocks');
     final generated = wire.GeneratedResponseMessage.fromJson(generatedJson);
     final fromIntegration = (json['from_integration'] as bool?) ?? generated.fromExternalIntegration;
     return ServerMessage.fromGeneratedResponse(
@@ -419,8 +426,13 @@ class ServerMessage {
   }
 
   static List<Map<String, dynamic>> _decodeContentBlocks(dynamic firstClass, String? metadata) {
-    final direct = _mapList(firstClass);
-    if (direct.isNotEmpty || firstClass is List) return direct;
+    // FCM data payloads are Dict[str, str], so a push (the only transport that
+    // carries a `day_summary` message today) delivers `content_blocks` as JSON
+    // text. Decode it here so both transports have one decoder; anything
+    // malformed degrades to "no blocks", never to a lost message.
+    final firstClassValue = firstClass is String ? _tryDecodeJson(firstClass) : firstClass;
+    final direct = _mapList(firstClassValue);
+    if (direct.isNotEmpty || firstClassValue is List) return direct;
     if (metadata == null || metadata.isEmpty) return const [];
     try {
       final decoded = jsonDecode(metadata);
@@ -434,6 +446,37 @@ class ServerMessage {
     if (value is! List) return const [];
     return value.whereType<Map>().map((item) => Map<String, dynamic>.from(item)).toList(growable: false);
   }
+
+  static Object? _tryDecodeJson(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return null;
+    try {
+      return jsonDecode(trimmed);
+    } on FormatException {
+      return null;
+    }
+  }
+
+  /// The `memoryReviewCard` block for this message, when it carries a usable one.
+  MemoryReviewCardBlock? get memoryReviewCard {
+    for (final block in contentBlocks) {
+      final card = MemoryReviewCardBlock.tryFromBlock(block);
+      if (card != null) return card;
+    }
+    return null;
+  }
+
+  /// The one grounded follow-up question the answer invites, when present.
+  String? get followUpQuestion {
+    for (final block in contentBlocks) {
+      if (!_followUpTypes.contains(block['type'])) continue;
+      final text = block['text'];
+      if (text is String && text.trim().isNotEmpty) return text.trim();
+    }
+    return null;
+  }
+
+  static const _followUpTypes = {'followUp', 'follow_up'};
 
   static const _desktopChatChromeTypes = {
     'goalLink',
@@ -503,6 +546,12 @@ class ServerMessage {
       case 'questionCard':
       case 'question_card':
         return value('text').isEmpty ? 'Question' : value('text');
+      case 'memoryReviewCard':
+      case 'memory_review_card':
+        return 'Things I learned today';
+      case 'followUp':
+      case 'follow_up':
+        return value('text');
       case 'taskCard':
       case 'task_card':
         return 'Task';

--- a/app/lib/pages/chat/widgets/ai_message.dart
+++ b/app/lib/pages/chat/widgets/ai_message.dart
@@ -20,6 +20,7 @@ import 'package:omi/backend/schema/app.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/message.dart';
 import 'package:omi/models/chat_evidence_reference.dart';
+import 'package:omi/pages/chat/widgets/chat_followup_chip.dart';
 import 'package:omi/pages/chat/widgets/files_handler_widget.dart';
 import 'package:omi/pages/chat/widgets/typing_indicator.dart';
 import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
@@ -34,6 +35,7 @@ import 'package:omi/widgets/extensions/string.dart';
 import 'package:omi/widgets/text_selection_controls.dart';
 import 'chart_message_widget.dart';
 import 'package:omi/widgets/components/chat_evidence_card.dart';
+import 'package:omi/widgets/components/memory_review_card.dart';
 import 'package:omi/utils/share_sheet.dart';
 import 'markdown_message_widget.dart';
 
@@ -325,17 +327,35 @@ Widget buildMessageWidget(
   }
 
   final evidence = visibleSupplementalEvidence(message);
-  if (evidence == null) return messageWidget;
+  // Native content blocks. Both are additive chrome: an absent or malformed
+  // block leaves the answer exactly as it renders today.
+  final reviewCard = showTypingIndicator ? null : message.memoryReviewCard;
+  final followUp = showTypingIndicator ? null : message.followUpQuestion;
+  if (evidence == null && reviewCard == null && followUp == null) return messageWidget;
   return Column(
     crossAxisAlignment: CrossAxisAlignment.start,
     mainAxisSize: MainAxisSize.min,
     children: [
       messageWidget,
-      const SizedBox(height: 8),
-      // The released mobile surface has no trusted evidence navigator yet.
-      // Keep cards non-actionable until one is supplied; arbitrary URI fields
-      // can never become an external action.
-      ChatEvidenceReferenceList(envelope: evidence),
+      if (reviewCard != null) ...[
+        const SizedBox(height: 12),
+        MemoryReviewCard(
+          items: reviewCard.items,
+          source: MemoryReviewSource.chatBlock,
+          impressionKey: reviewCard.id.isNotEmpty ? reviewCard.id : message.id,
+        ),
+      ],
+      if (evidence != null) ...[
+        const SizedBox(height: 8),
+        // The released mobile surface has no trusted evidence navigator yet.
+        // Keep cards non-actionable until one is supplied; arbitrary URI fields
+        // can never become an external action.
+        ChatEvidenceReferenceList(envelope: evidence),
+      ],
+      if (followUp != null) ...[
+        const SizedBox(height: 8),
+        ChatFollowUpChip(question: followUp, onSend: sendMessage),
+      ],
     ],
   );
 }

--- a/app/lib/pages/chat/widgets/chat_followup_chip.dart
+++ b/app/lib/pages/chat/widgets/chat_followup_chip.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+import 'package:omi/utils/platform/platform_manager.dart';
+
+/// The one grounded follow-up an answer invites, as a single tappable chip.
+///
+/// Tapping sends the chip's words as a normal user message through the existing
+/// chat send path; the chip owns no send logic of its own.
+class ChatFollowUpChip extends StatelessWidget {
+  const ChatFollowUpChip({
+    super.key,
+    required this.question,
+    required this.onSend,
+    this.source = 'chat_block',
+  });
+
+  final String question;
+  final void Function(String) onSend;
+  final String source;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Semantics(
+          button: true,
+          label: question,
+          child: InkWell(
+            key: const Key('chat_followup_chip'),
+            borderRadius: BorderRadius.circular(20),
+            onTap: () {
+              PlatformManager.instance.analytics.followUpChipTapped(source: source);
+              onSend(question);
+            },
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 9),
+              decoration: BoxDecoration(
+                color: const Color(0xFF1A1A1F),
+                borderRadius: BorderRadius.circular(20),
+                border: Border.all(color: Colors.white.withValues(alpha: 0.12)),
+              ),
+              child: Text(
+                question,
+                style: const TextStyle(color: Colors.white, fontSize: 14, height: 1.3),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/pages/settings/daily_summary_detail_page.dart
+++ b/app/lib/pages/settings/daily_summary_detail_page.dart
@@ -19,6 +19,7 @@ import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/platform/platform_service.dart';
 import 'package:omi/utils/share_links.dart';
 import 'package:omi/utils/share_sheet.dart';
+import 'package:omi/widgets/components/memory_review_card.dart';
 
 class DailySummaryDetailPage extends StatefulWidget {
   final String summaryId;
@@ -353,6 +354,10 @@ class _DailySummaryDetailPageState extends State<DailySummaryDetailPage> with Si
                 if (summary.decisionsMade.isNotEmpty) ...[
                   const SizedBox(height: 32),
                   _buildDecisionsMadeSection(summary),
+                ],
+                if (summary.memoriesLearned.isNotEmpty) ...[
+                  const SizedBox(height: 32),
+                  _buildMemoriesLearnedSection(summary),
                 ],
                 if (summary.knowledgeNuggets.isNotEmpty) ...[
                   const SizedBox(height: 32),
@@ -785,6 +790,17 @@ class _DailySummaryDetailPageState extends State<DailySummaryDetailPage> with Si
           );
         }),
       ],
+    );
+  }
+
+  /// The same review rows the day-summary chat card shows, so a verdict cast
+  /// in either place lands on the same memory. Placed before the LLM-prose
+  /// learnings, which stay exactly as they were.
+  Widget _buildMemoriesLearnedSection(DailySummary summary) {
+    return MemoryReviewCard(
+      items: summary.memoriesLearned,
+      source: MemoryReviewSource.dailySummaryDetail,
+      impressionKey: summary.id.isNotEmpty ? summary.id : widget.summaryId,
     );
   }
 

--- a/app/lib/utils/analytics/analytics_manager.dart
+++ b/app/lib/utils/analytics/analytics_manager.dart
@@ -761,6 +761,42 @@ class AnalyticsManager {
     );
   }
 
+  /// "Things I learned today" card became visible. Counts only — the card's
+  /// content and memory ids never leave the device through analytics.
+  void memoryReviewCardShown({required int itemCount, required String source}) {
+    track('memory_review_card_shown', properties: {'item_count': itemCount, 'source': source});
+  }
+
+  /// One accept / reject / edit verdict on a learned memory.
+  ///
+  /// [action] is accept|reject|edit, [outcome] is ok|error, [source] is
+  /// chat_block|daily_summary_detail. `memory_category` is the coarse category
+  /// label; no memory content and no raw memory id are ever attached.
+  void memoryReviewAction({
+    required String source,
+    required String action,
+    required String outcome,
+    required String memoryCategory,
+  }) {
+    track(
+      'memory_review_action',
+      properties: {
+        'source': source,
+        'action': action,
+        'outcome': outcome,
+        'memory_category': memoryCategory,
+      },
+    );
+  }
+
+  /// The one grounded follow-up chip under an answer was tapped.
+  ///
+  /// Mobile has no `question_asked` event to attribute to, so the origin is
+  /// carried by this event instead of as a property on a send event.
+  void followUpChipTapped({required String source}) {
+    track('followup_chip_tapped', properties: {'source': source});
+  }
+
   void memoriesAllVisibilityChanged(MemoryVisibility newVisibility, int count) {
     track('All Facts Visibility Changed', properties: {'new_visibility': newVisibility.name, 'facts_count': count});
   }

--- a/app/lib/widgets/components/memory_review_card.dart
+++ b/app/lib/widgets/components/memory_review_card.dart
@@ -1,0 +1,398 @@
+import 'package:flutter/material.dart';
+
+import 'package:collection/collection.dart';
+import 'package:provider/provider.dart';
+
+import 'package:omi/backend/schema/memory.dart';
+import 'package:omi/backend/schema/memory_review.dart';
+import 'package:omi/providers/memories_provider.dart';
+import 'package:omi/utils/platform/platform_manager.dart';
+
+/// Where a review card is rendered. Carried into analytics verbatim.
+enum MemoryReviewSource {
+  chatBlock('chat_block'),
+  dailySummaryDetail('daily_summary_detail');
+
+  final String analyticsValue;
+
+  const MemoryReviewSource(this.analyticsValue);
+}
+
+/// "Things I learned today" — up to three memories Omi stored, each with
+/// confirm / drop / correct controls.
+///
+/// The card owns no verdict state. Every row reads `userReview`/`edited` live
+/// from [MemoriesProvider], which is the single mutation owner: a vote cast on
+/// desktop shows here, and a vote cast here is not persisted in the chat
+/// message or in preferences. A tap paints optimistically only until the
+/// request returns, then the row goes back to reading the live memory.
+class MemoryReviewCard extends StatefulWidget {
+  const MemoryReviewCard({
+    super.key,
+    required this.items,
+    required this.source,
+    this.impressionKey,
+    this.title = 'Things I learned today',
+  });
+
+  final List<MemoryReviewItem> items;
+  final MemoryReviewSource source;
+
+  /// Stable identity for the shown-impression event. A chat card scrolled out
+  /// and back rebuilds its State; without this the impression count would
+  /// measure scrolling rather than reach.
+  final String? impressionKey;
+  final String title;
+
+  @override
+  State<MemoryReviewCard> createState() => _MemoryReviewCardState();
+}
+
+enum _RowState { loading, pending, confirmed, dropped, updated }
+
+class _MemoryReviewCardState extends State<MemoryReviewCard> {
+  static const _cardColor = Color(0xFF1A1A1F);
+
+  final Map<String, _RowState> _optimistic = {};
+  final Set<String> _inFlight = {};
+  final Set<String> _failed = {};
+  final Map<String, TextEditingController> _editors = {};
+
+  /// Ids this process has already asked the provider to go looking for. A card
+  /// scrolled in and out of the chat list rebuilds its State, and an id that is
+  /// genuinely absent from the account would otherwise re-trigger a full
+  /// memories fetch on every rebuild.
+  static final Set<String> _requestedIds = {};
+
+  /// Card identities already counted as shown in this process.
+  static final Set<String> _seenImpressions = {};
+
+  List<MemoryReviewItem> get _rows => widget.items.take(MemoryReviewCardBlock.maxItems).toList(growable: false);
+
+  @override
+  void initState() {
+    super.initState();
+    final impressionKey = widget.impressionKey;
+    if (_rows.isNotEmpty && (impressionKey == null || _seenImpressions.add('${widget.source.name}:$impressionKey'))) {
+      PlatformManager.instance.analytics.memoryReviewCardShown(
+        itemCount: _rows.length,
+        source: widget.source.analyticsValue,
+      );
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) => _ensureMemoriesLoaded());
+  }
+
+  @override
+  void dispose() {
+    for (final controller in _editors.values) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  MemoriesProvider? _memoriesProvider({required bool listen}) {
+    try {
+      return listen ? context.watch<MemoriesProvider>() : context.read<MemoriesProvider>();
+    } on ProviderNotFoundException {
+      return null;
+    }
+  }
+
+  /// A memory referenced by the card may not be in the provider's page yet.
+  /// There is no by-id read on this client, so ask the provider — the single
+  /// owner of memory state — to load its list once. Until it resolves the row
+  /// renders its content with the controls disabled.
+  void _ensureMemoriesLoaded() {
+    if (!mounted) return;
+    final provider = _memoriesProvider(listen: false);
+    if (provider == null || provider.loading) return;
+    final unresolved = _rows
+        .where((item) => _memoryFor(provider, item.memoryId) == null)
+        .map((item) => item.memoryId)
+        .where(_requestedIds.add)
+        .toList(growable: false);
+    if (unresolved.isEmpty) return;
+    provider.loadMemories();
+  }
+
+  Memory? _memoryFor(MemoriesProvider provider, String memoryId) {
+    return provider.memories.firstWhereOrNull((memory) => memory.id == memoryId);
+  }
+
+  /// Live state first: an optimistic verdict only survives until its request
+  /// returns, after which `userReview`/`edited` on the memory are authoritative.
+  _RowState _stateFor(Memory? memory, String memoryId) {
+    final optimistic = _optimistic[memoryId];
+    if (optimistic != null) return optimistic;
+    if (memory == null) return _RowState.loading;
+    if (memory.userReview == false) return _RowState.dropped;
+    if (memory.userReview == true) return _RowState.confirmed;
+    if (memory.edited) return _RowState.updated;
+    return _RowState.pending;
+  }
+
+  String _statusText(_RowState state) {
+    switch (state) {
+      case _RowState.confirmed:
+        return "Confirmed. I'll act on this.";
+      case _RowState.dropped:
+        return "Dropped. I'll avoid facts like this.";
+      case _RowState.updated:
+        return 'Updated.';
+      case _RowState.loading:
+      case _RowState.pending:
+        return '';
+    }
+  }
+
+  Future<void> _review(MemoryReviewItem item, Memory memory, bool accepted) async {
+    if (_inFlight.contains(item.memoryId)) return;
+    final provider = _memoriesProvider(listen: false);
+    if (provider == null) return;
+    setState(() {
+      _inFlight.add(item.memoryId);
+      _failed.remove(item.memoryId);
+      _optimistic[item.memoryId] = accepted ? _RowState.confirmed : _RowState.dropped;
+    });
+
+    final persisted = await provider.reviewMemory(memory, accepted);
+    if (!mounted) return;
+    setState(() {
+      _inFlight.remove(item.memoryId);
+      // Drop the optimistic paint either way: on success the provider has
+      // already applied the verdict to the memory this row reads.
+      _optimistic.remove(item.memoryId);
+      if (!persisted) _failed.add(item.memoryId);
+    });
+    PlatformManager.instance.analytics.memoryReviewAction(
+      source: widget.source.analyticsValue,
+      action: accepted ? 'accept' : 'reject',
+      outcome: persisted ? 'ok' : 'error',
+      memoryCategory: _categoryOf(item, memory),
+    );
+  }
+
+  Future<void> _saveEdit(MemoryReviewItem item, Memory memory) async {
+    final controller = _editors[item.memoryId];
+    final value = controller?.text.trim() ?? '';
+    if (value.isEmpty || _inFlight.contains(item.memoryId)) return;
+    final provider = _memoriesProvider(listen: false);
+    if (provider == null) return;
+    setState(() {
+      _inFlight.add(item.memoryId);
+      _failed.remove(item.memoryId);
+      _optimistic[item.memoryId] = _RowState.updated;
+    });
+
+    final persisted = await provider.editMemory(memory, value);
+    if (!mounted) return;
+    setState(() {
+      _inFlight.remove(item.memoryId);
+      if (persisted) {
+        _editors.remove(item.memoryId)?.dispose();
+        // A knowledge-ledger correction appends a new row under a new id, so
+        // the memory this reference points at can stop resolving. Keep the
+        // "Updated." state for this card rather than falling back to a
+        // disabled row.
+        _optimistic[item.memoryId] = _RowState.updated;
+      } else {
+        _optimistic.remove(item.memoryId);
+        _failed.add(item.memoryId);
+      }
+    });
+    PlatformManager.instance.analytics.memoryReviewAction(
+      source: widget.source.analyticsValue,
+      action: 'edit',
+      outcome: persisted ? 'ok' : 'error',
+      memoryCategory: _categoryOf(item, memory),
+    );
+  }
+
+  String _categoryOf(MemoryReviewItem item, Memory? memory) {
+    if (item.category.trim().isNotEmpty) return item.category.trim();
+    return memory?.category.name ?? '';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final rows = _rows;
+    if (rows.isEmpty) return const SizedBox.shrink();
+    final provider = _memoriesProvider(listen: true);
+
+    return Column(
+      key: const Key('memory_review_card'),
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          widget.title,
+          style: const TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(height: 10),
+        ...rows.map((item) => _buildRow(item, provider == null ? null : _memoryFor(provider, item.memoryId))),
+      ],
+    );
+  }
+
+  Widget _buildRow(MemoryReviewItem item, Memory? memory) {
+    final state = _stateFor(memory, item.memoryId);
+    final editing = _editors.containsKey(item.memoryId);
+    final dimmed = state == _RowState.dropped;
+    final content = memory?.content.trim().isNotEmpty == true ? memory!.content.trim() : item.content;
+
+    return Container(
+      key: Key('memory_review_row_${item.memoryId}'),
+      margin: const EdgeInsets.only(bottom: 10),
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(color: _cardColor, borderRadius: BorderRadius.circular(14)),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Only the opacity changes when a row is dropped, so the list never
+          // reflows under the user's finger.
+          AnimatedOpacity(
+            opacity: dimmed ? 0.45 : 1.0,
+            duration: const Duration(milliseconds: 150),
+            child: editing
+                ? _buildEditor(item, memory)
+                : Text(
+                    content,
+                    style: const TextStyle(color: Colors.white, fontSize: 15, height: 1.35),
+                  ),
+          ),
+          const SizedBox(height: 10),
+          SizedBox(
+            height: 28,
+            child: Row(
+              children: [
+                if (item.categoryLabel.isNotEmpty) ...[
+                  Text(
+                    item.categoryLabel,
+                    style: TextStyle(color: Colors.grey.shade500, fontSize: 11, letterSpacing: 0.3),
+                  ),
+                  const SizedBox(width: 12),
+                ],
+                Expanded(child: _buildTrailing(item, memory, state, editing)),
+              ],
+            ),
+          ),
+          if (_failed.contains(item.memoryId))
+            Padding(
+              padding: const EdgeInsets.only(top: 6),
+              child: Text(
+                "Couldn't save, try again",
+                key: Key('memory_review_error_${item.memoryId}'),
+                style: TextStyle(color: Colors.orange.shade300, fontSize: 12),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEditor(MemoryReviewItem item, Memory? memory) {
+    final controller = _editors[item.memoryId]!;
+    return TextField(
+      key: Key('memory_review_editor_${item.memoryId}'),
+      controller: controller,
+      maxLines: 1,
+      autofocus: true,
+      style: const TextStyle(color: Colors.white, fontSize: 15),
+      decoration: InputDecoration(
+        isDense: true,
+        contentPadding: const EdgeInsets.symmetric(vertical: 8),
+        enabledBorder: UnderlineInputBorder(borderSide: BorderSide(color: Colors.grey.shade700)),
+        focusedBorder: const UnderlineInputBorder(borderSide: BorderSide(color: Colors.white)),
+      ),
+      onSubmitted: memory == null ? null : (_) => _saveEdit(item, memory),
+    );
+  }
+
+  Widget _buildTrailing(MemoryReviewItem item, Memory? memory, _RowState state, bool editing) {
+    if (editing) {
+      return Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          _control(
+            key: Key('memory_review_cancel_${item.memoryId}'),
+            label: 'Cancel',
+            onTap: () => setState(() => _editors.remove(item.memoryId)?.dispose()),
+          ),
+          const SizedBox(width: 8),
+          _control(
+            key: Key('memory_review_save_${item.memoryId}'),
+            label: 'Save',
+            emphasized: true,
+            onTap: memory == null || _inFlight.contains(item.memoryId) ? null : () => _saveEdit(item, memory),
+          ),
+        ],
+      );
+    }
+
+    if (state != _RowState.pending && state != _RowState.loading) {
+      return Align(
+        alignment: Alignment.centerLeft,
+        child: Text(
+          _statusText(state),
+          key: Key('memory_review_status_${item.memoryId}'),
+          style: TextStyle(color: Colors.grey.shade400, fontSize: 12.5),
+        ),
+      );
+    }
+
+    final enabled = memory != null && !_inFlight.contains(item.memoryId);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: [
+        _control(
+          key: Key('memory_review_accept_${item.memoryId}'),
+          label: '✓ Right',
+          onTap: enabled ? () => _review(item, memory, true) : null,
+        ),
+        const SizedBox(width: 8),
+        _control(
+          key: Key('memory_review_reject_${item.memoryId}'),
+          label: '✗ Wrong',
+          onTap: enabled ? () => _review(item, memory, false) : null,
+        ),
+        const SizedBox(width: 8),
+        _control(
+          key: Key('memory_review_fix_${item.memoryId}'),
+          label: 'Fix',
+          onTap: enabled
+              ? () => setState(() {
+                    _failed.remove(item.memoryId);
+                    _editors[item.memoryId] = TextEditingController(text: memory.content.trim());
+                  })
+              : null,
+        ),
+      ],
+    );
+  }
+
+  Widget _control({required Key key, required String label, VoidCallback? onTap, bool emphasized = false}) {
+    final color = onTap == null
+        ? Colors.grey.shade700
+        : emphasized
+            ? Colors.white
+            : Colors.grey.shade300;
+    return Semantics(
+      button: true,
+      enabled: onTap != null,
+      label: label,
+      child: InkWell(
+        key: key,
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(20),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+          child: Text(
+            label,
+            style: TextStyle(color: color, fontSize: 13, fontWeight: emphasized ? FontWeight.w600 : FontWeight.w500),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/test/unit/memory_review_block_test.dart
+++ b/app/test/unit/memory_review_block_test.dart
@@ -1,0 +1,181 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/message.dart';
+
+/// The `day_summary` message reaches mobile only as an FCM push, and FCM data
+/// payloads are `Dict[str, str]`: `content_blocks` therefore arrives as JSON
+/// text, not as a list.
+Map<String, dynamic> _fcmDaySummaryData({Object? contentBlocks, String text = 'A busy day.'}) {
+  return {
+    'id': 'summary-message-1',
+    'created_at': '2026-09-01T23:00:00Z',
+    'text': text,
+    'sender': 'ai',
+    'type': 'day_summary',
+    'notification_type': 'daily_summary',
+    if (contentBlocks != null) 'content_blocks': contentBlocks,
+  };
+}
+
+const _reviewBlock = {
+  'type': 'memoryReviewCard',
+  'id': 'summary-1:memories',
+  'summaryId': 'summary-1',
+  'date': '2026-09-01',
+  'items': [
+    {'memoryId': 'mem-1', 'content': 'Prefers async standups', 'category': 'work'},
+    {'memoryId': 'mem-2', 'content': 'Runs on Tuesday mornings', 'category': 'lifestyle'},
+  ],
+};
+
+void main() {
+  test('decodes a memoryReviewCard delivered as FCM JSON text', () {
+    final message = ServerMessage.fromJson(
+      _fcmDaySummaryData(contentBlocks: jsonEncode([_reviewBlock])),
+    );
+
+    final card = message.memoryReviewCard;
+    expect(card, isNotNull);
+    expect(card!.summaryId, 'summary-1');
+    expect(card.date, '2026-09-01');
+    expect(card.items.map((item) => item.memoryId), ['mem-1', 'mem-2']);
+    expect(card.items.first.content, 'Prefers async standups');
+    expect(card.items.first.categoryLabel, 'Work');
+    // The push text is untouched by the block.
+    expect(message.text, 'A busy day.');
+  });
+
+  test('decodes the same block when it arrives as a real list', () {
+    final message = ServerMessage.fromJson(_fcmDaySummaryData(contentBlocks: [_reviewBlock]));
+
+    expect(message.memoryReviewCard?.items.length, 2);
+  });
+
+  test('absent, empty, and malformed content_blocks degrade to no card', () {
+    for (final payload in <Object?>[null, '', '   ', 'not json', '{"unclosed":', '"a string"', 12]) {
+      final message = ServerMessage.fromJson(_fcmDaySummaryData(contentBlocks: payload));
+      expect(message.contentBlocks, isEmpty, reason: 'payload: $payload');
+      expect(message.memoryReviewCard, isNull, reason: 'payload: $payload');
+      expect(message.text, 'A busy day.', reason: 'payload: $payload');
+    }
+  });
+
+  test('a card with no usable items is not rendered as an empty card', () {
+    final message = ServerMessage.fromJson(
+      _fcmDaySummaryData(
+        contentBlocks: jsonEncode([
+          {
+            'type': 'memoryReviewCard',
+            'id': 'summary-2:memories',
+            'summaryId': 'summary-2',
+            'date': '2026-09-01',
+            'items': [
+              {'memoryId': '', 'content': 'no identity'},
+              {'memoryId': 'mem-3', 'content': '   '},
+            ],
+          },
+        ]),
+      ),
+    );
+
+    expect(message.contentBlocks, hasLength(1));
+    expect(message.memoryReviewCard, isNull);
+  });
+
+  test('caps the card at three rows', () {
+    final message = ServerMessage.fromJson(
+      _fcmDaySummaryData(
+        contentBlocks: [
+          {
+            'type': 'memoryReviewCard',
+            'items': List.generate(6, (i) => {'memoryId': 'mem-$i', 'content': 'fact $i'}),
+          },
+        ],
+      ),
+    );
+
+    expect(message.memoryReviewCard?.items, hasLength(3));
+  });
+
+  test('exposes the one follow-up question a typed answer invites', () {
+    final message = ServerMessage.fromJson({
+      'id': 'message-2',
+      'created_at': '2026-09-01T12:00:00Z',
+      'text': 'You met Priya on Tuesday.',
+      'sender': 'ai',
+      'type': 'text',
+      'content_blocks': [
+        {'type': 'followUp', 'id': 'message-2:followup', 'text': 'Want the rest of what she said?'},
+      ],
+    });
+
+    expect(message.followUpQuestion, 'Want the rest of what she said?');
+    expect(message.text, 'You met Priya on Tuesday.');
+    // followUp is not desktop-only chrome; the answer still shows on mobile.
+    expect(message.hideFromMobileChat, isFalse);
+  });
+
+  test('a blank follow-up question is not a chip', () {
+    final message = ServerMessage.fromJson({
+      'id': 'message-3',
+      'created_at': '2026-09-01T12:00:00Z',
+      'text': 'Answer.',
+      'sender': 'ai',
+      'type': 'text',
+      'content_blocks': [
+        {'type': 'followUp', 'text': '   '},
+      ],
+    });
+
+    expect(message.followUpQuestion, isNull);
+  });
+
+  test('fallback text is sensible for both new block types', () {
+    final reviewOnly = ServerMessage.fromJson(
+      _fcmDaySummaryData(text: '', contentBlocks: [_reviewBlock]),
+    );
+    expect(reviewOnly.text, 'Things I learned today');
+
+    final followUpOnly = ServerMessage.fromJson({
+      'id': 'message-4',
+      'created_at': '2026-09-01T12:00:00Z',
+      'text': '',
+      'sender': 'ai',
+      'type': 'text',
+      'content_blocks': [
+        {'type': 'followUp', 'text': 'Should I pull the rest?'},
+      ],
+    });
+    expect(followUpOnly.text, 'Should I pull the rest?');
+  });
+
+  test('unknown and existing block types keep their previous fallback', () {
+    final unknown = ServerMessage.fromJson({
+      'id': 'message-5',
+      'created_at': '2026-09-01T12:00:00Z',
+      'text': '',
+      'sender': 'ai',
+      'type': 'text',
+      'content_blocks': [
+        {'type': 'somethingBrandNew', 'title': 'Title', 'summary': 'Summary'},
+      ],
+    });
+    expect(unknown.text, 'Chat item - Title - Summary');
+    expect(unknown.memoryReviewCard, isNull);
+    expect(unknown.followUpQuestion, isNull);
+
+    final conversation = ServerMessage.fromJson({
+      'id': 'message-6',
+      'created_at': '2026-09-01T12:00:00Z',
+      'text': '',
+      'sender': 'ai',
+      'type': 'text',
+      'content_blocks': [
+        {'type': 'conversationLink', 'conversationId': 'c-1', 'summary': 'Weekly planning'},
+      ],
+    });
+    expect(conversation.text, 'Meeting notes ready - Weekly planning');
+  });
+}

--- a/app/test/widgets/chat_content_block_test.dart
+++ b/app/test/widgets/chat_content_block_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/http/api/memories.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/memory.dart';
+import 'package:omi/backend/schema/message.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/chat/widgets/ai_message.dart';
+import 'package:omi/providers/connectivity_provider.dart';
+import 'package:omi/providers/conversation_provider.dart';
+import 'package:omi/providers/memories_provider.dart';
+import 'package:omi/widgets/components/memory_review_card.dart';
+
+ServerMessage _aiMessage({
+  required String text,
+  required MessageType type,
+  List<Map<String, dynamic>> contentBlocks = const [],
+}) {
+  return ServerMessage(
+    'ai-1',
+    DateTime.parse('2026-09-01T23:00:00Z'),
+    text,
+    MessageSender.ai,
+    type,
+    null,
+    false,
+    const [],
+    const [],
+    const [],
+    contentBlocks: contentBlocks,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({'uid': 'chat-block-user'});
+    await SharedPreferencesUtil.init();
+  });
+
+  Future<void> pumpMessage(
+    WidgetTester tester, {
+    required ServerMessage message,
+    void Function(String)? sendMessage,
+    List<Memory> memories = const [],
+  }) async {
+    final conversationProvider = ConversationProvider(isSignedIn: () => false);
+    addTearDown(conversationProvider.dispose);
+    final memoriesProvider = MemoriesProvider(
+      fetchMemoriesRequest: ({int limit = 100, int offset = 0, bool thisDeviceOnly = false}) async =>
+          GetMemoriesResult(memories, true),
+      fetchLedgerHistoryRequest: ({int limit = 500, int offset = 0}) async =>
+          const GetLedgerHistoryResult([], supported: true),
+      reviewMemoryRequest: (id, value) async => true,
+      editMemoryRequest: (id, value) async => const EditMemoryResult(persisted: true),
+    );
+    addTearDown(memoriesProvider.dispose);
+    await memoriesProvider.loadMemories();
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider.value(value: conversationProvider),
+          ChangeNotifierProvider.value(value: memoriesProvider),
+          ChangeNotifierProvider(create: (_) => ConnectivityProvider()),
+        ],
+        child: MaterialApp(
+          theme: ThemeData.dark(),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: AIMessage(
+                message: message,
+                sendMessage: sendMessage ?? (_) {},
+                displayOptions: false,
+                updateConversation: (_) {},
+                setMessageNps: (int value, {String? reason}) {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('a follow-up block renders one chip that sends its own words', (tester) async {
+    final sent = <String>[];
+    await pumpMessage(
+      tester,
+      message: _aiMessage(
+        text: 'You met Priya on Tuesday.',
+        type: MessageType.text,
+        contentBlocks: const [
+          {'type': 'followUp', 'id': 'ai-1:followup', 'text': 'Want the rest of what she said?'},
+        ],
+      ),
+      sendMessage: sent.add,
+    );
+
+    final chip = find.byKey(const Key('chat_followup_chip'));
+    expect(chip, findsOneWidget);
+    expect(find.text('Want the rest of what she said?'), findsOneWidget);
+
+    await tester.tap(chip);
+    await tester.pump();
+
+    expect(sent, ['Want the rest of what she said?']);
+  });
+
+  testWidgets('a day summary carrying a memoryReviewCard renders the review rows', (tester) async {
+    await pumpMessage(
+      tester,
+      message: _aiMessage(
+        text: 'A busy day.',
+        type: MessageType.daySummary,
+        contentBlocks: const [
+          {
+            'type': 'memoryReviewCard',
+            'id': 'summary-1:memories',
+            'summaryId': 'summary-1',
+            'date': '2026-09-01',
+            'items': [
+              {'memoryId': 'mem-1', 'content': 'Prefers async standups', 'category': 'work'},
+            ],
+          },
+        ],
+      ),
+      memories: [
+        Memory(
+          id: 'mem-1',
+          uid: 'chat-block-user',
+          content: 'Prefers async standups',
+          category: MemoryCategory.system,
+          createdAt: DateTime.utc(2026, 9, 1),
+          updatedAt: DateTime.utc(2026, 9, 1),
+          visibility: MemoryVisibility.private,
+        ),
+      ],
+    );
+
+    expect(find.byType(MemoryReviewCard), findsOneWidget);
+    expect(find.text('Things I learned today'), findsOneWidget);
+    expect(find.byKey(const Key('memory_review_accept_mem-1')), findsOneWidget);
+    expect(find.byKey(const Key('memory_review_reject_mem-1')), findsOneWidget);
+    expect(find.byKey(const Key('memory_review_fix_mem-1')), findsOneWidget);
+  });
+
+  testWidgets('a plain answer with no blocks gains neither a chip nor a card', (tester) async {
+    await pumpMessage(tester, message: _aiMessage(text: 'You met Priya on Tuesday.', type: MessageType.text));
+
+    expect(find.byKey(const Key('chat_followup_chip')), findsNothing);
+    expect(find.byType(MemoryReviewCard), findsNothing);
+  });
+}

--- a/app/test/widgets/daily_summary_detail_page_test.dart
+++ b/app/test/widgets/daily_summary_detail_page_test.dart
@@ -4,10 +4,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter_map/flutter_map.dart';
+import 'package:provider/provider.dart';
 
+import 'package:omi/backend/http/api/memories.dart';
 import 'package:omi/backend/schema/daily_summary.dart';
+import 'package:omi/backend/schema/memory.dart';
+import 'package:omi/backend/schema/memory_review.dart';
 import 'package:omi/l10n/app_localizations.dart';
 import 'package:omi/pages/settings/daily_summary_detail_page.dart';
+import 'package:omi/providers/memories_provider.dart';
+import 'package:omi/widgets/components/memory_review_card.dart';
 
 void main() {
   testWidgets('renders journey locations as compact accessible map rows', (tester) async {
@@ -68,9 +74,73 @@ void main() {
     expect(find.byKey(const ValueKey('daily_summary_location_row_2')), findsNothing);
     expect(find.text('Unknown'), findsNWidgets(2));
   });
+
+  testWidgets('memories learned render as review rows above the prose learnings', (tester) async {
+    final memoriesProvider = MemoriesProvider(
+      fetchMemoriesRequest: ({int limit = 100, int offset = 0, bool thisDeviceOnly = false}) async => GetMemoriesResult(
+        [
+          Memory(
+            id: 'mem-1',
+            uid: 'summary-user',
+            content: 'Prefers async standups',
+            category: MemoryCategory.system,
+            createdAt: DateTime.utc(2026, 7, 15),
+            updatedAt: DateTime.utc(2026, 7, 15),
+            visibility: MemoryVisibility.private,
+          ),
+        ],
+        true,
+      ),
+      fetchLedgerHistoryRequest: ({int limit = 500, int offset = 0}) async =>
+          const GetLedgerHistoryResult([], supported: true),
+      reviewMemoryRequest: (id, value) async => true,
+      editMemoryRequest: (id, value) async => const EditMemoryResult(persisted: true),
+    );
+    addTearDown(memoriesProvider.dispose);
+    await memoriesProvider.loadMemories();
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<MemoriesProvider>.value(
+        value: memoriesProvider,
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: ThemeData.dark(),
+          home: DailySummaryDetailPage(
+            summaryId: 'summary-learned',
+            summary: _summary(
+              locations: const [],
+              memoriesLearned: const [
+                MemoryReviewItem(memoryId: 'mem-1', content: 'Prefers async standups', category: 'work'),
+              ],
+              knowledgeNuggets: [KnowledgeNugget(insight: 'Async beats status meetings')],
+            ),
+            tileProvider: _MemoryTileProvider(),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 900));
+
+    expect(find.byType(MemoryReviewCard), findsOneWidget);
+    expect(find.byKey(const Key('memory_review_accept_mem-1')), findsOneWidget);
+    expect(find.byKey(const Key('memory_review_reject_mem-1')), findsOneWidget);
+    expect(find.byKey(const Key('memory_review_fix_mem-1')), findsOneWidget);
+    // The LLM-prose learnings are untouched, and stay below the review rows.
+    expect(find.text('Async beats status meetings'), findsOneWidget);
+    expect(
+      tester.getTopLeft(find.byType(MemoryReviewCard)).dy,
+      lessThan(tester.getTopLeft(find.text('Async beats status meetings')).dy),
+    );
+  });
 }
 
-DailySummary _summary({List<LocationPin>? locations}) {
+DailySummary _summary({
+  List<LocationPin>? locations,
+  List<MemoryReviewItem> memoriesLearned = const [],
+  List<KnowledgeNugget> knowledgeNuggets = const [],
+}) {
   return DailySummary(
     id: 'summary-1',
     date: '2026-07-15',
@@ -78,6 +148,8 @@ DailySummary _summary({List<LocationPin>? locations}) {
     headline: 'A day around the city',
     overview: 'A productive day.',
     stats: DayStats(totalConversations: 1, totalDurationMinutes: 30),
+    memoriesLearned: memoriesLearned,
+    knowledgeNuggets: knowledgeNuggets,
     locations: locations ??
         [
           LocationPin(latitude: 37.7749, longitude: -122.4194, address: 'Home, San Francisco', time: '08:00'),

--- a/app/test/widgets/memory_review_card_test.dart
+++ b/app/test/widgets/memory_review_card_test.dart
@@ -1,0 +1,267 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/http/api/memories.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/memory.dart';
+import 'package:omi/backend/schema/memory_review.dart';
+import 'package:omi/providers/memories_provider.dart';
+import 'package:omi/widgets/components/memory_review_card.dart';
+
+Memory _memory({
+  required String id,
+  String content = 'Prefers async standups',
+  bool? userReview,
+  bool edited = false,
+}) {
+  return Memory(
+    id: id,
+    uid: 'review-card-user',
+    content: content,
+    category: MemoryCategory.system,
+    createdAt: DateTime.utc(2026, 9, 1),
+    updatedAt: DateTime.utc(2026, 9, 1),
+    visibility: MemoryVisibility.private,
+    userReview: userReview,
+    edited: edited,
+  );
+}
+
+MemoryReviewItem _item(String id, {String content = 'Prefers async standups', String category = 'work'}) {
+  return MemoryReviewItem(memoryId: id, content: content, category: category);
+}
+
+MemoriesProvider _provider({
+  List<Memory> rows = const [],
+  ReviewMemoryRequest? reviewMemoryRequest,
+  EditMemoryRequest? editMemoryRequest,
+}) {
+  return MemoriesProvider(
+    fetchMemoriesRequest: ({int limit = 100, int offset = 0, bool thisDeviceOnly = false}) async =>
+        GetMemoriesResult(rows, true),
+    fetchLedgerHistoryRequest: ({int limit = 500, int offset = 0}) async =>
+        const GetLedgerHistoryResult([], supported: true),
+    reviewMemoryRequest: reviewMemoryRequest ?? (id, value) async => true,
+    editMemoryRequest: editMemoryRequest ?? (id, value) async => const EditMemoryResult(persisted: true),
+  );
+}
+
+Widget _harness(MemoriesProvider provider, List<MemoryReviewItem> items) {
+  return ChangeNotifierProvider<MemoriesProvider>.value(
+    value: provider,
+    child: MaterialApp(
+      theme: ThemeData.dark(),
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: MemoryReviewCard(items: items, source: MemoryReviewSource.chatBlock),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({'uid': 'review-card-user'});
+    await SharedPreferencesUtil.init();
+  });
+
+  testWidgets('renders one row per learned memory with all three controls', (tester) async {
+    final provider = _provider(rows: [_memory(id: 'mem-1'), _memory(id: 'mem-2', content: 'Runs on Tuesdays')]);
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    await tester.pumpWidget(_harness(provider, [_item('mem-1'), _item('mem-2', content: 'Runs on Tuesdays')]));
+    await tester.pump();
+
+    expect(find.text('Things I learned today'), findsOneWidget);
+    expect(find.text('Prefers async standups'), findsOneWidget);
+    expect(find.text('Runs on Tuesdays'), findsOneWidget);
+    expect(find.text('Work'), findsNWidgets(2));
+    for (final id in ['mem-1', 'mem-2']) {
+      expect(find.byKey(Key('memory_review_accept_$id')), findsOneWidget);
+      expect(find.byKey(Key('memory_review_reject_$id')), findsOneWidget);
+      expect(find.byKey(Key('memory_review_fix_$id')), findsOneWidget);
+    }
+  });
+
+  testWidgets('caps the card at three rows', (tester) async {
+    final rows = List.generate(5, (i) => _memory(id: 'mem-$i', content: 'fact $i'));
+    final provider = _provider(rows: rows);
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    await tester.pumpWidget(_harness(provider, rows.map((m) => _item(m.id, content: m.content)).toList()));
+    await tester.pump();
+
+    expect(find.byKey(const Key('memory_review_row_mem-2')), findsOneWidget);
+    expect(find.byKey(const Key('memory_review_row_mem-3')), findsNothing);
+  });
+
+  testWidgets('accepting paints optimistically before the request returns and calls the provider', (tester) async {
+    final completer = Completer<bool>();
+    final requested = <bool>[];
+    final provider = _provider(
+      rows: [_memory(id: 'mem-1')],
+      reviewMemoryRequest: (id, value) {
+        requested.add(value);
+        return completer.future;
+      },
+    );
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    await tester.pumpWidget(_harness(provider, [_item('mem-1')]));
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('memory_review_accept_mem-1')));
+    await tester.pump();
+
+    expect(requested, [true]);
+    expect(find.text("Confirmed. I'll act on this."), findsOneWidget);
+    expect(find.byKey(const Key('memory_review_accept_mem-1')), findsNothing);
+
+    completer.complete(true);
+    await tester.pumpAndSettle();
+
+    // Settled state is read back from the live memory, not from the tap.
+    expect(provider.memories.single.userReview, isTrue);
+    expect(find.text("Confirmed. I'll act on this."), findsOneWidget);
+  });
+
+  testWidgets('rejecting records the negative verdict and dims the row without a layout jump', (tester) async {
+    final requested = <bool>[];
+    final provider = _provider(
+      rows: [_memory(id: 'mem-1')],
+      reviewMemoryRequest: (id, value) async {
+        requested.add(value);
+        return true;
+      },
+    );
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    await tester.pumpWidget(_harness(provider, [_item('mem-1')]));
+    await tester.pump();
+    final heightBefore = tester.getSize(find.byKey(const Key('memory_review_row_mem-1'))).height;
+
+    await tester.tap(find.byKey(const Key('memory_review_reject_mem-1')));
+    await tester.pumpAndSettle();
+
+    expect(requested, [false]);
+    expect(provider.memories.single.userReview, isFalse);
+    expect(find.text("Dropped. I'll avoid facts like this."), findsOneWidget);
+    expect(tester.getSize(find.byKey(const Key('memory_review_row_mem-1'))).height, heightBefore);
+    final opacity = tester.widget<AnimatedOpacity>(
+      find.descendant(of: find.byKey(const Key('memory_review_row_mem-1')), matching: find.byType(AnimatedOpacity)),
+    );
+    expect(opacity.opacity, lessThan(1.0));
+  });
+
+  testWidgets('a rejected verdict that does not persist reverts and says so inline', (tester) async {
+    final provider = _provider(
+      rows: [_memory(id: 'mem-1')],
+      reviewMemoryRequest: (id, value) async => false,
+    );
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    await tester.pumpWidget(_harness(provider, [_item('mem-1')]));
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('memory_review_reject_mem-1')));
+    await tester.pumpAndSettle();
+
+    expect(provider.memories.single.userReview, isNull);
+    expect(find.byKey(const Key('memory_review_error_mem-1')), findsOneWidget);
+    expect(find.text("Dropped. I'll avoid facts like this."), findsNothing);
+    // The controls come back so the user can try again.
+    expect(find.byKey(const Key('memory_review_reject_mem-1')), findsOneWidget);
+  });
+
+  testWidgets('a live verdict cast elsewhere renders without any local tap', (tester) async {
+    final provider = _provider(rows: [_memory(id: 'mem-1', userReview: true)]);
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    await tester.pumpWidget(_harness(provider, [_item('mem-1')]));
+    await tester.pump();
+
+    expect(find.text("Confirmed. I'll act on this."), findsOneWidget);
+    expect(find.byKey(const Key('memory_review_accept_mem-1')), findsNothing);
+  });
+
+  testWidgets('fix opens a prefilled single-line editor and saves through the provider', (tester) async {
+    final edits = <String>[];
+    final provider = _provider(
+      rows: [_memory(id: 'mem-1')],
+      editMemoryRequest: (id, value) async {
+        edits.add(value);
+        return const EditMemoryResult(persisted: true);
+      },
+    );
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    await tester.pumpWidget(_harness(provider, [_item('mem-1')]));
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('memory_review_fix_mem-1')));
+    await tester.pumpAndSettle();
+
+    final editor = tester.widget<TextField>(find.byKey(const Key('memory_review_editor_mem-1')));
+    expect(editor.controller?.text, 'Prefers async standups');
+    expect(editor.maxLines, 1);
+
+    await tester.enterText(find.byKey(const Key('memory_review_editor_mem-1')), 'Prefers written standups');
+    await tester.tap(find.byKey(const Key('memory_review_save_mem-1')));
+    await tester.pumpAndSettle();
+
+    expect(edits, ['Prefers written standups']);
+    expect(find.text('Updated.'), findsOneWidget);
+    expect(find.byKey(const Key('memory_review_editor_mem-1')), findsNothing);
+  });
+
+  testWidgets('an edit that does not persist keeps the editor open and says so inline', (tester) async {
+    final provider = _provider(
+      rows: [_memory(id: 'mem-1')],
+      editMemoryRequest: (id, value) async => const EditMemoryResult(persisted: false),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    await tester.pumpWidget(_harness(provider, [_item('mem-1')]));
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('memory_review_fix_mem-1')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('memory_review_editor_mem-1')), 'Prefers written standups');
+    await tester.tap(find.byKey(const Key('memory_review_save_mem-1')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('memory_review_error_mem-1')), findsOneWidget);
+    expect(find.text('Updated.'), findsNothing);
+    expect(find.byKey(const Key('memory_review_editor_mem-1')), findsOneWidget);
+  });
+
+  testWidgets('an unresolved memory still shows its content with the controls disabled', (tester) async {
+    final provider = _provider(rows: const []);
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    await tester.pumpWidget(_harness(provider, [_item('mem-missing')]));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Prefers async standups'), findsOneWidget);
+    final accept = tester.widget<InkWell>(find.byKey(const Key('memory_review_accept_mem-missing')));
+    expect(accept.onTap, isNull);
+    expect(find.byKey(const Key('memory_review_status_mem-missing')), findsNothing);
+  });
+}

--- a/backend/models/daily_summary_payload.py
+++ b/backend/models/daily_summary_payload.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+from typing import Optional
+
 from pydantic import BaseModel, Field
 
 
@@ -31,3 +34,19 @@ class DailySummaryPayload(BaseModel):
     unresolved_questions: list[DailySummaryQuestion] = Field(default_factory=list)
     decisions_made: list[DailySummaryDecision] = Field(default_factory=list)
     knowledge_nuggets: list[DailySummaryKnowledgeNugget] = Field(default_factory=list)
+
+
+class LearnedMemoryRef(BaseModel):
+    """One memory the day actually produced, addressed by its canonical id.
+
+    This is the identity `knowledge_nuggets` never had: a client can render a
+    native review card and vote or correct through the existing memory
+    endpoints. Review state (`user_review`, `edited`) is deliberately absent —
+    clients read it live from the memory so a vote on one device shows on the
+    other.
+    """
+
+    memory_id: str
+    content: str
+    category: str = ""
+    captured_at: Optional[datetime] = None

--- a/backend/models/notification_message.py
+++ b/backend/models/notification_message.py
@@ -1,4 +1,5 @@
-from typing import Optional
+import json
+from typing import Any, Optional
 import uuid
 from datetime import datetime, timezone
 from pydantic import BaseModel, Field
@@ -14,6 +15,9 @@ class NotificationMessage(BaseModel):
     notification_type: str
     text: Optional[str] = ""
     navigate_to: Optional[str] = None
+    # Structured chat content blocks for the message the client materializes
+    # from this push. Same block vocabulary as `models.chat.Message.content_blocks`.
+    content_blocks: Optional[list[dict[str, Any]]] = None
 
     @staticmethod
     def get_message_as_dict(
@@ -28,5 +32,13 @@ class NotificationMessage(BaseModel):
 
         if message.navigate_to is None:
             del message_dict['navigate_to']
+
+        # FCM data payloads are Dict[str, str]: a nested list would make the whole
+        # batch send fail. Structured payloads travel as JSON text, the same shape
+        # `utils.notifications` already uses for batched action items.
+        if message.content_blocks:
+            message_dict['content_blocks'] = json.dumps(message.content_blocks, ensure_ascii=False)
+        else:
+            del message_dict['content_blocks']
 
         return message_dict

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -84,6 +84,7 @@ from utils.retrieval.graph import execute_chat_stream
 from utils.llm.usage_tracker import set_usage_context, reset_usage_context, Features
 from utils.users import get_user_display_name
 from utils.log_sanitizer import sanitize_pii
+from utils.chat_followup import followup_content_blocks
 from utils.observability import submit_langsmith_feedback
 from utils.observability.fallback import record_fallback
 from utils.journey_metrics_contract import resolve_client_kind, resolve_client_kind_from_headers
@@ -527,8 +528,9 @@ def send_message(
 
         memories_id = extract_memory_ids(memories) if memories else []
 
+        ai_message_id = str(uuid.uuid4())
         ai_message = Message(
-            id=str(uuid.uuid4()),
+            id=ai_message_id,
             text=response,
             created_at=datetime.now(timezone.utc),
             sender='ai',
@@ -540,6 +542,14 @@ def send_message(
             prompt_name=prompt_name,  # LangSmith prompt name for versioning
             prompt_commit=prompt_commit,  # LangSmith prompt commit for traceability
             evidence=evidence,
+            # One grounded next question, as a chip the client can tap. Empty for
+            # any turn that failed or has nothing to go one hop further into.
+            content_blocks=followup_content_blocks(
+                ai_message_id,
+                callback_data.get('followup'),
+                visible_text=response,
+                failed=bool(callback_data.get('error')),
+            ),
         )
         if chat_session:
             ai_message.chat_session_id = chat_session.id

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -119,7 +119,7 @@ from utils.notifications import send_notification, send_training_data_submitted_
 from utils.llm.external_integrations import generate_comprehensive_daily_summary
 from models.notification_message import NotificationMessage
 from models.daily_summary_payload import LearnedMemoryRef
-from utils.memory.learned_today import memory_review_card_block
+from utils.memory.learned_today import memories_learned_for_summary, memory_review_card_block
 from utils.other import endpoints as auth
 from utils.other.storage import (
     delete_all_conversation_recordings,
@@ -1589,6 +1589,24 @@ def update_daily_summary_settings(data: DailySummarySettingsUpdate, uid: str = D
     return {'status': 'ok'}
 
 
+def _memories_learned_payload(uid, conversations, start_date_utc, end_date_utc):
+    """Select the day's review items for a summary about to be generated.
+
+    The read lives here rather than inside generate_comprehensive_daily_summary:
+    that module is the LLM summary builder, and giving it a memory dependency
+    would put a Firestore read behind every caller and every test of it.
+    """
+    return [
+        ref.model_dump(mode='json')
+        for ref in memories_learned_for_summary(
+            uid,
+            conversation_ids=[c.id for c in conversations if not getattr(c, 'discarded', False)],
+            window_start=start_date_utc,
+            window_end=end_date_utc,
+        )
+    ]
+
+
 class TestDailySummaryRequest(BaseModel):
     date: Optional[str] = None  # YYYY-MM-DD format, defaults to today
 
@@ -1675,7 +1693,14 @@ def test_daily_summary(
     conversations = deserialize_conversations(conversations_data)
 
     # Generate summary (pass date range for fetching actual action items)
-    summary_data = generate_comprehensive_daily_summary(uid, conversations, date_str, start_date_utc, end_date_utc)
+    summary_data = generate_comprehensive_daily_summary(
+        uid,
+        conversations,
+        date_str,
+        start_date_utc,
+        end_date_utc,
+        memories_learned=_memories_learned_payload(uid, conversations, start_date_utc, end_date_utc),
+    )
 
     # Store in database
     summary_id = daily_summaries_db.create_daily_summary(uid, summary_data)
@@ -1841,7 +1866,14 @@ def regenerate_daily_summary(
 
     conversations = deserialize_conversations(conversations_data)
 
-    summary_data = generate_comprehensive_daily_summary(uid, conversations, date_str, start_date_utc, end_date_utc)
+    summary_data = generate_comprehensive_daily_summary(
+        uid,
+        conversations,
+        date_str,
+        start_date_utc,
+        end_date_utc,
+        memories_learned=_memories_learned_payload(uid, conversations, start_date_utc, end_date_utc),
+    )
     # Preserve fields readers care about that the generator silently resets:
     # - visibility: sharing state shouldn't toggle off on regenerate
     # - created_at: generator stamps a fresh utcnow(), but UI sorts/displays

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -118,6 +118,8 @@ from utils.llm.followup import followup_question_prompt
 from utils.notifications import send_notification, send_training_data_submitted_notification
 from utils.llm.external_integrations import generate_comprehensive_daily_summary
 from models.notification_message import NotificationMessage
+from models.daily_summary_payload import LearnedMemoryRef
+from utils.memory.learned_today import memory_review_card_block
 from utils.other import endpoints as auth
 from utils.other.storage import (
     delete_all_conversation_recordings,
@@ -312,6 +314,10 @@ class DailySummaryResponse(BaseModel):
     unresolved_questions: Optional[List[DailySummaryUnresolvedQuestion]] = None
     decisions_made: Optional[List[DailySummaryDecisionMade]] = None
     knowledge_nuggets: Optional[List[DailySummaryKnowledgeNugget]] = None
+    # Memories the day actually produced, addressed by canonical memory id, so a
+    # shell can render a native review card. Older summaries have no field;
+    # clients prefer this over `knowledge_nuggets` when it is non-empty.
+    memories_learned: List[LearnedMemoryRef] = Field(default_factory=list)
     locations: Optional[List[DailySummaryLocationPin]] = None
 
 
@@ -1680,12 +1686,22 @@ def test_daily_summary(
     if len(summary_body) > 150:
         summary_body = summary_body[:147] + "..."
 
+    # Native review card for the memories this day produced. The message text is
+    # unchanged, so a client that does not know the block renders exactly what it
+    # rendered before; the block is omitted entirely when nothing qualifies.
+    review_block = memory_review_card_block(
+        summary_id,
+        date=date_str,
+        memories_learned=summary_data.get('memories_learned') or [],
+    )
+
     ai_message = NotificationMessage(
         text=summary_body,
         from_integration='false',
         type='day_summary',
         notification_type='daily_summary',
         navigate_to=f"/daily-summary/{summary_id}",
+        content_blocks=[review_block] if review_block else None,
     )
 
     send_notification(

--- a/backend/scripts/generate_dart_models.py
+++ b/backend/scripts/generate_dart_models.py
@@ -319,6 +319,7 @@ SCHEMA_GROUPS = {
             'DailySummaryUnresolvedQuestion',
             'DailySummaryDecisionMade',
             'DailySummaryKnowledgeNugget',
+            'LearnedMemoryRef',
             'DailySummaryDayStats',
             'DailySummaryLocationPin',
             'DailySummaryResponse',

--- a/backend/tests/unit/test_app_client_dart_generator.py
+++ b/backend/tests/unit/test_app_client_dart_generator.py
@@ -98,7 +98,11 @@ def test_message_adapter_preserves_arbitrary_chart_data_union_payloads():
     assert "const requiredKeys = {'chart_type', 'title', 'datasets'};" in adapter
     assert "return (chartType == 'line' || chartType == 'bar') && requiredKeys.every(json.containsKey);" in adapter
     assert 'static ServerMessage fromResponseJson(Map<String, dynamic> json)' in adapter
-    assert "Map<String, dynamic>.from(json)..remove('evidence')" in adapter
+    # The cascade is formatted across lines by `dart format`, so match the
+    # operations rather than one physical line.
+    assert "Map<String, dynamic>.from(json)" in adapter
+    assert "..remove('evidence')" in adapter
+    assert "..remove('content_blocks')" in adapter
     assert 'wire.GeneratedResponseMessage.fromJson(generatedJson)' in adapter
     assert 'askForNps: generated.askForNps ?? false' in adapter
     assert 'final parsedChartData = chartData ?? ChartData.tryFromJson(rawChartData);' in adapter

--- a/backend/tests/unit/test_chat_followup_block.py
+++ b/backend/tests/unit/test_chat_followup_block.py
@@ -1,0 +1,200 @@
+"""The typed chat lane's grounded closing question.
+
+Two contracts are covered. The parser owns what a follow-up tail is: the
+delimiter and everything after it always leave the visible text, and only a
+specific, short, real question survives as a chip. The route owns delivery: the
+persisted assistant message carries the ``followUp`` content block on a grounded
+turn and carries nothing on a failed one, because a chip on a failed turn asks
+the user to go one hop further into an answer they never got.
+"""
+
+import pytest
+
+from tests.unit.test_chat_stream_error_fallback import _cleanup, _decode_done_frame, _make_client
+from utils.chat_followup import (
+    FOLLOWUP_DELIMITER,
+    FollowUpTailStreamFilter,
+    build_followup_block,
+    followup_content_blocks,
+    split_followup_tail,
+)
+
+
+def test_tail_is_lifted_off_the_visible_text():
+    visible, question = split_followup_tail(
+        f"You and Priya settled on shipping Thursday.\n{FOLLOWUP_DELIMITER} Who else was in that call?"
+    )
+    assert visible == "You and Priya settled on shipping Thursday."
+    assert question == "Who else was in that call?"
+    assert FOLLOWUP_DELIMITER not in visible
+
+
+def test_answer_without_a_tail_is_untouched():
+    assert split_followup_tail("Nothing came up for that.") == ("Nothing came up for that.", None)
+
+
+def test_empty_answer_yields_no_question():
+    assert split_followup_tail('') == ('', None)
+    assert split_followup_tail(None) == ('', None)
+
+
+@pytest.mark.parametrize(
+    'tail',
+    [
+        'Anything else?',
+        'anything else i can help with?',
+        'Want more detail?',
+        'Does that help?',
+        'Let me know if you want more.',
+        'Want me to keep going?',
+    ],
+)
+def test_generic_tails_are_dropped_but_still_stripped(tail):
+    visible, question = split_followup_tail(f"Here it is.\n{FOLLOWUP_DELIMITER} {tail}")
+    assert visible == 'Here it is.'
+    assert question is None
+
+
+def test_overlong_tail_is_dropped():
+    long_tail = ' '.join(['word'] * 30) + '?'
+    visible, question = split_followup_tail(f"Answer.\n{FOLLOWUP_DELIMITER} {long_tail}")
+    assert visible == 'Answer.'
+    assert question is None
+
+
+def test_tail_that_is_not_a_question_is_dropped():
+    visible, question = split_followup_tail(f"Answer.\n{FOLLOWUP_DELIMITER} I will check that next.")
+    assert visible == 'Answer.'
+    assert question is None
+
+
+def test_only_the_first_tail_line_is_the_question():
+    visible, question = split_followup_tail(
+        f"Answer.\n{FOLLOWUP_DELIMITER} When is the review due?\nAlso here is more prose."
+    )
+    assert visible == 'Answer.'
+    assert question == 'When is the review due?'
+
+
+def test_failed_turn_gets_no_block():
+    assert (
+        followup_content_blocks(
+            'm1',
+            'Who else was in that call?',
+            visible_text='Something went wrong.',
+            failed=True,
+        )
+        == []
+    )
+
+
+def test_refusal_or_empty_answer_gets_no_block():
+    assert followup_content_blocks('m1', 'Who else was there?', visible_text='   ', failed=False) == []
+
+
+def test_answer_that_is_itself_a_question_gets_no_block():
+    assert (
+        followup_content_blocks(
+            'm1',
+            'Who else was there?',
+            visible_text='Which standup did you mean — Monday or Thursday?',
+            failed=False,
+        )
+        == []
+    )
+
+
+def test_grounded_turn_gets_exactly_one_block_in_the_wire_shape():
+    blocks = followup_content_blocks(
+        'msg-7',
+        'Who else was in that call?',
+        visible_text='You and Priya settled on shipping Thursday.',
+        failed=False,
+    )
+    assert blocks == [{'type': 'followUp', 'id': 'msg-7:followup', 'text': 'Who else was in that call?'}]
+    assert build_followup_block('msg-7', 'Who else was in that call?') == blocks[0]
+
+
+def test_stream_filter_never_shows_the_tail_even_split_across_chunks():
+    stream_filter = FollowUpTailStreamFilter()
+    emitted = ''.join(
+        stream_filter.push(chunk)
+        for chunk in ['You and Priya ', 'settled on Thursday.\n<<<FOLL', 'OWUP>>> Who else was there?']
+    )
+    emitted += stream_filter.flush()
+    assert emitted == 'You and Priya settled on Thursday.\n'
+    assert stream_filter.suppressing
+
+
+def test_stream_filter_releases_text_that_only_looked_like_the_delimiter():
+    stream_filter = FollowUpTailStreamFilter()
+    emitted = ''.join(stream_filter.push(chunk) for chunk in ['a <<<b', ' and more'])
+    emitted += stream_filter.flush()
+    assert emitted == 'a <<<b and more'
+    assert not stream_filter.suppressing
+
+
+def _grounded_stream(answer: str, question: str):
+    async def stream(*args, **kwargs):
+        kwargs['callback_data']['answer'] = answer
+        kwargs['callback_data']['followup'] = question
+        yield None
+
+    return stream
+
+
+def test_persisted_message_carries_the_followup_block():
+    client, router_module, _chat_utils, chat_db, saved = _make_client()
+    try:
+        router_module.execute_chat_stream = _grounded_stream(
+            'You and Priya settled on shipping Thursday.', 'Who else was in that call?'
+        )
+
+        response = client.post(
+            '/v2/messages',
+            json={'text': 'what did priya say about the ship date', 'file_ids': []},
+            headers={'X-App-Platform': 'ios'},
+        )
+
+        assert response.status_code == 200
+        payload = _decode_done_frame(response.text)
+        assert payload['content_blocks'] == [
+            {'type': 'followUp', 'id': f"{payload['id']}:followup", 'text': 'Who else was in that call?'}
+        ]
+        # The chip's text is delivered once, not duplicated into the prose.
+        assert payload['text'] == 'You and Priya settled on shipping Thursday.'
+
+        ai_writes = [call.args[1] for call in chat_db.add_message.call_args_list if call.args[1].get('sender') == 'ai']
+        assert len(ai_writes) == 1
+        assert ai_writes[0]['content_blocks'] == payload['content_blocks']
+    finally:
+        _cleanup(saved)
+
+
+def test_failed_turn_persists_no_followup_block():
+    client, router_module, _chat_utils, chat_db, saved = _make_client()
+    try:
+
+        async def failing_stream(*args, **kwargs):
+            kwargs['callback_data']['error'] = 'idle_timeout'
+            kwargs['callback_data']['answer'] = 'Something went wrong on my side.'
+            kwargs['callback_data']['followup'] = 'Who else was in that call?'
+            yield None
+
+        router_module.execute_chat_stream = failing_stream
+
+        response = client.post(
+            '/v2/messages',
+            json={'text': 'what did priya say', 'file_ids': []},
+            headers={'X-App-Platform': 'ios'},
+        )
+
+        assert response.status_code == 200
+        payload = _decode_done_frame(response.text)
+        assert payload['content_blocks'] == []
+
+        ai_writes = [call.args[1] for call in chat_db.add_message.call_args_list if call.args[1].get('sender') == 'ai']
+        assert len(ai_writes) == 1
+        assert ai_writes[0]['content_blocks'] == []
+    finally:
+        _cleanup(saved)

--- a/backend/tests/unit/test_daily_summary_job_resilience.py
+++ b/backend/tests/unit/test_daily_summary_job_resilience.py
@@ -1,0 +1,465 @@
+"""Survivability contract for the daily-summary notifications job (#12530).
+
+The job is a Cloud Run Job with a 600s task timeout serving tens of thousands
+of users. Before this contract, an execution that ran out of wall clock was
+killed mid-batch and the next execution restarted at the head, so the users
+after the kill point were never reached on any run and produced no error of
+their own. These tests execute the real job functions through the module's own
+seams (fake Redis, injected clock, injected per-user worker).
+"""
+
+import asyncio
+import threading
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict, Iterator, List, Tuple
+
+from testing.import_isolation import AutoMockModule, load_module_fresh, stub_modules
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+def _module(name: str, **attributes: Any) -> ModuleType:
+    module = ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    return module
+
+
+class FakeRedis:
+    """Minimal Redis surface used by the job cursor."""
+
+    def __init__(self) -> None:
+        self.store: Dict[str, Any] = {}
+        self.fail = False
+
+    def get(self, key: str) -> Any:
+        if self.fail:
+            raise RuntimeError('redis down')
+        return self.store.get(key)
+
+    def set(self, key: str, value: Any, ex: Any = None) -> None:
+        if self.fail:
+            raise RuntimeError('redis down')
+        self.store[key] = value
+
+    def delete(self, key: str) -> None:
+        if self.fail:
+            raise RuntimeError('redis down')
+        self.store.pop(key, None)
+
+
+class FakeClock:
+    """Deterministic replacement for ``time.monotonic`` inside the job."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class RecordedFallbacks:
+    def __init__(self) -> None:
+        self.events: List[Dict[str, str]] = []
+
+    def __call__(self, **kwargs: Any) -> None:
+        self.events.append({k: str(v) for k, v in kwargs.items() if k != 'log'})
+
+    def reasons(self) -> List[str]:
+        return [event['reason'] for event in self.events]
+
+
+@contextmanager
+def _loaded_job() -> Iterator[Tuple[ModuleType, ModuleType, FakeRedis, RecordedFallbacks]]:
+    async def no_async_work(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def no_db_work(*_args: Any, **_kwargs: Any) -> List[Any]:
+        return []
+
+    fake_redis = FakeRedis()
+    fallbacks = RecordedFallbacks()
+    notification_db = _module(
+        'database.notifications',
+        get_users_for_daily_summary=no_db_work,
+        get_users_token_in_timezones=no_db_work,
+    )
+    notification_message = type(
+        'NotificationMessage',
+        (),
+        {
+            '__init__': lambda self, **kwargs: self.__dict__.update(kwargs),
+            'get_message_as_dict': staticmethod(lambda message: dict(message.__dict__)),
+        },
+    )
+    stubs = {
+        # utils.memory.learned_today -> models.memories -> database._client pulls
+        # the Firestore SDK into the import graph; the job never touches it here.
+        'database._client': AutoMockModule('database._client'),
+        'database.conversations': _module('database.conversations', get_conversations=lambda *_a, **_k: []),
+        'database.notifications': notification_db,
+        'database.redis_db': _module(
+            'database.redis_db',
+            try_acquire_daily_summary_lock=lambda *_args: True,
+            r=fake_redis,
+        ),
+        'models.notification_message': _module(
+            'models.notification_message',
+            NotificationMessage=notification_message,
+        ),
+        'utils.conversations.factory': _module('utils.conversations.factory', deserialize_conversation=lambda v: v),
+        'utils.llm.external_integrations': _module(
+            'utils.llm.external_integrations',
+            generate_comprehensive_daily_summary=lambda *_args: {},
+        ),
+        'utils.notifications': _module(
+            'utils.notifications',
+            send_bulk_notification=no_async_work,
+            send_notification=lambda *_a, **_k: None,
+        ),
+        'utils.observability.fallback': _module('utils.observability.fallback', record_fallback=fallbacks),
+        'utils.webhooks': _module('utils.webhooks', day_summary_webhook=no_async_work),
+        'database.daily_summaries': _module(
+            'database.daily_summaries',
+            get_daily_summary_by_date=lambda *_args: None,
+            create_daily_summary=lambda *_args: 'summary-id',
+        ),
+    }
+
+    with stub_modules(stubs):
+        notifications = load_module_fresh(
+            'utils.other.notifications',
+            str(BACKEND_DIR / 'utils' / 'other' / 'notifications.py'),
+        )
+        yield notifications, notification_db, fake_redis, fallbacks
+
+
+def _users(count: int, hour: int = 22) -> List[Tuple[str, List[str], str]]:
+    return [(f'uid-{i:02d}', [f'token-{i:02d}'], 'UTC') for i in range(count)]
+
+
+# --------------------------------------------------------------- per-user isolation
+
+
+def test_one_failing_user_does_not_abort_the_rest_of_the_group() -> None:
+    with _loaded_job() as (notifications, _db, _redis, _fallbacks):
+        served: List[str] = []
+
+        def worker(user: Tuple[Any, ...]) -> None:
+            served.append(user[0])
+            if user[0] == 'uid-02':
+                raise RuntimeError('Error code: 400 - context_length_exceeded')
+
+        notifications._send_summary_notification = worker
+        stats = notifications.DailySummaryJobStats()
+
+        finished = asyncio.run(notifications._send_bulk_summary_notification(_users(20), stats=stats, target_hour=22))
+
+        assert finished is True
+        assert len(served) == 20, 'every user in the group must still be attempted'
+        assert stats.attempted == 20
+        assert stats.failed == 1
+        assert stats.succeeded == 19
+
+
+def test_per_user_budget_exceeded_is_recorded_and_skipped() -> None:
+    with _loaded_job() as (notifications, _db, _redis, fallbacks):
+        notifications.DAILY_SUMMARY_USER_BUDGET_SECONDS = 0.05
+        release = threading.Event()
+        served: List[str] = []
+
+        def worker(user: Tuple[Any, ...]) -> None:
+            served.append(user[0])
+            if user[0] == 'uid-01':
+                assert release.wait(timeout=5)
+
+        notifications._send_summary_notification = worker
+        stats = notifications.DailySummaryJobStats()
+        try:
+            finished = asyncio.run(
+                notifications._send_bulk_summary_notification(_users(4), stats=stats, target_hour=22)
+            )
+        finally:
+            release.set()
+
+        assert finished is True
+        assert stats.timed_out == 1
+        assert stats.succeeded == 3, 'the slow account must not cost its batch-mates their summary'
+        assert 'timeout' in fallbacks.reasons()
+
+
+def test_failing_hour_group_does_not_abort_the_remaining_groups() -> None:
+    with _loaded_job() as (notifications, notification_db, _redis, _fallbacks):
+        notifications._get_timezones_grouped_by_hour = lambda: {21: ['UTC'], 22: ['Etc/GMT+1']}
+        served: List[str] = []
+
+        def read_users(timezones: List[str], target_hour: int) -> List[Any]:
+            if target_hour == 21:
+                raise RuntimeError('firestore unavailable')
+            return _users(3, hour=22)
+
+        notification_db.get_users_for_daily_summary = read_users
+        notifications._send_summary_notification = lambda user: served.append(user[0])
+
+        assert asyncio.run(notifications.send_daily_summary_notification()) is None
+        assert served == ['uid-00', 'uid-01', 'uid-02'], 'hour 22 must still be served after hour 21 failed'
+
+
+# ------------------------------------------------------------------ job budget
+
+
+def test_job_budget_checkpoints_the_unfinished_tail() -> None:
+    with _loaded_job() as (notifications, _db, redis, fallbacks):
+        clock = FakeClock()
+        notifications.monotonic = clock
+        notifications.DAILY_SUMMARY_JOB_BUDGET_SECONDS = 100.0
+        served: List[str] = []
+
+        def worker(user: Tuple[Any, ...]) -> None:
+            served.append(user[0])
+            clock.advance(10.0)
+
+        notifications._send_summary_notification = worker
+        stats = notifications.DailySummaryJobStats()
+
+        finished = asyncio.run(
+            notifications._send_bulk_summary_notification(
+                _users(17),
+                deadline=clock() + notifications.DAILY_SUMMARY_JOB_BUDGET_SECONDS,
+                stats=stats,
+                target_hour=22,
+                cursor_key='cursor-key',
+            )
+        )
+
+        assert finished is False
+        assert stats.succeeded == 16 and stats.skipped_for_budget == 1
+        assert served[-1] == 'uid-15'
+        cursor = notifications.summary_budget.read_job_cursor('cursor-key')
+        assert cursor == {'hour': 22, 'uid': 'uid-16'}, 'the unfinished tail must be checkpointed'
+        assert 'timeout' in fallbacks.reasons()
+
+
+def test_next_execution_resumes_at_the_checkpointed_tail() -> None:
+    with _loaded_job() as (notifications, notification_db, redis, _fallbacks):
+        notifications._get_timezones_grouped_by_hour = lambda: {22: ['UTC']}
+        notification_db.get_users_for_daily_summary = lambda _tz, _hour: _users(9)
+        notifications.summary_budget.write_job_cursor(
+            notifications.summary_budget.job_cursor_key(datetime.now(timezone.utc)),
+            {'hour': 22, 'uid': 'uid-08'},
+        )
+        served: List[str] = []
+        notifications._send_summary_notification = lambda user: served.append(user[0])
+
+        asyncio.run(notifications.send_daily_summary_notification())
+
+        assert served[0] == 'uid-08', 'the run must start at the tail the previous run could not reach'
+        assert sorted(served) == [f'uid-{i:02d}' for i in range(9)], 'rotation still covers the head'
+        assert redis.store == {}, 'a complete pass clears the checkpoint'
+
+
+def test_job_end_summary_line_reports_the_counters() -> None:
+    with _loaded_job() as (notifications, _db, _redis, _fallbacks):
+        stats = notifications.DailySummaryJobStats(
+            groups_attempted=2, groups_failed=1, attempted=10, succeeded=8, failed=1, timed_out=1, skipped_for_budget=5
+        )
+        line = stats.as_log()
+        for fragment in ('attempted=10', 'succeeded=8', 'failed=1', 'timed_out=1', 'skipped_for_budget=5'):
+            assert fragment in line
+
+
+# ---------------------------------------------------------------- input bound
+
+
+class _Conversation:
+    def __init__(self, index: int, size: int) -> None:
+        self.index = index
+        self.size = size
+        self.started_at = datetime(2026, 8, 23, tzinfo=timezone.utc) + timedelta(hours=index)
+
+
+def _render(conversation: _Conversation) -> str:
+    return 'x' * conversation.size
+
+
+def test_truncation_bound_keeps_the_most_recent_conversations() -> None:
+    from utils.other import daily_summary_budget
+
+    conversations = [_Conversation(i, 100) for i in range(10)]
+    bounded = daily_summary_budget.select_conversations_within_budget(conversations, 350, render=_render)
+
+    assert bounded.truncated is True
+    assert bounded.dropped == 7
+    assert [c.index for c in bounded.conversations] == [7, 8, 9], 'most recent first, chronological order preserved'
+    assert bounded.rendered_chars <= 350
+
+
+def test_truncation_bound_is_a_no_op_under_the_cap() -> None:
+    from utils.other import daily_summary_budget
+
+    conversations = [_Conversation(i, 10) for i in range(5)]
+    bounded = daily_summary_budget.select_conversations_within_budget(conversations, 10_000, render=_render)
+
+    assert bounded.truncated is False
+    assert [c.index for c in bounded.conversations] == [0, 1, 2, 3, 4]
+
+
+def test_truncation_bound_always_keeps_one_conversation() -> None:
+    from utils.other import daily_summary_budget
+
+    conversations = [_Conversation(0, 1_000_000), _Conversation(1, 1_000_000)]
+    bounded = daily_summary_budget.select_conversations_within_budget(conversations, 100, render=_render)
+
+    assert len(bounded.conversations) == 1
+    assert bounded.conversations[0].index == 1, 'the single kept conversation is the most recent one'
+    assert bounded.dropped == 1
+
+
+def test_truncation_bound_tolerates_naive_and_missing_timestamps() -> None:
+    from utils.other import daily_summary_budget
+
+    naive = _Conversation(1, 10)
+    naive.started_at = datetime(2026, 8, 23, 5)
+    undated = _Conversation(2, 10)
+    undated.started_at = None
+    bounded = daily_summary_budget.select_conversations_within_budget([naive, undated], 10_000, render=_render)
+
+    assert len(bounded.conversations) == 2
+
+
+# ------------------------------------------------------------- cursor helpers
+
+
+def test_rotate_to_starts_at_the_checkpoint_and_wraps() -> None:
+    from utils.other import daily_summary_budget
+
+    assert daily_summary_budget.rotate_to([0, 1, 2, 3], 2) == [2, 3, 0, 1]
+    assert daily_summary_budget.rotate_to([0, 1, 2, 3], None) == [0, 1, 2, 3]
+    assert daily_summary_budget.rotate_to([0, 1, 2, 3], 9) == [0, 1, 2, 3], 'a stale cursor must not strand anyone'
+
+
+def test_cursor_helpers_are_fail_soft_when_redis_is_down() -> None:
+    with _loaded_job() as (notifications, _db, redis, _fallbacks):
+        budget = notifications.summary_budget
+        redis.fail = True
+
+        assert budget.read_job_cursor('k') is None
+        budget.write_job_cursor('k', {'hour': 1, 'uid': 'u'})
+        budget.clear_job_cursor('k')
+
+
+def test_job_survives_a_redis_outage_end_to_end() -> None:
+    with _loaded_job() as (notifications, notification_db, redis, _fallbacks):
+        redis.fail = True
+        notifications._get_timezones_grouped_by_hour = lambda: {22: ['UTC']}
+        notification_db.get_users_for_daily_summary = lambda _tz, _hour: _users(3)
+        served: List[str] = []
+        notifications._send_summary_notification = lambda user: served.append(user[0])
+
+        assert asyncio.run(notifications.send_daily_summary_notification()) is None
+        assert len(served) == 3, 'losing the checkpoint costs a re-walk, never a summary'
+
+
+# ------------------------------------------------- memory review card on the real send
+
+
+class _FakeConversation:
+    def __init__(self) -> None:
+        self.discarded = False
+        self.transcript_segments = ['segment']
+        self.started_at = datetime(2026, 8, 23, 9, tzinfo=timezone.utc)
+
+
+@contextmanager
+def _loaded_send_path(memories_learned: List[Dict[str, Any]]) -> Iterator[Tuple[ModuleType, List[Any]]]:
+    """Load the job with the real NotificationMessage so FCM serialization is exercised."""
+
+    async def no_async_work(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    sends: List[Any] = []
+    summary_data = {
+        'day_emoji': '📅',
+        'headline': 'A good day',
+        'overview': 'You shipped the thing.',
+        'memories_learned': memories_learned,
+    }
+    stubs = {
+        'database._client': AutoMockModule('database._client'),
+        'database.conversations': _module(
+            'database.conversations',
+            get_conversations=lambda *_a, **_k: [{'is_locked': False}],
+        ),
+        'database.notifications': _module(
+            'database.notifications',
+            get_users_for_daily_summary=lambda *_a, **_k: [],
+            get_users_token_in_timezones=lambda *_a, **_k: [],
+        ),
+        'database.redis_db': _module(
+            'database.redis_db', try_acquire_daily_summary_lock=lambda *_args: True, r=FakeRedis()
+        ),
+        'utils.conversations.factory': _module(
+            'utils.conversations.factory', deserialize_conversation=lambda _v: _FakeConversation()
+        ),
+        'utils.conversations.render': _module('utils.conversations.render', conversations_to_string=lambda _c: 'text'),
+        'utils.llm.external_integrations': _module(
+            'utils.llm.external_integrations',
+            generate_comprehensive_daily_summary=lambda *_args: summary_data,
+        ),
+        'utils.notifications': _module(
+            'utils.notifications',
+            send_bulk_notification=no_async_work,
+            send_notification=lambda *args, **kwargs: sends.append((args, kwargs)),
+        ),
+        'utils.observability.fallback': _module('utils.observability.fallback', record_fallback=RecordedFallbacks()),
+        'utils.webhooks': _module('utils.webhooks', day_summary_webhook=no_async_work),
+        'database.daily_summaries': _module(
+            'database.daily_summaries',
+            get_daily_summary_by_date=lambda *_args: None,
+            create_daily_summary=lambda *_args: 'summary-id',
+        ),
+    }
+    with stub_modules(stubs):
+        notifications = load_module_fresh(
+            'utils.other.notifications',
+            str(BACKEND_DIR / 'utils' / 'other' / 'notifications.py'),
+        )
+        yield notifications, sends
+
+
+_MEMORY = {'memory_id': 'mem-1', 'content': 'Ships on Tuesdays', 'category': 'work'}
+
+
+def test_scheduled_send_carries_the_memory_review_card() -> None:
+    import json
+
+    with _loaded_send_path([_MEMORY]) as (notifications, sends):
+        notifications._send_summary_notification(('uid-00', ['token-00']))
+
+        assert len(sends) == 1
+        args, _kwargs = sends[0]
+        payload = args[3]
+        blocks = json.loads(payload['content_blocks'])
+        assert blocks[0]['type'] == 'memoryReviewCard'
+        assert blocks[0]['summaryId'] == 'summary-id'
+        assert blocks[0]['items'] == [{'memoryId': 'mem-1', 'content': 'Ships on Tuesdays', 'category': 'work'}]
+        assert payload['text'] == 'You shipped the thing.'
+        assert args[2] == 'You shipped the thing.'
+
+
+def test_scheduled_send_omits_the_card_when_no_memories_were_learned() -> None:
+    with _loaded_send_path([]) as (notifications, sends):
+        notifications._send_summary_notification(('uid-00', ['token-00']))
+
+        assert len(sends) == 1
+        args, _kwargs = sends[0]
+        payload = args[3]
+        assert 'content_blocks' not in payload, 'no card is sent when the day produced nothing to review'
+        assert payload['text'] == 'You shipped the thing.', 'the message text is identical either way'
+        assert args[2] == 'You shipped the thing.'

--- a/backend/tests/unit/test_daily_summary_memories_learned.py
+++ b/backend/tests/unit/test_daily_summary_memories_learned.py
@@ -1,0 +1,332 @@
+"""The daily summary's "memories learned today" review contract.
+
+`knowledge_nuggets` is LLM prose with no memory identity, so a client cannot let
+the owner accept, reject, or correct what Omi stored. `memories_learned` carries
+real canonical memory ids selected deterministically — no model call — and the
+`day_summary` push carries a `memoryReviewCard` block only when the selection is
+non-empty, so older clients see exactly the message they saw before.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from models.daily_summary_payload import LearnedMemoryRef
+from models.memories import MemoryCategory, MemoryDB
+from models.notification_message import NotificationMessage
+from utils.memory.learned_today import (
+    MEMORIES_LEARNED_LIMIT,
+    memories_learned_for_summary,
+    memory_review_card_block,
+    select_memories_learned,
+)
+
+DAY_START = datetime(2026, 9, 1, 7, 0, tzinfo=timezone.utc)
+DAY_END = DAY_START + timedelta(hours=24)
+
+
+def _memory(memory_id: str, **overrides) -> MemoryDB:
+    payload = {
+        'id': memory_id,
+        'uid': 'u1',
+        'content': f'fact {memory_id}',
+        'category': MemoryCategory.interesting,
+        'created_at': DAY_START + timedelta(hours=1),
+        'updated_at': DAY_START + timedelta(hours=1),
+        'conversation_id': 'c1',
+        'capture_confidence': 0.5,
+    }
+    payload.update(overrides)
+    return MemoryDB(**payload)
+
+
+def _select(memories, **kwargs):
+    params = {
+        'conversation_ids': ['c1', 'c2'],
+        'window_start': DAY_START,
+        'window_end': DAY_END,
+    }
+    params.update(kwargs)
+    return select_memories_learned(memories, **params)
+
+
+# --- selection rules -------------------------------------------------------
+
+
+def test_rejected_memory_is_never_offered_again():
+    """A memory the owner already rejected must not come back on tomorrow's card."""
+    picked = _select([_memory('keep'), _memory('rejected', user_review=False)])
+    assert [ref.memory_id for ref in picked] == ['keep']
+
+
+def test_reviewed_true_memory_still_qualifies():
+    """Accepting a memory is not a reason to hide it; only rejection is."""
+    picked = _select([_memory('accepted', user_review=True)])
+    assert [ref.memory_id for ref in picked] == ['accepted']
+
+
+def test_locked_memory_is_excluded():
+    picked = _select([_memory('keep'), _memory('locked', is_locked=True)])
+    assert [ref.memory_id for ref in picked] == ['keep']
+
+
+def test_invalidated_memory_is_excluded():
+    picked = _select([_memory('keep'), _memory('stale', invalid_at=DAY_START + timedelta(hours=2))])
+    assert [ref.memory_id for ref in picked] == ['keep']
+
+
+def test_superseded_memory_is_excluded():
+    picked = _select([_memory('keep'), _memory('old', superseded_by='newer')])
+    assert [ref.memory_id for ref in picked] == ['keep']
+
+
+def test_empty_content_is_excluded():
+    picked = _select([_memory('keep'), _memory('blank', content='   ')])
+    assert [ref.memory_id for ref in picked] == ['keep']
+
+
+def test_selection_is_capped_at_three():
+    picked = _select([_memory(f'm{i}', capture_confidence=0.9) for i in range(10)])
+    assert len(picked) == MEMORIES_LEARNED_LIMIT == 3
+
+
+def test_ordering_prefers_confidence_then_veracity_then_newest():
+    memories = [
+        _memory('low', capture_confidence=0.1, created_at=DAY_START + timedelta(hours=9)),
+        _memory('high', capture_confidence=0.9, created_at=DAY_START + timedelta(hours=1)),
+        _memory('mid_old', capture_confidence=0.5, veracity=0.9, created_at=DAY_START + timedelta(hours=2)),
+        _memory('mid_new', capture_confidence=0.5, veracity=0.9, created_at=DAY_START + timedelta(hours=8)),
+    ]
+    assert [ref.memory_id for ref in _select(memories, limit=4)] == ['high', 'mid_new', 'mid_old', 'low']
+
+
+def test_memory_from_another_days_conversation_is_excluded():
+    picked = _select([_memory('today'), _memory('other', conversation_id='c-not-summarised')])
+    assert [ref.memory_id for ref in picked] == ['today']
+
+
+def test_memory_without_a_conversation_falls_back_to_the_local_day_window():
+    inside = _memory('manual', conversation_id=None, created_at=DAY_START + timedelta(hours=3))
+    outside = _memory('yesterday', conversation_id=None, created_at=DAY_START - timedelta(hours=3))
+    picked = _select([inside, outside])
+    assert [ref.memory_id for ref in picked] == ['manual']
+
+
+def test_window_fallback_is_inert_without_a_window():
+    picked = _select(
+        [_memory('manual', conversation_id=None)],
+        window_start=None,
+        window_end=None,
+    )
+    assert picked == []
+
+
+def test_naive_timestamps_are_treated_as_utc():
+    naive = _memory('naive', conversation_id=None, created_at=DAY_START.replace(tzinfo=None) + timedelta(hours=2))
+    picked = _select([naive])
+    assert [ref.memory_id for ref in picked] == ['naive']
+    assert picked[0].captured_at.tzinfo is not None
+
+
+def test_selected_ref_carries_identity_content_and_category():
+    picked = _select([_memory('m1', category=MemoryCategory.manual, content='  drinks oat milk  ')])
+    assert picked[0].memory_id == 'm1'
+    assert picked[0].content == 'drinks oat milk'
+    assert picked[0].category == 'manual'
+    assert picked[0].captured_at == DAY_START + timedelta(hours=1)
+
+
+def test_no_review_state_is_copied_into_the_summary():
+    """Review state is read live from the memory so a vote on one device shows on the other."""
+    assert set(LearnedMemoryRef.model_fields) == {'memory_id', 'content', 'category', 'captured_at'}
+
+
+# --- read boundary ---------------------------------------------------------
+
+
+def test_read_failure_degrades_to_no_card_not_no_summary():
+    def _boom(*args, **kwargs):
+        raise RuntimeError('canonical memory unavailable')
+
+    assert (
+        memories_learned_for_summary(
+            'u1',
+            conversation_ids=['c1'],
+            window_start=DAY_START,
+            window_end=DAY_END,
+            read_memories=_boom,
+        )
+        == []
+    )
+
+
+def test_read_uses_one_bounded_newest_first_page():
+    calls = []
+
+    def _reader(uid, *, limit, offset):
+        calls.append((uid, limit, offset))
+        return [_memory('m1')]
+
+    picked = memories_learned_for_summary(
+        'u1',
+        conversation_ids=['c1'],
+        window_start=DAY_START,
+        window_end=DAY_END,
+        read_memories=_reader,
+        scan_limit=50,
+    )
+    assert calls == [('u1', 50, 0)]
+    assert [ref.memory_id for ref in picked] == ['m1']
+
+
+# --- chat content block ----------------------------------------------------
+
+
+def test_no_block_when_nothing_was_learned():
+    assert memory_review_card_block('sum-1', date='2026-09-01', memories_learned=[]) is None
+
+
+def test_block_shape():
+    block = memory_review_card_block(
+        'sum-1',
+        date='2026-09-01',
+        memories_learned=[LearnedMemoryRef(memory_id='m1', content='drinks oat milk', category='interesting')],
+    )
+    assert block == {
+        'type': 'memoryReviewCard',
+        'id': 'sum-1:memories',
+        'summaryId': 'sum-1',
+        'date': '2026-09-01',
+        'items': [{'memoryId': 'm1', 'content': 'drinks oat milk', 'category': 'interesting'}],
+    }
+
+
+def test_block_accepts_the_stored_dict_projection():
+    stored = LearnedMemoryRef(memory_id='m1', content='c', category='manual').model_dump(mode='json')
+    block = memory_review_card_block('sum-1', date='2026-09-01', memories_learned=[stored])
+    assert block['items'] == [{'memoryId': 'm1', 'content': 'c', 'category': 'manual'}]
+
+
+def test_notification_payload_omits_content_blocks_when_absent():
+    message = NotificationMessage(
+        text='body', from_integration='false', type='day_summary', notification_type='daily_summary'
+    )
+    assert 'content_blocks' not in NotificationMessage.get_message_as_dict(message)
+
+
+def test_notification_payload_encodes_blocks_as_fcm_safe_text():
+    """FCM data is Dict[str, str]; a nested list fails the whole batch send."""
+    block = memory_review_card_block(
+        'sum-1', date='2026-09-01', memories_learned=[LearnedMemoryRef(memory_id='m1', content='c')]
+    )
+    message = NotificationMessage(
+        text='body',
+        from_integration='false',
+        type='day_summary',
+        notification_type='daily_summary',
+        content_blocks=[block],
+    )
+    payload = NotificationMessage.get_message_as_dict(message)
+    assert all(isinstance(value, str) for value in payload.values())
+    import json
+
+    assert json.loads(payload['content_blocks'])[0]['type'] == 'memoryReviewCard'
+
+
+# --- response model round-trip --------------------------------------------
+
+
+def test_response_model_round_trips_memories_learned():
+    from routers.users import DailySummaryResponse
+
+    stored = {
+        'id': 'sum-1',
+        'date': '2026-09-01',
+        'knowledge_nuggets': [{'insight': 'prose', 'conversation_id': 'c1'}],
+        'memories_learned': [
+            {
+                'memory_id': 'm1',
+                'content': 'drinks oat milk',
+                'category': 'interesting',
+                'captured_at': '2026-09-01T08:00:00+00:00',
+            }
+        ],
+    }
+    response = DailySummaryResponse.model_validate(stored)
+    assert response.memories_learned[0].memory_id == 'm1'
+    assert response.memories_learned[0].captured_at == datetime(2026, 9, 1, 8, 0, tzinfo=timezone.utc)
+    dumped = response.model_dump(mode='json')
+    assert dumped['memories_learned'][0]['memory_id'] == 'm1'
+    # knowledge_nuggets stays untouched for older clients.
+    assert dumped['knowledge_nuggets'][0]['insight'] == 'prose'
+
+
+def test_response_model_defaults_to_empty_for_older_summaries():
+    from routers.users import DailySummaryResponse
+
+    assert DailySummaryResponse.model_validate({'id': 'old', 'date': '2026-01-01'}).memories_learned == []
+
+
+# --- day_summary message ---------------------------------------------------
+
+
+def _drive_day_summary_endpoint(monkeypatch, memories_learned):
+    """Run the real /v1/users/daily-summary-settings/test path and capture the push data."""
+    from routers import users as users_router
+
+    sent = {}
+    monkeypatch.setattr(users_router, 'enforce_chat_quota', lambda *a, **k: None)
+    monkeypatch.setattr(users_router.notification_db, 'get_user_time_zone', lambda uid: 'UTC')
+    monkeypatch.setattr(users_router.notification_db, 'get_all_tokens', lambda uid: ['tok1'])
+    monkeypatch.setattr(
+        users_router.conversations_db, 'get_conversations', lambda *a, **k: [{'id': 'c1', 'is_locked': False}]
+    )
+    monkeypatch.setattr(users_router, 'deserialize_conversations', lambda data: [object()])
+    monkeypatch.setattr(
+        users_router,
+        'generate_comprehensive_daily_summary',
+        lambda *a, **k: {
+            'id': 'sum-1',
+            'headline': 'H',
+            'day_emoji': 'X',
+            'overview': 'You had 1 conversation today.',
+            'memories_learned': memories_learned,
+        },
+    )
+    monkeypatch.setattr(users_router.daily_summaries_db, 'create_daily_summary', lambda uid, data: 'sum-1')
+    monkeypatch.setattr(
+        users_router, 'send_notification', lambda uid, title, body, data, tokens=None: sent.update(data=data, body=body)
+    )
+
+    users_router.test_daily_summary(
+        request=users_router.TestDailySummaryRequest(date='2026-09-01'),
+        uid='u1',
+        x_app_platform=None,
+    )
+    return sent
+
+
+def test_day_summary_push_carries_the_block_when_memories_were_learned(monkeypatch):
+    import json
+
+    sent = _drive_day_summary_endpoint(
+        monkeypatch,
+        [{'memory_id': 'm1', 'content': 'drinks oat milk', 'category': 'interesting', 'captured_at': None}],
+    )
+    blocks = json.loads(sent['data']['content_blocks'])
+    assert blocks == [
+        {
+            'type': 'memoryReviewCard',
+            'id': 'sum-1:memories',
+            'summaryId': 'sum-1',
+            'date': '2026-09-01',
+            'items': [{'memoryId': 'm1', 'content': 'drinks oat milk', 'category': 'interesting'}],
+        }
+    ]
+    # Older clients read `text`; it must be exactly what it was before the block existed.
+    assert sent['data']['text'] == 'You had 1 conversation today.'
+    assert sent['body'] == 'You had 1 conversation today.'
+
+
+def test_day_summary_push_omits_the_block_when_nothing_was_learned(monkeypatch):
+    sent = _drive_day_summary_endpoint(monkeypatch, [])
+    assert 'content_blocks' not in sent['data']
+    assert sent['data']['text'] == 'You had 1 conversation today.'

--- a/backend/tests/unit/test_daily_summary_memories_learned.py
+++ b/backend/tests/unit/test_daily_summary_memories_learned.py
@@ -12,6 +12,8 @@ from datetime import datetime, timedelta, timezone
 from models.daily_summary_payload import LearnedMemoryRef
 from models.memories import MemoryCategory, MemoryDB
 from models.notification_message import NotificationMessage
+from routers.users import DailySummaryResponse
+from routers import users as users_router
 from utils.memory.learned_today import (
     MEMORIES_LEARNED_LIMIT,
     memories_learned_for_summary,
@@ -235,8 +237,6 @@ def test_notification_payload_encodes_blocks_as_fcm_safe_text():
 
 
 def test_response_model_round_trips_memories_learned():
-    from routers.users import DailySummaryResponse
-
     stored = {
         'id': 'sum-1',
         'date': '2026-09-01',
@@ -260,8 +260,6 @@ def test_response_model_round_trips_memories_learned():
 
 
 def test_response_model_defaults_to_empty_for_older_summaries():
-    from routers.users import DailySummaryResponse
-
     assert DailySummaryResponse.model_validate({'id': 'old', 'date': '2026-01-01'}).memories_learned == []
 
 
@@ -270,9 +268,8 @@ def test_response_model_defaults_to_empty_for_older_summaries():
 
 def _drive_day_summary_endpoint(monkeypatch, memories_learned):
     """Run the real /v1/users/daily-summary-settings/test path and capture the push data."""
-    from routers import users as users_router
-
     sent = {}
+    seen = {}
     monkeypatch.setattr(users_router, 'enforce_chat_quota', lambda *a, **k: None)
     monkeypatch.setattr(users_router.notification_db, 'get_user_time_zone', lambda uid: 'UTC')
     monkeypatch.setattr(users_router.notification_db, 'get_all_tokens', lambda uid: ['tok1'])
@@ -280,17 +277,22 @@ def _drive_day_summary_endpoint(monkeypatch, memories_learned):
         users_router.conversations_db, 'get_conversations', lambda *a, **k: [{'id': 'c1', 'is_locked': False}]
     )
     monkeypatch.setattr(users_router, 'deserialize_conversations', lambda data: [object()])
-    monkeypatch.setattr(
-        users_router,
-        'generate_comprehensive_daily_summary',
-        lambda *a, **k: {
+    # The endpoint owns the memory read and hands it to the generator; stub the
+    # read at that seam and let the fake generator echo it back, so the test
+    # covers the real read -> generate -> store -> block wiring.
+    monkeypatch.setattr(users_router, '_memories_learned_payload', lambda *a, **k: memories_learned)
+
+    def _fake_generate(*args, **kwargs):
+        seen['memories_learned'] = kwargs.get('memories_learned')
+        return {
             'id': 'sum-1',
             'headline': 'H',
             'day_emoji': 'X',
             'overview': 'You had 1 conversation today.',
-            'memories_learned': memories_learned,
-        },
-    )
+            'memories_learned': kwargs.get('memories_learned') or [],
+        }
+
+    monkeypatch.setattr(users_router, 'generate_comprehensive_daily_summary', _fake_generate)
     monkeypatch.setattr(users_router.daily_summaries_db, 'create_daily_summary', lambda uid, data: 'sum-1')
     monkeypatch.setattr(
         users_router, 'send_notification', lambda uid, title, body, data, tokens=None: sent.update(data=data, body=body)
@@ -301,6 +303,7 @@ def _drive_day_summary_endpoint(monkeypatch, memories_learned):
         uid='u1',
         x_app_platform=None,
     )
+    sent['generator_kwarg'] = seen.get('memories_learned')
     return sent
 
 
@@ -330,3 +333,56 @@ def test_day_summary_push_omits_the_block_when_nothing_was_learned(monkeypatch):
     sent = _drive_day_summary_endpoint(monkeypatch, [])
     assert 'content_blocks' not in sent['data']
     assert sent['data']['text'] == 'You had 1 conversation today.'
+
+
+def test_generator_receives_the_selection_from_the_endpoint(monkeypatch):
+    """The endpoint owns the read; the generator must not reach into memory itself."""
+    refs = [{'memory_id': 'm1', 'content': 'c', 'category': 'interesting', 'captured_at': None}]
+    sent = _drive_day_summary_endpoint(monkeypatch, refs)
+    assert sent['generator_kwarg'] == refs
+
+
+def test_generate_comprehensive_daily_summary_does_not_read_memories_itself():
+    """Regression: an in-generator memory read put a Firestore call behind every
+    caller and every existing test of the daily summary, and cost 0.77s CPU in
+    tests/unit/test_daily_summary_zero_coordinate_locations.py. The selection is
+    a parameter, so the LLM summary builder stays free of the memory stack."""
+    import inspect
+
+    from utils.llm import external_integrations
+
+    source = inspect.getsource(external_integrations)
+    assert 'memories_learned_for_summary' not in source
+    assert 'memory_service' not in source
+    signature = inspect.signature(external_integrations.generate_comprehensive_daily_summary)
+    assert signature.parameters['memories_learned'].default is None
+
+
+def test_generator_defaults_to_no_card_without_a_selection():
+    from utils.llm.external_integrations import _basic_daily_summary
+
+    assert _basic_daily_summary('2026-09-01', 0, 0.0, [], [])['memories_learned'] == []
+    assert _basic_daily_summary('2026-09-01', 0, 0.0, [], [], [{'memory_id': 'm1'}])['memories_learned'] == [
+        {'memory_id': 'm1'}
+    ]
+
+
+def test_read_failure_reports_a_fallback_rather_than_swallowing_it(monkeypatch):
+    """A missing card is a correctness change; silent ops is not allowed."""
+    import utils.memory.learned_today as learned_today
+
+    recorded = []
+    monkeypatch.setattr(learned_today, 'record_fallback', lambda **kwargs: recorded.append(kwargs))
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError('canonical memory unavailable')
+
+    assert (
+        learned_today.memories_learned_for_summary(
+            'u1', conversation_ids=['c1'], window_start=DAY_START, window_end=DAY_END, read_memories=_boom
+        )
+        == []
+    )
+    assert len(recorded) == 1
+    assert recorded[0]['component'] == 'daily_summary'
+    assert recorded[0]['outcome'] == 'degraded'

--- a/backend/tests/unit/test_other_notifications_async_boundaries.py
+++ b/backend/tests/unit/test_other_notifications_async_boundaries.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, Iterator
 
-from testing.import_isolation import load_module_fresh, stub_modules
+from testing.import_isolation import AutoMockModule, load_module_fresh, stub_modules
 
 BACKEND_DIR = Path(__file__).resolve().parents[2]
 
@@ -39,6 +39,9 @@ def _loaded_other_notifications() -> Iterator[tuple[ModuleType, ModuleType]]:
         },
     )
     stubs = {
+        # utils.memory.learned_today -> models.memories -> database._client pulls
+        # the Firestore SDK into the import graph; the job never touches it here.
+        'database._client': AutoMockModule('database._client'),
         'database.conversations': _module('database.conversations', get_conversations=lambda *_args, **_kwargs: []),
         'database.notifications': notification_db,
         'database.redis_db': _module('database.redis_db', try_acquire_daily_summary_lock=lambda *_args: True),

--- a/backend/tests/unit/test_storage_fanout_limits.py
+++ b/backend/tests/unit/test_storage_fanout_limits.py
@@ -8,6 +8,7 @@ Behavioral tests use a standalone sliding-window implementation to verify the pa
 """
 
 import os
+import re
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, wait, FIRST_COMPLETED
@@ -234,22 +235,34 @@ class TestSpeakerIdentificationPool:
         assert 'sync_executor' in context
 
 
+def _bulk_summary_function_body() -> str:
+    """The whole `_send_bulk_summary_notification` body, up to the next top-level def.
+
+    The guard used to slice the first 400 characters after the signature; the
+    #12530 fix gave the function keyword-only parameters and a docstring, which
+    pushed the executor and batch references past that window without changing
+    what the function does. Asserting over the full body keeps the contract
+    (postprocess executor, batched fan-out) independent of signature length.
+    """
+    src = _read_source('utils/other/notifications.py')
+    func_start = src.index('async def _send_bulk_summary_notification')
+    next_def = re.search(r'^(?:async )?def ', src[func_start + 1 :], re.MULTILINE)
+    func_end = func_start + 1 + next_def.start() if next_def else len(src)
+    return src[func_start:func_end]
+
+
 class TestNotificationsFanOut:
     """notifications.py must not use storage_executor for summary work."""
 
     def test_bulk_summary_uses_postprocess_executor(self):
         """_send_bulk_summary_notification must use postprocess_executor, not storage_executor."""
-        src = _read_source('utils/other/notifications.py')
-        func_start = src.index('async def _send_bulk_summary_notification')
-        func_body = src[func_start : func_start + 400]
+        func_body = _bulk_summary_function_body()
         assert 'postprocess_executor' in func_body
         assert 'storage_executor' not in func_body
 
     def test_bulk_summary_is_batched(self):
         """_send_bulk_summary_notification must process users in batches."""
-        src = _read_source('utils/other/notifications.py')
-        func_start = src.index('async def _send_bulk_summary_notification')
-        func_body = src[func_start : func_start + 400]
+        func_body = _bulk_summary_function_body()
         assert '_BATCH_SIZE' in func_body
 
 

--- a/backend/utils/chat_followup.py
+++ b/backend/utils/chat_followup.py
@@ -1,0 +1,216 @@
+"""Grounded closing question for a typed chat answer.
+
+The on-device realtime voice lane already ends about two thirds of its answers
+with a grounded question, and those sessions run roughly four turns. The typed
+lanes end with a question 4-9% of the time, and recall answers ("what did X
+say", "when did we...") never do, even though most of them have an obvious next
+hop into the same source. This module is the typed lane's half of closing that
+gap: the model appends one question after a delimiter on its own final line,
+and the backend lifts it off the visible text into a structured
+``followUp`` content block the clients render as one tappable chip.
+
+The delimiter, not a heuristic, is what makes the tail separable. Guessing which
+trailing sentence of a free-form answer was "the follow-up" would mis-fire on
+answers that legitimately end in a question, and would leave the chip and the
+prose saying the same thing twice.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+# Chosen so it cannot occur in prose, Markdown, or code the model might quote.
+FOLLOWUP_DELIMITER = '<<<FOLLOWUP>>>'
+FOLLOWUP_BLOCK_TYPE = 'followUp'
+
+# A chip has to read in one glance. The prompt asks for under ~15 words; these
+# are the outer bounds a malformed generation cannot cross.
+MAX_FOLLOWUP_WORDS = 18
+MAX_FOLLOWUP_CHARS = 160
+
+# A generic tail is worse than no tail: it teaches the user the chip is filler.
+# Matched against the lowercased, punctuation-stripped question.
+_GENERIC_PATTERNS = [
+    re.compile(pattern)
+    for pattern in (
+        r'^anything else\b',
+        r'^is there anything else\b',
+        r'^(do you )?want (more|any more|additional|further) (detail|details|info|information|context)\b',
+        r'^want me to (go on|continue|keep going|elaborate|explain more)\b',
+        r'^(would you like|do you want) (me )?to (know more|hear more|continue|elaborate)\b',
+        r'^(does|did) that (help|make sense|answer)\b',
+        r'^(any|got any) (other )?questions\b',
+        r'^let me know\b',
+        r'^(can|could) i help\b',
+        r'^(sound|sounds) good\b',
+        r'^shall i (continue|go on)\b',
+        r'^(need|want) anything else\b',
+        r'^how can i help\b',
+        r'^what else\??$',
+    )
+]
+
+_WHITESPACE = re.compile(r'\s+')
+
+
+def _normalize_question(question: str) -> str:
+    collapsed = _WHITESPACE.sub(' ', question).strip()
+    return collapsed
+
+
+def _is_generic(question: str) -> bool:
+    probe = _normalize_question(question).lower().rstrip('?!. ')
+    if not probe:
+        return True
+    return any(pattern.search(probe) for pattern in _GENERIC_PATTERNS)
+
+
+def split_followup_tail(text: Optional[str]) -> Tuple[str, Optional[str]]:
+    """Split a raw model answer into its visible text and its follow-up question.
+
+    Returns ``(visible_text, question)``. ``question`` is ``None`` when the model
+    emitted no tail, or emitted one that cannot be shown as a chip (empty, not a
+    question, multi-sentence, over-long, or generic). The delimiter and anything
+    after it are removed from ``visible_text`` either way — a half-formed tail
+    must never leak into the transcript.
+    """
+    if not text:
+        return '', None
+    index = text.find(FOLLOWUP_DELIMITER)
+    if index < 0:
+        return text, None
+    visible = text[:index].rstrip()
+    raw_tail = text[index + len(FOLLOWUP_DELIMITER) :]
+    # Only the first line of the tail is the question; a model that keeps
+    # writing after it has already left the contract.
+    question = _normalize_question(raw_tail.split('\n', 1)[0])
+    if not question:
+        return visible, None
+    if not question.endswith('?'):
+        return visible, None
+    if len(question) > MAX_FOLLOWUP_CHARS or len(question.split()) > MAX_FOLLOWUP_WORDS:
+        return visible, None
+    if _is_generic(question):
+        return visible, None
+    return visible, question
+
+
+def _answer_is_itself_a_question(visible_text: str) -> bool:
+    """True when the answer already ends by asking the user something.
+
+    A clarifying answer plus a chip asks two questions at once, and the chip is
+    the one the user did not need.
+    """
+    for line in reversed(visible_text.strip().splitlines()):
+        stripped = line.strip()
+        if stripped:
+            return stripped.endswith('?')
+    return False
+
+
+def build_followup_block(message_id: str, question: str) -> Dict[str, Any]:
+    """The wire shape both shells render as one tappable chip."""
+    return {
+        'type': FOLLOWUP_BLOCK_TYPE,
+        'id': f'{message_id}:followup',
+        'text': question,
+    }
+
+
+def followup_content_blocks(
+    message_id: str,
+    question: Optional[str],
+    *,
+    visible_text: str,
+    failed: bool,
+) -> List[Dict[str, Any]]:
+    """The ``content_blocks`` a finished assistant turn should carry.
+
+    Empty for every turn that must not invite a next question: a failed,
+    errored, or timed-out turn, an empty answer, or an answer that is itself a
+    clarifying question.
+    """
+    if failed or not question:
+        return []
+    if not visible_text or not visible_text.strip():
+        return []
+    if _answer_is_itself_a_question(visible_text):
+        return []
+    return [build_followup_block(message_id, question)]
+
+
+class FollowUpTailStreamFilter:
+    """Withhold the follow-up tail from the token stream the user watches.
+
+    The tail is model output like any other token, so it would otherwise stream
+    into the visible answer and then be removed when the terminal frame lands —
+    the chip's text flashing in the prose first. This filter buffers only the
+    trailing characters that could still turn out to be the delimiter, so normal
+    text is emitted with no added latency.
+    """
+
+    def __init__(self, delimiter: str = FOLLOWUP_DELIMITER) -> None:
+        self._delimiter = delimiter
+        self._pending = ''
+        self._suppressing = False
+
+    @property
+    def suppressing(self) -> bool:
+        """Whether the delimiter has been seen and the rest is being swallowed."""
+        return self._suppressing
+
+    def push(self, chunk: str) -> str:
+        """Feed one streamed chunk; return the part safe to show now."""
+        if self._suppressing:
+            return ''
+        buffer = self._pending + chunk
+        index = buffer.find(self._delimiter)
+        if index >= 0:
+            self._suppressing = True
+            self._pending = ''
+            return buffer[:index]
+        hold = self._partial_delimiter_suffix_length(buffer)
+        if hold:
+            self._pending = buffer[len(buffer) - hold :]
+            return buffer[: len(buffer) - hold]
+        self._pending = ''
+        return buffer
+
+    def flush(self) -> str:
+        """Release anything still held once the stream ends without a tail."""
+        if self._suppressing:
+            self._pending = ''
+            return ''
+        remaining = self._pending
+        self._pending = ''
+        return remaining
+
+    def _partial_delimiter_suffix_length(self, buffer: str) -> int:
+        for length in range(min(len(buffer), len(self._delimiter) - 1), 0, -1):
+            if self._delimiter.startswith(buffer[len(buffer) - length :]):
+                return length
+        return 0
+
+
+FOLLOWUP_PROMPT_SECTION = f"""
+<closing_question>
+End a grounded answer with exactly one follow-up question, on its own final line, after the marker {FOLLOWUP_DELIMITER}.
+
+Format (the marker and question are the last thing you write):
+{FOLLOWUP_DELIMITER} <one question>
+
+Rules for that question:
+- Specific to what you just said or to the conversations/memories you cited. Never generic — never "anything else?", "want more detail?", "does that help?".
+- Answerable by you from data you can reach (their recall, people, tasks, screen activity). Never a question only they could answer from outside Omi.
+- Under 15 words, one sentence, ends with a question mark.
+- For a recall answer, go one hop further into the same source: who else was there, what was decided next, when it is due, what happened after.
+
+Write NO marker and NO question when:
+- The turn failed, errored, timed out, or you are refusing or saying you cannot do something.
+- You could not verify or find what was asked ("I don't have anything about that").
+- The question was general knowledge rather than about this user.
+- Your answer is itself a clarifying question back to the user.
+
+The marker line is stripped from the visible answer and shown as a tappable chip, so never repeat the question in the answer text itself.
+</closing_question>"""

--- a/backend/utils/llm/external_integrations.py
+++ b/backend/utils/llm/external_integrations.py
@@ -17,7 +17,6 @@ from utils.conversations.render import conversations_to_string
 from utils.llm.clients import get_llm, parser
 from utils.llm.usage_tracker import track_usage, Features
 from utils.llms.memory import get_prompt_memories
-from utils.memory.learned_today import memories_learned_for_summary
 from utils.log_sanitizer import sanitize, sanitize_validation_error
 import logging
 
@@ -197,12 +196,19 @@ def generate_comprehensive_daily_summary(
     date_str: str,
     start_date_utc: Optional[datetime] = None,
     end_date_utc: Optional[datetime] = None,
+    memories_learned: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """
     Generate a comprehensive daily summary with structured data for storage.
 
+    ``memories_learned`` is the already-selected review contract from
+    ``utils.memory.learned_today``. It is passed in rather than read here: this
+    module is the LLM summary builder, and making it reach into the memory stack
+    would put a Firestore read behind every caller and every test of it.
+
     Returns a dictionary matching the DailySummary model structure.
     """
+    learned_refs: List[Dict[str, Any]] = list(memories_learned or [])
     # Get user's timezone
     user_profile = users_db.get_user_profile(uid)
     user_tz_str = user_profile.get('time_zone', 'UTC')
@@ -275,20 +281,6 @@ def generate_comprehensive_daily_summary(
 
     # Build conversation ID mapping for the LLM
     convo_id_map = {i + 1: c.id for i, c in enumerate(non_discarded)}
-
-    # Deterministic "memories learned today" review contract. No model call:
-    # this is a bounded read of the canonical memory page filtered to the same
-    # conversation set the summary is being built from. It is computed before
-    # the LLM call so the fallback summary carries the same card.
-    memories_learned: List[Dict[str, Any]] = [
-        ref.model_dump(mode="json")
-        for ref in memories_learned_for_summary(
-            uid,
-            conversation_ids=[c.id for c in non_discarded],
-            window_start=start_date_utc,
-            window_end=end_date_utc,
-        )
-    ]
 
     prompt = f"""You are creating a daily summary for {user_name}. {memories_str}
 OUTPUT LANGUAGE: {output_language}. You MUST write every word of this summary in {output_language}, regardless of the language the conversations are in.
@@ -420,16 +412,16 @@ Respond with ONLY valid JSON. Do not include any other text or comments."""
             "unresolved_questions": unresolved_questions,
             "decisions_made": decisions_made,
             "knowledge_nuggets": knowledge_nuggets,
-            "memories_learned": memories_learned,
+            "memories_learned": learned_refs,
             "locations": locations,
         }
     except json.JSONDecodeError as e:
         logger.error("Failed to decode daily summary payload JSON: %s", sanitize(str(e)))
         return _basic_daily_summary(
-            date_str, total_conversations, total_duration_minutes, actual_action_items, locations, memories_learned
+            date_str, total_conversations, total_duration_minutes, actual_action_items, locations, learned_refs
         )
     except ValidationError as e:
         logger.error("Failed to validate daily summary payload: %s", sanitize_validation_error(cast(Any, e)))
         return _basic_daily_summary(
-            date_str, total_conversations, total_duration_minutes, actual_action_items, locations, memories_learned
+            date_str, total_conversations, total_duration_minutes, actual_action_items, locations, learned_refs
         )

--- a/backend/utils/llm/external_integrations.py
+++ b/backend/utils/llm/external_integrations.py
@@ -17,6 +17,7 @@ from utils.conversations.render import conversations_to_string
 from utils.llm.clients import get_llm, parser
 from utils.llm.usage_tracker import track_usage, Features
 from utils.llms.memory import get_prompt_memories
+from utils.memory.learned_today import memories_learned_for_summary
 from utils.log_sanitizer import sanitize, sanitize_validation_error
 import logging
 
@@ -40,6 +41,7 @@ def _basic_daily_summary(
     total_duration_minutes: float,
     actual_action_items: List[Dict[str, Any]],
     locations: List[Dict[str, Any]],
+    memories_learned: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     return {
         "id": str(uuid.uuid4()),
@@ -58,6 +60,7 @@ def _basic_daily_summary(
         "unresolved_questions": [],
         "decisions_made": [],
         "knowledge_nuggets": [],
+        "memories_learned": list(memories_learned or []),
         "locations": locations,
     }
 
@@ -273,6 +276,20 @@ def generate_comprehensive_daily_summary(
     # Build conversation ID mapping for the LLM
     convo_id_map = {i + 1: c.id for i, c in enumerate(non_discarded)}
 
+    # Deterministic "memories learned today" review contract. No model call:
+    # this is a bounded read of the canonical memory page filtered to the same
+    # conversation set the summary is being built from. It is computed before
+    # the LLM call so the fallback summary carries the same card.
+    memories_learned: List[Dict[str, Any]] = [
+        ref.model_dump(mode="json")
+        for ref in memories_learned_for_summary(
+            uid,
+            conversation_ids=[c.id for c in non_discarded],
+            window_start=start_date_utc,
+            window_end=end_date_utc,
+        )
+    ]
+
     prompt = f"""You are creating a daily summary for {user_name}. {memories_str}
 OUTPUT LANGUAGE: {output_language}. You MUST write every word of this summary in {output_language}, regardless of the language the conversations are in.
 
@@ -403,15 +420,16 @@ Respond with ONLY valid JSON. Do not include any other text or comments."""
             "unresolved_questions": unresolved_questions,
             "decisions_made": decisions_made,
             "knowledge_nuggets": knowledge_nuggets,
+            "memories_learned": memories_learned,
             "locations": locations,
         }
     except json.JSONDecodeError as e:
         logger.error("Failed to decode daily summary payload JSON: %s", sanitize(str(e)))
         return _basic_daily_summary(
-            date_str, total_conversations, total_duration_minutes, actual_action_items, locations
+            date_str, total_conversations, total_duration_minutes, actual_action_items, locations, memories_learned
         )
     except ValidationError as e:
         logger.error("Failed to validate daily summary payload: %s", sanitize_validation_error(cast(Any, e)))
         return _basic_daily_summary(
-            date_str, total_conversations, total_duration_minutes, actual_action_items, locations
+            date_str, total_conversations, total_duration_minutes, actual_action_items, locations, memories_learned
         )

--- a/backend/utils/memory/learned_today.py
+++ b/backend/utils/memory/learned_today.py
@@ -16,10 +16,16 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import Any, Callable, Iterable, List, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Optional, Sequence
 
 from models.daily_summary_payload import LearnedMemoryRef
-from models.memories import MemoryDB
+from utils.observability.fallback import record_fallback
+
+if TYPE_CHECKING:  # `models.memories` drags in database._client and the Firestore
+    # protos; this module is only annotating with MemoryDB, and callers that import
+    # it (the users router, the scheduled summary job) must not pay a Firestore
+    # import — or, under a stubbed sys.modules test, a duplicate proto registration.
+    from models.memories import MemoryDB
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +38,7 @@ MEMORIES_LEARNED_LIMIT = 3
 # page is enough to cover a single day for any realistic capture rate.
 MEMORIES_LEARNED_SCAN_LIMIT = 200
 
-MemoryReader = Callable[..., List[MemoryDB]]
+MemoryReader = Callable[..., List["MemoryDB"]]
 
 
 def _aware(value: Optional[datetime]) -> Optional[datetime]:
@@ -43,7 +49,7 @@ def _aware(value: Optional[datetime]) -> Optional[datetime]:
     return value
 
 
-def _is_eligible(memory: MemoryDB) -> bool:
+def _is_eligible(memory: "MemoryDB") -> bool:
     """Exclude every state the review card must never show.
 
     `MemoryService.read` already drops tombstoned, superseded, hidden, archived
@@ -66,7 +72,7 @@ def _is_eligible(memory: MemoryDB) -> bool:
 
 
 def _from_day(
-    memory: MemoryDB, *, conversation_ids: frozenset[str], start: Optional[datetime], end: Optional[datetime]
+    memory: "MemoryDB", *, conversation_ids: frozenset[str], start: Optional[datetime], end: Optional[datetime]
 ) -> bool:
     """Attribute a memory to the day the summary was built from.
 
@@ -89,7 +95,7 @@ def _from_day(
     return window_start <= created_at <= window_end
 
 
-def _rank(memory: MemoryDB) -> tuple[float, float, float, str]:
+def _rank(memory: "MemoryDB") -> tuple[float, float, float, str]:
     """Highest capture_confidence, then veracity, then newest, then stable id."""
     created_at = _aware(memory.created_at)
     created_ts = created_at.timestamp() if created_at else float('-inf')
@@ -102,7 +108,7 @@ def _rank(memory: MemoryDB) -> tuple[float, float, float, str]:
 
 
 def select_memories_learned(
-    memories: Iterable[MemoryDB],
+    memories: Iterable["MemoryDB"],
     *,
     conversation_ids: Sequence[str],
     window_start: Optional[datetime] = None,
@@ -149,8 +155,18 @@ def memories_learned_for_summary(
 
         reader = MemoryService().read
     try:
-        page: List[MemoryDB] = reader(uid, limit=scan_limit, offset=0)
+        page: List["MemoryDB"] = reader(uid, limit=scan_limit, offset=0)
     except Exception as error:  # noqa: BLE001 - the summary must still ship
+        # Fail-open: the day still gets a summary, just no review card. That is a
+        # correctness change, so it is reported rather than swallowed silently.
+        record_fallback(
+            component='daily_summary',
+            from_mode='memories_learned',
+            to_mode='none',
+            reason='malformed_doc' if isinstance(error, (TypeError, ValueError)) else 'other',
+            outcome='degraded',
+            log=logger,
+        )
         logger.warning('memories_learned read failed for daily summary: %s', type(error).__name__)
         return []
     return select_memories_learned(

--- a/backend/utils/memory/learned_today.py
+++ b/backend/utils/memory/learned_today.py
@@ -1,0 +1,197 @@
+"""Deterministic "memories learned today" selection for the daily summary.
+
+The daily summary already carries `knowledge_nuggets`, which are LLM prose with
+no memory identity: a client cannot vote on them, correct them, or show what
+Omi actually stored. This module picks the real memories the day produced so a
+shell can render a native review card.
+
+The selection is a pure filter/sort over the canonical read path
+(`MemoryService.read`) — no model call, no new query surface, and no second
+memory authority. Review state is deliberately **not** captured here: clients
+read `user_review`/`edited` live from the memory so a vote on one device shows
+on the other.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterable, List, Optional, Sequence
+
+from models.daily_summary_payload import LearnedMemoryRef
+from models.memories import MemoryDB
+
+logger = logging.getLogger(__name__)
+
+# Cap on rendered review items. Three is the product cap for the card; the card
+# is a glance, not a queue.
+MEMORIES_LEARNED_LIMIT = 3
+
+# Newest-first read depth. `MemoryService.read` returns the merged canonical +
+# historical page ordered by updated_at/created_at descending, so one bounded
+# page is enough to cover a single day for any realistic capture rate.
+MEMORIES_LEARNED_SCAN_LIMIT = 200
+
+MemoryReader = Callable[..., List[MemoryDB]]
+
+
+def _aware(value: Optional[datetime]) -> Optional[datetime]:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
+
+
+def _is_eligible(memory: MemoryDB) -> bool:
+    """Exclude every state the review card must never show.
+
+    `MemoryService.read` already drops tombstoned, superseded, hidden, archived
+    and restricted rows by service policy. These checks are the product-level
+    exclusions on top of that, and they also hold for a caller that injects a
+    narrower reader.
+    """
+    if memory.user_review is False:
+        # The owner already rejected this fact; re-asking is the bug.
+        return False
+    if memory.is_locked:
+        return False
+    if memory.invalid_at is not None:
+        return False
+    if memory.superseded_by:
+        return False
+    if not (memory.content or '').strip():
+        return False
+    return True
+
+
+def _from_day(
+    memory: MemoryDB, *, conversation_ids: frozenset[str], start: Optional[datetime], end: Optional[datetime]
+) -> bool:
+    """Attribute a memory to the day the summary was built from.
+
+    Primary rule: the memory points at one of the conversations the summary was
+    generated from. Fallback (a memory with no conversation evidence, e.g. a
+    manual capture): its `created_at` falls inside the summary's local-day
+    window. A memory that points at a conversation *outside* the summarised set
+    is deliberately excluded — it belongs to another day's card.
+    """
+    # `MemoryDB.memory_id` is a deprecated alias that always mirrors `id`, so
+    # `conversation_id` is the only conversation evidence on this model.
+    conversation_id = memory.conversation_id
+    if conversation_id:
+        return conversation_id in conversation_ids
+    window_start = _aware(start)
+    window_end = _aware(end)
+    created_at = _aware(memory.created_at)
+    if window_start is None or window_end is None or created_at is None:
+        return False
+    return window_start <= created_at <= window_end
+
+
+def _rank(memory: MemoryDB) -> tuple[float, float, float, str]:
+    """Highest capture_confidence, then veracity, then newest, then stable id."""
+    created_at = _aware(memory.created_at)
+    created_ts = created_at.timestamp() if created_at else float('-inf')
+    return (
+        -(memory.capture_confidence if memory.capture_confidence is not None else 0.0),
+        -(memory.veracity if memory.veracity is not None else 0.0),
+        -created_ts,
+        memory.id or '',
+    )
+
+
+def select_memories_learned(
+    memories: Iterable[MemoryDB],
+    *,
+    conversation_ids: Sequence[str],
+    window_start: Optional[datetime] = None,
+    window_end: Optional[datetime] = None,
+    limit: int = MEMORIES_LEARNED_LIMIT,
+) -> List[LearnedMemoryRef]:
+    """Pure selection over an already-read memory page."""
+    wanted = frozenset(cid for cid in conversation_ids if cid)
+    candidates = [
+        memory
+        for memory in memories
+        if _is_eligible(memory) and _from_day(memory, conversation_ids=wanted, start=window_start, end=window_end)
+    ]
+    candidates.sort(key=_rank)
+    return [
+        LearnedMemoryRef(
+            memory_id=memory.id,
+            content=(memory.content or '').strip(),
+            category=getattr(memory.category, 'value', memory.category) or '',
+            captured_at=_aware(memory.created_at),
+        )
+        for memory in candidates[: max(0, int(limit))]
+    ]
+
+
+def memories_learned_for_summary(
+    uid: str,
+    *,
+    conversation_ids: Sequence[str],
+    window_start: Optional[datetime] = None,
+    window_end: Optional[datetime] = None,
+    limit: int = MEMORIES_LEARNED_LIMIT,
+    read_memories: Optional[MemoryReader] = None,
+    scan_limit: int = MEMORIES_LEARNED_SCAN_LIMIT,
+) -> List[LearnedMemoryRef]:
+    """Read one bounded canonical page and select the day's review items.
+
+    Never raises: the daily summary is the product, and a memory-read failure
+    must degrade to "no card", not to "no summary".
+    """
+    reader = read_memories
+    if reader is None:
+        from utils.memory.memory_service import MemoryService  # local: heavy import, avoids a cycle
+
+        reader = MemoryService().read
+    try:
+        page: List[MemoryDB] = reader(uid, limit=scan_limit, offset=0)
+    except Exception as error:  # noqa: BLE001 - the summary must still ship
+        logger.warning('memories_learned read failed for daily summary: %s', type(error).__name__)
+        return []
+    return select_memories_learned(
+        page,
+        conversation_ids=conversation_ids,
+        window_start=window_start,
+        window_end=window_end,
+        limit=limit,
+    )
+
+
+def memory_review_card_block(
+    summary_id: str,
+    *,
+    date: str,
+    memories_learned: Sequence[Any],
+) -> Optional[dict[str, Any]]:
+    """Build the `memoryReviewCard` chat content block, or None when empty.
+
+    Accepts either `LearnedMemoryRef` objects or the stored dict projection so
+    both the generator and the router can call it.
+    """
+    items: List[dict[str, Any]] = []
+    for entry in memories_learned or []:
+        if isinstance(entry, dict):
+            memory_id = entry.get('memory_id')
+            content = entry.get('content')
+            category = entry.get('category')
+        else:
+            memory_id = getattr(entry, 'memory_id', None)
+            content = getattr(entry, 'content', None)
+            category = getattr(entry, 'category', None)
+        if not memory_id:
+            continue
+        items.append({'memoryId': memory_id, 'content': content or '', 'category': category or ''})
+    if not items:
+        return None
+    return {
+        'type': 'memoryReviewCard',
+        'id': f'{summary_id}:memories',
+        'summaryId': summary_id,
+        'date': date,
+        'items': items,
+    }

--- a/backend/utils/observability/fallback.py
+++ b/backend/utils/observability/fallback.py
@@ -73,6 +73,7 @@ ALLOWED_COMPONENTS = frozenset(
         'knowledge_graph',
         'agent_tools',
         'conversation_finalization',
+        'daily_summary',
         'other',
     }
 )

--- a/backend/utils/other/ARCHITECTURE.md
+++ b/backend/utils/other/ARCHITECTURE.md
@@ -1,0 +1,36 @@
+# `utils/other` architecture map
+
+This package is a grab bag by name and history, not by design. Nothing new
+should land here because it "fits nowhere else"; new modules belong beside the
+feature that owns them. The map below exists so the package stops growing
+unread. It is required by the architecture guardrail once a package passes 12
+source files.
+
+## What is here, by concern
+
+| Concern | Module | Owns |
+| --- | --- | --- |
+| Auth and account lifecycle at the HTTP/WS boundary | `endpoints.py` | `get_current_user_uid`, token verification, account-deletion and cutover gates that every router depends on. This is the package's only load-bearing import for request handling. |
+| Object storage | `storage.py` | GCS bucket access, public URL derivation, owner-scoped write gate, per-user deletion sweep, audio decode helpers. |
+| Local dev storage adapter | `local_storage.py` | Filesystem stand-in for `storage.py` used only by the owned local dev harness; never selected in a deployed image. |
+| Chat file attachments | `chat_file.py` | Provider upload/expiry of files attached to chat turns, and the typed errors the chat route maps to user-facing failures. |
+| Daily summary job | `notifications.py` | The scheduled daily-summary job: per-user fan-out, isolation, budgets, checkpoint cursor, FCM send, `day_summary` webhook. |
+| Daily summary bounds | `daily_summary_budget.py` | Pure helpers the job uses: bounded conversation selection for the generator input and the Redis checkpoint cursor encoding. No I/O. |
+| Bounded list reads | `list_budget.py` | Request-scoped time and document budget for list GET reads (`FC-bounded-read-exceeds-request-budget`). |
+| Request timeout | `timeout.py` | `TimeoutMiddleware`, the per-request wall-clock budget. |
+| Background execution primitives | `task.py`, `jobs.py`, `deferred_delete.py`, `backoff.py` | `safe_create_task`, job start helper, single-thread deferred deletion, jittered backoff. Small and dependency-free. |
+| Hume emotion API client | `hume.py` | Typed response models and the client for Hume batch jobs. |
+
+## Rules that hold across the package
+
+- `endpoints.py`, `storage.py`, and the job in `notifications.py` are imported
+  at module scope by many routers; keep them import-pure (no persistence
+  client at import time, see `backend-import-purity`).
+- The daily-summary job is the only scheduled entry point here. Its bounds live
+  in `daily_summary_budget.py` so they can be unit-tested without the job's
+  Firestore and FCM surface. Fail-open paths report through
+  `utils.observability.fallback.record_fallback` with component
+  `daily_summary`.
+- Anything that grows a new concern should move out rather than add a row
+  here. Candidates already identified: `hume.py` (integration client),
+  `chat_file.py` (chat feature), and the storage pair (a `storage/` package).

--- a/backend/utils/other/daily_summary_budget.py
+++ b/backend/utils/other/daily_summary_budget.py
@@ -1,0 +1,196 @@
+"""Bounding primitives for the daily-summary notifications job (#12530).
+
+The daily-summary cron is a Cloud Run Job with a hard 600s task timeout. Two
+unbounded quantities used to make it unsurvivable:
+
+1. **Per-user input.** ``generate_comprehensive_daily_summary`` renders *every*
+   conversation of the user's day into one prompt. A heavy day overflowed the
+   model context window (observed ~290k tokens against a 272k limit), which
+   raised a provider 400 every single day for the same account.
+2. **Job scope.** Every execution restarted the hour groups from the beginning,
+   so whoever sat past the 600s mark was never reached — a silent, permanent
+   tail loss rather than a visible failure.
+
+This module holds the two bounds, kept out of ``utils/other/notifications.py``
+so they are unit-testable without importing the job's dependency graph:
+
+* ``select_conversations_within_budget`` — most-recent-first selection under a
+  rendered-character budget.
+* ``read_job_cursor`` / ``write_job_cursor`` / ``clear_job_cursor`` — a
+  fail-soft Redis checkpoint so the next execution resumes at the unfinished
+  tail instead of re-walking the head.
+
+Every Redis helper here is *synchronous* and must be called through
+``run_blocking(db_executor, ...)`` from async code.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Sequence, TypeVar, cast
+
+logger = logging.getLogger(__name__)
+
+# Cursor keys are scoped to the UTC hour the job is serving: the hour groups are
+# recomputed from wall-clock every execution, so a cursor from a previous hour
+# points into a different user population. 2h TTL covers the every-minute
+# scheduler plus clock skew without leaving stale keys around.
+JOB_CURSOR_TTL_SECONDS = 60 * 60 * 2
+
+_CURSOR_HOUR = 'hour'
+_CURSOR_UID = 'uid'
+
+T = TypeVar('T')
+
+
+class BoundedConversations(NamedTuple):
+    """Result of applying the per-user input bound."""
+
+    conversations: List[Any]
+    dropped: int
+    rendered_chars: int
+
+    @property
+    def truncated(self) -> bool:
+        return self.dropped > 0
+
+
+def _sort_key(conversation: Any) -> datetime:
+    """Recency key that tolerates naive datetimes and missing fields."""
+    value = getattr(conversation, 'started_at', None) or getattr(conversation, 'created_at', None)
+    if not isinstance(value, datetime):
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _default_render(conversation: Any) -> str:
+    # Imported lazily: this module is loaded by unit tests that do not want the
+    # conversation model graph, and the renderer is only needed for measurement.
+    from utils.conversations.render import conversations_to_string
+
+    return conversations_to_string([conversation])
+
+
+def select_conversations_within_budget(
+    conversations: Sequence[Any],
+    max_chars: int,
+    render: Optional[Callable[[Any], str]] = None,
+) -> BoundedConversations:
+    """Keep the most recent conversations that fit inside ``max_chars``.
+
+    The summary prompt is built from the *whole* day, so a user with an
+    exceptional day could exceed the model's context window and get a provider
+    400 forever. Selection is most-recent-first (the part of the day a recap is
+    actually about), and the kept conversations are returned in their original
+    chronological order so the prompt's ``Conversation #N`` numbering and the
+    generator's id map stay consistent.
+
+    The first conversation is always kept: a single oversized conversation must
+    still produce a summary attempt rather than an empty prompt.
+    """
+    if max_chars <= 0 or not conversations:
+        return BoundedConversations(list(conversations), 0, 0)
+
+    render_one = render or _default_render
+    original_order = {id(c): i for i, c in enumerate(conversations)}
+    by_recency = sorted(conversations, key=_sort_key, reverse=True)
+
+    kept: List[Any] = []
+    used = 0
+    dropped = 0
+    for conversation in by_recency:
+        try:
+            size = len(render_one(conversation))
+        except Exception as e:  # a single unrenderable conversation must not sink the recap
+            logger.warning('daily_summary_budget_render_failed error=%s', e)
+            size = 0
+        if kept and used + size > max_chars:
+            dropped += 1
+            continue
+        kept.append(conversation)
+        used += size
+
+    kept.sort(key=lambda c: original_order[id(c)])
+    return BoundedConversations(kept, dropped, used)
+
+
+def job_cursor_key(now_utc: datetime) -> str:
+    """Cursor key for the UTC hour currently being served."""
+    return f'daily_summary_job_cursor:{now_utc.strftime("%Y-%m-%dT%H")}'
+
+
+def make_cursor(target_hour: Optional[int], uid: Optional[str]) -> Dict[str, Any]:
+    return {_CURSOR_HOUR: target_hour, _CURSOR_UID: uid}
+
+
+def cursor_hour(cursor: Optional[Dict[str, Any]]) -> Optional[int]:
+    if not cursor:
+        return None
+    value = cursor.get(_CURSOR_HOUR)
+    return value if isinstance(value, int) else None
+
+
+def cursor_uid(cursor: Optional[Dict[str, Any]]) -> Optional[str]:
+    if not cursor:
+        return None
+    value = cursor.get(_CURSOR_UID)
+    return value if isinstance(value, str) and value else None
+
+
+def rotate_to(items: Sequence[T], start: Optional[T]) -> List[T]:
+    """Rotate ``items`` so it begins at ``start`` (identity by equality).
+
+    Rotation rather than slicing: the unfinished tail is served first, but the
+    head is still covered in the same pass, so no user is systematically
+    starved and a stale cursor cannot strand anyone.
+    """
+    ordered = list(items)
+    if start is None:
+        return ordered
+    try:
+        index = ordered.index(start)
+    except ValueError:
+        return ordered
+    return ordered[index:] + ordered[:index]
+
+
+def _redis_client() -> Any:
+    from database.redis_db import r
+
+    return r
+
+
+def read_job_cursor(key: str) -> Optional[Dict[str, Any]]:
+    """Read the checkpoint. Never raises — a Redis outage just means no resume."""
+    try:
+        raw = _redis_client().get(key)
+    except Exception as e:
+        logger.warning('daily_summary_cursor_read_failed key=%s error=%s', key, e)
+        return None
+    if not raw:
+        return None
+    try:
+        loaded: object = json.loads(raw)
+    except Exception:
+        return None
+    return cast(Dict[str, Any], loaded) if isinstance(loaded, dict) else None
+
+
+def write_job_cursor(key: str, cursor: Dict[str, Any], ttl: int = JOB_CURSOR_TTL_SECONDS) -> None:
+    """Persist the checkpoint. Never raises — losing it only costs a re-walk."""
+    try:
+        _redis_client().set(key, json.dumps(cursor), ex=ttl)
+    except Exception as e:
+        logger.warning('daily_summary_cursor_write_failed key=%s error=%s', key, e)
+
+
+def clear_job_cursor(key: str) -> None:
+    """Drop the checkpoint after a full pass. Never raises."""
+    try:
+        _redis_client().delete(key)
+    except Exception as e:
+        logger.warning('daily_summary_cursor_clear_failed key=%s error=%s', key, e)

--- a/backend/utils/other/notifications.py
+++ b/backend/utils/other/notifications.py
@@ -1,8 +1,11 @@
 # async-blockers: no-import-scope
 # async-blockers: no-changed-range-scope  # pre-existing patterns surfaced by type-annotation import changes
 import asyncio
+import os
+from dataclasses import dataclass
 from datetime import datetime, time, timedelta
-from typing import Any, Dict, List, Tuple
+from time import monotonic
+from typing import Any, Dict, List, Optional, Tuple
 
 from utils.executors import db_executor, postprocess_executor, run_blocking
 
@@ -14,12 +17,94 @@ from database.redis_db import try_acquire_daily_summary_lock
 from models.notification_message import NotificationMessage
 from utils.conversations.factory import deserialize_conversation
 from utils.llm.external_integrations import generate_comprehensive_daily_summary
+from utils.memory.learned_today import memory_review_card_block
 from utils.notifications import send_bulk_notification, send_notification
+from utils.other import daily_summary_budget as summary_budget
 from utils.webhooks import day_summary_webhook
 import database.daily_summaries as daily_summaries_db
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name) or default)
+    except ValueError:
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name) or default)
+    except ValueError:
+        return default
+
+
+# --- Budgets for the daily-summary Cloud Run Job (#12530) --------------------
+# The job's Cloud Run task timeout is 600s. Before this, an execution simply ran
+# until SIGKILL: whoever sat past the 600s mark was never reached and never
+# produced an error attributable to them, so their recap silently vanished.
+#
+# The job now runs to its own budget (below the task timeout), checkpoints where
+# it stopped, and reports what it could not serve.
+DAILY_SUMMARY_JOB_BUDGET_SECONDS = _env_float('DAILY_SUMMARY_JOB_BUDGET_SECONDS', 480.0)
+# One account cannot own the job. A recap is one LLM call plus Firestore reads;
+# 90s is generous for that and still bounds a wedged provider call.
+DAILY_SUMMARY_USER_BUDGET_SECONDS = _env_float('DAILY_SUMMARY_USER_BUDGET_SECONDS', 90.0)
+# Rendered-character budget for the conversation material fed to the summary
+# prompt. ~360k chars is roughly 90k tokens, comfortably inside the 272k-token
+# model limit even alongside the prompt scaffolding and the user's memories.
+# The overflow seen in production was ~290k tokens of input.
+DAILY_SUMMARY_MAX_HISTORY_CHARS = _env_int('DAILY_SUMMARY_MAX_HISTORY_CHARS', 360_000)
+# A per-user timeout abandons (it cannot cancel) a worker thread. Stop the run
+# once enough threads are abandoned that the pool would starve the rest.
+DAILY_SUMMARY_MAX_ABANDONED_USERS = _env_int('DAILY_SUMMARY_MAX_ABANDONED_USERS', 12)
+
+_BATCH_SIZE = 8
+
+_FALLBACK_COMPONENT = 'daily_summary'
+
+
+def _record_daily_summary_fallback(*, from_mode: str, to_mode: str, reason: str, outcome: str) -> None:
+    """Emit the shared fallback counter for a daily-summary fail-open branch.
+
+    Imported lazily so loading this module in a test harness does not drag in
+    the Prometheus registry.
+    """
+    try:
+        from utils.observability.fallback import record_fallback
+
+        record_fallback(
+            component=_FALLBACK_COMPONENT,
+            from_mode=from_mode,
+            to_mode=to_mode,
+            reason=reason,
+            outcome=outcome,
+            log=logger,
+        )
+    except Exception as e:  # telemetry must never break the job
+        logger.warning('daily_summary_fallback_record_failed error=%s', e)
+
+
+@dataclass
+class DailySummaryJobStats:
+    """Per-execution accounting, emitted as one job-end line."""
+
+    groups_attempted: int = 0
+    groups_failed: int = 0
+    attempted: int = 0
+    succeeded: int = 0
+    failed: int = 0
+    timed_out: int = 0
+    skipped_for_budget: int = 0
+
+    def as_log(self) -> str:
+        return (
+            f'groups_attempted={self.groups_attempted} groups_failed={self.groups_failed} '
+            f'attempted={self.attempted} succeeded={self.succeeded} failed={self.failed} '
+            f'timed_out={self.timed_out} skipped_for_budget={self.skipped_for_budget}'
+        )
 
 
 def should_run_job() -> bool:
@@ -45,33 +130,119 @@ async def send_daily_summary_notification() -> None:
 
     Groups timezones by their current local hour, then for each hour group,
     queries users in those timezones who have that hour preference.
+
+    Survivability contract (#12530). This runs as a Cloud Run Job with a hard
+    600s task timeout, over tens of thousands of users:
+
+    * **Nothing aborts the whole run.** One hour group's Firestore read or one
+      user's provider error is caught where it happens; the run continues.
+    * **The run has its own budget**, below the task timeout, so it ends by
+      *deciding* to stop rather than by being killed mid-batch.
+    * **Progress is checkpointed** in Redis and the next execution rotates the
+      work to start at the unfinished tail. Before this, every execution
+      restarted at the head and died in the same place, so the users after that
+      point were never reached on any run — a permanent, silent tail loss.
+    * **The run reports itself**: a structured line per failed user and one
+      job-end line with attempted/succeeded/failed/skipped counts.
     """
+    deadline = monotonic() + DAILY_SUMMARY_JOB_BUDGET_SECONDS
+    stats = DailySummaryJobStats()
+    cursor_key = summary_budget.job_cursor_key(datetime.now(pytz.utc))
+
     try:
-        # Group timezones by their current local hour
         timezones_by_hour = _get_timezones_grouped_by_hour()
-
-        for target_hour, timezones in timezones_by_hour.items():
-            # Get users in those timezones who want notifications at this hour
-            users = await _get_users_for_daily_summary(timezones, target_hour)
-
-            if users:
-                logger.info(f"Sending daily summary to {len(users)} users at local hour {target_hour}")
-                await _send_bulk_summary_notification(users)
-
     except Exception as e:
         logger.error(f"Error sending daily summary: {e}")
         return None
 
+    cursor = await run_blocking(db_executor, summary_budget.read_job_cursor, cursor_key)
+    resume_hour = summary_budget.cursor_hour(cursor)
+    resume_uid = summary_budget.cursor_uid(cursor)
+
+    # Deterministic order, rotated to the checkpoint: the tail is served first
+    # and the head is still covered in the same pass.
+    ordered_hours = summary_budget.rotate_to(sorted(timezones_by_hour.keys()), resume_hour)
+    completed_all = True
+
+    for target_hour in ordered_hours:
+        if monotonic() >= deadline:
+            completed_all = False
+            await _checkpoint(cursor_key, target_hour, None)
+            _record_daily_summary_fallback(
+                from_mode='full_run', to_mode='resumable_tail', reason='timeout', outcome='degraded'
+            )
+            logger.warning('daily_summary_job_budget_exhausted resume_hour=%s', target_hour)
+            break
+
+        stats.groups_attempted += 1
+        try:
+            users = await _get_users_for_daily_summary(timezones_by_hour[target_hour], target_hour)
+        except Exception as e:
+            # One hour group's read failing must not cost the other 23 groups.
+            stats.groups_failed += 1
+            logger.error('daily_summary_group_failed hour=%s reason=user_query error=%s', target_hour, e)
+            continue
+
+        if not users:
+            continue
+
+        ordered_users = summary_budget.rotate_to(
+            sorted(users, key=lambda user: str(user[0])),
+            _resume_user(users, resume_uid) if target_hour == resume_hour else None,
+        )
+        resume_uid = None
+
+        logger.info(f"Sending daily summary to {len(ordered_users)} users at local hour {target_hour}")
+        finished_group = await _send_bulk_summary_notification(
+            ordered_users, deadline=deadline, stats=stats, target_hour=target_hour, cursor_key=cursor_key
+        )
+        if not finished_group:
+            completed_all = False
+            break
+
+    if completed_all:
+        await run_blocking(db_executor, summary_budget.clear_job_cursor, cursor_key)
+
+    logger.info('daily_summary_job_summary complete=%s %s', completed_all, stats.as_log())
+    return None
+
+
+def _resume_user(users: List[Tuple[Any, ...]], resume_uid: Optional[str]) -> Optional[Tuple[Any, ...]]:
+    """Map a checkpointed uid back onto this run's user tuple, if still present."""
+    if not resume_uid:
+        return None
+    for user in users:
+        if str(user[0]) == resume_uid:
+            return user
+    return None
+
+
+async def _checkpoint(cursor_key: str, target_hour: Optional[int], uid: Optional[str]) -> None:
+    await run_blocking(
+        db_executor, summary_budget.write_job_cursor, cursor_key, summary_budget.make_cursor(target_hour, uid)
+    )
+
 
 async def _get_users_for_daily_summary(timezones: List[str], target_hour: int) -> List[Tuple[str, List[str], Any]]:
     timezone_chunks = [timezones[i : i + 30] for i in range(0, len(timezones), 30)]
+    # return_exceptions: one failing timezone chunk degrades that chunk's users,
+    # it does not throw away the chunks that did read successfully.
     chunk_results = await asyncio.gather(
         *[
             run_blocking(db_executor, notification_db.get_users_for_daily_summary, chunk, target_hour)
             for chunk in timezone_chunks
-        ]
+        ],
+        return_exceptions=True,
     )
-    return [user for chunk in chunk_results for user in chunk]
+    users: List[Tuple[str, List[str], Any]] = []
+    for chunk_index, chunk in enumerate(chunk_results):
+        if isinstance(chunk, BaseException):
+            logger.error(
+                'daily_summary_user_query_chunk_failed hour=%s chunk=%d error=%s', target_hour, chunk_index, chunk
+            )
+            continue
+        users.extend(chunk)
+    return users
 
 
 def _get_timezones_grouped_by_hour() -> Dict[int, List[str]]:
@@ -175,6 +346,26 @@ def _send_summary_notification(user_data: Tuple[Any, ...]) -> None:
         logger.info(f'Skipping daily summary for uid={uid} on {date_str}: no conversations with transcript content')
         return
 
+    # Bound the generator's input (#12530). The summary prompt renders the user's
+    # whole day; one account's exceptional day overflowed the model context
+    # window (~290k tokens against a 272k limit) and returned a provider 400
+    # every single day. Keep the most recent conversations that fit, drop the
+    # rest loudly, and always keep at least one so a recap is still attempted.
+    bounded = summary_budget.select_conversations_within_budget(conversations, DAILY_SUMMARY_MAX_HISTORY_CHARS)
+    if bounded.truncated:
+        logger.warning(
+            'daily_summary_input_truncated uid=%s date=%s kept=%d dropped=%d rendered_chars=%d',
+            uid,
+            date_str,
+            len(bounded.conversations),
+            bounded.dropped,
+            bounded.rendered_chars,
+        )
+        _record_daily_summary_fallback(
+            from_mode='full_day', to_mode='truncated_day', reason='quota', outcome='degraded'
+        )
+    conversations = bounded.conversations
+
     summary_data = generate_comprehensive_daily_summary(uid, conversations, date_str, start_date_utc, end_date_utc)
 
     # Store in database
@@ -188,12 +379,24 @@ def _send_summary_notification(user_data: Tuple[Any, ...]) -> None:
     if len(summary_body) > 150:
         summary_body = summary_body[:147] + "..."
 
+    # Native review card for the memories this day produced. The scheduled send is
+    # the path users actually receive, so it must carry the same block the
+    # /v1/users/daily-summary-settings/test path builds. ``text`` is untouched: a
+    # client that does not know the block renders exactly what it rendered before,
+    # and the block is omitted entirely when the day produced nothing to review.
+    review_block = memory_review_card_block(
+        summary_id,
+        date=date_str,
+        memories_learned=summary_data.get('memories_learned') or [],
+    )
+
     ai_message = NotificationMessage(
         text=summary_body,
         from_integration='false',
         type='day_summary',
         notification_type='daily_summary',
         navigate_to=f"/daily-summary/{summary_id}",
+        content_blocks=[review_block] if review_block else None,
     )
 
     # Also send webhook with the full summary data (day_summary_webhook is async, so wrap in asyncio.run).
@@ -207,15 +410,101 @@ def _send_summary_notification(user_data: Tuple[Any, ...]) -> None:
     )
 
 
-async def _send_bulk_summary_notification(users: List[Tuple[Any, ...]]) -> None:
-    _BATCH_SIZE = 8
+async def _send_bulk_summary_notification(
+    users: List[Tuple[Any, ...]],
+    *,
+    deadline: Optional[float] = None,
+    stats: Optional[DailySummaryJobStats] = None,
+    target_hour: Optional[int] = None,
+    cursor_key: Optional[str] = None,
+) -> bool:
+    """Send one hour group's summaries. Returns True if the whole group was served.
+
+    Isolation is per user, not per batch: a provider error, a context overflow,
+    or a wedged call is recorded against that uid and the remaining users in the
+    same batch still complete. A user who exceeds the per-user budget is
+    abandoned (a worker thread cannot be cancelled) rather than allowed to hold
+    the batch barrier for the rest of the run.
+    """
+    counters = stats if stats is not None else DailySummaryJobStats()
+
     for i in range(0, len(users), _BATCH_SIZE):
+        if deadline is not None and monotonic() >= deadline:
+            counters.skipped_for_budget += len(users) - i
+            if cursor_key:
+                await _checkpoint(cursor_key, target_hour, str(users[i][0]))
+            _record_daily_summary_fallback(
+                from_mode='full_run', to_mode='resumable_tail', reason='timeout', outcome='degraded'
+            )
+            logger.warning(
+                'daily_summary_group_budget_exhausted hour=%s served=%d deferred=%d resume_uid=%s',
+                target_hour,
+                i,
+                len(users) - i,
+                users[i][0],
+            )
+            return False
+
         batch = users[i : i + _BATCH_SIZE]
-        tasks = [run_blocking(postprocess_executor, _send_summary_notification, user_tokens) for user_tokens in batch]
+        per_user_timeout = DAILY_SUMMARY_USER_BUDGET_SECONDS
+        if deadline is not None:
+            per_user_timeout = max(1.0, min(per_user_timeout, deadline - monotonic()))
+
+        tasks = [
+            asyncio.wait_for(
+                run_blocking(postprocess_executor, _send_summary_notification, user_tokens),
+                timeout=per_user_timeout,
+            )
+            for user_tokens in batch
+        ]
+        counters.attempted += len(batch)
         results = await asyncio.gather(*tasks, return_exceptions=True)
         for j, result in enumerate(results):
-            if isinstance(result, Exception):
-                logger.error(f"Daily summary failed for user batch[{i + j}]: {result}")
+            uid = str(batch[j][0])
+            if isinstance(result, (asyncio.TimeoutError, TimeoutError)):
+                counters.timed_out += 1
+                logger.error(
+                    'daily_summary_user_failed uid=%s hour=%s reason=user_budget_exceeded budget_seconds=%s',
+                    uid,
+                    target_hour,
+                    per_user_timeout,
+                )
+                _record_daily_summary_fallback(
+                    from_mode='generated', to_mode='skipped', reason='timeout', outcome='degraded'
+                )
+            elif isinstance(result, BaseException):
+                counters.failed += 1
+                logger.error(
+                    'daily_summary_user_failed uid=%s hour=%s reason=generation_error error_type=%s error=%s',
+                    uid,
+                    target_hour,
+                    type(result).__name__,
+                    result,
+                )
+            else:
+                counters.succeeded += 1
+
+        if cursor_key and i + _BATCH_SIZE < len(users):
+            await _checkpoint(cursor_key, target_hour, str(users[i + _BATCH_SIZE][0]))
+
+        if counters.timed_out >= DAILY_SUMMARY_MAX_ABANDONED_USERS:
+            # Abandoned threads still occupy postprocess_executor slots. Past this
+            # point the pool cannot serve the remaining users any faster than the
+            # next execution can, so stop and let the checkpoint carry the tail.
+            remaining = max(0, len(users) - (i + _BATCH_SIZE))
+            counters.skipped_for_budget += remaining
+            logger.error(
+                'daily_summary_group_abandoned_users hour=%s timed_out=%d deferred=%d',
+                target_hour,
+                counters.timed_out,
+                remaining,
+            )
+            _record_daily_summary_fallback(
+                from_mode='full_run', to_mode='resumable_tail', reason='capacity_full', outcome='degraded'
+            )
+            return False
+
+    return True
 
 
 async def send_daily_notification() -> None:

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -84,6 +84,11 @@ from utils.llm.usage_tracker import reset_usage_context, set_usage_context
 from utils.llm.chat import _get_agentic_qa_prompt, get_current_datetime_block, get_user_timezone
 from utils.executors import run_blocking, db_executor
 from utils.jit_rollout import JITDecisionStage, resolve_jit_rollout
+from utils.chat_followup import (
+    FOLLOWUP_PROMPT_SECTION,
+    FollowUpTailStreamFilter,
+    split_followup_tail,
+)
 from database.redis_db import get_cached_user_geolocation
 from database.users import get_user_location_context_consent
 from models.geolocation import Geolocation
@@ -1497,6 +1502,11 @@ IMPORTANT: Always call a matching integration tool when relevant. Never tell the
 You have fetch_url_tool available. When the user shares any URL (starting with http:// or https://), you MUST call fetch_url_tool to read its content before responding. Never say you cannot browse, visit, or read a URL. Always attempt to fetch it first.
 </url_fetching_instructions>"""
 
+    # The typed lanes almost never end an answer with a question, so a turn that
+    # had an obvious next hop still ends the session. The tail is stripped from
+    # the visible text below and delivered as one structured chip instead.
+    system_prompt += FOLLOWUP_PROMPT_SECTION
+
     # Live chat-agent tools are OpenAI chat-completions functions. Perplexity
     # covers web search; Anthropic server tools are not on this lane.
     tool_schemas, tool_registry = _convert_tools(core_tools, app_tools)
@@ -1548,6 +1558,9 @@ You have fetch_url_tool available. When the user shares any URL (starting with h
 
     full_response = []
     tool_usage_count = 0
+    # The follow-up tail is model output like any other token. Hold it back from
+    # what the user watches stream in so the chip's text never appears twice.
+    followup_filter = FollowUpTailStreamFilter()
 
     def attach_evidence_to_callback() -> None:
         """Expose only the bounded references collected by successful JIT tools."""
@@ -1581,10 +1594,12 @@ You have fetch_url_tool available. When the user shares any URL (starting with h
         """
         if callback_data is None:
             return False
-        streamed = ''.join(full_response)
+        streamed, _ = split_followup_tail(''.join(full_response))
         if not streamed:
             return False
         callback_data['answer'] = streamed
+        # A turn that stopped early is a failed turn; it never invites a next question.
+        callback_data.pop('followup', None)
         callback_data['memories_found'] = conversations_collected if conversations_collected else []
         callback_data['ask_for_nps'] = tool_usage_count > 0
         attach_evidence_to_callback()
@@ -1629,13 +1644,26 @@ You have fetch_url_tool available. When the user shares any URL (starting with h
             if chunk.startswith("think: ") and chunk != f'think: {AGENT_STREAM_PROGRESS_HEARTBEAT}':
                 tool_usage_count += 1
 
+            if chunk.startswith("data: "):
+                visible = followup_filter.push(chunk[len("data: ") :])
+                if not visible:
+                    continue
+                chunk = f'data: {visible}'
+
             yield chunk
 
         producer_failure = await task
 
+        held_back = followup_filter.flush()
+        if held_back:
+            yield f'data: {held_back}'
+
         # Store results in callback_data
         if callback_data is not None:
-            callback_data['answer'] = ''.join(full_response)
+            answer_text, followup_question = split_followup_tail(''.join(full_response))
+            callback_data['answer'] = answer_text
+            if followup_question and not producer_failure:
+                callback_data['followup'] = followup_question
             # Reported even though the stream ended cleanly, so the router can tell a failed
             # turn from one the model ended empty on its own.
             if producer_failure:

--- a/desktop/macos/Desktop/Sources/Analytics/AnalyticsManager+QuestionOrigin.swift
+++ b/desktop/macos/Desktop/Sources/Analytics/AnalyticsManager+QuestionOrigin.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+// Where a question came from, on top of which surface it was asked on.
+//
+// `question_asked` already answers "chat window or push-to-talk". It could not
+// answer "did Omi invite this question, or did the user arrive with it" — which
+// is the whole measurement for the grounded follow-up chip. 57% of asker-days
+// are exactly one question; a chip that works shows up as `followup` questions
+// with a continuation rate of its own, not as a bump in an undifferentiated
+// total.
+
+extension AnalyticsManager {
+  /// What prompted a question. `unprompted` is the default and covers every
+  /// question the user typed or spoke on their own.
+  enum QuestionOrigin: String, Sendable {
+    /// Tapped the grounded follow-up chip under an answer.
+    case followUp = "followup"
+    /// Typed or spoken with nothing offering it.
+    case unprompted
+    /// A suggestion chip that is not an answer's follow-up.
+    case chip
+    /// A card action (notch, dashboard, notification).
+    case card
+  }
+
+  /// Arm the origin for the next accepted question.
+  ///
+  /// A chip cannot pass the origin down the send path: the send funnels through
+  /// `chatMessageSent` / `floatingBarQuerySent`, which every other caller shares.
+  /// Arming it immediately before the send that emits keeps the attribution at
+  /// the tap, and consuming it on the first emit means a send the provider
+  /// rejects can never mislabel a later, unrelated question.
+  func questionOriginating(_ origin: QuestionOrigin) {
+    QuestionOriginContext.arm(origin)
+  }
+
+  /// The origin for the question being emitted right now, consumed so it
+  /// applies to exactly one event.
+  func consumeQuestionOrigin() -> QuestionOrigin {
+    QuestionOriginContext.consume()
+  }
+}
+
+/// One-shot main-actor store for the armed origin. Deliberately not a mutable
+/// global outside the actor: `AnalyticsManager` is `@MainActor`, and both the
+/// arm (a tap) and the emit (the provider's acceptance callback) run there.
+@MainActor
+enum QuestionOriginContext {
+  private static var armed: AnalyticsManager.QuestionOrigin?
+
+  static func arm(_ origin: AnalyticsManager.QuestionOrigin) {
+    armed = origin
+  }
+
+  static func consume() -> AnalyticsManager.QuestionOrigin {
+    defer { armed = nil }
+    return armed ?? .unprompted
+  }
+
+  /// Test seam: drop a previously armed origin without emitting.
+  static func resetForTests() {
+    armed = nil
+  }
+}

--- a/desktop/macos/Desktop/Sources/Analytics/AnalyticsManager+Questions.swift
+++ b/desktop/macos/Desktop/Sources/Analytics/AnalyticsManager+Questions.swift
@@ -46,6 +46,9 @@ extension AnalyticsManager {
       "message_length": messageLength,
     ]
     if let attemptID { props["attempt_id"] = attemptID }
+    // Added, never substituted: `surface` says where the question was asked,
+    // `origin` says what prompted it (see AnalyticsManager+QuestionOrigin).
+    props["origin"] = consumeQuestionOrigin().rawValue
     questionTelemetryCaptureForTests?("question_asked", props)
     PostHogManager.shared.track("question_asked", properties: props)
     Task { @MainActor in

--- a/desktop/macos/Desktop/Sources/Chat/ChatContentBlockCodec.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatContentBlockCodec.swift
@@ -140,6 +140,26 @@ enum ChatContentBlockCodec {
       case "memoryLink":
         guard let memoryId = dict["memoryId"] as? String, let summary = dict["summary"] as? String else { continue }
         blocks.append(.memoryLink(id: id, memoryId: memoryId, summary: summary))
+      case "memoryReviewCard":
+        guard let items = dict["items"] as? [[String: Any]] else { continue }
+        // A row without an id cannot be voted on or corrected, and a row without content has
+        // nothing to show, so neither is a review row. An empty card is not rendered at all.
+        let parsed = items.compactMap { entry -> MemoryReviewItem? in
+          guard let memoryID = entry["memoryId"] as? String,
+            !memoryID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            let content = entry["content"] as? String,
+            !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+          else { return nil }
+          return MemoryReviewItem(
+            memoryID: memoryID, content: content, category: entry["category"] as? String ?? "")
+        }
+        guard !parsed.isEmpty else { continue }
+        blocks.append(
+          .memoryReviewCard(
+            id: id,
+            summaryId: dict["summaryId"] as? String ?? "",
+            date: dict["date"] as? String ?? "",
+            items: parsed))
       case "citation":
         guard let ordinal = ChatJSONScalar.int(dict["ordinal"]),
           let kindValue = dict["kind"] as? String,
@@ -160,6 +180,9 @@ enum ChatContentBlockCodec {
               createdAt: dict["createdAt"] as? String ?? dict["created_at"] as? String,
               appName: dict["appName"] as? String ?? dict["app_name"] as? String,
               url: (dict["url"] as? String).flatMap(URL.init(string:)))))
+      case "followUp", "follow_up":
+        guard let question = ChatFollowUpTail.validatedQuestion(dict["text"] as? String ?? "") else { continue }
+        blocks.append(.followUp(id: id, text: question))
       case "agentSpawn":
         guard let sessionId = dict["sessionId"] as? String,
           !sessionId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
@@ -328,6 +351,16 @@ enum ChatContentBlockCodec {
       return dict
     case .memoryLink(let id, let memoryId, let summary):
       return ["type": "memoryLink", "id": id, "memoryId": memoryId, "summary": summary]
+    case .memoryReviewCard(let id, let summaryId, let date, let items):
+      return [
+        "type": "memoryReviewCard",
+        "id": id,
+        "summaryId": summaryId,
+        "date": date,
+        "items": items.map { item -> [String: Any] in
+          ["memoryId": item.memoryID, "content": item.content, "category": item.category]
+        },
+      ]
     case .citation(let id, let reference):
       var dict: [String: Any] = [
         "type": "citation",
@@ -343,6 +376,8 @@ enum ChatContentBlockCodec {
       if let value = reference.appName { dict["appName"] = value }
       if let value = reference.url { dict["url"] = value.absoluteString }
       return dict
+    case .followUp(let id, let text):
+      return ["type": "followUp", "id": id, "text": text]
     case .agentSpawn(
       let id, let pillId, let sessionId, let runId, let title, let objective, let provider
     ):

--- a/desktop/macos/Desktop/Sources/Chat/ChatFirstBlockValidation.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatFirstBlockValidation.swift
@@ -105,6 +105,21 @@ enum ChatFirstBlockWire {
         }
       }
       return result
+    case "memoryReviewCard":
+      guard let items = block["items"] as? [[String: Any]], !items.isEmpty else { return nil }
+      let backendItems = items.compactMap { item -> [String: Any]? in
+        guard let memoryID = item["memoryId"] as? String, let content = item["content"] as? String else {
+          return nil
+        }
+        return ["memory_id": memoryID, "content": content, "category": item["category"] as? String ?? ""]
+      }
+      guard backendItems.count == items.count else { return nil }
+      return [
+        "type": type,
+        "summary_id": block["summaryId"] as? String ?? "",
+        "date": block["date"] as? String ?? "",
+        "items": backendItems,
+      ]
     case "memoryLink":
       guard let memoryID = block["memoryId"] as? String, let summary = block["summary"] as? String else { return nil }
       return ["type": type, "memory_id": memoryID, "summary": summary]
@@ -173,6 +188,22 @@ enum ChatFirstBlockWire {
         }
       }
       return result
+    case "memoryReviewCard":
+      guard let items = block["items"] as? [[String: Any]], !items.isEmpty else { return nil }
+      let journalItems = items.compactMap { item -> [String: Any]? in
+        guard let memoryID = item["memory_id"] as? String, let content = item["content"] as? String else {
+          return nil
+        }
+        return ["memoryId": memoryID, "content": content, "category": item["category"] as? String ?? ""]
+      }
+      guard journalItems.count == items.count else { return nil }
+      return [
+        "type": type,
+        "id": id,
+        "summaryId": block["summary_id"] as? String ?? "",
+        "date": block["date"] as? String ?? "",
+        "items": journalItems,
+      ]
     case "memoryLink":
       guard let memoryID = block["memory_id"] as? String, let summary = block["summary"] as? String else { return nil }
       return ["type": type, "id": id, "memoryId": memoryID, "summary": summary]

--- a/desktop/macos/Desktop/Sources/Chat/ChatFollowUpTail.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatFollowUpTail.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+/// The grounded closing question a typed answer ends with.
+///
+/// The realtime voice lane already ends about two thirds of its answers with a
+/// question, and those sessions run about four turns. The typed lanes — the chat
+/// window and the floating bar — end with one 4-9% of the time, and recall
+/// answers never do, even though most of them have an obvious next hop into the
+/// same source. This type is the typed lanes' half of closing that gap: the
+/// model writes the question after a delimiter on its own final line, and the
+/// client lifts it off the visible text into one tappable chip.
+///
+/// The delimiter, not a heuristic, is what makes the tail separable. Guessing
+/// which trailing sentence of a free-form answer was "the follow-up" would
+/// mis-fire on answers that legitimately end in a question, and would leave the
+/// chip and the prose saying the same thing twice. Kept byte-identical to the
+/// backend's `utils/chat_followup.py` so both lanes produce the same block.
+enum ChatFollowUpTail {
+  /// Chosen so it cannot occur in prose, Markdown, or code the model quotes.
+  static let delimiter = "<<<FOLLOWUP>>>"
+  static let blockType = "followUp"
+
+  /// A chip has to read in one glance. The prompt asks for under ~15 words;
+  /// these are the outer bounds a malformed generation cannot cross.
+  static let maxWords = 18
+  static let maxCharacters = 160
+
+  /// A generic tail is worse than no tail: it teaches the reader the chip is
+  /// filler. Matched against the lowercased, punctuation-trimmed question.
+  private static let genericPrefixes = [
+    "anything else",
+    "is there anything else",
+    "want more detail",
+    "want any more detail",
+    "do you want more detail",
+    "want more info",
+    "want more information",
+    "want me to go on",
+    "want me to continue",
+    "want me to keep going",
+    "want me to elaborate",
+    "want me to explain more",
+    "would you like to know more",
+    "do you want to know more",
+    "does that help",
+    "did that help",
+    "does that make sense",
+    "does that answer",
+    "any questions",
+    "any other questions",
+    "got any questions",
+    "let me know",
+    "can i help",
+    "could i help",
+    "how can i help",
+    "sound good",
+    "sounds good",
+    "shall i continue",
+    "shall i go on",
+    "need anything else",
+    "want anything else",
+    "what else",
+  ]
+
+  /// Split a raw model answer into its visible text and its follow-up question.
+  ///
+  /// The delimiter and everything after it leave the visible text either way — a
+  /// half-formed tail must never reach the transcript. `question` is `nil` when
+  /// the model wrote no tail, or wrote one that cannot be a chip: empty, not a
+  /// question, over-long, or generic.
+  static func split(_ text: String) -> (visible: String, question: String?) {
+    guard let range = text.range(of: delimiter) else { return (text, nil) }
+    var visible = String(text[text.startIndex..<range.lowerBound])
+    while let last = visible.last, last.isWhitespace { visible.removeLast() }
+    let tail = String(text[range.upperBound...])
+    let firstLine =
+      tail.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
+      .first.map(String.init) ?? ""
+    guard let question = validatedQuestion(firstLine) else { return (visible, nil) }
+    return (visible, question)
+  }
+
+  /// The question a raw candidate can become, or `nil` when it cannot be a chip.
+  static func validatedQuestion(_ candidate: String) -> String? {
+    let question =
+      candidate
+      .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !question.isEmpty, question.hasSuffix("?") else { return nil }
+    guard question.count <= maxCharacters else { return nil }
+    guard question.split(separator: " ").count <= maxWords else { return nil }
+    guard !isGeneric(question) else { return nil }
+    return question
+  }
+
+  static func isGeneric(_ question: String) -> Bool {
+    let probe = question.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: " ?!."))
+    guard !probe.isEmpty else { return true }
+    return genericPrefixes.contains { probe.hasPrefix($0) }
+  }
+
+  /// What the reader should see while the answer is still streaming.
+  ///
+  /// The tail streams in like any other token, so without this the chip's words
+  /// appear in the prose first and are removed when the turn finalizes. Any
+  /// completed delimiter (and everything after it) is dropped, and so is a
+  /// trailing partial delimiter — but only once it is unambiguous (`<<<` or
+  /// longer), so ordinary text ending in `<` is never eaten.
+  static func strippingPendingTail(_ text: String) -> String {
+    if let range = text.range(of: delimiter) {
+      return String(text[text.startIndex..<range.lowerBound])
+    }
+    let characters = Array(text)
+    let delimiterCharacters = Array(delimiter)
+    let maxHold = min(characters.count, delimiterCharacters.count - 1)
+    if maxHold >= 3 {
+      for length in stride(from: maxHold, through: 3, by: -1) {
+        if Array(characters.suffix(length)) == Array(delimiterCharacters.prefix(length)) {
+          return String(characters.prefix(characters.count - length))
+        }
+      }
+    }
+    return text
+  }
+
+  /// Whether a finished turn may carry a chip at all.
+  ///
+  /// A failed turn never invites the reader one hop further into an answer they
+  /// did not get, and an answer that is itself a clarifying question would ask
+  /// two questions at once — the chip being the one nobody needed.
+  static func shouldAttach(question: String?, visibleText: String, failed: Bool) -> Bool {
+    guard !failed, let question, !question.isEmpty else { return false }
+    let trimmed = visibleText.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return false }
+    guard let lastLine = trimmed.split(separator: "\n").last?.trimmingCharacters(in: .whitespacesAndNewlines) else {
+      return false
+    }
+    return !lastLine.hasSuffix("?")
+  }
+
+  /// The block id both lanes mint for a message, matching the backend's shape.
+  static func blockID(messageID: String) -> String { "\(messageID):followup" }
+}

--- a/desktop/macos/Desktop/Sources/Chat/ChatPrompts.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatPrompts.swift
@@ -156,6 +156,27 @@ struct ChatPrompts {
     - Show times/dates in {user_name}'s timezone ({tz}), including the zone, in a natural, friendly way. Quote tool timestamps as printed.
     - When searching screen history, summarize findings naturally — don't dump raw data.
     </instructions>
+
+    <closing_question>
+    End a grounded answer with exactly one follow-up question, on its own final line, after the marker \(ChatFollowUpTail.delimiter).
+
+    Format (the marker and question are the last thing you write):
+    \(ChatFollowUpTail.delimiter) <one question>
+
+    Rules for that question:
+    - Specific to what you just said or to the conversations, memories, tasks or screen activity you just read. Never generic — never "anything else?", "want more detail?", "does that help?".
+    - Answerable by you from data you can reach with a tool. Never a question only {user_name} could answer from outside Omi.
+    - Under 15 words, one sentence, ends with a question mark.
+    - For a recall answer, go one hop further into the same source: who else was there, what was decided next, when it is due, what happened after.
+
+    Write NO marker and NO question when:
+    - The turn failed, errored, timed out, or you are refusing or saying you cannot do something.
+    - You could not verify or find what was asked ("I don't remember that coming up").
+    - The question was general knowledge rather than about {user_name}.
+    - Your answer is itself a clarifying question back to {user_name}.
+
+    The marker line is stripped from the visible answer and shown as a tappable chip, so never repeat the question in the answer text itself.
+    </closing_question>
     """
 
   // MARK: - Onboarding Chat Prompt

--- a/desktop/macos/Desktop/Sources/Chat/FollowUpChip.swift
+++ b/desktop/macos/Desktop/Sources/Chat/FollowUpChip.swift
@@ -1,0 +1,83 @@
+import OmiTheme
+import SwiftUI
+
+/// The one grounded next question under an answer, as a chip you can tap.
+///
+/// It is a chip rather than a sentence in the prose because the measurement it
+/// exists for is whether the reader takes it: a tap is an unambiguous accept,
+/// and it sends the exact question Omi offered rather than whatever the reader
+/// retypes. The secondary hint appears only where push-to-talk is actually
+/// available — offering a shortcut that does nothing on this surface is worse
+/// than offering none.
+struct FollowUpChip: View {
+  enum Palette {
+    /// The floating bar and notch, whose ink is the white-on-black glass scale.
+    case glass
+    /// The main window, on the standard semantic ink scale.
+    case standard
+  }
+
+  let question: String
+  var palette: Palette = .glass
+  /// Secondary hint, shown only where push-to-talk exists on this surface.
+  /// Nil elsewhere: a shortcut hint that does nothing is worse than none.
+  var voiceHint: String?
+  let action: () -> Void
+
+  @State private var isHovered = false
+
+  private var labelColor: Color {
+    switch palette {
+    case .glass: return NotchGlass.ink(.w85)
+    case .standard: return Ink.primary
+    }
+  }
+
+  private var hintColor: Color {
+    switch palette {
+    case .glass: return NotchGlass.quiet
+    case .standard: return Ink.secondary
+    }
+  }
+
+  private var fill: Color {
+    switch palette {
+    case .glass: return NotchGlass.ink(isHovered ? .w15 : .w1)
+    case .standard: return isHovered ? Ink.rowFillHover : Ink.rowFill
+    }
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+      Button(action: action) {
+        HStack(spacing: OmiSpacing.xs) {
+          Image(systemName: "arrow.turn.down.right")
+            .scaledFont(size: OmiType.micro)
+            .foregroundColor(hintColor)
+          Text(question)
+            .scaledFont(size: OmiType.caption, weight: .medium)
+            .foregroundColor(labelColor)
+            .multilineTextAlignment(.leading)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, OmiSpacing.sm)
+        .padding(.vertical, OmiSpacing.xs)
+        .background(fill)
+        .clipShape(RoundedRectangle(cornerRadius: OmiChrome.elementRadius, style: .continuous))
+        .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .onHover { isHovered = $0 }
+      .accessibilityLabel("Ask: \(question)")
+      .accessibilityIdentifier("chat-follow-up-chip")
+
+      if let voiceHint {
+        Text(voiceHint)
+          .scaledFont(size: OmiType.micro)
+          .foregroundColor(hintColor)
+          .padding(.leading, OmiSpacing.sm)
+          .accessibilityIdentifier("chat-follow-up-voice-hint")
+      }
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -216,6 +216,13 @@ struct ScopedDefaultsKey {
   static func taskInterruptionLedger(ownerID: String) -> Self {
     Self(rawValue: "proactiveTaskInterruptionLedger.v1.\(ownerID)")
   }
+
+  /// Owner-scoped record of which Home knows-list rows have already been shown,
+  /// opened, or dismissed. Without it a thin candidate source repeats the same
+  /// four rows on every visit; owner-scoped for the same bleed class as above.
+  static func homeKnowsImpressions(ownerID: String) -> Self {
+    Self(rawValue: "homeKnows.impressions.v1.\(ownerID)")
+  }
 }
 
 /// Typed accessors that take a `DefaultsKey` instead of a `String`.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
@@ -21,6 +21,13 @@ struct AIResponseView: View {
   var onShareLink: (() async -> String?)?
   var onOpenAgent: ((UUID, @escaping (Bool) -> Void) -> Void)?
   var onOpenAgentRef: ((AgentTimelineRef, @escaping (Bool) -> Void) -> Void)? = nil
+  /// Tapping the grounded follow-up chip sends its question as a new user turn
+  /// in this same lane. Nil leaves the chip out entirely rather than rendering
+  /// one that does nothing.
+  var onAskFollowUp: ((String) -> Void)?
+  /// The "or hold ⌥ to ask aloud" hint, named for the shortcut actually bound.
+  /// Nil where push-to-talk is off or unavailable.
+  var followUpVoiceHint: String?
 
   var body: some View {
     VStack(alignment: .leading, spacing: OmiSpacing.md) {
@@ -118,9 +125,13 @@ struct AIResponseView: View {
         return ["chatFirstConversation", id].joined(separator: "\u{1E}")
       case .memoryLink(let id, _, _):
         return ["chatFirstMemory", id].joined(separator: "\u{1E}")
+      case .memoryReviewCard(let id, _, _, let items):
+        return ["memoryReviewCard", id, String(items.count)].joined(separator: "\u{1E}")
       case .citation(let id, let reference):
         return ["citation", id, String(reference.ordinal), reference.sourceID]
           .joined(separator: "\u{1E}")
+      case .followUp(let id, let text):
+        return ["followUp", id, text].joined(separator: "\u{1E}")
       case .agentSpawn(
         let id, let pillId, let sessionId, let runId, let title, let objective, let provider
       ):
@@ -221,6 +232,16 @@ struct AIResponseView: View {
         // Keep journaled blocks inert if an older runtime projects them here.
         case .questionCard, .taskCard, .goalLink, .captureLink, .conversationLink, .memoryLink:
           EmptyView()
+        case .followUp(_, let question):
+          if let onAskFollowUp {
+            FollowUpChip(
+              question: question,
+              palette: .glass,
+              voiceHint: followUpVoiceHint,
+              action: { onAskFollowUp(question) }
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+          }
         case .agentSpawn(
           _, let pillId, let sessionId, let runId, let title, let objective, let provider
         ):

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
@@ -230,7 +230,10 @@ struct AIResponseView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         // The floating/notch surface never opts into rich chat-first controls.
         // Keep journaled blocks inert if an older runtime projects them here.
-        case .questionCard, .taskCard, .goalLink, .captureLink, .conversationLink, .memoryLink:
+        // The review card is three controls and an inline editor over stored memories — the
+        // clearest case of a rich control this passive surface does not own.
+        case .questionCard, .taskCard, .goalLink, .captureLink, .conversationLink, .memoryLink,
+          .memoryReviewCard:
           EmptyView()
         case .followUp(_, let question):
           if let onAskFollowUp {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -2113,7 +2113,7 @@ final class AgentPillsManager: ObservableObject {
           return String(trimmed.prefix(110))
         }
       case .thinking, .discoveryCard, .questionCard, .taskCard, .goalLink, .captureLink,
-        .conversationLink, .memoryLink, .citation, .followUp:
+        .conversationLink, .memoryLink, .citation, .followUp, .memoryReviewCard:
         continue
       }
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
@@ -2113,7 +2113,7 @@ final class AgentPillsManager: ObservableObject {
           return String(trimmed.prefix(110))
         }
       case .thinking, .discoveryCard, .questionCard, .taskCard, .goalLink, .captureLink,
-        .conversationLink, .memoryLink, .citation:
+        .conversationLink, .memoryLink, .citation, .followUp:
         continue
       }
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -1124,6 +1124,10 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
         // tappable next step into an answer that ends by asking out loud.
         case .followUp:
           return nil
+        // Nor is the review card: reading three stored memories aloud would narrate the card's
+        // controls instead of the answer.
+        case .memoryReviewCard:
+          return nil
         case .toolCall, .thinking:
           return nil
         }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -1120,6 +1120,10 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
         case .questionCard, .taskCard, .goalLink, .captureLink, .conversationLink, .memoryLink,
           .citation:
           return nil
+        // The chip is a control, not narration. Speaking it would turn a
+        // tappable next step into an answer that ends by asking out loud.
+        case .followUp:
+          return nil
         case .toolCall, .thinking:
           return nil
         }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
@@ -917,7 +917,9 @@ extension ChatContentBlock {
     case .captureLink(let id, _, _, _): return "c:\(id)"
     case .conversationLink(let id, _, _, _): return "v:\(id)"
     case .memoryLink(let id, _, _): return "m:\(id)"
+    case .memoryReviewCard(let id, _, _, let items): return "mr:\(id):\(items.count)"
     case .citation(let id, let reference): return "r:\(id):\(reference.ordinal)"
+    case .followUp(let id, let text): return "f:\(id):\(text.count)"
     case .agentSpawn(let id, let pillId, _, _, _, _, _): return "s:\(id):\(pillId?.uuidString ?? "")"
     case .agentCompletion(let id, let pillId, _, _, _, _, _, _): return "a:\(id):\(pillId?.uuidString ?? "")"
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -2194,7 +2194,7 @@ private struct AgentMainChatView: View {
           // follow-up chip belongs to the answer surface, not this agent-pill
           // transcript, which has no lane to send the next turn on.
           case .questionCard, .taskCard, .goalLink, .captureLink, .conversationLink, .memoryLink,
-            .followUp:
+            .followUp, .memoryReviewCard:
             EmptyView()
           case .agentSpawn(
             _, let pillId, let sessionId, let runId, let title, let objective, let provider

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -1643,6 +1643,15 @@ struct FloatingControlBarView: View {
     FloatingControlBarManager.shared.sharedFloatingProvider
   }
 
+  /// The chip's secondary hint names the shortcut actually bound, and is absent
+  /// when push-to-talk is off — a hint for a disabled gesture is a wrong hint.
+  @MainActor static func followUpVoiceHint(settings: ShortcutSettings = ShortcutSettings.shared) -> String? {
+    guard settings.pttEnabled else { return nil }
+    let tokens = settings.pttShortcut.displayTokens
+    guard let token = tokens.first, !token.isEmpty else { return nil }
+    return "or hold \(token) to ask aloud"
+  }
+
   private var aiResponseView: some View {
     // Re-read derived content when viewport anchors or streamed answer tokens change.
     let _ = state.chatViewport
@@ -1671,7 +1680,12 @@ struct FloatingControlBarView: View {
       },
       onOpenAgentRef: { ref, completion in
         openAgentInChat(ref: ref, completion: completion)
-      }
+      },
+      onAskFollowUp: { question in
+        AnalyticsManager.shared.questionOriginating(.followUp)
+        FloatingControlBarManager.shared.openAIInputWithQuery(question)
+      },
+      followUpVoiceHint: Self.followUpVoiceHint()
     )
     .transition(
       .asymmetric(
@@ -2176,8 +2190,11 @@ private struct AgentMainChatView: View {
           case .discoveryCard(_, let title, let summary, let fullText):
             DiscoveryCard(title: title, summary: summary, fullText: fullText)
               .frame(maxWidth: .infinity, alignment: .leading)
-          // Rich controls are main-chat-only; floating/notch stays passive.
-          case .questionCard, .taskCard, .goalLink, .captureLink, .conversationLink, .memoryLink:
+          // Rich controls are main-chat-only; floating/notch stays passive. The
+          // follow-up chip belongs to the answer surface, not this agent-pill
+          // transcript, which has no lane to send the next turn on.
+          case .questionCard, .taskCard, .goalLink, .captureLink, .conversationLink, .memoryLink,
+            .followUp:
             EmptyView()
           case .agentSpawn(
             _, let pillId, let sessionId, let runId, let title, let objective, let provider

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -5297,8 +5297,13 @@ class FloatingControlBarManager {
       // No error and no provider-backed answer content (text/blocks/resources).
       // Never call setLocalAnswerOverride when an answerMessageId is already
       // bound — that would clear the provider answer (including block-only).
+      // Honest, and deliberately not an invitation. The measured behaviour is
+      // that nobody takes a "want me to try again?" tail — they re-send the same
+      // question themselves — so the copy states what happened and stops. A
+      // failed turn never carries a follow-up chip either: the chip is appended
+      // only on the provider's accepted-answer path.
       barWindow.state.setLocalAnswerOverride(
-        ChatMessage(text: "Failed to get a response. Please try again.", sender: .ai)
+        ChatMessage(text: "Omi couldn't get an answer for that one.", sender: .ai)
       )
     }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/Blocks/ChatFirstContentBlockViews.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/Blocks/ChatFirstContentBlockViews.swift
@@ -667,6 +667,25 @@ struct MemoryLinkView: View {
   }
 }
 
+// MARK: - Memory review card
+
+/// The `memoryReviewCard` block, rendered as the same rows the daily summary card uses.
+///
+/// One row view, two arrival paths. The desktop's live path is the summary record — this app has
+/// no `day_summary` chat row today — but the block is the contract both shells share, and giving it
+/// a second row implementation is how the two surfaces would drift into disagreeing about what a
+/// verdict means.
+struct MemoryReviewCardView: View {
+  let summaryID: String
+  let date: String
+  let items: [MemoryReviewItem]
+
+  var body: some View {
+    MemoryReviewSection(items: items, source: .chatBlock)
+      .id("memory-review-block-\(summaryID)-\(date)")
+  }
+}
+
 private struct ChatFirstLinkBlockView: View {
   let eyebrow: String
   let systemImage: String

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift
@@ -1355,6 +1355,10 @@ enum ContentBlockGroup: Identifiable {
       case .discoveryCard, .questionCard, .taskCard, .goalLink, .captureLink, .conversationLink, .memoryLink,
         .agentSpawn, .agentCompletion:
         return group
+      // Like the follow-up chip: a card asking to be answered has no business
+      // appearing before the turn it belongs to has finished arriving.
+      case .memoryReviewCard:
+        return isStreaming ? nil : group
       // The chip is only ever attached to a finished, grounded answer, so it
       // never appears mid-stream to be tapped before the answer it follows from.
       case .followUp:

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift
@@ -545,6 +545,35 @@ struct ChatBubble: View {
           navigation: chatFirstRichBlockContext.navigation
         )
       )
+    case .memoryReviewCard(_, let summaryID, let date, let items):
+      return AnyView(MemoryReviewCardView(summaryID: summaryID, date: date, items: items))
+    case .followUp(_, let question):
+      guard let chatFirstRichBlockContext else { return AnyView(EmptyView()) }
+      let provider = chatFirstRichBlockContext.chatProvider
+      return AnyView(
+        FollowUpChip(
+          question: question,
+          palette: .standard,
+          action: {
+            Task { @MainActor in
+              // Analytics commit at the provider's own acceptance boundary: a
+              // send it refuses emits nothing and mislabels nothing later.
+              _ = await provider.sendMessage(
+                question,
+                surfaceRef: provider.mainChatSurfaceReference(),
+                turnOwner: .mainChat,
+                onAccepted: {
+                  AnalyticsManager.shared.questionOriginating(.followUp)
+                  AnalyticsManager.shared.chatMessageSent(
+                    messageLength: question.count,
+                    source: "follow_up_chip"
+                  )
+                }
+              )
+            }
+          }
+        )
+      )
     case .agentSpawn(
       _, let pillId, let sessionId, let runId, let title, let objective, let provider
     ):
@@ -1105,6 +1134,8 @@ enum ContentBlockGroup: Identifiable {
     recommendedActionItems: [ConversationLinkActionItem]
   )
   case memoryLink(id: String, memoryID: String, summary: String)
+  case memoryReviewCard(id: String, summaryID: String, date: String, items: [MemoryReviewItem])
+  case followUp(id: String, question: String)
   case agentSpawn(
     id: String,
     pillId: UUID?,
@@ -1138,6 +1169,8 @@ enum ContentBlockGroup: Identifiable {
     case .captureLink(let id, _, _, _): return id
     case .conversationLink(let id, _, _, _): return id
     case .memoryLink(let id, _, _): return id
+    case .memoryReviewCard(let id, _, _, _): return id
+    case .followUp(let id, _): return id
     case .agentSpawn(let id, _, _, _, _, _, _): return id
     case .agentCompletion(let id, _, _, _, _, _, _, _): return id
     }
@@ -1209,6 +1242,15 @@ enum ContentBlockGroup: Identifiable {
         flushToolCalls()
         guard richBlockRenderingEnabled else { continue }
         groups.append(.memoryLink(id: id, memoryID: memoryID, summary: summary))
+      case .memoryReviewCard(let id, let summaryID, let date, let items):
+        flushToolCalls()
+        // Ungated, like the follow-up chip: the rows need no Chat-first navigation context, and a
+        // card whose whole purpose is to be answered is not a rich-link preview to hold back.
+        guard !items.isEmpty else { continue }
+        groups.append(.memoryReviewCard(id: id, summaryID: summaryID, date: date, items: items))
+      case .followUp(let id, let question):
+        flushToolCalls()
+        groups.append(.followUp(id: id, question: question))
       case .citation:
         // Answer-level provenance is rendered by OmiMarkdown at the inline marker.
         continue
@@ -1313,6 +1355,10 @@ enum ContentBlockGroup: Identifiable {
       case .discoveryCard, .questionCard, .taskCard, .goalLink, .captureLink, .conversationLink, .memoryLink,
         .agentSpawn, .agentCompletion:
         return group
+      // The chip is only ever attached to a finished, grounded answer, so it
+      // never appears mid-stream to be tapped before the answer it follows from.
+      case .followUp:
+        return isStreaming ? nil : group
       case .thinking:
         return isStreaming ? group : nil
       case .toolCalls(let id, let calls):

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/AnalyticsManager+DailySummary.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/AnalyticsManager+DailySummary.swift
@@ -26,3 +26,52 @@ extension AnalyticsManager {
     PostHogManager.shared.track(Self.dailySummaryEvent, properties: ["phase": phase.rawValue])
   }
 }
+
+// MARK: - Memory review card telemetry
+//
+// What the card exists to move is the rate at which a claim about the owner gets answered rather
+// than only read, so the two events are "it was seen" and "it was acted on, and did the mutation
+// land". Bounded dimensions only (desktop `AGENTS.md` → product analytics integrity): the memory's
+// text is the owner's own life and never leaves the device, and no memory id is sent — a verdict
+// keyed to an id would make PostHog a second, weaker copy of the memory store's own review state.
+
+extension AnalyticsManager {
+  static let memoryReviewActionEvent = "memory_review_action"
+  static let memoryReviewCardShownEvent = "memory_review_card_shown"
+
+  /// One completed ✓ / ✗ / Fix, reported at the request's own outcome so a failure is never
+  /// counted as a correction the owner made.
+  func trackMemoryReviewAction(
+    source: MemoryReviewSource,
+    action: MemoryReviewAction,
+    succeeded: Bool,
+    category: String
+  ) {
+    PostHogManager.shared.track(
+      Self.memoryReviewActionEvent,
+      properties: [
+        "source": source.rawValue,
+        "action": action.rawValue,
+        "outcome": succeeded ? "ok" : "error",
+        "memory_category": Self.boundedMemoryCategory(category),
+      ])
+  }
+
+  /// The card rendered with rows in it. Emitted once per mount, not once per re-render.
+  func trackMemoryReviewCardShown(source: MemoryReviewSource, itemCount: Int) {
+    PostHogManager.shared.track(
+      Self.memoryReviewCardShownEvent,
+      properties: [
+        "source": source.rawValue,
+        "item_count": itemCount,
+      ])
+  }
+
+  /// Closed set. An unrecognised backend category becomes `other` rather than travelling as a
+  /// free-form string that could widen over time into an unbounded dimension.
+  nonisolated static func boundedMemoryCategory(_ category: String) -> String {
+    let trimmed = category.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty { return "unknown" }
+    return MemoryCategory(rawValue: trimmed) != nil ? trimmed : "other"
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/AnalyticsManager+HomeKnows.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/AnalyticsManager+HomeKnows.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+// MARK: - Home knows-list rotation telemetry
+//
+// The repetition this event exists to measure: over 14 days the owner's hub
+// showed the same four commitments 8–12 times each, and the only engagement was
+// asking the card to explain itself. `shows_before` makes that rate readable —
+// a healthy list is dominated by 0, a repeating one by 3+. `rotated_out_reason`
+// says why a slot went empty instead of repeating.
+//
+// Bounded dimensions only: kind, slot, and reason are closed enum rawValues and
+// `shows_before` is a small integer. The row's text is the reader's own tasks
+// and questions and never leaves the device (desktop `AGENTS.md` → product
+// analytics integrity).
+
+extension AnalyticsManager {
+  static let homeKnowsRowEvent = "desktop_home_knows_row"
+
+  /// One row rendered in the knows-list. Emitted once per visit per row, not
+  /// once per re-render — the in-visit rotation timer re-renders every few
+  /// seconds and would otherwise invent impressions.
+  func trackHomeKnowsRowShown(kind: String, slot: HomeKnowsSlot, showsBefore: Int) {
+    PostHogManager.shared.track(
+      Self.homeKnowsRowEvent,
+      properties: [
+        "kind": kind,
+        "slot": slot.rawValue,
+        "shows_before": showsBefore,
+      ])
+  }
+
+  /// A slot that stayed empty rather than repeating a row already seen.
+  func trackHomeKnowsSlotEmpty(slot: HomeKnowsSlot, reason: HomeKnowsRotationReason) {
+    PostHogManager.shared.track(
+      Self.homeKnowsRowEvent,
+      properties: [
+        "kind": "empty",
+        "slot": slot.rawValue,
+        "shows_before": 0,
+        "rotated_out_reason": reason.rawValue,
+      ])
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ChatDailySummaryCard.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ChatDailySummaryCard.swift
@@ -65,6 +65,14 @@ struct ChatDailySummaryCard: View {
           .fixedSize(horizontal: false, vertical: true)
       }
 
+      let learned = Self.memoriesLearned(in: summary)
+      if !learned.isEmpty {
+        // Keyed to the summary, so tomorrow's card starts from tomorrow's memories rather than
+        // inheriting a row model built for yesterday's.
+        MemoryReviewSection(items: learned, source: .dailySummaryChat)
+          .id("memory-review-\(summary.id)")
+      }
+
       if isExpanded {
         expandedBody(summary)
       }
@@ -234,5 +242,17 @@ struct ChatDailySummaryCard: View {
 
   nonisolated static func actionItems(in summary: DailySummaryRecord) -> [DailySummaryRecord.ActionItem] {
     (summary.actionItems ?? []).filter { !($0.description ?? "").isEmpty }
+  }
+
+  /// The review rows, and only from `memories_learned`.
+  ///
+  /// Deliberately never falls back to `knowledge_nuggets`: a nugget is LLM prose with no memory
+  /// behind it, so a ✓ on one would mutate nothing and a ✗ would teach extraction nothing. A day
+  /// with no qualifying memory shows no section, which is the honest empty state.
+  nonisolated static func memoriesLearned(in summary: DailySummaryRecord) -> [MemoryReviewItem] {
+    summary.memoriesLearned
+      .filter { !$0.memoryID.isEmpty && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+      .prefix(MemoryReviewSection.maxRows)
+      .map(MemoryReviewItem.init)
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsComposer.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsComposer.swift
@@ -136,7 +136,8 @@ enum HomeKnowsListComposer {
         !candidate.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
           && seenTaskIDs.insert(candidate.id).inserted
       }
-      .map { candidate in
+      .enumerated()
+      .map { index, candidate in
         Scored(
           element: candidate,
           facts: HomeKnowsCandidateFacts(
@@ -145,20 +146,23 @@ enum HomeKnowsListComposer {
               text: candidate.text, updatedAt: candidate.updatedAt),
             updatedAt: candidate.updatedAt,
             dueAt: candidate.dueAt,
-            isActive: candidate.isActive))
+            isActive: candidate.isActive),
+          order: index)
       }
 
     let insightCandidates =
       insights
       .filter { !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
-      .map { candidate in
+      .enumerated()
+      .map { index, candidate in
         Scored(
           element: candidate,
           facts: HomeKnowsCandidateFacts(
             key: HomeKnowsRotationPolicy.insightKey(candidate.id),
             contentHash: HomeKnowsRotationPolicy.contentHash(
               text: candidate.text, updatedAt: candidate.updatedAt),
-            updatedAt: candidate.updatedAt))
+            updatedAt: candidate.updatedAt),
+          order: index)
       }
 
     let trimmedTip = tip?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -171,13 +175,16 @@ enum HomeKnowsListComposer {
       questions
       .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
       .filter { !$0.isEmpty && seenQuestions.insert($0).inserted }
-      .map { text in Scored(element: text, facts: questionFacts(text)) }
+      .enumerated()
+      .map { index, text in Scored(element: text, facts: questionFacts(text), order: index) }
 
     let taskPool = pool(taskCandidates, ledger: ledger, now: now, calendar: calendar)
     let insightPool = pool(insightCandidates, ledger: ledger, now: now, calendar: calendar)
     let questionPool = pool(questionCandidates, ledger: ledger, now: now, calendar: calendar)
     let tipPool = cleanTip.map { text in
-      pool([Scored(element: text, facts: questionFacts(text))], ledger: ledger, now: now, calendar: calendar)
+      pool(
+        [Scored(element: text, facts: questionFacts(text), order: 0)],
+        ledger: ledger, now: now, calendar: calendar)
     }
 
     // Rotate each pool so the hub cycles through the qualifying candidates while
@@ -261,10 +268,12 @@ enum HomeKnowsListComposer {
 
   // MARK: Internals
 
-  /// A candidate paired with the facts the rotation rules read.
+  /// A candidate paired with the facts the rotation rules read, and its
+  /// position in the caller's own priority order.
   private struct Scored<Element> {
     let element: Element
     let facts: HomeKnowsCandidateFacts
+    let order: Int
   }
 
   /// The qualifying candidates for one slot, plus why the rest were held back.
@@ -329,9 +338,13 @@ enum HomeKnowsListComposer {
     if eligible.isEmpty {
       (eligible, reasons) = pass(allowSameDayRepeat: true)
     }
-    let ordered = eligible.sorted {
-      HomeKnowsRotationPolicy.freshnessRank($0.facts, ledger: ledger)
-        < HomeKnowsRotationPolicy.freshnessRank($1.facts, ledger: ledger)
+    // `sorted(by:)` is not stable, so the caller's order is the explicit final
+    // tie-break rather than something the sort happens to preserve.
+    let ordered = eligible.sorted { lhs, rhs in
+      let lhsRank = HomeKnowsRotationPolicy.freshnessRank(lhs.facts, ledger: ledger)
+      let rhsRank = HomeKnowsRotationPolicy.freshnessRank(rhs.facts, ledger: ledger)
+      if lhsRank != rhsRank { return lhsRank < rhsRank }
+      return lhs.order < rhs.order
     }
     return Pool(eligible: ordered, emptyReason: HomeKnowsRotationPolicy.dominantReason(reasons))
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsComposer.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsComposer.swift
@@ -8,11 +8,26 @@ enum HomeKnowsRowKind: Equatable {
   case task(id: String)
   case insight(id: String)
   case question
+
+  /// Bounded analytics dimension — never carries the row's text.
+  var analyticsKind: String {
+    switch self {
+    case .task: return "task"
+    case .insight: return "insight"
+    case .question: return "question"
+    }
+  }
 }
 
 struct HomeKnowsRow: Identifiable, Equatable {
   let kind: HomeKnowsRowKind
   let text: String
+  /// Stable identity in the impression ledger. Question rows hash their text.
+  var ledgerKey: String = ""
+  /// Hash of the underlying object; a dismissed row returns only when it moves.
+  var contentHash: String = ""
+  /// How many times this row had already been shown before this composition.
+  var showsBefore: Int = 0
 
   var id: String {
     switch kind {
@@ -23,14 +38,59 @@ struct HomeKnowsRow: Identifiable, Equatable {
   }
 }
 
+/// The four typed slots. Fixed so the list stays diverse instead of collapsing
+/// into all-tasks when one source is thin.
+enum HomeKnowsSlot: String, Equatable, Sendable, CaseIterable {
+  case pressingTask = "pressing_task"
+  case tip
+  case secondTask = "second_task"
+  case ask
+}
+
+/// A slot that stayed empty rather than repeating a row the reader has already
+/// seen. The list is allowed to be shorter than four.
+struct HomeKnowsEmptySlot: Equatable {
+  let slot: HomeKnowsSlot
+  let reason: HomeKnowsRotationReason
+}
+
+struct HomeKnowsComposition: Equatable {
+  static let empty = HomeKnowsComposition(rows: [], emptySlots: [], canRotate: false)
+
+  let rows: [HomeKnowsRow]
+  let emptySlots: [HomeKnowsEmptySlot]
+  /// True when more candidates qualify than the list shows, so the in-visit
+  /// rotation cycles to genuinely different rows instead of the same set.
+  let canRotate: Bool
+}
+
 struct HomeKnowsTaskCandidate: Equatable {
   let id: String
   let text: String
+  var dueAt: Date?
+  var updatedAt: Date?
+  /// False once the task is completed, retired, or deleted.
+  var isActive: Bool
+
+  init(id: String, text: String, dueAt: Date? = nil, updatedAt: Date? = nil, isActive: Bool = true) {
+    self.id = id
+    self.text = text
+    self.dueAt = dueAt
+    self.updatedAt = updatedAt
+    self.isActive = isActive
+  }
 }
 
 struct HomeKnowsInsightCandidate: Equatable {
   let id: String
   let text: String
+  var updatedAt: Date?
+
+  init(id: String, text: String, updatedAt: Date? = nil) {
+    self.id = id
+    self.text = text
+    self.updatedAt = updatedAt
+  }
 }
 
 /// Builds the hub rows under the greeting as a deliberately DIVERSE set — one
@@ -38,13 +98,23 @@ struct HomeKnowsInsightCandidate: Equatable {
 /// high-agency nudge you can hand Omi), a second task, and a prefilled ask.
 /// Fixed typed slots keep it from collapsing into an all-tasks list when one
 /// source (usually insights) is thin.
+///
+/// Every slot is gated by `HomeKnowsRotationPolicy` against the impression
+/// ledger, so a thin source produces a *shorter* list rather than the same four
+/// rows on every visit. An empty slot is the intended outcome, not a bug.
 enum HomeKnowsListComposer {
   static let maxRows = 4
 
-  /// How many candidates must exist beyond what's shown before the hub starts
-  /// rotating — otherwise the same rows would "rotate" back onto themselves.
-  static func canRotate(taskCount: Int, insightCount: Int, questionCount: Int) -> Bool {
-    taskCount > 2 || insightCount > 1 || questionCount > 1
+  /// Open tasks the reader has not dismissed — the count the greeting's daily
+  /// brief and composed tip are phrased around.
+  static func openTaskCount(
+    _ tasks: [HomeKnowsTaskCandidate],
+    ledger: HomeKnowsImpressionLedger = .empty
+  ) -> Int {
+    tasks.filter { candidate in
+      guard candidate.isActive else { return false }
+      return ledger.entry(HomeKnowsRotationPolicy.taskKey(candidate.id))?.dismissedAt == nil
+    }.count
   }
 
   static func compose(
@@ -52,65 +122,223 @@ enum HomeKnowsListComposer {
     insights: [HomeKnowsInsightCandidate],
     tip: String? = nil,
     questions: [String],
-    dismissedTaskIDs: Set<String> = [],
+    ledger: HomeKnowsImpressionLedger = .empty,
+    now: Date = Date(),
+    calendar: Calendar = .current,
     rotation: Int = 0
-  ) -> [HomeKnowsRow] {
-    let freshTasksRaw = tasks.filter { candidate in
-      !dismissedTaskIDs.contains(candidate.id)
-        && !candidate.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    }
-    let cleanInsightsRaw = insights.filter {
-      !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    }
+  ) -> HomeKnowsComposition {
+    // Task ids repeat across the overdue/today/no-due-date buckets the hub
+    // concatenates; a duplicate would collide as a ForEach ID.
+    var seenTaskIDs = Set<String>()
+    let taskCandidates =
+      tasks
+      .filter { candidate in
+        !candidate.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+          && seenTaskIDs.insert(candidate.id).inserted
+      }
+      .map { candidate in
+        Scored(
+          element: candidate,
+          facts: HomeKnowsCandidateFacts(
+            key: HomeKnowsRotationPolicy.taskKey(candidate.id),
+            contentHash: HomeKnowsRotationPolicy.contentHash(
+              text: candidate.text, updatedAt: candidate.updatedAt),
+            updatedAt: candidate.updatedAt,
+            dueAt: candidate.dueAt,
+            isActive: candidate.isActive))
+      }
+
+    let insightCandidates =
+      insights
+      .filter { !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+      .map { candidate in
+        Scored(
+          element: candidate,
+          facts: HomeKnowsCandidateFacts(
+            key: HomeKnowsRotationPolicy.insightKey(candidate.id),
+            contentHash: HomeKnowsRotationPolicy.contentHash(
+              text: candidate.text, updatedAt: candidate.updatedAt),
+            updatedAt: candidate.updatedAt))
+      }
+
     let trimmedTip = tip?.trimmingCharacters(in: .whitespacesAndNewlines)
     let cleanTip = (trimmedTip?.isEmpty == false) ? trimmedTip : nil
 
     // Question rows are identified by their text, so a repeated suggestion
     // would collide as a ForEach ID — keep only the first occurrence.
     var seenQuestions = Set<String>()
-    let cleanQuestionsRaw =
+    let questionCandidates =
       questions
       .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
       .filter { !$0.isEmpty && seenQuestions.insert($0).inserted }
+      .map { text in Scored(element: text, facts: questionFacts(text)) }
 
-    // Rotate each source so the hub cycles through fresh candidates over time
-    // while the diverse task · tip · task · ask structure below stays fixed.
-    func rotated<T>(_ arr: [T]) -> [T] {
-      guard arr.count > 1 else { return arr }
-      let k = ((rotation % arr.count) + arr.count) % arr.count
-      return Array(arr[k...] + arr[..<k])
+    let taskPool = pool(taskCandidates, ledger: ledger, now: now, calendar: calendar)
+    let insightPool = pool(insightCandidates, ledger: ledger, now: now, calendar: calendar)
+    let questionPool = pool(questionCandidates, ledger: ledger, now: now, calendar: calendar)
+    let tipPool = cleanTip.map { text in
+      pool([Scored(element: text, facts: questionFacts(text))], ledger: ledger, now: now, calendar: calendar)
     }
-    let freshTasks = rotated(freshTasksRaw)
-    let cleanInsights = rotated(cleanInsightsRaw)
-    let cleanQuestions = rotated(cleanQuestionsRaw)
+
+    // Rotate each pool so the hub cycles through the qualifying candidates while
+    // the diverse task · tip · task · ask structure below stays fixed.
+    let freshTasks = rotated(taskPool.eligible, by: rotation)
+    let freshInsights = rotated(insightPool.eligible, by: rotation)
+    let freshQuestions = rotated(questionPool.eligible, by: rotation)
     // The ask never duplicates the composed tip.
-    let ask = cleanQuestions.first { $0 != cleanTip }
+    let ask = freshQuestions.first { $0.element != cleanTip }
 
     var rows: [HomeKnowsRow] = []
+    var emptySlots: [HomeKnowsEmptySlot] = []
 
-    // 1) The single most pressing task.
-    if let task = freshTasks.first {
-      rows.append(HomeKnowsRow(kind: .task(id: task.id), text: task.text))
+    func fill(
+      _ slot: HomeKnowsSlot, with row: HomeKnowsRow?, otherwise reason: @autoclosure () -> HomeKnowsRotationReason
+    ) {
+      if let row {
+        rows.append(row)
+      } else {
+        emptySlots.append(HomeKnowsEmptySlot(slot: slot, reason: reason()))
+      }
     }
 
+    // 1) The single most pressing task.
+    fill(
+      .pressingTask,
+      with: freshTasks.first.map {
+        row(kind: .task(id: $0.element.id), text: $0.element.text, facts: $0.facts, ledger: ledger)
+      },
+      otherwise: taskPool.emptyReason)
+
     // 2) A tip — a real server insight, else a composed nudge that prefills chat.
-    if let insight = cleanInsights.first {
-      rows.append(HomeKnowsRow(kind: .insight(id: insight.id), text: insight.text))
-    } else if let cleanTip {
-      rows.append(HomeKnowsRow(kind: .question, text: cleanTip))
+    if let insight = freshInsights.first {
+      rows.append(
+        row(kind: .insight(id: insight.element.id), text: insight.element.text, facts: insight.facts, ledger: ledger))
+    } else if let tipPool, let tipRow = tipPool.eligible.first {
+      rows.append(row(kind: .question, text: tipRow.element, facts: tipRow.facts, ledger: ledger))
+    } else {
+      // Report the insight source's reason when there was one; a suppressed
+      // composed tip is why the slot is empty only when insights never existed.
+      let reason = insightCandidates.isEmpty ? (tipPool?.emptyReason ?? .noCandidate) : insightPool.emptyReason
+      emptySlots.append(HomeKnowsEmptySlot(slot: .tip, reason: reason))
     }
 
     // 3) A second concrete task — but only if the prefilled ask can still follow.
-    if freshTasks.count > 1, ask == nil || rows.count < maxRows - 1 {
-      let task = freshTasks[1]
-      rows.append(HomeKnowsRow(kind: .task(id: task.id), text: task.text))
+    // Yielding the slot to the ask is a layout choice, not a rotation outcome,
+    // so it is not reported as an empty slot.
+    if freshTasks.count > 1 {
+      if ask == nil || rows.count < maxRows - 1 {
+        let task = freshTasks[1]
+        rows.append(
+          row(kind: .task(id: task.element.id), text: task.element.text, facts: task.facts, ledger: ledger))
+      }
+    } else {
+      emptySlots.append(HomeKnowsEmptySlot(slot: .secondTask, reason: taskPool.emptyReason))
     }
 
     // 4) A prefilled ask, so there's always a distinct thing to hand Omi.
-    if let ask, rows.count < maxRows {
-      rows.append(HomeKnowsRow(kind: .question, text: ask))
+    if let ask {
+      if rows.count < maxRows {
+        rows.append(row(kind: .question, text: ask.element, facts: ask.facts, ledger: ledger))
+      }
+    } else {
+      emptySlots.append(HomeKnowsEmptySlot(slot: .ask, reason: questionPool.emptyReason))
     }
 
-    return Array(rows.prefix(maxRows))
+    return HomeKnowsComposition(
+      rows: Array(rows.prefix(maxRows)),
+      emptySlots: emptySlots,
+      canRotate: canRotate(
+        taskCount: taskPool.eligible.count,
+        insightCount: insightPool.eligible.count,
+        questionCount: questionPool.eligible.count))
+  }
+
+  /// How many candidates must qualify beyond what's shown before the hub starts
+  /// rotating — otherwise the same rows would "rotate" back onto themselves.
+  static func canRotate(taskCount: Int, insightCount: Int, questionCount: Int) -> Bool {
+    taskCount > 2 || insightCount > 1 || questionCount > 1
+  }
+
+  // MARK: Internals
+
+  /// A candidate paired with the facts the rotation rules read.
+  private struct Scored<Element> {
+    let element: Element
+    let facts: HomeKnowsCandidateFacts
+  }
+
+  /// The qualifying candidates for one slot, plus why the rest were held back.
+  private struct Pool<Element> {
+    let eligible: [Scored<Element>]
+    let emptyReason: HomeKnowsRotationReason
+  }
+
+  private static func questionFacts(_ text: String) -> HomeKnowsCandidateFacts {
+    HomeKnowsCandidateFacts(
+      key: HomeKnowsRotationPolicy.questionKey(text),
+      contentHash: HomeKnowsRotationPolicy.contentHash(text: text))
+  }
+
+  private static func row(
+    kind: HomeKnowsRowKind,
+    text: String,
+    facts: HomeKnowsCandidateFacts,
+    ledger: HomeKnowsImpressionLedger
+  ) -> HomeKnowsRow {
+    HomeKnowsRow(
+      kind: kind,
+      text: text,
+      ledgerKey: facts.key,
+      contentHash: facts.contentHash,
+      showsBefore: ledger.entry(facts.key)?.shows ?? 0)
+  }
+
+  /// Applies the rotation rules, then orders what survives by freshness:
+  /// never-shown first, then fewest shows, then most recent underlying update.
+  ///
+  /// Same-day repeats are relaxed only when the strict pass leaves the slot with
+  /// nothing at all — and even then the policy still requires a prior open.
+  private static func pool<Element>(
+    _ candidates: [Scored<Element>],
+    ledger: HomeKnowsImpressionLedger,
+    now: Date,
+    calendar: Calendar
+  ) -> Pool<Element> {
+    guard !candidates.isEmpty else { return Pool(eligible: [], emptyReason: .noCandidate) }
+
+    func pass(allowSameDayRepeat: Bool) -> ([Scored<Element>], [HomeKnowsRotationReason]) {
+      var eligible: [Scored<Element>] = []
+      var reasons: [HomeKnowsRotationReason] = []
+      for candidate in candidates {
+        if let reason = HomeKnowsRotationPolicy.suppression(
+          facts: candidate.facts,
+          entry: ledger.entry(candidate.facts.key),
+          now: now,
+          calendar: calendar,
+          allowSameDayRepeat: allowSameDayRepeat)
+        {
+          reasons.append(reason)
+        } else {
+          eligible.append(candidate)
+        }
+      }
+      return (eligible, reasons)
+    }
+
+    var (eligible, reasons) = pass(allowSameDayRepeat: false)
+    if eligible.isEmpty {
+      (eligible, reasons) = pass(allowSameDayRepeat: true)
+    }
+    let ordered = eligible.sorted {
+      HomeKnowsRotationPolicy.freshnessRank($0.facts, ledger: ledger)
+        < HomeKnowsRotationPolicy.freshnessRank($1.facts, ledger: ledger)
+    }
+    return Pool(eligible: ordered, emptyReason: HomeKnowsRotationPolicy.dominantReason(reasons))
+  }
+
+  private static func rotated<T>(_ arr: [T], by rotation: Int) -> [T] {
+    guard arr.count > 1 else { return arr }
+    let k = ((rotation % arr.count) + arr.count) % arr.count
+    return Array(arr[k...] + arr[..<k])
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsImpressionLedger.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsImpressionLedger.swift
@@ -1,0 +1,302 @@
+import CryptoKit
+import Foundation
+
+// MARK: - What the knows-list already showed
+
+/// One row's history in the Home knows-list.
+///
+/// The composer used to have no memory at all, so a thin source (four open
+/// commitments, one stale insight) re-rendered the same four rows on every
+/// visit — the owner's 14-day sample repeated "meet with <person>" nine times
+/// and "improve meeting notes quality" eight. This is the memory.
+struct HomeKnowsImpression: Codable, Equatable {
+  var shows: Int = 0
+  var firstShownAt: Date?
+  var lastShownAt: Date?
+  var lastOpenedAt: Date?
+  var dismissedAt: Date?
+  /// Hash of the underlying object the last time this entry was written.
+  /// A dismissed or capped row returns only when this changes.
+  var contentHash: String = ""
+}
+
+struct HomeKnowsImpressionLedger: Codable, Equatable {
+  static let empty = HomeKnowsImpressionLedger()
+
+  var entries: [String: HomeKnowsImpression] = [:]
+
+  func entry(_ key: String) -> HomeKnowsImpression? { entries[key] }
+}
+
+/// The identity and freshness facts the rotation rules need, independent of
+/// which source a candidate came from.
+struct HomeKnowsCandidateFacts: Equatable {
+  let key: String
+  let contentHash: String
+  /// When the underlying object last changed. `nil` sorts last on freshness.
+  let updatedAt: Date?
+  /// Due date for task rows; `nil` for everything else.
+  let dueAt: Date?
+  /// False once the underlying task is completed, retired, or deleted.
+  let isActive: Bool
+
+  init(
+    key: String,
+    contentHash: String,
+    updatedAt: Date? = nil,
+    dueAt: Date? = nil,
+    isActive: Bool = true
+  ) {
+    self.key = key
+    self.contentHash = contentHash
+    self.updatedAt = updatedAt
+    self.dueAt = dueAt
+    self.isActive = isActive
+  }
+}
+
+/// Why a candidate did not get its slot. Bounded set — it is a PostHog property.
+enum HomeKnowsRotationReason: String, Equatable, Sendable, CaseIterable {
+  /// The reader dismissed it and the underlying object has not changed since.
+  case dismissed
+  /// Shown the cap number of times without ever being opened.
+  case showCap = "show_cap"
+  /// Already shown today, and never opened, so it does not repeat.
+  case sameDay = "same_day"
+  /// Task due date is far enough past that surfacing it is noise.
+  case staleDueDate = "stale_due_date"
+  /// Underlying task was completed or deleted.
+  case inactive
+  /// The source had nothing to offer this slot at all.
+  case noCandidate = "no_candidate"
+}
+
+// MARK: - Rules
+
+/// Deterministic, clock-injected rotation rules. Pure by construction so the
+/// behaviour is unit-testable without UserDefaults or a running app.
+enum HomeKnowsRotationPolicy {
+  /// Shows without an open before a row rotates out.
+  static let showCapCount = 3
+  /// How long a capped row stays out.
+  static let showCapCooldown: TimeInterval = 7 * 24 * 60 * 60
+  /// How far past due a task may be before it stops being surfaced.
+  static let stalePastDueGrace: TimeInterval = 14 * 24 * 60 * 60
+
+  /// A stable content hash for a row's underlying object. A dismissed row
+  /// returns only when this changes, so it must move when the object does.
+  static func contentHash(text: String, updatedAt: Date? = nil) -> String {
+    let stamp = updatedAt.map { String(Int($0.timeIntervalSince1970)) } ?? "-"
+    return digest("\(text)|\(stamp)")
+  }
+
+  /// Ledger key for a free-text row (a suggested question or composed tip).
+  /// Hashed rather than raw so the persisted ledger is not a copy of the
+  /// reader's suggestions.
+  static func questionKey(_ text: String) -> String { "question:\(digest(text))" }
+  static func taskKey(_ id: String) -> String { "task:\(id)" }
+  static func insightKey(_ id: String) -> String { "insight:\(id)" }
+
+  private static func digest(_ value: String) -> String {
+    let hash = SHA256.hash(data: Data(value.utf8))
+    return String(hash.compactMap { String(format: "%02x", $0) }.joined().prefix(16))
+  }
+
+  /// Why this candidate must not take a slot right now, or `nil` if it may.
+  ///
+  /// - Parameter allowSameDayRepeat: set only when the slot has no other
+  ///   qualifying candidate. Even then a same-day repeat needs a prior open.
+  static func suppression(
+    facts: HomeKnowsCandidateFacts,
+    entry: HomeKnowsImpression?,
+    now: Date,
+    calendar: Calendar,
+    allowSameDayRepeat: Bool
+  ) -> HomeKnowsRotationReason? {
+    guard facts.isActive else { return .inactive }
+    if let dueAt = facts.dueAt, now.timeIntervalSince(dueAt) > stalePastDueGrace {
+      return .staleDueDate
+    }
+    guard let entry else { return nil }
+    // A changed underlying object is new information: it clears a dismissal and
+    // resets the show cap. That is the only way a dismissed row ever returns.
+    guard entry.contentHash == facts.contentHash else { return nil }
+    if entry.dismissedAt != nil { return .dismissed }
+
+    if entry.lastOpenedAt == nil, entry.shows >= showCapCount {
+      let lastShownAt = entry.lastShownAt ?? .distantPast
+      if now.timeIntervalSince(lastShownAt) < showCapCooldown { return .showCap }
+    }
+
+    if let lastShownAt = entry.lastShownAt, calendar.isDate(lastShownAt, inSameDayAs: now) {
+      guard allowSameDayRepeat, entry.lastOpenedAt != nil else { return .sameDay }
+    }
+    return nil
+  }
+
+  /// Freshness order inside one slot: never-shown first, then fewest shows,
+  /// then most recently updated. The key breaks ties so the order is stable.
+  static func freshnessRank(
+    _ facts: HomeKnowsCandidateFacts,
+    ledger: HomeKnowsImpressionLedger
+  ) -> (Int, Int, Double, String) {
+    let shows = ledger.entry(facts.key)?.shows ?? 0
+    let updated = facts.updatedAt?.timeIntervalSince1970 ?? 0
+    return (shows == 0 ? 0 : 1, shows, -updated, facts.key)
+  }
+
+  /// The one reason worth reporting when a whole slot came up empty. Fixed
+  /// priority so the telemetry is deterministic rather than dictionary-ordered.
+  static func dominantReason(_ reasons: [HomeKnowsRotationReason]) -> HomeKnowsRotationReason {
+    let priority: [HomeKnowsRotationReason] = [
+      .dismissed, .showCap, .sameDay, .staleDueDate, .inactive, .noCandidate,
+    ]
+    return priority.first { reasons.contains($0) } ?? .noCandidate
+  }
+}
+
+// MARK: - Persistence
+
+@MainActor
+protocol HomeKnowsImpressionPersisting: AnyObject {
+  func load() -> HomeKnowsImpressionLedger
+  func save(_ ledger: HomeKnowsImpressionLedger)
+}
+
+/// Owner-scoped so one account's dismissals never silence the knows-list for
+/// another account on the same Mac (the #9821 account-switch-bleed class).
+@MainActor
+final class HomeKnowsImpressionDefaults: HomeKnowsImpressionPersisting {
+  /// Entries with no activity inside this window are dropped on load, so the
+  /// ledger cannot grow without bound across months of tasks.
+  static let retention: TimeInterval = 90 * 24 * 60 * 60
+
+  private let defaults: UserDefaults
+  private let fixedOwnerID: String?
+  private let now: () -> Date
+
+  init(defaults: UserDefaults = .standard, ownerID: String? = nil, now: @escaping () -> Date = Date.init) {
+    self.defaults = defaults
+    fixedOwnerID = ownerID
+    self.now = now
+  }
+
+  private var key: ScopedDefaultsKey {
+    let dynamicOwner =
+      defaults === UserDefaults.standard
+      ? RuntimeOwnerIdentity.currentOwnerId()
+      : defaults.string(forKey: .authUserId)
+    return .homeKnowsImpressions(ownerID: fixedOwnerID ?? dynamicOwner ?? "signed-out")
+  }
+
+  func load() -> HomeKnowsImpressionLedger {
+    guard let data = defaults.data(forKey: key),
+      let decoded = try? JSONDecoder().decode(HomeKnowsImpressionLedger.self, from: data)
+    else { return .empty }
+    let cutoff = now().addingTimeInterval(-Self.retention)
+    var pruned = decoded
+    pruned.entries = decoded.entries.filter { _, impression in
+      let touched = [impression.lastShownAt, impression.dismissedAt, impression.lastOpenedAt]
+        .compactMap { $0 }
+        .max()
+      return (touched ?? .distantPast) >= cutoff
+    }
+    return pruned
+  }
+
+  func save(_ ledger: HomeKnowsImpressionLedger) {
+    defaults.set(try? JSONEncoder().encode(ledger), forKey: key)
+  }
+}
+
+// MARK: - Store (single mutation owner)
+
+/// The only thing that writes the knows-list ledger.
+///
+/// Views read a snapshot taken when the list appeared and hand every show,
+/// open, and dismiss back here; nothing else mutates impression state.
+@MainActor
+final class HomeKnowsImpressionStore {
+  static let shared = HomeKnowsImpressionStore()
+
+  private let persistence: any HomeKnowsImpressionPersisting
+  private let now: () -> Date
+  /// Row keys and slot names already reported during the current visit. One
+  /// visit is one impression: the in-visit rotation timer re-renders the same
+  /// row every few seconds and must not burn through the show cap.
+  private var reportedThisVisit: Set<String> = []
+
+  /// `persistence` defaults to owner-scoped `UserDefaults`. It is built inside
+  /// the initializer rather than as a default argument because default argument
+  /// expressions are evaluated outside this type's actor.
+  init(
+    persistence: (any HomeKnowsImpressionPersisting)? = nil,
+    now: @escaping () -> Date = Date.init
+  ) {
+    self.persistence = persistence ?? HomeKnowsImpressionDefaults()
+    self.now = now
+  }
+
+  /// Reads through to storage so an account switch cannot be served a cached
+  /// ledger from the previous owner.
+  func snapshot() -> HomeKnowsImpressionLedger { persistence.load() }
+
+  /// Starts a new visit to the knows-list. Resets in-visit de-duplication.
+  func beginVisit() { reportedThisVisit.removeAll() }
+
+  /// Records a row as shown. Returns the updated impression, or `nil` when this
+  /// row was already recorded during the current visit.
+  @discardableResult
+  func recordShown(key: String, contentHash: String) -> HomeKnowsImpression? {
+    guard reportedThisVisit.insert(key).inserted else { return nil }
+    return mutate(key: key) { impression in
+      let contentChanged = impression.contentHash != contentHash
+      let cooledDown =
+        impression.lastOpenedAt == nil
+        && impression.shows >= HomeKnowsRotationPolicy.showCapCount
+        && self.now().timeIntervalSince(impression.lastShownAt ?? .distantPast)
+          >= HomeKnowsRotationPolicy.showCapCooldown
+      if contentChanged || cooledDown {
+        impression.shows = 0
+        impression.firstShownAt = nil
+        impression.dismissedAt = nil
+      }
+      impression.shows += 1
+      impression.firstShownAt = impression.firstShownAt ?? self.now()
+      impression.lastShownAt = self.now()
+      impression.contentHash = contentHash
+    }
+  }
+
+  @discardableResult
+  func recordOpened(key: String, contentHash: String) -> HomeKnowsImpression {
+    mutate(key: key) { impression in
+      impression.lastOpenedAt = self.now()
+      impression.dismissedAt = nil
+      impression.contentHash = contentHash
+    }
+  }
+
+  @discardableResult
+  func recordDismissed(key: String, contentHash: String) -> HomeKnowsImpression {
+    mutate(key: key) { impression in
+      impression.dismissedAt = self.now()
+      impression.contentHash = contentHash
+    }
+  }
+
+  /// True the first time this visit that an empty slot is worth reporting.
+  func shouldReportEmptySlot(_ slot: String) -> Bool {
+    reportedThisVisit.insert("slot:\(slot)").inserted
+  }
+
+  @discardableResult
+  private func mutate(key: String, _ body: (inout HomeKnowsImpression) -> Void) -> HomeKnowsImpression {
+    var ledger = persistence.load()
+    var impression = ledger.entries[key] ?? HomeKnowsImpression()
+    body(&impression)
+    ledger.entries[key] = impression
+    persistence.save(ledger)
+    return impression
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsImpressionLedger.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsImpressionLedger.swift
@@ -135,14 +135,19 @@ enum HomeKnowsRotationPolicy {
   }
 
   /// Freshness order inside one slot: never-shown first, then fewest shows,
-  /// then most recently updated. The key breaks ties so the order is stable.
+  /// then most recently updated.
+  ///
+  /// Deliberately not tie-broken on the row key: candidates arrive in the
+  /// caller's own priority order (the most pressing task, the best-ranked
+  /// suggested question), and hashing that order away would silently reorder
+  /// equally-fresh rows. Callers break remaining ties on the source index.
   static func freshnessRank(
     _ facts: HomeKnowsCandidateFacts,
     ledger: HomeKnowsImpressionLedger
-  ) -> (Int, Int, Double, String) {
+  ) -> (Int, Int, Double) {
     let shows = ledger.entry(facts.key)?.shows ?? 0
     let updated = facts.updatedAt?.timeIntervalSince1970 ?? 0
-    return (shows == 0 ? 0 : 1, shows, -updated, facts.key)
+    return (shows == 0 ? 0 : 1, shows, -updated)
   }
 
   /// The one reason worth reporting when a whole slot came up empty. Fixed

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/MemoryReviewCard.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/MemoryReviewCard.swift
@@ -1,0 +1,379 @@
+import Foundation
+
+// MARK: - What a review row is
+
+/// One memory the day produced, as the card addresses it.
+///
+/// The card renders memories, not prose. `knowledge_nuggets` is an LLM sentence about the day with
+/// no identity behind it: the reader cannot tell Omi it is wrong, because there is nothing to be
+/// wrong *about*. A `MemoryReviewItem` is a row in the memory store, so ✓ / ✗ / Fix are real
+/// mutations on a real record and the verdict survives to the next extraction.
+struct MemoryReviewItem: Identifiable, Equatable, Sendable {
+  let memoryID: String
+  let content: String
+  let category: String
+
+  var id: String { memoryID }
+
+  init(memoryID: String, content: String, category: String = "") {
+    self.memoryID = memoryID
+    self.content = content
+    self.category = category
+  }
+
+  init(_ learned: DailySummaryRecord.LearnedMemory) {
+    self.init(memoryID: learned.memoryID, content: learned.content, category: learned.category)
+  }
+
+  /// The small label under the row. Bounded to the four known categories; anything else is shown
+  /// as the raw backend word rather than invented, and an empty category shows no label at all.
+  var categoryLabel: String? {
+    let trimmed = category.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    return MemoryCategory(rawValue: trimmed)?.displayName ?? trimmed.capitalized
+  }
+}
+
+/// Where a review action happened. Bounded, and the only `source` value telemetry ever sends.
+enum MemoryReviewSource: String, Sendable {
+  /// The "Things I learned today" section of the daily summary card in Chat.
+  case dailySummaryChat = "daily_summary_chat"
+  /// A `memoryReviewCard` content block rendered in the Chat-first transcript.
+  case chatBlock = "chat_block"
+}
+
+/// What the owner said about a memory. Derived from the memory itself, never stored by the card.
+///
+/// Single mutation owner: the memory API owns the verdict. Nothing here is written to defaults, to
+/// the chat row, or to the summary record — a vote on the phone and a vote on the Mac read back
+/// through the same field.
+enum MemoryReviewVerdict: Equatable, Sendable {
+  /// Not reviewed, not corrected. All three controls are live.
+  case none
+  /// `user_review == true`.
+  case accepted
+  /// `user_review == false`.
+  case rejected
+  /// The memory's content no longer matches what the summary captured.
+  case updated
+}
+
+/// The three mutations a row can start. One value, so telemetry and the in-flight fence agree.
+enum MemoryReviewAction: String, Equatable, Sendable {
+  case accept
+  case reject
+  case edit
+}
+
+// MARK: - Row state machine
+
+/// Everything one row shows, and nothing it does not.
+///
+/// `live` is what the memory says; `optimistic` is the local override held only while a request is
+/// in flight. The row draws `displayed`, so a failure that clears `optimistic` puts the row back
+/// exactly where it was before the click rather than somewhere new.
+struct MemoryReviewRowModel: Equatable, Sendable {
+  var live: MemoryReviewVerdict = .none
+  var optimistic: MemoryReviewVerdict?
+  var inFlight: MemoryReviewAction?
+  /// Non-nil exactly while the inline single-line editor is open. Esc clears it.
+  var draft: String?
+  /// Honest and inline. Never a toast, never silence.
+  var errorMessage: String?
+
+  var displayed: MemoryReviewVerdict { optimistic ?? live }
+  var isEditing: Bool { draft != nil }
+  var isBusy: Bool { inFlight != nil }
+  /// A settled row stops offering the three controls and shows what it settled on.
+  var isSettled: Bool { displayed != .none }
+  /// Rejection fades the row but keeps it in place until the card is refreshed: removing it here
+  /// would reflow every row below the one the reader just clicked.
+  var isFaded: Bool { displayed == .rejected }
+
+  /// The one line of copy under a settled row. Each is a promise the backend actually keeps:
+  /// rejection feeds bounded negative feedback into extraction, and an edit re-enters short-term
+  /// as a user assertion for the consolidation job to weigh — which is "Updated.", not "Confirmed".
+  var statusText: String? {
+    switch displayed {
+    case .none: return nil
+    case .accepted: return "Confirmed. I'll act on this."
+    case .rejected: return "Dropped. I'll avoid facts like this."
+    case .updated: return "Updated."
+    }
+  }
+}
+
+/// What the reducer asks the caller to do. Values, not callbacks.
+///
+/// The desktop guide's synchronous state-machine rule exists because a callback invoked mid
+/// transition can reduce against a half-published model. This machine cannot: `reduce` returns the
+/// next model and an effect *description*, so the transition is complete before anything runs, and
+/// a nested event can only arrive as another call to `reduce`.
+enum MemoryReviewEffect: Equatable, Sendable {
+  case none
+  case review(keep: Bool)
+  case edit(content: String)
+  /// Re-read `user_review` / `edited` from the memory after a mutation lands, so the row shows the
+  /// record's state rather than trusting the optimistic override indefinitely.
+  case refreshLiveState
+}
+
+enum MemoryReviewEvent: Equatable, Sendable {
+  /// A render-time or post-mutation read of the memory's own state.
+  case liveStateLoaded(MemoryReviewVerdict)
+  case accept
+  case reject
+  case beginEdit(prefill: String)
+  case draftChanged(String)
+  case cancelEdit
+  case saveEdit
+  case requestSucceeded(MemoryReviewAction)
+  case requestFailed(MemoryReviewAction)
+}
+
+/// Pure transition table for one row. No I/O, no actor, no view.
+enum MemoryReviewReducer {
+  static let failureMessage = "Couldn't save, try again"
+
+  static func reduce(
+    _ model: MemoryReviewRowModel,
+    _ event: MemoryReviewEvent
+  ) -> (MemoryReviewRowModel, MemoryReviewEffect) {
+    var next = model
+    switch event {
+    case .liveStateLoaded(let verdict):
+      // A read that comes back empty must not erase a verdict this device already made: the local
+      // mirror routinely lags the write it is being asked to confirm, and a row that flickered
+      // back to "unreviewed" a second after the click would read as the vote not landing.
+      if verdict != .none || (next.live == .none && next.optimistic == nil) {
+        next.live = verdict
+      }
+      if !next.isBusy { next.optimistic = nil }
+      return (next, .none)
+
+    case .accept:
+      guard !next.isBusy, !next.isEditing else { return (next, .none) }
+      next.errorMessage = nil
+      next.optimistic = .accepted
+      next.inFlight = .accept
+      return (next, .review(keep: true))
+
+    case .reject:
+      guard !next.isBusy, !next.isEditing else { return (next, .none) }
+      next.errorMessage = nil
+      next.optimistic = .rejected
+      next.inFlight = .reject
+      return (next, .review(keep: false))
+
+    case .beginEdit(let prefill):
+      guard !next.isBusy else { return (next, .none) }
+      next.errorMessage = nil
+      next.draft = prefill
+      return (next, .none)
+
+    case .draftChanged(let text):
+      guard next.isEditing else { return (next, .none) }
+      next.draft = text
+      return (next, .none)
+
+    case .cancelEdit:
+      next.draft = nil
+      return (next, .none)
+
+    case .saveEdit:
+      guard let draft = next.draft, !next.isBusy else { return (next, .none) }
+      let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+      // An empty correction is a cancel, not a mutation that blanks the memory.
+      guard !trimmed.isEmpty else {
+        next.draft = nil
+        return (next, .none)
+      }
+      next.draft = nil
+      next.errorMessage = nil
+      next.optimistic = .updated
+      next.inFlight = .edit
+      return (next, .edit(content: trimmed))
+
+    case .requestSucceeded(let action):
+      guard next.inFlight == action else { return (next, .none) }
+      next.inFlight = nil
+      // The override becomes the row's own state, then the re-read confirms it against the memory.
+      next.live = next.optimistic ?? next.live
+      next.optimistic = nil
+      next.errorMessage = nil
+      return (next, .refreshLiveState)
+
+    case .requestFailed(let action):
+      guard next.inFlight == action else { return (next, .none) }
+      next.inFlight = nil
+      next.optimistic = nil
+      next.errorMessage = failureMessage
+      return (next, .none)
+    }
+  }
+}
+
+// MARK: - Seams
+
+/// The mutations the card is allowed to make. Existing endpoints only — no new write path, and no
+/// verdict stored anywhere but the memory.
+protocol MemoryReviewMutating: Sendable {
+  func review(memoryID: String, keep: Bool) async throws
+  func edit(memoryID: String, content: String) async throws
+}
+
+/// The live read of `user_review` / `edited`, resolved per memory id.
+protocol MemoryReviewStateReading: Sendable {
+  func verdicts(for items: [MemoryReviewItem]) async -> [String: MemoryReviewVerdict]
+}
+
+struct LiveMemoryReviewMutator: MemoryReviewMutating {
+  func review(memoryID: String, keep: Bool) async throws {
+    try await APIClient.shared.reviewMemory(id: memoryID, keep: keep)
+  }
+
+  func edit(memoryID: String, content: String) async throws {
+    try await APIClient.shared.editMemory(id: memoryID, content: content)
+    // Keep the local mirror in step with the write, so the re-read below confirms the edit rather
+    // than reporting the text the reader just replaced.
+    try? await MemoryStorage.shared.updateContentByBackendId(memoryID, content: content)
+  }
+}
+
+/// Reads the verdict back out of the memory itself.
+///
+/// The desktop has no single-memory GET; `MemoryStorage` is the mirror the memory sync keeps in
+/// step with the backend, and `MemoriesViewModel.refreshSelectedMemory` already treats it as
+/// authoritative for one known id. `edited` is not on the desktop's `ServerMemory`, so a
+/// correction is recognised the way the reader would recognise it: the stored content no longer
+/// matches what the summary captured.
+struct LiveMemoryReviewStateReader: MemoryReviewStateReading {
+  func verdicts(for items: [MemoryReviewItem]) async -> [String: MemoryReviewVerdict] {
+    let ids = items.map(\.memoryID).filter { !$0.isEmpty }
+    guard !ids.isEmpty else { return [:] }
+    let stored: [ServerMemory]
+    do {
+      stored = try await MemoryStorage.shared.getMemories(backendIds: ids)
+    } catch {
+      return [:]
+    }
+    var byID: [String: ServerMemory] = [:]
+    for memory in stored { byID[memory.id] = memory }
+    var verdicts: [String: MemoryReviewVerdict] = [:]
+    for item in items {
+      guard let memory = byID[item.memoryID] else { continue }
+      verdicts[item.memoryID] = Self.verdict(for: item, memory: memory)
+    }
+    return verdicts
+  }
+
+  static func verdict(for item: MemoryReviewItem, memory: ServerMemory) -> MemoryReviewVerdict {
+    if memory.userReview == false { return .rejected }
+    if normalized(memory.content) != normalized(item.content) { return .updated }
+    if memory.userReview == true { return .accepted }
+    return .none
+  }
+
+  private static func normalized(_ text: String) -> String {
+    text.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+}
+
+// MARK: - Store
+
+/// Drives one card's rows: render-time live read, the three mutations, and the re-read after each.
+///
+/// One store per card, so the daily-summary section and a `memoryReviewCard` block never share
+/// row state. Every transition goes through `MemoryReviewReducer`; this type owns only I/O.
+@MainActor
+final class MemoryReviewCardStore: ObservableObject {
+  @Published private(set) var rows: [String: MemoryReviewRowModel]
+
+  let items: [MemoryReviewItem]
+  let source: MemoryReviewSource
+
+  private let mutator: MemoryReviewMutating
+  private let stateReader: MemoryReviewStateReading
+  /// Test seam only. `nil` means the real `AnalyticsManager`, so production has one path.
+  private let analytics: (@MainActor (MemoryReviewSource, MemoryReviewAction, Bool, String) -> Void)?
+  private var didLoadLiveState = false
+
+  init(
+    items: [MemoryReviewItem],
+    source: MemoryReviewSource,
+    mutator: MemoryReviewMutating = LiveMemoryReviewMutator(),
+    stateReader: MemoryReviewStateReading = LiveMemoryReviewStateReader(),
+    analytics: (@MainActor (MemoryReviewSource, MemoryReviewAction, Bool, String) -> Void)? = nil
+  ) {
+    self.items = items
+    self.source = source
+    self.mutator = mutator
+    self.stateReader = stateReader
+    self.analytics = analytics
+    var seeded: [String: MemoryReviewRowModel] = [:]
+    for item in items { seeded[item.memoryID] = MemoryReviewRowModel() }
+    self.rows = seeded
+  }
+
+  func row(_ memoryID: String) -> MemoryReviewRowModel {
+    rows[memoryID] ?? MemoryReviewRowModel()
+  }
+
+  /// Render-time read. Once per card mount: the section is chrome, not a poller.
+  func loadLiveStateIfNeeded() async {
+    guard !didLoadLiveState, !items.isEmpty else { return }
+    didLoadLiveState = true
+    await refreshLiveState()
+  }
+
+  func refreshLiveState() async {
+    let verdicts = await stateReader.verdicts(for: items)
+    for item in items {
+      send(.liveStateLoaded(verdicts[item.memoryID] ?? .none), to: item)
+    }
+  }
+
+  func send(_ event: MemoryReviewEvent, to item: MemoryReviewItem) {
+    let (next, effect) = MemoryReviewReducer.reduce(row(item.memoryID), event)
+    rows[item.memoryID] = next
+    perform(effect, for: item)
+  }
+
+  private func perform(_ effect: MemoryReviewEffect, for item: MemoryReviewItem) {
+    switch effect {
+    case .none:
+      return
+    case .review(let keep):
+      let action: MemoryReviewAction = keep ? .accept : .reject
+      Task { [mutator] in
+        do {
+          try await mutator.review(memoryID: item.memoryID, keep: keep)
+          self.complete(action, succeeded: true, for: item)
+        } catch {
+          self.complete(action, succeeded: false, for: item)
+        }
+      }
+    case .edit(let content):
+      Task { [mutator] in
+        do {
+          try await mutator.edit(memoryID: item.memoryID, content: content)
+          self.complete(.edit, succeeded: true, for: item)
+        } catch {
+          self.complete(.edit, succeeded: false, for: item)
+        }
+      }
+    case .refreshLiveState:
+      Task { await self.refreshLiveState() }
+    }
+  }
+
+  private func complete(_ action: MemoryReviewAction, succeeded: Bool, for item: MemoryReviewItem) {
+    if let analytics {
+      analytics(source, action, succeeded, item.category)
+    } else {
+      AnalyticsManager.shared.trackMemoryReviewAction(
+        source: source, action: action, succeeded: succeeded, category: item.category)
+    }
+    send(succeeded ? .requestSucceeded(action) : .requestFailed(action), to: item)
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/MemoryReviewRowView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/MemoryReviewRowView.swift
@@ -1,0 +1,219 @@
+import OmiTheme
+import SwiftUI
+
+/// "Things I learned today" — the memories the day produced, each one correctable.
+///
+/// The section is the whole point of the contract behind it. A summary that only *tells* the owner
+/// what Omi thinks it learned is a claim they cannot answer; three rows with ✓ / ✗ / Fix make the
+/// claim answerable, and every answer is a real mutation on the memory it names. Rejection is not
+/// cosmetic — it feeds bounded negative feedback back into extraction — so the copy under a dropped
+/// row is true rather than reassuring.
+///
+/// Empty renders nothing at all: no header, no frame, no "nothing yet". A quiet day is not a
+/// broken card.
+struct MemoryReviewSection: View {
+  @StateObject private var store: MemoryReviewCardStore
+  @State private var reportedImpression = false
+
+  private let title: String
+
+  init(
+    items: [MemoryReviewItem],
+    source: MemoryReviewSource,
+    title: String = "Things I learned today",
+    store: MemoryReviewCardStore? = nil
+  ) {
+    self.title = title
+    self._store = StateObject(
+      wrappedValue: store ?? MemoryReviewCardStore(items: items, source: source))
+  }
+
+  /// Up to three. More than that is a queue, and a queue at the top of Chat is a chore.
+  /// `nonisolated` so the card's pure row projection can bound itself by the same number the
+  /// section renders, rather than the two drifting apart.
+  nonisolated static let maxRows = 3
+
+  private var rows: [MemoryReviewItem] { Array(store.items.prefix(Self.maxRows)) }
+
+  var body: some View {
+    Group {
+      if !rows.isEmpty {
+        VStack(alignment: .leading, spacing: OmiSpacing.xs) {
+          Text(title)
+            .scaledFont(size: OmiType.micro, weight: .semibold)
+            .foregroundStyle(HomePalette.muted)
+            .tracking(0.6)
+          ForEach(rows) { item in
+            MemoryReviewRowView(item: item, model: store.row(item.memoryID)) { event in
+              store.send(event, to: item)
+            }
+          }
+        }
+        .accessibilityIdentifier("memory-review-section")
+        .task {
+          reportImpression()
+          await store.loadLiveStateIfNeeded()
+        }
+      }
+    }
+  }
+
+  private func reportImpression() {
+    guard !reportedImpression else { return }
+    reportedImpression = true
+    AnalyticsManager.shared.trackMemoryReviewCardShown(source: store.source, itemCount: rows.count)
+  }
+}
+
+/// One memory, one verdict.
+///
+/// The row never owns the verdict: it draws `model.displayed`, which is the memory's own state with
+/// an optimistic override held only while a request is in flight. A failed request clears the
+/// override and says so inline; nothing is written to defaults, and nothing about the vote lives in
+/// the chat row.
+struct MemoryReviewRowView: View {
+  let item: MemoryReviewItem
+  let model: MemoryReviewRowModel
+  let send: (MemoryReviewEvent) -> Void
+
+  @FocusState private var isRowFocused: Bool
+  @FocusState private var isEditorFocused: Bool
+  @State private var draft: String = ""
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+      if model.isEditing {
+        editor
+      } else {
+        HStack(alignment: .firstTextBaseline, spacing: OmiSpacing.sm) {
+          VStack(alignment: .leading, spacing: 1) {
+            Text(item.content)
+              .scaledFont(size: OmiType.body)
+              .foregroundStyle(HomePalette.ink)
+              .fixedSize(horizontal: false, vertical: true)
+            if let category = item.categoryLabel {
+              Text(category)
+                .scaledFont(size: OmiType.micro, weight: .medium)
+                .foregroundStyle(HomePalette.muted)
+                .tracking(0.4)
+            }
+          }
+          Spacer(minLength: OmiSpacing.sm)
+          if !model.isSettled {
+            controls
+          }
+        }
+      }
+
+      if let status = model.statusText {
+        Text(status)
+          .scaledFont(size: OmiType.micro)
+          .foregroundStyle(HomePalette.muted)
+          .accessibilityIdentifier("memory-review-status")
+      }
+
+      if let error = model.errorMessage {
+        Text(error)
+          .scaledFont(size: OmiType.micro)
+          .foregroundStyle(Ink.errorRed)
+          .accessibilityIdentifier("memory-review-error")
+      }
+    }
+    .padding(.vertical, OmiSpacing.xxs)
+    // A dropped row fades where it stands. Removing it would reflow every row below the one the
+    // reader just clicked, so it stays until the card is next refreshed.
+    .opacity(model.isFaded ? 0.45 : 1)
+    .contentShape(.rect)
+    .focusable(!model.isEditing)
+    .focused($isRowFocused)
+    .onKeyPress(.return) { keyAction(.accept) }
+    .onKeyPress(.delete) { keyAction(.reject) }
+    .onKeyPress(KeyEquivalent("e")) { keyAction(.beginEdit(prefill: item.content)) }
+    // Voice hook (not wired in this PR): hold ⌥ over a focused row to correct it by speaking would
+    // attach here, sending the transcript through `.beginEdit` + `.saveEdit` like the inline editor.
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("memory-review-row")
+  }
+
+  private var controls: some View {
+    HStack(spacing: OmiSpacing.xs) {
+      control("checkmark", label: "Right", identifier: "memory-review-accept") {
+        send(.accept)
+      }
+      control("xmark", label: "Wrong", identifier: "memory-review-reject") {
+        send(.reject)
+      }
+      control("pencil", label: "Fix", identifier: "memory-review-edit") {
+        send(.beginEdit(prefill: item.content))
+      }
+    }
+    .disabled(model.isBusy)
+  }
+
+  private func control(
+    _ symbol: String, label: String, identifier: String, action: @escaping () -> Void
+  ) -> some View {
+    Button(action: action) {
+      HStack(spacing: 3) {
+        Image(systemName: symbol)
+          .scaledFont(size: OmiType.micro, weight: .semibold)
+        Text(label)
+          .scaledFont(size: OmiType.micro, weight: .medium)
+      }
+      .foregroundStyle(HomePalette.secondary)
+      .padding(.horizontal, OmiSpacing.xs + 1)
+      .padding(.vertical, 2)
+      .background(Capsule().fill(Ink.rowFill))
+      .overlay(Capsule().stroke(Ink.separator, lineWidth: 1))
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel(label)
+    .accessibilityIdentifier(identifier)
+  }
+
+  /// Single line by design: the reader is correcting one fact, not drafting. Enter saves, Esc
+  /// cancels and leaves the memory exactly as it was.
+  private var editor: some View {
+    HStack(spacing: OmiSpacing.xs) {
+      TextField("", text: $draft)
+        .textFieldStyle(.plain)
+        .scaledFont(size: OmiType.body)
+        .foregroundStyle(HomePalette.ink)
+        .focused($isEditorFocused)
+        .lineLimit(1)
+        .onSubmit { commitEdit() }
+        .onChange(of: draft) { _, newValue in send(.draftChanged(newValue)) }
+        .onKeyPress(.escape) {
+          send(.cancelEdit)
+          return .handled
+        }
+        .accessibilityIdentifier("memory-review-editor")
+      Button("Save") { commitEdit() }
+        .buttonStyle(.plain)
+        .scaledFont(size: OmiType.micro, weight: .semibold)
+        .foregroundStyle(HomePalette.secondary)
+        .accessibilityIdentifier("memory-review-save")
+    }
+    .padding(.horizontal, OmiSpacing.xs)
+    .padding(.vertical, OmiSpacing.xxs)
+    .background(RoundedRectangle(cornerRadius: 7, style: .continuous).fill(Ink.rowFill))
+    .overlay(
+      RoundedRectangle(cornerRadius: 7, style: .continuous).stroke(Ink.separator, lineWidth: 1)
+    )
+    .onAppear {
+      draft = model.draft ?? item.content
+      isEditorFocused = true
+    }
+  }
+
+  private func commitEdit() {
+    send(.draftChanged(draft))
+    send(.saveEdit)
+  }
+
+  private func keyAction(_ event: MemoryReviewEvent) -> KeyPress.Result {
+    guard !model.isSettled, !model.isEditing, !model.isBusy else { return .ignored }
+    send(event)
+    return .handled
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -233,7 +233,6 @@ struct DashboardPage: View {
   /// Learned insights ("things about you") — surfaced in the home hub's rotating
   /// knows-list alongside tasks and asks, not just on the Insights page.
   @ObservedObject private var insightStorage = InsightStorage.shared
-  @State private var dismissedKnowsTaskIDs: Set<String> = []
   @State private var homeAskFocusPolicy = HomeAskFocusPolicy()
   @Binding var selectedIndex: Int
   @State private var selectedCatalogApp: OmiApp?
@@ -262,6 +261,15 @@ struct DashboardPage: View {
   /// cycles through fresh suggestions while you're looking at it.
   @State private var knowsRotation = 0
   private let knowsRotationTimer = Timer.publish(every: 7, on: .main, in: .common).autoconnect()
+  /// What the knows-list ledger said when this visit began.
+  ///
+  /// Composition is gated against the state at visit start, so rotating inside
+  /// one visit cannot suppress the rows you are currently looking at; the
+  /// across-visit rules (show cap, dismissal, same calendar day) still bite.
+  /// In-visit dismisses and opens are merged in below.
+  @State private var knowsLedger = HomeKnowsImpressionLedger.empty
+  /// Single mutation owner for that ledger — the view never writes it directly.
+  private var knowsLedgerStore: HomeKnowsImpressionStore { .shared }
 
   private var selectedApp: OmiApp? {
     guard let appId = chatProvider.selectedAppId else { return nil }
@@ -822,7 +830,7 @@ struct DashboardPage: View {
   /// an empty home chat — replaces the old greeting hero + knows-list cards.
   private var homeRollingSuggestions: some View {
     VStack(spacing: OmiSpacing.xs) {
-      ForEach(Array(homeKnowsRows.prefix(3))) { row in
+      ForEach(Array(homeKnowsRows.prefix(Self.rollingSuggestionCount))) { row in
         Button {
           openKnowsRow(row)
         } label: {
@@ -856,7 +864,15 @@ struct DashboardPage: View {
       else { return }
       knowsRotation += 1
     }
+    .onAppear { beginKnowsVisit(visibleRows: Self.rollingSuggestionCount) }
+    .onChange(of: knowsImpressionSignature) { _, _ in
+      recordKnowsImpressions(visibleRows: Self.rollingSuggestionCount)
+    }
   }
+
+  /// The chat-mode strip is shorter than the hub list; impressions are recorded
+  /// against what is actually on screen, not the full composition.
+  private static let rollingSuggestionCount = 3
 
   private func rollingSuggestionIcon(_ kind: HomeKnowsRowKind) -> String {
     switch kind {
@@ -904,52 +920,47 @@ struct DashboardPage: View {
     let learned = insightStorage.insightHistory
       .filter { !$0.isDismissed }
       .prefix(12)
-      .map { HomeKnowsInsightCandidate(id: $0.id, text: $0.insight.insight) }
+      .map { HomeKnowsInsightCandidate(id: $0.id, text: $0.insight.insight, updatedAt: $0.createdAt) }
     return recommendations + Array(learned)
   }
 
-  private var homeKnowsRows: [HomeKnowsRow] {
+  private var homeKnowsComposition: HomeKnowsComposition {
     HomeKnowsListComposer.compose(
       tasks: homeKnowsTaskCandidates,
       insights: homeKnowsInsightCandidates,
       tip: homeActionTip,
       questions: homeSuggestedQuestions,
-      dismissedTaskIDs: dismissedKnowsTaskIDs,
+      ledger: knowsLedger,
       rotation: knowsRotation
     )
   }
 
-  /// True when there are more candidates than the hub shows, so rotating cycles
-  /// to genuinely different rows instead of the same set.
-  private var homeKnowsCanRotate: Bool {
-    HomeKnowsListComposer.canRotate(
-      taskCount: homeKnowsTaskCandidates.filter { !dismissedKnowsTaskIDs.contains($0.id) }.count,
-      insightCount: homeKnowsInsightCandidates.count,
-      questionCount: homeSuggestedQuestions.count
-    )
-  }
+  private var homeKnowsRows: [HomeKnowsRow] { homeKnowsComposition.rows }
+
+  /// True when more candidates still qualify than the hub shows, so rotating
+  /// cycles to genuinely different rows instead of the same set.
+  private var homeKnowsCanRotate: Bool { homeKnowsComposition.canRotate }
 
   /// A composed, high-agency nudge for the tip slot when there's no server
   /// insight — one thing you can hand Omi with a tap (it prefills the chat).
   private var homeActionTip: String? {
-    let openCount =
-      homeKnowsTaskCandidates
-      .filter { !dismissedKnowsTaskIDs.contains($0.id) }
-      .count
-    if openCount >= 5 {
+    if homeOpenTaskCount >= 5 {
       return "Sort my open tasks — which 3 actually matter today?"
     }
     return "Recap what I got done today"
+  }
+
+  /// Open, undismissed tasks. Read from the ledger so the greeting and the rows
+  /// agree about what the reader has already waved off.
+  private var homeOpenTaskCount: Int {
+    HomeKnowsListComposer.openTaskCount(homeKnowsTaskCandidates, ledger: knowsLedger)
   }
 
   /// A short, conversational read on the day — what you've been doing and how
   /// much is waiting — shown under the greeting. It absorbs the focus status so
   /// the action rows below stay purely actionable.
   private var homeDailyBrief: String {
-    let openCount =
-      homeKnowsTaskCandidates
-      .filter { !dismissedKnowsTaskIDs.contains($0.id) }
-      .count
+    let openCount = homeOpenTaskCount
     let tail: String
     switch openCount {
     case 0: tail = "nothing's waiting on you."
@@ -960,10 +971,19 @@ struct DashboardPage: View {
     return tail.prefix(1).uppercased() + tail.dropFirst()
   }
 
+  /// Lifecycle and freshness travel with the candidate: the composer owns the
+  /// completed/deleted and past-due exclusions so one place decides what a row
+  /// is allowed to be.
   private var homeKnowsTaskCandidates: [HomeKnowsTaskCandidate] {
     (viewModel.overdueTasks + viewModel.todaysTasks + viewModel.recentTasks)
-      .filter { !$0.completed && !$0.isRetired }
-      .map { HomeKnowsTaskCandidate(id: $0.id, text: $0.description) }
+      .map {
+        HomeKnowsTaskCandidate(
+          id: $0.id,
+          text: $0.description,
+          dueAt: $0.dueAt,
+          updatedAt: $0.updatedAt,
+          isActive: !$0.completed && !$0.isRetired)
+      }
   }
 
   private func homeKnowsList(width: CGFloat) -> some View {
@@ -986,10 +1006,63 @@ struct DashboardPage: View {
       guard homeMode == .hub, !chatProvider.isSending, homeKnowsCanRotate else { return }
       knowsRotation += 1
     }
+    .onAppear { beginKnowsVisit() }
+    .onChange(of: knowsImpressionSignature) { _, _ in recordKnowsImpressions() }
     .accessibilityIdentifier("home-knows-list")
   }
 
+  /// Starts a visit to the knows-list: re-reads the ledger (so an account
+  /// switch cannot inherit the previous owner's history) and resets the
+  /// once-per-visit impression de-duplication.
+  private func beginKnowsVisit(visibleRows: Int = HomeKnowsListComposer.maxRows) {
+    knowsLedgerStore.beginVisit()
+    knowsLedger = knowsLedgerStore.snapshot()
+    knowsRotation = 0
+    recordKnowsImpressions(visibleRows: visibleRows)
+  }
+
+  /// Identity of what is currently on screen. Changes when the rotation timer
+  /// advances or the candidate sources change — the moments a new impression
+  /// genuinely happened.
+  private var knowsImpressionSignature: [String] {
+    let composition = homeKnowsComposition
+    return composition.rows.map(\.ledgerKey)
+      + composition.emptySlots.map { "\($0.slot.rawValue)=\($0.reason.rawValue)" }
+  }
+
+  /// Hands every visible row back to the ledger and reports it once per visit.
+  private func recordKnowsImpressions(visibleRows: Int = HomeKnowsListComposer.maxRows) {
+    let composition = homeKnowsComposition
+    for row in composition.rows.prefix(visibleRows) {
+      guard
+        let impression = knowsLedgerStore.recordShown(
+          key: row.ledgerKey, contentHash: row.contentHash)
+      else { continue }
+      AnalyticsManager.shared.trackHomeKnowsRowShown(
+        kind: row.kind.analyticsKind,
+        slot: slot(for: row, in: composition),
+        showsBefore: max(0, impression.shows - 1))
+    }
+    for empty in composition.emptySlots {
+      guard knowsLedgerStore.shouldReportEmptySlot(empty.slot.rawValue) else { continue }
+      AnalyticsManager.shared.trackHomeKnowsSlotEmpty(slot: empty.slot, reason: empty.reason)
+    }
+  }
+
+  /// Which typed slot a rendered row landed in — the filled slots are whatever
+  /// the empty ones are not, in the composer's fixed order.
+  private func slot(for row: HomeKnowsRow, in composition: HomeKnowsComposition) -> HomeKnowsSlot {
+    let empty = Set(composition.emptySlots.map(\.slot))
+    let filled = HomeKnowsSlot.allCases.filter { !empty.contains($0) }
+    guard let index = composition.rows.firstIndex(where: { $0.id == row.id }),
+      index < filled.count
+    else { return .ask }
+    return filled[index]
+  }
+
   private func openKnowsRow(_ row: HomeKnowsRow) {
+    knowsLedger.entries[row.ledgerKey] = knowsLedgerStore.recordOpened(
+      key: row.ledgerKey, contentHash: row.contentHash)
     switch row.kind {
     case .task(let id):
       if let task = (viewModel.overdueTasks + viewModel.todaysTasks + viewModel.recentTasks)
@@ -1016,10 +1089,13 @@ struct DashboardPage: View {
 
   private func knowsDismissHandler(for row: HomeKnowsRow) -> ((OmiAPI.TaskIntelligenceFeedbackReason?) -> Void)? {
     switch row.kind {
-    case .task(let id):
-      return { _ in dismissedKnowsTaskIDs.insert(id) }
+    case .task:
+      return { _ in recordKnowsDismiss(row) }
     case .insight(let id):
       return { reason in
+        // Learned insights have no server recommendation behind them; the
+        // ledger is what makes their dismissal stick either way.
+        recordKnowsDismiss(row)
         guard let recommendation = intelligenceStore.recommendations.first(where: { $0.id == id })
         else { return }
         Task { await intelligenceStore.dismiss(recommendation, reason: reason) }
@@ -1027,6 +1103,12 @@ struct DashboardPage: View {
     case .question:
       return nil
     }
+  }
+
+  /// A dismissed row never returns unless its underlying object changes.
+  private func recordKnowsDismiss(_ row: HomeKnowsRow) {
+    knowsLedger.entries[row.ledgerKey] = knowsLedgerStore.recordDismissed(
+      key: row.ledgerKey, contentHash: row.contentHash)
   }
 
   private func knowsLaterHandler(for row: HomeKnowsRow) -> (() -> Void)? {

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
@@ -1872,7 +1872,7 @@ struct OnboardingChatBubble: View {
       case .discoveryCard:
         return true
       case .questionCard, .taskCard, .goalLink, .captureLink, .conversationLink, .memoryLink,
-        .citation, .followUp:
+        .citation, .followUp, .memoryReviewCard:
         return false
       case .agentSpawn, .agentCompletion:
         return true

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
@@ -1872,7 +1872,7 @@ struct OnboardingChatBubble: View {
       case .discoveryCard:
         return true
       case .questionCard, .taskCard, .goalLink, .captureLink, .conversationLink, .memoryLink,
-        .citation:
+        .citation, .followUp:
         return false
       case .agentSpawn, .agentCompletion:
         return true

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -851,6 +851,10 @@ extension ChatContentBlock {
     // A copied answer is what Omi said, not the control offering the next turn.
     case .followUp:
       return nil
+    // Same rule for the review card: it is three controls over memories that already exist, not
+    // prose the reader would expect to find in a copied answer.
+    case .memoryReviewCard:
+      return nil
     case .agentSpawn(_, _, _, _, let title, let objective, _):
       let trimmed = objective.trimmingCharacters(in: .whitespacesAndNewlines)
       return trimmed.isEmpty ? title : "\(title)\n\(trimmed)"

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -349,9 +349,16 @@ enum ChatContentBlock: Identifiable {
     recommendedActionItems: [ConversationLinkActionItem]
   )
   case memoryLink(id: String, memoryId: String, summary: String)
+  /// The memories one day actually produced, each row correctable in place.
+  /// Review state is deliberately absent: it is read live from the memory, so a vote on the phone
+  /// shows on the Mac and the block never becomes a second copy of the verdict.
+  case memoryReviewCard(id: String, summaryId: String, date: String, items: [MemoryReviewItem])
   /// Answer-level provenance. Unlike a rich link card, this is rendered at the matching inline
   /// numeric marker and is otherwise invisible in the transcript.
   case citation(id: String, reference: ChatCitationReference)
+  /// One grounded next question, rendered as a tappable chip under the answer.
+  /// Tapping it sends the question as a new user turn in the same lane.
+  case followUp(id: String, text: String)
   case agentSpawn(
     id: String,
     pillId: UUID?,
@@ -384,7 +391,9 @@ enum ChatContentBlock: Identifiable {
     case .captureLink(let id, _, _, _): return id
     case .conversationLink(let id, _, _, _): return id
     case .memoryLink(let id, _, _): return id
+    case .memoryReviewCard(let id, _, _, _): return id
     case .citation(let id, _): return id
+    case .followUp(let id, _): return id
     case .agentSpawn(let id, _, _, _, _, _, _): return id
     case .agentCompletion(let id, _, _, _, _, _, _, _): return id
     }
@@ -838,6 +847,9 @@ extension ChatContentBlock {
       let trimmed = summary.trimmingCharacters(in: .whitespacesAndNewlines)
       return trimmed.isEmpty ? nil : trimmed
     case .citation:
+      return nil
+    // A copied answer is what Omi said, not the control offering the next turn.
+    case .followUp:
       return nil
     case .agentSpawn(_, _, _, _, let title, let objective, _):
       let trimmed = objective.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -5418,10 +5430,14 @@ class ChatProvider: ObservableObject {
           toolName: "get_work_context"
         )
       }
+      // The grounded closing question is lifted off the authoritative answer
+      // before anything else reads it, so the chip's words are delivered once —
+      // as a block — and never also sit in the prose.
+      let (answerText, followUpQuestion) = ChatFollowUpTail.split(queryResult.text)
       if messages.contains(where: { $0.id == aiMessageId }) {
         messageText = await finalizeAssistantMessageCitations(
           messageId: aiMessageId,
-          queryText: queryResult.text,
+          queryText: answerText,
           selectedReferences: toolCitationSnapshot.selectedReferences,
           requestedSources: ChatCitationMarkup.explicitlyRequestsSources(effectivePrompt),
           terminalCitationReferences: terminalCitationReferences)
@@ -5445,6 +5461,18 @@ class ChatProvider: ObservableObject {
             terminalStatus: .completed,
             scheduleJournal: false
           )
+          if ChatFollowUpTail.shouldAttach(
+            question: followUpQuestion,
+            visibleText: messages[index].text,
+            failed: false
+          ), let question = followUpQuestion,
+            !messages[index].contentBlocks.contains(where: {
+              if case .followUp = $0 { return true } else { return false }
+            })
+          {
+            messages[index].contentBlocks.append(
+              .followUp(id: ChatFollowUpTail.blockID(messageID: aiMessageId), text: question))
+          }
         }
       } else {
         // The assistant row this turn owns is gone from the transcript while
@@ -5452,7 +5480,7 @@ class ChatProvider: ObservableObject {
         // get here; a transcript reset that failed to revoke the turn lands
         // here too, and then reports a `completed` the user never saw. Name the
         // condition, not one guessed cause.
-        messageText = queryResult.text
+        messageText = answerText
         log(
           "ChatProvider: assistant row \(aiMessageId) missing at completion "
             + "(generation \(sendGen)); response not visible in the transcript"
@@ -6189,6 +6217,16 @@ class ChatProvider: ObservableObject {
     }
   }
 
+  /// What a streaming assistant message shows right now.
+  ///
+  /// The grounded follow-up tail streams in like any other token, so without
+  /// stripping it here the chip's words appear in the prose first and are
+  /// removed only when the turn finalizes. Composed with sentence spacing
+  /// because both are projections of the same accumulated text.
+  static func normalizeStreamingAssistantText(_ text: String) -> String {
+    normalizeAssistantSentenceSpacing(ChatFollowUpTail.strippingPendingTail(text))
+  }
+
   /// Normalize missing spaces after sentence punctuation in assistant messages.
   /// Example: "Hello.World" -> "Hello. World", "Great!Lets go" -> "Great! Lets go"
   ///
@@ -6263,7 +6301,7 @@ class ChatProvider: ObservableObject {
   private func flushStreamingBuffer() {
     streamingBuffer.flush(messages: &messages) { message, text in
       if message.sender == .ai {
-        return Self.normalizeAssistantSentenceSpacing(text)
+        return Self.normalizeStreamingAssistantText(text)
       }
       return text
     }
@@ -6295,7 +6333,7 @@ class ChatProvider: ObservableObject {
         messages: &messages,
         normalizeText: { message, text in
           if message.sender == .ai {
-            return Self.normalizeAssistantSentenceSpacing(text)
+            return Self.normalizeStreamingAssistantText(text)
           }
           return text
         }
@@ -6323,7 +6361,7 @@ class ChatProvider: ObservableObject {
         messages: &messages,
         normalizeText: { message, text in
           if message.sender == .ai {
-            return Self.normalizeAssistantSentenceSpacing(text)
+            return Self.normalizeStreamingAssistantText(text)
           }
           return text
         }
@@ -6615,7 +6653,7 @@ class ChatProvider: ObservableObject {
       messages: &messages,
       normalizeText: { message, text in
         if message.sender == .ai {
-          return Self.normalizeAssistantSentenceSpacing(text)
+          return Self.normalizeStreamingAssistantText(text)
         }
         return text
       }

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+DailySummaries.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+DailySummaries.swift
@@ -40,6 +40,41 @@ struct DailySummaryRecord: Decodable, Identifiable, Equatable {
     let summary: String?
   }
 
+  /// One memory the day actually produced, addressed by its canonical id.
+  ///
+  /// This is the identity `knowledge_nuggets` never had. `knowledge_nuggets` is LLM prose about
+  /// the day; a `LearnedMemory` is a row in the memory store, so the card can show what Omi
+  /// actually stored and the owner can accept, reject, or correct it through the existing memory
+  /// endpoints. Review state (`user_review` / `edited`) is deliberately *not* on the wire here:
+  /// clients read it live from the memory, so a vote on the phone shows on the Mac.
+  struct LearnedMemory: Decodable, Equatable {
+    let memoryID: String
+    let content: String
+    let category: String
+    let capturedAt: String?
+
+    enum CodingKeys: String, CodingKey {
+      case memoryID = "memory_id"
+      case content, category
+      case capturedAt = "captured_at"
+    }
+
+    init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      memoryID = try container.decodeIfPresent(String.self, forKey: .memoryID) ?? ""
+      content = try container.decodeIfPresent(String.self, forKey: .content) ?? ""
+      category = try container.decodeIfPresent(String.self, forKey: .category) ?? ""
+      capturedAt = try container.decodeIfPresent(String.self, forKey: .capturedAt)
+    }
+
+    init(memoryID: String, content: String, category: String = "", capturedAt: String? = nil) {
+      self.memoryID = memoryID
+      self.content = content
+      self.category = category
+      self.capturedAt = capturedAt
+    }
+  }
+
   let id: String
   let date: String?
   let createdAt: String?
@@ -49,12 +84,16 @@ struct DailySummaryRecord: Decodable, Identifiable, Equatable {
   let stats: Stats?
   let highlights: [Highlight]?
   let actionItems: [ActionItem]?
+  /// Empty rather than optional: "the field is absent" and "the day produced nothing to review"
+  /// are the same thing for every reader, and an older backend must not make the card ambiguous.
+  let memoriesLearned: [LearnedMemory]
 
   enum CodingKeys: String, CodingKey {
     case id, date, headline, overview, stats, highlights
     case createdAt = "created_at"
     case dayEmoji = "day_emoji"
     case actionItems = "action_items"
+    case memoriesLearned = "memories_learned"
   }
 
   init(from decoder: Decoder) throws {
@@ -71,12 +110,18 @@ struct DailySummaryRecord: Decodable, Identifiable, Equatable {
     stats = try container.decodeIfPresent(Stats.self, forKey: .stats)
     highlights = try container.decodeIfPresent([Highlight].self, forKey: .highlights)
     actionItems = try container.decodeIfPresent([ActionItem].self, forKey: .actionItems)
+    // A malformed entry must not cost the reader the whole summary, and a memory with no id
+    // cannot be voted on or corrected, so it is not a review row at all.
+    memoriesLearned =
+      (try? container.decodeIfPresent([LearnedMemory].self, forKey: .memoriesLearned))
+      .flatMap { $0 }?
+      .filter { !$0.memoryID.isEmpty && !$0.content.isEmpty } ?? []
   }
 
   init(
     id: String, date: String?, createdAt: String? = nil, headline: String?, overview: String?,
     dayEmoji: String? = nil, stats: Stats? = nil, highlights: [Highlight]? = nil,
-    actionItems: [ActionItem]? = nil
+    actionItems: [ActionItem]? = nil, memoriesLearned: [LearnedMemory] = []
   ) {
     self.id = id
     self.date = date
@@ -87,6 +132,7 @@ struct DailySummaryRecord: Decodable, Identifiable, Equatable {
     self.stats = stats
     self.highlights = highlights
     self.actionItems = actionItems
+    self.memoriesLearned = memoriesLearned
   }
 }
 

--- a/desktop/macos/Desktop/Tests/ChatFollowUpChipTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatFollowUpChipTests.swift
@@ -1,0 +1,182 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// The grounded closing question on the typed lanes.
+///
+/// The realtime voice lane ends about two thirds of its answers with a question
+/// and runs about four turns; the chat window and the floating bar end with one
+/// 4-9% of the time, and recall answers never do. These assert the three things
+/// that have to hold for the chip to be worth anything: the tail leaves the
+/// visible text exactly once, only a real question survives to become a chip,
+/// and a question the chip produced is attributable as such.
+@MainActor
+final class ChatFollowUpChipTests: XCTestCase {
+
+  override func setUp() async throws {
+    QuestionOriginContext.resetForTests()
+  }
+
+  override func tearDown() async throws {
+    QuestionOriginContext.resetForTests()
+    AnalyticsManager.shared.questionTelemetryCaptureForTests = nil
+  }
+
+  // MARK: - Tail parsing
+
+  func testTailIsLiftedOffTheVisibleAnswer() {
+    let (visible, question) = ChatFollowUpTail.split(
+      "You and Priya settled on shipping Thursday.\n\(ChatFollowUpTail.delimiter) Who else was in that call?"
+    )
+    XCTAssertEqual(visible, "You and Priya settled on shipping Thursday.")
+    XCTAssertEqual(question, "Who else was in that call?")
+    XCTAssertFalse(visible.contains(ChatFollowUpTail.delimiter))
+  }
+
+  func testAnswerWithoutATailIsUntouched() {
+    let (visible, question) = ChatFollowUpTail.split("Nothing came up for that.")
+    XCTAssertEqual(visible, "Nothing came up for that.")
+    XCTAssertNil(question)
+  }
+
+  func testGenericAndMalformedTailsAreDroppedButStillStripped() {
+    for tail in [
+      "Anything else?", "Want more detail?", "Does that help?", "Let me know if you want more.",
+      "I will check that next.", String(repeating: "word ", count: 30) + "?",
+    ] {
+      let (visible, question) = ChatFollowUpTail.split("Here it is.\n\(ChatFollowUpTail.delimiter) \(tail)")
+      XCTAssertEqual(visible, "Here it is.", "tail: \(tail)")
+      XCTAssertNil(question, "generic or malformed tail became a chip: \(tail)")
+    }
+  }
+
+  // MARK: - Streaming projection
+
+  func testStreamingHidesACompletedTailAndAnUnambiguousPartialOne() {
+    XCTAssertEqual(
+      ChatFollowUpTail.strippingPendingTail("Shipped Thursday.\n\(ChatFollowUpTail.delimiter) Who else?"),
+      "Shipped Thursday.\n")
+    XCTAssertEqual(ChatFollowUpTail.strippingPendingTail("Shipped Thursday.\n<<<FOLL"), "Shipped Thursday.\n")
+  }
+
+  func testStreamingNeverEatsOrdinaryTextThatOnlyLooksLikeTheMarker() {
+    XCTAssertEqual(ChatFollowUpTail.strippingPendingTail("a < b"), "a < b")
+    XCTAssertEqual(ChatFollowUpTail.strippingPendingTail("compare a << b"), "compare a << b")
+  }
+
+  func testStreamingProjectionRunsOnTheAssistantTextPath() {
+    XCTAssertEqual(
+      ChatProvider.normalizeStreamingAssistantText(
+        "Shipped Thursday.\n\(ChatFollowUpTail.delimiter) Who else was there?"),
+      "Shipped Thursday.\n")
+  }
+
+  // MARK: - Attachment policy
+
+  func testAFailedOrEmptyOrClarifyingTurnCarriesNoChip() {
+    XCTAssertFalse(
+      ChatFollowUpTail.shouldAttach(question: "Who else?", visibleText: "Something broke.", failed: true))
+    XCTAssertFalse(ChatFollowUpTail.shouldAttach(question: "Who else?", visibleText: "   ", failed: false))
+    XCTAssertFalse(
+      ChatFollowUpTail.shouldAttach(
+        question: "Who else?", visibleText: "Which standup — Monday or Thursday?", failed: false))
+    XCTAssertFalse(ChatFollowUpTail.shouldAttach(question: nil, visibleText: "An answer.", failed: false))
+  }
+
+  func testAGroundedTurnCarriesTheChip() {
+    XCTAssertTrue(
+      ChatFollowUpTail.shouldAttach(
+        question: "Who else was in that call?",
+        visibleText: "You and Priya settled on shipping Thursday.",
+        failed: false))
+  }
+
+  // MARK: - Codec
+
+  func testFollowUpBlockRoundTripsThroughTheCodec() {
+    let block = ChatContentBlock.followUp(id: "m1:followup", text: "Who else was in that call?")
+    let encoded = ChatContentBlockCodec.encodeArray([block])
+    XCTAssertEqual(
+      encoded.first as? [String: String],
+      ["type": "followUp", "id": "m1:followup", "text": "Who else was in that call?"])
+
+    let decoded = ChatContentBlockCodec.decode(encoded)
+    XCTAssertEqual(decoded.count, 1)
+    guard case .followUp(let id, let text) = decoded[0] else {
+      return XCTFail("followUp did not survive the round trip: \(decoded)")
+    }
+    XCTAssertEqual(id, "m1:followup")
+    XCTAssertEqual(text, "Who else was in that call?")
+  }
+
+  func testCodecAcceptsTheBackendSnakeCaseTypeAndRejectsAnUnusableQuestion() {
+    let accepted = ChatContentBlockCodec.decode([
+      ["type": "follow_up", "id": "m1:followup", "text": "When is that review due?"]
+    ])
+    XCTAssertEqual(accepted.count, 1, "the backend's wire type must decode on the client")
+
+    // A block that survived a bad generation must not become a chip that reads
+    // as filler or as a statement.
+    for text in ["", "Anything else?", "I will look into that next."] {
+      XCTAssertTrue(
+        ChatContentBlockCodec.decode([["type": "followUp", "id": "m1:followup", "text": text]]).isEmpty,
+        "decoded an unusable follow-up: \(text)")
+    }
+  }
+
+  func testBlockIDMatchesTheBackendShape() {
+    XCTAssertEqual(ChatFollowUpTail.blockID(messageID: "msg-7"), "msg-7:followup")
+  }
+
+  // MARK: - Attribution
+
+  func testAChipQuestionIsAttributedToTheFollowUpOrigin() {
+    var captured: [(String, [String: Any])] = []
+    AnalyticsManager.shared.questionTelemetryCaptureForTests = { name, props in
+      captured.append((name, props))
+    }
+
+    AnalyticsManager.shared.questionOriginating(.followUp)
+    AnalyticsManager.shared.chatMessageSent(messageLength: 12, source: "follow_up_chip")
+
+    let asked = captured.filter { $0.0 == "question_asked" }
+    XCTAssertEqual(asked.count, 1)
+    XCTAssertEqual(asked.first?.1["origin"] as? String, "followup")
+    // Existing properties are untouched by the addition.
+    XCTAssertEqual(asked.first?.1["surface"] as? String, "chat_window")
+    XCTAssertEqual(asked.first?.1["source"] as? String, "follow_up_chip")
+  }
+
+  func testAnUnpromptedQuestionKeepsTheDefaultOriginAndTheArmIsOneShot() {
+    var captured: [(String, [String: Any])] = []
+    AnalyticsManager.shared.questionTelemetryCaptureForTests = { name, props in
+      captured.append((name, props))
+    }
+
+    AnalyticsManager.shared.questionOriginating(.followUp)
+    AnalyticsManager.shared.chatMessageSent(messageLength: 12, source: "follow_up_chip")
+    AnalyticsManager.shared.chatMessageSent(messageLength: 4, source: "query_shell")
+
+    let origins = captured.filter { $0.0 == "question_asked" }.map { $0.1["origin"] as? String }
+    XCTAssertEqual(
+      origins, ["followup", "unprompted"],
+      "an armed origin must apply to exactly one question, never leak onto the next")
+  }
+
+  // MARK: - Voice hint
+
+  func testTheVoiceHintNamesTheBoundShortcutAndIsAbsentWhenPushToTalkIsOff() {
+    let settings = ShortcutSettings.shared
+    let wasEnabled = settings.pttEnabled
+    defer { settings.pttEnabled = wasEnabled }
+
+    settings.pttEnabled = false
+    XCTAssertNil(FloatingControlBarView.followUpVoiceHint(settings: settings))
+
+    settings.pttEnabled = true
+    let hint = FloatingControlBarView.followUpVoiceHint(settings: settings)
+    XCTAssertNotNil(hint)
+    XCTAssertTrue(hint?.hasPrefix("or hold ") == true, "hint: \(hint ?? "nil")")
+    XCTAssertTrue(hint?.hasSuffix(" to ask aloud") == true, "hint: \(hint ?? "nil")")
+  }
+}

--- a/desktop/macos/Desktop/Tests/HomeKnowsComposerTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeKnowsComposerTests.swift
@@ -14,7 +14,7 @@ final class HomeKnowsComposerTests: XCTestCase {
   private let questions = ["What should I do today?", "What did I spend my time on this week?"]
 
   func testComposePicksTaskInsightTaskQuestionWhenAllAvailable() {
-    let rows = HomeKnowsListComposer.compose(tasks: tasks, insights: insights, questions: questions)
+    let rows = HomeKnowsListComposer.compose(tasks: tasks, insights: insights, questions: questions).rows
 
     // Diverse 4-slot brief: pressing task, one insight, a second task, then a prefilled ask.
     XCTAssertEqual(rows.count, 4)
@@ -27,25 +27,40 @@ final class HomeKnowsComposerTests: XCTestCase {
   }
 
   func testDismissedTaskFallsThroughToNextTask() {
+    let ledger = HomeKnowsLedgerFixture.dismissing(taskID: "t1", text: "Submit the Design PR by 7pm")
     let rows = HomeKnowsListComposer.compose(
-      tasks: tasks, insights: insights, questions: questions, dismissedTaskIDs: ["t1"])
+      tasks: tasks, insights: insights, questions: questions, ledger: ledger
+    ).rows
 
     XCTAssertEqual(rows[0].kind, .task(id: "t2"))
   }
 
   func testAllTasksDismissedFillsWithOneInsightAndQuestion() {
-    let rows = HomeKnowsListComposer.compose(
-      tasks: tasks, insights: insights, questions: questions, dismissedTaskIDs: ["t1", "t2"])
+    var ledger = HomeKnowsLedgerFixture.dismissing(taskID: "t1", text: "Submit the Design PR by 7pm")
+    ledger.entries.merge(
+      HomeKnowsLedgerFixture.dismissing(taskID: "t2", text: "Reply to Sarah").entries
+    ) { _, new in new }
+
+    let composition = HomeKnowsListComposer.compose(
+      tasks: tasks, insights: insights, questions: questions, ledger: ledger)
 
     // At most one insight (the tip slot); the ask fills the remaining slot.
-    XCTAssertEqual(rows.count, 2)
-    XCTAssertEqual(rows[0].kind, .insight(id: "i1"))
-    XCTAssertEqual(rows[1].kind, .question)
+    XCTAssertEqual(composition.rows.count, 2)
+    XCTAssertEqual(composition.rows[0].kind, .insight(id: "i1"))
+    XCTAssertEqual(composition.rows[1].kind, .question)
+    // Both task slots report why they stayed empty rather than repeating.
+    XCTAssertEqual(
+      composition.emptySlots,
+      [
+        HomeKnowsEmptySlot(slot: .pressingTask, reason: .dismissed),
+        HomeKnowsEmptySlot(slot: .secondTask, reason: .dismissed),
+      ])
   }
 
   func testSingleAskWhenNoTasksOrInsights() {
     let rows = HomeKnowsListComposer.compose(
-      tasks: [], insights: [], questions: questions + ["Third question?"])
+      tasks: [], insights: [], questions: questions + ["Third question?"]
+    ).rows
 
     // Only one prefilled ask is ever surfaced — the list never collapses into all-questions.
     XCTAssertEqual(rows.count, 1)
@@ -54,7 +69,7 @@ final class HomeKnowsComposerTests: XCTestCase {
   }
 
   func testSecondTaskFillsLastSlotWhenNoQuestionExists() {
-    let rows = HomeKnowsListComposer.compose(tasks: tasks, insights: insights, questions: [])
+    let rows = HomeKnowsListComposer.compose(tasks: tasks, insights: insights, questions: []).rows
 
     // With no ask, the last slot goes to a second task — never a second insight.
     XCTAssertEqual(rows.count, 3)
@@ -67,7 +82,8 @@ final class HomeKnowsComposerTests: XCTestCase {
     let rows = HomeKnowsListComposer.compose(
       tasks: [HomeKnowsTaskCandidate(id: "t0", text: "   ")],
       insights: [HomeKnowsInsightCandidate(id: "i0", text: "")],
-      questions: ["  ", "Real question?"])
+      questions: ["  ", "Real question?"]
+    ).rows
 
     XCTAssertEqual(rows.count, 1)
     XCTAssertEqual(rows[0].kind, .question)
@@ -75,7 +91,7 @@ final class HomeKnowsComposerTests: XCTestCase {
   }
 
   func testEverythingEmptyProducesNoRows() {
-    XCTAssertTrue(HomeKnowsListComposer.compose(tasks: [], insights: [], questions: []).isEmpty)
+    XCTAssertTrue(HomeKnowsListComposer.compose(tasks: [], insights: [], questions: []).rows.isEmpty)
   }
 
   func testDuplicateQuestionsDoNotCollideAcrossQuestionRows() {
@@ -87,11 +103,210 @@ final class HomeKnowsComposerTests: XCTestCase {
     let rows = HomeKnowsListComposer.compose(
       tasks: [], insights: [],
       tip: "What should I do today?",
-      questions: ["What should I do today?", " What should I do today? ", "Second question?"])
+      questions: ["What should I do today?", " What should I do today? ", "Second question?"]
+    ).rows
 
     XCTAssertEqual(rows.count, 2)
     XCTAssertEqual(rows.map(\.kind), [.question, .question])
     XCTAssertEqual(rows.map(\.text), ["What should I do today?", "Second question?"])
     XCTAssertEqual(Set(rows.map(\.id)).count, rows.count)
+  }
+
+  func testDuplicateTaskIDsAcrossBucketsSurfaceOnce() {
+    // The hub concatenates overdue + today + no-due-date, which can repeat a row.
+    let rows = HomeKnowsListComposer.compose(
+      tasks: tasks + [HomeKnowsTaskCandidate(id: "t1", text: "Submit the Design PR by 7pm")],
+      insights: [], questions: []
+    ).rows
+
+    XCTAssertEqual(rows.map(\.kind), [.task(id: "t1"), .task(id: "t2")])
+  }
+
+  // MARK: Rotation — the list gets shorter rather than repeating
+
+  /// The reported defect: a thin source re-showed the same four rows on every
+  /// visit. With the ledger, the second visit that same day is short, not a repeat.
+  func testAlreadyShownRowsLeaveSlotsEmptyInsteadOfRepeating() {
+    let now = HomeKnowsLedgerFixture.noon
+    var ledger = HomeKnowsImpressionLedger.empty
+    for task in tasks {
+      ledger.entries[HomeKnowsRotationPolicy.taskKey(task.id)] =
+        HomeKnowsLedgerFixture.shownToday(text: task.text, now: now)
+    }
+    ledger.entries[HomeKnowsRotationPolicy.insightKey("i1")] =
+      HomeKnowsLedgerFixture.shownToday(text: insights[0].text, now: now)
+
+    let composition = HomeKnowsListComposer.compose(
+      tasks: tasks, insights: insights, questions: questions, ledger: ledger, now: now)
+
+    // Both tasks and the first insight were shown today; only the untouched
+    // insight and the ask still qualify. The list is shorter, never repeated.
+    XCTAssertEqual(composition.rows.map(\.kind), [.insight(id: "i2"), .question])
+    XCTAssertEqual(
+      composition.emptySlots,
+      [
+        HomeKnowsEmptySlot(slot: .pressingTask, reason: .sameDay),
+        HomeKnowsEmptySlot(slot: .secondTask, reason: .sameDay),
+      ])
+  }
+
+  func testEverySourceExhaustedProducesAnEmptyListNotAFallbackRepeat() {
+    let now = HomeKnowsLedgerFixture.noon
+    let tip = "Recap what I got done today"
+    var ledger = HomeKnowsImpressionLedger.empty
+    ledger.entries[HomeKnowsRotationPolicy.taskKey("t1")] = HomeKnowsLedgerFixture.shownToday(
+      text: tasks[0].text, now: now)
+    ledger.entries[HomeKnowsRotationPolicy.questionKey(questions[0])] =
+      HomeKnowsLedgerFixture.shownToday(text: questions[0], now: now)
+    ledger.entries[HomeKnowsRotationPolicy.questionKey(tip)] =
+      HomeKnowsLedgerFixture.shownToday(text: tip, now: now)
+
+    let composition = HomeKnowsListComposer.compose(
+      tasks: [tasks[0]], insights: [], tip: tip, questions: [questions[0]], ledger: ledger, now: now)
+
+    XCTAssertTrue(composition.rows.isEmpty)
+    XCTAssertEqual(composition.emptySlots.map(\.slot), [.pressingTask, .tip, .secondTask, .ask])
+    XCTAssertTrue(composition.emptySlots.allSatisfy { $0.reason == .sameDay })
+  }
+
+  func testSameDayRepeatIsAllowedOnlyForAPreviouslyOpenedRow() {
+    let now = HomeKnowsLedgerFixture.noon
+    var ledger = HomeKnowsImpressionLedger.empty
+    var opened = HomeKnowsLedgerFixture.shownToday(text: tasks[0].text, now: now)
+    opened.lastOpenedAt = HomeKnowsLedgerFixture.sameDay(as: now)
+    ledger.entries[HomeKnowsRotationPolicy.taskKey("t1")] = opened
+
+    // Nothing else qualifies for the task slot, and this row has been opened
+    // before, so the same-day rule relaxes for it.
+    let composition = HomeKnowsListComposer.compose(
+      tasks: [tasks[0]], insights: [], questions: [], ledger: ledger, now: now)
+
+    XCTAssertEqual(composition.rows.map(\.kind), [.task(id: "t1")])
+  }
+
+  func testAnotherQualifyingTaskWinsOverASameDayRepeat() {
+    let now = HomeKnowsLedgerFixture.noon
+    var ledger = HomeKnowsImpressionLedger.empty
+    var opened = HomeKnowsLedgerFixture.shownToday(text: tasks[0].text, now: now)
+    opened.lastOpenedAt = HomeKnowsLedgerFixture.sameDay(as: now)
+    ledger.entries[HomeKnowsRotationPolicy.taskKey("t1")] = opened
+
+    let composition = HomeKnowsListComposer.compose(
+      tasks: tasks, insights: [], questions: [], ledger: ledger, now: now)
+
+    // t2 has never been shown, so the strict pass succeeds and t1 stays out.
+    XCTAssertEqual(composition.rows.map(\.kind), [.task(id: "t2")])
+  }
+
+  func testStaleAndCompletedTasksAreExcluded() {
+    let now = HomeKnowsLedgerFixture.noon
+    let candidates = [
+      HomeKnowsTaskCandidate(id: "old", text: "Long-dead commitment", dueAt: now.addingTimeInterval(-20 * 86_400)),
+      HomeKnowsTaskCandidate(id: "done", text: "Finished thing", isActive: false),
+      HomeKnowsTaskCandidate(id: "live", text: "Still open", dueAt: now.addingTimeInterval(-3 * 86_400)),
+    ]
+
+    let composition = HomeKnowsListComposer.compose(
+      tasks: candidates, insights: [], questions: [], now: now)
+
+    XCTAssertEqual(composition.rows.map(\.kind), [.task(id: "live")])
+  }
+
+  func testFreshnessOrderPrefersNeverShownThenFewestShows() {
+    let now = HomeKnowsLedgerFixture.noon
+    let yesterday = HomeKnowsLedgerFixture.previousDay(before: now)
+    let candidates = [
+      HomeKnowsTaskCandidate(id: "seenTwice", text: "Seen twice"),
+      HomeKnowsTaskCandidate(id: "seenOnce", text: "Seen once"),
+      HomeKnowsTaskCandidate(id: "neverSeen", text: "Never seen"),
+    ]
+    var ledger = HomeKnowsImpressionLedger.empty
+    ledger.entries[HomeKnowsRotationPolicy.taskKey("seenTwice")] = HomeKnowsImpression(
+      shows: 2, lastShownAt: yesterday,
+      contentHash: HomeKnowsRotationPolicy.contentHash(text: "Seen twice"))
+    ledger.entries[HomeKnowsRotationPolicy.taskKey("seenOnce")] = HomeKnowsImpression(
+      shows: 1, lastShownAt: yesterday,
+      contentHash: HomeKnowsRotationPolicy.contentHash(text: "Seen once"))
+
+    let composition = HomeKnowsListComposer.compose(
+      tasks: candidates, insights: [], questions: [], ledger: ledger, now: now)
+
+    XCTAssertEqual(composition.rows.map(\.kind), [.task(id: "neverSeen"), .task(id: "seenOnce")])
+    XCTAssertEqual(composition.rows.map(\.showsBefore), [0, 1])
+  }
+
+  func testFreshnessOrderBreaksTiesOnMostRecentUpdate() {
+    let now = HomeKnowsLedgerFixture.noon
+    let candidates = [
+      HomeKnowsTaskCandidate(id: "stale", text: "Older update", updatedAt: now.addingTimeInterval(-7200)),
+      HomeKnowsTaskCandidate(id: "fresh", text: "Newer update", updatedAt: now.addingTimeInterval(-60)),
+    ]
+
+    let composition = HomeKnowsListComposer.compose(
+      tasks: candidates, insights: [], questions: [], now: now)
+
+    XCTAssertEqual(composition.rows.first?.kind, .task(id: "fresh"))
+  }
+
+  func testCanRotateOnlyWhenMoreCandidatesStillQualify() {
+    let now = HomeKnowsLedgerFixture.noon
+    XCTAssertFalse(
+      HomeKnowsListComposer.compose(tasks: tasks, insights: [], questions: [], now: now).canRotate)
+
+    let three = tasks + [HomeKnowsTaskCandidate(id: "t3", text: "Third task")]
+    XCTAssertTrue(
+      HomeKnowsListComposer.compose(tasks: three, insights: [], questions: [], now: now).canRotate)
+
+    // A third task that no longer qualifies does not make the list rotatable.
+    var ledger = HomeKnowsImpressionLedger.empty
+    ledger.entries[HomeKnowsRotationPolicy.taskKey("t3")] = HomeKnowsLedgerFixture.shownToday(
+      text: "Third task", now: now)
+    XCTAssertFalse(
+      HomeKnowsListComposer.compose(tasks: three, insights: [], questions: [], ledger: ledger, now: now)
+        .canRotate)
+  }
+
+  func testOpenTaskCountIgnoresDismissedAndCompletedTasks() {
+    let ledger = HomeKnowsLedgerFixture.dismissing(taskID: "t1", text: "Submit the Design PR by 7pm")
+    let candidates = tasks + [HomeKnowsTaskCandidate(id: "done", text: "Finished", isActive: false)]
+
+    XCTAssertEqual(HomeKnowsListComposer.openTaskCount(candidates), 2)
+    XCTAssertEqual(HomeKnowsListComposer.openTaskCount(candidates, ledger: ledger), 1)
+  }
+}
+
+/// Shared ledger fixtures. A fixed instant keeps the calendar-day rules
+/// deterministic regardless of when the suite runs.
+enum HomeKnowsLedgerFixture {
+  /// 2026-03-05 12:00:00 UTC — mid-day, so "same calendar day" is unambiguous.
+  static let noon = Date(timeIntervalSince1970: 1_772_884_800)
+
+  /// An instant guaranteed to be the same *local* calendar day as `now`, so the
+  /// same-day rule is asserted the same way in every timezone the suite runs in.
+  static func sameDay(as now: Date, calendar: Calendar = .current) -> Date {
+    calendar.startOfDay(for: now)
+  }
+
+  static func previousDay(before now: Date, calendar: Calendar = .current) -> Date {
+    calendar.startOfDay(for: now).addingTimeInterval(-1)
+  }
+
+  static func shownToday(text: String, now: Date, shows: Int = 1) -> HomeKnowsImpression {
+    HomeKnowsImpression(
+      shows: shows,
+      firstShownAt: sameDay(as: now),
+      lastShownAt: sameDay(as: now),
+      contentHash: HomeKnowsRotationPolicy.contentHash(text: text))
+  }
+
+  static func dismissing(taskID: String, text: String, at date: Date = noon) -> HomeKnowsImpressionLedger {
+    var ledger = HomeKnowsImpressionLedger.empty
+    ledger.entries[HomeKnowsRotationPolicy.taskKey(taskID)] = HomeKnowsImpression(
+      shows: 1,
+      firstShownAt: date,
+      lastShownAt: date,
+      dismissedAt: date,
+      contentHash: HomeKnowsRotationPolicy.contentHash(text: text))
+    return ledger
   }
 }

--- a/desktop/macos/Desktop/Tests/HomeKnowsComposerTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeKnowsComposerTests.swift
@@ -235,6 +235,16 @@ final class HomeKnowsComposerTests: XCTestCase {
     XCTAssertEqual(composition.rows.map(\.showsBefore), [0, 1])
   }
 
+  /// Equal freshness must fall back to the caller's own priority order. An
+  /// earlier revision tie-broke on the ledger key, which is a hash, and silently
+  /// reordered the suggested questions the caller had already ranked.
+  func testEquallyFreshCandidatesKeepTheCallersOrder() {
+    let composition = HomeKnowsListComposer.compose(
+      tasks: [], insights: [], questions: questions, now: HomeKnowsLedgerFixture.noon)
+
+    XCTAssertEqual(composition.rows.first?.text, questions[0])
+  }
+
   func testFreshnessOrderBreaksTiesOnMostRecentUpdate() {
     let now = HomeKnowsLedgerFixture.noon
     let candidates = [
@@ -278,7 +288,7 @@ final class HomeKnowsComposerTests: XCTestCase {
 /// Shared ledger fixtures. A fixed instant keeps the calendar-day rules
 /// deterministic regardless of when the suite runs.
 enum HomeKnowsLedgerFixture {
-  /// 2026-03-05 12:00:00 UTC — mid-day, so "same calendar day" is unambiguous.
+  /// 2026-03-07 12:00:00 UTC — mid-day, so "same calendar day" is unambiguous.
   static let noon = Date(timeIntervalSince1970: 1_772_884_800)
 
   /// An instant guaranteed to be the same *local* calendar day as `now`, so the

--- a/desktop/macos/Desktop/Tests/HomeKnowsImpressionLedgerTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeKnowsImpressionLedgerTests.swift
@@ -1,0 +1,353 @@
+import XCTest
+
+@testable import Omi_Computer
+
+// MARK: - Rules
+
+final class HomeKnowsRotationPolicyTests: XCTestCase {
+  private let now = HomeKnowsLedgerFixture.noon
+  private let calendar = Calendar.current
+
+  private func facts(
+    _ key: String = "task:t1",
+    text: String = "Meet with Priya",
+    updatedAt: Date? = nil,
+    dueAt: Date? = nil,
+    isActive: Bool = true
+  ) -> HomeKnowsCandidateFacts {
+    HomeKnowsCandidateFacts(
+      key: key,
+      contentHash: HomeKnowsRotationPolicy.contentHash(text: text, updatedAt: updatedAt),
+      updatedAt: updatedAt,
+      dueAt: dueAt,
+      isActive: isActive)
+  }
+
+  private func suppression(
+    _ facts: HomeKnowsCandidateFacts,
+    _ entry: HomeKnowsImpression?,
+    at instant: Date? = nil,
+    allowSameDayRepeat: Bool = false
+  ) -> HomeKnowsRotationReason? {
+    HomeKnowsRotationPolicy.suppression(
+      facts: facts,
+      entry: entry,
+      now: instant ?? now,
+      calendar: calendar,
+      allowSameDayRepeat: allowSameDayRepeat)
+  }
+
+  func testNeverShownRowQualifies() {
+    XCTAssertNil(suppression(facts(), nil))
+  }
+
+  func testThreeShowsWithoutAnOpenRotateOutForSevenDays() {
+    let subject = facts()
+    let lastShown = HomeKnowsLedgerFixture.previousDay(before: now)
+    let entry = HomeKnowsImpression(
+      shows: 3, firstShownAt: lastShown, lastShownAt: lastShown, contentHash: subject.contentHash)
+
+    XCTAssertEqual(suppression(subject, entry), .showCap)
+    // Still out one day before the cooldown ends…
+    XCTAssertEqual(
+      suppression(subject, entry, at: lastShown.addingTimeInterval(6 * 86_400)), .showCap)
+    // …and back once it has passed.
+    XCTAssertNil(suppression(subject, entry, at: lastShown.addingTimeInterval(7 * 86_400 + 1)))
+  }
+
+  func testTwoShowsDoNotHitTheCap() {
+    let subject = facts()
+    let lastShown = HomeKnowsLedgerFixture.previousDay(before: now)
+    let entry = HomeKnowsImpression(shows: 2, lastShownAt: lastShown, contentHash: subject.contentHash)
+
+    XCTAssertNil(suppression(subject, entry))
+  }
+
+  func testAnOpenedRowIsNeverCapped() {
+    let subject = facts()
+    let lastShown = HomeKnowsLedgerFixture.previousDay(before: now)
+    let entry = HomeKnowsImpression(
+      shows: 12, lastShownAt: lastShown, lastOpenedAt: lastShown, contentHash: subject.contentHash)
+
+    XCTAssertNil(suppression(subject, entry))
+  }
+
+  func testDismissedRowNeverReturnsWhileItsObjectIsUnchanged() {
+    let subject = facts()
+    let entry = HomeKnowsImpression(
+      shows: 1, dismissedAt: HomeKnowsLedgerFixture.previousDay(before: now),
+      contentHash: subject.contentHash)
+
+    XCTAssertEqual(suppression(subject, entry), .dismissed)
+    // Even a year later, and even when nothing else qualifies for the slot.
+    XCTAssertEqual(suppression(subject, entry, at: now.addingTimeInterval(365 * 86_400)), .dismissed)
+    XCTAssertEqual(suppression(subject, entry, allowSameDayRepeat: true), .dismissed)
+  }
+
+  func testDismissedRowReturnsOnceItsUnderlyingObjectChanges() {
+    let dismissed = facts(text: "Meet with Priya")
+    let entry = HomeKnowsImpression(
+      shows: 1, dismissedAt: HomeKnowsLedgerFixture.previousDay(before: now),
+      contentHash: dismissed.contentHash)
+
+    // Same row id, new content hash — a real edit to the task.
+    let edited = facts(text: "Meet with Priya about the Q3 plan")
+    XCTAssertNil(suppression(edited, entry))
+
+    // A new updated_at alone is enough, even with identical text.
+    let touched = facts(text: "Meet with Priya", updatedAt: now)
+    XCTAssertNil(suppression(touched, entry))
+  }
+
+  func testTaskMoreThanFourteenDaysPastDueIsExcluded() {
+    XCTAssertNil(suppression(facts(dueAt: now.addingTimeInterval(-13 * 86_400)), nil))
+    XCTAssertEqual(
+      suppression(facts(dueAt: now.addingTimeInterval(-15 * 86_400)), nil), .staleDueDate)
+    // A future due date is never stale.
+    XCTAssertNil(suppression(facts(dueAt: now.addingTimeInterval(86_400)), nil))
+  }
+
+  func testCompletedOrDeletedTaskIsExcluded() {
+    XCTAssertEqual(suppression(facts(isActive: false), nil), .inactive)
+  }
+
+  func testSameDayRepeatNeedsBothRelaxationAndAPriorOpen() {
+    let subject = facts()
+    let today = HomeKnowsLedgerFixture.sameDay(as: now)
+    let unopened = HomeKnowsImpression(shows: 1, lastShownAt: today, contentHash: subject.contentHash)
+    var opened = unopened
+    opened.lastOpenedAt = today
+
+    XCTAssertEqual(suppression(subject, unopened), .sameDay)
+    XCTAssertEqual(suppression(subject, unopened, allowSameDayRepeat: true), .sameDay)
+    XCTAssertEqual(suppression(subject, opened), .sameDay)
+    XCTAssertNil(suppression(subject, opened, allowSameDayRepeat: true))
+  }
+
+  func testFreshnessRankPrefersNeverShownThenFewestShowsThenNewestUpdate() {
+    var ledger = HomeKnowsImpressionLedger.empty
+    ledger.entries["task:seen"] = HomeKnowsImpression(shows: 2)
+    let never = facts("task:never")
+    let seen = facts("task:seen")
+
+    XCTAssertTrue(
+      HomeKnowsRotationPolicy.freshnessRank(never, ledger: ledger)
+        < HomeKnowsRotationPolicy.freshnessRank(seen, ledger: ledger))
+
+    let older = facts("task:a", updatedAt: now.addingTimeInterval(-3600))
+    let newer = facts("task:b", updatedAt: now)
+    XCTAssertTrue(
+      HomeKnowsRotationPolicy.freshnessRank(newer, ledger: .empty)
+        < HomeKnowsRotationPolicy.freshnessRank(older, ledger: .empty))
+  }
+
+  func testDominantReasonUsesAFixedPriorityRatherThanInputOrder() {
+    XCTAssertEqual(HomeKnowsRotationPolicy.dominantReason([.sameDay, .dismissed]), .dismissed)
+    XCTAssertEqual(HomeKnowsRotationPolicy.dominantReason([.staleDueDate, .showCap]), .showCap)
+    XCTAssertEqual(HomeKnowsRotationPolicy.dominantReason([]), .noCandidate)
+  }
+
+  func testContentHashMovesWithTextAndUpdatedAt() {
+    let base = HomeKnowsRotationPolicy.contentHash(text: "Meet with Priya")
+    XCTAssertEqual(base, HomeKnowsRotationPolicy.contentHash(text: "Meet with Priya"))
+    XCTAssertNotEqual(base, HomeKnowsRotationPolicy.contentHash(text: "Meet with Ravi"))
+    XCTAssertNotEqual(base, HomeKnowsRotationPolicy.contentHash(text: "Meet with Priya", updatedAt: now))
+  }
+
+  func testQuestionKeyHashesTheTextRatherThanStoringIt() {
+    let key = HomeKnowsRotationPolicy.questionKey("What did I commit to this week?")
+    XCTAssertTrue(key.hasPrefix("question:"))
+    XCTAssertFalse(key.contains("commit"))
+    XCTAssertEqual(key, HomeKnowsRotationPolicy.questionKey("What did I commit to this week?"))
+  }
+}
+
+// MARK: - Store
+
+@MainActor
+final class HomeKnowsImpressionStoreTests: XCTestCase {
+  /// In-memory persistence so the rules are asserted without UserDefaults.
+  private final class FakePersistence: HomeKnowsImpressionPersisting {
+    var ledger = HomeKnowsImpressionLedger.empty
+    var saves = 0
+
+    func load() -> HomeKnowsImpressionLedger { ledger }
+    func save(_ ledger: HomeKnowsImpressionLedger) {
+      self.ledger = ledger
+      saves += 1
+    }
+  }
+
+  private var persistence = FakePersistence()
+  private var clock = HomeKnowsLedgerFixture.noon
+  private var store = HomeKnowsImpressionStore()
+  private let hash = HomeKnowsRotationPolicy.contentHash(text: "Meet with Priya")
+
+  override func setUp() {
+    super.setUp()
+    persistence = FakePersistence()
+    clock = HomeKnowsLedgerFixture.noon
+    store = HomeKnowsImpressionStore(persistence: persistence, now: { self.clock })
+  }
+
+  func testShowIsRecordedOncePerVisitNotOncePerRender() {
+    store.beginVisit()
+    XCTAssertEqual(store.recordShown(key: "task:t1", contentHash: hash)?.shows, 1)
+    // The in-visit rotation timer re-renders the same row every few seconds.
+    XCTAssertNil(store.recordShown(key: "task:t1", contentHash: hash))
+    XCTAssertNil(store.recordShown(key: "task:t1", contentHash: hash))
+    XCTAssertEqual(persistence.ledger.entry("task:t1")?.shows, 1)
+
+    store.beginVisit()
+    XCTAssertEqual(store.recordShown(key: "task:t1", contentHash: hash)?.shows, 2)
+  }
+
+  func testEmptySlotIsReportedOncePerVisit() {
+    store.beginVisit()
+    XCTAssertTrue(store.shouldReportEmptySlot("tip"))
+    XCTAssertFalse(store.shouldReportEmptySlot("tip"))
+    store.beginVisit()
+    XCTAssertTrue(store.shouldReportEmptySlot("tip"))
+  }
+
+  func testFirstAndLastShownTrackSeparately() {
+    store.beginVisit()
+    store.recordShown(key: "task:t1", contentHash: hash)
+    let first = clock
+    clock = clock.addingTimeInterval(2 * 86_400)
+    store.beginVisit()
+    store.recordShown(key: "task:t1", contentHash: hash)
+
+    let entry = store.snapshot().entry("task:t1")
+    XCTAssertEqual(entry?.firstShownAt, first)
+    XCTAssertEqual(entry?.lastShownAt, clock)
+    XCTAssertEqual(entry?.shows, 2)
+  }
+
+  func testShowCountResetsAfterTheCooldownSoTheCapIsThreeShowsPerWindow() {
+    for _ in 0..<HomeKnowsRotationPolicy.showCapCount {
+      store.beginVisit()
+      store.recordShown(key: "task:t1", contentHash: hash)
+      clock = clock.addingTimeInterval(86_400)
+    }
+    XCTAssertEqual(store.snapshot().entry("task:t1")?.shows, 3)
+
+    clock = clock.addingTimeInterval(HomeKnowsRotationPolicy.showCapCooldown)
+    store.beginVisit()
+    XCTAssertEqual(store.recordShown(key: "task:t1", contentHash: hash)?.shows, 1)
+  }
+
+  func testChangedContentResetsTheCountAndClearsADismissal() {
+    store.beginVisit()
+    store.recordShown(key: "task:t1", contentHash: hash)
+    store.recordDismissed(key: "task:t1", contentHash: hash)
+    XCTAssertNotNil(store.snapshot().entry("task:t1")?.dismissedAt)
+
+    let edited = HomeKnowsRotationPolicy.contentHash(text: "Meet with Priya about Q3")
+    store.beginVisit()
+    let entry = store.recordShown(key: "task:t1", contentHash: edited)
+    XCTAssertEqual(entry?.shows, 1)
+    XCTAssertNil(entry?.dismissedAt)
+    XCTAssertEqual(entry?.contentHash, edited)
+  }
+
+  func testOpeningARowClearsAnEarlierDismissal() {
+    store.beginVisit()
+    store.recordDismissed(key: "insight:i1", contentHash: hash)
+    let entry = store.recordOpened(key: "insight:i1", contentHash: hash)
+
+    XCTAssertNil(entry.dismissedAt)
+    XCTAssertEqual(entry.lastOpenedAt, clock)
+  }
+
+  /// The composer reads the store's snapshot, so the two must agree: a row the
+  /// store has recorded three times is one the policy holds back.
+  func testStoreAndPolicyAgreeOnTheShowCap() {
+    for _ in 0..<HomeKnowsRotationPolicy.showCapCount {
+      store.beginVisit()
+      store.recordShown(key: "task:t1", contentHash: hash)
+      clock = clock.addingTimeInterval(86_400)
+    }
+
+    let composition = HomeKnowsListComposer.compose(
+      tasks: [HomeKnowsTaskCandidate(id: "t1", text: "Meet with Priya")],
+      insights: [], questions: [],
+      ledger: store.snapshot(), now: clock)
+
+    XCTAssertTrue(composition.rows.isEmpty)
+    XCTAssertEqual(
+      composition.emptySlots.first, HomeKnowsEmptySlot(slot: .pressingTask, reason: .showCap))
+  }
+}
+
+// MARK: - Persistence
+
+@MainActor
+final class HomeKnowsImpressionDefaultsTests: XCTestCase {
+  private var suiteName = ""
+  private var defaults = UserDefaults.standard
+
+  override func setUp() {
+    super.setUp()
+    suiteName = "HomeKnowsImpressionDefaultsTests.\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName) ?? .standard
+  }
+
+  override func tearDown() {
+    UserDefaults.standard.removePersistentDomain(forName: suiteName)
+    super.tearDown()
+  }
+
+  func testLedgerRoundTrips() {
+    let store = HomeKnowsImpressionDefaults(defaults: defaults, ownerID: "owner-a")
+    var ledger = HomeKnowsImpressionLedger.empty
+    ledger.entries["task:t1"] = HomeKnowsImpression(
+      shows: 2, lastShownAt: HomeKnowsLedgerFixture.noon, contentHash: "abc")
+    store.save(ledger)
+
+    XCTAssertEqual(HomeKnowsImpressionDefaults(defaults: defaults, ownerID: "owner-a").load(), ledger)
+  }
+
+  func testOneOwnersDismissalsDoNotSilenceAnother() {
+    let owner = HomeKnowsImpressionDefaults(defaults: defaults, ownerID: "owner-a")
+    var ledger = HomeKnowsImpressionLedger.empty
+    ledger.entries["task:t1"] = HomeKnowsImpression(
+      dismissedAt: HomeKnowsLedgerFixture.noon, contentHash: "abc")
+    owner.save(ledger)
+
+    let other = HomeKnowsImpressionDefaults(defaults: defaults, ownerID: "owner-b")
+    XCTAssertEqual(other.load(), .empty)
+  }
+
+  func testUntouchedEntriesArePrunedOnLoad() {
+    let now = HomeKnowsLedgerFixture.noon
+    let writer = HomeKnowsImpressionDefaults(defaults: defaults, ownerID: "owner-a")
+    var ledger = HomeKnowsImpressionLedger.empty
+    ledger.entries["task:recent"] = HomeKnowsImpression(
+      shows: 1, lastShownAt: now.addingTimeInterval(-30 * 86_400), contentHash: "a")
+    ledger.entries["task:ancient"] = HomeKnowsImpression(
+      shows: 1, lastShownAt: now.addingTimeInterval(-200 * 86_400), contentHash: "b")
+    writer.save(ledger)
+
+    let loaded = HomeKnowsImpressionDefaults(
+      defaults: defaults, ownerID: "owner-a", now: { now }
+    ).load()
+
+    XCTAssertEqual(Set(loaded.entries.keys), ["task:recent"])
+  }
+
+  func testCorruptPayloadLoadsAsAnEmptyLedgerRatherThanTrapping() {
+    let store = HomeKnowsImpressionDefaults(defaults: defaults, ownerID: "owner-a")
+    var ledger = HomeKnowsImpressionLedger.empty
+    ledger.entries["task:t1"] = HomeKnowsImpression(shows: 1, contentHash: "abc")
+    store.save(ledger)
+
+    // Overwrite whatever key the store chose with something undecodable; a bad
+    // payload must degrade to "no history", never trap the process.
+    let storageKey = defaults.dictionaryRepresentation().keys.first { $0.hasPrefix("homeKnows.") }
+    XCTAssertNotNil(storageKey)
+    defaults.set(Data("not json".utf8), forKey: storageKey ?? "")
+
+    XCTAssertEqual(store.load(), .empty)
+  }
+}

--- a/desktop/macos/Desktop/Tests/HomeKnowsImpressionLedgerTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeKnowsImpressionLedgerTests.swift
@@ -139,6 +139,12 @@ final class HomeKnowsRotationPolicyTests: XCTestCase {
     XCTAssertTrue(
       HomeKnowsRotationPolicy.freshnessRank(newer, ledger: .empty)
         < HomeKnowsRotationPolicy.freshnessRank(older, ledger: .empty))
+
+    // Two equally fresh rows must tie, so the caller's own priority order — not
+    // the row key — decides between them.
+    XCTAssertTrue(
+      HomeKnowsRotationPolicy.freshnessRank(facts("task:zzz"), ledger: .empty)
+        == HomeKnowsRotationPolicy.freshnessRank(facts("task:aaa"), ledger: .empty))
   }
 
   func testDominantReasonUsesAFixedPriorityRatherThanInputOrder() {
@@ -164,115 +170,123 @@ final class HomeKnowsRotationPolicyTests: XCTestCase {
 
 // MARK: - Store
 
-@MainActor
+/// Not `@MainActor` at the class level: `XCTestCase.setUp` is a nonisolated
+/// override and cannot build main-actor state. Each test makes its own harness.
 final class HomeKnowsImpressionStoreTests: XCTestCase {
-  /// In-memory persistence so the rules are asserted without UserDefaults.
-  private final class FakePersistence: HomeKnowsImpressionPersisting {
-    var ledger = HomeKnowsImpressionLedger.empty
-    var saves = 0
+  /// In-memory persistence plus a movable clock, so the rules are asserted
+  /// without UserDefaults and without waiting on the wall clock.
+  @MainActor
+  private final class Harness {
+    final class FakePersistence: HomeKnowsImpressionPersisting {
+      var ledger = HomeKnowsImpressionLedger.empty
 
-    func load() -> HomeKnowsImpressionLedger { ledger }
-    func save(_ ledger: HomeKnowsImpressionLedger) {
-      self.ledger = ledger
-      saves += 1
+      func load() -> HomeKnowsImpressionLedger { ledger }
+      func save(_ ledger: HomeKnowsImpressionLedger) { self.ledger = ledger }
     }
+
+    let persistence = FakePersistence()
+    var clock = HomeKnowsLedgerFixture.noon
+    lazy var store = HomeKnowsImpressionStore(persistence: persistence, now: { self.clock })
+    let hash = HomeKnowsRotationPolicy.contentHash(text: "Meet with Priya")
   }
 
-  private var persistence = FakePersistence()
-  private var clock = HomeKnowsLedgerFixture.noon
-  private var store = HomeKnowsImpressionStore()
-  private let hash = HomeKnowsRotationPolicy.contentHash(text: "Meet with Priya")
-
-  override func setUp() {
-    super.setUp()
-    persistence = FakePersistence()
-    clock = HomeKnowsLedgerFixture.noon
-    store = HomeKnowsImpressionStore(persistence: persistence, now: { self.clock })
-  }
-
+  @MainActor
   func testShowIsRecordedOncePerVisitNotOncePerRender() {
-    store.beginVisit()
-    XCTAssertEqual(store.recordShown(key: "task:t1", contentHash: hash)?.shows, 1)
+    let harness = Harness()
+    harness.store.beginVisit()
+    XCTAssertEqual(harness.store.recordShown(key: "task:t1", contentHash: harness.hash)?.shows, 1)
     // The in-visit rotation timer re-renders the same row every few seconds.
-    XCTAssertNil(store.recordShown(key: "task:t1", contentHash: hash))
-    XCTAssertNil(store.recordShown(key: "task:t1", contentHash: hash))
-    XCTAssertEqual(persistence.ledger.entry("task:t1")?.shows, 1)
+    XCTAssertNil(harness.store.recordShown(key: "task:t1", contentHash: harness.hash))
+    XCTAssertNil(harness.store.recordShown(key: "task:t1", contentHash: harness.hash))
+    XCTAssertEqual(harness.persistence.ledger.entry("task:t1")?.shows, 1)
 
-    store.beginVisit()
-    XCTAssertEqual(store.recordShown(key: "task:t1", contentHash: hash)?.shows, 2)
+    harness.store.beginVisit()
+    XCTAssertEqual(harness.store.recordShown(key: "task:t1", contentHash: harness.hash)?.shows, 2)
   }
 
+  @MainActor
   func testEmptySlotIsReportedOncePerVisit() {
-    store.beginVisit()
-    XCTAssertTrue(store.shouldReportEmptySlot("tip"))
-    XCTAssertFalse(store.shouldReportEmptySlot("tip"))
-    store.beginVisit()
-    XCTAssertTrue(store.shouldReportEmptySlot("tip"))
+    let harness = Harness()
+    harness.store.beginVisit()
+    XCTAssertTrue(harness.store.shouldReportEmptySlot("tip"))
+    XCTAssertFalse(harness.store.shouldReportEmptySlot("tip"))
+    harness.store.beginVisit()
+    XCTAssertTrue(harness.store.shouldReportEmptySlot("tip"))
   }
 
+  @MainActor
   func testFirstAndLastShownTrackSeparately() {
-    store.beginVisit()
-    store.recordShown(key: "task:t1", contentHash: hash)
-    let first = clock
-    clock = clock.addingTimeInterval(2 * 86_400)
-    store.beginVisit()
-    store.recordShown(key: "task:t1", contentHash: hash)
+    let harness = Harness()
+    harness.store.beginVisit()
+    harness.store.recordShown(key: "task:t1", contentHash: harness.hash)
+    let first = harness.clock
+    harness.clock = harness.clock.addingTimeInterval(2 * 86_400)
+    harness.store.beginVisit()
+    harness.store.recordShown(key: "task:t1", contentHash: harness.hash)
 
-    let entry = store.snapshot().entry("task:t1")
+    let entry = harness.store.snapshot().entry("task:t1")
     XCTAssertEqual(entry?.firstShownAt, first)
-    XCTAssertEqual(entry?.lastShownAt, clock)
+    XCTAssertEqual(entry?.lastShownAt, harness.clock)
     XCTAssertEqual(entry?.shows, 2)
   }
 
+  @MainActor
   func testShowCountResetsAfterTheCooldownSoTheCapIsThreeShowsPerWindow() {
+    let harness = Harness()
     for _ in 0..<HomeKnowsRotationPolicy.showCapCount {
-      store.beginVisit()
-      store.recordShown(key: "task:t1", contentHash: hash)
-      clock = clock.addingTimeInterval(86_400)
+      harness.store.beginVisit()
+      harness.store.recordShown(key: "task:t1", contentHash: harness.hash)
+      harness.clock = harness.clock.addingTimeInterval(86_400)
     }
-    XCTAssertEqual(store.snapshot().entry("task:t1")?.shows, 3)
+    XCTAssertEqual(harness.store.snapshot().entry("task:t1")?.shows, 3)
 
-    clock = clock.addingTimeInterval(HomeKnowsRotationPolicy.showCapCooldown)
-    store.beginVisit()
-    XCTAssertEqual(store.recordShown(key: "task:t1", contentHash: hash)?.shows, 1)
+    harness.clock = harness.clock.addingTimeInterval(HomeKnowsRotationPolicy.showCapCooldown)
+    harness.store.beginVisit()
+    XCTAssertEqual(harness.store.recordShown(key: "task:t1", contentHash: harness.hash)?.shows, 1)
   }
 
+  @MainActor
   func testChangedContentResetsTheCountAndClearsADismissal() {
-    store.beginVisit()
-    store.recordShown(key: "task:t1", contentHash: hash)
-    store.recordDismissed(key: "task:t1", contentHash: hash)
-    XCTAssertNotNil(store.snapshot().entry("task:t1")?.dismissedAt)
+    let harness = Harness()
+    harness.store.beginVisit()
+    harness.store.recordShown(key: "task:t1", contentHash: harness.hash)
+    harness.store.recordDismissed(key: "task:t1", contentHash: harness.hash)
+    XCTAssertNotNil(harness.store.snapshot().entry("task:t1")?.dismissedAt)
 
     let edited = HomeKnowsRotationPolicy.contentHash(text: "Meet with Priya about Q3")
-    store.beginVisit()
-    let entry = store.recordShown(key: "task:t1", contentHash: edited)
+    harness.store.beginVisit()
+    let entry = harness.store.recordShown(key: "task:t1", contentHash: edited)
     XCTAssertEqual(entry?.shows, 1)
     XCTAssertNil(entry?.dismissedAt)
     XCTAssertEqual(entry?.contentHash, edited)
   }
 
+  @MainActor
   func testOpeningARowClearsAnEarlierDismissal() {
-    store.beginVisit()
-    store.recordDismissed(key: "insight:i1", contentHash: hash)
-    let entry = store.recordOpened(key: "insight:i1", contentHash: hash)
+    let harness = Harness()
+    harness.store.beginVisit()
+    harness.store.recordDismissed(key: "insight:i1", contentHash: harness.hash)
+    let entry = harness.store.recordOpened(key: "insight:i1", contentHash: harness.hash)
 
     XCTAssertNil(entry.dismissedAt)
-    XCTAssertEqual(entry.lastOpenedAt, clock)
+    XCTAssertEqual(entry.lastOpenedAt, harness.clock)
   }
 
   /// The composer reads the store's snapshot, so the two must agree: a row the
   /// store has recorded three times is one the policy holds back.
+  @MainActor
   func testStoreAndPolicyAgreeOnTheShowCap() {
+    let harness = Harness()
     for _ in 0..<HomeKnowsRotationPolicy.showCapCount {
-      store.beginVisit()
-      store.recordShown(key: "task:t1", contentHash: hash)
-      clock = clock.addingTimeInterval(86_400)
+      harness.store.beginVisit()
+      harness.store.recordShown(key: "task:t1", contentHash: harness.hash)
+      harness.clock = harness.clock.addingTimeInterval(86_400)
     }
 
     let composition = HomeKnowsListComposer.compose(
       tasks: [HomeKnowsTaskCandidate(id: "t1", text: "Meet with Priya")],
       insights: [], questions: [],
-      ledger: store.snapshot(), now: clock)
+      ledger: harness.store.snapshot(), now: harness.clock)
 
     XCTAssertTrue(composition.rows.isEmpty)
     XCTAssertEqual(
@@ -282,7 +296,9 @@ final class HomeKnowsImpressionStoreTests: XCTestCase {
 
 // MARK: - Persistence
 
-@MainActor
+/// Not `@MainActor` at the class level: `XCTestCase.setUp`/`tearDown` are
+/// nonisolated overrides and cannot touch main-actor state. The individual
+/// tests carry the isolation the store requires.
 final class HomeKnowsImpressionDefaultsTests: XCTestCase {
   private var suiteName = ""
   private var defaults = UserDefaults.standard
@@ -298,27 +314,33 @@ final class HomeKnowsImpressionDefaultsTests: XCTestCase {
     super.tearDown()
   }
 
+  @MainActor
   func testLedgerRoundTrips() {
-    let store = HomeKnowsImpressionDefaults(defaults: defaults, ownerID: "owner-a")
+    let now = HomeKnowsLedgerFixture.noon
+    let store = HomeKnowsImpressionDefaults(defaults: defaults, ownerID: "owner-a", now: { now })
     var ledger = HomeKnowsImpressionLedger.empty
-    ledger.entries["task:t1"] = HomeKnowsImpression(
-      shows: 2, lastShownAt: HomeKnowsLedgerFixture.noon, contentHash: "abc")
+    ledger.entries["task:t1"] = HomeKnowsImpression(shows: 2, lastShownAt: now, contentHash: "abc")
     store.save(ledger)
 
-    XCTAssertEqual(HomeKnowsImpressionDefaults(defaults: defaults, ownerID: "owner-a").load(), ledger)
+    let reader = HomeKnowsImpressionDefaults(defaults: defaults, ownerID: "owner-a", now: { now })
+    XCTAssertEqual(reader.load(), ledger)
   }
 
+  @MainActor
   func testOneOwnersDismissalsDoNotSilenceAnother() {
     let owner = HomeKnowsImpressionDefaults(defaults: defaults, ownerID: "owner-a")
+    // Owner-b must see nothing regardless of retention, so both readers share a clock.
     var ledger = HomeKnowsImpressionLedger.empty
     ledger.entries["task:t1"] = HomeKnowsImpression(
       dismissedAt: HomeKnowsLedgerFixture.noon, contentHash: "abc")
     owner.save(ledger)
 
-    let other = HomeKnowsImpressionDefaults(defaults: defaults, ownerID: "owner-b")
+    let other = HomeKnowsImpressionDefaults(
+      defaults: defaults, ownerID: "owner-b", now: { HomeKnowsLedgerFixture.noon })
     XCTAssertEqual(other.load(), .empty)
   }
 
+  @MainActor
   func testUntouchedEntriesArePrunedOnLoad() {
     let now = HomeKnowsLedgerFixture.noon
     let writer = HomeKnowsImpressionDefaults(defaults: defaults, ownerID: "owner-a")
@@ -336,10 +358,13 @@ final class HomeKnowsImpressionDefaultsTests: XCTestCase {
     XCTAssertEqual(Set(loaded.entries.keys), ["task:recent"])
   }
 
+  @MainActor
   func testCorruptPayloadLoadsAsAnEmptyLedgerRatherThanTrapping() {
-    let store = HomeKnowsImpressionDefaults(defaults: defaults, ownerID: "owner-a")
+    let store = HomeKnowsImpressionDefaults(
+      defaults: defaults, ownerID: "owner-a", now: { HomeKnowsLedgerFixture.noon })
     var ledger = HomeKnowsImpressionLedger.empty
-    ledger.entries["task:t1"] = HomeKnowsImpression(shows: 1, contentHash: "abc")
+    ledger.entries["task:t1"] = HomeKnowsImpression(
+      shows: 1, lastShownAt: HomeKnowsLedgerFixture.noon, contentHash: "abc")
     store.save(ledger)
 
     // Overwrite whatever key the store chose with something undecodable; a bad

--- a/desktop/macos/Desktop/Tests/MemoryReviewCardTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryReviewCardTests.swift
@@ -1,0 +1,377 @@
+import Foundation
+import XCTest
+
+@testable import Omi_Computer
+
+/// "Things I learned today": what the wire carries, what the row machine does with a click, and
+/// what happens when the mutation behind that click fails.
+final class MemoryReviewCardTests: XCTestCase {
+
+  // MARK: - Record decoding
+
+  private func decodeRecord(_ json: String) throws -> DailySummaryRecord {
+    try JSONDecoder().decode(DailySummaryRecord.self, from: Data(json.utf8))
+  }
+
+  func testRecordDecodesMemoriesLearned() throws {
+    let record = try decodeRecord(
+      """
+      {
+        "id": "ds_1",
+        "date": "2026-09-01",
+        "headline": "A focused day",
+        "memories_learned": [
+          {
+            "memory_id": "mem_1",
+            "content": "David prefers async standups.",
+            "category": "system",
+            "captured_at": "2026-09-01T18:04:00Z"
+          },
+          { "memory_id": "mem_2", "content": "Ships desktop on Wednesdays.", "category": "interesting" }
+        ]
+      }
+      """)
+    XCTAssertEqual(record.memoriesLearned.count, 2)
+    XCTAssertEqual(record.memoriesLearned.first?.memoryID, "mem_1")
+    XCTAssertEqual(record.memoriesLearned.first?.content, "David prefers async standups.")
+    XCTAssertEqual(record.memoriesLearned.first?.category, "system")
+    XCTAssertEqual(record.memoriesLearned.first?.capturedAt, "2026-09-01T18:04:00Z")
+    XCTAssertNil(record.memoriesLearned.last?.capturedAt)
+  }
+
+  /// A backend that predates the field, and a day that produced nothing to review, must be the
+  /// same thing for every reader: an empty list, never a nil the card has to interpret.
+  func testRecordDecodesWithoutMemoriesLearned() throws {
+    let record = try decodeRecord(#"{"id": "ds_1", "date": "2026-09-01", "headline": "Quiet"}"#)
+    XCTAssertTrue(record.memoriesLearned.isEmpty)
+    XCTAssertEqual(record.headline, "Quiet")
+  }
+
+  /// One malformed entry must not cost the reader the whole summary, and a row with no id could
+  /// never be voted on or corrected.
+  func testRecordDropsUnusableLearnedEntriesWithoutLosingTheSummary() throws {
+    let record = try decodeRecord(
+      """
+      {
+        "id": "ds_1",
+        "overview": "You shipped the card.",
+        "memories_learned": [
+          { "memory_id": "", "content": "no id" },
+          { "memory_id": "mem_2", "content": "" },
+          { "memory_id": "mem_3", "content": "Keeps a Wednesday release train." }
+        ]
+      }
+      """)
+    XCTAssertEqual(record.overview, "You shipped the card.")
+    XCTAssertEqual(record.memoriesLearned.map(\.memoryID), ["mem_3"])
+  }
+
+  func testRecordSurvivesAMemoriesLearnedFieldOfTheWrongShape() throws {
+    let record = try decodeRecord(#"{"id": "ds_1", "headline": "Still here", "memories_learned": "nope"}"#)
+    XCTAssertEqual(record.headline, "Still here")
+    XCTAssertTrue(record.memoriesLearned.isEmpty)
+  }
+
+  // MARK: - Card projection
+
+  func testCardShowsAtMostThreeRowsAndNeverFallsBackToProse() {
+    let summary = DailySummaryRecord(
+      id: "ds_1", date: "2026-09-01", headline: "A day", overview: "Prose about the day.",
+      memoriesLearned: (1...5).map {
+        DailySummaryRecord.LearnedMemory(memoryID: "mem_\($0)", content: "Fact \($0)", category: "system")
+      })
+    let rows = ChatDailySummaryCard.memoriesLearned(in: summary)
+    XCTAssertEqual(rows.count, MemoryReviewSection.maxRows)
+    XCTAssertEqual(rows.map(\.memoryID), ["mem_1", "mem_2", "mem_3"])
+  }
+
+  /// The empty state is nothing at all — not a header, not a placeholder row.
+  func testCardRendersNoReviewRowsWhenTheDayLearnedNothing() {
+    let summary = DailySummaryRecord(
+      id: "ds_1", date: "2026-09-01", headline: "Quiet", overview: "A quiet day.")
+    XCTAssertTrue(ChatDailySummaryCard.memoriesLearned(in: summary).isEmpty)
+
+    let blank = DailySummaryRecord(
+      id: "ds_2", date: "2026-09-01", headline: "Quiet", overview: nil,
+      memoriesLearned: [DailySummaryRecord.LearnedMemory(memoryID: "mem_1", content: "   ")])
+    XCTAssertTrue(ChatDailySummaryCard.memoriesLearned(in: blank).isEmpty)
+  }
+
+  func testCategoryLabelIsBoundedButNeverInvented() {
+    XCTAssertEqual(MemoryReviewItem(memoryID: "m", content: "c", category: "system").categoryLabel, "About You")
+    XCTAssertEqual(MemoryReviewItem(memoryID: "m", content: "c", category: "workflow").categoryLabel, "Workflow")
+    XCTAssertEqual(MemoryReviewItem(memoryID: "m", content: "c", category: "brand-new").categoryLabel, "Brand-New")
+    XCTAssertNil(MemoryReviewItem(memoryID: "m", content: "c", category: "  ").categoryLabel)
+  }
+
+  // MARK: - Codec
+
+  private func reviewBlockJSON(items: [[String: Any]]) -> [String: Any] {
+    [
+      "type": "memoryReviewCard",
+      "id": "ds_1:memories",
+      "summaryId": "ds_1",
+      "date": "2026-09-01",
+      "items": items,
+    ]
+  }
+
+  func testCodecRoundTripsAMemoryReviewCard() throws {
+    let wire = reviewBlockJSON(items: [
+      ["memoryId": "mem_1", "content": "Prefers async standups.", "category": "system"],
+      ["memoryId": "mem_2", "content": "Ships on Wednesdays.", "category": "interesting"],
+    ])
+    let decoded = ChatContentBlockCodec.decode([wire])
+    XCTAssertEqual(decoded.count, 1)
+    guard case .memoryReviewCard(let id, let summaryId, let date, let items) = decoded[0] else {
+      return XCTFail("expected a memoryReviewCard block, got \(decoded)")
+    }
+    XCTAssertEqual(id, "ds_1:memories")
+    XCTAssertEqual(summaryId, "ds_1")
+    XCTAssertEqual(date, "2026-09-01")
+    XCTAssertEqual(items.map(\.memoryID), ["mem_1", "mem_2"])
+    XCTAssertEqual(items.map(\.category), ["system", "interesting"])
+
+    let encoded = ChatContentBlockCodec.encodeArray(decoded)
+    let reDecoded = ChatContentBlockCodec.decode(encoded)
+    XCTAssertEqual(reDecoded.count, 1)
+    guard case .memoryReviewCard(_, _, _, let reItems) = reDecoded[0] else {
+      return XCTFail("round trip lost the block: \(reDecoded)")
+    }
+    XCTAssertEqual(reItems, items)
+  }
+
+  func testCodecRoundTripsThroughTheMessageMetadataEnvelope() throws {
+    let block = ChatContentBlock.memoryReviewCard(
+      id: "ds_1:memories", summaryId: "ds_1", date: "2026-09-01",
+      items: [MemoryReviewItem(memoryID: "mem_1", content: "Prefers async standups.", category: "system")])
+    let metadata = ChatContentBlockCodec.mergeIntoMessageMetadata(nil, contentBlocks: [block])
+    let recovered = ChatContentBlockCodec.decodeFromMessageMetadata(metadata)
+    XCTAssertEqual(recovered.count, 1)
+    XCTAssertEqual(recovered.first?.id, "ds_1:memories")
+  }
+
+  /// A card with nothing votable in it is not a card. Dropping it here is what keeps an empty
+  /// frame off the transcript.
+  func testCodecDropsAReviewCardWithNoUsableRows() {
+    XCTAssertTrue(ChatContentBlockCodec.decode([reviewBlockJSON(items: [])]).isEmpty)
+    XCTAssertTrue(
+      ChatContentBlockCodec.decode([
+        reviewBlockJSON(items: [["memoryId": "", "content": "no id"], ["memoryId": "mem", "content": " "]])
+      ]).isEmpty)
+  }
+
+  // MARK: - Chat-first block validation
+
+  func testValidationAcceptsAMemoryReviewCardInBothDirections() throws {
+    let journalShaped: [String: Any] = [
+      "blocks": [
+        reviewBlockJSON(items: [["memoryId": "mem_1", "content": "Prefers async standups.", "category": "system"]])
+      ]
+    ]
+    let backend = try XCTUnwrap(ChatFirstBlockWire.backendBlocks(from: journalShaped))
+    XCTAssertEqual(backend.count, 1)
+    XCTAssertEqual(backend[0]["type"] as? String, "memoryReviewCard")
+    XCTAssertEqual(backend[0]["summary_id"] as? String, "ds_1")
+    let backendItems = try XCTUnwrap(backend[0]["items"] as? [[String: Any]])
+    XCTAssertEqual(backendItems.first?["memory_id"] as? String, "mem_1")
+
+    var receiptBlock = backend[0]
+    receiptBlock["id"] = "ds_1:memories"
+    let receipt = ChatFirstBlockValidationReceipt(
+      accepted: true, code: "ok", blocks: [OmiAnyCodable(receiptBlock)])
+    let journal = try XCTUnwrap(ChatFirstBlockWire.journalBlocks(from: receipt))
+    XCTAssertEqual(journal.count, 1)
+    let decoded = ChatContentBlockCodec.decode(journal)
+    guard case .memoryReviewCard(_, let summaryId, _, let items) = try XCTUnwrap(decoded.first) else {
+      return XCTFail("validation round trip lost the block: \(decoded)")
+    }
+    XCTAssertEqual(summaryId, "ds_1")
+    XCTAssertEqual(items.map(\.memoryID), ["mem_1"])
+  }
+
+  func testValidationRejectsAMemoryReviewCardWithNoItems() {
+    XCTAssertNil(ChatFirstBlockWire.backendBlocks(from: ["blocks": [reviewBlockJSON(items: [])]]))
+    XCTAssertNil(
+      ChatFirstBlockWire.backendBlocks(from: [
+        "blocks": [reviewBlockJSON(items: [["content": "no id at all"]])]
+      ]))
+  }
+
+  // MARK: - Reducer
+
+  private func drive(
+    _ start: MemoryReviewRowModel = MemoryReviewRowModel(),
+    events: [MemoryReviewEvent]
+  ) -> (MemoryReviewRowModel, [MemoryReviewEffect]) {
+    var model = start
+    var effects: [MemoryReviewEffect] = []
+    for event in events {
+      let (next, effect) = MemoryReviewReducer.reduce(model, event)
+      model = next
+      effects.append(effect)
+    }
+    return (model, effects)
+  }
+
+  func testAcceptShowsConfirmedOptimisticallyAndSettlesOnSuccess() {
+    let (pending, effects) = drive(events: [.accept])
+    XCTAssertEqual(effects, [.review(keep: true)])
+    XCTAssertEqual(pending.displayed, .accepted)
+    XCTAssertEqual(pending.statusText, "Confirmed. I'll act on this.")
+    XCTAssertTrue(pending.isBusy)
+    XCTAssertFalse(pending.isFaded)
+
+    let (settled, more) = drive(pending, events: [.requestSucceeded(.accept)])
+    // Success re-reads the memory rather than trusting the override indefinitely.
+    XCTAssertEqual(more, [.refreshLiveState])
+    XCTAssertEqual(settled.live, .accepted)
+    XCTAssertNil(settled.optimistic)
+    XCTAssertFalse(settled.isBusy)
+  }
+
+  func testRejectFadesTheRowButKeepsIt() {
+    let (model, effects) = drive(events: [.reject, .requestSucceeded(.reject)])
+    XCTAssertEqual(effects.first, .review(keep: false))
+    XCTAssertEqual(model.displayed, .rejected)
+    XCTAssertEqual(model.statusText, "Dropped. I'll avoid facts like this.")
+    XCTAssertTrue(model.isFaded)
+    XCTAssertTrue(model.isSettled)
+  }
+
+  /// The honest failure: the row goes back exactly where it was, and says so.
+  func testAFailedVerdictRevertsAndSaysSo() {
+    let (model, _) = drive(events: [.accept, .requestFailed(.accept)])
+    XCTAssertEqual(model.displayed, .none)
+    XCTAssertNil(model.optimistic)
+    XCTAssertNil(model.statusText)
+    XCTAssertEqual(model.errorMessage, MemoryReviewReducer.failureMessage)
+    XCTAssertFalse(model.isBusy)
+  }
+
+  func testAFailedEditRevertsToThePreviousSettledState() {
+    var settled = MemoryReviewRowModel()
+    settled.live = .accepted
+    let (model, _) = drive(
+      settled, events: [.beginEdit(prefill: "old"), .draftChanged("new"), .saveEdit, .requestFailed(.edit)])
+    XCTAssertEqual(model.displayed, .accepted)
+    XCTAssertEqual(model.errorMessage, MemoryReviewReducer.failureMessage)
+  }
+
+  func testEditSavesTheTrimmedDraftAndReadsUpdated() {
+    let (model, effects) = drive(events: [
+      .beginEdit(prefill: "Prefers async standups."),
+      .draftChanged("  Prefers written standups.  "),
+      .saveEdit,
+    ])
+    XCTAssertEqual(effects.last, .edit(content: "Prefers written standups."))
+    XCTAssertFalse(model.isEditing)
+    // An edit is not a promotion: the consolidation job still decides, so the copy is "Updated."
+    XCTAssertEqual(model.statusText, "Updated.")
+    XCTAssertEqual(model.displayed, .updated)
+  }
+
+  func testEscapeCancelsAnEditWithoutMutatingAnything() {
+    let (model, effects) = drive(events: [.beginEdit(prefill: "Prefers async standups."), .cancelEdit])
+    XCTAssertEqual(effects, [.none, .none])
+    XCTAssertFalse(model.isEditing)
+    XCTAssertEqual(model.displayed, .none)
+  }
+
+  /// Blanking the field and saving is a cancel, not a request that empties the memory.
+  func testSavingAnEmptyDraftMutatesNothing() {
+    let (model, effects) = drive(events: [.beginEdit(prefill: "Something"), .draftChanged("   "), .saveEdit])
+    XCTAssertEqual(effects.last, MemoryReviewEffect.none)
+    XCTAssertFalse(model.isEditing)
+    XCTAssertEqual(model.displayed, .none)
+  }
+
+  func testASecondClickWhileARequestIsInFlightIsIgnored() {
+    let (model, effects) = drive(events: [.accept, .reject, .beginEdit(prefill: "x")])
+    XCTAssertEqual(effects, [.review(keep: true), .none, .none])
+    XCTAssertEqual(model.inFlight, .accept)
+    XCTAssertEqual(model.displayed, .accepted)
+  }
+
+  /// Render derives the row from the memory, so a vote made on the phone shows on the Mac.
+  func testLiveStateFromTheMemoryDrivesTheRow() {
+    let (model, _) = drive(events: [.liveStateLoaded(.rejected)])
+    XCTAssertEqual(model.displayed, .rejected)
+    XCTAssertTrue(model.isSettled)
+  }
+
+  /// The local mirror can lag the write it is being asked to confirm; an empty read must not
+  /// erase a verdict this device just made, in flight or already settled.
+  func testAnEmptyLiveReadDoesNotEraseAVerdictThisDeviceMade() {
+    let (pending, _) = drive(events: [.accept])
+    let (inFlight, _) = drive(pending, events: [.liveStateLoaded(.none)])
+    XCTAssertEqual(inFlight.displayed, .accepted)
+
+    let (settled, _) = drive(pending, events: [.requestSucceeded(.accept), .liveStateLoaded(.none)])
+    XCTAssertEqual(settled.displayed, .accepted)
+  }
+
+  /// But a verdict made on another device does land, which is the whole reason the row reads the
+  /// memory instead of remembering its own clicks.
+  func testALiveReadFromAnotherDeviceOverridesTheRow() {
+    let (settled, _) = drive(events: [.accept, .requestSucceeded(.accept)])
+    let (model, _) = drive(settled, events: [.liveStateLoaded(.updated)])
+    XCTAssertEqual(model.displayed, .updated)
+    XCTAssertEqual(model.statusText, "Updated.")
+  }
+
+  // MARK: - Live verdict derivation
+
+  func testVerdictReadsRejectionFirstThenCorrectionThenAcceptance() {
+    let item = MemoryReviewItem(memoryID: "mem_1", content: "Prefers async standups.", category: "system")
+    XCTAssertEqual(
+      LiveMemoryReviewStateReader.verdict(for: item, memory: memory(content: item.content, review: false)),
+      .rejected)
+    XCTAssertEqual(
+      LiveMemoryReviewStateReader.verdict(
+        for: item, memory: memory(content: "Prefers written standups.", review: true)),
+      .updated)
+    XCTAssertEqual(
+      LiveMemoryReviewStateReader.verdict(for: item, memory: memory(content: item.content, review: true)),
+      .accepted)
+    XCTAssertEqual(
+      LiveMemoryReviewStateReader.verdict(for: item, memory: memory(content: " \(item.content) ", review: nil)),
+      .none)
+  }
+
+  // MARK: - Telemetry shape
+
+  func testTelemetryCategoryStaysBounded() {
+    XCTAssertEqual(AnalyticsManager.boundedMemoryCategory("system"), "system")
+    XCTAssertEqual(AnalyticsManager.boundedMemoryCategory("workflow"), "workflow")
+    XCTAssertEqual(AnalyticsManager.boundedMemoryCategory("something_new"), "other")
+    XCTAssertEqual(AnalyticsManager.boundedMemoryCategory(""), "unknown")
+  }
+
+  // MARK: - Helpers
+
+  private func memory(content: String, review: Bool?) -> ServerMemory {
+    ServerMemory(
+      id: "mem_1",
+      content: content,
+      category: .system,
+      createdAt: Date(timeIntervalSince1970: 1_000),
+      updatedAt: Date(timeIntervalSince1970: 1_000),
+      conversationId: nil,
+      reviewed: review != nil,
+      userReview: review,
+      visibility: "private",
+      manuallyAdded: false,
+      scoring: nil,
+      source: "desktop",
+      confidence: nil,
+      sourceApp: nil,
+      contextSummary: nil,
+      isRead: false,
+      isDismissed: false,
+      tags: [],
+      reasoning: nil,
+      currentActivity: nil,
+      inputDeviceName: nil)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260902-daily-summary-memory-review.json
+++ b/desktop/macos/changelog/unreleased/20260902-daily-summary-memory-review.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added a Things I learned today section to the daily summary in Chat where you can confirm, drop, or fix what Omi picked up"
+}

--- a/desktop/macos/changelog/unreleased/20260902-follow-up-chip.json
+++ b/desktop/macos/changelog/unreleased/20260902-follow-up-chip.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added a tappable follow-up question under grounded chat and floating-bar answers, never on failed turns"
+}

--- a/desktop/macos/changelog/unreleased/20260902-home-knows-rotation.json
+++ b/desktop/macos/changelog/unreleased/20260902-home-knows-rotation.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the Home suggestions list repeating the same tasks and tips day after day; rows you have seen or dismissed now rotate out"
+}

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -30,6 +30,10 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatScrollBehavior.swift
   - desktop/macos/Desktop/Sources/Chat/ChatContentBlockCodec.swift
+  # Follow-up chip: tail parser, chip view, and question-origin attribution ride the same hermetic chat turn.
+  - desktop/macos/Desktop/Sources/Chat/ChatFollowUpTail.swift
+  - desktop/macos/Desktop/Sources/Chat/FollowUpChip.swift
+  - desktop/macos/Desktop/Sources/Analytics/AnalyticsManager+QuestionOrigin.swift
   - desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
   - desktop/macos/Desktop/Sources/Chat/KernelJournalBackendSyncDriver.swift
   - desktop/macos/Desktop/Sources/Chat/KernelJournalEventHub.swift

--- a/desktop/macos/e2e/flows/home-stage.yaml
+++ b/desktop/macos/e2e/flows/home-stage.yaml
@@ -24,6 +24,11 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/HomeStagePresentation.swift
   - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeSuggestionsStore.swift
   - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsComposer.swift
+  # Knows-list impression ledger and the daily-summary memory review rows render on the same stage.
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsImpressionLedger.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/AnalyticsManager+HomeKnows.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/MemoryReviewCard.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/MemoryReviewRowView.swift
   - desktop/macos/Desktop/Sources/MainWindow/MainChatNavigationRequest.swift
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   # The five home_* actions every step below drives, lifted out of the registry.

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -1550,6 +1550,7 @@ export interface DailySummaryResponse {
   id?: string | null;
   knowledge_nuggets?: Array<DailySummaryKnowledgeNugget> | null;
   locations?: Array<DailySummaryLocationPin> | null;
+  memories_learned?: Array<LearnedMemoryRef>;
   overview?: string | null;
   stats?: DailySummaryDayStats | null;
   unresolved_questions?: Array<DailySummaryUnresolvedQuestion> | null;
@@ -2526,6 +2527,13 @@ export interface KnowledgeGraphResponse {
   node_limit?: number | null;
   nodes: Array<Record<string, unknown>>;
   truncated?: boolean;
+}
+
+export interface LearnedMemoryRef {
+  captured_at?: string | null;
+  category?: string;
+  content: string;
+  memory_id: string;
 }
 
 export interface LedgerMirrorAliasEnvelope {
@@ -5056,6 +5064,7 @@ export interface OmiApiSchemas {
   "JITTriggerSnapshotEnvelope": JITTriggerSnapshotEnvelope;
   "JITTriggerSnapshotRowEnvelope": JITTriggerSnapshotRowEnvelope;
   "KnowledgeGraphResponse": KnowledgeGraphResponse;
+  "LearnedMemoryRef": LearnedMemoryRef;
   "LedgerMirrorAliasEnvelope": LedgerMirrorAliasEnvelope;
   "LedgerMirrorRowEnvelope": LedgerMirrorRowEnvelope;
   "LedgerMirrorSnapshotEnvelope": LedgerMirrorSnapshotEnvelope;

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -9964,6 +9964,13 @@
             ],
             "title": "Locations"
           },
+          "memories_learned": {
+            "items": {
+              "$ref": "#/components/schemas/LearnedMemoryRef"
+            },
+            "title": "Memories Learned",
+            "type": "array"
+          },
           "overview": {
             "anyOf": [
               {
@@ -15759,6 +15766,42 @@
           "edges"
         ],
         "title": "KnowledgeGraphResponse",
+        "type": "object"
+      },
+      "LearnedMemoryRef": {
+        "description": "One memory the day actually produced, addressed by its canonical id.\n\nThis is the identity `knowledge_nuggets` never had: a client can render a\nnative review card and vote or correct through the existing memory\nendpoints. Review state (`user_review`, `edited`) is deliberately absent —\nclients read it live from the memory so a vote on one device shows on the\nother.",
+        "properties": {
+          "captured_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Captured At"
+          },
+          "category": {
+            "default": "",
+            "title": "Category",
+            "type": "string"
+          },
+          "content": {
+            "title": "Content",
+            "type": "string"
+          },
+          "memory_id": {
+            "title": "Memory Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "memory_id",
+          "content"
+        ],
+        "title": "LearnedMemoryRef",
         "type": "object"
       },
       "LedgerMirrorAliasEnvelope": {

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -1550,6 +1550,7 @@ export interface DailySummaryResponse {
   id?: string | null;
   knowledge_nuggets?: Array<DailySummaryKnowledgeNugget> | null;
   locations?: Array<DailySummaryLocationPin> | null;
+  memories_learned?: Array<LearnedMemoryRef>;
   overview?: string | null;
   stats?: DailySummaryDayStats | null;
   unresolved_questions?: Array<DailySummaryUnresolvedQuestion> | null;
@@ -2526,6 +2527,13 @@ export interface KnowledgeGraphResponse {
   node_limit?: number | null;
   nodes: Array<Record<string, unknown>>;
   truncated?: boolean;
+}
+
+export interface LearnedMemoryRef {
+  captured_at?: string | null;
+  category?: string;
+  content: string;
+  memory_id: string;
 }
 
 export interface LedgerMirrorAliasEnvelope {
@@ -5056,6 +5064,7 @@ export interface OmiApiSchemas {
   "JITTriggerSnapshotEnvelope": JITTriggerSnapshotEnvelope;
   "JITTriggerSnapshotRowEnvelope": JITTriggerSnapshotRowEnvelope;
   "KnowledgeGraphResponse": KnowledgeGraphResponse;
+  "LearnedMemoryRef": LearnedMemoryRef;
   "LedgerMirrorAliasEnvelope": LedgerMirrorAliasEnvelope;
   "LedgerMirrorRowEnvelope": LedgerMirrorRowEnvelope;
   "LedgerMirrorSnapshotEnvelope": LedgerMirrorSnapshotEnvelope;

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -1550,6 +1550,7 @@ export interface DailySummaryResponse {
   id?: string | null;
   knowledge_nuggets?: Array<DailySummaryKnowledgeNugget> | null;
   locations?: Array<DailySummaryLocationPin> | null;
+  memories_learned?: Array<LearnedMemoryRef>;
   overview?: string | null;
   stats?: DailySummaryDayStats | null;
   unresolved_questions?: Array<DailySummaryUnresolvedQuestion> | null;
@@ -2526,6 +2527,13 @@ export interface KnowledgeGraphResponse {
   node_limit?: number | null;
   nodes: Array<Record<string, unknown>>;
   truncated?: boolean;
+}
+
+export interface LearnedMemoryRef {
+  captured_at?: string | null;
+  category?: string;
+  content: string;
+  memory_id: string;
 }
 
 export interface LedgerMirrorAliasEnvelope {
@@ -5056,6 +5064,7 @@ export interface OmiApiSchemas {
   "JITTriggerSnapshotEnvelope": JITTriggerSnapshotEnvelope;
   "JITTriggerSnapshotRowEnvelope": JITTriggerSnapshotRowEnvelope;
   "KnowledgeGraphResponse": KnowledgeGraphResponse;
+  "LearnedMemoryRef": LearnedMemoryRef;
   "LedgerMirrorAliasEnvelope": LedgerMirrorAliasEnvelope;
   "LedgerMirrorRowEnvelope": LedgerMirrorRowEnvelope;
   "LedgerMirrorSnapshotEnvelope": LedgerMirrorSnapshotEnvelope;

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -1550,6 +1550,7 @@ export interface DailySummaryResponse {
   id?: string | null;
   knowledge_nuggets?: Array<DailySummaryKnowledgeNugget> | null;
   locations?: Array<DailySummaryLocationPin> | null;
+  memories_learned?: Array<LearnedMemoryRef>;
   overview?: string | null;
   stats?: DailySummaryDayStats | null;
   unresolved_questions?: Array<DailySummaryUnresolvedQuestion> | null;
@@ -2526,6 +2527,13 @@ export interface KnowledgeGraphResponse {
   node_limit?: number | null;
   nodes: Array<Record<string, unknown>>;
   truncated?: boolean;
+}
+
+export interface LearnedMemoryRef {
+  captured_at?: string | null;
+  category?: string;
+  content: string;
+  memory_id: string;
 }
 
 export interface LedgerMirrorAliasEnvelope {
@@ -5056,6 +5064,7 @@ export interface OmiApiSchemas {
   "JITTriggerSnapshotEnvelope": JITTriggerSnapshotEnvelope;
   "JITTriggerSnapshotRowEnvelope": JITTriggerSnapshotRowEnvelope;
   "KnowledgeGraphResponse": KnowledgeGraphResponse;
+  "LearnedMemoryRef": LearnedMemoryRef;
   "LedgerMirrorAliasEnvelope": LedgerMirrorAliasEnvelope;
   "LedgerMirrorRowEnvelope": LedgerMirrorRowEnvelope;
   "LedgerMirrorSnapshotEnvelope": LedgerMirrorSnapshotEnvelope;


### PR DESCRIPTION
## Summary

Four engagement fixes from the 2026-09-02 "Ask, Teach, Prove" evaluation, shipped together because they share one contract (the daily summary's `memories_learned` review card) and one measurement (`question_asked` origin attribution).

1. **Follow-up after every grounded typed answer.** On the owner's account the realtime voice lane already ends 65% of answers with a grounded question and those sessions run ~4 turns; the typed lanes end with a question 4–9% of the time and recall answers 0%, while 57% of asker-days are exactly one question. The agentic chat lane and the desktop typed lanes now append exactly one specific, answerable question after a `<<<FOLLOWUP>>>` tail; the backend strips the tail and delivers it as a `followUp` content block, a streaming filter keeps it out of the prose, and both shells render it as one tappable chip. Suppressed in code (not just prompted) on failed, errored, cut-short, empty, or clarifying turns; the floating bar's failure copy drops its "try again" invitation, which the data showed nobody took.
2. **"Things I learned today" review card** in the daily summary on both shells. The summary's `knowledge_nuggets` were LLM prose with no memory identity, so there was nothing to accept or reject. The summary now carries `memories_learned` (up to three memories the day's conversations actually produced, selected deterministically through `MemoryService`, zero new LLM calls) and the `day_summary` message carries a `memoryReviewCard` content block. Rows offer ✓ / ✗ / Fix through the existing review and edit endpoints, and the memory service stays the single mutation owner. State is read from the local memory rather than re-fetched: a vote made on this device is mirrored immediately, and a vote made on the phone appears once the memory sync has run. There is no single-memory GET to make that read authoritative, so "instantly cross-device" is not claimed. ✗ already feeds bounded rejection feedback into extraction, so the "I'll avoid facts like this" copy is true.
3. **#12530: daily summaries silently stopped for tail-of-batch users** (on the owner's account, since 2026-08-23). Per-user isolation, a per-user budget, a job budget under the 600s task limit with a Redis checkpoint that rotates the next run to the unserved tail, a bounded generator input, and loud per-user failure lines plus a job-end summary. Fixes #12530.
4. **Home knows-list repetition.** The list repeated the same four stale commitments 8–12 times each over two weeks because its dismiss state died with the view. An owner-scoped impression ledger now rotates rows out after three unopened shows, never resurrects a dismissed row until its content changes, excludes stale or completed tasks, and leaves a slot empty rather than repeating.

Also: `question_asked` gains an `origin` property (`followup | chip | card | unprompted`) so each surface's funnel is readable, and `daily_summary` fallback telemetry is registered.

Evidence: omi-knowledge-base `projects/engagement-feedback-loop`, `macos-churn-analysis/evidence/2026-09-02-first-48h-activation-and-pr-12608.md`, and the follow-up-vs-pills evaluation (session scratchpad, 143 turns / 48 sessions).

## Review round: what the bot found, and what was true

`cubic-dev-ai` raised 40 findings. Each was verified against the code path before
anything changed; several were wrong about the mechanism while right about the
symptom, and a few were simply wrong. Fixed, with the load-bearing ones first:

- **The review card never shipped.** The scheduled job called the summary
  generator without `memories_learned`, so the field was always empty and the
  `memoryReviewCard` block was never attached on the only path users receive.
  The feature was a no-op in production. Both senders now select through one
  helper.
- **The failure copy was read aloud.** This PR changed the empty-response text
  while `shouldSpeak` still suppressed one hardcoded string, so a failed voice
  query started speaking its own failure. Copy and guard now share one source.
- **The server rejected the card the Mac sends.** The desktop adapter converts a
  `memoryReviewCard` for the chat-first journal, but the block was not in the
  server union, so it was rejected as `invalid_request`. Added to the *request*
  union only: the server never emits this block, and adding it to the response
  union is a breaking change to a released app-client contract.
- **The streamed follow-up tail leaked.** `ChatStreamingBuffer` wrote the
  normalized projection back into the message and appended the next delta to it,
  so a projection that withholds the tail lost the evidence it needed and
  streamed the chip's question into the prose a token at a time. A replay of
  every flush boundary leaks at every boundary from the delimiter onward, not
  only at a split marker. Display-only, since the terminal answer overwrites it.
- **The checkpoint could not resume.** The cursor key carried the UTC hour, so
  the run that wrote the tail and the run that should have resumed it never
  shared a key, which defeated the point of the #12530 fix. Also: a failed
  timezone chunk let the run call itself complete and clear the cursor.
- **The FCM payload was unbounded.** An oversized card would have cost the whole
  daily-summary push, not just the card. Now bounded, block dropped first.
- Plus: multi-question chips, chips on guard-stopped turns, generic-prefix rules
  that diverged between client and server, a permanent optimistic override on
  mobile, a duplicated question when a follow-up block had no prose, per-item
  decoding so one bad row cannot drop the array, owner-scoped knows-list visits,
  and greeting counts that disagreed with the rows they described.

Three findings were **rejected with evidence** rather than fixed: the claim that
the stream filter persists its withheld suffix (the persisted answer is built by
the producer, and flushing would have pushed the fragment *into* the stream);
the prescription to reclassify a safety-guard stop as a provider failure (an
explicit, tested contract says a guard stop is a deliberate reply); and a pytest
marker that would have removed a file from CI entirely. Mobile localization stays
deferred, matching every neighbouring widget.

## End-to-end coverage: made real, not declared

An earlier commit on this branch satisfied `desktop-e2e-flow-coverage` by adding
`covers:` entries to two flows that never exercise the code. The gate is a text
match over the `covers:` list and never inspects steps, so the claim cost
nothing to write and would have given false confidence. Those entries were
removed, and the coverage was then built for real. Three new or extended flows:

- **Chat follow-up.** The hermetic stub can now emit a follow-up tail, the chat
  automation snapshot exposes the chip question, and a bridge action taps the
  chip and reports the origin the analytics emit actually carried. The flow
  asserts the visible answer by exact equality, which is what catches a tail
  left in the prose.
- **Memory review card** (`memory-review.yaml`). A local-only dev-harness route
  seeds a summary; the flow creates the memories through the production
  endpoint, renders the card, accepts one row and rejects another through the
  same store the buttons call, then re-reads to prove both verdicts survive the
  post-mutation refresh.
- **Knows-list rotation** (`home-knows-rotation.yaml`). Seeds tasks, clears the
  ledger through the same persistence the mutations use, and pins the first
  visit's rows, the within-visit de-duplication, and a later visit's view of a
  dismissed row and a merely-shown row.

`ChatStreamingBuffer` was initially judged uncoverable, because the defect is
mid-stream and the terminal answer overwrites the streamed text before any
assertion runs. That is true of assertions on the final text only. A non-prod
probe now keeps its own raw stream, compares every emitted projection against
the shipped tail-stripping rule, and the flow asserts zero leaks alongside two
liveness assertions so the zero cannot be vacuous. A negative-control unit test
feeds the probe the exact projection the pre-fix buffer emitted and asserts it
is counted.

Three things are deliberately **not** claimed, and say so next to their `covers:`
entry: the empty-slot telemetry (forcing it would require owning the account's
whole candidate pool), the three-show cap (it needs three calendar days or an
injected clock, and is unit-tested instead), and the 14-day stale-task rule,
which is unreachable from the hub because the dashboard query already cuts off
at seven days. That last one is a real finding and wants a follow-up.

## Invariants

Path-matched by `scripts/pr-preflight --suggest`:

- INV-AUTH-1: no change to auth; touched routers only add response fields and a content block.
- INV-CHAT-1: chat continuity preserved; the follow-up block rides the persisted message and the terminal frame, never a second message.
- INV-NAV-1: no navigation changes; the follow-up chip sends in the same lane.
- INV-VOICE-1: realtime hub prompt untouched; the floating bar's failure copy changed only to remove a retry invitation.
- INV-MEM-4: no new promotion path. An edit re-enters short-term as user-asserted and consolidation decides; a ✓ is a review, not a promotion.
- INV-MEM-1: memory reads go through `MemoryService`; the summary stores memory ids, never a second copy of review state.

## Failure class

Failure-Class: FC-batch-fault-domain-head-of-line-poison

That is the PR-level declaration (the #12530 fix). The protocol allows one per PR body; the other two fix commits carry their own trailers and are recorded here for the reader:

<!--
Failure-Class: FC-durable-state-scoped-to-view-lifetime  (b8fd1ef8e8, 47d5d96fb9: knows-list dismiss state died with the view)
Failure-Class: FC-model-import-reaches-persistence-client  (a7aba22030: the first contract commit read memories inside the LLM summary generator, pulling the Firestore client into every caller and hermetic test of it; the read now lives at the endpoint and learned_today is an import-pure leaf)
Failure-Class: FC-projection-fed-its-own-output  (c164760b6b: ChatStreamingBuffer wrote the normalized projection back into the message and appended the next delta to it, so a projection that withholds text lost the evidence it needed on the next flush)
-->

- `b8fd1ef8e8` / `47d5d96fb9`: FC-durable-state-scoped-to-view-lifetime. The knows-list dismiss state was a view `@State` and died with the view.
- `a7aba22030`: FC-model-import-reaches-persistence-client. The first contract commit read memories inside the LLM summary generator, which pulled the Firestore client into every caller and every hermetic test of that generator; the read now lives at the endpoint and `learned_today` is an import-pure leaf.

## Line-count exceptions

Line-Count-Exception: backend/routers/chat.py | 2097 -> 2107 | follow-up block attached where the assistant message is persisted; splitting the router is out of scope
Line-Count-Exception: backend/routers/users.py | 2247 -> 2295 | memories_learned wired at both summary call sites next to the uid/window they own
Line-Count-Exception: backend/utils/retrieval/agentic.py | 1690 -> 1736 | prompt section appended beside the existing url-fetching block; the live prompt is LangSmith-fetched so this is the only place it takes effect
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift | 3090 -> 3112 | exhaustive switch cases for the two new block types
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift | 5735 -> 5752 | exhaustive switch cases for the two new block types
Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift | 2032 -> 2082 | follow-up chip and review card render cases in the authoritative bubble renderer
Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift | 4186 -> 4328 | knows-list impression handoff; the ledger and policy live in new files
Line-Count-Exception: desktop/macos/Desktop/Sources/Providers/ChatProvider.swift | 7156 -> 7200 | streaming tail filter and block cases; the parser lives in Chat/ChatFollowUpTail.swift

## Verification

- `make preflight`: all manifest checks pass except the line-count ratchet, cleared by the exceptions above.
- Backend: `bash test.sh` over the changed and neighbouring test files (follow-up block, daily-summary contract, job resilience, race condition, zero-coordinate locations, stream error fallback, Dart/Swift generator guards) green under the duration guard; `typecheck.sh` 0 errors; OpenAPI app-client export written, public and integration surfaces `--check` clean, compatibility passed against merge-base `f50229752b`; Dart and Swift generators `--check` clean.
- Desktop: `swift build -c debug` green; `swift test` for `ChatFollowUpChipTests`, `MemoryReviewCardTests`, `HomeKnows*`, `ChatDailySummaryTests`, `HomeDailySummaryTests`, `ChatContentBlock*` (see the last CI-equivalent run in the PR checks); swift-format and SwiftLint clean; `check_desktop_test_quality.py` at baseline.
- Mobile: `bash app/test.sh` all passed (+1695); `analyze_ratchet.sh` passed; `dart format` clean.

## Not done here

- No dogfood on a signed-in bundle: the review card needs a deployed backend that emits `memories_learned`. Dogfood owed before beta promotion. The desktop mirror write on a review vote has no hermetic test (it talks to the real storage singleton), so that is the first thing to check by hand.
- **None of the three new or extended e2e flows has been executed.** Tier 2 needs Docker, and `docker info` fails on the authoring machine. Both sides of every string they assert are pinned by unit tests so drift fails in seconds rather than only at flow time, and the streaming probe has a falsifiable negative control. But someone with Docker must run `chat-hermetic`, `memory-review`, and `home-knows-rotation` before these are trusted. Two knows-list step expectations in particular rest on a reading of the composer's slot ordering that only a real run can confirm.
- An unserved user is still not re-queried an hour later: `get_users_for_daily_summary` matches `local_hour == preference`, so eligibility lasts exactly one local hour and the checkpoint only recovers the tail if the job runs more than once per hour. The repo disagrees with itself about the cadence and the real Cloud Scheduler setting is not in the tree; worth confirming.
- Interject "hold ⌥ to correct" is not wired to the review rows (one-line hook comment marks the spot).
- Mobile strings are hardcoded English, matching the adjacent chat chrome; l10n follow-up owed.
- `tests/unit/test_daily_memory_sweep.py::test_folder_backstop_never_overwrites_and_requires_obligation` hangs on an idle machine and is in CI's selector; pre-existing, tracked separately.
- From the #12530 watchdog thread, two items need a maintainer and are not in this PR: the scheduler runs `*/1 * * * *` instead of hourly, and `day_summary_webhook` is fire-and-forget on `postprocess_executor` and dropped at job exit.
- The summary generator receives a bounded conversation set; a truncated day reports the truncated count and emits `daily_summary_input_truncated`, but the prompt carries no in-text marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
