### PR TITLE
test: pin the reviewed daily-summary stats dump sites

### DIFF
--- a/backend/tests/unit/test_client_processing_trust_boundary.py
+++ b/backend/tests/unit/test_client_processing_trust_boundary.py
@@ -484,6 +484,11 @@ PINNED_CONVERSATION_DUMPS: FrozenSet[DumpSite] = frozenset(
         DumpSite('routers/developer.py', 'get_memories', 'model_dump'),
         DumpSite('routers/developer.py', '_create_conversation_from_segments', 'model_dump'),
         DumpSite('routers/developer.py', 'update_goal', 'model_dump'),
+        # DailySummaryDayStatsPayload aggregates (counts/minutes watched), not
+        # conversation content; transcripts reach the LLM via
+        # conversations_to_string. Reviewed with the daily-summary work (#12636).
+        DumpSite('utils/llm/external_integrations.py', '_basic_daily_summary', 'model_dump'),
+        DumpSite('utils/llm/external_integrations.py', 'generate_comprehensive_daily_summary', 'model_dump'),
         DumpSite(
             'utils/conversations/projection_payload.py',
             'client_processing_mutation',


### PR DESCRIPTION
## Summary
Main's trust-boundary pin (`test_pinned_conversation_dump_set_is_exact`) fails since #12636 landed: that PR's daily-summary work added two `DailySummaryDayStatsPayload.model_dump()` calls in `utils/llm/external_integrations.py` (`_basic_daily_summary`, `generate_comprehensive_daily_summary`) after #12661 froze the pin, and no main CI run of the gate has executed since (the pinned test only runs when scanned files change).

## Review (per the pin's contract)
Both new sites serialize `DailySummaryDayStatsPayload` — aggregate day statistics (conversation counts, minutes watched, action-item counts). No conversation content flows through these dumps; transcripts reach the summarizer via `conversations_to_string`, which predates this pin. Pinned as reviewed noise, exactly the mechanism the test documents.

## Verification
- `pytest backend/tests/unit/test_client_processing_trust_boundary.py` → 41 passed on this branch.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

