### PR TITLE
EXP-002: multi-arm experiment substrate + memory_v1 desktop identity arm

### DIFF
--- a/backend/config/desktop_experiments.py
+++ b/backend/config/desktop_experiments.py
@@ -1,0 +1,71 @@
+"""Registry for desktop product experiments (EXP-002 and successors).
+
+Pure constants and predicates — no IO, no clients — so routers, tests, and the
+pre-registration docs share one source of truth. The experiment id is the
+assignment salt: **never rename a running experiment** (see
+``utils/experiments.bucket_of``).
+
+Adding an arm to EXP-002 later is a registry change here (append a
+``(name, weight)`` pair to ``EXP_002_ARMS``); no new enroll path is written.
+The draw partitions buckets in list order, so inserting an arm re-splits only
+the buckets after its bound — the pre-registration records the reweight rule.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable
+
+# v1 ships two arms at equal weight. Arm names are persisted verbatim as the
+# ``variant`` field of the assignment document and attached to every tagged
+# event, log, and crash report.
+EXP_002_EXPERIMENT_ID = 'EXP-002-desktop-identity-memory-v1'
+EXP_002_ARMS: tuple[tuple[str, float], ...] = (
+    ('control', 1.0),
+    ('memory_v1', 1.0),
+)
+EXP_002_TREATMENT_ARM = 'memory_v1'
+
+# Kill switch, following the production PostHog flag pattern (server-side,
+# keyed on Firebase uid, tri-state fail-closed — see ``utils/jit_rollout``).
+# Both flags absent/unknown/error ⇒ no enrollment and control chrome.
+EXP_002_FLAG_KEY = 'exp-002-desktop-identity-v1'
+EXP_002_KILL_SWITCH_FLAG_KEY = 'exp-002-desktop-identity-kill-v1'
+
+# v1 exposure: the Beta bundle only. Stable stays control until explicitly
+# widened here. Named dev bundles never enroll; they exercise arms through the
+# client-side local override instead.
+EXP_002_ALLOWED_BUNDLE_IDS = frozenset({'com.omi.computer-macos.beta'})
+EXP_002_ALLOWED_CHANNEL = 'beta'
+
+# Only binaries that contain this chrome may enroll; older clients must not be
+# enrolled into arms they cannot render. The endpoint is new, so no shipped
+# binary can call it below this floor — this is defense in depth against
+# misreported versions, not the primary gate. Override for local harness runs
+# via EXP_002_MIN_DESKTOP_APP_VERSION.
+EXP_002_MIN_DESKTOP_APP_VERSION = '0.12.273'
+
+
+def exp_002_min_app_version() -> str:
+    override = os.getenv('EXP_002_MIN_DESKTOP_APP_VERSION', '').strip()
+    return override or EXP_002_MIN_DESKTOP_APP_VERSION
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for piece in version.strip().split('.'):
+        try:
+            parts.append(int(piece))
+        except ValueError:
+            break
+    return tuple(parts) if parts else (0,)
+
+
+def version_meets_floor(version: str, floor: str) -> bool:
+    """True when ``version`` >= ``floor`` under dotted-numeric comparison."""
+
+    return _version_tuple(version) >= _version_tuple(floor)
+
+
+def known_experiment_ids() -> Iterable[str]:
+    return (EXP_002_EXPERIMENT_ID,)

--- a/backend/desktop_backend.py
+++ b/backend/desktop_backend.py
@@ -23,6 +23,7 @@ from routers import (
     desktop_chat,
     desktop_core,
     desktop_deprecated,
+    desktop_experiments,
     desktop_proxy,
     metrics,
     desktop_proactivity,
@@ -110,6 +111,7 @@ def _build_app() -> FastAPI:
     app.include_router(desktop_chat.router)
     app.include_router(desktop_proxy.router)
     app.include_router(desktop_proactivity.router)
+    app.include_router(desktop_experiments.router)
     app.include_router(jit_ledger_snapshot.router)
     app.include_router(jit_rollout.router)
     app.include_router(desktop_realtime.router)

--- a/backend/docs/experiments/EXP-002-desktop-identity-memory-v1.md
+++ b/backend/docs/experiments/EXP-002-desktop-identity-memory-v1.md
@@ -1,0 +1,171 @@
+# EXP-002 — desktop identity: memory, not assistant (`control` vs `memory_v1`)
+
+**Status:** pre-registered, not started. First enrollment happens only after
+this merges, the Beta build containing it ships, and
+`exp-002-desktop-identity-v1` is set true in PostHog.
+**Registered:** 2026-09-03. **Owner:** desktop identity workstream.
+**Registry:** `backend/config/desktop_experiments.py` names this file's
+experiment id, arms, flag keys, channel, and version floor.
+
+This is the analysis contract. It is committed **before** the first
+enrollment, on the substrate of [`utils/experiments.py`](../../utils/experiments.py)
+and the
+[experimentation-substrate decision](../../../omi-knowledge/projects/macos-churn-analysis/decisions/2026-08-30-experimentation-substrate.md)
+(uid unit, deterministic draw, persisted assignment, both arms enrolled in
+one code path before treatment, intention-to-treat). Changing the primary
+metric, arm set, or eligibility after enrollment begins requires a **new
+experiment id**, because the assignment salt is the experiment id and the
+roster cannot be reconstructed retroactively. **Never rename this id.**
+
+## Hypothesis
+
+A macOS user for whom Omi behaves as *memory, not assistant* — the daily
+postcard is the home object, Interject is on, the proactive director is
+quiet, and generic web Q&A is starved — gets more value out of their own
+captured day than a user of today's assistant-chrome, measured on the causal
+path to retention rather than retention itself.
+
+## Arms and assignment
+
+- **Unit:** authenticated Firebase uid. Assignment unit = analysis unit.
+- **Arms (v1):** `control` weight 1.0, `memory_v1` weight 1.0 — equal split.
+  Adding a third arm later is a registry change in
+  `config/desktop_experiments.py` (name + weight), not a new enroll path;
+  the draw partitions buckets in list order.
+- **Assignment:** `POST /v1/desktop/experiments/enroll`
+  (`routers/desktop_experiments.py`), deterministic
+  `sha256("EXP-002-desktop-identity-memory-v1:<uid>")`, persisted to
+  `experiments/EXP-002-desktop-identity-memory-v1/assignments/{uid}` on the
+  customer data plane.
+- **Enrollment before paint:** the desktop app holds its shell on the
+  launch splash until the enroll call settles, signed-in, both arms, one
+  code path. The server emits `Experiment Enrolled` before responding, so
+  the event lands before any treatment UI. Fail-closed everywhere: a gate
+  refusal, persist failure, plane failure, or timeout paints `control` and
+  delivers no arm.
+- **Exposure (v1):** Beta bundle only (`com.omi.computer-macos.beta`),
+  app version ≥ the floor in the registry. Stable, dev, and named bundles
+  do not enroll. Named bundles dogfood arms through
+  `OMI_FORCE_EXPERIMENT_VARIANT` locally — that override applies chrome,
+  never writes assignments, and tags events with `experiment_forced: true`.
+
+### Treatment definition (`memory_v1`)
+
+Wiring and defaults only — no new product surface:
+
+1. **Postcard-first.** The daily summary / `memories_learned` review card is
+   the landing object: the chat surface opens on the postcard when a new
+   summary exists (arm-gated INV-CHAT-2 admission seed), and the hub stage
+   leads with the postcard section. Chat remains fully available.
+2. **Interject on**, through the existing merged flag path
+   (`desktop_interject` / `desktop_interject_kill`): armed users get
+   Interject == (arm == memory_v1); the fleet kill switch still disarms
+   every arm.
+3. **Director starved.** The context-director pipeline
+   (`ContextBucketsFeature.isEnabled`) returns false for this arm — the
+   existing gate, not a new director. JIT memory processing is untouched.
+4. **Generic web Q&A starved** in the agent prompt: a memory-identity
+   response instruction (answers not requiring the user's day are one short
+   sentence pointing back to their day) plus no public-web routing prefix
+   in the agent runtime. Personal retrieval (memories, conversations,
+   screen, work context) is unchanged by construction.
+
+Out of scope by design: Send/gift meeting-share, `h.omi.me`, the
+meeting-receipt reconciler, Brain Map, a second shell, computer-use,
+marketplace, and any capture-gate change (owned by ptt-improvement / #12616).
+The Hold/PTT surface is unchanged; its events are only tagged.
+
+## Kill switch
+
+PostHog server-side flags, tri-state fail-closed, following the production
+pattern (`utils/jit_rollout.py`): **`exp-002-desktop-identity-v1`** (exposure)
+and **`exp-002-desktop-identity-kill-v1`** (revoke). Absent, unknown, or
+false ⇒ no enrollment and control chrome. Flag off → paint control, leave
+existing assignments in place. No PostHog person/cohort targeting of new
+installs (that failed: 215/260 beta installs had a null person-side channel).
+
+## Beta bake vs Stable confirmatory
+
+The Beta roster is a **bug-finding bake**. The stats clock does **not**
+start on Beta enrollments: Beta users are self-selected early adopters on a
+dev-serving backend, and treating their behavior as confirmatory would
+re-import the selection bias the randomization exists to defeat. The
+**confirmatory roster is Stable enrollments**, collected after (and only
+after) the registry is widened to the stable bundle id — a separate,
+explicit decision. Beta enrollments still land in the same Firestore
+collection (the desktop-backend data-plane seam pins both channels to the
+customer plane), so the bake roster is inspectable, but no readout on it is
+promoted to a ship decision.
+
+## Metrics
+
+**Primary (near-term, on the causal path — not retention):**
+
+1. **Day-1 return** after enrollment (a value signal, not
+   launch-at-login: an active day means a real conversation or postcard
+   interaction).
+2. **Teach-rate on shown facts**: `memory_review_action` accept+fix /
+   `memory_review_card_shown` — did the postcard's ✓/✗/Fix rows get used?
+3. **First grounded bar/PTT success**: the first hold/PTT attempt after
+   enrollment ends in a `grounded` outcome (existing PTT lifecycle events,
+   now variant-tagged), not `too_short`/`silent_rejected`.
+
+**Secondary (monitored, may fall):** questions asked
+(`question_asked` / `question_answered`). The formulation predicts this
+*may fall* if silent capturers stay — a fall is not harm by itself; the
+primary metrics decide.
+
+**Guardrails:** crash-free sessions by arm (Sentry tags `experiment_id` /
+`experiment_variant`), enroll-endpoint failure rate, postcard render
+failures.
+
+**Descriptive only:** route mix, daily summary opens, Interject teach
+volume. Analysis is intention-to-treat; enrollment is the denominator.
+
+## Analysis
+
+Denominator = `Experiment Enrolled` where
+`experiment_id = 'EXP-002-desktop-identity-memory-v1'`, per the
+pre-registered roster. HogQL sketch:
+
+```sql
+SELECT
+  properties.variant AS variant,
+  count() AS enrolled
+FROM events
+WHERE event = 'Experiment Enrolled'
+  AND properties.experiment_id = 'EXP-002-desktop-identity-memory-v1'
+  AND timestamp >= {confirmatory_start}
+GROUP BY variant
+```
+
+Outcomes are left-joined onto that roster by `distinct_id` (= uid).
+Report absolute percentage-point differences with 95% CIs from two-proportion
+tests. No covariate adjustment. **Never condition the analysis on opened
+Chat** — Chat-openers are the engaged users; filtering on them re-imports
+the latent-engagement confounder inside a design that had solved it. No
+subgroup is promoted from exploratory to confirmatory within this id.
+
+## Plane note
+
+The enroll endpoint resolves assignments through the data-plane Firestore
+seam (`get_data_plane_firestore_client`), which both the dev desktop-backend
+(Beta traffic) and the prod backend pin to the customer data plane
+(`based-hardware`, verified in `backend/deploy/runtime_env/*.overlay.yaml`:
+`data_plane_project: based-hardware` in dev and prod). If that seam ever
+fails to resolve, the endpoint skips enrollment (reason
+`assignments_plane_unavailable`) rather than splitting the roster across
+planes.
+
+## Tests
+
+- `backend/tests/unit/test_experiments.py` — N-arm draw determinism,
+  weights, registry-extension stability, invalid registries, legacy binary
+  draw unchanged, arm-name persistence, idempotency, all-arms Enrolled,
+  fail-closed persist.
+- `backend/tests/routers/test_desktop_experiments.py` — channel/version
+  gates, kill-switch-off behavior, plane failure, persist failure,
+  idempotent re-enroll, both arms through one endpoint.
+- `desktop/macos/Desktop/Tests/DesktopExperimentTests.swift` — enrollment
+  policy (Beta-only), forced-variant parsing, fail-closed resolution, owner
+  change isolation, Interject arm binding, postcard landing latch.

--- a/backend/routers/desktop_experiments.py
+++ b/backend/routers/desktop_experiments.py
@@ -1,0 +1,240 @@
+"""Desktop experiment enrollment (EXP-002).
+
+Server-side assignment for the macOS desktop identity experiment, following the
+ratified substrate (``backend/utils/experiments.py``): Firebase uid unit,
+deterministic draw, idempotent persisted assignment, both arms enrolled in the
+same code path before any treatment UI, intention-to-treat analysis.
+
+Contract highlights (pre-registered in
+``backend/docs/experiments/EXP-002-desktop-identity-memory-v1.md``):
+
+- **Fail closed.** Any gate or persist failure returns control chrome and no
+  assignment. A delivered-but-unrecorded treatment corrupts the control arm;
+  an undelivered one is a lost data point.
+- **Channel gate.** v1 enrolls only the Beta bundle. Stable and unknown
+  bundles are refused without writing.
+- **Version floor.** Binaries below the minimum are refused: they cannot
+  render the arms they would be enrolled into.
+- **Kill switch.** Server-side PostHog flags, tri-state fail-closed. Flag off
+  paints control and leaves existing assignments in place.
+- **One Firestore plane.** Assignments resolve through the data-plane seam so
+  the dev desktop-backend (Beta) and the prod backend (Stable later) write the
+  same ``experiments/{id}/assignments`` collection. If the plane cannot be
+  established, enrollment is skipped rather than split across planes.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from config.desktop_experiments import (
+    EXP_002_ALLOWED_BUNDLE_IDS,
+    EXP_002_ALLOWED_CHANNEL,
+    EXP_002_ARMS,
+    EXP_002_EXPERIMENT_ID,
+    EXP_002_FLAG_KEY,
+    EXP_002_KILL_SWITCH_FLAG_KEY,
+    exp_002_min_app_version,
+    known_experiment_ids,
+    version_meets_floor,
+)
+from database._client import get_data_plane_firestore_client, get_firestore_client
+from utils.executors import db_executor, run_blocking
+from utils.experiments import enroll, existing_assignment
+from utils.jit_rollout import PostHogJITFlagProvider, TriState
+from utils.other.endpoints import get_current_user_uid
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_flag_provider = PostHogJITFlagProvider(
+    rollout_flag_key=EXP_002_FLAG_KEY,
+    kill_switch_flag_key=EXP_002_KILL_SWITCH_FLAG_KEY,
+)
+
+
+class DesktopExperimentEnrollRequest(BaseModel):
+    experiment_id: str
+    channel: str
+    bundle_id: str
+    app_version: str
+    app_build: Optional[str] = None
+    platform: str = 'macos'
+
+
+class DesktopExperimentEnrollResponse(BaseModel):
+    experiment_id: str
+    variant: Optional[str] = None
+    enrolled: bool = False
+    newly_enrolled: bool = False
+    # The client applies arm chrome only when this is true. False paints
+    # control regardless of any persisted variant (kill switch, gate refusal,
+    # or persist failure).
+    chrome_enabled: bool = False
+    reason: str = 'enrolled'
+
+
+@dataclass(frozen=True)
+class _GateDecision:
+    allowed: bool
+    reason: str
+
+
+def _channel_gate(request: DesktopExperimentEnrollRequest) -> _GateDecision:
+    if request.channel != EXP_002_ALLOWED_CHANNEL or request.bundle_id not in EXP_002_ALLOWED_BUNDLE_IDS:
+        return _GateDecision(False, 'channel_not_allowed')
+    if not version_meets_floor(request.app_version, exp_002_min_app_version()):
+        return _GateDecision(False, 'app_version_below_minimum')
+    return _GateDecision(True, 'gates_passed')
+
+
+async def _experiment_flag_enabled(uid: str) -> bool:
+    """Tri-state fail-closed read of the enrollment flags."""
+
+    try:
+        evaluation = await _flag_provider(uid)
+    except Exception:
+        logger.exception('desktop experiments: flag evaluation failed uid_present=%s', bool(uid))
+        return False
+    return evaluation.rollout == TriState.ENABLED and evaluation.kill_switch != TriState.ENABLED
+
+
+def _assignments_client() -> Any:
+    """The Firestore client that owns experiment assignments on this surface.
+
+    The desktop-backend compute project differs from the customer data plane,
+    so its ``db`` default would land assignments in the wrong project. The
+    data-plane seam pins to the mounted customer plane (and refuses a
+    mismatched configuration). The emulator harness keeps its local plane.
+    """
+
+    if os.getenv('FIRESTORE_EMULATOR_HOST'):
+        return get_firestore_client()
+    return get_data_plane_firestore_client()
+
+
+def _plane_name(client: Any) -> str:
+    project = getattr(client, 'project', None)
+    return str(project) if project else 'unknown'
+
+
+async def _persisted_variant(uid: str, client: Any) -> Optional[str]:
+    record = await run_blocking(
+        db_executor,
+        existing_assignment,
+        EXP_002_EXPERIMENT_ID,
+        uid,
+        firestore_client=client,
+    )
+    if record and record.get('variant'):
+        return str(record['variant'])
+    return None
+
+
+@router.post('/v1/desktop/experiments/enroll')
+async def enroll_desktop_experiment(
+    request: DesktopExperimentEnrollRequest,
+    uid: str = Depends(get_current_user_uid),
+) -> DesktopExperimentEnrollResponse:
+    if request.experiment_id not in known_experiment_ids():
+        raise HTTPException(status_code=404, detail='Unknown experiment')
+
+    gate = _channel_gate(request)
+    if not gate.allowed:
+        # Gated clients never receive arm chrome and are never written.
+        logger.info(
+            'desktop experiment enrollment refused experiment_id=%s uid_present=%s channel=%s '
+            'bundle_id=%s app_version=%s reason=%s',
+            request.experiment_id,
+            bool(uid),
+            request.channel,
+            request.bundle_id,
+            request.app_version,
+            gate.reason,
+        )
+        return DesktopExperimentEnrollResponse(experiment_id=request.experiment_id, reason=gate.reason)
+
+    flag_enabled = await _experiment_flag_enabled(uid)
+
+    try:
+        client = _assignments_client()
+    except Exception:
+        logger.exception(
+            'desktop experiment enrollment plane unavailable experiment_id=%s uid_present=%s',
+            request.experiment_id,
+            bool(uid),
+        )
+        return DesktopExperimentEnrollResponse(
+            experiment_id=request.experiment_id, reason='assignments_plane_unavailable'
+        )
+
+    plane = _plane_name(client)
+
+    if not flag_enabled:
+        # Kill switch: paint control, leave any existing assignment in place.
+        variant = await _persisted_variant(uid, client)
+        logger.info(
+            'desktop experiment enrollment disabled experiment_id=%s uid_present=%s variant=%s plane=%s',
+            request.experiment_id,
+            bool(uid),
+            variant or 'none',
+            plane,
+        )
+        return DesktopExperimentEnrollResponse(
+            experiment_id=request.experiment_id,
+            variant=variant,
+            enrolled=variant is not None,
+            chrome_enabled=False,
+            reason='kill_switch_off',
+        )
+
+    enrollment = await run_blocking(
+        db_executor,
+        enroll,
+        experiment_id=EXP_002_EXPERIMENT_ID,
+        uid=uid,
+        arms=EXP_002_ARMS,
+        eligibility={
+            'channel': request.channel,
+            'bundle_id': request.bundle_id,
+            'app_version': request.app_version,
+            'app_build': request.app_build,
+            'plane': plane,
+        },
+        source='desktop',
+        firestore_client=client,
+    )
+
+    if enrollment is None:
+        # Persist failed: fail closed to control chrome, no variant delivered.
+        logger.error(
+            'desktop experiment enrollment persist failed experiment_id=%s uid_present=%s plane=%s',
+            request.experiment_id,
+            bool(uid),
+            plane,
+        )
+        return DesktopExperimentEnrollResponse(experiment_id=request.experiment_id, reason='persist_failed')
+
+    logger.info(
+        'desktop experiment enrolled experiment_id=%s variant=%s newly_enrolled=%s plane=%s ' 'app_version=%s',
+        request.experiment_id,
+        enrollment.variant,
+        enrollment.newly_enrolled,
+        plane,
+        request.app_version,
+    )
+    return DesktopExperimentEnrollResponse(
+        experiment_id=request.experiment_id,
+        variant=enrollment.variant,
+        enrolled=True,
+        newly_enrolled=enrollment.newly_enrolled,
+        chrome_enabled=True,
+        reason='enrolled',
+    )

--- a/backend/routers/desktop_experiments.py
+++ b/backend/routers/desktop_experiments.py
@@ -164,7 +164,7 @@ async def enroll_desktop_experiment(
     flag_enabled = await _experiment_flag_enabled(uid)
 
     try:
-        client = _assignments_client()
+        client = await run_blocking(db_executor, _assignments_client)
     except Exception:
         logger.exception(
             'desktop experiment enrollment plane unavailable experiment_id=%s uid_present=%s',

--- a/backend/tests/routers/test_desktop_experiments.py
+++ b/backend/tests/routers/test_desktop_experiments.py
@@ -1,0 +1,202 @@
+"""EXP-002 desktop enrollment endpoint: gates, fail-closed, and plane choice.
+
+The contract under test (see
+``backend/docs/experiments/EXP-002-desktop-identity-memory-v1.md``):
+
+- Stable and non-beta bundles never enroll (channel gate) and never receive
+  arm chrome.
+- Binaries below the version floor never enroll.
+- Kill switch off → no write, control chrome, existing assignment preserved.
+- Persist or plane failure → control chrome, no variant delivered.
+- Successful enrollment persists the arm name and enables chrome, and is
+  idempotent across calls.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from routers import desktop_experiments as router
+from tests.unit.fixtures.generic_firestore_fake import FakeFirestore
+from utils.jit_rollout import JITDecisionReason, JITErrorClass, JITFlagEvaluation, TriState
+
+
+def _request(
+    *,
+    experiment_id: str = router.EXP_002_EXPERIMENT_ID,
+    channel: str = 'beta',
+    bundle_id: str = 'com.omi.computer-macos.beta',
+    app_version: str = '0.12.273',
+) -> router.DesktopExperimentEnrollRequest:
+    return router.DesktopExperimentEnrollRequest(
+        experiment_id=experiment_id,
+        channel=channel,
+        bundle_id=bundle_id,
+        app_version=app_version,
+    )
+
+
+class _FakeFlagProvider:
+    def __init__(self, enabled: bool):
+        self.enabled = enabled
+
+    async def __call__(self, uid: str) -> JITFlagEvaluation:
+        state = TriState.ENABLED if self.enabled else TriState.DISABLED
+        return JITFlagEvaluation(state, TriState.DISABLED, JITDecisionReason.EVALUATED, JITErrorClass.NONE)
+
+
+@pytest.fixture
+def direct_run_blocking(monkeypatch):
+    async def _run_blocking(_executor, fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr(router, 'run_blocking', _run_blocking)
+
+
+@pytest.fixture
+def firestore(monkeypatch, direct_run_blocking):
+    db = FakeFirestore()
+    monkeypatch.setattr(router, '_assignments_client', lambda: db)
+    return db
+
+
+@pytest.fixture(autouse=True)
+def _telemetry(monkeypatch):
+    from utils.product_telemetry import set_product_telemetry_client_for_tests
+
+    class _FakePosthog:
+        def __init__(self):
+            self.events: list[dict[str, Any]] = []
+
+        def capture(self, **event):
+            self.events.append(event)
+
+    monkeypatch.setenv('POSTHOG_PROJECT_API_KEY', 'fake-key')
+    fake = _FakePosthog()
+    set_product_telemetry_client_for_tests(fake)
+    yield fake.events
+    set_product_telemetry_client_for_tests(None)
+
+
+def _flag(monkeypatch, enabled: bool):
+    monkeypatch.setattr(router, '_flag_provider', _FakeFlagProvider(enabled))
+
+
+async def test_unknown_experiment_is_404():
+    with pytest.raises(HTTPException) as exc:
+        await router.enroll_desktop_experiment(_request(experiment_id='EXP-999-nope'), uid='uid1')
+    assert exc.value.status_code == 404
+
+
+async def test_stable_channel_is_refused_without_writing(firestore, monkeypatch):
+    _flag(monkeypatch, True)
+    response = await router.enroll_desktop_experiment(
+        _request(channel='stable', bundle_id='com.omi.computer-macos'), uid='uid1'
+    )
+    assert response.enrolled is False
+    assert response.chrome_enabled is False
+    assert response.reason == 'channel_not_allowed'
+    assert response.variant is None
+
+
+async def test_non_beta_bundle_is_refused_without_writing(firestore, monkeypatch):
+    _flag(monkeypatch, True)
+    response = await router.enroll_desktop_experiment(_request(bundle_id='com.omi.omi-dev-dogfood'), uid='uid1')
+    assert response.reason == 'channel_not_allowed'
+    assert response.enrolled is False
+
+
+async def test_below_minimum_version_is_refused(firestore, monkeypatch):
+    _flag(monkeypatch, True)
+    response = await router.enroll_desktop_experiment(_request(app_version='0.12.200'), uid='uid1')
+    assert response.reason == 'app_version_below_minimum'
+    assert response.enrolled is False
+    assert response.chrome_enabled is False
+
+
+async def test_kill_switch_off_leaves_assignments_and_paints_control(firestore, monkeypatch):
+    _flag(monkeypatch, False)
+    response = await router.enroll_desktop_experiment(_request(), uid='uid1')
+    assert response.enrolled is False
+    assert response.chrome_enabled is False
+    assert response.reason == 'kill_switch_off'
+    assert response.variant is None
+
+
+async def test_kill_switch_off_returns_existing_assignment_without_rewriting(firestore, monkeypatch, _telemetry):
+    _flag(monkeypatch, True)
+    first = await router.enroll_desktop_experiment(_request(), uid='uid1')
+    assert first.enrolled and first.chrome_enabled
+    written_before = len(_telemetry)
+
+    _flag(monkeypatch, False)
+    second = await router.enroll_desktop_experiment(_request(), uid='uid1')
+    assert second.enrolled is True
+    assert second.variant == first.variant
+    assert second.chrome_enabled is False
+    assert second.reason == 'kill_switch_off'
+    assert len(_telemetry) == written_before
+
+
+async def test_enrollment_persists_arm_name_and_enables_chrome(firestore, monkeypatch, _telemetry):
+    _flag(monkeypatch, True)
+    response = await router.enroll_desktop_experiment(_request(), uid='uid1')
+    assert response.enrolled is True
+    assert response.chrome_enabled is True
+    assert response.variant in {'control', 'memory_v1'}
+    assert response.newly_enrolled is True
+    assert any(e['event'] == 'Experiment Enrolled' for e in _telemetry)
+    enrolled = [e for e in _telemetry if e['event'] == 'Experiment Enrolled']
+    assert enrolled[0]['properties']['variant'] == response.variant
+    assert enrolled[0]['properties']['experiment_id'] == router.EXP_002_EXPERIMENT_ID
+
+
+async def test_reenroll_is_idempotent_and_keeps_variant(firestore, monkeypatch, _telemetry):
+    _flag(monkeypatch, True)
+    first = await router.enroll_desktop_experiment(_request(), uid='uid1')
+    count_after_first = len(_telemetry)
+    second = await router.enroll_desktop_experiment(_request(), uid='uid1')
+    assert second.variant == first.variant
+    assert second.newly_enrolled is False
+    assert len(_telemetry) == count_after_first
+
+
+async def test_persist_failure_fails_closed_to_control(monkeypatch, direct_run_blocking):
+    class _RaisingFirestore(FakeFirestore):
+        def collection(self, path):
+            raise RuntimeError('firestore unavailable')
+
+    monkeypatch.setattr(router, '_assignments_client', lambda: _RaisingFirestore())
+    _flag(monkeypatch, True)
+    response = await router.enroll_desktop_experiment(_request(), uid='uid1')
+    assert response.enrolled is False
+    assert response.chrome_enabled is False
+    assert response.variant is None
+    assert response.reason == 'persist_failed'
+
+
+async def test_unavailable_plane_skips_enrollment(monkeypatch, direct_run_blocking):
+    def _raise():
+        raise RuntimeError('OMI_FIRESTORE_DATA_PLANE_PROJECT is required on desktop-backend')
+
+    monkeypatch.setattr(router, '_assignments_client', _raise)
+    _flag(monkeypatch, True)
+    response = await router.enroll_desktop_experiment(_request(), uid='uid1')
+    assert response.enrolled is False
+    assert response.chrome_enabled is False
+    assert response.reason == 'assignments_plane_unavailable'
+
+
+async def test_both_arms_enroll_through_the_same_endpoint(firestore, monkeypatch, _telemetry):
+    """The endpoint must produce both arms over enough uids — the holdout has
+    to appear in the roster for the experiment to be analyzable at all."""
+    _flag(monkeypatch, True)
+    variants = set()
+    for i in range(40):
+        response = await router.enroll_desktop_experiment(_request(), uid=f'both-arms-{i}')
+        assert response.enrolled
+        variants.add(response.variant)
+    assert variants == {'control', 'memory_v1'}

--- a/backend/tests/unit/test_desktop_rest_inventory.py
+++ b/backend/tests/unit/test_desktop_rest_inventory.py
@@ -45,6 +45,7 @@ OUT_OF_SCOPE_PREFIXES = (
     '/v2/chat/',  # streaming chat / Rust
     '/v2/chat-sessions',  # Rust desktop backend
     '/v2/desktop/',  # Rust desktop backend
+    '/v1/desktop/experiments',  # Python desktop-backend experiment enrollment
     '/v2/messages/',  # SSE streaming
     '/v2/files',  # multipart upload
     '/v2/apps',  # Rust-proxied app routes (desktop uses v1/apps)

--- a/backend/tests/unit/test_experiments.py
+++ b/backend/tests/unit/test_experiments.py
@@ -22,6 +22,7 @@ from utils.experiments import (
     enrollment_counts,
     existing_assignment,
 )
+from utils.experiments import ArmSpec
 from utils.product_telemetry import set_product_telemetry_client_for_tests
 
 
@@ -47,6 +48,10 @@ def _posthog(monkeypatch):
 
 EXPERIMENT_A = 'EXP-TEST-A'
 EXPERIMENT_B = 'EXP-TEST-B'
+
+
+EXP_002_ARMS: tuple[ArmSpec, ...] = (('control', 1.0), ('memory_v1', 1.0))
+THREE_ARMS: tuple[ArmSpec, ...] = (('control', 5.0), ('memory_v1', 3.0), ('assistant_v1', 2.0))
 
 
 def test_assignment_is_deterministic_and_stable():
@@ -153,3 +158,111 @@ def test_enrollment_counts_reflects_persisted_assignments():
     counts = enrollment_counts(EXPERIMENT_A, firestore_client=db)
     assert counts[CONTROL] + counts[TREATMENT] == len(uids)
     assert counts[CONTROL] > 0 and counts[TREATMENT] > 0
+
+
+def test_multiarm_draw_is_deterministic_and_only_returns_registered_names():
+    for uid in ('uid-1', 'uid-2', 'uid-multi'):
+        first = assigned_variant(EXPERIMENT_A, uid, arms=EXP_002_ARMS)
+        assert first in {'control', 'memory_v1'}
+        for _ in range(5):
+            assert assigned_variant(EXPERIMENT_A, uid, arms=EXP_002_ARMS) == first
+
+
+def test_multiarm_weights_are_respected_over_many_synthetic_uids():
+    n = 6000
+    counts = {'control': 0, 'memory_v1': 0, 'assistant_v1': 0}
+    for i in range(n):
+        counts[assigned_variant(EXPERIMENT_A, f'multi-{i}', arms=THREE_ARMS)] += 1
+    assert sum(counts.values()) == n
+    assert 0.47 <= counts['control'] / n <= 0.53
+    assert 0.27 <= counts['memory_v1'] / n <= 0.33
+    assert 0.17 <= counts['assistant_v1'] / n <= 0.23
+
+
+def test_multiarm_registry_change_keeps_the_draw_partition_stable_per_bucket():
+    """Adding a third arm re-splits only the buckets the new registry covers.
+
+    A uid that drew ``control`` under the two-arm registry at a bucket below
+    the two-arm control bound must keep drawing ``control`` under a registry
+    that only subdivides the treatment region, and vice versa. This pins the
+    "adding an arm is a registry change, not a new enroll path" contract.
+    """
+    split_registry = (('control', 1.0), ('memory_v1', 0.5), ('assistant_v1', 0.5))
+    for i in range(300):
+        uid = f'registry-{i}'
+        binary = assigned_variant(EXPERIMENT_A, uid, arms=EXP_002_ARMS)
+        redrawn = assigned_variant(EXPERIMENT_A, uid, arms=split_registry)
+        if binary == 'control':
+            assert redrawn == 'control'
+        else:
+            assert redrawn in {'memory_v1', 'assistant_v1'}
+
+
+@pytest.mark.parametrize(
+    'arms',
+    [
+        (),
+        (('control', 1.0), ('control', 2.0)),
+        (('', 1.0),),
+        (('control', 0.0),),
+        (('control', -1.0),),
+        (('control', float('nan')),),
+        (('control',),),
+    ],
+)
+def test_invalid_arm_registrations_are_rejected(arms):
+    with pytest.raises(ValueError):
+        assigned_variant(EXPERIMENT_A, 'uid-x', arms=arms)
+
+
+def test_legacy_binary_draw_unchanged_when_no_arms_passed():
+    """EXP-001 must keep drawing exactly what it always drew."""
+    for i in range(200):
+        uid = f'legacy-{i}'
+        expected = TREATMENT if bucket_of(EXPERIMENT_A, uid) < 5000 else CONTROL
+        assert assigned_variant(EXPERIMENT_A, uid) == expected
+
+
+def test_enroll_with_arms_persists_the_arm_name(_posthog):
+    db = FakeFirestore()
+    result = enroll(experiment_id=EXPERIMENT_A, uid='uid-multi', arms=EXP_002_ARMS, firestore_client=db)
+    assert result is not None
+    assert result.variant in {'control', 'memory_v1'}
+    record = existing_assignment(EXPERIMENT_A, 'uid-multi', firestore_client=db)
+    assert record is not None
+    assert record['variant'] == result.variant
+
+
+def test_enroll_with_arms_is_idempotent_and_keeps_variant_across_registry_extension(_posthog):
+    db = FakeFirestore()
+    first = enroll(experiment_id=EXPERIMENT_A, uid='uid-sticky', arms=EXP_002_ARMS, firestore_client=db)
+    assert first is not None
+    # A later registry extension must not reassign an already-persisted user.
+    second = enroll(experiment_id=EXPERIMENT_A, uid='uid-sticky', arms=THREE_ARMS, firestore_client=db)
+    assert second is not None
+    assert second.variant == first.variant
+    assert second.newly_enrolled is False
+    assert len(_posthog.events) == 1
+
+
+def test_all_arms_emit_experiment_enrolled_under_multiarm(_posthog):
+    db = FakeFirestore()
+    uids = [f'multi-holdout-{i}' for i in range(90)]
+    enrollments = [enroll(experiment_id=EXPERIMENT_A, uid=uid, arms=THREE_ARMS, firestore_client=db) for uid in uids]
+    assert all(e is not None for e in enrollments)
+    variants_seen = {e.variant for e in enrollments}
+    assert variants_seen == {'control', 'memory_v1', 'assistant_v1'}
+    assert len(_posthog.events) == len(uids)
+    assert {event['properties']['variant'] for event in _posthog.events} == variants_seen
+
+
+def test_enroll_with_arms_write_failure_returns_none_and_does_not_emit(_posthog):
+    class _RaisingFirestore(FakeFirestore):
+        def collection(self, path):
+            raise RuntimeError('firestore unavailable')
+
+    result = enroll(
+        experiment_id=EXPERIMENT_A, uid='uid-multi-fail', arms=EXP_002_ARMS, firestore_client=_RaisingFirestore()
+    )
+    assert result is None
+    assert _posthog.events == []

--- a/backend/utils/experiments.py
+++ b/backend/utils/experiments.py
@@ -51,6 +51,8 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import math
+
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Mapping, Optional, Sequence
@@ -62,6 +64,9 @@ logger = logging.getLogger(__name__)
 ENROLLED_EVENT = 'Experiment Enrolled'
 CONTROL = 'control'
 TREATMENT = 'treatment'
+ArmSpec = tuple[str, float]
+"""One named arm: ``(name, weight)``. Weights are relative and need not sum to 1."""
+
 
 # A draw resolution of 10_000 makes splits expressible to a basis point, which
 # is finer than any split we can power at this volume, and keeps the bucket
@@ -96,8 +101,69 @@ def bucket_of(experiment_id: str, uid: str) -> int:
     return int.from_bytes(digest[:4], 'big') % _BUCKET_RESOLUTION
 
 
-def assigned_variant(experiment_id: str, uid: str, *, treatment_share: float = 0.5) -> str:
-    """Draw a variant. Pure, deterministic, and side-effect free."""
+def _normalized_arms(arms: Sequence[ArmSpec]) -> list[tuple[str, int]]:
+    """Validate an ordered arm list and return ``(name, bucket_bound)`` pairs.
+
+    The bound is the exclusive upper bucket for the arm on [0, 10000),
+    cumulative in list order. Integer bounds keep the draw exact and stable:
+    the same ordered registry always partitions the same buckets, so adding a
+    third arm later is a registry change, not a new enroll path.
+    """
+    items = list(arms)
+    if not items:
+        raise ValueError('arms must contain at least one arm')
+    seen: set[str] = set()
+    weights: list[float] = []
+    names: list[str] = []
+    for item in items:
+        if not isinstance(item, (tuple, list)) or len(item) != 2:
+            raise ValueError('each arm must be a (name, weight) pair')
+        name, weight = item
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError('arm names must be non-empty strings')
+        if name in seen:
+            raise ValueError(f'duplicate arm name: {name}')
+        if not isinstance(weight, (int, float)) or not math.isfinite(float(weight)) or weight <= 0:
+            raise ValueError(f'arm weight for {name!r} must be a positive finite number')
+        seen.add(name)
+        names.append(name)
+        weights.append(float(weight))
+    total = sum(weights)
+    bounds: list[tuple[str, int]] = []
+    cumulative = 0.0
+    for name, weight in zip(names, weights):
+        cumulative += weight
+        bound = round(cumulative / total * _BUCKET_RESOLUTION)
+        previous = bounds[-1][1] if bounds else 0
+        # Monotonic under adversarial rounding: every arm after the first
+        # keeps at least one bucket, and the last arm owns the remainder.
+        bounds.append((name, max(bound, previous + 1)))
+    return bounds
+
+
+def assigned_variant(
+    experiment_id: str,
+    uid: str,
+    *,
+    treatment_share: float = 0.5,
+    arms: Optional[Sequence[ArmSpec]] = None,
+) -> str:
+    """Draw a variant. Pure, deterministic, and side-effect free.
+
+    ``arms`` is the multi-arm form: an ordered list of ``(name, weight)``
+    pairs (e.g. ``(('control', 1), ('memory_v1', 1))``). Without it the
+    legacy binary ``control``/``treatment`` draw via ``treatment_share`` is
+    used unchanged — running experiments (EXP-001) must keep drawing the
+    exact variants they always have.
+    """
+    if arms is not None:
+        bucket = bucket_of(experiment_id, uid)
+        for name, bound in _normalized_arms(arms):
+            if bucket < bound:
+                return name
+        # Rounding can leave the final bound below the resolution; the last
+        # arm owns the remainder.
+        return _normalized_arms(arms)[-1][0]
     if not 0.0 <= treatment_share <= 1.0:
         raise ValueError('treatment_share must be within [0, 1]')
     return TREATMENT if bucket_of(experiment_id, uid) < round(treatment_share * _BUCKET_RESOLUTION) else CONTROL
@@ -126,6 +192,7 @@ def enroll(
     experiment_id: str,
     uid: str,
     treatment_share: float = 0.5,
+    arms: Optional[Sequence[ArmSpec]] = None,
     eligibility: Optional[Mapping[str, Any]] = None,
     source: str = '',
     firestore_client: Any | None = None,
@@ -153,7 +220,7 @@ def enroll(
     if already and already.get('variant'):
         return Enrollment(uid=uid, experiment_id=experiment_id, variant=str(already['variant']), newly_enrolled=False)
 
-    variant = assigned_variant(experiment_id, uid, treatment_share=treatment_share)
+    variant = assigned_variant(experiment_id, uid, treatment_share=treatment_share, arms=arms)
     record = {
         'uid': uid,
         'experiment_id': experiment_id,

--- a/backend/utils/experiments.py
+++ b/backend/utils/experiments.py
@@ -116,14 +116,18 @@ def _normalized_arms(arms: Sequence[ArmSpec]) -> list[tuple[str, int]]:
     weights: list[float] = []
     names: list[str] = []
     for item in items:
-        if not isinstance(item, (tuple, list)) or len(item) != 2:
+        # Runtime validation of registry edits: the annotation promises
+        # ArmSpec, but a malformed constant must fail loud at first draw,
+        # not silently re-split the buckets. Pyright cannot see that intent.
+        if not isinstance(item, (tuple, list)) or len(item) != 2:  # pyright: ignore[reportUnnecessaryIsInstance]
             raise ValueError('each arm must be a (name, weight) pair')
         name, weight = item
-        if not isinstance(name, str) or not name.strip():
+        if not isinstance(name, str) or not name.strip():  # pyright: ignore[reportUnnecessaryIsInstance]
             raise ValueError('arm names must be non-empty strings')
         if name in seen:
             raise ValueError(f'duplicate arm name: {name}')
-        if not isinstance(weight, (int, float)) or not math.isfinite(float(weight)) or weight <= 0:
+        weight_is_numeric = isinstance(weight, (int, float))  # pyright: ignore[reportUnnecessaryIsInstance]
+        if not weight_is_numeric or not math.isfinite(float(weight)) or weight <= 0:
             raise ValueError(f'arm weight for {name!r} must be a positive finite number')
         seen.add(name)
         names.append(name)

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -2578,6 +2578,16 @@ actor AgentRuntimeProcess {
       authorizationSnapshot,
       expectedAuthorityEpoch: admissionAuthorityEpoch)
     env = Self.childBackendRoutingEnvironment(baseEnvironment: env, rustBase: rustBase)
+    // EXP-002: the agent child starves generic public-web routing for the
+    // memory_v1 arm (pi-mono reads this once per turn). The arm resolves
+    // before the main shell paints and the runtime spawns lazily on first
+    // chat use, so the value is settled by the time a spawn can happen; the
+    // per-turn responseContext instruction remains authoritative regardless.
+    if let assignment = await MainActor.run(body: { DesktopExperimentCoordinator.shared.assignment }) {
+      env["OMI_EXPERIMENT_VARIANT"] = assignment.variant
+    } else {
+      env.removeValue(forKey: "OMI_EXPERIMENT_VARIANT")
+    }
     if rustBase.isEmpty && preferredAdapterId == .piMono {
       log("AgentRuntimeProcess: pi-mono start refused, OMI_DESKTOP_API_URL is not configured")
       throw BridgeError.bridgeScriptNotFound

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -191,6 +191,14 @@ struct ScopedDefaultsKey {
     Self(rawValue: "dailySummary.lastSeenID.v1.\(ownerID)")
   }
 
+  /// Owner-scoped id of the newest daily summary the memory_v1 postcard-first
+  /// landing has already opened on. Separate from the notch-announcement latch
+  /// so neither consumes the other; the arm lands on the postcard exactly once
+  /// per summary.
+  static func dailySummaryPostcardLandedID(ownerID: String) -> Self {
+    Self(rawValue: "dailySummary.postcardLandedID.v1.\(ownerID)")
+  }
+
   static func importConnectorAvailabilityText(connectorID: String) -> Self {
     Self(rawValue: "appsImportConnectorAvailabilityText.\(connectorID)")
   }

--- a/desktop/macos/Desktop/Sources/Experiments/DesktopExperiment.swift
+++ b/desktop/macos/Desktop/Sources/Experiments/DesktopExperiment.swift
@@ -1,0 +1,188 @@
+import Foundation
+import Sentry
+
+/// EXP-002 — desktop identity experiment (`control` vs `memory_v1`).
+///
+/// One shell; the arm is a parameter pack. `control` is byte-identical to the
+/// un-enrolled experience. `memory_v1` changes only wiring and defaults:
+/// postcard-first landing, Interject on, director starved, generic web Q&A
+/// starved in the agent prompt. See `backend/docs/experiments/EXP-002-desktop-identity-memory-v1.md`.
+///
+/// The experiment id is the assignment salt server-side: **never rename it**.
+enum DesktopExperiment {
+  static let experimentId = "EXP-002-desktop-identity-memory-v1"
+  static let controlVariant = "control"
+  static let memoryV1Variant = "memory_v1"
+
+  /// Which launch paths may call the enrollment endpoint at all. v1 exposes
+  /// the Beta bundle only; stable stays control until explicitly widened, and
+  /// named/dev bundles exercise arms through the local environment override
+  /// instead (they never enroll and never write assignments).
+  static func shouldRequestEnrollment(isNonProduction: Bool, isBetaProductionBundle: Bool) -> Bool {
+    isBetaProductionBundle && !isNonProduction
+  }
+
+  /// The local dogfood override for non-production bundles:
+  /// `OMI_FORCE_EXPERIMENT_VARIANT=memory_v1` (or `control`). Returns nil for
+  /// unknown values so a typo cannot invent an arm.
+  static func forcedVariant(environment env: [String: String]) -> String? {
+    guard let raw = env["OMI_FORCE_EXPERIMENT_VARIANT"]?.trimmingCharacters(in: .whitespaces),
+      !raw.isEmpty
+    else { return nil }
+    return raw == memoryV1Variant || raw == controlVariant ? raw : nil
+  }
+}
+
+/// The arm this launch renders, and where it came from. `enrolled` came from
+/// the server-side assignment (persisted, both arms through one code path);
+/// `forcedLocal` is a non-production dogfood override that never touched the
+/// roster.
+struct DesktopExperimentAssignment: Equatable {
+  enum Source: String, Equatable {
+    case enrolled
+    case forcedLocal
+  }
+
+  let variant: String
+  let source: Source
+
+  var isMemoryV1: Bool { variant == DesktopExperiment.memoryV1Variant }
+}
+
+/// Resolves the arm once per owner, **before the main shell paints**, and
+/// publishes it for every consumer (landing, Interject, director, chat
+/// prompt, telemetry, Sentry, logs).
+///
+/// Fail-closed: any error, timeout, gate refusal, or kill switch resolves to
+/// no assignment — the app then paints control chrome. A treatment arm that
+/// cannot be confirmed is never applied.
+@MainActor
+final class DesktopExperimentCoordinator: ObservableObject {
+  static let shared = DesktopExperimentCoordinator()
+
+  enum Phase: Equatable {
+    case pending
+    case resolved
+  }
+
+  @Published private(set) var phase: Phase = .pending
+  @Published private(set) var assignment: DesktopExperimentAssignment?
+
+  /// Bounded so a slow network cannot hold the launch splash indefinitely;
+  /// the request timeout resolves control (fail closed) and the next launch
+  /// retries. Public for `APIClient+Experiments` to reuse.
+  static let enrollmentTimeout: TimeInterval = 4.0
+
+  private var inFlightOwnerID: String?
+
+  var isMemoryV1: Bool { assignment?.isMemoryV1 == true }
+
+  /// Non-production bundles resolve the arm from the launch environment.
+  /// Never enrolled, never persisted — purely local chrome for dogfooding.
+  func resolveFromLaunchEnvironment() {
+    guard phase == .pending else { return }
+    guard AppBuild.isNonProduction else { return }
+    if let variant = DesktopExperiment.forcedVariant(environment: ProcessInfo.processInfo.environment) {
+      apply(DesktopExperimentAssignment(variant: variant, source: .forcedLocal))
+      log("DesktopExperiment: forced local arm \(variant) (OMI_FORCE_EXPERIMENT_VARIANT)")
+    } else {
+      resolveWithoutAssignment(reason: "non-production bundle without override")
+    }
+  }
+
+  /// Requests server-side enrollment for the current owner. Idempotent: the
+  /// backend returns the persisted assignment for an already-enrolled owner.
+  func resolveForCurrentOwner() async {
+    guard phase == .pending else { return }
+    guard
+      DesktopExperiment.shouldRequestEnrollment(
+        isNonProduction: AppBuild.isNonProduction,
+        isBetaProductionBundle: AppBuild.isBetaProductionBundle)
+    else {
+      resolveWithoutAssignment(reason: "channel does not enroll in v1")
+      return
+    }
+    guard let ownerID = RuntimeOwnerIdentity.currentOwnerId() else {
+      // No stable uid: unit-of-assignment is the Firebase uid, so there is
+      // nothing to enroll. Control chrome, no retry this launch.
+      resolveWithoutAssignment(reason: "no owner")
+      return
+    }
+    guard
+      let authorization = RuntimeOwnerIdentity.captureAuthorizationSnapshot(expectedOwnerID: ownerID)
+    else {
+      resolveWithoutAssignment(reason: "stale owner")
+      return
+    }
+    inFlightOwnerID = ownerID
+
+    do {
+      let response = try await APIClient.shared.enrollDesktopExperiment(
+        experimentId: DesktopExperiment.experimentId,
+        expectedOwnerId: ownerID,
+        authorizationSnapshot: authorization
+      )
+      guard inFlightOwnerID == ownerID else { return }
+      if let variant = response.variant, response.chromeEnabled {
+        apply(DesktopExperimentAssignment(variant: variant, source: .enrolled))
+        log(
+          "DesktopExperiment: enrolled variant=\(variant) newly=\(response.newlyEnrolled) reason=\(response.reason)"
+        )
+      } else {
+        resolveWithoutAssignment(reason: response.reason)
+      }
+    } catch {
+      guard inFlightOwnerID == ownerID else { return }
+      // Fail closed to control chrome; the next launch retries.
+      resolveWithoutAssignment(reason: "enrollment unavailable")
+      log("DesktopExperiment: enrollment failed (\(type(of: error))) — painting control")
+    }
+  }
+
+  /// Owner switch (account change): the previous owner's arm must not leak
+  /// into the next owner's chrome. Resets to pending so the shell gate
+  /// re-resolves.
+  func ownerDidChange() {
+    inFlightOwnerID = nil
+    assignment = nil
+    phase = .pending
+  }
+
+  // MARK: - Resolution
+
+  private func apply(_ assignment: DesktopExperimentAssignment) {
+    self.assignment = assignment
+    phase = .resolved
+    attachTelemetryContext(assignment)
+  }
+
+  /// Test seam for pinning an assignment without a bundle, backend, or
+  /// PostHog. Deliberately skips telemetry attachment: tests assert
+  /// coordinator state, not the telemetry context.
+  func applyForTests(_ assignment: DesktopExperimentAssignment) {
+    self.assignment = assignment
+    phase = .resolved
+  }
+
+  private func resolveWithoutAssignment(reason: String) {
+    assignment = nil
+    phase = .resolved
+    log("DesktopExperiment: control chrome (reason=\(reason))")
+  }
+
+  /// `experiment_id` + `variant` on every PostHog event (super-properties),
+  /// every Sentry crash (scope tags), and every desktop log line.
+  private func attachTelemetryContext(_ assignment: DesktopExperimentAssignment) {
+    PostHogManager.shared.setExperimentContext(
+      experimentId: DesktopExperiment.experimentId,
+      variant: assignment.variant,
+      forced: assignment.source == .forcedLocal)
+    SentrySDK.configureScope { scope in
+      scope.setTag(value: DesktopExperiment.experimentId, key: "experiment_id")
+      scope.setTag(value: assignment.variant, key: "experiment_variant")
+    }
+    setLogExperimentContext(
+      experimentId: DesktopExperiment.experimentId,
+      variant: assignment.variant)
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/Interject/InterjectFeature.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/Interject/InterjectFeature.swift
@@ -7,6 +7,12 @@ import Foundation
 /// byte-identical to the pre-Interject build. Beta dogfoods it by default
 /// (kill-switchable); stable stays dark until `desktop_interject` is true;
 /// non-production bundles require `OMI_FORCE_INTERJECT=1`.
+///
+/// EXP-002: an enrolled arm owns this decision for the experiment's
+/// population — `memory_v1` turns Interject on, enrolled `control` turns it
+/// off (the assistant-chrome comparator). Un-enrolled users keep the dogfood
+/// decision untouched. The fleet kill switch (`desktop_interject_kill`)
+/// still disarms every arm; ops authority is never overridden.
 enum InterjectFeature {
   static let flagName = "desktop_interject"
   static let killSwitchFlagName = "desktop_interject_kill"
@@ -21,12 +27,40 @@ enum InterjectFeature {
     set { overrideLock.withLock { cachedTestOverride = newValue } }
   }
 
+  /// The arm-driven decision, with every input passed in so it can be
+  /// exercised without a bundle, a PostHog client, or an enrolled owner.
+  /// An arm (enrolled or forced-local dogfood) owns the decision for its
+  /// population: `memory_v1` on, `control` off. Un-armed users keep the
+  /// dogfood decision untouched. The fleet kill switch disarms every arm.
+  @MainActor
+  static func isEnabled(
+    experimentVariant: String?,
+    killSwitchEnabled: Bool,
+    unenrolledDecision: Bool
+  ) -> Bool {
+    guard let experimentVariant else {
+      return unenrolledDecision
+    }
+    if killSwitchEnabled {
+      return false
+    }
+    return experimentVariant == DesktopExperiment.memoryV1Variant
+  }
+
   @MainActor static var isEnabled: Bool {
     if let testOverride { return testOverride }
-    return BetaDogfoodRollout.isEnabled(
-      flagName: flagName,
-      killSwitchFlagName: killSwitchFlagName,
-      localOverrideName: localOverrideName
+    let experimentVariant = DesktopExperimentCoordinator.shared.assignment?.variant
+    let killSwitchEnabled =
+      !AppBuild.isNonProduction && AppBuild.isBetaProductionBundle
+      && PostHogManager.shared.isFeatureEnabled(killSwitchFlagName)
+    return isEnabled(
+      experimentVariant: experimentVariant,
+      killSwitchEnabled: killSwitchEnabled,
+      unenrolledDecision: BetaDogfoodRollout.isEnabled(
+        flagName: flagName,
+        killSwitchFlagName: killSwitchFlagName,
+        localOverrideName: localOverrideName
+      )
     )
   }
 }

--- a/desktop/macos/Desktop/Sources/Logger.swift
+++ b/desktop/macos/Desktop/Sources/Logger.swift
@@ -27,6 +27,20 @@ enum OmiLogPathResolver {
 
 private let logBundleIdentifier = Bundle.main.bundleIdentifier ?? "unknown"
 private let logProcessID = getpid()
+
+/// EXP-002: launch-scoped experiment context appended to every structured
+/// desktop log line once the arm resolves, so logs are sliceable by arm
+/// alongside PostHog events and Sentry tags. Written once per launch on the
+/// main actor before the main shell paints.
+private nonisolated(unsafe) var logExperimentContext: (experimentId: String, variant: String)?
+private let logExperimentContextLock = NSLock()
+
+func setLogExperimentContext(experimentId: String, variant: String) {
+  logExperimentContextLock.withLock {
+    logExperimentContext = (experimentId, variant)
+  }
+}
+
 private let logFile: String = OmiLogPathResolver.logPath(
   isNonProduction: AppBuild.isNonProduction,
   bundleIdentifier: logBundleIdentifier,
@@ -194,7 +208,11 @@ private func ensureLogParentDirectories() -> Bool {
 }
 
 private func logLine(timestamp: String, category: String, message: String) -> String {
-  "[\(timestamp)] [\(category)] [bundle_id=\(logBundleIdentifier) pid=\(logProcessID)] \(message)"
+  let experiment = logExperimentContextLock.withLock { logExperimentContext }
+  let experimentFields =
+    experiment.map { " [experiment_id=\($0.experimentId) variant=\($0.variant)]" } ?? ""
+  return
+    "[\(timestamp)] [\(category)] [bundle_id=\(logBundleIdentifier) pid=\(logProcessID)]\(experimentFields) \(message)"
 }
 
 func writeToLogFile(

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -94,6 +94,9 @@ enum ChatConversationSwitch {
   }
 }
 
+/// Scroll anchor for the EXP-002 `memory_v1` postcard-first placement.
+private let chatPostcardAnchorID = "daily-summary-postcard"
+
 /// Lifecycle state for the one-shot launch placement. A pending placement may
 /// be retried if SwiftUI removes the chat surface during Home's launch
 /// transition; explicit reader input permanently wins for this view lifetime.
@@ -383,6 +386,14 @@ struct ChatMessagesView<WelcomeContent: View>: View {
   /// surface the app opens on, and the summary is a read the user should meet without navigating
   /// to it. Task chat opts out: that thread is about one task, not about the day.
   var showsDailySummary: Bool = true
+  /// EXP-002 `memory_v1`: the postcard is the landing object. When true and
+  /// the latest daily summary has not been landed on yet, the transcript
+  /// opens on the postcard (top of the document) instead of the live edge,
+  /// and the card is admitted without the scroll-follow precondition — an
+  /// arm-gated seed of INV-CHAT-2, not a global change. Every later open
+  /// follows the bottom unchanged.
+  var postcardFirstLanding: Bool = false
+
   @ViewBuilder var welcomeContent: () -> WelcomeContent
 
   // MARK: - Scroll State
@@ -394,6 +405,7 @@ struct ChatMessagesView<WelcomeContent: View>: View {
   /// Whether the daily summary card is currently allowed above the thread.
   /// See `admitDailySummaryIfFollowing` (INV-CHAT-2).
   @State private var dailySummaryAdmitted = false
+
   @ObservedObject private var dailySummaryStore: HomeDailySummaryStore = ChatDailySummaryCoordinator.shared.store
   /// Throttle token for scrollToBottom — prevents the streaming + scroll
   /// detection feedback loop from saturating the main thread.
@@ -570,6 +582,7 @@ struct ChatMessagesView<WelcomeContent: View>: View {
         // the transcript has rows, and it records no turn (INV-CHAT-1).
         if showsDailySummary, dailySummaryAdmitted {
           ChatDailySummaryCard()
+            .id(chatPostcardAnchorID)
         }
         messageContent
       }
@@ -803,13 +816,19 @@ struct ChatMessagesView<WelcomeContent: View>: View {
     }
   }
 
-  // MARK: - Initial Restore
-
   /// On the first load of a saved conversation, follow the latest message.
   /// Chat surfaces should open at the live edge; if the reader wants older
   /// context, explicit scroll input switches the mode to free-scrolling.
+  ///
+  /// EXP-002 `memory_v1` exception: when the postcard is the landing object
+  /// and its summary has not been landed on yet, this open lands on the
+  /// postcard instead — the "night object" the arm exists to ship.
   private func handleInitialRestore(proxy: ScrollViewProxy) {
     guard initialRestoreState.canStart else { return }
+
+    if postcardFirstLanding, placeAtUnseenPostcard(proxy: proxy) {
+      return
+    }
 
     scrollMode = .followingBottom
     hasActivityBelow = false
@@ -831,6 +850,65 @@ struct ChatMessagesView<WelcomeContent: View>: View {
         delay: delay,
         completesInitialRestore: index == delays.index(before: delays.endIndex)
       )
+    }
+  }
+
+  /// Attempts the postcard-first placement. Returns true when this open
+  /// landed on the postcard (the summary was unseen and is now consumed).
+  private func placeAtUnseenPostcard(proxy: ScrollViewProxy) -> Bool {
+    guard showsDailySummary, dailySummaryStore.latest != nil,
+      ChatDailySummaryCoordinator.shared.consumeUnseenSummaryForPostcardLanding()
+    else { return false }
+
+    // Arm-gated INV-CHAT-2 seed: the card enters now because this open is
+    // *for* it, and the placement below cannot move the reader — they start
+    // here. Free-scrolling keeps later arrivals below (activity pill) instead
+    // of yanking the reader off the postcard.
+    dailySummaryAdmitted = true
+    scrollMode = .freeScrolling
+    hasActivityBelow = !messages.isEmpty
+    initialRestoreState = .pending
+    proxy.scrollTo(chatPostcardAnchorID, anchor: .top)
+
+    // Same settling passes as the live-edge placement: the card's rich
+    // Markdown expands across later layout turns.
+    let delays = ChatScrollLiveEdge.initialRestoreSettlingDelays
+    guard !delays.isEmpty else {
+      initialRestoreState = .completed
+      return true
+    }
+    for (index, delay) in delays.enumerated() {
+      schedulePostcardScroll(
+        proxy: proxy,
+        delay: delay,
+        completesInitialRestore: index == delays.index(before: delays.endIndex)
+      )
+    }
+    return true
+  }
+
+  /// Schedules a delayed postcard scroll that is cancelable. Reader input
+  /// cancels it through the shared `cancelAllPendingScrolls`.
+  private func schedulePostcardScroll(
+    proxy: ScrollViewProxy,
+    delay: TimeInterval,
+    completesInitialRestore: Bool
+  ) {
+    var workItem: DispatchWorkItem?
+    workItem = DispatchWorkItem { [self] in
+      if scrollMode == .freeScrolling {
+        proxy.scrollTo(chatPostcardAnchorID, anchor: .top)
+        if completesInitialRestore, initialRestoreState == .pending {
+          initialRestoreState = .completed
+        }
+      }
+      if let workItem {
+        initialScrollWorkItems.removeAll { $0 === workItem }
+      }
+    }
+    if let workItem {
+      initialScrollWorkItems.append(workItem)
+      DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ChatDailySummaryCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ChatDailySummaryCoordinator.swift
@@ -92,6 +92,26 @@ final class ChatDailySummaryCoordinator: ObservableObject {
     AnalyticsManager.shared.trackDailySummary(.cardShown)
   }
 
+  // MARK: - EXP-002 postcard-first landing
+
+  /// True when the latest summary has not been landed on yet, and marks it
+  /// landed. The `memory_v1` arm opens the Chat surface on the postcard for
+  /// exactly those summaries — the night object — instead of the live edge;
+  /// every later open follows the bottom as usual. Uses its own latch so it
+  /// can never consume the notch announcement (or vice versa), and only
+  /// counts a summary whose overview has filled in, matching
+  /// `announceIfNew`'s "not consumed until actually shown" rule.
+  func consumeUnseenSummaryForPostcardLanding() -> Bool {
+    guard let record = store.latest,
+      ChatDailySummaryPresentation.cardBody(for: record.overview) != nil,
+      let owner = ownerID()
+    else { return false }
+    let key = ScopedDefaultsKey.dailySummaryPostcardLandedID(ownerID: owner)
+    guard defaults.string(forKey: key) != record.id else { return false }
+    defaults.set(record.id, forKey: key)
+    return true
+  }
+
   private static let defaultCardSink: CardSink = { ownerID, title, body in
     // Fenced to the owner the summary was fetched for, not whoever is current now.
     guard let snapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot(expectedOwnerID: ownerID) else {

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -86,6 +86,8 @@ struct DesktopHomeView: View {
   @State private var automationPresentationReadinessGate =
     DesktopAutomationPresentationReadinessGate()
   @State private var chatFirstCapabilitySample = ChatFirstShellCapabilitySample()
+  /// EXP-002 arm state; the body gate holds the shell until it resolves.
+  @ObservedObject private var desktopExperiment = DesktopExperimentCoordinator.shared
 
   // Pre-loaded hero logo to avoid NSImage init crashes during SwiftUI body evaluation
   private static let heroLogoImage: NSImage? = {
@@ -328,10 +330,20 @@ struct DesktopHomeView: View {
       if shouldShowAuthEntryShell {
         authEntryShell
       } else if case .unresolved = chatFirstCapabilitySample.variant {
-        // Hold the legacy shell until the server-authoritative cohort settles.
         ChatFirstCapabilityLoadingView()
           .task(id: RuntimeOwnerIdentity.currentOwnerId() ?? "missing-owner") {
             await resolveChatFirstCapabilityIfNeeded()
+          }
+          .task(id: RuntimeOwnerIdentity.currentOwnerId() ?? "missing-owner") {
+            await resolveDesktopExperimentIfNeeded()
+          }
+      } else if desktopExperiment.phase == .pending {
+        // EXP-002: the arm resolves before the main shell paints, so
+        // treatment UI never renders ahead of its assignment. Enrollment
+        // (both arms, one server code path) completes inside this hold.
+        ChatFirstCapabilityLoadingView()
+          .task(id: RuntimeOwnerIdentity.currentOwnerId() ?? "missing-owner") {
+            await resolveDesktopExperimentIfNeeded()
           }
       } else {
         ZStack {
@@ -449,6 +461,9 @@ struct DesktopHomeView: View {
     .onReceive(NotificationCenter.default.publisher(for: .runtimeOwnerDidChange)) { _ in
       reconcileOnboardingCompletionOwner()
       chatFirstCapabilitySample.ownerDidChange(to: RuntimeOwnerIdentity.currentOwnerId())
+      // EXP-002: the previous owner's arm must not leak into the next
+      // owner's chrome; the body gate re-resolves from pending.
+      DesktopExperimentCoordinator.shared.ownerDidChange()
       // The provider's owner-bound gate rejects the previous sample for this
       // owner; no replacement sample is persisted or inferred locally.
       reportAutomationState()
@@ -1130,6 +1145,20 @@ struct DesktopHomeView: View {
       )
     )
     reportAutomationState()
+  }
+
+  /// EXP-002: resolve the identity-experiment arm for this owner before the
+  /// main shell paints. Non-production bundles use the local environment
+  /// override (never enrolled); the Beta bundle enrolls server-side
+  /// (idempotent); every other channel paints control. Failures resolve
+  /// control — a treatment arm is never applied unconfirmed.
+  private func resolveDesktopExperimentIfNeeded() async {
+    guard DesktopExperimentCoordinator.shared.phase == .pending else { return }
+    if AppBuild.isNonProduction {
+      DesktopExperimentCoordinator.shared.resolveFromLaunchEnvironment()
+      return
+    }
+    await DesktopExperimentCoordinator.shared.resolveForCurrentOwner()
   }
 
   private func navigateAfterOnboarding() {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -599,6 +599,7 @@ struct DashboardPage: View {
         },
         onOpenAgentRef: FloatingControlBarManager.shared.openAgentChatFromTimeline(ref:completion:),
         chatFirstRichBlockContext: chatFirstRichBlockContext,
+        postcardFirstLanding: DesktopExperimentCoordinator.shared.isMemoryV1,
         welcomeContent: { dashboardChatWelcome }
       )
       .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -751,6 +752,17 @@ struct DashboardPage: View {
 
     return VStack(spacing: 0) {
       Spacer(minLength: 0)
+
+      // EXP-002 `memory_v1`: the postcard is the home object on the hub —
+      // what happened, what Omi thinks is true, tap if wrong. Same store and
+      // card the Chat surface mounts; control and un-armed users see the hub
+      // unchanged.
+      if DesktopExperimentCoordinator.shared.isMemoryV1 {
+        HomeDailySummarySection(store: ChatDailySummaryCoordinator.shared.store)
+          .frame(width: columnWidth)
+          .padding(.bottom, OmiSpacing.xl)
+          .transition(.homeHubFade)
+      }
 
       homeHubHeadline
         .transition(.homeHubFade)
@@ -1155,6 +1167,7 @@ struct DashboardPage: View {
         chatFirstRichBlockContext: chatFirstRichBlockContext,
         verticalContentPadding: OmiSpacing.sm,
         trailingContentPadding: OmiSpacing.md,
+        postcardFirstLanding: DesktopExperimentCoordinator.shared.isMemoryV1,
         welcomeContent: { dashboardChatWelcome }
       )
       .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryAnswerThread.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryAnswerThread.swift
@@ -74,6 +74,7 @@ struct QueryAnswerThread: View {
         chatFirstRichBlockContext: chatFirstRichBlockContext,
         transcriptWindowPolicy: .compactHome,
         verticalContentPadding: OmiSpacing.sm,
+        postcardFirstLanding: DesktopExperimentCoordinator.shared.isMemoryV1,
         // **The one thing an empty transcript here is ever allowed to say.** The post-onboarding
         // opener is composed by the provider the moment onboarding finishes — a greeting by name
         // and tappable starters — and its only renderer was the deleted chat page and the legacy

--- a/desktop/macos/Desktop/Sources/PostHogManager.swift
+++ b/desktop/macos/Desktop/Sources/PostHogManager.swift
@@ -112,6 +112,24 @@ class PostHogManager {
     log("PostHog: Tracked event '\(eventName)'")
   }
 
+  /// EXP-002: attach `experiment_id` + `variant` to every captured event as
+  /// super-properties, so all product events (`question_asked`/`question_answered`,
+  /// `desktop_daily_summary`, PTT lifecycle, Interject teach) are sliceable by
+  /// arm without per-event plumbing. Distinct id stays the uid — the variant is
+  /// a property, never an identity. Called once the launch's arm resolves.
+  func setExperimentContext(experimentId: String, variant: String, forced: Bool) {
+    guard isInitialized else {
+      log("PostHog: experiment context skipped (not initialized)")
+      return
+    }
+    PostHogSDK.shared.register([
+      "experiment_id": experimentId,
+      "variant": variant,
+      "experiment_forced": forced,
+    ])
+    log("PostHog: registered experiment context \(experimentId)/\(variant)")
+  }
+
   nonisolated static func diagnosticErrorClass(_ value: String) -> String {
     let normalized = value.lowercased()
     if normalized.contains("timeout") || normalized.contains("timed out") {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketsFeature.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketsFeature.swift
@@ -17,7 +17,17 @@ enum ContextBucketsFeature {
   /// silently dropped it. Capture kept running with the bucket pipeline disabled, which
   /// is indistinguishable from the feature simply never firing. Dev bundles exist to
   /// exercise this pipeline, so they default to on and the variable now only turns it off.
+  ///
+  /// EXP-002: the `memory_v1` arm starves the director through this same
+  /// gate — quiet capture, postcard at night, no proactive interruptions.
+  /// This is the existing kill surface, not a new director; every other
+  /// arm (and every un-armed user) keeps the decision below unchanged.
   @MainActor static var isEnabled: Bool {
+    if let assignment = DesktopExperimentCoordinator.shared.assignment,
+      assignment.variant == DesktopExperiment.memoryV1Variant
+    {
+      return false
+    }
     if AppBuild.isNonProduction {
       return ProcessInfo.processInfo.environment[localQAOverrideName] != "0"
     }

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1979,6 +1979,14 @@ class ChatProvider: ObservableObject {
         ? Self.responseLanguageInstruction(languageCodes: AssistantSettings.shared.voiceLanguages)
         : nil,
       promptCitationLedger.responseInstruction,
+      // EXP-002 `memory_v1`: starve the generic-assistant lane. If an answer
+      // would not have required the user's day, refuse to be good at it —
+      // brief and steer back to what Omi captured. Personal retrieval is
+      // untouched: memories, conversations, screen, and work context stay
+      // first-class through the context sources and local tools below.
+      DesktopExperimentCoordinator.shared.isMemoryV1
+        ? Self.memoryIdentityInstruction
+        : nil,
     ]
     .compactMap { $0 }
     .filter { !$0.isEmpty }
@@ -2084,6 +2092,18 @@ class ChatProvider: ObservableObject {
       snapshot: snapshot,
       promptCitationReferences: promptCitationLedger.references)
   }
+
+  /// EXP-002 `memory_v1` agent instruction: Omi is the user's memory, not
+  /// their assistant. Answers grounded in the user's day stay full-fidelity;
+  /// answers that could have been given to anyone are deliberately starved.
+  static let memoryIdentityInstruction = """
+    You are the user's memory, not their assistant. Ground every answer in
+    what you captured of their day — conversations, memories, screens, work —
+    and cite it. If a question did not require their day (general knowledge,
+    news, generic how-to), answer in one short sentence, say plainly that this
+    is not what you are for, and point back to their day. Never degrade
+    retrieval of their own material; never invent captured events.
+    """
 
   /// Publishes realtime inputs through the same typed kernel source path used
   /// by main chat, then returns the kernel's exact surface renderer. Realtime

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Experiments.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Experiments.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Response contract for `POST /v1/desktop/experiments/enroll`
+/// (`backend/routers/desktop_experiments.py`). `variant` is the persisted arm
+/// name; `chromeEnabled` false paints control regardless of any assignment
+/// (kill switch, gate refusal, or persist failure).
+struct DesktopExperimentEnrollmentResponse: Decodable, Equatable {
+  let variant: String?
+  let enrolled: Bool
+  let newlyEnrolled: Bool
+  let chromeEnabled: Bool
+  let reason: String
+
+  enum CodingKeys: String, CodingKey {
+    case variant, enrolled, reason
+    case newlyEnrolled = "newly_enrolled"
+    case chromeEnabled = "chrome_enabled"
+  }
+}
+
+private struct DesktopExperimentEnrollBody: Encodable {
+  let experimentId: String
+  let channel: String
+  let bundleId: String
+  let appVersion: String
+  let appBuild: String?
+  let platform: String = "macos"
+
+  enum CodingKeys: String, CodingKey {
+    case channel, platform
+    case experimentId = "experiment_id"
+    case bundleId = "bundle_id"
+    case appVersion = "app_version"
+    case appBuild = "app_build"
+  }
+}
+
+extension APIClient {
+  /// Requests EXP-002 enrollment for the signed-in owner. Both arms resolve
+  /// through this one call; the server emits `Experiment Enrolled` before the
+  /// response, so enrollment lands before any treatment UI. The request
+  /// timeout bounds launch blocking — a slow network resolves control
+  /// (fail closed) rather than holding the splash.
+  func enrollDesktopExperiment(
+    experimentId: String,
+    expectedOwnerId: String,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot?
+  ) async throws -> DesktopExperimentEnrollmentResponse {
+    try await post(
+      "v1/desktop/experiments/enroll",
+      body: DesktopExperimentEnrollBody(
+        experimentId: experimentId,
+        channel: AppBuild.isBetaProductionBundle ? "beta" : "stable",
+        bundleId: AppBuild.bundleIdentifier,
+        appVersion: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "",
+        appBuild: Bundle.main.infoDictionary?["CFBundleVersion"] as? String),
+      expectedOwnerId: expectedOwnerId,
+      authorizationSnapshot: authorizationSnapshot,
+      requestTimeout: DesktopExperimentCoordinator.enrollmentTimeout)
+  }
+}

--- a/desktop/macos/Desktop/Tests/DesktopExperimentTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopExperimentTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// EXP-002 — desktop identity experiment (`control` vs `memory_v1`).
+///
+/// Pins the arm contract: which channels may enroll, how the local dogfood
+/// override resolves, that failures never apply a treatment arm, and how the
+/// arm binds Interject and the director through their existing gates.
+final class DesktopExperimentTests: XCTestCase {
+  // MARK: - Enrollment policy
+
+  func testOnlyTheBetaProductionBundleRequestsEnrollment() {
+    XCTAssertTrue(
+      DesktopExperiment.shouldRequestEnrollment(isNonProduction: false, isBetaProductionBundle: true))
+    // Stable stays control in v1.
+    XCTAssertFalse(
+      DesktopExperiment.shouldRequestEnrollment(isNonProduction: false, isBetaProductionBundle: false))
+    // Named/dev bundles dogfood through the local override instead.
+    XCTAssertFalse(
+      DesktopExperiment.shouldRequestEnrollment(isNonProduction: true, isBetaProductionBundle: false))
+  }
+
+  func testForcedVariantAcceptsOnlyKnownArms() {
+    XCTAssertEqual(
+      DesktopExperiment.forcedVariant(environment: ["OMI_FORCE_EXPERIMENT_VARIANT": "memory_v1"]),
+      "memory_v1")
+    XCTAssertEqual(
+      DesktopExperiment.forcedVariant(environment: ["OMI_FORCE_EXPERIMENT_VARIANT": "control"]),
+      "control")
+    XCTAssertEqual(
+      DesktopExperiment.forcedVariant(environment: ["OMI_FORCE_EXPERIMENT_VARIANT": "  memory_v1  "]),
+      "memory_v1")
+    // A typo cannot invent an arm.
+    XCTAssertNil(DesktopExperiment.forcedVariant(environment: ["OMI_FORCE_EXPERIMENT_VARIANT": "mem_v1"]))
+    XCTAssertNil(DesktopExperiment.forcedVariant(environment: ["OMI_FORCE_EXPERIMENT_VARIANT": ""]))
+    XCTAssertNil(DesktopExperiment.forcedVariant(environment: [:]))
+  }
+
+  // MARK: - Coordinator fail-closed
+
+  @MainActor
+  func testEnrollmentRefusalResolvesControlChromeWithoutAssignment() async {
+    let coordinator = DesktopExperimentCoordinator()
+    await coordinator.resolveForCurrentOwner()
+    // This process is not a beta production bundle, so the channel gate
+    // refuses before any network work: resolved, control chrome, no arm.
+    XCTAssertEqual(coordinator.phase, .resolved)
+    XCTAssertNil(coordinator.assignment)
+    XCTAssertFalse(coordinator.isMemoryV1)
+  }
+
+  @MainActor
+  func testEnvironmentOverrideAppliesTheArmLocally() {
+    let coordinator = DesktopExperimentCoordinator()
+    let environment = ["OMI_FORCE_EXPERIMENT_VARIANT": "memory_v1"]
+    let variant = DesktopExperiment.forcedVariant(environment: environment)
+    XCTAssertEqual(variant, "memory_v1")
+    // The forced path resolves synchronously and never enrolls.
+    coordinator.applyForTests(
+      DesktopExperimentAssignment(variant: variant ?? "", source: .forcedLocal))
+    XCTAssertTrue(coordinator.isMemoryV1)
+    XCTAssertEqual(coordinator.phase, .resolved)
+  }
+
+  @MainActor
+  func testOwnerChangeClearsTheArmSoItCannotLeakAcrossAccounts() {
+    let coordinator = DesktopExperimentCoordinator()
+    coordinator.applyForTests(DesktopExperimentAssignment(variant: "memory_v1", source: .enrolled))
+    XCTAssertTrue(coordinator.isMemoryV1)
+    coordinator.ownerDidChange()
+    XCTAssertEqual(coordinator.phase, .pending)
+    XCTAssertNil(coordinator.assignment)
+    XCTAssertFalse(coordinator.isMemoryV1)
+  }
+
+  @MainActor
+  func testInterjectIsOnOnlyForMemoryV1AmongArmedUsers() {
+    let decision: (String?, Bool, Bool) -> Bool = {
+      InterjectFeature.isEnabled(
+        experimentVariant: $0, killSwitchEnabled: $1, unenrolledDecision: $2)
+    }
+    // memory_v1 turns it on; armed control turns it off.
+    XCTAssertTrue(decision("memory_v1", false, false))
+    XCTAssertFalse(decision("control", false, true))
+    // The fleet kill switch disarms every arm.
+    XCTAssertFalse(decision("memory_v1", true, true))
+    // Un-armed users keep the existing dogfood decision untouched.
+    XCTAssertTrue(decision(nil, false, true))
+    XCTAssertFalse(decision(nil, false, false))
+  }
+
+  @MainActor
+  func testPostcardLandingConsumesEachSummaryExactlyOnce() async throws {
+    let defaults = UserDefaults(suiteName: "desktop-experiment-tests-\(UUID().uuidString)")!
+    let box = SummaryBox()
+    let store = HomeDailySummaryStore(
+      ownerFence: { { true } },
+      fetch: { _ in box.records },
+      now: Date.init)
+    let coordinator = ChatDailySummaryCoordinator(
+      store: store,
+      defaults: defaults,
+      ownerID: { "owner-1" },
+      cardSink: { _, _, _ in }
+    )
+    // No summary: never lands.
+    XCTAssertFalse(coordinator.consumeUnseenSummaryForPostcardLanding())
+
+    box.records = [
+      DailySummaryRecord(id: "summary-1", date: "2026-09-02", headline: "h", overview: "o")
+    ]
+    await coordinator.refreshIfNeeded()
+    XCTAssertEqual(store.latest?.id, "summary-1")
+
+    // First consume lands, second does not — at most once per summary.
+    XCTAssertTrue(coordinator.consumeUnseenSummaryForPostcardLanding())
+    XCTAssertFalse(coordinator.consumeUnseenSummaryForPostcardLanding())
+
+    // A new summary lands again.
+    box.records = [
+      DailySummaryRecord(id: "summary-2", date: "2026-09-03", headline: "h", overview: "o")
+    ]
+    await coordinator.refresh()
+    XCTAssertEqual(store.latest?.id, "summary-2")
+    XCTAssertTrue(coordinator.consumeUnseenSummaryForPostcardLanding())
+
+    // The landing writes its own latch, not the notch-announcement latch:
+    // neither consumes the other.
+    let landedKey = ScopedDefaultsKey.dailySummaryPostcardLandedID(ownerID: "owner-1")
+    XCTAssertEqual(defaults.string(forKey: landedKey), "summary-2")
+  }
+}
+
+private final class SummaryBox: @unchecked Sendable {
+  nonisolated(unsafe) var records: [DailySummaryRecord] = []
+}

--- a/desktop/macos/Desktop/Tests/DesktopExperimentTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopExperimentTests.swift
@@ -92,7 +92,8 @@ final class DesktopExperimentTests: XCTestCase {
 
   @MainActor
   func testPostcardLandingConsumesEachSummaryExactlyOnce() async throws {
-    let defaults = UserDefaults(suiteName: "desktop-experiment-tests-\(UUID().uuidString)")!
+    let defaults = try XCTUnwrap(
+      UserDefaults(suiteName: "desktop-experiment-tests-\(UUID().uuidString)"))
     let box = SummaryBox()
     let store = HomeDailySummaryStore(
       ownerFence: { { true } },

--- a/desktop/macos/agent/src/adapters/pi-mono.ts
+++ b/desktop/macos/agent/src/adapters/pi-mono.ts
@@ -226,6 +226,13 @@ function resolveBundledExtension(): string {
 
 const PUBLIC_WEB_ROUTING_INSTRUCTION = "<omi_retrieval_policy>Web search is required and available for this fresh public request. Use a live public-web or search tool before answering. Base time-sensitive claims only on that lookup and identify the source. Never say, imply, or hedge that you lack internet, web-search, real-time-data, or tool access; if the lookup itself fails, state that the lookup failed instead. Do not use private Omi context unless the user explicitly asks for it.</omi_retrieval_policy>";
 
+// EXP-002 `memory_v1`: Omi is the user's memory, not their assistant. The arm
+// starves generic public-web routing — no turn may be flagged as requiring a
+// live web lookup, so the backend keeps the turn on the chat-agent lane
+// instead of swapping to the web-search lane. Personal retrieval is unaffected:
+// it flows through context sources and Omi tools, not this routing prefix.
+const MEMORY_IDENTITY_VARIANT = "memory_v1";
+
 const EXPLICIT_WEB_REQUESTS = [
   "search the web", "search web", "search the internet", "search online",
   "look it up online", "look this up online", "look that up online",
@@ -424,6 +431,10 @@ type PublicWebTurnState = {
 /// the instruction here guarantees public-web queries keep working for main
 /// agents and subagents while the backend fleet rolls forward independently.
 export function routePromptForPublicWeb(message: string): string {
+  // EXP-002 memory_v1: the arm never flags a turn for public-web routing.
+  if ((globalThis.process?.env?.OMI_EXPERIMENT_VARIANT ?? "").trim() === MEMORY_IDENTITY_VARIANT) {
+    return message;
+  }
   // The adapter receives the full rendered prompt, including inherited context
   // and prior turns. Inspect only the current user instruction when deciding
   // whether this particular turn requires a public-web lookup.

--- a/desktop/macos/agent/tests/pi-mono-adapter.test.ts
+++ b/desktop/macos/agent/tests/pi-mono-adapter.test.ts
@@ -252,6 +252,43 @@ describe("PiMonoAdapter prompt correlation", () => {
     }
   });
 
+  it("EXP-002 memory_v1 never routes a turn onto the public web", () => {
+    const previous = process.env.OMI_EXPERIMENT_VARIANT;
+    process.env.OMI_EXPERIMENT_VARIANT = "memory_v1";
+    try {
+      for (const message of [
+        "Search the web for the latest SwiftUI changes.",
+        "What is the current weather in NYC?",
+        "google it",
+      ]) {
+        expect(routePromptForPublicWeb(message)).toBe(message);
+      }
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OMI_EXPERIMENT_VARIANT;
+      } else {
+        process.env.OMI_EXPERIMENT_VARIANT = previous;
+      }
+    }
+  });
+
+  it("EXP-002 control and un-armed turns keep the routing contract", () => {
+    const previous = process.env.OMI_EXPERIMENT_VARIANT;
+    process.env.OMI_EXPERIMENT_VARIANT = "control";
+    try {
+      expect(routePromptForPublicWeb("Search the web for the latest SwiftUI changes.")).toContain(
+        "<omi_retrieval_policy>"
+      );
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OMI_EXPERIMENT_VARIANT;
+      } else {
+        process.env.OMI_EXPERIMENT_VARIANT = previous;
+      }
+    }
+    expect(routePromptForPublicWeb("What did I do today?")).toBe("What did I do today?");
+  });
+
   it("keeps the trusted query separate from appended untrusted tool context", () => {
     const privateQueryWithToolContext = [
       "[Kernel Context Snapshot version=1 generation=2]",

--- a/desktop/macos/changelog/unreleased/20260903-exp-002-memory-identity.json
+++ b/desktop/macos/changelog/unreleased/20260903-exp-002-memory-identity.json
@@ -1,0 +1,3 @@
+{
+  "change": "Beta experiment: a randomized group sees Omi as memory first — the daily postcard leads, Interject on, proactive director quiet, generic web answers starved — while everyone else keeps today's experience"
+}

--- a/desktop/macos/e2e/flows/experiment-arm-resolution.yaml
+++ b/desktop/macos/e2e/flows/experiment-arm-resolution.yaml
@@ -1,0 +1,41 @@
+version: 1
+name: experiment-arm-resolution
+tier: 1
+description: >
+  EXP-002 launch gate. The main shell must not paint until the identity
+  experiment arm resolves: non-production bundles resolve the local
+  OMI_FORCE_EXPERIMENT_VARIANT override (never enrolling), and any failure
+  resolves control chrome. The observable contract is that the shell leaves
+  the loading variant and the app reaches a settled main state.
+app: non-prod
+covers:
+  - desktop/macos/Desktop/Sources/Experiments/DesktopExperiment.swift
+  - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Experiments.swift
+preconditions:
+  - automation_bridge_ready
+steps:
+  - id: S0
+    name: Park automation UI without taking the desktop
+    bridge.action:
+      name: set_automation_ui_presentation
+      params:
+        mode: quiet
+    expect:
+      result.detail.mode: quiet
+
+  - id: S1
+    name: Wait for the shell to settle past the experiment hold
+    wait:
+      state.appState: signed_in
+    timeout_seconds: 120
+
+  - id: S2
+    name: Shell variant is resolved, not loading
+    state.expect:
+      state.shellVariant:
+        not: loading
+
+  - id: S3
+    name: Capture settled shell visual
+    visual.export:
+      name: experiment-shell

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -1712,6 +1712,9 @@ build_launch_env_args() {
     if [ -n "${OMI_FORCE_MEETING_NOTE_SCREENSHOTS:-}" ]; then
         LAUNCH_ENV_ARGS+=(--env "OMI_FORCE_MEETING_NOTE_SCREENSHOTS=$OMI_FORCE_MEETING_NOTE_SCREENSHOTS")
     fi
+    if [ -n "${OMI_FORCE_EXPERIMENT_VARIANT:-}" ]; then
+        LAUNCH_ENV_ARGS+=(--env "OMI_FORCE_EXPERIMENT_VARIANT=$OMI_FORCE_EXPERIMENT_VARIANT")
+    fi
     # Forward automation token overrides when the caller already pinned them
     # (e.g. desktop-core-harness.sh). Default token discovery prefers Darwin
     # user temp in harness clients, matching NSTemporaryDirectory().


### PR DESCRIPTION
## Summary

EXP-002: multi-arm experiment infrastructure plus the first competing product arm. Arm `control` is byte-identical to today's macOS desktop experience; arm `memory_v1` is the shippable slice of "Omi is your memory, not your assistant" — postcard-first landing, Interject on, director starved, generic web Q&A starved. One shell; the arm is a parameter pack (a second shell already proved inert, #12598).

**Experiment substrate (backend):**
- `utils/experiments.py` extended from binary `control`/`treatment` to **N named arms**: `assigned_variant`/`enroll` accept an ordered `((name, weight), ...)` registry, persist the arm name as `variant`, and keep the legacy binary draw byte-identical for running experiments (EXP-001). Adding a third arm later is a registry change in `config/desktop_experiments.py`, not a new enroll path.
- New `POST /v1/desktop/experiments/enroll` on the desktop backend (`routers/desktop_experiments.py`): Beta-bundle channel gate (`com.omi.computer-macos.beta` only — Stable/default channel does not enroll in v1), app-version floor, server-side PostHog kill switch (`exp-002-desktop-identity-v1` / `exp-002-desktop-identity-kill-v1`, tri-state fail-closed per the `jit_rollout` pattern), assignment writes pinned through the data-plane Firestore seam (skip enrollment rather than split the roster across planes), and **fail-closed-to-control** on any persist failure. Idempotent: re-enroll returns the persisted arm.
- Pre-registration merged in the same PR: `backend/docs/experiments/EXP-002-desktop-identity-memory-v1.md` (arms/weights, near-term primaries — day-1 return, teach-rate on shown facts, first grounded bar/PTT **success**; secondary questions-asked may fall; Beta bake vs Stable confirmatory roster; kill-switch names; never rename the id; HogQL ITT denominator over enrollment; never condition on opened Chat).

**Desktop (`memory_v1` only, wiring and defaults — not Send, not a PTT rewrite):**
- `DesktopExperimentCoordinator` resolves the arm once per owner **before the main shell paints**: the Beta bundle enrolls through the endpoint (bounded request timeout, both arms one code path, server emits `Experiment Enrolled` before the response); named/dev bundles dogfood via `OMI_FORCE_EXPERIMENT_VARIANT` locally (never enrolled, never written); every failure path resolves control chrome. Owner switches reset the arm.
- **Postcard-first**: the chat surface opens on the daily-summary postcard when a new summary exists (arm-gated INV-CHAT-2 admission seed + top-of-document placement with its own once-per-summary latch, independent of the notch-announcement latch), and the hub stage leads with the postcard section (`HomeDailySummarySection`, previously unmounted). Chat remains fully available.
- **Interject on** for this arm through the existing merged flag path: armed users get Interject == (arm == memory_v1); the fleet kill switch `desktop_interject_kill` still disarms every arm; un-armed users keep the dogfood decision untouched.
- **Director starved or off** via the existing gate: `ContextBucketsFeature.isEnabled` returns false for memory_v1. No new director; JIT memory processing untouched.
- **Generic web Q&A starved**: a memory-identity response instruction rides `prepareKernelQueryContext` (answers that did not require the user's day get one short sentence pointing back to their day), and the agent child (`OMI_EXPERIMENT_VARIANT` env) never emits the public-web routing prefix for memory_v1, so the backend lane never swaps to `omi:auto:web-search`. Personal retrieval — context sources and local tools — is unchanged by construction.
- **Tagged everywhere**: `experiment_id` + `variant` as PostHog super-properties (covers `question_asked`/`question_answered`, `desktop_daily_summary`, PTT lifecycle, Interject teach — attached as event properties, distinct id stays the uid), Sentry scope tags on every crash, a launch-scoped field on every structured desktop log line, and `experiment_id`/`variant` on the backend enroll request logs.
- Changelog fragment for the user-visible Beta behavior.

Out of scope by design: Send/gift meeting-share, `h.omi.me`, meeting-receipt reconciler, Brain Map, a second shell, capture-gate changes (owned by ptt-improvement / #12616 — the bar/PTT surface is only *tagged*).

## Verification

- Backend unit: `python -m pytest tests/unit/test_experiments.py` — **23 passed** (N-arm draw determinism, weight respect, registry-extension stability, invalid registries rejected, legacy binary draw pinned unchanged, arm-name persistence, idempotency across registry extension, all-arms Enrolled, fail-closed persist).
- Backend router: `python -m pytest tests/routers/test_desktop_experiments.py` — **11 passed** (channel gate, version floor, 404, kill-switch-off leaves assignments + paints control, plane-unavailable skip, persist failure fail-closed, idempotent re-enroll, both arms through one endpoint).
- Desktop: `xcrun swift build -c debug --package-path Desktop` — Build complete. `xcrun swift test --filter 'DesktopExperimentTests|BetaDogfoodRolloutTests|ChatDailySummaryTests|HomeDailySummaryTests|MemoryReviewCardTests'` — **61 passed, 0 failures** (enrollment policy Beta-only, forced-variant parsing, fail-closed resolution, owner-change isolation, Interject arm binding incl. fleet kill switch, postcard landing latch).
- Agent runtime: `npm test -- tests/pi-mono-adapter.test.ts` — **48 passed** (incl. memory_v1 never routes onto the public web; control/un-armed keep the routing contract).
- Live endpoint probes against the local desktop-backend (offline harness, emulator plane): stable channel → `channel_not_allowed`; below-floor version → `app_version_below_minimum`; unknown id → 404; valid Beta request with PostHog flags absent → `kill_switch_off`, no assignment written (the intended dark default until the flag is set).
- Named-bundle exercise (`OMI_APP_NAME=omi-exp-002 OMI_FORCE_EXPERIMENT_VARIANT=memory_v1 ./run.sh`): log shows `DesktopExperiment: forced local arm memory_v1` resolved **before** shell paint (shell held on loading until the arm settled), and every subsequent structured log line carries `[experiment_id=EXP-002-desktop-identity-memory-v1 variant=memory_v1]`. Example PostHog/Sentry attachment points: `PostHogManager.setExperimentContext` (super-properties), `SentrySDK.configureScope` tags `experiment_id`/`experiment_variant`, `logLine` experiment fields.

## Product invariants affected

- INV-AUTH-1 — the enroll-before-paint hold reuses the existing auth-entry gate ordering in `DesktopHomeView`; session invalidation ownership is untouched, and a failed/absent enrollment resolves control chrome without touching session state.
- INV-CHAT-1 — the postcard stays chrome above the thread (no turn, no journal entry, no synthetic message); the memory_v1 placement only changes where the transcript opens, never what is a message.
- INV-CHAT-2 — the launch-placement invariant is preserved for control/un-armed users byte-for-byte; memory_v1 seeds card admission and opens on the postcard only through an arm-gated path with its own once-per-summary latch, so the admission rule itself is unchanged for everyone else.
- INV-NAV-1 — both shells receive the same arm parameter pack: postcard-first applies to the chat-first surface and the hub stage alike; no shell-only feature was added.

## Line-Count-Exception

Line-Count-Exception: desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift | 4365 -> 4375 | one bounded env injection block so the agent child can starve public-web routing per arm; splitting the 4.3k-line runtime host for 10 lines adds risk, not structure
Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift | 1689 -> 1718 | the enroll-before-paint gate lives in the body's existing hold-point (same seam as the chat-first capability hold) plus the resolve function and owner-change reset
Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift | 4268 -> 4281 | arm-gated postcard mount in the hub stage and one parameter passed to the two ChatMessagesView hosts
Line-Count-Exception: desktop/macos/Desktop/Sources/Providers/ChatProvider.swift | 7198 -> 7218 | memory-identity instruction appended in the established responseContext seam plus one typed constant

## Rollout

Dark by default: the enroll endpoint refuses everything until `exp-002-desktop-identity-v1` is explicitly true in PostHog, and only the Beta bundle enrolls. No merge-time exposure, no Stable flip, no deploy performed. Kill switch names and the confirmatory-roster rule are in the pre-registration.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

