### PR TITLE
SCA-443: LocalInferenceService protocol, localhost adapter, and fail-closed kill switches (S9)

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -1433,6 +1433,7 @@ final class DesktopDiagnosticsManager {
     "task_workflow",
     "auth_storage",
     "state_authority",
+    "local_llm",
     "ptt_input_routing",
     "account_cutover",
     "other",
@@ -1468,6 +1469,7 @@ final class DesktopDiagnosticsManager {
     "db_backoff",
     "state_divergence",
     "status_inferred",
+    "engine_failed",
   ]
 
   private func bucketFallbackArea(_ area: String) -> String {

--- a/desktop/macos/Desktop/Sources/LocalInference/DeterministicConversationMinimum.swift
+++ b/desktop/macos/Desktop/Sources/LocalInference/DeterministicConversationMinimum.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Client-side copy of W1 §1.7. Pure: same input, same title; the only clock
+/// is `startedAt`. This is the fail-closed result when no local engine can run.
+/// Overview stays empty — never a fabricated summary that looks like content.
+struct DeterministicConversationMinimum: Sendable, Equatable, Codable {
+  var title: String
+  var overview: String
+  var category: String
+  var processingState: String
+
+  static let emptyOverview = ""
+  static let requiredCategory = "other"
+  static let terminalProcessingState = "none"
+  static let titleCharacterBudget = 60
+
+  static func make(from input: DeterministicMinimumInput) -> DeterministicConversationMinimum {
+    DeterministicConversationMinimum(
+      title: Self.title(from: input),
+      overview: emptyOverview,
+      category: requiredCategory,
+      processingState: terminalProcessingState
+    )
+  }
+
+  static func title(from input: DeterministicMinimumInput) -> String {
+    let sentence = firstNonEmptySentence(input.transcript)
+    if sentence.isEmpty {
+      return fallbackTitle(sourceLabel: input.sourceLabel, startedAt: input.startedAt, timeZone: input.timeZone)
+    }
+    return truncateToWordBoundary(sentence, maxCharacters: titleCharacterBudget)
+  }
+}
+
+struct DeterministicMinimumInput: Sendable, Equatable {
+  var transcript: String
+  var startedAt: Date
+  var sourceLabel: String
+  var timeZone: TimeZone
+
+  init(
+    transcript: String,
+    startedAt: Date,
+    sourceLabel: String = "Recording",
+    timeZone: TimeZone = .current
+  ) {
+    self.transcript = transcript
+    self.startedAt = startedAt
+    self.sourceLabel = sourceLabel
+    self.timeZone = timeZone
+  }
+}
+
+private func firstNonEmptySentence(_ transcript: String) -> String {
+  let collapsed =
+    transcript
+    .replacingOccurrences(of: "\r\n", with: "\n")
+    .components(separatedBy: .newlines)
+    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+    .filter { !$0.isEmpty }
+    .joined(separator: " ")
+  guard !collapsed.isEmpty else { return "" }
+
+  var sentence = ""
+  for character in collapsed {
+    sentence.append(character)
+    if character == "." || character == "!" || character == "?" {
+      break
+    }
+  }
+  return sentence.trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+private func truncateToWordBoundary(_ text: String, maxCharacters: Int) -> String {
+  if text.count <= maxCharacters { return text }
+  let end = text.index(text.startIndex, offsetBy: maxCharacters)
+  let prefix = String(text[..<end])
+  guard let lastSpace = prefix.lastIndex(of: " "), lastSpace > prefix.startIndex else {
+    return prefix
+  }
+  return String(prefix[..<lastSpace]).trimmingCharacters(in: .whitespaces)
+}
+
+private func fallbackTitle(sourceLabel: String, startedAt: Date, timeZone: TimeZone) -> String {
+  let formatter = DateFormatter()
+  formatter.locale = Locale(identifier: "en_US_POSIX")
+  formatter.timeZone = timeZone
+  formatter.dateFormat = "h:mm a"
+  let label = sourceLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+  let source = label.isEmpty ? "Recording" : label
+  return "\(source) · \(formatter.string(from: startedAt))"
+}

--- a/desktop/macos/Desktop/Sources/LocalInference/LocalInferenceKillSwitches.swift
+++ b/desktop/macos/Desktop/Sources/LocalInference/LocalInferenceKillSwitches.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Operator kill switches for local inference.
+///
+/// Mirrors `OMI_FORCE_PARAKEET_FAIL` / `forceParakeetFail`: each switch is
+/// readable from the process environment **or** the app's UserDefaults.
+///
+/// - `OMI_DISABLE_LOCAL_INFERENCE=1` / `defaults write <bundle> disableLocalInference -bool true`
+///   skips every engine and fail-closes to the deterministic minimum.
+/// - `OMI_FORCE_LOCAL_INFERENCE_ENGINE=<id>` / `defaults write <bundle> forceLocalInferenceEngine -string <id>`
+///   pins the engine. Unknown or unimplemented ids fail closed; they never
+///   fall through to a cloud LLM.
+struct LocalInferenceKillSwitches: Sendable, Equatable {
+  static let disableEnvironmentKey = "OMI_DISABLE_LOCAL_INFERENCE"
+  static let disableDefaultsKey = "disableLocalInference"
+  static let forceEngineEnvironmentKey = "OMI_FORCE_LOCAL_INFERENCE_ENGINE"
+  static let forceEngineDefaultsKey = "forceLocalInferenceEngine"
+  static let serverURLEnvironmentKey = "OMI_LOCAL_INFERENCE_URL"
+  static let serverURLDefaultsKey = "localInferenceServerURL"
+  static let modelEnvironmentKey = "OMI_LOCAL_INFERENCE_MODEL"
+  static let modelDefaultsKey = "localInferenceModel"
+
+  var isDisabled: Bool
+  var forcedEngineRaw: String?
+
+  var forcedEngine: LocalInferenceEngineID? {
+    guard let forcedEngineRaw, !forcedEngineRaw.isEmpty else { return nil }
+    return LocalInferenceEngineID.parse(forcedEngineRaw)
+  }
+
+  static let enabled = LocalInferenceKillSwitches(isDisabled: false, forcedEngineRaw: nil)
+
+  static func resolve(
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    defaults: UserDefaults = .standard
+  ) -> LocalInferenceKillSwitches {
+    let envDisabled = environment[Self.disableEnvironmentKey] == "1"
+    let defaultsDisabled = defaults.bool(forKey: Self.disableDefaultsKey)
+    let envEngine = trimmed(environment[Self.forceEngineEnvironmentKey])
+    let defaultsEngine = trimmed(defaults.string(forKey: Self.forceEngineDefaultsKey))
+    return LocalInferenceKillSwitches(
+      isDisabled: envDisabled || defaultsDisabled,
+      forcedEngineRaw: envEngine ?? defaultsEngine
+    )
+  }
+
+  static func localServerURL(
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    defaults: UserDefaults = .standard
+  ) -> URL {
+    let raw =
+      trimmed(environment[Self.serverURLEnvironmentKey])
+      ?? trimmed(defaults.string(forKey: Self.serverURLDefaultsKey))
+      ?? "http://127.0.0.1:11434/v1"
+    return URL(string: raw) ?? URL(string: "http://127.0.0.1:11434/v1")!
+  }
+
+  static func localServerModel(
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    defaults: UserDefaults = .standard
+  ) -> String {
+    trimmed(environment[Self.modelEnvironmentKey])
+      ?? trimmed(defaults.string(forKey: Self.modelDefaultsKey))
+      ?? "local"
+  }
+
+  private static func trimmed(_ value: String?) -> String? {
+    guard let value else { return nil }
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+}

--- a/desktop/macos/Desktop/Sources/LocalInference/LocalInferenceKillSwitches.swift
+++ b/desktop/macos/Desktop/Sources/LocalInference/LocalInferenceKillSwitches.swift
@@ -51,9 +51,21 @@ struct LocalInferenceKillSwitches: Sendable, Equatable {
     let raw =
       trimmed(environment[Self.serverURLEnvironmentKey])
       ?? trimmed(defaults.string(forKey: Self.serverURLDefaultsKey))
-      ?? "http://127.0.0.1:11434/v1"
-    return URL(string: raw) ?? URL(string: "http://127.0.0.1:11434/v1")!
+    if let raw, let parsed = URL(string: raw) {
+      return parsed
+    }
+    return defaultLoopbackURL
+
   }
+
+  private static let defaultLoopbackURL: URL = {
+    var components = URLComponents()
+    components.scheme = "http"
+    components.host = "127.0.0.1"
+    components.port = 11434
+    components.path = "/v1"
+    return components.url ?? URL(fileURLWithPath: "/v1")
+  }()
 
   static func localServerModel(
     environment: [String: String] = ProcessInfo.processInfo.environment,

--- a/desktop/macos/Desktop/Sources/LocalInference/LocalInferenceRuntime.swift
+++ b/desktop/macos/Desktop/Sources/LocalInference/LocalInferenceRuntime.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+/// Fail-closed coordinator in front of `LocalInferenceService` engines.
+///
+/// Ladder: selected local engine → retry once → deterministic minimum.
+/// There is no cloud step. A second registered engine is never consulted on
+/// failure (AFM is a selection, not a fallback). Kill switches short-circuit
+/// before any HTTP.
+struct LocalInferenceRuntime: Sendable {
+  var engines: [any LocalInferenceService]
+  var killSwitches: LocalInferenceKillSwitches
+  var fallback: any LocalInferenceFallbackRecording
+  var defaultEngineID: LocalInferenceEngineID
+
+  init(
+    engines: [any LocalInferenceService],
+    killSwitches: LocalInferenceKillSwitches = .enabled,
+    fallback: any LocalInferenceFallbackRecording = DesktopLocalInferenceFallbackRecorder(),
+    defaultEngineID: LocalInferenceEngineID = .localServer
+  ) {
+    self.engines = engines
+    self.killSwitches = killSwitches
+    self.fallback = fallback
+    self.defaultEngineID = defaultEngineID
+  }
+
+  static func makeDefault(
+    httpClient: any LocalInferenceHTTPClient = URLSessionLocalInferenceHTTPClient(),
+    killSwitches: LocalInferenceKillSwitches = .resolve(),
+    configuration: LocalServerInferenceConfiguration = .fromKillSwitchSources()
+  ) -> LocalInferenceRuntime {
+    LocalInferenceRuntime(
+      engines: [LocalServerInferenceAdapter(configuration: configuration, httpClient: httpClient)],
+      killSwitches: killSwitches,
+      fallback: DesktopLocalInferenceFallbackRecorder(),
+      defaultEngineID: .localServer
+    )
+  }
+
+  func generateStructuredFailClosed<T: Decodable & Sendable>(
+    prompt: String,
+    schema: LocalInferenceJSONSchema,
+    minimumInput: DeterministicMinimumInput
+  ) async -> LocalInferenceGeneration<T> {
+    if killSwitches.isDisabled {
+      return failClosed(
+        from: selectedEngineID()?.rawValue ?? "none",
+        reason: "dispatch_disabled",
+        input: minimumInput
+      )
+    }
+
+    switch selectEngine() {
+    case .failure(let reason, let from):
+      return failClosed(from: from, reason: reason, input: minimumInput)
+    case .success(let engine):
+      return await invoke(engine, prompt: prompt, schema: schema, minimumInput: minimumInput)
+    }
+  }
+
+  func runToolLoopFailClosed(
+    prompt: String,
+    tools: [LocalInferenceToolSpec],
+    budget: ToolLoopBudget,
+    minimumInput: DeterministicMinimumInput
+  ) async -> LocalInferenceGeneration<ToolLoopResult> {
+    if killSwitches.isDisabled {
+      return failClosed(
+        from: selectedEngineID()?.rawValue ?? "none",
+        reason: "dispatch_disabled",
+        input: minimumInput
+      )
+    }
+    switch selectEngine() {
+    case .failure(let reason, let from):
+      return failClosed(from: from, reason: reason, input: minimumInput)
+    case .success(let engine):
+      guard engine.capabilities.toolLoop else {
+        return failClosed(from: engine.engineID.rawValue, reason: "capability_mismatch", input: minimumInput)
+      }
+      do {
+        let result = try await engine.runToolLoop(prompt: prompt, tools: tools, budget: budget)
+        return .engine(result, engineID: engine.engineID)
+      } catch {
+        return failClosed(from: engine.engineID.rawValue, reason: reason(for: error), input: minimumInput)
+      }
+    }
+  }
+
+  private enum Selection {
+    case success(any LocalInferenceService)
+    case failure(reason: String, from: String)
+  }
+
+  private func selectedEngineID() -> LocalInferenceEngineID? {
+    if let raw = killSwitches.forcedEngineRaw, !raw.isEmpty {
+      return LocalInferenceEngineID.parse(raw)
+    }
+    return defaultEngineID
+  }
+
+  private func selectEngine() -> Selection {
+    if let raw = killSwitches.forcedEngineRaw, !raw.isEmpty, killSwitches.forcedEngine == nil {
+      return .failure(reason: "config_incomplete", from: raw)
+    }
+    let wanted = selectedEngineID() ?? defaultEngineID
+    if wanted == .afm {
+      // S12 lands the AFM adapter. Selecting it today is a closed door, not luna.
+      if let engine = engines.first(where: { $0.engineID == .afm }) {
+        return .success(engine)
+      }
+      return .failure(reason: "capability_mismatch", from: wanted.rawValue)
+    }
+    guard let engine = engines.first(where: { $0.engineID == wanted }) else {
+      return .failure(reason: "engine_failed", from: wanted.rawValue)
+    }
+    return .success(engine)
+  }
+
+  private func invoke<T: Decodable & Sendable>(
+    _ engine: any LocalInferenceService,
+    prompt: String,
+    schema: LocalInferenceJSONSchema,
+    minimumInput: DeterministicMinimumInput
+  ) async -> LocalInferenceGeneration<T> {
+    guard engine.capabilities.structuredOutput else {
+      return failClosed(from: engine.engineID.rawValue, reason: "capability_mismatch", input: minimumInput)
+    }
+    do {
+      let value: T = try await engine.generateStructured(prompt: prompt, schema: schema)
+      return .engine(value, engineID: engine.engineID)
+    } catch {
+      do {
+        let value: T = try await engine.generateStructured(prompt: prompt, schema: schema)
+        fallback.recordLocalInferenceFallback(
+          from: engine.engineID.rawValue,
+          to: engine.engineID.rawValue,
+          reason: reason(for: error),
+          outcome: .recovered
+        )
+        return .engine(value, engineID: engine.engineID)
+      } catch let retryError {
+        return failClosed(
+          from: engine.engineID.rawValue,
+          reason: reason(for: retryError),
+          input: minimumInput
+        )
+      }
+    }
+  }
+
+  private func failClosed<T: Sendable>(
+    from: String,
+    reason: String,
+    input: DeterministicMinimumInput
+  ) -> LocalInferenceGeneration<T> {
+    fallback.recordLocalInferenceFallback(
+      from: from,
+      to: "deterministic_minimum",
+      reason: reason,
+      outcome: .exhausted
+    )
+    return .deterministicMinimum(DeterministicConversationMinimum.make(from: input))
+  }
+
+  private func reason(for error: Error) -> String {
+    switch error as? LocalInferenceError {
+    case .disabled:
+      return "dispatch_disabled"
+    case .nonLoopbackBaseURL:
+      return "policy"
+    case .httpStatus(let status) where status == 429:
+      return "provider_429"
+    case .httpStatus(let status) where status >= 500:
+      return "provider_5xx"
+    case .capabilityUnavailable:
+      return "capability_mismatch"
+    case .engineUnavailable, .unknownEngine:
+      return "config_incomplete"
+    default:
+      return "engine_failed"
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/LocalInference/LocalInferenceService.swift
+++ b/desktop/macos/Desktop/Sources/LocalInference/LocalInferenceService.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Engine identifiers the runtime knows how to select.
+///
+/// AFM is named so `forceLocalInferenceEngine=afm` fails closed in this shard
+/// (S12 lands the adapter). There is no cloud case: a missing or failed local
+/// engine becomes the deterministic minimum, never luna.
+enum LocalInferenceEngineID: String, Sendable, Equatable, CaseIterable {
+  case localServer = "local-server"
+  case afm = "afm"
+
+  static func parse(_ raw: String) -> LocalInferenceEngineID? {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    switch trimmed {
+    case Self.localServer.rawValue, "local_server", "local", "ollama", "llamacpp":
+      return .localServer
+    case Self.afm.rawValue, "foundation-models", "foundation_models":
+      return .afm
+    default:
+      return nil
+    }
+  }
+}
+
+struct LocalInferenceCapabilities: Sendable, Equatable {
+  var structuredOutput: Bool
+  var toolLoop: Bool
+  var contextWindowTokens: Int
+}
+
+struct LocalInferenceJSONSchema: Sendable, Equatable {
+  var name: String
+  var json: Data
+}
+
+struct LocalInferenceToolSpec: Sendable, Equatable {
+  var name: String
+  var description: String
+  var parametersJSON: Data
+}
+
+struct ToolLoopBudget: Sendable, Equatable {
+  var maxIterations: Int
+}
+
+struct ToolLoopResult: Sendable, Equatable {
+  var content: String
+  var toolCallNames: [String]
+}
+
+enum LocalInferenceError: Error, Equatable {
+  case disabled
+  case engineUnavailable(LocalInferenceEngineID)
+  case unknownEngine(String)
+  case nonLoopbackBaseURL(String)
+  case engineFailed(String)
+  case capabilityUnavailable(String)
+  case invalidResponse(String)
+  case httpStatus(Int)
+}
+
+/// Local LLM execution port. Engines implement this; the runtime selects one
+/// and fail-closes to the deterministic minimum. Tool loops ship as a stub
+/// (TBD-2 / S12) and stay feature-detected per engine.
+protocol LocalInferenceService: Sendable {
+  var engineID: LocalInferenceEngineID { get }
+  var capabilities: LocalInferenceCapabilities { get }
+
+  func generateStructured<T: Decodable>(prompt: String, schema: LocalInferenceJSONSchema) async throws -> T
+  func runToolLoop(prompt: String, tools: [LocalInferenceToolSpec], budget: ToolLoopBudget) async throws
+    -> ToolLoopResult
+}
+
+enum LocalInferenceGeneration<T: Sendable>: Sendable {
+  case engine(T, engineID: LocalInferenceEngineID)
+  case deterministicMinimum(DeterministicConversationMinimum)
+}
+
+protocol LocalInferenceFallbackRecording: Sendable {
+  func recordLocalInferenceFallback(
+    from: String,
+    to: String,
+    reason: String,
+    outcome: DesktopFallbackOutcome
+  )
+}
+
+struct DesktopLocalInferenceFallbackRecorder: LocalInferenceFallbackRecording {
+  func recordLocalInferenceFallback(
+    from: String,
+    to: String,
+    reason: String,
+    outcome: DesktopFallbackOutcome
+  ) {
+    DesktopDiagnosticsManager.shared.recordFallback(
+      area: "local_llm",
+      from: from,
+      to: to,
+      reason: reason,
+      outcome: outcome
+    )
+  }
+}

--- a/desktop/macos/Desktop/Sources/LocalInference/LocalServerInferenceAdapter.swift
+++ b/desktop/macos/Desktop/Sources/LocalInference/LocalServerInferenceAdapter.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+protocol LocalInferenceHTTPClient: Sendable {
+  func send(_ request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+struct URLSessionLocalInferenceHTTPClient: LocalInferenceHTTPClient {
+  var session: URLSession = .shared
+
+  func send(_ request: URLRequest) async throws -> (Data, URLResponse) {
+    try await session.data(for: request)
+  }
+}
+
+enum LocalInferenceLoopback {
+  /// Fail closed: the local-server adapter may only speak to a loopback host.
+  /// A misconfigured paid or remote endpoint is an error, never a silent
+  /// route onto a cloud provider.
+  static func isAllowed(_ url: URL) -> Bool {
+    guard let host = url.host?.trimmingCharacters(in: .whitespacesAndNewlines), !host.isEmpty else {
+      return false
+    }
+    let normalized = host.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+    if normalized == "localhost" || normalized == "::1" { return true }
+    return isLoopbackIPv4(normalized)
+  }
+
+  static func requireLoopback(_ url: URL) throws {
+    guard isAllowed(url) else {
+      throw LocalInferenceError.nonLoopbackBaseURL(url.absoluteString)
+    }
+  }
+
+  private static func isLoopbackIPv4(_ host: String) -> Bool {
+    let parts = host.split(separator: ".", omittingEmptySubsequences: false)
+    guard parts.count == 4, parts.first == "127" else { return false }
+    return parts.allSatisfy { part in
+      guard let value = Int(part) else { return false }
+      return (0...255).contains(value)
+    }
+  }
+}
+
+struct LocalServerInferenceConfiguration: Sendable, Equatable {
+  var baseURL: URL
+  var model: String
+  var contextWindowTokens: Int
+  var timeout: TimeInterval
+
+  static func fromKillSwitchSources(
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    defaults: UserDefaults = .standard
+  ) -> LocalServerInferenceConfiguration {
+    LocalServerInferenceConfiguration(
+      baseURL: LocalInferenceKillSwitches.localServerURL(environment: environment, defaults: defaults),
+      model: LocalInferenceKillSwitches.localServerModel(environment: environment, defaults: defaults),
+      contextWindowTokens: 8192,
+      timeout: 60
+    )
+  }
+}
+
+/// OpenAI-compatible localhost client. Does not start or bundle a runtime.
+struct LocalServerInferenceAdapter: LocalInferenceService {
+  var engineID: LocalInferenceEngineID { .localServer }
+  var capabilities: LocalInferenceCapabilities {
+    LocalInferenceCapabilities(
+      structuredOutput: true,
+      toolLoop: false,
+      contextWindowTokens: configuration.contextWindowTokens
+    )
+  }
+
+  var configuration: LocalServerInferenceConfiguration
+  var httpClient: any LocalInferenceHTTPClient
+
+  init(
+    configuration: LocalServerInferenceConfiguration,
+    httpClient: any LocalInferenceHTTPClient = URLSessionLocalInferenceHTTPClient()
+  ) {
+    self.configuration = configuration
+    self.httpClient = httpClient
+  }
+
+  func generateStructured<T: Decodable>(prompt: String, schema: LocalInferenceJSONSchema) async throws -> T {
+    try LocalInferenceLoopback.requireLoopback(configuration.baseURL)
+    var request = URLRequest(
+      url: chatCompletionsURL(baseURL: configuration.baseURL),
+      timeoutInterval: configuration.timeout
+    )
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try encodeChatRequest(prompt: prompt, schema: schema)
+
+    let (data, response) = try await httpClient.send(request)
+    let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+    guard (200...299).contains(status) else {
+      throw LocalInferenceError.httpStatus(status)
+    }
+    let completion = try JSONDecoder().decode(OpenAIChatCompletionResponse.self, from: data)
+    let content = try unwrapContent(completion)
+    let payload = try jsonObjectData(from: content)
+    return try JSONDecoder().decode(T.self, from: payload)
+  }
+
+  func runToolLoop(prompt _: String, tools _: [LocalInferenceToolSpec], budget _: ToolLoopBudget) async throws
+    -> ToolLoopResult
+  {
+    throw LocalInferenceError.capabilityUnavailable("tool_loop")
+  }
+
+  private func chatCompletionsURL(baseURL: URL) -> URL {
+    var path = baseURL.absoluteString
+    if path.hasSuffix("/") { path.removeLast() }
+    if path.hasSuffix("/chat/completions") {
+      return URL(string: path) ?? baseURL
+    }
+    return URL(string: path + "/chat/completions") ?? baseURL.appendingPathComponent("chat/completions")
+  }
+
+  private func encodeChatRequest(prompt: String, schema: LocalInferenceJSONSchema) throws -> Data {
+    let schemaObject = try JSONSerialization.jsonObject(with: schema.json)
+    let body: [String: Any] = [
+      "model": configuration.model,
+      "messages": [
+        ["role": "user", "content": prompt]
+      ],
+      "response_format": [
+        "type": "json_schema",
+        "json_schema": [
+          "name": schema.name,
+          "strict": true,
+          "schema": schemaObject,
+        ],
+      ],
+    ]
+    return try JSONSerialization.data(withJSONObject: body)
+  }
+
+  private func unwrapContent(_ completion: OpenAIChatCompletionResponse) throws -> String {
+    guard let content = completion.choices.first?.message.content?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !content.isEmpty
+    else {
+      throw LocalInferenceError.invalidResponse("empty_content")
+    }
+    return content
+  }
+
+  private func jsonObjectData(from content: String) throws -> Data {
+    var json = content
+    if json.hasPrefix("```") {
+      json = json.replacingOccurrences(of: "^```(?:json)?\\s*", with: "", options: .regularExpression)
+      json = json.replacingOccurrences(of: "\\s*```$", with: "", options: .regularExpression)
+    }
+    guard let data = json.data(using: .utf8) else {
+      throw LocalInferenceError.invalidResponse("undecodable_content")
+    }
+    return data
+  }
+}
+
+private struct OpenAIChatCompletionResponse: Decodable {
+  struct Choice: Decodable {
+    struct Message: Decodable {
+      var content: String?
+    }
+    var message: Message
+  }
+  var choices: [Choice]
+}

--- a/desktop/macos/Desktop/Tests/LocalInferenceRuntimeFailClosedTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalInferenceRuntimeFailClosedTests.swift
@@ -82,7 +82,7 @@ private func minimumInput() -> DeterministicMinimumInput {
     transcript: "We decided to ship the local runtime today. Extra sentence.",
     startedAt: Date(timeIntervalSince1970: 1_704_140_040),  // 2024-01-01 20:14:00 UTC
     sourceLabel: "Recording",
-    timeZone: TimeZone(secondsFromGMT: 0)!
+    timeZone: TimeZone.gmt
   )
 }
 

--- a/desktop/macos/Desktop/Tests/LocalInferenceRuntimeFailClosedTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalInferenceRuntimeFailClosedTests.swift
@@ -1,0 +1,294 @@
+import Foundation
+import XCTest
+
+@testable import Omi_Computer
+
+private struct ProbeSummary: Codable, Sendable, Equatable {
+  var title: String
+}
+
+private final class CallCountingEngine: LocalInferenceService, @unchecked Sendable {
+  let engineID: LocalInferenceEngineID
+  let capabilities: LocalInferenceCapabilities
+  private let lock = NSLock()
+  private var generateResults: [Result<ProbeSummary, Error>]
+  private var toolLoopError: Error?
+  private(set) var generateCallCount = 0
+  private(set) var toolLoopCallCount = 0
+
+  init(
+    engineID: LocalInferenceEngineID,
+    capabilities: LocalInferenceCapabilities = LocalInferenceCapabilities(
+      structuredOutput: true,
+      toolLoop: false,
+      contextWindowTokens: 2048
+    ),
+    generateResults: [Result<ProbeSummary, Error>],
+    toolLoopError: Error? = LocalInferenceError.capabilityUnavailable("tool_loop")
+  ) {
+    self.engineID = engineID
+    self.capabilities = capabilities
+    self.generateResults = generateResults
+    self.toolLoopError = toolLoopError
+  }
+
+  func generateStructured<T: Decodable>(prompt _: String, schema _: LocalInferenceJSONSchema) async throws -> T {
+    let result: Result<ProbeSummary, Error> = lock.withLock {
+      generateCallCount += 1
+      if generateResults.isEmpty {
+        return .failure(LocalInferenceError.engineFailed("exhausted_script"))
+      }
+      return generateResults.removeFirst()
+    }
+    let summary = try result.get()
+    return try JSONDecoder().decode(T.self, from: JSONEncoder().encode(summary))
+  }
+
+  func runToolLoop(prompt _: String, tools _: [LocalInferenceToolSpec], budget _: ToolLoopBudget) async throws
+    -> ToolLoopResult
+  {
+    lock.withLock { toolLoopCallCount += 1 }
+    if let toolLoopError {
+      throw toolLoopError
+    }
+    return ToolLoopResult(content: "", toolCallNames: [])
+  }
+}
+
+private actor RecordingLocalInferenceHTTPClient: LocalInferenceHTTPClient {
+  private(set) var requests: [URLRequest] = []
+  var result: Result<(Data, URLResponse), Error> = .failure(URLError(.cannotConnectToHost))
+
+  func send(_ request: URLRequest) async throws -> (Data, URLResponse) {
+    requests.append(request)
+    return try result.get()
+  }
+
+  func recordedURLs() -> [URL] {
+    requests.compactMap(\.url)
+  }
+}
+
+private struct ProbeSchema {
+  static let json = LocalInferenceJSONSchema(
+    name: "probe",
+    json: Data(
+      #"{"type":"object","properties":{"title":{"type":"string"}},"required":["title"]}"#.utf8)
+  )
+}
+
+private func minimumInput() -> DeterministicMinimumInput {
+  DeterministicMinimumInput(
+    transcript: "We decided to ship the local runtime today. Extra sentence.",
+    startedAt: Date(timeIntervalSince1970: 1_704_140_040),  // 2024-01-01 20:14:00 UTC
+    sourceLabel: "Recording",
+    timeZone: TimeZone(secondsFromGMT: 0)!
+  )
+}
+
+#if DEBUG
+  final class LocalInferenceRuntimeFailClosedTests: XCTestCase {
+    override func setUp() {
+      super.setUp()
+      DesktopDiagnosticsManager.shared.resetForTests()
+    }
+
+    override func tearDown() {
+      DesktopDiagnosticsManager.shared.resetForTests()
+      super.tearDown()
+    }
+
+    func testForcedEngineFailureReturnsDeterministicMinimumRecordsFallbackAndDoesNotCallCloud() async throws {
+      let local = CallCountingEngine(
+        engineID: .localServer,
+        generateResults: [
+          .failure(LocalInferenceError.engineFailed("forced failure")),
+          .failure(LocalInferenceError.engineFailed("forced failure")),
+        ]
+      )
+      let cloud = CallCountingEngine(
+        engineID: .afm,
+        generateResults: [.success(ProbeSummary(title: "cloud should never run"))]
+      )
+      let runtime = LocalInferenceRuntime(
+        engines: [local, cloud],
+        killSwitches: .enabled,
+        fallback: DesktopLocalInferenceFallbackRecorder(),
+        defaultEngineID: .localServer
+      )
+
+      let result: LocalInferenceGeneration<ProbeSummary> = await runtime.generateStructuredFailClosed(
+        prompt: "summarize",
+        schema: ProbeSchema.json,
+        minimumInput: minimumInput()
+      )
+
+      guard case .deterministicMinimum(let minimum) = result else {
+        return XCTFail("forced engine failure must yield the deterministic minimum, not an engine payload")
+      }
+      XCTAssertEqual(minimum.title, "We decided to ship the local runtime today.")
+      XCTAssertEqual(minimum.overview, "")
+      XCTAssertEqual(minimum.category, "other")
+      XCTAssertEqual(minimum.processingState, "none")
+      XCTAssertEqual(local.generateCallCount, 2)
+      XCTAssertEqual(cloud.generateCallCount, 0, "failure must not cascade to another engine or a cloud path")
+
+      let snapshot = try latestFallbackSnapshot()
+      XCTAssertEqual(snapshot["event"] as? String, "fallback_triggered")
+      XCTAssertEqual(snapshot["area"] as? String, "local_llm")
+      XCTAssertEqual(snapshot["from"] as? String, "local-server")
+      XCTAssertEqual(snapshot["to"] as? String, "deterministic_minimum")
+      XCTAssertEqual(snapshot["reason"] as? String, "engine_failed")
+      XCTAssertEqual(snapshot["outcome"] as? String, "exhausted")
+    }
+
+    func testDisableKillSwitchSkipsEveryEngine() async {
+      let local = CallCountingEngine(
+        engineID: .localServer,
+        generateResults: [.success(ProbeSummary(title: "should not run"))]
+      )
+      let runtime = LocalInferenceRuntime(
+        engines: [local],
+        killSwitches: LocalInferenceKillSwitches(isDisabled: true, forcedEngineRaw: nil),
+        fallback: DesktopLocalInferenceFallbackRecorder()
+      )
+
+      let result: LocalInferenceGeneration<ProbeSummary> = await runtime.generateStructuredFailClosed(
+        prompt: "summarize",
+        schema: ProbeSchema.json,
+        minimumInput: minimumInput()
+      )
+
+      guard case .deterministicMinimum = result else {
+        return XCTFail("disableLocalInference must fail closed")
+      }
+      XCTAssertEqual(local.generateCallCount, 0)
+
+      let snapshot = try? latestFallbackSnapshot()
+      XCTAssertEqual(snapshot?["reason"] as? String, "dispatch_disabled")
+      XCTAssertEqual(snapshot?["area"] as? String, "local_llm")
+    }
+
+    func testForcedAFMWithoutAdapterDoesNotFallThroughToLocalServer() async {
+      let local = CallCountingEngine(
+        engineID: .localServer,
+        generateResults: [.success(ProbeSummary(title: "local would be a leak"))]
+      )
+      let runtime = LocalInferenceRuntime(
+        engines: [local],
+        killSwitches: LocalInferenceKillSwitches(isDisabled: false, forcedEngineRaw: "afm"),
+        fallback: DesktopLocalInferenceFallbackRecorder()
+      )
+
+      let result: LocalInferenceGeneration<ProbeSummary> = await runtime.generateStructuredFailClosed(
+        prompt: "summarize",
+        schema: ProbeSchema.json,
+        minimumInput: minimumInput()
+      )
+
+      guard case .deterministicMinimum = result else {
+        return XCTFail("unimplemented AFM must fail closed, not select local-server or cloud")
+      }
+      XCTAssertEqual(local.generateCallCount, 0)
+      let snapshot = try? latestFallbackSnapshot()
+      XCTAssertEqual(snapshot?["reason"] as? String, "capability_mismatch")
+    }
+
+    func testUnknownForcedEngineFailsClosed() async {
+      let local = CallCountingEngine(
+        engineID: .localServer,
+        generateResults: [.success(ProbeSummary(title: "no"))]
+      )
+      let runtime = LocalInferenceRuntime(
+        engines: [local],
+        killSwitches: LocalInferenceKillSwitches(isDisabled: false, forcedEngineRaw: "luna"),
+        fallback: DesktopLocalInferenceFallbackRecorder()
+      )
+
+      let result: LocalInferenceGeneration<ProbeSummary> = await runtime.generateStructuredFailClosed(
+        prompt: "summarize",
+        schema: ProbeSchema.json,
+        minimumInput: minimumInput()
+      )
+
+      guard case .deterministicMinimum = result else {
+        return XCTFail("unknown engine id must not route anywhere")
+      }
+      XCTAssertEqual(local.generateCallCount, 0)
+    }
+
+    func testRetryOnceCanRecoverWithoutTouchingAnotherEngine() async {
+      let local = CallCountingEngine(
+        engineID: .localServer,
+        generateResults: [
+          .failure(LocalInferenceError.engineFailed("transient")),
+          .success(ProbeSummary(title: "recovered locally")),
+        ]
+      )
+      let other = CallCountingEngine(
+        engineID: .afm,
+        generateResults: [.success(ProbeSummary(title: "other engine"))]
+      )
+      let runtime = LocalInferenceRuntime(
+        engines: [local, other],
+        killSwitches: .enabled,
+        fallback: DesktopLocalInferenceFallbackRecorder()
+      )
+
+      let result: LocalInferenceGeneration<ProbeSummary> = await runtime.generateStructuredFailClosed(
+        prompt: "summarize",
+        schema: ProbeSchema.json,
+        minimumInput: minimumInput()
+      )
+
+      guard case .engine(let summary, let engineID) = result else {
+        return XCTFail("retry on the same local engine should recover")
+      }
+      XCTAssertEqual(summary.title, "recovered locally")
+      XCTAssertEqual(engineID, .localServer)
+      XCTAssertEqual(local.generateCallCount, 2)
+      XCTAssertEqual(other.generateCallCount, 0)
+      let snapshot = try? latestFallbackSnapshot()
+      XCTAssertEqual(snapshot?["outcome"] as? String, "recovered")
+      XCTAssertEqual(snapshot?["area"] as? String, "local_llm")
+    }
+
+    func testToolLoopStubFailsClosedWithoutCallingASecondEngine() async {
+      let local = CallCountingEngine(
+        engineID: .localServer,
+        generateResults: [.success(ProbeSummary(title: "unused"))]
+      )
+      let other = CallCountingEngine(
+        engineID: .afm,
+        generateResults: [.success(ProbeSummary(title: "unused"))]
+      )
+      let runtime = LocalInferenceRuntime(
+        engines: [local, other],
+        killSwitches: .enabled,
+        fallback: DesktopLocalInferenceFallbackRecorder()
+      )
+
+      let result = await runtime.runToolLoopFailClosed(
+        prompt: "agent",
+        tools: [],
+        budget: ToolLoopBudget(maxIterations: 1),
+        minimumInput: minimumInput()
+      )
+
+      guard case .deterministicMinimum = result else {
+        return XCTFail("tool loops are stubbed and must fail closed")
+      }
+      XCTAssertEqual(local.toolLoopCallCount, 0)
+      XCTAssertEqual(other.toolLoopCallCount, 0)
+    }
+
+    private func latestFallbackSnapshot() throws -> [String: Any] {
+      let url = try XCTUnwrap(DesktopDiagnosticsManager.shared.writeDiagnosticsAttachment())
+      defer { try? FileManager.default.removeItem(at: url) }
+      let data = try Data(contentsOf: url)
+      let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+      let snapshots = try XCTUnwrap(root["snapshots"] as? [[String: Any]])
+      return try XCTUnwrap(snapshots.last { ($0["event"] as? String) == "fallback_triggered" })
+    }
+  }
+#endif

--- a/desktop/macos/Desktop/Tests/LocalServerInferenceAdapterTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalServerInferenceAdapterTests.swift
@@ -34,7 +34,7 @@ final class LocalServerInferenceAdapterTests: XCTestCase {
     let http = RecordingLocalInferenceHTTPClient()
     let adapter = LocalServerInferenceAdapter(
       configuration: LocalServerInferenceConfiguration(
-        baseURL: URL(string: "https://api.openai.com/v1")!,
+        baseURL: try XCTUnwrap(URL(string: "https://api.openai.com/v1")),
         model: "gpt-4o",
         contextWindowTokens: 8192,
         timeout: 5
@@ -60,18 +60,18 @@ final class LocalServerInferenceAdapterTests: XCTestCase {
     let payload = """
       {"choices":[{"message":{"content":"{\\"title\\":\\"on device\\"}"}}]}
       """
-    let url = URL(string: "http://127.0.0.1:11434/v1/chat/completions")!
+    let url = try XCTUnwrap(URL(string: "http://127.0.0.1:11434/v1/chat/completions"))
     await http.setResult(
       .success(
         (
           Data(payload.utf8),
-          HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+          try XCTUnwrap(HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil))
         )
       )
     )
     let adapter = LocalServerInferenceAdapter(
       configuration: LocalServerInferenceConfiguration(
-        baseURL: URL(string: "http://127.0.0.1:11434/v1")!,
+        baseURL: try XCTUnwrap(URL(string: "http://127.0.0.1:11434/v1")),
         model: "local",
         contextWindowTokens: 8192,
         timeout: 5
@@ -93,13 +93,13 @@ final class LocalServerInferenceAdapterTests: XCTestCase {
     XCTAssertTrue(LocalInferenceLoopback.isAllowed(url))
   }
 
-  func testRuntimeFailClosedOnCloudBaseURLSendsNoHTTP() async {
+  func testRuntimeFailClosedOnCloudBaseURLSendsNoHTTP() async throws {
     let http = RecordingLocalInferenceHTTPClient()
     let runtime = LocalInferenceRuntime(
       engines: [
         LocalServerInferenceAdapter(
           configuration: LocalServerInferenceConfiguration(
-            baseURL: URL(string: "https://generativelanguage.googleapis.com/v1")!,
+            baseURL: try XCTUnwrap(URL(string: "https://generativelanguage.googleapis.com/v1")),
             model: "gemini",
             contextWindowTokens: 8192,
             timeout: 5
@@ -117,7 +117,7 @@ final class LocalServerInferenceAdapterTests: XCTestCase {
       minimumInput: DeterministicMinimumInput(
         transcript: "Hello there.",
         startedAt: Date(timeIntervalSince1970: 0),
-        timeZone: TimeZone(secondsFromGMT: 0)!
+        timeZone: TimeZone.gmt
       )
     )
 
@@ -128,10 +128,10 @@ final class LocalServerInferenceAdapterTests: XCTestCase {
     XCTAssertEqual(urls, [])
   }
 
-  func testToolLoopIsStubbedOnTheAdapter() async {
+  func testToolLoopIsStubbedOnTheAdapter() async throws {
     let adapter = LocalServerInferenceAdapter(
       configuration: LocalServerInferenceConfiguration(
-        baseURL: URL(string: "http://127.0.0.1:11434/v1")!,
+        baseURL: try XCTUnwrap(URL(string: "http://127.0.0.1:11434/v1")),
         model: "local",
         contextWindowTokens: 8192,
         timeout: 5
@@ -151,42 +151,44 @@ final class LocalServerInferenceAdapterTests: XCTestCase {
     }
   }
 
-  func testLoopbackHelperRejectsPublicHosts() {
-    XCTAssertTrue(LocalInferenceLoopback.isAllowed(URL(string: "http://127.0.0.1:8080/v1")!))
-    XCTAssertTrue(LocalInferenceLoopback.isAllowed(URL(string: "http://localhost:11434/v1")!))
-    XCTAssertTrue(LocalInferenceLoopback.isAllowed(URL(string: "http://[::1]:8080/v1")!))
-    XCTAssertFalse(LocalInferenceLoopback.isAllowed(URL(string: "https://api.openai.com/v1")!))
-    XCTAssertFalse(LocalInferenceLoopback.isAllowed(URL(string: "https://generativelanguage.googleapis.com")!))
-    XCTAssertFalse(LocalInferenceLoopback.isAllowed(URL(string: "http://10.0.0.4/v1")!))
+  func testLoopbackHelperRejectsPublicHosts() throws {
+    XCTAssertTrue(LocalInferenceLoopback.isAllowed(try XCTUnwrap(URL(string: "http://127.0.0.1:8080/v1"))))
+    XCTAssertTrue(LocalInferenceLoopback.isAllowed(try XCTUnwrap(URL(string: "http://localhost:11434/v1"))))
+    XCTAssertTrue(LocalInferenceLoopback.isAllowed(try XCTUnwrap(URL(string: "http://[::1]:8080/v1"))))
+    XCTAssertFalse(LocalInferenceLoopback.isAllowed(try XCTUnwrap(URL(string: "https://api.openai.com/v1"))))
+    XCTAssertFalse(
+      LocalInferenceLoopback.isAllowed(try XCTUnwrap(URL(string: "https://generativelanguage.googleapis.com")))
+    )
+    XCTAssertFalse(LocalInferenceLoopback.isAllowed(try XCTUnwrap(URL(string: "http://10.0.0.4/v1"))))
   }
 }
 
 final class LocalInferenceKillSwitchTests: XCTestCase {
-  func testEnvironmentDisableWins() {
+  func testEnvironmentDisableWins() throws {
     let switches = LocalInferenceKillSwitches.resolve(
       environment: [LocalInferenceKillSwitches.disableEnvironmentKey: "1"],
-      defaults: UserDefaults(suiteName: UUID().uuidString)!
+      defaults: try XCTUnwrap(UserDefaults(suiteName: UUID().uuidString))
     )
     XCTAssertTrue(switches.isDisabled)
   }
 
-  func testUserDefaultsDisable() {
-    let defaults = UserDefaults(suiteName: UUID().uuidString)!
+  func testUserDefaultsDisable() throws {
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: UUID().uuidString))
     defaults.set(true, forKey: LocalInferenceKillSwitches.disableDefaultsKey)
     let switches = LocalInferenceKillSwitches.resolve(environment: [:], defaults: defaults)
     XCTAssertTrue(switches.isDisabled)
   }
 
-  func testForceEngineFromEnvironment() {
+  func testForceEngineFromEnvironment() throws {
     let switches = LocalInferenceKillSwitches.resolve(
       environment: [LocalInferenceKillSwitches.forceEngineEnvironmentKey: "local-server"],
-      defaults: UserDefaults(suiteName: UUID().uuidString)!
+      defaults: try XCTUnwrap(UserDefaults(suiteName: UUID().uuidString))
     )
     XCTAssertEqual(switches.forcedEngine, .localServer)
   }
 
-  func testForceEngineFromDefaultsWhenEnvAbsent() {
-    let defaults = UserDefaults(suiteName: UUID().uuidString)!
+  func testForceEngineFromDefaultsWhenEnvAbsent() throws {
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: UUID().uuidString))
     defaults.set("afm", forKey: LocalInferenceKillSwitches.forceEngineDefaultsKey)
     let switches = LocalInferenceKillSwitches.resolve(environment: [:], defaults: defaults)
     XCTAssertEqual(switches.forcedEngine, .afm)
@@ -214,7 +216,7 @@ final class DeterministicConversationMinimumTests: XCTestCase {
         transcript: "   \n",
         startedAt: started,
         sourceLabel: "Recording",
-        timeZone: TimeZone(secondsFromGMT: 0)!
+        timeZone: TimeZone.gmt
       )
     )
     XCTAssertEqual(minimum.title, "Recording · 8:14 PM")
@@ -235,7 +237,7 @@ final class DeterministicConversationMinimumTests: XCTestCase {
     let input = DeterministicMinimumInput(
       transcript: "",
       startedAt: Date(timeIntervalSince1970: 1_704_140_040),
-      timeZone: TimeZone(secondsFromGMT: 0)!
+      timeZone: TimeZone.gmt
     )
     XCTAssertEqual(
       DeterministicConversationMinimum.title(from: input),

--- a/desktop/macos/Desktop/Tests/LocalServerInferenceAdapterTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalServerInferenceAdapterTests.swift
@@ -1,0 +1,276 @@
+import Foundation
+import XCTest
+
+@testable import Omi_Computer
+
+private struct ProbeSummary: Decodable, Sendable, Equatable {
+  var title: String
+}
+
+private actor RecordingLocalInferenceHTTPClient: LocalInferenceHTTPClient {
+  private(set) var requests: [URLRequest] = []
+  var result: Result<(Data, URLResponse), Error> = .failure(URLError(.cannotConnectToHost))
+
+  func setResult(_ result: Result<(Data, URLResponse), Error>) {
+    self.result = result
+  }
+
+  func send(_ request: URLRequest) async throws -> (Data, URLResponse) {
+    requests.append(request)
+    return try result.get()
+  }
+
+  func recordedURLs() -> [URL] {
+    requests.compactMap(\.url)
+  }
+
+  func recordedBodies() -> [Data] {
+    requests.compactMap(\.httpBody)
+  }
+}
+
+final class LocalServerInferenceAdapterTests: XCTestCase {
+  func testRejectsNonLoopbackURLWithoutSendingHTTP() async throws {
+    let http = RecordingLocalInferenceHTTPClient()
+    let adapter = LocalServerInferenceAdapter(
+      configuration: LocalServerInferenceConfiguration(
+        baseURL: URL(string: "https://api.openai.com/v1")!,
+        model: "gpt-4o",
+        contextWindowTokens: 8192,
+        timeout: 5
+      ),
+      httpClient: http
+    )
+
+    do {
+      let _: ProbeSummary = try await adapter.generateStructured(
+        prompt: "hi",
+        schema: LocalInferenceJSONSchema(name: "probe", json: Data(#"{"type":"object"}"#.utf8))
+      )
+      XCTFail("non-loopback base URL must throw")
+    } catch LocalInferenceError.nonLoopbackBaseURL(let url) {
+      XCTAssertTrue(url.contains("api.openai.com"))
+    }
+    let urls = await http.recordedURLs()
+    XCTAssertEqual(urls, [], "a paid/cloud host must never receive a request")
+  }
+
+  func testAllowsIPv4LoopbackAndDecodesStructuredJSON() async throws {
+    let http = RecordingLocalInferenceHTTPClient()
+    let payload = """
+      {"choices":[{"message":{"content":"{\\"title\\":\\"on device\\"}"}}]}
+      """
+    let url = URL(string: "http://127.0.0.1:11434/v1/chat/completions")!
+    await http.setResult(
+      .success(
+        (
+          Data(payload.utf8),
+          HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        )
+      )
+    )
+    let adapter = LocalServerInferenceAdapter(
+      configuration: LocalServerInferenceConfiguration(
+        baseURL: URL(string: "http://127.0.0.1:11434/v1")!,
+        model: "local",
+        contextWindowTokens: 8192,
+        timeout: 5
+      ),
+      httpClient: http
+    )
+
+    let summary: ProbeSummary = try await adapter.generateStructured(
+      prompt: "summarize",
+      schema: LocalInferenceJSONSchema(
+        name: "probe",
+        json: Data(#"{"type":"object","properties":{"title":{"type":"string"}}}"#.utf8)
+      )
+    )
+
+    XCTAssertEqual(summary.title, "on device")
+    let urls = await http.recordedURLs()
+    XCTAssertEqual(urls, [url])
+    XCTAssertTrue(LocalInferenceLoopback.isAllowed(url))
+  }
+
+  func testRuntimeFailClosedOnCloudBaseURLSendsNoHTTP() async {
+    let http = RecordingLocalInferenceHTTPClient()
+    let runtime = LocalInferenceRuntime(
+      engines: [
+        LocalServerInferenceAdapter(
+          configuration: LocalServerInferenceConfiguration(
+            baseURL: URL(string: "https://generativelanguage.googleapis.com/v1")!,
+            model: "gemini",
+            contextWindowTokens: 8192,
+            timeout: 5
+          ),
+          httpClient: http
+        )
+      ],
+      killSwitches: .enabled,
+      fallback: DesktopLocalInferenceFallbackRecorder()
+    )
+
+    let result: LocalInferenceGeneration<ProbeSummary> = await runtime.generateStructuredFailClosed(
+      prompt: "summarize",
+      schema: LocalInferenceJSONSchema(name: "probe", json: Data(#"{"type":"object"}"#.utf8)),
+      minimumInput: DeterministicMinimumInput(
+        transcript: "Hello there.",
+        startedAt: Date(timeIntervalSince1970: 0),
+        timeZone: TimeZone(secondsFromGMT: 0)!
+      )
+    )
+
+    guard case .deterministicMinimum = result else {
+      return XCTFail("cloud-shaped base URL must fail closed")
+    }
+    let urls = await http.recordedURLs()
+    XCTAssertEqual(urls, [])
+  }
+
+  func testToolLoopIsStubbedOnTheAdapter() async {
+    let adapter = LocalServerInferenceAdapter(
+      configuration: LocalServerInferenceConfiguration(
+        baseURL: URL(string: "http://127.0.0.1:11434/v1")!,
+        model: "local",
+        contextWindowTokens: 8192,
+        timeout: 5
+      )
+    )
+    do {
+      _ = try await adapter.runToolLoop(
+        prompt: "x",
+        tools: [],
+        budget: ToolLoopBudget(maxIterations: 1)
+      )
+      XCTFail("tool loop must stay stubbed in S9")
+    } catch LocalInferenceError.capabilityUnavailable(let name) {
+      XCTAssertEqual(name, "tool_loop")
+    } catch {
+      XCTFail("unexpected error \(error)")
+    }
+  }
+
+  func testLoopbackHelperRejectsPublicHosts() {
+    XCTAssertTrue(LocalInferenceLoopback.isAllowed(URL(string: "http://127.0.0.1:8080/v1")!))
+    XCTAssertTrue(LocalInferenceLoopback.isAllowed(URL(string: "http://localhost:11434/v1")!))
+    XCTAssertTrue(LocalInferenceLoopback.isAllowed(URL(string: "http://[::1]:8080/v1")!))
+    XCTAssertFalse(LocalInferenceLoopback.isAllowed(URL(string: "https://api.openai.com/v1")!))
+    XCTAssertFalse(LocalInferenceLoopback.isAllowed(URL(string: "https://generativelanguage.googleapis.com")!))
+    XCTAssertFalse(LocalInferenceLoopback.isAllowed(URL(string: "http://10.0.0.4/v1")!))
+  }
+}
+
+final class LocalInferenceKillSwitchTests: XCTestCase {
+  func testEnvironmentDisableWins() {
+    let switches = LocalInferenceKillSwitches.resolve(
+      environment: [LocalInferenceKillSwitches.disableEnvironmentKey: "1"],
+      defaults: UserDefaults(suiteName: UUID().uuidString)!
+    )
+    XCTAssertTrue(switches.isDisabled)
+  }
+
+  func testUserDefaultsDisable() {
+    let defaults = UserDefaults(suiteName: UUID().uuidString)!
+    defaults.set(true, forKey: LocalInferenceKillSwitches.disableDefaultsKey)
+    let switches = LocalInferenceKillSwitches.resolve(environment: [:], defaults: defaults)
+    XCTAssertTrue(switches.isDisabled)
+  }
+
+  func testForceEngineFromEnvironment() {
+    let switches = LocalInferenceKillSwitches.resolve(
+      environment: [LocalInferenceKillSwitches.forceEngineEnvironmentKey: "local-server"],
+      defaults: UserDefaults(suiteName: UUID().uuidString)!
+    )
+    XCTAssertEqual(switches.forcedEngine, .localServer)
+  }
+
+  func testForceEngineFromDefaultsWhenEnvAbsent() {
+    let defaults = UserDefaults(suiteName: UUID().uuidString)!
+    defaults.set("afm", forKey: LocalInferenceKillSwitches.forceEngineDefaultsKey)
+    let switches = LocalInferenceKillSwitches.resolve(environment: [:], defaults: defaults)
+    XCTAssertEqual(switches.forcedEngine, .afm)
+  }
+}
+
+final class DeterministicConversationMinimumTests: XCTestCase {
+  func testUsesFirstSentenceAndEmptyOverview() {
+    let minimum = DeterministicConversationMinimum.make(
+      from: DeterministicMinimumInput(
+        transcript: "Ship the runtime today. Do not call luna.",
+        startedAt: Date(timeIntervalSince1970: 0)
+      )
+    )
+    XCTAssertEqual(minimum.title, "Ship the runtime today.")
+    XCTAssertEqual(minimum.overview, "")
+    XCTAssertEqual(minimum.category, "other")
+    XCTAssertEqual(minimum.processingState, "none")
+  }
+
+  func testEmptyTranscriptUsesSourceAndStartedAtNotNow() {
+    let started = Date(timeIntervalSince1970: 1_704_140_040)
+    let minimum = DeterministicConversationMinimum.make(
+      from: DeterministicMinimumInput(
+        transcript: "   \n",
+        startedAt: started,
+        sourceLabel: "Recording",
+        timeZone: TimeZone(secondsFromGMT: 0)!
+      )
+    )
+    XCTAssertEqual(minimum.title, "Recording · 8:14 PM")
+    XCTAssertEqual(minimum.overview, "")
+  }
+
+  func testTruncatesLongSentenceOnAWordBoundary() {
+    let words = Array(repeating: "word", count: 40).joined(separator: " ")
+    let title = DeterministicConversationMinimum.title(
+      from: DeterministicMinimumInput(transcript: words, startedAt: Date(timeIntervalSince1970: 0))
+    )
+    XCTAssertLessThanOrEqual(title.count, 60)
+    XCTAssertFalse(title.hasSuffix(" "))
+    XCTAssertTrue(title.hasPrefix("word"))
+  }
+
+  func testTitleIsPureOverStartedAt() {
+    let input = DeterministicMinimumInput(
+      transcript: "",
+      startedAt: Date(timeIntervalSince1970: 1_704_140_040),
+      timeZone: TimeZone(secondsFromGMT: 0)!
+    )
+    XCTAssertEqual(
+      DeterministicConversationMinimum.title(from: input),
+      DeterministicConversationMinimum.title(from: input)
+    )
+  }
+}
+
+final class LocalInferenceCloudEscapeTripwireTests: XCTestCase {
+  func testLocalInferenceSourcesDoNotNameACloudLLMClient() throws {
+    let sourcesRoot = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources")
+      .appendingPathComponent("LocalInference")
+    let files = try FileManager.default.contentsOfDirectory(atPath: sourcesRoot.path).filter { $0.hasSuffix(".swift") }
+    XCTAssertFalse(files.isEmpty)
+
+    let forbidden = [
+      "GeminiClient",
+      "ProactiveLaneClient",
+      "generativelanguage.googleapis.com",
+      "api.openai.com",
+      "desktop_proxy",
+      "get_llm",
+    ]
+    for file in files {
+      // omi-test-quality: source-inspection -- static contract: local inference fail-closed path cannot name a cloud LLM client
+      let text = try String(contentsOf: sourcesRoot.appendingPathComponent(file), encoding: .utf8)
+      for token in forbidden {
+        XCTAssertFalse(
+          text.contains(token),
+          "\(file) must not name cloud LLM surface \(token)"
+        )
+      }
+    }
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260903-s9-local-inference-service.json
+++ b/desktop/macos/changelog/unreleased/20260903-s9-local-inference-service.json
@@ -1,0 +1,4 @@
+{
+  "kind": "none",
+  "reason": "S9 lands the local inference protocol, localhost adapter, and kill switches behind tests. Finalization is not wired yet, so there is no user-visible behavior change."
+}

--- a/desktop/macos/e2e/flows/recording-finalization.yaml
+++ b/desktop/macos/e2e/flows/recording-finalization.yaml
@@ -7,6 +7,15 @@ covers:
   - desktop/macos/Desktop/Sources/ConversationProcessingProgress.swift
   - desktop/macos/Desktop/Sources/ProcessingConversationWatcher.swift
   - desktop/macos/Desktop/Sources/AnalyticsManager+ConversationProcessing.swift
+  # S9 runtime port. Not consulted by this flow until S11 wires
+  # ConversationFinalizationService; the XCTest fail-closed suite is the
+  # behavioral proof. Registering here keeps the e2e ratchet on the path
+  # that will own local inference once it is live.
+  - desktop/macos/Desktop/Sources/LocalInference/LocalInferenceService.swift
+  - desktop/macos/Desktop/Sources/LocalInference/LocalInferenceRuntime.swift
+  - desktop/macos/Desktop/Sources/LocalInference/LocalInferenceKillSwitches.swift
+  - desktop/macos/Desktop/Sources/LocalInference/LocalServerInferenceAdapter.swift
+  - desktop/macos/Desktop/Sources/LocalInference/DeterministicConversationMinimum.swift
   - desktop/Desktop/Sources/AppState.swift
   - desktop/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
   - desktop/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift


### PR DESCRIPTION
## S9 — LocalInferenceService protocol, localhost adapter, fail-closed kill switches

Shard S9 of the local-models free-tier program (`60-shards.md` row S9; spec `20-desktop-local-runtime.md` §2.1; deterministic minimum `10-backend-plumbing.md` §1.7; flags `50-rollout-and-verification.md`). Shipped Swift macOS app only (`desktop/macos/`), not the rewrite WebKit shell. **Dark:** nothing in the conversation finalization path is wired yet (S11).

Closes SCA-443

### What changed

- **`LocalInferenceService`** — `generateStructured` + `runToolLoop`. Engine IDs: `local-server` and `afm` (named so `forceLocalInferenceEngine=afm` is a closed door until S12, not a fall-through to luna).
- **`LocalInferenceRuntime`** — fail-closed coordinator. Ladder is selected local engine → retry once on that same engine → deterministic minimum. A second registered engine is never consulted. Kill switches short-circuit before HTTP.
- **`LocalServerInferenceAdapter`** — OpenAI-compatible `POST …/chat/completions` with `json_schema`. Loopback-only (`localhost`, `::1`, `127.0.0.0/8`). Non-loopback URLs throw before any HTTP. Tool loop throws `.capabilityUnavailable("tool_loop")`.
- **Kill switches** (env or UserDefaults, Parakeet-style): `OMI_DISABLE_LOCAL_INFERENCE` / `disableLocalInference`, `OMI_FORCE_LOCAL_INFERENCE_ENGINE` / `forceLocalInferenceEngine`, plus URL/model defaults `http://127.0.0.1:11434/v1` and `local`.
- **Deterministic minimum (client §1.7)** — first sentence, ≤60 characters on a word boundary; empty transcript → `{source} · h:mm a` from `startedAt` only; overview `""`; category `other`; `processingState` `none`.
- **Fallback telemetry** — `recordFallback(area: "local_llm", …)`. Allowlisted `local_llm` and `engine_failed`.
- **E2E ratchet** — `recording-finalization.yaml` `covers:` names the S9 sources so the coverage gate holds until S11 wires finalization. The flow does not call the runtime yet.

### Automatic-or-dead check

`LocalInferenceRuntimeFailClosedTests.testForcedEngineFailureReturnsDeterministicMinimumRecordsFallbackAndDoesNotCallCloud`: a throwing `local-server` engine plus an AFM spy. Forced failure yields the deterministic minimum, emits `recordFallback` (`area=local_llm`, `reason=engine_failed`, `outcome=exhausted`, `to=deterministic_minimum`), retries once on the same engine (`generateCallCount == 2`), and the AFM spy stays at `callCount == 0`.

Also covered: disable skip, force `afm` with no adapter (`capability_mismatch`, local-server not called), unknown engine `luna`, retry recover without touching another engine, tool-loop stub, loopback-only HTTP (zero requests to `api.openai.com` / Google), title purity (`1_704_140_040` UTC → `Recording · 8:14 PM`), and a source-inspection tripwire that the fail-closed path cannot name a cloud LLM client.

### Proof

- `xcrun swift test --package-path Desktop --filter LocalInference…` — **20 tests, 0 failures** (host Xcode 26.6 / macOS 26). CI pins **Xcode 16.4** (`/Applications/Xcode_16.4.app` is not installed here), so this is not the CI toolchain.
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — OK (source-inspection site annotated).
- `desktop/macos/scripts/swift-format-wrapper.sh lint` on the new files — OK.

### Cut list

- AFM adapter (S12).
- Tool loops (stub / feature-detect only).
- Bundling or starting a local runtime.
- Wiring into `ConversationFinalizationService` (S11).

### Line-count ratchet

Line-Count-Exception: desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift | 1521 -> 1523 | allowlist local_llm area and engine_failed reason so S9 fallback telemetry is queryable

### Product invariants

none (checker: no locked invariant matched these paths)

### Failure class

No `fix:` commits in this range.

Failure-Class: none

### Plan notes

- Program HANDOFF said not to start desktop until S4. SCA-443 overrode that ("S9 has no dependencies — start immediately"). This PR is the runtime port only and does not stack on S4. Current `origin/main` now includes S4 (#12661); this branch fast-forwarded onto that tip without taking a dependency.
- Server `_build_deferred_structured` is first 8 words / title `"Recording"`; this client follows §1.7. S3 owns server alignment.
- Retry-once lives in `LocalInferenceRuntime` (S9 choke point), not ConversationFinalization (S11).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
