### PR TITLE
refactor(sdks/device/cpp): replace the SimpleBLE dependency with an injectable BleBackend

### DIFF
--- a/.github/workflows/sdk-cpp.yml
+++ b/.github/workflows/sdk-cpp.yml
@@ -24,3 +24,5 @@ jobs:
       - run: cmake -S . -B build -DOMI_DEVICE_BUILD_TESTS=ON
       - run: cmake --build build
       - run: ctest --test-dir build --output-on-failure
+      # Consumers of the retired SimpleBLE flags must fail at configure time.
+      - run: bash tests/retired-ble-flags.sh

--- a/.github/workflows/sdk-cpp.yml
+++ b/.github/workflows/sdk-cpp.yml
@@ -1,0 +1,26 @@
+name: C++ Device SDK
+
+on:
+  pull_request:
+    paths:
+      - "sdks/device/cpp/**"
+      - ".github/workflows/sdk-cpp.yml"
+  push:
+    branches: [main]
+    paths:
+      - "sdks/device/cpp/**"
+      - ".github/workflows/sdk-cpp.yml"
+
+jobs:
+  cpp:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/device/cpp
+    steps:
+      - uses: actions/checkout@v7
+      # No third-party dependency step: the package must configure and build
+      # from a bare checkout. A dependency that needs fetching fails here.
+      - run: cmake -S . -B build -DOMI_DEVICE_BUILD_TESTS=ON
+      - run: cmake --build build
+      - run: ctest --test-dir build --output-on-failure

--- a/sdks/device/PARITY.md
+++ b/sdks/device/PARITY.md
@@ -3,9 +3,9 @@
 | Capability | Python | Swift | React Native | TS device | Go | Rust | Dart | C++ |
 |------------|--------|-------|--------------|-----------|----|------|------|-----|
 | BLE UUIDs / packet strip | yes | yes | yes | yes | yes | yes | yes (app models.dart) | yes |
-| Full BLE scan/connect/listen | yes (bleak) | yes (CoreBluetooth) | yes (ble-plx) | optional `@stoprocent/noble` | `-tags ble` tinygo bluetooth | feature `ble` btleplug | **flutter_blue_plus** (app UUID map) | `OMI_DEVICE_BLE` SimpleBLE |
+| Full BLE scan/connect/listen | yes (bleak) | yes (CoreBluetooth) | yes (ble-plx) | optional `@stoprocent/noble` | `-tags ble` tinygo bluetooth | feature `ble` btleplug | **flutter_blue_plus** (app UUID map) | injectable `BleBackend` |
 | Audio notify + header strip | yes | yes | yes | yes | yes | yes | yes | yes |
-| Read codec / battery | yes | yes | yes | partial | codec yes | via chars | yes (app parity) | via SimpleBLE |
+| Read codec / battery | yes | yes | yes | partial | codec yes | via chars | yes (app parity) | via backend |
 | STT Deepgram | yes | yes | yes | yes | yes | feature | yes | URL helper |
 | STT Whisper | optional/runner | SwiftWhisper | runner | runner | runner | feature | runner | macro |
 | STT Parakeet `/v3/stream` | yes | yes | yes | yes | yes | feature | yes | URL helper |

--- a/sdks/device/README.md
+++ b/sdks/device/README.md
@@ -17,7 +17,7 @@ Portable **device BLE protocol** helpers for languages that do not yet have a fu
 | TypeScript | [`typescript/`](typescript/) | UUIDs, header strip, transport interface |
 | Go | [`go/`](go/) | UUIDs + `StripPacketHeader` + optional BLE (`-tags ble`, tinygo bluetooth) |
 | Rust | [`rust/`](rust/) | UUIDs + `strip_packet_header` |
-| C++ | [`cpp/`](cpp/) | UUIDs + `StripPacketHeader` |
+| C++ | [`cpp/`](cpp/) | UUIDs + `StripPacketHeader` + injectable `BleBackend` |
 | Dart | [`dart/`](dart/) | UUIDs + `stripPacketHeader` |
 
 Protocol source of truth: [`PROTOCOL.md`](PROTOCOL.md).
@@ -49,4 +49,4 @@ All languages expose the same engine names: `deepgram`, `whisper`, `parakeet`.
 | Go | tinygo.org/x/bluetooth | `-tags ble` |
 | Rust | btleplug | feature `ble` |
 | Dart | flutter_blue_plus (app UUID map) | Flutter package |
-| C++ | SimpleBLE | `-DOMI_DEVICE_BLE=ON` |
+| C++ | your own (`BleBackend`) | `SetBleBackend()` |

--- a/sdks/device/STT.md
+++ b/sdks/device/STT.md
@@ -28,7 +28,7 @@ PCM contract matches BLE decode: **16-bit LE mono @ 16 kHz**.
 | Go | build tag `ble` | default net | build tag `whisper` | default net |
 | Rust | feature `ble` | feature `stt-deepgram` | feature `stt-whisper` | feature `stt-parakeet` |
 | Dart | optional BLE package later | always-on | optional runner | always-on |
-| C++ | `OMI_DEVICE_BLE` | `OMI_STT_DEEPGRAM` | `OMI_STT_WHISPER` | `OMI_STT_PARAKEET` |
+| C++ | injected `BleBackend` | `OMI_STT_DEEPGRAM` | `OMI_STT_WHISPER` | `OMI_STT_PARAKEET` |
 
 ## Parakeet wire format
 

--- a/sdks/device/cpp/CMakeLists.txt
+++ b/sdks/device/cpp/CMakeLists.txt
@@ -6,6 +6,21 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(OMI_DEVICE_BUILD_TESTS "Build omi_device tests" OFF)
 
+# The SimpleBLE-backed BLE client was removed (BUSL-1.1). A consumer that still
+# passes the retired flags must fail here, not silently configure and then throw
+# BleDisabled at runtime on the first Scan/Listen.
+foreach(_omi_retired_ble_var OMI_DEVICE_BLE OMI_DEVICE_SIMPLEBLE_SOURCE_DIR)
+  if(DEFINED ${_omi_retired_ble_var})
+    message(FATAL_ERROR
+      "${_omi_retired_ble_var} was removed along with the SimpleBLE dependency.\n"
+      "omi_device now takes the BLE stack from the application: implement "
+      "omi::device::BleBackend against CoreBluetooth, Windows.Devices.Bluetooth, "
+      "or BlueZ and install it with omi::device::SetBleBackend(). Scan/Listen/"
+      "ListenPayload are otherwise unchanged.\n"
+      "Migration guide: sdks/device/cpp/README.md")
+  endif()
+endforeach()
+
 # This package has no third-party dependencies. The BLE surface in
 # include/omi/device/ble.hpp is an interface the embedding application binds to
 # its own platform stack (CoreBluetooth, WinRT, BlueZ) via SetBleBackend().

--- a/sdks/device/cpp/CMakeLists.txt
+++ b/sdks/device/cpp/CMakeLists.txt
@@ -4,66 +4,26 @@ project(omi_device VERSION 0.1.0 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-option(OMI_DEVICE_BLE "Build optional SimpleBLE client (scan/listen)" OFF)
-set(OMI_DEVICE_SIMPLEBLE_SOURCE_DIR "" CACHE PATH
-  "Path to a vendored SimpleBLE source tree (overrides the pinned FetchContent download)")
+option(OMI_DEVICE_BUILD_TESTS "Build omi_device tests" OFF)
 
-set(OMI_DEVICE_SOURCES src/protocol.cpp)
+# This package has no third-party dependencies. The BLE surface in
+# include/omi/device/ble.hpp is an interface the embedding application binds to
+# its own platform stack (CoreBluetooth, WinRT, BlueZ) via SetBleBackend().
+add_library(omi_device
+  src/protocol.cpp
+  src/ble.cpp
+)
 
-if(OMI_DEVICE_BLE)
-  set(OMI_DEVICE_BLE_LINKED OFF)
-
-  find_package(simpleble CONFIG QUIET)
-  if(simpleble_FOUND)
-    set(OMI_DEVICE_BLE_LINKED ON)
-    message(STATUS "OMI_DEVICE_BLE: using installed simpleble")
-  else()
-    # Explicit vendored or pinned FetchContent path for SimpleBLE.
-    if(OMI_DEVICE_SIMPLEBLE_SOURCE_DIR)
-      set(_omi_simpleble_src "${OMI_DEVICE_SIMPLEBLE_SOURCE_DIR}")
-      message(STATUS "OMI_DEVICE_BLE: using vendored SimpleBLE at ${_omi_simpleble_src}")
-    else()
-      include(FetchContent)
-      FetchContent_Declare(
-        simpleble
-        GIT_REPOSITORY https://github.com/simpleble/simpleble.git
-        GIT_TAG        v0.10.3
-        GIT_SHALLOW    TRUE
-        GIT_PROGRESS   TRUE
-      )
-      FetchContent_MakeAvailable(simpleble)
-      set(_omi_simpleble_src "${simpleble_SOURCE_DIR}")
-      message(STATUS "OMI_DEVICE_BLE: using fetched SimpleBLE v0.10.3 from ${_omi_simpleble_src}")
-    endif()
-
-    set(_omi_simpleble_cmake "${_omi_simpleble_src}/simpleble/CMakeLists.txt")
-    if(NOT EXISTS "${_omi_simpleble_cmake}")
-      message(FATAL_ERROR
-        "OMI_DEVICE_BLE=ON but SimpleBLE was not found.\n"
-        "Install simpleble (find_package simpleble), set "
-        "-DOMI_DEVICE_SIMPLEBLE_SOURCE_DIR=<path>, or ensure network access for the "
-        "pinned FetchContent download from https://github.com/simpleble/simpleble.git (v0.10.3).")
-    endif()
-
-    set(SIMPLEBLE_INSTALL OFF CACHE BOOL "" FORCE)
-    add_subdirectory("${_omi_simpleble_src}/simpleble" "${CMAKE_BINARY_DIR}/_deps/simpleble-build")
-    set(OMI_DEVICE_BLE_LINKED ON)
-  endif()
-
-  if(OMI_DEVICE_BLE_LINKED)
-    list(APPEND OMI_DEVICE_SOURCES src/ble.cpp)
-  endif()
-endif()
-
-add_library(omi_device ${OMI_DEVICE_SOURCES})
 target_include_directories(omi_device PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
 
-if(OMI_DEVICE_BLE AND OMI_DEVICE_BLE_LINKED)
-  target_link_libraries(omi_device PUBLIC simpleble::simpleble)
-  target_compile_definitions(omi_device PUBLIC OMI_DEVICE_BLE=1)
+if(OMI_DEVICE_BUILD_TESTS)
+  enable_testing()
+  add_executable(omi_device_tests tests/ble_test.cpp)
+  target_link_libraries(omi_device_tests PRIVATE omi_device)
+  add_test(NAME omi_device_tests COMMAND omi_device_tests)
 endif()
 
 install(TARGETS omi_device)

--- a/sdks/device/cpp/README.md
+++ b/sdks/device/cpp/README.md
@@ -1,0 +1,59 @@
+# `omi_device` (C++)
+
+Omi device protocol helpers: GATT UUIDs, the 3-byte packet header strip, STT URL
+builders, and a BLE surface you bind to your own platform stack.
+
+**No third-party dependencies.** `cmake -S . -B build && cmake --build build`.
+
+## Protocol only
+
+```cpp
+#include "omi/device/protocol.hpp"
+
+auto payload = omi::device::StripPacketHeader(data, len);  // drops 3 bytes
+```
+
+## BLE
+
+This package ships no BLE implementation. Cross-platform C++ BLE libraries are
+either OS-specific or non-permissively licensed, so `omi::device` takes the stack
+as an interface and the Omi clients that speak BLE (Python/Swift/React
+Native/Flutter) bind their own. Implement `BleBackend` against CoreBluetooth
+(Apple), `Windows.Devices.Bluetooth` (WinRT), or BlueZ (Linux):
+
+```cpp
+#include "omi/device/ble.hpp"
+
+class MyBackend : public omi::device::BleBackend {
+ public:
+  std::vector<omi::device::BleDevice> Scan(int timeout_ms) override {
+    // ... platform scan, return {id, name, rssi} ...
+  }
+
+  void Notify(const std::string& device_id, const std::string& service_uuid,
+              const std::string& characteristic_uuid,
+              omi::device::PacketCallback on_packet) override {
+    // ... connect, subscribe, call on_packet(bytes) per notification,
+    //     block until disconnect ...
+  }
+};
+
+omi::device::SetBleBackend(std::make_shared<MyBackend>());
+
+for (const auto& device : omi::device::Scan(5000)) { /* ... */ }
+
+// Raw notifications, header included:
+omi::device::Listen(device_id, [](const std::vector<std::uint8_t>& packet) { /* ... */ });
+
+// Header already stripped:
+omi::device::ListenPayload(device_id, [](const std::vector<std::uint8_t>& pcm_or_opus) { /* ... */ });
+```
+
+`Listen` subscribes to `kAudioDataUuid` on `kServiceUuid`. Without a backend,
+`Scan`/`Listen`/`ListenPayload` throw `omi::device::BleDisabled`.
+
+## Tests
+
+```sh
+cmake -S . -B build -DOMI_DEVICE_BUILD_TESTS=ON && cmake --build build && ctest --test-dir build
+```

--- a/sdks/device/cpp/README.md
+++ b/sdks/device/cpp/README.md
@@ -52,6 +52,13 @@ omi::device::ListenPayload(device_id, [](const std::vector<std::uint8_t>& pcm_or
 `Listen` subscribes to `kAudioDataUuid` on `kServiceUuid`. Without a backend,
 `Scan`/`Listen`/`ListenPayload` throw `omi::device::BleDisabled`.
 
+## Migrating from `-DOMI_DEVICE_BLE=ON`
+
+That flag and `-DOMI_DEVICE_SIMPLEBLE_SOURCE_DIR` are gone, along with the
+SimpleBLE dependency they pulled in. Passing either is a hard configure error
+that points here rather than a silent no-op. Implement `BleBackend` as above and
+install it with `SetBleBackend()`; `Scan`/`Listen`/`ListenPayload` are unchanged.
+
 ## Tests
 
 ```sh

--- a/sdks/device/cpp/include/omi/device/ble.hpp
+++ b/sdks/device/cpp/include/omi/device/ble.hpp
@@ -4,6 +4,8 @@
 
 #include <cstdint>
 #include <functional>
+#include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -18,11 +20,44 @@ struct BleDevice {
 
 using PacketCallback = std::function<void(const std::vector<std::uint8_t>&)>;
 
-// Requires OMI_DEVICE_BLE=ON and SimpleBLE linked.
+// Thrown by Scan/Listen/ListenPayload when no backend has been installed.
+class BleDisabled : public std::runtime_error {
+ public:
+  BleDisabled()
+      : std::runtime_error(
+            "omi::device: no BLE backend installed; call SetBleBackend() with a "
+            "platform stack (see sdks/device/cpp/README.md)") {}
+};
+
+// The platform BLE stack, supplied by the embedding application.
+//
+// This package ships no third-party BLE dependency: cross-platform C++ BLE
+// libraries are either OS-specific or non-permissively licensed, and the Omi
+// clients that do speak BLE (Python/Swift/React Native/Flutter) already bind
+// their own stack. Implement this against CoreBluetooth (Apple),
+// Windows.Devices.Bluetooth (WinRT), or BlueZ (Linux).
+class BleBackend {
+ public:
+  virtual ~BleBackend() = default;
+
+  // Discover nearby peripherals, scanning for up to timeout_ms.
+  virtual std::vector<BleDevice> Scan(int timeout_ms) = 0;
+
+  // Connect to device_id, subscribe to characteristic_uuid on service_uuid, and
+  // invoke on_packet with each raw notification. Blocks until disconnect.
+  virtual void Notify(const std::string& device_id, const std::string& service_uuid,
+                      const std::string& characteristic_uuid, PacketCallback on_packet) = 0;
+};
+
+// Installs the backend used by Scan/Listen/ListenPayload. Pass nullptr to clear.
+void SetBleBackend(std::shared_ptr<BleBackend> backend);
+std::shared_ptr<BleBackend> GetBleBackend();
+
+// Discover nearby devices. Throws BleDisabled without a backend.
 std::vector<BleDevice> Scan(int timeout_ms = 5000);
 
-// Connect to device_id, notify on kAudioDataUuid, invoke callback with raw bytes.
-// Blocks until disconnect. Uses kServiceUuid / kAudioDataUuid from protocol.hpp.
+// Notify on kAudioDataUuid, invoke callback with raw bytes (header included).
+// Blocks until disconnect. Throws BleDisabled without a backend.
 void Listen(const std::string& device_id, PacketCallback callback);
 
 // Same as Listen but strips the 3-byte Omi packet header before callback.

--- a/sdks/device/cpp/include/omi/device/stt/stt.hpp
+++ b/sdks/device/cpp/include/omi/device/stt/stt.hpp
@@ -30,7 +30,8 @@ inline std::string DeepgramWsUrl(int sample_rate = 16000) {
 //  - define OMI_STT_DEEPGRAM and link a WS stack to enable Deepgram
 //  - define OMI_STT_PARAKEET similarly
 //  - define OMI_STT_WHISPER and inject a local runner for Whisper
-// BLE stacks similarly gate with OMI_DEVICE_BLE (CoreBluetooth/WinRT/Android JNI).
+// BLE is injected rather than gated: implement omi::device::BleBackend against
+// CoreBluetooth/WinRT/BlueZ and install it with SetBleBackend(). See README.md.
 
 }  // namespace stt
 }  // namespace device

--- a/sdks/device/cpp/src/ble.cpp
+++ b/sdks/device/cpp/src/ble.cpp
@@ -1,82 +1,52 @@
 #include "omi/device/ble.hpp"
 
-#include <chrono>
+#include <mutex>
 #include <stdexcept>
-#include <thread>
-
-#include <simpleble/SimpleBLE.h>
+#include <utility>
 
 namespace omi {
 namespace device {
 namespace {
 
-SimpleBLE::Adapter GetAdapter() {
-  if (!SimpleBLE::Adapter::bluetooth_enabled()) {
-    throw std::runtime_error("Bluetooth is disabled");
-  }
-  auto adapters = SimpleBLE::Adapter::get_adapters();
-  if (adapters.empty()) {
-    throw std::runtime_error("No Bluetooth adapters found");
-  }
-  return adapters.front();
+std::mutex& BackendMutex() {
+  static std::mutex mu;
+  return mu;
 }
 
-SimpleBLE::Peripheral FindPeripheral(SimpleBLE::Adapter& adapter, const std::string& device_id) {
-  adapter.scan_for(2000);
-  for (auto& p : adapter.scan_get_results()) {
-    if (p.address() == device_id || p.identifier() == device_id) {
-      return p;
-    }
+std::shared_ptr<BleBackend>& BackendSlot() {
+  static std::shared_ptr<BleBackend> backend;
+  return backend;
+}
+
+std::shared_ptr<BleBackend> RequireBackend() {
+  auto backend = GetBleBackend();
+  if (!backend) {
+    throw BleDisabled();
   }
-  // Also check already-connected/paired lists when available.
-  for (auto& p : adapter.get_paired_peripherals()) {
-    if (p.address() == device_id || p.identifier() == device_id) {
-      return p;
-    }
-  }
-  throw std::runtime_error("BLE device not found: " + device_id);
+  return backend;
 }
 
 }  // namespace
 
-std::vector<BleDevice> Scan(int timeout_ms) {
-  auto adapter = GetAdapter();
-  adapter.scan_for(timeout_ms < 0 ? 0 : timeout_ms);
+void SetBleBackend(std::shared_ptr<BleBackend> backend) {
+  std::lock_guard<std::mutex> lock(BackendMutex());
+  BackendSlot() = std::move(backend);
+}
 
-  std::vector<BleDevice> out;
-  for (auto& p : adapter.scan_get_results()) {
-    out.push_back(BleDevice{p.address(), p.identifier(), static_cast<int>(p.rssi())});
-  }
-  return out;
+std::shared_ptr<BleBackend> GetBleBackend() {
+  std::lock_guard<std::mutex> lock(BackendMutex());
+  return BackendSlot();
+}
+
+std::vector<BleDevice> Scan(int timeout_ms) {
+  return RequireBackend()->Scan(timeout_ms < 0 ? 0 : timeout_ms);
 }
 
 void Listen(const std::string& device_id, PacketCallback callback) {
   if (!callback) {
     throw std::invalid_argument("Listen callback is empty");
   }
-  auto adapter = GetAdapter();
-  auto peripheral = FindPeripheral(adapter, device_id);
-  peripheral.connect();
-
-  bool alive = true;
-  peripheral.set_callback_on_disconnected([&]() { alive = false; });
-
-  peripheral.notify(kServiceUuid, kAudioDataUuid, [&](SimpleBLE::ByteArray bytes) {
-    std::vector<std::uint8_t> raw(bytes.begin(), bytes.end());
-    callback(raw);
-  });
-
-  while (alive && peripheral.is_connected()) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-  }
-
-  if (peripheral.is_connected()) {
-    try {
-      peripheral.unsubscribe(kServiceUuid, kAudioDataUuid);
-    } catch (...) {
-    }
-    peripheral.disconnect();
-  }
+  RequireBackend()->Notify(device_id, kServiceUuid, kAudioDataUuid, std::move(callback));
 }
 
 void ListenPayload(const std::string& device_id, PacketCallback callback) {
@@ -84,9 +54,6 @@ void ListenPayload(const std::string& device_id, PacketCallback callback) {
     throw std::invalid_argument("ListenPayload callback is empty");
   }
   Listen(device_id, [callback = std::move(callback)](const std::vector<std::uint8_t>& packet) {
-    if (packet.size() <= kPacketHeaderBytes) {
-      return;
-    }
     auto payload = StripPacketHeader(packet.data(), packet.size());
     if (!payload.empty()) {
       callback(payload);

--- a/sdks/device/cpp/tests/ble_test.cpp
+++ b/sdks/device/cpp/tests/ble_test.cpp
@@ -1,0 +1,180 @@
+// Hermetic tests for the injectable BLE surface: no adapter, no network.
+#include "omi/device/ble.hpp"
+#include "omi/device/protocol.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+int g_failures = 0;
+
+void Check(bool ok, const char* what) {
+  if (!ok) {
+    std::fprintf(stderr, "FAIL: %s\n", what);
+    ++g_failures;
+  }
+}
+
+// Records what the SDK asked the platform stack to do, and replays packets.
+class FakeBackend : public omi::device::BleBackend {
+ public:
+  explicit FakeBackend(std::vector<std::vector<std::uint8_t>> packets)
+      : packets_(std::move(packets)) {}
+
+  std::vector<omi::device::BleDevice> Scan(int timeout_ms) override {
+    scan_timeout_ms = timeout_ms;
+    return {omi::device::BleDevice{"AA:BB:CC:DD:EE:FF", "Omi", -42}};
+  }
+
+  void Notify(const std::string& device_id, const std::string& service_uuid,
+              const std::string& characteristic_uuid,
+              omi::device::PacketCallback on_packet) override {
+    notify_device_id = device_id;
+    notify_service_uuid = service_uuid;
+    notify_characteristic_uuid = characteristic_uuid;
+    for (const auto& packet : packets_) {
+      on_packet(packet);
+    }
+  }
+
+  int scan_timeout_ms = -1;
+  std::string notify_device_id;
+  std::string notify_service_uuid;
+  std::string notify_characteristic_uuid;
+
+ private:
+  std::vector<std::vector<std::uint8_t>> packets_;
+};
+
+template <typename Fn>
+bool ThrowsBleDisabled(Fn fn) {
+  try {
+    fn();
+  } catch (const omi::device::BleDisabled&) {
+    return true;
+  } catch (...) {
+    return false;
+  }
+  return false;
+}
+
+// Default build links no BLE stack: every entry point must refuse, not dial out.
+void TestDisabledWithoutBackend() {
+  omi::device::SetBleBackend(nullptr);
+
+  Check(omi::device::GetBleBackend() == nullptr, "GetBleBackend is null by default");
+  Check(ThrowsBleDisabled([] { omi::device::Scan(10); }), "Scan throws BleDisabled");
+  Check(ThrowsBleDisabled([] { omi::device::Listen("id", [](const std::vector<std::uint8_t>&) {}); }),
+        "Listen throws BleDisabled");
+  Check(ThrowsBleDisabled(
+            [] { omi::device::ListenPayload("id", [](const std::vector<std::uint8_t>&) {}); }),
+        "ListenPayload throws BleDisabled");
+}
+
+void TestScanUsesBackend() {
+  auto backend = std::make_shared<FakeBackend>(std::vector<std::vector<std::uint8_t>>{});
+  omi::device::SetBleBackend(backend);
+
+  auto devices = omi::device::Scan(1234);
+  Check(devices.size() == 1, "Scan returns backend devices");
+  Check(devices[0].id == "AA:BB:CC:DD:EE:FF", "Scan preserves device id");
+  Check(devices[0].name == "Omi", "Scan preserves device name");
+  Check(devices[0].rssi == -42, "Scan preserves rssi");
+  Check(backend->scan_timeout_ms == 1234, "Scan forwards timeout");
+
+  omi::device::Scan(-5);
+  Check(backend->scan_timeout_ms == 0, "Scan clamps a negative timeout to 0");
+
+  omi::device::SetBleBackend(nullptr);
+}
+
+void TestListenSubscribesToAudioCharacteristic() {
+  const std::vector<std::uint8_t> packet{0x01, 0x00, 0x00, 0xAA, 0xBB};
+  auto backend = std::make_shared<FakeBackend>(std::vector<std::vector<std::uint8_t>>{packet});
+  omi::device::SetBleBackend(backend);
+
+  std::vector<std::vector<std::uint8_t>> got;
+  omi::device::Listen("dev-1", [&](const std::vector<std::uint8_t>& bytes) { got.push_back(bytes); });
+
+  Check(backend->notify_device_id == "dev-1", "Listen forwards the device id");
+  Check(backend->notify_service_uuid == std::string(omi::device::kServiceUuid),
+        "Listen subscribes on kServiceUuid");
+  Check(backend->notify_characteristic_uuid == std::string(omi::device::kAudioDataUuid),
+        "Listen subscribes to kAudioDataUuid");
+  Check(got.size() == 1 && got[0] == packet, "Listen delivers raw packets with the header intact");
+
+  omi::device::SetBleBackend(nullptr);
+}
+
+void TestListenPayloadStripsHeader() {
+  const std::vector<std::uint8_t> full{0x01, 0x00, 0x00, 0xAA, 0xBB};
+  const std::vector<std::uint8_t> header_only{0x01, 0x00, 0x00};
+  const std::vector<std::uint8_t> too_short{0x01, 0x00};
+  auto backend = std::make_shared<FakeBackend>(
+      std::vector<std::vector<std::uint8_t>>{full, header_only, too_short});
+  omi::device::SetBleBackend(backend);
+
+  std::vector<std::vector<std::uint8_t>> got;
+  omi::device::ListenPayload("dev-1",
+                             [&](const std::vector<std::uint8_t>& bytes) { got.push_back(bytes); });
+
+  Check(got.size() == 1, "ListenPayload drops header-only and short packets");
+  Check(got.size() == 1 && got[0] == std::vector<std::uint8_t>({0xAA, 0xBB}),
+        "ListenPayload strips the 3-byte header");
+
+  omi::device::SetBleBackend(nullptr);
+}
+
+void TestEmptyCallbackRejected() {
+  auto backend = std::make_shared<FakeBackend>(std::vector<std::vector<std::uint8_t>>{});
+  omi::device::SetBleBackend(backend);
+
+  bool listen_threw = false;
+  try {
+    omi::device::Listen("dev-1", nullptr);
+  } catch (const std::invalid_argument&) {
+    listen_threw = true;
+  }
+  Check(listen_threw, "Listen rejects an empty callback");
+
+  bool payload_threw = false;
+  try {
+    omi::device::ListenPayload("dev-1", nullptr);
+  } catch (const std::invalid_argument&) {
+    payload_threw = true;
+  }
+  Check(payload_threw, "ListenPayload rejects an empty callback");
+
+  omi::device::SetBleBackend(nullptr);
+}
+
+void TestStripPacketHeader() {
+  const std::vector<std::uint8_t> full{0x01, 0x00, 0x00, 0xAA, 0xBB};
+  auto payload = omi::device::StripPacketHeader(full.data(), full.size());
+  Check(payload == std::vector<std::uint8_t>({0xAA, 0xBB}), "StripPacketHeader drops 3 bytes");
+  Check(omi::device::StripPacketHeader(nullptr, 8).empty(), "StripPacketHeader tolerates nullptr");
+  Check(omi::device::StripPacketHeader(full.data(), omi::device::kPacketHeaderBytes).empty(),
+        "StripPacketHeader returns empty for a header-only packet");
+}
+
+}  // namespace
+
+int main() {
+  TestDisabledWithoutBackend();
+  TestScanUsesBackend();
+  TestListenSubscribesToAudioCharacteristic();
+  TestListenPayloadStripsHeader();
+  TestEmptyCallbackRejected();
+  TestStripPacketHeader();
+
+  if (g_failures != 0) {
+    std::fprintf(stderr, "%d check(s) failed\n", g_failures);
+    return EXIT_FAILURE;
+  }
+  std::printf("all omi_device checks passed\n");
+  return EXIT_SUCCESS;
+}

--- a/sdks/device/cpp/tests/retired-ble-flags.sh
+++ b/sdks/device/cpp/tests/retired-ble-flags.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Regression guard: a consumer still passing the retired SimpleBLE flags must
+# fail at configure time with a migration message, never configure silently and
+# then throw BleDisabled on the first Scan/Listen at runtime.
+set -uo pipefail
+
+cpp_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+failures=0
+
+expect_configure_failure() {
+  local flag="$1"
+  local build_dir="$work_dir/${flag}"
+  local output
+  output="$(cmake -S "$cpp_dir" -B "$build_dir" "-D${flag}=ON" 2>&1)"
+  local status=$?
+  # CMake word-wraps message() output, so match against a single flattened line.
+  local flat
+  flat="$(tr '\n' ' ' <<<"$output" | tr -s ' ')"
+
+  if [ "$status" -eq 0 ]; then
+    echo "FAIL: -D${flag}=ON configured successfully; it must be a hard error"
+    failures=$((failures + 1))
+    return
+  fi
+  if ! grep -q "was removed along with the SimpleBLE dependency" <<<"$flat"; then
+    echo "FAIL: -D${flag}=ON failed without the migration message:"
+    echo "$output"
+    failures=$((failures + 1))
+    return
+  fi
+  if ! grep -q "SetBleBackend" <<<"$flat"; then
+    echo "FAIL: -D${flag}=ON message does not name the replacement API"
+    failures=$((failures + 1))
+    return
+  fi
+  echo "ok: -D${flag}=ON fails at configure time with the migration message"
+}
+
+expect_clean_configure() {
+  local build_dir="$work_dir/clean"
+  if ! cmake -S "$cpp_dir" -B "$build_dir" >/dev/null 2>&1; then
+    echo "FAIL: a plain configure must still succeed"
+    failures=$((failures + 1))
+    return
+  fi
+  echo "ok: plain configure succeeds"
+}
+
+expect_configure_failure OMI_DEVICE_BLE
+expect_configure_failure OMI_DEVICE_SIMPLEBLE_SOURCE_DIR
+expect_clean_configure
+
+if [ "$failures" -ne 0 ]; then
+  echo "$failures check(s) failed"
+  exit 1
+fi
+echo "all retired-flag checks passed"


### PR DESCRIPTION
## What

The C++ device SDK reached SimpleBLE through a CMake `FetchContent` pin (`v0.10.3`). SimpleBLE has been **Business Source License 1.1** since Jan 20 2025 — non-production use only, converting to GPLv3 on 2029-06-24. That does not belong referenced from an MIT repo, so this replaces the dependency with an interface the embedding application binds itself.

Nothing shipped it, and this changes no product behavior:

- `option(OMI_DEVICE_BLE ...)` defaulted to **OFF**
- no workflow built `sdks/device/cpp` (grep of `.github/` returned nothing)
- every Omi client that speaks BLE uses CoreBluetooth (Swift/macOS), `flutter_blue_plus` (app), `bleak` (Python), `ble-plx` (React Native), or tinygo bluetooth (Go)

## How

The public surface is unchanged. `Scan` / `Listen` / `ListenPayload` keep their signatures, `Listen` still subscribes to `kAudioDataUuid` on `kServiceUuid`, and `ListenPayload` still strips the 3-byte header. What changed is where the stack comes from:

```cpp
class MyBackend : public omi::device::BleBackend { /* CoreBluetooth / WinRT / BlueZ */ };
omi::device::SetBleBackend(std::make_shared<MyBackend>());
```

Without a backend the entry points throw `omi::device::BleDisabled` instead of touching an adapter — the same stub-plus-backend shape the Go SDK uses (`ErrBLEDisabled`), and the injection pattern `stt.hpp` already documents for Whisper runners.

The package now has **no third-party dependencies at all**, so it configures and builds from a bare checkout with no network access. The new `sdk-cpp.yml` workflow deliberately has no dependency step, so a re-added fetched dependency fails there.

## Verification

Built and ran locally on macOS (`sdks/device/cpp`):

```
$ cmake -S . -B build -DOMI_DEVICE_BUILD_TESTS=ON && cmake --build build
[100%] Built target omi_device_tests

$ ctest --test-dir build --output-on-failure
1/1 Test #1: omi_device_tests .......... Passed 0.18 sec
100% tests passed, 0 tests failed out of 1

$ nm -a build/libomi_device.a | grep -i simpleble
(no SimpleBLE symbols in libomi_device.a)

$ ls build/_deps
(absent — nothing was fetched)

$ grep -rniI -e simpleble -e OMI_DEVICE_BLE .
(no matches repo-wide)

$ make preflight
PR preflight passed: 17 checks in 20.74s.
```

`tests/ble_test.cpp` is hermetic (no adapter, no network) and covers the behavior that matters:

- no backend installed → `Scan`/`Listen`/`ListenPayload` throw `BleDisabled` — the guard that keeps a default build from reaching any third-party stack
- `Scan` returns backend devices, forwards the timeout, clamps a negative timeout to 0
- `Listen` subscribes on `kServiceUuid`/`kAudioDataUuid` and delivers raw packets header-intact
- `ListenPayload` strips the 3-byte header and drops header-only and short packets
- empty callbacks are rejected; `StripPacketHeader` edge cases

## Migration is a hard error, not a silent change

Review caught that `-DOMI_DEVICE_BLE=ON` used to configure with exit 0 and only a "Manually-specified variables were not used" warning, so a consumer would not learn anything changed until `Scan`/`Listen` threw `BleDisabled` at runtime. Both retired flags are now a `FATAL_ERROR` at configure time naming the replacement API:

```
$ cmake -S . -B build -DOMI_DEVICE_BLE=ON
CMake Error at CMakeLists.txt:14 (message):
  OMI_DEVICE_BLE was removed along with the SimpleBLE dependency.
  omi_device now takes the BLE stack from the application: implement
  omi::device::BleBackend ... and install it with omi::device::SetBleBackend().
  Scan/Listen/ListenPayload are otherwise unchanged.
  Migration guide: sdks/device/cpp/README.md
```

`tests/retired-ble-flags.sh` asserts the failure, the message content, and that a plain configure still succeeds. `sdk-cpp.yml` runs it.

### Why not a permissively licensed BLE library instead?

There isn't one. SimpleBLE is BUSL-1.1 from v0.9.0 and GPLv3 for v0.7.3-v0.8.1; only v0.6.1 (2022) is MIT. btleplug is Rust and tinygo bluetooth is Go — already the backends for those SDKs. Qt Bluetooth is LGPL/commercial, gattlib is dual GPL/commercial. The remaining option is hand-writing CoreBluetooth + WinRT + BlueZ backends: ~300-600 lines each of hardware-dependent code that cannot be exercised in CI or without an attached device. Three unverifiable BLE stacks is a worse outcome than an interface, so the package takes the stack as an injection point — the same shape `ble_stub.go`/`ErrBLEDisabled` uses in the Go SDK and `stt.hpp` already documents for Whisper runners.

### Why `sdk-cpp.yml` rather than a `checks-manifest.yaml` entry

The manifest scopes itself (line 1) to "deterministic, diff-scoped, stdlib-or-repo-only checks"; a CMake configure plus a C++ compiler is neither, and registering it would break `make preflight` on a machine without cmake. No `sdks/**` check is in the manifest — `sdk-rust.yml` (Rust toolchain) and `python-cli-ci.yml` are standalone path-filtered workflows, and `sdk-cpp.yml` is modelled on `sdk-rust.yml`.

## Docs

`sdks/device/cpp/README.md` (new) shows how to bind a platform stack. `sdks/device/README.md`, `PARITY.md`, `STT.md`, and the `stt.hpp` comment now say "injectable `BleBackend`" instead of `-DOMI_DEVICE_BLE=ON` / SimpleBLE.

## Product invariants affected

none

Failure-Class: none
