### PR TITLE
chore(ci): register FC-shadowed-route-handler class definition (registry-only, accompanies #12697)

### DIFF
--- a/.github/failure-classes/FC-shadowed-route-handler.json
+++ b/.github/failure-classes/FC-shadowed-route-handler.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-shadowed-route-handler",
+  "violated_contract": "A path registered by two routers must not silently resolve to the first-mounted handler: FastAPI first-match wins, so the second (richer) handler — and any cleanup-only-it-performs — is unreachable while tests written against it stay green.",
+  "canonical_prevention": "Fail on duplicate path registrations across routers before merge: parse every @router decorator (method + resolved prefix + path) and diff the full registered-path set per mounted app, the same way route_policy/tooling resolves paths; a collision must force dedupe or an explicit mount-order decision in the PR.",
+  "canonical_prevention_artifact": [
+    ".github/scripts/check_duplicate_routes.py",
+    ".github/scripts/test_check_duplicate_routes.py"
+  ],
+  "evidence_prs": [12697],
+  "scope_hints": [
+    "backend/routers/",
+    "backend/main.py",
+    "backend/desktop_backend.py",
+    "backend/pusher/main.py"
+  ],
+  "status": "open"
+}


### PR DESCRIPTION
# Registry-only lifecycle PR: add FC-shadowed-route-handler

This is a **registry-only** failure-class lifecycle PR, per the protocol rule
that an instance-fix PR must not edit failure-class definitions
(`instance_fix_mutates_registry`: "other registry edits need a separate
registry-only lifecycle PR").

- It adds exactly one file: the `FC-shadowed-route-handler` class definition.
- The instance fix itself, plus this class's `canonical_prevention_artifact`
  (the duplicate-route guard `.github/scripts/check_duplicate_routes.py`, its
  self-test, and the checks-manifest entries), are already in #12697, which
  this PR accompanies and cites as `evidence_prs: [12697]`.

## Merge ordering (expected red until #12697 lands)

`failure-class validate` fails any definition whose `canonical_prevention_artifact`
paths do not exist in the tree ("Recording an artifact that does not exist fails
`scripts/failure-class validate`", docs/product/failure-classes.md). Those two guard
files ship in #12697, not on `main` yet, so this PR's `PR Metadata Preflight` stays
red with `missing_canonical_prevention_artifact` until #12697 merges; this branch is
expected to rebase onto post-#12697 `main` and merge after it. That ordering is the
protocol working as designed: the class must not exist without its guard.

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

