### PR TITLE
fix(backend): red-proof deletion-fence read errors and revert dormant plane splits

### DIFF
--- a/backend/database/first_open_obligations.py
+++ b/backend/database/first_open_obligations.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
-from database._client import get_data_plane_firestore_client, run_transactional
+from database._client import get_firestore_client, run_transactional
 from database.account_deletion_policy import account_deletion_blocks_access, normalize_account_deletion_status
 from database.firestore_index_registry import FIRST_OPEN_FOLDER_CONVERSATION_COUNT_QUERY
 from database.read_boundary import parse_snapshot_strict
@@ -91,7 +91,7 @@ def _conversation_ref(client: Any, uid: str, conversation_id: str) -> Any:
 
 
 def initialize_first_open_work(uid: str, conversation_id: str, *, firestore_client: Any = None) -> bool:
-    client = firestore_client or get_data_plane_firestore_client()
+    client = firestore_client or get_firestore_client()
     ref = _conversation_ref(client, uid, conversation_id)
 
     @firestore.transactional
@@ -137,7 +137,7 @@ def _live_effect(snapshot: Any, control: Optional[MemoryControlState], token: st
 def first_open_effect_is_authorized(
     uid: str, conversation_id: str, token: str, effect: str, *, firestore_client: Any = None
 ) -> bool:
-    client = firestore_client or get_data_plane_firestore_client()
+    client = firestore_client or get_firestore_client()
     ref = _conversation_ref(client, uid, conversation_id)
 
     @firestore.transactional
@@ -159,7 +159,7 @@ def commit_first_open_conversation_patch(
 ) -> bool:
     if not patch:
         return False
-    client = firestore_client or get_data_plane_firestore_client()
+    client = firestore_client or get_firestore_client()
     ref = _conversation_ref(client, uid, conversation_id)
 
     @firestore.transactional
@@ -185,7 +185,7 @@ def commit_first_open_app_result(
     """Persist an app result and its resumable receipt in one transaction."""
     if not app_id or not patch:
         return False
-    client = firestore_client or get_data_plane_firestore_client()
+    client = firestore_client or get_firestore_client()
     ref = _conversation_ref(client, uid, conversation_id)
 
     @firestore.transactional
@@ -227,7 +227,7 @@ def complete_first_open_effect(
 ) -> bool:
     if effect not in FIRST_OPEN_EFFECTS:
         raise ValueError(f'unknown first-open effect: {effect}')
-    client = firestore_client or get_data_plane_firestore_client()
+    client = firestore_client or get_firestore_client()
     ref = _conversation_ref(client, uid, conversation_id)
 
     @firestore.transactional
@@ -272,7 +272,7 @@ def complete_first_open_effect(
 def commit_first_open_folder_count(
     uid: str, conversation_id: str, token: str, folder_id: str, *, firestore_client: Any = None
 ) -> bool:
-    client = firestore_client or get_data_plane_firestore_client()
+    client = firestore_client or get_firestore_client()
     user = client.collection('users').document(uid)
     query = FIRST_OPEN_FOLDER_CONVERSATION_COUNT_QUERY.build(
         user.collection(CONVERSATIONS_COLLECTION),
@@ -305,7 +305,7 @@ def commit_first_open_app_usage(
     *,
     firestore_client: Any = None,
 ) -> bool:
-    client = firestore_client or get_data_plane_firestore_client()
+    client = firestore_client or get_firestore_client()
     conversation_ref = _conversation_ref(client, uid, conversation_id)
     plugin_ref = client.collection('plugins_data').document(app_id)
     usage_ref = client.collection('plugins').document(app_id).collection('usage_history').document(conversation_id)
@@ -359,7 +359,7 @@ def claim_first_open_work(
     now: Optional[datetime] = None,
     firestore_client: Any = None,
 ) -> Optional[str]:
-    client = firestore_client or get_data_plane_firestore_client()
+    client = firestore_client or get_firestore_client()
     ref = _conversation_ref(client, uid, conversation_id)
     current_time = now or datetime.now(timezone.utc)
     token = str(uuid.uuid4())
@@ -413,7 +413,7 @@ def finish_first_open_work(
     firestore_client: Any = None,
 ) -> bool:
     del succeeded
-    client = firestore_client or get_data_plane_firestore_client()
+    client = firestore_client or get_firestore_client()
     ref = _conversation_ref(client, uid, conversation_id)
 
     @firestore.transactional

--- a/backend/database/goals.py
+++ b/backend/database/goals.py
@@ -39,7 +39,7 @@ TASK_INTELLIGENCE_CONTROL_COLLECTION = 'task_intelligence_control'
 TASK_INTELLIGENCE_CONTROL_DOCUMENT = 'state'
 MUTATION_RECEIPTS_COLLECTION = 'workflow_mutation_receipts'
 # Legacy test/call-site compatibility only; new persistence paths use _get_db().
-db = getattr(_client, 'data_plane_db', _client.db)
+db = _client.db
 
 
 class GoalStoreError(RuntimeError):
@@ -57,8 +57,8 @@ class GoalConflictError(GoalStoreError):
 def _get_db(firestore_client: Any = None) -> Any:
     if firestore_client is not None:
         return firestore_client
-    getter = getattr(_client, 'get_data_plane_firestore_client', None)
-    return getter() if getter is not None else db
+    getter = getattr(_client, 'get_firestore_client', None)
+    return getter() if getter is not None else _client.db
 
 
 def _goal_ref(uid: str, goal_id: str, *, firestore_client: Any = None):

--- a/backend/tests/unit/test_account_deletion_auth_fence.py
+++ b/backend/tests/unit/test_account_deletion_auth_fence.py
@@ -168,3 +168,39 @@ def test_auth_fence_fails_closed_when_the_data_plane_client_cannot_be_resolved(m
 
     assert error.value.status_code == 503
     assert error.value.detail == {"code": "account_deletion_state_unavailable", "retryable": True}
+
+
+class _RaisingGetClient:
+    """Resolved data-plane client whose document get() fails after the client is already in hand."""
+
+    def collection(self, name):
+        document = MagicMock()
+        document.get.side_effect = RuntimeError("firestore ServiceUnavailable")
+        collection = MagicMock()
+        collection.document.return_value = document
+        return collection
+
+
+def test_auth_fence_fails_closed_when_the_resolved_data_plane_read_raises(monkeypatch):
+    """A timeout/ServiceUnavailable after client resolution must be HTTP 503, not a clean miss.
+
+    The production marker has no except around snapshot.get(). Swallowing only that
+    get() into None is the mutation this test is for: the fence would then allow.
+    """
+    compute_plane = _PlaneClient({})
+    data_plane = _RaisingGetClient()
+
+    monkeypatch.setattr(users, "get_firestore_client", lambda: compute_plane)
+    monkeypatch.setattr(users, "get_data_plane_firestore_client", lambda: data_plane, raising=False)
+    monkeypatch.setattr("database._client.get_firestore_client", lambda: compute_plane)
+    monkeypatch.setattr("database._client.get_data_plane_firestore_client", lambda: data_plane)
+    monkeypatch.setattr(
+        "database.account_deletion_marker.get_data_plane_firestore_client", lambda: data_plane, raising=False
+    )
+    monkeypatch.setattr("database.account_deletion_marker.get_firestore_client", lambda: compute_plane, raising=False)
+
+    with pytest.raises(HTTPException) as error:
+        endpoints.enforce_account_deletion_http_access("old-uid")
+
+    assert error.value.status_code == 503
+    assert error.value.detail == {"code": "account_deletion_state_unavailable", "retryable": True}

--- a/backend/tests/unit/test_agent_vm_firebase_project_split.py
+++ b/backend/tests/unit/test_agent_vm_firebase_project_split.py
@@ -157,3 +157,40 @@ def test_desktop_chat_quota_reads_customer_firestore_without_provisioning() -> N
     assert "provision=False" in quota_source
     assert "get_customer_firestore_client()" in paywall_source
     assert "provision=False" in paywall_source
+
+
+def test_screen_vector_entitlement_reads_customer_firestore_without_provisioning() -> None:
+    import inspect
+
+    from utils.subscription import grants_cloud_screen_vectors
+
+    source = inspect.getsource(grants_cloud_screen_vectors)
+    assert "get_customer_firestore_client()" in source
+    assert "provision=False" in source
+
+
+def test_screen_vector_entitlement_does_not_write_when_customer_subscription_doc_is_missing(monkeypatch) -> None:
+    from database import users as users_db
+    from models.users import PlanType
+    from utils.subscription import grants_cloud_screen_vectors
+    import utils.subscription as subscription
+
+    uid = "uid-missing-customer-subscription"
+    subscription.clear_cloud_screen_vector_entitlement_cache(uid)
+
+    user_ref = MagicMock()
+    snapshot = MagicMock()
+    snapshot.exists = False
+    user_ref.get.return_value = snapshot
+    customer_client = MagicMock()
+    customer_client.collection.return_value.document.return_value = user_ref
+
+    monkeypatch.setattr(subscription, "get_customer_firestore_client", lambda: customer_client)
+
+    entitled = grants_cloud_screen_vectors(uid)
+    stored = users_db.get_user_valid_subscription(uid, firestore_client=customer_client, provision=False)
+
+    assert entitled is False
+    assert stored is not None
+    assert stored.plan == PlanType.basic
+    user_ref.set.assert_not_called()

--- a/backend/tests/unit/test_conversation_archive_filter_contract.py
+++ b/backend/tests/unit/test_conversation_archive_filter_contract.py
@@ -151,10 +151,8 @@ def conversations_db():
 
     database_client = ModuleType("database._client")
     database_client.db = firestore
-    database_client.data_plane_db = firestore
     database_client.delete_collection_recursive = MagicMock()
     database_client.get_firestore_client = MagicMock()
-    database_client.get_data_plane_firestore_client = lambda: firestore
     database_client.run_transactional = MagicMock()
     firestore_read_metrics = ModuleType("database.firestore_read_metrics")
     firestore_read_metrics.FirestoreReadOutcome = SimpleNamespace(HIT="hit", MISS="miss")

--- a/backend/tests/unit/test_goals_id_fallback.py
+++ b/backend/tests/unit/test_goals_id_fallback.py
@@ -26,8 +26,6 @@ def goals():
     """Fresh database.goals against a stubbed database._client + firestore chain."""
     client_stub = ModuleType("database._client")
     client_stub.db = MagicMock(name="db")
-    client_stub.data_plane_db = client_stub.db
-    client_stub.get_data_plane_firestore_client = lambda: client_stub.db
     client_stub.document_id_from_seed = MagicMock(return_value="doc-id")
 
     firestore_stub = ModuleType("google.cloud.firestore")

--- a/backend/tests/unit/test_goals_sort_missing_created_at.py
+++ b/backend/tests/unit/test_goals_sort_missing_created_at.py
@@ -31,8 +31,6 @@ def goals():
     """Load a fresh database.goals against a stubbed database._client + firestore chain."""
     client_stub = ModuleType("database._client")
     client_stub.db = MagicMock(name="db")
-    client_stub.data_plane_db = client_stub.db
-    client_stub.get_data_plane_firestore_client = lambda: client_stub.db
 
     firestore_stub = ModuleType("google.cloud.firestore")
     firestore_stub.FieldFilter = MagicMock()

--- a/backend/tests/unit/test_knowledge_ledger_tools.py
+++ b/backend/tests/unit/test_knowledge_ledger_tools.py
@@ -156,7 +156,7 @@ def test_read_current_playbook_applies_chat_visibility_and_ledger_semantics(monk
 def test_tools_are_owner_scoped_bounded_and_fail_closed(monkeypatch):
     import database._client as database_client
 
-    monkeypatch.setattr(database_client, "get_data_plane_firestore_client", lambda: "db")
+    monkeypatch.setattr(database_client, "get_firestore_client", lambda: "db")
     monkeypatch.setattr(
         tools,
         "search_current_knowledge",
@@ -268,7 +268,7 @@ def test_search_historical_facts_is_fact_only_owner_scoped_and_partial(monkeypat
                 next_offset=8,
             )
 
-    monkeypatch.setattr(database_client, "get_data_plane_firestore_client", lambda: "db")
+    monkeypatch.setattr(database_client, "get_firestore_client", lambda: "db")
     monkeypatch.setattr(tools, "MemoryService", FakeService)
 
     result = tools.search_historical_facts.invoke(
@@ -325,7 +325,7 @@ def test_historical_fact_renderer_hard_cap_preserves_both_disclosures():
 def test_search_historical_facts_rejects_unsearchable_and_oversized_requests(monkeypatch):
     import database._client as database_client
 
-    monkeypatch.setattr(database_client, "get_data_plane_firestore_client", lambda: "db")
+    monkeypatch.setattr(database_client, "get_firestore_client", lambda: "db")
     service = SimpleNamespace(search_ledger_history_page=MagicMock())
     service.search_ledger_history_page.side_effect = ValueError("historical ledger query must contain a token")
     monkeypatch.setattr(tools, "MemoryService", lambda *, db_client: service)
@@ -373,7 +373,7 @@ def test_search_historical_facts_requires_explicit_rejected_audit(monkeypatch):
                 next_offset=None,
             )
 
-    monkeypatch.setattr(database_client, "get_data_plane_firestore_client", lambda: "db")
+    monkeypatch.setattr(database_client, "get_firestore_client", lambda: "db")
     monkeypatch.setattr(tools, "MemoryService", FakeService)
 
     result = tools.search_historical_facts.invoke(
@@ -392,7 +392,7 @@ def test_tool_errors_do_not_echo_storage_details(monkeypatch):
     def unavailable():
         raise RuntimeError("private-project users/u1/memory_items")
 
-    monkeypatch.setattr(database_client, "get_data_plane_firestore_client", unavailable)
+    monkeypatch.setattr(database_client, "get_firestore_client", unavailable)
     config = {"configurable": {"user_id": "u1"}}
     assert tools.search_knowledge.invoke({"query": "release"}, config=config) == "Error searching current knowledge"
     assert tools.read_playbook.invoke({"memory_id": "mem_playbook"}, config=config) == "Playbook unavailable."
@@ -401,7 +401,7 @@ def test_tool_errors_do_not_echo_storage_details(monkeypatch):
 def test_read_playbook_bounds_malformed_stored_content(monkeypatch):
     import database._client as database_client
 
-    monkeypatch.setattr(database_client, "get_data_plane_firestore_client", lambda: "db")
+    monkeypatch.setattr(database_client, "get_firestore_client", lambda: "db")
     oversized = _playbook().model_copy(
         update={
             "content": "d" * (tools.MAX_PLAYBOOK_DESCRIPTION_CHARACTERS + 20),

--- a/backend/utils/retrieval/tools/knowledge_ledger_tools.py
+++ b/backend/utils/retrieval/tools/knowledge_ledger_tools.py
@@ -322,14 +322,14 @@ def search_knowledge(
         return "Error: User ID not found in configuration"
 
     try:
-        from database._client import get_data_plane_firestore_client
+        from database._client import get_firestore_client
 
         rows = search_current_knowledge(
             uid,
             normalized_query,
             kinds=parsed_kinds,
             limit=limit,
-            db_client=get_data_plane_firestore_client(),
+            db_client=get_firestore_client(),
         )
         return _format_search_results(rows, query=normalized_query)
     except Exception as exc:
@@ -374,9 +374,9 @@ def search_historical_facts(
         return "Error: User ID not found in configuration"
 
     try:
-        from database._client import get_data_plane_firestore_client
+        from database._client import get_firestore_client
 
-        page = MemoryService(db_client=get_data_plane_firestore_client()).search_ledger_history_page(
+        page = MemoryService(db_client=get_firestore_client()).search_ledger_history_page(
             uid,
             normalized_query,
             limit=limit,
@@ -426,9 +426,9 @@ def read_playbook(
         return "Error: User ID not found in configuration"
 
     try:
-        from database._client import get_data_plane_firestore_client
+        from database._client import get_firestore_client
 
-        item = read_current_playbook(uid, normalized_id, db_client=get_data_plane_firestore_client())
+        item = read_current_playbook(uid, normalized_id, db_client=get_firestore_client())
         if item is None:
             return "Playbook unavailable."
         description = " ".join((item.content or "").split())[:MAX_PLAYBOOK_DESCRIPTION_CHARACTERS]


### PR DESCRIPTION
## What changed and why

Follow-up to merged #12667. The deletion fence itself is on `main`. The adversarial review of that PR found no blocking defect; this change lands the two remaining should-fix guards and stops creating dormant plane splits.

Writers and readers of `account_deletions/{uid}` already share `account_deletion_firestore_client()` → `get_data_plane_firestore_client()`. A resolved-client Firestore **read** error (timeout, `ServiceUnavailable`) already propagated to HTTP 503, but swallowing only `snapshot.get()` into `None` left every fence test green. This PR drives `enforce_account_deletion_http_access` through the real `get_user_deletion_wipe_status` with a resolved data-plane client whose `.collection().document().get()` raises, and asserts 503.

`grants_cloud_screen_vectors` already called `get_user_valid_subscription(..., firestore_client=get_customer_firestore_client(), provision=False)`. Flipping `provision` back to `True` JIT-writes `plan: basic` onto a missing customer subscription doc, and no test failed on that flip. This PR adds a source pin and a behavioral test: a missing subscription doc with the customer client must not call `user_ref.set` and must resolve to basic. Lookup exceptions still fail open.

#12667 also pinned `first_open_obligations.py`, `goals.py`, and the three `get_data_plane_firestore_client()` injections in `knowledge_ledger_tools.py`. Those modules are unreachable from desktop-backend, and their sibling readers/writers of the same collections still default to the compute client. This PR restores their `origin/main` (pre-#12667) behaviour exactly, including the test-stub exports that existed only for those pins, so those three do not land as dormant `FC-plane-seam-adopted-by-reader-not-writer` splits. Every other pin from #12667 stays.

## Product invariants affected

none

## How it was verified

- `test_auth_fence_fails_closed_when_the_resolved_data_plane_read_raises` drives `enforce_account_deletion_http_access` → the real `get_user_deletion_wipe_status` in `account_deletion_marker.py` with a resolved data-plane client whose `.get()` raises, and asserts HTTP 503. Baseline with the new test: `16 passed`.
- Red-proof (review §6 mutation a2: wrap only `snapshot.get()` in `except Exception: return None`):

```
FAILED tests/unit/test_account_deletion_auth_fence.py::test_auth_fence_fails_closed_when_the_resolved_data_plane_read_raises
Failed: DID NOT RAISE <class 'fastapi.exceptions.HTTPException'>
1 failed, 15 passed in 0.29s
```

The other 15 fence tests stay green on that swallow. Restoring the uncaught `.get()` returns `16 passed`.
- `test_screen_vector_entitlement_does_not_write_when_customer_subscription_doc_is_missing` drives `grants_cloud_screen_vectors` with a customer client whose `users/{uid}` doc is missing; `user_ref.set` is not called and the in-memory plan is `PlanType.basic` (not entitled). `test_screen_vector_entitlement_reads_customer_firestore_without_provisioning` source-pins `get_customer_firestore_client()` and `provision=False`. Flipping `provision=False` back to `True`:

```
FAILED test_screen_vector_entitlement_reads_customer_firestore_without_provisioning
assert 'provision=False' in source
FAILED test_screen_vector_entitlement_does_not_write_when_customer_subscription_doc_is_missing
AssertionError: Expected 'set' to not have been called. Called 1 times.
2 failed in 1.94s
```

Lookup exceptions still fail open (`test_the_entitlement_gate_fails_open`).
- CI-shaped backend unit run: `cd backend && BACKEND_PYTEST_FILE_ISOLATION=1 bash scripts/run-unit-ci.sh --changed-files <changed-files>`. `first_open_obligations.py` selects the full backend unit suite. `test_mentor_notifications.py::test_process_mentor_proactive_notification_sends` hangs past 90s on this branch **and** on current `origin/main` `77575a8f7f` (unmocked `current_date_for_uid` → live `db.collection('users')` with ADC); it is not this change.
- Pyright on the changed backend production files: 0 errors.
- Line-count ratchet: `OK: no unapproved line-count increase across 3 changed product source file(s).` No `Line-Count-Exception` (the #12667 `subscription.py` 1680→1682 growth is already on `main`).

Could not exercise a live Beta request against production Firestore (no production access). The two-plane unit test remains the behavioral stand-in for that path.

## Tests

- `test_auth_fence_fails_closed_when_the_resolved_data_plane_read_raises`
- `test_screen_vector_entitlement_reads_customer_firestore_without_provisioning`
- `test_screen_vector_entitlement_does_not_write_when_customer_subscription_doc_is_missing`

Existing fence, cutover, BYOK, goals, first-open, and knowledge-ledger tests keep their importer-binding patches. The goals / first-open / knowledge-ledger isolation stubs no longer export `get_data_plane_firestore_client` because those modules no longer import it.

## Failure class (fixes)

Failure-Class: FC-plane-seam-adopted-by-reader-not-writer

## Rollback hazards

- Reverting the three unreachable pins restores pre-#12667 compute defaults for first-open, goals, and knowledge-ledger **read** tools. On GKE with `SERVICE_ACCOUNT_JSON` those accessors still coincide with the data plane. On a split plane they again match their compute-default siblings (`conversations.py` CRUD, `action_items.py` / `task_intelligence_control.py`, `MemoryService` / canonical adapter).
- Mixed desktop-backend fleet (from #12667, still true): during a mixed desktop-backend rollout, old revisions read BYOK and assistant settings on the compute plane and will miss values the new revision wrote. That is mixed-fleet degradation (BYOK looks unenrolled; web-search opt-out looks absent/allowed), not a deleting account reopening. Old Cloud Run `backend` sees the same data plane because its accessors coincide.
- Screen-vector entitlement stays at `provision=False` plus the customer Firestore client. A miss defaults to basic (no cloud screen vectors) instead of JIT-creating a subscription doc. Lookup exceptions still fail open and write vectors.
- Rolling this follow-up back re-introduces the three dormant reader/writer splits on first-open, goals, and knowledge-ledger tools. It does not reopen the Beta deletion-fence miss.

## Named sibling seams

| Seam | Verdict |
|---|---|
| BYOK key lookup (`utils/byok.py` → `users.get_byok_state`) | **Fixed in #12667.** `get_byok_state` / `set_byok_active` / `clear_byok_active` use `get_data_plane_firestore_client()` (`users.py:285`, `:331`, `:337`). |
| Screen-vector entitlement with `provision=True` | **Fixed in #12667; ratcheted here.** `grants_cloud_screen_vectors` calls `get_user_valid_subscription(..., firestore_client=get_customer_firestore_client(), provision=False)` (`subscription.py:144-146`). A missing customer subscription doc does not call `user_ref.set`. Lookup exceptions still fail open. |
| Web-search opt-out | **Fixed in #12667.** `get_assistant_settings` / `_get_raw_assistant_settings` / `update_assistant_settings` read and write `users/{uid}` through `get_data_plane_firestore_client()` (`users.py:2204`, `:2217`, `:2249`). |
| Pinecone / Typesense wipe fence | **Fixed in #12667.** `vector_db.py` defaults to `data_plane_db`; `atom_keyword_index.py` imports `data_plane_db as default_db_client`. |
| Deletion marker, legal holds, cutover, memory ledger, MCP OAuth | **Fixed in #12667; kept.** Reachable from desktop-backend, or no compute-default sibling on the same collection. |

## Follow-ups

Next instances of `FC-plane-seam-adopted-by-reader-not-writer`. Move each module together with its sibling(s) in one change; do not pin the reader (or writer) alone.

- `backend/database/first_open_obligations.py` — sibling `backend/database/conversations.py:561` (CRUD defaults at `:795`, `:835`, `:919`, `:1624` also `get_firestore_client()`). Same `users/{uid}/conversations/{id}` family (`jit_first_open` lives on the conversation). Not reachable from desktop-backend.
- `backend/database/goals.py` — siblings `backend/database/action_items.py:53` (`firestore_client or db`) and `backend/database/task_intelligence_control.py:20` (`from database._client import db`). Same `users/{uid}/goals` and `task_intelligence_control` collections. `/v1/goals` is a 410 on desktop-backend.
- `backend/utils/retrieval/tools/knowledge_ledger_tools.py` — siblings `backend/utils/memory/memory_service.py:19` and `backend/utils/memory/canonical_memory_adapter.py:18` (both default `db`). Same `users/{uid}/memory_items` / apply-control collections. Desktop-backend JIT snapshots already inject the data plane; the read tools are not invoked from `desktop_chat.py`.
- `backend/routers/mcp_sse.py` authorize path (`:1788-1801`) does not call `enforce_account_deletion_http_access`. It relies on `create_grant_and_authorization_code_if_allowed` reading `account_deletions` through `data_plane_db` (`mcp_oauth.py:575-590`). An unresolvable data-plane client raises out of the grant write as HTTP 500, not mapped to 503. Fail-closed, different status. MCP is not mounted on desktop-backend. Subsequent MCP data calls do use the HTTP fence.
- Field-disjoint `users/{uid}` telemetry writers still on compute: `record_client_device` / `record_user_platform` (`users.py:135`, `:178`) merge-write the compute copy while BYOK and `assistant_settings` now live on the data plane. Field-disjoint, so it does not reopen deletion or clobber `byok`. Pre-existing telemetry-to-empty-dev-Firestore.

The `.get()`-swallow guard named in the #12667 review is fixed in this PR.

## New guards

The resolved-client `.get()` raise test is the recurrence guard for swallowing a deletion-marker read error into a clean miss. The `provision=False` behavioral test is the recurrence guard for JIT-writing Free onto a missing customer subscription doc from screen-vector entitlement. They are not a repo-wide plane-seam checker because the plane is a runtime client identity, not a static import graph.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

