### PR TITLE
fix(backend): gate app generate and icon routes on chat quota

### DIFF
--- a/.github/failure-classes/FC-sibling-managed-llm-missing-chat-quota-gate.json
+++ b/.github/failure-classes/FC-sibling-managed-llm-missing-chat-quota-gate.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-sibling-managed-llm-missing-chat-quota-gate",
+  "violated_contract": "User-initiated managed LLM/image endpoints that share the same billable feature (for example Features.APP_GENERATOR via track_usage) must call enforce_chat_quota before spend. Leaving a sibling route ungated while related routes in the same router already enforce chat quota lets free users past FREE_CHAT_QUESTIONS_PER_MONTH trigger Omi-paid generation.",
+  "canonical_prevention": "At every user-triggered APP_GENERATOR (or equivalent tracked) entrypoint, call enforce_chat_quota(uid, platform=X-App-Platform) before track_usage / provider work — matching generate-description and generate-description-emoji. Pin the wiring with hermetic router tests that assert a 402 from the gate prevents the LLM/image helper from being awaited.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_free_quota_gate_wiring.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/routers/apps.py",
+    "backend/utils/subscription.py",
+    "backend/utils/llm/usage_tracker.py",
+    "backend/tests/unit/test_free_quota_gate_wiring.py"
+  ],
+  "status": "open"
+}

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -1588,6 +1588,10 @@ async def generate_app_endpoint(data: GenerateAppRequest, uid: str = Depends(aut
     """
     from utils.llm.app_generator import generate_app_from_prompt
 
+    # User-initiated LLM generation — same free-tier gate as chat (402 past cap).
+    # Sibling description generators already enforce; this path was left ungated.
+    enforce_chat_quota(uid)
+
     prompt = data.prompt.strip()
     if not prompt:
         raise HTTPException(status_code=422, detail='Prompt is required')
@@ -1627,6 +1631,10 @@ async def generate_app_icon_endpoint(data: GenerateAppIconRequest, uid: str = De
     """
     from utils.llm.app_generator import generate_app_icon
     import base64
+
+    # User-initiated image generation — same free-tier gate as chat (402 past cap).
+    # Sibling description generators already enforce; this path was left ungated.
+    enforce_chat_quota(uid)
 
     app_name = data.name.strip()
     app_description = data.description.strip()

--- a/backend/tests/unit/test_free_quota_gate_wiring.py
+++ b/backend/tests/unit/test_free_quota_gate_wiring.py
@@ -3,8 +3,9 @@
 Regression for the enforcement-coverage gap where a free user past
 FREE_CHAT_QUESTIONS_PER_MONTH could still trigger managed LLM spend through
 daily-summary regeneration, goal progress extraction, app description
-generation, and the omni realtime relay. Each test proves the endpoint calls
-the shared gate BEFORE doing LLM work and lets the 402 propagate.
+generation, AI app/icon generation, and the omni realtime relay. Each test
+proves the endpoint calls the shared gate BEFORE doing LLM work and lets the
+402 propagate.
 
 `enforce_chat_quota`'s own decision logic is covered in test_chat_quota.py;
 these tests only pin the call-site wiring, so the gate is patched at each
@@ -197,6 +198,72 @@ class TestAppGeneratorGates:
                 apps_router.generate_description_and_emoji_endpoint(data, uid='u1', x_app_platform='macos')
             assert exc_info.value.status_code == 402
             gate.assert_called_once_with('u1', platform='macos')
+
+    def test_generate_app_blocked_past_cap(self):
+        """POST /v1/app/generate must gate before billable APP_GENERATOR spend."""
+        import routers.apps as apps_router
+
+        data = apps_router.GenerateAppRequest(prompt='build a meeting notes extractor app')
+        with patch.object(apps_router, 'enforce_chat_quota', side_effect=_quota_402()) as gate, patch(
+            'utils.llm.app_generator.generate_app_from_prompt', new_callable=AsyncMock
+        ) as llm:
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(apps_router.generate_app_endpoint(data, uid='u1'))
+            assert exc_info.value.status_code == 402
+            gate.assert_called_once_with('u1')
+            llm.assert_not_awaited()
+
+    def test_generate_app_allowed_proceeds(self):
+        import routers.apps as apps_router
+
+        generated = MagicMock()
+        generated.name = 'Notes'
+        generated.description = 'extracts action items'
+        generated.category = 'productivity'
+        generated.capabilities = ['chat']
+        generated.chat_prompt = 'help'
+        generated.memory_prompt = 'remember'
+        data = apps_router.GenerateAppRequest(prompt='build a meeting notes extractor app')
+        with patch.object(apps_router, 'enforce_chat_quota') as gate, patch(
+            'utils.llm.app_generator.generate_app_from_prompt', new_callable=AsyncMock, return_value=generated
+        ) as llm:
+            result = asyncio.run(apps_router.generate_app_endpoint(data, uid='u1'))
+            assert result['status'] == 'ok'
+            assert result['app']['name'] == 'Notes'
+            gate.assert_called_once_with('u1')
+            llm.assert_awaited_once()
+
+    def test_generate_app_icon_blocked_past_cap(self):
+        """POST /v1/app/generate-icon must gate before billable image generation."""
+        import routers.apps as apps_router
+
+        data = apps_router.GenerateAppIconRequest(
+            name='Notes', description='extracts action items', category='productivity'
+        )
+        with patch.object(apps_router, 'enforce_chat_quota', side_effect=_quota_402()) as gate, patch(
+            'utils.llm.app_generator.generate_app_icon', new_callable=AsyncMock
+        ) as llm:
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(apps_router.generate_app_icon_endpoint(data, uid='u1'))
+            assert exc_info.value.status_code == 402
+            gate.assert_called_once_with('u1')
+            llm.assert_not_awaited()
+
+    def test_generate_app_icon_allowed_proceeds(self):
+        import routers.apps as apps_router
+
+        data = apps_router.GenerateAppIconRequest(
+            name='Notes', description='extracts action items', category='productivity'
+        )
+        with patch.object(apps_router, 'enforce_chat_quota') as gate, patch(
+            'utils.llm.app_generator.generate_app_icon', new_callable=AsyncMock, return_value=b'png-bytes'
+        ) as llm:
+            result = asyncio.run(apps_router.generate_app_icon_endpoint(data, uid='u1'))
+            assert result['status'] == 'ok'
+            assert result['mime_type'] == 'image/png'
+            assert result['icon_base64']  # base64 of png-bytes
+            gate.assert_called_once_with('u1')
+            llm.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #12715.

## Summary

`POST /v1/app/generate` and `POST /v1/app/generate-icon` bill managed LLM/image spend under `Features.APP_GENERATOR` via `track_usage`, but never called `enforce_chat_quota`. Sibling description generators in the same router already gate free users past the monthly chat cap with a 402.

This adds the same `enforce_chat_quota(uid)` call before provider work on those two endpoints.

## Change

- `backend/routers/apps.py` — `enforce_chat_quota` on generate + generate-icon
- `backend/tests/unit/test_free_quota_gate_wiring.py` — blocked + allowed wiring coverage for both routes
- `.github/failure-classes/FC-sibling-managed-llm-missing-chat-quota-gate.json` — new failure class

Left alone on purpose: `/v1/app/generate-prompts`, `/v1/personas/twitter/initial-message`. No OpenAPI/signature change (platform header not added) so free-tier gating lands without generated-client churn.

## Verification

- Code on `main` (`fab60317`): description endpoints call `enforce_chat_quota`; generate/generate-icon only `track_usage` (no quota). `track_usage` does not enforce.
- After fix: `pytest tests/unit/test_free_quota_gate_wiring.py::TestAppGeneratorGates` → **6 passed**; full wiring file → **15 passed**

## Honest gaps

- No live free-tier Firebase/Redis integration run (hermetic gate patch only).
- Does not pass `X-App-Platform` into the gate (description siblings do); free monthly cap still enforces. Platform-aware trial paywall on these two routes can follow later if product wants parity.
- Physical device smoke not run (no kit; backend-only change).

Failure-Class: new

Line-Count-Exception: backend/routers/apps.py | 2454 -> 2462 | reason: add enforce_chat_quota calls to generate and generate-icon to match sibling description generators; no safe split for a two-call-site wiring fix


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

