### PR TITLE
fix(backend): reserve PTT stream STT budget at connect

### DIFF
--- a/.github/failure-classes/FC-concurrent-ptt-stream-budget-overspend.json
+++ b/.github/failure-classes/FC-concurrent-ptt-stream-budget-overspend.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-concurrent-ptt-stream-budget-overspend",
+  "violated_contract": "Concurrent /v2/voice-message/transcribe-stream sessions for the same uid must not each admit against the same remaining daily STT duration slice. Probe-only check_budget at connect plus force-record at end lets N sessions freeze identical remaining_ms and overspend the shared voice_duration budget after the fact.",
+  "canonical_prevention": "Atomically reserve up to MAX_SESSION_DURATION_S at WS connect via try_reserve_session_budget (Lua force=2 consume-up-to). Cap mid-session audio to the reserved amount. On successful drain, settle_reserved_duration(reserved, actual); on terminal provider failure, refund the full reservation. Pin with fakeredis Lua tests that show probe+force overspend and reserve-up-to mutual exclusion.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_voice_duration_limiter.py",
+    "backend/tests/unit/test_desktop_transcribe.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/routers/chat.py",
+    "backend/utils/voice_duration_limiter.py"
+  ],
+  "status": "open"
+}

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -92,10 +92,12 @@ from utils.observability.fallback import record_fallback
 from utils.journey_metrics_contract import resolve_client_kind, resolve_client_kind_from_headers
 from utils.observability.journeys import ClientJourneyAttempt, JourneyAttempt
 from utils.voice_duration_limiter import (
+    MAX_SESSION_DURATION_S,
     compute_pcm_duration_ms,
     read_wav_duration_ms,
     try_consume_budget,
-    check_budget,
+    try_reserve_session_budget,
+    settle_reserved_duration,
     record_actual_duration,
 )
 from testing.parity_pack_v0.live_capture import SurfaceParityCapture
@@ -1372,16 +1374,10 @@ async def transcribe_voice_message_stream(
     except Exception:
         pass  # Fail-open, consistent with Redis rate limiting elsewhere
 
-    # Daily budget check — reject if already exhausted before opening a provider connection.
-    budget_remaining_ms = None  # None = fail-open (no enforcement)
-    try:
-        has_budget, used_ms, remaining_ms = check_budget(uid)
-        if not has_budget:
-            await websocket.close(code=1008, reason='Daily transcription budget exhausted')
-            return
-        budget_remaining_ms = remaining_ms
-    except Exception:
-        pass  # Fail-open
+    # Daily budget reservation is taken inside the session try/finally so every
+    # exit path (including STT connect failure) can settle/refund.
+    budget_remaining_ms = None  # None = fail-open (no mid-session enforcement)
+    budget_reserved_ms = 0
 
     websocket_active = True
     dg_socket = None
@@ -1617,12 +1613,26 @@ async def transcribe_voice_message_stream(
         return False
 
     def record_stt_usage_once() -> None:
-        """Record accepted provider audio only after a terminal provider drain."""
+        """Settle the connect-time reservation after a successful provider drain."""
         nonlocal usage_recorded
-        if usage_recorded or accepted_audio_bytes <= 0 or bytes_per_second <= 0:
+        if usage_recorded or bytes_per_second <= 0:
             return
-        actual_duration_ms = compute_pcm_duration_ms(accepted_audio_bytes, sample_rate, channels)
-        record_actual_duration(uid, actual_duration_ms)
+        actual_duration_ms = (
+            compute_pcm_duration_ms(accepted_audio_bytes, sample_rate, channels) if accepted_audio_bytes > 0 else 0
+        )
+        if budget_reserved_ms > 0:
+            settle_reserved_duration(uid, budget_reserved_ms, actual_duration_ms)
+        elif actual_duration_ms > 0:
+            # Fail-open path never reserved; keep force-record tracking.
+            record_actual_duration(uid, actual_duration_ms)
+        usage_recorded = True
+
+    def refund_reservation_once() -> None:
+        """Release an unused reservation when the session never drained successfully."""
+        nonlocal usage_recorded
+        if usage_recorded or budget_reserved_ms <= 0:
+            return
+        settle_reserved_duration(uid, budget_reserved_ms, 0)
         usage_recorded = True
 
     async def drain_stt_or_close() -> bool:
@@ -1644,6 +1654,22 @@ async def transcribe_voice_message_stream(
         return True
 
     try:
+        # Atomically reserve up to one session before opening a provider.
+        # Probe-only check_budget + force-record at end lets concurrent WS
+        # sessions each freeze the same remaining slice and overspend.
+        try:
+            allowed, reserved_ms, _used_ms, _remaining_ms = try_reserve_session_budget(
+                uid, MAX_SESSION_DURATION_S * 1000
+            )
+            if not allowed:
+                await websocket.close(code=1008, reason='Daily transcription budget exhausted')
+                return
+            if reserved_ms > 0:
+                budget_reserved_ms = reserved_ms
+                budget_remaining_ms = reserved_ms
+        except Exception:
+            pass  # Fail-open
+
         if stt_service == STTService.parakeet:
             dg_socket, stt_service = await connect_stt_socket_with_fallback(
                 primary_service=STTService.parakeet,
@@ -1775,6 +1801,9 @@ async def transcribe_voice_message_stream(
         # A rejected send still gets a best-effort close but no final transcript or usage charge.
         if dg_socket and not stt_send_failed and await drain_stt_or_close():
             record_stt_usage_once()
+        else:
+            # Provider never drained successfully — refund the connect-time reservation.
+            refund_reservation_once()
 
         if dg_socket and not stt_drained:
             try:

--- a/backend/tests/unit/_chat_router_test_harness.py
+++ b/backend/tests/unit/_chat_router_test_harness.py
@@ -282,7 +282,10 @@ def wire_common_stubs(install) -> SimpleNamespace:
     limiter.read_wav_duration_ms = MagicMock(return_value=1000)
     limiter.try_consume_budget = MagicMock(return_value=(True, 1000, 7199000))
     limiter.check_budget = MagicMock(return_value=(True, 0, 7200000))
+    limiter.try_reserve_session_budget = MagicMock(return_value=(True, 120000, 120000, 7080000))
+    limiter.settle_reserved_duration = MagicMock()
     limiter.record_actual_duration = MagicMock()
+    limiter.MAX_SESSION_DURATION_S = 120
 
     multipart = install('multipart', ModuleType('multipart'))
     multipart.__version__ = '0.0.20'

--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -863,7 +863,10 @@ def _stub_router_deps():
     limiter_stub.read_wav_duration_ms = MagicMock(return_value=1000)
     limiter_stub.try_consume_budget = MagicMock(return_value=(True, 0, 7200000))
     limiter_stub.check_budget = MagicMock(return_value=(True, 0, 7200000))
+    limiter_stub.try_reserve_session_budget = MagicMock(return_value=(True, 120000, 120000, 7080000))
+    limiter_stub.settle_reserved_duration = MagicMock()
     limiter_stub.record_actual_duration = MagicMock()
+    limiter_stub.MAX_SESSION_DURATION_S = 120
     sys.modules['utils.voice_duration_limiter'] = limiter_stub
     subscription_stub = sys.modules.setdefault('utils.subscription', MagicMock())
     subscription_stub.enforce_chat_quota = MagicMock()
@@ -1223,7 +1226,7 @@ class TestTranscribeStreamWebSocket:
                 mock_dg_socket.finish = MagicMock()
                 return mock_dg_socket
 
-            with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+            with patch.object(module, 'try_reserve_session_budget', return_value=(True, 120000, 120000, 7080000)):
                 with patch.object(
                     module, 'get_stt_service_for_language', return_value=(module.STTService.parakeet, 'en', 'parakeet')
                 ):
@@ -1310,7 +1313,7 @@ class TestTranscribeStreamWebSocket:
             async def mock_process_audio_modulate(stream_transcript, sample_rate, language):
                 return fallback_socket
 
-            with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+            with patch.object(module, 'try_reserve_session_budget', return_value=(True, 120000, 120000, 7080000)):
                 with patch.object(
                     module,
                     'get_stt_service_for_language',
@@ -1365,11 +1368,11 @@ class TestTranscribeStreamWebSocket:
                     return 'parakeet'
                 return None
 
-            with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+            with patch.object(module, 'try_reserve_session_budget', return_value=(True, 120000, 120000, 7080000)):
                 with patch.object(module, 'get_stt_service_for_language', side_effect=select_provider):
                     with patch.object(module, 'provider_for_service', side_effect=provider_for, create=True):
                         with patch.object(module, 'process_audio_parakeet', side_effect=mock_process_audio_parakeet):
-                            with patch.object(module, 'record_actual_duration') as mock_record_duration:
+                            with patch.object(module, 'settle_reserved_duration') as mock_record_duration:
                                 with pytest.raises(WebSocketDisconnect) as exc_info:
                                     with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
                                         ws.send_bytes(b'\x00' * 960)
@@ -1380,7 +1383,7 @@ class TestTranscribeStreamWebSocket:
             mock_dg_socket.send.assert_called_once_with(b'\x00' * 960)
             mock_dg_socket.finalize.assert_not_called()
             mock_dg_socket.finish.assert_called_once()
-            mock_record_duration.assert_not_called()
+            mock_record_duration.assert_called_once_with('test-uid', 120000, 0)
         finally:
             _cleanup_chat_client(saved)
 
@@ -1460,7 +1463,7 @@ class TestTranscribeStreamWebSocket:
                     return 'modulate'
                 return None
 
-            with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+            with patch.object(module, 'try_reserve_session_budget', return_value=(True, 120000, 120000, 7080000)):
                 with patch.object(module, 'get_stt_service_for_language', side_effect=select_provider):
                     with patch.object(module, 'provider_for_service', side_effect=provider_for, create=True):
                         with patch.object(module, 'process_audio_parakeet', side_effect=mock_process_audio_parakeet):
@@ -1468,7 +1471,7 @@ class TestTranscribeStreamWebSocket:
                                 module, 'process_audio_modulate', side_effect=mock_process_audio_modulate
                             ):
                                 with patch.object(module, 'ClientJourneyAttempt', return_value=attempt):
-                                    with patch.object(module, 'record_actual_duration'):
+                                    with patch.object(module, 'settle_reserved_duration'):
                                         with client.websocket_connect(
                                             '/v2/voice-message/transcribe-stream?language=en&sample_rate=16000',
                                             headers={'X-App-Platform': 'macos'},
@@ -1538,7 +1541,7 @@ class TestTranscribeStreamWebSocket:
                     return 'modulate'
                 return None
 
-            with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+            with patch.object(module, 'try_reserve_session_budget', return_value=(True, 120000, 120000, 7080000)):
                 with patch.object(module, 'get_stt_service_for_language', side_effect=select_provider):
                     with patch.object(module, 'provider_for_service', side_effect=provider_for, create=True):
                         with patch.object(module, 'process_audio_parakeet', side_effect=mock_process_audio_parakeet):
@@ -1546,7 +1549,7 @@ class TestTranscribeStreamWebSocket:
                                 module, 'process_audio_modulate', side_effect=mock_process_audio_modulate
                             ):
                                 with patch.object(module, 'ClientJourneyAttempt', return_value=attempt):
-                                    with patch.object(module, 'record_actual_duration') as mock_record_duration:
+                                    with patch.object(module, 'settle_reserved_duration') as mock_record_duration:
                                         with pytest.raises(WebSocketDisconnect) as exc_info:
                                             with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
                                                 ws.send_bytes(b'\x00' * 960)
@@ -1562,7 +1565,7 @@ class TestTranscribeStreamWebSocket:
             assert selector_calls[1] == frozenset({'modulate'})
             attempt.fail.assert_called_once_with('provider_error')
             attempt.succeed.assert_not_called()
-            mock_record_duration.assert_not_called()
+            mock_record_duration.assert_called_once_with('test-uid', 120000, 0)
         finally:
             _cleanup_chat_client(saved)
 
@@ -1580,12 +1583,12 @@ class TestTranscribeStreamWebSocket:
             async def mock_process_audio_parakeet(stream_transcript, **kwargs):
                 return mock_dg_socket
 
-            with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+            with patch.object(module, 'try_reserve_session_budget', return_value=(True, 120000, 120000, 7080000)):
                 with patch.object(
                     module, 'get_stt_service_for_language', return_value=(module.STTService.parakeet, 'en', 'parakeet')
                 ):
                     with patch.object(module, 'process_audio_parakeet', side_effect=mock_process_audio_parakeet):
-                        with patch.object(module, 'record_actual_duration') as mock_record_duration:
+                        with patch.object(module, 'settle_reserved_duration') as mock_record_duration:
                             with pytest.raises(WebSocketDisconnect) as exc_info:
                                 with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
                                     ws.send_bytes(b'\x00' * 500)
@@ -1598,7 +1601,7 @@ class TestTranscribeStreamWebSocket:
             mock_dg_socket.send.assert_called_once_with(b'\x00' * 500)
             mock_dg_socket.finalize.assert_called_once()
             mock_dg_socket.finish.assert_called_once()
-            mock_record_duration.assert_not_called()
+            mock_record_duration.assert_called_once_with('test-uid', 120000, 0)
         finally:
             _cleanup_chat_client(saved)
 
@@ -1654,7 +1657,7 @@ class TestTranscribeStreamWebSocket:
                 mock_dg_socket.finish = MagicMock()
                 return mock_dg_socket
 
-            with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+            with patch.object(module, 'try_reserve_session_budget', return_value=(True, 120000, 120000, 7080000)):
                 with patch.object(
                     module, 'get_stt_service_for_language', return_value=(module.STTService.parakeet, 'en', 'parakeet')
                 ):
@@ -1944,7 +1947,7 @@ class TestWsBudgetAndSessionCap:
         """WS should close with 1008 if daily budget is exhausted at connect."""
         client, module, saved = _make_chat_client()
         try:
-            with patch.object(module, 'check_budget', return_value=(False, 7200000, 0)):
+            with patch.object(module, 'try_reserve_session_budget', return_value=(False, 0, 7200000, 0)):
                 with pytest.raises(Exception):
                     with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
                         ws.receive_json()
@@ -1952,7 +1955,7 @@ class TestWsBudgetAndSessionCap:
             _cleanup_chat_client(saved)
 
     def test_ws_records_actual_duration_on_close(self):
-        """WS should call record_actual_duration with correct ms after session ends."""
+        """WS should settle the connect-time reservation to actual accepted ms."""
         client, module, saved = _make_chat_client()
         try:
             mock_dg_socket = MagicMock()
@@ -1965,23 +1968,20 @@ class TestWsBudgetAndSessionCap:
                 mock_dg_socket.finish = MagicMock()
                 return mock_dg_socket
 
-            with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+            with patch.object(module, 'try_reserve_session_budget', return_value=(True, 120000, 120000, 7080000)):
                 with patch.object(
                     module, 'get_stt_service_for_language', return_value=(module.STTService.parakeet, 'en', 'parakeet')
                 ):
                     with patch.object(module, 'process_audio_parakeet', side_effect=mock_process_audio_parakeet):
-                        with patch.object(module, 'record_actual_duration') as mock_record:
+                        with patch.object(module, 'settle_reserved_duration') as mock_record:
                             with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
                                 # Send 32000 bytes = 1s at 16kHz mono
                                 ws.send_bytes(b'\x00' * 32000)
                                 deadline = time.time() + 1.0
                                 while not mock_dg_socket.send.called and time.time() < deadline:
                                     time.sleep(0.01)
-                            # After WS close, finally block should have called record_actual_duration
-                            mock_record.assert_called_once()
-                            call_args = mock_record.call_args[0]
-                            assert call_args[0] == 'test-uid'
-                            assert call_args[1] == 1000  # 32000 / (16000*1*2) * 1000
+                            # After WS close, finally block should have settled the reservation
+                            mock_record.assert_called_once_with('test-uid', 120000, 1000)
         finally:
             _cleanup_chat_client(saved)
 
@@ -2048,14 +2048,14 @@ class TestWsIdleTimeout:
 
             # Set idle timeout very short for test
             with patch.object(module, '_WS_IDLE_TIMEOUT_S', 0.1):
-                with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+                with patch.object(module, 'try_reserve_session_budget', return_value=(True, 120000, 120000, 7080000)):
                     with patch.object(
                         module,
                         'get_stt_service_for_language',
                         return_value=(module.STTService.parakeet, 'en', 'parakeet'),
                     ):
                         with patch.object(module, 'process_audio_parakeet', side_effect=mock_process_audio_parakeet):
-                            with patch.object(module, 'record_actual_duration'):
+                            with patch.object(module, 'settle_reserved_duration'):
                                 with pytest.raises(Exception):
                                     with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
                                         # Don't send any audio — idle timeout should fire
@@ -2082,14 +2082,14 @@ class TestWsIdleTimeout:
 
             # Set idle timeout very short for test
             with patch.object(module, '_WS_IDLE_TIMEOUT_S', 0.2):
-                with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+                with patch.object(module, 'try_reserve_session_budget', return_value=(True, 120000, 120000, 7080000)):
                     with patch.object(
                         module,
                         'get_stt_service_for_language',
                         return_value=(module.STTService.parakeet, 'en', 'parakeet'),
                     ):
                         with patch.object(module, 'process_audio_parakeet', side_effect=mock_process_audio_parakeet):
-                            with patch.object(module, 'record_actual_duration'):
+                            with patch.object(module, 'settle_reserved_duration'):
                                 with pytest.raises(Exception):
                                     with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
                                         import time
@@ -2236,12 +2236,12 @@ class TestWsMidSessionBudgetEnforcement:
                 return mock_dg_socket
 
             # User has only 500ms of budget remaining
-            with patch.object(module, 'check_budget', return_value=(True, 7199500, 500)):
+            with patch.object(module, 'try_reserve_session_budget', return_value=(True, 500, 7200000, 0)):
                 with patch.object(
                     module, 'get_stt_service_for_language', return_value=(module.STTService.parakeet, 'en', 'parakeet')
                 ):
                     with patch.object(module, 'process_audio_parakeet', side_effect=mock_process_audio_parakeet):
-                        with patch.object(module, 'record_actual_duration') as mock_record:
+                        with patch.object(module, 'settle_reserved_duration') as mock_record:
                             with pytest.raises(Exception):
                                 with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
                                     # Send 32000 bytes = 1000ms at 16kHz mono — exceeds 500ms remaining
@@ -2250,9 +2250,8 @@ class TestWsMidSessionBudgetEnforcement:
 
                                     time.sleep(0.1)
                                     ws.receive_json()  # should fail — WS closed due to budget
-                            # The triggering frame is NOT counted (check happens before increment),
-                            # so record_actual_duration should NOT be called (0 bytes processed)
-                            mock_record.assert_not_called()
+                            # Triggering frame not accepted; settle refunds the full reservation.
+                            mock_record.assert_called_once_with('test-uid', 500, 0)
         finally:
             _cleanup_chat_client(saved)
 
@@ -2271,12 +2270,12 @@ class TestWsMidSessionBudgetEnforcement:
                 return mock_dg_socket
 
             # User has 60s of budget remaining
-            with patch.object(module, 'check_budget', return_value=(True, 7140000, 60000)):
+            with patch.object(module, 'try_reserve_session_budget', return_value=(True, 60000, 7200000, 0)):
                 with patch.object(
                     module, 'get_stt_service_for_language', return_value=(module.STTService.parakeet, 'en', 'parakeet')
                 ):
                     with patch.object(module, 'process_audio_parakeet', side_effect=mock_process_audio_parakeet):
-                        with patch.object(module, 'record_actual_duration'):
+                        with patch.object(module, 'settle_reserved_duration'):
                             with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
                                 # Send 32000 bytes = 1000ms at 16kHz mono — well within 60s remaining
                                 ws.send_bytes(b'\x00' * 32000)
@@ -2299,12 +2298,12 @@ class TestWsMidSessionBudgetEnforcement:
                 return mock_dg_socket
 
             # User has 1500ms of budget remaining
-            with patch.object(module, 'check_budget', return_value=(True, 7198500, 1500)):
+            with patch.object(module, 'try_reserve_session_budget', return_value=(True, 1500, 7200000, 0)):
                 with patch.object(
                     module, 'get_stt_service_for_language', return_value=(module.STTService.parakeet, 'en', 'parakeet')
                 ):
                     with patch.object(module, 'process_audio_parakeet', side_effect=mock_process_audio_parakeet):
-                        with patch.object(module, 'record_actual_duration') as mock_record:
+                        with patch.object(module, 'settle_reserved_duration') as mock_record:
                             with pytest.raises(Exception):
                                 with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
                                     # Frame 1: 32000 bytes = 1000ms — within 1500ms budget
@@ -2315,10 +2314,8 @@ class TestWsMidSessionBudgetEnforcement:
 
                                     time.sleep(0.1)
                                     ws.receive_json()
-                            # Only frame 1 was processed (1000ms), frame 2 was rejected
-                            mock_record.assert_called_once()
-                            call_args = mock_record.call_args[0]
-                            assert call_args[1] == 1000  # 32000 / (16000*1*2) * 1000
+                            # Frame 1 accepted (1000ms); settle reserved 1500 → actual 1000
+                            mock_record.assert_called_once_with('test-uid', 1500, 1000)
         finally:
             _cleanup_chat_client(saved)
 

--- a/backend/tests/unit/test_voice_duration_limiter.py
+++ b/backend/tests/unit/test_voice_duration_limiter.py
@@ -479,3 +479,65 @@ class TestConstants:
         from utils.voice_duration_limiter import DAILY_BUDGET_MS
 
         assert DAILY_BUDGET_MS == 7_200_000  # 2 hours
+
+
+# ===========================================================================
+# Concurrent WS admission (real Lua via fakeredis)
+# ===========================================================================
+
+
+class TestConcurrentSessionReservation:
+    """Prove probe+force overspend and that reserve-up-to prevents it."""
+
+    def _bind_lua(self):
+        import fakeredis
+        import utils.voice_duration_limiter as limiter
+
+        fake = fakeredis.FakeRedis(decode_responses=True)
+        script = fake.register_script(limiter._CONSUME_LUA_SRC)
+        return limiter, script
+
+    def test_legacy_probe_and_force_overspends_under_concurrency(self):
+        """Pre-fix failure class: two probe admits + two force-records past budget."""
+        limiter, script = self._bind_lua()
+        key = 'voice_duration:concurrent_probe'
+        now = 1_700_000_000.0
+        # Seed: 60s remaining
+        script(keys=[key], args=[now, 86400, limiter.DAILY_BUDGET_MS, limiter.DAILY_BUDGET_MS - 60_000, 1])
+
+        a = script(keys=[key], args=[now, 86400, limiter.DAILY_BUDGET_MS, 0, 0])
+        b = script(keys=[key], args=[now, 86400, limiter.DAILY_BUDGET_MS, 0, 0])
+        assert int(a[0]) == 1 and int(b[0]) == 1
+        assert int(a[2]) == 60_000 and int(b[2]) == 60_000
+
+        script(keys=[key], args=[now, 86400, limiter.DAILY_BUDGET_MS, 60_000, 1])
+        final = script(keys=[key], args=[now, 86400, limiter.DAILY_BUDGET_MS, 60_000, 1])
+        assert int(final[1]) == limiter.DAILY_BUDGET_MS + 60_000
+
+    def test_reserve_up_to_admits_only_remaining_under_concurrency(self):
+        """Two concurrent reserve-up-to calls cannot both take the same remaining slice."""
+        limiter, script = self._bind_lua()
+        key = 'voice_duration:concurrent_reserve'
+        now = 1_700_000_000.0
+        script(keys=[key], args=[now, 86400, limiter.DAILY_BUDGET_MS, limiter.DAILY_BUDGET_MS - 60_000, 1])
+
+        a = script(keys=[key], args=[now, 86400, limiter.DAILY_BUDGET_MS, 120_000, 2])
+        b = script(keys=[key], args=[now, 86400, limiter.DAILY_BUDGET_MS, 120_000, 2])
+        assert int(a[0]) == 1 and int(a[1]) == 60_000
+        assert int(b[0]) == 0 and int(b[1]) == 0
+        assert int(a[2]) == limiter.DAILY_BUDGET_MS
+
+    def test_settle_refunds_unused_reservation(self):
+        limiter, script = self._bind_lua()
+        with patch('utils.voice_duration_limiter._consume_lua', script):
+            with patch('utils.voice_duration_limiter._budget_key', return_value='voice_duration:settle'):
+                allowed, reserved, used, remaining = limiter.try_reserve_session_budget('settle', 120_000)
+                assert allowed is True
+                assert reserved == 120_000
+                assert used == 120_000
+                assert remaining == limiter.DAILY_BUDGET_MS - 120_000
+
+                assert limiter.settle_reserved_duration('settle', reserved, 1_000) is True
+                status = limiter.get_budget_status('settle')
+                assert status['used_ms'] == 1_000
+                assert status['remaining_ms'] == limiter.DAILY_BUDGET_MS - 1_000

--- a/backend/utils/voice_duration_limiter.py
+++ b/backend/utils/voice_duration_limiter.py
@@ -10,6 +10,9 @@ Design:
 - Atomic Lua script: prune stale entries → sum consumed → reject or record.
 - Fail-open on Redis errors (consistent with existing rate limiting).
 - Separate namespace from fair_use.py DG budget (different purpose/scope).
+- WebSocket PTT sessions atomically reserve up to MAX_SESSION_DURATION_S at
+  connect (force=2), then settle to actual duration at end (refund unused).
+  Probe-only admission + force-record at end is unsafe under concurrency.
 
 Constants:
 - MAX_SESSION_DURATION_S: 120 seconds per request/session.
@@ -38,8 +41,14 @@ _WINDOW_S = 86400  # 24 hours in seconds
 # ARGV[2] = window size (seconds)
 # ARGV[3] = budget limit (ms)
 # ARGV[4] = duration to consume (ms)
+# ARGV[5] = force mode:
+#   0 = consume-or-reject (REST)
+#   1 = force-record / settle delta (may be negative for refunds)
+#   2 = reserve-up-to (WS connect): consume min(request, remaining)
 #
-# Returns: [allowed (0/1), used_ms, remaining_ms]
+# Returns:
+#   force 0/1: [allowed (0/1), used_ms, remaining_ms]
+#   force 2:   [allowed (0/1), reserved_ms, used_ms, remaining_ms]
 #
 # The sorted set stores (score=timestamp, member=timestamp:random) with value
 # encoded in the member as "timestamp_ms:duration_ms".  We use the score for
@@ -51,7 +60,7 @@ local now       = tonumber(ARGV[1])
 local window    = tonumber(ARGV[2])
 local budget    = tonumber(ARGV[3])
 local request   = tonumber(ARGV[4])
-local force     = tonumber(ARGV[5] or 0)  -- 1 = force-record (skip budget check)
+local force     = tonumber(ARGV[5] or 0)
 
 -- 1. Prune entries older than the rolling window
 local cutoff = now - window
@@ -75,8 +84,26 @@ for _, member in ipairs(entries) do
     end
 end
 
+-- force=2: atomically reserve up to `request` ms from remaining budget.
+-- Returns 4-tuple so the caller knows how much was reserved.
+if force == 2 then
+    local remaining = math.max(0, budget - used)
+    if remaining <= 0 then
+        return {0, 0, used, 0}
+    end
+    local take = math.min(request, remaining)
+    if take > 0 then
+        local counter = redis.call('INCR', key .. ':seq')
+        local member = tostring(math.floor(now * 1000)) .. ':' .. tostring(take) .. ':' .. tostring(counter)
+        redis.call('ZADD', key, now, member)
+        redis.call('EXPIRE', key, window + 3600)
+        redis.call('EXPIRE', key .. ':seq', window + 3600)
+    end
+    return {1, take, used + take, math.max(0, budget - used - take)}
+end
+
 -- 3. Check budget (> so users can consume the full allowance)
--- Skip check when force=1 (post-session recording must always succeed)
+-- Skip check when force=1 (post-session recording / settle must always succeed)
 if force ~= 1 then
     if used + request > budget and request > 0 then
         return {0, used, math.max(0, budget - used)}
@@ -87,8 +114,9 @@ if force ~= 1 then
     end
 end
 
--- 4. Record consumption (skip if request is zero — probe-only call)
-if request > 0 then
+-- 4. Record consumption (skip if request is zero — probe-only call).
+-- force=1 may pass a negative request to refund unused WS reservation.
+if request ~= 0 then
     -- Use INCR counter as nonce to guarantee unique members even within
     -- the same millisecond (prevents ZADD overwrite under concurrency).
     local counter = redis.call('INCR', key .. ':seq')
@@ -154,17 +182,48 @@ def check_budget(uid: str) -> tuple[bool, int, int]:
     return try_consume_budget(uid, 0)
 
 
-def record_actual_duration(uid: str, duration_ms: int) -> bool:
-    """Record actual consumed duration (used by WebSocket on session end).
+def try_reserve_session_budget(uid: str, max_ms: int) -> tuple[bool, int, int, int]:
+    """Atomically reserve up to max_ms of remaining budget for a WS session.
 
-    For WebSocket sessions where the exact duration isn't known upfront,
-    call this after the session ends with the actual duration.
-    Uses force-record to always persist the usage even if over budget,
-    so the overspend is tracked for subsequent requests.
+    Unlike try_consume_budget (all-or-nothing), this consumes min(max_ms, remaining)
+    when any budget remains, so two concurrent PTT streams cannot both admit the
+    same remaining slice.
+
+    Returns:
+        (allowed, reserved_ms, used_ms, remaining_ms).
+        On Redis error: (True, 0, 0, DAILY_BUDGET_MS) — fail-open (no reservation).
+    """
+    if max_ms <= 0:
+        return False, 0, 0, 0
+
+    if _consume_lua is None:
+        return True, 0, 0, DAILY_BUDGET_MS
+
+    try:
+        result = _consume_lua(
+            keys=[_budget_key(uid)],
+            args=[time.time(), _WINDOW_S, DAILY_BUDGET_MS, max_ms, 2],  # force=2 reserve-up-to
+        )
+        allowed = bool(result[0])
+        reserved_ms = int(result[1])
+        used_ms = int(result[2])
+        remaining_ms = int(result[3])
+        return allowed, reserved_ms, used_ms, remaining_ms
+    except Exception as e:
+        logger.error(f'voice_duration_limiter: Redis error reserving budget for uid={uid}: {e}')
+        return True, 0, 0, DAILY_BUDGET_MS
+
+
+def record_actual_duration(uid: str, duration_ms: int) -> bool:
+    """Force-record a duration delta (positive charge or negative refund).
+
+    Used by settle_reserved_duration and by fail-open WS paths that never
+    reserved. force=1 always persists so overspend stays visible to later
+    requests; it is not a substitute for atomic admission.
 
     Returns True on success, False on error (but still fail-open).
     """
-    if duration_ms <= 0:
+    if duration_ms == 0:
         return True
 
     if _consume_lua is None:
@@ -179,6 +238,19 @@ def record_actual_duration(uid: str, duration_ms: int) -> bool:
     except Exception as e:
         logger.error(f'voice_duration_limiter: Redis error recording duration for uid={uid}: {e}')
         return True  # Fail-open
+
+
+def settle_reserved_duration(uid: str, reserved_ms: int, actual_ms: int) -> bool:
+    """Reconcile a WS reservation with the audio actually accepted by the provider.
+
+    Charges only the delta: refunds unused reservation (negative force-record)
+    or force-records a rare excess past the reserved cap.
+    """
+    if reserved_ms < 0:
+        reserved_ms = 0
+    if actual_ms < 0:
+        actual_ms = 0
+    return record_actual_duration(uid, actual_ms - reserved_ms)
 
 
 def get_budget_status(uid: str) -> Dict[str, Any]:


### PR DESCRIPTION
## What changed and why

Concurrent `/v2/voice-message/transcribe-stream` sessions probed the shared daily STT duration budget without reserving (`check_budget` = `try_consume_budget(uid, 0)`), froze that remaining slice mid-session, then `record_actual_duration(..., force=1)` at end. Two sessions near the limit could both admit the same remaining slice and overspend `#12720`.

Fix: atomically `try_reserve_session_budget` (Lua force=2 consume-up-to `MAX_SESSION_DURATION_S`) at connect, cap mid-session audio to the reservation, `settle_reserved_duration` after a successful drain, and refund the full reservation on terminal provider failure. Single-session force-record for tracking is unchanged on the fail-open path.

## Product invariants affected

none

## How it was verified

```bash
cd backend
echo 'tests/unit/test_voice_duration_limiter.py
tests/unit/test_desktop_transcribe.py' > /tmp/bug5-tests.txt
PYTHON=/path/to/backend/.venv/bin/python \
BACKEND_UNIT_TEST_FILE_LIST=/tmp/bug5-tests.txt BACKEND_PYTEST_FILE_ISOLATION=0 BACKEND_PYTEST_XDIST=0 \
  bash test.sh -q
# → 103 passed, 5 deselected
```

Pre-fix hermetic Lua (fakeredis): seed `DAILY_BUDGET_MS - 60_000`; two probes both see 60s remaining; two force-records → used `DAILY_BUDGET_MS + 60_000`. Reserve-up-to admits only the first concurrent session.

## Tests

- `test_legacy_probe_and_force_overspends_under_concurrency`
- `test_reserve_up_to_admits_only_remaining_under_concurrency`
- `test_settle_refunds_unused_reservation`
- Updated WS budget / no-charge-on-provider-failure settle assertions

## Failure class (fixes)

Failure-Class: new

## Line count

Line-Count-Exception: backend/routers/chat.py | 2130 -> 2159 | Atomic probe-only WS budget admit with reserve-at-connect + settle/refund in the PTT stream handler.

## Honest gaps

- No live multi-client Redis/provider soak (hermetic Lua + WS unit coverage only).
- Physical / on-device smoke not run (no kit).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

