### PR TITLE
Let the direct-provider inventory see a call reached through an accessor

### DIFF
--- a/backend/docs/llm/model_endpoint_inventory.yaml
+++ b/backend/docs/llm/model_endpoint_inventory.yaml
@@ -119,17 +119,17 @@ surfaces:
     test_guardrail_coverage: backend/tests/unit/test_llm_gateway_client_config.py::test_app_icon_generation_always_uses_gateway
   - surface: file_chat_vision
     code_path: backend/utils/other/chat_file.py:_ask_files_stream
-    current_provider_model: gateway lane omi:auto:file-chat-vision (openai/gpt-5.6-luna); direct OpenAI only when OMI_LLM_GATEWAY_FEATURE_MODE is off
+    current_provider_model: gateway lane omi:auto:file-chat-vision (openai/gpt-5.6-luna); direct OpenAI when OMI_LLM_GATEWAY_FEATURE_MODE is off, and as a degrade when the gateway answers the lane with model-not-found (is_gateway_model_not_found)
     request_shape: streaming vision chat completion (image_url data URIs)
     gateway_lane_capability_needed: generated omi:auto:file-chat-vision lane with image_url content parts
-    migration_status: gateway_routed_file_chat; OpenAI Files upload/download stays direct by design (file bytes/file_id lifecycle, no model tokens) and the completions call hops the gateway in feature mode; BYOK OpenAI is not used (Files file_id namespace is company-owned, so completions stay Omi-paid)
+    migration_status: gateway_routed_file_chat; OpenAI Files upload/download stays direct by design (file bytes/file_id lifecycle, no model tokens) and the completions call hops the gateway in feature mode; the model-not-found degrade calls OpenAI directly, so that request is not recorded in llm_gateway_attempts and carries no lane accounting; BYOK OpenAI is not used (Files file_id namespace is company-owned, so completions stay Omi-paid)
     test_guardrail_coverage: backend/tests/unit/test_chat_file_gateway_surface.py and backend/tests/unit/test_chat_file_completions.py
   - surface: file_chat_completions
     code_path: backend/utils/other/chat_file.py:FileChatTool
-    current_provider_model: gateway lane omi:auto:file-chat-documents (openai/gpt-5.6-luna file parts for PDFs); direct OpenAI only when OMI_LLM_GATEWAY_FEATURE_MODE is off
+    current_provider_model: gateway lane omi:auto:file-chat-documents (openai/gpt-5.6-luna file parts for PDFs); direct OpenAI when OMI_LLM_GATEWAY_FEATURE_MODE is off, and as a degrade when the gateway answers the lane with model-not-found (is_gateway_model_not_found)
     request_shape: file upload purpose=user_data, streaming chat completion file input parts
     gateway_lane_capability_needed: generated omi:auto:file-chat-documents lane with OpenAI file content parts
-    migration_status: gateway_routed_file_chat; Assistants/Threads retired after the 2026-08-26 sunset; OpenAI Files upload/download stays direct by design; BYOK OpenAI is not used (same company-owned file_id namespace as vision)
+    migration_status: gateway_routed_file_chat; Assistants/Threads retired after the 2026-08-26 sunset; OpenAI Files upload/download stays direct by design; the model-not-found degrade calls OpenAI directly, so that request is not recorded in llm_gateway_attempts and carries no lane accounting; BYOK OpenAI is not used (same company-owned file_id namespace as vision)
     test_guardrail_coverage: backend/tests/unit/test_chat_file_gateway_surface.py and backend/tests/unit/test_chat_file_completions.py
   - surface: desktop_gemini_proxy
     code_path: backend/routers/desktop_proxy.py:_proxy_unobserved

--- a/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+++ b/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import textwrap
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -166,6 +167,70 @@ def test_inventory_surfaces_have_status_guardrails_and_resolvable_code_paths():
         assert _inventory_file_exists(surface['code_path']), surface['code_path']
 
 
+_ACCESSOR_PROBE_SOURCE = textwrap.dedent("""
+    import openai
+    from openai import AsyncOpenAI
+
+    _async_openai = None
+
+
+    def _get_async_openai() -> AsyncOpenAI:
+        global _async_openai
+        if _async_openai is None:
+            _async_openai = AsyncOpenAI(timeout=120.0)
+        return _async_openai
+
+
+    def _get_sync_openai():
+        return openai
+
+
+    async def ask():
+        await _get_async_openai().chat.completions.create(model='m', messages=[])
+        _get_sync_openai().files.create(file=None, purpose='assistants')
+    """)
+
+
+def test_direct_provider_scan_sees_through_a_provider_accessor():
+    """A helper that hands back a provider client is not a boundary.
+
+    ``_dotted_name`` drops the receiver when it is a call, so
+    ``_get_async_openai().chat.completions.create(...)`` read as the unowned
+    ``chat.completions.create`` and the scan saw nothing. That is how a real
+    direct-OpenAI fallback in ``utils/other/chat_file.py`` became invisible
+    while its allowlist entry stayed behind as a stale one, which is what
+    this whole test module reports.
+
+    The accessor resolves by return annotation, by returning an imported
+    provider module, or by returning a name bound to a constructor call —
+    all three appear in the probe below.
+
+    red-proof: drop the accessor re-read in ``_direct_provider_uses`` and both
+    assertions fail; the plain dotted-name walk yields no provider symbol.
+    """
+    uses = {use.symbol for use in _direct_provider_uses('probe.py', ast.parse(_ACCESSOR_PROBE_SOURCE))}
+
+    assert 'openai.chat.completions' in uses, 'a lazily constructed client reached through an accessor'
+    assert 'openai.files' in uses, 'the provider module itself returned by an accessor'
+
+
+def test_direct_provider_scan_reports_the_file_chat_direct_fallback():
+    """The live site the accessor blind spot hid.
+
+    ``chat_file.py`` falls back to direct OpenAI when the gateway lane is
+    missing or returns a model-not-found. That call is real, it is
+    allowlisted, and the scan must keep seeing it: an inventory that silently
+    stops detecting a direct provider call is worse than one that never had
+    the entry.
+    """
+    rel = 'utils/other/chat_file.py'
+    tree = ast.parse((BACKEND_DIR / rel).read_text(encoding='utf-8'))
+
+    uses = {use.symbol for use in _direct_provider_uses(rel, tree)}
+
+    assert 'openai.chat.completions' in uses
+
+
 @pytest.mark.slow
 def test_direct_provider_usage_stays_inside_approved_boundaries():
     detected = set()
@@ -255,17 +320,119 @@ def _is_skipped_path(rel: str) -> bool:
 
 def _direct_provider_uses(rel: str, tree: ast.AST) -> set[DirectUse]:
     aliases = _import_aliases(tree)
+    accessors = _provider_accessors(tree, aliases)
     uses: set[DirectUse] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Call):
             call_name = _expanded_name(_dotted_name(node.func), aliases)
             matched = _direct_symbol(call_name)
+            if matched is None:
+                # ``_dotted_name`` drops the receiver when it is a call, so
+                # ``_get_async_openai().chat.completions.create`` reads as the
+                # unowned ``chat.completions.create``. Re-read it with the
+                # accessor resolved to its provider root.
+                through = _expanded_name(_dotted_name_through_accessors(node.func, accessors), aliases)
+                matched = _direct_symbol(through)
             if matched is not None:
                 uses.add(DirectUse(rel, matched))
             env_var = _provider_env_var_from_call(node)
             if env_var is not None:
                 uses.add(DirectUse(rel, env_var))
     return uses
+
+
+# Provider roots reachable through an accessor, derived from the constructor
+# names above so the two cannot drift apart.
+DIRECT_PROVIDER_ROOTS = {name.rsplit('.', 1)[0] for name in DIRECT_CONSTRUCTOR_NAMES}
+
+
+def _provider_root(expanded: str | None) -> str | None:
+    """The provider root a resolved name belongs to, if any."""
+    if not expanded:
+        return None
+    if expanded in DIRECT_PROVIDER_ROOTS:
+        return expanded
+    for constructor in DIRECT_CONSTRUCTOR_NAMES:
+        if expanded == constructor:
+            return constructor.rsplit('.', 1)[0]
+    return None
+
+
+def _module_level_constructor_bindings(tree: ast.AST, aliases: dict[str, str]) -> dict[str, str]:
+    """Module-level names bound to a direct-provider constructor call.
+
+    ``_async_openai = AsyncOpenAI(...)`` anywhere in the module binds that name
+    to the ``openai`` root, including the lazy-singleton form where the
+    assignment lives inside the accessor under ``global``.
+    """
+    bound: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        value = node.value
+        if not isinstance(value, ast.Call):
+            continue
+        root = _provider_root(_expanded_name(_dotted_name(value.func), aliases))
+        if root is None:
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        for target in targets:
+            if isinstance(target, ast.Name):
+                bound[target.id] = root
+    return bound
+
+
+def _provider_accessors(tree: ast.AST, aliases: dict[str, str]) -> dict[str, str]:
+    """Module-level functions that hand back a provider module or SDK client.
+
+    ``_get_sync_openai().chat.completions.create(...)`` is a direct provider
+    call, but the receiver is a ``Call`` node, so a dotted-name walk bottoms
+    out at ``None`` and the scanner sees nothing. Resolving the accessor to
+    its provider root is what makes the indirection visible: a helper is not
+    a boundary.
+
+    An accessor resolves by its return annotation, or by returning an
+    imported provider module, or by returning a name bound to a direct
+    constructor call.
+    """
+    accessors: dict[str, str] = {}
+    bound = _module_level_constructor_bindings(tree, aliases)
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        root = _provider_root(_expanded_name(_dotted_name(node.returns), aliases)) if node.returns else None
+        if root is None:
+            for child in ast.walk(node):
+                if not isinstance(child, ast.Return) or child.value is None:
+                    continue
+                returned = child.value
+                if isinstance(returned, ast.Name) and returned.id in bound:
+                    root = bound[returned.id]
+                    break
+                candidate = _expanded_name(_dotted_name(returned), aliases)
+                root = _provider_root(candidate)
+                if root is None and isinstance(returned, ast.Call):
+                    root = _provider_root(_expanded_name(_dotted_name(returned.func), aliases))
+                if root is not None:
+                    break
+        if root is not None:
+            accessors[node.name] = root
+    return accessors
+
+
+def _dotted_name_through_accessors(node: ast.AST, accessors: dict[str, str]) -> str | None:
+    """``_dotted_name`` that resolves a provider accessor call as its root."""
+    if isinstance(node, ast.Call):
+        callee = _dotted_name(node.func)
+        if callee is not None:
+            return accessors.get(callee.rsplit('.', 1)[-1])
+        return None
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _dotted_name_through_accessors(node.value, accessors)
+        return f'{parent}.{node.attr}' if parent else None
+    return None
 
 
 def _import_aliases(tree: ast.AST) -> dict[str, str]:


### PR DESCRIPTION
## The direct-provider inventory stopped seeing a direct provider call

`backend/tests/unit/test_llm_gateway_coverage_guardrails.py::test_direct_provider_usage_stays_inside_approved_boundaries` fails on `main` today. Not on `violations` — on `stale_allowlist`. The allowlist says `utils/other/chat_file.py` makes direct `openai.chat.completions` calls; the scanner no longer detects them.

The calls are still there. They moved behind accessors:

```python
_async_openai: AsyncOpenAI | None = None

def _get_async_openai() -> AsyncOpenAI: ...
def _get_sync_openai() -> Any: return openai

await _get_async_openai().chat.completions.create(...)   # ~338, ~346
_get_sync_openai().chat.completions.create(...)          # ~390, ~397
```

`_dotted_name` walks an attribute chain and returns `node.attr` when the receiver does not resolve, so `_get_async_openai().chat.completions.create` reads as the unowned `chat.completions.create` and matches no provider prefix. The entry became stale to the scanner while staying true in the code — which is the worst state for an inventory to be in, and why deleting the entry to get a green check would have been the wrong fix.

### What changed

- **`_provider_accessors`** resolves a module-level function to a provider root by any of three signals, all of which appear in `chat_file.py`: the return annotation (`-> AsyncOpenAI`), returning an imported provider module (`return openai`), or returning a name bound to a direct constructor call (the `global _async_openai` lazy singleton). `DIRECT_PROVIDER_ROOTS` is derived from `DIRECT_CONSTRUCTOR_NAMES` so the two cannot drift.
- **`_dotted_name_through_accessors`** re-reads a call chain with the accessor substituted for its root, and returns `None` rather than a bare attribute when the receiver is unresolvable — so it never invents a name.
- **`_direct_provider_uses`** tries the plain walk first and only falls back to the accessor re-read when nothing matched. Existing detections are untouched.
- **The inventory** now records the second direct path. `docs/llm/model_endpoint_inventory.yaml` said direct OpenAI happens "only when `OMI_LLM_GATEWAY_FEATURE_MODE` is off". It also happens on the `is_gateway_model_not_found` degrade with feature mode **on**, and that request is not recorded in `llm_gateway_attempts` and carries no lane accounting. Both file-chat surfaces now say so.

### Scope of the widening, measured

Scanned every file the guardrail scans, with and without the accessor re-read:

```
NEWLY VISIBLE:  utils/other/chat_file.py  openai.chat.completions
lost:           (none)
newly visible NOT in allowlist: (none)
```

One site, already allowlisted. No detection lost, no new violation introduced anywhere in `backend/`.

### Automatic-or-dead check

`test_direct_provider_scan_sees_through_a_provider_accessor` runs the scanner over a synthetic module exercising all three resolution signals, so it stays meaningful if `chat_file.py` changes. `test_direct_provider_scan_reports_the_file_chat_direct_fallback` pins the live site, because an inventory that silently stops detecting a real direct provider call is worse than one that never had the entry.

Red-proofs applied and seen red, then reverted:

| Mutation | Result |
| --- | --- |
| drop the accessor re-read in `_direct_provider_uses` | all three tests red |
| `_provider_accessors` returns an empty map | all three tests red |

11 passed in that file; 27 passed across it plus `test_chat_file_gateway_surface.py` and `test_chat_file_completions.py`.

### Cut list

- Ledgering the model-not-found degrade, or gating it. It is recorded here, not changed: file chat is an allowlisted basic-plan feature, so this is an attribution gap rather than an authorization one, and the fix belongs to whoever owns the degrade's cost story.
- Teaching the scanner to follow accessors across module boundaries. Every case found in `backend/` today is module-local.

### Line-count ratchet

No product source grew. The only non-test change is a documentation line in `docs/llm/model_endpoint_inventory.yaml`.

### Product invariants

- `INV-DATA-1` — no deployment authority, credential or routing change. The scanner is a test; the inventory is documentation.
- `INV-MEM-4` — no memory promotion, admission or Long-term authority path is touched.
- `INV-TASK-2` — no task-capture authority path is touched.

### What this was

A static inventory lost sight of the call its own allowlist describes, because the matcher was a literal attribute chain and ordinary refactoring moved the call behind an accessor. The allowlist entry that stayed behind is what turned a silent coverage loss into a visible failure — the check was right to be red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

