### PR TITLE
fix(backend): unreadable WAV duration must not skip STT budget check (#12718)

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -92,6 +92,7 @@ from utils.observability.fallback import record_fallback
 from utils.journey_metrics_contract import resolve_client_kind, resolve_client_kind_from_headers
 from utils.observability.journeys import ClientJourneyAttempt, JourneyAttempt
 from utils.voice_duration_limiter import (
+    MAX_SESSION_DURATION_S,
     compute_pcm_duration_ms,
     read_wav_duration_ms,
     try_consume_budget,
@@ -875,12 +876,14 @@ def create_voice_message_stream(
         # Daily budget check (first file only — matches actual DG usage).
         # A quota rejection is not an STT attempt and therefore is not an
         # invalid-input or provider-outcome metric.
+        # An unreadable duration must not skip the budget check (STT still
+        # runs on it) — charge the worst case instead of charging nothing.
         first_wav = wav_paths[0]
         duration_ms = read_wav_duration_ms(first_wav)
-        if duration_ms is not None:
-            allowed, used_ms, remaining_ms = try_consume_budget(uid, duration_ms)
-            if not allowed:
-                raise HTTPException(status_code=429, detail='Daily transcription budget exhausted')
+        budget_duration_ms = duration_ms if duration_ms is not None else MAX_SESSION_DURATION_S * 1000
+        allowed, used_ms, remaining_ms = try_consume_budget(uid, budget_duration_ms)
+        if not allowed:
+            raise HTTPException(status_code=429, detail='Daily transcription budget exhausted')
     except TranscriptionFailure as failure:
         _record_preparation_failure(failure)
         _cleanup_temp_voice_wavs(paths + wav_paths, uid)
@@ -1178,15 +1181,15 @@ async def transcribe_voice_message(
 
         # Daily budget check (sum all files). This is not a provider outcome,
         # so do it before recording an accepted transcription attempt.
+        # An unreadable duration must not skip the budget check (STT still
+        # runs on it) — charge the worst case instead of charging nothing.
         total_duration_ms = 0
         for wav_path in wav_paths:
             duration_ms = await run_blocking(storage_executor, read_wav_duration_ms, wav_path)
-            if duration_ms is not None:
-                total_duration_ms += duration_ms
-        if total_duration_ms > 0:
-            allowed, used_ms, remaining_ms = try_consume_budget(uid, total_duration_ms)
-            if not allowed:
-                raise HTTPException(status_code=429, detail='Daily transcription budget exhausted')
+            total_duration_ms += duration_ms if duration_ms is not None else MAX_SESSION_DURATION_S * 1000
+        allowed, used_ms, remaining_ms = try_consume_budget(uid, total_duration_ms)
+        if not allowed:
+            raise HTTPException(status_code=429, detail='Daily transcription budget exhausted')
 
         is_multi = resolved_language == 'multi'
         attempt = TranscriptionAttempt(

--- a/backend/tests/unit/_chat_router_test_harness.py
+++ b/backend/tests/unit/_chat_router_test_harness.py
@@ -278,6 +278,7 @@ def wire_common_stubs(install) -> SimpleNamespace:
     usage_tracker.Features = Features
 
     limiter = install('utils.voice_duration_limiter', ModuleType('utils.voice_duration_limiter'))
+    limiter.MAX_SESSION_DURATION_S = 120
     limiter.compute_pcm_duration_ms = MagicMock(return_value=1000)
     limiter.read_wav_duration_ms = MagicMock(return_value=1000)
     limiter.try_consume_budget = MagicMock(return_value=(True, 1000, 7199000))

--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -857,6 +857,7 @@ def _stub_router_deps():
     pydub_stub.AudioSegment = MagicMock()
     sys.modules['pydub'] = pydub_stub
     limiter_stub = ModuleType('utils.voice_duration_limiter')
+    limiter_stub.MAX_SESSION_DURATION_S = 120
     limiter_stub.compute_pcm_duration_ms = lambda byte_count, sample_rate, channels: int(
         byte_count / (sample_rate * channels * 2) * 1000
     )
@@ -1936,6 +1937,31 @@ class TestVoiceMessagesEndpointBudget:
         finally:
             _cleanup_chat_client(saved)
 
+    def test_voice_messages_unreadable_wav_does_not_skip_budget_check(self):
+        """An unreadable WAV duration on /v2/voice-messages must still be
+        metered (charged the worst case) instead of transcribing for free."""
+        import io
+
+        client, module, saved = _make_chat_client()
+        try:
+            with patch.object(module, 'retrieve_file_paths', return_value=['/tmp/test_vm.wav']):
+                with patch.object(module, 'decode_files_to_wav', return_value=['/tmp/test_vm_decoded.wav']):
+                    with patch.object(module, 'read_wav_duration_ms', return_value=None):
+                        with patch.object(
+                            module, 'try_consume_budget', return_value=(False, 7200000, 0)
+                        ) as mock_budget:
+                            resp = client.post(
+                                '/v2/voice-messages',
+                                files=[('files', ('test.wav', io.BytesIO(b'\x00' * 100), 'audio/wav'))],
+                            )
+                            assert resp.status_code == 429
+                            assert 'budget exhausted' in resp.json()['detail']
+                            mock_budget.assert_called_once()
+                            call_args = mock_budget.call_args[0]
+                            assert call_args[1] == module.MAX_SESSION_DURATION_S * 1000
+        finally:
+            _cleanup_chat_client(saved)
+
 
 class TestWsBudgetAndSessionCap:
     """Test WS budget gate and actual duration recording."""
@@ -2184,16 +2210,22 @@ class TestMultipartBudgetAggregation:
     """Test that multipart multi-file uploads sum WAV durations correctly."""
 
     def test_multipart_multi_file_budget_sums_durations(self):
-        """Budget should be consumed with sum of all WAV durations."""
+        """Budget should be consumed with sum of all WAV durations, charging the
+        worst case (MAX_SESSION_DURATION_S) for any file whose duration is
+        unreadable — an unreadable file must not transcribe for free."""
         import io
 
         client, module, saved = _make_chat_client()
         try:
-            # Simulate 3 files: 1000ms, None (unreadable), 2000ms → budget call with 3000
+            # Simulate 3 files: 1000ms, None (unreadable), 2000ms →
+            # budget call with 1000 + MAX_SESSION_DURATION_S*1000 + 2000
             duration_values = iter([1000, None, 2000])
+            expected_total = 1000 + module.MAX_SESSION_DURATION_S * 1000 + 2000
 
             with patch.object(module, 'read_wav_duration_ms', side_effect=lambda p: next(duration_values)):
-                with patch.object(module, 'try_consume_budget', return_value=(True, 3000, 7197000)) as mock_budget:
+                with patch.object(
+                    module, 'try_consume_budget', return_value=(True, expected_total, 7200000 - expected_total)
+                ) as mock_budget:
                     with patch.object(module, 'transcribe_voice_message_segment', return_value=('hello', 'en')):
                         resp = client.post(
                             '/v2/voice-message/transcribe',
@@ -2204,11 +2236,31 @@ class TestMultipartBudgetAggregation:
                             ],
                         )
                         assert resp.status_code == 200
-                        # Budget consumed with sum: 1000 + 2000 = 3000 (None skipped)
                         mock_budget.assert_called_once()
                         call_args = mock_budget.call_args[0]
                         assert call_args[0] == 'test-uid'
-                        assert call_args[1] == 3000
+                        assert call_args[1] == expected_total
+        finally:
+            _cleanup_chat_client(saved)
+
+    def test_multipart_unreadable_wav_does_not_skip_budget_check(self):
+        """An unreadable WAV duration must still be metered and can trip the
+        429 budget-exhausted gate, instead of transcribing for free."""
+        import io
+
+        client, module, saved = _make_chat_client()
+        try:
+            with patch.object(module, 'read_wav_duration_ms', return_value=None):
+                with patch.object(module, 'try_consume_budget', return_value=(False, 7200000, 0)) as mock_budget:
+                    resp = client.post(
+                        '/v2/voice-message/transcribe',
+                        files=[('files', ('a.wav', io.BytesIO(b'\x00' * 100), 'audio/wav'))],
+                    )
+                    assert resp.status_code == 429
+                    assert 'budget exhausted' in resp.json()['detail']
+                    mock_budget.assert_called_once()
+                    call_args = mock_budget.call_args[0]
+                    assert call_args[1] == module.MAX_SESSION_DURATION_S * 1000
         finally:
             _cleanup_chat_client(saved)
 


### PR DESCRIPTION
## Bug

On the WAV/multipart voice STT routes, when `read_wav_duration_ms` returns `None` (unreadable/corrupt audio), the daily STT duration budget check was skipped entirely — but paid transcription still ran on that file. Free/under-metered STT spend, and a way to dodge the daily budget by uploading files that fail duration parsing.

- `/v2/voice-messages` (SSE, `backend/routers/chat.py:879`): only called `try_consume_budget` `if duration_ms is not None`.
- `/v2/voice-message/transcribe` (multipart, `backend/routers/chat.py:1183`): summed only the readable files' durations, and skipped `try_consume_budget` entirely if the sum was `0` (e.g. every file in the batch was unreadable).

The PCM REST path (`compute_pcm_duration_ms` → `try_consume_budget`, always run) never had this gap.

## Fix

When `read_wav_duration_ms` returns `None`, charge the worst case (`MAX_SESSION_DURATION_S` = 120s) against the budget instead of skipping the check, on both endpoints. This closes the free-transcription/budget-bypass gap while still letting legitimate short unreadable-duration files through unless the user is already near their daily limit.

## Tested

- Added `test_multipart_unreadable_wav_does_not_skip_budget_check` and `test_voice_messages_unreadable_wav_does_not_skip_budget_check`: assert the budget call fires with the `MAX_SESSION_DURATION_S * 1000` fallback when duration is unreadable, and that it can trip the 429 gate.
- Updated `test_multipart_multi_file_budget_sums_durations`, which previously asserted the old (buggy) skip-on-`None` behavior, to expect the worst-case charge for the unreadable file in the batch.
- `ENCRYPTION_SECRET=test .venv/bin/python -m pytest backend/tests/unit/test_desktop_transcribe.py backend/tests/unit/test_voice_duration_limiter.py -q` → 107 passed.
- Also ran the other 6 suites sharing `_chat_router_test_harness.py` (which needed the same `MAX_SESSION_DURATION_S` stub addition): 39 passed, no regressions.

Fixes #12718.

Line-Count-Exception: backend/routers/chat.py | 2130 -> 2133 | net +3 lines from the budget-check fallback (comment + one fewer nested `if`), not a size violation worth splitting the file over

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

