### PR TITLE
test(desktop): prove the PTT reveal press starts its turn

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -88,6 +88,26 @@ struct PTTSilentMicRecoveryPolicy {
 /// The gate deliberately has no timing policy. `PushToTalkManager` supplies the
 /// short hold delay, while this model makes the admission/cancellation contract
 /// deterministic and independently testable.
+/// Routes a shortcut press through the reveal decision. Both PTT entry points call this,
+/// so injecting `reveal`/`start` in a test exercises the shipping ordering rather than a
+/// restatement of it.
+///
+/// The bar used to swallow the very press that revealed it, which cost the start sound,
+/// the listening animation and — a double tap being two presses — locked mode. That bit
+/// every press on a second display, where following the cursor re-places the window so it
+/// is routinely not yet visible.
+enum PushToTalkBarRevealPolicy {
+  /// Reveals the bar when it is hidden, then *always* starts the turn.
+  static func startPress(
+    barVisible: Bool,
+    reveal: () -> Void,
+    start: () -> Void
+  ) {
+    if !barVisible { reveal() }
+    start()
+  }
+}
+
 struct ModifierOnlyPTTActivationGate {
   enum Action: Equatable {
     case scheduleStart
@@ -562,11 +582,15 @@ class PushToTalkManager: ObservableObject {
       return
     }
     lastModifierQuickTapTime = 0
-    if !FloatingControlBarManager.shared.isVisible {
-      FloatingControlBarManager.shared.show()
-    }
-    log("PushToTalkManager: modifier-only double tap — entering locked listening")
-    enterLockedListening()
+    // Same reveal rule as a held press: the lock must happen even when the bar was not
+    // showing on this display yet, or the double tap is lost on a second monitor.
+    PushToTalkBarRevealPolicy.startPress(
+      barVisible: FloatingControlBarManager.shared.isVisible,
+      reveal: { FloatingControlBarManager.shared.show() },
+      start: {
+        log("PushToTalkManager: modifier-only double tap — entering locked listening")
+        self.enterLockedListening()
+      })
   }
 
   private func cancelPendingModifierOnlyShortcutStart() {
@@ -587,18 +611,13 @@ class PushToTalkManager: ObservableObject {
     // Let the first shortcut press reveal the compact bar instead of requiring it
     // to already be visible. This keeps onboarding step 3 quiet on entry while
     // still allowing the user to trigger the bar by pressing the key.
-    if !FloatingControlBarManager.shared.isVisible {
-      FloatingControlBarManager.shared.show()
-    }
-
-    // The press that reveals the bar must still start the turn. Dropping it cost the
-    // user the start sound, the listening animation and — a double tap being two
-    // presses — locked mode, every time the bar had to be revealed first. That happens
-    // routinely on a second display, where following the cursor re-places the window.
-    if !FloatingControlBarManager.shared.isVisible {
-      log("PushToTalkManager: bar not visible after show() — starting the turn anyway")
-    }
-    handleShortcutDown()
+    PushToTalkBarRevealPolicy.startPress(
+      barVisible: FloatingControlBarManager.shared.isVisible,
+      reveal: {
+        FloatingControlBarManager.shared.show()
+        log("PushToTalkManager: revealed the bar for this press — starting the turn")
+      },
+      start: { self.handleShortcutDown() })
   }
 
   private func handleShortcutDown() {

--- a/desktop/macos/Desktop/Tests/PushToTalkShortcutActivationTests.swift
+++ b/desktop/macos/Desktop/Tests/PushToTalkShortcutActivationTests.swift
@@ -65,6 +65,49 @@ final class PushToTalkShortcutActivationTests: XCTestCase {
     XCTAssertEqual(gate.modifierStateChanged(isShortcutActive: false), .releaseStartedTurn)
   }
 
+  // MARK: - Bar reveal must never swallow the press
+
+  /// Records the order of the two effects the shipping handlers pass to the seam.
+  private func recordPress(barVisible: Bool) -> [String] {
+    var calls: [String] = []
+    PushToTalkBarRevealPolicy.startPress(
+      barVisible: barVisible,
+      reveal: { calls.append("reveal") },
+      start: { calls.append("start") })
+    return calls
+  }
+
+  func testHiddenBarPressRevealsTheBarThenStartsTheTurn() {
+    // Regression: `handleKeyShortcutDown` revealed the bar and then returned before
+    // `handleShortcutDown()`, so startListening() never ran — no start sound, no
+    // listening animation. On a second display the bar is re-placed as it follows the
+    // cursor, so it is routinely hidden at press time and every first press was lost.
+    // This fails if the start effect is ever skipped or ordered before the reveal.
+    XCTAssertEqual(recordPress(barVisible: false), ["reveal", "start"])
+  }
+
+  func testVisibleBarPressStartsTheTurnWithoutRevealing() {
+    XCTAssertEqual(recordPress(barVisible: true), ["start"])
+  }
+
+  func testHiddenBarDoubleTapRevealsThenEntersLockedListening() {
+    // The same early return ate the first tap of a double tap, which is why locked mode
+    // did not work on a second display. The gate reports both quick taps regardless of
+    // bar visibility, and the lock site runs through the same seam.
+    var gate = ModifierOnlyPTTActivationGate()
+    for _ in 0..<2 {
+      XCTAssertEqual(gate.modifierStateChanged(isShortcutActive: true), .scheduleStart)
+      XCTAssertEqual(
+        gate.modifierStateChanged(isShortcutActive: false), .cancelPendingStartAsQuickTap)
+    }
+    var calls: [String] = []
+    PushToTalkBarRevealPolicy.startPress(
+      barVisible: false,
+      reveal: { calls.append("reveal") },
+      start: { calls.append("enterLockedListening") })
+    XCTAssertEqual(calls, ["reveal", "enterLockedListening"])
+  }
+
   func testQuickModifierTapNeverStartsOrReleasesPTT() {
     // A quick tap still starts no turn — an accidental brush of the modifier must
     // never record. It is only reported as a quick tap so the double-tap detector


### PR DESCRIPTION
Follow-up to #12646. Replaces a tautological policy (`startsTurn` was hard-coded `true`) with a seam both shipping PTT entry points run through, and asserts the reveal-then-start ordering that the fix depends on.

```
hidden bar press      -> [reveal, start]
visible bar press     -> [start]
hidden bar double tap -> [reveal, enterLockedListening]
```

These fail against the pre-fix code, where the handler returned before `handleShortcutDown()`.

Verification: `swift test --filter PushToTalkShortcutActivationTests` — 11 tests, 0 failures.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

