### PR TITLE
feat: make push campaigns measurable end to end

### DIFF
--- a/app/lib/services/notifications.dart
+++ b/app/lib/services/notifications.dart
@@ -57,10 +57,10 @@ class NotificationUtil {
   }
 
   static Future<void> onActionReceivedMethodImpl(ReceivedAction receivedAction) async {
-    if (receivedAction.payload == null || receivedAction.payload!.isEmpty) {
-      return;
-    }
-    await _handleAppLinkOrDeepLink(receivedAction.payload!);
+    // A payloadless notification is still a tap. Returning early here would drop
+    // it from the open count entirely, so pass an empty payload through and let
+    // the handler emit the event and then no-op on routing (#12645).
+    await _handleAppLinkOrDeepLink(receivedAction.payload ?? const <String, dynamic>{});
   }
 
   /// Public entry for FCM background/terminated notification taps (#5126).
@@ -92,7 +92,11 @@ class NotificationUtil {
     put('campaign_id', payload['campaign_id']);
     put('navigate_to', payload['navigate_to']);
     // Senders set one or the other; `notification_type` is the newer spelling.
-    put('notification_type', payload['notification_type'] ?? payload['type']);
+    // `??` alone would keep an empty `notification_type` and lose a valid legacy
+    // `type`, since an empty string is not null but is dropped by `put`.
+    final notificationType = payload['notification_type'];
+    final hasNotificationType = notificationType is String && notificationType.isNotEmpty;
+    put('notification_type', hasNotificationType ? notificationType : payload['type']);
     return properties;
   }
 
@@ -168,7 +172,12 @@ class NotificationUtil {
     final externalTarget = externalTargetFor(navigateTo);
     if (externalTarget != null) {
       try {
-        await launchUrl(externalTarget, mode: LaunchMode.externalApplication);
+        // launchUrl reports "no handler" by returning false, not by throwing, so
+        // the result has to be checked or a CTA that never opened looks succeeded.
+        final launched = await launchUrl(externalTarget, mode: LaunchMode.externalApplication);
+        if (!launched) {
+          Logger.debug('No handler opened external navigate_to=$navigateTo');
+        }
       } catch (e) {
         Logger.debug('Failed to open external navigate_to=$navigateTo: $e');
       }

--- a/app/lib/services/notifications.dart
+++ b/app/lib/services/notifications.dart
@@ -8,8 +8,10 @@ import 'package:awesome_notifications/awesome_notifications.dart';
 
 import 'package:omi/app_globals.dart';
 import 'package:omi/pages/home/page.dart';
+import 'package:omi/utils/analytics/analytics_manager.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/logger.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 // Re-export the main notification service for backward compatibility
 // All notification functionality is now handled by the platform-aware service
@@ -62,9 +64,53 @@ class NotificationUtil {
   }
 
   /// Public entry for FCM background/terminated notification taps (#5126).
-  static void handleNavigateTo(String route) {
+  ///
+  /// Takes the whole FCM `data` map rather than just the route: the tap event
+  /// reads keys beyond `navigate_to` — notably `campaign_id` — and forwarding
+  /// only the route dropped them before they reached analytics (#12645).
+  static void handleFcmTap(Map<String, dynamic> data) {
     // Fire-and-forget: waits for navigator readiness before pushing (terminated cold start).
-    unawaited(_handleAppLinkOrDeepLink({'navigate_to': route}));
+    unawaited(_handleAppLinkOrDeepLink(Map<String, dynamic>.from(data)));
+  }
+
+  /// Properties for the single `Notification Opened` event emitted per tap.
+  ///
+  /// Senders put `campaign_id` on the FCM `data` map, which reaches the client
+  /// untouched, so an open can be tied back to the send that caused it. Keys
+  /// absent from the payload are omitted rather than sent as null, so a query
+  /// filtering on `campaign_id` sees only real campaign traffic (#12645).
+  @visibleForTesting
+  static Map<String, dynamic> notificationOpenedProperties(Map<String, dynamic> payload) {
+    final properties = <String, dynamic>{};
+
+    void put(String key, dynamic value) {
+      if (value is String && value.isNotEmpty) {
+        properties[key] = value;
+      }
+    }
+
+    put('campaign_id', payload['campaign_id']);
+    put('navigate_to', payload['navigate_to']);
+    // Senders set one or the other; `notification_type` is the newer spelling.
+    put('notification_type', payload['notification_type'] ?? payload['type']);
+    return properties;
+  }
+
+  /// The external destination [navigateTo] addresses, or null for an in-app route.
+  ///
+  /// Campaign CTAs point at an absolute URL — the desktop download route carrying
+  /// the campaign id — so that tap has to leave the app rather than be pushed onto
+  /// the navigator as a route name, which lands on a dead route (#12645).
+  ///
+  /// Only http and https qualify. A notification payload is attacker-influenced
+  /// input, and handing an arbitrary scheme to the platform launcher would let one
+  /// address anything the OS knows how to open.
+  @visibleForTesting
+  static Uri? externalTargetFor(String navigateTo) {
+    final uri = Uri.tryParse(navigateTo);
+    if (uri == null || !uri.hasScheme || !uri.hasAuthority) return null;
+    if (uri.scheme != 'http' && uri.scheme != 'https') return null;
+    return uri;
   }
 
   /// Extract a chat/conversation deep-link from an FCM data map.
@@ -103,9 +149,29 @@ class NotificationUtil {
   static Future<void> _handleAppLinkOrDeepLink(Map<String, dynamic> payload) async {
     WidgetsFlutterBinding.ensureInitialized();
 
-    final navigateTo = payload['navigate_to'];
-    if (navigateTo is! String || navigateTo.isEmpty) {
+    // Exactly one event per tap: both entry points — Awesome Notifications
+    // actions and FCM background/terminated taps — funnel through here. Emitted
+    // before the route check, so a push whose payload carries no `navigate_to`
+    // is still counted; PostHog's `$push_notification_opened` is Android
+    // autocapture only, so until now iOS opens were invisible (#12645).
+    AnalyticsManager().track('Notification Opened', properties: notificationOpenedProperties(payload));
+
+    final navigateTo = navigateToFromFcmData(payload);
+    if (navigateTo == null) {
       Logger.debug('Navigate To is null');
+      return;
+    }
+
+    // A campaign CTA points outside the app — the download route carrying the
+    // campaign id. Handled before the navigator wait: an external target needs no
+    // navigator, and waiting would stall the launch for up to 15s on a cold start.
+    final externalTarget = externalTargetFor(navigateTo);
+    if (externalTarget != null) {
+      try {
+        await launchUrl(externalTarget, mode: LaunchMode.externalApplication);
+      } catch (e) {
+        Logger.debug('Failed to open external navigate_to=$navigateTo: $e');
+      }
       return;
     }
 

--- a/app/lib/services/notifications/notification_service_fcm.dart
+++ b/app/lib/services/notifications/notification_service_fcm.dart
@@ -265,10 +265,9 @@ class _FCMNotificationService implements NotificationInterface {
 
     void handleNotificationTap(RemoteMessage? message) {
       if (message == null) return;
-      final navigateTo = NotificationUtil.navigateToFromFcmData(message.data);
-      if (navigateTo != null) {
-        NotificationUtil.handleNavigateTo(navigateTo);
-      }
+      // The whole data map goes through, not just the route: the tap event reads
+      // `campaign_id` from it, and routing still ignores everything else (#12645).
+      NotificationUtil.handleFcmTap(message.data);
     }
 
     // Background: app is backgrounded and the user taps a push notification (#5126).

--- a/app/lib/services/notifications/notification_service_fcm.dart
+++ b/app/lib/services/notifications/notification_service_fcm.dart
@@ -210,6 +210,17 @@ class _FCMNotificationService implements NotificationInterface {
         if (navigateTo != null && navigateTo.toString().isNotEmpty) {
           payload['navigate_to'] = navigateTo.toString();
         }
+        // Attribution keys ride along with the foreground notification too. A tap
+        // on it re-enters through onActionReceivedMethodImpl rather than
+        // handleFcmTap, so without these the Android foreground case — the user
+        // already has the app open, which is when a campaign matters most — would
+        // emit a `Notification Opened` carrying no campaign_id (#12645).
+        for (final key in const ['campaign_id', 'notification_type', 'type']) {
+          final value = data[key];
+          if (value != null && value.toString().isNotEmpty) {
+            payload[key] = value.toString();
+          }
+        }
 
         // Handle action item data messages
         final messageType = data['type'];

--- a/app/test/unit/notification_fcm_navigate_to_test.dart
+++ b/app/test/unit/notification_fcm_navigate_to_test.dart
@@ -86,6 +86,17 @@ void main() {
       );
     });
 
+    test('falls back to the legacy type when notification_type is an empty string', () {
+      // `??` alone would keep the empty value and drop the valid legacy one, so a
+      // sender that sets both would lose its notification type entirely.
+      expect(
+        NotificationUtil.notificationOpenedProperties(
+          const {'notification_type': '', 'type': 'day_summary'},
+        )['notification_type'],
+        'day_summary',
+      );
+    });
+
     test('prefers notification_type over the legacy type key', () {
       expect(
         NotificationUtil.notificationOpenedProperties(

--- a/app/test/unit/notification_fcm_navigate_to_test.dart
+++ b/app/test/unit/notification_fcm_navigate_to_test.dart
@@ -53,4 +53,97 @@ void main() {
       expect(result, isNull);
     });
   });
+
+  group('NotificationUtil.notificationOpenedProperties (#12645)', () {
+    test('carries the campaign id straight off the FCM data map', () {
+      expect(
+        NotificationUtil.notificationOpenedProperties(const {
+          'campaign_id': 'macos-push-2026-09-02',
+          'navigate_to': '/chat/omi',
+          'notification_type': 'campaign',
+        }),
+        {
+          'campaign_id': 'macos-push-2026-09-02',
+          'navigate_to': '/chat/omi',
+          'notification_type': 'campaign',
+        },
+      );
+    });
+
+    test('omits campaign_id entirely when the notification is not a campaign', () {
+      final properties = NotificationUtil.notificationOpenedProperties(const {'navigate_to': '/chat/omi'});
+
+      // Absent rather than null: a query filtering on campaign_id must see only
+      // real campaign traffic.
+      expect(properties.containsKey('campaign_id'), isFalse);
+      expect(properties['navigate_to'], '/chat/omi');
+    });
+
+    test('falls back to the legacy type key when notification_type is absent', () {
+      expect(
+        NotificationUtil.notificationOpenedProperties(const {'type': 'day_summary'})['notification_type'],
+        'day_summary',
+      );
+    });
+
+    test('prefers notification_type over the legacy type key', () {
+      expect(
+        NotificationUtil.notificationOpenedProperties(
+          const {'notification_type': 'campaign', 'type': 'day_summary'},
+        )['notification_type'],
+        'campaign',
+      );
+    });
+
+    test('drops empty and non-String values instead of reporting them', () {
+      expect(
+        NotificationUtil.notificationOpenedProperties(const {'campaign_id': '', 'navigate_to': 42}),
+        isEmpty,
+      );
+    });
+
+    test('a payload with no recognised keys yields no properties', () {
+      expect(NotificationUtil.notificationOpenedProperties(const {}), isEmpty);
+    });
+  });
+
+  group('NotificationUtil.externalTargetFor (#12645)', () {
+    test('treats an absolute https campaign CTA as external', () {
+      final target = NotificationUtil.externalTargetFor(
+        'https://api.omi.me/v2/desktop/download/latest?campaign_id=macos-push-2026-09-02',
+      );
+
+      expect(target, isNotNull);
+      expect(target!.host, 'api.omi.me');
+      expect(target.queryParameters['campaign_id'], 'macos-push-2026-09-02');
+    });
+
+    test('treats http as external too', () {
+      expect(NotificationUtil.externalTargetFor('http://omi.me/download')?.host, 'omi.me');
+    });
+
+    test('leaves an in-app route alone', () {
+      // Must stay null, or every deep link would try to open in a browser.
+      expect(NotificationUtil.externalTargetFor('/chat/omi'), isNull);
+      expect(NotificationUtil.externalTargetFor('conversations'), isNull);
+    });
+
+    test('refuses schemes other than http and https', () {
+      // A notification payload is attacker-influenced: handing an arbitrary
+      // scheme to the platform launcher would address anything the OS can open.
+      for (final hostile in const [
+        'file:///etc/passwd',
+        'javascript:alert(1)',
+        'mailto:someone@example.com',
+        'tel:+15551234567',
+        'omi://settings',
+      ]) {
+        expect(NotificationUtil.externalTargetFor(hostile), isNull, reason: hostile);
+      }
+    });
+
+    test('refuses a scheme with no authority', () {
+      expect(NotificationUtil.externalTargetFor('https:'), isNull);
+    });
+  });
 }

--- a/backend/campaign_attribution.py
+++ b/backend/campaign_attribution.py
@@ -1,0 +1,21 @@
+"""One definition of a push-campaign id, shared by its producer and consumer.
+
+A campaign id travels from the send (`POST /v1/notification`) through the client
+tap to the download CTA (`GET /v2/desktop/download/latest`), where it lands on a
+space-separated Cloud Logging line. Both ends validate against the rules here:
+if the sender accepted an id the download route rejects, the send would look fine
+and the CTA would 400, losing exactly the attribution the campaign was set up to
+capture.
+
+Deliberately dependency-free so either router can import it without pulling in a
+notification or release-pipeline import graph.
+"""
+
+# Excludes whitespace so an id cannot forge a field in the log line it lands on.
+CAMPAIGN_ID_MAX_LENGTH = 64
+CAMPAIGN_ID_PATTERN = r'^[A-Za-z0-9._:-]+$'
+
+# Stands in for "this download carried no campaign". Parentheses sit outside
+# CAMPAIGN_ID_PATTERN, so a real campaign cannot collide with the sentinel and be
+# silently counted into the untracked bucket.
+NO_CAMPAIGN_SENTINEL = '(absent)'

--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -92,6 +92,21 @@ def save_token(
 
 @router.post('/v1/notification')
 def send_notification_to_user(data: Dict[str, Any], secret_key: str = Header(...)) -> Dict[str, str]:
+    """Send one FCM notification to a user.
+
+    `data.data` is forwarded to FCM untouched and reaches the client as the tap
+    payload. Two keys in it are a convention rather than transport:
+
+      kind         "campaign" marks a marketing or growth send.
+      campaign_id  identifies that campaign. The client emits it back on the
+                   notification tap, and a campaign CTA carries it into
+                   /v2/desktop/download/latest, so sends, opens and downloads
+                   share one id.
+
+    A campaign send without a campaign_id is rejected. Afterwards it is
+    indistinguishable from an untracked send, and the gap only surfaces once the
+    campaign is over and the opens can no longer be recovered.
+    """
     if secret_key != os.getenv('ADMIN_KEY'):
         raise HTTPException(status_code=403, detail='You are not authorized to perform this action')
     if not data.get('uid'):
@@ -100,6 +115,11 @@ def send_notification_to_user(data: Dict[str, Any], secret_key: str = Header(...
     title = cast(str, data['title'])
     body = cast(str, data['body'])
     notification_data = cast(Dict[str, Any], data.get('data', {}))
+    if notification_data.get('kind') == 'campaign' and not notification_data.get('campaign_id'):
+        raise HTTPException(
+            status_code=400,
+            detail='data.campaign_id is required when data.kind is "campaign"',
+        )
     send_notification(uid, title, body, notification_data)
     return {'status': 'Ok'}
 

--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -1,4 +1,5 @@
 import os
+import re
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Tuple, cast
 
@@ -15,6 +16,7 @@ from utils.app_integrations import send_app_notification
 import database.notifications as notification_db
 from models.other import FcmTokenResponse, SaveFcmTokenRequest
 from models.integrations import IntegrationNotificationResponse
+from campaign_attribution import CAMPAIGN_ID_MAX_LENGTH, CAMPAIGN_ID_PATTERN
 from utils.notifications import (
     send_notification,
 )
@@ -114,12 +116,26 @@ def send_notification_to_user(data: Dict[str, Any], secret_key: str = Header(...
     uid = cast(str, data['uid'])
     title = cast(str, data['title'])
     body = cast(str, data['body'])
-    notification_data = cast(Dict[str, Any], data.get('data', {}))
-    if notification_data.get('kind') == 'campaign' and not notification_data.get('campaign_id'):
-        raise HTTPException(
-            status_code=400,
-            detail='data.campaign_id is required when data.kind is "campaign"',
-        )
+    # `or {}` rather than a default: an explicit "data": null previously reached
+    # send_notification, which tolerates it, so it must not start raising here.
+    notification_data = cast(Dict[str, Any], data.get('data') or {})
+    if notification_data.get('kind') == 'campaign':
+        campaign_id = notification_data.get('campaign_id')
+        # Validated against the same rule the download CTA enforces. Accepting an
+        # id that /v2/desktop/download/latest rejects would let the send succeed
+        # and the CTA 400, losing the attribution this gate exists to guarantee.
+        if (
+            not isinstance(campaign_id, str)
+            or len(campaign_id) > CAMPAIGN_ID_MAX_LENGTH
+            or not re.match(CAMPAIGN_ID_PATTERN, campaign_id)
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    'data.campaign_id is required when data.kind is "campaign", and must match '
+                    f'{CAMPAIGN_ID_PATTERN} within {CAMPAIGN_ID_MAX_LENGTH} characters'
+                ),
+            )
     send_notification(uid, title, body, notification_data)
     return {'status': 'Ok'}
 

--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -127,7 +127,14 @@ def send_notification_to_user(data: Dict[str, Any], secret_key: str = Header(...
         if (
             not isinstance(campaign_id, str)
             or len(campaign_id) > CAMPAIGN_ID_MAX_LENGTH
-            or not re.match(CAMPAIGN_ID_PATTERN, campaign_id)
+            # fullmatch, not match: Python's `$` also matches just before a
+            # trailing newline, so `re.match` accepts an id ending in one while
+            # the CTA's pydantic pattern (whole-string) rejects it — the exact
+            # send-ok/CTA-400 split this shared rule exists to prevent, and a
+            # newline would break the space-separated log line it feeds. The
+            # pattern itself cannot use `\Z`: pydantic's Rust regex has no such
+            # escape and the Query would fail to build.
+            or not re.fullmatch(CAMPAIGN_ID_PATTERN, campaign_id)
         ):
             raise HTTPException(
                 status_code=400,

--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -823,11 +823,32 @@ async def get_desktop_appcast_xml(
         raise HTTPException(status_code=500, detail=f"Error generating appcast: {str(e)}")
 
 
+def _log_download_served(*, platform: str, channel: str, version: str, campaign_id: Optional[str]) -> None:
+    """Emit one greppable line per served installer page.
+
+    Cloud Logging is the counting surface for campaign attribution: a push CTA
+    points here with campaign_id, and that campaign's download count is a filter
+    on this line. Emitted for every served page, with campaign_id=none when the
+    request carries no campaign, so a campaign's count keeps a denominator.
+    """
+    logger.info(
+        "desktop_download_served platform=%s channel=%s version=%s campaign_id=%s",
+        platform,
+        channel,
+        version,
+        campaign_id or "none",
+    )
+
+
 @router.get("/v2/desktop/download/latest")
 async def download_latest_desktop_release(
     platform: str = Query(default="macos", pattern="^(macos|windows|linux)$"),
     channel: str = Query(default="stable", pattern="^(beta|stable)$"),
     identity: Optional[str] = Query(default=None, pattern="^(stable|beta)$"),
+    # Attribution only: never changes which installer is served. The pattern
+    # bounds it to log-safe characters so a campaign id cannot inject a field
+    # separator or a newline into the line Cloud Logging counts.
+    campaign_id: Optional[str] = Query(default=None, max_length=64, pattern="^[A-Za-z0-9._:-]+$"),
 ):
     """
     Serve the latest desktop release installer as an auto-download landing page.
@@ -840,6 +861,8 @@ async def download_latest_desktop_release(
     When identity is absent it follows the channel (channel=beta alone serves
     the beta-identity DMG — the macos.omi.me/beta redirect contract); pass
     identity explicitly to request the cross product.
+    campaign_id attributes the download to a push campaign and is recorded on
+    the served-page log line; it does not affect resolution.
     """
     if identity is None:
         # macos.omi.me/beta redirects here with only channel=beta — the URL-map redirect
@@ -864,6 +887,7 @@ async def download_latest_desktop_release(
             installer_url = await _resolve_beta_identity_dmg(entry)
             if installer_url:
                 version = entry["version_info"]["version"]
+                _log_download_served(platform=platform, channel=channel, version=version, campaign_id=campaign_id)
                 return HTMLResponse(
                     content=download_landing_html(installer_url, channel=channel, version=version, platform=platform)
                 )
@@ -874,6 +898,7 @@ async def download_latest_desktop_release(
         raise HTTPException(status_code=404, detail=f"No installer found for platform {platform}, channel: {channel}")
     entry, installer_url = picked
     version = entry["version_info"]["version"]
+    _log_download_served(platform=platform, channel=channel, version=version, campaign_id=campaign_id)
     return HTMLResponse(
         content=download_landing_html(installer_url, channel=channel, version=version, platform=platform)
     )

--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -833,8 +833,8 @@ def _log_download_served(*, platform: str, channel: str, version: str, campaign_
 
     Cloud Logging is the counting surface for campaign attribution: a push CTA
     points here with campaign_id, and that campaign's download count is a filter
-    on this line. Emitted for every served page, with campaign_id=none when the
-    request carries no campaign, so a campaign's count keeps a denominator.
+    on this line. Emitted for every served page, with NO_CAMPAIGN_SENTINEL when the request
+    carries no campaign, so a campaign's count keeps a denominator.
     """
     logger.info(
         "desktop_download_served platform=%s channel=%s version=%s campaign_id=%s",

--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -14,6 +14,11 @@ from fastapi.responses import Response, HTMLResponse
 from pydantic import BaseModel, ConfigDict, Field, StrictBool
 
 from desktop_download_page import download_landing_html
+from campaign_attribution import (
+    CAMPAIGN_ID_MAX_LENGTH,
+    CAMPAIGN_ID_PATTERN,
+    NO_CAMPAIGN_SENTINEL,
+)
 from database.desktop_previews import delist_preview, get_current_preview, get_preview_manifest, publish_preview
 from database.desktop_update_channels import (
     admit_qualified_beta_manifest,
@@ -836,7 +841,7 @@ def _log_download_served(*, platform: str, channel: str, version: str, campaign_
         platform,
         channel,
         version,
-        campaign_id or "none",
+        campaign_id or NO_CAMPAIGN_SENTINEL,
     )
 
 
@@ -845,10 +850,10 @@ async def download_latest_desktop_release(
     platform: str = Query(default="macos", pattern="^(macos|windows|linux)$"),
     channel: str = Query(default="stable", pattern="^(beta|stable)$"),
     identity: Optional[str] = Query(default=None, pattern="^(stable|beta)$"),
-    # Attribution only: never changes which installer is served. The pattern
-    # bounds it to log-safe characters so a campaign id cannot inject a field
-    # separator or a newline into the line Cloud Logging counts.
-    campaign_id: Optional[str] = Query(default=None, max_length=64, pattern="^[A-Za-z0-9._:-]+$"),
+    # Attribution only: never changes which installer is served. Shares its rule
+    # with the sender so an accepted send cannot produce a CTA this route rejects,
+    # and the character set bounds it to log-safe values.
+    campaign_id: Optional[str] = Query(default=None, max_length=CAMPAIGN_ID_MAX_LENGTH, pattern=CAMPAIGN_ID_PATTERN),
 ):
     """
     Serve the latest desktop release installer as an auto-download landing page.

--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -1298,6 +1298,29 @@ class TestDownloadEndpoint:
         assert "campaign_id=(absent)" not in caplog.text
 
     @pytest.mark.asyncio
+    async def test_the_served_line_never_contains_a_newline(self, caplog):
+        # One record per download, fields separated by spaces. A newline anywhere
+        # in it would forge a second record in Cloud Logging and corrupt the count.
+        mock_releases = [
+            {
+                "channel": "stable",
+                "version_info": {"version": "1.2.3+45", "build": "45"},
+                "release": {"assets": [_dmg_asset("https://example.com/Omi-stable.dmg")]},
+            },
+        ]
+        with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                with caplog.at_level(logging.INFO, logger="routers.updates"):
+                    await client.get("/v2/desktop/download/latest?channel=stable&campaign_id=macos-push-2026-09-02")
+                    await client.get("/v2/desktop/download/latest?channel=stable")
+
+        served = [r.getMessage() for r in caplog.records if "desktop_download_served" in r.getMessage()]
+        assert len(served) == 2
+        for line in served:
+            assert chr(10) not in line
+            assert chr(13) not in line
+
+    @pytest.mark.asyncio
     async def test_campaign_id_carrying_a_log_separator_is_rejected(self):
         # The id lands in a space-separated log line, so a value carrying a space
         # or a newline could forge a field or a whole record.

--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -1,5 +1,6 @@
 """Tests for desktop update system (appcast XML, channel filtering, download endpoint)."""
 
+import logging
 from datetime import timedelta
 import xml.etree.ElementTree as ET
 from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
@@ -1213,6 +1214,76 @@ class TestDownloadEndpoint:
                 resp = await client.get("/v2/desktop/download/windows?channel=beta")
         assert resp.status_code == 404
         assert "channel: beta" in resp.json()["detail"]
+
+    # --- campaign attribution (#12645) ---
+    #
+    # Cloud Logging is the counting surface: a push CTA points here carrying
+    # campaign_id, and that campaign's downloads are a filter on the served line.
+
+    @pytest.mark.asyncio
+    async def test_campaign_id_is_recorded_on_the_served_page(self, caplog):
+        mock_releases = [
+            {
+                "channel": "stable",
+                "version_info": {"version": "1.2.3+45", "build": "45"},
+                "release": {"assets": [_dmg_asset("https://example.com/Omi-stable.dmg")]},
+            },
+        ]
+        with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                with caplog.at_level(logging.INFO, logger="routers.updates"):
+                    resp = await client.get(
+                        "/v2/desktop/download/latest?channel=stable&campaign_id=macos-push-2026-09-02"
+                    )
+
+        assert resp.status_code == 200
+        assert "https://example.com/Omi-stable.dmg" in resp.text
+        assert "desktop_download_served" in caplog.text
+        assert "campaign_id=macos-push-2026-09-02" in caplog.text
+        assert "version=1.2.3+45" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_download_without_a_campaign_still_logs_a_countable_line(self, caplog):
+        mock_releases = [
+            {
+                "channel": "stable",
+                "version_info": {"version": "1.2.3+45", "build": "45"},
+                "release": {"assets": [_dmg_asset("https://example.com/Omi-stable.dmg")]},
+            },
+        ]
+        with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                with caplog.at_level(logging.INFO, logger="routers.updates"):
+                    resp = await client.get("/v2/desktop/download/latest?channel=stable")
+
+        assert resp.status_code == 200
+        # A campaign's count needs a denominator, so the line is always emitted.
+        assert "campaign_id=none" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_campaign_id_does_not_change_which_installer_is_served(self):
+        mock_releases = [
+            {
+                "channel": "stable",
+                "version_info": {"version": "1.2.3+45", "build": "45"},
+                "release": {"assets": [_dmg_asset("https://example.com/Omi-stable.dmg")]},
+            },
+        ]
+        with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                plain = await client.get("/v2/desktop/download/latest?channel=stable")
+                attributed = await client.get("/v2/desktop/download/latest?channel=stable&campaign_id=abc")
+
+        assert plain.status_code == attributed.status_code == 200
+        assert plain.text == attributed.text
+
+    @pytest.mark.asyncio
+    async def test_campaign_id_carrying_a_log_separator_is_rejected(self):
+        # The id lands in a space-separated log line, so a value carrying a space
+        # or a newline could forge a field or a whole record.
+        async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+            resp = await client.get("/v2/desktop/download/latest?channel=stable&campaign_id=a%20b")
+        assert resp.status_code == 422
 
 
 # --- Clear cache endpoint ---

--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -1258,7 +1258,7 @@ class TestDownloadEndpoint:
 
         assert resp.status_code == 200
         # A campaign's count needs a denominator, so the line is always emitted.
-        assert "campaign_id=none" in caplog.text
+        assert "campaign_id=(absent)" in caplog.text
 
     @pytest.mark.asyncio
     async def test_campaign_id_does_not_change_which_installer_is_served(self):
@@ -1276,6 +1276,26 @@ class TestDownloadEndpoint:
 
         assert plain.status_code == attributed.status_code == 200
         assert plain.text == attributed.text
+
+    @pytest.mark.asyncio
+    async def test_a_campaign_literally_named_none_is_not_read_as_absent(self, caplog):
+        # The sentinel must not be spellable as a campaign id, or that campaign's
+        # downloads would be silently counted into the untracked bucket.
+        mock_releases = [
+            {
+                "channel": "stable",
+                "version_info": {"version": "1.2.3+45", "build": "45"},
+                "release": {"assets": [_dmg_asset("https://example.com/Omi-stable.dmg")]},
+            },
+        ]
+        with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                with caplog.at_level(logging.INFO, logger="routers.updates"):
+                    resp = await client.get("/v2/desktop/download/latest?channel=stable&campaign_id=none")
+
+        assert resp.status_code == 200
+        assert "campaign_id=none" in caplog.text
+        assert "campaign_id=(absent)" not in caplog.text
 
     @pytest.mark.asyncio
     async def test_campaign_id_carrying_a_log_separator_is_rejected(self):

--- a/backend/tests/unit/test_integration_notification_validation.py
+++ b/backend/tests/unit/test_integration_notification_validation.py
@@ -208,6 +208,10 @@ def test_campaign_send_with_a_null_data_body_does_not_500(monkeypatch):
     [
         'has spaces',
         'has\nnewline',
+        # A trailing newline specifically: Python's `$` matches just before one,
+        # so re.match let this through the send gate while the CTA 422s it. The
+        # two ends disagreeing is the whole failure this shared rule prevents.
+        'ab\n',
         'hash#char',
         '   ',
         'x' * 65,

--- a/backend/tests/unit/test_integration_notification_validation.py
+++ b/backend/tests/unit/test_integration_notification_validation.py
@@ -139,3 +139,50 @@ def test_check_rate_limit_allows_full_hourly_quota():
     assert allowed[:max_n] == [True] * max_n  # full quota deliverable
     assert allowed[max_n] is False  # only the (max_n + 1)th request is throttled
     assert results[0][1] == max_n - 1  # first send reports the full remaining quota, not one short
+
+
+# --- POST /v1/notification: campaign attribution convention (#12645) -------------
+#
+# `data.data` is forwarded to FCM untouched, so campaign_id is a convention rather
+# than transport. A campaign send that omits it is indistinguishable afterwards
+# from an untracked send, and the gap only surfaces once the campaign is over.
+
+
+def test_campaign_send_without_campaign_id_returns_400(monkeypatch):
+    monkeypatch.setenv('ADMIN_KEY', 'admin-key')
+
+    with pytest.raises(HTTPException) as e:
+        notif_mod.send_notification_to_user(
+            data={'uid': 'uid1', 'title': 't', 'body': 'b', 'data': {'kind': 'campaign'}},
+            secret_key='admin-key',
+        )
+
+    assert e.value.status_code == 400
+    assert 'campaign_id' in e.value.detail
+
+
+def test_campaign_send_with_campaign_id_forwards_the_payload_untouched(monkeypatch):
+    monkeypatch.setenv('ADMIN_KEY', 'admin-key')
+    payload = {'kind': 'campaign', 'campaign_id': 'macos-push-2026-09-02', 'navigate_to': '/chat'}
+
+    with patch.object(notif_mod, 'send_notification') as send:
+        result = notif_mod.send_notification_to_user(
+            data={'uid': 'uid1', 'title': 't', 'body': 'b', 'data': payload},
+            secret_key='admin-key',
+        )
+
+    assert result == {'status': 'Ok'}
+    send.assert_called_once_with('uid1', 't', 'b', payload)
+
+
+def test_non_campaign_send_does_not_require_a_campaign_id(monkeypatch):
+    monkeypatch.setenv('ADMIN_KEY', 'admin-key')
+
+    with patch.object(notif_mod, 'send_notification') as send:
+        result = notif_mod.send_notification_to_user(
+            data={'uid': 'uid1', 'title': 't', 'body': 'b', 'data': {'navigate_to': '/chat'}},
+            secret_key='admin-key',
+        )
+
+    assert result == {'status': 'Ok'}
+    send.assert_called_once_with('uid1', 't', 'b', {'navigate_to': '/chat'})

--- a/backend/tests/unit/test_integration_notification_validation.py
+++ b/backend/tests/unit/test_integration_notification_validation.py
@@ -186,3 +186,57 @@ def test_non_campaign_send_does_not_require_a_campaign_id(monkeypatch):
 
     assert result == {'status': 'Ok'}
     send.assert_called_once_with('uid1', 't', 'b', {'navigate_to': '/chat'})
+
+
+def test_campaign_send_with_a_null_data_body_does_not_500(monkeypatch):
+    # "data": null used to reach send_notification, which tolerates it. The new
+    # campaign gate must not turn that into an AttributeError -> HTTP 500.
+    monkeypatch.setenv('ADMIN_KEY', 'admin-key')
+
+    with patch.object(notif_mod, 'send_notification') as send:
+        result = notif_mod.send_notification_to_user(
+            data={'uid': 'uid1', 'title': 't', 'body': 'b', 'data': None},
+            secret_key='admin-key',
+        )
+
+    assert result == {'status': 'Ok'}
+    send.assert_called_once_with('uid1', 't', 'b', {})
+
+
+@pytest.mark.parametrize(
+    'campaign_id',
+    [
+        'has spaces',
+        'has\nnewline',
+        'hash#char',
+        '   ',
+        'x' * 65,
+    ],
+)
+def test_campaign_id_the_download_route_would_reject_is_refused_at_send(monkeypatch, campaign_id):
+    # The download CTA constrains campaign_id. Accepting one here that it rejects
+    # would let the send succeed and the CTA 400, losing the attribution outright.
+    monkeypatch.setenv('ADMIN_KEY', 'admin-key')
+
+    with pytest.raises(HTTPException) as e:
+        notif_mod.send_notification_to_user(
+            data={
+                'uid': 'uid1',
+                'title': 't',
+                'body': 'b',
+                'data': {'kind': 'campaign', 'campaign_id': campaign_id},
+            },
+            secret_key='admin-key',
+        )
+
+    assert e.value.status_code == 400
+    assert 'campaign_id' in e.value.detail
+
+
+def test_sender_and_download_route_share_one_campaign_id_rule():
+    # Both ends must read the same constants, not two literals that can drift: a
+    # sender that accepts what the CTA rejects loses the attribution silently.
+    import campaign_attribution
+
+    assert notif_mod.CAMPAIGN_ID_PATTERN is campaign_attribution.CAMPAIGN_ID_PATTERN
+    assert notif_mod.CAMPAIGN_ID_MAX_LENGTH is campaign_attribution.CAMPAIGN_ID_MAX_LENGTH


### PR DESCRIPTION
## What this does

Closes #12645.

The 2026-09-02 macOS push reached ~31,000 users and afterwards nobody could say how many tapped it. This gives the send, the open and the download one shared id.

**1. The tap, both platforms** — `app/lib/services/notifications.dart`

Both entry points already funnel through `_handleAppLinkOrDeepLink` (the Awesome Notifications action path, and the FCM background/terminated path), so `Notification Opened` is emitted there and is **exactly one per tap by construction**. It fires before the `navigate_to` check, so a push carrying no route is still counted.

The FCM path forwarded only the route, which dropped `campaign_id` before analytics could see it. That entry now takes the whole FCM data map (`handleFcmTap`); routing still ignores every key but `navigate_to`. The route check reuses `navigateToFromFcmData` instead of repeating the missing/empty/non-String rule inline, so its existing tests still cover it.

`navigate_to` may now be an **absolute URL**. A campaign CTA points at the download route carrying the campaign id, and without this the tap pushed that URL onto the navigator as a route name and landed on a dead route — so the download could never be attributed back to the send. External targets launch before the navigator wait, since they need no navigator and waiting would stall the launch up to 15s on a cold start.

`externalTargetFor` admits only `http` and `https`. A notification payload is attacker-influenced input, and handing an arbitrary scheme to the platform launcher would let one address anything the OS can open — `file:`, `javascript:`, `mailto:`, `tel:` and custom schemes are each refused, with a test apiece.

`notificationOpenedProperties` and `externalTargetFor` are pure functions, so the payload → properties mapping and the external/in-app decision are testable without a PostHog double or a platform channel. Absent keys are omitted rather than sent as null, so a query filtering on `campaign_id` sees only real campaign traffic.

**2. The sender convention** — `POST /v1/notification`

Documents what the `data` payload already allowed. `data.kind == "campaign"` marks a growth send and now requires `data.campaign_id`; the payload is still forwarded to FCM untouched. Rejecting is the point: afterwards an untracked campaign is indistinguishable from a tracked one, and the gap only surfaces once the opens can no longer be recovered — which is what happened on 09-02.

**3. The download** — `GET /v2/desktop/download/latest`

Accepts `campaign_id` and records it on a `desktop_download_served` log line, so per-campaign downloads are a Cloud Logging filter and don't depend on the marketing site's analytics.

- Attribution only. It never changes which installer is resolved, and a test asserts the served page is byte-identical with and without it.
- The pattern bounds it to log-safe characters: the id lands in a space-separated line, so a value carrying a space or newline could forge a field or a whole record.
- Emitted for every served page, `campaign_id=none` included, so a campaign's count keeps a denominator.

## Product invariants affected

- INV-BETA-1

`backend/routers/updates.py` is on the invariant's path glob. The change is compatible: `campaign_id` is attribution only and beta-identity resolution is untouched — `_resolve_beta_identity_dmg`, the `identity` handling, and the rule that a beta-identity request never falls back to the stable `omi.dmg` are all unchanged. The only edit inside that branch is a log call placed before the existing `return`. `test_campaign_id_does_not_change_which_installer_is_served` pins that the served page is identical either way.

## Verification

Windows. Backend on `backend/.venv-ci` matching `backend/pylock.toml`; app on **Flutter 3.44.5**, the version `mobile-app-checks.yml` pins.

**Backend (`20e9d7a`)**

| Command | Result |
|---|---|
| `pytest tests/unit/test_desktop_updates.py tests/unit/test_integration_notification_validation.py` | **145 passed** |
| `scripts/backend-python-format --check` on all 4 files | clean |

Reverting only the two router edits and keeping the tests: 3 of the 4 download tests fail (`campaign_id` absent from the log line; the log-separator id accepted instead of rejected), and `test_campaign_send_without_campaign_id_returns_400` fails. The two that still pass are invariance assertions by design — that `campaign_id` does not change the served installer, and that a non-campaign send is forwarded untouched.

**App (0fc1a73)**

| Command | Result |
|---|---|
| `flutter test test/unit/notification_fcm_navigate_to_test.dart` | **18 passed** — 11 new, plus the 4 existing `navigateToFromFcmData` and 3 `waitUntilNonNull` cases |
| `flutter test` (full suite) | **1668 passed**, 5 skipped, 3 failed |
| `git diff --exit-code -- lib` after codegen | passes — `build_runner` produced no content change |
| `dart analyze` | **0 ERROR-severity issues**; my three files contribute **0** new issues |

The 3 suite failures are `on_device_transcription_upgrade`, `plans_sheet_l10n` and `voice_recorder_mic_contention`. I checked them out at `upstream/main` for the two source files I changed and re-ran: identical `+14 -3`. Pre-existing and unrelated — the last is a Windows file-lock (`PathAccessException ... used by another process`).

`scripts/analyze_ratchet.sh` itself needs `jq`, which this machine lacks, so I reproduced its comparison directly: every lint is at or under `analysis_baseline.json` except `unused_element` (2 vs 0), and both instances are in `lib/utils/manifest/manifest.g.dart` — a generated file that is byte-identical to `upstream/main` and absent from this diff. The four analyzer notes inside my files (`avoid_print` ×3, one unnecessary `dart:ui` import) are all on lines that predate this change.

**Preflight:** `pr_preflight.py --base upstream/main` over all 7 files passes, including `product-invariants` with INV-BETA-1 named. Its one failure is `desktop-backend-release-boundary-fixtures`, which needs `jq` and fails identically on unmodified `upstream/main`.

## What closes the loop

Send carries `campaign_id`, the tap emits it, the CTA carries it into the download route. Then "opens by platform" and "downloads by campaign" are the two queries the issue asks for — PostHog HogQL and Cloud Logging respectively.
Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

