### PR TITLE
docs(desktop): keep the activation-gate doc comment on its own type

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -80,14 +80,6 @@ struct PTTSilentMicRecoveryPolicy {
   }
 }
 
-/// Modifier-only shortcuts (Option, Fn, etc.) overlap with normal text editing:
-/// Option-arrow navigation and dead-key entry first emit `flagsChanged`, then a
-/// normal key-down. Do not let that first modifier event barge into an active
-/// spoken reply before the accompanying editing key arrives.
-///
-/// The gate deliberately has no timing policy. `PushToTalkManager` supplies the
-/// short hold delay, while this model makes the admission/cancellation contract
-/// deterministic and independently testable.
 /// Routes a shortcut press through the reveal decision. Both PTT entry points call this,
 /// so injecting `reveal`/`start` in a test exercises the shipping ordering rather than a
 /// restatement of it.
@@ -108,6 +100,14 @@ enum PushToTalkBarRevealPolicy {
   }
 }
 
+/// Modifier-only shortcuts (Option, Fn, etc.) overlap with normal text editing:
+/// Option-arrow navigation and dead-key entry first emit `flagsChanged`, then a
+/// normal key-down. Do not let that first modifier event barge into an active
+/// spoken reply before the accompanying editing key arrives.
+///
+/// The gate deliberately has no timing policy. `PushToTalkManager` supplies the
+/// short hold delay, while this model makes the admission/cancellation contract
+/// deterministic and independently testable.
 struct ModifierOnlyPTTActivationGate {
   enum Action: Equatable {
     case scheduleStart


### PR DESCRIPTION
Follow-up to #12646/#12653. The reveal-policy enum had been inserted between `ModifierOnlyPTTActivationGate`'s documentation and the struct itself, so the gate's docs read as the policy's. Each type now carries its own comment.

No behaviour change. `swift test --filter PushToTalkShortcutActivationTests` — 11 tests, 0 failures.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

