### PR TITLE
fix(web-search): hop-2 primary-source retry after thin sonar-pro miss

### DIFF
--- a/backend/routers/desktop_chat.py
+++ b/backend/routers/desktop_chat.py
@@ -50,6 +50,7 @@ from utils.journey_metrics_contract import ClientKind, resolve_client_kind_from_
 from utils.observability.fallback import record_fallback
 from utils.observability.journeys import ClientJourneyAttempt
 from utils.other import endpoints as auth
+from utils.retrieval.tools.perplexity_tools import WEB_SEARCH_RETRIEVAL_APPENDIX
 from utils.subscription import enforce_desktop_chat_quota
 
 _MAX_BODY_BYTES = 16 * 1024 * 1024
@@ -467,6 +468,31 @@ def _with_public_web_routing_instruction(messages: list[dict[str, object]]) -> l
     return [{'role': 'system', 'content': _PUBLIC_WEB_ROUTING_INSTRUCTION}, *updated]
 
 
+def _append_web_search_retrieval_appendix(messages: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Append the fixed primary-source retrieval hint to the last user message.
+
+    The managed web-search lane sends the raw client question to sonar-pro,
+    which retrieves what the query describes — product-history questions stop
+    at the vendor marketing site (live RCA 2026-09-02). The same appendix the
+    agentic tool's hop-2 uses redirects retrieval at founder interviews,
+    Product Hunt launch posts, and postmortems. Idempotent.
+    """
+    updated = [dict(message) for message in messages]
+    for message in reversed(updated):
+        if message.get('role') != 'user':
+            continue
+        content = message.get('content')
+        if isinstance(content, str):
+            if WEB_SEARCH_RETRIEVAL_APPENDIX not in content:
+                message['content'] = f'{content}{WEB_SEARCH_RETRIEVAL_APPENDIX}'
+        elif isinstance(content, list) and not any(
+            isinstance(block, Mapping) and block.get('text') == WEB_SEARCH_RETRIEVAL_APPENDIX for block in content
+        ):
+            message['content'] = [*content, {'type': 'text', 'text': WEB_SEARCH_RETRIEVAL_APPENDIX}]
+        return updated
+    return updated
+
+
 def _carries_private_tool_output(messages: object) -> bool:
     # The desktop hub also inlines tool output into the user turn behind a
     # literal marker instead of sending an OpenAI `tool` message, so the same
@@ -666,7 +692,7 @@ def _gateway_body(body: Mapping[str, object], lane_id: str = CHAT_AGENT_AUTO_LAN
         # are a live lookup, not a client-tool continuation.
         result.pop('tools', None)
         result.pop('tool_choice', None)
-        result['messages'] = _with_public_web_routing_instruction(translated)
+        result['messages'] = _append_web_search_retrieval_appendix(_with_public_web_routing_instruction(translated))
     return result
 
 

--- a/backend/tests/unit/test_desktop_chat.py
+++ b/backend/tests/unit/test_desktop_chat.py
@@ -1468,6 +1468,54 @@ def test_gateway_body_strips_tools_on_the_web_search_lane():
     assert desktop_chat._PUBLIC_WEB_ROUTING_INSTRUCTION in body['messages'][0]['content']
 
 
+def test_gateway_body_appends_web_search_retrieval_appendix_on_the_last_user_message():
+    request = {
+        'model': 'omi-sonnet',
+        'messages': [
+            {'role': 'system', 'content': 'be concise'},
+            {'role': 'user', 'content': 'how long did Whisper Flow take to build v1?'},
+            {'role': 'assistant', 'content': 'earlier turn'},
+            {'role': 'user', 'content': 'news?'},
+        ],
+        'tools': [{'type': 'function', 'function': {'name': 'weather', 'parameters': {'type': 'object'}}}],
+    }
+    body = desktop_chat._gateway_body(request, desktop_chat.WEB_SEARCH_AUTO_LANE_ID)
+    # The appendix lands on the last user message only, next to the policy
+    # instruction the lane already injects elsewhere in the transcript.
+    assert body['messages'][-1]['content'] == 'news?' + desktop_chat.WEB_SEARCH_RETRIEVAL_APPENDIX
+    assert body['messages'][1]['content'] == 'how long did Whisper Flow take to build v1?'
+    assert desktop_chat._PUBLIC_WEB_ROUTING_INSTRUCTION in body['messages'][0]['content']
+    assert 'tools' not in body
+    assert 'tool_choice' not in body
+    # Idempotent: re-building the gateway body never stacks appendices.
+    rebuilt = desktop_chat._gateway_body(
+        {'model': 'omi-sonnet', 'messages': body['messages']}, desktop_chat.WEB_SEARCH_AUTO_LANE_ID
+    )
+    assert rebuilt['messages'][-1]['content'] == body['messages'][-1]['content']
+    # Other lanes keep the client question untouched.
+    chat_body = desktop_chat._gateway_body(request)
+    assert chat_body['messages'][3]['content'] == 'news?'
+
+
+def test_gateway_body_appends_web_search_appendix_as_a_text_block_for_multimodal_turns():
+    request = {
+        'model': 'omi-sonnet',
+        'messages': [
+            {
+                'role': 'user',
+                'content': [
+                    {'type': 'text', 'text': 'what is in this screenshot?'},
+                    {'type': 'image_url', 'image_url': {'url': 'https://example.com/a.png'}},
+                ],
+            }
+        ],
+    }
+    body = desktop_chat._gateway_body(request, desktop_chat.WEB_SEARCH_AUTO_LANE_ID)
+    blocks = body['messages'][-1]['content']
+    assert blocks[0] == {'type': 'text', 'text': 'what is in this screenshot?'}
+    assert blocks[-1] == {'type': 'text', 'text': desktop_chat.WEB_SEARCH_RETRIEVAL_APPENDIX}
+
+
 def test_gateway_body_normalizes_openai_tool_history_content():
     body = desktop_chat._gateway_body(
         {

--- a/backend/tests/unit/test_perplexity_web_search_hop.py
+++ b/backend/tests/unit/test_perplexity_web_search_hop.py
@@ -1,0 +1,152 @@
+"""Hop-2 behavior for the Perplexity gateway web-search tool.
+
+sonar-pro stops at the vendor marketing site for product-history questions
+(live RCA 2026-09-02). A thin first answer triggers exactly one retry whose
+query carries the fixed primary-source retrieval appendix; a substantive first
+answer never triggers a second call, and a failing hop-2 keeps the first
+answer. httpx is mocked — no live Perplexity in CI.
+"""
+
+from typing import Any
+
+import httpx
+import pytest
+
+from utils.retrieval.tools import perplexity_tools
+from utils.retrieval.tools.perplexity_tools import (
+    WEB_SEARCH_RETRIEVAL_APPENDIX,
+    _looks_like_thin_miss,
+)
+
+_QUERY = 'How long did Whisper Flow take to build the first version of their desktop app?'
+_THIN_ANSWER = (
+    "I couldn't find public information about how long it took to build the first version. "
+    "The company's site focuses on features and pricing."
+)
+_SUBSTANTIVE_ANSWER = (
+    "Wispr Flow founder Tanay Kothari built the first version in about six weeks; hardware was "
+    "killed in July 2024 and the launch moved to October 1, 2024."
+)
+
+
+def _sonar_result(text: str, citations: list[str] | None = None) -> dict[str, Any]:
+    return {'choices': [{'message': {'content': text}}], 'citations': citations or []}
+
+
+def _ok(text: str, citations: list[str] | None = None) -> httpx.Response:
+    return httpx.Response(200, json=_sonar_result(text, citations))
+
+
+class _RecordingGateway:
+    """Async stand-in for the shared webhook client's POST surface."""
+
+    def __init__(self, outcomes: list[Any]):
+        self._outcomes = list(outcomes)
+        self.requests: list[dict[str, Any]] = []
+
+    async def post(self, url: str, **kwargs: Any) -> httpx.Response:
+        self.requests.append({'url': url, **kwargs})
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+@pytest.fixture
+def gateway(monkeypatch):
+    def _install(outcomes: list[Any]) -> _RecordingGateway:
+        client = _RecordingGateway(outcomes)
+        monkeypatch.setattr(perplexity_tools, 'get_webhook_client', lambda: client)
+        return client
+
+    return _install
+
+
+@pytest.mark.asyncio
+async def test_thin_first_answer_triggers_one_hop2_with_rewritten_query(gateway):
+    client = gateway(
+        [
+            _ok(_THIN_ANSWER, citations=['https://wisprflow.ai']),
+            _ok(_SUBSTANTIVE_ANSWER, citations=['https://www.producthunt.com/stories/go-with-the-flow']),
+        ]
+    )
+
+    result = await perplexity_tools._perplexity_gateway_search(_QUERY)
+
+    assert len(client.requests) == 2
+    assert client.requests[0]['json']['messages'][0]['content'] == _QUERY
+    assert client.requests[1]['json']['messages'][0]['content'] == _QUERY + WEB_SEARCH_RETRIEVAL_APPENDIX
+    assert _SUBSTANTIVE_ANSWER in result
+    assert 'producthunt.com' in result
+    assert _THIN_ANSWER not in result
+    # The retry stays on the proven lane configuration: same model, same token budget.
+    assert all(request['json']['max_tokens'] == 1000 for request in client.requests)
+    assert {request['json']['model'] for request in client.requests} == {
+        perplexity_tools.feature_auto_lane_id('web_search')
+    }
+
+
+@pytest.mark.asyncio
+async def test_substantive_first_answer_makes_exactly_one_call(gateway):
+    client = gateway([_ok(_SUBSTANTIVE_ANSWER, citations=['https://example.com/founder-interview'])])
+
+    result = await perplexity_tools._perplexity_gateway_search(_QUERY)
+
+    assert len(client.requests) == 1
+    assert client.requests[0]['json']['messages'][0]['content'] == _QUERY
+    assert _SUBSTANTIVE_ANSWER in result
+
+
+@pytest.mark.asyncio
+async def test_non_200_first_response_keeps_the_existing_error_path(gateway):
+    client = gateway([httpx.Response(503, text='unavailable')])
+
+    result = await perplexity_tools._perplexity_gateway_search(_QUERY)
+
+    assert len(client.requests) == 1
+    assert result == 'Error: Perplexity API returned status 503. Please try again later.'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'hop2_outcome',
+    [
+        httpx.ConnectError('boom'),
+        httpx.Response(500, text='boom'),
+        httpx.Response(200, text='not json'),
+    ],
+    ids=['transport-error', 'non-200', 'malformed-json'],
+)
+async def test_hop2_failure_returns_the_first_formatted_result(gateway, hop2_outcome):
+    client = gateway([_ok(_THIN_ANSWER, citations=['https://wisprflow.ai']), hop2_outcome])
+
+    result = await perplexity_tools._perplexity_gateway_search(_QUERY)
+
+    assert len(client.requests) == 2
+    assert _THIN_ANSWER in result
+    assert 'wisprflow.ai' in result
+
+
+@pytest.mark.asyncio
+async def test_second_thin_answer_is_returned_without_a_third_call(gateway):
+    client = gateway(
+        [
+            _ok(_THIN_ANSWER, citations=['https://wisprflow.ai']),
+            _ok("Still couldn't find a launch timeline.", citations=['https://wisprflow.ai/pricing']),
+        ]
+    )
+
+    result = await perplexity_tools._perplexity_gateway_search(_QUERY)
+
+    assert len(client.requests) == 2
+    assert "Still couldn't find a launch timeline." in result
+
+
+def test_thin_miss_detector_flags_the_failure_class_not_substance():
+    assert _looks_like_thin_miss("I couldn't find public info about the launch timeline.")
+    assert _looks_like_thin_miss('There is no public timeline for the first version.')
+    assert _looks_like_thin_miss("The company's site focuses on features.")
+    assert _looks_like_thin_miss('No detailed information is available about the build period.')
+    assert _looks_like_thin_miss('The marketing site does not disclose build dates.')
+    assert not _looks_like_thin_miss(_SUBSTANTIVE_ANSWER)
+    assert not _looks_like_thin_miss('')

--- a/backend/utils/retrieval/tools/perplexity_tools.py
+++ b/backend/utils/retrieval/tools/perplexity_tools.py
@@ -3,6 +3,7 @@ Tools for performing web searches using Perplexity AI.
 """
 
 import logging
+import re
 from typing import Any, cast
 
 import httpx
@@ -14,6 +15,52 @@ from utils.log_sanitizer import sanitize
 logger = logging.getLogger(__name__)
 
 # Legacy QoS coverage anchor: web search maps to get_model('web_search') in model_config.
+
+# Fixed primary-source retrieval appendix shared by this tool's hop-2 retry and
+# the desktop managed web-search lane. sonar-pro stops at the vendor marketing
+# site for product-history questions unless the query itself asks for primary
+# sources (live RCA 2026-09-02: a rewritten query and a hop-2 retry both found
+# the founder interviews; context size, search_type, and reasoning models did
+# not move the retrieved URL set).
+WEB_SEARCH_RETRIEVAL_APPENDIX = (
+    "\n\nGo beyond the product's own marketing and documentation pages: search for primary sources such as "
+    'founder interviews, podcast and conference appearances, Product Hunt launch posts and their comment '
+    'threads, launch postmortems, and press coverage. Try likely alternative spellings and former names of '
+    'the product (for example, a spoken "Whisper Flow" may be written "Wispr Flow") and search the founders\' '
+    'names alongside the product. Report concrete dates and timelines from those primary sources.'
+)
+
+# Thin-miss markers on the model text of an otherwise HTTP 200 answer: the
+# retrieval landed only on the vendor marketing site and produced no primary
+# citation. Cheap phrase heuristic by design — a false positive costs one extra
+# bounded sonar call, and hop count is capped at two either way.
+_THIN_MISS_PHRASES = (
+    "couldn't find",
+    "couldn’t find",
+    'could not find',
+    "can't find",
+    "can’t find",
+    'cannot find',
+    'unable to find',
+    "couldn't locate",
+    'could not locate',
+    'no public information',
+    'no public info',
+    'no publicly available',
+    'not publicly available',
+    'no public timeline',
+    'no exact timeline',
+    'no specific timeline',
+    'no official timeline',
+    'no public details',
+    'no specific information',
+    'no detailed information',
+    'limited public information',
+    'no primary source',
+    'site focuses on',
+    'marketing site',
+)
+_THIN_MISS_PATTERN = re.compile('|'.join(re.escape(phrase) for phrase in _THIN_MISS_PHRASES), re.IGNORECASE)
 
 
 @tool
@@ -53,18 +100,7 @@ async def perplexity_web_search_tool(
 
 async def _perplexity_gateway_search(query: str) -> str:
     try:
-        response = await get_webhook_client().post(
-            f'{get_llm_gateway_base_url()}/v1/chat/completions',
-            json={
-                "model": feature_auto_lane_id('web_search'),
-                "messages": [{"role": "user", "content": query}],
-                "temperature": 0.2,
-                "max_tokens": 1000,
-            },
-            headers=llm_gateway_headers(),
-            timeout=30.0,
-        )
-
+        response = await _post_gateway_chat_completion(query)
         if response.status_code != 200:
             logger.error(
                 f"❌ perplexity_web_search_tool - Gateway API error: {response.status_code} - "
@@ -72,7 +108,27 @@ async def _perplexity_gateway_search(query: str) -> str:
             )
             return f"Error: Perplexity API returned status {response.status_code}. Please try again later."
 
-        return _format_perplexity_response(response.json())
+        result = response.json()
+        formatted = _format_perplexity_response(result)
+        if not _looks_like_thin_miss(_model_text(result)):
+            return formatted
+
+        # Hop-2: the first retrieval stopped at the vendor marketing site.
+        # Exactly one retry with the primary-source appendix — never a third
+        # call, and any hop-2 failure keeps the first formatted answer.
+        logger.info("🔁 perplexity_web_search_tool - Thin result, retrying with primary-source query rewrite")
+        try:
+            retry_response = await _post_gateway_chat_completion(query + WEB_SEARCH_RETRIEVAL_APPENDIX)
+            if retry_response.status_code != 200:
+                logger.error(
+                    f"❌ perplexity_web_search_tool - Hop-2 Gateway API error: {retry_response.status_code} - "
+                    f"{sanitize(retry_response.text[:200])}"
+                )
+                return formatted
+            return _format_perplexity_response(retry_response.json())
+        except Exception as e:
+            logger.warning(f"🔁 perplexity_web_search_tool - Hop-2 failed ({type(e).__name__}), returning first result")
+            return formatted
     except httpx.TimeoutException:
         logger.warning("❌ perplexity_web_search_tool - Gateway timeout")
         return "Error: Web search is temporarily unavailable. Please try again later."
@@ -85,6 +141,32 @@ async def _perplexity_gateway_search(query: str) -> str:
     except Exception as e:
         logger.error(f"❌ perplexity_web_search_tool - Unexpected error: {e}")
         return f"Error: An unexpected error occurred while searching: {str(e)}"
+
+
+async def _post_gateway_chat_completion(content: str) -> httpx.Response:
+    return await get_webhook_client().post(
+        f'{get_llm_gateway_base_url()}/v1/chat/completions',
+        json={
+            "model": feature_auto_lane_id('web_search'),
+            "messages": [{"role": "user", "content": content}],
+            "temperature": 0.2,
+            "max_tokens": 1000,
+        },
+        headers=llm_gateway_headers(),
+        timeout=30.0,
+    )
+
+
+def _looks_like_thin_miss(text: str) -> bool:
+    return bool(text) and _THIN_MISS_PATTERN.search(text) is not None
+
+
+def _model_text(result: dict[str, Any]) -> str:
+    try:
+        content: Any = result['choices'][0]['message']['content']
+    except (KeyError, IndexError, TypeError):
+        return ''
+    return content if isinstance(content, str) else ''
 
 
 def _format_perplexity_response(result: dict[str, Any]) -> str:


### PR DESCRIPTION
## What

Omi's Perplexity `sonar-pro` web search answered the Wispr Flow product-history question ("how long did the first desktop version take to build?") with *"couldn't find public info… site focuses on features"* while competitors returned the founder interview: six weeks, Tanay Kothari, hardware killed Jul 2024, launch pulled to Oct 1 2024. Retrieval followed the raw query and stopped at the vendor marketing site.

Live RCA (2026-09-02, prod `PERPLEXITY_API_KEY` against `api.perplexity.ai`): `search_type=pro`, `web_search_options.search_context_size` medium/high, `sonar-reasoning-pro`, cheaper `sonar`, and a "prefer interviews" system prompt all reproduced the same miss — only **rewriting the query** moved the retrieved URL set. So this PR rewrites the query, exactly once, at both sonar call sites:

- **Agentic tool** (`backend/utils/retrieval/tools/perplexity_tools.py`): after an HTTP 200 whose model text looks like a thin miss (couldn't find / no public timeline / site focuses on features / marketing site …), `_perplexity_gateway_search` makes exactly one second gateway call whose user content is the original query plus a fixed primary-source retrieval appendix (founder interviews, podcast/conference appearances, Product Hunt launch posts and comment threads, launch postmortems, press coverage, likely alternative product-name spellings, founder names). Hard cap of **2 sonar calls** per invocation; any hop-2 failure (transport error, non-200, malformed JSON) returns the first formatted answer; existing error strings and logging style preserved; model stays `feature_auto_lane_id('web_search')` (sonar-pro), `max_tokens` stays 1000.
- **Desktop managed lane** (`backend/routers/desktop_chat.py`): when `_gateway_body` builds the `WEB_SEARCH_AUTO_LANE_ID` body, the same appendix is appended to the **last user message** (string content concatenated; multimodal block content gets a trailing text block), in addition to the existing `<omi_retrieval_policy>` instruction. Idempotent. `tools`/`tool_choice` stay popped; no blocking preflight hop in front of the stream.

Not changed: Perplexity model, FEATURE_MODE, chat-agent routing, the phrase-list router, desktop typed-chat tool manifest, Anthropic server `web_search`. Those are the D-honesty follow-up, out of scope here.

## Why this shape

The appendix is one shared constant (`WEB_SEARCH_RETRIEVAL_APPENDIX`) so the agentic hop-2 rewrite and the desktop lane rewrite cannot drift. The thin-miss detector is a phrase heuristic on the **model text** (not URL allow/deny lists) — a false positive costs one extra bounded sonar call (~$0.01 on misses, cost delta already accepted), and the cap is two calls either way. Hop-2 is required to change the search **query**, not only the system prompt: one low-context run in the RCA said "6 weeks" while still citing the miss URLs, i.e. ungrounded.

## Test evidence (all mocked httpx — no live Perplexity in CI)

```
backend$ .venv/bin/python -m pytest tests/unit/test_perplexity_web_search_hop.py -q
8 passed
backend$ .venv/bin/python -m pytest tests/unit/test_desktop_chat.py -q
86 passed
```

- `test_perplexity_web_search_hop.py` (new): hop-2 fires once with rewritten content on a thin first answer; substantive first answer makes exactly one call; non-200 first response keeps the existing error path; hop-2 failure (transport error / non-200 / malformed JSON) returns the first formatted result; a second thin answer is returned without a third call; detector flags the failure class but not substantive answers.
- `test_desktop_chat.py` (extended): managed web-search gateway body carries the appendix on the last user message (and as a text block for multimodal turns), `tools` still popped, idempotent under re-build, other lanes untouched.

Real-path self-check (not committed): drove `perplexity_web_search_tool.ainvoke` through the shared httpx webhook client against a local fake gateway over real HTTP — the thin first answer triggered exactly one hop-2 call carrying the appendix, and the substantive second answer with the `producthunt.com/stories/go-with-the-flow` citation was returned.

Pre-existing failures (verified identical on pristine `origin/main` via stash, not caused by this diff): `tests/unit/test_llm_gateway_client_config.py` (5 × `ModuleNotFoundError: langchain_core.env`) and `tests/unit/test_omi_qos_tiers.py` (model-string drift) — unchanged by this PR.

## Product invariants

`scripts/pr-preflight --suggest`: none matched by these paths.

## Failure class

Failure-Class: none

Quality gap in retrieval query construction, not a violated registry contract (no matching FC slug; RCA experiment table in SCA-428). The commit message carries the same declaration.

Line-Count-Exception: backend/routers/desktop_chat.py | 1804 -> 1830 | Managed web-search lane appends the shared primary-source retrieval appendix to the last user message (SCA-428): one import, one idempotent helper beside `_with_public_web_routing_instruction`, one wiring line in `_gateway_body` — the appendix constant itself lives in perplexity_tools.py and is shared with the agentic hop-2 so the two rewrites cannot drift.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

