### PR TITLE
SCA-399: stop Interject speaking classification on PTT audio

### DIFF
--- a/.github/failure-classes/FC-control-plane-vocabulary-on-speech-channel.json
+++ b/.github/failure-classes/FC-control-plane-vocabulary-on-speech-channel.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-control-plane-vocabulary-on-speech-channel",
+  "violated_contract": "Control-plane vocabulary must not share the speech channel. Asking a speech model to emit classification tokens or verb labels on native PCM or TTS teaches the model to speak machine verbs instead of the user-facing answer.",
+  "canonical_prevention": "Carry classification on a silent hub tool whose result is opaque and unspeakable. Hub inject instructions must not list speakable output tokens. Native PCM is not sanitized by spokenText; do not add a speech-channel regex as a substitute for the non-speech channel.",
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/FloatingControlBar/Interject/**",
+    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift",
+    "desktop/macos/agent/src/runtime/omi-tool-manifest.ts"
+  ],
+  "status": "open",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Sources/FloatingControlBar/Interject/InterjectHubFeedbackTool.swift",
+    "desktop/macos/Desktop/Tests/InterjectVoiceFeedbackRoutingTests.swift"
+  ]
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -3823,10 +3823,10 @@ class FloatingControlBarManager {
       evaluationID: evaluation, suggestionID: stored.notificationID)
   }
 
-  /// Hub journal finalization is the realtime path into the ledger. Same
-  /// mutation owner as the batch `sendVoiceOnlyQuery` path.
+  /// Hub classification writes through `record_interject_feedback`. Parsing a
+  /// leftover token here would double-fire the ledger against the silent tool.
   func consumeInterjectHubTranscript(_ text: String) async {
-    await consumeInterjectVoiceReplyAsync(text)
+    _ = text
   }
 
   func consumeInterjectVoiceReply(_ text: String) {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/Interject/InterjectHubFeedbackTool.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/Interject/InterjectHubFeedbackTool.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Silent hub tool for Interject classification. The verb travels here, not
+/// on the speech channel. The tool result is opaque so a speech model cannot
+/// read it aloud.
+enum InterjectHubFeedbackTool {
+  static let opaqueResult = #"{"ok":true}"#
+
+  /// Local, flag-gated write through the single mutation owner. Invalid verb,
+  /// missing card identity, and flag-off are all no-ops — no store, no analytics.
+  @MainActor
+  static func recordIfAuthorized(
+    verbRaw: String?,
+    isEnabled: Bool = InterjectFeature.isEnabled,
+    identity: SuggestionAssistantTelemetry.NotificationIdentity? = FloatingControlBarManager.shared
+      .recentNotchCardFeedbackIdentity(),
+    store: InterjectSuggestionFeedbackStore = .shared,
+    emitAnalytics: Bool = true
+  ) async {
+    guard isEnabled,
+      let verbRaw,
+      let verb = InterjectFeedbackVerb(rawValue: verbRaw),
+      let identity
+    else { return }
+    await InterjectSuggestionFeedbackMutation.record(
+      evaluationID: identity.evaluationID,
+      suggestionID: identity.suggestionID,
+      verb: verb,
+      store: store,
+      emitAnalytics: emitAnalytics
+    )
+  }
+}
+
+extension RealtimeHubController {
+  /// Local Interject classification — same placement as
+  /// `report_screen_observation`, before kernel-authorized tools.
+  func handleInterjectFeedbackReport(
+    source: RealtimeHubSession,
+    callId: String,
+    arguments: [String: Any],
+    expectedTurnEpoch: Int
+  ) {
+    let verbRaw = arguments["verb"] as? String
+    Task { await InterjectHubFeedbackTool.recordIfAuthorized(verbRaw: verbRaw) }
+    sendToolResultIfCurrent(
+      source: source,
+      callId: callId,
+      name: HubTool.recordInterjectFeedback.rawValue,
+      output: InterjectHubFeedbackTool.opaqueResult,
+      expectedTurnEpoch: expectedTurnEpoch)
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/Interject/InterjectHubFeedbackTool.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/Interject/InterjectHubFeedbackTool.swift
@@ -6,25 +6,49 @@ import Foundation
 enum InterjectHubFeedbackTool {
   static let opaqueResult = #"{"ok":true}"#
 
-  /// Local, flag-gated write through the single mutation owner. Invalid verb,
-  /// missing card identity, and flag-off are all no-ops — no store, no analytics.
+  /// Card identity captured when the tool call is admitted (synchronous with
+  /// the hub event). The async write must not blindly re-read mutable UI
+  /// state: it rechecks the live recent card against this snapshot, so an
+  /// owner or card change between admission and the write can never classify
+  /// the wrong card.
+  struct AdmittedFeedback: Sendable {
+    let identity: SuggestionAssistantTelemetry.NotificationIdentity
+  }
+
+  /// Admission: capture the current card identity synchronously with the hub
+  /// event. Flag-off or no current card admits nothing.
   @MainActor
-  static func recordIfAuthorized(
-    verbRaw: String?,
+  static func admit(
     isEnabled: Bool = InterjectFeature.isEnabled,
     identity: SuggestionAssistantTelemetry.NotificationIdentity? = FloatingControlBarManager.shared
+      .recentNotchCardFeedbackIdentity()
+  ) -> AdmittedFeedback? {
+    guard isEnabled, let identity else { return nil }
+    return AdmittedFeedback(identity: identity)
+  }
+
+  /// Write the admitted classification through the single mutation owner.
+  /// Owner/turn fence: immediately before the mutation the live recent card
+  /// must still match the admitted snapshot. Invalid verb, missing admission,
+  /// and a replaced card are all no-ops — no store, no analytics.
+  @MainActor
+  static func recordIfAdmitted(
+    _ admitted: AdmittedFeedback?,
+    verbRaw: String?,
+    currentIdentity: SuggestionAssistantTelemetry.NotificationIdentity? = FloatingControlBarManager.shared
       .recentNotchCardFeedbackIdentity(),
     store: InterjectSuggestionFeedbackStore = .shared,
     emitAnalytics: Bool = true
   ) async {
-    guard isEnabled,
+    guard let admitted,
       let verbRaw,
       let verb = InterjectFeedbackVerb(rawValue: verbRaw),
-      let identity
+      let currentIdentity,
+      currentIdentity == admitted.identity
     else { return }
     await InterjectSuggestionFeedbackMutation.record(
-      evaluationID: identity.evaluationID,
-      suggestionID: identity.suggestionID,
+      evaluationID: admitted.identity.evaluationID,
+      suggestionID: admitted.identity.suggestionID,
       verb: verb,
       store: store,
       emitAnalytics: emitAnalytics
@@ -34,7 +58,9 @@ enum InterjectHubFeedbackTool {
 
 extension RealtimeHubController {
   /// Local Interject classification — same placement as
-  /// `report_screen_observation`, before kernel-authorized tools.
+  /// `report_screen_observation`, before kernel-authorized tools. The card
+  /// identity is captured at admission; the async write rechecks the live
+  /// card against that snapshot before mutating.
   func handleInterjectFeedbackReport(
     source: RealtimeHubSession,
     callId: String,
@@ -42,7 +68,10 @@ extension RealtimeHubController {
     expectedTurnEpoch: Int
   ) {
     let verbRaw = arguments["verb"] as? String
-    Task { await InterjectHubFeedbackTool.recordIfAuthorized(verbRaw: verbRaw) }
+    let admitted = InterjectHubFeedbackTool.admit()
+    Task {
+      await InterjectHubFeedbackTool.recordIfAdmitted(admitted, verbRaw: verbRaw)
+    }
     sendToolResultIfCurrent(
       source: source,
       callId: callId,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/Interject/InterjectVoiceFeedbackRouting.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/Interject/InterjectVoiceFeedbackRouting.swift
@@ -2,23 +2,30 @@ import Foundation
 
 /// Instructions and parse for the user-initiated interjection turn.
 ///
-/// Classification rides that one turn — no extra model call. The token is
-/// stripped before speech; the remainder is the spoken acknowledgment.
+/// Hub/PTT classification is a silent `record_interject_feedback` tool call.
+/// Leading `[[interject:…]]` tokens remain only for selected-voice / typed
+/// history sanitizing — they must not be taught on the hub speech path.
 enum InterjectVoiceFeedbackRouting {
   static let classificationInstruction = """
-    The user's latest utterance may be a reply to the card quoted above. Classify \
-    it as exactly one of these and act in the same turn:
-    - Feedback verbs (JIT Decision 24): useful, false_positive, snooze, disable, missed.
-      Silence and a dismiss are never feedback — only this utterance is.
+    The user's latest utterance may be a reply to the card quoted above. If it \
+    is, call record_interject_feedback silently with the matching verb, then \
+    speak only the user-facing reply.
+    - Feedback verbs (JIT Decision 24): useful, false_positive, snooze, disable, \
+    missed. Silence and a dismiss are never feedback — only this utterance is.
     - correction: the card got a fact wrong. Use the existing memory amend/close \
-      tools so the ledger supersedes the wrong row. The spoken acknowledgment must \
-      name exactly what changed ("Got it — Thursday. I'd had it as Wednesday; fixed.").
-    - riff: they are continuing the topic. Answer in place; do not switch surfaces.
-    Put exactly one token on its own first line, then the spoken reply:
-    [[interject:useful]] or [[interject:false_positive]] or [[interject:snooze]] \
-    or [[interject:disable]] or [[interject:missed]] or [[interject:correction]] \
-    or [[interject:riff]]
-    Do not read the token aloud. Do not mention the classification.
+    tools so the ledger supersedes the wrong row. Speak one consequence sentence \
+    that names the fact that changed ("Got it — Thursday. I'd had it as \
+    Wednesday; fixed."), then any leftover question. Never speak the taxonomy \
+    name.
+    - riff, or a question about the card ("what is this suggestion for?"): call \
+    with riff, or omit the tool. Your first audio must be the answer. Do not say \
+    got it, continuing the topic, or any acknowledgement before the answer. Riff \
+    does not write teach-rate.
+    If you omit the tool, treat the utterance as riff: answer anyway. Do not \
+    mention classification. Do not say you could not classify.
+    Call record_interject_feedback silently and immediately. Do not speak a \
+    heads-up. The app does not play a canned acknowledgement for this tool. \
+    Never speak verb names as labels. Never read the tool result aloud.
     """
 
   static func parse(_ text: String) -> (verb: InterjectFeedbackVerb?, spoken: String) {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
@@ -934,6 +934,14 @@ extension RealtimeHubController {
         expectedTurnEpoch: toolTurnEpoch)
       return
     }
+    if name == HubTool.recordInterjectFeedback.rawValue {
+      handleInterjectFeedbackReport(
+        source: source,
+        callId: callId,
+        arguments: arguments,
+        expectedTurnEpoch: toolTurnEpoch)
+      return
+    }
     invokeExternallyAuthorizedTool(
       source: source,
       turnID: turnID,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
@@ -160,6 +160,7 @@ final class RealtimeHubTestHarness: NSObject, RealtimeHubSessionDelegate {
     case .setDesktopAttentionOverride: stub = "Attention override applied."
     case .screenshot: stub = "Screen captured."
     case .reportScreenObservation: stub = "Screen observation accepted."
+    case .recordInterjectFeedback: stub = #"{"ok":true}"#
     case .pointClick: stub = "Clicked."
     case .none: stub = "ok"
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTools.swift
@@ -158,7 +158,9 @@ enum RealtimeHubTools {
       tool call, and never read tool JSON or ids aloud. The think_deeper and web_search tool cards \
       are exceptions: call either one silently and immediately because the app speaks an instant \
       acknowledgement after the kernel accepts it. Do not repeat that acknowledgement when its \
-      result arrives. You cannot see the user's data without calling a tool. \
+      result arrives. record_interject_feedback is also silent and immediate: call it without a \
+      spoken heads-up; the app does not play a canned acknowledgement for that tool, unlike \
+      think_deeper, so go straight to the user-facing reply. You cannot see the user's data without calling a tool. \
       \(screenRule(turnFrameAttached: turnScreenFrameAttached))
 
       Keep latency low for simple requests. Never skip a tool call required by its declaration \

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedRealtimeTools.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedRealtimeTools.swift
@@ -28,6 +28,7 @@ enum HubTool: String {
   case webSearch = "web_search"
   case screenshot = "screenshot"
   case reportScreenObservation = "report_screen_observation"
+  case recordInterjectFeedback = "record_interject_feedback"
   case pointClick = "point_click"
 }
 
@@ -742,6 +743,32 @@ enum GeneratedRealtimeTools {
       },
       "required": [
         "observation"
+      ]
+    }
+  },
+  {
+    "type": "function",
+    "name": "record_interject_feedback",
+    "description": "Record how the user's latest utterance relates to the proactive card, then speak only the user-facing reply. Call silently and immediately: do not speak a heads-up, do not speak the verb, and do not read the tool result. The app does not play a canned acknowledgement. For a question or continuation, use riff or omit this tool and let the first audio be the answer. For a correction, speak one English consequence sentence that names the fact that changed. Never speak taxonomy names as labels.",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "verb": {
+          "type": "string",
+          "enum": [
+            "useful",
+            "false_positive",
+            "snooze",
+            "disable",
+            "missed",
+            "correction",
+            "riff"
+          ],
+          "description": "How the utterance relates to the card. riff is continuation or a question about the card."
+        }
+      },
+      "required": [
+        "verb"
       ]
     }
   },

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
@@ -758,6 +758,18 @@ enum GeneratedToolCapabilities {
     ]
     ),
     Capability(
+      toolName: "record_interject_feedback",
+      title: "Record Interject Feedback",
+      latency: .fastLocal,
+      surfaces: Set([.realtimeHub]),
+      summary: "Silently record how the user's utterance relates to the proactive card.",
+      bullets: [
+      "Call silently when the latest utterance is a reply to the quoted card, then speak only the user-facing answer.",
+      "For a question or continuation, use riff or omit this tool; the first audio must be the answer.",
+      "Never speak the verb, a heads-up, or the tool result."
+    ]
+    ),
+    Capability(
       toolName: "point_click",
       title: "Point Click",
       latency: .fastLocal,
@@ -809,6 +821,6 @@ enum GeneratedToolCapabilities {
   }
 
   static var realtimeToolNames: [String] {
-    ["cancel_agent_run","check_permission_status","create_action_item","create_calendar_event","get_action_items","get_agent_run","get_conversations","get_daily_recap","get_memories","get_tasks","inspect_agent_artifacts","list_agent_sessions","point_click","read_tool_output","report_screen_observation","request_permission","screenshot","search_conversations","search_memories","search_screen_history","search_tool_output","set_desktop_attention_override","spawn_agent","think_deeper","update_action_item","update_agent_artifact_lifecycle","web_search"]
+    ["cancel_agent_run","check_permission_status","create_action_item","create_calendar_event","get_action_items","get_agent_run","get_conversations","get_daily_recap","get_memories","get_tasks","inspect_agent_artifacts","list_agent_sessions","point_click","read_tool_output","record_interject_feedback","report_screen_observation","request_permission","screenshot","search_conversations","search_memories","search_screen_history","search_tool_output","set_desktop_attention_override","spawn_agent","think_deeper","update_action_item","update_agent_artifact_lifecycle","web_search"]
   }
 }

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
@@ -40,6 +40,7 @@ enum GeneratedSwiftTool: String, CaseIterable {
   case webSearch = "web_search"
   case screenshot = "screenshot"
   case reportScreenObservation = "report_screen_observation"
+  case recordInterjectFeedback = "record_interject_feedback"
   case pointClick = "point_click"
   case createCanonicalGoal = "create_canonical_goal"
   case getCanonicalGoals = "get_canonical_goals"
@@ -54,8 +55,8 @@ enum GeneratedSwiftToolExecutor: String {
 
 enum GeneratedToolExecutors {
   static let manifestVersion = 1
-  static let manifestDigest = "sha256:05dbd2cd609bbec77a825b010d6bc75e9dec8131d1ccaee3ea6c851e728fdccc"
-  static let chatFirstManifestDigest = "sha256:910b2affcb4d24cfe8f2112eb92d015bdb646032e610924ed90b9cfbb431fd59"
+  static let manifestDigest = "sha256:1bd2977d5d8fb9ef82a7bd68f21c3ec48742b9ff7f7d986bcf8e5a41dcca88e0"
+  static let chatFirstManifestDigest = "sha256:0e5eee8efe788d11d169b202d8cf04238481ec9797601db09373e2bd79dbfec3"
 
   static let aliasToCanonical: [String: GeneratedSwiftTool] = [
     "search_screen_history": .semanticSearch,
@@ -102,6 +103,7 @@ enum GeneratedToolExecutors {
     .webSearch: .realtimeHub,
     .screenshot: .realtimeHub,
     .reportScreenObservation: .realtimeHub,
+    .recordInterjectFeedback: .realtimeHub,
     .pointClick: .realtimeHub,
     .createCanonicalGoal: .chatToolExecutor,
     .getCanonicalGoals: .chatToolExecutor,

--- a/desktop/macos/Desktop/Tests/HubEscalationTests.swift
+++ b/desktop/macos/Desktop/Tests/HubEscalationTests.swift
@@ -12,6 +12,9 @@ final class HubEscalationTests: XCTestCase {
       RealtimeSlowToolAcknowledgementKind(toolName: HubTool.webSearch.rawValue),
       .publicWebSearch)
     XCTAssertNil(RealtimeSlowToolAcknowledgementKind(toolName: HubTool.getTasks.rawValue))
+    XCTAssertNil(
+      RealtimeSlowToolAcknowledgementKind(toolName: HubTool.recordInterjectFeedback.rawValue),
+      "Interject classification must not play a canned ack")
 
     let phrases = RealtimeSlowToolAcknowledgementKind.allCases.flatMap(\.phrases)
     XCTAssertGreaterThanOrEqual(phrases.count, 8)

--- a/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
+++ b/desktop/macos/Desktop/Tests/HubSystemInstructionTests.swift
@@ -477,6 +477,8 @@ final class HubSystemInstructionTests: XCTestCase {
     XCTAssertTrue(instruction.contains("think_deeper and web_search tool cards are exceptions"))
     XCTAssertTrue(instruction.contains("call either one silently and immediately"))
     XCTAssertTrue(instruction.contains("Do not repeat that acknowledgement"))
+    XCTAssertTrue(instruction.contains("record_interject_feedback is also silent and immediate"))
+    XCTAssertTrue(instruction.contains("does not play a canned acknowledgement"))
     XCTAssertTrue(instruction.contains("Keep latency low for simple requests"))
     XCTAssertTrue(instruction.contains("Never skip a tool call required by its declaration"))
     XCTAssertFalse(instruction.contains("prefer answering directly when you can"))

--- a/desktop/macos/Desktop/Tests/InterjectVoiceFeedbackRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/InterjectVoiceFeedbackRoutingTests.swift
@@ -73,4 +73,51 @@ final class InterjectVoiceFeedbackRoutingTests: XCTestCase {
       "Thanks — I'll keep that."
     )
   }
+
+  func testClassificationInstructionDoesNotListSpeakableOutputTokens() {
+    let instruction = InterjectVoiceFeedbackRouting.classificationInstruction
+    let trusted = InterjectVoiceFeedbackRouting.trustedTurnInstruction
+    for text in [instruction, trusted] {
+      XCTAssertFalse(
+        text.contains("[[interject:"),
+        "hub inject must not teach a speakable classification token")
+      XCTAssertFalse(
+        text.lowercased().contains("interject riff"),
+        "hub inject must not name the spoken classification phrase")
+      XCTAssertFalse(
+        text.contains("Put exactly one token on its own first line"),
+        "hub inject must not ask for a first-line speech token")
+      for verb in InterjectFeedbackVerb.allCases {
+        XCTAssertFalse(
+          text.contains("[[interject:\(verb.rawValue)]]"),
+          "verb \(verb.rawValue) must not appear as a speakable output token")
+      }
+    }
+    XCTAssertTrue(instruction.contains("record_interject_feedback"))
+    XCTAssertTrue(trusted.contains(instruction))
+  }
+
+  func testHubDidEmitTextSpeaksSpokenTextOnlyWhenNativeAudioMissing() throws {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent(
+        "Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift")
+    // omi-test-quality: source-inspection -- static contract: native PCM is never sanitized by spokenText; speakOneShot of spokenText(from: assistantText) may run only behind if !audioReceivedThisTurn
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+    XCTAssertTrue(source.contains("spokenText(from: assistantText)"))
+    XCTAssertTrue(source.contains("if !audioReceivedThisTurn, !reply.isEmpty,"))
+    XCTAssertTrue(source.contains("speakOneShot(reply, lease: lease)"))
+
+    let fnRange = try XCTUnwrap(source.range(of: "func hubDidEmitText("))
+    let afterFn = source[fnRange.lowerBound...]
+    let searchStart = afterFn.index(after: fnRange.lowerBound)
+    let nextFn = afterFn.range(of: "\n  func ", range: searchStart..<afterFn.endIndex)
+    let body = String(afterFn[..<(nextFn?.lowerBound ?? afterFn.endIndex)])
+    XCTAssertEqual(
+      body.components(separatedBy: "speakOneShot(reply, lease: lease)").count - 1, 1)
+    let speakIndex = try XCTUnwrap(body.range(of: "speakOneShot(reply, lease: lease)"))
+    let guardIndex = try XCTUnwrap(body.range(of: "if !audioReceivedThisTurn, !reply.isEmpty,"))
+    XCTAssertLessThan(guardIndex.lowerBound, speakIndex.lowerBound)
+  }
 }

--- a/desktop/macos/Desktop/Tests/InterjectWiringTests.swift
+++ b/desktop/macos/Desktop/Tests/InterjectWiringTests.swift
@@ -48,7 +48,7 @@ final class InterjectWiringTests: XCTestCase {
   }
 
   @MainActor
-  func testHubTranscriptPathWritesTheSameLedger() async throws {
+  func testHubTranscriptWithoutATokenDoesNotWriteTheLedger() async throws {
     try await withInterjectHarness {
       let deliveryID = try XCTUnwrap(UUID(uuidString: "cccccccc-cccc-cccc-cccc-cccccccccccc"))
       let cardID = try XCTUnwrap(UUID(uuidString: "dddddddd-dddd-dddd-dddd-dddddddddddd"))
@@ -67,12 +67,96 @@ final class InterjectWiringTests: XCTestCase {
       )
 
       await FloatingControlBarManager.shared.consumeInterjectHubTranscript(
+        "It's a focus suggestion for the meeting you have next.")
+      await FloatingControlBarManager.shared.consumeInterjectHubTranscript(
         "[[interject:false_positive]] Okay — I won't nudge you about that.")
 
       let record = await InterjectSuggestionFeedbackStore.shared.current(
         evaluationID: deliveryID, suggestionID: cardID)
-      XCTAssertEqual(record?.verb, .falsePositive)
+      XCTAssertNil(record, "hub transcript must not parse a token onto the ledger")
     }
+  }
+
+  @MainActor
+  func testHubFeedbackToolRiffDoesNotWriteTeachRate() async throws {
+    try await withInterjectHarness {
+      let deliveryID = try XCTUnwrap(UUID(uuidString: "11111111-1111-1111-1111-111111111111"))
+      let cardID = try XCTUnwrap(UUID(uuidString: "22222222-2222-2222-2222-222222222222"))
+      FloatingControlBarManager.shared.seedInterjectRecentCardForTests(
+        ownerID: ownerID,
+        title: "Focus",
+        createdAt: Date(),
+        context: FloatingBarNotificationContext(
+          sourceTitle: "Focus",
+          assistantId: "context-director",
+          provenanceRef: deliveryID.uuidString),
+        identity: nil,
+        notificationID: cardID
+      )
+
+      await InterjectHubFeedbackTool.recordIfAuthorized(verbRaw: "riff")
+
+      let record = await InterjectSuggestionFeedbackStore.shared.current(
+        evaluationID: deliveryID, suggestionID: cardID)
+      XCTAssertNil(record, "riff must not write teach-rate")
+    }
+  }
+
+  @MainActor
+  func testHubFeedbackToolUsefulWritesThroughMutationOwner() async throws {
+    try await withInterjectHarness {
+      let deliveryID = try XCTUnwrap(UUID(uuidString: "33333333-3333-3333-3333-333333333333"))
+      let cardID = try XCTUnwrap(UUID(uuidString: "44444444-4444-4444-4444-444444444444"))
+      FloatingControlBarManager.shared.seedInterjectRecentCardForTests(
+        ownerID: ownerID,
+        title: "Focus",
+        createdAt: Date(),
+        context: FloatingBarNotificationContext(
+          sourceTitle: "Focus",
+          assistantId: "context-director",
+          provenanceRef: deliveryID.uuidString),
+        identity: nil,
+        notificationID: cardID
+      )
+
+      await InterjectHubFeedbackTool.recordIfAuthorized(verbRaw: "useful")
+
+      let record = await InterjectSuggestionFeedbackStore.shared.current(
+        evaluationID: deliveryID, suggestionID: cardID)
+      XCTAssertEqual(record?.verb, .useful)
+    }
+  }
+
+  @MainActor
+  func testHubFeedbackToolFlagOffIsANoOp() async throws {
+    try await withInterjectHarness {
+      InterjectFeature.testOverride = false
+      let deliveryID = try XCTUnwrap(UUID(uuidString: "55555555-5555-5555-5555-555555555555"))
+      let cardID = try XCTUnwrap(UUID(uuidString: "66666666-6666-6666-6666-666666666666"))
+      FloatingControlBarManager.shared.seedInterjectRecentCardForTests(
+        ownerID: ownerID,
+        title: "Focus",
+        createdAt: Date(),
+        context: FloatingBarNotificationContext(
+          sourceTitle: "Focus",
+          assistantId: "context-director",
+          provenanceRef: deliveryID.uuidString),
+        identity: nil,
+        notificationID: cardID
+      )
+
+      await InterjectHubFeedbackTool.recordIfAuthorized(verbRaw: "useful")
+
+      let record = await InterjectSuggestionFeedbackStore.shared.current(
+        evaluationID: deliveryID, suggestionID: cardID)
+      XCTAssertNil(record, "flag-off hub tool must not write")
+    }
+  }
+
+  func testHubFeedbackToolResultIsOpaque() {
+    XCTAssertEqual(InterjectHubFeedbackTool.opaqueResult, #"{"ok":true}"#)
+    XCTAssertFalse(InterjectHubFeedbackTool.opaqueResult.contains("riff"))
+    XCTAssertFalse(InterjectHubFeedbackTool.opaqueResult.contains("useful"))
   }
 
   @MainActor

--- a/desktop/macos/Desktop/Tests/InterjectWiringTests.swift
+++ b/desktop/macos/Desktop/Tests/InterjectWiringTests.swift
@@ -48,7 +48,7 @@ final class InterjectWiringTests: XCTestCase {
   }
 
   @MainActor
-  func testHubTranscriptWithoutATokenDoesNotWriteTheLedger() async throws {
+  func testHubTranscriptDoesNotParseTokenOntoTheLedger() async throws {
     try await withInterjectHarness {
       let deliveryID = try XCTUnwrap(UUID(uuidString: "cccccccc-cccc-cccc-cccc-cccccccccccc"))
       let cardID = try XCTUnwrap(UUID(uuidString: "dddddddd-dddd-dddd-dddd-dddddddddddd"))
@@ -94,7 +94,8 @@ final class InterjectWiringTests: XCTestCase {
         notificationID: cardID
       )
 
-      await InterjectHubFeedbackTool.recordIfAuthorized(verbRaw: "riff")
+      let admitted = InterjectHubFeedbackTool.admit()
+      await InterjectHubFeedbackTool.recordIfAdmitted(admitted, verbRaw: "riff")
 
       let record = await InterjectSuggestionFeedbackStore.shared.current(
         evaluationID: deliveryID, suggestionID: cardID)
@@ -119,7 +120,8 @@ final class InterjectWiringTests: XCTestCase {
         notificationID: cardID
       )
 
-      await InterjectHubFeedbackTool.recordIfAuthorized(verbRaw: "useful")
+      let admitted = InterjectHubFeedbackTool.admit()
+      await InterjectHubFeedbackTool.recordIfAdmitted(admitted, verbRaw: "useful")
 
       let record = await InterjectSuggestionFeedbackStore.shared.current(
         evaluationID: deliveryID, suggestionID: cardID)
@@ -145,11 +147,60 @@ final class InterjectWiringTests: XCTestCase {
         notificationID: cardID
       )
 
-      await InterjectHubFeedbackTool.recordIfAuthorized(verbRaw: "useful")
+      let admitted = InterjectHubFeedbackTool.admit()
+      XCTAssertNil(admitted, "flag-off hub tool must admit nothing")
+      await InterjectHubFeedbackTool.recordIfAdmitted(admitted, verbRaw: "useful")
 
       let record = await InterjectSuggestionFeedbackStore.shared.current(
         evaluationID: deliveryID, suggestionID: cardID)
       XCTAssertNil(record, "flag-off hub tool must not write")
+    }
+  }
+
+  /// Owner/turn fence: if the recent card changes between admission and the
+  /// async write, the stale admission must not classify the new card.
+  @MainActor
+  func testHubFeedbackToolReplacedCardDoesNotGetClassified() async throws {
+    try await withInterjectHarness {
+      let deliveryID = try XCTUnwrap(UUID(uuidString: "77777777-7777-7777-7777-777777777777"))
+      let cardID = try XCTUnwrap(UUID(uuidString: "88888888-8888-8888-8888-888888888888"))
+      FloatingControlBarManager.shared.seedInterjectRecentCardForTests(
+        ownerID: ownerID,
+        title: "Focus",
+        createdAt: Date(),
+        context: FloatingBarNotificationContext(
+          sourceTitle: "Focus",
+          assistantId: "context-director",
+          provenanceRef: deliveryID.uuidString),
+        identity: nil,
+        notificationID: cardID
+      )
+      let admitted = InterjectHubFeedbackTool.admit()
+      XCTAssertNotNil(admitted)
+
+      // The latest card changes before the async write runs.
+      let replacementDeliveryID = try XCTUnwrap(UUID(uuidString: "99999999-9999-9999-9999-999999999999"))
+      let replacementCardID = try XCTUnwrap(UUID(uuidString: "aaaaaaaa-8888-8888-8888-888888888888"))
+      FloatingControlBarManager.shared.seedInterjectRecentCardForTests(
+        ownerID: ownerID,
+        title: "Call Sam",
+        createdAt: Date(),
+        context: FloatingBarNotificationContext(
+          sourceTitle: "Task",
+          assistantId: "context-director",
+          provenanceRef: replacementDeliveryID.uuidString),
+        identity: nil,
+        notificationID: replacementCardID
+      )
+
+      await InterjectHubFeedbackTool.recordIfAdmitted(admitted, verbRaw: "useful")
+
+      let staleRecord = await InterjectSuggestionFeedbackStore.shared.current(
+        evaluationID: deliveryID, suggestionID: cardID)
+      XCTAssertNil(staleRecord, "stale admission must not write the original card")
+      let replacementRecord = await InterjectSuggestionFeedbackStore.shared.current(
+        evaluationID: replacementDeliveryID, suggestionID: replacementCardID)
+      XCTAssertNil(replacementRecord, "stale admission must not classify the replacement card")
     }
   }
 

--- a/desktop/macos/Desktop/Tests/UntrustedNotificationContextTests.swift
+++ b/desktop/macos/Desktop/Tests/UntrustedNotificationContextTests.swift
@@ -126,6 +126,10 @@ final class UntrustedNotificationContextTests: XCTestCase {
     XCTAssertTrue(
       afterClose.contains(InterjectVoiceFeedbackRouting.classificationInstruction),
       "classification must sit outside the untrusted block")
+    XCTAssertTrue(afterClose.contains("record_interject_feedback"))
+    XCTAssertFalse(
+      afterClose.contains("[[interject:"),
+      "the hub instruction must not re-teach a speakable token")
   }
 
   // MARK: - Suggestion grounding

--- a/desktop/macos/agent/scripts/eval-realtime-routing.mjs
+++ b/desktop/macos/agent/scripts/eval-realtime-routing.mjs
@@ -185,7 +185,7 @@ function systemInstruction(variant) {
   return [
     "You are Omi, a fast spoken-voice assistant on the user's Mac. Reply conversationally in one or two sentences by default.",
     "The declared tools describe the capabilities available on this surface. A tool call is only a proposal; the kernel makes the authoritative route and permission decision.",
-    "When a request needs a tool, ordinarily give a brief request-specific spoken heads-up and call the tool in the same turn. The think_deeper and web_search cards are exceptions: call them silently and immediately because the app acknowledges the accepted tool. Do not answer before a required tool returns.",
+    "When a request needs a tool, ordinarily give a brief request-specific spoken heads-up and call the tool in the same turn. The think_deeper and web_search cards are exceptions: call them silently and immediately because the app acknowledges the accepted tool. record_interject_feedback is also silent and immediate, but the app does not play a canned acknowledgement for it. Do not answer before a required tool returns.",
     variant.latency,
   ].join("\n\n");
 }

--- a/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
@@ -824,6 +824,34 @@ const swiftToolSurfacePatches: Record<string, OmiToolSurfacePatch> = {
         "After screenshot succeeds for a current-screen question, report exactly one concise grounding observation. This report is internal verification, not the user-facing answer: when it succeeds, answer the user's original request naturally from the attached image.",
     },
   },
+  record_interject_feedback: {
+    surfaces: ["realtime_voice"],
+    capabilityDoc: doc(
+      "Record Interject Feedback",
+      "Silently record how the user's utterance relates to the proactive card.",
+      [
+        "Call silently when the latest utterance is a reply to the quoted card, then speak only the user-facing answer.",
+        "For a question or continuation, use riff or omit this tool; the first audio must be the answer.",
+        "Never speak the verb, a heads-up, or the tool result.",
+      ],
+    ),
+    executor: { kind: "swiftTool", executorName: "realtimeHub" },
+    voice: {
+      realtimeDescription:
+        "Record how the user's latest utterance relates to the proactive card, then speak only the user-facing reply. Call silently and immediately: do not speak a heads-up, do not speak the verb, and do not read the tool result. The app does not play a canned acknowledgement. For a question or continuation, use riff or omit this tool and let the first audio be the answer. For a correction, speak one English consequence sentence that names the fact that changed. Never speak taxonomy names as labels.",
+      schemaOverride: schema(
+        {
+          verb: {
+            type: "string",
+            enum: ["useful", "false_positive", "snooze", "disable", "missed", "correction", "riff"],
+            description:
+              "How the utterance relates to the card. riff is continuation or a question about the card.",
+          },
+        },
+        ["verb"],
+      ),
+    },
+  },
   point_click: {
     surfaces: ["realtime_voice"],
     capabilityDoc: doc("Point Click", "Click at on-screen pixel coordinates.", [
@@ -1834,6 +1862,31 @@ const swiftToolManifestDrafts: OmiToolManifestEntryDraft[] = [
     executor: { kind: "swiftTool", executorName: "realtimeHub" },
     intendedForAgents: true,
     runtimePreconditions: ["Realtime voice only; screenshot evidence must belong to the active PTT turn."],
+    adapters: {},
+  },
+  {
+    name: "record_interject_feedback",
+    label: "Record Interject Feedback",
+    description:
+      "Silently record how the user's latest utterance relates to the proactive card. Not a user-facing reply.",
+    promptSnippet: "record_interject_feedback - Silently classify a card reply, then speak only the answer",
+    latency: "fast local",
+    inputSchema: schema(
+      {
+        verb: {
+          type: "string",
+          enum: ["useful", "false_positive", "snooze", "disable", "missed", "correction", "riff"],
+          description:
+            "How the utterance relates to the card. riff is continuation or a question about the card.",
+        },
+      },
+      ["verb"],
+    ),
+    annotations: localWrite,
+    timeoutClass: "normal",
+    executor: { kind: "swiftTool", executorName: "realtimeHub" },
+    intendedForAgents: true,
+    runtimePreconditions: ["Realtime voice only; Interject classification for the current PTT turn."],
     adapters: {},
   },
   {

--- a/desktop/macos/agent/tests/fixtures/tool-manifest.json
+++ b/desktop/macos/agent/tests/fixtures/tool-manifest.json
@@ -5641,6 +5641,87 @@
     }
   },
   {
+    "name": "record_interject_feedback",
+    "label": "Record Interject Feedback",
+    "description": "Silently record how the user's latest utterance relates to the proactive card. Not a user-facing reply.",
+    "promptSnippet": "record_interject_feedback - Silently classify a card reply, then speak only the answer",
+    "latency": "fast local",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "verb": {
+          "type": "string",
+          "enum": [
+            "useful",
+            "false_positive",
+            "snooze",
+            "disable",
+            "missed",
+            "correction",
+            "riff"
+          ],
+          "description": "How the utterance relates to the card. riff is continuation or a question about the card."
+        }
+      },
+      "required": [
+        "verb"
+      ],
+      "additionalProperties": false
+    },
+    "annotations": {
+      "readOnlyHint": false,
+      "destructiveHint": false,
+      "openWorldHint": false
+    },
+    "timeoutClass": "normal",
+    "executor": {
+      "kind": "swiftTool",
+      "executorName": "realtimeHub"
+    },
+    "intendedForAgents": true,
+    "runtimePreconditions": [
+      "Realtime voice only; Interject classification for the current PTT turn."
+    ],
+    "adapters": {},
+    "surfaces": [
+      "realtime_voice"
+    ],
+    "capabilityDoc": {
+      "title": "Record Interject Feedback",
+      "summary": "Silently record how the user's utterance relates to the proactive card.",
+      "bullets": [
+        "Call silently when the latest utterance is a reply to the quoted card, then speak only the user-facing answer.",
+        "For a question or continuation, use riff or omit this tool; the first audio must be the answer.",
+        "Never speak the verb, a heads-up, or the tool result."
+      ]
+    },
+    "voice": {
+      "realtimeDescription": "Record how the user's latest utterance relates to the proactive card, then speak only the user-facing reply. Call silently and immediately: do not speak a heads-up, do not speak the verb, and do not read the tool result. The app does not play a canned acknowledgement. For a question or continuation, use riff or omit this tool and let the first audio be the answer. For a correction, speak one English consequence sentence that names the fact that changed. Never speak taxonomy names as labels.",
+      "schemaOverride": {
+        "type": "object",
+        "properties": {
+          "verb": {
+            "type": "string",
+            "enum": [
+              "useful",
+              "false_positive",
+              "snooze",
+              "disable",
+              "missed",
+              "correction",
+              "riff"
+            ],
+            "description": "How the utterance relates to the card. riff is continuation or a question about the card."
+          }
+        },
+        "required": [
+          "verb"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  {
     "name": "point_click",
     "label": "Point Click",
     "description": "Click at on-screen pixel coordinates.",

--- a/desktop/macos/agent/tests/run-tool-capability.test.ts
+++ b/desktop/macos/agent/tests/run-tool-capability.test.ts
@@ -524,6 +524,7 @@ describe("RunToolCapabilityBroker", () => {
     expect(capability.allowedToolNames).toContain("think_deeper");
     expect(capability.allowedToolNames).toContain("web_search");
     expect(capability.allowedToolNames).toContain("point_click");
+    expect(capability.allowedToolNames).toContain("record_interject_feedback");
     const authorized = broker.authorize({
       capabilityRef: capability.capabilityRef,
       invocationId: "invoke-voice",
@@ -547,6 +548,7 @@ describe("RunToolCapabilityBroker", () => {
     expect(chatCapability.allowedToolNames).not.toContain("think_deeper");
     expect(chatCapability.allowedToolNames).not.toContain("web_search");
     expect(chatCapability.allowedToolNames).not.toContain("point_click");
+    expect(chatCapability.allowedToolNames).not.toContain("record_interject_feedback");
     chat.store.close();
   });
 

--- a/desktop/macos/agent/tests/runtime-stdio-contract.test.ts
+++ b/desktop/macos/agent/tests/runtime-stdio-contract.test.ts
@@ -43,7 +43,7 @@ class RuntimeProcessFixture {
 
   async waitForMessage(
     predicate: (message: OutboundMessage) => boolean,
-    timeoutMs = 5_000,
+    timeoutMs = 20_000,
   ): Promise<OutboundMessage> {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {

--- a/desktop/macos/changelog/unreleased/20260901-interject-stop-speaking-classification.json
+++ b/desktop/macos/changelog/unreleased/20260901-interject-stop-speaking-classification.json
@@ -1,0 +1,3 @@
+{
+  "change": "Stopped Interject from speaking classification labels during voice replies"
+}

--- a/desktop/macos/changelog/unreleased/20260901-interject-stop-speaking-classification.json
+++ b/desktop/macos/changelog/unreleased/20260901-interject-stop-speaking-classification.json
@@ -1,3 +1,3 @@
 {
-  "change": "Stopped Interject from speaking classification labels during voice replies"
+  "change": "Omi no longer reads Interject's classification aloud during voice replies"
 }

--- a/desktop/macos/e2e/flows/floating-bar-functional.yaml
+++ b/desktop/macos/e2e/flows/floating-bar-functional.yaml
@@ -34,6 +34,7 @@ covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/Interject/InterjectDisplayTimer.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/Interject/InterjectFeature.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/Interject/InterjectGraceWindow.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/Interject/InterjectHubFeedbackTool.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/Interject/InterjectReplyHint.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/Interject/InterjectReplyWindow.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/Interject/InterjectSuggestionFeedbackStore.swift


### PR DESCRIPTION
## Product invariants affected

- INV-AGENT-*
- INV-CHAT-1

This change does not add a second transcript store, does not move session
identity out of the kernel, and does not assemble policy from Swift-supplied
prompt fragments. Hub classification is a local Swift tool that writes the
existing Interject mutation owner; the kernel still authorizes every other
realtime tool.

## Summary

Closes SCA-399

Proactive-notification PTT follow-up was teaching the realtime speech model to
emit Interject control vocabulary (`[[interject:riff]]`, “Interject riff”) on
native PCM. `spokenText` only sanitizes the selected-voice **fallback** path
when native audio is missing, so the spoken token reached the user.

This PR moves hub classification onto a silent local tool,
`record_interject_feedback`. Verbs live in the tool schema. The tool result is
opaque (`{"ok":true}`). The app does **not** play a canned acknowledgement
(unlike `think_deeper`). Speech is only the user-facing answer.

## Invariant

Control-plane vocabulary must not share the speech channel. Native PCM and TTS
carry user-facing language only. Machine verbs travel a non-speech channel
(hub tool), same pattern as `report_screen_observation`.

## RCA (Omi Beta 0.12.254)

- `InterjectClassificationDelivery` injected `classificationInstruction`, which
  listed `[[interject:riff]]` and said “Do not read the token aloud.”
- Native PCM played (`audio=true`). System-audio STT: “Interject riff it’s a
  focus suggestion…”
- `hubDidEmitText` runs `spokenText` only behind `if !audioReceivedThisTurn`.

SCA-373 shipped the token-on-speech design. This residual is a new branch from
current `origin/main`.

## Tests

- `testClassificationInstructionDoesNotListSpeakableOutputTokens`
- leading-token strip tests unchanged (`spokenText` / `displayText`)
- `testHubDidEmitTextSpeaksSpokenTextOnlyWhenNativeAudioMissing` (source-inspection)
- hub tool: `riff` does not write teach-rate; `useful` writes through
  `InterjectSuggestionFeedbackMutation`; flag-off is a no-op; hub transcript
  without a token does not write
- untrusted wrapper still keeps classification outside the card block

```
python3 desktop/macos/scripts/check_desktop_test_quality.py
# OK: 54 source-reading files / 147 sites, 16 waits

cd desktop/macos && xcrun swift test --package-path Desktop --filter \
  'InterjectVoiceFeedbackRoutingTests|InterjectWiringTests|InterjectSuggestionFeedbackStoreTests|UntrustedNotificationContextTests|HubEscalationTests|HubSystemInstructionTests'
# Executed 83 tests, with 0 failures

cd desktop/macos/agent && node node_modules/vitest/vitest.mjs run \
  tests/tool-surfaces-exhaustiveness.test.ts tests/run-tool-capability.test.ts
# Test Files  2 passed (2) / Tests  38 passed (38)
```

## Dogfood

Could not dogfood a live hub PTT turn in this run. Did not stop or restart
`Omi.app` / `Omi Beta.app`. No named `omi-*` bundle was launched against a
live OpenAI session.

Failure-Class: new

`.github/failure-classes/FC-control-plane-vocabulary-on-speech-channel.json`

Control-plane vocabulary asked of a speech model on the audio channel.

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift | 1549 -> 1557 | local hub dispatch for silent interject classification tool


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

