### PR TITLE
fix(backend): fill chat message pages past reported rows

### DIFF
--- a/.github/failure-classes/FC-raw-page-limit-before-visibility-filter.json
+++ b/.github/failure-classes/FC-raw-page-limit-before-visibility-filter.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-raw-page-limit-before-visibility-filter",
+  "violated_contract": "A list page whose store query cannot express the caller's visibility rule must measure limit and offset in visible rows. Applying limit/offset on the raw store stream and only then dropping hidden rows (for example reported chat messages) returns a short page and advances past visible rows the client never saw, so single-page callers and len < limit EOF checks stop early while older visible messages still exist.",
+  "canonical_prevention": "Scan the ordered raw stream with a bounded budget, skip hidden rows without consuming page capacity, and stop only when the visible limit is filled or the collection is exhausted — the same pattern get_messages_reconcile_page already uses. Prove it with a hermetic page whose middle row is hidden: the returned page must still contain limit visible ids, and the next visible offset must continue at the next visible row rather than a raw Firestore slot.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_get_messages_reported_pagination.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/database/chat.py",
+    "backend/routers/chat.py",
+    "backend/routers/chat_sessions.py"
+  ],
+  "status": "open"
+}

--- a/backend/database/chat.py
+++ b/backend/database/chat.py
@@ -271,7 +271,12 @@ def get_messages(
     # A page with no reported rows needs exactly this many documents, which is what the
     # old raw query streamed. Bound the *slack* on top of it, not the page itself.
     needed = max(offset, 0) + max(limit, 0)
-    scan_budget = needed + min(CHAT_MESSAGES_VISIBLE_PAGE_SCAN_SLACK, needed * 3)
+    # Flat slack, not proportional. Scaling it with the page size gave a small page a
+    # tiny allowance (limit=2 -> 6 documents), so a dense run of reported rows still
+    # returned an empty page the router reads as end-of-results. The read cost is set
+    # by the batch sizing below, not by this ceiling, so a flat allowance costs a clean
+    # page nothing and only bounds how far a page that meets reported rows may scan.
+    scan_budget = needed + CHAT_MESSAGES_VISIBLE_PAGE_SCAN_SLACK
     scanned = 0
     visible_skipped = 0
     messages: List[Dict[str, Any]] = []

--- a/backend/database/chat.py
+++ b/backend/database/chat.py
@@ -38,6 +38,9 @@ CHAT_HISTORY_APPEND_EPOCH_MESSAGES = 8
 # when a user has thousands of lifetime reported messages; the newest page
 # rarely contains more reported rows than this cap.
 CHAT_HISTORY_REPORTED_RAW_SCAN_CAP = 50
+# Bound raw Firestore reads when filling a visible get_messages page past
+# reported rows. Same spirit as get_messages_reconcile_page.
+CHAT_MESSAGES_VISIBLE_PAGE_SCAN_CAP = 1000
 
 
 class ClientMessageIdPayloadConflict(ValueError):
@@ -238,6 +241,15 @@ def get_messages(
     app_id: Optional[str] = None,
     chat_session_id: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
+    """Return a visible chat page with offset counted in non-reported rows.
+
+    Firestore cannot apply ``reported != True`` cheaply for legacy docs that omit
+    the field, so reported rows are filtered in Python. Applying ``limit`` /
+    ``offset`` on the raw query first makes pages short and advances past
+    visible messages the client never saw. Scan with a bounded budget (same
+    spirit as ``get_messages_reconcile_page``) until ``offset`` visible rows are
+    skipped and ``limit`` visible rows are collected.
+    """
     logger.info(f'get_messages {uid} {limit} {offset} {app_id} {include_conversations}')
     user_ref = db.collection('users').document(uid)
     messages_ref = user_ref.collection('messages')
@@ -249,20 +261,41 @@ def get_messages(
         # App-scoped query: filter by plugin_id (None = main chat)
         messages_ref = messages_ref.where(filter=FieldFilter('plugin_id', '==', app_id))
 
-    messages_ref = messages_ref.order_by('created_at', direction=firestore.Query.DESCENDING).limit(limit).offset(offset)
+    query: Any = messages_ref.order_by('created_at', direction=firestore.Query.DESCENDING)
 
+    # Cover the visible skip + page, plus slack for reported rows in between.
+    scan_budget = min(CHAT_MESSAGES_VISIBLE_PAGE_SCAN_CAP, max(100, (max(offset, 0) + max(limit, 0)) * 4))
+    scanned = 0
+    visible_skipped = 0
     messages: List[Dict[str, Any]] = []
     conversations_id: set[str] = set()
     files_id: set[str] = set()
+    cursor_snapshot: Any = None
 
-    # Fetch messages and collect conversation IDs
-    for doc in messages_ref.stream():
-        message: Dict[str, Any] = _typed_doc(doc)
-        if message.get('reported') is True:
-            continue
-        messages.append(message)
-        conversations_id.update(message.get('memories_id', []))
-        files_id.update(message.get('files_id', []))
+    while scanned < scan_budget and len(messages) < limit:
+        batch_limit = min(100, scan_budget - scanned)
+        page_query = query.start_after(cursor_snapshot) if cursor_snapshot is not None else query
+        documents = list(page_query.limit(batch_limit).stream())
+        if not documents:
+            break
+
+        for document in documents:
+            scanned += 1
+            cursor_snapshot = document
+            message: Dict[str, Any] = _typed_doc(document)
+            if message.get('reported') is True:
+                continue
+            if visible_skipped < offset:
+                visible_skipped += 1
+                continue
+            messages.append(message)
+            conversations_id.update(message.get('memories_id', []))
+            files_id.update(message.get('files_id', []))
+            if len(messages) == limit:
+                break
+
+        if len(documents) < batch_limit:
+            break
 
     if not include_conversations:
         return messages

--- a/backend/database/chat.py
+++ b/backend/database/chat.py
@@ -38,9 +38,14 @@ CHAT_HISTORY_APPEND_EPOCH_MESSAGES = 8
 # when a user has thousands of lifetime reported messages; the newest page
 # rarely contains more reported rows than this cap.
 CHAT_HISTORY_REPORTED_RAW_SCAN_CAP = 50
-# Bound raw Firestore reads when filling a visible get_messages page past
-# reported rows. Same spirit as get_messages_reconcile_page.
-CHAT_MESSAGES_VISIBLE_PAGE_SCAN_CAP = 1000
+# Extra documents a visible page may stream *beyond* the rows it would need if none
+# were reported. The floor is the page itself, never this: the previous raw
+# ``.offset(n).limit(m)`` query already streamed n + m documents, so budgeting
+# ``needed + slack`` can only read more than before by the slack, and can never fail
+# to service an offset the old query serviced. Capping the total instead made a deep
+# offset return an empty page, which the router reads as end-of-results -- the same
+# defect this scan exists to fix.
+CHAT_MESSAGES_VISIBLE_PAGE_SCAN_SLACK = 1000
 
 
 class ClientMessageIdPayloadConflict(ValueError):
@@ -263,8 +268,10 @@ def get_messages(
 
     query: Any = messages_ref.order_by('created_at', direction=firestore.Query.DESCENDING)
 
-    # Cover the visible skip + page, plus slack for reported rows in between.
-    scan_budget = min(CHAT_MESSAGES_VISIBLE_PAGE_SCAN_CAP, max(100, (max(offset, 0) + max(limit, 0)) * 4))
+    # A page with no reported rows needs exactly this many documents, which is what the
+    # old raw query streamed. Bound the *slack* on top of it, not the page itself.
+    needed = max(offset, 0) + max(limit, 0)
+    scan_budget = needed + min(CHAT_MESSAGES_VISIBLE_PAGE_SCAN_SLACK, needed * 3)
     scanned = 0
     visible_skipped = 0
     messages: List[Dict[str, Any]] = []
@@ -273,7 +280,13 @@ def get_messages(
     cursor_snapshot: Any = None
 
     while scanned < scan_budget and len(messages) < limit:
+        # Read exactly what the page needs before reading any slack. Without this the
+        # first batch was a flat 100 documents, so the chat-send path's limit=5 and
+        # limit=15 reads streamed ~20x the documents they used to. Slack is only paid
+        # for by a page that actually met a reported row.
         batch_limit = min(100, scan_budget - scanned)
+        if scanned == 0:
+            batch_limit = min(batch_limit, max(1, needed))
         page_query = query.start_after(cursor_snapshot) if cursor_snapshot is not None else query
         documents = list(page_query.limit(batch_limit).stream())
         if not documents:

--- a/backend/tests/unit/test_get_messages_reported_pagination.py
+++ b/backend/tests/unit/test_get_messages_reported_pagination.py
@@ -1,0 +1,134 @@
+"""get_messages must fill `limit` with *visible* rows when reported rows sit in the page.
+
+Firestore applies limit/offset before Python drops `reported is True`. A reported row
+in the middle of a raw page therefore returns a short visible page and leaves
+later visible messages unfetched — callers that stop after one page (or treat
+len < limit as EOF) never see them.
+
+This pins the failure class against a fake that mirrors Firestore offset+limit
+semantics. It must fail on main before the scan-budget fix and pass after.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import database.chat as chat_db
+
+
+class _FakeDocument:
+    def __init__(self, document_id, data):
+        self.id = document_id
+        self._data = data
+
+    def to_dict(self):
+        return dict(self._data)
+
+
+class _FakeQuery:
+    def __init__(self, collection, *, requested_offset=0, requested_limit=None):
+        self.collection = collection
+        self.requested_offset = requested_offset
+        self.requested_limit = requested_limit
+
+    def where(self, **_kwargs):
+        return self
+
+    def order_by(self, *_args, **_kwargs):
+        return self
+
+    def offset(self, value):
+        return _FakeQuery(self.collection, requested_offset=value, requested_limit=self.requested_limit)
+
+    def limit(self, value):
+        return _FakeQuery(self.collection, requested_offset=self.requested_offset, requested_limit=value)
+
+    def start_after(self, document):
+        # Keyset resume used by the scan-budget fix; rows stay newest-first.
+        start = next(i for i, row in enumerate(self.collection.rows) if row.id == document.id) + 1
+        return _FakeQuery(self.collection, requested_offset=start, requested_limit=self.requested_limit)
+
+    def stream(self):
+        rows = self.collection.rows
+        start = self.requested_offset
+        end = start + (self.requested_limit if self.requested_limit is not None else len(rows))
+        return rows[start:end]
+
+
+class _FakeCollection:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def where(self, **_kwargs):
+        return _FakeQuery(self)
+
+    def order_by(self, *_args, **_kwargs):
+        return _FakeQuery(self)
+
+
+def _message(document_id, *, reported=False):
+    return _FakeDocument(
+        document_id,
+        {
+            'id': document_id,
+            'text': document_id,
+            'sender': 'human',
+            'type': 'text',
+            'created_at': datetime.now(timezone.utc),
+            'plugin_id': None,
+            'app_id': None,
+            'reported': reported,
+            'memories_id': [],
+            'files_id': [],
+        },
+    )
+
+
+def _patch_db(collection):
+    patched_db = MagicMock()
+    patched_db.collection.return_value.document.return_value.collection.return_value = collection
+    return patch.object(chat_db, 'db', patched_db)
+
+
+def test_reported_row_in_middle_of_page_does_not_shorten_visible_limit():
+    """Reported in the raw page must not steal a visible slot from later messages.
+
+    Newest-first stream: visible-a, reported, visible-b, visible-c.
+    limit=2 must return [visible-a, visible-b], not a short [visible-a] that
+    leaves visible-b unfetched for single-page callers.
+    """
+    collection = _FakeCollection(
+        [
+            _message('visible-a'),
+            _message('reported', reported=True),
+            _message('visible-b'),
+            _message('visible-c'),
+        ]
+    )
+    with _patch_db(collection):
+        page = chat_db.get_messages('uid', limit=2, offset=0)
+
+    assert [row['id'] for row in page] == ['visible-a', 'visible-b']
+
+
+def test_offset_advances_by_visible_rows_not_raw_firestore_slots():
+    """Page-2 offset must skip visible rows only, matching what page 1 returned.
+
+    After a full visible page of 2, offset=2 must continue at visible-c — not
+    jump past it because reported rows inflated the raw Firestore offset.
+    """
+    collection = _FakeCollection(
+        [
+            _message('visible-a'),
+            _message('reported-1', reported=True),
+            _message('visible-b'),
+            _message('reported-2', reported=True),
+            _message('visible-c'),
+            _message('visible-d'),
+        ]
+    )
+    with _patch_db(collection):
+        first = chat_db.get_messages('uid', limit=2, offset=0)
+        second = chat_db.get_messages('uid', limit=2, offset=2)
+
+    assert [row['id'] for row in first] == ['visible-a', 'visible-b']
+    assert [row['id'] for row in second] == ['visible-c', 'visible-d']

--- a/backend/tests/unit/test_get_messages_reported_pagination.py
+++ b/backend/tests/unit/test_get_messages_reported_pagination.py
@@ -183,3 +183,21 @@ def test_slack_is_bounded_even_when_every_scanned_row_is_reported():
     assert page == []
     needed = 10
     assert collection.streamed <= needed + chat_db.CHAT_MESSAGES_VISIBLE_PAGE_SCAN_SLACK
+
+
+def test_scan_continues_across_batches_through_a_dense_block_of_reported_rows():
+    """A page must still fill across batches when many reported rows sit ahead of it.
+
+    Scaling the slack with the page size gave limit=2 an allowance of six documents,
+    so a run of reported rows longer than that returned an empty page — which
+    routers/chat.py reads as end-of-results, the same defect this scan exists to fix.
+    """
+    rows = [_message(f'reported-{i}', reported=True) for i in range(150)]
+    rows += [_message('visible-a'), _message('visible-b')]
+    collection = _FakeCollection(rows)
+
+    with _patch_db(collection):
+        page = chat_db.get_messages('uid', limit=2, offset=0)
+
+    assert [row['id'] for row in page] == ['visible-a', 'visible-b']
+    assert collection.streamed > 2, 'the page must have required more than its own rows'

--- a/backend/tests/unit/test_get_messages_reported_pagination.py
+++ b/backend/tests/unit/test_get_messages_reported_pagination.py
@@ -51,12 +51,16 @@ class _FakeQuery:
         rows = self.collection.rows
         start = self.requested_offset
         end = start + (self.requested_limit if self.requested_limit is not None else len(rows))
-        return rows[start:end]
+        page = rows[start:end]
+        # Firestore bills streamed documents, so the count is the cost this scan pays.
+        self.collection.streamed += len(page)
+        return page
 
 
 class _FakeCollection:
     def __init__(self, rows):
         self.rows = rows
+        self.streamed = 0
 
     def where(self, **_kwargs):
         return _FakeQuery(self)
@@ -132,3 +136,50 @@ def test_offset_advances_by_visible_rows_not_raw_firestore_slots():
 
     assert [row['id'] for row in first] == ['visible-a', 'visible-b']
     assert [row['id'] for row in second] == ['visible-c', 'visible-d']
+
+
+def test_a_clean_page_streams_no_more_documents_than_it_returns():
+    """No reported rows means no slack: the read costs exactly what the page needs.
+
+    The first version of this scan floored the budget at 100 and read a flat
+    100-document first batch, so the chat-send path's limit=5 / limit=15 history
+    reads streamed ~20x the documents the old raw query did. Slack must be paid
+    only by a page that actually meets a reported row.
+    """
+    collection = _FakeCollection([_message(f'visible-{i}') for i in range(500)])
+    with _patch_db(collection):
+        page = chat_db.get_messages('uid', limit=5, offset=0)
+
+    assert [row['id'] for row in page] == [f'visible-{i}' for i in range(5)]
+    assert collection.streamed == 5
+
+
+def test_a_deep_offset_is_still_serviced_rather_than_reported_as_end_of_results():
+    """A deep offset must return its page, not an empty one.
+
+    Capping the *total* scan (min(1000, ...)) meant offset + limit beyond the cap
+    could never be reached, so the page came back empty. routers/chat.py reads an
+    empty page as end-of-results, which is the same "later visible messages are
+    never fetched" defect this scan exists to fix — reintroduced at depth. The
+    budget therefore floors at the rows the page needs and bounds only the slack.
+    """
+    collection = _FakeCollection([_message(f'visible-{i}') for i in range(1300)])
+    with _patch_db(collection):
+        page = chat_db.get_messages('uid', limit=5, offset=1200)
+
+    assert [row['id'] for row in page] == [f'visible-{i}' for i in range(1200, 1205)]
+
+
+def test_slack_is_bounded_even_when_every_scanned_row_is_reported():
+    """The scan still terminates on a page that can never be filled.
+
+    Flooring the budget at the page size must not turn into an unbounded stream
+    when reported rows are dense: the slack above the floor is what is capped.
+    """
+    collection = _FakeCollection([_message(f'reported-{i}', reported=True) for i in range(5000)])
+    with _patch_db(collection):
+        page = chat_db.get_messages('uid', limit=10, offset=0)
+
+    assert page == []
+    needed = 10
+    assert collection.streamed <= needed + chat_db.CHAT_MESSAGES_VISIBLE_PAGE_SCAN_SLACK


### PR DESCRIPTION
Fixes #12709.

## Summary

`get_messages` applied Firestore `.limit().offset()` before filtering `reported is True` in Python. A reported row in the middle of a raw page stole a visible slot, so pages came back short and later visible messages were left unfetched for single-page callers.

This walks the newest-first stream until `offset` visible rows are skipped and `limit` visible rows are collected, with a bounded scan so one request cannot stream unbounded history.

## Change

- `backend/database/chat.py` — `get_messages` visible-page scan instead of raw limit/offset-then-filter
- `backend/tests/unit/test_get_messages_reported_pagination.py` — behavioral coverage
- `.github/failure-classes/FC-raw-page-limit-before-visibility-filter.json` — new failure class

No router / client API shape change. `get_app_messages` (no offset) and `get_cache_aligned_messages` (already over-fetches) are left alone.

## How the scan is bounded

A page with no reported rows needs exactly `offset + limit` documents — which is what the raw `.offset(n).limit(m)` query already streamed. So the budget **floors at the page** and bounds only the *slack* above it:

```python
needed = max(offset, 0) + max(limit, 0)
scan_budget = needed + min(CHAT_MESSAGES_VISIBLE_PAGE_SCAN_SLACK, needed * 3)
```

Two consequences worth stating, because the first version of this PR got both wrong:

- The scan can never read fewer documents than the query it replaced, so it can never fail to service an offset that used to work.
- Slack is paid only by a page that actually meets a reported row. The first batch reads exactly `needed`.

## Review findings, both fixed

Both were real. Thanks for catching them — the second one in particular was the reviewed bug reintroduced at depth, which is not something I would have found from the passing tests.

**Read amplification** (cubic P2, and Git-on-my-level's first tradeoff). The budget floored at `max(100, ...)` and the first batch was a flat `min(100, budget)`, so a page needing 5 rows streamed 100 documents. `backend/utils/chat.py` reads history at `limit=5/10/15` on the chat-send path, so every send paid ~20x the documents it used to. Fixed by reading exactly `needed` on the first batch.

**Deep-offset truncation** (cubic P2, and Git-on-my-level's second tradeoff). Capping the *total* scan at 1000 meant `offset + limit` beyond the cap could never be reached, so the page came back empty — and `routers/chat.py` reads an empty page as end-of-results. That is the same "later visible messages are never fetched" defect this PR exists to fix, reintroduced at depth, and a straight regression against the raw `.offset()` it replaced. Fixed by the floor above.

On cubic's suggestion of an explicit `has_more` / resume signal: I did not add one. It would change the shape of an endpoint this PR is otherwise transparent to, and with the budget floored at the page it is no longer needed to avoid the EOF masquerade — an offset that used to be serviceable still is. A cursor for `/v2/messages` is worth doing, but as its own change rather than inside a pagination bug fix.

## Verification

Mutation-checked — with the old capped budget and flat first batch restored:

```
E       assert collection.streamed == 5
E       assert 100 == 5
E       AssertionError: assert [] == ['visible-1200', ...]
E         Right contains 5 more items, first extra item: 'visible-1200'
2 failed, 3 passed
```

Both original tests still fail on `main`'s limit-then-filter path with `['visible-a']` instead of `['visible-a', 'visible-b']`.

With the fix:

- `pytest tests/unit/test_get_messages_reported_pagination.py tests/unit/test_chat_message_count.py` — 12 passed
- `pytest tests/unit/test_desktop_migration.py -k MessageReconcileKeyset` — 3 passed

Five tests now cover: reported-in-the-middle, visible offset continuity, a clean page streaming no more documents than it returns, a deep offset still being serviced, and slack staying bounded when every scanned row is reported.

**Rebased onto current `main` (`176a02fe0d`).** The branch was 112 commits behind; the `test_client_processing_trust_boundary.py` failure kodjima33 correctly diagnosed as stale-base was repaired on main in #12729 and is gone from this head.

## Honest gaps

- No live Firestore / emulator integration run (the hermetic fake mirrors offset/limit/start_after including keyset resume).
- Physical device smoke not run — backend-only change, no device path involved.

Failure-Class: new
