### PR TITLE
test(desktop): repin the public web prompt after "thoroughly" landed

### DIFF
--- a/desktop/macos/Desktop/Tests/HubEscalationTests.swift
+++ b/desktop/macos/Desktop/Tests/HubEscalationTests.swift
@@ -84,7 +84,8 @@ final class HubEscalationTests: XCTestCase {
     let prompt = RealtimeHubTools.publicWebSearchPrompt(
       query: "What is the weather in New York right now?")
 
-    XCTAssertTrue(prompt.hasPrefix("Search the live public web before answering this request."))
+    XCTAssertTrue(
+      prompt.hasPrefix("Search the live public web thoroughly before answering this request."))
     XCTAssertTrue(prompt.contains("weather in New York right now"))
     XCTAssertTrue(prompt.contains("one to four concise"))
     XCTAssertTrue(prompt.contains("Name the source"))


### PR DESCRIPTION
## `main` is red; this repins one stale assertion

`HubEscalationTests.testPublicWebPromptIsSpeakableAndExcludesPrivateToolContext` fails on plain `origin/main`, so **Desktop Swift Static & Test Contracts is failing on every desktop-touching PR**, not just changed ones.

`bce354d767` ("fix(desktop): preserve realtime voice context boundaries", 2026-09-02) changed the prompt's first sentence to:

> Search the live public web **thoroughly** before answering this request.

The test still pinned the sentence without `thoroughly`, via `hasPrefix`. The prompt edit was deliberate; only the pin was left behind.

## Verification

- Confirmed against plain `origin/main` (`85480fff5b`): the source carries `thoroughly`, the test does not.
- The test fails there in isolation — `XCTAssertTrue failed` at `HubEscalationTests.swift:87` — with no local changes applied.
- `HubEscalationTests` 6/6 with this change.

## Scope

Only the prefix moved. Everything else this test exists to guard is untouched and still asserted: speakable output, one to four sentences, sources named, and no `Tool-provided context` leaking into a public web prompt.

## One thing worth flagging

An exact-sentence `hasPrefix` on prompt copy breaks on any wording edit, and this edit was both deliberate and harmless. The contract worth pinning is "the prompt does not begin with private tool context", not the adverb. I kept it exact to match how the rest of this suite pins rather than quietly loosening a guard in a drive-by fix — but it will break again the next time someone improves that sentence, and loosening it to a stable substring would be a reasonable follow-up.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

