### PR TITLE
feat(backend): illustrated install steps + launch-day Product Hunt badge on the download page

### DIFF
--- a/backend/desktop_download_page.py
+++ b/backend/desktop_download_page.py
@@ -1,0 +1,260 @@
+"""HTML for the desktop download landing page.
+
+Split out of ``routers/updates.py``: the appcast/update-routing logic and the
+marketing-facing download page change for unrelated reasons and at unrelated
+times, and keeping both in one module pushed it past the product file
+line-count ratchet.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+LANDING_ASSET_BASE = "https://storage.googleapis.com/omi_macos_updates/landing"
+
+_CURSOR_SVG = (
+    '<svg class="cursor" viewBox="0 0 12 18" width="12" height="18" aria-hidden="true">'
+    '<path d="M1 1l9.2 8.4-4.1.3 2.4 5-1.9.9-2.4-5-3.2 2.6z" fill="#fff" stroke="#000"'
+    ' stroke-width="1" stroke-linejoin="round"/></svg>'
+)
+
+
+def install_steps_html(platform: str) -> str:
+    """Three illustrated install steps, drawn from real app chrome rather than a text list."""
+    if platform == "windows":
+        panels = [
+            (
+                '<div class="win-file"><div class="win-file-glyph">EXE</div>'
+                '<div class="win-file-name">omi-setup.exe</div></div>' + _CURSOR_SVG,
+                'Open <b>omi-setup.exe</b> from<br>your <b>Downloads</b> folder',
+            ),
+            (
+                '<div class="win-dialog"><div class="win-dialog-title">Windows protected your PC</div>'
+                '<div class="win-dialog-link">More info</div>'
+                '<div class="win-dialog-run">Run anyway</div></div>',
+                'If SmartScreen appears, click<br><b>More info</b> &rarr; <b>Run anyway</b>',
+            ),
+            (
+                '<div class="app-row is-omi"><img src="' + LANDING_ASSET_BASE + '/omi-icon.png"'
+                ' alt="" width="26" height="26"><span>Omi</span></div>'
+                '<div class="app-row"><span class="app-dot"></span><span>Start menu</span></div>',
+                'Launch <b>Omi</b> and finish<br>the setup wizard',
+            ),
+        ]
+    else:
+        panels = [
+            (
+                '<div class="finder">'
+                '<div class="finder-bar"><i></i><i></i><i></i><span>Downloads</span></div>'
+                '<div class="app-row is-omi"><span class="dmg-glyph"></span><span>omi.dmg</span>'
+                + _CURSOR_SVG
+                + '</div>'
+                '<div class="app-row"><span class="app-dot"></span><span>Screenshot.png</span></div>'
+                '</div>',
+                'Open <b>omi.dmg</b> from<br>your <b>Downloads</b> folder',
+            ),
+            (
+                '<div class="drag">'
+                '<img class="drag-app" src="' + LANDING_ASSET_BASE + '/omi-icon.png"'
+                ' alt="Omi" width="66" height="66">'
+                '<span class="drag-arrow"></span>'
+                '<span class="drop-target">'
+                '<img src="' + LANDING_ASSET_BASE + '/apps-folder.png" alt="Applications"'
+                ' width="60" height="60"></span>'
+                '</div>',
+                'Drag the <b>Omi</b> icon into<br>your <b>Applications</b> folder',
+            ),
+            (
+                '<div class="finder">'
+                '<div class="finder-bar"><i></i><i></i><i></i><span>Applications</span></div>'
+                '<div class="app-row"><span class="app-dot"></span><span>Notes</span></div>'
+                '<div class="app-row is-omi">'
+                '<img src="' + LANDING_ASSET_BASE + '/omi-icon.png" alt="" width="22" height="22">'
+                '<span>Omi</span></div>'
+                '<div class="app-row"><span class="app-dot"></span><span>Safari</span></div>'
+                '</div>',
+                'Open <b>Omi</b> from your<br><b>Applications</b> folder',
+            ),
+        ]
+
+    cards = []
+    for index, (art, caption) in enumerate(panels, start=1):
+        cards.append(
+            f'<li class="step"><span class="step-num">{index}</span>'
+            f'<div class="step-art">{art}</div>'
+            f'<p class="step-caption">{caption}</p></li>'
+        )
+    return "".join(cards)
+
+
+# Product Hunt launch badge for "Omi Desktop" — shown on the download landing page
+# only during the launch day, then it disappears on its own. Product Hunt days run
+# midnight-to-midnight Pacific, so the window closes at 2026-09-04 07:00 UTC (Sep 3 PDT).
+# One-time launch scaffolding: delete this constant, _product_hunt_badge_html, and its
+# tests once the launch window has passed.
+PRODUCT_HUNT_BADGE_ENDS_AT = datetime(2026, 9, 4, 7, 0, 0, tzinfo=timezone.utc)
+PRODUCT_HUNT_POST_URL = (
+    "https://www.producthunt.com/products/open-source-ai-necklace-friend?embed=true"
+    "&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-omi-desktop-2"
+)
+PRODUCT_HUNT_BADGE_IMAGE = "https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1240025&theme=dark"
+
+
+def product_hunt_badge_html(now: Optional[datetime] = None) -> str:
+    """Render the Product Hunt badge while the launch window is open, else nothing.
+
+    Product Hunt bakes the upvote count into the SVG itself, so the embed snippet's
+    fixed `t` cache-buster would pin every visitor to whatever count was rendered the
+    first time they loaded the page. Bucketing `t` by the hour keeps the count moving
+    through the launch day without re-fetching the badge on every request.
+    """
+    current = now or datetime.now(timezone.utc)
+    if current >= PRODUCT_HUNT_BADGE_ENDS_AT:
+        return ""
+    hour_bucket = int(current.timestamp()) // 3600
+    return (
+        f'<a class="ph-badge" href="{PRODUCT_HUNT_POST_URL}" target="_blank" rel="noopener noreferrer">'
+        f'<img alt="Omi Desktop - Ask your Mac anything you saw or heard | Product Hunt" '
+        f'width="250" height="54" src="{PRODUCT_HUNT_BADGE_IMAGE}&t={hour_bucket}"></a>'
+    )
+
+
+def download_landing_html(
+    dmg_url: str, channel: str = "stable", version: str = "", platform: str = "macos", notice: str = ""
+) -> str:
+    """Generate an HTML landing page that auto-triggers the installer download."""
+    channel_label = "Beta " if channel == "beta" else ""
+    version_display = f"v{version}" if version else ""
+    notice_html = f'<p class="notice">{notice}</p>' if notice else ""
+    product_hunt_html = product_hunt_badge_html()
+    os_name = "Windows" if platform == "windows" else "macOS"
+    install_steps = install_steps_html(platform)
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Download Omi {channel_label}for {os_name}</title>
+    <meta http-equiv="refresh" content="2;url={dmg_url}">
+    <style>
+        * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+        body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+               background: #0a0a0a; color: #fff; display: flex; align-items: center;
+               justify-content: center; min-height: 100vh; text-align: center; }}
+        .container {{ max-width: 960px; padding: 40px 24px; }}
+        h1 {{ font-size: 28px; font-weight: 600; margin-bottom: 12px; }}
+        .version {{ color: #555; font-size: 14px; margin-bottom: 24px; }}
+        .subtitle {{ color: #888; font-size: 16px; margin-bottom: 32px; }}
+        .status {{ width: 40px; height: 40px; margin: 0 auto 24px; position: relative; }}
+        .spinner {{ width: 40px; height: 40px; border: 3px solid #333; border-top-color: #fff;
+                    border-radius: 50%; animation: spin 0.8s linear infinite; }}
+        .checkmark {{ display: none; font-size: 36px; color: #4ade80; }}
+        .done .spinner {{ display: none; }}
+        .done .checkmark {{ display: block; }}
+        .done .subtitle {{ color: #4ade80; }}
+        @keyframes spin {{ to {{ transform: rotate(360deg); }} }}
+        .notice {{ color: #fbbf24; font-size: 14px; margin-bottom: 24px; }}
+        .download-link {{ color: #6C8FFF; text-decoration: none; font-size: 15px; }}
+        .download-link:hover {{ text-decoration: underline; }}
+        .video-container {{ margin-top: 32px; border-radius: 12px; overflow: hidden;
+                            background: #151515; display: none; }}
+        .video-container video {{ width: 100%; display: block; }}
+        .video-label {{ color: #888; font-size: 13px; padding: 12px 16px; text-align: center; }}
+        .steps {{ list-style: none; display: grid; grid-template-columns: repeat(3, 1fr);
+                  gap: 28px; margin-top: 40px; padding: 0; }}
+        .steps-title {{ font-size: 17px; font-weight: 600; color: #fff; margin-top: 44px; }}
+        .steps-sub {{ font-size: 13px; color: #666; margin-top: 6px; }}
+        .step {{ display: flex; flex-direction: column; align-items: center; }}
+        .step-num {{ width: 30px; height: 30px; border-radius: 50%; background: #f2f2f2;
+                     border: none; color: #0a0a0a; font-size: 14px; font-weight: 700;
+                     display: flex; align-items: center; justify-content: center;
+                     margin-bottom: 14px; font-variant-numeric: tabular-nums; }}
+        .step-art {{ position: relative; width: 100%; height: 168px; border-radius: 14px;
+                     background: #141414; border: 1px solid #232323; display: flex;
+                     align-items: center; justify-content: center; overflow: hidden; }}
+        .step-caption {{ margin-top: 14px; font-size: 13px; line-height: 1.55; color: #8a8a8a; }}
+        .step-caption b {{ color: #e6e6e6; font-weight: 600; }}
+        .finder {{ width: 86%; border-radius: 9px; overflow: hidden; background: #1d1d1f;
+                   border: 1px solid #2f2f31; text-align: left; }}
+        .finder-bar {{ display: flex; align-items: center; gap: 5px; padding: 7px 9px;
+                       background: #262628; border-bottom: 1px solid #333; }}
+        .finder-bar i {{ width: 7px; height: 7px; border-radius: 50%; background: #3f3f42; }}
+        .finder-bar span {{ margin-left: 6px; font-size: 10px; color: #8a8a8f;
+                            letter-spacing: 0.02em; }}
+        .finder-row, .app-row {{ display: flex; align-items: center; gap: 8px;
+                                 padding: 7px 10px; font-size: 12px; color: #d0d0d4; }}
+        .dmg-glyph {{ width: 20px; height: 20px; border-radius: 4px; flex: none;
+                      background: linear-gradient(160deg, #f4f4f6, #c9ccd6);
+                      box-shadow: inset 0 0 0 1px rgba(0,0,0,0.18); }}
+        .app-dot {{ width: 18px; height: 18px; border-radius: 5px; flex: none; background: #333336; }}
+        .app-row.is-omi {{ background: #2f6bff; color: #fff; border-radius: 5px;
+                           margin: 0 5px; font-weight: 500; }}
+        .app-row img, .finder-row img {{ border-radius: 5px; flex: none; }}
+        .cursor {{ position: absolute; left: 52%; top: 58%;
+                   filter: drop-shadow(0 1px 3px rgba(0,0,0,0.75)); }}
+        .app-row.is-omi {{ position: relative; }}
+        .drag {{ display: flex; align-items: center; gap: 14px; }}
+        .drag-app {{ border-radius: 14px; }}
+        .drag-arrow {{ width: 30px; height: 2px; background: #6a6a6e; position: relative; }}
+        .drag-arrow::after {{ content: ""; position: absolute; right: -2px; top: -4px;
+                              border: 5px solid transparent; border-left-color: #6a6a6e; }}
+        .drop-target {{ width: 84px; height: 84px; border-radius: 14px; display: flex;
+                        align-items: center; justify-content: center;
+                        border: 2px dashed #4a4a4e; }}
+        .win-file {{ display: flex; flex-direction: column; align-items: center; gap: 8px; }}
+        .win-file-glyph {{ width: 52px; height: 62px; border-radius: 6px; display: flex;
+                           align-items: center; justify-content: center; font-size: 11px;
+                           font-weight: 700; color: #4b5563;
+                           background: linear-gradient(160deg, #f4f4f6, #c9ccd6); }}
+        .win-file-name {{ font-size: 12px; color: #d0d0d4; }}
+        .win-dialog {{ width: 78%; border-radius: 9px; background: #1d1d1f;
+                       border: 1px solid #2f2f31; padding: 12px; text-align: left; }}
+        .win-dialog-title {{ font-size: 12px; color: #d0d0d4; margin-bottom: 8px; }}
+        .win-dialog-link {{ font-size: 11px; color: #6C8FFF; margin-bottom: 10px; }}
+        .win-dialog-run {{ display: inline-block; font-size: 11px; color: #fff; padding: 4px 10px;
+                           border-radius: 5px; background: #2f6bff; }}
+        @media (max-width: 720px) {{
+          .steps {{ grid-template-columns: 1fr; gap: 22px; }}
+          .step-art {{ height: 150px; }}
+        }}
+        .ph-badge {{ display: inline-block; margin-bottom: 28px; line-height: 0;
+                     opacity: 0.92; transition: opacity 0.15s ease; }}
+        .ph-badge:hover {{ opacity: 1; }}
+        .ph-badge img {{ width: 250px; height: 54px; }}
+        .discord {{ margin-top: 24px; font-size: 14px; color: #888; }}
+        .discord a {{ color: #5865F2; text-decoration: none; }}
+        .discord a:hover {{ text-decoration: underline; }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Downloading Omi {channel_label}for {os_name}</h1>
+        <p class="version">{version_display}</p>
+        {product_hunt_html}
+        {notice_html}
+        <p class="subtitle" id="status-text">Your download should start automatically&hellip;</p>
+        <div class="status" id="status-icon">
+            <div class="spinner"></div>
+            <div class="checkmark">&#10003;</div>
+        </div>
+        <p><a class="download-link" href="{dmg_url}">Click here if the download doesn&rsquo;t start</a></p>
+        <div class="video-container" id="demo-video">
+            <video autoplay muted loop playsinline>
+                <source src="https://storage.googleapis.com/omi_macos_updates/omi-demo.mp4" type="video/mp4">
+            </video>
+            <p class="video-label">See how Omi works</p>
+        </div>
+        <h2 class="steps-title">Just a few steps left</h2>
+        <p class="steps-sub">Takes about 20 seconds.</p>
+        <ol class="steps">{install_steps}</ol>
+        <p class="discord">Need help? Join our <a href="https://discord.com/invite/8MP3b9ymvx">Discord community</a></p>
+    </div>
+    <script>
+        setTimeout(function() {{
+            window.location.href = "{dmg_url}";
+            document.getElementById("status-icon").classList.add("done");
+            document.getElementById("status-text").textContent = "Download started!";
+            document.getElementById("demo-video").style.display = "block";
+        }}, 2000);
+    </script>
+</body>
+</html>"""

--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, HTTPException, Header, Query
 from fastapi.responses import Response, HTMLResponse
 from pydantic import BaseModel, ConfigDict, Field, StrictBool
 
+from desktop_download_page import download_landing_html
 from database.desktop_previews import delist_preview, get_current_preview, get_preview_manifest, publish_preview
 from database.desktop_update_channels import (
     admit_qualified_beta_manifest,
@@ -607,257 +608,6 @@ def _pick_windows_update_feed_entry(entries: List[Dict], channel: str) -> Option
     return None
 
 
-LANDING_ASSET_BASE = "https://storage.googleapis.com/omi_macos_updates/landing"
-
-_CURSOR_SVG = (
-    '<svg class="cursor" viewBox="0 0 12 18" width="12" height="18" aria-hidden="true">'
-    '<path d="M1 1l9.2 8.4-4.1.3 2.4 5-1.9.9-2.4-5-3.2 2.6z" fill="#fff" stroke="#000"'
-    ' stroke-width="1" stroke-linejoin="round"/></svg>'
-)
-
-
-def _install_steps_html(platform: str) -> str:
-    """Three illustrated install steps, drawn from real app chrome rather than a text list."""
-    if platform == "windows":
-        panels = [
-            (
-                '<div class="win-file"><div class="win-file-glyph">EXE</div>'
-                '<div class="win-file-name">omi-setup.exe</div></div>' + _CURSOR_SVG,
-                'Open <b>omi-setup.exe</b> from<br>your <b>Downloads</b> folder',
-            ),
-            (
-                '<div class="win-dialog"><div class="win-dialog-title">Windows protected your PC</div>'
-                '<div class="win-dialog-link">More info</div>'
-                '<div class="win-dialog-run">Run anyway</div></div>',
-                'If SmartScreen appears, click<br><b>More info</b> &rarr; <b>Run anyway</b>',
-            ),
-            (
-                '<div class="app-row is-omi"><img src="' + LANDING_ASSET_BASE + '/omi-icon.png"'
-                ' alt="" width="26" height="26"><span>Omi</span></div>'
-                '<div class="app-row"><span class="app-dot"></span><span>Start menu</span></div>',
-                'Launch <b>Omi</b> and finish<br>the setup wizard',
-            ),
-        ]
-    else:
-        panels = [
-            (
-                '<div class="finder">'
-                '<div class="finder-bar"><i></i><i></i><i></i><span>Downloads</span></div>'
-                '<div class="app-row is-omi"><span class="dmg-glyph"></span><span>omi.dmg</span>'
-                + _CURSOR_SVG
-                + '</div>'
-                '<div class="app-row"><span class="app-dot"></span><span>Screenshot.png</span></div>'
-                '</div>',
-                'Open <b>omi.dmg</b> from<br>your <b>Downloads</b> folder',
-            ),
-            (
-                '<div class="drag">'
-                '<img class="drag-app" src="' + LANDING_ASSET_BASE + '/omi-icon.png"'
-                ' alt="Omi" width="66" height="66">'
-                '<span class="drag-arrow"></span>'
-                '<span class="drop-target">'
-                '<img src="' + LANDING_ASSET_BASE + '/apps-folder.png" alt="Applications"'
-                ' width="60" height="60"></span>'
-                '</div>',
-                'Drag the <b>Omi</b> icon into<br>your <b>Applications</b> folder',
-            ),
-            (
-                '<div class="finder">'
-                '<div class="finder-bar"><i></i><i></i><i></i><span>Applications</span></div>'
-                '<div class="app-row"><span class="app-dot"></span><span>Notes</span></div>'
-                '<div class="app-row is-omi">'
-                '<img src="' + LANDING_ASSET_BASE + '/omi-icon.png" alt="" width="22" height="22">'
-                '<span>Omi</span></div>'
-                '<div class="app-row"><span class="app-dot"></span><span>Safari</span></div>'
-                '</div>',
-                'Open <b>Omi</b> from your<br><b>Applications</b> folder',
-            ),
-        ]
-
-    cards = []
-    for index, (art, caption) in enumerate(panels, start=1):
-        cards.append(
-            f'<li class="step"><span class="step-num">{index}</span>'
-            f'<div class="step-art">{art}</div>'
-            f'<p class="step-caption">{caption}</p></li>'
-        )
-    return "".join(cards)
-
-
-# Product Hunt launch badge for "Omi Desktop" — shown on the download landing page
-# only during the launch day, then it disappears on its own. Product Hunt days run
-# midnight-to-midnight Pacific, so the window closes at 2026-09-04 07:00 UTC (Sep 3 PDT).
-# One-time launch scaffolding: delete this constant, _product_hunt_badge_html, and its
-# tests once the launch window has passed.
-PRODUCT_HUNT_BADGE_ENDS_AT = datetime(2026, 9, 4, 7, 0, 0, tzinfo=timezone.utc)
-PRODUCT_HUNT_POST_URL = (
-    "https://www.producthunt.com/products/open-source-ai-necklace-friend?embed=true"
-    "&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-omi-desktop-2"
-)
-PRODUCT_HUNT_BADGE_IMAGE = "https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1240025&theme=dark"
-
-
-def _product_hunt_badge_html(now: Optional[datetime] = None) -> str:
-    """Render the Product Hunt badge while the launch window is open, else nothing.
-
-    Product Hunt bakes the upvote count into the SVG itself, so the embed snippet's
-    fixed `t` cache-buster would pin every visitor to whatever count was rendered the
-    first time they loaded the page. Bucketing `t` by the hour keeps the count moving
-    through the launch day without re-fetching the badge on every request.
-    """
-    current = now or datetime.now(timezone.utc)
-    if current >= PRODUCT_HUNT_BADGE_ENDS_AT:
-        return ""
-    hour_bucket = int(current.timestamp()) // 3600
-    return (
-        f'<a class="ph-badge" href="{PRODUCT_HUNT_POST_URL}" target="_blank" rel="noopener noreferrer">'
-        f'<img alt="Omi Desktop - Ask your Mac anything you saw or heard | Product Hunt" '
-        f'width="250" height="54" src="{PRODUCT_HUNT_BADGE_IMAGE}&t={hour_bucket}"></a>'
-    )
-
-
-def _download_landing_html(
-    dmg_url: str, channel: str = "stable", version: str = "", platform: str = "macos", notice: str = ""
-) -> str:
-    """Generate an HTML landing page that auto-triggers the installer download."""
-    channel_label = "Beta " if channel == "beta" else ""
-    version_display = f"v{version}" if version else ""
-    notice_html = f'<p class="notice">{notice}</p>' if notice else ""
-    product_hunt_html = _product_hunt_badge_html()
-    os_name = "Windows" if platform == "windows" else "macOS"
-    install_steps = _install_steps_html(platform)
-    return f"""<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Download Omi {channel_label}for {os_name}</title>
-    <meta http-equiv="refresh" content="2;url={dmg_url}">
-    <style>
-        * {{ margin: 0; padding: 0; box-sizing: border-box; }}
-        body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-               background: #0a0a0a; color: #fff; display: flex; align-items: center;
-               justify-content: center; min-height: 100vh; text-align: center; }}
-        .container {{ max-width: 960px; padding: 40px 24px; }}
-        h1 {{ font-size: 28px; font-weight: 600; margin-bottom: 12px; }}
-        .version {{ color: #555; font-size: 14px; margin-bottom: 24px; }}
-        .subtitle {{ color: #888; font-size: 16px; margin-bottom: 32px; }}
-        .status {{ width: 40px; height: 40px; margin: 0 auto 24px; position: relative; }}
-        .spinner {{ width: 40px; height: 40px; border: 3px solid #333; border-top-color: #fff;
-                    border-radius: 50%; animation: spin 0.8s linear infinite; }}
-        .checkmark {{ display: none; font-size: 36px; color: #4ade80; }}
-        .done .spinner {{ display: none; }}
-        .done .checkmark {{ display: block; }}
-        .done .subtitle {{ color: #4ade80; }}
-        @keyframes spin {{ to {{ transform: rotate(360deg); }} }}
-        .notice {{ color: #fbbf24; font-size: 14px; margin-bottom: 24px; }}
-        .download-link {{ color: #6C8FFF; text-decoration: none; font-size: 15px; }}
-        .download-link:hover {{ text-decoration: underline; }}
-        .video-container {{ margin-top: 32px; border-radius: 12px; overflow: hidden;
-                            background: #151515; display: none; }}
-        .video-container video {{ width: 100%; display: block; }}
-        .video-label {{ color: #888; font-size: 13px; padding: 12px 16px; text-align: center; }}
-        .steps {{ list-style: none; display: grid; grid-template-columns: repeat(3, 1fr);
-                  gap: 28px; margin-top: 40px; padding: 0; }}
-        .steps-title {{ font-size: 17px; font-weight: 600; color: #fff; margin-top: 44px; }}
-        .steps-sub {{ font-size: 13px; color: #666; margin-top: 6px; }}
-        .step {{ display: flex; flex-direction: column; align-items: center; }}
-        .step-num {{ width: 30px; height: 30px; border-radius: 50%; background: #f2f2f2;
-                     border: none; color: #0a0a0a; font-size: 14px; font-weight: 700;
-                     display: flex; align-items: center; justify-content: center;
-                     margin-bottom: 14px; font-variant-numeric: tabular-nums; }}
-        .step-art {{ position: relative; width: 100%; height: 168px; border-radius: 14px;
-                     background: #141414; border: 1px solid #232323; display: flex;
-                     align-items: center; justify-content: center; overflow: hidden; }}
-        .step-caption {{ margin-top: 14px; font-size: 13px; line-height: 1.55; color: #8a8a8a; }}
-        .step-caption b {{ color: #e6e6e6; font-weight: 600; }}
-        .finder {{ width: 86%; border-radius: 9px; overflow: hidden; background: #1d1d1f;
-                   border: 1px solid #2f2f31; text-align: left; }}
-        .finder-bar {{ display: flex; align-items: center; gap: 5px; padding: 7px 9px;
-                       background: #262628; border-bottom: 1px solid #333; }}
-        .finder-bar i {{ width: 7px; height: 7px; border-radius: 50%; background: #3f3f42; }}
-        .finder-bar span {{ margin-left: 6px; font-size: 10px; color: #8a8a8f;
-                            letter-spacing: 0.02em; }}
-        .finder-row, .app-row {{ display: flex; align-items: center; gap: 8px;
-                                 padding: 7px 10px; font-size: 12px; color: #d0d0d4; }}
-        .dmg-glyph {{ width: 20px; height: 20px; border-radius: 4px; flex: none;
-                      background: linear-gradient(160deg, #f4f4f6, #c9ccd6);
-                      box-shadow: inset 0 0 0 1px rgba(0,0,0,0.18); }}
-        .app-dot {{ width: 18px; height: 18px; border-radius: 5px; flex: none; background: #333336; }}
-        .app-row.is-omi {{ background: #2f6bff; color: #fff; border-radius: 5px;
-                           margin: 0 5px; font-weight: 500; }}
-        .app-row img, .finder-row img {{ border-radius: 5px; flex: none; }}
-        .cursor {{ position: absolute; left: 52%; top: 58%;
-                   filter: drop-shadow(0 1px 3px rgba(0,0,0,0.75)); }}
-        .app-row.is-omi {{ position: relative; }}
-        .drag {{ display: flex; align-items: center; gap: 14px; }}
-        .drag-app {{ border-radius: 14px; }}
-        .drag-arrow {{ width: 30px; height: 2px; background: #6a6a6e; position: relative; }}
-        .drag-arrow::after {{ content: ""; position: absolute; right: -2px; top: -4px;
-                              border: 5px solid transparent; border-left-color: #6a6a6e; }}
-        .drop-target {{ width: 84px; height: 84px; border-radius: 14px; display: flex;
-                        align-items: center; justify-content: center;
-                        border: 2px dashed #4a4a4e; }}
-        .win-file {{ display: flex; flex-direction: column; align-items: center; gap: 8px; }}
-        .win-file-glyph {{ width: 52px; height: 62px; border-radius: 6px; display: flex;
-                           align-items: center; justify-content: center; font-size: 11px;
-                           font-weight: 700; color: #4b5563;
-                           background: linear-gradient(160deg, #f4f4f6, #c9ccd6); }}
-        .win-file-name {{ font-size: 12px; color: #d0d0d4; }}
-        .win-dialog {{ width: 78%; border-radius: 9px; background: #1d1d1f;
-                       border: 1px solid #2f2f31; padding: 12px; text-align: left; }}
-        .win-dialog-title {{ font-size: 12px; color: #d0d0d4; margin-bottom: 8px; }}
-        .win-dialog-link {{ font-size: 11px; color: #6C8FFF; margin-bottom: 10px; }}
-        .win-dialog-run {{ display: inline-block; font-size: 11px; color: #fff; padding: 4px 10px;
-                           border-radius: 5px; background: #2f6bff; }}
-        @media (max-width: 720px) {{
-          .steps {{ grid-template-columns: 1fr; gap: 22px; }}
-          .step-art {{ height: 150px; }}
-        }}
-        .ph-badge {{ display: inline-block; margin-bottom: 28px; line-height: 0;
-                     opacity: 0.92; transition: opacity 0.15s ease; }}
-        .ph-badge:hover {{ opacity: 1; }}
-        .ph-badge img {{ width: 250px; height: 54px; }}
-        .discord {{ margin-top: 24px; font-size: 14px; color: #888; }}
-        .discord a {{ color: #5865F2; text-decoration: none; }}
-        .discord a:hover {{ text-decoration: underline; }}
-    </style>
-</head>
-<body>
-    <div class="container">
-        <h1>Downloading Omi {channel_label}for {os_name}</h1>
-        <p class="version">{version_display}</p>
-        {product_hunt_html}
-        {notice_html}
-        <p class="subtitle" id="status-text">Your download should start automatically&hellip;</p>
-        <div class="status" id="status-icon">
-            <div class="spinner"></div>
-            <div class="checkmark">&#10003;</div>
-        </div>
-        <p><a class="download-link" href="{dmg_url}">Click here if the download doesn&rsquo;t start</a></p>
-        <div class="video-container" id="demo-video">
-            <video autoplay muted loop playsinline>
-                <source src="https://storage.googleapis.com/omi_macos_updates/omi-demo.mp4" type="video/mp4">
-            </video>
-            <p class="video-label">See how Omi works</p>
-        </div>
-        <h2 class="steps-title">Just a few steps left</h2>
-        <p class="steps-sub">Takes about 20 seconds.</p>
-        <ol class="steps">{install_steps}</ol>
-        <p class="discord">Need help? Join our <a href="https://discord.com/invite/8MP3b9ymvx">Discord community</a></p>
-    </div>
-    <script>
-        setTimeout(function() {{
-            window.location.href = "{dmg_url}";
-            document.getElementById("status-icon").classList.add("done");
-            document.getElementById("status-text").textContent = "Download started!";
-            document.getElementById("demo-video").style.display = "block";
-        }}, 2000);
-    </script>
-</body>
-</html>"""
-
-
 def _preview_download_landing_html(manifest: Dict[str, Any]) -> str:
     """Render a public preview landing page from already-validated metadata.
 
@@ -1116,7 +866,7 @@ async def download_latest_desktop_release(
             if installer_url:
                 version = entry["version_info"]["version"]
                 return HTMLResponse(
-                    content=_download_landing_html(installer_url, channel=channel, version=version, platform=platform)
+                    content=download_landing_html(installer_url, channel=channel, version=version, platform=platform)
                 )
         raise HTTPException(status_code=404, detail=f"No installer found for platform {platform}, channel: {channel}")
 
@@ -1126,7 +876,7 @@ async def download_latest_desktop_release(
     entry, installer_url = picked
     version = entry["version_info"]["version"]
     return HTMLResponse(
-        content=_download_landing_html(installer_url, channel=channel, version=version, platform=platform)
+        content=download_landing_html(installer_url, channel=channel, version=version, platform=platform)
     )
 
 
@@ -1235,7 +985,7 @@ async def download_windows_desktop_release(
             f"No {channel} build is published right now &mdash; serving the latest {served_channel} release instead."
         )
     return HTMLResponse(
-        content=_download_landing_html(
+        content=download_landing_html(
             installer_url,
             channel=served_channel,
             version=entry["version_info"]["version"],

--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from html import escape as html_escape
 import hmac
 import hashlib
@@ -606,6 +607,115 @@ def _pick_windows_update_feed_entry(entries: List[Dict], channel: str) -> Option
     return None
 
 
+LANDING_ASSET_BASE = "https://storage.googleapis.com/omi_macos_updates/landing"
+
+_CURSOR_SVG = (
+    '<svg class="cursor" viewBox="0 0 12 18" width="12" height="18" aria-hidden="true">'
+    '<path d="M1 1l9.2 8.4-4.1.3 2.4 5-1.9.9-2.4-5-3.2 2.6z" fill="#fff" stroke="#000"'
+    ' stroke-width="1" stroke-linejoin="round"/></svg>'
+)
+
+
+def _install_steps_html(platform: str) -> str:
+    """Three illustrated install steps, drawn from real app chrome rather than a text list."""
+    if platform == "windows":
+        panels = [
+            (
+                '<div class="win-file"><div class="win-file-glyph">EXE</div>'
+                '<div class="win-file-name">omi-setup.exe</div></div>' + _CURSOR_SVG,
+                'Open <b>omi-setup.exe</b> from<br>your <b>Downloads</b> folder',
+            ),
+            (
+                '<div class="win-dialog"><div class="win-dialog-title">Windows protected your PC</div>'
+                '<div class="win-dialog-link">More info</div>'
+                '<div class="win-dialog-run">Run anyway</div></div>',
+                'If SmartScreen appears, click<br><b>More info</b> &rarr; <b>Run anyway</b>',
+            ),
+            (
+                '<div class="app-row is-omi"><img src="' + LANDING_ASSET_BASE + '/omi-icon.png"'
+                ' alt="" width="26" height="26"><span>Omi</span></div>'
+                '<div class="app-row"><span class="app-dot"></span><span>Start menu</span></div>',
+                'Launch <b>Omi</b> and finish<br>the setup wizard',
+            ),
+        ]
+    else:
+        panels = [
+            (
+                '<div class="finder">'
+                '<div class="finder-bar"><i></i><i></i><i></i><span>Downloads</span></div>'
+                '<div class="app-row is-omi"><span class="dmg-glyph"></span><span>omi.dmg</span>'
+                + _CURSOR_SVG
+                + '</div>'
+                '<div class="app-row"><span class="app-dot"></span><span>Screenshot.png</span></div>'
+                '</div>',
+                'Open <b>omi.dmg</b> from<br>your <b>Downloads</b> folder',
+            ),
+            (
+                '<div class="drag">'
+                '<img class="drag-app" src="' + LANDING_ASSET_BASE + '/omi-icon.png"'
+                ' alt="Omi" width="66" height="66">'
+                '<span class="drag-arrow"></span>'
+                '<span class="drop-target">'
+                '<img src="' + LANDING_ASSET_BASE + '/apps-folder.png" alt="Applications"'
+                ' width="60" height="60"></span>'
+                '</div>',
+                'Drag the <b>Omi</b> icon into<br>your <b>Applications</b> folder',
+            ),
+            (
+                '<div class="finder">'
+                '<div class="finder-bar"><i></i><i></i><i></i><span>Applications</span></div>'
+                '<div class="app-row"><span class="app-dot"></span><span>Notes</span></div>'
+                '<div class="app-row is-omi">'
+                '<img src="' + LANDING_ASSET_BASE + '/omi-icon.png" alt="" width="22" height="22">'
+                '<span>Omi</span></div>'
+                '<div class="app-row"><span class="app-dot"></span><span>Safari</span></div>'
+                '</div>',
+                'Open <b>Omi</b> from your<br><b>Applications</b> folder',
+            ),
+        ]
+
+    cards = []
+    for index, (art, caption) in enumerate(panels, start=1):
+        cards.append(
+            f'<li class="step"><span class="step-num">{index}</span>'
+            f'<div class="step-art">{art}</div>'
+            f'<p class="step-caption">{caption}</p></li>'
+        )
+    return "".join(cards)
+
+
+# Product Hunt launch badge for "Omi Desktop" — shown on the download landing page
+# only during the launch day, then it disappears on its own. Product Hunt days run
+# midnight-to-midnight Pacific, so the window closes at 2026-09-04 07:00 UTC (Sep 3 PDT).
+# One-time launch scaffolding: delete this constant, _product_hunt_badge_html, and its
+# tests once the launch window has passed.
+PRODUCT_HUNT_BADGE_ENDS_AT = datetime(2026, 9, 4, 7, 0, 0, tzinfo=timezone.utc)
+PRODUCT_HUNT_POST_URL = (
+    "https://www.producthunt.com/products/open-source-ai-necklace-friend?embed=true"
+    "&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-omi-desktop-2"
+)
+PRODUCT_HUNT_BADGE_IMAGE = "https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1240025&theme=dark"
+
+
+def _product_hunt_badge_html(now: Optional[datetime] = None) -> str:
+    """Render the Product Hunt badge while the launch window is open, else nothing.
+
+    Product Hunt bakes the upvote count into the SVG itself, so the embed snippet's
+    fixed `t` cache-buster would pin every visitor to whatever count was rendered the
+    first time they loaded the page. Bucketing `t` by the hour keeps the count moving
+    through the launch day without re-fetching the badge on every request.
+    """
+    current = now or datetime.now(timezone.utc)
+    if current >= PRODUCT_HUNT_BADGE_ENDS_AT:
+        return ""
+    hour_bucket = int(current.timestamp()) // 3600
+    return (
+        f'<a class="ph-badge" href="{PRODUCT_HUNT_POST_URL}" target="_blank" rel="noopener noreferrer">'
+        f'<img alt="Omi Desktop - Ask your Mac anything you saw or heard | Product Hunt" '
+        f'width="250" height="54" src="{PRODUCT_HUNT_BADGE_IMAGE}&t={hour_bucket}"></a>'
+    )
+
+
 def _download_landing_html(
     dmg_url: str, channel: str = "stable", version: str = "", platform: str = "macos", notice: str = ""
 ) -> str:
@@ -613,19 +723,9 @@ def _download_landing_html(
     channel_label = "Beta " if channel == "beta" else ""
     version_display = f"v{version}" if version else ""
     notice_html = f'<p class="notice">{notice}</p>' if notice else ""
+    product_hunt_html = _product_hunt_badge_html()
     os_name = "Windows" if platform == "windows" else "macOS"
-    if platform == "windows":
-        install_steps = (
-            "1. Open the downloaded installer (omi-setup.exe)<br>"
-            "2. If Windows SmartScreen appears, click <b>More info</b> &rarr; <b>Run anyway</b><br>"
-            "3. Follow the setup wizard and launch Omi"
-        )
-    else:
-        install_steps = (
-            "1. Open the downloaded .dmg file<br>"
-            "2. Drag Omi to your Applications folder<br>"
-            "3. Launch Omi from Applications"
-        )
+    install_steps = _install_steps_html(platform)
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -657,9 +757,67 @@ def _download_landing_html(
                             background: #151515; display: none; }}
         .video-container video {{ width: 100%; display: block; }}
         .video-label {{ color: #888; font-size: 13px; padding: 12px 16px; text-align: center; }}
-        .steps {{ color: #888; font-size: 13px; margin-top: 20px; line-height: 1.8; text-align: left;
-                  background: #151515; border-radius: 12px; padding: 20px 24px; }}
-        .steps b {{ color: #ccc; }}
+        .steps {{ list-style: none; display: grid; grid-template-columns: repeat(3, 1fr);
+                  gap: 28px; margin-top: 40px; padding: 0; }}
+        .steps-title {{ font-size: 17px; font-weight: 600; color: #fff; margin-top: 44px; }}
+        .steps-sub {{ font-size: 13px; color: #666; margin-top: 6px; }}
+        .step {{ display: flex; flex-direction: column; align-items: center; }}
+        .step-num {{ width: 30px; height: 30px; border-radius: 50%; background: #f2f2f2;
+                     border: none; color: #0a0a0a; font-size: 14px; font-weight: 700;
+                     display: flex; align-items: center; justify-content: center;
+                     margin-bottom: 14px; font-variant-numeric: tabular-nums; }}
+        .step-art {{ position: relative; width: 100%; height: 168px; border-radius: 14px;
+                     background: #141414; border: 1px solid #232323; display: flex;
+                     align-items: center; justify-content: center; overflow: hidden; }}
+        .step-caption {{ margin-top: 14px; font-size: 13px; line-height: 1.55; color: #8a8a8a; }}
+        .step-caption b {{ color: #e6e6e6; font-weight: 600; }}
+        .finder {{ width: 86%; border-radius: 9px; overflow: hidden; background: #1d1d1f;
+                   border: 1px solid #2f2f31; text-align: left; }}
+        .finder-bar {{ display: flex; align-items: center; gap: 5px; padding: 7px 9px;
+                       background: #262628; border-bottom: 1px solid #333; }}
+        .finder-bar i {{ width: 7px; height: 7px; border-radius: 50%; background: #3f3f42; }}
+        .finder-bar span {{ margin-left: 6px; font-size: 10px; color: #8a8a8f;
+                            letter-spacing: 0.02em; }}
+        .finder-row, .app-row {{ display: flex; align-items: center; gap: 8px;
+                                 padding: 7px 10px; font-size: 12px; color: #d0d0d4; }}
+        .dmg-glyph {{ width: 20px; height: 20px; border-radius: 4px; flex: none;
+                      background: linear-gradient(160deg, #f4f4f6, #c9ccd6);
+                      box-shadow: inset 0 0 0 1px rgba(0,0,0,0.18); }}
+        .app-dot {{ width: 18px; height: 18px; border-radius: 5px; flex: none; background: #333336; }}
+        .app-row.is-omi {{ background: #2f6bff; color: #fff; border-radius: 5px;
+                           margin: 0 5px; font-weight: 500; }}
+        .app-row img, .finder-row img {{ border-radius: 5px; flex: none; }}
+        .cursor {{ position: absolute; left: 52%; top: 58%;
+                   filter: drop-shadow(0 1px 3px rgba(0,0,0,0.75)); }}
+        .app-row.is-omi {{ position: relative; }}
+        .drag {{ display: flex; align-items: center; gap: 14px; }}
+        .drag-app {{ border-radius: 14px; }}
+        .drag-arrow {{ width: 30px; height: 2px; background: #6a6a6e; position: relative; }}
+        .drag-arrow::after {{ content: ""; position: absolute; right: -2px; top: -4px;
+                              border: 5px solid transparent; border-left-color: #6a6a6e; }}
+        .drop-target {{ width: 84px; height: 84px; border-radius: 14px; display: flex;
+                        align-items: center; justify-content: center;
+                        border: 2px dashed #4a4a4e; }}
+        .win-file {{ display: flex; flex-direction: column; align-items: center; gap: 8px; }}
+        .win-file-glyph {{ width: 52px; height: 62px; border-radius: 6px; display: flex;
+                           align-items: center; justify-content: center; font-size: 11px;
+                           font-weight: 700; color: #4b5563;
+                           background: linear-gradient(160deg, #f4f4f6, #c9ccd6); }}
+        .win-file-name {{ font-size: 12px; color: #d0d0d4; }}
+        .win-dialog {{ width: 78%; border-radius: 9px; background: #1d1d1f;
+                       border: 1px solid #2f2f31; padding: 12px; text-align: left; }}
+        .win-dialog-title {{ font-size: 12px; color: #d0d0d4; margin-bottom: 8px; }}
+        .win-dialog-link {{ font-size: 11px; color: #6C8FFF; margin-bottom: 10px; }}
+        .win-dialog-run {{ display: inline-block; font-size: 11px; color: #fff; padding: 4px 10px;
+                           border-radius: 5px; background: #2f6bff; }}
+        @media (max-width: 720px) {{
+          .steps {{ grid-template-columns: 1fr; gap: 22px; }}
+          .step-art {{ height: 150px; }}
+        }}
+        .ph-badge {{ display: inline-block; margin-bottom: 28px; line-height: 0;
+                     opacity: 0.92; transition: opacity 0.15s ease; }}
+        .ph-badge:hover {{ opacity: 1; }}
+        .ph-badge img {{ width: 250px; height: 54px; }}
         .discord {{ margin-top: 24px; font-size: 14px; color: #888; }}
         .discord a {{ color: #5865F2; text-decoration: none; }}
         .discord a:hover {{ text-decoration: underline; }}
@@ -669,6 +827,7 @@ def _download_landing_html(
     <div class="container">
         <h1>Downloading Omi {channel_label}for {os_name}</h1>
         <p class="version">{version_display}</p>
+        {product_hunt_html}
         {notice_html}
         <p class="subtitle" id="status-text">Your download should start automatically&hellip;</p>
         <div class="status" id="status-icon">
@@ -682,10 +841,9 @@ def _download_landing_html(
             </video>
             <p class="video-label">See how Omi works</p>
         </div>
-        <div class="steps">
-            <b>Installation steps:</b><br>
-            {install_steps}
-        </div>
+        <h2 class="steps-title">Just a few steps left</h2>
+        <p class="steps-sub">Takes about 20 seconds.</p>
+        <ol class="steps">{install_steps}</ol>
         <p class="discord">Need help? Join our <a href="https://discord.com/invite/8MP3b9ymvx">Discord community</a></p>
     </div>
     <script>

--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -1,4 +1,3 @@
-from datetime import datetime, timezone
 from html import escape as html_escape
 import hmac
 import hashlib

--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -1,5 +1,6 @@
 """Tests for desktop update system (appcast XML, channel filtering, download endpoint)."""
 
+from datetime import timedelta
 import xml.etree.ElementTree as ET
 from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
@@ -19,7 +20,11 @@ from routers.updates import (
     _get_windows_update_feed_url,
     _parse_changelog_to_changes,
     _parse_desktop_version,
+    _download_landing_html,
+    _install_steps_html,
     _preview_download_landing_html,
+    _product_hunt_badge_html,
+    PRODUCT_HUNT_BADGE_ENDS_AT,
     _xml_attr,
     router as updates_router,
 )
@@ -1944,3 +1949,57 @@ class TestBetaIdentityServing:
 
         assert resp.status_code == 404
         assert "omi.dmg" not in resp.text
+
+
+class TestDownloadLandingInstallSteps:
+    """The landing page's install guidance is illustrated cards, not a text list."""
+
+    def test_macos_steps_name_the_dmg_the_drag_and_the_launch(self):
+        html = _install_steps_html("macos")
+
+        assert html.count('class="step"') == 3
+        assert "omi.dmg" in html
+        assert "Applications" in html
+        # The old plain-text list is gone: no "1." / "2." prefixes, no <br> ladder.
+        assert "1. Open the downloaded" not in html
+
+    def test_windows_steps_cover_smartscreen(self):
+        html = _install_steps_html("windows")
+
+        assert html.count('class="step"') == 3
+        assert "omi-setup.exe" in html
+        assert "Run anyway" in html
+
+    def test_landing_page_renders_the_steps_below_the_video(self):
+        html = _download_landing_html("https://example.com/omi.dmg", version="0.12.264")
+
+        assert html.index('id="demo-video"') < html.index('class="steps"')
+        assert "Installation steps:" not in html
+
+
+class TestProductHuntBadge:
+    """Launch-day badge: visible during the window, gone afterwards, no code change needed."""
+
+    def test_badge_renders_during_the_launch_window(self):
+        html = _product_hunt_badge_html(PRODUCT_HUNT_BADGE_ENDS_AT - timedelta(hours=1))
+
+        assert "post_id=1240025" in html
+        assert 'rel="noopener noreferrer"' in html
+
+    def test_badge_disappears_once_the_window_closes(self):
+        assert _product_hunt_badge_html(PRODUCT_HUNT_BADGE_ENDS_AT) == ""
+        assert _product_hunt_badge_html(PRODUCT_HUNT_BADGE_ENDS_AT + timedelta(days=1)) == ""
+
+    def test_badge_cache_buster_advances_with_the_hour(self):
+        # Product Hunt bakes the vote count into the SVG, so a fixed `t` would freeze it.
+        first = _product_hunt_badge_html(PRODUCT_HUNT_BADGE_ENDS_AT - timedelta(hours=3))
+        second = _product_hunt_badge_html(PRODUCT_HUNT_BADGE_ENDS_AT - timedelta(hours=2))
+
+        assert first != second
+
+    def test_landing_page_drops_the_badge_after_the_window(self):
+        html = _download_landing_html("https://example.com/omi.dmg", version="0.12.264")
+
+        # Renders today; the gate is exercised directly above. Guard the markup contract
+        # so a future edit cannot leave a dangling empty anchor behind.
+        assert html.count('class="ph-badge"') <= 1

--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -20,13 +20,15 @@ from routers.updates import (
     _get_windows_update_feed_url,
     _parse_changelog_to_changes,
     _parse_desktop_version,
-    _download_landing_html,
-    _install_steps_html,
     _preview_download_landing_html,
-    _product_hunt_badge_html,
-    PRODUCT_HUNT_BADGE_ENDS_AT,
     _xml_attr,
     router as updates_router,
+)
+from desktop_download_page import (
+    PRODUCT_HUNT_BADGE_ENDS_AT,
+    download_landing_html,
+    install_steps_html,
+    product_hunt_badge_html,
 )
 from database.desktop_update_policy import get_desktop_update_policy
 
@@ -1955,7 +1957,7 @@ class TestDownloadLandingInstallSteps:
     """The landing page's install guidance is illustrated cards, not a text list."""
 
     def test_macos_steps_name_the_dmg_the_drag_and_the_launch(self):
-        html = _install_steps_html("macos")
+        html = install_steps_html("macos")
 
         assert html.count('class="step"') == 3
         assert "omi.dmg" in html
@@ -1964,14 +1966,14 @@ class TestDownloadLandingInstallSteps:
         assert "1. Open the downloaded" not in html
 
     def test_windows_steps_cover_smartscreen(self):
-        html = _install_steps_html("windows")
+        html = install_steps_html("windows")
 
         assert html.count('class="step"') == 3
         assert "omi-setup.exe" in html
         assert "Run anyway" in html
 
     def test_landing_page_renders_the_steps_below_the_video(self):
-        html = _download_landing_html("https://example.com/omi.dmg", version="0.12.264")
+        html = download_landing_html("https://example.com/omi.dmg", version="0.12.264")
 
         assert html.index('id="demo-video"') < html.index('class="steps"')
         assert "Installation steps:" not in html
@@ -1981,24 +1983,24 @@ class TestProductHuntBadge:
     """Launch-day badge: visible during the window, gone afterwards, no code change needed."""
 
     def test_badge_renders_during_the_launch_window(self):
-        html = _product_hunt_badge_html(PRODUCT_HUNT_BADGE_ENDS_AT - timedelta(hours=1))
+        html = product_hunt_badge_html(PRODUCT_HUNT_BADGE_ENDS_AT - timedelta(hours=1))
 
         assert "post_id=1240025" in html
         assert 'rel="noopener noreferrer"' in html
 
     def test_badge_disappears_once_the_window_closes(self):
-        assert _product_hunt_badge_html(PRODUCT_HUNT_BADGE_ENDS_AT) == ""
-        assert _product_hunt_badge_html(PRODUCT_HUNT_BADGE_ENDS_AT + timedelta(days=1)) == ""
+        assert product_hunt_badge_html(PRODUCT_HUNT_BADGE_ENDS_AT) == ""
+        assert product_hunt_badge_html(PRODUCT_HUNT_BADGE_ENDS_AT + timedelta(days=1)) == ""
 
     def test_badge_cache_buster_advances_with_the_hour(self):
         # Product Hunt bakes the vote count into the SVG, so a fixed `t` would freeze it.
-        first = _product_hunt_badge_html(PRODUCT_HUNT_BADGE_ENDS_AT - timedelta(hours=3))
-        second = _product_hunt_badge_html(PRODUCT_HUNT_BADGE_ENDS_AT - timedelta(hours=2))
+        first = product_hunt_badge_html(PRODUCT_HUNT_BADGE_ENDS_AT - timedelta(hours=3))
+        second = product_hunt_badge_html(PRODUCT_HUNT_BADGE_ENDS_AT - timedelta(hours=2))
 
         assert first != second
 
     def test_landing_page_drops_the_badge_after_the_window(self):
-        html = _download_landing_html("https://example.com/omi.dmg", version="0.12.264")
+        html = download_landing_html("https://example.com/omi.dmg", version="0.12.264")
 
         # Renders today; the gate is exercised directly above. Guard the markup contract
         # so a future edit cannot leave a dangling empty anchor behind.


### PR DESCRIPTION
## What

Two changes to the desktop download landing page (`/v2/desktop/download/latest`).

**1. Install steps are illustrated cards now, not a text block.** The page ended in a grey box titled "Installation steps:" holding a `1./2./3.` list joined by `<br>`. It now renders three cards below the demo video, drawn with the real Omi app icon and the macOS Applications folder icon: open `omi.dmg` from Downloads, drag Omi into Applications, open Omi from Applications. Windows keeps the same three-card shape with the SmartScreen step it actually needs.

**2. Product Hunt badge for the launch, above the fold.** It is gated on a launch-window constant and renders nothing once the window closes, so it takes itself down instead of needing a follow-up PR.

Two details worth calling out:

- The badge URL's cache-buster is bucketed by the hour rather than using the embed snippet's fixed `t=1788421572228`. Product Hunt bakes the vote count into the SVG itself, so a fixed value pins every visitor to whatever count was rendered when they first loaded the page.
- The count currently renders as `???` because Product Hunt has not made post `1240025` live yet. Other post ids return real numbers through the same widget, so this is the post's state and not a broken embed; it fills in on its own at launch.

The second commit moves the landing-page HTML into `backend/desktop_download_page.py`. `routers/updates.py` crossed the product file line-count ratchet, and the appcast routing and the marketing page change for unrelated reasons, so they get separate modules rather than a line-count exception. Every in-tree caller moved in the same commit and no aliases stay behind. `routers/updates.py`: 1539 → 1290 lines.

## Product invariants

- **INV-BETA-1** — matched by path glob on `backend/routers/updates.py`. Behavior unchanged: this PR only touches the HTML the download landing page returns. Beta app identity, the packaged beta artifacts, and the identity-aware appcast feed are untouched, and the 135 tests in `test_desktop_updates.py` (which cover the identity-aware feed) still pass.

## Verification

Exercised the real endpoint rather than the template: called `GET /v2/desktop/download/latest?platform=macos&channel=stable` through the ASGI app with the GitHub release fetch stubbed, then rendered the exact response body in headless Chrome. Re-ran this after the module split, not just before it.

- 1100px: badge renders, three cards render, old list gone (`"Installation steps:" not in response`)
- 500px: cards stack to one column; an in-page overflow probe reports `scrollWidth == clientWidth` with zero elements past the viewport edge
- Both landing assets return HTTP 200 from the same public bucket the page already uses for its demo video
- `backend/tests/unit/test_desktop_updates.py`: **135 passed**
- `make preflight`: all manifest checks pass

New tests cover what can silently rot: the three macOS steps, the Windows SmartScreen step, steps rendering after the video, badge present inside the window, badge empty at and after the window boundary, and the cache-buster advancing with the hour.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

