### PR TITLE
fix: make the review card, the voice guard, and the follow-up tail actually work (#12635 follow-up)

### DIFF
--- a/.github/failure-classes/FC-projection-fed-its-own-output.json
+++ b/.github/failure-classes/FC-projection-fed-its-own-output.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-projection-fed-its-own-output",
+  "violated_contract": "A projection that may withhold part of its input must be applied to the accumulated raw input on every pass. Storing the projection's output back into the only buffer and extending that buffer with the next delta destroys the evidence the projection needs, so anything withheld once is emitted on a later pass.",
+  "canonical_prevention": "Accumulate the raw input separately from the projected output: append deltas to the raw accumulator, project the whole accumulator, and write the result outward without ever reading it back. Release the accumulator when the stream terminates so a reused identity cannot resume from a previous one. Prove it by replaying the same input broken at every possible boundary and asserting the withheld content never appears in any intermediate output.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/ChatStreamingTailProjectionTests.swift"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/Chat/ChatStreamingBuffer.swift",
+    "desktop/macos/Desktop/Sources/Chat/ChatFollowUpTail.swift",
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift"
+  ],
+  "status": "open"
+}

--- a/app/lib/backend/schema/message.dart
+++ b/app/lib/backend/schema/message.dart
@@ -545,10 +545,15 @@ class ServerMessage {
         return value('text').isEmpty ? 'Question' : value('text');
       case 'memoryReviewCard':
       case 'memory_review_card':
-        return 'Things I learned today';
       case 'followUp':
       case 'follow_up':
-        return value('text');
+        // Both render natively on mobile — MemoryReviewCard draws its own
+        // "Things I learned today" heading, and ChatFollowUpChip draws the
+        // question. Inventing the same words as fallback prose says them
+        // twice; and when the block is malformed enough that no card renders
+        // (MemoryReviewCardBlock.tryFromBlock returns null for an item-less
+        // block), a bare heading over nothing is worse than no heading.
+        return '';
       case 'taskCard':
       case 'task_card':
         return 'Task';

--- a/app/lib/widgets/components/memory_review_card.dart
+++ b/app/lib/widgets/components/memory_review_card.dart
@@ -58,11 +58,24 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
   final Set<String> _failed = {};
   final Map<String, TextEditingController> _editors = {};
 
+  /// The text a persisted correction submitted, per row. A knowledge-ledger
+  /// correction appends a new row under a *new* id, so the id this card
+  /// references stops resolving in the provider; without this the row would
+  /// fall back to the original learned text under an "Updated." status.
+  final Map<String, String> _settledEdits = {};
+
   /// Ids this process has already asked the provider to go looking for. A card
   /// scrolled in and out of the chat list rebuilds its State, and an id that is
   /// genuinely absent from the account would otherwise re-trigger a full
   /// memories fetch on every rebuild.
   static final Set<String> _requestedIds = {};
+
+  /// Whether this process has already asked the provider to load its list.
+  /// Nothing in app start-up initialises [MemoriesProvider] — only the memories
+  /// page calls `init()` — and a provider that has never loaded still reports
+  /// `loading == true`, so "already loading" cannot be read as "a fetch is in
+  /// flight" until this card has started one itself.
+  static bool _loadRequested = false;
 
   /// Card identities already counted as shown in this process.
   static final Set<String> _seenImpressions = {};
@@ -105,13 +118,18 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
   void _ensureMemoriesLoaded() {
     if (!mounted) return;
     final provider = _memoriesProvider(listen: false);
-    if (provider == null || provider.loading) return;
+    if (provider == null) return;
     final unresolved = _rows
         .where((item) => _memoryFor(provider, item.memoryId) == null)
         .map((item) => item.memoryId)
         .where(_requestedIds.add)
         .toList(growable: false);
     if (unresolved.isEmpty) return;
+    // Only skip when a fetch this process started is still running. Chat and
+    // the daily summary are usually the first memory surface a session opens,
+    // and there `loading` is just the never-loaded initial value.
+    if (_loadRequested && provider.loading) return;
+    _loadRequested = true;
     provider.loadMemories();
   }
 
@@ -124,7 +142,10 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
   _RowState _stateFor(Memory? memory, String memoryId) {
     final optimistic = _optimistic[memoryId];
     if (optimistic != null) return optimistic;
-    if (memory == null) return _RowState.loading;
+    // A correction that appended a replacement row leaves this id unresolvable.
+    // That is settled, not still loading — but only while nothing live answers
+    // for the id, so a later refresh or another device still wins.
+    if (memory == null) return _settledEdits.containsKey(memoryId) ? _RowState.updated : _RowState.loading;
     if (memory.userReview == false) return _RowState.dropped;
     if (memory.userReview == true) return _RowState.confirmed;
     if (memory.edited) return _RowState.updated;
@@ -188,15 +209,18 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
     if (!mounted) return;
     setState(() {
       _inFlight.remove(item.memoryId);
+      // Drop the optimistic paint either way. What the row shows next is
+      // derived state: the live memory when the id still resolves, otherwise
+      // the correction recorded below.
+      _optimistic.remove(item.memoryId);
       if (persisted) {
         _editors.remove(item.memoryId)?.dispose();
         // A knowledge-ledger correction appends a new row under a new id, so
-        // the memory this reference points at can stop resolving. Keep the
-        // "Updated." state for this card rather than falling back to a
-        // disabled row.
-        _optimistic[item.memoryId] = _RowState.updated;
+        // the memory this reference points at can stop resolving. Remember what
+        // was submitted so the row shows the corrected text under "Updated."
+        // rather than the original learned text under a disabled control.
+        _settledEdits[item.memoryId] = value;
       } else {
-        _optimistic.remove(item.memoryId);
         _failed.add(item.memoryId);
       }
     });
@@ -238,7 +262,8 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
     final state = _stateFor(memory, item.memoryId);
     final editing = _editors.containsKey(item.memoryId);
     final dimmed = state == _RowState.dropped;
-    final content = memory?.content.trim().isNotEmpty == true ? memory!.content.trim() : item.content;
+    final live = memory?.content.trim() ?? '';
+    final content = live.isNotEmpty ? live : (_settledEdits[item.memoryId] ?? item.content);
 
     return Container(
       key: Key('memory_review_row_${item.memoryId}'),

--- a/app/lib/widgets/components/memory_review_card.dart
+++ b/app/lib/widgets/components/memory_review_card.dart
@@ -384,9 +384,9 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
           label: 'Fix',
           onTap: enabled
               ? () => setState(() {
-                    _failed.remove(item.memoryId);
-                    _editors[item.memoryId] = TextEditingController(text: memory.content.trim());
-                  })
+                  _failed.remove(item.memoryId);
+                  _editors[item.memoryId] = TextEditingController(text: memory.content.trim());
+                })
               : null,
         ),
       ],
@@ -397,8 +397,8 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
     final color = onTap == null
         ? Colors.grey.shade700
         : emphasized
-            ? Colors.white
-            : Colors.grey.shade300;
+        ? Colors.white
+        : Colors.grey.shade300;
     return Semantics(
       button: true,
       enabled: onTap != null,

--- a/app/lib/widgets/components/memory_review_card.dart
+++ b/app/lib/widgets/components/memory_review_card.dart
@@ -384,9 +384,9 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
           label: 'Fix',
           onTap: enabled
               ? () => setState(() {
-                  _failed.remove(item.memoryId);
-                  _editors[item.memoryId] = TextEditingController(text: memory.content.trim());
-                })
+                    _failed.remove(item.memoryId);
+                    _editors[item.memoryId] = TextEditingController(text: memory.content.trim());
+                  })
               : null,
         ),
       ],
@@ -397,8 +397,8 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
     final color = onTap == null
         ? Colors.grey.shade700
         : emphasized
-        ? Colors.white
-        : Colors.grey.shade300;
+            ? Colors.white
+            : Colors.grey.shade300;
     return Semantics(
       button: true,
       enabled: onTap != null,

--- a/app/test/unit/memory_review_block_test.dart
+++ b/app/test/unit/memory_review_block_test.dart
@@ -130,9 +130,24 @@ void main() {
     expect(message.followUpQuestion, isNull);
   });
 
-  test('fallback text is sensible for both new block types', () {
-    final reviewOnly = ServerMessage.fromJson(_fcmDaySummaryData(text: '', contentBlocks: [_reviewBlock]));
-    expect(reviewOnly.text, 'Things I learned today');
+  test('neither natively rendered block invents fallback prose that repeats it', () {
+    // MemoryReviewCard draws "Things I learned today" itself and
+    // ChatFollowUpChip draws the question, so a prose copy would either say the
+    // same words twice or — when the block is too malformed to render a card —
+    // leave a heading standing over nothing.
+    final reviewOnly = ServerMessage.fromJson(
+      _fcmDaySummaryData(text: '', contentBlocks: [_reviewBlock]),
+    );
+    expect(reviewOnly.text, '');
+    expect(reviewOnly.memoryReviewCard, isNotNull);
+
+    final malformedReviewOnly = ServerMessage.fromJson(
+      _fcmDaySummaryData(text: '', contentBlocks: [
+        {'type': 'memoryReviewCard', 'id': 'summary-9:memories', 'items': []},
+      ]),
+    );
+    expect(malformedReviewOnly.memoryReviewCard, isNull);
+    expect(malformedReviewOnly.text, '');
 
     final followUpOnly = ServerMessage.fromJson({
       'id': 'message-4',
@@ -144,7 +159,8 @@ void main() {
         {'type': 'followUp', 'text': 'Should I pull the rest?'},
       ],
     });
-    expect(followUpOnly.text, 'Should I pull the rest?');
+    expect(followUpOnly.text, '');
+    expect(followUpOnly.followUpQuestion, 'Should I pull the rest?');
   });
 
   test('unknown and existing block types keep their previous fallback', () {

--- a/app/test/unit/memory_review_block_test.dart
+++ b/app/test/unit/memory_review_block_test.dart
@@ -135,16 +135,17 @@ void main() {
     // ChatFollowUpChip draws the question, so a prose copy would either say the
     // same words twice or — when the block is too malformed to render a card —
     // leave a heading standing over nothing.
-    final reviewOnly = ServerMessage.fromJson(
-      _fcmDaySummaryData(text: '', contentBlocks: [_reviewBlock]),
-    );
+    final reviewOnly = ServerMessage.fromJson(_fcmDaySummaryData(text: '', contentBlocks: [_reviewBlock]));
     expect(reviewOnly.text, '');
     expect(reviewOnly.memoryReviewCard, isNotNull);
 
     final malformedReviewOnly = ServerMessage.fromJson(
-      _fcmDaySummaryData(text: '', contentBlocks: [
-        {'type': 'memoryReviewCard', 'id': 'summary-9:memories', 'items': []},
-      ]),
+      _fcmDaySummaryData(
+        text: '',
+        contentBlocks: [
+          {'type': 'memoryReviewCard', 'id': 'summary-9:memories', 'items': []},
+        ],
+      ),
     );
     expect(malformedReviewOnly.memoryReviewCard, isNull);
     expect(malformedReviewOnly.text, '');

--- a/app/test/widgets/chat_content_block_test.dart
+++ b/app/test/widgets/chat_content_block_test.dart
@@ -35,6 +35,23 @@ ServerMessage _aiMessage({
   );
 }
 
+/// Built through the wire decoder, so the content-block fallback that fills an
+/// empty `text` actually runs. The direct constructor above bypasses it.
+ServerMessage _decodedAiMessage({
+  required String text,
+  required String type,
+  List<Map<String, dynamic>> contentBlocks = const [],
+}) {
+  return ServerMessage.fromJson({
+    'id': 'ai-1',
+    'created_at': '2026-09-01T23:00:00Z',
+    'text': text,
+    'sender': 'ai',
+    'type': type,
+    'content_blocks': contentBlocks,
+  });
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -150,6 +167,74 @@ void main() {
     expect(find.byKey(const Key('memory_review_accept_mem-1')), findsOneWidget);
     expect(find.byKey(const Key('memory_review_reject_mem-1')), findsOneWidget);
     expect(find.byKey(const Key('memory_review_fix_mem-1')), findsOneWidget);
+  });
+
+  testWidgets('an answer that is only a follow-up asks it once, as the chip', (tester) async {
+    // With no prose of its own the message text falls back to its content
+    // blocks. The chip renders the question natively, so a prose copy would put
+    // the same words on screen twice.
+    await pumpMessage(
+      tester,
+      message: _decodedAiMessage(
+        text: '',
+        type: 'text',
+        contentBlocks: const [
+          {'type': 'followUp', 'id': 'ai-1:followup', 'text': 'Want the rest of what she said?'},
+        ],
+      ),
+    );
+
+    expect(find.byKey(const Key('chat_followup_chip')), findsOneWidget);
+    expect(find.text('Want the rest of what she said?'), findsOneWidget);
+  });
+
+  testWidgets('a memoryReviewCard heading is not also rendered as prose', (tester) async {
+    await pumpMessage(
+      tester,
+      message: _decodedAiMessage(
+        text: '',
+        type: 'day_summary',
+        contentBlocks: const [
+          {
+            'type': 'memoryReviewCard',
+            'id': 'summary-2:memories',
+            'items': [
+              {'memoryId': 'mem-dup', 'content': 'Prefers async standups', 'category': 'work'},
+            ],
+          },
+        ],
+      ),
+      memories: [
+        Memory(
+          id: 'mem-dup',
+          uid: 'chat-block-user',
+          content: 'Prefers async standups',
+          category: MemoryCategory.system,
+          createdAt: DateTime.utc(2026, 9, 1),
+          updatedAt: DateTime.utc(2026, 9, 1),
+          visibility: MemoryVisibility.private,
+        ),
+      ],
+    );
+
+    expect(find.byType(MemoryReviewCard), findsOneWidget);
+    expect(find.text('Things I learned today'), findsOneWidget);
+  });
+
+  testWidgets('a memoryReviewCard with no usable items leaves no heading behind', (tester) async {
+    await pumpMessage(
+      tester,
+      message: _decodedAiMessage(
+        text: '',
+        type: 'day_summary',
+        contentBlocks: const [
+          {'type': 'memoryReviewCard', 'id': 'summary-3:memories', 'items': []},
+        ],
+      ),
+    );
+
+    expect(find.byType(MemoryReviewCard), findsNothing);
+    expect(find.text('Things I learned today'), findsNothing);
   });
 
   testWidgets('a plain answer with no blocks gains neither a chip nor a card', (tester) async {

--- a/app/test/widgets/memory_review_card_test.dart
+++ b/app/test/widgets/memory_review_card_test.dart
@@ -46,6 +46,19 @@ MemoriesProvider _provider({
   );
 }
 
+/// A provider whose next fetch reflects later mutations of [rows], so a test can
+/// model a refresh that carries another device's verdict or a ledger append.
+MemoriesProvider _mutableProvider(List<Memory> rows) {
+  return MemoriesProvider(
+    fetchMemoriesRequest: ({int limit = 100, int offset = 0, bool thisDeviceOnly = false}) async =>
+        GetMemoriesResult(List<Memory>.from(rows), true),
+    fetchLedgerHistoryRequest: ({int limit = 500, int offset = 0}) async =>
+        const GetLedgerHistoryResult([], supported: true),
+    reviewMemoryRequest: (id, value) async => true,
+    editMemoryRequest: (id, value) async => const EditMemoryResult(persisted: true),
+  );
+}
+
 Widget _harness(MemoriesProvider provider, List<MemoryReviewItem> items) {
   return ChangeNotifierProvider<MemoriesProvider>.value(
     value: provider,
@@ -249,6 +262,79 @@ void main() {
     expect(find.byKey(const Key('memory_review_error_mem-1')), findsOneWidget);
     expect(find.text('Updated.'), findsNothing);
     expect(find.byKey(const Key('memory_review_editor_mem-1')), findsOneWidget);
+  });
+
+  testWidgets('loads the memories itself when the provider was never initialised', (tester) async {
+    // Nothing in app start-up calls MemoriesProvider.init(); only the memories
+    // page does. Chat and the daily summary are usually the first memory
+    // surface a session opens, and a never-loaded provider reports
+    // `loading == true` forever, so the card must not read that as "a fetch is
+    // already in flight".
+    final provider = _provider(rows: [_memory(id: 'mem-cold')]);
+    addTearDown(provider.dispose);
+    expect(provider.loading, isTrue, reason: 'a provider that has never loaded still reports loading');
+
+    await tester.pumpWidget(_harness(provider, [_item('mem-cold')]));
+    await tester.pumpAndSettle();
+
+    expect(provider.memories.single.id, 'mem-cold');
+    final accept = tester.widget<InkWell>(find.byKey(const Key('memory_review_accept_mem-cold')));
+    expect(accept.onTap, isNotNull);
+  });
+
+  testWidgets('a correction that replaced the referenced row shows the corrected text', (tester) async {
+    // A knowledge-ledger correction appends a replacement under a new id, so
+    // the id this card references stops resolving. The row must not fall back
+    // to the original learned text while saying "Updated."
+    final rows = <Memory>[_memory(id: 'mem-ledger')];
+    final provider = _mutableProvider(rows);
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    await tester.pumpWidget(_harness(provider, [_item('mem-ledger')]));
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('memory_review_fix_mem-ledger')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('memory_review_editor_mem-ledger')), 'Prefers written standups');
+    await tester.tap(find.byKey(const Key('memory_review_save_mem-ledger')));
+    await tester.pumpAndSettle();
+
+    // The ledger append: the referenced id is gone on the next refresh.
+    rows.clear();
+    await provider.loadMemories();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Updated.'), findsOneWidget);
+    expect(find.text('Prefers written standups'), findsOneWidget);
+    expect(find.text('Prefers async standups'), findsNothing);
+  });
+
+  testWidgets('a verdict cast elsewhere after a correction still wins', (tester) async {
+    // The optimistic paint is not a permanent override: once the write has
+    // persisted the row is derived from live memory state again.
+    final row = _memory(id: 'mem-live');
+    final provider = _mutableProvider([row]);
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    await tester.pumpWidget(_harness(provider, [_item('mem-live')]));
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('memory_review_fix_mem-live')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('memory_review_editor_mem-live')), 'Prefers written standups');
+    await tester.tap(find.byKey(const Key('memory_review_save_mem-live')));
+    await tester.pumpAndSettle();
+    expect(find.text('Updated.'), findsOneWidget);
+
+    // A verdict cast on another device arrives on the next refresh.
+    row.userReview = true;
+    await provider.loadMemories();
+    await tester.pumpAndSettle();
+
+    expect(find.text("Confirmed. I'll act on this."), findsOneWidget);
+    expect(find.text('Updated.'), findsNothing);
   });
 
   testWidgets('an unresolved memory still shows its content with the controls disabled', (tester) async {

--- a/backend/config/task_intelligence_sources_v1.json
+++ b/backend/config/task_intelligence_sources_v1.json
@@ -32,6 +32,7 @@
       "policy_class": "direct_command",
       "owner_paths": [
         "desktop/macos/Desktop/Sources/Stores/TasksStore.swift",
+        "desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift",
         "desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift",
         "desktop/macos/Desktop/Sources/APIClient.swift",
         "desktop/macos/Desktop/Sources/MainWindow/Dashboard/WhatMattersNowSection.swift",
@@ -47,6 +48,8 @@
       "test_adapter": "direct_command_contract",
       "writer_anchors": [
         {"path": "desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift", "symbol": "client.createTask", "discover": true},
+        {"path": "desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift", "symbol": "client.createTask", "discover": true},
+        {"path": "desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift", "symbol": "client.deleteTask", "discover": true},
         {"path": "backend/routers/desktop_core.py", "symbol": "action_items_db.create_action_item", "discover": true}
       ]
     },

--- a/backend/main.py
+++ b/backend/main.py
@@ -54,6 +54,7 @@ from routers import (
     candidates,
     chat_first,
     chat_first_e2e,
+    daily_summary_e2e,
     task_integrations,
     integrations,
     x_connector,
@@ -191,6 +192,10 @@ if is_chat_first_e2e_harness_runtime():
     # The fixture router has its own runtime check as defense in depth.  It is
     # intentionally absent from dev/prod route tables, not merely disabled.
     app.include_router(chat_first_e2e.router)
+    # Same stage boundary, same defense in depth: the desktop memory-review flow
+    # needs a daily summary carrying `memories_learned`, which only the nightly
+    # job produces in a deployable environment.
+    app.include_router(daily_summary_e2e.router)
 app.include_router(task_integrations.router)
 app.include_router(integrations.router)
 app.include_router(x_connector.router)

--- a/backend/models/chat_first.py
+++ b/backend/models/chat_first.py
@@ -94,8 +94,46 @@ class MemoryLinkSpec(_StrictModel):
     summary: str = Field(min_length=1, max_length=200)
 
 
+class MemoryReviewItemSpec(_StrictModel):
+    """One reviewable claim about the owner, as the desktop adapter sends it.
+
+    ``content`` and ``category`` are permitted to arrive empty: the desktop
+    adapter forwards whatever the daily-summary block carried, and the client
+    codec — not this contract — decides an empty row is not worth rendering.
+    Rejecting the whole card over one blank field would journal nothing at all.
+    """
+
+    memory_id: StableId
+    content: str = Field(max_length=1000)
+    category: str = Field(default='', max_length=64)
+
+
+class MemoryReviewCardSpec(_StrictModel):
+    """The daily-summary review rows, journaled through the chat-first tool.
+
+    ``summary_id`` and ``date`` are opaque provenance the card carries back to
+    its summary; the adapter substitutes an empty string when the source block
+    had neither, so neither is an identity this contract can constrain.
+    """
+
+    type: Literal['memoryReviewCard']
+    summary_id: str = Field(default='', max_length=128)
+    date: str = Field(default='', max_length=32)
+    # The generator selects three (``MEMORIES_LEARNED_LIMIT``); the bound is the
+    # ceiling on the entity reads one card costs, not a product limit.
+    items: list[MemoryReviewItemSpec] = Field(min_length=1, max_length=8)
+
+
 ChatFirstBlockSpec = Annotated[
-    Union[QuestionCardSpec, TaskCardSpec, GoalLinkSpec, CaptureLinkSpec, ConversationLinkSpec, MemoryLinkSpec],
+    Union[
+        QuestionCardSpec,
+        TaskCardSpec,
+        GoalLinkSpec,
+        CaptureLinkSpec,
+        ConversationLinkSpec,
+        MemoryLinkSpec,
+        MemoryReviewCardSpec,
+    ],
     Field(discriminator='type'),
 ]
 
@@ -428,6 +466,8 @@ __all__ = [
     'MaterializePromptsRequest',
     'MaterializePromptsResponse',
     'MemoryLinkSpec',
+    'MemoryReviewCardSpec',
+    'MemoryReviewItemSpec',
     'ProactiveBudgetReservation',
     'ProactiveBudgetState',
     'ProactiveDeferral',

--- a/backend/models/chat_first.py
+++ b/backend/models/chat_first.py
@@ -132,6 +132,23 @@ ChatFirstBlockSpec = Annotated[
         CaptureLinkSpec,
         ConversationLinkSpec,
         MemoryLinkSpec,
+    ],
+    Field(discriminator='type'),
+]
+
+# What a client may ask the journal to accept, which is a superset of what the
+# server emits. ``memoryReviewCard`` is authored by the daily-summary card on the
+# client and journaled back; no proactive intent ever produces one. Keeping it out
+# of ``ChatFirstBlockSpec`` keeps it out of the materialization *response* schema,
+# where a new union branch is a breaking change for every released app client.
+ChatFirstJournalBlockSpec = Annotated[
+    Union[
+        QuestionCardSpec,
+        TaskCardSpec,
+        GoalLinkSpec,
+        CaptureLinkSpec,
+        ConversationLinkSpec,
+        MemoryLinkSpec,
         MemoryReviewCardSpec,
     ],
     Field(discriminator='type'),
@@ -149,7 +166,7 @@ class ChatFirstBlockValidationRequest(_StrictModel):
     owner_fence: StableId
     run_id: StableId
     attempt_id: StableId
-    blocks: list[ChatFirstBlockSpec] = Field(min_length=1, max_length=8)
+    blocks: list[ChatFirstJournalBlockSpec] = Field(min_length=1, max_length=8)
 
 
 class ChatFirstBlockValidationReceipt(_StrictModel):
@@ -442,7 +459,7 @@ class DeferralReceipt(_StrictModel):
     state: Literal['pending', 'released']
 
 
-def stable_block_id(*, uid: str, generation: int, block: ChatFirstBlockSpec) -> str:
+def stable_block_id(*, uid: str, generation: int, block: ChatFirstJournalBlockSpec) -> str:
     """Generate an opaque, retry-stable block ID without exposing block text."""
 
     canonical = block.model_dump_json(exclude_none=True)
@@ -454,6 +471,7 @@ __all__ = [
     'CaptureLinkSpec',
     'ConversationLinkSpec',
     'ChatFirstBlockSpec',
+    'ChatFirstJournalBlockSpec',
     'ChatFirstBlockValidationReceipt',
     'ChatFirstBlockValidationRequest',
     'ChatFirstSubject',

--- a/backend/models/notification_message.py
+++ b/backend/models/notification_message.py
@@ -1,8 +1,20 @@
 import json
+import logging
 from typing import Any, Optional
 import uuid
 from datetime import datetime, timezone
 from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# FCM rejects any message whose `data` payload exceeds 4KB, and it rejects the
+# whole message — an oversized card would take the daily summary down with it,
+# so the push would silently never arrive. `content_blocks` is the only
+# variable-size entry in the payload; the rest (id, timestamps, a body already
+# truncated to 150 chars, a deep link) is comfortably under 1KB. Bound the card
+# below that headroom and drop it if it does not fit: losing the card costs a
+# render, losing the message costs the recap.
+MAX_CONTENT_BLOCKS_BYTES = 3000
 
 
 class NotificationMessage(BaseModel):
@@ -37,7 +49,17 @@ class NotificationMessage(BaseModel):
         # batch send fail. Structured payloads travel as JSON text, the same shape
         # `utils.notifications` already uses for batched action items.
         if message.content_blocks:
-            message_dict['content_blocks'] = json.dumps(message.content_blocks, ensure_ascii=False)
+            encoded = json.dumps(message.content_blocks, ensure_ascii=False)
+            if len(encoded.encode('utf-8')) > MAX_CONTENT_BLOCKS_BYTES:
+                logger.warning(
+                    'notification_content_blocks_dropped type=%s bytes=%d limit=%d',
+                    message.type,
+                    len(encoded.encode('utf-8')),
+                    MAX_CONTENT_BLOCKS_BYTES,
+                )
+                del message_dict['content_blocks']
+            else:
+                message_dict['content_blocks'] = encoded
         else:
             del message_dict['content_blocks']
 

--- a/backend/routers/chat_first.py
+++ b/backend/routers/chat_first.py
@@ -39,6 +39,7 @@ from models.chat_first import (
     ProactiveMaterializationRejectionOutcome,
     ProactiveMaterializationReceiptOutcome,
     MemoryLinkSpec,
+    MemoryReviewCardSpec,
     TaskCardSpec,
     stable_block_id,
 )
@@ -208,6 +209,14 @@ def _entity_available(uid: str, block: ChatFirstBlockSpec) -> bool:
     if isinstance(block, MemoryLinkSpec):
         try:
             return bool(fetch_memory_dict(uid, block.memory_id, db_client=getattr(db_client_module, 'db', None)))
+        except HTTPException:
+            return False
+    if isinstance(block, MemoryReviewCardSpec):
+        # Every row is a claim the owner can accept or correct in place, so the
+        # card is only admissible if each one is a memory this account still owns.
+        client = getattr(db_client_module, 'db', None)
+        try:
+            return all(bool(fetch_memory_dict(uid, item.memory_id, db_client=client)) for item in block.items)
         except HTTPException:
             return False
     subject = block.subject

--- a/backend/routers/chat_first.py
+++ b/backend/routers/chat_first.py
@@ -24,6 +24,7 @@ from models.chat_first import (
     CaptureLinkSpec,
     ConversationLinkSpec,
     ChatFirstBlockSpec,
+    ChatFirstJournalBlockSpec,
     ChatFirstBlockValidationReceipt,
     ChatFirstBlockValidationRequest,
     ChatFirstSubject,
@@ -178,7 +179,7 @@ def _maybe_persist_cold_start(uid: str, *, control_generation: int, now: datetim
         logger.warning('chat_first_cold_start_prepare_failed uid=%s error=%s', sanitize_pii(uid), type(exc).__name__)
 
 
-def _entity_available(uid: str, block: ChatFirstBlockSpec) -> bool:
+def _entity_available(uid: str, block: ChatFirstJournalBlockSpec) -> bool:
     if isinstance(block, TaskCardSpec):
         task = action_items_db.get_action_item(uid, block.task_id)
         return bool(task and not task.get('is_locked', False))

--- a/backend/routers/daily_summary_e2e.py
+++ b/backend/routers/daily_summary_e2e.py
@@ -1,0 +1,134 @@
+"""Local/offline-only daily-summary fixture for the desktop memory-review flow.
+
+The desktop's "Things I learned today" review rows are rendered only from a
+daily summary's ``memories_learned``, and the only producer of that record is
+the scheduled nightly job: it needs a day of conversations and a model call, so
+a hermetic bundle can never reach one. That left the whole review card —
+projection, row state machine, and the three mutations — unreachable from an
+E2E flow, which is why ``memory-review.yaml`` did not exist.
+
+This writes the record the job would have written, and nothing else. It does
+**not** create memories: the flow creates those through the production
+``POST /v3/memories`` so the ids it hands over address real rows that
+``/v3/memories/{id}/review`` and ``PATCH /v3/memories/{id}`` really mutate. A
+fixture that minted its own memory rows would prove the card can render and
+prove nothing about whether a vote lands.
+
+Local/offline only, by the same stage boundary as the Chat-first E2E fixture:
+the router is not registered elsewhere, and the handler repeats the check.
+"""
+
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from config.chat_first_e2e_fixture import is_chat_first_e2e_harness_runtime
+from database import daily_summaries as daily_summaries_db
+from models.daily_summary_payload import LearnedMemoryRef
+from utils.other import endpoints as auth
+
+router = APIRouter(prefix='/v1/dev-harness/daily-summary', include_in_schema=False)
+
+# The card renders at most three rows; the fixture accepts a few more so a flow
+# can prove the bound rather than assume it.
+MAX_FIXTURE_MEMORIES = 8
+MAX_FIXTURE_CONTENT_CHARS = 400
+
+
+class DailySummaryFixtureMemory(BaseModel):
+    memory_id: str
+    content: str
+    category: str = ''
+
+
+class DailySummaryFixtureRequest(BaseModel):
+    memories: List[DailySummaryFixtureMemory] = Field(default_factory=list)
+    date: Optional[str] = None
+    headline: str = 'Your day in review'
+    overview: str = 'A hermetic fixture day for the memory review card.'
+
+
+class DailySummaryFixtureResponse(BaseModel):
+    status: str
+    summary_id: str
+    date: str
+    memories_learned: int
+
+
+def _require_local_harness() -> None:
+    # Defense in depth: main.py does not register this router outside local or
+    # offline, and a direct router inclusion in a test/server still fails here.
+    if not is_chat_first_e2e_harness_runtime():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Not found')
+
+
+def _resolved_date(raw: Optional[str]) -> str:
+    if raw is None:
+        return datetime.now(timezone.utc).date().isoformat()
+    try:
+        return datetime.strptime(raw, '%Y-%m-%d').date().isoformat()
+    except ValueError:
+        raise HTTPException(status_code=400, detail='Invalid date format. Use YYYY-MM-DD') from None
+
+
+def _learned_refs(memories: List[DailySummaryFixtureMemory]) -> List[LearnedMemoryRef]:
+    """Type the entries through the model production writes, so the two cannot drift.
+
+    A blank id or blank content is rejected rather than trimmed away: the flow
+    asserts row identity, and a row whose ✓ / ✗ / Fix addresses no memory would
+    make the fixture look richer than it is.
+    """
+    refs: List[LearnedMemoryRef] = []
+    for memory in memories:
+        memory_id = memory.memory_id.strip()
+        content = memory.content.strip()
+        if not memory_id or not content:
+            raise HTTPException(status_code=400, detail='Every fixture memory needs a memory_id and content')
+        refs.append(
+            LearnedMemoryRef(
+                memory_id=memory_id,
+                content=content[:MAX_FIXTURE_CONTENT_CHARS],
+                category=memory.category.strip(),
+                captured_at=datetime.now(timezone.utc),
+            )
+        )
+    return refs
+
+
+@router.post('/seed', response_model=DailySummaryFixtureResponse)
+def seed_daily_summary_fixture(
+    request: DailySummaryFixtureRequest,
+    uid: str = Depends(auth.get_current_user_uid),
+) -> DailySummaryFixtureResponse:
+    _require_local_harness()
+    if not request.memories:
+        raise HTTPException(status_code=400, detail='At least one fixture memory is required')
+    if len(request.memories) > MAX_FIXTURE_MEMORIES:
+        raise HTTPException(status_code=400, detail=f'At most {MAX_FIXTURE_MEMORIES} fixture memories')
+
+    date_str = _resolved_date(request.date)
+    refs = _learned_refs(request.memories)
+    # Deterministic id keyed to the day, so re-running the flow overwrites the
+    # record it wrote last time instead of leaving two summaries competing for
+    # the newest-first read the desktop makes.
+    summary_id = f'dev-harness-daily-summary-{date_str}'
+    summary_data = {
+        'id': summary_id,
+        'date': date_str,
+        'created_at': datetime.now(timezone.utc),
+        'headline': request.headline,
+        'overview': request.overview,
+        'day_emoji': '🧪',
+        'highlights': [],
+        'action_items': [],
+        'memories_learned': [ref.model_dump(mode='json') for ref in refs],
+    }
+    daily_summaries_db.create_daily_summary(uid, summary_data)
+    return DailySummaryFixtureResponse(
+        status='ok',
+        summary_id=summary_id,
+        date=date_str,
+        memories_learned=len(refs),
+    )

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -120,7 +120,7 @@ from utils.notifications import send_notification, send_training_data_submitted_
 from utils.llm.external_integrations import generate_comprehensive_daily_summary
 from models.notification_message import NotificationMessage
 from models.daily_summary_payload import LearnedMemoryRef
-from utils.memory.learned_today import memories_learned_for_summary, memory_review_card_block
+from utils.memory.learned_today import memories_learned_payload, memory_review_card_block
 from utils.other import endpoints as auth
 from utils.other.storage import (
     delete_all_conversation_recordings,
@@ -1597,19 +1597,15 @@ def update_daily_summary_settings(data: DailySummarySettingsUpdate, uid: str = D
 def _memories_learned_payload(uid, conversations, start_date_utc, end_date_utc):
     """Select the day's review items for a summary about to be generated.
 
-    The read lives here rather than inside generate_comprehensive_daily_summary:
-    that module is the LLM summary builder, and giving it a memory dependency
-    would put a Firestore read behind every caller and every test of it.
+    Thin adapter over the shared selection so this route and the scheduled job
+    cannot drift into two different definitions of "learned today".
     """
-    return [
-        ref.model_dump(mode='json')
-        for ref in memories_learned_for_summary(
-            uid,
-            conversation_ids=[c.id for c in conversations if not getattr(c, 'discarded', False)],
-            window_start=start_date_utc,
-            window_end=end_date_utc,
-        )
-    ]
+    return memories_learned_payload(
+        uid,
+        conversations,
+        window_start=start_date_utc,
+        window_end=end_date_utc,
+    )
 
 
 class TestDailySummaryRequest(BaseModel):

--- a/backend/tests/unit/test_chat_first_blocks.py
+++ b/backend/tests/unit/test_chat_first_blocks.py
@@ -321,3 +321,66 @@ def test_chat_first_validate_returns_a_typed_rejection_for_malformed_block_schem
 
     assert response.status_code == 200
     assert response.json() == {'accepted': False, 'code': 'invalid_request', 'blocks': []}
+
+
+def test_chat_first_validate_admits_the_desktop_memory_review_card(monkeypatch):
+    _enable_chat_first(monkeypatch)
+    monkeypatch.setattr(
+        chat_first_router,
+        'fetch_memory_dict',
+        lambda uid, memory_id, **kwargs: {'id': memory_id, 'content': 'private-content-not-returned'},
+    )
+
+    # The exact shape the desktop adapter emits, including the empty-string
+    # substitutions it makes when the source block carried no provenance.
+    response = _client().post(
+        '/v1/chat-first/blocks/validate',
+        json=_request(
+            blocks=[
+                {
+                    'type': 'memoryReviewCard',
+                    'summary_id': '',
+                    'date': '',
+                    'items': [
+                        {'memory_id': 'memory-1', 'content': 'Prefers async standups', 'category': 'work'},
+                        {'memory_id': 'memory-2', 'content': 'Runs on Tuesdays', 'category': ''},
+                    ],
+                }
+            ]
+        ),
+    )
+
+    assert response.status_code == 200
+    assert response.json()['accepted'] is True
+    block = response.json()['blocks'][0]
+    assert block['type'] == 'memoryReviewCard'
+    assert [item['memory_id'] for item in block['items']] == ['memory-1', 'memory-2']
+
+
+def test_chat_first_validate_rejects_a_memory_review_card_the_account_does_not_own(monkeypatch):
+    _enable_chat_first(monkeypatch)
+    monkeypatch.setattr(
+        chat_first_router,
+        'fetch_memory_dict',
+        lambda uid, memory_id, **kwargs: {'id': memory_id} if memory_id == 'memory-1' else None,
+    )
+
+    response = _client().post(
+        '/v1/chat-first/blocks/validate',
+        json=_request(
+            blocks=[
+                {
+                    'type': 'memoryReviewCard',
+                    'summary_id': 'summary-1',
+                    'date': '2026-09-02',
+                    'items': [
+                        {'memory_id': 'memory-1', 'content': 'Owned', 'category': ''},
+                        {'memory_id': 'memory-9', 'content': 'Not this account', 'category': ''},
+                    ],
+                }
+            ]
+        ),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {'accepted': False, 'code': 'entity_unavailable', 'blocks': []}

--- a/backend/tests/unit/test_chat_followup_block.py
+++ b/backend/tests/unit/test_chat_followup_block.py
@@ -198,3 +198,43 @@ def test_failed_turn_persists_no_followup_block():
         assert ai_writes[0]['content_blocks'] == []
     finally:
         _cleanup(saved)
+
+
+@pytest.mark.parametrize(
+    'tail',
+    [
+        'Who else was there? What did they decide?',
+        'That was the Q3 review. Want the attendee list?',
+        'Nice! Should I pull the attendee list?',
+    ],
+)
+def test_tail_with_more_than_one_sentence_is_dropped(tail):
+    """One chip carries one question; a packed tail has left the contract."""
+    visible, question = split_followup_tail(f"Answer.\n{FOLLOWUP_DELIMITER} {tail}")
+    assert visible == 'Answer.'
+    assert question is None
+
+
+@pytest.mark.parametrize(
+    'tail',
+    [
+        'Want the notes from the 10 a.m. standup?',
+        'Should I check what the 3.5 release changed?',
+    ],
+)
+def test_one_question_survives_an_internal_period(tail):
+    """A decimal or a lowercase abbreviation is not a sentence boundary."""
+    visible, question = split_followup_tail(f"Answer.\n{FOLLOWUP_DELIMITER} {tail}")
+    assert visible == 'Answer.'
+    assert question == tail
+
+
+def test_a_turn_cut_short_mid_marker_leaves_no_residue():
+    """A timeout can stop the model part-way through the delimiter it was writing."""
+    visible, question = split_followup_tail('You and Priya settled on Thursday.\n<<<FOLL')
+    assert visible == 'You and Priya settled on Thursday.\n'
+    assert question is None
+
+
+def test_text_that_merely_ends_in_an_angle_bracket_is_kept():
+    assert split_followup_tail('The condition is x <') == ('The condition is x <', None)

--- a/backend/tests/unit/test_chat_followup_outcome_text.py
+++ b/backend/tests/unit/test_chat_followup_outcome_text.py
@@ -1,0 +1,33 @@
+"""Backend-authored outcome text must survive a pending follow-up marker.
+
+A model can write its closing-question marker and still leave tool calls to run.
+If the turn then ends on a safety limit or a provider error, the text the backend
+appends to explain that lands *after* the marker — where the parser drops it with
+the rest of the tail. The user would be left with a partial answer, no reason for
+it, and a chip inviting them one hop further into a turn that never finished.
+"""
+
+from tests.unit.test_prompt_cache_integration import _get_agentic_module
+from utils.chat_followup import FOLLOWUP_DELIMITER, split_followup_tail
+
+
+async def _finished_answer(text: str) -> tuple[str, str | None]:
+    agentic_mod = _get_agentic_module()
+    callback = agentic_mod.AsyncStreamingCallback()
+    full_response = [f'Here is what I found.\n{FOLLOWUP_DELIMITER} Who else was in that call?']
+    await agentic_mod._put_outcome_text(callback, full_response, text)
+    return split_followup_tail(''.join(full_response))
+
+
+async def test_guard_message_survives_and_voids_the_chip():
+    answer, question = await _finished_answer('\n\nI seem to be stuck trying to answer that.')
+    assert answer == 'Here is what I found.\n\nI seem to be stuck trying to answer that.'
+    assert question is None, 'a turn that stopped on a limit must not invite a next question'
+
+
+async def test_model_text_after_no_marker_is_untouched():
+    agentic_mod = _get_agentic_module()
+    callback = agentic_mod.AsyncStreamingCallback()
+    full_response = ['Here is what I found.']
+    await agentic_mod._put_outcome_text(callback, full_response, '\n\nSorry, I encountered an error.')
+    assert ''.join(full_response) == 'Here is what I found.\n\nSorry, I encountered an error.'

--- a/backend/tests/unit/test_daily_summary_e2e_fixture.py
+++ b/backend/tests/unit/test_daily_summary_e2e_fixture.py
@@ -1,0 +1,112 @@
+"""Hermetic contracts for the local-only daily-summary review-card fixture."""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import routers.daily_summary_e2e as fixture_router
+
+UID = 'auth-emulator-review-card-fixture'
+
+
+def _client(monkeypatch, *, local: bool = True):
+    written: list[tuple[str, dict]] = []
+    monkeypatch.setattr(fixture_router, 'is_chat_first_e2e_harness_runtime', lambda: local)
+    monkeypatch.setattr(
+        fixture_router.daily_summaries_db,
+        'create_daily_summary',
+        lambda uid, data: written.append((uid, data)) or data['id'],
+    )
+    app = FastAPI()
+    app.include_router(fixture_router.router)
+    app.dependency_overrides[fixture_router.auth.get_current_user_uid] = lambda: UID
+    return TestClient(app), written
+
+
+def test_seed_writes_the_wire_shape_the_desktop_card_reads(monkeypatch):
+    client, written = _client(monkeypatch)
+
+    response = client.post(
+        '/v1/dev-harness/daily-summary/seed',
+        json={
+            'date': '2026-03-04',
+            'memories': [
+                {'memory_id': 'mem_a', 'content': 'Prefers async standups.', 'category': 'system'},
+                {'memory_id': 'mem_b', 'content': 'Ships on Wednesdays.', 'category': 'workflow'},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {
+        'status': 'ok',
+        'summary_id': 'dev-harness-daily-summary-2026-03-04',
+        'date': '2026-03-04',
+        'memories_learned': 2,
+    }
+    uid, data = written[0]
+    assert uid == UID
+    assert data['id'] == 'dev-harness-daily-summary-2026-03-04'
+    assert data['date'] == '2026-03-04'
+    # The desktop decodes `memories_learned` by these exact keys
+    # (`DailySummaryRecord.LearnedMemory`); a rename here renders no rows at all.
+    assert [(entry['memory_id'], entry['content'], entry['category']) for entry in data['memories_learned']] == [
+        ('mem_a', 'Prefers async standups.', 'system'),
+        ('mem_b', 'Ships on Wednesdays.', 'workflow'),
+    ]
+    assert all(isinstance(entry['captured_at'], str) for entry in data['memories_learned'])
+
+
+def test_seed_is_idempotent_for_one_day(monkeypatch):
+    client, written = _client(monkeypatch)
+    payload = {'date': '2026-03-04', 'memories': [{'memory_id': 'mem_a', 'content': 'One.'}]}
+
+    first = client.post('/v1/dev-harness/daily-summary/seed', json=payload)
+    second = client.post('/v1/dev-harness/daily-summary/seed', json=payload)
+
+    # One doc id per day, so a re-run overwrites rather than leaving two
+    # summaries competing for the desktop's newest-first read of one record.
+    assert first.json()['summary_id'] == second.json()['summary_id']
+    assert {data['id'] for _, data in written} == {'dev-harness-daily-summary-2026-03-04'}
+
+
+@pytest.mark.parametrize(
+    'memories',
+    [
+        [],
+        [{'memory_id': '  ', 'content': 'No identity.'}],
+        [{'memory_id': 'mem_a', 'content': '   '}],
+    ],
+)
+def test_seed_refuses_rows_that_address_no_memory(monkeypatch, memories):
+    client, written = _client(monkeypatch)
+
+    response = client.post('/v1/dev-harness/daily-summary/seed', json={'memories': memories})
+
+    assert response.status_code == 400
+    assert written == []
+
+
+def test_seed_refuses_an_invalid_date(monkeypatch):
+    client, written = _client(monkeypatch)
+
+    response = client.post(
+        '/v1/dev-harness/daily-summary/seed',
+        json={'date': '04-03-2026', 'memories': [{'memory_id': 'mem_a', 'content': 'One.'}]},
+    )
+
+    assert response.status_code == 400
+    assert written == []
+
+
+def test_fixture_router_is_defensively_hidden_when_directly_included_outside_local(monkeypatch):
+    client, written = _client(monkeypatch, local=False)
+
+    response = client.post(
+        '/v1/dev-harness/daily-summary/seed',
+        json={'memories': [{'memory_id': 'mem_a', 'content': 'One.'}]},
+    )
+
+    assert response.status_code == 404
+    assert written == []

--- a/backend/tests/unit/test_daily_summary_empty_overview.py
+++ b/backend/tests/unit/test_daily_summary_empty_overview.py
@@ -29,6 +29,10 @@ def _drive(monkeypatch, overview):
     monkeypatch.setattr(notif.daily_summaries_db, 'create_daily_summary', lambda *a, **k: 'sid')
     monkeypatch.setattr(notif.postprocess_executor, 'submit', lambda *a, **k: None)
     monkeypatch.setattr(notif, 'day_summary_webhook', lambda *a, **k: None)
+    # The scheduled send now selects the day's learned memories for the review
+    # card. Without a stub this reaches the real MemoryService and issues a live
+    # Firestore query from a unit test, which hangs under api_core's retry.
+    monkeypatch.setattr(notif, 'memories_learned_payload', lambda *a, **k: [])
     monkeypatch.setattr(notif, 'send_notification', lambda *a, **k: sent.append(a))
 
     notif._send_summary_notification(('u1', ['tok1']))

--- a/backend/tests/unit/test_daily_summary_job_resilience.py
+++ b/backend/tests/unit/test_daily_summary_job_resilience.py
@@ -18,6 +18,13 @@ from typing import Any, Dict, Iterator, List, Tuple
 
 from testing.import_isolation import AutoMockModule, load_module_fresh, stub_modules
 
+# Imported for its side effect on import cost, not for its API: the job imports
+# learned_today lazily, so without this the pydantic model build inside
+# models.daily_summary_payload lands in the call phase of the test below and
+# trips the fast-unit CPU duration guard. Paying it at collection keeps the
+# guard measuring the test rather than a one-time import.
+import utils.memory.learned_today  # noqa: F401
+
 BACKEND_DIR = Path(__file__).resolve().parents[2]
 
 

--- a/backend/tests/unit/test_daily_summary_job_resilience.py
+++ b/backend/tests/unit/test_daily_summary_job_resilience.py
@@ -116,7 +116,7 @@ def _loaded_job() -> Iterator[Tuple[ModuleType, ModuleType, FakeRedis, RecordedF
         'utils.conversations.factory': _module('utils.conversations.factory', deserialize_conversation=lambda v: v),
         'utils.llm.external_integrations': _module(
             'utils.llm.external_integrations',
-            generate_comprehensive_daily_summary=lambda *_args: {},
+            generate_comprehensive_daily_summary=lambda *_a, **_k: {},
         ),
         'utils.notifications': _module(
             'utils.notifications',
@@ -253,7 +253,7 @@ def test_next_execution_resumes_at_the_checkpointed_tail() -> None:
         notifications._get_timezones_grouped_by_hour = lambda: {22: ['UTC']}
         notification_db.get_users_for_daily_summary = lambda _tz, _hour: _users(9)
         notifications.summary_budget.write_job_cursor(
-            notifications.summary_budget.job_cursor_key(datetime.now(timezone.utc)),
+            notifications.summary_budget.job_cursor_key(),
             {'hour': 22, 'uid': 'uid-08'},
         )
         served: List[str] = []
@@ -264,6 +264,36 @@ def test_next_execution_resumes_at_the_checkpointed_tail() -> None:
         assert served[0] == 'uid-08', 'the run must start at the tail the previous run could not reach'
         assert sorted(served) == [f'uid-{i:02d}' for i in range(9)], 'rotation still covers the head'
         assert redis.store == {}, 'a complete pass clears the checkpoint'
+
+
+def test_a_partially_read_hour_group_does_not_clear_the_checkpoint() -> None:
+    """A dropped timezone chunk is a partial enumeration. Finishing the run as if
+    it were complete retires users the job never even listed."""
+    with _loaded_job() as (notifications, notification_db, redis, fallbacks):
+        notifications._get_timezones_grouped_by_hour = lambda: {22: [f'tz-{i:02d}' for i in range(40)]}
+        served: List[str] = []
+
+        def read_users(timezones: List[str], _target_hour: int) -> List[Any]:
+            if 'tz-30' in timezones:
+                raise RuntimeError('firestore unavailable')
+            return _users(3)
+
+        notification_db.get_users_for_daily_summary = read_users
+        notifications._send_summary_notification = lambda user: served.append(user[0])
+
+        asyncio.run(notifications.send_daily_summary_notification())
+
+        assert served == ['uid-00', 'uid-01', 'uid-02'], 'the chunk that did read is still served'
+        assert redis.store, 'a partial read must leave the run resumable'
+
+
+def test_the_checkpoint_key_survives_the_hour_rollover() -> None:
+    """The key used to carry the UTC hour, so the execution that wrote the tail
+    and the execution that should resume it never shared a key."""
+    from utils.other import daily_summary_budget
+
+    assert daily_summary_budget.job_cursor_key() == daily_summary_budget.job_cursor_key()
+    assert 'T' not in daily_summary_budget.job_cursor_key()
 
 
 def test_job_end_summary_line_reports_the_counters() -> None:
@@ -323,6 +353,55 @@ def test_truncation_bound_always_keeps_one_conversation() -> None:
     assert bounded.dropped == 1
 
 
+def test_a_nonpositive_budget_falls_back_to_the_bound_not_past_it() -> None:
+    """Returning the whole day for max_chars <= 0 removed the only protection
+    against the context overflow this bound exists for."""
+    from utils.other import daily_summary_budget
+
+    conversations = [_Conversation(i, 100) for i in range(10)]
+    bounded = daily_summary_budget.select_conversations_within_budget(conversations, 0, render=_render)
+
+    assert bounded.rendered_chars <= daily_summary_budget.DEFAULT_MAX_HISTORY_CHARS
+    assert len(bounded.conversations) == 10, 'a small day still fits under the fallback bound'
+
+    bounded = daily_summary_budget.select_conversations_within_budget(
+        [_Conversation(i, 200_000) for i in range(5)], -1, render=_render
+    )
+    assert bounded.truncated is True, 'the fallback bound is applied, not skipped'
+
+
+def test_an_unrenderable_conversation_is_dropped_and_counted() -> None:
+    """Keeping it at zero cost only moved the failure into the summary render,
+    where it costs the whole recap instead of one conversation."""
+    from utils.other import daily_summary_budget
+
+    def render(conversation: _Conversation) -> str:
+        if conversation.index == 1:
+            raise ValueError('unrenderable segment')
+        return 'x' * conversation.size
+
+    conversations = [_Conversation(i, 10) for i in range(3)]
+    bounded = daily_summary_budget.select_conversations_within_budget(conversations, 10_000, render=render)
+
+    assert [c.index for c in bounded.conversations] == [0, 2]
+    assert bounded.dropped == 1
+
+
+def test_a_renderer_that_fails_for_everything_still_hands_the_day_over() -> None:
+    """If nothing renders the fault is the renderer, not the conversations, and
+    dropping the whole day would turn that into a silently missing recap."""
+    from utils.other import daily_summary_budget
+
+    def render(_conversation: _Conversation) -> str:
+        raise ImportError('renderer unavailable')
+
+    conversations = [_Conversation(i, 10) for i in range(3)]
+    bounded = daily_summary_budget.select_conversations_within_budget(conversations, 10_000, render=render)
+
+    assert bounded.conversations == conversations
+    assert bounded.truncated is False
+
+
 def test_truncation_bound_tolerates_naive_and_missing_timestamps() -> None:
     from utils.other import daily_summary_budget
 
@@ -374,25 +453,45 @@ def test_job_survives_a_redis_outage_end_to_end() -> None:
 
 class _FakeConversation:
     def __init__(self) -> None:
+        self.id = 'convo-1'
         self.discarded = False
         self.transcript_segments = ['segment']
         self.started_at = datetime(2026, 8, 23, 9, tzinfo=timezone.utc)
 
 
 @contextmanager
-def _loaded_send_path(memories_learned: List[Dict[str, Any]]) -> Iterator[Tuple[ModuleType, List[Any]]]:
-    """Load the job with the real NotificationMessage so FCM serialization is exercised."""
+def _loaded_send_path(
+    memories_learned: List[Dict[str, Any]],
+) -> Iterator[Tuple[ModuleType, List[Any], Dict[str, Any]]]:
+    """Load the job with the real NotificationMessage so FCM serialization is exercised.
+
+    The generator stub behaves like the real one: ``memories_learned`` is a
+    *parameter* it echoes into the summary, never something it reads for itself.
+    A stub that returned the refs regardless of what it was passed would pass
+    whether or not the scheduled path selects them — which is exactly how the
+    card shipped dead.
+    """
 
     async def no_async_work(*_args: Any, **_kwargs: Any) -> None:
         return None
 
     sends: List[Any] = []
+    seen: Dict[str, Any] = {}
     summary_data = {
         'day_emoji': '📅',
         'headline': 'A good day',
         'overview': 'You shipped the thing.',
-        'memories_learned': memories_learned,
     }
+
+    def generate(*args: Any, memories_learned: Any = None, **_kwargs: Any) -> Dict[str, Any]:
+        seen['generator_args'] = args
+        seen['generator_kwarg'] = memories_learned
+        return {**summary_data, 'memories_learned': list(memories_learned or [])}
+
+    def select_payload(uid: str, conversations: Any, window_start: Any, window_end: Any) -> List[Dict[str, Any]]:
+        seen['selection_args'] = (uid, [c.id for c in conversations], window_start, window_end)
+        return memories_learned
+
     stubs = {
         'database._client': AutoMockModule('database._client'),
         'database.conversations': _module(
@@ -413,7 +512,7 @@ def _loaded_send_path(memories_learned: List[Dict[str, Any]]) -> Iterator[Tuple[
         'utils.conversations.render': _module('utils.conversations.render', conversations_to_string=lambda _c: 'text'),
         'utils.llm.external_integrations': _module(
             'utils.llm.external_integrations',
-            generate_comprehensive_daily_summary=lambda *_args: summary_data,
+            generate_comprehensive_daily_summary=generate,
         ),
         'utils.notifications': _module(
             'utils.notifications',
@@ -433,18 +532,28 @@ def _loaded_send_path(memories_learned: List[Dict[str, Any]]) -> Iterator[Tuple[
             'utils.other.notifications',
             str(BACKEND_DIR / 'utils' / 'other' / 'notifications.py'),
         )
-        yield notifications, sends
+        # The selection itself is a Firestore read; the job's obligation under
+        # test is that it makes the call and threads the result through.
+        notifications.memories_learned_payload = select_payload
+        yield notifications, sends, seen
 
 
 _MEMORY = {'memory_id': 'mem-1', 'content': 'Ships on Tuesdays', 'category': 'work'}
 
 
 def test_scheduled_send_carries_the_memory_review_card() -> None:
+    """Regression (#12635 review): the scheduled job called the generator without
+    ``memories_learned``, so the parameter kept its None default, the summary's
+    list was always empty, and the block was never attached on the only path real
+    users receive. The card was dead in production as shipped."""
     import json
 
-    with _loaded_send_path([_MEMORY]) as (notifications, sends):
+    with _loaded_send_path([_MEMORY]) as (notifications, sends, seen):
         notifications._send_summary_notification(('uid-00', ['token-00']))
 
+        assert seen['generator_kwarg'] == [_MEMORY], 'the scheduled path must select the day\'s memories'
+        assert seen['selection_args'][0] == 'uid-00'
+        assert seen['selection_args'][1] == ['convo-1'], 'selection is scoped to the bounded conversation set'
         assert len(sends) == 1
         args, _kwargs = sends[0]
         payload = args[3]
@@ -457,7 +566,7 @@ def test_scheduled_send_carries_the_memory_review_card() -> None:
 
 
 def test_scheduled_send_omits_the_card_when_no_memories_were_learned() -> None:
-    with _loaded_send_path([]) as (notifications, sends):
+    with _loaded_send_path([]) as (notifications, sends, _seen):
         notifications._send_summary_notification(('uid-00', ['token-00']))
 
         assert len(sends) == 1
@@ -466,3 +575,16 @@ def test_scheduled_send_omits_the_card_when_no_memories_were_learned() -> None:
         assert 'content_blocks' not in payload, 'no card is sent when the day produced nothing to review'
         assert payload['text'] == 'You shipped the thing.', 'the message text is identical either way'
         assert args[2] == 'You shipped the thing.'
+
+
+def test_an_oversized_card_costs_the_card_not_the_notification() -> None:
+    """FCM rejects the whole message past 4KB of data, so an unbounded card would
+    take the recap down with it rather than degrade."""
+    huge = [{'memory_id': f'mem-{i}', 'content': 'x' * 900, 'category': 'work'} for i in range(6)]
+    with _loaded_send_path(huge) as (notifications, sends, _seen):
+        notifications._send_summary_notification(('uid-00', ['token-00']))
+
+        assert len(sends) == 1, 'the summary must still be sent'
+        payload = sends[0][0][3]
+        assert 'content_blocks' not in payload
+        assert payload['text'] == 'You shipped the thing.'

--- a/backend/tests/unit/test_desktop_llm_stub.py
+++ b/backend/tests/unit/test_desktop_llm_stub.py
@@ -6,6 +6,7 @@ import json
 
 import pytest
 
+from utils.chat_followup import FOLLOWUP_DELIMITER, split_followup_tail
 from utils.llm import desktop_llm_stub as stub
 
 
@@ -93,3 +94,31 @@ def test_gemini_proxy_stub_echoes_marker():
     )
     payload = stub.stub_gemini_proxy_json(body)
     assert payload['candidates'][0]['content']['parts'][0]['text'] == 'Stub saw marker: gemini-stub'
+
+
+def test_followup_probe_emits_a_separable_tail():
+    """The one stub answer `chat-hermetic.yaml` drives its follow-up chip from.
+
+    Asserted against the shared splitter, not against a hand-written expectation:
+    a tail the backend's own rules reject is a tail the desktop client rejects
+    too, and the flow would then assert a chip that never appears.
+    """
+    body = _user_body('Recap the storage migration and end with a grounded follow-up question.')
+    directive = stub.stub_directive(body)
+    assert isinstance(directive, stub._TextDirective)
+    assert FOLLOWUP_DELIMITER in directive.text
+
+    visible, question = split_followup_tail(directive.text)
+    assert visible == stub.FOLLOWUP_PROBE_ANSWER
+    assert question == stub.FOLLOWUP_PROBE_QUESTION
+    # The flow asserts the visible answer verbatim; the question must not survive
+    # anywhere inside it, which is the defect the chip exists to prevent.
+    assert stub.FOLLOWUP_PROBE_QUESTION not in visible
+
+
+def test_followup_probe_beats_the_exact_reply_path():
+    """`exact_reply_token` strips the trailing `?`, so it must not claim this query."""
+    body = _user_body('Reply with a recap and end with a grounded follow-up question.')
+    directive = stub.stub_directive(body)
+    assert isinstance(directive, stub._TextDirective)
+    assert directive.text == stub.followup_probe_answer()

--- a/backend/tests/unit/test_learned_today_conversation_evidence.py
+++ b/backend/tests/unit/test_learned_today_conversation_evidence.py
@@ -1,0 +1,121 @@
+"""Day attribution for the memory review card reads *all* conversation evidence.
+
+`MemoryDB.conversation_id` is a single scalar that `memory_item_to_memorydb`
+overwrites once per conversation-sourced evidence row, so a memory supported by
+two conversations keeps only the last one. Matching on that scalar alone dropped
+memories genuinely produced by one of the summarised day's conversations.
+`MemoryService.retract_conversation_memories` already matches evidence this way.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from models.memories import MemoryCategory, MemoryDB
+import utils.memory.learned_today as learned_today
+from utils.memory.learned_today import memories_learned_for_summary, select_memories_learned
+
+DAY_START = datetime(2026, 9, 1, 7, 0, tzinfo=timezone.utc)
+DAY_END = DAY_START + timedelta(hours=24)
+
+
+def _evidence(source_id: str, source_type: str = 'conversation') -> dict:
+    return {
+        'evidence_id': f'ev-{source_id}',
+        'source_id': source_id,
+        'source_type': source_type,
+        'independence_group': source_id,
+    }
+
+
+def _memory(memory_id: str, **overrides) -> MemoryDB:
+    payload = {
+        'id': memory_id,
+        'uid': 'u1',
+        'content': f'fact {memory_id}',
+        'category': MemoryCategory.interesting,
+        'created_at': DAY_START + timedelta(hours=1),
+        'updated_at': DAY_START + timedelta(hours=1),
+        'capture_confidence': 0.5,
+    }
+    payload.update(overrides)
+    return MemoryDB(**payload)
+
+
+def _select(memories):
+    return select_memories_learned(memories, conversation_ids=['c-today'], window_start=DAY_START, window_end=DAY_END)
+
+
+def test_evidence_from_a_summarised_conversation_counts_even_when_the_scalar_points_elsewhere():
+    merged = _memory(
+        'merged',
+        conversation_id='c-yesterday',
+        evidence=[_evidence('c-yesterday'), _evidence('c-today')],
+    )
+    assert [ref.memory_id for ref in _select([merged])] == ['merged']
+
+
+def test_a_memory_with_no_evidence_from_the_day_is_still_excluded():
+    other = _memory('other', conversation_id='c-yesterday', evidence=[_evidence('c-yesterday')])
+    assert _select([other]) == []
+
+
+def test_non_conversation_evidence_does_not_attribute_a_memory_to_the_day():
+    api = _memory('api', conversation_id=None, evidence=[_evidence('c-today', source_type='developer_api')])
+    api.created_at = DAY_START - timedelta(days=3)
+    assert _select([api]) == [], 'only conversation evidence attributes a memory to the summarised set'
+
+
+def test_the_scan_pages_past_a_full_page_and_stops_at_the_first_short_one():
+    """`MemoryService.read` orders by updated_at, so a bulk touch can push more
+    than one page of older memories in front of the day being summarised."""
+    calls = []
+    day_memory = _memory('wanted', conversation_id='c-today')
+
+    def reader(uid, *, limit, offset):
+        calls.append((limit, offset))
+        if offset == 0:
+            return [_memory(f'old-{i}', conversation_id='c-old') for i in range(limit)]
+        return [day_memory]
+
+    picked = memories_learned_for_summary(
+        'u1',
+        conversation_ids=['c-today'],
+        window_start=DAY_START,
+        window_end=DAY_END,
+        read_memories=reader,
+        scan_limit=4,
+    )
+
+    assert [ref.memory_id for ref in picked] == ['wanted']
+    assert calls == [(4, 0), (4, 4)], 'a short page ends the scan; the page cap bounds it either way'
+
+
+def test_a_short_first_page_costs_exactly_one_read():
+    calls = []
+
+    def reader(uid, *, limit, offset):
+        calls.append((limit, offset))
+        return [_memory('m1', conversation_id='c-today')]
+
+    memories_learned_for_summary(
+        'u1',
+        conversation_ids=['c-today'],
+        window_start=DAY_START,
+        window_end=DAY_END,
+        read_memories=reader,
+        scan_limit=50,
+    )
+    assert calls == [(50, 0)], 'the overwhelming majority of users still pay for one page'
+
+
+def test_a_failure_reaching_the_memory_stack_costs_the_card_not_the_recap(monkeypatch):
+    """The lazy MemoryService import sits on the same fail-open path as the read
+    itself; letting it propagate cost the whole daily summary, not just the card."""
+    reported = []
+    monkeypatch.setattr(learned_today, '_report_read_failure', lambda error: reported.append(type(error).__name__))
+    monkeypatch.setitem(__import__('sys').modules, 'utils.memory.memory_service', None)
+
+    assert (
+        memories_learned_for_summary('u1', conversation_ids=['c-today'], window_start=DAY_START, window_end=DAY_END)
+        == []
+    )
+    assert reported and reported[0].endswith('Error'), 'the failure is reported, never swallowed'

--- a/backend/tests/unit/test_other_notifications_async_boundaries.py
+++ b/backend/tests/unit/test_other_notifications_async_boundaries.py
@@ -7,6 +7,12 @@ from typing import Any, Iterator
 
 from testing.import_isolation import AutoMockModule, load_module_fresh, stub_modules
 
+# Imported for its cost, not its API. The job imports learned_today, which builds
+# the pydantic models in models.daily_summary_payload. Without this the build lands
+# inside the call phase of the fresh-module loads below and trips the fast-unit CPU
+# duration guard, which measures the call phase only.
+import utils.memory.learned_today  # noqa: F401
+
 BACKEND_DIR = Path(__file__).resolve().parents[2]
 
 

--- a/backend/utils/chat_followup.py
+++ b/backend/utils/chat_followup.py
@@ -53,6 +53,34 @@ _GENERIC_PATTERNS = [
 
 _WHITESPACE = re.compile(r'\s+')
 
+# One chip carries one question. A tail that packs a second question, or a
+# statement in front of the question, is a contract violation rather than a
+# chip: the user would be shown several prompts on one tappable surface. The
+# period arm only fires on a real sentence boundary (". W"), so decimals and
+# lowercase abbreviations ("3.5", "10 a.m. standup") stay legal.
+_INTERNAL_TERMINATOR = re.compile(r'[?!]|\.\s+["\'(\[]*[A-Z0-9]')
+
+# A turn cut short mid-marker leaves residue like ``<<<`` or ``<<<FOLL``. One
+# stray ``<`` is far more likely to be real text than marker residue, so the
+# transcript keeps it; two or more is only ever the delimiter starting.
+_MIN_MARKER_RESIDUE = 2
+
+
+def _partial_delimiter_suffix_length(text: str, delimiter: str) -> int:
+    """Length of the trailing run of ``text`` that could still become ``delimiter``."""
+    for length in range(min(len(text), len(delimiter) - 1), 0, -1):
+        if delimiter.startswith(text[len(text) - length :]):
+            return length
+    return 0
+
+
+def strip_partial_followup_delimiter(text: str) -> str:
+    """Drop a half-written delimiter left at the end of a cut-short answer."""
+    held = _partial_delimiter_suffix_length(text, FOLLOWUP_DELIMITER)
+    if held < _MIN_MARKER_RESIDUE:
+        return text
+    return text[: len(text) - held]
+
 
 def _normalize_question(question: str) -> str:
     collapsed = _WHITESPACE.sub(' ', question).strip()
@@ -79,7 +107,9 @@ def split_followup_tail(text: Optional[str]) -> Tuple[str, Optional[str]]:
         return '', None
     index = text.find(FOLLOWUP_DELIMITER)
     if index < 0:
-        return text, None
+        # A timed-out or cut-short turn can stop part-way through the marker.
+        # A half-formed tail must never leak into the transcript either.
+        return strip_partial_followup_delimiter(text), None
     visible = text[:index].rstrip()
     raw_tail = text[index + len(FOLLOWUP_DELIMITER) :]
     # Only the first line of the tail is the question; a model that keeps
@@ -88,6 +118,8 @@ def split_followup_tail(text: Optional[str]) -> Tuple[str, Optional[str]]:
     if not question:
         return visible, None
     if not question.endswith('?'):
+        return visible, None
+    if _INTERNAL_TERMINATOR.search(question[:-1]):
         return visible, None
     if len(question) > MAX_FOLLOWUP_CHARS or len(question.split()) > MAX_FOLLOWUP_WORDS:
         return visible, None
@@ -170,7 +202,7 @@ class FollowUpTailStreamFilter:
             self._suppressing = True
             self._pending = ''
             return buffer[:index]
-        hold = self._partial_delimiter_suffix_length(buffer)
+        hold = _partial_delimiter_suffix_length(buffer, self._delimiter)
         if hold:
             self._pending = buffer[len(buffer) - hold :]
             return buffer[: len(buffer) - hold]
@@ -185,12 +217,6 @@ class FollowUpTailStreamFilter:
         remaining = self._pending
         self._pending = ''
         return remaining
-
-    def _partial_delimiter_suffix_length(self, buffer: str) -> int:
-        for length in range(min(len(buffer), len(self._delimiter) - 1), 0, -1):
-            if self._delimiter.startswith(buffer[len(buffer) - length :]):
-                return length
-        return 0
 
 
 FOLLOWUP_PROMPT_SECTION = f"""

--- a/backend/utils/llm/desktop_llm_stub.py
+++ b/backend/utils/llm/desktop_llm_stub.py
@@ -15,8 +15,25 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Any, Literal
 
+from utils.chat_followup import FOLLOWUP_DELIMITER
+
 DEFAULT_ASSISTANT_TEXT = 'Hermetic LLM stub response.'
 EXACT_MEMORY_AGENT_REQUEST = "Have an agent look through my memories today and surface one surprising insight."
+
+# The one deterministic answer that carries a grounded follow-up tail.
+#
+# Every other steerable path here is unusable for the follow-up chip:
+# ``exact_reply_token`` strips trailing non-alphanumerics, so it cannot even
+# produce the ``?`` a chip question requires, and no other branch emits the
+# delimiter at all. Without this the hermetic chat lane could never produce a
+# chip, so nothing about the tail — that the question leaves the prose, that the
+# chip carries it, that tapping it is attributed — was reachable from an e2e
+# flow. Both halves are asserted verbatim by ``chat-hermetic.yaml``: change them
+# and change the flow in the same commit.
+FOLLOWUP_PROBE_TRIGGER = 'end with a grounded follow-up question'
+FOLLOWUP_PROBE_ANSWER = 'Priya flagged the storage migration in the Tuesday review.'
+FOLLOWUP_PROBE_QUESTION = 'What did Priya say about the storage migration?'
+
 _USER_MESSAGE_BOUNDARY = '\n\n# User Message\n'
 _HARNESS_TOKEN_RE = re.compile(r'(?:GAUNTLET|RESILIENCE)-[A-Z0-9_-]*')
 _MARKER_RE = re.compile(r'\[\[MARKER:([^\]]+)\]\]')
@@ -158,6 +175,16 @@ def exact_reply_token(user_text: str) -> str | None:
     return token or None
 
 
+def followup_probe_answer() -> str:
+    """A grounded answer plus one follow-up tail, in the model's own wire shape.
+
+    The delimiter is imported from ``utils.chat_followup`` rather than repeated
+    so a change to the marker cannot leave the stub emitting the old one and the
+    flow silently asserting a chip that no longer appears.
+    """
+    return f'{FOLLOWUP_PROBE_ANSWER}\n\n{FOLLOWUP_DELIMITER} {FOLLOWUP_PROBE_QUESTION}'
+
+
 def quoted_title(user_text: str) -> str | None:
     lowercase = user_text.lower()
     marker_start = lowercase.find('background agent titled')
@@ -267,6 +294,11 @@ def stub_directive(body: Mapping[str, object]) -> StubDirective:
 
     if 'single word probe only' in normalized:
         return _TextDirective('PROBE')
+
+    # Checked before `exact_reply_token` because that path would otherwise claim
+    # a probe query that also contains "reply with".
+    if FOLLOWUP_PROBE_TRIGGER in normalized:
+        return _TextDirective(followup_probe_answer())
 
     exact = exact_reply_token(user_text)
     if exact:

--- a/backend/utils/memory/learned_today.py
+++ b/backend/utils/memory/learned_today.py
@@ -34,10 +34,14 @@ logger = logging.getLogger(__name__)
 # is a glance, not a queue.
 MEMORIES_LEARNED_LIMIT = 3
 
-# Newest-first read depth. `MemoryService.read` returns the merged canonical +
-# historical page ordered by updated_at/created_at descending, so one bounded
-# page is enough to cover a single day for any realistic capture rate.
+# Newest-first read depth. `MemoryService.read` orders by **updated_at**, not
+# created_at, so a bulk touch (a sweep job, a re-processing pass, an edit spree)
+# can push more than one page of older memories in front of the day being
+# summarised and leave the card silently empty. One page still ends the scan for
+# every user whose page comes back short — the overwhelming majority — and only
+# a user who actually has a full page pays for the next one.
 MEMORIES_LEARNED_SCAN_LIMIT = 200
+MEMORIES_LEARNED_SCAN_PAGES = 3
 
 MemoryReader = Callable[..., List["MemoryDB"]]
 
@@ -93,17 +97,33 @@ def _from_day(
     window. A memory that points at a conversation *outside* the summarised set
     is deliberately excluded — it belongs to another day's card.
     """
-    # `MemoryDB.memory_id` is a deprecated alias that always mirrors `id`, so
-    # `conversation_id` is the only conversation evidence on this model.
-    conversation_id = memory.conversation_id
-    if conversation_id:
-        return conversation_id in conversation_ids
+    # `MemoryDB.conversation_id` is NOT the only conversation evidence on this
+    # model: `memory_item_to_memorydb` walks every evidence row and overwrites
+    # `conversation_id` with each conversation-sourced `source_id`, so a memory
+    # supported by two conversations keeps only the last one. Matching on that
+    # scalar alone would reject a memory genuinely produced by one of today's
+    # conversations because a later merge attributed it elsewhere.
+    # `MemoryService.retract_conversation_memories` already matches evidence the
+    # same way.
+    evidence_ids = _conversation_evidence(memory)
+    if evidence_ids:
+        return bool(evidence_ids & conversation_ids)
     window_start = _aware(start)
     window_end = _aware(end)
     created_at = _aware(memory.created_at)
     if window_start is None or window_end is None or created_at is None:
         return False
     return window_start <= created_at <= window_end
+
+def _conversation_evidence(memory: "MemoryDB") -> frozenset[str]:
+    """Every conversation this memory carries evidence from."""
+    found: set[str] = set()
+    if memory.conversation_id:
+        found.add(memory.conversation_id)
+    for evidence in memory.evidence or []:
+        if evidence.source_id and evidence.source_type == 'conversation':
+            found.add(evidence.source_id)
+    return frozenset(found)
 
 
 def _rank(memory: "MemoryDB") -> _MemoryRank:
@@ -145,6 +165,24 @@ def select_memories_learned(
     ]
 
 
+def _report_read_failure(error: BaseException) -> None:
+    """Fail-open: the day still gets a summary, just no review card.
+
+    That is a correctness change, so it is reported rather than swallowed. Every
+    way of reaching the memory stack is covered, the lazy import included: a
+    failure there used to propagate and cost the whole recap.
+    """
+    record_fallback(
+        component='daily_summary',
+        from_mode='memories_learned',
+        to_mode='none',
+        reason='malformed_doc' if isinstance(error, (TypeError, ValueError)) else 'other',
+        outcome='degraded',
+        log=logger,
+    )
+    logger.warning('memories_learned read failed for daily summary: %s', type(error).__name__)
+
+
 def memories_learned_for_summary(
     uid: str,
     *,
@@ -154,32 +192,35 @@ def memories_learned_for_summary(
     limit: int = MEMORIES_LEARNED_LIMIT,
     read_memories: Optional[MemoryReader] = None,
     scan_limit: int = MEMORIES_LEARNED_SCAN_LIMIT,
+    scan_pages: int = MEMORIES_LEARNED_SCAN_PAGES,
 ) -> List[LearnedMemoryRef]:
-    """Read one bounded canonical page and select the day's review items.
+    """Read a bounded newest-first window and select the day's review items.
+
+    The window is at most ``scan_pages`` pages and stops at the first short page,
+    so the common user costs exactly one read and no user costs an unbounded scan.
 
     Never raises: the daily summary is the product, and a memory-read failure
     must degrade to "no card", not to "no summary".
     """
     reader = read_memories
     if reader is None:
-        from utils.memory.memory_service import MemoryService  # local: heavy import, avoids a cycle
+        try:
+            from utils.memory.memory_service import MemoryService  # local: heavy import, avoids a cycle
 
-        reader = MemoryService().read
-    try:
-        page: List["MemoryDB"] = reader(uid, limit=scan_limit, offset=0)
-    except Exception as error:  # noqa: BLE001 - the summary must still ship
-        # Fail-open: the day still gets a summary, just no review card. That is a
-        # correctness change, so it is reported rather than swallowed silently.
-        record_fallback(
-            component='daily_summary',
-            from_mode='memories_learned',
-            to_mode='none',
-            reason='malformed_doc' if isinstance(error, (TypeError, ValueError)) else 'other',
-            outcome='degraded',
-            log=logger,
-        )
-        logger.warning('memories_learned read failed for daily summary: %s', type(error).__name__)
-        return []
+            reader = MemoryService().read
+        except Exception as error:  # noqa: BLE001 - resolving the memory stack can fail too
+            _report_read_failure(error)
+            return []
+    page: List["MemoryDB"] = []
+    for page_index in range(max(1, int(scan_pages))):
+        try:
+            rows: List["MemoryDB"] = reader(uid, limit=scan_limit, offset=page_index * scan_limit)
+        except Exception as error:  # noqa: BLE001 - the summary must still ship
+            _report_read_failure(error)
+            break
+        page.extend(rows)
+        if len(rows) < scan_limit:
+            break
     return select_memories_learned(
         page,
         conversation_ids=conversation_ids,
@@ -187,6 +228,37 @@ def memories_learned_for_summary(
         window_end=window_end,
         limit=limit,
     )
+
+
+def memories_learned_payload(
+    uid: str,
+    conversations: Sequence[Any],
+    window_start: Optional[datetime] = None,
+    window_end: Optional[datetime] = None,
+) -> List[dict[str, Any]]:
+    """Stored projection of the day's review items for a summary being generated.
+
+    Both senders — the scheduled job and the /daily-summary-settings/test route —
+    build the card from what the generator returns, so both must select through
+    this one helper. The read lives here rather than inside
+    ``generate_comprehensive_daily_summary``: that module is the LLM summary
+    builder, and giving it a memory dependency would put a Firestore read behind
+    every caller and every test of it.
+    """
+    return [
+        ref.model_dump(mode='json')
+        for ref in memories_learned_for_summary(
+            uid,
+            # getattr, not attribute access: this selection is fail-open by
+            # contract, so a conversation shape without an id must cost the card
+            # and never the recap it is attached to.
+            conversation_ids=[
+                getattr(c, 'id', None) or '' for c in conversations if not getattr(c, 'discarded', False)
+            ],
+            window_start=window_start,
+            window_end=window_end,
+        )
+    ]
 
 
 def memory_review_card_block(

--- a/backend/utils/memory/learned_today.py
+++ b/backend/utils/memory/learned_today.py
@@ -115,6 +115,7 @@ def _from_day(
         return False
     return window_start <= created_at <= window_end
 
+
 def _conversation_evidence(memory: "MemoryDB") -> frozenset[str]:
     """Every conversation this memory carries evidence from."""
     found: set[str] = set()

--- a/backend/utils/other/ARCHITECTURE.md
+++ b/backend/utils/other/ARCHITECTURE.md
@@ -15,7 +15,7 @@ source files.
 | Local dev storage adapter | `local_storage.py` | Filesystem stand-in for `storage.py` used only by the owned local dev harness; never selected in a deployed image. |
 | Chat file attachments | `chat_file.py` | Provider upload/expiry of files attached to chat turns, and the typed errors the chat route maps to user-facing failures. |
 | Daily summary job | `notifications.py` | The scheduled daily-summary job: per-user fan-out, isolation, budgets, checkpoint cursor, FCM send, `day_summary` webhook. |
-| Daily summary bounds | `daily_summary_budget.py` | Pure helpers the job uses: bounded conversation selection for the generator input and the Redis checkpoint cursor encoding. No I/O. |
+| Daily summary bounds | `daily_summary_budget.py` | Bounds the job uses: bounded conversation selection for the generator input (pure) and the resume checkpoint. The cursor helpers do synchronous Redis I/O and must be called through `run_blocking(db_executor, ...)`; every one of them is fail-soft, so losing the checkpoint costs a re-walk and never a summary. |
 | Bounded list reads | `list_budget.py` | Request-scoped time and document budget for list GET reads (`FC-bounded-read-exceeds-request-budget`). |
 | Request timeout | `timeout.py` | `TimeoutMiddleware`, the per-request wall-clock budget. |
 | Background execution primitives | `task.py`, `jobs.py`, `deferred_delete.py`, `backoff.py` | `safe_create_task`, job start helper, single-thread deferred deletion, jittered backoff. Small and dependency-free. |

--- a/backend/utils/other/daily_summary_budget.py
+++ b/backend/utils/other/daily_summary_budget.py
@@ -33,11 +33,25 @@ from typing import Any, Callable, Dict, List, NamedTuple, Optional, Sequence, Ty
 
 logger = logging.getLogger(__name__)
 
-# Cursor keys are scoped to the UTC hour the job is serving: the hour groups are
-# recomputed from wall-clock every execution, so a cursor from a previous hour
-# points into a different user population. 2h TTL covers the every-minute
-# scheduler plus clock skew without leaving stale keys around.
+# The checkpoint is a single stable key, bounded only by its TTL. It used to be
+# scoped to the UTC hour being served, which made it unreadable by design: the
+# execution that exhausted its budget wrote `...:2026-09-02T18` and the next
+# execution read `...:2026-09-02T19`, so the unfinished tail was never resumed
+# and the whole point of the checkpoint was lost. The serving cohort that a
+# checkpoint describes has to outlive the hour bucket, so the key must too.
+#
+# Starvation is prevented by `rotate_to`, not by the key: a run rotates the hour
+# groups to start at the checkpoint and then walks the *whole* rotated list, so
+# a carried-over cursor reorders a pass and never removes an hour from it. The
+# TTL is the staleness bound — a cursor no execution reached within two hours
+# describes a population that no longer exists, and expiring it costs a
+# re-walk from the head, never a lost summary.
 JOB_CURSOR_TTL_SECONDS = 60 * 60 * 2
+JOB_CURSOR_KEY = 'daily_summary_job_cursor'
+
+# Fallback bound when the deployed budget is missing or nonpositive. ~360k chars
+# is roughly 90k tokens, comfortably inside the 272k-token model limit.
+DEFAULT_MAX_HISTORY_CHARS = 360_000
 
 _CURSOR_HOUR = 'hour'
 _CURSOR_UID = 'uid'
@@ -92,8 +106,14 @@ def select_conversations_within_budget(
     The first conversation is always kept: a single oversized conversation must
     still produce a summary attempt rather than an empty prompt.
     """
-    if max_chars <= 0 or not conversations:
-        return BoundedConversations(list(conversations), 0, 0)
+    if not conversations:
+        return BoundedConversations([], 0, 0)
+    if max_chars <= 0:
+        # A nonpositive budget used to return the whole day, i.e. it removed the
+        # only bound protecting the prompt from the context overflow this module
+        # exists for. Misconfiguration falls back to the bound, never past it.
+        logger.warning('daily_summary_budget_invalid_max_chars value=%s', max_chars)
+        max_chars = DEFAULT_MAX_HISTORY_CHARS
 
     render_one = render or _default_render
     original_order = {id(c): i for i, c in enumerate(conversations)}
@@ -106,21 +126,32 @@ def select_conversations_within_budget(
         try:
             size = len(render_one(conversation))
         except Exception as e:  # a single unrenderable conversation must not sink the recap
+            # Counting it as zero and keeping it only moved the failure into the
+            # summary render, where it costs the whole recap instead of one
+            # conversation. Drop it and report it as dropped.
             logger.warning('daily_summary_budget_render_failed error=%s', e)
-            size = 0
+            dropped += 1
+            continue
         if kept and used + size > max_chars:
             dropped += 1
             continue
         kept.append(conversation)
         used += size
 
+    if not kept:
+        # Every render failed, so the fault is in the renderer, not in any one
+        # conversation. Dropping the whole day would turn that into a silently
+        # missing recap; hand the material over and let the generator fail
+        # loudly on its own instead.
+        logger.warning('daily_summary_budget_all_renders_failed count=%d', len(conversations))
+        return BoundedConversations(list(conversations), 0, 0)
     kept.sort(key=lambda c: original_order[id(c)])
     return BoundedConversations(kept, dropped, used)
 
 
-def job_cursor_key(now_utc: datetime) -> str:
-    """Cursor key for the UTC hour currently being served."""
-    return f'daily_summary_job_cursor:{now_utc.strftime("%Y-%m-%dT%H")}'
+def job_cursor_key() -> str:
+    """Checkpoint key for the daily-summary job. Stable across hour rollovers."""
+    return JOB_CURSOR_KEY
 
 
 def make_cursor(target_hour: Optional[int], uid: Optional[str]) -> Dict[str, Any]:

--- a/backend/utils/other/notifications.py
+++ b/backend/utils/other/notifications.py
@@ -17,7 +17,7 @@ from models.notification_message import NotificationMessage
 from utils.conversations.factory import deserialize_conversation
 from utils.executors import db_executor, postprocess_executor, run_blocking
 from utils.llm.external_integrations import generate_comprehensive_daily_summary
-from utils.memory.learned_today import memory_review_card_block
+from utils.memory.learned_today import memories_learned_payload, memory_review_card_block
 from utils.notifications import send_bulk_notification, send_notification
 from utils.other import daily_summary_budget as summary_budget
 from utils.webhooks import day_summary_webhook
@@ -56,7 +56,7 @@ DAILY_SUMMARY_USER_BUDGET_SECONDS = _env_float('DAILY_SUMMARY_USER_BUDGET_SECOND
 # prompt. ~360k chars is roughly 90k tokens, comfortably inside the 272k-token
 # model limit even alongside the prompt scaffolding and the user's memories.
 # The overflow seen in production was ~290k tokens of input.
-DAILY_SUMMARY_MAX_HISTORY_CHARS = _env_int('DAILY_SUMMARY_MAX_HISTORY_CHARS', 360_000)
+DAILY_SUMMARY_MAX_HISTORY_CHARS = _env_int('DAILY_SUMMARY_MAX_HISTORY_CHARS', summary_budget.DEFAULT_MAX_HISTORY_CHARS)
 # A per-user timeout abandons (it cannot cancel) a worker thread. Stop the run
 # once enough threads are abandoned that the pool would starve the rest.
 DAILY_SUMMARY_MAX_ABANDONED_USERS = _env_int('DAILY_SUMMARY_MAX_ABANDONED_USERS', 12)
@@ -154,7 +154,7 @@ async def send_daily_summary_notification() -> DailySummaryCronOutcome:
     """
     deadline = monotonic() + DAILY_SUMMARY_JOB_BUDGET_SECONDS
     stats = DailySummaryJobStats()
-    cursor_key = summary_budget.job_cursor_key(datetime.now(pytz.utc))
+    cursor_key = summary_budget.job_cursor_key()
 
     try:
         timezones_by_hour = _get_timezones_grouped_by_hour()
@@ -189,7 +189,7 @@ async def send_daily_summary_notification() -> DailySummaryCronOutcome:
 
         stats.groups_attempted += 1
         try:
-            users, query_error = await _get_users_for_daily_summary(timezones, target_hour)
+            users, query_error, group_fully_read = await _get_users_for_daily_summary(timezones, target_hour)
         except Exception as e:
             # One hour group's read failing must not cost the other 23 groups.
             stats.groups_failed += 1
@@ -200,6 +200,18 @@ async def send_daily_summary_notification() -> DailySummaryCronOutcome:
             stats.groups_failed += 1
             logger.error('daily_summary_group_failed hour=%s reason=user_query error=%s', target_hour, query_error)
             return ProcessOutcome.reject(str(query_error), reason='user_query')
+
+        if not group_fully_read:
+            # A dropped timezone chunk means this hour was only *partially*
+            # enumerated. Serving what did read is right, but declaring the run
+            # complete afterwards would clear the checkpoint and retire users the
+            # job never even listed. Keep the run resumable and point the next
+            # execution at this hour.
+            completed_all = False
+            await _checkpoint(cursor_key, target_hour, None)
+            _record_daily_summary_fallback(
+                from_mode='full_run', to_mode='resumable_tail', reason='other', outcome='degraded'
+            )
 
         if not users:
             return ProcessOutcome.ack()
@@ -272,7 +284,16 @@ async def _checkpoint(cursor_key: str, target_hour: Optional[int], uid: Optional
 
 async def _get_users_for_daily_summary(
     timezones: List[str], target_hour: int
-) -> Tuple[List[Tuple[str, List[str], Any]], Optional[BaseException]]:
+ ) -> Tuple[List[Tuple[str, List[str], Any]], Optional[BaseException], bool]:
+    """Read one hour group's users.
+
+    Returns ``(users, query_error, every_chunk_read)``. A dropped chunk is a
+    *partial* read, and a caller that cannot tell the difference finishes the
+    hour, clears the checkpoint, and permanently retires users it never listed.
+    Serving the chunks that did read is still right — the flag only stops the
+    run from calling itself complete.
+
+    """
     timezone_chunks = [timezones[i : i + 30] for i in range(0, len(timezones), 30)]
     # return_exceptions: one failing timezone chunk degrades that chunk's users,
     # it does not throw away the chunks that did read successfully.
@@ -285,15 +306,17 @@ async def _get_users_for_daily_summary(
     )
     users: List[Tuple[str, List[str], Any]] = []
     chunk_errors: List[BaseException] = []
+    every_chunk_read = True
     for chunk_index, chunk in enumerate(chunk_results):
         if isinstance(chunk, BaseException):
+            every_chunk_read = False
             logger.error(
                 'daily_summary_user_query_chunk_failed hour=%s chunk=%d error=%s', target_hour, chunk_index, chunk
             )
             chunk_errors.append(chunk)
             continue
         users.extend(chunk)
-    return users, chunk_errors[0] if chunk_errors else None
+    return users, chunk_errors[0] if chunk_errors else None, every_chunk_read
 
 
 def _get_timezones_grouped_by_hour() -> Dict[int, List[str]]:
@@ -416,8 +439,19 @@ def _send_summary_notification(user_data: Tuple[Any, ...]) -> None:
             from_mode='full_day', to_mode='truncated_day', reason='quota', outcome='degraded'
         )
     conversations = bounded.conversations
-
-    summary_data = generate_comprehensive_daily_summary(uid, conversations, date_str, start_date_utc, end_date_utc)
+    # The review card is built from what the generator returns, so the scheduled
+    # path — the only path real users receive — has to make the same selection
+    # the /v1/users/daily-summary-settings/test path makes. Omitting it left
+    # ``memories_learned`` at its None default, which made the block below
+    # unconditionally None: the card was dead in production as shipped.
+    summary_data = generate_comprehensive_daily_summary(
+        uid,
+        conversations,
+        date_str,
+        start_date_utc,
+        end_date_utc,
+        memories_learned=memories_learned_payload(uid, conversations, start_date_utc, end_date_utc),
+    )
 
     # Store in database
     summary_id = daily_summaries_db.create_daily_summary(uid, summary_data)

--- a/backend/utils/other/notifications.py
+++ b/backend/utils/other/notifications.py
@@ -284,7 +284,7 @@ async def _checkpoint(cursor_key: str, target_hour: Optional[int], uid: Optional
 
 async def _get_users_for_daily_summary(
     timezones: List[str], target_hour: int
- ) -> Tuple[List[Tuple[str, List[str], Any]], Optional[BaseException], bool]:
+) -> Tuple[List[Tuple[str, List[str], Any]], Optional[BaseException], bool]:
     """Read one hour group's users.
 
     Returns ``(users, query_error, every_chunk_read)``. A dropped chunk is a

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -85,6 +85,7 @@ from utils.llm.chat import _get_agentic_qa_prompt, get_current_datetime_block, g
 from utils.executors import run_blocking, db_executor
 from utils.jit_rollout import JITDecisionStage, resolve_jit_rollout
 from utils.chat_followup import (
+    FOLLOWUP_DELIMITER,
     FOLLOWUP_PROMPT_SECTION,
     FollowUpTailStreamFilter,
     split_followup_tail,
@@ -549,7 +550,7 @@ async def _execute_independent_tool_calls(
             stub_after = True
             break
         except SafetyGuardError as error:
-            await _put_answer_text(callback, full_response, f'\n\n{str(error)}')
+            await _put_outcome_text(callback, full_response, f'\n\n{str(error)}')
             logger.error('Safety Guard blocked tool call: %s', error)
             await callback.end()
             return None
@@ -586,7 +587,7 @@ async def _execute_independent_tool_calls(
         try:
             safety_guard.check_context_size(result)
         except SafetyGuardError as error:
-            await _put_answer_text(callback, full_response, f'\n\n{str(error)}')
+            await _put_outcome_text(callback, full_response, f'\n\n{str(error)}')
             logger.error('Safety Guard blocked due to context size: %s', error)
             await callback.end()
             return None
@@ -793,6 +794,23 @@ async def _put_answer_text(callback: AsyncStreamingCallback, full_response: list
     await callback.put_data(text)
 
 
+async def _put_outcome_text(callback: AsyncStreamingCallback, full_response: list, text: str) -> None:
+    """Record backend-authored text that ends the turn, voiding any follow-up tail.
+
+    A model can emit its closing-question marker and still leave tool calls to run. If the turn
+    then ends on a safety limit or an error, the parser would split the answer at that marker and
+    drop this message with the rest of the tail — the user would be left with the partial answer
+    and no reason for it. Backend outcome text supersedes the tail: the marker is removed, so this
+    message stays in the persisted answer and the failed turn offers no chip. ``full_response`` is
+    rebuilt when that happens, so no caller may hold an index into it across this call.
+    """
+    joined = ''.join(full_response)
+    marker = joined.find(FOLLOWUP_DELIMITER)
+    if marker >= 0:
+        full_response[:] = [joined[:marker].rstrip()]
+    await _put_answer_text(callback, full_response, text)
+
+
 def _has_answer(full_response: list) -> bool:
     """Whether anything the router would render as an answer has been delivered.
 
@@ -960,7 +978,7 @@ async def _run_anthropic_agent_stream(
                 await handle_llm_error_async(e, 'anthropic', feature='chat_agent', model=ANTHROPIC_AGENT_MODEL)
                 # ``put_data`` alone reaches the live stream but not the persisted answer, so the
                 # router would overwrite this apology with its own canned error.
-                await _put_answer_text(callback, full_response, "\n\nSorry, I encountered an error. Please try again.")
+                await _put_outcome_text(callback, full_response, "\n\nSorry, I encountered an error. Please try again.")
                 await callback.end()
                 return f'provider_{type(e).__name__}'
 
@@ -981,7 +999,7 @@ async def _run_anthropic_agent_stream(
         if response.stop_reason == "refusal":
             logger.warning('Chat agent turn refused by provider category=%s', _refusal_category(response))
             if not _has_answer(full_response):
-                await _put_answer_text(callback, full_response, AGENT_REFUSAL_MESSAGE)
+                await _put_outcome_text(callback, full_response, AGENT_REFUSAL_MESSAGE)
             await callback.end()
             return 'provider_refusal'
 
@@ -1220,7 +1238,7 @@ async def _run_openai_agent_stream(
                     continue
 
                 await handle_llm_error_async(error, 'openai', feature='chat_agent', model='omi:auto:chat-agent')
-                await _put_answer_text(callback, full_response, '\n\nSorry, I encountered an error. Please try again.')
+                await _put_outcome_text(callback, full_response, '\n\nSorry, I encountered an error. Please try again.')
                 await callback.end()
                 return f'provider_{type(error).__name__}'
 

--- a/desktop/macos/Desktop/Sources/Analytics/AnalyticsManager+QuestionOrigin.swift
+++ b/desktop/macos/Desktop/Sources/Analytics/AnalyticsManager+QuestionOrigin.swift
@@ -39,6 +39,17 @@ extension AnalyticsManager {
   func consumeQuestionOrigin() -> QuestionOrigin {
     QuestionOriginContext.consume()
   }
+
+  /// Drop an armed origin whose dispatch never reached a question at all.
+  ///
+  /// The arm is one-shot but it does not expire: a dispatch that returns before
+  /// anything is sent — no floating window, no provider, a voice turn already
+  /// handed off — emits no `question_asked` to consume it, so the arm survives
+  /// and stamps `followup` on the next, unrelated question the user asks. The
+  /// surface that armed it is the one that knows the send never happened.
+  func questionOriginationAborted() {
+    QuestionOriginContext.clear()
+  }
 }
 
 /// One-shot main-actor store for the armed origin. Deliberately not a mutable
@@ -57,8 +68,13 @@ enum QuestionOriginContext {
     return armed ?? .unprompted
   }
 
-  /// Test seam: drop a previously armed origin without emitting.
-  static func resetForTests() {
+  /// Drop a previously armed origin without emitting.
+  static func clear() {
     armed = nil
+  }
+
+  /// Test seam.
+  static func resetForTests() {
+    clear()
   }
 }

--- a/desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift
+++ b/desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift
@@ -7,7 +7,8 @@
 //  (`openMainAppChat(prefilledDraft:)`) so `chat_drafts_snapshot` can show the draft landed unsent,
 //  `tap_chat_follow_up_chip` performs the chip's own send so the `followup` question origin is
 //  observable end to end, and `seed_memory_review_fixture` / `memory_review_snapshot` /
-//  `memory_review_vote` bring up and drive the "Things I learned today" rows. Every one is a
+//  `memory_review_vote` bring up and drive the "Things I learned today" rows, and the
+//  `home_knows_*` family drives one visit to the Home hub's knows-list at a time. Every one is a
 //  second caller of production code, never a second implementation.
 //
 //  Registered from `DesktopAutomationActionRegistry.registerBuiltins()` next to the Home-stage
@@ -122,6 +123,7 @@ extension DesktopAutomationActionRegistry {
     }
 
     registerMemoryReviewActions()
+    registerHomeKnowsActions()
   }
 
   // MARK: - Memory review card
@@ -260,6 +262,362 @@ extension DesktopAutomationActionRegistry {
       detail["settledInTime"] = settled ? "true" : "false"
       return detail
     }
+  }
+
+  // MARK: - Home knows-list
+
+  /// Seed, reset, read, and drive the Home hub's knows-list.
+  ///
+  /// The rows are composed inside `DashboardPage`'s `body` and published nowhere, and the ledger
+  /// they are gated against is `UserDefaults`-backed and outlives the app. So before this the list
+  /// was unreachable twice over: a flow could not read which rows the hub bound, and could not put
+  /// the ledger into a known state to make the next visit's answer mean anything.
+  ///
+  /// `home_knows_reset` gives the ledger a known state, `seed_home_knows_tasks` gives the composer
+  /// a known task source, and the rest go through `HomeKnowsAutomationRegistry` — the page's own
+  /// `beginKnowsVisit`, `recordKnowsImpressions`, `openKnowsRow` and dismiss handler. Every emit
+  /// they report is read at the `AnalyticsManager` seam, so a flow asserts what production emitted
+  /// rather than what the bridge recomputed.
+  private func registerHomeKnowsActions() {
+    register(
+      name: "home_knows_reset",
+      summary:
+        "Clear the Home knows-list impression ledger for the signed-in owner so the next visit "
+        + "starts from no history (non-production only)",
+      params: [],
+      category: "home",
+      surfaces: ["home"],
+      sideEffects: ["erases the knows-list impression ledger for the signed-in account"]
+    ) { _ in
+      guard AppBuild.isNonProduction else {
+        return ["error": "home_knows_reset is disabled on production bundles"]
+      }
+      let before = HomeKnowsImpressionStore.shared.snapshot().entries.count
+      HomeKnowsImpressionStore.shared.resetForAutomation()
+      // Deliberately does not touch the mounted page: `beginKnowsVisit` would immediately record a
+      // visit's impressions, and the flow's first observed visit would then be its second.
+      return [
+        "clearedEntries": String(before),
+        "entries": String(HomeKnowsImpressionStore.shared.snapshot().entries.count),
+      ]
+    }
+
+    register(
+      name: "seed_home_knows_tasks",
+      summary:
+        "Create the knows-list fixture tasks through the production TasksStore path and reload the "
+        + "dashboard lanes the hub composes from",
+      params: ["timeoutMs"],
+      category: "home",
+      surfaces: ["home"],
+      sideEffects: ["creates and replaces tasks on the signed-in local account"]
+    ) { params in
+      guard AppBuild.isNonProduction else {
+        return ["error": "seed_home_knows_tasks is disabled on production bundles"]
+      }
+      let removed = await HomeKnowsFixture.removeSeededTasks()
+      // Created back to front: ties in the freshness order break on the most recently updated
+      // candidate, so the catalog's first entry has to be the last one written to be the hub's
+      // first row.
+      for text in HomeKnowsFixture.taskCatalog.reversed() {
+        guard await TasksStore.shared.createTask(description: text, dueAt: nil, priority: nil) != nil else {
+          return ["error": "createTask failed for \(text)"]
+        }
+      }
+      // `createTask` only inserts into `incompleteTasks`; the three dashboard lanes the hub reads
+      // (`overdueTasks` / `todaysTasks` / `tasksWithoutDueDate`) are a separate SQLite read.
+      await TasksStore.shared.loadDashboardTasks()
+      let timeoutMs = Int(params["timeoutMs"] ?? "") ?? 8000
+      let visible = await HomeKnowsFixture.waitForSeededCandidates(timeoutMs: timeoutMs)
+      return [
+        "removedExisting": String(removed),
+        "createdCount": String(HomeKnowsFixture.taskCatalog.count),
+        "candidateCount": String(visible),
+      ]
+    }
+
+    register(
+      name: "clear_home_knows_tasks",
+      summary: "Delete the knows-list fixture tasks again (flow teardown)",
+      params: [],
+      category: "home",
+      surfaces: ["home"],
+      sideEffects: ["deletes the fixture tasks it created on the signed-in local account"]
+    ) { _ in
+      guard AppBuild.isNonProduction else {
+        return ["error": "clear_home_knows_tasks is disabled on production bundles"]
+      }
+      let removed = await HomeKnowsFixture.removeSeededTasks()
+      await TasksStore.shared.loadDashboardTasks()
+      return ["removed": String(removed)]
+    }
+
+    register(
+      name: "home_knows_snapshot",
+      summary: "Rows the mounted Home knows-list composed, the slots it left empty, and why",
+      params: [],
+      category: "home",
+      surfaces: ["home"],
+      safety: "read_only"
+    ) { _ in
+      guard AppBuild.isNonProduction else {
+        return ["error": "home_knows_snapshot is disabled on production bundles"]
+      }
+      guard let handle = HomeKnowsAutomationRegistry.mounted else {
+        return ["error": "no Home knows-list is mounted", "mounted": "false"]
+      }
+      return HomeKnowsFixture.detail(handle.snapshot())
+    }
+
+    register(
+      name: "home_knows_visit",
+      summary:
+        "Start a new visit to the mounted knows-list (the same `beginKnowsVisit` the list's "
+        + "onAppear calls) and report the `desktop_home_knows_row` events it emitted",
+      params: [],
+      category: "home",
+      surfaces: ["home"]
+    ) { _ in
+      guard AppBuild.isNonProduction else {
+        return ["error": "home_knows_visit is disabled on production bundles"]
+      }
+      guard let handle = HomeKnowsAutomationRegistry.mounted else {
+        return ["error": "no Home knows-list is mounted", "mounted": "false"]
+      }
+      let emits = HomeKnowsFixture.capturingEmits { handle.beginVisit() }
+      return HomeKnowsFixture.detail(handle.snapshot()).merging(emits) { current, _ in current }
+    }
+
+    register(
+      name: "home_knows_impressions",
+      summary:
+        "Re-run the list's impression reporting without starting a new visit, and report what it "
+        + "emitted — zero, once a visit has already reported its rows",
+      params: [],
+      category: "home",
+      surfaces: ["home"]
+    ) { _ in
+      guard AppBuild.isNonProduction else {
+        return ["error": "home_knows_impressions is disabled on production bundles"]
+      }
+      guard let handle = HomeKnowsAutomationRegistry.mounted else {
+        return ["error": "no Home knows-list is mounted", "mounted": "false"]
+      }
+      let emits = HomeKnowsFixture.capturingEmits { handle.recordImpressions() }
+      return HomeKnowsFixture.detail(handle.snapshot()).merging(emits) { current, _ in current }
+    }
+
+    register(
+      name: "home_knows_open",
+      summary:
+        "Open the visible knows-list row carrying `text` (the row's own tap) and report the ledger "
+        + "entry it wrote",
+      params: ["text"],
+      category: "home",
+      surfaces: ["home"]
+    ) { params in
+      guard AppBuild.isNonProduction else {
+        return ["error": "home_knows_open is disabled on production bundles"]
+      }
+      guard let handle = HomeKnowsAutomationRegistry.mounted else {
+        return ["error": "no Home knows-list is mounted", "mounted": "false"]
+      }
+      let text = params["text"] ?? ""
+      guard let index = handle.snapshot().rows.firstIndex(where: { $0.text == text }) else {
+        return ["error": "no row on screen carries that text", "onScreen": "false"]
+      }
+      guard handle.open(index) else { return ["error": "row \(index) refused the open"] }
+      // Read back through the store, not the page: a task row navigates to Tasks as it opens, so
+      // the list may already be unmounted behind this call.
+      return HomeKnowsFixture.ledgerDetail(text: text)
+        .merging(["opened": "true"]) { current, _ in current }
+    }
+
+    register(
+      name: "home_knows_dismiss",
+      summary:
+        "Dismiss the visible knows-list row carrying `text` (the row's own ✕) and report the ledger "
+        + "entry it wrote",
+      params: ["text"],
+      category: "home",
+      surfaces: ["home"]
+    ) { params in
+      guard AppBuild.isNonProduction else {
+        return ["error": "home_knows_dismiss is disabled on production bundles"]
+      }
+      guard let handle = HomeKnowsAutomationRegistry.mounted else {
+        return ["error": "no Home knows-list is mounted", "mounted": "false"]
+      }
+      let text = params["text"] ?? ""
+      guard let index = handle.snapshot().rows.firstIndex(where: { $0.text == text }) else {
+        return ["error": "no row on screen carries that text", "onScreen": "false"]
+      }
+      guard handle.dismiss(index) else {
+        return ["error": "row \(index) has no dismiss (question rows carry none)"]
+      }
+      return HomeKnowsFixture.ledgerDetail(text: text)
+        .merging(["dismissed": "true"]) { current, _ in current }
+    }
+
+    register(
+      name: "home_knows_probe",
+      summary:
+        "What the ledger says about one fixture task, and whether the list is showing it right now",
+      params: ["text"],
+      category: "home",
+      surfaces: ["home"],
+      safety: "read_only"
+    ) { params in
+      guard AppBuild.isNonProduction else {
+        return ["error": "home_knows_probe is disabled on production bundles"]
+      }
+      let text = params["text"] ?? ""
+      var detail = HomeKnowsFixture.ledgerDetail(text: text)
+      // Addressed by row text rather than by slot on purpose. Which slot a row lands in depends on
+      // every other candidate the account happens to carry, but whether *this* row is on screen and
+      // what the ledger says about it are facts about this row alone — the only shape of assertion
+      // that stays honest on an account the flow did not create from scratch.
+      if let handle = HomeKnowsAutomationRegistry.mounted {
+        detail["mounted"] = "true"
+        detail["present"] = handle.snapshot().rows.contains { $0.text == text } ? "true" : "false"
+      } else {
+        detail["mounted"] = "false"
+      }
+      return detail
+    }
+  }
+}
+
+/// Fixture tasks, the slot-named projections, and the analytics capture the `home_knows_*` actions
+/// report through.
+///
+/// Harness scaffolding only: nothing here composes a row, decides a suppression, or names a
+/// rotation reason. Every value it reports came out of `HomeKnowsListComposer`, the impression
+/// ledger, or the `AnalyticsManager` emit seam.
+@MainActor
+enum HomeKnowsFixture {
+  /// Asserted verbatim by `home-knows-rotation.yaml`: change one and change the flow in the same
+  /// commit. Deliberately not marker-templated — the harness substitutes `[[MARKER:…]]`, and these
+  /// strings are compared for exact equality as the hub's own row text.
+  /// Three, not two: the hub gives tasks exactly two of its four slots, so the third is the one a
+  /// flow can reach only after a dismissal has freed a slot — which is how the dismissal is proved
+  /// to have changed the list rather than only the ledger.
+  static let taskCatalog = [
+    "Send Priya the storage migration summary",
+    "Book the Thursday design review room",
+    "Reply to the vendor security questionnaire",
+  ]
+
+  /// The ledger entry for one fixture task, read through the store rather than the page.
+  ///
+  /// The key is `HomeKnowsRotationPolicy.taskKey` applied to the id the dashboard lanes carry — the
+  /// shipped keying function called a second time, so a flow can never assert against a key the
+  /// composer would not have used.
+  static func ledgerDetail(text: String) -> [String: String] {
+    let store = TasksStore.shared
+    let lanes = store.overdueTasks + store.todaysTasks + store.tasksWithoutDueDate
+    guard let task = lanes.first(where: { $0.description == text }) else {
+      return ["error": "no dashboard-lane task carries that text", "known": "false"]
+    }
+    let key = HomeKnowsRotationPolicy.taskKey(task.id)
+    let entry = HomeKnowsImpressionStore.shared.snapshot().entry(key)
+    return [
+      "known": "true",
+      "key": key,
+      "shows": String(entry?.shows ?? 0),
+      "wasOpened": entry?.lastOpenedAt == nil ? "false" : "true",
+      "wasDismissed": entry?.dismissedAt == nil ? "false" : "true",
+    ]
+  }
+
+  /// Remove any fixture task left by an earlier run before creating this run's.
+  ///
+  /// A knows-list row is keyed by task id, not by text, so two runs' copies of the same sentence
+  /// are two candidates: the second run would open on a list that already looks right and prove
+  /// nothing about the rules underneath it.
+  static func removeSeededTasks() async -> Int {
+    let doomed = TasksStore.shared.tasks.filter { taskCatalog.contains($0.description) }
+    for task in doomed {
+      await TasksStore.shared.deleteTask(task)
+    }
+    return doomed.count
+  }
+
+  /// How many of the fixture tasks the hub's own candidate lanes can see.
+  static func waitForSeededCandidates(timeoutMs: Int) async -> Int {
+    let deadline = Date().addingTimeInterval(Double(max(0, timeoutMs)) / 1000.0)
+    while seededCandidateCount() < taskCatalog.count {
+      guard Date() < deadline else { break }
+      try? await Task.sleep(nanoseconds: 100_000_000)
+    }
+    return seededCandidateCount()
+  }
+
+  private static func seededCandidateCount() -> Int {
+    let store = TasksStore.shared
+    let lanes = store.overdueTasks + store.todaysTasks + store.tasksWithoutDueDate
+    return lanes.filter { taskCatalog.contains($0.description) }.count
+  }
+
+  /// Installs the knows-list telemetry capture for the duration of `body` and projects what it saw.
+  ///
+  /// `rotated_out_reason` is the rotation policy's verdict and is readable nowhere after the emit
+  /// consumes it, so it is observed at the seam rather than recomputed here.
+  static func capturingEmits(_ body: @MainActor () -> Void) -> [String: String] {
+    let previous = AnalyticsManager.homeKnowsTelemetryCaptureForTests
+    var rows: [String: String] = [:]
+    var empties: [String: String] = [:]
+    var count = 0
+    AnalyticsManager.homeKnowsTelemetryCaptureForTests = { event, properties in
+      guard event == AnalyticsManager.homeKnowsRowEvent else { return }
+      count += 1
+      let slot = properties["slot"] as? String ?? ""
+      let kind = properties["kind"] as? String ?? ""
+      if kind == "empty" {
+        empties[slot] = properties["rotated_out_reason"] as? String ?? ""
+      } else {
+        rows[slot] = "\(kind):\(properties["shows_before"] as? Int ?? -1)"
+      }
+    }
+    body()
+    AnalyticsManager.homeKnowsTelemetryCaptureForTests = previous
+
+    var detail = ["emittedCount": String(count)]
+    for slot in HomeKnowsSlot.allCases {
+      detail["emitted_row_" + slot.rawValue] = rows[slot.rawValue] ?? ""
+      detail["emitted_empty_" + slot.rawValue] = empties[slot.rawValue] ?? ""
+    }
+    return detail
+  }
+
+  /// What the list currently shows, named by slot rather than by index.
+  ///
+  /// Slot-named because the row array is the composer's fixed slot order with the empty slots
+  /// removed, so the index of a task row moves when the tip above it rotates out — and a flow
+  /// asserting `row2` would then be asserting nothing in particular.
+  static func detail(_ snapshot: HomeKnowsAutomationRegistry.Snapshot) -> [String: String] {
+    var detail: [String: String] = [
+      "mounted": "true",
+      "rowCount": String(snapshot.rows.count),
+      "canRotate": snapshot.canRotate ? "true" : "false",
+      "openTaskCount": String(snapshot.openTaskCount),
+      "ledgerEntries": String(snapshot.ledger.entries.count),
+    ]
+    let taskRows = snapshot.rows.filter { $0.kind == "task" }
+    detail["taskRowCount"] = String(taskRows.count)
+    for (index, row) in taskRows.prefix(2).enumerated() {
+      detail["taskRow\(index)_text"] = row.text
+      detail["taskRow\(index)_showsBefore"] = String(row.showsBefore)
+    }
+    for (index, row) in snapshot.rows.prefix(4).enumerated() {
+      detail["row\(index)_kind"] = row.kind
+      detail["row\(index)_text"] = row.text
+    }
+    let empties = Dictionary(snapshot.emptySlots.map { ($0.slot, $0.reason) }) { current, _ in current }
+    for slot in HomeKnowsSlot.allCases {
+      detail["emptySlot_" + slot.rawValue] = empties[slot.rawValue] ?? ""
+    }
+    return detail
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift
+++ b/desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift
@@ -1,11 +1,13 @@
 //
 //  DesktopAutomationActivationActions.swift — bridge actions for the first-48h activation surfaces.
 //
-//  Two read/drive seams so a QA bundle can prove the surfaces without the cursor:
-//  `daily_summary_snapshot` reports the shared daily-summary store shape-only, and
+//  Three read/drive seams so a QA bundle can prove the surfaces without the cursor:
+//  `daily_summary_snapshot` reports the shared daily-summary store shape-only,
 //  `open_chat_prefilled` drives the one prefill-without-send entry
-//  (`openMainAppChat(prefilledDraft:)`) so `chat_drafts_snapshot` can show the draft landed unsent.
-//  Both are second callers of production code, never a second implementation.
+//  (`openMainAppChat(prefilledDraft:)`) so `chat_drafts_snapshot` can show the draft landed unsent,
+//  and `tap_chat_follow_up_chip` performs the chip's own send so the `followup` question origin is
+//  observable end to end. All three are second callers of production code, never a second
+//  implementation.
 //
 //  Registered from `DesktopAutomationActionRegistry.registerBuiltins()` next to the Home-stage
 //  actions.
@@ -68,6 +70,49 @@ extension DesktopAutomationActionRegistry {
       return [
         "requested": "true",
         "pendingDraftLength": String(MainChatNavigationRequestStore.shared.pendingDraft?.count ?? 0),
+      ]
+    }
+
+    register(
+      name: "tap_chat_follow_up_chip",
+      summary:
+        "Tap the follow-up chip under the last main-chat answer (same send as the chip) and report "
+        + "the `question_asked` origin it produced",
+      params: [],
+      category: "chat",
+      surfaces: ["main_chat"]
+    ) { _ in
+      guard AppBuild.isNonProduction else {
+        return ["error": "tap_chat_follow_up_chip is disabled on production bundles"]
+      }
+      guard let provider = ChatProvider.mainInstance else {
+        return ["error": "main ChatProvider not yet initialized"]
+      }
+      // The chip is a property of the answer, so a missing one is a real finding
+      // rather than a harness setup error: report it instead of throwing, and
+      // the flow's expectation on `question` fails with the reason attached.
+      guard let question = provider.automationLastFollowUpQuestion() else {
+        return ["error": "no follow-up chip on the last assistant message", "has_chip": "false"]
+      }
+      // `origin` is only observable where it is emitted: the property is
+      // consumed inside `questionAsked` and gone by the time the send returns.
+      // Reading it at the same seam the unit tests use keeps this a report of
+      // what production emitted rather than a second guess at it.
+      let analytics = AnalyticsManager.shared
+      let previousCapture = analytics.questionTelemetryCaptureForTests
+      var observedOrigin: String?
+      analytics.questionTelemetryCaptureForTests = { event, properties in
+        guard event == "question_asked", observedOrigin == nil else { return }
+        observedOrigin = properties["origin"] as? String
+      }
+      defer { analytics.questionTelemetryCaptureForTests = previousCapture }
+
+      let accepted = await FollowUpChipTap.send(question: question, provider: provider) != nil
+      return [
+        "has_chip": "true",
+        "question": question,
+        "accepted": accepted ? "true" : "false",
+        "question_origin": observedOrigin ?? "",
       ]
     }
   }

--- a/desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift
+++ b/desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift
@@ -1,13 +1,14 @@
 //
 //  DesktopAutomationActivationActions.swift — bridge actions for the first-48h activation surfaces.
 //
-//  Three read/drive seams so a QA bundle can prove the surfaces without the cursor:
+//  Read/drive seams so a QA bundle can prove the surfaces without the cursor:
 //  `daily_summary_snapshot` reports the shared daily-summary store shape-only,
 //  `open_chat_prefilled` drives the one prefill-without-send entry
 //  (`openMainAppChat(prefilledDraft:)`) so `chat_drafts_snapshot` can show the draft landed unsent,
-//  and `tap_chat_follow_up_chip` performs the chip's own send so the `followup` question origin is
-//  observable end to end. All three are second callers of production code, never a second
-//  implementation.
+//  `tap_chat_follow_up_chip` performs the chip's own send so the `followup` question origin is
+//  observable end to end, and `seed_memory_review_fixture` / `memory_review_snapshot` /
+//  `memory_review_vote` bring up and drive the "Things I learned today" rows. Every one is a
+//  second caller of production code, never a second implementation.
 //
 //  Registered from `DesktopAutomationActionRegistry.registerBuiltins()` next to the Home-stage
 //  actions.
@@ -46,6 +47,10 @@ extension DesktopAutomationActionRegistry {
         "hasStats": latest.stats == nil ? "false" : "true",
         "highlightCount": String(latest.highlights?.count ?? 0),
         "actionItemCount": String(latest.actionItems?.count ?? 0),
+        // Count only, still no text. It is what makes `MemoryReviewSection.maxRows` observable:
+        // the wire can carry more learned memories than the card ever renders, and without this
+        // a flow cannot tell a card that bounded its rows from a day that produced only three.
+        "memoriesLearnedCount": String(latest.memoriesLearned.count),
         "followUp": ChatDailySummaryPresentation.followUpQuestion(for: latest.date, now: Date()),
       ]
     }
@@ -115,5 +120,278 @@ extension DesktopAutomationActionRegistry {
         "question_origin": observedOrigin ?? "",
       ]
     }
+
+    registerMemoryReviewActions()
+  }
+
+  // MARK: - Memory review card
+
+  /// Bring up, read, and vote on the "Things I learned today" rows.
+  ///
+  /// The rows render only from a daily summary's `memories_learned`, and the only producer of that
+  /// record is the nightly job — a day of conversations and a model call. So on a hermetic bundle
+  /// the card was unreachable, and with it the row state machine, the three mutations, and the
+  /// verdict read-back. `seed_memory_review_fixture` creates real memories through the production
+  /// `POST /v3/memories` and hands their ids to the local-only daily-summary fixture, so the record
+  /// arrives through the same `getDailySummaries` read production uses and every ✓ / ✗ addresses a
+  /// memory that `/v3/memories/{id}/review` really mutates.
+  private func registerMemoryReviewActions() {
+    register(
+      name: "seed_memory_review_fixture",
+      summary:
+        "Create `count` real memories and a local-only daily summary that learned them, then "
+        + "refresh the shared store so the review card mounts (offline dev stack only)",
+      params: ["count", "timeoutMs"],
+      category: "chat",
+      surfaces: ["main_chat"],
+      sideEffects: ["creates memories on the signed-in local account"]
+    ) { params in
+      guard AppBuild.isNonProduction else {
+        return ["error": "seed_memory_review_fixture is disabled on production bundles"]
+      }
+      let requested = Int(params["count"] ?? "") ?? MemoryReviewFixture.defaultCount
+      guard let wanted = MemoryReviewFixture.rows(count: requested) else {
+        return ["error": "count must be 1...\(MemoryReviewFixture.catalog.count)"]
+      }
+
+      var seeded: [MemoryReviewFixture.WireMemory] = []
+      for row in wanted {
+        do {
+          let created = try await APIClient.shared.createMemory(
+            content: row.content, category: row.category)
+          seeded.append(
+            .init(memoryID: created.id, content: row.content, category: row.category.rawValue))
+        } catch {
+          // Named stage, so a flow failure says which half of the fixture broke rather than
+          // leaving an empty card to be read as "the card is broken".
+          return [
+            "error": "createMemory failed: \(MemoryReviewFixture.reason(error))",
+            "createdCount": String(seeded.count),
+          ]
+        }
+      }
+
+      let response: MemoryReviewFixture.SeedResponse
+      do {
+        response = try await APIClient.shared.post(
+          MemoryReviewFixture.seedEndpoint,
+          body: MemoryReviewFixture.SeedRequest(memories: seeded))
+      } catch {
+        return [
+          "error": "daily-summary fixture seed failed: \(MemoryReviewFixture.reason(error))",
+          "createdCount": String(seeded.count),
+        ]
+      }
+
+      // The store's own refresh, not the coordinator's: `ChatDailySummaryCoordinator.refresh()`
+      // also announces a new summary as a notch card, and a harness must not fire the one
+      // user-visible notification this surface owns.
+      await ChatDailySummaryCoordinator.shared.store.refresh()
+
+      let timeoutMs = Int(params["timeoutMs"] ?? "") ?? 8000
+      let mountedRows = await MemoryReviewFixture.waitForMountedRows(
+        seeded: Set(seeded.map(\.memoryID)), timeoutMs: timeoutMs)
+      return [
+        "createdCount": String(seeded.count),
+        "summaryId": response.summaryID,
+        "memoriesLearned": String(response.memoriesLearned),
+        "mountedRows": String(mountedRows),
+      ]
+    }
+
+    register(
+      name: "memory_review_snapshot",
+      summary: "Rows the mounted 'Things I learned today' section bound, and the first two verdicts",
+      params: [],
+      category: "chat",
+      surfaces: ["main_chat"],
+      safety: "read_only"
+    ) { _ in
+      guard AppBuild.isNonProduction else {
+        return ["error": "memory_review_snapshot is disabled on production bundles"]
+      }
+      guard let store = MemoryReviewCardRegistry.mounted else {
+        return ["error": "no memory review section is mounted", "mounted": "false"]
+      }
+      var detail: [String: String] = [
+        "mounted": "true",
+        "source": store.source.rawValue,
+        "rowCount": String(store.items.count),
+        "maxRows": String(MemoryReviewSection.maxRows),
+      ]
+      for (index, item) in store.items.prefix(2).enumerated() {
+        detail.merge(MemoryReviewFixture.rowDetail(index: index, item: item, store: store)) { current, _ in current }
+      }
+      return detail
+    }
+
+    register(
+      name: "memory_review_vote",
+      summary:
+        "Vote on one mounted review row through the store the ✓ / ✗ buttons call, then report the "
+        + "row once the mutation settles",
+      params: ["row", "verdict", "timeoutMs"],
+      category: "chat",
+      surfaces: ["main_chat"]
+    ) { params in
+      guard AppBuild.isNonProduction else {
+        return ["error": "memory_review_vote is disabled on production bundles"]
+      }
+      guard let store = MemoryReviewCardRegistry.mounted else {
+        return ["error": "no memory review section is mounted", "mounted": "false"]
+      }
+      let index = Int(params["row"] ?? "") ?? 0
+      guard store.items.indices.contains(index) else {
+        return ["error": "row \(index) is outside the \(store.items.count) mounted rows"]
+      }
+      let raw = (params["verdict"] ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+      guard let event = MemoryReviewFixture.event(for: raw) else {
+        return ["error": "verdict must be 'accept' or 'reject'"]
+      }
+
+      let item = store.items[index]
+      // The exact call the row's button makes (`MemoryReviewRowView.controls` → `send(.accept)` →
+      // the section's closure). Nothing about the transition is re-decided here.
+      store.send(event, to: item)
+      let timeoutMs = Int(params["timeoutMs"] ?? "") ?? 15000
+      let settled = await MemoryReviewFixture.waitForSettled(store: store, item: item, timeoutMs: timeoutMs)
+
+      var detail = MemoryReviewFixture.rowDetail(index: index, item: item, store: store)
+      detail["settledInTime"] = settled ? "true" : "false"
+      return detail
+    }
+  }
+}
+
+/// Fixture rows, wire types, and the two bounded waits the memory-review actions need.
+///
+/// Separated from the closures only so the actions above read as what they drive. Everything here
+/// is harness scaffolding; none of it decides anything about a verdict.
+@MainActor
+enum MemoryReviewFixture {
+  static let seedEndpoint = "v1/dev-harness/daily-summary/seed"
+  /// Four, so a flow can seed more learned memories than the card renders and prove the bound.
+  static let defaultCount = 4
+
+  struct CatalogRow {
+    let content: String
+    let category: MemoryCategory
+  }
+
+  /// Deterministic and asserted verbatim by `memory-review.yaml`: change one and change the flow
+  /// in the same commit.
+  static let catalog: [CatalogRow] = [
+    CatalogRow(content: "Prefers async standups over daily calls.", category: .system),
+    CatalogRow(content: "Ships desktop releases on Wednesdays.", category: .workflow),
+    CatalogRow(content: "Reviews the storage migration with Priya.", category: .interesting),
+    CatalogRow(content: "Keeps a written weekly plan before Monday.", category: .system),
+  ]
+
+  static func rows(count: Int) -> [CatalogRow]? {
+    guard count >= 1, count <= catalog.count else { return nil }
+    return Array(catalog.prefix(count))
+  }
+
+  struct WireMemory: Encodable {
+    let memoryID: String
+    let content: String
+    let category: String
+
+    enum CodingKeys: String, CodingKey {
+      case memoryID = "memory_id"
+      case content, category
+    }
+  }
+
+  struct SeedRequest: Encodable {
+    let memories: [WireMemory]
+  }
+
+  struct SeedResponse: Decodable {
+    let status: String
+    let summaryID: String
+    let date: String
+    let memoriesLearned: Int
+
+    enum CodingKeys: String, CodingKey {
+      case status, date
+      case summaryID = "summary_id"
+      case memoriesLearned = "memories_learned"
+    }
+  }
+
+  /// Bounded so an error string can never carry an unbounded response body into flow evidence.
+  static func reason(_ error: Error) -> String {
+    String(String(describing: error).prefix(200))
+  }
+
+  static func event(for verdict: String) -> MemoryReviewEvent? {
+    switch verdict {
+    case "accept": return .accept
+    case "reject": return .reject
+    default: return nil
+    }
+  }
+
+  /// What one row shows, named by index so a flow can assert two rows in one snapshot.
+  static func rowDetail(
+    index: Int, item: MemoryReviewItem, store: MemoryReviewCardStore
+  ) -> [String: String] {
+    let model = store.row(item.memoryID)
+    let prefix = "row\(index)_"
+    return [
+      prefix + "id": item.memoryID,
+      prefix + "content": item.content,
+      prefix + "category": item.categoryLabel ?? "",
+      prefix + "verdict": verdictName(model.displayed),
+      prefix + "status": model.statusText ?? "",
+      prefix + "settled": model.isSettled ? "true" : "false",
+      prefix + "faded": model.isFaded ? "true" : "false",
+      prefix + "busy": model.isBusy ? "true" : "false",
+      prefix + "error": model.errorMessage ?? "",
+    ]
+  }
+
+  private static func verdictName(_ verdict: MemoryReviewVerdict) -> String {
+    switch verdict {
+    case .none: return "none"
+    case .accepted: return "accepted"
+    case .rejected: return "rejected"
+    case .updated: return "updated"
+    }
+  }
+
+  /// How many rows the mounted section bound, once the store's refresh has reached the card.
+  ///
+  /// Waits for the section built from *these* memory ids, not merely for a mounted section. A
+  /// re-run of the flow overwrites the same day's summary with freshly created memories, and the
+  /// previous run's card — same content, already voted on — stays mounted until SwiftUI rebuilds
+  /// it. Waiting on "any rows" would read that one and see a settled verdict on a row the flow
+  /// has not clicked yet.
+  static func waitForMountedRows(seeded ids: Set<String>, timeoutMs: Int) async -> Int {
+    await waitUntil(timeoutMs: timeoutMs) {
+      guard let items = MemoryReviewCardRegistry.mounted?.items, !items.isEmpty else { return false }
+      return items.allSatisfy { ids.contains($0.memoryID) }
+    }
+    let items = MemoryReviewCardRegistry.mounted?.items ?? []
+    return items.allSatisfy { ids.contains($0.memoryID) } ? items.count : 0
+  }
+
+  /// True when the row's request finished inside the budget. A timeout is reported rather than
+  /// thrown: the row detail beside it says what the row settled on, which is the finding.
+  static func waitForSettled(
+    store: MemoryReviewCardStore, item: MemoryReviewItem, timeoutMs: Int
+  ) async -> Bool {
+    await waitUntil(timeoutMs: timeoutMs) { !store.row(item.memoryID).isBusy }
+  }
+
+  @discardableResult
+  private static func waitUntil(timeoutMs: Int, _ isDone: @MainActor () -> Bool) async -> Bool {
+    let deadline = Date().addingTimeInterval(Double(max(0, timeoutMs)) / 1000.0)
+    while !isDone() {
+      guard Date() < deadline else { return false }
+      try? await Task.sleep(nanoseconds: 100_000_000)
+    }
+    return true
   }
 }

--- a/desktop/macos/Desktop/Sources/Chat/ChatFollowUpTail.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatFollowUpTail.swift
@@ -26,41 +26,27 @@ enum ChatFollowUpTail {
   static let maxCharacters = 160
 
   /// A generic tail is worse than no tail: it teaches the reader the chip is
-  /// filler. Matched against the lowercased, punctuation-trimmed question.
-  private static let genericPrefixes = [
-    "anything else",
-    "is there anything else",
-    "want more detail",
-    "want any more detail",
-    "do you want more detail",
-    "want more info",
-    "want more information",
-    "want me to go on",
-    "want me to continue",
-    "want me to keep going",
-    "want me to elaborate",
-    "want me to explain more",
-    "would you like to know more",
-    "do you want to know more",
-    "does that help",
-    "did that help",
-    "does that make sense",
-    "does that answer",
-    "any questions",
-    "any other questions",
-    "got any questions",
-    "let me know",
-    "can i help",
-    "could i help",
-    "how can i help",
-    "sound good",
-    "sounds good",
-    "shall i continue",
-    "shall i go on",
-    "need anything else",
-    "want anything else",
-    "what else",
-  ]
+  /// filler. These are the backend's `_GENERIC_PATTERNS` verbatim — same
+  /// anchors, same word boundaries, and the same end-anchor on "what else" —
+  /// because the two rules have to agree. Prefix matching, which this replaced,
+  /// dropped every specific chip that opened with a generic phrase ("What else
+  /// did Priya flag?"), on the client, after the server had already built it.
+  private static let genericPatterns: [NSRegularExpression] = [
+    #"^anything else\b"#,
+    #"^is there anything else\b"#,
+    #"^(do you )?want (more|any more|additional|further) (detail|details|info|information|context)\b"#,
+    #"^want me to (go on|continue|keep going|elaborate|explain more)\b"#,
+    #"^(would you like|do you want) (me )?to (know more|hear more|continue|elaborate)\b"#,
+    #"^(does|did) that (help|make sense|answer)\b"#,
+    #"^(any|got any) (other )?questions\b"#,
+    #"^let me know\b"#,
+    #"^(can|could) i help\b"#,
+    #"^(sound|sounds) good\b"#,
+    #"^shall i (continue|go on)\b"#,
+    #"^(need|want) anything else\b"#,
+    #"^how can i help\b"#,
+    #"^what else\??$"#,
+  ].compactMap { try? NSRegularExpression(pattern: $0) }
 
   /// Split a raw model answer into its visible text and its follow-up question.
   ///
@@ -93,10 +79,19 @@ enum ChatFollowUpTail {
     return question
   }
 
+  /// Mirrors the backend's `_is_generic`: collapse whitespace, lowercase, then
+  /// strip trailing `?!. ` only — the leading end is left alone there, so it is
+  /// left alone here.
   static func isGeneric(_ question: String) -> Bool {
-    let probe = question.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: " ?!."))
+    var probe =
+      question
+      .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .lowercased()
+    while let last = probe.last, "?!. ".contains(last) { probe.removeLast() }
     guard !probe.isEmpty else { return true }
-    return genericPrefixes.contains { probe.hasPrefix($0) }
+    let range = NSRange(probe.startIndex..<probe.endIndex, in: probe)
+    return genericPatterns.contains { $0.firstMatch(in: probe, options: [], range: range) != nil }
   }
 
   /// What the reader should see while the answer is still streaming.
@@ -106,6 +101,17 @@ enum ChatFollowUpTail {
   /// completed delimiter (and everything after it) is dropped, and so is a
   /// trailing partial delimiter — but only once it is unambiguous (`<<<` or
   /// longer), so ordinary text ending in `<` is never eaten.
+  ///
+  /// - Precondition: `text` is the **raw** accumulated answer, delimiter and
+  ///   all — never this function's own previous output plus the next delta.
+  ///   The projection is one-way: both the completed-delimiter branch and the
+  ///   partial-delimiter branch delete characters the next call needs. Feed it
+  ///   its own output and the delimiter is gone from the only buffer left, so
+  ///   every token of the question that arrives after that flush is prose with
+  ///   nothing left to mark it — the exact leak this function exists to
+  ///   prevent, now permanent for the rest of the stream. The backend's
+  ///   `FollowUpTailStreamFilter` holds that same state in `_pending` /
+  ///   `_suppressing`; on this side the raw accumulator belongs to the caller.
   static func strippingPendingTail(_ text: String) -> String {
     if let range = text.range(of: delimiter) {
       return String(text[text.startIndex..<range.lowerBound])

--- a/desktop/macos/Desktop/Sources/Chat/ChatStreamingBuffer.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatStreamingBuffer.swift
@@ -13,7 +13,22 @@ final class ChatStreamingBuffer {
     }
   }
 
+  /// The raw, un-normalized text a streaming message has received so far.
+  ///
+  /// `normalizeText` is a *projection*, not an edit: it may legitimately withhold
+  /// text it cannot yet classify — the follow-up tail marker arrives split across
+  /// flushes, and the question after it must never appear in the transcript. Feeding
+  /// a projection its own previous output destroys the evidence it needs on the next
+  /// flush, so what was withheld once leaks token by token afterwards. The raw text
+  /// is therefore accumulated here and the projection is only ever *written to* the
+  /// message, never read back out of it.
+  private struct RawAccumulator {
+    var text: String = ""
+    var blocks: [String: String] = [:]
+  }
+
   private var pendingSegments: [PendingSegment] = []
+  private var rawAccumulators: [String: RawAccumulator] = [:]
   private var flushWorkItem: DispatchWorkItem?
   private let flushInterval: TimeInterval
 
@@ -36,11 +51,21 @@ final class ChatStreamingBuffer {
     flushWorkItem = nil
   }
 
+  /// Release the raw accumulator for a finished turn.
+  ///
+  /// Called when the authoritative terminal answer replaces the streamed text.
+  /// Without this the map grows for the life of the session, and a message id
+  /// that streams a second time would resume from the first turn's text.
+  func finishStreaming(messageId: String) {
+    rawAccumulators[messageId] = nil
+  }
+
   /// Drop only the buffered deltas for a revoked turn. A newer turn may already
   /// share this buffer, so cancelling or flushing the whole queue would either
   /// lose its tokens or apply the stopped turn's late output.
   func discardPendingSegments(messageId: String) {
     pendingSegments.removeAll { $0.messageId == messageId }
+    rawAccumulators[messageId] = nil
     if pendingSegments.isEmpty {
       cancelPendingFlush()
     }
@@ -145,20 +170,29 @@ final class ChatStreamingBuffer {
     to message: inout ChatMessage,
     normalizeText: (_ message: ChatMessage, _ text: String) -> String
   ) {
-    message.text = normalizeText(message, message.text + text)
+    // Seed from what the message already carries the first time this turn
+    // appends, so a message that was restored or resumed keeps its prefix.
+    var accumulator = rawAccumulators[message.id] ?? RawAccumulator(text: message.text)
+    accumulator.text += text
+    message.text = normalizeText(message, accumulator.text)
 
     if let lastBlockIndex = message.contentBlocks.indices.last,
       case .text(let blockId, let existing) = message.contentBlocks[lastBlockIndex]
     {
+      let rawBlock = (accumulator.blocks[blockId] ?? existing) + text
+      accumulator.blocks[blockId] = rawBlock
       message.contentBlocks[lastBlockIndex] = .text(
         id: blockId,
-        text: normalizeText(message, existing + text)
+        text: normalizeText(message, rawBlock)
       )
     } else {
+      let blockId = UUID().uuidString
+      accumulator.blocks[blockId] = text
       message.contentBlocks.append(
-        .text(id: UUID().uuidString, text: normalizeText(message, text))
+        .text(id: blockId, text: normalizeText(message, text))
       )
     }
+    rawAccumulators[message.id] = accumulator
   }
 
   private func appendThinkingSegment(_ text: String, to message: inout ChatMessage) {

--- a/desktop/macos/Desktop/Sources/Chat/ChatStreamingBuffer.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatStreamingBuffer.swift
@@ -32,8 +32,14 @@ final class ChatStreamingBuffer {
   private var flushWorkItem: DispatchWorkItem?
   private let flushInterval: TimeInterval
 
-  init(flushInterval: TimeInterval) {
+  /// Non-production leak detector for the projections this buffer emits. Nil on any bundle the
+  /// automation bridge is not enabled on, so a shipped app allocates nothing and runs no extra
+  /// work per flush. See `ChatStreamingTailProbe`.
+  let tailProjectionProbe: ChatStreamingTailProbe?
+
+  init(flushInterval: TimeInterval, probe: ChatStreamingTailProbe? = nil) {
     self.flushInterval = flushInterval
+    tailProjectionProbe = probe ?? (DesktopAutomationLaunchOptions.isEnabled ? ChatStreamingTailProbe() : nil)
   }
 
   func appendText(messageId: String, text: String, scheduleFlush: @escaping () -> Void) {
@@ -58,6 +64,7 @@ final class ChatStreamingBuffer {
   /// that streams a second time would resume from the first turn's text.
   func finishStreaming(messageId: String) {
     rawAccumulators[messageId] = nil
+    tailProjectionProbe?.forget(messageId: messageId)
   }
 
   /// Drop only the buffered deltas for a revoked turn. A newer turn may already
@@ -66,6 +73,7 @@ final class ChatStreamingBuffer {
   func discardPendingSegments(messageId: String) {
     pendingSegments.removeAll { $0.messageId == messageId }
     rawAccumulators[messageId] = nil
+    tailProjectionProbe?.forget(messageId: messageId)
     if pendingSegments.isEmpty {
       cancelPendingFlush()
     }
@@ -172,9 +180,14 @@ final class ChatStreamingBuffer {
   ) {
     // Seed from what the message already carries the first time this turn
     // appends, so a message that was restored or resumed keeps its prefix.
+    let seedText = message.text
     var accumulator = rawAccumulators[message.id] ?? RawAccumulator(text: message.text)
     accumulator.text += text
     message.text = normalizeText(message, accumulator.text)
+    // Watched against a raw stream this buffer does not own, so the check survives the buffer
+    // losing its own. See `ChatStreamingTailProbe`.
+    tailProjectionProbe?.observe(
+      messageId: message.id, seed: seedText, delta: text, projection: message.text)
 
     if let lastBlockIndex = message.contentBlocks.indices.last,
       case .text(let blockId, let existing) = message.contentBlocks[lastBlockIndex]
@@ -378,5 +391,62 @@ enum ToolCallBlockUpdater {
       return toolUseId == requestedToolUseId || (toolUseId == nil && name == requestedName)
     }
     return name == requestedName
+  }
+}
+
+/// Counts projections that leaked text the follow-up tail rule had withheld.
+///
+/// The tail's damage is entirely mid-stream: the authoritative terminal answer overwrites
+/// `message.text` when the turn finishes, so every assertion a flow can make *after* the turn
+/// passes whether or not the chip's question was typed into the prose a token at a time on the way
+/// there. c164760b6b fixed exactly that leak and could be proved only by unit-testing the buffer
+/// directly. This makes the same property observable from a live app: not "the final text is
+/// right", but "no intermediate projection the reader saw ever contained the withheld tail".
+///
+/// It is an observer, not a second projection. It keeps its own raw stream — seeded once from the
+/// message and extended with the deltas the buffer is handed — and calls the shipped
+/// `ChatFollowUpTail.strippingPendingTail` on it. Keeping its own stream is the whole point: the
+/// defect was the buffer re-deriving the projection from its own withheld output, and a probe that
+/// read the buffer's accumulator would have agreed with the bug. Two projections of the same raw
+/// text differ only by the spacing normalizer, which inserts whitespace and never removes a
+/// character, so the comparison is on non-whitespace content and is exact rather than fuzzy.
+///
+/// Nil in production (`ChatStreamingBuffer.init`), so nothing here is a shipped path and the
+/// shipped projection is unchanged.
+final class ChatStreamingTailProbe {
+  /// Raw text per streaming message, independent of the buffer's own accumulator.
+  private var rawByMessage: [String: String] = [:]
+
+  /// How many projections have been checked. A flow reads it to know the probe was actually fed.
+  private(set) var projectionCount = 0
+  /// Whether any raw stream has carried a complete delimiter. Without this a zero leak count is
+  /// unfalsifiable: a turn that never produced a tail cannot leak one.
+  private(set) var delimiterSeen = false
+  /// Projections whose visible content did not match what the tail rule would have shown.
+  private(set) var leakCount = 0
+
+  /// - Parameters:
+  ///   - seed: the message text before this flush wrote to it, used only the first time this probe
+  ///     sees the message so a resumed turn keeps its prefix.
+  ///   - delta: the raw tokens this flush is applying.
+  ///   - projection: what the buffer just wrote to `message.text`.
+  func observe(messageId: String, seed: String, delta: String, projection: String) {
+    let raw = (rawByMessage[messageId] ?? seed) + delta
+    rawByMessage[messageId] = raw
+    projectionCount += 1
+    if raw.range(of: ChatFollowUpTail.delimiter) != nil { delimiterSeen = true }
+    if Self.significant(projection) != Self.significant(ChatFollowUpTail.strippingPendingTail(raw)) {
+      leakCount += 1
+    }
+  }
+
+  func forget(messageId: String) {
+    rawByMessage[messageId] = nil
+  }
+
+  /// Everything the spacing normalizer is not allowed to touch. It only ever inserts whitespace,
+  /// so two projections of the same raw text agree here exactly.
+  private static func significant(_ text: String) -> String {
+    text.filter { !$0.isWhitespace }
   }
 }

--- a/desktop/macos/Desktop/Sources/Chat/FollowUpChip.swift
+++ b/desktop/macos/Desktop/Sources/Chat/FollowUpChip.swift
@@ -81,3 +81,33 @@ struct FollowUpChip: View {
     }
   }
 }
+
+/// The send a main-window chip performs, as one function rather than a closure
+/// inside the bubble.
+///
+/// It is lifted out so the automation bridge's `tap_chat_follow_up_chip` is a
+/// second *caller* of the tap and never a second implementation of it. A copied
+/// closure would keep passing whatever the harness wrote into it long after the
+/// real chip changed — and the one thing the harness is there to prove is the
+/// attribution, which lives entirely in the order of these three lines.
+@MainActor
+enum FollowUpChipTap {
+  /// - Returns: the message id the provider accepted, or `nil` when it refused.
+  @discardableResult
+  static func send(question: String, provider: ChatProvider) async -> String? {
+    // Analytics commit at the provider's own acceptance boundary: a send it
+    // refuses emits nothing and mislabels nothing later.
+    await provider.sendMessage(
+      question,
+      surfaceRef: provider.mainChatSurfaceReference(),
+      turnOwner: .mainChat,
+      onAccepted: {
+        AnalyticsManager.shared.questionOriginating(.followUp)
+        AnalyticsManager.shared.chatMessageSent(
+          messageLength: question.count,
+          source: "follow_up_chip"
+        )
+      }
+    )
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -1100,7 +1100,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
     }
   }
 
-  private nonisolated static func cleanedPlaybackText(from message: ChatMessage?) -> String {
+  nonisolated static func cleanedPlaybackText(from message: ChatMessage?) -> String {
     guard let message else { return "" }
 
     let baseText: String
@@ -1140,9 +1140,9 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
     return collapsedWhitespace.trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
-  private nonisolated static func shouldSpeak(_ text: String) -> Bool {
+  nonisolated static func shouldSpeak(_ text: String) -> Bool {
     let lowercased = text.lowercased()
-    if lowercased == "failed to get a response. please try again." {
+    if FloatingBarAnswerFailureCopy.isFailureCopy(lowercased) {
       return false
     }
     if lowercased.hasPrefix("⚠️") || lowercased.hasPrefix("warning:") {
@@ -1405,4 +1405,29 @@ enum VoiceSynthesisFallbackPolicy {
 private enum PlaybackMode: Sendable {
   case openAI(voiceID: String, instructions: String)
   case systemVoice(ShortcutSettings.VoiceOption)
+}
+
+/// The copy the floating bar shows in place of an answer it could not get.
+///
+/// One home for those strings, because the voice lane must never read them
+/// aloud and the two halves have already drifted once: the empty-response copy
+/// was rewritten while `shouldSpeak` went on matching the retired sentence, so
+/// a voice query that produced nothing had its failure notice spoken. Adding a
+/// line here suppresses it by construction; a copy edit that forgets this type
+/// no longer has a silent failure mode, because the copy *is* this type.
+enum FloatingBarAnswerFailureCopy {
+  /// The turn finished with no answer content at all — no text, no blocks.
+  static let emptyResponse = "Omi couldn't get an answer for that one."
+
+  /// Retired wording. Kept because a transcript written by an older build can
+  /// still hold it, and because staying silent on it costs one string.
+  static let retired = ["Failed to get a response. Please try again."]
+
+  private static let unspoken: Set<String> = Set(
+    ([emptyResponse] + retired).map { $0.lowercased() })
+
+  /// Whether already-lowercased spoken text is one of those notices.
+  static func isFailureCopy(_ lowercasedText: String) -> Bool {
+    unspoken.contains(lowercasedText)
+  }
 }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -1649,11 +1649,16 @@ struct FloatingControlBarView: View {
 
   /// The chip's secondary hint names the shortcut actually bound, and is absent
   /// when push-to-talk is off — a hint for a disabled gesture is a wrong hint.
+  ///
+  /// Every token, not the first: a chord binding (`⌃⌥`, or a modifier plus a
+  /// key) renders as several tokens, and naming only the first one tells the
+  /// user to hold a key that does not start voice. Joined the way the sibling
+  /// hold hint joins them, so the two read the same on the same bar.
   @MainActor static func followUpVoiceHint(settings: ShortcutSettings = ShortcutSettings.shared) -> String? {
     guard settings.pttEnabled else { return nil }
-    let tokens = settings.pttShortcut.displayTokens
-    guard let token = tokens.first, !token.isEmpty else { return nil }
-    return "or hold \(token) to ask aloud"
+    let shortcut = settings.pttShortcut.displayTokens.joined()
+    guard !shortcut.isEmpty else { return nil }
+    return "or hold \(shortcut) to ask aloud"
   }
 
   private var aiResponseView: some View {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -4059,13 +4059,25 @@ class FloatingControlBarManager {
     fromVoice: Bool = false,
     voiceTurnID: VoiceTurnID? = nil
   ) {
-    guard let window = window else { return }
-    guard let provider = activeFloatingProvider() else { return }
+    // A caller that armed a question origin (the follow-up chip, a card action)
+    // armed it for *this* send. Every return below is a send that never
+    // happened, so the arm has to go with it or it lands on the next question.
+    guard let window = window else {
+      AnalyticsManager.shared.questionOriginationAborted()
+      return
+    }
+    guard let provider = activeFloatingProvider() else {
+      AnalyticsManager.shared.questionOriginationAborted()
+      return
+    }
 
     if fromVoice {
       guard let voiceTurnID,
         VoiceTurnCoordinator.shared.requireCurrentOwner(for: voiceTurnID) != nil
-      else { return }
+      else {
+        AnalyticsManager.shared.questionOriginationAborted()
+        return
+      }
       chatCancellable?.cancel()
       chatCancellable = nil
       window.cancelInputHeightObserver()
@@ -5338,7 +5350,7 @@ class FloatingControlBarManager {
       // failed turn never carries a follow-up chip either: the chip is appended
       // only on the provider's accepted-answer path.
       barWindow.state.setLocalAnswerOverride(
-        ChatMessage(text: "Omi couldn't get an answer for that one.", sender: .ai)
+        ChatMessage(text: FloatingBarAnswerFailureCopy.emptyResponse, sender: .ai)
       )
     }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift
@@ -560,20 +560,7 @@ struct ChatBubble: View {
           palette: .standard,
           action: {
             Task { @MainActor in
-              // Analytics commit at the provider's own acceptance boundary: a
-              // send it refuses emits nothing and mislabels nothing later.
-              _ = await provider.sendMessage(
-                question,
-                surfaceRef: provider.mainChatSurfaceReference(),
-                turnOwner: .mainChat,
-                onAccepted: {
-                  AnalyticsManager.shared.questionOriginating(.followUp)
-                  AnalyticsManager.shared.chatMessageSent(
-                    messageLength: question.count,
-                    source: "follow_up_chip"
-                  )
-                }
-              )
+              await FollowUpChipTap.send(question: question, provider: provider)
             }
           }
         )

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/AnalyticsManager+HomeKnows.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/AnalyticsManager+HomeKnows.swift
@@ -16,28 +16,44 @@ import Foundation
 extension AnalyticsManager {
   static let homeKnowsRowEvent = "desktop_home_knows_row"
 
+  /// Scoped observation of the two emits below, in the style of
+  /// `questionTelemetryCaptureForTests`: nil in production, and installed at the same boundary as
+  /// PostHog so what a test or the automation bridge reads is what production emitted rather than
+  /// a second guess at it.
+  ///
+  /// `static` on this extension rather than a stored property on `AnalyticsManager`, which is the
+  /// only difference from that seam. The manager is a 1,600-line file that this event has nothing
+  /// else to do with, and the two readers of this seam are the two functions directly underneath
+  /// it. The isolation is identical — `AnalyticsManager` is `@MainActor`, so this is too.
+  ///
+  /// Why a seam at all: `rotated_out_reason` is the only place the rotation policy's verdict is
+  /// ever named. It is computed inside `HomeKnowsListComposer`, consumed by this emit, and
+  /// readable nowhere afterwards, so a flow that could not watch the emit could see a slot go
+  /// empty and never learn whether it went empty for the reason the reader's ledger says it should.
+  static var homeKnowsTelemetryCaptureForTests: (@MainActor (String, [String: Any]) -> Void)?
+
   /// One row rendered in the knows-list. Emitted once per visit per row, not
   /// once per re-render — the in-visit rotation timer re-renders every few
   /// seconds and would otherwise invent impressions.
   func trackHomeKnowsRowShown(kind: String, slot: HomeKnowsSlot, showsBefore: Int) {
-    PostHogManager.shared.track(
-      Self.homeKnowsRowEvent,
-      properties: [
-        "kind": kind,
-        "slot": slot.rawValue,
-        "shows_before": showsBefore,
-      ])
+    let properties: [String: Any] = [
+      "kind": kind,
+      "slot": slot.rawValue,
+      "shows_before": showsBefore,
+    ]
+    Self.homeKnowsTelemetryCaptureForTests?(Self.homeKnowsRowEvent, properties)
+    PostHogManager.shared.track(Self.homeKnowsRowEvent, properties: properties)
   }
 
   /// A slot that stayed empty rather than repeating a row already seen.
   func trackHomeKnowsSlotEmpty(slot: HomeKnowsSlot, reason: HomeKnowsRotationReason) {
-    PostHogManager.shared.track(
-      Self.homeKnowsRowEvent,
-      properties: [
-        "kind": "empty",
-        "slot": slot.rawValue,
-        "shows_before": 0,
-        "rotated_out_reason": reason.rawValue,
-      ])
+    let properties: [String: Any] = [
+      "kind": "empty",
+      "slot": slot.rawValue,
+      "shows_before": 0,
+      "rotated_out_reason": reason.rawValue,
+    ]
+    Self.homeKnowsTelemetryCaptureForTests?(Self.homeKnowsRowEvent, properties)
+    PostHogManager.shared.track(Self.homeKnowsRowEvent, properties: properties)
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ChatDailySummaryCard.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ChatDailySummaryCard.swift
@@ -67,10 +67,10 @@ struct ChatDailySummaryCard: View {
 
       let learned = Self.memoriesLearned(in: summary)
       if !learned.isEmpty {
-        // Keyed to the summary, so tomorrow's card starts from tomorrow's memories rather than
-        // inheriting a row model built for yesterday's.
+        // Keyed to the rows themselves, so tomorrow's card starts from tomorrow's memories rather
+        // than inheriting a row model built for yesterday's.
         MemoryReviewSection(items: learned, source: .dailySummaryChat)
-          .id("memory-review-\(summary.id)")
+          .id(Self.reviewSectionIdentity(summaryID: summary.id, items: learned))
       }
 
       if isExpanded {
@@ -251,8 +251,26 @@ struct ChatDailySummaryCard: View {
   /// with no qualifying memory shows no section, which is the honest empty state.
   nonisolated static func memoriesLearned(in summary: DailySummaryRecord) -> [MemoryReviewItem] {
     summary.memoriesLearned
-      .filter { !$0.memoryID.isEmpty && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+      .filter {
+        // Trimmed, not merely non-empty: a blank-but-present id would render a row whose ✓ / ✗ /
+        // Fix address no memory at all.
+        !$0.memoryID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+          && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      }
       .prefix(MemoryReviewSection.maxRows)
       .map(MemoryReviewItem.init)
+  }
+
+  /// Identity for the review section.
+  ///
+  /// The section holds one `MemoryReviewCardStore`, and the store captures its rows at init. A
+  /// summary regenerated for the same day keeps its id, so keying on the id alone kept the old
+  /// store alive: new memories never appeared and corrected ones kept the text the record no
+  /// longer contained. Folding the rows in rebuilds the section exactly when they change.
+  nonisolated static func reviewSectionIdentity(
+    summaryID: String, items: [MemoryReviewItem]
+  ) -> String {
+    let rows = items.map { "\($0.memoryID)\u{1F}\($0.content)" }.joined(separator: "\u{1E}")
+    return "memory-review-\(summaryID)\u{1E}\(rows)"
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsComposer.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsComposer.swift
@@ -107,14 +107,45 @@ enum HomeKnowsListComposer {
 
   /// Open tasks the reader has not dismissed — the count the greeting's daily
   /// brief and composed tip are phrased around.
+  ///
+  /// Counted through the same eligibility predicate the rows are, so the
+  /// greeting cannot disagree with the list beneath it: the same duplicate ids
+  /// collapse, a long-dead past-due task is out of both, and a dismissal the
+  /// reader's own edit has since invalidated is back in both. Rotation state
+  /// (show cap, same-day) deliberately does not count — a task you have already
+  /// seen three times today still needs you.
   static func openTaskCount(
     _ tasks: [HomeKnowsTaskCandidate],
-    ledger: HomeKnowsImpressionLedger = .empty
+    ledger: HomeKnowsImpressionLedger = .empty,
+    now: Date = Date()
   ) -> Int {
-    tasks.filter { candidate in
-      guard candidate.isActive else { return false }
-      return ledger.entry(HomeKnowsRotationPolicy.taskKey(candidate.id))?.dismissedAt == nil
+    distinctTasks(tasks).filter { candidate in
+      let facts = taskFacts(candidate)
+      return HomeKnowsRotationPolicy.availability(
+        facts: facts, entry: ledger.entry(facts.key), now: now) == nil
     }.count
+  }
+
+  /// The task candidates a row could be built from, in the caller's own
+  /// priority order. Task ids repeat across the overdue/today/no-due-date
+  /// buckets the hub concatenates; a duplicate would collide as a ForEach ID
+  /// and be counted twice by the greeting.
+  private static func distinctTasks(_ tasks: [HomeKnowsTaskCandidate]) -> [HomeKnowsTaskCandidate] {
+    var seenTaskIDs = Set<String>()
+    return tasks.filter { candidate in
+      !candidate.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        && seenTaskIDs.insert(candidate.id).inserted
+    }
+  }
+
+  private static func taskFacts(_ candidate: HomeKnowsTaskCandidate) -> HomeKnowsCandidateFacts {
+    HomeKnowsCandidateFacts(
+      key: HomeKnowsRotationPolicy.taskKey(candidate.id),
+      contentHash: HomeKnowsRotationPolicy.contentHash(
+        text: candidate.text, updatedAt: candidate.updatedAt),
+      updatedAt: candidate.updatedAt,
+      dueAt: candidate.dueAt,
+      isActive: candidate.isActive)
   }
 
   static func compose(
@@ -127,27 +158,14 @@ enum HomeKnowsListComposer {
     calendar: Calendar = .current,
     rotation: Int = 0
   ) -> HomeKnowsComposition {
-    // Task ids repeat across the overdue/today/no-due-date buckets the hub
-    // concatenates; a duplicate would collide as a ForEach ID.
-    var seenTaskIDs = Set<String>()
+    // Unavailable tasks stay in the pool rather than being filtered out here:
+    // `pool` is what reports *why* a slot came up empty, and a pre-filtered
+    // dismissal would be indistinguishable from having no task at all.
     let taskCandidates =
-      tasks
-      .filter { candidate in
-        !candidate.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-          && seenTaskIDs.insert(candidate.id).inserted
-      }
+      distinctTasks(tasks)
       .enumerated()
       .map { index, candidate in
-        Scored(
-          element: candidate,
-          facts: HomeKnowsCandidateFacts(
-            key: HomeKnowsRotationPolicy.taskKey(candidate.id),
-            contentHash: HomeKnowsRotationPolicy.contentHash(
-              text: candidate.text, updatedAt: candidate.updatedAt),
-            updatedAt: candidate.updatedAt,
-            dueAt: candidate.dueAt,
-            isActive: candidate.isActive),
-          order: index)
+        Scored(element: candidate, facts: taskFacts(candidate), order: index)
       }
 
     let insightCandidates =

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsImpressionLedger.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsImpressionLedger.swift
@@ -352,3 +352,96 @@ final class HomeKnowsImpressionStore {
     return impression
   }
 }
+
+// MARK: - Harness handle
+
+/// The knows-list currently on screen, for non-production automation only.
+///
+/// `DashboardPage` composes the rows in a computed property and publishes them nowhere: the
+/// composition, the slots it left empty, and the ledger snapshot it was gated against all live for
+/// one `body` evaluation and are gone. A flow could therefore watch the hub render and still not
+/// read which rows it bound, which candidate it held back, or why — and could not open or dismiss
+/// one without the cursor.
+///
+/// This is that handle. Every closure is one of the page's own functions — `beginKnowsVisit`,
+/// `recordKnowsImpressions`, `openKnowsRow`, and the dismiss handler the row's ✕ invokes — so the
+/// bridge's `home_knows_*` actions are second *callers* of the rotation code and never a second
+/// rotation policy. A copied composer would keep agreeing with whatever the harness wrote into it
+/// long after the real one changed, and the whole point of the flow is that the two agree.
+///
+/// Gated: on a production bundle `register` does nothing and `mounted` is always nil, so nothing
+/// here is a shipped path.
+@MainActor
+enum HomeKnowsAutomationRegistry {
+  /// One composed row, projected to strings so the bridge never re-derives anything.
+  struct Row: Equatable {
+    let key: String
+    let kind: String
+    let text: String
+    let showsBefore: Int
+  }
+
+  struct EmptySlot: Equatable {
+    let slot: String
+    let reason: String
+  }
+
+  struct Snapshot {
+    let rows: [Row]
+    let emptySlots: [EmptySlot]
+    let canRotate: Bool
+    /// What the greeting's "N things need you" is counting, so a flow can prove the headline and
+    /// the list below it read the same ledger.
+    let openTaskCount: Int
+    let ledger: HomeKnowsImpressionLedger
+  }
+
+  /// The page's own functions, in the order one visit calls them.
+  struct Handle {
+    let token: UUID
+    let snapshot: @MainActor () -> Snapshot
+    let beginVisit: @MainActor () -> Void
+    let recordImpressions: @MainActor () -> Void
+    /// - Returns: false when the index is outside the rows currently on screen.
+    let open: @MainActor (Int) -> Bool
+    /// - Returns: false when the index is outside the rows, or when that row kind has no ✕
+    ///   (question rows are not dismissible).
+    let dismiss: @MainActor (Int) -> Bool
+  }
+
+  private(set) static var mounted: Handle?
+
+  static func register(_ handle: Handle) { register(handle, enabled: AppBuild.isNonProduction) }
+
+  /// The gate as a parameter, because `AppBuild.isNonProduction` reads `Bundle.main`, and under
+  /// `swift test` that is the test runner rather than an Omi bundle — so a test asserting the
+  /// production no-op would pass for the wrong reason and a test asserting the registration could
+  /// not run at all.
+  static func register(_ handle: Handle, enabled: Bool) {
+    guard enabled else { return }
+    mounted = handle
+  }
+
+  /// Token-checked: the hub list and the chat strip are two renderings of the same rows and can
+  /// overlap for a frame while the stage animates, and the outgoing one must not clear the handle
+  /// the incoming one just took.
+  static func unregister(token: UUID) {
+    guard mounted?.token == token else { return }
+    mounted = nil
+  }
+}
+
+extension HomeKnowsImpressionStore {
+  /// Drop every entry for the current owner and start a fresh visit.
+  ///
+  /// Harness-only, and called from exactly one place: the non-production `home_knows_reset` bridge
+  /// action. The ledger is `UserDefaults`-backed and deliberately outlives the app, so without
+  /// this a second run of `home-knows-rotation.yaml` on the same bundle would open on rows that
+  /// were already same-day-suppressed by the first — and would read a correct suppression as a
+  /// composer that had stopped producing rows. It writes through the same persistence the
+  /// mutations use rather than reaching around it.
+  func resetForAutomation() {
+    persistence.save(.empty)
+    beginVisit()
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsImpressionLedger.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsImpressionLedger.swift
@@ -102,6 +102,29 @@ enum HomeKnowsRotationPolicy {
     return String(hash.compactMap { String(format: "%02x", $0) }.joined().prefix(16))
   }
 
+  /// Why this candidate is not something to surface at all right now, or `nil`
+  /// if it still is. Independent of how often it has been shown.
+  ///
+  /// Split out because two callers need exactly this much and no more: the
+  /// composer, which then layers the rotation rules on top, and the greeting's
+  /// open-task count, which must not shrink just because a row has already had
+  /// its three impressions today. One predicate is what keeps "3 things need
+  /// you" honest about the list underneath it.
+  static func availability(
+    facts: HomeKnowsCandidateFacts,
+    entry: HomeKnowsImpression?,
+    now: Date
+  ) -> HomeKnowsRotationReason? {
+    guard facts.isActive else { return .inactive }
+    if let dueAt = facts.dueAt, now.timeIntervalSince(dueAt) > stalePastDueGrace {
+      return .staleDueDate
+    }
+    // A changed underlying object is new information: it clears a dismissal and
+    // resets the show cap. That is the only way a dismissed row ever returns.
+    guard let entry, entry.contentHash == facts.contentHash else { return nil }
+    return entry.dismissedAt != nil ? .dismissed : nil
+  }
+
   /// Why this candidate must not take a slot right now, or `nil` if it may.
   ///
   /// - Parameter allowSameDayRepeat: set only when the slot has no other
@@ -113,15 +136,10 @@ enum HomeKnowsRotationPolicy {
     calendar: Calendar,
     allowSameDayRepeat: Bool
   ) -> HomeKnowsRotationReason? {
-    guard facts.isActive else { return .inactive }
-    if let dueAt = facts.dueAt, now.timeIntervalSince(dueAt) > stalePastDueGrace {
-      return .staleDueDate
-    }
-    guard let entry else { return nil }
-    // A changed underlying object is new information: it clears a dismissal and
-    // resets the show cap. That is the only way a dismissed row ever returns.
-    guard entry.contentHash == facts.contentHash else { return nil }
-    if entry.dismissedAt != nil { return .dismissed }
+    if let unavailable = availability(facts: facts, entry: entry, now: now) { return unavailable }
+    // Past this point the entry exists and still describes this exact content;
+    // anything else was already admitted by `availability`.
+    guard let entry, entry.contentHash == facts.contentHash else { return nil }
 
     if entry.lastOpenedAt == nil, entry.shows >= showCapCount {
       let lastShownAt = entry.lastShownAt ?? .distantPast
@@ -226,33 +244,57 @@ final class HomeKnowsImpressionStore {
 
   private let persistence: any HomeKnowsImpressionPersisting
   private let now: () -> Date
+  private let ownerID: () -> String?
   /// Row keys and slot names already reported during the current visit. One
   /// visit is one impression: the in-visit rotation timer re-renders the same
   /// row every few seconds and must not burn through the show cap.
   private var reportedThisVisit: Set<String> = []
+  /// The owner the keys above belong to. The ledger itself is owner-scoped at
+  /// every read and write, but this set is not — and a shared key (a suggested
+  /// question is keyed by its text) would silence the new owner's first
+  /// impression on a switch that leaves the dashboard mounted.
+  private var visitOwnerID: String?
 
   /// `persistence` defaults to owner-scoped `UserDefaults`. It is built inside
   /// the initializer rather than as a default argument because default argument
   /// expressions are evaluated outside this type's actor.
   init(
     persistence: (any HomeKnowsImpressionPersisting)? = nil,
-    now: @escaping () -> Date = Date.init
+    now: @escaping () -> Date = Date.init,
+    ownerID: (() -> String?)? = nil
   ) {
     self.persistence = persistence ?? HomeKnowsImpressionDefaults()
     self.now = now
+    self.ownerID = ownerID ?? { RuntimeOwnerIdentity.currentOwnerId() }
   }
 
   /// Reads through to storage so an account switch cannot be served a cached
   /// ledger from the previous owner.
-  func snapshot() -> HomeKnowsImpressionLedger { persistence.load() }
+  func snapshot() -> HomeKnowsImpressionLedger {
+    adoptCurrentOwner()
+    return persistence.load()
+  }
 
   /// Starts a new visit to the knows-list. Resets in-visit de-duplication.
-  func beginVisit() { reportedThisVisit.removeAll() }
+  func beginVisit() {
+    visitOwnerID = ownerID()
+    reportedThisVisit.removeAll()
+  }
+
+  /// An owner change is the start of a new visit whether or not the view was
+  /// rebuilt: the previous owner's keys describe another account's ledger.
+  private func adoptCurrentOwner() {
+    let current = ownerID()
+    guard current != visitOwnerID else { return }
+    visitOwnerID = current
+    reportedThisVisit.removeAll()
+  }
 
   /// Records a row as shown. Returns the updated impression, or `nil` when this
   /// row was already recorded during the current visit.
   @discardableResult
   func recordShown(key: String, contentHash: String) -> HomeKnowsImpression? {
+    adoptCurrentOwner()
     guard reportedThisVisit.insert(key).inserted else { return nil }
     return mutate(key: key) { impression in
       let contentChanged = impression.contentHash != contentHash
@@ -266,6 +308,10 @@ final class HomeKnowsImpressionStore {
         impression.firstShownAt = nil
         impression.dismissedAt = nil
       }
+      // A prior open belonged to the old text. Carrying it across exempted the
+      // new content from the show cap and the same-day rule for good — the one
+      // row in the ledger that could repeat itself indefinitely.
+      if contentChanged { impression.lastOpenedAt = nil }
       impression.shows += 1
       impression.firstShownAt = impression.firstShownAt ?? self.now()
       impression.lastShownAt = self.now()
@@ -292,7 +338,8 @@ final class HomeKnowsImpressionStore {
 
   /// True the first time this visit that an empty slot is worth reporting.
   func shouldReportEmptySlot(_ slot: String) -> Bool {
-    reportedThisVisit.insert("slot:\(slot)").inserted
+    adoptCurrentOwner()
+    return reportedThisVisit.insert("slot:\(slot)").inserted
   }
 
   @discardableResult

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/MemoryReviewCard.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/MemoryReviewCard.swift
@@ -396,3 +396,40 @@ final class MemoryReviewCardStore: ObservableObject {
     send(succeeded ? .requestSucceeded(action) : .requestFailed(action), to: item)
   }
 }
+
+// MARK: - Harness handle
+
+/// The store of the review section currently on screen, for non-production automation only.
+///
+/// The section owns its store as a `@StateObject` built at init, so a mounted card was reachable
+/// from nowhere: an E2E flow could seed a summary and see a card render, but could not read which
+/// rows it had bound or click one of them without the cursor. The bridge's `memory_review_*`
+/// actions read and drive through this handle, which makes them second *callers* of the same
+/// `MemoryReviewCardStore.send` the ✓ / ✗ buttons call — never a second row state machine.
+///
+/// `weak`, so the handle never keeps a dismissed card's rows alive, and gated: on a production
+/// bundle `register` does nothing and `mounted` is always nil, so nothing here is a shipped path.
+@MainActor
+enum MemoryReviewCardRegistry {
+  private(set) static weak var mounted: MemoryReviewCardStore?
+
+  static func register(_ store: MemoryReviewCardStore) {
+    register(store, enabled: AppBuild.isNonProduction)
+  }
+
+  /// The gate as a parameter, because `AppBuild.isNonProduction` reads `Bundle.main`, and under
+  /// `swift test` that is the test runner rather than an Omi bundle — so a test asserting the
+  /// production no-op would pass for the wrong reason and a test asserting the registration
+  /// could not run at all.
+  static func register(_ store: MemoryReviewCardStore, enabled: Bool) {
+    guard enabled else { return }
+    mounted = store
+  }
+
+  /// Identity-checked: two sections can overlap for a frame while the card rebuilds on new rows,
+  /// and the outgoing one must not clear the handle the incoming one just took.
+  static func unregister(_ store: MemoryReviewCardStore) {
+    guard mounted === store else { return }
+    mounted = nil
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/MemoryReviewCard.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/MemoryReviewCard.swift
@@ -223,13 +223,22 @@ protocol MemoryReviewMutating: Sendable {
 }
 
 /// The live read of `user_review` / `edited`, resolved per memory id.
+///
+/// Throwing rather than optional-returning: "the read failed" and "nobody has voted on any of
+/// these" are different facts, and a card that cannot tell them apart shows a settled verdict as
+/// unreviewed and offers the controls again.
 protocol MemoryReviewStateReading: Sendable {
-  func verdicts(for items: [MemoryReviewItem]) async -> [String: MemoryReviewVerdict]
+  func verdicts(for items: [MemoryReviewItem]) async throws -> [String: MemoryReviewVerdict]
 }
 
 struct LiveMemoryReviewMutator: MemoryReviewMutating {
   func review(memoryID: String, keep: Bool) async throws {
     try await APIClient.shared.reviewMemory(id: memoryID, keep: keep)
+    // Same reason the edit path below mirrors its content. The verdict lives on the memory and the
+    // backend remains its only writer; this records what that write already accepted into the local
+    // mirror the desktop reads memories from, so the verdict survives the card being rebuilt
+    // instead of reverting to "unreviewed" until an unrelated memory sync happens to run.
+    try? await Self.mirrorVerdict(memoryID: memoryID, keep: keep)
   }
 
   func edit(memoryID: String, content: String) async throws {
@@ -237,6 +246,14 @@ struct LiveMemoryReviewMutator: MemoryReviewMutating {
     // Keep the local mirror in step with the write, so the re-read below confirms the edit rather
     // than reporting the text the reader just replaced.
     try? await MemoryStorage.shared.updateContentByBackendId(memoryID, content: content)
+  }
+
+  private static func mirrorVerdict(memoryID: String, keep: Bool) async throws {
+    guard var record = try await MemoryStorage.shared.getMemoryByBackendId(memoryID) else { return }
+    record.reviewed = true
+    record.userReview = keep
+    guard let mirrored = record.toServerMemory() else { return }
+    try await MemoryStorage.shared.syncServerMemory(mirrored)
   }
 }
 
@@ -248,15 +265,10 @@ struct LiveMemoryReviewMutator: MemoryReviewMutating {
 /// correction is recognised the way the reader would recognise it: the stored content no longer
 /// matches what the summary captured.
 struct LiveMemoryReviewStateReader: MemoryReviewStateReading {
-  func verdicts(for items: [MemoryReviewItem]) async -> [String: MemoryReviewVerdict] {
+  func verdicts(for items: [MemoryReviewItem]) async throws -> [String: MemoryReviewVerdict] {
     let ids = items.map(\.memoryID).filter { !$0.isEmpty }
     guard !ids.isEmpty else { return [:] }
-    let stored: [ServerMemory]
-    do {
-      stored = try await MemoryStorage.shared.getMemories(backendIds: ids)
-    } catch {
-      return [:]
-    }
+    let stored = try await MemoryStorage.shared.getMemories(backendIds: ids)
     var byID: [String: ServerMemory] = [:]
     for memory in stored { byID[memory.id] = memory }
     var verdicts: [String: MemoryReviewVerdict] = [:]
@@ -320,17 +332,24 @@ final class MemoryReviewCardStore: ObservableObject {
   }
 
   /// Render-time read. Once per card mount: the section is chrome, not a poller.
+  ///
+  /// The attempt counts only once it has actually succeeded. Marking it up front meant a cancelled
+  /// or failed read left every row reading "unreviewed" for as long as the card stayed mounted,
+  /// silently and with no way back; leaving the flag down lets the next mount try again.
   func loadLiveStateIfNeeded() async {
     guard !didLoadLiveState, !items.isEmpty else { return }
-    didLoadLiveState = true
-    await refreshLiveState()
+    didLoadLiveState = await refreshLiveState()
   }
 
-  func refreshLiveState() async {
-    let verdicts = await stateReader.verdicts(for: items)
+  /// Returns whether the memories could be read at all. A failed read sends no events: reporting
+  /// every row as `.none` would be indistinguishable from a day nobody has voted on.
+  @discardableResult
+  func refreshLiveState() async -> Bool {
+    guard let verdicts = try? await stateReader.verdicts(for: items) else { return false }
     for item in items {
       send(.liveStateLoaded(verdicts[item.memoryID] ?? .none), to: item)
     }
+    return true
   }
 
   func send(_ event: MemoryReviewEvent, to item: MemoryReviewItem) {

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/MemoryReviewRowView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/MemoryReviewRowView.swift
@@ -51,9 +51,14 @@ struct MemoryReviewSection: View {
         }
         .accessibilityIdentifier("memory-review-section")
         .task {
+          // Non-production only, and a no-op on a shipped bundle: this is how the automation
+          // bridge reaches the rows a real card bound, so `memory-review.yaml` can assert them
+          // and vote through the same `store.send` the ✓ / ✗ buttons below call.
+          MemoryReviewCardRegistry.register(store)
           reportImpression()
           await store.loadLiveStateIfNeeded()
         }
+        .onDisappear { MemoryReviewCardRegistry.unregister(store) }
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -1043,7 +1043,9 @@ struct DashboardPage: View {
         slot: slot(for: row, in: composition),
         showsBefore: max(0, impression.shows - 1))
     }
-    for empty in composition.emptySlots {
+    // An empty slot only cost the reader a row when the rail came up short of
+    // what it can show; the chat strip never renders a fourth slot at all.
+    for empty in composition.emptySlots.prefix(max(0, visibleRows - composition.rows.count)) {
       guard knowsLedgerStore.shouldReportEmptySlot(empty.slot.rawValue) else { continue }
       AnalyticsManager.shared.trackHomeKnowsSlotEmpty(slot: empty.slot, reason: empty.reason)
     }
@@ -1061,8 +1063,6 @@ struct DashboardPage: View {
   }
 
   private func openKnowsRow(_ row: HomeKnowsRow) {
-    knowsLedger.entries[row.ledgerKey] = knowsLedgerStore.recordOpened(
-      key: row.ledgerKey, contentHash: row.contentHash)
     switch row.kind {
     case .task(let id):
       if let task = (viewModel.overdueTasks + viewModel.todaysTasks + viewModel.recentTasks)
@@ -1072,19 +1072,29 @@ struct DashboardPage: View {
       }
       navigate(to: .tasks)
     case .insight(let id):
+      // Nothing opens when the recommendation is gone, and an open is recorded
+      // only once one happened: a row counted as opened is exempt from the show
+      // cap and the same-day rule for good.
       guard let recommendation = intelligenceStore.recommendations.first(where: { $0.id == id })
       else { return }
       Task {
-        if await openRecommendation(recommendation) {
-          await intelligenceStore.recordPrimaryAction(recommendation)
-        }
+        guard await openRecommendation(recommendation) else { return }
+        recordKnowsOpened(row)
+        await intelligenceStore.recordPrimaryAction(recommendation)
       }
+      return
     case .question:
       // Prefill the ask bar so you can glance it over and edit before sending,
       // rather than firing the suggestion blindly.
       chatProvider.draftText = row.text
       homeAskFieldFocused = true
     }
+    recordKnowsOpened(row)
+  }
+
+  private func recordKnowsOpened(_ row: HomeKnowsRow) {
+    knowsLedger.entries[row.ledgerKey] = knowsLedgerStore.recordOpened(
+      key: row.ledgerKey, contentHash: row.contentHash)
   }
 
   private func knowsDismissHandler(for row: HomeKnowsRow) -> ((OmiAPI.TaskIntelligenceFeedbackReason?) -> Void)? {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -270,6 +270,9 @@ struct DashboardPage: View {
   @State private var knowsLedger = HomeKnowsImpressionLedger.empty
   /// Single mutation owner for that ledger — the view never writes it directly.
   private var knowsLedgerStore: HomeKnowsImpressionStore { .shared }
+  /// Identity of this page's automation handle, so a stage that is animating out cannot clear the
+  /// handle the one animating in just took. Non-production only; see `knowsAutomationHandle`.
+  @State private var knowsAutomationToken = UUID()
 
   private var selectedApp: OmiApp? {
     guard let appId = chatProvider.selectedAppId else { return nil }
@@ -1006,9 +1009,56 @@ struct DashboardPage: View {
       guard homeMode == .hub, !chatProvider.isSending, homeKnowsCanRotate else { return }
       knowsRotation += 1
     }
-    .onAppear { beginKnowsVisit() }
+    .onAppear {
+      beginKnowsVisit()
+      // Non-production only, and a no-op on a shipped bundle: this is how `home-knows-rotation.yaml`
+      // reaches the rows the hub actually composed. Registered from the hub list rather than the
+      // chat strip because the hub is where all four slots exist; the strip renders three
+      // (`rollingSuggestionCount`) and would report a truncation as a rotation.
+      HomeKnowsAutomationRegistry.register(knowsAutomationHandle)
+    }
+    .onDisappear { HomeKnowsAutomationRegistry.unregister(token: knowsAutomationToken) }
     .onChange(of: knowsImpressionSignature) { _, _ in recordKnowsImpressions() }
     .accessibilityIdentifier("home-knows-list")
+  }
+
+  /// The page's own knows-list functions, handed to the automation registry.
+  ///
+  /// Read and drive only — every closure forwards to the function the on-screen control calls, so
+  /// the bridge cannot compose a row, decide a suppression, or write the ledger on its own.
+  private var knowsAutomationHandle: HomeKnowsAutomationRegistry.Handle {
+    HomeKnowsAutomationRegistry.Handle(
+      token: knowsAutomationToken,
+      snapshot: {
+        let composition = homeKnowsComposition
+        return HomeKnowsAutomationRegistry.Snapshot(
+          rows: composition.rows.map {
+            HomeKnowsAutomationRegistry.Row(
+              key: $0.ledgerKey, kind: $0.kind.analyticsKind, text: $0.text, showsBefore: $0.showsBefore)
+          },
+          emptySlots: composition.emptySlots.map {
+            HomeKnowsAutomationRegistry.EmptySlot(slot: $0.slot.rawValue, reason: $0.reason.rawValue)
+          },
+          canRotate: composition.canRotate,
+          openTaskCount: homeOpenTaskCount,
+          ledger: knowsLedger)
+      },
+      beginVisit: { beginKnowsVisit() },
+      recordImpressions: { recordKnowsImpressions() },
+      open: { index in
+        let rows = homeKnowsRows
+        guard rows.indices.contains(index) else { return false }
+        openKnowsRow(rows[index])
+        return true
+      },
+      dismiss: { index in
+        let rows = homeKnowsRows
+        guard rows.indices.contains(index), let handler = knowsDismissHandler(for: rows[index]) else {
+          return false
+        }
+        handler(nil)
+        return true
+      })
   }
 
   /// Starts a visit to the knows-list: re-reads the ledger (so an account

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+AutomationSnapshot.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+AutomationSnapshot.swift
@@ -18,6 +18,18 @@ extension ChatProvider {
     automationChatSnapshot(limit: limit)
   }
 
+  /// The grounded follow-up question on the newest answer, or `nil` when it
+  /// carries no chip. One reader for both the snapshot field and the
+  /// `tap_chat_follow_up_chip` action, so a flow can never assert a chip the
+  /// tap would then fail to find.
+  func automationLastFollowUpQuestion() -> String? {
+    guard let lastAssistant = messages.last(where: { $0.sender != .user }) else { return nil }
+    return lastAssistant.contentBlocks.compactMap { block -> String? in
+      if case .followUp(_, let text) = block { return text }
+      return nil
+    }.last
+  }
+
   func automationChatSnapshot(limit: Int) -> [String: String] {
     let boundedLimit = max(1, limit)
     let runtimeChatId = mainChatRuntimeChatId(sessionId: currentSessionId)
@@ -50,8 +62,16 @@ extension ChatProvider {
       "message_count": "\(messages.count)",
       "messages_json": messagesJSON,
     ]
-    if let lastAssistant = messages.last(where: { $0.sender != .user })?.copyableText {
-      detail["last_assistant_text"] = lastAssistant
+    if let lastAssistant = messages.last(where: { $0.sender != .user }) {
+      detail["last_assistant_text"] = lastAssistant.copyableText
+      // The grounded follow-up chip, projected out of the block list so a flow
+      // can assert it without string-matching `messages_json`. The pair matters
+      // more than either half: `last_assistant_text` is the visible prose and
+      // excludes this block, so asserting both pins the tail as *moved* rather
+      // than merely present — the exact defect the split exists to prevent.
+      if let question = automationLastFollowUpQuestion() {
+        detail["last_assistant_follow_up_question"] = question
+      }
     }
     if let ownerId = runtimeOwnerId {
       detail["owner_id"] = ownerId

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+AutomationSnapshot.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+AutomationSnapshot.swift
@@ -73,6 +73,16 @@ extension ChatProvider {
         detail["last_assistant_follow_up_question"] = question
       }
     }
+    if let probe = streamingBuffer.tailProjectionProbe {
+      // The half of the follow-up split that only exists while the answer is streaming. The chip's
+      // question must never have been visible as prose, and the terminal answer overwrites the
+      // streamed text, so `last_assistant_text` above cannot tell. `delimiter_seen` is asserted
+      // alongside the leak count on purpose: without it a turn that produced no tail at all would
+      // report zero leaks and read as a pass.
+      detail["streaming_tail_projections"] = String(probe.projectionCount)
+      detail["streaming_tail_delimiter_seen"] = probe.delimiterSeen ? "true" : "false"
+      detail["streaming_tail_leaks"] = String(probe.leakCount)
+    }
     if let ownerId = runtimeOwnerId {
       detail["owner_id"] = ownerId
     }

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
@@ -161,6 +161,9 @@ extension ChatProvider {
       durableToolReferences,
       ChatCitationProvenanceRegistry.references(
         fromToolCallBlocks: messages[index].contentBlocks))
+    // The authoritative answer replaces every streamed projection, so the raw
+    // accumulator this turn was built from has no further reader.
+    streamingBuffer.finishStreaming(messageId: messageId)
     messages[index].applyAuthoritativeTerminalAnswer(queryText)
     messages[index].applySelectedSourceFallback(
       selectedReferences: selectedReferences,

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1404,7 +1404,9 @@ class ChatProvider: ObservableObject {
   // MARK: - Streaming Buffer
   /// Accumulates text and thinking deltas during streaming and flushes them to
   /// the published messages array in batches, reducing SwiftUI re-render frequency.
-  private let streamingBuffer = ChatStreamingBuffer(flushInterval: 0.035)
+  // Not private: the journal projection extension releases the turn's raw
+  // accumulator when the authoritative answer lands.
+  let streamingBuffer = ChatStreamingBuffer(flushInterval: 0.035)
 
   // MARK: - Filtered Sessions
   var filteredSessions: [ChatSession] {

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+DailySummaries.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+DailySummaries.swift
@@ -61,7 +61,10 @@ struct DailySummaryRecord: Decodable, Identifiable, Equatable {
 
     init(from decoder: Decoder) throws {
       let container = try decoder.container(keyedBy: CodingKeys.self)
-      memoryID = try container.decodeIfPresent(String.self, forKey: .memoryID) ?? ""
+      // Trimmed at the wire: every reader treats a blank id as "not a review row", and a
+      // whitespace-only id would otherwise pass each of those emptiness checks.
+      memoryID = (try container.decodeIfPresent(String.self, forKey: .memoryID) ?? "")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
       content = try container.decodeIfPresent(String.self, forKey: .content) ?? ""
       category = try container.decodeIfPresent(String.self, forKey: .category) ?? ""
       capturedAt = try container.decodeIfPresent(String.self, forKey: .capturedAt)
@@ -111,10 +114,13 @@ struct DailySummaryRecord: Decodable, Identifiable, Equatable {
     highlights = try container.decodeIfPresent([Highlight].self, forKey: .highlights)
     actionItems = try container.decodeIfPresent([ActionItem].self, forKey: .actionItems)
     // A malformed entry must not cost the reader the whole summary, and a memory with no id
-    // cannot be voted on or corrected, so it is not a review row at all.
+    // cannot be voted on or corrected, so it is not a review row at all. Entries decode
+    // independently: one bad element drops itself, not every valid row beside it. The outer
+    // `try?` still absorbs a `memories_learned` that is not an array at all.
     memoriesLearned =
-      (try? container.decodeIfPresent([LearnedMemory].self, forKey: .memoriesLearned))
+      (try? container.decodeIfPresent([LenientLearnedMemory].self, forKey: .memoriesLearned))
       .flatMap { $0 }?
+      .compactMap(\.value)
       .filter { !$0.memoryID.isEmpty && !$0.content.isEmpty } ?? []
   }
 
@@ -133,6 +139,15 @@ struct DailySummaryRecord: Decodable, Identifiable, Equatable {
     self.highlights = highlights
     self.actionItems = actionItems
     self.memoriesLearned = memoriesLearned
+  }
+}
+
+/// One `memories_learned` element, decoded so that its own failure is local to it.
+private struct LenientLearnedMemory: Decodable {
+  let value: DailySummaryRecord.LearnedMemory?
+
+  init(from decoder: Decoder) throws {
+    value = try? DailySummaryRecord.LearnedMemory(from: decoder)
   }
 }
 

--- a/desktop/macos/Desktop/Tests/ChatFollowUpChipTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatFollowUpChipTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 
 @testable import Omi_Computer
@@ -50,6 +51,33 @@ final class ChatFollowUpChipTests: XCTestCase {
     }
   }
 
+  /// The client's generic filter is the backend's `_GENERIC_PATTERNS`. Prefix
+  /// matching dropped chips the server had already built and sent — anything
+  /// merely *starting* with a generic phrase, however specific the rest.
+  func testTheGenericFilterMatchesTheBackendRuleRatherThanAPrefix() {
+    for generic in [
+      "Anything else?", "Want more details?", "Do you want more information?",
+      "Does that make sense?", "Any other questions?", "Shall I go on?",
+      "Would you like to know more?", "What else?",
+      // The prefix list matched "does that answer" and nothing else; the
+      // backend's `(does|did) that (help|make sense|answer)` matches both.
+      "Did that answer your question?",
+    ] {
+      XCTAssertTrue(ChatFollowUpTail.isGeneric(generic), "should be generic: \(generic)")
+    }
+
+    for specific in [
+      "What else did Priya flag in that review?",
+      "What else was decided in that standup?",
+      "Want me to pull the Thursday thread?",
+      "Does that Thursday date still hold?",
+    ] {
+      XCTAssertFalse(
+        ChatFollowUpTail.isGeneric(specific),
+        "a specific chip the backend accepts was dropped by the client: \(specific)")
+    }
+  }
+
   // MARK: - Streaming projection
 
   func testStreamingHidesACompletedTailAndAnUnambiguousPartialOne() {
@@ -62,6 +90,27 @@ final class ChatFollowUpChipTests: XCTestCase {
   func testStreamingNeverEatsOrdinaryTextThatOnlyLooksLikeTheMarker() {
     XCTAssertEqual(ChatFollowUpTail.strippingPendingTail("a < b"), "a < b")
     XCTAssertEqual(ChatFollowUpTail.strippingPendingTail("compare a << b"), "compare a << b")
+  }
+
+  /// The projection is one-way, so it has to be fed the raw accumulated answer
+  /// on every flush — never its own previous output plus the next delta. Under
+  /// that contract no flush boundary can put a character of the tail on screen:
+  /// whatever is shown is the visible answer, at most followed by a still
+  /// ambiguous head of the delimiter (`<` or `<<`, which are left alone so real
+  /// prose is never eaten).
+  func testNoRawFlushBoundaryEverShowsAPieceOfTheTail() {
+    let visible = "Shipped Thursday.\n"
+    let answer = visible + ChatFollowUpTail.delimiter + " Who else was in that call?"
+    for boundary in 1...answer.count {
+      let shown = ChatFollowUpTail.strippingPendingTail(String(answer.prefix(boundary)))
+      guard shown.hasPrefix(visible) || visible.hasPrefix(shown) else {
+        return XCTFail("flush boundary \(boundary) showed non-answer text: \(shown)")
+      }
+      let extra = shown.hasPrefix(visible) ? String(shown.dropFirst(visible.count)) : ""
+      XCTAssertTrue(
+        ChatFollowUpTail.delimiter.hasPrefix(extra),
+        "flush boundary \(boundary) leaked \(extra) into the visible answer")
+    }
   }
 
   func testStreamingProjectionRunsOnTheAssistantTextPath() {
@@ -163,6 +212,26 @@ final class ChatFollowUpChipTests: XCTestCase {
       "an armed origin must apply to exactly one question, never leak onto the next")
   }
 
+  /// Arming happens at the tap, but the dispatch can return before anything is
+  /// sent — no floating window, no provider — and then no question event ever
+  /// consumes the arm. Without an explicit abort the arm survives and stamps
+  /// `followup` on the next, unrelated question.
+  func testAnAbortedDispatchDoesNotLeaveTheOriginArmed() {
+    var captured: [(String, [String: Any])] = []
+    AnalyticsManager.shared.questionTelemetryCaptureForTests = { name, props in
+      captured.append((name, props))
+    }
+
+    AnalyticsManager.shared.questionOriginating(.followUp)
+    AnalyticsManager.shared.questionOriginationAborted()
+    AnalyticsManager.shared.chatMessageSent(messageLength: 4, source: "query_shell")
+
+    let origins = captured.filter { $0.0 == "question_asked" }.map { $0.1["origin"] as? String }
+    XCTAssertEqual(
+      origins, ["unprompted"],
+      "an arm whose send never happened must not label the next question")
+  }
+
   // MARK: - Voice hint
 
   func testTheVoiceHintNamesTheBoundShortcutAndIsAbsentWhenPushToTalkIsOff() {
@@ -178,5 +247,45 @@ final class ChatFollowUpChipTests: XCTestCase {
     XCTAssertNotNil(hint)
     XCTAssertTrue(hint?.hasPrefix("or hold ") == true, "hint: \(hint ?? "nil")")
     XCTAssertTrue(hint?.hasSuffix(" to ask aloud") == true, "hint: \(hint ?? "nil")")
+  }
+
+  /// A chord binding renders as several tokens. Naming only the first told the
+  /// user to hold a key that does not start voice.
+  func testTheVoiceHintNamesEveryTokenOfAChordBinding() {
+    let settings = ShortcutSettings.shared
+    let wasEnabled = settings.pttEnabled
+    let wasShortcut = settings.pttShortcut
+    defer {
+      settings.pttShortcut = wasShortcut
+      settings.pttEnabled = wasEnabled
+    }
+
+    settings.pttEnabled = true
+    settings.pttShortcut = ShortcutSettings.KeyboardShortcut(modifierOnly: [.control, .option])
+    XCTAssertEqual(
+      settings.pttShortcut.displayTokens, ["⌃", "⌥"], "precondition: a two-token binding")
+    XCTAssertEqual(FloatingControlBarView.followUpVoiceHint(settings: settings), "or hold ⌃⌥ to ask aloud")
+  }
+
+  // MARK: - Failure copy is never spoken
+
+  /// The empty-response notice and the voice guard that silences it went out of
+  /// sync once already: the copy was rewritten and `shouldSpeak` went on
+  /// matching the retired sentence, so a voice query that produced nothing had
+  /// its failure notice read aloud. Both halves now come from one type; this
+  /// asserts the whole playback path stays silent on every string in it.
+  func testFailureCopyIsNeverReadAloud() {
+    for copy in [FloatingBarAnswerFailureCopy.emptyResponse] + FloatingBarAnswerFailureCopy.retired {
+      let spoken = FloatingBarVoicePlaybackService.cleanedPlaybackText(
+        from: ChatMessage(text: copy, sender: .ai))
+      XCTAssertFalse(
+        FloatingBarVoicePlaybackService.shouldSpeak(spoken),
+        "failure copy would be spoken aloud: \(copy)")
+    }
+
+    let answer = FloatingBarVoicePlaybackService.cleanedPlaybackText(
+      from: ChatMessage(text: "You and Priya settled on shipping Thursday.", sender: .ai))
+    XCTAssertTrue(
+      FloatingBarVoicePlaybackService.shouldSpeak(answer), "a real answer must still be spoken")
   }
 }

--- a/desktop/macos/Desktop/Tests/ChatFollowUpChipTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatFollowUpChipTests.swift
@@ -177,6 +177,57 @@ final class ChatFollowUpChipTests: XCTestCase {
     XCTAssertEqual(ChatFollowUpTail.blockID(messageID: "msg-7"), "msg-7:followup")
   }
 
+  // MARK: - The hermetic e2e contract
+
+  /// The one stub reply that carries a tail, in the wire shape it is sent in.
+  ///
+  /// `chat-hermetic.yaml` S8 asserts both halves of this verbatim, and the
+  /// backend pins the producer in `tests/unit/test_desktop_llm_stub.py`. This is
+  /// the consumer half: if the client's rules ever stop admitting that answer,
+  /// the flow starts asserting a chip that no longer appears, and it should fail
+  /// here — in a second — rather than on a fifteen-minute tier-2 run.
+  func testTheHermeticStubTailBecomesTheStringsTheFlowAsserts() {
+    let answer = "Priya flagged the storage migration in the Tuesday review."
+    let chipQuestion = "What did Priya say about the storage migration?"
+    let wire = "\(answer)\n\n\(ChatFollowUpTail.delimiter) \(chipQuestion)"
+
+    let (visible, question) = ChatFollowUpTail.split(wire)
+    XCTAssertEqual(visible, answer)
+    XCTAssertEqual(question, chipQuestion)
+    XCTAssertFalse(
+      visible.contains(chipQuestion),
+      "the question must leave the prose entirely — the chip and the answer saying it twice is the defect")
+    XCTAssertTrue(
+      ChatFollowUpTail.shouldAttach(question: question, visibleText: visible, failed: false))
+  }
+
+  /// The field `chat-hermetic.yaml` S8 reads, and the value
+  /// `tap_chat_follow_up_chip` sends. One reader, so a flow can never assert a
+  /// chip the tap would then fail to find.
+  func testTheAutomationSnapshotProjectsTheChipQuestionOutOfTheVisibleAnswer() {
+    let provider = ChatProvider()
+    let chipQuestion = "What did Priya say about the storage migration?"
+    provider.messages = [
+      ChatMessage(id: "user-1", text: "Recap the storage migration.", sender: .user),
+      ChatMessage(
+        id: "assistant-1",
+        text: "Priya flagged the storage migration in the Tuesday review.",
+        sender: .ai,
+        contentBlocks: [
+          .text(id: "assistant-1:text", text: "Priya flagged the storage migration in the Tuesday review."),
+          .followUp(id: ChatFollowUpTail.blockID(messageID: "assistant-1"), text: chipQuestion),
+        ]),
+    ]
+
+    XCTAssertEqual(provider.automationLastFollowUpQuestion(), chipQuestion)
+    let snapshot = provider.automationMainChatSnapshot(limit: 10)
+    XCTAssertEqual(snapshot["last_assistant_follow_up_question"], chipQuestion)
+    XCTAssertEqual(
+      snapshot["last_assistant_text"],
+      "Priya flagged the storage migration in the Tuesday review.",
+      "the visible answer must not carry the chip's question")
+  }
+
   // MARK: - Attribution
 
   func testAChipQuestionIsAttributedToTheFollowUpOrigin() {

--- a/desktop/macos/Desktop/Tests/ChatStreamingTailProjectionTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatStreamingTailProjectionTests.swift
@@ -93,3 +93,78 @@ final class ChatStreamingTailProjectionTests: XCTestCase {
     XCTAssertEqual(messages[0].text, "Second answer.")
   }
 }
+
+/// The probe that makes the leak above observable from a running app.
+///
+/// The tests above prove the buffer does not leak by inspecting `messages` directly, which only a
+/// unit test can do. `chat-hermetic.yaml` cannot: the authoritative terminal answer overwrites the
+/// streamed text before any step runs. `ChatStreamingTailProbe` records the property as each
+/// projection is emitted so the flow can assert it afterwards — which is only worth anything if
+/// the probe can actually fail, hence the negative control.
+@MainActor
+final class ChatStreamingTailProbeTests: XCTestCase {
+  private let answer = "Kubernetes reschedules the pod on the surviving node."
+  private let tail = " <<<FOLLOWUP>>> Want the eviction timeline for that node?"
+
+  private func normalize(_ message: ChatMessage, _ text: String) -> String {
+    guard message.sender == .ai else { return text }
+    return ChatProvider.normalizeStreamingAssistantText(text)
+  }
+
+  func testTokenAtATimeStreamRecordsNoLeakAndSeesTheDelimiter() {
+    let probe = ChatStreamingTailProbe()
+    let messageId = "assistant-probe"
+    var messages = [ChatMessage(id: messageId, text: "", sender: .ai, isStreaming: true)]
+    let buffer = ChatStreamingBuffer(flushInterval: 0.1, probe: probe)
+
+    for character in answer + tail {
+      buffer.appendText(messageId: messageId, text: String(character), scheduleFlush: {})
+      buffer.flush(messages: &messages, normalizeText: normalize)
+    }
+
+    XCTAssertEqual(probe.leakCount, 0)
+    XCTAssertTrue(probe.delimiterSeen, "a turn with no delimiter makes a zero leak count vacuous")
+    XCTAssertEqual(probe.projectionCount, answer.count + tail.count)
+  }
+
+  /// The negative control: the same probe, handed the projection the pre-c164760b6b buffer emitted.
+  ///
+  /// That buffer re-derived each projection from its own withheld output, so the delimiter was gone
+  /// from the only text it had left and the question streamed out as prose. The probe keeps its own
+  /// raw stream precisely so it disagrees rather than agreeing with that.
+  func testAProjectionCarryingTheWithheldTailIsCounted() {
+    let probe = ChatStreamingTailProbe()
+    probe.observe(messageId: "m", seed: "", delta: answer + " <<<FOL", projection: answer)
+    XCTAssertEqual(probe.leakCount, 0)
+
+    probe.observe(
+      messageId: "m",
+      seed: "",
+      delta: "LOWUP>>> Want the eviction",
+      projection: answer + "LOWUP>>> Want the eviction")
+    XCTAssertEqual(probe.leakCount, 1, "the leaked suffix went unnoticed")
+  }
+
+  func testASettledTurnReleasesItsRawStreamButKeepsTheCount() {
+    let probe = ChatStreamingTailProbe()
+    let messageId = "assistant-released"
+    var messages = [ChatMessage(id: messageId, text: "", sender: .ai, isStreaming: true)]
+    let buffer = ChatStreamingBuffer(flushInterval: 0.1, probe: probe)
+
+    buffer.appendText(messageId: messageId, text: answer + tail, scheduleFlush: {})
+    buffer.flush(messages: &messages, normalizeText: normalize)
+    XCTAssertTrue(probe.delimiterSeen)
+    buffer.finishStreaming(messageId: messageId)
+
+    // A reused id resumes from nothing, exactly as the buffer's own accumulator does — otherwise
+    // the second turn's projection would be compared against the first turn's raw text and every
+    // flush of it would be reported as a leak.
+    messages[0].text = ""
+    messages[0].contentBlocks = []
+    buffer.appendText(messageId: messageId, text: "Second answer.", scheduleFlush: {})
+    buffer.flush(messages: &messages, normalizeText: normalize)
+
+    XCTAssertEqual(probe.leakCount, 0)
+    XCTAssertTrue(probe.delimiterSeen, "the count is cumulative across the session, not per turn")
+  }
+}

--- a/desktop/macos/Desktop/Tests/ChatStreamingTailProjectionTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatStreamingTailProjectionTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// The streaming buffer must never feed a withholding projection its own output.
+///
+/// `normalizeStreamingAssistantText` withholds the follow-up tail so the chip's
+/// words never appear as prose. That is only sound while the projection sees the
+/// whole raw answer on every flush: written back into the message, the withheld
+/// delimiter is gone by the next flush and the question leaks a token at a time.
+@MainActor
+final class ChatStreamingTailProjectionTests: XCTestCase {
+  private let answer = "Kubernetes reschedules the pod on the surviving node."
+  private let tail = " <<<FOLLOWUP>>> Want the eviction timeline for that node?"
+
+  private func normalize(_ message: ChatMessage, _ text: String) -> String {
+    guard message.sender == .ai else { return text }
+    return ChatProvider.normalizeStreamingAssistantText(text)
+  }
+
+  /// Replay the same stream broken at every possible flush boundary.
+  func testNoFlushBoundaryLeaksAnyPartOfTheTail() {
+    let stream = Array(answer + tail)
+
+    for boundary in 1..<stream.count {
+      let messageId = "assistant-\(boundary)"
+      var messages = [ChatMessage(id: messageId, text: "", sender: .ai, isStreaming: true)]
+      let buffer = ChatStreamingBuffer(flushInterval: 0.1)
+
+      let first = String(stream[0..<boundary])
+      let second = String(stream[boundary...])
+
+      buffer.appendText(messageId: messageId, text: first, scheduleFlush: {})
+      buffer.flush(messages: &messages, normalizeText: normalize)
+      let afterFirst = messages[0].text
+
+      buffer.appendText(messageId: messageId, text: second, scheduleFlush: {})
+      buffer.flush(messages: &messages, normalizeText: normalize)
+      let afterSecond = messages[0].text
+
+      for visible in [afterFirst, afterSecond] {
+        XCTAssertFalse(
+          visible.contains("FOLLOWUP"),
+          "boundary \(boundary) leaked the marker: \(visible)")
+        XCTAssertFalse(
+          visible.contains("eviction"),
+          "boundary \(boundary) leaked the question: \(visible)")
+        XCTAssertFalse(
+          visible.contains("<<<"),
+          "boundary \(boundary) leaked a partial marker: \(visible)")
+      }
+      XCTAssertEqual(
+        afterSecond.trimmingCharacters(in: .whitespaces), answer,
+        "boundary \(boundary) did not settle on the answer alone")
+    }
+  }
+
+  /// Token-at-a-time delivery, which is what the transport actually does.
+  func testCharacterByCharacterStreamNeverLeaksTheTail() {
+    let messageId = "assistant-chars"
+    var messages = [ChatMessage(id: messageId, text: "", sender: .ai, isStreaming: true)]
+    let buffer = ChatStreamingBuffer(flushInterval: 0.1)
+
+    for character in answer + tail {
+      buffer.appendText(messageId: messageId, text: String(character), scheduleFlush: {})
+      buffer.flush(messages: &messages, normalizeText: normalize)
+      XCTAssertFalse(messages[0].text.contains("FOLLOWUP"))
+      XCTAssertFalse(messages[0].text.contains("eviction"))
+    }
+
+    XCTAssertEqual(messages[0].text.trimmingCharacters(in: .whitespaces), answer)
+    guard case .text(_, let blockText) = messages[0].contentBlocks[0] else {
+      return XCTFail("Expected one text block")
+    }
+    XCTAssertFalse(blockText.contains("eviction"), "the trailing text block leaked the question")
+  }
+
+  /// The accumulator is per turn: a released id starts clean, not from the last answer.
+  func testFinishStreamingReleasesTheTurnsAccumulator() {
+    let messageId = "assistant-reused"
+    var messages = [ChatMessage(id: messageId, text: "", sender: .ai, isStreaming: true)]
+    let buffer = ChatStreamingBuffer(flushInterval: 0.1)
+
+    buffer.appendText(messageId: messageId, text: "First answer.", scheduleFlush: {})
+    buffer.flush(messages: &messages, normalizeText: normalize)
+    buffer.finishStreaming(messageId: messageId)
+
+    messages[0].text = ""
+    messages[0].contentBlocks = []
+    buffer.appendText(messageId: messageId, text: "Second answer.", scheduleFlush: {})
+    buffer.flush(messages: &messages, normalizeText: normalize)
+
+    XCTAssertEqual(messages[0].text, "Second answer.")
+  }
+}

--- a/desktop/macos/Desktop/Tests/HomeKnowsComposerTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeKnowsComposerTests.swift
@@ -283,6 +283,33 @@ final class HomeKnowsComposerTests: XCTestCase {
     XCTAssertEqual(HomeKnowsListComposer.openTaskCount(candidates), 2)
     XCTAssertEqual(HomeKnowsListComposer.openTaskCount(candidates, ledger: ledger), 1)
   }
+
+  /// The greeting counts what the list can show. Three ways the two used to
+  /// disagree, each of which made "N things need you" name a row that was not
+  /// under it: the hub's concatenated buckets repeat a task id, a long-dead
+  /// past-due task is not surfaced, and a dismissal stops applying once the
+  /// task's own text moves.
+  func testOpenTaskCountAgreesWithTheRowsItIsPhrasedAround() {
+    let now = HomeKnowsLedgerFixture.noon
+    let duplicated = tasks + [HomeKnowsTaskCandidate(id: "t1", text: "Submit the Design PR by 7pm")]
+    XCTAssertEqual(HomeKnowsListComposer.openTaskCount(duplicated, now: now), 2)
+
+    let stale = [
+      HomeKnowsTaskCandidate(id: "old", text: "Long-dead commitment", dueAt: now.addingTimeInterval(-20 * 86_400)),
+      HomeKnowsTaskCandidate(id: "live", text: "Still open", dueAt: now.addingTimeInterval(-3 * 86_400)),
+    ]
+    XCTAssertEqual(
+      HomeKnowsListComposer.compose(tasks: stale, insights: [], questions: [], now: now).rows.count, 1)
+    XCTAssertEqual(HomeKnowsListComposer.openTaskCount(stale, now: now), 1)
+
+    // Dismissed, then edited: `compose` surfaces it again, so the count does too.
+    let ledger = HomeKnowsLedgerFixture.dismissing(taskID: "t1", text: "Submit the Design PR by 7pm")
+    let edited = [HomeKnowsTaskCandidate(id: "t1", text: "Submit the Design PR by 9pm")]
+    XCTAssertEqual(
+      HomeKnowsListComposer.compose(tasks: edited, insights: [], questions: [], ledger: ledger, now: now)
+        .rows.map(\.kind), [.task(id: "t1")])
+    XCTAssertEqual(HomeKnowsListComposer.openTaskCount(edited, ledger: ledger, now: now), 1)
+  }
 }
 
 /// Shared ledger fixtures. A fixed instant keeps the calendar-day rules

--- a/desktop/macos/Desktop/Tests/HomeKnowsImpressionLedgerTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeKnowsImpressionLedgerTests.swift
@@ -412,3 +412,131 @@ final class HomeKnowsImpressionDefaultsTests: XCTestCase {
     XCTAssertEqual(store.load(), .empty)
   }
 }
+
+// MARK: - Harness seams
+
+/// The two non-production seams `home-knows-rotation.yaml` reaches the list through.
+///
+/// Both are gated, and the gate is the thing worth pinning: a registry that stayed live on a
+/// shipped bundle would hold a strong-enough reference to a dismissed card's rows and would put a
+/// drive path for the reader's own list behind a name anything in-process could call.
+@MainActor
+final class HomeKnowsAutomationSeamTests: XCTestCase {
+  private func handle(token: UUID) -> HomeKnowsAutomationRegistry.Handle {
+    HomeKnowsAutomationRegistry.Handle(
+      token: token,
+      snapshot: {
+        HomeKnowsAutomationRegistry.Snapshot(
+          rows: [], emptySlots: [], canRotate: false, openTaskCount: 0, ledger: .empty)
+      },
+      beginVisit: {},
+      recordImpressions: {},
+      open: { _ in false },
+      dismiss: { _ in false })
+  }
+
+  override func tearDown() async throws {
+    if let mounted = HomeKnowsAutomationRegistry.mounted {
+      HomeKnowsAutomationRegistry.unregister(token: mounted.token)
+    }
+  }
+
+  /// On a production bundle the page registers and nothing happens.
+  func testRegistrationIsANoOpWhenDisabled() {
+    HomeKnowsAutomationRegistry.register(handle(token: UUID()), enabled: false)
+    XCTAssertNil(HomeKnowsAutomationRegistry.mounted)
+  }
+
+  func testRegistrationPublishesTheMountedList() {
+    let token = UUID()
+    HomeKnowsAutomationRegistry.register(handle(token: token), enabled: true)
+    XCTAssertEqual(HomeKnowsAutomationRegistry.mounted?.token, token)
+  }
+
+  /// The hub list and the chat strip render the same rows and overlap for a frame while the stage
+  /// animates: the one leaving must not clear the handle the one arriving just took.
+  func testUnregisteringAnOlderListLeavesTheCurrentOne() {
+    let outgoing = UUID()
+    let incoming = UUID()
+    HomeKnowsAutomationRegistry.register(handle(token: outgoing), enabled: true)
+    HomeKnowsAutomationRegistry.register(handle(token: incoming), enabled: true)
+
+    HomeKnowsAutomationRegistry.unregister(token: outgoing)
+    XCTAssertEqual(HomeKnowsAutomationRegistry.mounted?.token, incoming)
+
+    HomeKnowsAutomationRegistry.unregister(token: incoming)
+    XCTAssertNil(HomeKnowsAutomationRegistry.mounted)
+  }
+
+  /// What `home_knows_reset` buys the flow: the ledger outlives the app, so without a cleared
+  /// starting state the second run of the flow opens on rows the first run already suppressed.
+  func testResetForAutomationClearsTheLedgerAndStartsAFreshVisit() {
+    let persistence = HomeKnowsAutomationSeamTests.FakePersistence()
+    let store = HomeKnowsImpressionStore(
+      persistence: persistence, now: { HomeKnowsLedgerFixture.noon }, ownerID: { "owner-a" })
+    let hash = HomeKnowsRotationPolicy.contentHash(text: "Meet with Priya")
+    store.beginVisit()
+    XCTAssertEqual(store.recordShown(key: "task:t1", contentHash: hash)?.shows, 1)
+    XCTAssertNil(store.recordShown(key: "task:t1", contentHash: hash), "same visit")
+
+    store.resetForAutomation()
+
+    XCTAssertTrue(store.snapshot().entries.isEmpty)
+    // The de-duplication set is reset too, or the first visit after a reset would report nothing
+    // and the flow would read a silent list as a composer that had stopped producing rows.
+    XCTAssertEqual(store.recordShown(key: "task:t1", contentHash: hash)?.shows, 1)
+  }
+
+  private final class FakePersistence: HomeKnowsImpressionPersisting {
+    var ledger = HomeKnowsImpressionLedger.empty
+    func load() -> HomeKnowsImpressionLedger { ledger }
+    func save(_ ledger: HomeKnowsImpressionLedger) { self.ledger = ledger }
+  }
+}
+
+// MARK: - Telemetry seam
+
+/// `rotated_out_reason` is the rotation policy's verdict and is readable nowhere after the emit
+/// consumes it. The capture seam is how both a test and the automation bridge observe it at the
+/// boundary production writes it, rather than recomputing the reason and asserting their own work.
+@MainActor
+final class HomeKnowsTelemetrySeamTests: XCTestCase {
+  override func tearDown() async throws {
+    AnalyticsManager.homeKnowsTelemetryCaptureForTests = nil
+  }
+
+  func testRowShownCarriesItsKindSlotAndPriorShowCount() {
+    var captured: [(String, [String: Any])] = []
+    AnalyticsManager.homeKnowsTelemetryCaptureForTests = { name, props in captured.append((name, props)) }
+
+    AnalyticsManager.shared.trackHomeKnowsRowShown(kind: "task", slot: .pressingTask, showsBefore: 2)
+
+    XCTAssertEqual(captured.count, 1)
+    XCTAssertEqual(captured.first?.0, AnalyticsManager.homeKnowsRowEvent)
+    XCTAssertEqual(captured.first?.1["kind"] as? String, "task")
+    XCTAssertEqual(captured.first?.1["slot"] as? String, "pressing_task")
+    XCTAssertEqual(captured.first?.1["shows_before"] as? Int, 2)
+    XCTAssertNil(captured.first?.1["rotated_out_reason"], "a rendered row rotated nothing out")
+  }
+
+  func testEmptySlotCarriesTheRotationReason() {
+    var captured: [String: Any] = [:]
+    AnalyticsManager.homeKnowsTelemetryCaptureForTests = { _, props in captured = props }
+
+    AnalyticsManager.shared.trackHomeKnowsSlotEmpty(slot: .secondTask, reason: .dismissed)
+
+    XCTAssertEqual(captured["kind"] as? String, "empty")
+    XCTAssertEqual(captured["slot"] as? String, "second_task")
+    XCTAssertEqual(captured["rotated_out_reason"] as? String, "dismissed")
+    XCTAssertEqual(captured["shows_before"] as? Int, 0)
+  }
+
+  /// The property is a closed set because it is a PostHog dimension: an unbounded one would make
+  /// the breakdown unreadable and is the failure this enum exists to prevent.
+  func testEveryRotationReasonIsASnakeCaseRawValue() {
+    for reason in HomeKnowsRotationReason.allCases {
+      XCTAssertFalse(reason.rawValue.isEmpty)
+      XCTAssertEqual(reason.rawValue, reason.rawValue.lowercased())
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/HomeKnowsImpressionLedgerTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeKnowsImpressionLedgerTests.swift
@@ -186,7 +186,11 @@ final class HomeKnowsImpressionStoreTests: XCTestCase {
 
     let persistence = FakePersistence()
     var clock = HomeKnowsLedgerFixture.noon
-    lazy var store = HomeKnowsImpressionStore(persistence: persistence, now: { self.clock })
+    /// Injected so an account switch is a value in the test rather than a
+    /// mutation of the process-wide defaults.
+    var owner: String? = "owner-a"
+    lazy var store = HomeKnowsImpressionStore(
+      persistence: persistence, now: { self.clock }, ownerID: { self.owner })
     let hash = HomeKnowsRotationPolicy.contentHash(text: "Meet with Priya")
   }
 
@@ -259,6 +263,38 @@ final class HomeKnowsImpressionStoreTests: XCTestCase {
     XCTAssertEqual(entry?.shows, 1)
     XCTAssertNil(entry?.dismissedAt)
     XCTAssertEqual(entry?.contentHash, edited)
+  }
+
+  /// A prior open belongs to the text that was open. Carrying it onto changed
+  /// content left the row exempt from the show cap and the same-day rule for
+  /// good — the one entry that could repeat itself indefinitely.
+  @MainActor
+  func testChangedContentAlsoClearsAnEarlierOpen() {
+    let harness = Harness()
+    harness.store.beginVisit()
+    harness.store.recordOpened(key: "task:t1", contentHash: harness.hash)
+    XCTAssertNotNil(harness.store.snapshot().entry("task:t1")?.lastOpenedAt)
+
+    let edited = HomeKnowsRotationPolicy.contentHash(text: "Meet with Priya about Q3")
+    harness.store.beginVisit()
+    XCTAssertNil(harness.store.recordShown(key: "task:t1", contentHash: edited)?.lastOpenedAt)
+  }
+
+  /// The ledger is owner-scoped at every read and write, but the once-per-visit
+  /// de-duplication set is not: a question row is keyed by its text, so the
+  /// previous owner's key would silence the new owner's first impression.
+  @MainActor
+  func testAnAccountSwitchStartsAFreshVisit() {
+    let harness = Harness()
+    harness.store.beginVisit()
+    XCTAssertEqual(harness.store.recordShown(key: "question:q1", contentHash: harness.hash)?.shows, 1)
+    XCTAssertNil(harness.store.recordShown(key: "question:q1", contentHash: harness.hash))
+    XCTAssertTrue(harness.store.shouldReportEmptySlot("tip"))
+    XCTAssertFalse(harness.store.shouldReportEmptySlot("tip"))
+
+    harness.owner = "owner-b"
+    XCTAssertEqual(harness.store.recordShown(key: "question:q1", contentHash: harness.hash)?.shows, 2)
+    XCTAssertTrue(harness.store.shouldReportEmptySlot("tip"))
   }
 
   @MainActor

--- a/desktop/macos/Desktop/Tests/MemoryReviewCardTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryReviewCardTests.swift
@@ -422,6 +422,111 @@ final class MemoryReviewCardTests: XCTestCase {
     XCTAssertEqual(AnalyticsManager.boundedMemoryCategory(""), "unknown")
   }
 
+  // MARK: - Harness handle (memory-review.yaml)
+
+  /// The bridge reaches a mounted card through this handle; without it `memory-review.yaml` could
+  /// see a card render but never read which rows it bound or vote on one.
+  @MainActor
+  func testTheMountedHandleIsIdentityCheckedAcrossARebuild() {
+    let first = store(items: [MemoryReviewItem(memoryID: "mem_1", content: "One.")])
+    let second = store(items: [MemoryReviewItem(memoryID: "mem_2", content: "Two.")])
+
+    MemoryReviewCardRegistry.register(first, enabled: true)
+    MemoryReviewCardRegistry.register(second, enabled: true)
+    // The card rebuilds its section when the rows change, and both are mounted for a frame. The
+    // outgoing one must not clear the handle the incoming one just took.
+    MemoryReviewCardRegistry.unregister(first)
+    XCTAssertTrue(MemoryReviewCardRegistry.mounted === second)
+
+    MemoryReviewCardRegistry.unregister(second)
+    XCTAssertNil(MemoryReviewCardRegistry.mounted)
+  }
+
+  @MainActor
+  func testAProductionBundleRegistersNothing() {
+    // Compared against whatever was mounted rather than asserted nil, so the test says the same
+    // thing whichever order the suite runs in.
+    let before = MemoryReviewCardRegistry.mounted
+    MemoryReviewCardRegistry.register(
+      store(items: [MemoryReviewItem(memoryID: "mem_1", content: "One.")]), enabled: false)
+    XCTAssertTrue(MemoryReviewCardRegistry.mounted === before)
+  }
+
+  // MARK: - Fixture wire shape
+
+  /// Pinned against `backend/tests/unit/test_daily_summary_e2e_fixture.py`: the seed writes
+  /// `memory_id`, and a rename on either side leaves the card rendering no rows at all.
+  func testTheSeedRequestUsesTheKeysTheFixtureRouterReads() throws {
+    let request = MemoryReviewFixture.SeedRequest(
+      memories: [
+        MemoryReviewFixture.WireMemory(memoryID: "mem_1", content: "One.", category: "system")
+      ])
+    let json = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: try JSONEncoder().encode(request)) as? [String: Any])
+    let memories = try XCTUnwrap(json["memories"] as? [[String: Any]])
+    XCTAssertEqual(memories[0]["memory_id"] as? String, "mem_1")
+    XCTAssertEqual(memories[0]["content"] as? String, "One.")
+    XCTAssertEqual(memories[0]["category"] as? String, "system")
+  }
+
+  func testTheSeedResponseDecodesTheFixtureRouterReply() throws {
+    let response = try JSONDecoder().decode(
+      MemoryReviewFixture.SeedResponse.self,
+      from: Data(
+        """
+        {"status":"ok","summary_id":"dev-harness-daily-summary-2026-03-04",
+         "date":"2026-03-04","memories_learned":4}
+        """.utf8))
+    XCTAssertEqual(response.summaryID, "dev-harness-daily-summary-2026-03-04")
+    XCTAssertEqual(response.memoriesLearned, 4)
+  }
+
+  /// The flow seeds four and asserts three rows, so the catalog must be able to overfill the card.
+  @MainActor
+  func testTheFixtureCatalogCanOverfillTheCard() {
+    XCTAssertGreaterThan(MemoryReviewFixture.catalog.count, MemoryReviewSection.maxRows)
+    XCTAssertNil(MemoryReviewFixture.rows(count: 0))
+    XCTAssertNil(MemoryReviewFixture.rows(count: MemoryReviewFixture.catalog.count + 1))
+    // Asserted verbatim by `memory-review.yaml` S6.
+    XCTAssertEqual(
+      MemoryReviewFixture.rows(count: 4)?.map(\.content).first,
+      "Prefers async standups over daily calls.")
+    XCTAssertEqual(MemoryReviewFixture.rows(count: 4)?.count, 4)
+  }
+
+  @MainActor
+  func testOnlyTheTwoDrivableVerdictsAreAccepted() {
+    XCTAssertEqual(MemoryReviewFixture.event(for: "accept"), .accept)
+    XCTAssertEqual(MemoryReviewFixture.event(for: "reject"), .reject)
+    // `edit` needs a draft the row view owns, so the bridge refuses rather than half-driving it.
+    XCTAssertNil(MemoryReviewFixture.event(for: "edit"))
+    XCTAssertNil(MemoryReviewFixture.event(for: ""))
+  }
+
+  /// What the bridge reports is the row's own model, so the flow's expectations and the reducer
+  /// cannot drift: this asserts the exact strings `memory-review.yaml` S7 pins.
+  @MainActor
+  func testRowDetailReportsTheSettledRowTheFlowAsserts() async {
+    let item = MemoryReviewItem(memoryID: "mem_1", content: "Prefers async standups.", category: "system")
+    let card = store(items: [item])
+
+    let before = MemoryReviewFixture.rowDetail(index: 0, item: item, store: card)
+    XCTAssertEqual(before["row0_id"], "mem_1")
+    XCTAssertEqual(before["row0_category"], "About You")
+    XCTAssertEqual(before["row0_verdict"], "none")
+    XCTAssertEqual(before["row0_settled"], "false")
+
+    card.send(.accept, to: item)
+    _ = await MemoryReviewFixture.waitForSettled(store: card, item: item, timeoutMs: 2_000)
+
+    let after = MemoryReviewFixture.rowDetail(index: 0, item: item, store: card)
+    XCTAssertEqual(after["row0_verdict"], "accepted")
+    XCTAssertEqual(after["row0_settled"], "true")
+    XCTAssertEqual(after["row0_status"], "Confirmed. I'll act on this.")
+    XCTAssertEqual(after["row0_error"], "")
+    XCTAssertEqual(after["row0_busy"], "false")
+  }
+
   // MARK: - Helpers
 
   /// Fails until it is given a result, so "the read failed" and "nobody has voted" are two
@@ -437,6 +542,13 @@ final class MemoryReviewCardTests: XCTestCase {
       guard let result else { throw ReadFailed() }
       return result
     }
+  }
+
+  @MainActor
+  private func store(items: [MemoryReviewItem]) -> MemoryReviewCardStore {
+    MemoryReviewCardStore(
+      items: items, source: .dailySummaryChat, mutator: UnusedMutator(),
+      stateReader: FlakyStateReader(), analytics: { _, _, _, _ in })
   }
 
   private struct UnusedMutator: MemoryReviewMutating {

--- a/desktop/macos/Desktop/Tests/MemoryReviewCardTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryReviewCardTests.swift
@@ -66,6 +66,36 @@ final class MemoryReviewCardTests: XCTestCase {
     XCTAssertEqual(record.memoriesLearned.map(\.memoryID), ["mem_3"])
   }
 
+  /// One entry of the wrong shape is one row lost, not the whole section: the rest of the array
+  /// decodes independently around it.
+  func testOneMalformedLearnedEntryDoesNotDiscardTheValidRowsBesideIt() throws {
+    let record = try decodeRecord(
+      """
+      {
+        "id": "ds_1",
+        "memories_learned": [
+          { "memory_id": 17, "content": "id is a number" },
+          "not an object at all",
+          { "memory_id": "mem_2", "content": "Keeps a Wednesday release train." }
+        ]
+      }
+      """)
+    XCTAssertEqual(record.memoriesLearned.map(\.memoryID), ["mem_2"])
+  }
+
+  /// A blank-but-present id passes an emptiness check and produces a row whose ✓ / ✗ / Fix would
+  /// address no memory at all.
+  func testAWhitespaceOnlyMemoryIDIsNotAReviewRow() throws {
+    let record = try decodeRecord(
+      #"{"id": "ds_1", "memories_learned": [{"memory_id": "  ", "content": "Real content."}]}"#)
+    XCTAssertTrue(record.memoriesLearned.isEmpty)
+
+    let summary = DailySummaryRecord(
+      id: "ds_1", date: "2026-09-01", headline: nil, overview: nil,
+      memoriesLearned: [DailySummaryRecord.LearnedMemory(memoryID: " ", content: "Real content.")])
+    XCTAssertTrue(ChatDailySummaryCard.memoriesLearned(in: summary).isEmpty)
+  }
+
   func testRecordSurvivesAMemoriesLearnedFieldOfTheWrongShape() throws {
     let record = try decodeRecord(#"{"id": "ds_1", "headline": "Still here", "memories_learned": "nope"}"#)
     XCTAssertEqual(record.headline, "Still here")
@@ -95,6 +125,25 @@ final class MemoryReviewCardTests: XCTestCase {
       id: "ds_2", date: "2026-09-01", headline: "Quiet", overview: nil,
       memoriesLearned: [DailySummaryRecord.LearnedMemory(memoryID: "mem_1", content: "   ")])
     XCTAssertTrue(ChatDailySummaryCard.memoriesLearned(in: blank).isEmpty)
+  }
+
+  /// The section captures its rows when it is built, so a summary regenerated under the same id
+  /// must not reuse the old one: new memories would never appear and corrected ones would keep the
+  /// text the record no longer contains.
+  func testTheReviewSectionIsRebuiltWhenARegeneratedSummaryChangesItsRows() {
+    let first = [MemoryReviewItem(memoryID: "mem_1", content: "Prefers async standups.")]
+    let corrected = [MemoryReviewItem(memoryID: "mem_1", content: "Prefers written standups.")]
+    let added = first + [MemoryReviewItem(memoryID: "mem_2", content: "Ships on Wednesdays.")]
+
+    let identity = ChatDailySummaryCard.reviewSectionIdentity(summaryID: "ds_1", items: first)
+    XCTAssertEqual(
+      identity, ChatDailySummaryCard.reviewSectionIdentity(summaryID: "ds_1", items: first))
+    XCTAssertNotEqual(
+      identity, ChatDailySummaryCard.reviewSectionIdentity(summaryID: "ds_1", items: corrected))
+    XCTAssertNotEqual(
+      identity, ChatDailySummaryCard.reviewSectionIdentity(summaryID: "ds_1", items: added))
+    XCTAssertNotEqual(
+      identity, ChatDailySummaryCard.reviewSectionIdentity(summaryID: "ds_2", items: first))
   }
 
   func testCategoryLabelIsBoundedButNeverInvented() {
@@ -339,6 +388,31 @@ final class MemoryReviewCardTests: XCTestCase {
       .none)
   }
 
+  // MARK: - Live read
+
+  /// A failed mirror read used to burn the once-per-mount flag: every row then read as unreviewed
+  /// for as long as the card stayed mounted, indistinguishable from a day nobody voted on.
+  @MainActor
+  func testAFailedLiveReadIsRetriedInsteadOfSettlingEveryRowAsUnreviewed() async {
+    let reader = FlakyStateReader()
+    let item = MemoryReviewItem(memoryID: "mem_1", content: "Prefers async standups.")
+    let store = MemoryReviewCardStore(
+      items: [item], source: .dailySummaryChat, mutator: UnusedMutator(), stateReader: reader)
+
+    await store.loadLiveStateIfNeeded()
+    XCTAssertEqual(reader.reads, 1)
+    XCTAssertEqual(store.row("mem_1").displayed, .none)
+
+    reader.result = ["mem_1": .accepted]
+    await store.loadLiveStateIfNeeded()
+    XCTAssertEqual(reader.reads, 2)
+    XCTAssertEqual(store.row("mem_1").displayed, .accepted)
+
+    // Once it has succeeded the section stops reading: it is chrome, not a poller.
+    await store.loadLiveStateIfNeeded()
+    XCTAssertEqual(reader.reads, 2)
+  }
+
   // MARK: - Telemetry shape
 
   func testTelemetryCategoryStaysBounded() {
@@ -349,6 +423,26 @@ final class MemoryReviewCardTests: XCTestCase {
   }
 
   // MARK: - Helpers
+
+  /// Fails until it is given a result, so "the read failed" and "nobody has voted" are two
+  /// different observable outcomes rather than the same empty dictionary.
+  private final class FlakyStateReader: MemoryReviewStateReading, @unchecked Sendable {
+    struct ReadFailed: Error {}
+
+    var result: [String: MemoryReviewVerdict]?
+    private(set) var reads = 0
+
+    func verdicts(for items: [MemoryReviewItem]) async throws -> [String: MemoryReviewVerdict] {
+      reads += 1
+      guard let result else { throw ReadFailed() }
+      return result
+    }
+  }
+
+  private struct UnusedMutator: MemoryReviewMutating {
+    func review(memoryID: String, keep: Bool) async throws {}
+    func edit(memoryID: String, content: String) async throws {}
+  }
 
   private func memory(content: String, review: Bool?) -> ServerMemory {
     ServerMemory(

--- a/desktop/macos/changelog/unreleased/20260903-review-round-fixes.json
+++ b/desktop/macos/changelog/unreleased/20260903-review-round-fixes.json
@@ -1,0 +1,4 @@
+{
+  "kind": "none",
+  "reason": "Corrects three features that are still unreleased and already described by the 20260902 fragments: the learned-memory review card, the follow-up chip, and knows-list rotation. The user-visible promises in those fragments are unchanged; this PR makes them true. The one behavior a user could have noticed, a failed voice query reading its own failure aloud, was introduced and fixed within the same unreleased window."
+}

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -44,6 +44,12 @@ covers:
   # renders from and S10 drives `FollowUpChipTap`, the send its button performs.
   - desktop/macos/Desktop/Sources/Chat/FollowUpChip.swift
   - desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift
+  # Deliberately no entry for ChatStreamingBuffer, even though S6's tail streams
+  # through it. Its defect class is display-only — the authoritative terminal
+  # answer overwrites the streamed text — so every assertion available after
+  # `wait_main_chat_idle` passes whether or not the projection leaked the
+  # question mid-stream. Covering it needs an assertion *during* streaming,
+  # which no typed step can express today.
   - desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
   - desktop/macos/Desktop/Sources/Chat/KernelJournalBackendSyncDriver.swift
   - desktop/macos/Desktop/Sources/Chat/KernelJournalEventHub.swift

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -44,12 +44,16 @@ covers:
   # renders from and S10 drives `FollowUpChipTap`, the send its button performs.
   - desktop/macos/Desktop/Sources/Chat/FollowUpChip.swift
   - desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift
-  # Deliberately no entry for ChatStreamingBuffer, even though S6's tail streams
-  # through it. Its defect class is display-only — the authoritative terminal
-  # answer overwrites the streamed text — so every assertion available after
-  # `wait_main_chat_idle` passes whether or not the projection leaked the
-  # question mid-stream. Covering it needs an assertion *during* streaming,
-  # which no typed step can express today.
+  # The streaming buffer, S6-S8. Its defect class is display-only — the
+  # authoritative terminal answer overwrites the streamed text — so no assertion
+  # made *after* `wait_main_chat_idle` can see whether the question leaked into
+  # the prose a token at a time on the way there, and that is what c164760b6b
+  # fixed. The property is nonetheless a fact about the run rather than about the
+  # last frame: no projection the reader ever saw contained the withheld tail.
+  # `ChatStreamingTailProbe` records it as the buffer emits each projection, and
+  # S8 asserts it — with `streaming_tail_delimiter_seen`, so a turn that produced
+  # no tail cannot report zero leaks and pass.
+  - desktop/macos/Desktop/Sources/Chat/ChatStreamingBuffer.swift
   - desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
   - desktop/macos/Desktop/Sources/Chat/KernelJournalBackendSyncDriver.swift
   - desktop/macos/Desktop/Sources/Chat/KernelJournalEventHub.swift
@@ -157,12 +161,22 @@ steps:
       result.detail.idle: "true"
 
   - id: S8
-    name: The question left the prose and is on the chip instead
+    name: The question left the prose, on the chip and at every frame in between
     # Exact equality on the visible answer, deliberately, not `contains`: what
     # this step is for is the ABSENCE of the question from the prose. A split
     # that failed leaves the tail in the answer and says the same thing twice —
     # the defect two separate fixes on this branch were about — and only an
     # exact match catches it.
+    #
+    # The last three are the same property while the answer was still arriving.
+    # The terminal answer overwrites the streamed text, so `last_assistant_text`
+    # is silent about the leak c164760b6b fixed, where the projection was fed its
+    # own output and streamed the withheld question out a token at a time.
+    # `streaming_tail_leaks` counts projections whose visible content did not
+    # match what the tail rule would have shown; `..._delimiter_seen` is asserted
+    # with it because a turn that never carried a tail would otherwise report
+    # zero leaks and read as a pass, and `..._projections` proves the probe was
+    # fed at all rather than silently disarmed.
     bridge.action:
       name: main_chat_snapshot
       params:
@@ -170,6 +184,9 @@ steps:
     expect:
       result.detail.last_assistant_text: "Priya flagged the storage migration in the Tuesday review."
       result.detail.last_assistant_follow_up_question: "What did Priya say about the storage migration?"
+      result.detail.streaming_tail_projections: { min: 1 }
+      result.detail.streaming_tail_delimiter_seen: "true"
+      result.detail.streaming_tail_leaks: "0"
 
   - id: S9
     name: The chip is on screen under the answer

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -32,11 +32,18 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatScrollBehavior.swift
   - desktop/macos/Desktop/Sources/Chat/ChatContentBlockCodec.swift
-  # Deliberately no entry for the follow-up chip (ChatFollowUpTail, FollowUpChip,
-  # AnalyticsManager+QuestionOrigin). This turn runs against OMI_LLM_STUB, whose
-  # replies never carry a `<<<FOLLOWUP>>>` tail, so no chip is produced; and
-  # main_chat_snapshot exposes no field that could assert one. Add the steps
-  # first — a covers: entry with no step behind it reads as coverage that exists.
+  # The grounded follow-up chip, S6-S10. The stub gained one delimiter-carrying
+  # reply so a tail is reachable hermetically at all; S8 asserts the split by
+  # exact equality (the question is absent from the prose and present on the
+  # block), and S10 taps the chip's own send and reads back the origin the
+  # `question_asked` emit carried.
+  - desktop/macos/Desktop/Sources/Chat/ChatFollowUpTail.swift
+  - desktop/macos/Desktop/Sources/Analytics/AnalyticsManager+QuestionOrigin.swift
+  # The chip view itself is asserted by S9's `ax.expect`, which runs on the ui
+  # lane only; on the bridge lane the tier ladder runs, S8 pins the block it
+  # renders from and S10 drives `FollowUpChipTap`, the send its button performs.
+  - desktop/macos/Desktop/Sources/Chat/FollowUpChip.swift
+  - desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift
   - desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
   - desktop/macos/Desktop/Sources/Chat/KernelJournalBackendSyncDriver.swift
   - desktop/macos/Desktop/Sources/Chat/KernelJournalEventHub.swift
@@ -121,6 +128,65 @@ steps:
       result.detail.last_assistant_text: "MARKER:chat-hermetic"
 
   - id: S6
+    name: Ask for an answer that ends with a grounded follow-up tail
+    # The stub's one delimiter-carrying reply (FOLLOWUP_PROBE_* in
+    # backend/utils/llm/desktop_llm_stub.py). Its other steerable path,
+    # `exact_reply_token`, strips trailing non-alphanumerics and so cannot
+    # produce the `?` a chip question requires — this trigger is the only way a
+    # tail exists on a hermetic bundle.
+    bridge.action:
+      name: ask_main_chat
+      params:
+        query: "Recap the storage migration and end with a grounded follow-up question."
+    expect:
+      result.detail.accepted: "true"
+
+  - id: S7
+    name: Wait for chat idle
+    bridge.action:
+      name: wait_main_chat_idle
+      params:
+        timeoutMs: "120000"
+    expect:
+      result.detail.idle: "true"
+
+  - id: S8
+    name: The question left the prose and is on the chip instead
+    # Exact equality on the visible answer, deliberately, not `contains`: what
+    # this step is for is the ABSENCE of the question from the prose. A split
+    # that failed leaves the tail in the answer and says the same thing twice —
+    # the defect two separate fixes on this branch were about — and only an
+    # exact match catches it.
+    bridge.action:
+      name: main_chat_snapshot
+      params:
+        limit: "12"
+    expect:
+      result.detail.last_assistant_text: "Priya flagged the storage migration in the Tuesday review."
+      result.detail.last_assistant_follow_up_question: "What did Priya say about the storage migration?"
+
+  - id: S9
+    name: The chip is on screen under the answer
+    # UI lane only; skipped on the bridge lane, where S8 pins the block this
+    # view renders from and S10 drives the send its button performs.
+    ax.expect:
+      identifiers_visible:
+        - chat-follow-up-chip
+
+  - id: S10
+    name: Tapping the chip attributes the question to the chip
+    # `origin` cannot be read after the fact — it is consumed inside the
+    # `question_asked` emit — so the action reports what that emit carried.
+    # `unprompted` here is the arm failing to reach the send.
+    bridge.action:
+      name: tap_chat_follow_up_chip
+    expect:
+      result.detail.has_chip: "true"
+      result.detail.question: "What did Priya say about the storage migration?"
+      result.detail.accepted: "true"
+      result.detail.question_origin: "followup"
+
+  - id: S11
     name: Logs clean
     log.expect:
       absent:

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -32,10 +32,11 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatScrollBehavior.swift
   - desktop/macos/Desktop/Sources/Chat/ChatContentBlockCodec.swift
-  # Follow-up chip: tail parser, chip view, and question-origin attribution ride the same hermetic chat turn.
-  - desktop/macos/Desktop/Sources/Chat/ChatFollowUpTail.swift
-  - desktop/macos/Desktop/Sources/Chat/FollowUpChip.swift
-  - desktop/macos/Desktop/Sources/Analytics/AnalyticsManager+QuestionOrigin.swift
+  # Deliberately no entry for the follow-up chip (ChatFollowUpTail, FollowUpChip,
+  # AnalyticsManager+QuestionOrigin). This turn runs against OMI_LLM_STUB, whose
+  # replies never carry a `<<<FOLLOWUP>>>` tail, so no chip is produced; and
+  # main_chat_snapshot exposes no field that could assert one. Add the steps
+  # first — a covers: entry with no step behind it reads as coverage that exists.
   - desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
   - desktop/macos/Desktop/Sources/Chat/KernelJournalBackendSyncDriver.swift
   - desktop/macos/Desktop/Sources/Chat/KernelJournalEventHub.swift

--- a/desktop/macos/e2e/flows/home-knows-rotation.yaml
+++ b/desktop/macos/e2e/flows/home-knows-rotation.yaml
@@ -1,0 +1,236 @@
+version: 2
+name: home-knows-rotation
+tier: 2
+description: >-
+  The Home hub's knows-list rotation, driven through the list the hub actually composed. Three
+  fixture tasks are created through the production TasksStore path, the impression ledger is put
+  into a known state, and then one visit at a time proves what the ledger does to the next one: a
+  row shown today does not come back, a dismissed row stays out, and the impression is reported
+  once per visit rather than once per re-render.
+app: non-prod
+covers:
+  # The ledger, the rotation rules, and the store that is their only mutation owner. S6 is the
+  # first visit against a cleared ledger and pins what `recordShown` wrote (`shows_before` 0 on
+  # both task slots); S7 re-runs the reporting inside the same visit and asserts it emitted
+  # nothing, which is `reportedThisVisit` and nothing else; S9 drives `recordDismissed` and S10
+  # `recordOpened`; S13-S15 re-read after a fresh visit, where `suppression` has had to decide each
+  # row again — same-day for the row that was only shown, `dismissed` for the row that was waved
+  # off, and both survive a ledger that is reloaded from UserDefaults in between.
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsImpressionLedger.swift
+  # `trackHomeKnowsRowShown`, asserted exactly by S6: kind, slot, and `shows_before` for both task
+  # rows, read at the `AnalyticsManager` capture seam rather than recomputed by the bridge. Its
+  # sibling `trackHomeKnowsSlotEmpty` is deliberately NOT asserted here: an empty slot needs the
+  # fixture to be the whole candidate pool for that slot, and the hub composes from whatever tasks,
+  # insights and suggestions the signed-in account already carries. A flow that emptied the account
+  # to make that assertion hold would delete the reader's tasks on a dev bundle; one that asserted
+  # it anyway would be asserting the account's contents. `HomeKnowsRotationReason` itself is
+  # covered — S13 and S15 are `dismissed` and `same_day` observed through their effect on the list.
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/AnalyticsManager+HomeKnows.swift
+  # The composer the rows come out of, and the page that publishes them. `DashboardPage` holds the
+  # composition in a computed property and the ledger in `@State`; `HomeKnowsAutomationRegistry` is
+  # how a flow reaches either, and every closure behind it is one of the page's own functions.
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsComposer.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+  # The seven home_knows_* actions every step below drives, and the fixture behind them.
+  - desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift
+  # The candidate source. The rows are the reader's real tasks, and S4 creates them through the
+  # store's own create path so the ids the ledger keys on address tasks the app really has.
+  - desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+preconditions:
+  - automation_bridge_ready
+  - auth_ready
+  # The hub — and so the knows-list — is mounted only by the chat-first shell's Chat route, exactly
+  # as in `home-stage.yaml`. On a legacy bundle S2 fails immediately and says why.
+  - chat_first_cohort_named_bundle
+
+steps:
+  - id: S1
+    name: Reset main chat so Home rests on the hub
+    # Not only isolation: the stage's resting mode is the hub only while the chat has no history,
+    # so without this S3 collapses into a loaded chat and the knows-list never mounts.
+    bridge.action:
+      name: reset_main_chat
+    expect:
+      result.detail.reset: "true"
+
+  - id: S2
+    name: Mount the shell that owns the Home stage
+    bridge.navigate:
+      target: chat
+      activateApp: false
+    wait:
+      state.shellVariant: chat_first
+      state.chatFirstRoute: chat
+
+  - id: S3
+    name: Collapse to the resting hub, where the knows-list lives
+    bridge.action:
+      name: home_close_panel
+    wait:
+      state.homeMode: hub
+
+  - id: S4
+    name: Seed the three fixture tasks
+    # Created through `TasksStore.createTask` and read back out of the three dashboard lanes the hub
+    # composes from, so these are candidates by the same route a real task is. `candidateCount` is
+    # the lanes' own answer: `createTask` only touches `incompleteTasks`, and a fixture that
+    # reported its own creations would pass while the hub still saw nothing.
+    bridge.action:
+      name: seed_home_knows_tasks
+      params:
+        timeoutMs: "15000"
+    expect:
+      result.detail.createdCount: "3"
+      result.detail.candidateCount: "3"
+
+  - id: S5
+    name: Clear the impression ledger
+    # The ledger is UserDefaults-backed and deliberately outlives the app, so a second run would
+    # open on rows the first run had already same-day-suppressed — and would read a correct
+    # suppression as a composer that had stopped producing rows.
+    bridge.action:
+      name: home_knows_reset
+    expect:
+      result.detail.entries: "0"
+
+  - id: S6
+    name: The first visit shows the two newest tasks and reports each once
+    # `shows_before` is the number this event exists to make readable: a healthy list is dominated
+    # by 0 and a repeating one by 3+. Against a cleared ledger both task slots must report 0, and
+    # the two rows must be the fixture's first two entries — the composer orders ties by most
+    # recently updated, and these three were written seconds ago, so anything else here means the
+    # freshness order stopped working rather than that the account is busy.
+    bridge.action:
+      name: home_knows_visit
+    expect:
+      result.detail.taskRowCount: "2"
+      result.detail.taskRow0_text: "Send Priya the storage migration summary"
+      result.detail.taskRow1_text: "Book the Thursday design review room"
+      result.detail.taskRow0_showsBefore: "0"
+      result.detail.taskRow1_showsBefore: "0"
+      result.detail.emitted_row_pressing_task: "task:0"
+      result.detail.emitted_row_second_task: "task:0"
+
+  - id: S7
+    name: Re-reporting inside the same visit emits nothing
+    # One visit is one impression. The in-visit rotation timer re-renders the same row every seven
+    # seconds and the composition is re-derived on every candidate change, so without the
+    # once-per-visit guard the list would burn through its own show cap while the reader looked at
+    # it — and `shows_before` would measure the timer rather than the repetition.
+    bridge.action:
+      name: home_knows_impressions
+    expect:
+      result.detail.emittedCount: "0"
+      result.detail.taskRowCount: "2"
+
+  - id: S8
+    name: The ledger recorded that first show
+    bridge.action:
+      name: home_knows_probe
+      params:
+        text: "Send Priya the storage migration summary"
+    expect:
+      result.detail.known: "true"
+      result.detail.present: "true"
+      result.detail.shows: "1"
+      result.detail.wasOpened: "false"
+      result.detail.wasDismissed: "false"
+
+  - id: S9
+    name: Dismissing a row writes the dismissal and frees its slot
+    # The list is composed against the ledger as it was at the start of the visit, with in-visit
+    # dismisses merged in — so the row leaves immediately while the rows beside it stay put. The
+    # third fixture task, which had no slot until now, is what proves the slot was actually freed
+    # rather than the row merely greyed out.
+    bridge.action:
+      name: home_knows_dismiss
+      params:
+        text: "Send Priya the storage migration summary"
+    expect:
+      result.detail.dismissed: "true"
+      result.detail.wasDismissed: "true"
+      result.detail.shows: "1"
+
+  - id: S10
+    name: Opening a row records the open
+    # A row counted as opened is exempt from the show cap and the same-day rule for good, so this
+    # is the one ledger write that must never happen speculatively. The task row's own tap navigates
+    # to Tasks as it records, which is why this is the last thing done on the hub.
+    bridge.action:
+      name: home_knows_open
+      params:
+        text: "Reply to the vendor security questionnaire"
+    expect:
+      result.detail.opened: "true"
+      result.detail.wasOpened: "true"
+
+  - id: S11
+    name: Back to the Chat route the hub belongs to
+    bridge.navigate:
+      target: chat
+      activateApp: false
+    wait:
+      state.chatFirstRoute: chat
+
+  - id: S12
+    name: Rest on the hub again
+    bridge.action:
+      name: home_close_panel
+    wait:
+      state.homeMode: hub
+
+  - id: S13
+    name: A dismissed row stays out of the next visit
+    # Re-read after a fresh visit, so this is the ledger reloaded from UserDefaults deciding the row
+    # again rather than the in-visit merge still holding it out. `dismissed` outranks every other
+    # rotation reason precisely because it is the reader's own instruction.
+    bridge.action:
+      name: home_knows_visit
+    expect:
+      ok: true
+
+  - id: S14
+    name: The dismissal survived the reload
+    bridge.action:
+      name: home_knows_probe
+      params:
+        text: "Send Priya the storage migration summary"
+    expect:
+      result.detail.present: "false"
+      result.detail.wasDismissed: "true"
+      result.detail.shows: "1"
+
+  - id: S15
+    name: A row shown today, and never opened, does not repeat today
+    # The repetition this whole surface exists to stop: over 14 days the owner's hub showed the same
+    # four commitments 8-12 times each. `shows` staying at 1 is the other half — a row held back by
+    # the same-day rule must not be counted as shown again while it is held back.
+    bridge.action:
+      name: home_knows_probe
+      params:
+        text: "Book the Thursday design review room"
+    expect:
+      result.detail.present: "false"
+      result.detail.wasOpened: "false"
+      result.detail.wasDismissed: "false"
+      result.detail.shows: "1"
+
+  - id: S16
+    name: The knows-list is on screen
+    # UI lane only; skipped on the bridge lane, where S6-S15 pin the rows this view renders from.
+    ax.expect:
+      identifiers_visible:
+        - home-knows-list
+
+  - id: S17
+    name: Remove the fixture tasks
+    bridge.action:
+      name: clear_home_knows_tasks
+    expect:
+      result.detail.removed: "3"
+
+  - id: S18
+    name: Logs clean
+    log.expect:
+      absent:
+        - "DesktopAutomationBridge: failed"

--- a/desktop/macos/e2e/flows/home-stage.yaml
+++ b/desktop/macos/e2e/flows/home-stage.yaml
@@ -24,11 +24,12 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/HomeStagePresentation.swift
   - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeSuggestionsStore.swift
   - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsComposer.swift
-  # Knows-list impression ledger and the daily-summary memory review rows render on the same stage.
-  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeKnowsImpressionLedger.swift
-  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/AnalyticsManager+HomeKnows.swift
-  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/MemoryReviewCard.swift
-  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/MemoryReviewRowView.swift
+  # Deliberately no entry for the knows-list impression ledger
+  # (HomeKnowsImpressionLedger, AnalyticsManager+HomeKnows) or the memory review
+  # rows (MemoryReviewCard, MemoryReviewRowView). No step here opens the knows
+  # list or asserts rotation/dismissal, and `daily_summary_snapshot` is
+  # shape-only and renders no review rows. Add a driving action and its
+  # assertions first — a covers: entry with no step behind it reads as coverage.
   - desktop/macos/Desktop/Sources/MainWindow/MainChatNavigationRequest.swift
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   # The five home_* actions every step below drives, lifted out of the registry.

--- a/desktop/macos/e2e/flows/home-stage.yaml
+++ b/desktop/macos/e2e/flows/home-stage.yaml
@@ -28,8 +28,9 @@ covers:
   # (HomeKnowsImpressionLedger, AnalyticsManager+HomeKnows) or the memory review
   # rows (MemoryReviewCard, MemoryReviewRowView). No step here opens the knows
   # list or asserts rotation/dismissal, and `daily_summary_snapshot` is
-  # shape-only and renders no review rows. Add a driving action and its
-  # assertions first — a covers: entry with no step behind it reads as coverage.
+  # shape-only and renders no review rows. Those live in their own flows —
+  # home-knows-rotation.yaml and memory-review.yaml — which seed the state each
+  # one needs and drive it. This flow stays the stage's own flow.
   - desktop/macos/Desktop/Sources/MainWindow/MainChatNavigationRequest.swift
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   # The five home_* actions every step below drives, lifted out of the registry.

--- a/desktop/macos/e2e/flows/memory-review.yaml
+++ b/desktop/macos/e2e/flows/memory-review.yaml
@@ -1,0 +1,169 @@
+version: 2
+name: memory-review
+tier: 2
+description: >-
+  "Things I learned today" — the review rows on the daily-summary card, seeded from real memories
+  and voted on through the store the ✓ / ✗ buttons call. The rows render only from a daily
+  summary's `memories_learned`, and only the nightly job produces one, so the flow seeds the record
+  through a local/offline-only fixture and reads it back through the app's own
+  `getDailySummaries`.
+app: non-prod
+covers:
+  # The row projection, the row state machine, and both mutations. S4 mounts the section from a
+  # real summary; S6 reads which items it bound and what each row shows; S7 and S8 drive
+  # `MemoryReviewCardStore.send` — the exact call the ✓ and ✗ buttons make — and assert the settled
+  # verdict, the copy under it, and that no inline error was raised; S9 re-reads after each
+  # mutation's `refreshLiveState`, which is where a verdict this device just made would be erased
+  # by a mirror that has not caught up yet.
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/MemoryReviewCard.swift
+  # `MemoryReviewSection` lives here with the row view. S4's `mountedRows` and S6's `rowCount` vs
+  # `maxRows`, read against S5's `memoriesLearnedCount`, assert the section's own bound: four
+  # learned memories on the wire, three rows rendered. The row *view* is asserted by S10's
+  # `ax.expect`, which runs on the ui lane only; on the bridge lane S6-S9 pin the row model it
+  # draws from, including the faded/settled state its opacity and copy come from.
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/MemoryReviewRowView.swift
+  # The three actions S4/S6/S7 drive, and `daily_summary_snapshot`'s learned-memory count.
+  - desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift
+  # The card that hosts the section, and the store whose refresh brings the seeded record in.
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/ChatDailySummaryCard.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeDailySummaryStore.swift
+  - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+DailySummaries.swift
+preconditions:
+  - automation_bridge_ready
+  - auth_ready
+  # The inline Home chat is what mounts `ChatMessagesView`, and so the daily-summary card; the
+  # stage that opens it exists only on the chat-first shell, exactly as in `home-stage.yaml`.
+  - chat_first_cohort_named_bundle
+  # S4 writes through `POST /v1/dev-harness/daily-summary/seed`, which `main.py` registers only
+  # when `OMI_ENV_STAGE` is local or offline. On any other stack S4 reports a failed seed and the
+  # flow stops there rather than reading an empty card as a pass.
+  - offline_dev_stack
+
+steps:
+  - id: S1
+    name: Reset main chat for flow isolation
+    # Also what makes the card admissible: `ChatMessagesView` admits the summary above the thread
+    # only while the transcript follows the live edge or is empty (INV-CHAT-2).
+    bridge.action:
+      name: reset_main_chat
+    expect:
+      result.detail.reset: "true"
+
+  - id: S2
+    name: Mount the shell that owns the Home stage
+    bridge.navigate:
+      target: chat
+      activateApp: false
+    wait:
+      state.shellVariant: chat_first
+      state.chatFirstRoute: chat
+
+  - id: S3
+    name: Open the inline chat, which is where the daily-summary card renders
+    bridge.action:
+      name: home_open_chat
+    wait:
+      state.homeMode: chat
+
+  - id: S4
+    name: Seed four real memories and the summary that learned them
+    # The memories are created through the production `POST /v3/memories`, so the ids the summary
+    # carries address rows `/v3/memories/{id}/review` really mutates. `mountedRows` is the
+    # section's own answer once the store's refresh has brought the record in.
+    bridge.action:
+      name: seed_memory_review_fixture
+      params:
+        count: "4"
+        timeoutMs: "15000"
+    expect:
+      result.detail.createdCount: "4"
+      result.detail.memoriesLearned: "4"
+      result.detail.mountedRows: "3"
+
+  - id: S5
+    name: The wire carried four learned memories
+    # Shape-only, and the other half of the bound: the record has four, the card renders three.
+    bridge.action:
+      name: daily_summary_snapshot
+    expect:
+      result.detail.hasSummary: "true"
+      result.detail.memoriesLearnedCount: "4"
+
+  - id: S6
+    name: The section bound three rows, unreviewed, with their categories
+    bridge.action:
+      name: memory_review_snapshot
+    expect:
+      result.detail.mounted: "true"
+      result.detail.source: daily_summary_chat
+      result.detail.rowCount: "3"
+      result.detail.maxRows: "3"
+      result.detail.row0_content: "Prefers async standups over daily calls."
+      result.detail.row0_category: About You
+      result.detail.row0_verdict: none
+      result.detail.row0_settled: "false"
+      result.detail.row1_content: "Ships desktop releases on Wednesdays."
+      result.detail.row1_category: Workflow
+      result.detail.row1_verdict: none
+
+  - id: S7
+    name: ✓ settles the first row on a promise the backend keeps
+    # The copy is asserted verbatim, not merely "settled": rejection feeds bounded negative
+    # feedback into extraction and an edit re-enters short-term as a user assertion, so each line
+    # is a claim about backend behaviour and drifting it silently would make the card lie.
+    bridge.action:
+      name: memory_review_vote
+      params:
+        row: "0"
+        verdict: accept
+        timeoutMs: "20000"
+    expect:
+      result.detail.settledInTime: "true"
+      result.detail.row0_verdict: accepted
+      result.detail.row0_settled: "true"
+      result.detail.row0_status: "Confirmed. I'll act on this."
+      result.detail.row0_error: ""
+
+  - id: S8
+    name: ✗ fades the second row where it stands rather than removing it
+    bridge.action:
+      name: memory_review_vote
+      params:
+        row: "1"
+        verdict: reject
+        timeoutMs: "20000"
+    expect:
+      result.detail.settledInTime: "true"
+      result.detail.row1_verdict: rejected
+      result.detail.row1_faded: "true"
+      result.detail.row1_status: "Dropped. I'll avoid facts like this."
+      result.detail.row1_error: ""
+
+  - id: S9
+    name: Both verdicts survive the post-mutation re-read
+    # The failure this catches: each mutation ends in `refreshLiveState`, and the local memory
+    # mirror routinely lags the write it is being asked to confirm. A row that flickered back to
+    # "unreviewed" a second after the click reads as the vote not landing, and the reader votes
+    # again. `rowCount` is re-asserted because a rejected row must stay in place until the card is
+    # next refreshed — removing it would reflow every row below the one just clicked.
+    bridge.action:
+      name: memory_review_snapshot
+    expect:
+      result.detail.rowCount: "3"
+      result.detail.row0_verdict: accepted
+      result.detail.row1_verdict: rejected
+
+  - id: S10
+    name: The section, a row, and the settled copy are on screen
+    # UI lane only; skipped on the bridge lane, where S6-S9 pin the row model this view draws from.
+    ax.expect:
+      identifiers_visible:
+        - memory-review-section
+        - memory-review-row
+        - memory-review-status
+
+  - id: S11
+    name: Logs clean
+    log.expect:
+      absent:
+        - "DesktopAutomationBridge: failed"


### PR DESCRIPTION
## Summary

Follow-up to #12635, which merged before this review round landed. Everything
here is a fix to what that PR shipped, found by adversarial review of it and
verified against the code path before being changed.

Three of these are defects that make shipped code wrong today on `main`:

1. **The learned-memory review card is dead in production.** The scheduled
   daily-summary job called the summary generator without `memories_learned`, so
   the field was always empty, so the `memoryReviewCard` block was never attached
   on the only path real users receive. Only the `/daily-summary-settings/test`
   route passed it. Both senders now select through one shared helper, and a test
   fails without the fix.
2. **A failed voice query now reads its own failure aloud.** #12635 changed the
   empty-response copy while `FloatingBarVoicePlaybackService.shouldSpeak` still
   suppressed one exact hardcoded string, which no longer exists in the tree. Copy
   and guard now share one source, pinned by a test that drives the real playback
   path rather than the string compare.
3. **The server rejects the review card the Mac sends.** The desktop adapter
   converts a `memoryReviewCard` for the chat-first journal, but the block was not
   in the server union, so every such request failed validation as
   `invalid_request` and the card was never journaled. Added to the *request*
   union only: the server never emits this block, and adding it to the
   materialization response union is a breaking change to a released app-client
   contract (`check_app_client_openapi_compatibility` confirms both directions).

Two more undercut claims #12635 itself made:

4. **The daily-summary checkpoint could not resume.** The cursor key carried the
   UTC hour, so the run that wrote the tail and the run that should have resumed it
   never shared a key — which defeats the point of the #12530 fix. A failed
   timezone chunk also let the run call itself complete and clear the cursor.
5. **The Mac review card never saw its own vote.** A vote wrote to the backend but
   was not mirrored locally, so the row reverted to unreviewed on the next card
   build. Now mirrored through existing storage, with the backend still the only
   writer.

And one the review only half-saw:

6. **The streamed follow-up tail leaked into the transcript.** `ChatStreamingBuffer`
   wrote the normalized projection back into the message and appended the next
   delta to it, so a projection that deliberately withholds the tail lost the
   evidence it needed on the next flush. A replay of every flush boundary leaks at
   every boundary from the delimiter onward, not only at a split marker, and the
   question always spans several flushes. Display-only, since the authoritative
   answer overwrites it, but the reader watched the chip's question get typed into
   the answer and then snatched away.

Also fixed: multi-question chips, chips on guard-stopped turns, generic-prefix
rules that diverged between client and server, a permanent optimistic override on
mobile, a duplicated question when a follow-up block had no prose, per-item
decoding so one malformed row cannot drop the whole array, owner-scoped knows-list
visits, a content-change reset that skipped the show cap, and greeting counts that
disagreed with the rows they described.

Three findings were **rejected with evidence** rather than fixed: that the stream
filter persists its withheld suffix (the persisted answer is built by the
producer, and flushing would have pushed the fragment *into* the stream); that a
safety-guard stop should be reclassified as a provider failure (an explicit,
tested contract says a guard stop is a deliberate reply); and a pytest marker that
would have removed a file from CI entirely.

## End-to-end coverage: made real

#12635 satisfied `desktop-e2e-flow-coverage` by adding `covers:` entries to two
flows that never exercise the code. The gate is a text match over the `covers:`
list and never inspects steps, so the claim cost nothing to write and gave false
confidence that these modules were end-to-end covered. Those entries are removed
here and the coverage is built instead:

- **Chat follow-up.** The hermetic stub can now emit a follow-up tail, the chat
  automation snapshot exposes the chip question, and a bridge action taps the chip
  and reports the origin the analytics emit actually carried. The flow asserts the
  visible answer by exact equality, which is what catches a tail left in the prose.
- **Memory review card** (`memory-review.yaml`). A local-only dev-harness route
  seeds a summary, the flow creates the memories through the production endpoint,
  renders the card, accepts one row and rejects another through the same store the
  buttons call, then re-reads to prove both verdicts survive the refresh.
- **Knows-list rotation** (`home-knows-rotation.yaml`). Seeds tasks, clears the
  ledger through the same persistence the mutations use, and pins the first visit's
  rows, the within-visit de-duplication, and a later visit's view of a dismissed row
  and a merely-shown row.
- **Streaming buffer.** Judged uncoverable at first, because the defect is
  mid-stream and the terminal answer overwrites the streamed text before any
  assertion runs. True of the final text only: a non-prod probe now keeps its own
  raw stream, compares every emitted projection against the shipped tail-stripping
  rule, and the flow asserts zero leaks alongside two liveness assertions so the
  zero cannot be vacuous. A negative-control unit test feeds the probe the exact
  projection the pre-fix buffer emitted and asserts it is counted.

Three things are deliberately **not** claimed, each stated next to its `covers:`
entry: the empty-slot telemetry, the three-show cap (it needs three calendar days
or an injected clock, and is unit-tested instead), and the 14-day stale-task rule,
which is unreachable from the hub because the dashboard query already cuts off at
seven days. That last one is a real finding and wants a follow-up.

## Invariants

- INV-AUTH-1: no change to auth.
- INV-CHAT-1: chat continuity preserved; the follow-up block rides the persisted message.
- INV-NAV-1: no navigation changes.
- INV-VOICE-1: realtime hub prompt untouched; the voice guard change makes failure copy silent again, as it was before #12635.
- INV-MEM-4: no new promotion path; a vote is a review, not a promotion.
- INV-MEM-1: memory reads go through `MemoryService`; the local mirror carries no second copy of review state and the backend remains the only writer.

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1
- INV-VOICE-1
- INV-MEM-4
- INV-MEM-1
- INV-TASK-2

## Failure class

Failure-Class: new

This PR adds one definition, `FC-projection-fed-its-own-output`: `ChatStreamingBuffer` re-derived its output from
its own previous output, so a projection that withholds text destroyed the
evidence it needed on the next pass. The protocol allows one declaration per body;
the others are recorded here for the reader.

<!--
Failure-Class: FC-contract-wired-on-one-of-two-senders  (the scheduled job never passed memories_learned, so the review card was dead on the only path users receive while the test route worked)
Failure-Class: FC-guard-pinned-to-a-copy-string  (shouldSpeak suppressed one exact string; changing the copy made the failure speak)
Failure-Class: FC-checkpoint-keyed-outside-its-retry-window  (the resume cursor carried the UTC hour, so the next run never read the tail)
-->

## Line-count exceptions

Line-Count-Exception: backend/utils/retrieval/agentic.py | 1718 -> 1736 | outcome-text helper voids a pending marker at the five backend-authored sites
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift | 3107 -> 3112 | chord-aware push-to-talk hint
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift | 5740 -> 5752 | failure copy moved to a shared constant the voice guard also reads
Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift | 4268 -> 4328 | per-branch open recording plus the non-prod knows automation registry
Line-Count-Exception: desktop/macos/Desktop/Sources/Providers/ChatProvider.swift | 7210 -> 7212 | the streaming buffer's raw accumulator is released when the terminal answer lands

## Verification

- `make preflight`: all 39 checks pass, including `desktop-e2e-flow-coverage` at 0 uncovered.
- Backend: scoped runs through `test.sh` (via `BACKEND_UNIT_TEST_FILE_LIST`, since positional paths are ignored) green under the CPU duration guard, including four consecutive runs of the daily-summary files at load average 61. `check_app_client_openapi_compatibility` passes; all four generated clients are `--check` clean.
- Desktop: `swift build -c debug` green; the follow-up, review-card, knows-list, and streaming-probe suites pass; swift-format, SwiftLint, the baseline ratchet, test-quality, and the main-actor hook check are clean.
- Mobile: `app/test.sh` all passed; `dart format` clean.

## Not done here

- **None of the three new or extended e2e flows has been executed.** Tier 2 needs Docker, and `docker info` fails on the authoring machine. Both sides of every string they assert are pinned by unit tests so drift fails in seconds, and the streaming probe has a falsifiable negative control, but someone with Docker must run `chat-hermetic`, `memory-review`, and `home-knows-rotation` before they are trusted. Two knows-list expectations rest on a reading of the composer's slot ordering that only a real run can confirm.
- No dogfood on a signed-in bundle. The desktop mirror write on a review vote has no hermetic test, so it is the first thing to check by hand.
- A cross-device vote still appears only after the memory sync runs: there is no single-memory GET to make the card's read authoritative.
- An unserved daily-summary user is still not re-queried an hour later, because eligibility matches one local hour. The checkpoint only recovers the tail if the job runs more than once per hour, and the repo disagrees with itself about the cadence.
- Mobile strings stay hardcoded English, matching every neighbouring widget.
- Interject is still not wired to the review rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->