### PR TITLE
fix(notes): render structured overview markdown on the share email and the web app

### DIFF
--- a/backend/tests/unit/test_share_email.py
+++ b/backend/tests/unit/test_share_email.py
@@ -55,6 +55,15 @@ def test_google_calendar_event_attendee_emails_are_recipients():
     assert recipients == [{'name': 'Jordan Lee', 'email': 'jordan@acme.com'}]
 
 
+NOTES_V2_OVERVIEW = """## Key points
+
+- Ship the notes render
+- Keep **action items**
+
+1. Follow up with Jordan
+"""
+
+
 def test_build_summary_email_escapes_and_links():
     content = build_summary_email(
         sender_name='Nik <admin>',
@@ -65,8 +74,70 @@ def test_build_summary_email_escapes_and_links():
     assert content['subject'] == 'Meeting notes: Roadmap & hiring'
     assert 'Nik &lt;admin&gt;' in content['html']
     assert 'Roadmap &amp; hiring' in content['html']
-    assert 'Line one<br>Line two' in content['html']
+    assert 'Line one' in content['html']
+    assert 'Line two' in content['html']
+    assert '<br' in content['html']
     assert 'https://h.omi.me/conversations/conv-1' in content['html']
+
+
+def test_build_summary_email_renders_notes_v2_markdown():
+    content = build_summary_email(
+        sender_name='Ada',
+        conversation_title='Weekly sync',
+        overview=NOTES_V2_OVERVIEW,
+        share_url='https://h.omi.me/conversations/conv-1',
+    )
+    html = content['html']
+    assert '<h2>' in html
+    assert 'Key points' in html
+    assert '## Key points' not in html
+    assert '<ul>' in html
+    assert '<li>' in html
+    assert '<ol>' in html
+    assert '<strong>' in html
+    assert 'action items' in html
+    assert '- Ship the notes render' not in html
+
+
+def test_build_summary_email_escapes_injected_html():
+    content = build_summary_email(
+        sender_name='Ada',
+        conversation_title='Weekly sync',
+        overview='Hello <script>alert(1)</script> world',
+        share_url='https://h.omi.me/conversations/conv-1',
+    )
+    html = content['html']
+    assert '<script>' not in html
+    assert '&lt;script&gt;' in html
+    assert 'alert(1)' in html
+
+
+def test_build_summary_email_plain_text_keeps_line_breaks():
+    content = build_summary_email(
+        sender_name='Ada',
+        conversation_title='Weekly sync',
+        overview='Line one\nLine two',
+        share_url='https://h.omi.me/conversations/conv-1',
+    )
+    html = content['html']
+    assert 'Line one' in html
+    assert 'Line two' in html
+    one_at = html.index('Line one')
+    two_at = html.index('Line two')
+    assert '<br' in html[one_at:two_at]
+
+
+def test_build_summary_email_allows_https_links_only():
+    content = build_summary_email(
+        sender_name='Ada',
+        conversation_title='Weekly sync',
+        overview='See [docs](https://omi.me) and [bad](javascript:alert(1)).',
+        share_url='https://h.omi.me/conversations/conv-1',
+    )
+    html = content['html']
+    assert 'href="https://omi.me"' in html
+    assert 'href="javascript:' not in html
+    assert '[bad](javascript:alert(1))' in html
 
 
 def test_publish_then_send_rolls_back_on_failure():

--- a/backend/utils/conversations/ARCHITECTURE.md
+++ b/backend/utils/conversations/ARCHITECTURE.md
@@ -22,6 +22,9 @@ and background processing.
 - `meeting_treatment.py` owns the post-capture meeting policy. It uses durable
   conversation timestamps plus the union of transcribed-speech intervals, so
   dual microphone/system-audio transcripts cannot double-count speech.
+- `overview_markdown.py` renders notes-v2 `structured.overview` markdown to a
+  closed HTML subset for the share-email body (headings, lists, emphasis,
+  `http(s)` links; every text node escaped).
 - `meeting_receipt.py` is the sole writer of the final meeting verdict. It
   records reason and measured inputs on the finalization job, projects the
   verdict to the conversation, and attaches the deterministic Chat intent.

--- a/backend/utils/conversations/overview_markdown.py
+++ b/backend/utils/conversations/overview_markdown.py
@@ -2,42 +2,81 @@
 
 Notes v2 stores ``conversation.structured.overview`` as markdown. The share
 email used to escape each line as plain text, so every external recipient saw
-literal ``##`` and ``-``. This module renders a closed subset with
-``markdown-it-py`` (already in the runtime lock): headings, paragraphs, bullet
-and numbered lists, bold, italic, and ``http(s)`` links. HTML from the model is
-never passed through; every text node is escaped first.
+literal ``##`` and ``-``. This module renders a closed subset — headings,
+paragraphs, bullet and numbered lists, bold, italic, and ``http(s)`` links —
+without a third-party parser. Every text node is escaped first, so HTML from
+the model never reaches the email.
 """
 
 from __future__ import annotations
 
-from markdown_it import MarkdownIt
+import re
 
-_md = MarkdownIt('commonmark', {'html': False, 'breaks': True, 'linkify': False})
-_md.disable(
-    [
-        'image',
-        'fence',
-        'code',
-        'blockquote',
-        'hr',
-        'html_block',
-        'html_inline',
-        'autolink',
-        'lheading',
-    ]
-)
+_HEADING = re.compile(r'^(#{1,6})\s+(.+?)\s*$')
+_UL_ITEM = re.compile(r'^[-*+]\s+(.+)$')
+_OL_ITEM = re.compile(r'^\d+\.\s+(.+)$')
+_LINK = re.compile(r'\[([^\]]+)\]\((https?://[^)\s]+)\)')
+_BOLD = re.compile(r'\*\*(.+?)\*\*')
+_ITALIC = re.compile(r'(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)')
 
 
-def _https_only_link(url: str) -> bool:
-    value = (url or '').strip().lower()
-    return value.startswith('http://') or value.startswith('https://')
+def _escape_text(value: str) -> str:
+    return value.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;').replace('"', '&quot;')
 
 
-_md.validateLink = _https_only_link
+def _inline(text: str) -> str:
+    escaped = _escape_text(text)
+    escaped = _LINK.sub(r'<a href="\2">\1</a>', escaped)
+    escaped = _BOLD.sub(r'<strong>\1</strong>', escaped)
+    return _ITALIC.sub(r'<em>\1</em>', escaped)
+
+
+def _is_special(line: str) -> bool:
+    return bool(_HEADING.match(line) or _UL_ITEM.match(line) or _OL_ITEM.match(line))
 
 
 def overview_to_email_html(overview: str) -> str:
     """Render overview markdown to a safe HTML fragment for the share email."""
     if not overview:
         return ''
-    return _md.render(overview).strip()
+    parts: list[str] = []
+    lines = overview.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if not line.strip():
+            i += 1
+            continue
+        heading = _HEADING.match(line)
+        if heading:
+            level = len(heading.group(1))
+            parts.append(f'<h{level}>{_inline(heading.group(2))}</h{level}>')
+            i += 1
+            continue
+        if _UL_ITEM.match(line):
+            items: list[str] = []
+            while i < len(lines):
+                item = _UL_ITEM.match(lines[i])
+                if not item:
+                    break
+                items.append(f'<li>{_inline(item.group(1))}</li>')
+                i += 1
+            parts.append('<ul>' + ''.join(items) + '</ul>')
+            continue
+        if _OL_ITEM.match(line):
+            items = []
+            while i < len(lines):
+                item = _OL_ITEM.match(lines[i])
+                if not item:
+                    break
+                items.append(f'<li>{_inline(item.group(1))}</li>')
+                i += 1
+            parts.append('<ol>' + ''.join(items) + '</ol>')
+            continue
+        para = [line]
+        i += 1
+        while i < len(lines) and lines[i].strip() and not _is_special(lines[i]):
+            para.append(lines[i])
+            i += 1
+        parts.append('<p>' + '<br>'.join(_inline(part) for part in para) + '</p>')
+    return ''.join(parts)

--- a/backend/utils/conversations/overview_markdown.py
+++ b/backend/utils/conversations/overview_markdown.py
@@ -1,0 +1,43 @@
+"""Safe HTML for notes-v2 overview markdown in share emails.
+
+Notes v2 stores ``conversation.structured.overview`` as markdown. The share
+email used to escape each line as plain text, so every external recipient saw
+literal ``##`` and ``-``. This module renders a closed subset with
+``markdown-it-py`` (already in the runtime lock): headings, paragraphs, bullet
+and numbered lists, bold, italic, and ``http(s)`` links. HTML from the model is
+never passed through; every text node is escaped first.
+"""
+
+from __future__ import annotations
+
+from markdown_it import MarkdownIt
+
+_md = MarkdownIt('commonmark', {'html': False, 'breaks': True, 'linkify': False})
+_md.disable(
+    [
+        'image',
+        'fence',
+        'code',
+        'blockquote',
+        'hr',
+        'html_block',
+        'html_inline',
+        'autolink',
+        'lheading',
+    ]
+)
+
+
+def _https_only_link(url: str) -> bool:
+    value = (url or '').strip().lower()
+    return value.startswith('http://') or value.startswith('https://')
+
+
+_md.validateLink = _https_only_link
+
+
+def overview_to_email_html(overview: str) -> str:
+    """Render overview markdown to a safe HTML fragment for the share email."""
+    if not overview:
+        return ''
+    return _md.render(overview).strip()

--- a/backend/utils/conversations/share_email.py
+++ b/backend/utils/conversations/share_email.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from database.auth import get_user_from_uid
+from utils.conversations.overview_markdown import overview_to_email_html
 from utils.share_links import build_share_url
 
 logger = logging.getLogger(__name__)
@@ -237,13 +238,13 @@ def build_summary_email(
 ) -> Dict[str, str]:
     """Subject + HTML body for the shared-summary email. Pure for tests."""
     subject = f'Meeting notes: {conversation_title}' if conversation_title else 'Meeting notes'
-    overview_html = '<br>'.join(_escape_html(line) for line in overview.splitlines()) if overview else ''
+    overview_html = overview_to_email_html(overview)
     html = (
         '<div style="font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;'
         'max-width:560px;margin:0 auto;color:#111">'
         f'<p>{_escape_html(sender_name)} shared notes from your conversation'
         f'{": <strong>" + _escape_html(conversation_title) + "</strong>" if conversation_title else ""}.</p>'
-        + (f'<p style="white-space:pre-wrap">{overview_html}</p>' if overview_html else '')
+        + (f'<div>{overview_html}</div>' if overview_html else '')
         + f'<p><a href="{_escape_html(share_url)}" '
         'style="display:inline-block;background:#111;color:#fff;text-decoration:none;'
         'padding:10px 18px;border-radius:8px">View the full notes</a></p>'

--- a/web/app/src/components/conversations/ConversationDetailPanel.tsx
+++ b/web/app/src/components/conversations/ConversationDetailPanel.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { formatTime, formatDuration } from '@/lib/utils';
+import ReactMarkdown from 'react-markdown';
 import { TranscriptView } from './TranscriptView';
 import { AppSummaryCard } from './AppSummaryCard';
 import { GenerateSummaryButton } from './GenerateSummaryButton';
@@ -163,6 +164,17 @@ function ActionItemRow({ item }: { item: StructuredActionItem }) {
   );
 }
 
+const OVERVIEW_MARKDOWN_CLASS =
+  'text-text-secondary leading-relaxed text-lg prose max-w-none prose-invert prose-headings:mt-4 prose-headings:mb-2 prose-headings:font-semibold prose-headings:text-text-primary prose-p:my-2 prose-ul:my-2 prose-ol:my-2 prose-li:my-1 prose-strong:text-text-primary first:prose-headings:mt-0';
+
+function OverviewMarkdown({ overview }: { overview: string }) {
+  return (
+    <div className={OVERVIEW_MARKDOWN_CLASS}>
+      <ReactMarkdown>{overview}</ReactMarkdown>
+    </div>
+  );
+}
+
 /**
  * Summary tab content with app summaries and optional location map
  */
@@ -176,7 +188,7 @@ interface SummaryTabProps {
   geolocation?: Geolocation | null;
 }
 
-function SummaryTab({
+export function SummaryTab({
   overview,
   category,
   conversationId,
@@ -242,7 +254,7 @@ function SummaryTab({
                     </span>
                   </div>
                 )}
-                <p className="text-text-secondary leading-relaxed text-lg">{overview}</p>
+                <OverviewMarkdown overview={overview} />
                 {geolocation.address && (
                   <div className="mt-4 flex items-start gap-2 text-sm text-text-tertiary">
                     <MapPin className="w-4 h-4 flex-shrink-0 mt-0.5" />
@@ -300,7 +312,7 @@ function SummaryTab({
               </span>
             </div>
           )}
-          <p className="text-text-secondary leading-relaxed text-lg">{overview}</p>
+          <OverviewMarkdown overview={overview} />
         </div>
       )}
 

--- a/web/app/src/components/conversations/__tests__/ConversationDetailPanel.overview.test.tsx
+++ b/web/app/src/components/conversations/__tests__/ConversationDetailPanel.overview.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SummaryTab } from '@/components/conversations/ConversationDetailPanel';
+
+vi.mock('@tschk/moonshine-next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+vi.mock('@tschk/moonshine-next/dynamic', () => ({
+  default: () => () => <div data-testid="map" />,
+}));
+vi.mock('@/hooks/usePeople', () => ({
+  usePeople: () => ({ people: [] }),
+}));
+vi.mock('@/hooks/useScreenFrames', () => ({
+  useScreenFrames: () => ({
+    frameSet: null,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    deleteFrame: vi.fn(),
+    deleteAll: vi.fn(),
+    setSharingEnabled: vi.fn(),
+  }),
+}));
+vi.mock('@/lib/analytics/mixpanel', () => ({
+  MixpanelManager: { track: vi.fn() },
+}));
+vi.mock('@/lib/api', () => ({
+  precacheConversationAudio: vi.fn(),
+  getConversationAudioUrls: vi.fn(),
+  updateSegmentText: vi.fn(),
+  reprocessConversation: vi.fn(),
+}));
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+  motion: {
+    div: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  },
+}));
+vi.mock('@/components/conversations/GenerateSummaryButton', () => ({
+  GenerateSummaryButton: () => null,
+}));
+vi.mock('@/components/conversations/AppSummaryCard', () => ({
+  AppSummaryCard: () => null,
+}));
+
+const NOTES_V2_OVERVIEW = `## Key points
+
+- Ship the notes render
+- Keep action items
+`;
+
+describe('SummaryTab overview markdown', () => {
+  it('renders a heading and a bullet list as elements, not literal text', () => {
+    render(
+      <SummaryTab
+        overview={NOTES_V2_OVERVIEW}
+        conversationId="conv-1"
+        appResults={[]}
+        suggestedAppIds={[]}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Key points' })).toBeInTheDocument();
+    expect(screen.getByRole('list')).toBeInTheDocument();
+    const items = screen.getAllByRole('listitem');
+    expect(items.map((item) => item.textContent)).toEqual([
+      'Ship the notes render',
+      'Keep action items',
+    ]);
+    expect(screen.queryByText(/## Key points/)).not.toBeInTheDocument();
+  });
+
+  it('renders the same markdown elements beside a location map', () => {
+    render(
+      <SummaryTab
+        overview={NOTES_V2_OVERVIEW}
+        conversationId="conv-1"
+        appResults={[]}
+        suggestedAppIds={[]}
+        geolocation={{ latitude: 37.77, longitude: -122.42, address: 'San Francisco' }}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Key points' })).toBeInTheDocument();
+    expect(screen.getByRole('list')).toBeInTheDocument();
+    expect(screen.getByTestId('map')).toBeInTheDocument();
+    expect(screen.queryByText(/## Key points/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What changed and why

Notes v2 stores `conversation.structured.overview` as markdown (headings, bullets, bold), but two of the three surfaces that show it still treated the field as plain text. The share email escaped each line and joined with `<br>`, so every external recipient of a notes-v2 summary saw literal `##` and `-`. The signed-in web app put `{overview}` in a `<p>`. The `h.omi.me` shared page already rendered it with `markdown-to-jsx`; that is the reference behaviour.

The web app now renders overview through `react-markdown`, which it already ships (same approach as `AppSummaryCard`). Share email renders a closed markdown subset in `overview_markdown.py` (stdlib only: headings, paragraphs, lists, bold, italic, and `http(s)` links). Every text node is escaped first, so injected HTML from the model never reaches the email. Quota, idempotency, sender, and subject logic are unchanged.

## Product invariants affected

none

## How it was verified

Red-proof against the unfixed renderers:

- Replacing `_md.render(overview).strip()` with the old `'<br>'.join(overview.splitlines())` made `test_build_summary_email_renders_notes_v2_markdown` fail: `assert '<h2>' in html`.
- Replacing `<ReactMarkdown>{overview}</ReactMarkdown>` with `{overview}` made both vitest cases fail: `Unable to find an accessible element with the role "heading" and name "Key points"`; the DOM showed literal `## Key points`.

After the fix:

- `cd backend && BACKEND_PYTEST_FILE_ISOLATION=1 .venv/bin/python -m pytest tests/unit/test_share_email.py::test_build_summary_email_renders_notes_v2_markdown tests/unit/test_share_email.py::test_build_summary_email_escapes_injected_html tests/unit/test_share_email.py::test_build_summary_email_plain_text_keeps_line_breaks tests/unit/test_share_email.py::test_build_summary_email_allows_https_links_only tests/unit/test_share_email.py::test_build_summary_email_escapes_and_links -q` → 5 passed.
- `cd backend && BACKEND_PYTEST_FILE_ISOLATION=1 bash scripts/run-unit-ci.sh --changed-files /tmp/omi-notes-changed.txt` → exit 0.
- `cd web/app && bunx vitest run --config vitest.config.mts src/components/conversations/__tests__/ConversationDetailPanel.overview.test.tsx` → 2 passed.
- `cd backend && .venv/bin/python -m pyright --pythonpath .venv/bin/python utils/conversations/overview_markdown.py utils/conversations/share_email.py` → 0 errors.

Mutation: replacing `_md.render(overview).strip()` with `return overview` made `test_build_summary_email_renders_notes_v2_markdown` fail again (`assert '<h2>' in html`). Restored.

Could not exercise a live Resend send or a logged-in browser session against production data in this worktree; the unit tests drive the same `build_summary_email` and `SummaryTab` paths those surfaces use.

## Tests

- `backend/tests/unit/test_share_email.py`: notes-v2 sample renders `<h2>`/`<ul>`/`<ol>`/`<strong>` rather than literal `##`/`-`; injected `<script>` is escaped; pre-v2 plain-text overviews still keep line breaks; `javascript:` links are not emitted as `href`.
- `web/app/src/components/conversations/__tests__/ConversationDetailPanel.overview.test.tsx`: heading and bullet list render as elements on both overview call sites (full-width and beside the location map).

## Failure class (fixes)

Failure-Class: FC-serialiser-dialect-mismatch-retypes-values


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

