### PR TITLE
fix(tooling): scope local repo scans to the tree CI checks out

### DIFF
--- a/.github/scripts/check_agents_md_lean.py
+++ b/.github/scripts/check_agents_md_lean.py
@@ -20,6 +20,7 @@ that is cheaper than the file you are editing.
 
 from __future__ import annotations
 
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -69,10 +70,52 @@ def check_file(path: Path, budget: tuple[int, int], label: str) -> list[str]:
     return errors
 
 
+def ignored_paths(repo: Path) -> set[Path]:
+    """Directories and files git ignores, as absolute paths.
+
+    The scan walks the working tree, but the contract is about the tree CI checks
+    out. A developer machine also holds gitignored siblings — `.claude/worktrees/`
+    is a documented multi-worktree pattern — and each of those contains its own
+    copy of the repo's tracked AGENTS.md files. Walking into them reports a file
+    that is neither new nor in the pushed diff, and the only way past it is
+    `--no-verify`, which drops every other pre-push guard too.
+
+    Returns an empty set when git cannot answer, so the check degrades to the
+    static SKIP_PARTS list rather than failing.
+    """
+    try:
+        completed = subprocess.run(
+            [
+                "git", "-C", str(repo), "ls-files", "--others", "--ignored",
+                "--exclude-standard", "--directory", "-z",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    return {
+        (repo / entry).resolve()
+        for entry in completed.stdout.split("\0")
+        if entry
+    }
+
+
 def discover(repo: Path) -> list[Path]:
+    ignored = ignored_paths(repo)
+
+    def is_ignored(path: Path) -> bool:
+        resolved = path.resolve()
+        return any(
+            resolved == candidate or candidate in resolved.parents
+            for candidate in ignored
+        )
+
     return sorted(
         p for p in repo.rglob("AGENTS.md")
-        if not SKIP_PARTS.intersection(p.parts)
+        if not SKIP_PARTS.intersection(p.parts) and not is_ignored(p)
     )
 
 
@@ -91,6 +134,30 @@ def self_test() -> None:
         f.write_text("y" * 101)
         assert any("bytes" in e for e in check_file(f, (10_000, 100), "t")), (
             "over-bytes must fail"
+        )
+
+    # A gitignored sibling worktree holds its own copy of every tracked AGENTS.md.
+    # Discovering those reports files that are neither new nor in the pushed diff
+    # (#12572), so `discover` must see the same tree CI checks out.
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        try:
+            subprocess.run(
+                ["git", "init", "-q", str(repo)],
+                capture_output=True, timeout=60, check=True,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return  # git unavailable: the check degrades to SKIP_PARTS, nothing to prove
+
+        (repo / ".gitignore").write_text(".claude/\n")
+        (repo / "AGENTS.md").write_text("# tracked\n")
+        worktree = repo / ".claude" / "worktrees" / "agent-abc" / ".github"
+        worktree.mkdir(parents=True)
+        (worktree / "AGENTS.md").write_text("# copy inside an ignored sibling worktree\n")
+
+        found = {p.relative_to(repo).as_posix() for p in discover(repo)}
+        assert found == {"AGENTS.md"}, (
+            f"ignored worktree copies must not be discovered, got {sorted(found)}"
         )
 
 

--- a/backend/scripts/generate_plan_catalog.py
+++ b/backend/scripts/generate_plan_catalog.py
@@ -94,6 +94,42 @@ SOURCE_SCAN_EXCLUDED_PARTS = {
 }
 
 
+def _git_ignored_paths(root: Path) -> set[Path]:
+    """Absolute paths git ignores under `root`.
+
+    The Stripe-literal scan walks the working tree, but the contract is about the
+    tree CI checks out. A developer machine also carries gitignored siblings —
+    `.claude/worktrees/` is a documented multi-worktree pattern — each holding a
+    full copy of the repo. Walking into those reports chart values files that are
+    untracked, absent from the diff, and absent in CI, so the gate fails only
+    locally and reads as broken (#12476).
+
+    Returns an empty set when git cannot answer, leaving the static
+    SOURCE_SCAN_EXCLUDED_PARTS behaviour unchanged.
+    """
+    try:
+        completed = subprocess.run(
+            [
+                'git',
+                '-C',
+                str(root),
+                'ls-files',
+                '--others',
+                '--ignored',
+                '--exclude-standard',
+                '--directory',
+                '-z',
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    return {(root / entry).resolve() for entry in completed.stdout.split('\0') if entry}
+
+
 def load_catalog(path: Path = CATALOG_PATH) -> dict[str, Any]:
     with path.open(encoding='utf-8') as catalog_file:
         value = json.load(catalog_file)
@@ -660,8 +696,13 @@ def scan_embedded_stripe_ids(catalog: Mapping[str, Any]) -> list[str]:
     known_prices = set(_recognized_price_map(catalog))
     known_products = set(_recognized_product_map(catalog))
     errors: list[str] = []
+    ignored = _git_ignored_paths(ROOT)
     for directory, directory_names, file_names in os.walk(ROOT):
-        directory_names[:] = sorted(name for name in directory_names if name not in SOURCE_SCAN_EXCLUDED_PARTS)
+        directory_names[:] = sorted(
+            name
+            for name in directory_names
+            if name not in SOURCE_SCAN_EXCLUDED_PARTS and (Path(directory) / name).resolve() not in ignored
+        )
         for file_name in sorted(file_names):
             path = Path(directory) / file_name
             if not _is_scannable_source(path):

--- a/backend/tests/unit/test_plan_catalog_contract.py
+++ b/backend/tests/unit/test_plan_catalog_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from copy import deepcopy
 
 import pytest
@@ -55,6 +56,32 @@ def test_source_scan_covers_production_code_and_ignores_tests_and_docs(tmp_path,
     assert scan_embedded_stripe_ids(load_catalog()) == [
         'service/plans.ts: embedded Stripe price price_1234567890abcdef is absent from plan_catalog.json',
         'worker/Dockerfile: embedded Stripe product prod_1234567890abcd is absent from plan_catalog.json',
+    ]
+
+
+def test_source_scan_skips_gitignored_sibling_worktrees(tmp_path, monkeypatch):
+    """A gitignored sibling worktree is not part of the tree CI checks out.
+
+    `.claude/worktrees/` is a documented multi-worktree pattern, and each entry holds a
+    full copy of the repo. Scanning into them fails `plan-catalog-contract` locally on
+    files that are untracked, absent from the diff, and absent in CI, so the gate reads
+    as broken and the only way past it is a skip hatch (#12476).
+    """
+    subprocess.run(['git', 'init', '-q', str(tmp_path)], check=True, capture_output=True, timeout=60)
+    (tmp_path / '.gitignore').write_text('.claude/\n', encoding='utf-8')
+
+    tracked = tmp_path / 'service' / 'plans.ts'
+    tracked.parent.mkdir()
+    tracked.write_text("const id = 'price_1234567890abcdef';", encoding='utf-8')
+
+    stale = tmp_path / '.claude' / 'worktrees' / 'old-session' / 'backend' / 'charts' / 'values.yaml'
+    stale.parent.mkdir(parents=True)
+    stale.write_text("priceId: price_stale1234567890\nproductId: prod_stale1234567\n", encoding='utf-8')
+
+    monkeypatch.setattr(plan_catalog_compiler, 'ROOT', tmp_path)
+
+    assert scan_embedded_stripe_ids(load_catalog()) == [
+        'service/plans.ts: embedded Stripe price price_1234567890abcdef is absent from plan_catalog.json',
     ]
 
 


### PR DESCRIPTION
Fixes #12572 and #12476 — one root cause, two reported symptoms.

## The defect

`agents-md-lean` and `plan-catalog-contract` both walk the working directory. On a developer machine that directory also holds **gitignored siblings**: `.claude/worktrees/` is the multi-worktree pattern documented in `docs/multi-worktree-dev.md`, and each entry there holds a full copy of the repo.

So both checks report files that are untracked, absent from the pushed diff, and absent in a CI checkout:

```
.claude/worktrees/agent-a49a501fb54466d1b/.github/AGENTS.md: new AGENTS.md has no budget
.claude/worktrees/<old-branch>/backend/charts/values.yaml: embedded Stripe price ... is absent
```

Both pass in CI and fail only locally, so they read as a broken gate rather than a real contract violation.

**This costs more than annoyance.** The escapes are `git push --no-verify` and `PRE_PUSH_SKIP_PR_PREFLIGHT=1`, and each drops *every other guard in that lane*. A cosmetic false positive is paid for in real coverage — #12474 was pushed with the preflight hatch for exactly this reason.

## The fix

Both scanners now skip what git reports as ignored:

```
git ls-files --others --ignored --exclude-standard --directory -z
```

A local run then sees the same tree CI does. When git cannot answer, both fall back to their existing static exclusion lists rather than failing, so neither check becomes weaker.

**Why not the fix each issue proposed.** Both suggested adding `.claude` to an exclusion list. Deferring to git covers the same case without a list that must be extended for the next ignored sibling — and `.claude/worktrees/` is only one of them.

## Verification

Each defect was **reproduced before fixing** and **mutation-checked after**:

- `check_agents_md_lean.py`'s self-test builds a git repo containing a gitignored `.claude/worktrees/agent-abc/.github/AGENTS.md`. Reverting the fix fails it:
  ```
  AssertionError: ignored worktree copies must not be discovered,
  got ['.claude/worktrees/agent-abc/.github/AGENTS.md', 'AGENTS.md']
  ```
- `test_source_scan_skips_gitignored_sibling_worktrees` covers the catalog scan; reverting the fix fails it. 23/23 in `test_plan_catalog_contract.py`.
- Planting a real `.claude/worktrees/<name>/backend/charts/values.yaml` in this checkout reproduced the reported failure verbatim against the unfixed script:
  ```
  - .claude/worktrees/fake-old-session/backend/charts/values.yaml: embedded Stripe price ... is absent from plan_catalog.json
  - .claude/worktrees/fake-old-session/backend/charts/values.yaml: embedded Stripe product ... is absent from plan_catalog.json
  ```
  and is clean against the fixed one.

Both checks pass on this branch, and the fallback path keeps CI behaviour identical — in CI there are no ignored siblings, so the scanned set is unchanged.

## Scope

Only the two scanners the issues name. **25 other scripts** under `.github/scripts/` and `backend/scripts/` walk the tree without excluding gitignored paths and can carry the same defect — only `check_agent_doc_references.py` currently excludes `.claude`. That survey is worth its own change rather than being widened into this one; happy to file it.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

