### PR TITLE
fix(backend): name the HTTP status when the Grafana alert-route check fails

### DIFF
--- a/backend/scripts/verify_pusher_live_alert_route.py
+++ b/backend/scripts/verify_pusher_live_alert_route.py
@@ -53,7 +53,17 @@ def _request_json(base_url: str, path: str, token: str) -> Any:
     try:
         with urllib.request.urlopen(request, timeout=15) as response:
             body = response.read(1_000_001)
-    except (OSError, urllib.error.HTTPError, urllib.error.URLError) as exc:
+    except urllib.error.HTTPError as exc:
+        # Name the status. Collapsing every failure into "HTTPError" cost ~37h of red
+        # deploys in #12668 because CI could not tell an unprovisioned rule (404) from a
+        # revoked token (401) — two failures with completely different owners and fixes.
+        # Status and reason phrase only: the response body can carry Grafana detail we do
+        # not want in a public log.
+        raise AlertRouteError(f"Grafana API request failed for {path}: HTTP {exc.code} {exc.reason}") from exc
+    except urllib.error.URLError as exc:
+        # Subclass of OSError, superclass of HTTPError, so it has to sit between the two.
+        raise AlertRouteError(f"Grafana API request failed for {path}: URLError {exc.reason}") from exc
+    except OSError as exc:
         raise AlertRouteError(f"Grafana API request failed for {path}: {type(exc).__name__}") from exc
     if len(body) > 1_000_000:
         raise AlertRouteError(f"Grafana API response exceeded the size limit for {path}")

--- a/backend/tests/unit/test_verify_pusher_live_alert_route.py
+++ b/backend/tests/unit/test_verify_pusher_live_alert_route.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import copy
+import io
 import runpy
+import urllib.error
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -88,6 +90,54 @@ def test_rejects_unprotected_live_alert_paths(verifier: SimpleNamespace, mutatio
     )
     assert any(expected in error for error in errors)
     assert "must-never-be-logged" not in " ".join(errors)
+
+
+@pytest.mark.parametrize(
+    ("code", "reason", "expected"),
+    [
+        (401, "Unauthorized", "HTTP 401 Unauthorized"),
+        (404, "Not Found", "HTTP 404 Not Found"),
+        (503, "Service Unavailable", "HTTP 503 Service Unavailable"),
+    ],
+)
+def test_request_failure_names_the_http_status(
+    verifier: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, code: int, reason: str, expected: str
+) -> None:
+    """#12668: 401 and 404 have different owners — a revoked token vs an unprovisioned
+    rule — so the failure line has to distinguish them. Collapsing both into `HTTPError`
+    turned a one-line diagnosis into a multi-hour one across 13 consecutive red deploys."""
+
+    def _raise(*_args, **_kwargs):
+        raise urllib.error.HTTPError(url="https://monitor.example/api", code=code, msg=reason, hdrs=None, fp=None)
+
+    monkeypatch.setattr(verifier.urllib.request, "urlopen", _raise)
+
+    with pytest.raises(verifier.AlertRouteError) as excinfo:
+        verifier._request_json("https://monitor.example", "/api/v1/provisioning/alert-rules/x", "token")
+
+    assert expected in str(excinfo.value)
+
+
+def test_request_failure_does_not_leak_the_response_body(
+    verifier: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Grafana error bodies can carry detail that must not reach a public CI log."""
+
+    def _raise(*_args, **_kwargs):
+        raise urllib.error.HTTPError(
+            url="https://monitor.example/api",
+            code=401,
+            msg="Unauthorized",
+            hdrs=None,
+            fp=io.BytesIO(b'{"message":"must-never-be-logged"}'),
+        )
+
+    monkeypatch.setattr(verifier.urllib.request, "urlopen", _raise)
+
+    with pytest.raises(verifier.AlertRouteError) as excinfo:
+        verifier._request_json("https://monitor.example", "/api/v1/provisioning/alert-rules/x", "token")
+
+    assert "must-never-be-logged" not in str(excinfo.value)
 
 
 def test_rejects_world_readable_token_file(verifier: SimpleNamespace, tmp_path: Path) -> None:

--- a/backend/tests/unit/test_verify_pusher_live_alert_route.py
+++ b/backend/tests/unit/test_verify_pusher_live_alert_route.py
@@ -118,6 +118,40 @@ def test_request_failure_names_the_http_status(
     assert expected in str(excinfo.value)
 
 
+def test_request_failure_names_the_url_error_reason(verifier: SimpleNamespace, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`URLError` sits between the other two handlers on purpose: it subclasses `OSError`
+    and is the superclass of `HTTPError`. Catching `OSError` first would swallow both
+    specific cases and report a bare type name, so the ordering needs its own pin."""
+
+    def _raise(*_args, **_kwargs):
+        raise urllib.error.URLError("nodename nor servname provided")
+
+    monkeypatch.setattr(verifier.urllib.request, "urlopen", _raise)
+
+    with pytest.raises(verifier.AlertRouteError) as excinfo:
+        verifier._request_json("https://monitor.example", "/api/v1/provisioning/alert-rules/x", "token")
+
+    message = str(excinfo.value)
+    assert "URLError" in message
+    assert "nodename nor servname provided" in message
+
+
+def test_request_failure_falls_back_to_the_type_name_for_a_plain_os_error(
+    verifier: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A socket-level failure that is not a URLError keeps the original behaviour."""
+
+    def _raise(*_args, **_kwargs):
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr(verifier.urllib.request, "urlopen", _raise)
+
+    with pytest.raises(verifier.AlertRouteError) as excinfo:
+        verifier._request_json("https://monitor.example", "/api/v1/provisioning/alert-rules/x", "token")
+
+    assert "TimeoutError" in str(excinfo.value)
+
+
 def test_request_failure_does_not_leak_the_response_body(
     verifier: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Partial fix for #12668 — the in-repo hardening that issue asks for. **It does not turn the deploy green**; see Scope.

## The problem

`_request_json` collapsed every failure into the exception class name:

```python
except (OSError, urllib.error.HTTPError, urllib.error.URLError) as exc:
    raise AlertRouteError(f"Grafana API request failed for {path}: {type(exc).__name__}") from exc
```

So `Verify live finalization alert route before publishing` could only ever say:

```
FAIL: Grafana API request failed for /api/v1/provisioning/alert-rules/omi-capture-finalization-memory-fence: HTTPError
```

**401 and 404 have different owners here.** A 401 means the `GRAFANA_TOKEN` secret is revoked or wrong; a 404 means the committed rule was never provisioned on `monitor.omiapi.com`. Different people, different fixes — and the log distinguished neither. #12668 records **13+ consecutive red deploys over ~37h**, resolved by live probing rather than by anything CI printed.

## The change

`HTTPError` now reports status and reason phrase. `URLError` reports its reason. Plain `OSError` keeps the type name.

The handler order matters and is deliberate: `URLError` subclasses `OSError` and is itself the superclass of `HTTPError`, so `HTTPError` has to be caught first and `OSError` last, or the specific cases are swallowed.

**The response body is deliberately excluded.** Grafana error payloads can carry detail that should not land in a public CI log, so only the status line is reported. A test pins that.

## Scope — this does not close the issue

Both real fixes need a Grafana admin for `monitor.omiapi.com`, which is outside what a PR can do:

1. provision the committed finalization rules (at minimum `omi-capture-finalization-memory-fence`), or
2. rotate/repair the `GRAFANA_TOKEN` repo secret.

What this buys is that the *next* occurrence names which of the two it is, in the failure line, instead of costing another multi-hour diagnosis. Leaving #12668 open for the Grafana-side action.

## Verification

- 14/14 in `test_verify_pusher_live_alert_route.py`.
- Both new tests **mutation-checked**, not just green: restoring `type(exc).__name__` fails the status assertions (401/404/503), and adding the response body to the message fails the leak assertion.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

