### PR TITLE
fix(backend): let custom-STT users get summaries again

### DIFF
--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -293,10 +293,10 @@ class Conversation(BaseModel):
     language: Optional[str] = None  # applies only to Friend # TODO: once released migrate db to default 'en'
 
     # True when this conversation was transcribed on a third-party (custom STT)
-    # provider, so no Omi transcription credits were consumed. The durable marker
-    # lets post-processing decide whether Omi-paid LLM work (structure, summaries,
-    # memories, action items) should run at all: a custom-STT user without their
-    # own LLM BYOK key must not rack up unbounded Omi LLM cost.
+    # provider, so no Omi transcription credits were consumed. Provenance only:
+    # post-processing does not gate on it — custom-STT conversations get the same
+    # Omi-paid enrichment as any other. The marker keeps custom-STT spend
+    # queryable, and feeds the isolated fair-use lane (#7690).
     uses_custom_stt: bool = False
 
     structured: Structured

--- a/backend/routers/listen/conversations.py
+++ b/backend/routers/listen/conversations.py
@@ -257,10 +257,9 @@ class LiveConversationController:
             if action == RecordingSessionReconnectAction.resume_current:
                 self.host.state.current_conversation_id = conversation_id
                 # Persist the custom-STT marker on resume so a conversation that
-                # started under normal STT but continues under custom STT (or vice
-                # versa) cannot bypass the Omi-paid LLM cost gate: once any session
-                # was custom-STT, the conversation must not run Omi-paid enrichment
-                # without an LLM BYOK key.
+                # started under normal STT but continues under custom STT keeps
+                # accurate provenance: once any session was custom-STT, the
+                # conversation is marked as such.
                 if self.host.use_custom_stt and not existing.get('uses_custom_stt', False):
                     await self.host.persistence.call(
                         conversations_db.update_conversation,

--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -31,7 +31,6 @@ else:
 
 from fastapi.websockets import WebSocketDisconnect
 
-import database.users as users_db
 from models.conversation_photo import ConversationPhoto
 from models.message_event import PhotoDescribedEvent, PhotoProcessingEvent
 from models.transcript_segment import SpeakerIdentityStatus
@@ -39,9 +38,6 @@ from utils.aac import AACDecoder
 from utils.llm.openglass import describe_image
 from utils.request_validation import ImageChunkEnvelope
 from utils.speaker_assignment import update_speaker_assignment_maps
-from utils.subscription import request_has_llm_byok_key
-from utils.executors import db_executor, run_blocking
-from utils.transcribe_decisions import should_skip_custom_stt_postprocessing
 from utils.stt.live_failure import (
     MAX_STT_FAILOVERS,
     flush_live_stt_buffer,
@@ -646,35 +642,12 @@ class ListenReceiver:
     async def _process_photo(self, image_b64: str, temporary_id: str) -> None:
         photo_id = str(uuid.uuid4())
         await self.host.asend_event(PhotoProcessingEvent(temp_id=temporary_id, photo_id=photo_id))
-        # Custom-STT sessions without an active LLM BYOK enrollment + request key
-        # must not incur Omi-paid LLM spend (same discriminator as
-        # process_conversation, #7690). WebSocket BYOK headers are copied into
-        # context in _admit without HTTP middleware validation, so a raw
-        # X-BYOK-* header alone is not enough — require users_db.is_byok_active.
-        # Defer both lookups so Omi-STT sessions never pay for them. Offload the
-        # Firestore enrollment read onto db_executor (async blocker gate).
-        if self.host.use_custom_stt:
-            try:
-                byok_active = await run_blocking(db_executor, users_db.is_byok_active, self.host.request.uid)
-            except Exception as error:
-                logger.warning('Custom-STT photo BYOK enrollment lookup failed type=%s', type(error).__name__)
-                byok_active = False
-            has_llm_byok_key = bool(byok_active and request_has_llm_byok_key())
-            skip_photo_description = should_skip_custom_stt_postprocessing(
-                uses_custom_stt=True,
-                has_llm_byok_key=has_llm_byok_key,
-            )
-        else:
-            skip_photo_description = False
-        if skip_photo_description:
-            description, discarded = 'Custom STT: photo description skipped (no LLM BYOK key).', False
-        else:
-            try:
-                description = await describe_image(self.host.request.uid, image_b64)
-                discarded = not description or not description.strip()
-            except Exception as error:
-                logger.error('Image description failed type=%s', type(error).__name__)
-                description, discarded = 'Could not generate description.', True
+        try:
+            description = await describe_image(self.host.request.uid, image_b64)
+            discarded = not description or not description.strip()
+        except Exception as error:
+            logger.error('Image description failed type=%s', type(error).__name__)
+            description, discarded = 'Could not generate description.', True
         self.host.transcripts.photo_buffer.append(
             ConversationPhoto(id=photo_id, base64=image_b64, description=description, discarded=discarded)
         )

--- a/backend/tests/unit/test_listen_multichannel_mix_buffer_leak.py
+++ b/backend/tests/unit/test_listen_multichannel_mix_buffer_leak.py
@@ -101,9 +101,10 @@ async def _process_photo(recv, image_b64: str = 'ZmFrZS1pbWFnZQ=='):
     await receiver.ListenReceiver._process_photo(recv, image_b64, 'temp-1')
 
 
-def test_custom_stt_photo_skips_omi_description_without_llm_byok_key(monkeypatch):
-    """#7690: a custom-STT session without an LLM BYOK key must not pay for
-    describe_image; the photo is still stored with a placeholder description."""
+def test_custom_stt_photo_runs_description_without_llm_byok_key(monkeypatch):
+    """Regression for #7690's revert: custom-STT sessions were storing photos
+    with a "Custom STT: photo description skipped" placeholder instead of a real
+    description. Descriptions must run regardless of BYOK state."""
     recv = _make_photo_receiver(use_custom_stt=True)
     described = []
 
@@ -112,110 +113,28 @@ def test_custom_stt_photo_skips_omi_description_without_llm_byok_key(monkeypatch
         return 'a description'
 
     monkeypatch.setattr(receiver, 'describe_image', _describe)
-    monkeypatch.setattr(receiver, 'request_has_llm_byok_key', lambda: False)
-    monkeypatch.setattr(receiver.users_db, 'is_byok_active', lambda _uid: False)
 
     asyncio.run(_process_photo(recv))
 
-    assert described == [], 'describe_image ran for a custom-STT session without an LLM BYOK key'
+    assert described, 'describe_image was skipped for a custom-STT session'
     assert len(recv.host.transcripts.photo_buffer) == 1
     photo = recv.host.transcripts.photo_buffer[0]
     assert photo.discarded is False
-    assert 'Custom STT' in photo.description
+    assert photo.description == 'a description'
 
 
-def test_custom_stt_photo_uses_placeholder_when_byok_enrollment_lookup_fails(monkeypatch):
-    """A failed enrollment read must fail closed without dropping the photo."""
+def test_photo_description_failure_stores_a_discarded_placeholder(monkeypatch):
+    """describe_image failures must not drop the photo."""
     recv = _make_photo_receiver(use_custom_stt=True)
-    described = []
 
     async def _describe(_uid, _img):
-        described.append(1)
-        return 'a description'
+        raise RuntimeError('vision unavailable')
 
     monkeypatch.setattr(receiver, 'describe_image', _describe)
-    monkeypatch.setattr(receiver, 'request_has_llm_byok_key', lambda: True)
-
-    def _enrollment_failure(_uid):
-        raise RuntimeError('firestore unavailable')
-
-    monkeypatch.setattr(receiver.users_db, 'is_byok_active', _enrollment_failure)
 
     asyncio.run(_process_photo(recv))
 
-    assert described == []
     assert len(recv.host.transcripts.photo_buffer) == 1
-    assert 'Custom STT' in recv.host.transcripts.photo_buffer[0].description
-
-
-def test_custom_stt_photo_runs_description_with_llm_byok_key(monkeypatch):
-    """A custom-STT user with active BYOK enrollment and an OpenAI/Anthropic
-    request key pays their own bill, so photo descriptions must still run."""
-    recv = _make_photo_receiver(use_custom_stt=True)
-    described = []
-
-    async def _describe(_uid, _img):
-        described.append(1)
-        return 'a description'
-
-    monkeypatch.setattr(receiver, 'describe_image', _describe)
-    monkeypatch.setattr(receiver, 'request_has_llm_byok_key', lambda: True)
-    monkeypatch.setattr(receiver.users_db, 'is_byok_active', lambda _uid: True)
-
-    asyncio.run(_process_photo(recv))
-
-    assert described, 'describe_image was skipped despite an LLM BYOK key'
-    assert recv.host.transcripts.photo_buffer[0].description == 'a description'
-
-
-def test_custom_stt_photo_skips_description_when_byok_header_present_but_inactive(monkeypatch):
-    """WebSocket X-BYOK-* headers are copied into context without enrollment
-    validation. A raw LLM header with inactive BYOK must not escape the gate."""
-    recv = _make_photo_receiver(use_custom_stt=True)
-    described = []
-    active_checks = []
-
-    async def _describe(_uid, _img):
-        described.append(1)
-        return 'a description'
-
-    monkeypatch.setattr(receiver, 'describe_image', _describe)
-    monkeypatch.setattr(receiver, 'request_has_llm_byok_key', lambda: True)
-    monkeypatch.setattr(
-        receiver.users_db,
-        'is_byok_active',
-        lambda uid: active_checks.append(uid) or False,
-    )
-
-    asyncio.run(_process_photo(recv))
-
-    assert active_checks == ['test-uid']
-    assert described == [], 'describe_image ran for inactive BYOK despite a raw LLM header'
-    assert 'Custom STT' in recv.host.transcripts.photo_buffer[0].description
-
-
-def test_omi_stt_photo_always_runs_description(monkeypatch):
-    """Omi-STT sessions are unaffected: descriptions always run, and the BYOK
-    enrollment/key lookups are deferred so the hot path never pays for them."""
-    recv = _make_photo_receiver(use_custom_stt=False)
-    described = []
-    byok_calls = []
-    active_calls = []
-
-    async def _describe(_uid, _img):
-        described.append(1)
-        return 'a description'
-
-    monkeypatch.setattr(receiver, 'describe_image', _describe)
-    monkeypatch.setattr(receiver, 'request_has_llm_byok_key', lambda: byok_calls.append('llm') or True)
-    monkeypatch.setattr(
-        receiver.users_db,
-        'is_byok_active',
-        lambda uid: active_calls.append(uid) or True,
-    )
-
-    asyncio.run(_process_photo(recv))
-
-    assert described, 'describe_image was skipped for an Omi-STT session'
-    assert byok_calls == [], f'BYOK key lookup fired on the Omi-STT photo path: {byok_calls}'
-    assert active_calls == [], f'is_byok_active fired on the Omi-STT photo path: {active_calls}'
+    photo = recv.host.transcripts.photo_buffer[0]
+    assert photo.discarded is True
+    assert photo.description == 'Could not generate description.'

--- a/backend/tests/unit/test_listen_process_pending_shutdown.py
+++ b/backend/tests/unit/test_listen_process_pending_shutdown.py
@@ -268,8 +268,8 @@ class _ResumeController(LiveConversationController):
 
 async def test_resume_persists_custom_stt_marker_when_session_uses_custom_stt():
     """A conversation that started under normal STT but resumes under custom STT
-    must get the durable uses_custom_stt marker, or it could run Omi-paid LLM
-    enrichment without a BYOK key (#7690)."""
+    must get the durable uses_custom_stt marker, or its custom-STT provenance is
+    lost for metering and the fair-use lane (#7690)."""
     host = _ResumeHost(
         existing_conversation={'id': 'conv-1', 'status': 'in_progress', 'discarded': False, 'uses_custom_stt': False},
         use_custom_stt=True,

--- a/backend/tests/unit/test_merge_audio_chunk_copy_failure.py
+++ b/backend/tests/unit/test_merge_audio_chunk_copy_failure.py
@@ -102,9 +102,9 @@ def test_no_chunks_anywhere_returns_empty(monkeypatch):
 
 def test_merge_propagates_custom_stt_marker_from_any_source(monkeypatch):
     """Regression for #7690: a merged conversation must carry `uses_custom_stt=True`
-    when ANY source was custom-STT, so process_conversation keeps the merged row
-    behind the Omi-paid LLM gate. A custom-STT source must not shed the marker by
-    merging with a normal-STT one (default False would bypass the gate)."""
+    when ANY source was custom-STT, so the merged row keeps accurate custom-STT
+    provenance. A custom-STT source must not shed the marker by merging with a
+    normal-STT one (default False would misreport the merged row)."""
     from datetime import datetime, timedelta, timezone
 
     now = datetime.now(timezone.utc)

--- a/backend/tests/unit/test_process_conversation_usage_context.py
+++ b/backend/tests/unit/test_process_conversation_usage_context.py
@@ -1895,9 +1895,11 @@ def test_finalization_survives_an_unavailable_memory_extractor(monkeypatch):
     assert '_save_action_items' in {getattr(call.args[1], '__name__', '') for call in submitted.call_args_list}
 
 
-def test_custom_stt_conversation_without_llm_byok_key_skips_llm_work(monkeypatch):
-    """Regression for #7690: a custom-STT conversation with no LLM BYOK key must
-    not run any Omi-paid LLM post-processing (structure, summaries, memories)."""
+def test_custom_stt_conversation_without_llm_byok_key_runs_llm_work(monkeypatch):
+    """Regression for #7690's revert: custom-STT users transcribe on their own
+    provider, but their conversations must still get Omi summaries. The gate
+    that skipped all LLM post-processing for a custom-STT conversation with no
+    LLM BYOK key left those users with no title, overview, or memories."""
     completed_conversation = Conversation(
         id='conversation-custom-stt',
         created_at=datetime(2026, 7, 21, tzinfo=timezone.utc),
@@ -1917,32 +1919,17 @@ def test_custom_stt_conversation_without_llm_byok_key_skips_llm_work(monkeypatch
     )
     monkeypatch.setattr(process_conversation, '_get_conversation_obj', lambda *a, **k: completed_conversation)
     monkeypatch.setattr(process_conversation, 'trigger_conversation_apps', lambda *a, **k: None)
-    # No LLM BYOK key on this request, so Omi would pay — the gate must fire.
+    monkeypatch.setattr(process_conversation, 'submit_with_context', MagicMock())
+    # No LLM BYOK key: enrichment must run anyway, on Omi's bill.
     monkeypatch.setattr(process_conversation.users_db, 'is_byok_active', lambda _uid: False)
-    monkeypatch.setattr(process_conversation, 'request_has_llm_byok_key', lambda: False)
-    # The completed status must be durably persisted, not left in `processing`.
-    persisted = {}
-    monkeypatch.setattr(
-        process_conversation.lifecycle_service,
-        'persist_processed_conversation',
-        lambda uid, data: persisted.update(uid=uid, status=data.get('status')) or True,
-    )
 
-    result = process_conversation.process_conversation('uid', 'en', completed_conversation)
+    process_conversation.process_conversation('uid', 'en', completed_conversation)
 
-    # The gate returns the conversation with no LLM work, but the completed
-    # status is durably persisted so the record is not stuck in `processing`.
-    assert result is completed_conversation
-    assert structured_calls == [], 'LLM structuring ran for a custom-STT conversation without an LLM key'
-    assert completed_conversation.status == ConversationStatus.completed
-    assert (
-        persisted.get('status') == ConversationStatus.completed
-    ), f'custom-STT skip path did not durably persist the completed status: {persisted}'
+    assert structured_calls, 'LLM structuring was skipped for a custom-STT conversation'
 
 
 def test_custom_stt_conversation_with_llm_byok_key_runs_llm_work(monkeypatch):
-    """A custom-STT user who brings their own LLM key pays their own bill, so
-    Omi-paid enrichment must still run (BYOK escape hatch)."""
+    """A custom-STT user who brings their own LLM key keeps full enrichment."""
     completed_conversation = Conversation(
         id='conversation-custom-stt-byok',
         created_at=datetime(2026, 7, 21, tzinfo=timezone.utc),
@@ -1968,51 +1955,11 @@ def test_custom_stt_conversation_with_llm_byok_key_runs_llm_work(monkeypatch):
     monkeypatch.setattr(process_conversation, '_get_conversation_obj', lambda *a, **k: completed_conversation)
     monkeypatch.setattr(process_conversation, 'trigger_conversation_apps', lambda *a, **k: None)
     monkeypatch.setattr(process_conversation, 'submit_with_context', MagicMock())
-    # The user carries an OpenAI key — enrichment runs on their bill.
     monkeypatch.setattr(process_conversation.users_db, 'is_byok_active', lambda _uid: True)
-    monkeypatch.setattr(process_conversation, 'request_has_llm_byok_key', lambda: True)
 
     process_conversation.process_conversation('uid', 'en', input_conversation)
 
     assert structured_calls, 'LLM structuring was skipped despite an LLM BYOK key'
-
-
-def test_omi_stt_conversation_never_reads_byok_state(monkeypatch):
-    """Regression for #7690: the deferred BYOK lookup must not fire a Firestore
-    read on the ordinary Omi-STT hot path. users_db.is_byok_active is an
-    uncached users/... document read; it must only run for custom-STT
-    conversations, whose gate decision actually depends on it."""
-    completed_conversation = Conversation(
-        id='conversation-omi-stt',
-        created_at=datetime(2026, 7, 21, tzinfo=timezone.utc),
-        started_at=datetime(2026, 7, 21, tzinfo=timezone.utc),
-        finished_at=datetime(2026, 7, 21, 0, 1, tzinfo=timezone.utc),
-        source=ConversationSource.omi,
-        structured=Structured(title='Title', overview='Overview'),
-        transcript_segments=[],
-        status=ConversationStatus.completed,
-        discarded=False,
-        uses_custom_stt=False,
-    )
-
-    structured_calls = []
-    monkeypatch.setattr(
-        process_conversation, '_get_structured', lambda *a, **k: structured_calls.append(1) or (MagicMock(), False)
-    )
-    monkeypatch.setattr(process_conversation, '_get_conversation_obj', lambda *a, **k: completed_conversation)
-    monkeypatch.setattr(process_conversation, 'trigger_conversation_apps', lambda *a, **k: None)
-    byok_calls = []
-    monkeypatch.setattr(
-        process_conversation.users_db,
-        'is_byok_active',
-        lambda _uid: byok_calls.append(_uid) or True,
-    )
-    monkeypatch.setattr(process_conversation, 'request_has_llm_byok_key', lambda: byok_calls.append('llm') or True)
-
-    process_conversation.process_conversation('uid', 'en', completed_conversation)
-
-    assert structured_calls, 'Omi-STT conversation should still run LLM enrichment'
-    assert byok_calls == [], f'BYOK Firestore read fired on the Omi-STT hot path: {byok_calls}'
 
 
 def test_dedup_candidates_exclude_own_and_merge_source_items():

--- a/backend/tests/unit/test_transcribe_decisions.py
+++ b/backend/tests/unit/test_transcribe_decisions.py
@@ -29,7 +29,6 @@ from utils.transcribe_decisions import (
     should_process_on_disconnect,
     should_queue_speaker_embedding,
     should_remove_in_progress_pointer,
-    should_skip_custom_stt_postprocessing,
     should_skip_speaker_detection,
     should_spawn_speaker_match,
     stt_buffer_flush_size,
@@ -174,16 +173,6 @@ def test_speech_profile_and_speaker_id_gates():
         )
         is False
     )
-
-
-def test_custom_stt_postprocessing_skip_gate():
-    # Custom-STT without an LLM BYOK key: skip Omi-paid post-processing.
-    assert should_skip_custom_stt_postprocessing(uses_custom_stt=True, has_llm_byok_key=False) is True
-    # Custom-STT with an LLM BYOK key: the user pays their own bill, allow it.
-    assert should_skip_custom_stt_postprocessing(uses_custom_stt=True, has_llm_byok_key=True) is False
-    # Omi-STT conversations are unaffected by this gate.
-    assert should_skip_custom_stt_postprocessing(uses_custom_stt=False, has_llm_byok_key=False) is False
-    assert should_skip_custom_stt_postprocessing(uses_custom_stt=False, has_llm_byok_key=True) is False
 
 
 def test_conversation_lifecycle_actions():

--- a/backend/utils/conversations/merge_conversations.py
+++ b/backend/utils/conversations/merge_conversations.py
@@ -275,9 +275,9 @@ def perform_merge_async(
         private_cloud_sync_enabled = any(c.get("private_cloud_sync_enabled", False) for c in sorted_convs)
 
         # Custom STT: True if any source was transcribed on a third-party
-        # provider, so the merged conversation stays behind the Omi-paid LLM
-        # post-processing gate (#7690). A custom-STT source must not be able to
-        # shed the marker by merging with a normal-STT one.
+        # provider, so the merged conversation keeps accurate provenance (#7690).
+        # A custom-STT source must not be able to shed the marker by merging with
+        # a normal-STT one.
         uses_custom_stt = any(c.get('uses_custom_stt', False) for c in sorted_convs)
 
         # Discarded: only if ALL are discarded

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -71,8 +71,6 @@ from utils.observability.finalization import FinalizationFailureReason, record_f
 from utils.product_telemetry import emit_product_event
 from utils.task_intelligence.workstream_association import associate_canonical_evidence
 from utils.subscription import is_trial_paywalled, should_defer_desktop_processing
-from utils.subscription import request_has_llm_byok_key
-from utils.transcribe_decisions import should_skip_custom_stt_postprocessing
 from models.other import Person
 from models.structured import Structured  # type: ignore[reportAttributeAccessIssue]  # SDK/fallback export is runtime-complete.
 from utils.notifications import send_important_conversation_message
@@ -2090,50 +2088,6 @@ def process_conversation(
             except Exception:
                 pass
         report_persistence(False)
-        return cast(Conversation, conversation)
-
-    # Custom-STT conversations are transcribed on the user's own provider, so no
-    # Omi transcription credits were consumed. Their LLM post-processing still
-    # runs on Omi's infrastructure; without a cap that is unbounded Omi spend.
-    # Skip the Omi-paid enrichment unless the request carries an LLM BYOK key
-    # (the user then pays their own LLM bill — the same discriminator
-    # enforce_chat_quota uses). Mirrors the trial-paywall gate: keep the
-    # conversation valid and completed, but do no LLM / Pinecone / app work.
-    # The BYOK lookup is deferred until after the custom-STT check so the hot
-    # Omi-STT path never pays for the uncached users/... document read.
-    uses_custom_stt = getattr(conversation, 'uses_custom_stt', False) is True
-    if uses_custom_stt:
-        # Deferred: users_db.is_byok_active does an uncached Firestore read, so
-        # it only runs for custom-STT conversations, not every finalization.
-        has_llm_byok_key = bool(users_db.is_byok_active(uid) and request_has_llm_byok_key())
-    else:
-        has_llm_byok_key = False
-    if uses_custom_stt and should_skip_custom_stt_postprocessing(
-        uses_custom_stt=True,
-        has_llm_byok_key=has_llm_byok_key,
-    ):
-        logger.info(
-            "custom STT: skipping Omi-paid post-processing for uid=%s conv=%s",
-            uid,
-            getattr(conversation, 'id', '?'),
-        )
-        if isinstance(conversation, Conversation):
-            try:
-                conversation.status = ConversationStatus.completed
-                # Durably persist the completed status so the conversation is not
-                # left stuck in `processing` (the finalizer is told nothing more
-                # will be persisted). A fresh listen creation is written through
-                # the completed-lifecycle path; existing conversations go through
-                # the processing-result persist path.
-                if is_initial_creation:
-                    lifecycle_service.create_completed_conversation(uid, conversation.dict(), idempotent=True)
-                else:
-                    lifecycle_service.persist_processed_conversation(uid, conversation.dict())
-                report_persistence(True)
-            except Exception:
-                report_persistence(False)
-        else:
-            report_persistence(False)
         return cast(Conversation, conversation)
 
     # Lazy desktop processing (freemium cost cut): desktop users without a desktop-entitled

--- a/backend/utils/pusher_finalization.py
+++ b/backend/utils/pusher_finalization.py
@@ -46,7 +46,7 @@ async def process_conversation_task(
     """
     if byok_keys:
         # Listen already validated these against enrollment; mark them validated
-        # so process_conversation can reuse request_has_llm_byok_key().
+        # so the LLM/STT clients inside process_conversation route through them.
         set_validated_byok_keys(byok_keys, uid)
 
     async def send_result(result: Dict[str, Any]) -> None:

--- a/backend/utils/transcribe_decisions.py
+++ b/backend/utils/transcribe_decisions.py
@@ -158,18 +158,6 @@ def should_load_speech_profile(*, use_custom_stt: bool, is_multi_channel: bool, 
     return not use_custom_stt and not is_multi_channel and include_speech_profile
 
 
-def should_skip_custom_stt_postprocessing(*, uses_custom_stt: bool, has_llm_byok_key: bool) -> bool:
-    """Whether Omi-paid LLM post-processing must be skipped for a conversation.
-
-    A custom-STT conversation was transcribed on the user's own provider, so no
-    Omi transcription credits were consumed; its LLM enrichment would still run
-    on Omi's infrastructure. Skip it unless the request carries an LLM BYOK key
-    (the user then pays their own LLM bill). Mirrors the BYOK discriminator in
-    enforce_chat_quota.
-    """
-    return uses_custom_stt and not has_llm_byok_key
-
-
 def should_enable_speaker_identification(
     *,
     use_custom_stt: bool,


### PR DESCRIPTION
## What changed and why

Reverts the Omi-paid LLM post-processing gate from #7690 (commit `3c998bf`, PR #10962).

Custom-STT users bring their own STT key. The gate skipped **all** LLM enrichment for
their conversations — title, overview, memories, action items, embeddings, app results —
unless they *also* carried an OpenAI/Anthropic BYOK key on the request. Bringing an STT
key is not a request to lose summaries, and almost nobody carries a second LLM key, so
in practice the cost cap read as "summarization is off" for the entire custom-STT
population. Same story on the live photo path: `_process_photo` stored the literal string
`Custom STT: photo description skipped (no LLM BYOK key).` instead of calling
`describe_image`.

## Removed

- The `process_conversation` gate and its deferred `is_byok_active` lookup.
- The `_process_photo` gate in `routers/listen/receiver.py`.
- `should_skip_custom_stt_postprocessing`, now unreferenced.

## Kept

`Conversation.uses_custom_stt` and its creation / resume / merge plumbing. It is
provenance only now — it keeps custom-STT spend queryable and feeds the isolated
fair-use lane (#10127) — so the API contract and the generated Dart/OpenAPI clients
are unchanged. Comments that described it as a cost gate were corrected to match.

Cost visibility therefore survives the revert; only the enforcement is gone. If a cap
is wanted later it belongs in the fair-use lane that already meters this traffic, keyed
on actual spend rather than on a BYOK key almost no gated user holds.

## Product invariants affected

- INV-MEM-4
- INV-TASK-2

Neither changes behavior here. The diff removes an early return, so custom-STT
conversations now reach exactly the promotion and task-capture paths every other
conversation already takes. No guard test needed updating.

## Failure class (fixes)

Failure-Class: none

The gate did what it was written to do; the policy behind it was wrong for the
population it selected. This is a product-policy revert, not the repair of a violated
code contract, so no class is declared and none is opened.

## Tests

The two gate assertions are inverted into regression tests: a custom-STT conversation
with no LLM BYOK key must run structuring, and a custom-STT photo must reach
`describe_image`. The "hot path never reads BYOK state" deferral tests are dropped
along with the deferral they guarded.

## Verification

`cd backend && pytest tests/unit/<file>.py` (one file at a time):

| File | Result |
|---|---|
| `test_process_conversation_usage_context.py` | 53 passed |
| `test_listen_multichannel_mix_buffer_leak.py` | 5 passed |
| `test_transcribe_decisions.py` | 25 passed |
| `test_listen_process_pending_shutdown.py` | 13 passed |
| `test_merge_audio_chunk_copy_failure.py` | 5 passed |
| `test_shared_conversation_field_exposure.py` | 8 passed |
| `test_byok_security_enrollment.py` | 34 passed |
| `test_new_usage_tracking_gaps.py` | 45 passed |

`make preflight` — all manifest checks pass.

Not exercised against a live custom-STT session: that needs a real third-party STT key
bound to an account. The behavior is covered at the `process_conversation` and
`_process_photo` seams instead.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

