### PR TITLE
fix(desktop): preserve mixed-format memory imports

### DIFF
--- a/desktop/macos/Desktop/Sources/Integrations/IntegrationConnectTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/Integrations/IntegrationConnectTelemetry.swift
@@ -79,6 +79,7 @@ enum IntegrationConnectTelemetry {
     case permission = "permission"
     case authentication = "authentication"
     case conflict = "conflict"
+    case server = "server"
     case invalidResponse = "invalid_response"
     case resourceExhausted = "resource_exhausted"
     case unknown = "unknown"
@@ -140,7 +141,7 @@ enum IntegrationConnectTelemetry {
     case .notSignedIn, .sessionExpired, .noBrowser, .decryptFailed, .authentication:
       return true
     case .configuration, .storeNotFound, .authorizationDenied, .network, .timeout,
-      .cancelled, .noContent, .rateLimit, .permission, .conflict, .invalidResponse,
+      .cancelled, .noContent, .rateLimit, .permission, .conflict, .server, .invalidResponse,
       .resourceExhausted, .unknown:
       return false
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConnectorImportOperations.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConnectorImportOperations.swift
@@ -91,7 +91,7 @@ enum ConnectorImportOperations {
     case .server:
       return .failure(
         message: "Omi's memory service is temporarily unavailable. Try again shortly.",
-        failureClass: .invalidResponse)
+        failureClass: .server)
     case .invalidResponse:
       return .failure(
         message: "Omi couldn't read the extracted memories. Try the import again.",

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingMemoryLogImportService.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingMemoryLogImportService.swift
@@ -177,12 +177,20 @@ actor OnboardingMemoryLogImportService {
     var memories: [String] = []
     var seen: Set<String> = []
     for rawLine in rawText.components(separatedBy: .newlines) {
+      let trimmedLine = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmedLine.isEmpty, !trimmedLine.hasPrefix("```") else { continue }
+
       let range = NSRange(rawLine.startIndex..<rawLine.endIndex, in: rawLine)
       guard
         let match = regex.firstMatch(in: rawLine, range: range),
         let tagRange = Range(match.range(at: 1), in: rawLine),
         let contentRange = Range(match.range(at: 2), in: rawLine)
-      else { continue }
+      else {
+        // A mixed-format paste is not safe to import locally: silently ignoring
+        // its untagged lines could lose durable memories. Let the managed
+        // extractor interpret the complete paste instead.
+        return nil
+      }
 
       let tag = String(rawLine[tagRange]).lowercased()
       let content = String(rawLine[contentRange])

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift
@@ -337,13 +337,20 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
 
     let result = await OnboardingMemoryLogImportService.shared.importMemoryLog(
       rawText, source: source)
-    guard case .imported(let memories, _, let profileSummary) = result else {
+    guard case .imported(let memories, let failed, let profileSummary) = result else {
       if case .failure(let message, failureClass: _) =
         ConnectorImportOperations.memoryLogOutcome(result, source: source)
       {
         lastActionError = message
       }
       return
+    }
+
+    if failed > 0,
+      case .success(_, let message) =
+        ConnectorImportOperations.memoryLogOutcome(result, source: source)
+    {
+      lastActionError = message
     }
 
     let defaults = UserDefaults.standard

--- a/desktop/macos/Desktop/Tests/ConnectorImportOperationsTests.swift
+++ b/desktop/macos/Desktop/Tests/ConnectorImportOperationsTests.swift
@@ -106,6 +106,14 @@ final class ConnectorImportOperationsTests: XCTestCase {
     XCTAssertEqual(failureClass, .network)
   }
 
+  func testMemoryLogServerFailureKeepsDistinctTelemetryClass() {
+    let outcome = ConnectorImportOperations.memoryLogOutcome(.failed(.server), source: .chatgpt)
+    guard case .failure(_, failureClass: let failureClass) = outcome else {
+      return XCTFail("expected failure, got \(outcome)")
+    }
+    XCTAssertEqual(failureClass, .server)
+  }
+
   func testCompletedXImportWithZeroPostsDoesNotSayStillRunning() {
     let message = ConnectorImportOperations.xImportCompletionMessage(
       handle: "omi",

--- a/desktop/macos/Desktop/Tests/OnboardingMemoryLogImportServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingMemoryLogImportServiceTests.swift
@@ -29,7 +29,6 @@ final class OnboardingMemoryLogImportServiceTests: XCTestCase {
 
   func testTaggedParserHandlesExportWrappersBulletsUnknownAndDuplicates() throws {
     let input = """
-      Here is the export:
       ```text
       - [recent] Prefers direct answers.
       2. [2026-08-30] Started a maker project.
@@ -50,10 +49,19 @@ final class OnboardingMemoryLogImportServiceTests: XCTestCase {
       ])
   }
 
-  func testUnstructuredPasteFallsBackToManagedExtractor() {
+  func testUnstructuredPasteDoesNotQualifyForLocalTaggedImport() {
     XCTAssertNil(
       OnboardingMemoryLogImportService.extractTaggedMemories(
         from: "I prefer concise answers and I enjoy sailing."))
+  }
+
+  func testMixedTaggedAndUntaggedPasteDoesNotSilentlyDropContent() {
+    XCTAssertNil(
+      OnboardingMemoryLogImportService.extractTaggedMemories(
+        from: """
+          [long-term] Prefers direct answers.
+          Enjoys sailing.
+          """))
   }
 
   func testExtractionErrorsMapToBoundedFailureClasses() {

--- a/desktop/macos/changelog/unreleased/20260904-memory-import-review-fixes.json
+++ b/desktop/macos/changelog/unreleased/20260904-memory-import-review-fixes.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved ChatGPT and Claude memory imports so mixed-format exports stay complete and partial saves are clearly reported"
+}


### PR DESCRIPTION
## Summary

Follow-up to #12666 that addresses every actionable finding from the post-merge Cubic review.

- fall back to the managed extractor when a paste mixes tagged and untagged memory lines, preventing silent data loss
- preserve a distinct `server` telemetry class for backend 5xx failures
- surface partial-save counts during onboarding as well as on the Apps connector surface
- clarify the user-facing changelog entry and align test names with what they prove

## Root cause

The local parser treated any paste containing at least one recognized `[tag]` line as fully structured. That bypassed the managed extractor and discarded every unmatched non-empty line. Separately, onboarding ignored the service's partial-save count, and server failures were collapsed into `invalid_response` telemetry.

## Verification

- exact #12442 ten-line ChatGPT export remains covered
- mixed tagged/untagged input now returns to the complete-text managed extraction path
- partial saves retain their unsaved count in onboarding messaging
- backend 5xx errors emit the bounded `server` telemetry class
- focused Swift suite: 75 tests passed, 0 failed for the identical review patch before rebasing onto current `main`
- `git diff --check`: clean

## Scope

macOS desktop only. No iOS, Android, Windows, or hardware behavior changes.

Product-Invariant: INV-INT-1

Failure-Class: none

Line-Count-Exception: desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift | 1933 -> 1940 | surface the existing bounded partial-save outcome during onboarding without creating a second result-mapping path


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

