### PR TITLE
fix(desktop): make tagged memory imports provider-independent

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConnectorImportOperations.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConnectorImportOperations.swift
@@ -41,10 +41,14 @@ enum ConnectorImportOperations {
     source: OnboardingMemoryLogSource
   ) -> Outcome {
     switch result {
-    case .imported(let memories, _):
+    case .imported(let memories, let failed, _):
+      let message =
+        failed > 0
+        ? "Imported \(memories.formatted()) memories from \(source.displayName); \(failed.formatted()) couldn't be saved. Import again to retry them."
+        : "Imported \(memories.formatted()) memories from \(source.displayName)."
       return .success(
         SyncResult(sourceCount: nil, memoryCount: memories, newItems: memories),
-        message: "Imported \(memories.formatted()) memories from \(source.displayName)."
+        message: message
       )
     case .noDurableMemories:
       // Not a connect failure — the parse succeeded but produced nothing
@@ -55,8 +59,55 @@ enum ConnectorImportOperations {
           + "Make sure you pasted \(source.displayName)'s full response, then import again.",
         failureClass: .noContent
       )
-    case .failed:
-      return .failure(message: "The import couldn't run. Try again.")
+    case .failed(let failure):
+      return memoryLogFailureOutcome(failure)
+    }
+  }
+
+  private static func memoryLogFailureOutcome(
+    _ failure: OnboardingMemoryLogImportService.ImportFailure
+  ) -> Outcome {
+    switch failure {
+    case .authentication:
+      return .failure(
+        message: "Your session expired. Sign in again, then retry the import.",
+        failureClass: .authentication)
+    case .planRequired:
+      return .failure(
+        message: "Memory extraction isn't available on your current plan.",
+        failureClass: .authorizationDenied)
+    case .rateLimited:
+      return .failure(
+        message: "Too many memory imports are running. Wait a minute, then try again.",
+        failureClass: .rateLimit)
+    case .network:
+      return .failure(
+        message: "Omi couldn't reach the memory service. Check your connection, then try again.",
+        failureClass: .network)
+    case .timeout:
+      return .failure(
+        message: "Memory extraction took too long. Try the import again.",
+        failureClass: .timeout)
+    case .server:
+      return .failure(
+        message: "Omi's memory service is temporarily unavailable. Try again shortly.",
+        failureClass: .invalidResponse)
+    case .invalidResponse:
+      return .failure(
+        message: "Omi couldn't read the extracted memories. Try the import again.",
+        failureClass: .invalidResponse)
+    case .requestRejected:
+      return .failure(
+        message: "The memory service rejected this import. Check the pasted text, then try again.",
+        failureClass: .invalidResponse)
+    case .saveFailed:
+      return .failure(
+        message: "Memories were extracted, but Omi couldn't save them. Check your connection, then try again.",
+        failureClass: .unknown)
+    case .fixtureUnavailable:
+      return .failure(
+        message: "This import test is only available in development builds.",
+        failureClass: .configuration)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingMemoryLogImportService.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingMemoryLogImportService.swift
@@ -55,6 +55,19 @@ enum OnboardingMemoryLogSource: String, CaseIterable, Sendable {
 actor OnboardingMemoryLogImportService {
   static let shared = OnboardingMemoryLogImportService()
 
+  enum ImportFailure: String, Sendable {
+    case authentication = "extract_auth_failed"
+    case planRequired = "extract_plan_required"
+    case rateLimited = "extract_rate_limited"
+    case network = "extract_network_failed"
+    case timeout = "extract_timeout"
+    case server = "extract_backend_5xx"
+    case invalidResponse = "extract_invalid_response"
+    case requestRejected = "extract_backend_4xx"
+    case saveFailed = "save_failed"
+    case fixtureUnavailable = "fixture_unavailable"
+  }
+
   struct ExtractedMemoryLog: Sendable {
     let memories: [String]
     let profileSummary: String
@@ -64,9 +77,9 @@ actor OnboardingMemoryLogImportService {
   /// user can fix by pasting the right content) from "the import itself
   /// broke" (LLM/parse/save failure worth retrying as-is).
   enum ImportOutcome: Sendable {
-    case imported(memories: Int, profileSummary: String)
+    case imported(memories: Int, failed: Int, profileSummary: String)
     case noDurableMemories
-    case failed
+    case failed(ImportFailure)
   }
 
   func importMemoryLog(
@@ -80,9 +93,15 @@ actor OnboardingMemoryLogImportService {
     let extracted: ExtractedMemoryLog
     if let extractedFixture {
       guard AppBuild.isNonProduction else {
-        return .failed
+        return .failed(.fixtureUnavailable)
       }
       extracted = extractedFixture
+    } else if let taggedMemories = Self.extractTaggedMemories(from: trimmed) {
+      // Omi's export prompt asks ChatGPT/Claude to produce one explicitly tagged,
+      // durable memory per line. That output is already the final memory shape, so
+      // importing it locally avoids an unnecessary provider call and keeps the
+      // documented paste flow working during an extraction-service outage.
+      extracted = ExtractedMemoryLog(memories: taggedMemories, profileSummary: "")
     } else {
       do {
         let response = try await APIClient.shared.extractMemoryLog(
@@ -92,8 +111,11 @@ actor OnboardingMemoryLogImportService {
           memories: response.memories,
           profileSummary: response.profile)
       } catch {
-        log("OnboardingMemoryLogImportService: \(source.displayName) import failed: \(error)")
-        return .failed
+        let failure = Self.failure(for: error)
+        log(
+          "OnboardingMemoryLogImportService: \(source.displayName) extraction failed [\(failure.rawValue)]"
+        )
+        return .failed(failure)
       }
     }
 
@@ -134,8 +156,81 @@ actor OnboardingMemoryLogImportService {
     }
 
     guard saveResult.saved > 0 else {
-      return .failed
+      return .failed(.saveFailed)
     }
-    return .imported(memories: saveResult.saved, profileSummary: extracted.profileSummary)
+    return .imported(
+      memories: saveResult.saved,
+      failed: saveResult.failed,
+      profileSummary: extracted.profileSummary)
+  }
+
+  /// Parses the explicit one-memory-per-line format requested by Omi's own
+  /// ChatGPT/Claude export prompt. Returns nil when the paste is unstructured so
+  /// the managed extractor remains the fallback; an empty tagged item is ignored.
+  static func extractTaggedMemories(from rawText: String) -> [String]? {
+    let pattern =
+      #"^\s*(?:(?:[-*•]|\d+[.)])\s+)?\[((?:\d{4}-\d{2}-\d{2})|recent|earlier|long-term|unknown)\]\s*(.+?)\s*$"#
+    guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+      return nil
+    }
+
+    var memories: [String] = []
+    var seen: Set<String> = []
+    for rawLine in rawText.components(separatedBy: .newlines) {
+      let range = NSRange(rawLine.startIndex..<rawLine.endIndex, in: rawLine)
+      guard
+        let match = regex.firstMatch(in: rawLine, range: range),
+        let tagRange = Range(match.range(at: 1), in: rawLine),
+        let contentRange = Range(match.range(at: 2), in: rawLine)
+      else { continue }
+
+      let tag = String(rawLine[tagRange]).lowercased()
+      let content = String(rawLine[contentRange])
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !content.isEmpty else { continue }
+
+      let boundedContent = String(content.prefix(2_000))
+      let memory = tag == "unknown" ? boundedContent : "[\(tag)] \(boundedContent)"
+      let dedupeKey = memory.lowercased().split(whereSeparator: \Character.isWhitespace).joined(
+        separator: " ")
+      guard seen.insert(dedupeKey).inserted else { continue }
+      memories.append(memory)
+      if memories.count == 200 { break }
+    }
+
+    return memories.isEmpty ? nil : memories
+  }
+
+  static func failure(for error: Error) -> ImportFailure {
+    if let authError = error as? AuthError {
+      switch authError {
+      case .timeout: return .timeout
+      default: return .authentication
+      }
+    }
+    if let urlError = error as? URLError {
+      return urlError.code == .timedOut ? .timeout : .network
+    }
+    if let apiError = error as? APIError {
+      switch apiError {
+      case .unauthorized:
+        return .authentication
+      case .httpError(let statusCode, _):
+        switch statusCode {
+        case 401, 403: return .authentication
+        case 402: return .planRequired
+        case 408: return .timeout
+        case 429: return .rateLimited
+        case 500...599: return .server
+        default: return .requestRejected
+        }
+      case .invalidResponse, .decodingError:
+        return .invalidResponse
+      default:
+        return .requestRejected
+      }
+    }
+    if error is DecodingError { return .invalidResponse }
+    return .invalidResponse
   }
 }

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift
@@ -337,9 +337,12 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
 
     let result = await OnboardingMemoryLogImportService.shared.importMemoryLog(
       rawText, source: source)
-    guard case .imported(let memories, let profileSummary) = result else {
-      lastActionError =
-        "Couldn’t extract durable memories from the pasted \(source.displayName) log."
+    guard case .imported(let memories, _, let profileSummary) = result else {
+      if case .failure(let message, failureClass: _) =
+        ConnectorImportOperations.memoryLogOutcome(result, source: source)
+      {
+        lastActionError = message
+      }
       return
     }
 

--- a/desktop/macos/Desktop/Tests/ConnectorImportOperationsTests.swift
+++ b/desktop/macos/Desktop/Tests/ConnectorImportOperationsTests.swift
@@ -67,13 +67,23 @@ final class ConnectorImportOperationsTests: XCTestCase {
 
   func testMemoryLogImportedMapsToSuccessWithCounts() {
     let outcome = ConnectorImportOperations.memoryLogOutcome(
-      .imported(memories: 14, profileSummary: "profile"), source: .claude)
+      .imported(memories: 14, failed: 0, profileSummary: "profile"), source: .claude)
     guard case .success(let result, let message) = outcome else {
       return XCTFail("expected success, got \(outcome)")
     }
     XCTAssertEqual(result.memoryCount, 14)
     XCTAssertEqual(result.newItems, 14)
     XCTAssertEqual(message, "Imported 14 memories from Claude.")
+  }
+
+  func testMemoryLogPartialSaveReportsRetryableCount() {
+    let outcome = ConnectorImportOperations.memoryLogOutcome(
+      .imported(memories: 7, failed: 3, profileSummary: "profile"), source: .chatgpt)
+    guard case .success(let result, let message) = outcome else {
+      return XCTFail("expected success, got \(outcome)")
+    }
+    XCTAssertEqual(result.memoryCount, 7)
+    XCTAssertEqual(message, "Imported 7 memories from ChatGPT; 3 couldn't be saved. Import again to retry them.")
   }
 
   func testMemoryLogNoDurableMemoriesGuidesPasteFix() {
@@ -88,11 +98,12 @@ final class ConnectorImportOperationsTests: XCTestCase {
   }
 
   func testMemoryLogFailedGuidesRetry() {
-    let outcome = ConnectorImportOperations.memoryLogOutcome(.failed, source: .claude)
-    guard case .failure(let message, failureClass: _) = outcome else {
+    let outcome = ConnectorImportOperations.memoryLogOutcome(.failed(.network), source: .claude)
+    guard case .failure(let message, failureClass: let failureClass) = outcome else {
       return XCTFail("expected failure, got \(outcome)")
     }
-    XCTAssertEqual(message, "The import couldn't run. Try again.")
+    XCTAssertEqual(message, "Omi couldn't reach the memory service. Check your connection, then try again.")
+    XCTAssertEqual(failureClass, .network)
   }
 
   func testCompletedXImportWithZeroPostsDoesNotSayStillRunning() {

--- a/desktop/macos/Desktop/Tests/OnboardingMemoryLogImportServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingMemoryLogImportServiceTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class OnboardingMemoryLogImportServiceTests: XCTestCase {
+  func testIssue12442TenLineChatGPTExportParsesWithoutProvider() throws {
+    let input = """
+      [long-term] My name is Dennis Cox.
+      [long-term] Call me Captain Stormy or Dennis.
+      [long-term] I live in Edmonton, Alberta, Canada.
+      [long-term] I am a Canadian Navy veteran.
+      [long-term] I run Stormy Sailors Maker Lab.
+      [long-term] I use Linux, macOS, WordPress, servers, QR systems, and maker technology.
+      [long-term] I value direct communication and honest disagreement.
+      [long-term] I prefer concise answers for simple questions and detailed explanations for complex ones.
+      [long-term] My long-term goal is to live aboard a motor vessel on Canada's west coast.
+      [long-term] The Tactical Pirate is one of my major maker projects.
+      """
+
+    let memories = try XCTUnwrap(
+      OnboardingMemoryLogImportService.extractTaggedMemories(from: input))
+
+    XCTAssertEqual(memories.count, 10)
+    XCTAssertEqual(memories.first, "[long-term] My name is Dennis Cox.")
+    XCTAssertEqual(
+      memories.last,
+      "[long-term] The Tactical Pirate is one of my major maker projects.")
+  }
+
+  func testTaggedParserHandlesExportWrappersBulletsUnknownAndDuplicates() throws {
+    let input = """
+      Here is the export:
+      ```text
+      - [recent] Prefers direct answers.
+      2. [2026-08-30] Started a maker project.
+      * [unknown] Enjoys sailing.
+      [RECENT] Prefers direct answers.
+      ```
+      """
+
+    let memories = try XCTUnwrap(
+      OnboardingMemoryLogImportService.extractTaggedMemories(from: input))
+
+    XCTAssertEqual(
+      memories,
+      [
+        "[recent] Prefers direct answers.",
+        "[2026-08-30] Started a maker project.",
+        "Enjoys sailing.",
+      ])
+  }
+
+  func testUnstructuredPasteFallsBackToManagedExtractor() {
+    XCTAssertNil(
+      OnboardingMemoryLogImportService.extractTaggedMemories(
+        from: "I prefer concise answers and I enjoy sailing."))
+  }
+
+  func testExtractionErrorsMapToBoundedFailureClasses() {
+    XCTAssertEqual(
+      OnboardingMemoryLogImportService.failure(
+        for: APIError.httpError(statusCode: 429, detail: "sensitive detail")),
+      .rateLimited)
+    XCTAssertEqual(
+      OnboardingMemoryLogImportService.failure(
+        for: APIError.httpError(statusCode: 503, detail: "sensitive detail")),
+      .server)
+    XCTAssertEqual(
+      OnboardingMemoryLogImportService.failure(for: URLError(.notConnectedToInternet)),
+      .network)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260903-chatgpt-memory-import.json
+++ b/desktop/macos/changelog/unreleased/20260903-chatgpt-memory-import.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed ChatGPT and Claude tagged memory imports and added actionable failure messages"
+}

--- a/desktop/macos/e2e/flows/connector-import.yaml
+++ b/desktop/macos/e2e/flows/connector-import.yaml
@@ -19,10 +19,8 @@ steps:
       name: memory_log_import_probe
       params:
         source: chatgpt
-        fixture: structured
         text: |
-          # Memory log
-          [[MARKER:connector-import]] hermetic connector import probe
+          [long-term] [[MARKER:connector-import]] hermetic connector import probe
     expect:
       result.detail.outcome: "success"
 


### PR DESCRIPTION
## What changed and why

Fixes the macOS ChatGPT/Claude memory import failure reported in #12442. Omi's export prompt already asks the provider for one durable, explicitly tagged memory per line, but the desktop app sent that final-form output through a second model extraction request; any extraction outage or rejection collapsed into the same generic error.

The importer now parses the documented `[date]`, `[recent]`, `[earlier]`, `[long-term]`, and `[unknown]` line format locally, then sends the resulting artifacts through the existing authenticated batch persistence path. Unstructured paste still uses the managed extractor. Extraction/save failures are classified into bounded categories and shown as actionable messages, and partial saves report the unsaved count.

Closes #12442

## Product invariants affected

- INV-INT-1 — connector imports continue to use the canonical authenticated evidence batch path; only the redundant extraction hop is skipped for already-structured exports.

## How it was verified

- Reproduced the reported input shape with the exact 10-line `[long-term]` sample from #12442; the regression test parses all 10 memories without calling a provider.
- Built and launched the named macOS bundle `com.omi.omi-memory-import` against the offline local auth/backend/Firestore/Typesense stack.
- Ran `connector-import.yaml` through the desktop automation bridge: PASS in 542.72 ms, zero log errors.
- The app made a real `POST /v3/memory-imports/batch`; an independent Firestore emulator query found exactly one active `chatgpt_memory_log` artifact containing `[long-term] [[MARKER:connector-import]] hermetic connector import probe` for the signed-in synthetic user.
- `desktop-core-harness.sh --self-check --skip-backend-contracts`: PASS (74 flows, 188 registered actions).
- `make preflight`: PASS with this PR body.

## Tests

- `./scripts/dev-feedback.py --once swift 'OnboardingMemoryLogImportServiceTests|ConnectorImportOperationsTests|DesktopAutomationSecondaryActionTests'`
  - 54 tests passed, 0 failures on the current `origin/main` head.
- `OnboardingMemoryLogImportServiceTests.testIssue12442TenLineChatGPTExportParsesWithoutProvider` is the issue-specific regression guard.
- Parser coverage includes export wrappers, bullets, numbered items, case normalization, unknown tags, deduplication, unstructured fallback, and bounded network/backend failure classification.
- Outcome mapping coverage includes full success, partial save reporting, empty extraction guidance, and actionable network failure copy.

## Failure class (fixes)

Failure-Class: none

Line-Count-Exception: desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift | 1930 -> 1940 | reuse the shared connector outcome mapper so onboarding reports actionable failures and partial-save counts consistently with the connector surface


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

