### PR TITLE
fix(desktop): stop the notification-settings query from killing a non-app host

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+NotificationSettings.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+NotificationSettings.swift
@@ -11,6 +11,15 @@ struct UserNotificationSettingsSnapshot: Sendable {
   let soundSetting: UNNotificationSetting
   let badgeSetting: UNNotificationSetting
 
+  /// The answer for a host process that cannot own notification authorization at all,
+  /// such as the xctest tool. Distinct from a real `.notDetermined` only in origin.
+  static let hostProcessUnavailable = UserNotificationSettingsSnapshot(
+    authorizationStatus: .notDetermined,
+    alertStyle: .none,
+    soundSetting: .notSupported,
+    badgeSetting: .notSupported
+  )
+
   init(_ settings: UNNotificationSettings) {
     authorizationStatus = settings.authorizationStatus
     alertStyle = settings.alertStyle
@@ -221,9 +230,30 @@ enum UserNotificationCallbackBridge {
     return true
   }
 
-  nonisolated private static func systemNotificationSettingsQuery(
+  /// True when the running process is an app bundle, which `UNUserNotificationCenter`
+  /// requires.
+  ///
+  /// `UNUserNotificationCenter.current()` does not fail softly off an app bundle: it raises
+  /// `NSInternalInconsistencyException` ("bundleProxyForCurrentProcess is nil"), and an
+  /// Objective-C exception cannot be caught in Swift, so it terminates the whole process.
+  /// Under `swift test` the main bundle is the xctest tool
+  /// (`…/Xcode.app/Contents/Developer/usr/bin/`), so any suite that reaches this query kills
+  /// the run — see #9029, where the victim suite moved with test ordering because the crash
+  /// lands on whichever suite is executing, not on the one that triggered it.
+  nonisolated static var hostProcessIsAppBundle: Bool {
+    Bundle.main.bundleURL.pathExtension == "app"
+  }
+
+  nonisolated static func systemNotificationSettingsQuery(
     completion: @escaping @Sendable (UserNotificationSettingsSnapshot) -> Void
   ) {
+    guard hostProcessIsAppBundle else {
+      // No app bundle means no notification authorization to report. Answering
+      // `.notDetermined` keeps callers on their unauthorized path, which is the same
+      // answer a fresh install gives.
+      completion(.hostProcessUnavailable)
+      return
+    }
     UNUserNotificationCenter.current().getNotificationSettings { settings in
       completion(UserNotificationSettingsSnapshot(settings))
     }

--- a/desktop/macos/Desktop/Tests/NotificationSettingsHostBundleTests.swift
+++ b/desktop/macos/Desktop/Tests/NotificationSettingsHostBundleTests.swift
@@ -1,0 +1,52 @@
+import UserNotifications
+import XCTest
+
+@testable import Omi_Computer
+
+/// #9029: the desktop suite hard-crashed in a single `swift test` process with no assertion
+/// failure, and the victim suite moved with test ordering.
+///
+/// The cause was `UNUserNotificationCenter.current()` in the production notification-settings
+/// query. Off an app bundle it raises `NSInternalInconsistencyException`
+/// ("bundleProxyForCurrentProcess is nil"), and an Objective-C exception cannot be caught in
+/// Swift — so it terminated the whole run, landing on whichever suite happened to be
+/// executing rather than the one that reached the query.
+///
+/// These run in the xctest host, whose main bundle is the Xcode command-line tool, so they
+/// exercise the real non-app-bundle condition rather than a simulated one. Before the guard,
+/// the second test terminated the process instead of failing.
+final class NotificationSettingsHostBundleTests: XCTestCase {
+  func testTestHostIsNotAnAppBundle() {
+    XCTAssertFalse(
+      UserNotificationCallbackBridge.hostProcessIsAppBundle,
+      "the xctest host has no .app bundle; if this ever passes, the guard below stops being exercised"
+    )
+  }
+
+  func testSystemQueryAnswersWithoutTouchingUNUserNotificationCenter() {
+    let answered = expectation(description: "settings query completes")
+    let box = SnapshotBox()
+
+    UserNotificationCallbackBridge.systemNotificationSettingsQuery { result in
+      box.store(result)
+      answered.fulfill()
+    }
+
+    wait(for: [answered], timeout: 5)
+    let snapshot = box.value
+    XCTAssertEqual(snapshot?.authorizationStatus, .notDetermined)
+    XCTAssertEqual(snapshot?.soundSetting, .notSupported)
+  }
+}
+
+/// The query answers on an arbitrary queue, so the result crosses an isolation boundary.
+private final class SnapshotBox: @unchecked Sendable {
+  private let lock = NSLock()
+  private var stored: UserNotificationSettingsSnapshot?
+
+  var value: UserNotificationSettingsSnapshot? { lock.withLock { stored } }
+
+  func store(_ snapshot: UserNotificationSettingsSnapshot) {
+    lock.withLock { stored = snapshot }
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260903-notification-settings-host-guard.json
+++ b/desktop/macos/changelog/unreleased/20260903-notification-settings-host-guard.json
@@ -1,0 +1,4 @@
+{
+  "kind": "none",
+  "reason": "Test-process crash guard. The shipped app always runs from an .app bundle, so the notification-settings query behaves exactly as before for users; only a non-app host such as the xctest tool takes the new path."
+}


### PR DESCRIPTION
Fixes the process-terminating crash in #9029.

## Reproduced first

`swift test --package-path Desktop` (single combined process) on current `main`:

```
started=2652  completed=2650  failed=1
libc++abi: terminating due to uncaught exception of type NSException
```

The victim moved between my two runs of the same tree (`ChatTranscriptGestureHarnessTests`, then `HomeDailySummaryTests`) — the ordering signature the issue describes.

## Root cause

One call, `ProactiveAssistantsPlugin+NotificationSettings.swift:227`:

```
bundleProxyForCurrentProcess is nil: mainBundle.bundleURL file:///Applications/Xcode.app/Contents/Developer/usr/bin/
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException'
```

`UNUserNotificationCenter.current()` does **not** fail softly off an app bundle. It raises an Objective-C exception, and Swift cannot catch one, so it terminates the whole process. Under `swift test` the main bundle is the xctest tool, so any suite that reaches the production settings query kills the run.

That explains all three symptoms the issue lists:

- **no assertion failure** — it is a process termination, not a test failure
- **victim moves with ordering** — the crash lands on whichever suite is executing, not the one that reached the query
- **every suite passes in isolation** — per-suite processes contain the blast radius, which is exactly what the `test.sh` mitigation does

## The fix

The injection seam already existed — `notificationSettings(query:handler:)` takes the query — and only the production default was unsafe. It now answers `.notDetermined` when the host is not an app bundle, the same answer a fresh install gives, and never constructs `UNUserNotificationCenter`.

No test suite had to change, because the guard sits where every caller routes through.

## Verification

Full combined run, same command, before and after:

| | crash lines | tests completed |
|---|---|---|
| before | 1 | 2650 (run died) |
| after | **0** | **3023** |

`NotificationSettingsHostBundleTests` pins both halves **in the real xctest host** rather than a simulated one: the host is not an app bundle, and the production query answers rather than terminating. Before this change the second test took the process down instead of failing — that is the regression it guards.

Also verified with `-strict-concurrency=complete`, not just a debug build.

## Scope — what this does not do

- **Does not close #9029 by itself.** The issue also asks for DI seams across `RewindDatabase.shared`, `MemoryStorage.shared`, `AuthState.shared`, `StagedTaskStorage.shared` and `UserDefaults.standard`. This removes the one defect that terminates the process; ordinary shared-state coupling remains.
- **Does not remove the per-suite mitigation** in `test.sh`. That is a separate call once the combined run has been trusted for a while, and it should be its own PR.
- **`ChatDiscoverabilityTests.testDesktopCapabilitiesExistInAgentToolDeclarations` still fails**, before and after, and in isolation on `main`. Pre-existing and unrelated; left alone rather than folded in.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

