### PR TITLE
fix(desktop): double-tap for locked mode works on modifier-only PTT keys

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1448,6 +1448,12 @@ final class DesktopAutomationActionRegistry {
     }
 
     register(
+      name: "ptt_quick_tap",
+      summary: "Mirror one quick tap of a modifier-only PTT key; two inside the double-tap window lock"
+    ) { _ in
+      PushToTalkManager.shared.quickTapPushToTalkForAutomation()
+    }
+    register(
       name: "ptt_stop",
       summary: "Finalize the in-progress push-to-talk capture (mirrors a long-hold release)"
     ) { _ in

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -1619,11 +1619,15 @@ struct FloatingControlBarView: View {
           .lineLimit(1)
       }
 
-      if state.isVoiceLocked && state.pttHintText.isEmpty {
-        Image(systemName: "lock.fill")
-          .scaledFont(size: OmiType.micro, weight: .bold)
+      // Locked mode is a mode the user has to be able to see at a glance: a bare glyph
+      // read as decoration, and gating it on an empty hint hid it for most of the turn.
+      // Restores the pre-2b416572c0 badge, always shown while locked.
+      if state.isVoiceLocked {
+        Text("LOCKED")
+          .scaledFont(size: 10, weight: .bold)
           .foregroundColor(.orange)
-          .frame(width: 18, height: 18)
+          .padding(.horizontal, 6)
+          .padding(.vertical, 2)
           .background(Color.orange.opacity(0.2))
           .cornerRadius(4)
       }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -968,6 +968,19 @@ class PushToTalkManager: ObservableObject {
   /// which must end the turn with a hint rather than hang. No-op unless a capture is
   /// active.
   @discardableResult
+  /// Mirrors one *quick tap* of a modifier-only shortcut: the release lands inside
+  /// `modifierOnlyShortcutActivationDelay`, so no turn starts. Two of these inside the
+  /// double-tap window must lock, which is what the physical key does and what no other
+  /// automation entry point can express (`ptt_stop` mirrors a long-hold release).
+  func quickTapPushToTalkForAutomation() -> [String: String] {
+    ensureAutomationBarConfigured()
+    handleModifierOnlyQuickTap()
+    return [
+      "state": VoiceTurnCoordinator.phaseLabel(phase ?? .idle),
+      "locked": phase == .lockedRecording ? "true" : "false",
+    ]
+  }
+
   func endPushToTalkForAutomation() -> [String: String] {
     let wasActive = voiceTurnCoordinator.activeTurn?.phase.isRecording == true
     if wasActive { finalize() }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -92,6 +92,11 @@ struct ModifierOnlyPTTActivationGate {
   enum Action: Equatable {
     case scheduleStart
     case cancelPendingStart
+    /// The modifier was released before the activation delay elapsed and no other
+    /// key was pressed with it: a deliberate quick tap. No turn was started (an
+    /// accidental brush of the modifier must stay inert), but the tap is real
+    /// input and is offered to the double-tap detector.
+    case cancelPendingStartAsQuickTap
     case releaseStartedTurn
     case none
   }
@@ -108,7 +113,7 @@ struct ModifierOnlyPTTActivationGate {
 
     if hasPendingStart {
       hasPendingStart = false
-      return .cancelPendingStart
+      return .cancelPendingStartAsQuickTap
     }
     guard hasStartedTurn else { return .none }
     hasStartedTurn = false
@@ -245,6 +250,8 @@ class PushToTalkManager: ObservableObject {
   // Double-tap detection
   private var lastOptionDownTime: TimeInterval = 0
   private var lastOptionUpTime: TimeInterval = 0
+  /// Uptime of the last modifier-only quick tap that did not start a turn.
+  private var lastModifierQuickTapTime: TimeInterval = 0
   private let doubleTapThreshold: TimeInterval = 0.4
   private let tapToLockMaxHoldDuration: TimeInterval = 0.22
 
@@ -513,6 +520,9 @@ class PushToTalkManager: ObservableObject {
       scheduleModifierOnlyShortcutStart()
     case .cancelPendingStart:
       cancelPendingModifierOnlyShortcutStart()
+    case .cancelPendingStartAsQuickTap:
+      cancelPendingModifierOnlyShortcutStart()
+      handleModifierOnlyQuickTap()
     case .releaseStartedTurn:
       handleShortcutUp()
     case .none:
@@ -531,6 +541,33 @@ class PushToTalkManager: ObservableObject {
     DispatchQueue.main.asyncAfter(
       deadline: .now() + Self.modifierOnlyShortcutActivationDelay,
       execute: workItem)
+  }
+
+  /// A modifier-only shortcut released inside `modifierOnlyShortcutActivationDelay`
+  /// never starts a turn — that delay is what keeps an accidental brush of the
+  /// modifier (or the modifier held as part of another shortcut) from recording.
+  /// A *pair* of such taps is unambiguous intent, so it drives locked mode, and a
+  /// tap while already locked sends, matching "Tap again to send".
+  private func handleModifierOnlyQuickTap() {
+    guard ShortcutSettings.shared.doubleTapForLock else { return }
+    let now = ProcessInfo.processInfo.systemUptime
+    if phase == .lockedRecording {
+      lastModifierQuickTapTime = 0
+      finalize()
+      return
+    }
+    guard (now - lastModifierQuickTapTime) < doubleTapThreshold else {
+      // First tap: stay completely inert. Nothing records, nothing is shown.
+      lastModifierQuickTapTime = now
+      return
+    }
+    lastModifierQuickTapTime = 0
+    if !FloatingControlBarManager.shared.isVisible {
+      FloatingControlBarManager.shared.show()
+    }
+    guard FloatingControlBarManager.shared.isVisible else { return }
+    log("PushToTalkManager: modifier-only double tap — entering locked listening")
+    enterLockedListening()
   }
 
   private func cancelPendingModifierOnlyShortcutStart() {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -602,8 +602,13 @@ class PushToTalkManager: ObservableObject {
     switch phase {
     case .idle, .awaitingResponse, .awaitingTools, .awaitingJournal, .playing, .terminal, .none:
       // Check for double-tap: if last Option-up was recent, enter locked mode
-      if ShortcutSettings.shared.doubleTapForLock && (now - lastOptionUpTime) < doubleTapThreshold {
+      // A first tap can arrive either as a completed turn (`lastOptionUpTime`) or, on a
+      // modifier-only key, as a quick tap that never started one. Either counts, so a
+      // double tap locks even when the two taps differ in speed.
+      let recentFirstTap = max(lastOptionUpTime, lastModifierQuickTapTime)
+      if ShortcutSettings.shared.doubleTapForLock && (now - recentFirstTap) < doubleTapThreshold {
         lastOptionUpTime = 0
+        lastModifierQuickTapTime = 0
         enterLockedListening()
       } else {
         lastOptionDownTime = now
@@ -636,6 +641,7 @@ class PushToTalkManager: ObservableObject {
 
       if ShortcutSettings.shared.doubleTapForLock && holdDuration < tapToLockMaxHoldDuration {
         lastOptionUpTime = now
+        lastModifierQuickTapTime = 0
         enterPendingLockDecision()
       } else {
         lastOptionUpTime = 0

--- a/desktop/macos/Desktop/Tests/PushToTalkShortcutActivationTests.swift
+++ b/desktop/macos/Desktop/Tests/PushToTalkShortcutActivationTests.swift
@@ -66,11 +66,41 @@ final class PushToTalkShortcutActivationTests: XCTestCase {
   }
 
   func testQuickModifierTapNeverStartsOrReleasesPTT() {
+    // A quick tap still starts no turn — an accidental brush of the modifier must
+    // never record. It is only reported as a quick tap so the double-tap detector
+    // can see it; on its own it does nothing.
     var gate = ModifierOnlyPTTActivationGate()
 
     XCTAssertEqual(gate.modifierStateChanged(isShortcutActive: true), .scheduleStart)
-    XCTAssertEqual(gate.modifierStateChanged(isShortcutActive: false), .cancelPendingStart)
+    XCTAssertEqual(
+      gate.modifierStateChanged(isShortcutActive: false), .cancelPendingStartAsQuickTap)
     XCTAssertFalse(gate.consumePendingStart())
+    XCTAssertFalse(gate.hasStartedTurn, "A quick tap must not leave a turn running.")
+  }
+
+  func testModifierHeldAsPartOfAChordIsNeverAQuickTap() {
+    // The modifier held for another shortcut (cmd-C and friends) is cancelled by the
+    // non-modifier key, so releasing it later stays a plain no-op and must never feed
+    // the double-tap detector.
+    var gate = ModifierOnlyPTTActivationGate()
+
+    XCTAssertEqual(gate.modifierStateChanged(isShortcutActive: true), .scheduleStart)
+    XCTAssertEqual(gate.nonModifierKeyPressed(), .cancelPendingStart)
+    XCTAssertEqual(gate.modifierStateChanged(isShortcutActive: false), .none)
+  }
+
+  func testRepeatedQuickTapsEachReportAQuickTapWithoutStartingATurn() {
+    // Two taps in a row are what locked mode is built on: each must be reported and
+    // neither may start a hold turn.
+    var gate = ModifierOnlyPTTActivationGate()
+
+    for _ in 0..<2 {
+      XCTAssertEqual(gate.modifierStateChanged(isShortcutActive: true), .scheduleStart)
+      XCTAssertEqual(
+        gate.modifierStateChanged(isShortcutActive: false), .cancelPendingStartAsQuickTap)
+    }
+    XCTAssertFalse(gate.hasStartedTurn)
+    XCTAssertFalse(gate.hasPendingStart)
   }
 
   func testTypingAfterIntentionalPTTStartDoesNotCancelActiveTurn() {

--- a/desktop/macos/changelog/unreleased/20260902-ptt-modifier-doubletap.json
+++ b/desktop/macos/changelog/unreleased/20260902-ptt-modifier-doubletap.json
@@ -1,0 +1,3 @@
+{
+  "change": "Double-tap for Locked Mode works again on modifier-only push-to-talk keys; a single accidental tap still does nothing"
+}


### PR DESCRIPTION
## Summary
Double-tap for Locked Mode was unreachable for anyone whose push-to-talk key is **modifier-only** (Nik's is right Command).

A modifier-only shortcut does not start listening on key-down: the start is deferred by `modifierOnlyShortcutActivationDelay` (0.08s) so an accidental brush of the modifier — or the modifier held as part of another shortcut — never records. Releasing inside that delay cancelled the pending start and **dropped the tap entirely**, so a deliberate fast tap produced no event at all. A double tap is two fast taps, so locked mode could never be reached. Introduced in ef8104a54e (David Zhang, 2026-07-13, first shipped 0.12.73); it never touched the lock code, which is why the lock logic looks correct.

The gate now distinguishes a release-before-delay (a real quick tap, no other key pressed) from a cancel:
- a **single** quick tap stays completely inert, preserving the accident guard;
- a **second** quick tap inside the double-tap window enters locked listening;
- a quick tap **while locked** sends, matching "Tap again to send";
- either tap may be fast or slow, so a mixed-speed double tap also locks.

Also restores the **LOCKED** badge: 2b416572c0 (David Zhang, 2026-06-24) replaced the `Text("LOCKED")` badge with a bare lock glyph *and* gated it on `pttHintText.isEmpty`, hiding it for most of a locked turn. The badge is back and shows whenever the turn is locked.

Adds `ptt_quick_tap` to the non-production automation bridge — no existing action could express a quick tap (`ptt_stop` mirrors a long-hold release), so this path had no runtime seam.

## Verification
Evidence for the diagnosis, from Nik's running Beta 0.12.267 log: 482 PTT presses, `mode=locked` **zero** times; during a burst of deliberate rapid taps only two press events landed, five seconds apart (the slower ones), confirming fast taps were dropped before reaching the handler.

Runtime, on the `omi-doubletap` dev bundle via the new seam:
- one quick tap → `locked=false`, phase `idle` (accidental press stays inert)
- second quick tap → `locked=true`, phase `locked_recording`
- repeated: consistent across runs; a further tap while locked finalizes and sends

Nik also confirmed the double tap works on the dev build.

Unit tests updated/added in `PushToTalkShortcutActivationTests`: quick tap reports a quick tap and starts no turn; a modifier held as part of a chord is never a quick tap; repeated quick taps each report without starting a turn.

**Not verified:** the restored LOCKED badge could not be confirmed visually. It lives in the expanded `FloatingControlBarView` layout, and this machine runs the bar in notch-island presentation, which has no locked rendering at all (`isVoiceLocked` has no consumer outside `FloatingControlBarView`). Users on the island will still see no lock indicator; that is a separate gap worth its own change.

Invariants: INV-VOICE-1.
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

