### PR TITLE
fix(backend): download chip says where the file went, not that a process completed

### DIFF
--- a/backend/desktop_download_page.py
+++ b/backend/desktop_download_page.py
@@ -237,7 +237,7 @@ def download_landing_html(
 <body>
     <div class="container">
         <p class="status-chip" id="status-chip">
-            <span class="status-dot" aria-hidden="true"></span><span id="status-text">Starting download</span>
+            <span class="status-dot" aria-hidden="true"></span><span id="status-text">Downloading</span>
         </p>
         <h1>Omi {channel_label}for {os_name}</h1>
         <p class="meta">{version_display} &middot; Didn&rsquo;t start?
@@ -259,7 +259,7 @@ def download_landing_html(
         setTimeout(function() {{
             window.location.href = "{dmg_url}";
             document.body.classList.add("done");
-            document.getElementById("status-text").textContent = "Download started";
+            document.getElementById("status-text").textContent = "In your Downloads";
             document.getElementById("demo-video").style.display = "block";
         }}, 2000);
     </script>

--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -1983,6 +1983,8 @@ class TestDownloadLandingInstallSteps:
         assert 'class="checkmark"' not in html
         assert 'id="status-icon"' not in html
         assert "Your download should start automatically" not in html
+        # the chip says where the file went, not that a process completed
+        assert "Downloading" in html and "Download started" not in html
         # the manual fallback survives, inline in the meta line rather than on its own row
         assert 'class="meta"' in html
         assert html.count('class="download-link"') == 1


### PR DESCRIPTION
## What

Follow-up to #12673. Nik: *"'Download started' looks too AI - fix"*.

He's right. "Download started" is status-report voice — it announces that a process changed state, which is not what someone staring at a download page wants to know. The chip now reads:

- **`Downloading`** while it runs
- **`In your Downloads`** once it fires

That is concrete, it is the thing the reader actually needs, and it hands straight off to step 1 of the install guide directly below it ("Open `omi.dmg` from your **Downloads** folder").

Copy-only change: no markup, styling, or behavior touched.

## Failure class

Failure-Class: none

`fix:` by prefix, but this is copy. No behavioral contract was violated and nothing was broken for users.

## Verification

Served the real router locally and rendered `GET /v2/desktop/download/latest?platform=macos&channel=stable` in headless Chrome in both states: `DOWNLOADING` before the timer fires, `IN YOUR DOWNLOADS` after.

`backend/tests/unit/test_desktop_updates.py`: **136 passed**. The existing status-chip test now also pins the copy, so "Download started" cannot come back silently.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

