### PR TITLE
feat(desktop,backend,app): fold desktop watching and proactive usage into the daily summary

### DIFF
--- a/app/lib/backend/schema/daily_summary.dart
+++ b/app/lib/backend/schema/daily_summary.dart
@@ -105,8 +105,20 @@ class DayStats {
   final int totalConversations; // Excluding discarded
   final int totalDurationMinutes; // Excluding discarded
   final int actionItemsCount;
+  final int? memoriesCreated;
+  final int? actionItemsCreated;
+  final int? watchingMinutes;
+  final int? proactiveMoments;
 
-  DayStats({this.totalConversations = 0, this.totalDurationMinutes = 0, this.actionItemsCount = 0});
+  DayStats({
+    this.totalConversations = 0,
+    this.totalDurationMinutes = 0,
+    this.actionItemsCount = 0,
+    this.memoriesCreated,
+    this.actionItemsCreated,
+    this.watchingMinutes,
+    this.proactiveMoments,
+  });
 
   factory DayStats.fromJson(Map<String, dynamic> json) {
     return DayStats.fromGenerated(wire.GeneratedDailySummaryDayStats.fromJson(json));
@@ -117,15 +129,23 @@ class DayStats {
       totalConversations: generated.totalConversations ?? 0,
       totalDurationMinutes: generated.totalDurationMinutes ?? 0,
       actionItemsCount: generated.actionItemsCount ?? 0,
+      memoriesCreated: generated.memoriesCreated,
+      actionItemsCreated: generated.actionItemsCreated,
+      watchingMinutes: generated.watchingMinutes,
+      proactiveMoments: generated.proactiveMoments,
     );
   }
 
-  String get formattedDuration {
-    if (totalDurationMinutes < 60) {
-      return '${totalDurationMinutes}m';
+  String get formattedDuration => _formatMinutes(totalDurationMinutes);
+
+  String? get formattedWatchingDuration => watchingMinutes == null ? null : _formatMinutes(watchingMinutes!);
+
+  static String _formatMinutes(int minutes) {
+    if (minutes < 60) {
+      return '${minutes}m';
     }
-    final hours = totalDurationMinutes ~/ 60;
-    final mins = totalDurationMinutes % 60;
+    final hours = minutes ~/ 60;
+    final mins = minutes % 60;
     return mins > 0 ? '${hours}h ${mins}m' : '${hours}h';
   }
 }

--- a/app/lib/backend/schema/gen/users_wire.g.dart
+++ b/app/lib/backend/schema/gen/users_wire.g.dart
@@ -592,28 +592,44 @@ class GeneratedLearnedMemoryRef {
 
 class GeneratedDailySummaryDayStats {
   final int? actionItemsCount;
+  final int? actionItemsCreated;
+  final int? memoriesCreated;
+  final int? proactiveMoments;
   final int? totalConversations;
   final int? totalDurationMinutes;
+  final int? watchingMinutes;
 
   const GeneratedDailySummaryDayStats({
     this.actionItemsCount,
+    this.actionItemsCreated,
+    this.memoriesCreated,
+    this.proactiveMoments,
     this.totalConversations,
     this.totalDurationMinutes,
+    this.watchingMinutes,
   });
 
   factory GeneratedDailySummaryDayStats.fromJson(Map<String, dynamic> json) {
     return GeneratedDailySummaryDayStats(
       actionItemsCount: _readFieldValue<int>(_readField(json, const ["action_items_count"]), "action_items_count", _readInt, requiredField: false, nullable: true),
+      actionItemsCreated: _readFieldValue<int>(_readField(json, const ["action_items_created"]), "action_items_created", _readInt, requiredField: false, nullable: true),
+      memoriesCreated: _readFieldValue<int>(_readField(json, const ["memories_created"]), "memories_created", _readInt, requiredField: false, nullable: true),
+      proactiveMoments: _readFieldValue<int>(_readField(json, const ["proactive_moments"]), "proactive_moments", _readInt, requiredField: false, nullable: true),
       totalConversations: _readFieldValue<int>(_readField(json, const ["total_conversations"]), "total_conversations", _readInt, requiredField: false, nullable: true),
       totalDurationMinutes: _readFieldValue<int>(_readField(json, const ["total_duration_minutes"]), "total_duration_minutes", _readInt, requiredField: false, nullable: true),
+      watchingMinutes: _readFieldValue<int>(_readField(json, const ["watching_minutes"]), "watching_minutes", _readInt, requiredField: false, nullable: true),
     );
   }
 
   Map<String, dynamic> toJson() {
     return {
       'action_items_count': actionItemsCount,
+      'action_items_created': actionItemsCreated,
+      'memories_created': memoriesCreated,
+      'proactive_moments': proactiveMoments,
       'total_conversations': totalConversations,
       'total_duration_minutes': totalDurationMinutes,
+      'watching_minutes': watchingMinutes,
     };
   }
 }

--- a/app/lib/pages/settings/daily_summary_detail_page.dart
+++ b/app/lib/pages/settings/daily_summary_detail_page.dart
@@ -490,33 +490,44 @@ class _DailySummaryDetailPageState extends State<DailySummaryDetailPage> with Si
   }
 
   Widget _buildStatsRow(DailySummary summary) {
-    return Row(
-      children: [
-        _buildStatItem(FontAwesomeIcons.message, '${summary.stats.totalConversations}'),
-        const SizedBox(width: 8),
-        _buildStatItem(FontAwesomeIcons.clock, summary.stats.formattedDuration),
-        const SizedBox(width: 8),
-        _buildStatItem(FontAwesomeIcons.circleCheck, '${summary.stats.actionItemsCount}'),
-      ],
+    final items = <Widget>[
+      _buildStatItem(FontAwesomeIcons.message, '${summary.stats.totalConversations}'),
+      _buildStatItem(FontAwesomeIcons.clock, summary.stats.formattedDuration),
+      _buildStatItem(FontAwesomeIcons.circleCheck, '${summary.stats.actionItemsCount}'),
+    ];
+    if ((summary.stats.watchingMinutes ?? 0) > 0) {
+      items.add(_buildStatItem(FontAwesomeIcons.eye, summary.stats.formattedWatchingDuration!));
+    }
+    if ((summary.stats.proactiveMoments ?? 0) > 0) {
+      items.add(_buildStatItem(FontAwesomeIcons.bell, '${summary.stats.proactiveMoments}'));
+    }
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final columns = items.length > 3 ? 3 : items.length;
+        final itemWidth = (constraints.maxWidth - (columns - 1) * 8) / columns;
+        return Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [for (final item in items) SizedBox(width: itemWidth, child: item)],
+        );
+      },
     );
   }
 
   Widget _buildStatItem(FaIconData icon, String value) {
-    return Expanded(
-      child: Container(
-        padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 12),
-        decoration: BoxDecoration(color: const Color(0xFF1A1A1F), borderRadius: BorderRadius.circular(16)),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            FaIcon(icon, color: Colors.grey.shade400, size: 14),
-            const SizedBox(width: 8),
-            Text(
-              value,
-              style: const TextStyle(color: Colors.white, fontSize: 15, fontWeight: FontWeight.w600),
-            ),
-          ],
-        ),
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 12),
+      decoration: BoxDecoration(color: const Color(0xFF1A1A1F), borderRadius: BorderRadius.circular(16)),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          FaIcon(icon, color: Colors.grey.shade400, size: 14),
+          const SizedBox(width: 8),
+          Text(
+            value,
+            style: const TextStyle(color: Colors.white, fontSize: 15, fontWeight: FontWeight.w600),
+          ),
+        ],
       ),
     );
   }

--- a/app/test/widgets/daily_summary_detail_page_test.dart
+++ b/app/test/widgets/daily_summary_detail_page_test.dart
@@ -132,12 +132,34 @@ void main() {
       lessThan(tester.getTopLeft(find.text('Async beats status meetings')).dy),
     );
   });
+
+  testWidgets('shows positive desktop watching and proactive stats', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        theme: ThemeData.dark(),
+        home: DailySummaryDetailPage(
+          summaryId: 'summary-stats',
+          summary: _summary(
+            stats: DayStats(totalConversations: 1, totalDurationMinutes: 30, watchingMinutes: 17, proactiveMoments: 9),
+          ),
+          tileProvider: _MemoryTileProvider(),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.text('17m'), findsOneWidget);
+    expect(find.text('9'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
 }
 
 DailySummary _summary({
   List<LocationPin>? locations,
   List<MemoryReviewItem> memoriesLearned = const [],
   List<KnowledgeNugget> knowledgeNuggets = const [],
+  DayStats? stats,
 }) {
   return DailySummary(
     id: 'summary-1',
@@ -145,7 +167,7 @@ DailySummary _summary({
     createdAt: DateTime(2026, 7, 16),
     headline: 'A day around the city',
     overview: 'A productive day.',
-    stats: DayStats(totalConversations: 1, totalDurationMinutes: 30),
+    stats: stats ?? DayStats(totalConversations: 1, totalDurationMinutes: 30),
     memoriesLearned: memoriesLearned,
     knowledgeNuggets: knowledgeNuggets,
     locations: locations ??

--- a/backend/database/daily_summaries.py
+++ b/backend/database/daily_summaries.py
@@ -16,8 +16,15 @@ users/{uid}/daily_summaries/{summary_id}
     ├── stats: DayStats
     ├── tomorrow_focus: str
     └── overall_sentiment: str
+
+users/{uid}/desktop_daily_usage/{date}__{client_device_id}
+    ├── date/timezone/client_device_id
+    ├── watching_seconds/listening_seconds
+    ├── proactive_cards_shown/proactive_cards_acted/ptt_turns
+    └── updated_at
 """
 
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, cast
 
 from google.cloud.firestore_v1.base_query import FieldFilter
@@ -26,6 +33,65 @@ from ._client import db
 from . import redis_db
 
 DAILY_SUMMARIES_COLLECTION = 'daily_summaries'
+DESKTOP_DAILY_USAGE_COLLECTION = 'desktop_daily_usage'
+DESKTOP_DAILY_USAGE_COUNTER_FIELDS = (
+    'watching_seconds',
+    'listening_seconds',
+    'proactive_cards_shown',
+    'proactive_cards_acted',
+    'ptt_turns',
+)
+
+
+def upsert_desktop_daily_usage(
+    uid: str,
+    date: str,
+    timezone_name: str,
+    client_device_id: str,
+    counters: Dict[str, int],
+) -> None:
+    """Atomically merge one device's running daily counters by maximum value."""
+    user_ref = db.collection('users').document(uid)
+    usage_ref = user_ref.collection(DESKTOP_DAILY_USAGE_COLLECTION).document(f'{date}__{client_device_id}')
+    transaction = db.transaction()
+
+    @firestore.transactional
+    def merge_running_totals(write_transaction: Any) -> None:
+        snapshot = usage_ref.get(transaction=write_transaction)
+        existing_raw = snapshot.to_dict() if getattr(snapshot, 'exists', False) else {}
+        existing = existing_raw if isinstance(existing_raw, dict) else {}
+        payload: Dict[str, Any] = {
+            'date': date,
+            'timezone': timezone_name,
+            'client_device_id': client_device_id,
+            'updated_at': datetime.now(timezone.utc),
+        }
+        for field in DESKTOP_DAILY_USAGE_COUNTER_FIELDS:
+            previous = existing.get(field, 0)
+            previous_value = previous if isinstance(previous, int) and not isinstance(previous, bool) else 0
+            payload[field] = max(previous_value, counters[field])
+        write_transaction.set(usage_ref, payload)
+
+    merge_running_totals(transaction)
+
+
+def get_desktop_daily_usage(uid: str, date: str) -> Dict[str, int]:
+    """Sum every device's counters for one local calendar date.
+
+    A date with no usage documents returns every counter as zero.
+    """
+    user_ref = db.collection('users').document(uid)
+    query = user_ref.collection(DESKTOP_DAILY_USAGE_COLLECTION).where(filter=FieldFilter('date', '==', date))
+    totals = {field: 0 for field in DESKTOP_DAILY_USAGE_COUNTER_FIELDS}
+    for doc in query.stream():
+        raw = doc.to_dict()
+        if not isinstance(raw, dict):
+            continue
+        for field in DESKTOP_DAILY_USAGE_COUNTER_FIELDS:
+            value = raw.get(field)
+            if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+                totals[field] += value
+    return totals
 
 
 def create_daily_summary(uid: str, summary_data: Dict[str, Any]) -> str:

--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -996,6 +996,28 @@ ACTION_ITEMS_CREATED_RANGE_QUERY = FirestoreQuerySpec(
     index_fields=(_asc('created_at'), _asc('__name__')),
 )
 
+MEMORIES_CREATED_RANGE_QUERY = FirestoreQuerySpec(
+    identifier='memories_created_range',
+    collection_group='memories',
+    query_scope='COLLECTION',
+    filters=(
+        FirestoreQueryFilter('created_at', '>=', 'start'),
+        FirestoreQueryFilter('created_at', '<=', 'end'),
+    ),
+    index_fields=(_asc('created_at'), _asc('__name__')),
+)
+
+CANONICAL_MEMORIES_CAPTURED_RANGE_QUERY = FirestoreQuerySpec(
+    identifier='canonical_memories_captured_range',
+    collection_group='memory_items',
+    query_scope='COLLECTION',
+    filters=(
+        FirestoreQueryFilter('captured_at', '>=', 'start'),
+        FirestoreQueryFilter('captured_at', '<=', 'end'),
+    ),
+    index_fields=(_asc('captured_at'), _asc('__name__')),
+)
+
 ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY = FirestoreQuerySpec(
     identifier='action_items_completed_created_range',
     collection_group='action_items',
@@ -1283,6 +1305,8 @@ QUERY_SPECS = (
     ACTION_ITEMS_COMPLETED_DUE_RANGE_QUERY,
     ACTION_ITEMS_CREATED_RANGE_QUERY,
     ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY,
+    MEMORIES_CREATED_RANGE_QUERY,
+    CANONICAL_MEMORIES_CAPTURED_RANGE_QUERY,
     CANDIDATES_COMPATIBILITY_QUERY,
     DUE_MEMORY_OUTBOX_QUERY,
     EXPIRED_MEMORY_OUTBOX_LEASE_QUERY,

--- a/backend/database/memories.py
+++ b/backend/database/memories.py
@@ -20,6 +20,8 @@ from google.cloud.firestore_v1 import transactional  # type: ignore[reportUnknow
 from config.memory_confidence import SOURCE_SIGNAL_CAPTURE_PRIORS
 from database import memory_ledger
 from database.firestore_index_registry import (
+    CANONICAL_MEMORIES_CAPTURED_RANGE_QUERY,
+    MEMORIES_CREATED_RANGE_QUERY,
     UNIVERSAL_HISTORICAL_CREATED_LIST_SCAN_QUERY,
     UNIVERSAL_HISTORICAL_UPDATED_LIST_SCAN_QUERY,
 )
@@ -427,6 +429,26 @@ def get_memories(
         memory for memory in memories if _memory_passes_list_visibility(memory, include_invalidated=include_invalidated)
     ]
     return result
+
+
+def count_memories_created(uid: str, start_date: datetime, end_date: datetime, *, firestore_client: Any = None) -> int:
+    """Count canonical memory items with legacy compatibility, deduplicated by stable id."""
+    database = _get_db(firestore_client)
+    legacy_collection = database.collection(users_collection).document(uid).collection(memories_collection)
+    legacy_query = MEMORIES_CREATED_RANGE_QUERY.build(
+        legacy_collection,
+        {'start': start_date, 'end': end_date},
+        field_filter_factory=FieldFilter,
+    )
+    canonical_collection = database.collection(MemoryCollections(uid=uid).memory_items)
+    canonical_query = CANONICAL_MEMORIES_CAPTURED_RANGE_QUERY.build(
+        canonical_collection,
+        {'start': start_date, 'end': end_date},
+        field_filter_factory=FieldFilter,
+    )
+    canonical_ids = {doc.id for doc in canonical_query.stream()}
+    legacy_ids = {doc.id for doc in legacy_query.stream()}
+    return len(canonical_ids | legacy_ids)
 
 
 _HISTORICAL_SCAN_PAGE_MAX = 500

--- a/backend/models/daily_summary_payload.py
+++ b/backend/models/daily_summary_payload.py
@@ -26,6 +26,16 @@ class DailySummaryKnowledgeNugget(BaseModel):
     conversation_number: int | None = None
 
 
+class DailySummaryDayStatsPayload(BaseModel):
+    total_conversations: int = 0
+    total_duration_minutes: int = 0
+    action_items_count: int = 0
+    memories_created: int = 0
+    action_items_created: int = 0
+    watching_minutes: int = 0
+    proactive_moments: int = 0
+
+
 class DailySummaryPayload(BaseModel):
     headline: str = "Your Day in Review"
     overview: str = ""
@@ -34,6 +44,7 @@ class DailySummaryPayload(BaseModel):
     unresolved_questions: list[DailySummaryQuestion] = Field(default_factory=list)
     decisions_made: list[DailySummaryDecision] = Field(default_factory=list)
     knowledge_nuggets: list[DailySummaryKnowledgeNugget] = Field(default_factory=list)
+    stats: DailySummaryDayStatsPayload | None = None
 
 
 class LearnedMemoryRef(BaseModel):

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -267,6 +267,29 @@ routes:
         placement: dependency
   - route_type: http
     method: POST
+    path: /v1/users/desktop-usage/daily
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - firebase_id_token
+        placement: dependency
+        scopes: []
+      byok: not_applicable
+      rate_limit:
+        policy_name: users:desktop_usage_daily
+        key_subject: uid
+        enforcement: fail_open
+        placement: dependency
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: first_party
+      data_domain: user_profile
+      deprecation:
+        state: active
+      owner: backend
+  - route_type: http
+    method: POST
     path: /v1/frame-requests
     policy: &jit_frame_request_policy
       review_status: reviewed

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import re
 import uuid
-from typing import List, Dict, Any, Union, Optional
+from typing import Annotated, List, Dict, Any, Union, Optional
 import os
 import asyncio
 
 import pytz
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from database import (
     conversations as conversations_db,
@@ -290,6 +290,10 @@ class DailySummaryDayStats(BaseModel):
     total_conversations: Optional[int] = None
     total_duration_minutes: Optional[int] = None
     action_items_count: Optional[int] = None
+    memories_created: Optional[int] = None
+    action_items_created: Optional[int] = None
+    watching_minutes: Optional[int] = None
+    proactive_moments: Optional[int] = None
 
 
 class DailySummaryLocationPin(BaseModel):
@@ -1747,6 +1751,81 @@ def test_daily_summary(
 
 
 # Daily Summaries API
+
+
+DesktopUsageSeconds = Annotated[int, Field(strict=True, ge=0, le=86400)]
+DesktopUsageCount = Annotated[int, Field(strict=True, ge=0, le=10000)]
+
+
+class DesktopDailyUsageRequest(BaseModel):
+    date: str
+    timezone: str
+    client_device_id: str = Field(min_length=1, max_length=200)
+    watching_seconds: DesktopUsageSeconds
+    listening_seconds: DesktopUsageSeconds
+    proactive_cards_shown: DesktopUsageCount
+    proactive_cards_acted: DesktopUsageCount
+    ptt_turns: DesktopUsageCount
+
+    @field_validator('date')
+    @classmethod
+    def validate_date_format(cls, value: str) -> str:
+        try:
+            parsed = datetime.strptime(value, '%Y-%m-%d').date()
+        except ValueError as exc:
+            raise ValueError('date must be a real date in YYYY-MM-DD format') from exc
+        if parsed.strftime('%Y-%m-%d') != value:
+            raise ValueError('date must be a real date in YYYY-MM-DD format')
+        return value
+
+    @field_validator('timezone')
+    @classmethod
+    def validate_timezone(cls, value: str) -> str:
+        try:
+            pytz.timezone(value)
+        except pytz.UnknownTimeZoneError as exc:
+            raise ValueError('timezone must be a valid IANA timezone') from exc
+        return value
+
+    @field_validator('client_device_id')
+    @classmethod
+    def validate_client_device_id(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError('client_device_id cannot be blank')
+        return value
+
+    @model_validator(mode='after')
+    def validate_date_window(self):
+        target_date = datetime.strptime(self.date, '%Y-%m-%d').date()
+        local_today = datetime.now(pytz.timezone(self.timezone)).date()
+        if abs((target_date - local_today).days) > 2:
+            raise ValueError('date must be within 2 days of today in the supplied timezone')
+        return self
+
+
+class DesktopDailyUsageResponse(BaseModel):
+    ok: bool
+
+
+@router.post('/v1/users/desktop-usage/daily', tags=['v1'], response_model=DesktopDailyUsageResponse)
+def record_desktop_daily_usage(
+    data: DesktopDailyUsageRequest,
+    uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, 'users:desktop_usage_daily')),
+):
+    daily_summaries_db.upsert_desktop_daily_usage(
+        uid,
+        data.date,
+        data.timezone,
+        data.client_device_id,
+        {
+            'watching_seconds': data.watching_seconds,
+            'listening_seconds': data.listening_seconds,
+            'proactive_cards_shown': data.proactive_cards_shown,
+            'proactive_cards_acted': data.proactive_cards_acted,
+            'ptt_turns': data.ptt_turns,
+        },
+    )
+    return {'ok': True}
 
 
 @router.get('/v1/users/daily-summaries', tags=['v1'], response_model=DailySummariesResponse)

--- a/backend/scripts/firestore_query_coverage_baseline.json
+++ b/backend/scripts/firestore_query_coverage_baseline.json
@@ -1,5 +1,5 @@
 {
-  "eligible_serving": 114,
+  "eligible_serving": 117,
   "raw_unregistered": [
     "05fdb282df637274",
     "0c75b579eb9f7f04",
@@ -39,7 +39,7 @@
     "fbf6a1e1fdc6920e",
     "fcb4a9e8a36ebd5e"
   ],
-  "registered_serving": 74,
+  "registered_serving": 77,
   "schema_version": 1,
   "unsupported": [
     "4a1b611f6580fc78",

--- a/backend/tests/unit/test_daily_summary_memories_learned.py
+++ b/backend/tests/unit/test_daily_summary_memories_learned.py
@@ -9,7 +9,7 @@ non-empty, so older clients see exactly the message they saw before.
 
 from datetime import datetime, timedelta, timezone
 
-from models.daily_summary_payload import LearnedMemoryRef
+from models.daily_summary_payload import DailySummaryDayStatsPayload, LearnedMemoryRef
 from models.memories import MemoryCategory, MemoryDB
 from models.notification_message import NotificationMessage
 from routers.users import DailySummaryResponse
@@ -361,8 +361,9 @@ def test_generate_comprehensive_daily_summary_does_not_read_memories_itself():
 def test_generator_defaults_to_no_card_without_a_selection():
     from utils.llm.external_integrations import _basic_daily_summary
 
-    assert _basic_daily_summary('2026-09-01', 0, 0.0, [], [])['memories_learned'] == []
-    assert _basic_daily_summary('2026-09-01', 0, 0.0, [], [], [{'memory_id': 'm1'}])['memories_learned'] == [
+    stats = DailySummaryDayStatsPayload()
+    assert _basic_daily_summary('2026-09-01', 0, 0.0, [], [], stats)['memories_learned'] == []
+    assert _basic_daily_summary('2026-09-01', 0, 0.0, [], [], stats, [{'memory_id': 'm1'}])['memories_learned'] == [
         {'memory_id': 'm1'}
     ]
 

--- a/backend/tests/unit/test_daily_summary_zero_coordinate_locations.py
+++ b/backend/tests/unit/test_daily_summary_zero_coordinate_locations.py
@@ -63,9 +63,10 @@ def ext():
         "models": _real_pkg("models", "models"),
         "database": _real_pkg("database", "database"),
         "database.action_items": _leaf("database.action_items"),
+        "database.daily_summaries": _leaf("database.daily_summaries"),
+        "database.memories": _leaf("database.memories"),
         "database.users": _leaf("database.users"),
         "models.conversation": _leaf("models.conversation"),
-        "models.daily_summary_payload": _leaf("models.daily_summary_payload"),
         "models.structured": _leaf("models.structured"),
         "models.structured_extraction": _leaf("models.structured_extraction"),
         "models.other": _leaf("models.other"),
@@ -93,12 +94,13 @@ class _Geo:
 
 
 class _Convo:
-    def __init__(self, id, geolocation=None, started_at=None, discarded=False):
+    def __init__(self, id, geolocation=None, started_at=None, discarded=False, source='omi'):
         self.id = id
         self.geolocation = geolocation
         self.started_at = started_at
         self.finished_at = None
         self.discarded = discarded
+        self.source = source
 
     def get_person_ids(self):
         return []
@@ -108,6 +110,16 @@ def _configure(ext):
     ext.users_db.get_user_profile = MagicMock(return_value={"time_zone": "UTC", "language": "en"})
     ext.users_db.get_people_by_ids = MagicMock(return_value=[])
     ext.action_items_db.get_action_items = MagicMock(return_value=[])
+    ext.memories_db.count_memories_created = MagicMock(return_value=0)
+    ext.daily_summaries_db.get_desktop_daily_usage = MagicMock(
+        return_value={
+            "watching_seconds": 0,
+            "listening_seconds": 0,
+            "proactive_cards_shown": 0,
+            "proactive_cards_acted": 0,
+            "ptt_turns": 0,
+        }
+    )
     ext.get_prompt_memories = MagicMock(return_value=("TestUser", ""))
     ext.conversations_to_string = MagicMock(return_value="history")
     # Non-JSON LLM output -> JSONDecodeError -> _basic_daily_summary(..., locations)
@@ -143,3 +155,43 @@ def test_conversation_without_geolocation_is_excluded(ext):
     result = ext.generate_comprehensive_daily_summary("uid", convos, "2026-06-29")
 
     assert result["locations"] == []
+    assert result["stats"]["memories_created"] == 0
+    assert result["stats"]["action_items_created"] == 0
+    assert result["stats"]["watching_minutes"] == 0
+    assert result["stats"]["proactive_moments"] == 0
+
+
+def test_daily_summary_populates_new_stats_and_prompt_context(ext):
+    _configure(ext)
+    ext.memories_db.count_memories_created.return_value = 4
+    ext.daily_summaries_db.get_desktop_daily_usage.return_value = {
+        "watching_seconds": 389,
+        "listening_seconds": 120,
+        "proactive_cards_shown": 7,
+        "proactive_cards_acted": 2,
+        "ptt_turns": 3,
+    }
+
+    def action_items_for_scope(_uid, **kwargs):
+        if kwargs.get("conversation_id"):
+            return [{"description": "Follow up", "conversation_id": kwargs["conversation_id"]}]
+        return [{"id": "a1"}, {"id": "a2"}]
+
+    ext.action_items_db.get_action_items.side_effect = action_items_for_scope
+    started = datetime(2026, 6, 29, 14, 0, tzinfo=timezone.utc)
+    conversation = _Convo("desktop-conversation", started_at=started, source='desktop')
+    conversation.finished_at = started.replace(minute=35)
+
+    result = ext.generate_comprehensive_daily_summary("uid", [conversation], "2026-06-29")
+
+    assert result["stats"] == {
+        "total_conversations": 1,
+        "total_duration_minutes": 35,
+        "action_items_count": 1,
+        "memories_created": 4,
+        "action_items_created": 2,
+        "watching_minutes": 6,
+        "proactive_moments": 7,
+    }
+    prompt = ext.get_llm.return_value.invoke.call_args.args[0]
+    assert "Daily stats: 4 memories created, 2 action items created, 6 minutes watched, 7 proactive moments." in prompt

--- a/backend/tests/unit/test_desktop_daily_usage.py
+++ b/backend/tests/unit/test_desktop_daily_usage.py
@@ -1,0 +1,119 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timezone
+
+import database.daily_summaries as daily_summaries_db
+import database.memories as memories_db
+
+
+def _usage_db(existing=None):
+    fake_db = MagicMock()
+    user_ref = fake_db.collection.return_value.document.return_value
+    collection_ref = user_ref.collection.return_value
+    usage_ref = collection_ref.document.return_value
+    snapshot = MagicMock()
+    snapshot.exists = existing is not None
+    snapshot.to_dict.return_value = existing
+    usage_ref.get.return_value = snapshot
+    return fake_db, collection_ref, usage_ref
+
+
+def test_desktop_daily_usage_upsert_max_merges_running_totals():
+    fake_db, collection_ref, usage_ref = _usage_db(
+        {
+            'watching_seconds': 300,
+            'listening_seconds': 20,
+            'proactive_cards_shown': 4,
+            'proactive_cards_acted': 2,
+            'ptt_turns': 8,
+        }
+    )
+    transaction = fake_db.transaction.return_value
+
+    with patch.object(daily_summaries_db, 'db', fake_db), patch.object(
+        daily_summaries_db.firestore, 'transactional', side_effect=lambda fn: fn
+    ):
+        daily_summaries_db.upsert_desktop_daily_usage(
+            'uid1',
+            '2026-09-01',
+            'America/Los_Angeles',
+            'macos_abc123',
+            {
+                'watching_seconds': 200,
+                'listening_seconds': 40,
+                'proactive_cards_shown': 6,
+                'proactive_cards_acted': 1,
+                'ptt_turns': 10,
+            },
+        )
+
+    collection_ref.document.assert_called_once_with('2026-09-01__macos_abc123')
+    payload = transaction.set.call_args.args[1]
+    assert payload['watching_seconds'] == 300
+    assert payload['listening_seconds'] == 40
+    assert payload['proactive_cards_shown'] == 6
+    assert payload['proactive_cards_acted'] == 2
+    assert payload['ptt_turns'] == 10
+    assert payload['date'] == '2026-09-01'
+    assert payload['timezone'] == 'America/Los_Angeles'
+    assert payload['client_device_id'] == 'macos_abc123'
+    assert payload['updated_at'].tzinfo is not None
+    usage_ref.get.assert_called_once_with(transaction=transaction)
+
+
+def test_get_desktop_daily_usage_sums_devices_and_returns_zero_for_missing_fields():
+    fake_db, collection_ref, _usage_ref = _usage_db()
+    query = collection_ref.where.return_value
+    query.stream.return_value = [
+        SimpleNamespace(
+            to_dict=lambda: {
+                'watching_seconds': 60,
+                'listening_seconds': 10,
+                'proactive_cards_shown': 2,
+                'proactive_cards_acted': 1,
+                'ptt_turns': 3,
+            }
+        ),
+        SimpleNamespace(
+            to_dict=lambda: {
+                'watching_seconds': 90,
+                'listening_seconds': 20,
+                'proactive_cards_shown': 4,
+                'proactive_cards_acted': 2,
+            }
+        ),
+    ]
+
+    with patch.object(daily_summaries_db, 'db', fake_db):
+        result = daily_summaries_db.get_desktop_daily_usage('uid1', '2026-09-01')
+
+    assert result == {
+        'watching_seconds': 150,
+        'listening_seconds': 30,
+        'proactive_cards_shown': 6,
+        'proactive_cards_acted': 3,
+        'ptt_turns': 3,
+    }
+
+
+def test_memories_created_counts_canonical_and_legacy_shapes_without_duplicates():
+    fake_db = MagicMock()
+    canonical_query = MagicMock()
+    legacy_query = MagicMock()
+    canonical_query.stream.return_value = [SimpleNamespace(id='canonical-only'), SimpleNamespace(id='shared')]
+    legacy_query.stream.return_value = [SimpleNamespace(id='legacy-only'), SimpleNamespace(id='shared')]
+    start = datetime(2026, 9, 1, tzinfo=timezone.utc)
+    end = datetime(2026, 9, 2, tzinfo=timezone.utc)
+
+    with patch.object(
+        memories_db,
+        'CANONICAL_MEMORIES_CAPTURED_RANGE_QUERY',
+        SimpleNamespace(build=MagicMock(return_value=canonical_query)),
+    ), patch.object(
+        memories_db,
+        'MEMORIES_CREATED_RANGE_QUERY',
+        SimpleNamespace(build=MagicMock(return_value=legacy_query)),
+    ):
+        result = memories_db.count_memories_created('uid1', start, end, firestore_client=fake_db)
+
+    assert result == 3

--- a/backend/utils/llm/external_integrations.py
+++ b/backend/utils/llm/external_integrations.py
@@ -1,15 +1,17 @@
 import json
 import re
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, time, timezone
 from typing import Any, Dict, List, Optional, cast
 import pytz
 from langchain_core.prompts import ChatPromptTemplate
 from pydantic import ValidationError
 import database.action_items as action_items_db
+import database.daily_summaries as daily_summaries_db
+import database.memories as memories_db
 import database.users as users_db
 from models.conversation import Conversation
-from models.daily_summary_payload import DailySummaryPayload
+from models.daily_summary_payload import DailySummaryDayStatsPayload, DailySummaryPayload
 from models.structured import Structured
 from models.structured_extraction import StructuredExtraction
 from models.other import Person
@@ -40,6 +42,7 @@ def _basic_daily_summary(
     total_duration_minutes: float,
     actual_action_items: List[Dict[str, Any]],
     locations: List[Dict[str, Any]],
+    stats: DailySummaryDayStatsPayload,
     memories_learned: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     return {
@@ -49,11 +52,7 @@ def _basic_daily_summary(
         "headline": "Your Day in Review",
         "overview": f"You had {total_conversations} conversations today.",
         "day_emoji": "📅",
-        "stats": {
-            "total_conversations": total_conversations,
-            "total_duration_minutes": int(total_duration_minutes),
-            "action_items_count": len(actual_action_items),
-        },
+        "stats": stats.model_dump(),
         "highlights": [],
         "action_items": actual_action_items,
         "unresolved_questions": [],
@@ -240,6 +239,28 @@ def generate_comprehensive_daily_summary(
         (c.finished_at - c.started_at).total_seconds() / 60 for c in non_discarded if c.finished_at and c.started_at
     )
 
+    stats_start_date_utc = start_date_utc
+    stats_end_date_utc = end_date_utc
+    if stats_start_date_utc is None or stats_end_date_utc is None:
+        target_date = datetime.strptime(date_str, '%Y-%m-%d').date()
+        start_of_day = user_tz.localize(datetime.combine(target_date, time.min))
+        end_of_day = user_tz.localize(datetime.combine(target_date, time.max))
+        stats_start_date_utc = stats_start_date_utc or start_of_day.astimezone(pytz.UTC)
+        stats_end_date_utc = stats_end_date_utc or end_of_day.astimezone(pytz.UTC)
+    assert stats_start_date_utc is not None and stats_end_date_utc is not None
+
+    memories_created = memories_db.count_memories_created(uid, stats_start_date_utc, stats_end_date_utc)
+    action_items_created = len(
+        action_items_db.get_action_items(
+            uid,
+            start_date=stats_start_date_utc,
+            end_date=stats_end_date_utc,
+        )
+    )
+    desktop_usage = daily_summaries_db.get_desktop_daily_usage(uid, date_str)
+    watching_minutes = int(round(desktop_usage.get('watching_seconds', 0) / 60))
+    proactive_moments = desktop_usage.get('proactive_cards_shown', 0)
+
     # Extract ALL locations from non-discarded conversations.
     # latitude/longitude are required floats on the Geolocation model, so guarding on
     # their truthiness wrongly drops a valid coordinate of exactly 0.0 (for example
@@ -279,6 +300,16 @@ def generate_comprehensive_daily_summary(
                 }
             )
 
+    stats = DailySummaryDayStatsPayload(
+        total_conversations=total_conversations,
+        total_duration_minutes=int(total_duration_minutes),
+        action_items_count=len(actual_action_items),
+        memories_created=memories_created,
+        action_items_created=action_items_created,
+        watching_minutes=watching_minutes,
+        proactive_moments=proactive_moments,
+    )
+
     # Build conversation ID mapping for the LLM
     convo_id_map = {i + 1: c.id for i, c in enumerate(non_discarded)}
 
@@ -287,6 +318,7 @@ OUTPUT LANGUAGE: {output_language}. You MUST write every word of this summary in
 
 Today's date: {date_str}
 Conversations: {total_conversations}
+Daily stats: {memories_created} memories created, {action_items_created} action items created, {watching_minutes} minutes watched, {proactive_moments} proactive moments.
 
 Here are {user_name}'s conversations from today (numbered 1-{total_conversations}):
 ```
@@ -402,11 +434,7 @@ Respond with ONLY valid JSON. Do not include any other text or comments."""
             "headline": summary_data.headline,
             "overview": summary_data.overview,
             "day_emoji": summary_data.day_emoji,
-            "stats": {
-                "total_conversations": total_conversations,
-                "total_duration_minutes": int(total_duration_minutes),
-                "action_items_count": len(actual_action_items),
-            },
+            "stats": stats.model_dump(),
             "highlights": highlights,
             "action_items": actual_action_items,
             "unresolved_questions": unresolved_questions,
@@ -418,10 +446,22 @@ Respond with ONLY valid JSON. Do not include any other text or comments."""
     except json.JSONDecodeError as e:
         logger.error("Failed to decode daily summary payload JSON: %s", sanitize(str(e)))
         return _basic_daily_summary(
-            date_str, total_conversations, total_duration_minutes, actual_action_items, locations, learned_refs
+            date_str,
+            total_conversations,
+            total_duration_minutes,
+            actual_action_items,
+            locations,
+            stats,
+            memories_learned=learned_refs,
         )
     except ValidationError as e:
         logger.error("Failed to validate daily summary payload: %s", sanitize_validation_error(cast(Any, e)))
         return _basic_daily_summary(
-            date_str, total_conversations, total_duration_minutes, actual_action_items, locations, learned_refs
+            date_str,
+            total_conversations,
+            total_duration_minutes,
+            actual_action_items,
+            locations,
+            stats,
+            memories_learned=learned_refs,
         )

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -87,6 +87,9 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     # cheaper than :create — no Deepgram, just LLM structuring). Used per finished
     # conversation by Parakeet/local-STT users, so a bit more headroom than :create.
     "conversations:from-segments": (30, 3600),
+    # Desktop sends running per-day totals periodically; allow several devices
+    # plus reconnect bursts while still capping accidental hot loops.
+    "users:desktop_usage_daily": (600, 3600),
     # Chat — 2-6 LLM calls per message
     "chat:send_message": (120, 3600),
     "chat:initial": (60, 3600),

--- a/desktop/macos/Desktop/Sources/AccountCutover/DesktopHomeSignedInStartup.swift
+++ b/desktop/macos/Desktop/Sources/AccountCutover/DesktopHomeSignedInStartup.swift
@@ -63,6 +63,13 @@ enum DesktopHomeSignedInStartup {
     if let barState = FloatingControlBarManager.shared.barState {
       PushToTalkManager.shared.setup(barState: barState)
     }
+
+    DesktopUsageDailyReporter.shared.start(
+      isWatching: { ProactiveAssistantsPlugin.shared.isMonitoring },
+      isListening: { [weak appState] in
+        appState?.isLiveCapturing == true
+          || VoiceTurnCoordinator.shared.activeTurn?.phase.isRecording == true
+      })
   }
 
   static func loadDataIfAdmitted(

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -4444,6 +4444,8 @@ class FloatingControlBarManager {
       let window
     else { return }
 
+    DesktopUsageDailyReporter.shared.recordProactiveCardActed()
+
     AnalyticsManager.shared.notificationClicked(
       notificationId: notification.id.uuidString,
       title: notification.title,
@@ -4556,6 +4558,7 @@ class FloatingControlBarManager {
       surface: "floating_bar",
       suggestionIdentity: notification.suggestionTelemetryIdentity
     )
+    DesktopUsageDailyReporter.shared.recordProactiveCardShown()
 
     // A persistent card (meeting summary share) stays until the user acts on
     // it — Copy/Send/close are its only exits, all of which route through

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
@@ -1133,6 +1133,10 @@ extension RealtimeHubController {
             terminal: .success,
             idempotencyKey: completedTurnIdempotencyKey,
             acceptedSpawnOwnerID: acceptedSpawnOwnerID) ?? false
+        if accepted, !resolution.userText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+          let repliedToCard = FloatingControlBarManager.shared.recentNotchCardVoiceContext() != nil
+          DesktopUsageDailyReporter.shared.recordCompletedPTTTurn(repliedToCard: repliedToCard)
+        }
         self?.lastTurnDiagnostics = [
           "provider": provider,
           "provider_transcript": heard,

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -13478,6 +13478,32 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
+  public static func recordDesktopDailyUsageV1UsersDesktopUsageDailyPost(client: OmiApiClient, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, body: OmiAnyCodable) async throws -> OmiAnyCodable {
+    let _path = "/v1/users/desktop-usage/daily"
+    guard let components = URLComponents(string: client.baseURL + _path) else {
+      throw OmiApiError.invalidURL
+    }
+    guard let url = components.url else { throw OmiApiError.invalidURL }
+    var req = URLRequest(url: url)
+    req.httpMethod = "POST"
+    for (name, value) in client.headers { req.setValue(value, forHTTPHeaderField: name) }
+    if let token = client.token {
+      req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    }
+    if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
+    if let xAppPlatform { req.setValue(String(xAppPlatform), forHTTPHeaderField: "X-App-Platform") }
+    if let xDeviceIdHash { req.setValue(String(xDeviceIdHash), forHTTPHeaderField: "X-Device-Id-Hash") }
+    if let xAppVersion { req.setValue(String(xAppVersion), forHTTPHeaderField: "X-App-Version") }
+    req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    req.httpBody = try JSONEncoder().encode(body)
+    let (data, resp) = try await URLSession.shared.data(for: req)
+    guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }
+    guard (200..<300).contains(http.statusCode) else {
+      throw OmiApiError.httpError(status: http.statusCode, data: data)
+    }
+    return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
+  }
+
   public static func getUserWebhookEndpointV1UsersDeveloperWebhookWtypeGet(client: OmiApiClient, wtype: String, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil) async throws -> OmiAnyCodable {
     let _path = "/v1/users/developer/webhook/\(wtype)"
     guard let components = URLComponents(string: client.baseURL + _path) else {
@@ -16437,5 +16463,5 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  // Total: 433 Swift client methods generated.
+  // Total: 434 Swift client methods generated.
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/DesktopUsageDailyReporter.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/DesktopUsageDailyReporter.swift
@@ -1,0 +1,276 @@
+import Foundation
+
+struct DesktopUsageAccumulator: Codable, Equatable, Sendable {
+  var records: [String: DesktopUsageDailyPayload] = [:]
+  var dirtyDates: Set<String> = []
+
+  mutating func sample(
+    dateKey: String,
+    timezone: String,
+    clientDeviceID: String,
+    watching: Bool,
+    listening: Bool,
+    intervalSeconds: Int = 60
+  ) {
+    ensureRecord(dateKey: dateKey, timezone: timezone, clientDeviceID: clientDeviceID)
+    if watching { records[dateKey]?.watchingSeconds += intervalSeconds }
+    if listening { records[dateKey]?.listeningSeconds += intervalSeconds }
+    if watching || listening { dirtyDates.insert(dateKey) }
+  }
+
+  mutating func incrementShown(dateKey: String, timezone: String, clientDeviceID: String) {
+    ensureRecord(dateKey: dateKey, timezone: timezone, clientDeviceID: clientDeviceID)
+    records[dateKey]?.proactiveCardsShown += 1
+    dirtyDates.insert(dateKey)
+  }
+
+  mutating func incrementActed(dateKey: String, timezone: String, clientDeviceID: String) {
+    ensureRecord(dateKey: dateKey, timezone: timezone, clientDeviceID: clientDeviceID)
+    records[dateKey]?.proactiveCardsActed += 1
+    dirtyDates.insert(dateKey)
+  }
+
+  mutating func incrementPTT(dateKey: String, timezone: String, clientDeviceID: String) {
+    ensureRecord(dateKey: dateKey, timezone: timezone, clientDeviceID: clientDeviceID)
+    records[dateKey]?.pttTurns += 1
+    dirtyDates.insert(dateKey)
+  }
+
+  mutating func markUploaded(_ dateKey: String) {
+    dirtyDates.remove(dateKey)
+  }
+
+  mutating func retainLatestDays(_ count: Int) {
+    let retained = Set(records.keys.sorted().suffix(max(0, count)))
+    records = records.filter { retained.contains($0.key) }
+    dirtyDates = dirtyDates.intersection(retained)
+  }
+
+  private mutating func ensureRecord(dateKey: String, timezone: String, clientDeviceID: String) {
+    guard records[dateKey] == nil else { return }
+    records[dateKey] = DesktopUsageDailyPayload(
+      date: dateKey,
+      timezone: timezone,
+      clientDeviceID: clientDeviceID,
+      watchingSeconds: 0,
+      listeningSeconds: 0,
+      proactiveCardsShown: 0,
+      proactiveCardsActed: 0,
+      pttTurns: 0)
+  }
+}
+
+@MainActor
+final class DesktopUsageDailyReporter {
+  static let shared = DesktopUsageDailyReporter()
+
+  static let persistedKey = "desktopUsageDailyRecords"
+  private static let sampleInterval: TimeInterval = 60
+  private static let uploadInterval: TimeInterval = 10 * 60
+
+  private let defaults: UserDefaults
+  private let now: () -> Date
+  private let calendar: Calendar
+  private let timezone: () -> TimeZone
+  private let deviceID: () -> String
+  private let ownerID: () -> String?
+  private let uploadPayload: @Sendable (DesktopUsageDailyPayload) async throws -> Void
+  private var isWatching: () -> Bool = { false }
+  private var isListening: () -> Bool = { false }
+  private var accumulator: DesktopUsageAccumulator
+  private var sampleTimer: Timer?
+  private var uploadTimer: Timer?
+  private var lastDateKey: String?
+  private var retryAttempts: [String: Int] = [:]
+  private var retryAfter: [String: Date] = [:]
+  private var started = false
+  nonisolated(unsafe) private var ownerObserver: NSObjectProtocol?
+  private var boundOwnerID: String?
+
+  init(
+    defaults: UserDefaults = .standard,
+    now: @escaping () -> Date = { Date() },
+    calendar: Calendar = .current,
+    timezone: @escaping () -> TimeZone = { .current },
+    deviceID: @escaping () -> String = { ClientDeviceService.shared.clientDeviceId },
+    ownerID: @escaping () -> String? = { RuntimeOwnerIdentity.currentOwnerId() },
+    uploadPayload: @escaping @Sendable (DesktopUsageDailyPayload) async throws -> Void = {
+      try await APIClient.shared.postDesktopUsageDaily($0)
+    }
+  ) {
+    self.defaults = defaults
+    self.now = now
+    self.calendar = calendar
+    self.timezone = timezone
+    self.deviceID = deviceID
+    self.ownerID = ownerID
+    self.uploadPayload = uploadPayload
+    boundOwnerID = ownerID()
+    if let boundOwnerID, let data = defaults.data(forKey: Self.persistedKey + "." + boundOwnerID),
+      var decoded = try? JSONDecoder().decode(DesktopUsageAccumulator.self, from: data)
+    {
+      decoded.retainLatestDays(7)
+      accumulator = decoded
+    } else {
+      accumulator = DesktopUsageAccumulator()
+    }
+    ownerObserver = NotificationCenter.default.addObserver(
+      forName: .runtimeOwnerDidChange, object: nil, queue: .main
+    ) { [weak self] _ in
+      MainActor.assumeIsolated { self?.resetForOwnerChange() }
+    }
+  }
+
+  deinit {
+    if let ownerObserver { NotificationCenter.default.removeObserver(ownerObserver) }
+  }
+
+  func start(isWatching: @escaping () -> Bool, isListening: @escaping () -> Bool) {
+    self.isWatching = isWatching
+    self.isListening = isListening
+    guard !started else { return }
+    reloadForCurrentOwner()
+    guard boundOwnerID != nil else { return }
+    started = true
+    lastDateKey = dateKey(for: now())
+    sampleTimer = Timer.scheduledTimer(withTimeInterval: Self.sampleInterval, repeats: true) {
+      [weak self] _ in
+      Task { @MainActor in self?.sampleNow() }
+    }
+    uploadTimer = Timer.scheduledTimer(withTimeInterval: Self.uploadInterval, repeats: true) {
+      [weak self] _ in
+      Task { @MainActor in await self?.uploadDirtyRecords() }
+    }
+    Task { await uploadDirtyRecords() }
+  }
+
+  func recordProactiveCardShown() {
+    let date = now()
+    accumulator.incrementShown(
+      dateKey: dateKey(for: date),
+      timezone: timezone().identifier,
+      clientDeviceID: deviceID())
+    persist()
+  }
+
+  func recordProactiveCardActed() {
+    let date = now()
+    accumulator.incrementActed(
+      dateKey: dateKey(for: date),
+      timezone: timezone().identifier,
+      clientDeviceID: deviceID())
+    persist()
+  }
+
+  func recordCompletedPTTTurn(repliedToCard: Bool) {
+    let date = now()
+    let key = dateKey(for: date)
+    accumulator.incrementPTT(dateKey: key, timezone: timezone().identifier, clientDeviceID: deviceID())
+    if repliedToCard {
+      accumulator.incrementActed(dateKey: key, timezone: timezone().identifier, clientDeviceID: deviceID())
+    }
+    persist()
+  }
+
+  func sampleForTesting(watching: Bool, listening: Bool, at date: Date) {
+    sample(watching: watching, listening: listening, at: date)
+  }
+
+  func snapshotForTesting() -> DesktopUsageAccumulator { accumulator }
+
+  private func sampleNow() {
+    sample(watching: isWatching(), listening: isListening(), at: now())
+  }
+
+  private func sample(watching: Bool, listening: Bool, at date: Date) {
+    let key = dateKey(for: date)
+    let rolledOver = lastDateKey != nil && lastDateKey != key
+    let priorDate = lastDateKey
+    accumulator.sample(
+      dateKey: key,
+      timezone: timezone().identifier,
+      clientDeviceID: deviceID(),
+      watching: watching,
+      listening: listening)
+    accumulator.retainLatestDays(7)
+    lastDateKey = key
+    persist()
+    if rolledOver, let priorDate {
+      Task { await upload(dateKey: priorDate) }
+    }
+  }
+
+  private func uploadDirtyRecords() async {
+    for dateKey in accumulator.dirtyDates.sorted() {
+      await upload(dateKey: dateKey)
+    }
+  }
+
+  private func upload(dateKey: String) async {
+    guard let payload = accumulator.records[dateKey], let boundOwnerID,
+      let authorization = RuntimeOwnerIdentity.captureAuthorizationSnapshot(expectedOwnerID: boundOwnerID),
+      RuntimeOwnerIdentity.isAuthorizationCurrent(authorization)
+    else {
+      log("DesktopUsageDailyReporter: owner authorization changed before usage upload")
+      return
+    }
+    if let retry = retryAfter[dateKey], retry > now() { return }
+    do {
+      try await uploadPayload(payload)
+      guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorization), self.boundOwnerID == boundOwnerID else {
+        log("DesktopUsageDailyReporter: owner authorization changed during usage upload")
+        return
+      }
+      if accumulator.records[dateKey] == payload {
+        accumulator.markUploaded(dateKey)
+      }
+      retryAttempts.removeValue(forKey: dateKey)
+      retryAfter.removeValue(forKey: dateKey)
+      persist()
+    } catch {
+      let attempt = min(6, retryAttempts[dateKey, default: 0] + 1)
+      retryAttempts[dateKey] = attempt
+      retryAfter[dateKey] = now().addingTimeInterval(min(Self.uploadInterval, pow(2, Double(attempt)) * 15))
+      logError("DesktopUsageDailyReporter: daily usage upload failed", error: error)
+    }
+  }
+
+  private func dateKey(for date: Date) -> String {
+    var components = calendar.dateComponents(in: timezone(), from: date)
+    components.calendar = calendar
+    return String(format: "%04d-%02d-%02d", components.year ?? 0, components.month ?? 0, components.day ?? 0)
+  }
+
+  private func persist() {
+    guard let boundOwnerID, ownerID() == boundOwnerID,
+      let data = try? JSONEncoder().encode(accumulator)
+    else { return }
+    defaults.set(data, forKey: Self.persistedKey + "." + boundOwnerID)
+  }
+
+  private func resetForOwnerChange() {
+    sampleTimer?.invalidate()
+    uploadTimer?.invalidate()
+    sampleTimer = nil
+    uploadTimer = nil
+    started = false
+    accumulator = DesktopUsageAccumulator()
+    retryAttempts.removeAll()
+    retryAfter.removeAll()
+    lastDateKey = nil
+    boundOwnerID = nil
+  }
+
+  private func reloadForCurrentOwner() {
+    let currentOwner = ownerID()
+    guard currentOwner != boundOwnerID else { return }
+    boundOwnerID = currentOwner
+    accumulator = DesktopUsageAccumulator()
+    guard let currentOwner,
+      let data = defaults.data(forKey: Self.persistedKey + "." + currentOwner),
+      var decoded = try? JSONDecoder().decode(DesktopUsageAccumulator.self, from: data)
+    else { return }
+    decoded.retainLatestDays(7)
+    accumulator = decoded
+  }
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/DesktopUsageDailyReporter.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/DesktopUsageDailyReporter.swift
@@ -83,6 +83,7 @@ final class DesktopUsageDailyReporter {
   private var lastDateKey: String?
   private var retryAttempts: [String: Int] = [:]
   private var retryAfter: [String: Date] = [:]
+  private var testingAssumeAuthorized = false
   private var started = false
   nonisolated(unsafe) private var ownerObserver: NSObjectProtocol?
   private var boundOwnerID: String?
@@ -178,6 +179,22 @@ final class DesktopUsageDailyReporter {
 
   func snapshotForTesting() -> DesktopUsageAccumulator { accumulator }
 
+  func assumeAuthorizedForTesting() {
+    testingAssumeAuthorized = true
+  }
+
+  func uploadDirtyRecordsForTesting() async {
+    await uploadDirtyRecords()
+  }
+
+  func retryAttemptsForTesting(_ dateKey: String) -> Int {
+    retryAttempts[dateKey, default: 0]
+  }
+
+  func retryAfterForTesting(_ dateKey: String) -> Date? {
+    retryAfter[dateKey]
+  }
+
   private func sampleNow() {
     sample(watching: isWatching(), listening: isListening(), at: now())
   }
@@ -207,19 +224,29 @@ final class DesktopUsageDailyReporter {
   }
 
   private func upload(dateKey: String) async {
-    guard let payload = accumulator.records[dateKey], let boundOwnerID,
-      let authorization = RuntimeOwnerIdentity.captureAuthorizationSnapshot(expectedOwnerID: boundOwnerID),
-      RuntimeOwnerIdentity.isAuthorizationCurrent(authorization)
-    else {
+    guard let payload = accumulator.records[dateKey], let boundOwnerID else { return }
+    let authorization: RuntimeOwnerAuthorizationSnapshot?
+    if testingAssumeAuthorized {
+      authorization = nil
+    } else if let captured = RuntimeOwnerIdentity.captureAuthorizationSnapshot(
+      expectedOwnerID: boundOwnerID),
+      RuntimeOwnerIdentity.isAuthorizationCurrent(captured)
+    {
+      authorization = captured
+    } else {
       log("DesktopUsageDailyReporter: owner authorization changed before usage upload")
       return
     }
     if let retry = retryAfter[dateKey], retry > now() { return }
     do {
       try await uploadPayload(payload)
-      guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorization), self.boundOwnerID == boundOwnerID else {
-        log("DesktopUsageDailyReporter: owner authorization changed during usage upload")
-        return
+      if !testingAssumeAuthorized {
+        guard let authorization, RuntimeOwnerIdentity.isAuthorizationCurrent(authorization),
+          self.boundOwnerID == boundOwnerID
+        else {
+          log("DesktopUsageDailyReporter: owner authorization changed during usage upload")
+          return
+        }
       }
       if accumulator.records[dateKey] == payload {
         accumulator.markUploaded(dateKey)

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+DesktopUsage.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+DesktopUsage.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct DesktopUsageDailyPayload: Codable, Equatable, Sendable {
+  let date: String
+  let timezone: String
+  let clientDeviceID: String
+  var watchingSeconds: Int
+  var listeningSeconds: Int
+  var proactiveCardsShown: Int
+  var proactiveCardsActed: Int
+  var pttTurns: Int
+
+  enum CodingKeys: String, CodingKey {
+    case date
+    case timezone
+    case clientDeviceID = "client_device_id"
+    case watchingSeconds = "watching_seconds"
+    case listeningSeconds = "listening_seconds"
+    case proactiveCardsShown = "proactive_cards_shown"
+    case proactiveCardsActed = "proactive_cards_acted"
+    case pttTurns = "ptt_turns"
+  }
+}
+
+extension APIClient {
+  private struct DesktopUsageDailyResponse: Decodable {}
+
+  func postDesktopUsageDaily(_ payload: DesktopUsageDailyPayload) async throws {
+    let _: DesktopUsageDailyResponse = try await post(
+      "v1/users/desktop-usage/daily",
+      body: payload,
+      includeBYOK: false)
+  }
+}

--- a/desktop/macos/Desktop/Tests/DesktopUsageDailyReporterTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopUsageDailyReporterTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class DesktopUsageDailyReporterTests: XCTestCase {
+  func testUsageReporterAccumulatesAndRollsOverWithoutDroppingPriorDay() throws {
+    let suite = "DesktopUsageDailyReporterTests.\(UUID().uuidString)"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+    defer { defaults.removePersistentDomain(forName: suite) }
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
+    let dayOne = Date(timeIntervalSince1970: 1_788_230_400)
+    let dayTwo = try XCTUnwrap(calendar.date(byAdding: .day, value: 1, to: dayOne))
+    let reporter = DesktopUsageDailyReporter(
+      defaults: defaults,
+      now: { dayOne },
+      calendar: calendar,
+      timezone: { calendar.timeZone },
+      deviceID: { "device-1" })
+
+    reporter.sampleForTesting(watching: true, listening: false, at: dayOne)
+    reporter.recordProactiveCardShown()
+    reporter.recordProactiveCardActed()
+    reporter.recordCompletedPTTTurn(repliedToCard: true)
+    reporter.sampleForTesting(watching: true, listening: true, at: dayTwo)
+
+    let snapshot = reporter.snapshotForTesting()
+    let keys = snapshot.records.keys.sorted()
+    XCTAssertEqual(keys.count, 2)
+    XCTAssertEqual(snapshot.records[keys[0]]?.watchingSeconds, 60)
+    XCTAssertEqual(snapshot.records[keys[1]]?.watchingSeconds, 60)
+    XCTAssertEqual(snapshot.records[keys[1]]?.listeningSeconds, 60)
+    XCTAssertEqual(snapshot.records[keys[0]]?.proactiveCardsShown, 1)
+    XCTAssertEqual(snapshot.records[keys[0]]?.proactiveCardsActed, 2)
+    XCTAssertEqual(snapshot.records[keys[0]]?.pttTurns, 1)
+  }
+
+  func testUsagePersistenceIsNamespacedByOwner() throws {
+    let suite = "DesktopUsageDailyReporterTests.\(UUID().uuidString)"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+    defer { defaults.removePersistentDomain(forName: suite) }
+    let ownerA = DesktopUsageDailyReporter(defaults: defaults, ownerID: { "owner-a" })
+    ownerA.recordProactiveCardShown()
+    let ownerB = DesktopUsageDailyReporter(defaults: defaults, ownerID: { "owner-b" })
+
+    XCTAssertEqual(ownerA.snapshotForTesting().dirtyDates.count, 1)
+    XCTAssertTrue(ownerB.snapshotForTesting().dirtyDates.isEmpty)
+  }
+}

--- a/desktop/macos/Desktop/Tests/DesktopUsageDailyReporterTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopUsageDailyReporterTests.swift
@@ -48,4 +48,172 @@ final class DesktopUsageDailyReporterTests: XCTestCase {
     XCTAssertEqual(ownerA.snapshotForTesting().dirtyDates.count, 1)
     XCTAssertTrue(ownerB.snapshotForTesting().dirtyDates.isEmpty)
   }
+
+  func testFailedUploadKeepsDirtyCountersAndSchedulesRetry() async throws {
+    let harness = try makeUploadHarness(shouldFail: true)
+    defer { harness.defaults.removePersistentDomain(forName: harness.suite) }
+
+    harness.reporter.sampleForTesting(watching: true, listening: false, at: harness.clock.now)
+    await harness.reporter.uploadDirtyRecordsForTesting()
+
+    let snapshot = harness.reporter.snapshotForTesting()
+    let dateKey = try XCTUnwrap(snapshot.dirtyDates.first)
+    XCTAssertEqual(harness.probe.calls.count, 1)
+    XCTAssertEqual(snapshot.records[dateKey]?.watchingSeconds, 60)
+    XCTAssertEqual(harness.reporter.retryAttemptsForTesting(dateKey), 1)
+    XCTAssertEqual(
+      harness.reporter.retryAfterForTesting(dateKey),
+      harness.clock.now.addingTimeInterval(30))
+  }
+
+  func testRepeatedUploadFailuresBackOffInsteadOfRetryingImmediately() async throws {
+    let harness = try makeUploadHarness(shouldFail: true)
+    defer { harness.defaults.removePersistentDomain(forName: harness.suite) }
+
+    harness.reporter.sampleForTesting(watching: true, listening: false, at: harness.clock.now)
+    await harness.reporter.uploadDirtyRecordsForTesting()
+    await harness.reporter.uploadDirtyRecordsForTesting()
+    XCTAssertEqual(harness.probe.calls.count, 1)
+
+    let dateKey = try XCTUnwrap(harness.reporter.snapshotForTesting().dirtyDates.first)
+    let firstRetryAfter = try XCTUnwrap(harness.reporter.retryAfterForTesting(dateKey))
+    harness.clock.now = firstRetryAfter
+    await harness.reporter.uploadDirtyRecordsForTesting()
+    XCTAssertEqual(harness.probe.calls.count, 2)
+    XCTAssertEqual(harness.reporter.retryAttemptsForTesting(dateKey), 2)
+
+    let secondRetryAfter = try XCTUnwrap(harness.reporter.retryAfterForTesting(dateKey))
+    XCTAssertEqual(secondRetryAfter.timeIntervalSince(harness.clock.now), 60)
+    await harness.reporter.uploadDirtyRecordsForTesting()
+    XCTAssertEqual(harness.probe.calls.count, 2)
+  }
+
+  func testUploadedDayIsNotReuploaded() async throws {
+    let harness = try makeUploadHarness(shouldFail: false)
+    defer { harness.defaults.removePersistentDomain(forName: harness.suite) }
+
+    harness.reporter.sampleForTesting(watching: true, listening: false, at: harness.clock.now)
+    await harness.reporter.uploadDirtyRecordsForTesting()
+    XCTAssertEqual(harness.probe.calls.count, 1)
+    XCTAssertTrue(harness.reporter.snapshotForTesting().dirtyDates.isEmpty)
+
+    await harness.reporter.uploadDirtyRecordsForTesting()
+    XCTAssertEqual(harness.probe.calls.count, 1)
+    XCTAssertEqual(
+      harness.reporter.retryAttemptsForTesting(try XCTUnwrap(harness.probe.calls.first?.date)),
+      0)
+  }
+
+  func testCountersAccumulatedDuringFailedUploadSurviveNextAttempt() async throws {
+    let harness = try makeUploadHarness(shouldFail: true)
+    defer { harness.defaults.removePersistentDomain(forName: harness.suite) }
+
+    harness.reporter.sampleForTesting(watching: true, listening: false, at: harness.clock.now)
+    await harness.reporter.uploadDirtyRecordsForTesting()
+    harness.reporter.sampleForTesting(watching: true, listening: true, at: harness.clock.now)
+    harness.reporter.recordProactiveCardShown()
+
+    let dateKey = try XCTUnwrap(harness.reporter.snapshotForTesting().dirtyDates.first)
+    harness.clock.now = try XCTUnwrap(harness.reporter.retryAfterForTesting(dateKey))
+    harness.probe.shouldFail = false
+    await harness.reporter.uploadDirtyRecordsForTesting()
+
+    XCTAssertEqual(harness.probe.calls.count, 2)
+    XCTAssertEqual(harness.probe.calls.last?.watchingSeconds, 120)
+    XCTAssertEqual(harness.probe.calls.last?.listeningSeconds, 60)
+    XCTAssertEqual(harness.probe.calls.last?.proactiveCardsShown, 1)
+    XCTAssertTrue(harness.reporter.snapshotForTesting().dirtyDates.isEmpty)
+  }
+
+  func testRelaunchRetriesDirtyDayImmediatelyBecauseBackoffIsInMemoryOnly() async throws {
+    let harness = try makeUploadHarness(shouldFail: true)
+    defer { harness.defaults.removePersistentDomain(forName: harness.suite) }
+
+    harness.reporter.sampleForTesting(watching: true, listening: false, at: harness.clock.now)
+    await harness.reporter.uploadDirtyRecordsForTesting()
+    XCTAssertEqual(harness.probe.calls.count, 1)
+
+    let relaunchProbe = UploadProbe(shouldFail: false)
+    let relaunched = DesktopUsageDailyReporter(
+      defaults: harness.defaults,
+      now: { harness.clock.now },
+      calendar: harness.calendar,
+      timezone: { harness.calendar.timeZone },
+      deviceID: { "device-1" },
+      ownerID: { "owner-a" },
+      uploadPayload: { try await relaunchProbe.upload($0) })
+    relaunched.assumeAuthorizedForTesting()
+
+    let snapshot = relaunched.snapshotForTesting()
+    let dateKey = try XCTUnwrap(snapshot.dirtyDates.first)
+    XCTAssertNil(relaunched.retryAfterForTesting(dateKey))
+    XCTAssertEqual(relaunched.retryAttemptsForTesting(dateKey), 0)
+    XCTAssertEqual(snapshot.records[dateKey]?.watchingSeconds, 60)
+
+    await relaunched.uploadDirtyRecordsForTesting()
+    XCTAssertEqual(relaunchProbe.calls.count, 1)
+    XCTAssertTrue(relaunched.snapshotForTesting().dirtyDates.isEmpty)
+  }
+
+  private struct UploadHarness {
+    let suite: String
+    let defaults: UserDefaults
+    let calendar: Calendar
+    let clock: TestClock
+    let probe: UploadProbe
+    let reporter: DesktopUsageDailyReporter
+  }
+
+  private func makeUploadHarness(shouldFail: Bool) throws -> UploadHarness {
+    let suite = "DesktopUsageDailyReporterTests.\(UUID().uuidString)"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
+    let clock = TestClock(Date(timeIntervalSince1970: 1_788_230_400))
+    let probe = UploadProbe(shouldFail: shouldFail)
+    let reporter = DesktopUsageDailyReporter(
+      defaults: defaults,
+      now: { clock.now },
+      calendar: calendar,
+      timezone: { calendar.timeZone },
+      deviceID: { "device-1" },
+      ownerID: { "owner-a" },
+      uploadPayload: { try await probe.upload($0) })
+    reporter.assumeAuthorizedForTesting()
+    return UploadHarness(
+      suite: suite,
+      defaults: defaults,
+      calendar: calendar,
+      clock: clock,
+      probe: probe,
+      reporter: reporter)
+  }
+}
+
+private enum TestUploadError: Error {
+  case rejected
+}
+
+private final class TestClock: @unchecked Sendable {
+  var now: Date
+  init(_ now: Date) { self.now = now }
+}
+
+private final class UploadProbe: @unchecked Sendable {
+  private let lock = NSLock()
+  var shouldFail: Bool
+  private var _calls: [DesktopUsageDailyPayload] = []
+
+  init(shouldFail: Bool) {
+    self.shouldFail = shouldFail
+  }
+
+  var calls: [DesktopUsageDailyPayload] {
+    lock.withLock { _calls }
+  }
+
+  func upload(_ payload: DesktopUsageDailyPayload) async throws {
+    lock.withLock { _calls.append(payload) }
+    if shouldFail { throw TestUploadError.rejected }
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260902-desktop-usage-daily-stats.json
+++ b/desktop/macos/changelog/unreleased/20260902-desktop-usage-daily-stats.json
@@ -1,0 +1,3 @@
+{
+  "change": "Daily summaries now include time watched and proactive moments from the Mac app"
+}

--- a/desktop/macos/e2e/flows/account-cutover-gate.yaml
+++ b/desktop/macos/e2e/flows/account-cutover-gate.yaml
@@ -8,6 +8,9 @@ covers:
   - desktop/macos/Desktop/Sources/AccountCutover/AccountCutoverBlockingOverlay.swift
   - desktop/macos/Desktop/Sources/AccountCutover/AccountCutoverControl.swift
   - desktop/macos/Desktop/Sources/AccountCutover/DesktopHomeSignedInStartup.swift
+  # Daily usage starts with admitted product services and POSTs via this client.
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/DesktopUsageDailyReporter.swift
+  - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+DesktopUsage.swift
   - desktop/macos/Desktop/Sources/MainWindow/Tasks/SuggestedTasksStore.swift
   - desktop/macos/Desktop/Sources/Stores/TasksStore.swift
   - desktop/macos/Desktop/Sources/Chat/KernelJournalBackendSyncDriver.swift

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -1517,8 +1517,12 @@ export interface DailySummaryActionItem {
 
 export interface DailySummaryDayStats {
   action_items_count?: number | null;
+  action_items_created?: number | null;
+  memories_created?: number | null;
+  proactive_moments?: number | null;
   total_conversations?: number | null;
   total_duration_minutes?: number | null;
+  watching_minutes?: number | null;
 }
 
 export interface DailySummaryDecisionMade {
@@ -1655,6 +1659,21 @@ export interface DeleteKnowledgeGraphResponse {
 export interface DeleteLimitlessConversationsResponse {
   deleted_count: number;
   message: string;
+}
+
+export interface DesktopDailyUsageRequest {
+  client_device_id: string;
+  date: string;
+  listening_seconds: number;
+  proactive_cards_acted: number;
+  proactive_cards_shown: number;
+  ptt_turns: number;
+  timezone: string;
+  watching_seconds: number;
+}
+
+export interface DesktopDailyUsageResponse {
+  ok: boolean;
 }
 
 export interface DeterministicFacts {
@@ -4959,6 +4978,8 @@ export interface OmiApiSchemas {
   "DeleteImportJobResponse": DeleteImportJobResponse;
   "DeleteKnowledgeGraphResponse": DeleteKnowledgeGraphResponse;
   "DeleteLimitlessConversationsResponse": DeleteLimitlessConversationsResponse;
+  "DesktopDailyUsageRequest": DesktopDailyUsageRequest;
+  "DesktopDailyUsageResponse": DesktopDailyUsageResponse;
   "DeterministicFacts": DeterministicFacts;
   "DevApiKey": DevApiKey;
   "DevApiKeyCreate": DevApiKeyCreate;
@@ -8649,6 +8670,16 @@ export interface OmiApiPaths {
       operationId: "delete_account_v1_users_delete_account_delete";
       responses: {
         "200": UserStatusResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/desktop-usage/daily": {
+    post: {
+      operationId: "record_desktop_daily_usage_v1_users_desktop_usage_daily_post";
+      responses: {
+        "200": DesktopDailyUsageResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -16078,6 +16109,27 @@ export async function delete_account_v1_users_delete_account_delete(header: { au
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function record_desktop_daily_usage_v1_users_desktop_usage_daily_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: DesktopDailyUsageRequest, init?: OmiApiClientInit): Promise<DesktopDailyUsageResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/desktop-usage/daily`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_webhook_endpoint_v1_users_developer_webhook__wtype__get(path: { wtype: WebhookType }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<UserWebhookUrlResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/developer/webhook/${path.wtype}`;
@@ -18344,4 +18396,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 433 client methods generated.
+// Total: 434 client methods generated.

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -9692,6 +9692,39 @@
             ],
             "title": "Action Items Count"
           },
+          "action_items_created": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Items Created"
+          },
+          "memories_created": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memories Created"
+          },
+          "proactive_moments": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Proactive Moments"
+          },
           "total_conversations": {
             "anyOf": [
               {
@@ -9713,6 +9746,17 @@
               }
             ],
             "title": "Total Duration Minutes"
+          },
+          "watching_minutes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Watching Minutes"
           }
         },
         "title": "DailySummaryDayStats",
@@ -10525,6 +10569,79 @@
           "message"
         ],
         "title": "DeleteLimitlessConversationsResponse",
+        "type": "object"
+      },
+      "DesktopDailyUsageRequest": {
+        "properties": {
+          "client_device_id": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Client Device Id",
+            "type": "string"
+          },
+          "date": {
+            "title": "Date",
+            "type": "string"
+          },
+          "listening_seconds": {
+            "maximum": 86400.0,
+            "minimum": 0.0,
+            "title": "Listening Seconds",
+            "type": "integer"
+          },
+          "proactive_cards_acted": {
+            "maximum": 10000.0,
+            "minimum": 0.0,
+            "title": "Proactive Cards Acted",
+            "type": "integer"
+          },
+          "proactive_cards_shown": {
+            "maximum": 10000.0,
+            "minimum": 0.0,
+            "title": "Proactive Cards Shown",
+            "type": "integer"
+          },
+          "ptt_turns": {
+            "maximum": 10000.0,
+            "minimum": 0.0,
+            "title": "Ptt Turns",
+            "type": "integer"
+          },
+          "timezone": {
+            "title": "Timezone",
+            "type": "string"
+          },
+          "watching_seconds": {
+            "maximum": 86400.0,
+            "minimum": 0.0,
+            "title": "Watching Seconds",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "date",
+          "timezone",
+          "client_device_id",
+          "watching_seconds",
+          "listening_seconds",
+          "proactive_cards_shown",
+          "proactive_cards_acted",
+          "ptt_turns"
+        ],
+        "title": "DesktopDailyUsageRequest",
+        "type": "object"
+      },
+      "DesktopDailyUsageResponse": {
+        "properties": {
+          "ok": {
+            "title": "Ok",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok"
+        ],
+        "title": "DesktopDailyUsageResponse",
         "type": "object"
       },
       "DeterministicFacts": {
@@ -56902,6 +57019,93 @@
           }
         ],
         "summary": "Delete Account",
+        "tags": [
+          "v1"
+        ]
+      }
+    },
+    "/v1/users/desktop-usage/daily": {
+      "post": {
+        "operationId": "record_desktop_daily_usage_v1_users_desktop_usage_daily_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Platform",
+            "required": false,
+            "schema": {
+              "title": "X-App-Platform",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Device-Id-Hash",
+            "required": false,
+            "schema": {
+              "title": "X-Device-Id-Hash",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Version",
+            "required": false,
+            "schema": {
+              "title": "X-App-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DesktopDailyUsageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DesktopDailyUsageResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Record Desktop Daily Usage",
         "tags": [
           "v1"
         ]

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -1517,8 +1517,12 @@ export interface DailySummaryActionItem {
 
 export interface DailySummaryDayStats {
   action_items_count?: number | null;
+  action_items_created?: number | null;
+  memories_created?: number | null;
+  proactive_moments?: number | null;
   total_conversations?: number | null;
   total_duration_minutes?: number | null;
+  watching_minutes?: number | null;
 }
 
 export interface DailySummaryDecisionMade {
@@ -1655,6 +1659,21 @@ export interface DeleteKnowledgeGraphResponse {
 export interface DeleteLimitlessConversationsResponse {
   deleted_count: number;
   message: string;
+}
+
+export interface DesktopDailyUsageRequest {
+  client_device_id: string;
+  date: string;
+  listening_seconds: number;
+  proactive_cards_acted: number;
+  proactive_cards_shown: number;
+  ptt_turns: number;
+  timezone: string;
+  watching_seconds: number;
+}
+
+export interface DesktopDailyUsageResponse {
+  ok: boolean;
 }
 
 export interface DeterministicFacts {
@@ -4959,6 +4978,8 @@ export interface OmiApiSchemas {
   "DeleteImportJobResponse": DeleteImportJobResponse;
   "DeleteKnowledgeGraphResponse": DeleteKnowledgeGraphResponse;
   "DeleteLimitlessConversationsResponse": DeleteLimitlessConversationsResponse;
+  "DesktopDailyUsageRequest": DesktopDailyUsageRequest;
+  "DesktopDailyUsageResponse": DesktopDailyUsageResponse;
   "DeterministicFacts": DeterministicFacts;
   "DevApiKey": DevApiKey;
   "DevApiKeyCreate": DevApiKeyCreate;
@@ -8649,6 +8670,16 @@ export interface OmiApiPaths {
       operationId: "delete_account_v1_users_delete_account_delete";
       responses: {
         "200": UserStatusResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/desktop-usage/daily": {
+    post: {
+      operationId: "record_desktop_daily_usage_v1_users_desktop_usage_daily_post";
+      responses: {
+        "200": DesktopDailyUsageResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -16078,6 +16109,27 @@ export async function delete_account_v1_users_delete_account_delete(header: { au
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function record_desktop_daily_usage_v1_users_desktop_usage_daily_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: DesktopDailyUsageRequest, init?: OmiApiClientInit): Promise<DesktopDailyUsageResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/desktop-usage/daily`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_webhook_endpoint_v1_users_developer_webhook__wtype__get(path: { wtype: WebhookType }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<UserWebhookUrlResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/developer/webhook/${path.wtype}`;
@@ -18344,4 +18396,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 433 client methods generated.
+// Total: 434 client methods generated.

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -1517,8 +1517,12 @@ export interface DailySummaryActionItem {
 
 export interface DailySummaryDayStats {
   action_items_count?: number | null;
+  action_items_created?: number | null;
+  memories_created?: number | null;
+  proactive_moments?: number | null;
   total_conversations?: number | null;
   total_duration_minutes?: number | null;
+  watching_minutes?: number | null;
 }
 
 export interface DailySummaryDecisionMade {
@@ -1655,6 +1659,21 @@ export interface DeleteKnowledgeGraphResponse {
 export interface DeleteLimitlessConversationsResponse {
   deleted_count: number;
   message: string;
+}
+
+export interface DesktopDailyUsageRequest {
+  client_device_id: string;
+  date: string;
+  listening_seconds: number;
+  proactive_cards_acted: number;
+  proactive_cards_shown: number;
+  ptt_turns: number;
+  timezone: string;
+  watching_seconds: number;
+}
+
+export interface DesktopDailyUsageResponse {
+  ok: boolean;
 }
 
 export interface DeterministicFacts {
@@ -4959,6 +4978,8 @@ export interface OmiApiSchemas {
   "DeleteImportJobResponse": DeleteImportJobResponse;
   "DeleteKnowledgeGraphResponse": DeleteKnowledgeGraphResponse;
   "DeleteLimitlessConversationsResponse": DeleteLimitlessConversationsResponse;
+  "DesktopDailyUsageRequest": DesktopDailyUsageRequest;
+  "DesktopDailyUsageResponse": DesktopDailyUsageResponse;
   "DeterministicFacts": DeterministicFacts;
   "DevApiKey": DevApiKey;
   "DevApiKeyCreate": DevApiKeyCreate;
@@ -8649,6 +8670,16 @@ export interface OmiApiPaths {
       operationId: "delete_account_v1_users_delete_account_delete";
       responses: {
         "200": UserStatusResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/desktop-usage/daily": {
+    post: {
+      operationId: "record_desktop_daily_usage_v1_users_desktop_usage_daily_post";
+      responses: {
+        "200": DesktopDailyUsageResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -16078,6 +16109,27 @@ export async function delete_account_v1_users_delete_account_delete(header: { au
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function record_desktop_daily_usage_v1_users_desktop_usage_daily_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: DesktopDailyUsageRequest, init?: OmiApiClientInit): Promise<DesktopDailyUsageResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/desktop-usage/daily`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_webhook_endpoint_v1_users_developer_webhook__wtype__get(path: { wtype: WebhookType }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<UserWebhookUrlResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/developer/webhook/${path.wtype}`;
@@ -18344,4 +18396,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 433 client methods generated.
+// Total: 434 client methods generated.

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -1517,8 +1517,12 @@ export interface DailySummaryActionItem {
 
 export interface DailySummaryDayStats {
   action_items_count?: number | null;
+  action_items_created?: number | null;
+  memories_created?: number | null;
+  proactive_moments?: number | null;
   total_conversations?: number | null;
   total_duration_minutes?: number | null;
+  watching_minutes?: number | null;
 }
 
 export interface DailySummaryDecisionMade {
@@ -1655,6 +1659,21 @@ export interface DeleteKnowledgeGraphResponse {
 export interface DeleteLimitlessConversationsResponse {
   deleted_count: number;
   message: string;
+}
+
+export interface DesktopDailyUsageRequest {
+  client_device_id: string;
+  date: string;
+  listening_seconds: number;
+  proactive_cards_acted: number;
+  proactive_cards_shown: number;
+  ptt_turns: number;
+  timezone: string;
+  watching_seconds: number;
+}
+
+export interface DesktopDailyUsageResponse {
+  ok: boolean;
 }
 
 export interface DeterministicFacts {
@@ -4959,6 +4978,8 @@ export interface OmiApiSchemas {
   "DeleteImportJobResponse": DeleteImportJobResponse;
   "DeleteKnowledgeGraphResponse": DeleteKnowledgeGraphResponse;
   "DeleteLimitlessConversationsResponse": DeleteLimitlessConversationsResponse;
+  "DesktopDailyUsageRequest": DesktopDailyUsageRequest;
+  "DesktopDailyUsageResponse": DesktopDailyUsageResponse;
   "DeterministicFacts": DeterministicFacts;
   "DevApiKey": DevApiKey;
   "DevApiKeyCreate": DevApiKeyCreate;
@@ -8649,6 +8670,16 @@ export interface OmiApiPaths {
       operationId: "delete_account_v1_users_delete_account_delete";
       responses: {
         "200": UserStatusResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/desktop-usage/daily": {
+    post: {
+      operationId: "record_desktop_daily_usage_v1_users_desktop_usage_daily_post";
+      responses: {
+        "200": DesktopDailyUsageResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -16078,6 +16109,27 @@ export async function delete_account_v1_users_delete_account_delete(header: { au
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function record_desktop_daily_usage_v1_users_desktop_usage_daily_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: DesktopDailyUsageRequest, init?: OmiApiClientInit): Promise<DesktopDailyUsageResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/desktop-usage/daily`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_webhook_endpoint_v1_users_developer_webhook__wtype__get(path: { wtype: WebhookType }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<UserWebhookUrlResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/developer/webhook/${path.wtype}`;
@@ -18344,4 +18396,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 433 client methods generated.
+// Total: 434 client methods generated.


### PR DESCRIPTION
## Summary

The Mac app already knows how long it watched and listened and how many proactive cards it showed. This change uploads those per-local-day totals and folds them into the daily summary the user already gets, so the summary can say "4h watched, 6 proactive moments" instead of only counting conversations. Mobile and desktop both render the richer stats row.

`POST /v1/users/desktop-usage/daily` is Firebase-authed, rate-limited, and max-merges counters per date + device so reconnects cannot shrink a day. The daily-summary generator adds `memories_created`, `action_items_created`, `watching_minutes`, and `proactive_moments` without changing memory-tier or session-death policy.

The desktop reporter lives under `ProactiveAssistants/Services/` (it is not a first-run/onboarding object) and starts only after the existing signed-in cutover admission. Completed PTT turns are counted at the live kernel-persistence site in `RealtimeHubController+SessionDelegate.swift`, not via the abandoned FirstRun observer.

The development Python backend does not have this endpoint until this lands, so a desktop build pointed at dev gets a 404 and retries with exponential backoff (`2^attempt * 15s`, capped at the 10-minute upload interval) instead of dropping the day's counters. `retryAttempts` / `retryAfter` are in-memory only: they are not written to `UserDefaults` with the accumulator. A relaunch therefore retries any still-dirty day immediately rather than waiting out the previous backoff. That is the path every install hits until this endpoint is deployed.

## Failure class

Failure-Class: none

## Product invariants affected

`scripts/pr-preflight --suggest` named INV-CUTOVER-1, INV-CHAT-1, and INV-MEM-1. INV-AUTH-1 is not path-matched but is addressed because the new request uses the default session-token policy.

- **INV-CUTOVER-1** — `DesktopHomeSignedInStartup` still gates product services on `AccountCutoverControlManager.shared.isProductShellAdmitted`. The reporter starts only after that existing admission; no cutover authority, cohort, or control primitive is added or duplicated.
- **INV-MEM-1** — `backend/database/memories.py` gains `count_memories_created`, a `created_at`/`captured_at` aggregation over canonical `memory_items` unioned with legacy `memories`. Tier vocabulary, default access (short-term + long-term), and visibility filters are unchanged.
- **INV-AUTH-1** — the new route uses `auth.with_rate_limit(auth.get_current_user_uid, 'users:desktop_usage_daily')` (default Firebase session-token policy, `includeBYOK: false` on the desktop client). It never calls `invalidateSession` and never preserves a dead session.
- **INV-CHAT-1** — `FloatingControlBarWindow` and `RealtimeHubController+SessionDelegate` only increment local usage counters around existing notification present/act and kernel-persistence paths. No second transcript store, no extra journal write, no change to kernel apply.

## Verification

- `cd backend && .venv/bin/python -m pytest tests/unit/test_desktop_daily_usage.py tests/unit/test_daily_summary_zero_coordinate_locations.py -v` — **6 passed**
- `cd backend && .venv/bin/python -m pytest tests/unit/test_firestore_query_contract.py tests/unit/test_app_client_dart_generator.py tests/unit/test_app_client_ts_generator.py tests/unit/test_app_client_swift_generator.py -q` — **89 passed**
- `cd backend && scripts/backend-python-format --write <changed py files>` — already formatted
- `cd backend && scripts/openapi_runner.sh scripts/export_openapi.py --surface app-client --write` then `generate_ts_openapi_types.py`, `generate_swift_openapi_types.py`, `generate_dart_models.py --group users`
- `cd backend && scripts/openapi_runner.sh scripts/generate_ts_openapi_types.py --check && ... generate_swift_openapi_types.py --check && ... generate_dart_models.py --group users --check && ... export_openapi.py --surface app-client --check` — **byte-identical / up to date**
- `cd app && flutter pub get && flutter test test/widgets/daily_summary_detail_page_test.dart` — **3 passed** (including the new watching/proactive stats test)
- `cd app && flutter analyze lib/backend/schema/daily_summary.dart lib/pages/settings/daily_summary_detail_page.dart test/widgets/daily_summary_detail_page_test.dart` — **No issues found**
- `cd desktop/macos && xcrun swift build -c debug --package-path Desktop` — **Build complete** (143.99s; Xcode 26.6)
- `cd desktop/macos && xcrun swift test --package-path Desktop --filter DesktopUsageDailyReporterTests` — **7 passed** (including failed-upload retry, backoff, skip already-uploaded days, counters surviving a failed window, and in-memory backoff reset on relaunch)
- `cd desktop/macos && ./scripts/swift-format-wrapper.sh format -i Desktop/Sources/ProactiveAssistants/Services/DesktopUsageDailyReporter.swift Desktop/Tests/DesktopUsageDailyReporterTests.swift` — formatted
- `cd desktop/macos && python3 scripts/check-e2e-flow-coverage.py --strict --base $(git merge-base origin/main HEAD)` — **0 uncovered** (`account-cutover-gate` covers the reporter and `APIClient+DesktopUsage`)
- `cd desktop/macos && python3 scripts/desktop-flow-lint.py` — **OK** (74 flows, 188 registered actions)
- `cd web/admin && npx tsc --noEmit` — **exit 0**

Could not run:

- `desktop/macos/scripts/run-swift-ci.sh` — CI pins Xcode 16.4 at `/Applications/Xcode_16.4.app`; this Mac only has Xcode 26.6 (`/Applications/Xcode.app`). Local `swift build` cannot see the strict-concurrency errors CI rejects.
- Full backend `test.sh` suite — shared venv is missing `langchain_anthropic`; brief said to run the changed files only.
- Live desktop upload against the remote dev Python backend — that host 404s until this endpoint deploys; the reporter keeps the day's counters dirty and retries with in-memory backoff (immediate retry again after relaunch).

## Line-count exceptions

Line-Count-Exception: backend/routers/users.py | 2300 -> 2379 | new desktop daily-usage endpoint and request validators live next to the existing daily-summary routes
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift | 5740 -> 5743 | two usage-reporter call sites on existing notification present/act paths
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift | 1547 -> 1551 | record completed PTT turns at the existing kernel-persistence site

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->