### PR TITLE
fix(backend): cap NLLB in-flight and fail probes when saturated

### DIFF
--- a/backend/charts/nllb-translation/dev_omi_nllb_translation_values.yaml
+++ b/backend/charts/nllb-translation/dev_omi_nllb_translation_values.yaml
@@ -60,10 +60,11 @@ resources:
     nvidia.com/gpu: 1
 
 livenessProbe:
-  tcpSocket:
+  httpGet:
+    path: /live
     port: 8080
-  failureThreshold: 10
-  periodSeconds: 30
+  failureThreshold: 3
+  periodSeconds: 10
 
 readinessProbe:
   httpGet:

--- a/backend/charts/nllb-translation/prod_omi_nllb_translation_values.yaml
+++ b/backend/charts/nllb-translation/prod_omi_nllb_translation_values.yaml
@@ -60,10 +60,11 @@ resources:
     nvidia.com/gpu: 1
 
 livenessProbe:
-  tcpSocket:
+  httpGet:
+    path: /live
     port: 8080
-  failureThreshold: 10
-  periodSeconds: 30
+  failureThreshold: 3
+  periodSeconds: 10
 
 readinessProbe:
   httpGet:

--- a/backend/charts/nllb-translation/values.yaml
+++ b/backend/charts/nllb-translation/values.yaml
@@ -38,10 +38,11 @@ env: []
 resources: {}
 
 livenessProbe:
-  tcpSocket:
+  httpGet:
+    path: /live
     port: 8080
-  failureThreshold: 10
-  periodSeconds: 30
+  failureThreshold: 3
+  periodSeconds: 10
 
 readinessProbe:
   httpGet:

--- a/backend/nllb_translation/README.md
+++ b/backend/nllb_translation/README.md
@@ -41,14 +41,27 @@ Response:
 - `source_language_code` is optional — omit for auto-detect (no source token prefix)
 - `contents` max batch size controlled by `NLLB_MAX_BATCH_SIZE` (default 64)
 - Language codes: BCP-47 (en, es, zh-CN, etc.) or NLLB native (eng_Latn, spa_Latn, etc.)
-
+- Admission control: at most `NLLB_MAX_IN_FLIGHT` requests run concurrently. Requests beyond
+  the cap are rejected immediately with HTTP 503 `{"detail": "admission_full"}` — they are
+  never queued on the inference executor. Callers treat 503 like any 5xx (listen falls back
+  to Gemini).
 ### `GET /health` — Health Check
 
-Returns model config and load status. Used by startup probe.
+Returns model config and load status. Used by startup probe. Always 200 once the server is
+up, regardless of saturation — the startup probe must not die while translations are slow.
 
 ### `GET /ready` — Readiness
 
-Returns 200 when model is loaded and ready for inference, 503 otherwise. Used by readiness probe.
+Returns 200 only when the model is loaded **and** in-flight requests are below the admission
+cap. 503 (pod dropped from Endpoints) when the model is not loaded or the service is
+saturated, so callers fail fast instead of timing out against a saturated replica. Used by
+readiness probe.
+
+### `GET /live` — Liveness
+
+Returns 200 while the service is healthy — including short bursts at the admission cap. If
+in-flight has been at or above the cap continuously for `NLLB_SATURATED_LIVE_SECONDS`
+ (default 180s), returns 503 so kubelet restarts the stuck pod. Used by liveness probe.
 
 ### `GET /metrics` — Prometheus Metrics
 
@@ -104,6 +117,8 @@ Unsupported language codes return HTTP 400.
 | `NLLB_MAX_BATCH_SIZE` | `64` | Max sentences per request |
 | `NLLB_BEAM_SIZE` | `1` | Beam search width (1 = greedy, fastest) |
 | `NLLB_INFERENCE_WORKERS` | `2` | Thread pool size for GPU inference |
+| `NLLB_MAX_IN_FLIGHT` | `INFERENCE_WORKERS * 2` | Admission cap: max concurrent accepted requests. Beyond it → immediate 503 `admission_full` (never queued). Clamped to ≥ `NLLB_INFERENCE_WORKERS` |
+| `NLLB_SATURATED_LIVE_SECONDS` | `180` | How long in-flight may stay at/above the cap before `/live` fails 503 and kubelet restarts the pod |
 | `PORT` | `8080` | Server port |
 
 ## Performance

--- a/backend/nllb_translation/main.py
+++ b/backend/nllb_translation/main.py
@@ -56,6 +56,16 @@ BEAM_SIZE = int(os.environ.get("NLLB_BEAM_SIZE", "1"))
 INFERENCE_WORKERS = int(os.environ.get("NLLB_INFERENCE_WORKERS", "2"))
 PORT = int(os.environ.get("PORT", "8080"))
 
+_requested_max_in_flight = int(os.environ.get("NLLB_MAX_IN_FLIGHT", str(INFERENCE_WORKERS * 2)))
+if _requested_max_in_flight < INFERENCE_WORKERS:
+    logger.warning(
+        "NLLB_MAX_IN_FLIGHT=%d is below NLLB_INFERENCE_WORKERS=%d; clamping to worker count",
+        _requested_max_in_flight,
+        INFERENCE_WORKERS,
+    )
+MAX_IN_FLIGHT = max(INFERENCE_WORKERS, _requested_max_in_flight)
+SATURATED_LIVE_SECONDS = float(os.environ.get("NLLB_SATURATED_LIVE_SECONDS", "180"))
+
 BCP47_TO_NLLB: Dict[str, str] = {
     "en": "eng_Latn",
     "es": "spa_Latn",
@@ -194,6 +204,24 @@ def _resolve_nllb_code(bcp47_code: str) -> Optional[str]:
 
 _inference_pool = ThreadPoolExecutor(max_workers=INFERENCE_WORKERS, thread_name_prefix="nllb-infer")
 
+# Admission control: at most MAX_IN_FLIGHT requests may hold an inference slot
+# at once. Anything beyond the cap is rejected with 503 immediately instead of
+# parking on the executor queue (2026-09-03: the unbounded queue grew to 38k
+# in-flight while the pod stayed Ready behind a TCP-only liveness probe).
+_admission = asyncio.Semaphore(MAX_IN_FLIGHT)
+_in_flight = 0
+_saturation_since: Optional[float] = None
+
+
+def _update_saturation() -> None:
+    """Stamp when in-flight first reaches the cap; clear once it drops below."""
+    global _saturation_since
+    if _in_flight >= MAX_IN_FLIGHT:
+        if _saturation_since is None:
+            _saturation_since = time.monotonic()
+    else:
+        _saturation_since = None
+
 
 def _translate_batch(
     texts: List[str], source_nllb: str, target_nllb: str, t_queued: float = 0.0
@@ -241,7 +269,17 @@ def _translate_batch(
 
 @app.post("/v1/translate", response_model=TranslateResponse)
 async def translate(req: TranslateRequest):
+    global _in_flight
+
+    if _admission.locked():
+        # Saturated: fail fast with 503 instead of queueing on the executor.
+        # Listen maps HTTP >=500 to provider_5xx and falls back to Gemini.
+        raise HTTPException(status_code=503, detail="admission_full")
+
     t_queued = time.monotonic()
+    await _admission.acquire()
+    _in_flight += 1
+    _update_saturation()
     ACTIVE_REQUESTS.inc()
     try:
         target_nllb = _resolve_nllb_code(req.target_language_code)
@@ -284,6 +322,9 @@ async def translate(req: TranslateRequest):
         raise HTTPException(status_code=500, detail="Internal translation error")
     finally:
         ACTIVE_REQUESTS.dec()
+        _in_flight -= 1
+        _update_saturation()
+        _admission.release()
 
 
 @app.get("/health")
@@ -305,7 +346,19 @@ async def health():
 async def ready():
     if _translator is None or _tokenizer is None:
         raise HTTPException(status_code=503, detail="Model not loaded")
+    if _in_flight >= MAX_IN_FLIGHT:
+        # Saturated pod: drop from Endpoints so callers fail fast elsewhere
+        # instead of timing out against this replica.
+        raise HTTPException(status_code=503, detail="saturated")
     return {"status": "ready"}
+
+
+@app.get("/live")
+async def live():
+    if _saturation_since is not None and time.monotonic() - _saturation_since >= SATURATED_LIVE_SECONDS:
+        # Stuck saturated for the full window: let kube restart the pod.
+        raise HTTPException(status_code=503, detail="saturated")
+    return {"status": "alive"}
 
 
 @app.get("/metrics")

--- a/backend/tests/unit/test_nllb_service_metrics.py
+++ b/backend/tests/unit/test_nllb_service_metrics.py
@@ -11,9 +11,12 @@ import os
 import sys
 import time
 import unittest
+import asyncio
 from functools import partial
 from types import ModuleType
 from unittest.mock import MagicMock, patch
+
+from fastapi import HTTPException
 
 os.environ.setdefault("NLLB_MODEL_DIR", "/tmp/fake-nllb-model")
 os.environ.setdefault("CT2_DEVICE", "cpu")
@@ -175,6 +178,116 @@ class TestSlowBurnAlertVolumeGate(unittest.TestCase):
         assert (
             "sum(rate(nllb_requests_total[30m])) > 0.1" in slow_burn_section
         ), "Slow burn alert must have volume gate to prevent noisy alerts during low traffic"
+
+
+class TestAdmissionControl(unittest.TestCase):
+    """503-at-cap admission (SCA-439): reject immediately instead of queueing forever."""
+
+    def _request(self):
+        return _nllb_main.TranslateRequest(contents=["hello"], target_language_code="es")
+
+    def test_max_in_flight_at_least_worker_count(self):
+        assert _nllb_main.MAX_IN_FLIGHT >= _nllb_main.INFERENCE_WORKERS
+        assert _nllb_main.MAX_IN_FLIGHT == _nllb_main.INFERENCE_WORKERS * 2  # default cap
+
+    def test_translate_rejects_503_at_cap_without_executor(self):
+        drained = asyncio.Semaphore(0)  # locked(): admission full
+        mock_loop = MagicMock()
+        with patch.object(_nllb_main, "_admission", drained), patch.object(
+            _nllb_main, "_translate_batch", MagicMock()
+        ) as mock_batch, patch("asyncio.get_running_loop", return_value=mock_loop):
+            with self.assertRaises(HTTPException) as ctx:
+                asyncio.run(_nllb_main.translate(self._request()))
+        assert ctx.exception.status_code == 503
+        assert ctx.exception.detail == "admission_full"
+        mock_batch.assert_not_called()
+        mock_loop.run_in_executor.assert_not_called()
+
+    def test_active_requests_gauge_not_incremented_on_reject(self):
+        drained = asyncio.Semaphore(0)
+        with patch.object(_nllb_main, "_admission", drained), patch.object(
+            _nllb_main.ACTIVE_REQUESTS, "inc"
+        ) as mock_inc, patch.object(_nllb_main.ACTIVE_REQUESTS, "dec") as mock_dec:
+            with self.assertRaises(HTTPException):
+                asyncio.run(_nllb_main.translate(self._request()))
+        mock_inc.assert_not_called()
+        mock_dec.assert_not_called()
+
+
+class TestReadinessShed(unittest.TestCase):
+    """/ready sheds load when saturated so kube drops the pod from Endpoints."""
+
+    def test_ready_503_when_model_not_loaded(self):
+        with patch.object(_nllb_main, "_translator", None), patch.object(_nllb_main, "_tokenizer", None):
+            with self.assertRaises(HTTPException) as ctx:
+                asyncio.run(_nllb_main.ready())
+        assert ctx.exception.status_code == 503
+
+    def test_ready_503_when_in_flight_at_cap(self):
+        model = MagicMock()
+        with patch.object(_nllb_main, "_translator", model), patch.object(
+            _nllb_main, "_tokenizer", model
+        ), patch.object(_nllb_main, "_in_flight", _nllb_main.MAX_IN_FLIGHT):
+            with self.assertRaises(HTTPException) as ctx:
+                asyncio.run(_nllb_main.ready())
+        assert ctx.exception.status_code == 503
+        assert ctx.exception.detail == "saturated"
+
+    def test_ready_200_when_model_loaded_and_below_cap(self):
+        model = MagicMock()
+        with patch.object(_nllb_main, "_translator", model), patch.object(
+            _nllb_main, "_tokenizer", model
+        ), patch.object(_nllb_main, "_in_flight", _nllb_main.MAX_IN_FLIGHT - 1):
+            assert asyncio.run(_nllb_main.ready()) == {"status": "ready"}
+
+
+class TestLivenessSaturation(unittest.TestCase):
+    """/live kills the pod only when saturation is continuous past the window."""
+
+    def test_live_200_on_short_saturation_burst(self):
+        with patch.object(_nllb_main, "_saturation_since", time.monotonic()):
+            assert asyncio.run(_nllb_main.live()) == {"status": "alive"}
+
+    def test_live_200_when_not_saturated(self):
+        with patch.object(_nllb_main, "_saturation_since", None):
+            assert asyncio.run(_nllb_main.live()) == {"status": "alive"}
+
+    def test_live_503_after_continuous_saturation_window(self):
+        started = time.monotonic() - (_nllb_main.SATURATED_LIVE_SECONDS + 1)
+        with patch.object(_nllb_main, "_saturation_since", started):
+            with self.assertRaises(HTTPException) as ctx:
+                asyncio.run(_nllb_main.live())
+        assert ctx.exception.status_code == 503
+        assert ctx.exception.detail == "saturated"
+
+    def test_live_503_immediately_when_threshold_is_zero(self):
+        with patch.object(_nllb_main, "_saturation_since", time.monotonic()), patch.object(
+            _nllb_main, "SATURATED_LIVE_SECONDS", 0
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                asyncio.run(_nllb_main.live())
+        assert ctx.exception.status_code == 503
+
+    def test_saturation_tracker_stamps_on_crossing_and_clears_below_cap(self):
+        with patch.object(_nllb_main, "_in_flight", _nllb_main.MAX_IN_FLIGHT), patch.object(
+            _nllb_main, "_saturation_since", None
+        ):
+            _nllb_main._update_saturation()
+            self.assertIsNotNone(_nllb_main._saturation_since)
+        with patch.object(_nllb_main, "_in_flight", _nllb_main.MAX_IN_FLIGHT - 1):
+            _nllb_main._update_saturation()
+            self.assertIsNone(_nllb_main._saturation_since)
+
+
+class TestHealthUnaffectedBySaturation(unittest.TestCase):
+    """/health must stay 200 while saturated — the startup probe cannot die."""
+
+    def test_health_200_while_saturated(self):
+        with patch.object(_nllb_main, "_in_flight", _nllb_main.MAX_IN_FLIGHT), patch.object(
+            _nllb_main, "_saturation_since", time.monotonic() - 3600
+        ):
+            result = asyncio.run(_nllb_main.health())
+        assert result["status"] == "ok"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## RCA

On 2026-09-03 the prod `nllb-translation` pod stayed Ready while `nllb_active_requests` climbed from 0 to ~38k: FastAPI's `run_in_executor` queued translation work with **no admission limit** (one L4 replica, `NLLB_INFERENCE_WORKERS=2`), listen-side timeouts (`TRANSLATION_NLLB_TIMEOUT_SECONDS=5`) abandoned requests but the server never cancelled the executor work, and the liveness probe was **TCP-only on :8080**, so a wedged queue never failed a probe. HPA (CPU 70%, live ~51%) never fired. A restart cleared the queue; Gemini fallback (#12497) had kept users translating, so the blast radius was ~$1/h of Flash-Lite spend instead of errors. This PR makes the service shed load before queueing and self-recover when wedged.

## What changed

**`backend/nllb_translation/main.py`**
- Admission control: `POST /v1/translate` try-acquires an `asyncio.Semaphore` sized by new env `NLLB_MAX_IN_FLIGHT` (default `NLLB_INFERENCE_WORKERS * 2` → cap 4 in prod; clamped to ≥ workers with a warning). A full semaphore returns **503 `{"detail":"admission_full"}`** immediately — the request never parks on the executor and never increments `nllb_active_requests`. Listen already maps HTTP ≥500 to `provider_5xx` and Gemini-falls-back; no listen changes.
- `GET /ready`: 503 while in-flight ≥ cap (kube drops the pod from Endpoints → callers fail fast instead of burning the 5s timeout), in addition to the existing model-not-loaded 503.
- `GET /live` (new): 503 only after in-flight has been ≥ cap **continuously** for `NLLB_SATURATED_LIVE_SECONDS` (default 180s), tracked via `time.monotonic()` — short bursts stay 200; a wedged pod gets restarted. `GET /health` is untouched and stays 200 for the startupProbe.

**`backend/charts/nllb-translation/{values,prod_omi_nllb_translation_values,dev_omi_nllb_translation_values}.yaml`** — `livenessProbe` switches from `tcpSocket :8080` to `httpGet /live :8080` (`failureThreshold: 3`, `periodSeconds: 10`). Readiness (`/ready`) and startup (`/health`) probes unchanged. HPA / prometheus-adapter / `requestsPerPod` untouched.

**`backend/nllb_translation/README.md`** — documents `/live`, the two new env vars, and 503 admission behavior.

## Test plan

- `backend/tests/unit/test_nllb_service_metrics.py` extended (17 tests total, no GPU, ctranslate2 stubbed): at-cap request → 503 `admission_full` with no executor call and no `nllb_active_requests` increment; `/ready` 503 at cap / 200 below cap with model loaded / 503 model-not-loaded; `/live` 200 on short burst and unsaturated, 503 after the continuous-saturation window (and immediately with threshold 0), tracker stamps on crossing and clears below cap; `/health` stays 200 while saturated.
- Local: `backend/.venv/bin/python -m pytest backend/tests/unit/test_nllb_service_metrics.py -q` → 17 passed.
- `scripts/pr-preflight --pr-body-file` and `make preflight` on the final head.
- CI on the PR head (reported, not merged).

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

