### PR TITLE
docs: correct the backend deploy command in AGENTS.md and name the desktop-backend workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ The unit of work is the violated contract, not only the line where the symptom a
 - Make individual commits per feature or testable surface, not per file or unrelated bulk changes.
 - If push fails (remote ahead): `git pull --rebase && git push`.
 - **PR size is reported, not bounded** (`pr-scope` manifest check — advisory annotations, never blocks): 1,500+ changed production-source lines warns; 3,000+ cites the audited history of missed regressions. Split only when the pieces are independently verifiable; otherwise give the one PR proportional review depth.
-- **RELEASE command:** branch from `main`, individual commits, push, open PR, merge without squash, switch back to `main` and pull. **RELEASEWITHBACKEND:** RELEASE + `gh workflow run gcp_backend.yml -f environment=prod -f branch=main`.
+- **RELEASE command:** branch from `main`, individual commits, push, open PR, merge without squash, switch back to `main` and pull. **RELEASEWITHBACKEND:** `gh workflow run gcp_backend.yml -f environment=prod -f release_sha=<SHA>`.
 
 ## Issues
 
@@ -130,7 +130,7 @@ Click at coordinates: `cliclick c:X,Y`. Mac screenshots: `screencapture -x /tmp/
 ## Deploys & Release Pipelines
 
 - Desktop (hourly candidate → signed-smoke Beta → manual Stable): `desktop/macos/AGENTS.md` → Release Pipeline.
-- Backend: `gh workflow run gcp_backend.yml -f environment=prod -f branch=main`. Runtime env contract: `backend/AGENTS.md` → Service Map.
+- Backend: `gcp_backend.yml` is main stack (`environment`, `release_sha`, `release_version`, `mode`, `deploy_targets`; no `branch`). Prod `release_sha` needs first-attempt Release Eligibility. desktop-backend: `desktop_backend_prod.yml` (`release_sha`, confirm `deploy-desktop-backend-prod`, reason).
 - Firmware (Omi CV1): `omi/firmware/AGENTS.md`.
 
 **Every gated surface has a break-glass hatch. A broken gate is never a reason to be stuck.** Each records a tracking issue; repeated use means the gate is the defect.


### PR DESCRIPTION
## What changed and why

`AGENTS.md` documented `gh workflow run gcp_backend.yml -f environment=prod -f branch=main`. There is no `branch` input (the API returns 422). Following that text on 2026-08-18 caused an unintended production deploy of the wrong service.

The real `gcp_backend.yml` `workflow_dispatch` inputs are `environment`, `release_sha`, `release_version`, `mode`, `deploy_targets`, and related hatches. A prod deploy needs a `release_sha` whose Release Eligibility push run succeeded on the first attempt. That workflow deploys only the main backend stack. desktop-backend has its own `desktop_backend_prod.yml`, which requires `release_sha`, typed confirmation `deploy-desktop-backend-prod`, and a reason.

## Product invariants affected

none

## How it was verified

Read `.github/workflows/gcp_backend.yml` `workflow_dispatch` inputs and `.github/workflows/desktop_backend_prod.yml` (`release_sha`, `confirm`, `reason`, `--require-first-attempt`). Confirmed there is no `branch` input. `python3 .github/scripts/check_agents_md_lean.py` → `ok: 10 AGENTS.md files within budget` (root file 152 lines / 18000 bytes).

Did not dispatch either workflow.

## Tests

No test change: this is a docs correction of the operator command in `AGENTS.md`. The workflows already enforce the contract.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

