### PR TITLE
fix(dev-harness): require Java 21+ for Firebase emulators at prereq time

### DIFF
--- a/scripts/dev-harness/dev_harness/cli.py
+++ b/scripts/dev-harness/dev_harness/cli.py
@@ -7,6 +7,7 @@ import functools
 import hashlib
 import json
 import os
+import re
 import shutil
 import signal
 import socket
@@ -291,25 +292,36 @@ def _python_importable(module: str) -> bool:
     )
 
 
-def _java_runtime_present() -> bool:
-    """Report whether a usable JVM exists, not merely whether `java` is on PATH.
+# firebase-tools refuses to start the emulators on a JDK older than 21
+# ("firebase-tools no longer supports Java version before 21"), so the harness
+# rejects it at prereq time instead of failing firestore/auth health checks.
+FIREBASE_EMULATORS_MIN_JAVA_MAJOR = 21
+
+
+def _java_major_version() -> int | None:
+    """Major JDK version `java -version` reports, or None when unusable.
 
     macOS ships a stub at /usr/bin/java that is always present and exits 1 with
     "Unable to locate a Java Runtime" when no JDK is installed, so a PATH lookup
-    passes on every Mac. Running the binary is the only check that distinguishes
-    the stub from a real runtime.
+    passes on every Mac. Running the binary and parsing its version line is the
+    only check that distinguishes the stub from a real runtime — and reports the
+    version firebase-tools would otherwise reject only at emulator start.
     """
     if not _which("java"):
-        return False
+        return None
     try:
-        return (
-            subprocess.run(
-                ["java", "-version"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=30
-            ).returncode
-            == 0
-        )
+        proc = subprocess.run(["java", "-version"], capture_output=True, text=True, timeout=30)
     except (OSError, subprocess.SubprocessError):
-        return False
+        return None
+    if proc.returncode != 0:
+        return None
+    match = re.search(r'version "([0-9][0-9._]*)', proc.stderr)
+    if not match:
+        return None
+    parts = match.group(1).split(".")  # "21.0.1" → 21; legacy "1.8.0_191" → 8
+    if parts[0] == "1" and len(parts) > 1:
+        return int(parts[1])
+    return int(parts[0])
 
 
 def prerequisite_report(cfg: config.HarnessConfig) -> tuple[list[str], list[str]]:
@@ -321,10 +333,17 @@ def prerequisite_report(cfg: config.HarnessConfig) -> tuple[list[str], list[str]
         missing.append(
             "firebase-tools CLI or npx (install with npm install, npm install -g firebase-tools, or use npx)"
         )
-    if not _java_runtime_present():
+    java_major = _java_major_version()
+    if java_major is None:
         missing.append(
             "java runtime (required by the Firestore and Auth emulators; "
             "install one with `brew install --cask temurin` or from https://adoptium.net)"
+        )
+    elif java_major < FIREBASE_EMULATORS_MIN_JAVA_MAJOR:
+        missing.append(
+            f"java {java_major} is too old for the Firebase emulators (firebase-tools requires "
+            f"Java {FIREBASE_EMULATORS_MIN_JAVA_MAJOR}+; install e.g. `brew install openjdk@21` "
+            "and put it first on PATH)"
         )
     if not _which("redis-server"):
         missing.append("redis-server (required for local Redis on loopback)")

--- a/scripts/dev-harness/tests/test_cli.py
+++ b/scripts/dev-harness/tests/test_cli.py
@@ -67,6 +67,10 @@ def test_real_check_lists_provider_credentials(monkeypatch: pytest.MonkeyPatch, 
     assert any("DEEPGRAM_API_KEY" in item for item in missing)
 
 
+def _fake_java(returncode: int, stderr: str = "") -> object:
+    return lambda *_args, **_kwargs: subprocess.CompletedProcess([], returncode, stderr=stderr)
+
+
 def test_java_stub_that_exits_nonzero_is_not_a_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     """macOS ships /usr/bin/java as a stub that is always on PATH but has no JVM behind it.
 
@@ -74,16 +78,25 @@ def test_java_stub_that_exits_nonzero_is_not_a_runtime(monkeypatch: pytest.Monke
     ~135s later as an unexplained firestore/auth health-check timeout.
     """
     monkeypatch.setattr(cli, "_which", lambda _name: "/usr/bin/java")
-    monkeypatch.setattr(cli.subprocess, "run", lambda *_args, **_kwargs: subprocess.CompletedProcess([], 1))
+    monkeypatch.setattr(cli.subprocess, "run", _fake_java(1))
 
-    assert cli._java_runtime_present() is False
+    assert cli._java_major_version() is None
 
 
-def test_java_present_when_the_binary_reports_a_version(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_java_reports_its_major_version(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cli, "_which", lambda _name: "/usr/bin/java")
-    monkeypatch.setattr(cli.subprocess, "run", lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0))
+    monkeypatch.setattr(
+        cli.subprocess, "run", _fake_java(0, 'openjdk version "21.0.12.1" 2026-08-18\n')
+    )
 
-    assert cli._java_runtime_present() is True
+    assert cli._java_major_version() == 21
+
+
+def test_legacy_java_1_8_version_line_reports_major_8(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli, "_which", lambda _name: "/usr/bin/java")
+    monkeypatch.setattr(cli.subprocess, "run", _fake_java(0, 'java version "1.8.0_191"\n'))
+
+    assert cli._java_major_version() == 8
 
 
 def test_missing_java_runtime_is_reported_as_a_prerequisite(
@@ -91,12 +104,28 @@ def test_missing_java_runtime_is_reported_as_a_prerequisite(
 ) -> None:
     monkeypatch.setenv("PROVIDER_MODE", "offline")
     monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
-    monkeypatch.setattr(cli, "_java_runtime_present", lambda: False)
+    monkeypatch.setattr(cli, "_java_major_version", lambda: None)
     cfg = config.load_config(REPO_ROOT)
 
     missing, _warnings = cli.prerequisite_report(cfg)
 
     assert any("java runtime" in item for item in missing)
+
+
+def test_pre_21_java_is_reported_as_a_prerequisite(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """firebase-tools rejects JDKs before 21, so the harness must too — not at
+    emulator start (45s/90s health-check timeout) but in the prereq report.
+    """
+    monkeypatch.setenv("PROVIDER_MODE", "offline")
+    monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
+    monkeypatch.setattr(cli, "_java_major_version", lambda: 17)
+    cfg = config.load_config(REPO_ROOT)
+
+    missing, _warnings = cli.prerequisite_report(cfg)
+
+    assert any("too old" in item and "17" in item and "Java 21" in item for item in missing)
 
 
 def test_npx_firebase_tools_does_not_wait_on_an_install_prompt(


### PR DESCRIPTION
The prereq report only checked that `java` runs (`_java_runtime_present`), so a Mac whose PATH resolves a JDK 17 or older passed `make dev-up` preflight and then failed 45s/90s later as opaque firestore/auth health-check timeouts — current firebase-tools refuses to start the emulators on any Java before 21 ("firebase-tools no longer supports Java version before 21").

`_java_major_version()` now parses the major version out of `java -version` stderr (handling modern "21.0.1" and legacy "1.8.0_191" lines) and the prereq report lists an actionable "java 17 is too old ... install `brew install openjdk@21`" item when the found JDK is below FIREBASE_EMULATORS_MIN_JAVA_MAJOR (21). The macOS /usr/bin/java stub (always present, exits 1 when no JDK is installed) still reports "missing".

Tests: scripts/dev-harness/run-tests.sh — 122 passed, 7 skipped (new: version parsing for stub / 21 / legacy-1.8, pre-21 prereq rejection). Real machine: default PATH (JBR 17) → reported as too old; with /opt/homebrew/opt/openjdk@21/bin first on PATH → prereq passes and the full offline harness comes up with all seven services healthy.

Failure-Class: none

<!-- Keep this short and honest. Reviewers read the Verification section first. -->

## What changed and why

<!-- One or two sentences. Link the issue if there is one. -->

## Product invariants affected

<!-- Name locked invariant IDs this PR touches (e.g. INV-CHAT-1), or "none".
     Registry: product/invariants/ — required when changing paths listed
     on a locked invariant. -->

## How it was verified

<!-- The commands you ran and what they showed. Exercising the real user-facing
     path counts as verification; compiling or lint passing does not.
     If something could not be verified, say so explicitly. -->

## Tests

<!-- Bug fix: point to the regression test that would have caught the bug.
     Feature: point to the tests for the core path and main error path.
     No test change: explain why none was needed. -->

## Failure class (fixes)

<!-- Every `fix:` commit needs this exact, machine-validated declaration. Write one
     of these three lines, exactly — the value is a single token, never a list:
         Failure-Class: FC-<lower-kebab-slug>
         Failure-Class: new
         Failure-Class: none
     `scripts/failure-class prepare` lists the classes whose scope_hints overlap your
     change (add --all-candidates for the whole registry); `explain <id>` prints one.
     `harden:` commits may cite a class but do not need a declaration. -->

Failure-Class: none

## Failure-class transition narrative (only when needed)

<!-- Required only when declaring `new`, changing a class's canonical prevention
     primitive/owner, or making a registry-only lifecycle transition.

     Declaring `new` means adding exactly one
     .github/failure-classes/FC-<lower-kebab-slug>.json in THIS PR, alongside the fix.
     Its `evidence_prs` may be `[]` — this PR is the evidence, and its number does not
     exist yet.

     Every OTHER registry transition — dormant, reopen, or changing an existing class's
     canonical prevention — goes in a separate registry-only PR, never in the
     instance-fix PR. A dormant transition sets `status: dormant` and an ISO-8601
     `dormant_since`; a reopen sets `status: open` and removes `dormant_since`.

     State the violated contract, the canonical guard, and the supporting evidence.
     Delete this section for an ordinary instance fix. -->

## New guards (only when adding a check or ratchet)

<!-- Cite the real merged PR or incident this guard would have caught, then answer
     in one sentence: why is this not a shared primitive instead? Delete this
     section when no check or ratchet is added. -->

## Scoped cleanups (optional)

<!-- Related fixes you made along the way (see AGENTS.md → "Leave It Better
     Than You Found It"). Each should be its own commit and verifiable. -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

