### PR TITLE
fix(backend): fail closed when WAV duration is unreadable for STT budget

### DIFF
--- a/.github/failure-classes/FC-unmeterable-audio-skips-stt-budget-gate.json
+++ b/.github/failure-classes/FC-unmeterable-audio-skips-stt-budget-gate.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-unmeterable-audio-skips-stt-budget-gate",
+  "violated_contract": "Voice STT routes that bill against the rolling daily duration budget must not invoke a paid transcription provider when audio duration cannot be metered. Skipping try_consume_budget when read_wav_duration_ms returns None (or omitting an unreadable file from a multi-file sum) lets paid STT run free; the PCM REST path always meters via compute_pcm_duration_ms and must remain the contrast.",
+  "canonical_prevention": "Before any paid STT call on WAV/multipart/SSE voice routes, require a readable duration for every file that will be transcribed; reject with TranscriptionOutcome.INVALID_INPUT (HTTP 400) when duration is unreadable, then call try_consume_budget with the full metered sum. Pin with hermetic tests that assert STT helpers are not called when duration is None.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_desktop_transcribe.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/routers/chat.py",
+    "backend/utils/voice_duration_limiter.py",
+    "backend/tests/unit/test_desktop_transcribe.py"
+  ],
+  "status": "open"
+}

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -873,14 +873,18 @@ def create_voice_message_stream(
             )
 
         # Daily budget check (first file only — matches actual DG usage).
-        # A quota rejection is not an STT attempt and therefore is not an
-        # invalid-input or provider-outcome metric.
+        # Unreadable duration must fail closed before paid STT (PCM always meters).
         first_wav = wav_paths[0]
         duration_ms = read_wav_duration_ms(first_wav)
-        if duration_ms is not None:
-            allowed, used_ms, remaining_ms = try_consume_budget(uid, duration_ms)
-            if not allowed:
-                raise HTTPException(status_code=429, detail='Daily transcription budget exhausted')
+        if duration_ms is None:
+            raise TranscriptionFailure(
+                TranscriptionOutcome.INVALID_INPUT,
+                provider=stt_provider,
+                retryable=False,
+            )
+        allowed, used_ms, remaining_ms = try_consume_budget(uid, duration_ms)
+        if not allowed:
+            raise HTTPException(status_code=429, detail='Daily transcription budget exhausted')
     except TranscriptionFailure as failure:
         _record_preparation_failure(failure)
         _cleanup_temp_voice_wavs(paths + wav_paths, uid)
@@ -1176,17 +1180,20 @@ async def transcribe_voice_message(
                 retryable=False,
             )
 
-        # Daily budget check (sum all files). This is not a provider outcome,
-        # so do it before recording an accepted transcription attempt.
+        # Daily budget check (sum all files). Fail closed if any duration is unreadable.
         total_duration_ms = 0
         for wav_path in wav_paths:
             duration_ms = await run_blocking(storage_executor, read_wav_duration_ms, wav_path)
-            if duration_ms is not None:
-                total_duration_ms += duration_ms
-        if total_duration_ms > 0:
-            allowed, used_ms, remaining_ms = try_consume_budget(uid, total_duration_ms)
-            if not allowed:
-                raise HTTPException(status_code=429, detail='Daily transcription budget exhausted')
+            if duration_ms is None:
+                raise TranscriptionFailure(
+                    TranscriptionOutcome.INVALID_INPUT,
+                    provider=stt_provider,
+                    retryable=False,
+                )
+            total_duration_ms += duration_ms
+        allowed, used_ms, remaining_ms = try_consume_budget(uid, total_duration_ms)
+        if not allowed:
+            raise HTTPException(status_code=429, detail='Daily transcription budget exhausted')
 
         is_multi = resolved_language == 'multi'
         attempt = TranscriptionAttempt(

--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -1913,6 +1913,28 @@ class TestDurationBudgetEnforcement:
         finally:
             _cleanup_chat_client(saved)
 
+    def test_multipart_unreadable_duration_rejects_before_stt(self):
+        """Unreadable WAV duration must fail closed before paid STT — not skip the budget gate."""
+        import io
+
+        client, module, saved = _make_chat_client()
+        try:
+            with patch.object(module, 'read_wav_duration_ms', return_value=None):
+                with patch.object(module, 'try_consume_budget') as mock_budget:
+                    with patch.object(
+                        module, 'transcribe_voice_message_segment', return_value=('hello', 'en')
+                    ) as mock_stt:
+                        resp = client.post(
+                            '/v2/voice-message/transcribe',
+                            files=[('files', ('test.wav', io.BytesIO(b'\x00' * 100), 'audio/wav'))],
+                        )
+                        assert resp.status_code == 400
+                        assert resp.json()['detail']['outcome'] == 'invalid_input'
+                        mock_budget.assert_not_called()
+                        mock_stt.assert_not_called()
+        finally:
+            _cleanup_chat_client(saved)
+
 
 class TestVoiceMessagesEndpointBudget:
     """Test /v2/voice-messages daily budget enforcement."""
@@ -1933,6 +1955,28 @@ class TestVoiceMessagesEndpointBudget:
                             )
                             assert resp.status_code == 429
                             assert 'budget exhausted' in resp.json()['detail']
+        finally:
+            _cleanup_chat_client(saved)
+
+    def test_voice_messages_unreadable_duration_rejects_before_stt(self):
+        """Unreadable first-WAV duration must fail closed before streaming paid STT."""
+        import io
+
+        client, module, saved = _make_chat_client()
+        try:
+            with patch.object(module, 'retrieve_file_paths', return_value=['/tmp/test_vm.wav']):
+                with patch.object(module, 'decode_files_to_wav', return_value=['/tmp/test_vm_decoded.wav']):
+                    with patch.object(module, 'read_wav_duration_ms', return_value=None):
+                        with patch.object(module, 'try_consume_budget') as mock_budget:
+                            with patch.object(module, 'process_voice_message_segment_stream') as mock_stt:
+                                resp = client.post(
+                                    '/v2/voice-messages',
+                                    files=[('files', ('test.wav', io.BytesIO(b'\x00' * 100), 'audio/wav'))],
+                                )
+                                assert resp.status_code == 400
+                                assert resp.json()['detail']['outcome'] == 'invalid_input'
+                                mock_budget.assert_not_called()
+                                mock_stt.assert_not_called()
         finally:
             _cleanup_chat_client(saved)
 
@@ -2189,11 +2233,10 @@ class TestMultipartBudgetAggregation:
 
         client, module, saved = _make_chat_client()
         try:
-            # Simulate 3 files: 1000ms, None (unreadable), 2000ms → budget call with 3000
-            duration_values = iter([1000, None, 2000])
+            duration_values = iter([1000, 2000, 500])
 
             with patch.object(module, 'read_wav_duration_ms', side_effect=lambda p: next(duration_values)):
-                with patch.object(module, 'try_consume_budget', return_value=(True, 3000, 7197000)) as mock_budget:
+                with patch.object(module, 'try_consume_budget', return_value=(True, 3500, 7196500)) as mock_budget:
                     with patch.object(module, 'transcribe_voice_message_segment', return_value=('hello', 'en')):
                         resp = client.post(
                             '/v2/voice-message/transcribe',
@@ -2204,11 +2247,38 @@ class TestMultipartBudgetAggregation:
                             ],
                         )
                         assert resp.status_code == 200
-                        # Budget consumed with sum: 1000 + 2000 = 3000 (None skipped)
                         mock_budget.assert_called_once()
                         call_args = mock_budget.call_args[0]
                         assert call_args[0] == 'test-uid'
-                        assert call_args[1] == 3000
+                        assert call_args[1] == 3500
+        finally:
+            _cleanup_chat_client(saved)
+
+    def test_multipart_any_unreadable_duration_rejects_before_stt(self):
+        """One unreadable file in a multi-file upload must not leave that file unmetered."""
+        import io
+
+        client, module, saved = _make_chat_client()
+        try:
+            duration_values = iter([1000, None, 2000])
+
+            with patch.object(module, 'read_wav_duration_ms', side_effect=lambda p: next(duration_values)):
+                with patch.object(module, 'try_consume_budget') as mock_budget:
+                    with patch.object(
+                        module, 'transcribe_voice_message_segment', return_value=('hello', 'en')
+                    ) as mock_stt:
+                        resp = client.post(
+                            '/v2/voice-message/transcribe',
+                            files=[
+                                ('files', ('a.wav', io.BytesIO(b'\x00' * 100), 'audio/wav')),
+                                ('files', ('b.wav', io.BytesIO(b'\x00' * 100), 'audio/wav')),
+                                ('files', ('c.wav', io.BytesIO(b'\x00' * 100), 'audio/wav')),
+                            ],
+                        )
+                        assert resp.status_code == 400
+                        assert resp.json()['detail']['outcome'] == 'invalid_input'
+                        mock_budget.assert_not_called()
+                        mock_stt.assert_not_called()
         finally:
             _cleanup_chat_client(saved)
 


### PR DESCRIPTION
## What changed and why

When `read_wav_duration_ms` returned `None`, `/v2/voice-messages` and multipart `/v2/voice-message/transcribe` skipped `try_consume_budget` but still ran paid STT (#12718). Reject with typed `invalid_input` (400) before STT so unmeterable audio cannot bypass the daily duration budget. PCM REST already always meters via `compute_pcm_duration_ms`.

## Product invariants affected

none

## How it was verified

```bash
cd backend
echo 'tests/unit/test_desktop_transcribe.py' > /tmp/bug4-tests.txt
BACKEND_UNIT_TEST_FILE_LIST=/tmp/bug4-tests.txt BACKEND_PYTEST_FILE_ISOLATION=0 BACKEND_PYTEST_XDIST=0 \
  bash test.sh -k 'unreadable_duration or multipart_multi_file_budget or budget_exhausted or budget_consumed or octet_stream_budget' -q
# → 69 passed, 5 deselected
```

Pre-fix hermetic proof: with `read_wav_duration_ms` patched to `None`, multipart and `/v2/voice-messages` returned 200 and invoked STT without `try_consume_budget`; multi-file charged only readable files while still transcribing the unreadable one.

## Tests

- `test_multipart_unreadable_duration_rejects_before_stt`
- `test_voice_messages_unreadable_duration_rejects_before_stt`
- `test_multipart_any_unreadable_duration_rejects_before_stt`

## Failure class (fixes)

Failure-Class: new

## Line count

Line-Count-Exception: backend/routers/chat.py | 2130 -> 2137 | Fail-closed unreadable WAV duration checks at both voice STT budget gates.

## Honest gaps

- No live provider / Redis budget integration run (hermetic unit coverage only).
- Physical / on-device smoke not run (no kit).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

