### PR TITLE
fix(backend): account-deletion fence reads the data plane the marker is written on

### DIFF
--- a/backend/database/account_cutover.py
+++ b/backend/database/account_cutover.py
@@ -22,7 +22,7 @@ class AccountCutoverConcurrencyError(RuntimeError):
 
 
 def _control_ref(uid: str, *, firestore_client: Any = None):
-    client = firestore_client if firestore_client is not None else _client.get_firestore_client()
+    client = firestore_client if firestore_client is not None else _client.get_data_plane_firestore_client()
     return client.collection('users').document(uid).collection(CONTROL_COLLECTION).document(CONTROL_DOCUMENT)
 
 
@@ -177,7 +177,7 @@ def cas_set_account_cutover_record(
     if record.uid != uid:
         raise ValueError('cutover record uid mismatch')
 
-    client = firestore_client if firestore_client is not None else _client.get_firestore_client()
+    client = firestore_client if firestore_client is not None else _client.get_data_plane_firestore_client()
     doc_ref = _control_ref(uid, firestore_client=client)
     payload = record.persisted_payload()
     lock = getattr(client, 'lock', None)

--- a/backend/database/account_deletion_marker.py
+++ b/backend/database/account_deletion_marker.py
@@ -1,0 +1,64 @@
+"""Single Firestore plane for the account_deletions/{uid} marker.
+
+Writers (the deletion executor) and readers (the auth fence) must resolve the
+same database. The marker is stored on the customer data plane; a compute-plane
+default on desktop-backend is a clean miss that reopens a deleting account.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from database._client import get_data_plane_firestore_client
+from database.account_deletion_policy import normalize_account_deletion_status
+from database.firestore_read_metrics import FirestoreReadOutcome, FirestoreReadSite, record_document_read
+
+ACCOUNT_DELETION_COLLECTION = "account_deletions"
+
+
+def account_deletion_firestore_client(*, firestore_client: Any | None = None) -> Any:
+    """The Firestore client that owns account_deletions/{uid}.
+
+    Injected clients are for tests. Production always pins the data plane so a
+    compute-plane fallback cannot silently miss the marker. If the data plane
+    cannot be resolved, this raises and the auth fence maps that to HTTP 503.
+    """
+    if firestore_client is not None:
+        return firestore_client
+    return get_data_plane_firestore_client()
+
+
+def account_deletion_collection(*, firestore_client: Any | None = None) -> Any:
+    return account_deletion_firestore_client(firestore_client=firestore_client).collection(ACCOUNT_DELETION_COLLECTION)
+
+
+def account_deletion_document(uid: str, *, firestore_client: Any | None = None) -> Any:
+    return account_deletion_collection(firestore_client=firestore_client).document(uid)
+
+
+def get_user_deletion_wipe_status(uid: str, *, firestore_client: Any | None = None) -> str | None:
+    """Return the authoritative deletion lifecycle state for an authenticated UID.
+
+    This intentionally bypasses caches: an accepted deletion must become an
+    access barrier on the very next request, and a cached pre-delete miss would
+    reopen the exact half-deleted-account window this marker closes.
+    """
+    client = account_deletion_firestore_client(firestore_client=firestore_client)
+    snapshot = account_deletion_document(uid, firestore_client=client).get()
+    record_document_read(
+        FirestoreReadSite.USER_DELETION_WIPE_STATUS,
+        FirestoreReadOutcome.HIT if snapshot.exists else FirestoreReadOutcome.MISS,
+    )
+    if not snapshot.exists:
+        return None
+    status = (snapshot.to_dict() or {}).get("wipe_status")
+    return normalize_account_deletion_status(marker_exists=True, raw_status=status)
+
+
+__all__ = [
+    "ACCOUNT_DELETION_COLLECTION",
+    "account_deletion_collection",
+    "account_deletion_document",
+    "account_deletion_firestore_client",
+    "get_user_deletion_wipe_status",
+]

--- a/backend/database/first_open_obligations.py
+++ b/backend/database/first_open_obligations.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
-from database._client import get_firestore_client, run_transactional
+from database._client import get_data_plane_firestore_client, run_transactional
 from database.account_deletion_policy import account_deletion_blocks_access, normalize_account_deletion_status
 from database.firestore_index_registry import FIRST_OPEN_FOLDER_CONVERSATION_COUNT_QUERY
 from database.read_boundary import parse_snapshot_strict
@@ -91,7 +91,7 @@ def _conversation_ref(client: Any, uid: str, conversation_id: str) -> Any:
 
 
 def initialize_first_open_work(uid: str, conversation_id: str, *, firestore_client: Any = None) -> bool:
-    client = firestore_client or get_firestore_client()
+    client = firestore_client or get_data_plane_firestore_client()
     ref = _conversation_ref(client, uid, conversation_id)
 
     @firestore.transactional
@@ -137,7 +137,7 @@ def _live_effect(snapshot: Any, control: Optional[MemoryControlState], token: st
 def first_open_effect_is_authorized(
     uid: str, conversation_id: str, token: str, effect: str, *, firestore_client: Any = None
 ) -> bool:
-    client = firestore_client or get_firestore_client()
+    client = firestore_client or get_data_plane_firestore_client()
     ref = _conversation_ref(client, uid, conversation_id)
 
     @firestore.transactional
@@ -159,7 +159,7 @@ def commit_first_open_conversation_patch(
 ) -> bool:
     if not patch:
         return False
-    client = firestore_client or get_firestore_client()
+    client = firestore_client or get_data_plane_firestore_client()
     ref = _conversation_ref(client, uid, conversation_id)
 
     @firestore.transactional
@@ -185,7 +185,7 @@ def commit_first_open_app_result(
     """Persist an app result and its resumable receipt in one transaction."""
     if not app_id or not patch:
         return False
-    client = firestore_client or get_firestore_client()
+    client = firestore_client or get_data_plane_firestore_client()
     ref = _conversation_ref(client, uid, conversation_id)
 
     @firestore.transactional
@@ -227,7 +227,7 @@ def complete_first_open_effect(
 ) -> bool:
     if effect not in FIRST_OPEN_EFFECTS:
         raise ValueError(f'unknown first-open effect: {effect}')
-    client = firestore_client or get_firestore_client()
+    client = firestore_client or get_data_plane_firestore_client()
     ref = _conversation_ref(client, uid, conversation_id)
 
     @firestore.transactional
@@ -272,7 +272,7 @@ def complete_first_open_effect(
 def commit_first_open_folder_count(
     uid: str, conversation_id: str, token: str, folder_id: str, *, firestore_client: Any = None
 ) -> bool:
-    client = firestore_client or get_firestore_client()
+    client = firestore_client or get_data_plane_firestore_client()
     user = client.collection('users').document(uid)
     query = FIRST_OPEN_FOLDER_CONVERSATION_COUNT_QUERY.build(
         user.collection(CONVERSATIONS_COLLECTION),
@@ -305,7 +305,7 @@ def commit_first_open_app_usage(
     *,
     firestore_client: Any = None,
 ) -> bool:
-    client = firestore_client or get_firestore_client()
+    client = firestore_client or get_data_plane_firestore_client()
     conversation_ref = _conversation_ref(client, uid, conversation_id)
     plugin_ref = client.collection('plugins_data').document(app_id)
     usage_ref = client.collection('plugins').document(app_id).collection('usage_history').document(conversation_id)
@@ -359,7 +359,7 @@ def claim_first_open_work(
     now: Optional[datetime] = None,
     firestore_client: Any = None,
 ) -> Optional[str]:
-    client = firestore_client or get_firestore_client()
+    client = firestore_client or get_data_plane_firestore_client()
     ref = _conversation_ref(client, uid, conversation_id)
     current_time = now or datetime.now(timezone.utc)
     token = str(uuid.uuid4())
@@ -413,7 +413,7 @@ def finish_first_open_work(
     firestore_client: Any = None,
 ) -> bool:
     del succeeded
-    client = firestore_client or get_firestore_client()
+    client = firestore_client or get_data_plane_firestore_client()
     ref = _conversation_ref(client, uid, conversation_id)
 
     @firestore.transactional

--- a/backend/database/goals.py
+++ b/backend/database/goals.py
@@ -39,7 +39,7 @@ TASK_INTELLIGENCE_CONTROL_COLLECTION = 'task_intelligence_control'
 TASK_INTELLIGENCE_CONTROL_DOCUMENT = 'state'
 MUTATION_RECEIPTS_COLLECTION = 'workflow_mutation_receipts'
 # Legacy test/call-site compatibility only; new persistence paths use _get_db().
-db = _client.db
+db = getattr(_client, 'data_plane_db', _client.db)
 
 
 class GoalStoreError(RuntimeError):
@@ -57,8 +57,8 @@ class GoalConflictError(GoalStoreError):
 def _get_db(firestore_client: Any = None) -> Any:
     if firestore_client is not None:
         return firestore_client
-    getter = getattr(_client, 'get_firestore_client', None)
-    return getter() if getter is not None else _client.db
+    getter = getattr(_client, 'get_data_plane_firestore_client', None)
+    return getter() if getter is not None else db
 
 
 def _goal_ref(uid: str, goal_id: str, *, firestore_client: Any = None):

--- a/backend/database/legal_holds.py
+++ b/backend/database/legal_holds.py
@@ -17,7 +17,7 @@ from uuid import uuid4
 
 from google.cloud.firestore_v1 import transactional
 
-from database._client import get_firestore_client
+from database.account_deletion_marker import account_deletion_firestore_client
 from database.account_deletion_policy import account_deletion_blocks_access, normalize_account_deletion_status
 
 LEGAL_HOLDS_COLLECTION = "legal_holds"
@@ -129,7 +129,7 @@ def assert_account_deletion_permitted(uid: str, *, firestore_client: Any | None 
 
     if not uid:
         raise LegalHoldAuthorityUnavailable("account deletion legal-hold lookup requires a uid")
-    client = firestore_client or get_firestore_client()
+    client = account_deletion_firestore_client(firestore_client=firestore_client)
     try:
         snapshot = _document(client, f"{LEGAL_HOLDS_COLLECTION}/{uid}").get()
         _assert_hold_inactive(snapshot)
@@ -182,7 +182,7 @@ def place_legal_hold(
     current = now or datetime.now(timezone.utc)
     if current.tzinfo is None or current.utcoffset() is None:
         raise LegalHoldAuthorityUnavailable("legal-hold placement timestamp must be timezone-aware")
-    client = firestore_client or get_firestore_client()
+    client = account_deletion_firestore_client(firestore_client=firestore_client)
     _place_legal_hold_transaction(client.transaction(), client, uid, issuer, active, current)
 
 
@@ -242,7 +242,7 @@ def acquire_destructive_operation(
     if not uid or not kind.strip() or not token.strip():
         raise LegalHoldAuthorityUnavailable("destructive operation identity is invalid")
     current = now or datetime.now(timezone.utc)
-    client = firestore_client or get_firestore_client()
+    client = account_deletion_firestore_client(firestore_client=firestore_client)
     _acquire_destructive_operation_transaction(client.transaction(), client, uid, kind, token, current)
 
 
@@ -278,7 +278,7 @@ def finish_destructive_operation(
 ) -> None:
     if outcome not in {"failed", "completed"}:
         raise ValueError("destructive operation outcome must be failed or completed")
-    client = firestore_client or get_firestore_client()
+    client = account_deletion_firestore_client(firestore_client=firestore_client)
     _finish_destructive_operation_transaction(
         client.transaction(), client, uid, kind, token, outcome, now or datetime.now(timezone.utc)
     )
@@ -345,7 +345,7 @@ def destructive_operation_gate(
         yield active_token
         return
     token = uuid4().hex
-    client = firestore_client or get_firestore_client()
+    client = account_deletion_firestore_client(firestore_client=firestore_client)
     acquire_destructive_operation(uid, kind=kind, token=token, firestore_client=client)
     reset = _ACTIVE_GATE.set((uid, kind, token))
     try:
@@ -381,7 +381,7 @@ def external_write_fence(uid: str, *, firestore_client: Any | None = None) -> It
 
     if not uid:
         raise LegalHoldAuthorityUnavailable("external write fence requires a uid")
-    client = firestore_client or get_firestore_client()
+    client = account_deletion_firestore_client(firestore_client=firestore_client)
     account_payload = _snapshot_payload(
         _document(client, f"account_deletions/{uid}").get(), label="account deletion authority"
     )

--- a/backend/database/mcp_oauth.py
+++ b/backend/database/mcp_oauth.py
@@ -12,7 +12,7 @@ from urllib.parse import unquote, urlsplit
 
 from google.cloud import firestore
 
-from database._client import db
+from database._client import data_plane_db as db
 from database.account_deletion_policy import account_deletion_blocks_access, normalize_account_deletion_status
 from database.memory_app_key_grants import (
     APP_KEY_MEMORY_GRANT_DOC_ID,

--- a/backend/database/memories.py
+++ b/backend/database/memories.py
@@ -42,8 +42,7 @@ users_collection = 'users'
 def _account_write_gated(function: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(function)
     def wrapped(uid: str, *args: Any, **kwargs: Any) -> Any:
-        database = _get_db(kwargs.get("firestore_client"))
-        with external_write_fence(uid, firestore_client=database):
+        with external_write_fence(uid, firestore_client=kwargs.get("firestore_client")):
             return function(uid, *args, **kwargs)
 
     return wrapped
@@ -52,8 +51,7 @@ def _account_write_gated(function: Callable[..., Any]) -> Callable[..., Any]:
 def _destination_account_write_gated(function: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(function)
     def wrapped(prev_uid: str, new_uid: str, *args: Any, **kwargs: Any) -> Any:
-        database = _get_db(kwargs.get("firestore_client"))
-        with external_write_fence(new_uid, firestore_client=database):
+        with external_write_fence(new_uid, firestore_client=kwargs.get("firestore_client")):
             return function(prev_uid, new_uid, *args, **kwargs)
 
     return wrapped

--- a/backend/database/memory_ledger.py
+++ b/backend/database/memory_ledger.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Dict, List, Optional, TypeVar, cast
 
 from google.cloud.firestore_v1 import transactional  # type: ignore[reportUnknownMemberType]  # firestore SDK stub gap
 
+from database import _client as _client_mod
 from database import projection_repair
 from database.account_deletion_policy import account_deletion_blocks_access, normalize_account_deletion_status
 from database.firestore_transaction_retry import run_with_transaction_contention_retry
@@ -17,7 +18,8 @@ from models.memory_state_head import (
     trusted_memory_state_head_fields_from_control,
     trusted_memory_state_head_fields_from_state,
 )
-from ._client import db
+
+db = getattr(_client_mod, 'data_plane_db', _client_mod.db)
 
 T = TypeVar("T")
 

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -5,14 +5,19 @@ from typing import Any, Literal, Optional, TypedDict
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter, transactional
 from ._client import db, delete_collection_recursive, document_id_from_seed, get_firestore_client
-from database.account_deletion_policy import normalize_account_deletion_status
+from ._client import get_data_plane_firestore_client
+from database.account_deletion_marker import (
+    account_deletion_collection,
+    account_deletion_document,
+    account_deletion_firestore_client,
+    get_user_deletion_wipe_status,
+)
 from database.account_deletion_transitions import (
     adopt_legacy_late_agent_vm_cleanup as _adopt_legacy_late_agent_vm_cleanup_txn,
     mark_wipe_completed as _mark_user_deletion_wipe_completed_txn,
     record_late_agent_vm_cleanup as _record_late_agent_vm_cleanup_txn,
 )
 from database.firestore_cache import CachePolicy, get_or_fetch, invalidate
-from database.firestore_read_metrics import FirestoreReadOutcome, FirestoreReadSite, record_document_read
 from database.person_aliases import rename_person_retaining_aliases
 from database.read_boundary import parse_snapshot_or_none, parse_snapshot_strict
 from database.redis_db import (
@@ -277,7 +282,7 @@ BYOK_HEARTBEAT_TTL_SECONDS = 7 * 24 * 60 * 60  # 7 days
 
 
 def get_byok_state(uid: str, *, firestore_client: Any | None = None) -> dict:
-    user_ref = (firestore_client or db).collection('users').document(uid)
+    user_ref = (firestore_client or get_data_plane_firestore_client()).collection('users').document(uid)
     data = user_ref.get().to_dict() or {}
     return data.get('byok', {})
 
@@ -323,12 +328,13 @@ def _set_byok_active_transaction(transaction, user_ref, fingerprints: dict):
 
 
 def set_byok_active(uid: str, fingerprints: dict):
-    user_ref = db.collection('users').document(uid)
-    _set_byok_active_transaction(db.transaction(), user_ref, fingerprints)
+    client = get_data_plane_firestore_client()
+    user_ref = client.collection('users').document(uid)
+    _set_byok_active_transaction(client.transaction(), user_ref, fingerprints)
 
 
 def clear_byok_active(uid: str):
-    user_ref = db.collection('users').document(uid)
+    user_ref = get_data_plane_firestore_client().collection('users').document(uid)
     user_ref.set(
         {
             'byok': {
@@ -345,7 +351,7 @@ def set_user_deletion_feedback(uid: str, reason: Optional[str], reason_details: 
     # Stored in a top-level collection so it survives the user record being deleted.
     # Use merge=True so a retried delete request does not erase a durable wipe marker
     # (pending/failed/retrying/deleting_auth) already written to the same document.
-    db.collection('account_deletions').document(uid).set(
+    account_deletion_document(uid).set(
         {
             'uid': uid,
             'reason': reason or '',
@@ -354,25 +360,6 @@ def set_user_deletion_feedback(uid: str, reason: Optional[str], reason_details: 
         },
         merge=True,
     )
-
-
-def get_user_deletion_wipe_status(uid: str, *, firestore_client: Any | None = None) -> str | None:
-    """Return the authoritative deletion lifecycle state for an authenticated UID.
-
-    This intentionally bypasses caches: an accepted deletion must become an
-    access barrier on the very next request, and a cached pre-delete miss would
-    reopen the exact half-deleted-account window this marker closes.
-    """
-    client = firestore_client or get_firestore_client()
-    snapshot = client.collection('account_deletions').document(uid).get()
-    record_document_read(
-        FirestoreReadSite.USER_DELETION_WIPE_STATUS,
-        FirestoreReadOutcome.HIT if snapshot.exists else FirestoreReadOutcome.MISS,
-    )
-    if not snapshot.exists:
-        return None
-    status = (snapshot.to_dict() or {}).get('wipe_status')
-    return normalize_account_deletion_status(marker_exists=True, raw_status=status)
 
 
 def mark_user_deletion_wipe_running(uid: str):
@@ -388,7 +375,7 @@ def mark_user_deletion_wipe_running(uid: str):
     ``stale_after`` (default 10 min) and re-enqueued concurrently, leading to
     duplicate work where a later failure overwrites a successful completion.
     """
-    db.collection('account_deletions').document(uid).set(
+    account_deletion_document(uid).set(
         {'wipe_status': 'running', 'wipe_running_at': datetime.now(timezone.utc)},
         merge=True,
     )
@@ -439,8 +426,9 @@ def mark_user_deletion_wipe_intent(uid: str) -> DeletionWipeIntent:
     remains a legacy recovery state and is promoted by a retry or reconciler.
     """
     wipe_job_id = uuid.uuid4().hex
-    doc_ref = db.collection('account_deletions').document(uid)
-    transaction = db.transaction()
+    client = account_deletion_firestore_client()
+    doc_ref = account_deletion_document(uid, firestore_client=client)
+    transaction = client.transaction()
     return _mark_user_deletion_wipe_intent_txn(transaction, doc_ref, wipe_job_id)
 
 
@@ -467,20 +455,23 @@ def _mark_user_deletion_wipe_started_txn(transaction, doc_ref, wipe_job_id: str)
 
 def mark_user_deletion_wipe_started(uid: str, wipe_job_id: str) -> bool:
     """Atomically promote one newly-created wipe intent to queue-pending."""
-    doc_ref = db.collection('account_deletions').document(uid)
-    transaction = db.transaction()
+    client = account_deletion_firestore_client()
+    doc_ref = account_deletion_document(uid, firestore_client=client)
+    transaction = client.transaction()
     return _mark_user_deletion_wipe_started_txn(transaction, doc_ref, wipe_job_id)
 
 
 def mark_user_deletion_wipe_completed(uid: str) -> bool:
     """Complete the wipe only if no provider cleanup remains outstanding."""
-    doc_ref = db.collection('account_deletions').document(uid)
-    return _mark_user_deletion_wipe_completed_txn(db.transaction(), doc_ref)
+    client = account_deletion_firestore_client()
+    return _mark_user_deletion_wipe_completed_txn(
+        client.transaction(), account_deletion_document(uid, firestore_client=client)
+    )
 
 
 def mark_user_deletion_wipe_failed(uid: str):
     """Mark the background data wipe as failed so a reconciliation worker can retry."""
-    db.collection('account_deletions').document(uid).set(
+    account_deletion_document(uid).set(
         {
             'wipe_status': 'failed',
             'wipe_failed_at': datetime.now(timezone.utc),
@@ -497,9 +488,10 @@ def record_late_agent_vm_cleanup(
     expected_instance_id: str | None = None,
 ) -> bool:
     """Persist a late VM only when an admitted deletion owns its cleanup."""
-    doc_ref = db.collection('account_deletions').document(uid)
+    client = account_deletion_firestore_client()
+    doc_ref = account_deletion_document(uid, firestore_client=client)
     return _record_late_agent_vm_cleanup_txn(
-        db.transaction(),
+        client.transaction(),
         doc_ref,
         vm_name,
         zone,
@@ -509,7 +501,7 @@ def record_late_agent_vm_cleanup(
 
 def get_late_agent_vm_cleanup(uid: str) -> dict[str, str] | None:
     """Return a late-created VM that must be retried independently of user data."""
-    snapshot = db.collection('account_deletions').document(uid).get()
+    snapshot = account_deletion_document(uid).get()
     data = snapshot.to_dict() or {}
     pending = data.get('late_agent_vm_cleanup') if snapshot.exists else None
     if not isinstance(pending, dict):
@@ -533,13 +525,14 @@ def get_late_agent_vm_cleanup(uid: str) -> dict[str, str] | None:
 
 def adopt_legacy_late_agent_vm_cleanup(uid: str, vm_name: str, zone: str, expected_instance_id: str) -> bool:
     """CAS-upgrade a pre-instance-ID cleanup record before provider deletion."""
-    doc_ref = db.collection('account_deletions').document(uid)
-    return _adopt_legacy_late_agent_vm_cleanup_txn(db.transaction(), doc_ref, vm_name, zone, expected_instance_id)
+    client = account_deletion_firestore_client()
+    doc_ref = account_deletion_document(uid, firestore_client=client)
+    return _adopt_legacy_late_agent_vm_cleanup_txn(client.transaction(), doc_ref, vm_name, zone, expected_instance_id)
 
 
 def clear_late_agent_vm_cleanup(uid: str, vm_name: str) -> None:
     """Clear a late-VM retry record only after its matching GCE instance is gone."""
-    doc_ref = db.collection('account_deletions').document(uid)
+    doc_ref = account_deletion_document(uid)
     snapshot = doc_ref.get()
     pending = (snapshot.to_dict() or {}).get('late_agent_vm_cleanup') if snapshot.exists else None
     if isinstance(pending, dict) and pending.get('vmName') == vm_name:
@@ -565,14 +558,15 @@ def ensure_deletion_wipe_job_id(uid: str) -> str | None:
     the reconciler claims the state first, then atomically assigns an opaque id
     before it re-enqueues the task.
     """
-    doc_ref = db.collection('account_deletions').document(uid)
-    transaction = db.transaction()
+    client = account_deletion_firestore_client()
+    doc_ref = account_deletion_document(uid, firestore_client=client)
+    transaction = client.transaction()
     return _ensure_deletion_wipe_job_id_txn(transaction, doc_ref, uuid.uuid4().hex)
 
 
 def resolve_deletion_wipe_job_id(wipe_job_id: str) -> DeletionWipeTaskResolution:
     """Resolve an opaque task id to one canonical deletion job document."""
-    docs = list(db.collection('account_deletions').where('wipe_job_id', '==', wipe_job_id).limit(2).stream())
+    docs = list(account_deletion_collection().where('wipe_job_id', '==', wipe_job_id).limit(2).stream())
     if not docs:
         return {'outcome': 'missing', 'uid': None}
     if len(docs) != 1:
@@ -595,7 +589,7 @@ def resolve_legacy_deletion_wipe_uid(legacy_uid: str) -> DeletionWipeTaskResolut
     It must name a still-actionable canonical deletion record, and the handler
     uses the document id returned here rather than the payload value.
     """
-    doc = db.collection('account_deletions').document(legacy_uid).get()
+    doc = account_deletion_document(legacy_uid).get()
     if not doc.exists:
         return {'outcome': 'missing', 'uid': None}
     status = (doc.to_dict() or {}).get('wipe_status')
@@ -633,8 +627,9 @@ def mark_user_deletion_billing_failed(uid: str, subscription_id: str | None, err
     Never clobbers an actionable or terminal wipe state. A billing failure can
     only block deletion before a destructive wipe has been queued or started.
     """
-    doc_ref = db.collection('account_deletions').document(uid)
-    transaction = db.transaction()
+    client = account_deletion_firestore_client()
+    doc_ref = account_deletion_document(uid, firestore_client=client)
+    transaction = client.transaction()
     return _mark_user_deletion_billing_failed_txn(transaction, doc_ref, uid, subscription_id, error)
 
 
@@ -645,7 +640,7 @@ def cancel_user_deletion_wipe(uid: str):
     persisted. Without this, the reconciliation worker would later wipe the
     user's data even though their Firebase account still exists.
     """
-    db.collection('account_deletions').document(uid).set(
+    account_deletion_document(uid).set(
         {'wipe_status': 'cancelled', 'wipe_cancelled_at': datetime.now(timezone.utc)},
         merge=True,
     )
@@ -698,7 +693,7 @@ def get_pending_deletion_wipes(
     # entirely of records still inside their backoff window and starve one that is ready.
     now = datetime.now(timezone.utc)
     result: list[dict] = []
-    failed_docs = db.collection('account_deletions').where('wipe_status', '==', 'failed').stream()
+    failed_docs = account_deletion_collection().where('wipe_status', '==', 'failed').stream()
     for doc in failed_docs:
         if len(result) >= limit:
             break
@@ -716,7 +711,7 @@ def get_pending_deletion_wipes(
         # first page of fresh pending docs, leaving them permanently unqueued.
         # The ``account_deletions`` collection only holds deletion events so
         # the full scan is bounded.
-        pending_docs = db.collection('account_deletions').where('wipe_status', '==', 'pending').stream()
+        pending_docs = account_deletion_collection().where('wipe_status', '==', 'pending').stream()
         for doc in pending_docs:
             if len(result) >= limit:
                 break
@@ -732,7 +727,7 @@ def get_pending_deletion_wipes(
         # behind other cleanup jobs) can take several minutes; we only want to
         # reclaim a ``running`` marker when the worker has almost certainly
         # crashed or the pod was killed mid-execution.
-        running_docs = db.collection('account_deletions').where('wipe_status', '==', 'running').stream()
+        running_docs = account_deletion_collection().where('wipe_status', '==', 'running').stream()
         for doc in running_docs:
             if len(result) >= limit:
                 break
@@ -747,7 +742,7 @@ def get_pending_deletion_wipes(
         # 'pending') usually means a crash/deploy after auth.delete_account()
         # succeeded. The reconciler verifies the Firebase user is gone before
         # recovering these — see reconcile_pending_deletion_wipes.
-        deleting_auth_docs = db.collection('account_deletions').where('wipe_status', '==', 'deleting_auth').stream()
+        deleting_auth_docs = account_deletion_collection().where('wipe_status', '==', 'deleting_auth').stream()
         for doc in deleting_auth_docs:
             if len(result) >= limit:
                 break
@@ -757,7 +752,7 @@ def get_pending_deletion_wipes(
                 result.append(data | {'uid': doc.id})
 
     if len(result) < limit:
-        retrying_docs = db.collection('account_deletions').where('wipe_status', '==', 'retrying').stream()
+        retrying_docs = account_deletion_collection().where('wipe_status', '==', 'retrying').stream()
         for doc in retrying_docs:
             if len(result) >= limit:
                 break
@@ -851,8 +846,9 @@ def claim_deletion_wipe(
     another worker already owns a non-stale claim. This prevents the same wipe
     from being re-enqueued concurrently by multiple workers or scheduler runs.
     """
-    doc_ref = db.collection('account_deletions').document(uid)
-    transaction = db.transaction()
+    client = account_deletion_firestore_client()
+    doc_ref = account_deletion_document(uid, firestore_client=client)
+    transaction = client.transaction()
     return _claim_deletion_wipe_txn(transaction, doc_ref, stale_after, running_stale_after)
 
 
@@ -895,8 +891,9 @@ def claim_deletion_wipe_for_task(uid: str, running_stale_after: timedelta = DELE
     Returns one of: ``claimed``, ``running``, ``completed``, ``missing``, or
     ``not_actionable``. Only ``claimed`` callers may run the destructive wipe.
     """
-    doc_ref = db.collection('account_deletions').document(uid)
-    transaction = db.transaction()
+    client = account_deletion_firestore_client()
+    doc_ref = account_deletion_document(uid, firestore_client=client)
+    transaction = client.transaction()
     return _claim_deletion_wipe_task_txn(transaction, doc_ref, running_stale_after)
 
 
@@ -2204,7 +2201,7 @@ def update_notification_settings(uid: str, enabled: bool = None, frequency: int 
 
 def _get_raw_assistant_settings(uid: str) -> dict:
     """Read only the assistant_settings sub-map (without update_channel injection)."""
-    user_ref = db.collection('users').document(uid)
+    user_ref = get_data_plane_firestore_client().collection('users').document(uid)
     doc = user_ref.get()
     if not doc.exists:
         return {}
@@ -2217,7 +2214,7 @@ def get_assistant_settings(uid: str) -> dict:
     Injects top-level ``update_channel`` into the response dict (it lives
     outside ``assistant_settings`` in Firestore but the API returns it together).
     """
-    user_ref = db.collection('users').document(uid)
+    user_ref = get_data_plane_firestore_client().collection('users').document(uid)
     doc = user_ref.get()
     if not doc.exists:
         return {}
@@ -2249,7 +2246,7 @@ def update_assistant_settings(uid: str, settings: dict) -> dict:
         else:
             existing[section] = values
 
-    user_ref = db.collection('users').document(uid)
+    user_ref = get_data_plane_firestore_client().collection('users').document(uid)
     updates = {'assistant_settings': existing}
     if update_channel is not None:
         updates['update_channel'] = update_channel

--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Dict, List, Optional, TypedDict, TypeVar, cast
 from pinecone import Pinecone
 
 from database import projection_repair
-from database._client import db as default_db_client
+from database._client import data_plane_db as default_db_client
 from database.legal_holds import external_write_fence
 from database.memory_vector_metadata import (
     build_archive_memory_vector_filter,

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -76,7 +76,7 @@ def _historical_memory_ids(uid: str) -> list[str]:
 def _delete_memory_maintenance_registry(uid: str) -> None:
     """Remove the content-free global inventory marker during account wipe."""
 
-    delete_canonical_memory_maintenance_registry_entry(uid, db_client=database_client.db)
+    delete_canonical_memory_maintenance_registry_entry(uid, db_client=database_client.get_data_plane_firestore_client())
 
 
 def delete_account_credentials(uid: str) -> None:
@@ -213,7 +213,9 @@ def purge_derived_user_data(uid: str) -> PurgeResult:
         logger.error(f'delete_account purge frame request pixels failed for {uid}: {sanitize(str(e))}')
 
     try:
-        canonical_result = purge_canonical_derived_user_data(uid)
+        canonical_result = purge_canonical_derived_user_data(
+            uid, db_client=database_client.get_data_plane_firestore_client()
+        )
         vector_ids = canonical_result.get('vector_ids', [])
         if isinstance(vector_ids, list):
             result['vectors_deleted'] += len(cast(list[object], vector_ids))
@@ -304,7 +306,6 @@ def background_wipe_user_data(uid: str, retry_count: int = 0, terminal: bool = F
             uid,
             kind='account_deletion',
             token=deletion_gate_token,
-            firestore_client=database_client.db,
         )
         deletion_gate_acquired = True
         # Transition to ``running`` so the reconciler can distinguish a
@@ -356,7 +357,6 @@ def background_wipe_user_data(uid: str, retry_count: int = 0, terminal: bool = F
                     kind='account_deletion',
                     token=deletion_gate_token,
                     outcome='failed',
-                    firestore_client=database_client.db,
                 )
             except Exception as gate_err:
                 # An uncertain running gate intentionally remains fail-closed;
@@ -397,7 +397,6 @@ def background_wipe_user_data(uid: str, retry_count: int = 0, terminal: bool = F
                 kind='account_deletion',
                 token=deletion_gate_token,
                 outcome='completed',
-                firestore_client=database_client.db,
             )
         except Exception as e:
             logger.error(f'delete_account legal-hold gate completion failed for {uid}: {sanitize(str(e))}')

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -1516,7 +1516,10 @@ def test_purge_derived_user_data_continues_after_each_failure(monkeypatch):
     account_deletion.delete_action_item_vectors_batch.assert_called_once_with('uid1', ['a1'])
     account_deletion.delete_screen_activity_vectors.assert_called_once_with('uid1', ['s1'])
     account_deletion.delete_all_conversation_recordings.assert_called_once_with('uid1')
-    account_deletion.purge_canonical_derived_user_data.assert_called_once_with('uid1')
+    account_deletion.purge_canonical_derived_user_data.assert_called_once()
+    purge_args, purge_kwargs = account_deletion.purge_canonical_derived_user_data.call_args
+    assert purge_args == ('uid1',)
+    assert 'db_client' in purge_kwargs
     assert [failure['operation'] for failure in result['required_failures']] == [
         'conversation_vectors',
         'transcript_chunk_vectors',

--- a/backend/tests/unit/test_account_deletion_auth_fence.py
+++ b/backend/tests/unit/test_account_deletion_auth_fence.py
@@ -80,3 +80,91 @@ def test_deletion_status_reads_the_injected_firestore_client():
 
     assert users.get_user_deletion_wipe_status("old-uid", firestore_client=client) == "running"
     client.collection.assert_called_once_with("account_deletions")
+
+
+class _PlaneSnapshot:
+    def __init__(self, payload):
+        self.exists = payload is not None
+        self._payload = payload or {}
+
+    def to_dict(self):
+        return dict(self._payload)
+
+
+class _PlaneDocument:
+    def __init__(self, docs, path):
+        self._docs = docs
+        self._path = path
+
+    def get(self):
+        return _PlaneSnapshot(self._docs.get(self._path))
+
+
+class _PlaneCollection:
+    def __init__(self, docs, name):
+        self._docs = docs
+        self._name = name
+
+    def document(self, uid):
+        return _PlaneDocument(self._docs, f"{self._name}/{uid}")
+
+
+class _PlaneClient:
+    """Minimal Firestore stand-in that only serves collection/document/get."""
+
+    def __init__(self, docs):
+        self._docs = docs
+
+    def collection(self, name):
+        return _PlaneCollection(self._docs, name)
+
+
+def test_auth_fence_refuses_when_the_deletion_marker_is_only_on_the_data_plane(monkeypatch):
+    """The Beta serving plane's compute Firestore is empty; the marker lives on the data plane.
+
+    A clean miss on the compute plane must not reopen access. This is the
+    2026-08-30 adversarial finding: get_user_deletion_wipe_status fell back to
+    get_firestore_client(), every caller passed no client, and 503 only fired
+    on an exception.
+    """
+    compute_plane = _PlaneClient({})
+    data_plane = _PlaneClient({"account_deletions/old-uid": {"wipe_status": "running"}})
+
+    monkeypatch.setattr(users, "get_firestore_client", lambda: compute_plane)
+    monkeypatch.setattr(users, "get_data_plane_firestore_client", lambda: data_plane, raising=False)
+    monkeypatch.setattr("database._client.get_firestore_client", lambda: compute_plane)
+    monkeypatch.setattr("database._client.get_data_plane_firestore_client", lambda: data_plane)
+    monkeypatch.setattr(
+        "database.account_deletion_marker.get_data_plane_firestore_client", lambda: data_plane, raising=False
+    )
+    monkeypatch.setattr("database.account_deletion_marker.get_firestore_client", lambda: compute_plane, raising=False)
+
+    with pytest.raises(HTTPException) as error:
+        endpoints.enforce_account_deletion_http_access("old-uid")
+
+    assert error.value.status_code == 403
+    assert error.value.detail == {
+        "code": "account_deletion_in_progress",
+        "status": "running",
+        "retryable": False,
+    }
+
+
+def test_auth_fence_fails_closed_when_the_data_plane_client_cannot_be_resolved(monkeypatch):
+    compute_plane = _PlaneClient({})
+
+    def unresolved():
+        raise RuntimeError("OMI_FIRESTORE_DATA_PLANE_PROJECT is required on desktop-backend")
+
+    monkeypatch.setattr(users, "get_firestore_client", lambda: compute_plane)
+    monkeypatch.setattr(users, "get_data_plane_firestore_client", unresolved, raising=False)
+    monkeypatch.setattr("database._client.get_firestore_client", lambda: compute_plane)
+    monkeypatch.setattr("database._client.get_data_plane_firestore_client", unresolved)
+    monkeypatch.setattr("database.account_deletion_marker.get_data_plane_firestore_client", unresolved, raising=False)
+    monkeypatch.setattr("database.account_deletion_marker.get_firestore_client", lambda: compute_plane, raising=False)
+
+    with pytest.raises(HTTPException) as error:
+        endpoints.enforce_account_deletion_http_access("old-uid")
+
+    assert error.value.status_code == 503
+    assert error.value.detail == {"code": "account_deletion_state_unavailable", "retryable": True}

--- a/backend/tests/unit/test_claim_deletion_wipe_txn.py
+++ b/backend/tests/unit/test_claim_deletion_wipe_txn.py
@@ -46,6 +46,8 @@ setattr(_fake_client_mod, 'db', MagicMock())
 setattr(_fake_client_mod, 'delete_collection_recursive', MagicMock())
 setattr(_fake_client_mod, 'document_id_from_seed', MagicMock())
 setattr(_fake_client_mod, 'get_firestore_client', MagicMock())
+setattr(_fake_client_mod, 'get_data_plane_firestore_client', MagicMock())
+setattr(_fake_client_mod, 'data_plane_db', getattr(_fake_client_mod, 'db'))
 _install_stub('database._client', _fake_client_mod)
 
 # Stub database.firestore_cache and database.redis_db since database/users.py
@@ -517,7 +519,7 @@ def test_get_pending_deletion_wipes_finds_stale_after_fresh_window():
     fake_db = types.SimpleNamespace()
     fake_db.collection = lambda name: fake_collection
 
-    with patch.object(users_db, 'db', fake_db):
+    with patch.object(users_db, 'account_deletion_collection', lambda **_kwargs: fake_collection):
         result = users_db.get_pending_deletion_wipes(limit=100, stale_after=stale_after)
 
     uids = [r['uid'] for r in result]
@@ -547,7 +549,7 @@ def test_get_pending_deletion_wipes_respects_limit_with_over_fetch():
     fake_db = types.SimpleNamespace()
     fake_db.collection = lambda name: fake_collection
 
-    with patch.object(users_db, 'db', fake_db):
+    with patch.object(users_db, 'account_deletion_collection', lambda **_kwargs: fake_collection):
         result = users_db.get_pending_deletion_wipes(limit=2, stale_after=stale_after)
 
     uids = {r['uid'] for r in result}
@@ -579,7 +581,7 @@ def test_get_pending_deletion_wipes_includes_stale_running():
     fake_db = types.SimpleNamespace()
     fake_db.collection = lambda name: fake_collection
 
-    with patch.object(users_db, 'db', fake_db):
+    with patch.object(users_db, 'account_deletion_collection', lambda **_kwargs: fake_collection):
         result = users_db.get_pending_deletion_wipes(limit=100)
 
     uids = [r['uid'] for r in result]

--- a/backend/tests/unit/test_conversation_archive_filter_contract.py
+++ b/backend/tests/unit/test_conversation_archive_filter_contract.py
@@ -151,8 +151,10 @@ def conversations_db():
 
     database_client = ModuleType("database._client")
     database_client.db = firestore
+    database_client.data_plane_db = firestore
     database_client.delete_collection_recursive = MagicMock()
     database_client.get_firestore_client = MagicMock()
+    database_client.get_data_plane_firestore_client = lambda: firestore
     database_client.run_transactional = MagicMock()
     firestore_read_metrics = ModuleType("database.firestore_read_metrics")
     firestore_read_metrics.FirestoreReadOutcome = SimpleNamespace(HIT="hit", MISS="miss")

--- a/backend/tests/unit/test_deletion_wipe_retry_backoff.py
+++ b/backend/tests/unit/test_deletion_wipe_retry_backoff.py
@@ -58,9 +58,8 @@ class _Collection:
 
 def _patch_db(monkeypatch, by_status=None, doc_ref=None):
     collection = _Collection(by_status or {}, doc_ref or MagicMock())
-    fake = MagicMock()
-    fake.collection.return_value = collection
-    monkeypatch.setattr(users, 'db', fake)
+    monkeypatch.setattr(users, 'account_deletion_collection', lambda **_kwargs: collection)
+    monkeypatch.setattr(users, 'account_deletion_document', lambda uid, **_kwargs: collection.document(uid))
 
 
 def _failed(uid, *, minutes_ago, attempts=None):

--- a/backend/tests/unit/test_desktop_screen_crisp.py
+++ b/backend/tests/unit/test_desktop_screen_crisp.py
@@ -296,10 +296,11 @@ def test_the_entitlement_gate_fails_open(monkeypatch):
     import utils.subscription as subscription
 
     subscription.clear_cloud_screen_vector_entitlement_cache("uid-under-test")
+    monkeypatch.setattr(subscription, "get_customer_firestore_client", lambda: object())
     monkeypatch.setattr(
         subscription.users_db,
         "get_user_valid_subscription",
-        lambda uid: (_ for _ in ()).throw(RuntimeError("firestore unavailable")),
+        lambda uid, **_kwargs: (_ for _ in ()).throw(RuntimeError("firestore unavailable")),
     )
 
     assert subscription.grants_cloud_screen_vectors("uid-under-test") is True

--- a/backend/tests/unit/test_firestore_read_site_attribution.py
+++ b/backend/tests/unit/test_firestore_read_site_attribution.py
@@ -6,7 +6,7 @@ must survive the `@prepare_for_read` / `@with_photos` decorator chain and land o
 right outcome (hit/miss) with the right count, without changing what the helpers
 return. Also covers the `record_document_read` primitive itself (hit vs miss labeling,
 and that an internal failure never propagates) and the uncached account-deletion fence
-in `database/users.py`.
+in `database/account_deletion_marker.py`.
 """
 
 from __future__ import annotations
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional
 
 import database.conversations as conversations_db
 import database.users as users_db
+from database import account_deletion_marker as deletion_marker
 from database.firestore_read_metrics import FirestoreReadOutcome, FirestoreReadSite
 
 # ---------------------------------------------------------------------------
@@ -277,7 +278,7 @@ def test_batch_helper_return_value_is_unaffected_by_read_site(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# database/users.py: get_user_deletion_wipe_status — the uncached deletion
+# database/account_deletion_marker.py: get_user_deletion_wipe_status — the uncached deletion
 # fence. Instrumentation must not touch its caching/behaviour.
 # ---------------------------------------------------------------------------
 
@@ -317,7 +318,7 @@ class _DeletionClient:
 
 
 def test_user_deletion_wipe_status_hit_records_hit_and_keeps_behaviour(monkeypatch):
-    recorded = _spy_record_document_read(monkeypatch, users_db)
+    recorded = _spy_record_document_read(monkeypatch, deletion_marker)
     client = _DeletionClient(_DeletionSnapshot(exists=True, data={'wipe_status': 'running'}))
 
     status = users_db.get_user_deletion_wipe_status('uid-1', firestore_client=client)
@@ -327,7 +328,7 @@ def test_user_deletion_wipe_status_hit_records_hit_and_keeps_behaviour(monkeypat
 
 
 def test_user_deletion_wipe_status_miss_records_miss_and_keeps_behaviour(monkeypatch):
-    recorded = _spy_record_document_read(monkeypatch, users_db)
+    recorded = _spy_record_document_read(monkeypatch, deletion_marker)
     client = _DeletionClient(_DeletionSnapshot(exists=False))
 
     status = users_db.get_user_deletion_wipe_status('uid-1', firestore_client=client)

--- a/backend/tests/unit/test_goals_id_fallback.py
+++ b/backend/tests/unit/test_goals_id_fallback.py
@@ -26,6 +26,8 @@ def goals():
     """Fresh database.goals against a stubbed database._client + firestore chain."""
     client_stub = ModuleType("database._client")
     client_stub.db = MagicMock(name="db")
+    client_stub.data_plane_db = client_stub.db
+    client_stub.get_data_plane_firestore_client = lambda: client_stub.db
     client_stub.document_id_from_seed = MagicMock(return_value="doc-id")
 
     firestore_stub = ModuleType("google.cloud.firestore")

--- a/backend/tests/unit/test_goals_sort_missing_created_at.py
+++ b/backend/tests/unit/test_goals_sort_missing_created_at.py
@@ -31,6 +31,8 @@ def goals():
     """Load a fresh database.goals against a stubbed database._client + firestore chain."""
     client_stub = ModuleType("database._client")
     client_stub.db = MagicMock(name="db")
+    client_stub.data_plane_db = client_stub.db
+    client_stub.get_data_plane_firestore_client = lambda: client_stub.db
 
     firestore_stub = ModuleType("google.cloud.firestore")
     firestore_stub.FieldFilter = MagicMock()

--- a/backend/tests/unit/test_knowledge_ledger_tools.py
+++ b/backend/tests/unit/test_knowledge_ledger_tools.py
@@ -156,7 +156,7 @@ def test_read_current_playbook_applies_chat_visibility_and_ledger_semantics(monk
 def test_tools_are_owner_scoped_bounded_and_fail_closed(monkeypatch):
     import database._client as database_client
 
-    monkeypatch.setattr(database_client, "get_firestore_client", lambda: "db")
+    monkeypatch.setattr(database_client, "get_data_plane_firestore_client", lambda: "db")
     monkeypatch.setattr(
         tools,
         "search_current_knowledge",
@@ -268,7 +268,7 @@ def test_search_historical_facts_is_fact_only_owner_scoped_and_partial(monkeypat
                 next_offset=8,
             )
 
-    monkeypatch.setattr(database_client, "get_firestore_client", lambda: "db")
+    monkeypatch.setattr(database_client, "get_data_plane_firestore_client", lambda: "db")
     monkeypatch.setattr(tools, "MemoryService", FakeService)
 
     result = tools.search_historical_facts.invoke(
@@ -325,7 +325,7 @@ def test_historical_fact_renderer_hard_cap_preserves_both_disclosures():
 def test_search_historical_facts_rejects_unsearchable_and_oversized_requests(monkeypatch):
     import database._client as database_client
 
-    monkeypatch.setattr(database_client, "get_firestore_client", lambda: "db")
+    monkeypatch.setattr(database_client, "get_data_plane_firestore_client", lambda: "db")
     service = SimpleNamespace(search_ledger_history_page=MagicMock())
     service.search_ledger_history_page.side_effect = ValueError("historical ledger query must contain a token")
     monkeypatch.setattr(tools, "MemoryService", lambda *, db_client: service)
@@ -373,7 +373,7 @@ def test_search_historical_facts_requires_explicit_rejected_audit(monkeypatch):
                 next_offset=None,
             )
 
-    monkeypatch.setattr(database_client, "get_firestore_client", lambda: "db")
+    monkeypatch.setattr(database_client, "get_data_plane_firestore_client", lambda: "db")
     monkeypatch.setattr(tools, "MemoryService", FakeService)
 
     result = tools.search_historical_facts.invoke(
@@ -392,7 +392,7 @@ def test_tool_errors_do_not_echo_storage_details(monkeypatch):
     def unavailable():
         raise RuntimeError("private-project users/u1/memory_items")
 
-    monkeypatch.setattr(database_client, "get_firestore_client", unavailable)
+    monkeypatch.setattr(database_client, "get_data_plane_firestore_client", unavailable)
     config = {"configurable": {"user_id": "u1"}}
     assert tools.search_knowledge.invoke({"query": "release"}, config=config) == "Error searching current knowledge"
     assert tools.read_playbook.invoke({"memory_id": "mem_playbook"}, config=config) == "Playbook unavailable."
@@ -401,7 +401,7 @@ def test_tool_errors_do_not_echo_storage_details(monkeypatch):
 def test_read_playbook_bounds_malformed_stored_content(monkeypatch):
     import database._client as database_client
 
-    monkeypatch.setattr(database_client, "get_firestore_client", lambda: "db")
+    monkeypatch.setattr(database_client, "get_data_plane_firestore_client", lambda: "db")
     oversized = _playbook().model_copy(
         update={
             "content": "d" * (tools.MAX_PLAYBOOK_DESCRIPTION_CHARACTERS + 20),

--- a/backend/tests/unit/test_legal_holds.py
+++ b/backend/tests/unit/test_legal_holds.py
@@ -81,7 +81,7 @@ def _client_for(*, exists: bool, data: dict | None = None):
 
 def test_missing_hold_allows_deletion(monkeypatch):
     client = _client_for(exists=False)
-    monkeypatch.setattr(legal_holds, "get_firestore_client", lambda: client)
+    monkeypatch.setattr(legal_holds, "account_deletion_firestore_client", lambda **_kwargs: client)
 
     legal_holds.assert_account_deletion_permitted("uid1")
 

--- a/backend/tests/unit/test_memory_ledger.py
+++ b/backend/tests/unit/test_memory_ledger.py
@@ -34,6 +34,8 @@ def _load_modules():
     client_stub = ModuleType("database._client")
     client_stub.db = MagicMock(name="db")
     client_stub.get_firestore_client = lambda: client_stub.db
+    client_stub.get_data_plane_firestore_client = lambda: client_stub.db
+    client_stub.data_plane_db = client_stub.db
     client_stub.document_id_from_seed = lambda seed: "id-" + str(abs(hash(seed)) % (10**12))
 
     legal_holds_stub = ModuleType("database.legal_holds")

--- a/backend/tests/unit/test_users_add_sample_transaction.py
+++ b/backend/tests/unit/test_users_add_sample_transaction.py
@@ -30,6 +30,10 @@ def users_db():
     client_stub.get_customer_firestore_client = MagicMock(
         name="get_customer_firestore_client", return_value=client_stub.db
     )
+    client_stub.get_data_plane_firestore_client = MagicMock(
+        name="get_data_plane_firestore_client", return_value=client_stub.db
+    )
+    client_stub.data_plane_db = client_stub.db
 
     firestore_stub = ModuleType("google.cloud.firestore")
     google_pkg = ModuleType("google")

--- a/backend/tests/unit/test_users_missing_doc_guards.py
+++ b/backend/tests/unit/test_users_missing_doc_guards.py
@@ -47,6 +47,9 @@ def users():
             delete_collection_recursive=MagicMock(),
             document_id_from_seed=lambda seed: "id",
             get_firestore_client=MagicMock(),
+            get_data_plane_firestore_client=MagicMock(),
+            get_customer_firestore_client=MagicMock(),
+            data_plane_db=MagicMock(),
         ),
         "database.firestore_cache": _module(
             "database.firestore_cache", CachePolicy=MagicMock(), get_or_fetch=MagicMock(), invalidate=MagicMock()

--- a/backend/utils/memory/atom_keyword_index.py
+++ b/backend/utils/memory/atom_keyword_index.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from datetime import timezone
 from typing import Any, Collection, Dict, List, Optional, cast
 
-from database._client import db as default_db_client
+from database._client import data_plane_db as default_db_client
 from database.memory_vector_metadata import canonical_memory_provider_id
 from database.legal_holds import external_write_fence
 from models.knowledge_ledger_search import (
@@ -293,7 +293,8 @@ def upsert_atom_keyword_doc(item: MemoryItem, *, db_client: Any = None) -> bool:
     if not is_indexable_long_term_atom(item):
         return False
     try:
-        with external_write_fence(item.uid, firestore_client=db_client):
+        client = db_client if db_client is not None else default_db_client
+        with external_write_fence(item.uid, firestore_client=client):
             ensure_memories_collection()
             if item.ledger_schema_version == "knowledge_ledger.v1":
                 ensure_ledger_keyword_schema()

--- a/backend/utils/memory/atom_keyword_index.py
+++ b/backend/utils/memory/atom_keyword_index.py
@@ -293,8 +293,7 @@ def upsert_atom_keyword_doc(item: MemoryItem, *, db_client: Any = None) -> bool:
     if not is_indexable_long_term_atom(item):
         return False
     try:
-        client = db_client if db_client is not None else default_db_client
-        with external_write_fence(item.uid, firestore_client=client):
+        with external_write_fence(item.uid, firestore_client=db_client):
             ensure_memories_collection()
             if item.ledger_schema_version == "knowledge_ledger.v1":
                 ensure_ledger_keyword_schema()

--- a/backend/utils/retrieval/tools/knowledge_ledger_tools.py
+++ b/backend/utils/retrieval/tools/knowledge_ledger_tools.py
@@ -322,14 +322,14 @@ def search_knowledge(
         return "Error: User ID not found in configuration"
 
     try:
-        from database._client import get_firestore_client
+        from database._client import get_data_plane_firestore_client
 
         rows = search_current_knowledge(
             uid,
             normalized_query,
             kinds=parsed_kinds,
             limit=limit,
-            db_client=get_firestore_client(),
+            db_client=get_data_plane_firestore_client(),
         )
         return _format_search_results(rows, query=normalized_query)
     except Exception as exc:
@@ -374,9 +374,9 @@ def search_historical_facts(
         return "Error: User ID not found in configuration"
 
     try:
-        from database._client import get_firestore_client
+        from database._client import get_data_plane_firestore_client
 
-        page = MemoryService(db_client=get_firestore_client()).search_ledger_history_page(
+        page = MemoryService(db_client=get_data_plane_firestore_client()).search_ledger_history_page(
             uid,
             normalized_query,
             limit=limit,
@@ -426,9 +426,9 @@ def read_playbook(
         return "Error: User ID not found in configuration"
 
     try:
-        from database._client import get_firestore_client
+        from database._client import get_data_plane_firestore_client
 
-        item = read_current_playbook(uid, normalized_id, db_client=get_firestore_client())
+        item = read_current_playbook(uid, normalized_id, db_client=get_data_plane_firestore_client())
         if item is None:
             return "Playbook unavailable."
         description = " ".join((item.content or "").split())[:MAX_PLAYBOOK_DESCRIPTION_CHARACTERS]

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -141,7 +141,9 @@ def grants_cloud_screen_vectors(uid: str) -> bool:
     if cached is not None and time.monotonic() - cached[1] < _SCREEN_VECTOR_ENTITLEMENT_CACHE_TTL_SECONDS:
         return cached[0]
     try:
-        subscription = users_db.get_user_valid_subscription(uid)
+        subscription = users_db.get_user_valid_subscription(
+            uid, firestore_client=get_customer_firestore_client(), provision=False
+        )
         plan = subscription.plan if subscription else PlanType.basic
         entitled = effective_desktop_access_tier(plan, subscription) != DESKTOP_ACCESS_TIER_FREE
     except Exception as e:


### PR DESCRIPTION
## What changed and why

The account-deletion auth fence read `account_deletions/{uid}` through `get_firestore_client()` (compute plane). The deletion executor writes that marker on the customer data plane. On Omi Beta (desktop-backend) the planes differ, so the lookup missed cleanly, returned `None`, and a user whose deletion was in progress kept reading and writing production data. HTTP 503 only fired on an exception, never on a clean miss.

Writers and readers now share one accessor, `account_deletion_firestore_client()` in `backend/database/account_deletion_marker.py`, which pins `get_data_plane_firestore_client()`. If that client cannot be resolved, the fence fails closed (503). Sibling per-user markers that had the same reader/writer split are pinned the same way.

## Product invariants affected

- INV-MEM-1
- INV-MEM-3
- INV-MEM-4
- INV-CUTOVER-1

## How it was verified

- Guard test: `backend/tests/unit/test_account_deletion_auth_fence.py::test_auth_fence_refuses_when_the_deletion_marker_is_only_on_the_data_plane` runs the production fence (`enforce_account_deletion_http_access` → `get_user_deletion_wipe_status`) with two fake Firestore clients (compute empty, data plane holding `wipe_status=running`) and asserts HTTP 403.
- Fail-closed: `test_auth_fence_fails_closed_when_the_data_plane_client_cannot_be_resolved` asserts HTTP 503 when the data-plane client cannot be resolved.
- Red-proof: mutating `account_deletion_firestore_client` to `return get_firestore_client()`:

```
FAILED test_auth_fence_refuses_when_the_deletion_marker_is_only_on_the_data_plane
FAILED test_auth_fence_fails_closed_when_the_data_plane_client_cannot_be_resolved
Failed: DID NOT RAISE <class 'fastapi.exceptions.HTTPException'>
2 failed in 0.59s
```

Restoring the data-plane accessor: `15 passed in 0.69s`. Reintroducing the same fallback: `Failed: DID NOT RAISE HTTPException` again (`1 failed in 0.65s`).
- Isolation stubs that `load_module_fresh` `database.users` / `database.conversations` now export `get_data_plane_firestore_client` so the new import does not die at collection time. Typesense upserts default to `data_plane_db` (matching Pinecone) instead of passing `None` into the fence.
- CI-shaped backend unit run: `cd backend && BACKEND_PYTEST_FILE_ISOLATION=1 bash scripts/run-unit-ci.sh --changed-files <changed-files>`. `test_mentor_notifications.py::test_process_mentor_proactive_notification_sends` hangs past 90s on this branch **and** on `origin/main` `e37febd0b3` (unmocked `current_date_for_uid` → live `db.collection('users')` with ADC); it is not this fence change.
- Pyright on the changed backend files: 0 errors.

Could not exercise a live Beta request against production Firestore (no production access). The two-plane unit test is the behavioral stand-in for that path.

## Tests

Regression that would have caught the bug: `test_auth_fence_refuses_when_the_deletion_marker_is_only_on_the_data_plane`. Existing fence, cutover, and BYOK tests keep their importer-binding patches.

## Failure class (fixes)

Failure-Class: FC-plane-seam-adopted-by-reader-not-writer

Line-Count-Exception: backend/utils/subscription.py | 1680 -> 1682 | screen-vector entitlement pins customer Firestore with provision=False

## Rollback hazards

- Desktop-backend without `OMI_FIRESTORE_DATA_PLANE_PROJECT` fails closed (HTTP 503) on every authenticated request instead of serving. That env var is already required on desktop-backend; this makes the deletion fence honor it.
- A data-plane service-account / `OMI_FIRESTORE_DATA_PLANE_PROJECT` mismatch still raises (existing `_build_data_plane_firestore_client` behavior) and now maps to 503 on the fence.
- Screen-vector entitlement uses `provision=False` plus the customer Firestore client. A miss now defaults to basic (no cloud screen vectors) instead of JIT-creating a subscription doc. Lookup exceptions still fail open and write vectors (existing fail-open).
- Legal-hold acquire/finish on the wipe executor no longer injects compute `database_client.db`. On a split plane the gate and the marker stay on the data plane together; rolling back re-splits them.
- Memory write fences that used to pass a compute-default client now omit it so the shared accessor resolves the data plane. Typesense upserts default to `data_plane_db` (same as Pinecone) and pass that client into the fence. If the data plane cannot be resolved, those writes fail closed instead of proceeding.
- Rolling this PR back reopens the Beta deletion-fence miss: a deleting account keeps access.
- Goals, memory ledger, MCP OAuth, first-open obligations, and knowledge-ledger **read** tools now default to the data plane. On GKE with `SERVICE_ACCOUNT_JSON` that coincides with the old client.

## Named sibling seams

| Seam | Verdict |
|---|---|
| BYOK key lookup (`utils/byok.py` → `users.get_byok_state`) | **Fixed.** `get_byok_state` / `set_byok_active` / `clear_byok_active` use `get_data_plane_firestore_client()` (`users.py:285`, `:331`, `:337`). |
| Screen-vector entitlement with `provision=True` | **Fixed.** `grants_cloud_screen_vectors` now calls `get_user_valid_subscription(..., firestore_client=get_customer_firestore_client(), provision=False)` (`subscription.py:144-146`). Entitlements stay on the customer client, not the data-plane user-doc client. |
| Web-search opt-out | **Fixed.** `get_assistant_settings` / `_get_raw_assistant_settings` / `update_assistant_settings` read and write `users/{uid}` through `get_data_plane_firestore_client()` (`users.py:2204`, `:2217`, `:2249`). |
| Pinecone wipe fence | **Fixed.** `vector_db.py` defaults to `data_plane_db` and `external_write_fence` uses that client (`vector_db.py:15`, `:50`). `memories.py:46` / `:54` omit an injected client so the shared accessor resolves the data plane. `atom_keyword_index.py` imports `data_plane_db as default_db_client` and passes that resolved client into the fence (`atom_keyword_index.py:16`, `:297`), matching Pinecone. |

Also pinned in this sweep (same reader/writer class):

- Deletion marker R/W: `account_deletion_firestore_client()` imported by `users.py`, `legal_holds.py`.
- Wipe executor legal-hold acquire/finish: dropped `firestore_client=database_client.db` so the accessor owns the plane (`account_deletion.py` `background_wipe_user_data`).
- Canonical derived purge and maintenance-registry delete: `get_data_plane_firestore_client()`.
- Account cutover control docs: `get_data_plane_firestore_client()` (`account_cutover.py:25`, `:180`).
- First-open obligations: `get_data_plane_firestore_client()` (`first_open_obligations.py:13`, `:94`).
- Goals: `_get_db` prefers `get_data_plane_firestore_client` (`goals.py:60`).
- Memory ledger: `data_plane_db` (`memory_ledger.py:22`).
- MCP OAuth: `data_plane_db` (`mcp_oauth.py:15`).
- Knowledge-ledger **read** tools: `get_data_plane_firestore_client()` (`knowledge_ledger_tools.py:325+`). Write tools already threaded a data-plane client.

## Remaining `get_firestore_client()` readers of deletion / JIT / cutover collections

Verified against a backend-wide grep of `get_firestore_client()` after the sweep.

| Site | Why it is already correct, or remaining |
|---|---|
| `account_deletion_transitions.py:21` `read_agent_vm_migration_journals` | **Verified-safe.** `users/{uid}/agentVmMigrations` is compute-local (GCE / `agentVm`). Must keep `get_firestore_client()`. |
| `users.py:2110` `get_agent_vm` | **Verified-safe.** Reads compute-local `agentVm` on `db`. |
| `users.py:1751`, `:1796` location-context consent | **Verified-safe for this class.** Reader and writer share `get_firestore_client()`; there is no reader/writer split. On GKE, `SERVICE_ACCOUNT_JSON` makes this the data plane. |
| `users.py:1678` `get_user_subscription` | **Verified-safe for the named seam.** Defaults to `db`; screen-vector now injects `get_customer_firestore_client()`. Quota/paywall callers that need production entitlements already pass the customer client. |
| `users.py:1304` `delete_user_data` | **Verified-safe.** Wipe runs on GKE, where `SERVICE_ACCOUNT_JSON` makes `db` the data plane. Not the Beta serving-plane split. |
| `account_deletion_projection_fence.py:22` | **Verified-safe.** Requires an injected `db_client`. Callers (`memory_system.py:52`, `canonical_memory_adapter.py:3545`, `daily_memory_sweep.py:2853`, `jit_proactivity_store` via `data_plane_db`) pass the data-plane client. |
| `jit_proactivity_store.py:83` | **Verified-safe.** Defaults to `data_plane_db`; reads `account_deletions/{uid}` on that client. |
| `knowledge_ledger_writer_transition.py:399` `_client_or_default` | **Verified-safe.** Default is `get_firestore_client()`, but production `knowledge_ledger_migration.py:344` always threads `db_client`. |
| `canonical_graph.py:89`, `routers/knowledge_graph.py:73`, `:258` | **Remaining default, GKE-coinciding.** Graph routes run on the GKE backend, where `SERVICE_ACCOUNT_JSON` makes `get_firestore_client()` the data plane. Not served on desktop-backend. |
| `memories.py:125` `_get_db` | **Remaining default for memory **writes**.** The deletion **fence** no longer uses this client. Memory document CRUD still defaults to `get_firestore_client()`; GKE coincides. |
| `mcp_api_key.py:41`, `dev_api_key.py:34` | **Verified-safe.** Credential wipe runs on GKE; `SERVICE_ACCOUNT_JSON` is the data plane. |
| `conversations.py`, `action_items.py`, `recording_sessions.py`, and other `get_firestore_client()` user-subtree modules | **Remaining GKE-coinciding defaults.** The deletion executor wipes `users/{uid}` through `delete_user_data` on GKE (`db` == data plane). These are not the Beta auth-fence path. Migrating every user-doc default is a follow-up, not this fence fix. |

## New guards

The two-plane auth-fence unit test is the recurrence guard for this class on the deletion marker. It is not a repo-wide plane-seam checker because the plane is a runtime client identity, not a static import graph; a shared primitive that grepped `get_firestore_client()` would false-positive every compute-local `agentVm` path. The real merged instance this would have caught is the 2026-08-30 adversarial finding (same class as PR #12402).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

