### PR TITLE
fix(desktop): PTT on a second display responds to the first press

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -565,7 +565,6 @@ class PushToTalkManager: ObservableObject {
     if !FloatingControlBarManager.shared.isVisible {
       FloatingControlBarManager.shared.show()
     }
-    guard FloatingControlBarManager.shared.isVisible else { return }
     log("PushToTalkManager: modifier-only double tap — entering locked listening")
     enterLockedListening()
   }
@@ -592,7 +591,13 @@ class PushToTalkManager: ObservableObject {
       FloatingControlBarManager.shared.show()
     }
 
-    guard FloatingControlBarManager.shared.isVisible else { return }
+    // The press that reveals the bar must still start the turn. Dropping it cost the
+    // user the start sound, the listening animation and — a double tap being two
+    // presses — locked mode, every time the bar had to be revealed first. That happens
+    // routinely on a second display, where following the cursor re-places the window.
+    if !FloatingControlBarManager.shared.isVisible {
+      log("PushToTalkManager: bar not visible after show() — starting the turn anyway")
+    }
     handleShortcutDown()
   }
 

--- a/desktop/macos/changelog/unreleased/20260903-ptt-second-monitor.json
+++ b/desktop/macos/changelog/unreleased/20260903-ptt-second-monitor.json
@@ -1,0 +1,3 @@
+{
+  "change": "Push-to-talk on a second display now plays the start sound and shows the listening animation on the first press instead of the second"
+}


### PR DESCRIPTION
## Summary
Push-to-talk on a second display gave no start sound and no listening animation on the first press; the second press worked.

`handleKeyShortcutDown` revealed the bar and then dropped the very press that revealed it:

```swift
if !FloatingControlBarManager.shared.isVisible { FloatingControlBarManager.shared.show() }
guard FloatingControlBarManager.shared.isVisible else { return }   // ← press discarded here
handleShortcutDown()
```

`handleShortcutDown` → `startListening()` is what plays the start sound and puts the bar into its listening presentation, so neither happened. On a second display the bar is re-placed as it follows the cursor (`followed cursor to screen …`, `reconciled screen change …` in the logs), so it is routinely not yet visible at press time and the first press was lost every time — while on the built-in display the bar is usually already showing, which is why it only reproduced on the external monitor.

The same gate discarded the first tap of a double tap, which is why locked mode also did not work on the second display.

The revealing press now proceeds to `handleShortcutDown`, and the modifier-only double-tap lock path is no longer gated on bar visibility.

## Verification
`omi-doubletap` dev bundle, with the floating bar on the **second display** (`floatingBarFrame {{4856, 1330}, …}`, `usesNotchIsland false`):
- two quick taps → `locked=true`, phase `locked_recording`
- log: `modifier-only double tap — entering locked listening` → `entered locked listening mode (mode=locked)`

**Not verified by me:** the start sound and the listening animation on a physical key press on the external monitor — that needs a real keypress on Nik's hardware, which I don't drive. The mechanism is the same dropped call (`startListening()` is where both the sound and the listening state come from), and locking on the second display is now proven, but the audible/visual result on a physical press is unconfirmed.

Invariants: INV-VOICE-1.
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

