### PR TITLE
SCA: converge the free tier's terminal store on the §1.7 deterministic minimum (S3)

### DIFF
--- a/app/lib/backend/schema/gen/conversation_wire.g.dart
+++ b/app/lib/backend/schema/gen/conversation_wire.g.dart
@@ -705,6 +705,7 @@ class GeneratedConversation {
   final bool privateCloudSyncEnabled;
   final String? processingConversationId;
   final String? processingMemoryId;
+  final String? processingState;
   final bool screenshotSharingEnabled;
   final String? source;
   final bool starred;
@@ -749,6 +750,7 @@ class GeneratedConversation {
     this.privateCloudSyncEnabled = false,
     this.processingConversationId,
     this.processingMemoryId,
+    this.processingState,
     this.screenshotSharingEnabled = true,
     this.source = "omi",
     this.starred = false,
@@ -795,6 +797,7 @@ class GeneratedConversation {
       privateCloudSyncEnabled: _required(_readFieldValue<bool>(_readField(json, const ["private_cloud_sync_enabled"]), "private_cloud_sync_enabled", _readBool, requiredField: false, nullable: false, defaultValue: false), "private_cloud_sync_enabled"),
       processingConversationId: _readFieldValue<String>(_readField(json, const ["processing_conversation_id"]), "processing_conversation_id", _readString, requiredField: false, nullable: true),
       processingMemoryId: _readFieldValue<String>(_readField(json, const ["processing_memory_id"]), "processing_memory_id", _readString, requiredField: false, nullable: true),
+      processingState: _readFieldValue<String>(_readField(json, const ["processing_state"]), "processing_state", _readString, requiredField: false, nullable: true),
       screenshotSharingEnabled: _required(_readFieldValue<bool>(_readField(json, const ["screenshot_sharing_enabled"]), "screenshot_sharing_enabled", _readBool, requiredField: false, nullable: false, defaultValue: true), "screenshot_sharing_enabled"),
       source: _readFieldValue<String>(_readField(json, const ["source"]), "source", _readString, requiredField: false, nullable: true, defaultValue: "omi"),
       starred: _required(_readFieldValue<bool>(_readField(json, const ["starred"]), "starred", _readBool, requiredField: false, nullable: false, defaultValue: false), "starred"),
@@ -842,6 +845,7 @@ class GeneratedConversation {
       'private_cloud_sync_enabled': privateCloudSyncEnabled,
       'processing_conversation_id': processingConversationId,
       'processing_memory_id': processingMemoryId,
+      'processing_state': processingState,
       'screenshot_sharing_enabled': screenshotSharingEnabled,
       'source': source,
       'starred': starred,
@@ -1078,6 +1082,7 @@ class GeneratedConversationSearchItem {
   final bool privateCloudSyncEnabled;
   final String? processingConversationId;
   final String? processingMemoryId;
+  final String? processingState;
   final bool screenshotSharingEnabled;
   final String? source;
   final bool starred;
@@ -1123,6 +1128,7 @@ class GeneratedConversationSearchItem {
     this.privateCloudSyncEnabled = false,
     this.processingConversationId,
     this.processingMemoryId,
+    this.processingState,
     this.screenshotSharingEnabled = true,
     this.source = "omi",
     this.starred = false,
@@ -1170,6 +1176,7 @@ class GeneratedConversationSearchItem {
       privateCloudSyncEnabled: _required(_readFieldValue<bool>(_readField(json, const ["private_cloud_sync_enabled"]), "private_cloud_sync_enabled", _readBool, requiredField: false, nullable: false, defaultValue: false), "private_cloud_sync_enabled"),
       processingConversationId: _readFieldValue<String>(_readField(json, const ["processing_conversation_id"]), "processing_conversation_id", _readString, requiredField: false, nullable: true),
       processingMemoryId: _readFieldValue<String>(_readField(json, const ["processing_memory_id"]), "processing_memory_id", _readString, requiredField: false, nullable: true),
+      processingState: _readFieldValue<String>(_readField(json, const ["processing_state"]), "processing_state", _readString, requiredField: false, nullable: true),
       screenshotSharingEnabled: _required(_readFieldValue<bool>(_readField(json, const ["screenshot_sharing_enabled"]), "screenshot_sharing_enabled", _readBool, requiredField: false, nullable: false, defaultValue: true), "screenshot_sharing_enabled"),
       source: _readFieldValue<String>(_readField(json, const ["source"]), "source", _readString, requiredField: false, nullable: true, defaultValue: "omi"),
       starred: _required(_readFieldValue<bool>(_readField(json, const ["starred"]), "starred", _readBool, requiredField: false, nullable: false, defaultValue: false), "starred"),
@@ -1218,6 +1225,7 @@ class GeneratedConversationSearchItem {
       'private_cloud_sync_enabled': privateCloudSyncEnabled,
       'processing_conversation_id': processingConversationId,
       'processing_memory_id': processingMemoryId,
+      'processing_state': processingState,
       'screenshot_sharing_enabled': screenshotSharingEnabled,
       'source': source,
       'starred': starred,

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -11,6 +11,7 @@ from models.chat import Message
 from models.client_processing import ClientProcessing
 from models.conversation_enums import (
     CategoryEnum,
+    ConversationProcessingState,
     ConversationSource,
     ConversationStatus,
     ConversationVisibility,
@@ -304,6 +305,10 @@ class Conversation(BaseModel):
     # Untrusted client-authored display projection. Sibling of structured, never
     # inside it or external_data. Display only — never an input to intelligence.
     client_processing: Optional[ClientProcessing] = None
+    # Why `structured` holds the §1.7 deterministic minimum instead of an
+    # enriched summary. Server-authored; absent on every enriched conversation.
+    # Clients read `client_processing` first — see the enum's docstring.
+    processing_state: Optional[ConversationProcessingState] = None
     transcript_segments: List[TranscriptSegment] = []
     transcript_segments_compressed: Optional[bool] = False
     geolocation: Optional[Geolocation] = None

--- a/backend/models/conversation_enums.py
+++ b/backend/models/conversation_enums.py
@@ -98,3 +98,23 @@ class ExternalIntegrationConversationSource(str, Enum):
     audio = 'audio_transcript'
     message = 'message'
     other = 'other_text'
+
+
+class ConversationProcessingState(str, Enum):
+    """Why a conversation's ``structured`` holds the §1.7 deterministic minimum.
+
+    Absent (``None``) on every conversation the server enriched itself, and on a
+    conversation that already carries a ``client_processing`` projection.
+    Clients check ``client_processing`` FIRST: a projection that arrives after
+    the terminal persist is stamped by its own ingress mutation and does not
+    rewrite this field, so a projected conversation may still read
+    ``local_pending`` and must render the projection regardless.
+
+    - ``local_pending``: a capable client is expected to deliver a projection.
+      Render a spinner with a timeout, not a permanent empty state.
+    - ``none``: no projection is coming. Render "Summary unavailable on the
+      free plan".
+    """
+
+    local_pending = 'local_pending'
+    none = 'none'

--- a/backend/tests/unit/test_client_processing_acceptance.py
+++ b/backend/tests/unit/test_client_processing_acceptance.py
@@ -36,7 +36,7 @@ from models.client_processing import (
     ProjectionProvenance,
 )
 from models.conversation import Conversation, CreateConversation
-from models.conversation_enums import ConversationSource, ConversationStatus
+from models.conversation_enums import ConversationProcessingState, ConversationSource, ConversationStatus
 from models.structured import Structured
 from models.transcript_segment import TranscriptSegment
 from utils.conversations.projection_payload import PROVENANCE_LOG_MAX_CHARS
@@ -878,6 +878,76 @@ def test_store_deterministic_minimum_without_projection_omits_field(stack) -> No
     payload = _persisted_payload(created)
     assert 'client_processing' not in payload
     assert _nested(payload, 'structured', 'title') == _SEGMENT_TEXT
+
+
+# --- S3: §1.7 processing_state on the terminal persist ------------------------
+
+
+# red-proof: drop `conversation.processing_state = _minimum_processing_state(...)`
+def test_desktop_minimum_without_projection_is_local_pending(stack) -> None:
+    """A capable client is expected to deliver, so the client spins with a
+    timeout rather than showing a permanent empty state (§1.7 row 5)."""
+    pc, _dev = stack
+    created = pc.lifecycle_service.create_completed_conversation
+    created.reset_mock()
+    stored, persisted = pc._store_deterministic_minimum(_UID, _desktop_create(), _minimum_plan(pc))
+    assert persisted is True
+    assert stored.processing_state is ConversationProcessingState.local_pending
+    assert _persisted_payload(created)['processing_state'] == 'local_pending'
+
+
+# red-proof: return `local_pending` unconditionally from `_minimum_processing_state`
+def test_non_desktop_minimum_is_none_because_no_projection_is_coming(stack) -> None:
+    pc, _dev = stack
+    created = pc.lifecycle_service.create_completed_conversation
+    created.reset_mock()
+    create = _desktop_create()
+    create.source = ConversationSource.omi
+    stored, persisted = pc._store_deterministic_minimum(_UID, create, _minimum_plan(pc))
+    assert persisted is True
+    assert stored.processing_state is ConversationProcessingState.none
+    assert _persisted_payload(created)['processing_state'] == 'none'
+
+
+# red-proof: set a processing_state when a projection is already in hand
+def test_projected_conversation_carries_no_processing_state(stack) -> None:
+    """Nothing is pending: the projection IS the summary."""
+    pc, _dev = stack
+    created = pc.lifecycle_service.create_completed_conversation
+    created.reset_mock()
+    stored, persisted = pc._store_projected_conversation(
+        _UID, _desktop_create(), _projection_plan(pc), client_projection=_projection()
+    )
+    assert persisted is True
+    assert stored.processing_state is None
+    assert _persisted_payload(created)['processing_state'] is None
+
+
+# red-proof: revert `_store_deterministic_minimum` to `_build_deferred_structured`
+def test_minimum_structured_is_the_spec_row_not_the_deferred_placeholder(stack) -> None:
+    """§1.7: first *sentence*, empty overview, category `other`. The deferred
+    placeholder's first-8-words title is a different algorithm on a different
+    path and must not leak into the terminal store."""
+    pc, _dev = stack
+    created = pc.lifecycle_service.create_completed_conversation
+    created.reset_mock()
+    create = _desktop_create()
+    create.transcript_segments = [
+        TranscriptSegment(
+            text='One two three four five six seven eight nine ten. Second sentence.',
+            speaker='SPEAKER_00',
+            is_user=False,
+            start=0.0,
+            end=4.0,
+        )
+    ]
+    pc._store_deterministic_minimum(_UID, create, _minimum_plan(pc))
+    payload = _persisted_payload(created)
+    assert _nested(payload, 'structured', 'title') == 'One two three four five six seven eight nine ten.'
+    assert _nested(payload, 'structured', 'overview') == ''
+    assert _nested(payload, 'structured', 'category') == 'other'
+    assert _nested(payload, 'structured', 'action_items') == []
+    assert _nested(payload, 'structured', 'events') == []
 
 
 # red-proof: skip the after-process `client_processing_mutation` on non-idempotent ingest (paid persist strips and never stores)

--- a/backend/tests/unit/test_client_processing_trust_boundary.py
+++ b/backend/tests/unit/test_client_processing_trust_boundary.py
@@ -587,6 +587,10 @@ PINNED_CONVERSATION_FIELDS: FrozenSet[str] = frozenset(
         'uses_custom_stt',
         'structured',
         'client_processing',
+        # S3 (§1.7): server-authored, NOT projection-family. It says why
+        # `structured` is the deterministic minimum; it carries no client text,
+        # so the integration redactor must not strip it.
+        'processing_state',
         'transcript_segments',
         'transcript_segments_compressed',
         'geolocation',

--- a/backend/tests/unit/test_deterministic_minimum.py
+++ b/backend/tests/unit/test_deterministic_minimum.py
@@ -1,0 +1,227 @@
+"""S3: the §1.7 deterministic minimum, table-driven over the spec.
+
+Spec: ``10-backend-plumbing.md`` §1.7. Every row of that table is asserted here,
+including the empty-transcript fallback title and the rule that no managed call
+is reachable from this path.
+
+Automatic-or-dead: ``test_deterministic_minimum_module_reaches_no_managed_call``
+walks the module's real import closure. Route the minimum through anything that
+can reach ``get_llm`` and it goes red — the assertion is not a copy of the
+module's import list, it is the closure of the module as loaded.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+os.environ.setdefault('OPENAI_API_KEY', 'test-openai-key-not-real')
+
+from models.conversation_enums import CategoryEnum, ConversationProcessingState
+from utils.conversations.deterministic_minimum import (
+    TITLE_MAX_CHARS,
+    build_deterministic_minimum_structured,
+    deterministic_minimum_title,
+    fallback_title,
+    first_sentence,
+    truncate_on_word_boundary,
+)
+
+_BACKEND = Path(__file__).resolve().parents[2]
+_STARTED_AT = datetime(2026, 9, 4, 15, 14, 0, tzinfo=timezone.utc)
+
+
+def _conversation(*texts: str, started_at: datetime | None = _STARTED_AT) -> SimpleNamespace:
+    return SimpleNamespace(
+        transcript_segments=[SimpleNamespace(text=text) for text in texts],
+        started_at=started_at,
+    )
+
+
+# ---------------------------------------------------------------- title table
+
+
+_TITLE_CASES = [
+    # (id, segment texts, expected title)
+    ('first_sentence_wins', ('We shipped the fence today. Then we broke it.',), 'We shipped the fence today.'),
+    ('no_terminator_uses_whole_text', ('Standup with the backend crew',), 'Standup with the backend crew'),
+    ('question_terminates', ('Can we ship on Friday? Probably not.',), 'Can we ship on Friday?'),
+    ('exclamation_terminates', ('It works! Finally.',), 'It works!'),
+    (
+        'leading_blank_segment_skipped',
+        ('', '   ', 'Second segment carries the title.'),
+        'Second segment carries the title.',
+    ),
+    (
+        'segments_join_into_one_sentence',
+        ('The migration ran', 'and every shard came back green.'),
+        'The migration ran and every shard came back green.',
+    ),
+    ('internal_whitespace_collapses', ('Too    many\n\nspaces here.',), 'Too many spaces here.'),
+]
+
+
+@pytest.mark.parametrize(
+    'texts,expected',
+    [(case[1], case[2]) for case in _TITLE_CASES],
+    ids=[case[0] for case in _TITLE_CASES],
+)
+def test_title_follows_the_spec_table(texts, expected) -> None:
+    assert deterministic_minimum_title(_conversation(*texts)) == expected
+
+
+def test_long_sentence_truncates_on_a_word_boundary() -> None:
+    sentence = 'The quarterly planning review covering every workstream and its owners and their dates.'
+    title = deterministic_minimum_title(_conversation(sentence))
+    assert len(title) <= TITLE_MAX_CHARS
+    assert not title.endswith(' ')
+    # Cut between words, never mid-word: the truncated title is a word-aligned
+    # prefix of the sentence.
+    assert sentence.startswith(title)
+    assert sentence[len(title)] == ' '
+
+
+def test_single_token_longer_than_the_budget_is_hard_cut() -> None:
+    token = 'x' * (TITLE_MAX_CHARS + 20)
+    assert deterministic_minimum_title(_conversation(token)) == 'x' * TITLE_MAX_CHARS
+
+
+def test_truncate_helper_is_a_noop_under_the_budget() -> None:
+    assert truncate_on_word_boundary('short enough') == 'short enough'
+
+
+def test_first_sentence_of_empty_text_is_empty() -> None:
+    assert first_sentence('') == ''
+    assert first_sentence('   \n  ') == ''
+
+
+# ------------------------------------------------------------- fallback title
+
+
+def test_empty_transcript_falls_back_to_source_and_start_time() -> None:
+    title = deterministic_minimum_title(_conversation())
+    assert title == 'Recording · 3:14 PM'
+
+
+def test_fallback_uses_started_at_not_the_wall_clock() -> None:
+    early = _conversation(started_at=datetime(2026, 9, 4, 6, 5, tzinfo=timezone.utc))
+    assert deterministic_minimum_title(early) == 'Recording · 6:05 AM'
+
+
+def test_fallback_renders_in_the_users_zone_when_one_is_supplied() -> None:
+    title = deterministic_minimum_title(_conversation(), tz_name_provider=lambda: 'America/Los_Angeles')
+    assert title == 'Recording · 8:14 AM'
+
+
+def test_unknown_timezone_falls_back_to_utc_rather_than_raising() -> None:
+    title = deterministic_minimum_title(_conversation(), tz_name_provider=lambda: 'Not/AZone')
+    assert title == 'Recording · 3:14 PM'
+
+
+def test_timezone_is_not_resolved_when_the_transcript_has_text() -> None:
+    calls: list[int] = []
+
+    def provider() -> str:
+        calls.append(1)
+        return 'America/Los_Angeles'
+
+    assert deterministic_minimum_title(_conversation('Has a transcript.'), tz_name_provider=provider) == (
+        'Has a transcript.'
+    )
+    assert calls == []
+
+
+def test_naive_started_at_is_read_as_utc() -> None:
+    assert fallback_title(datetime(2026, 9, 4, 15, 14)) == 'Recording · 3:14 PM'
+
+
+def test_missing_started_at_still_yields_a_non_empty_title() -> None:
+    # An empty title is what `_get_conversation_obj` reads as "discarded".
+    assert deterministic_minimum_title(_conversation(started_at=None)) == 'Recording'
+
+
+def test_source_label_is_configurable() -> None:
+    assert fallback_title(_STARTED_AT, source_label='Meeting') == 'Meeting · 3:14 PM'
+    assert fallback_title(_STARTED_AT, source_label='   ') == 'Recording · 3:14 PM'
+
+
+def test_title_is_pure_over_repeated_calls() -> None:
+    conversation = _conversation()
+    assert deterministic_minimum_title(conversation) == deterministic_minimum_title(conversation)
+
+
+# ------------------------------------------------------------- the whole row
+
+
+def test_structured_matches_every_column_of_the_spec_table() -> None:
+    structured = build_deterministic_minimum_structured(_conversation('Kickoff for the free tier.'))
+    assert structured.title == 'Kickoff for the free tier.'
+    # NOT a fabricated summary and NOT a placeholder that looks like content.
+    assert structured.overview == ''
+    assert structured.category == CategoryEnum.other
+    assert structured.action_items == []
+    assert structured.events == []
+    assert structured.sections == []
+
+
+def test_structured_title_is_never_empty_for_an_empty_conversation() -> None:
+    assert build_deterministic_minimum_structured(_conversation()).title != ''
+
+
+# ------------------------------------------------------- processing_state vocab
+
+
+def test_processing_state_vocabulary_is_exactly_the_spec_pair() -> None:
+    assert {state.value for state in ConversationProcessingState} == {'local_pending', 'none'}
+
+
+# --------------------------------------------------- automatic-or-dead: no LLM
+
+
+def _module_import_closure(entry: Path) -> set[str]:
+    """Every first-party module reachable from ``entry`` by static import."""
+    seen: set[str] = set()
+    queue = [entry]
+    while queue:
+        path = queue.pop()
+        try:
+            tree = ast.parse(path.read_text(encoding='utf-8'))
+        except (OSError, SyntaxError):
+            continue
+        for node in ast.walk(tree):
+            names: list[str] = []
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+                names = [node.module]
+            for name in names:
+                if name in seen:
+                    continue
+                candidate = _BACKEND / (name.replace('.', '/') + '.py')
+                if not candidate.exists():
+                    continue
+                seen.add(name)
+                queue.append(candidate)
+    return seen
+
+
+def test_deterministic_minimum_module_reaches_no_managed_call() -> None:
+    entry = _BACKEND / 'utils' / 'conversations' / 'deterministic_minimum.py'
+    closure = _module_import_closure(entry)
+    # The minimum is the deny-fallback for `authorize_managed_compute`; if it
+    # could reach a model client it could not be the fallback.
+    forbidden = {'utils.llm.clients', 'utils.llms.clients', 'llm_gateway'}
+    reachable_llm = {module for module in closure if module in forbidden or module.startswith('llm_gateway')}
+    assert reachable_llm == set(), f'deterministic minimum reaches a model client: {sorted(reachable_llm)}'
+
+    # omi-test-quality: source-inspection -- static contract: the §1.7 minimum must be spendless by construction
+    sources = [entry] + [_BACKEND / (module.replace('.', '/') + '.py') for module in sorted(closure)]
+    for source in sources:
+        text = source.read_text(encoding='utf-8')
+        assert 'get_llm(' not in text, f'{source.relative_to(_BACKEND)} calls get_llm on the minimum path'

--- a/backend/utils/conversations/deterministic_minimum.py
+++ b/backend/utils/conversations/deterministic_minimum.py
@@ -1,0 +1,158 @@
+"""The §1.7 deterministic minimum — the exact no-LLM state a free conversation lands in.
+
+Spec: `omi-knowledge-base/projects/local-models-free-tier/implementation/`
+`10-backend-plumbing.md` §1.7. Referenced by W1/W2/W3/W4 and by the desktop
+client's own copy (`desktop/macos/Desktop/Sources/LocalInference/`
+`DeterministicConversationMinimum.swift`, S9) — keep the two algorithms in step.
+
+Everything here is pure: same input, same output, and the only clock read is
+``started_at``. Nothing in this module may import a model client, and the
+guardrail test asserts that. This is what makes the minimum usable as the
+deny-fallback for ``authorize_managed_compute``: it cannot itself spend.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from datetime import tzinfo
+from typing import Any, Callable, Iterable, List, Optional
+
+from models.conversation_enums import CategoryEnum
+from models.structured import Structured  # type: ignore[reportAttributeAccessIssue]  # SDK/fallback export is runtime-complete.
+
+# ~60 chars, cut on a word boundary. Long enough for a real first sentence,
+# short enough to stay one line in every conversation list we ship.
+TITLE_MAX_CHARS = 60
+
+# The schema requires a category and we refuse to infer one without a model.
+MINIMUM_CATEGORY = CategoryEnum.other
+
+DEFAULT_SOURCE_LABEL = 'Recording'
+
+_SENTENCE_TERMINATORS = frozenset('.!?')
+
+
+def transcript_text(conversation: Any) -> str:
+    """Flatten a conversation's transcript segments into one space-joined string.
+
+    Segment order is the transcript's own order. Blank segments are dropped so a
+    leading empty segment cannot swallow the title.
+    """
+    segments: Iterable[Any] = list(getattr(conversation, 'transcript_segments', None) or [])
+    parts: List[str] = []
+    for segment in segments:
+        text = (getattr(segment, 'text', '') or '').strip()
+        if text:
+            parts.append(text)
+    return ' '.join(parts)
+
+
+def first_sentence(text: str) -> str:
+    """The first sentence of ``text``: everything up to and including the first
+    ``.``/``!``/``?``, or the whole string when it has no terminator."""
+    collapsed = ' '.join((text or '').split())
+    if not collapsed:
+        return ''
+    for index, character in enumerate(collapsed):
+        if character in _SENTENCE_TERMINATORS:
+            return collapsed[: index + 1]
+    return collapsed
+
+
+def truncate_on_word_boundary(text: str, max_chars: int = TITLE_MAX_CHARS) -> str:
+    """Cut ``text`` to at most ``max_chars``, never mid-word when a boundary exists."""
+    if len(text) <= max_chars:
+        return text
+    head = text[:max_chars]
+    boundary = head.rfind(' ')
+    if boundary <= 0:
+        # One unbroken token longer than the budget: a hard cut is the only cut.
+        return head
+    return head[:boundary].rstrip()
+
+
+def fallback_title(
+    started_at: Optional[datetime],
+    *,
+    source_label: str = DEFAULT_SOURCE_LABEL,
+    tz_name: Optional[str] = None,
+) -> str:
+    """``"Recording · 3:14 PM"`` — the empty-transcript title.
+
+    ``started_at`` is the only clock. A naive datetime is read as UTC.
+    ``tz_name`` is the user's IANA zone when the caller has one; without it the
+    time is rendered in UTC, which is wrong for the user's wall clock but never
+    non-deterministic. Callers that can cheaply resolve the zone should.
+    """
+    label = (source_label or '').strip() or DEFAULT_SOURCE_LABEL
+    moment = started_at
+    if moment is None:
+        # No transcript and no start time: the label alone still satisfies the
+        # non-empty-title invariant `_get_conversation_obj` reads as "discarded".
+        return label
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    zone = _resolve_zone(tz_name)
+    if zone is not None:
+        moment = moment.astimezone(zone)
+    # %-I is a GNU/BSD extension; both CI and Cloud Run are POSIX. Strip the
+    # zero by hand so the format is portable rather than platform-lucky.
+    rendered = moment.strftime('%I:%M %p').lstrip('0')
+    return f'{label} · {rendered}'
+
+
+def _resolve_zone(tz_name: Optional[str]) -> Optional[tzinfo]:
+    if not tz_name:
+        return None
+    try:
+        from zoneinfo import ZoneInfo
+
+        return ZoneInfo(tz_name)
+    except Exception:
+        # An unknown or malformed zone falls back to UTC rather than raising:
+        # this path is the fail-closed store and must not be able to throw.
+        return None
+
+
+def deterministic_minimum_title(
+    conversation: Any,
+    *,
+    source_label: str = DEFAULT_SOURCE_LABEL,
+    tz_name_provider: Optional[Callable[[], Optional[str]]] = None,
+) -> str:
+    """§1.7's title. Never empty — an empty title marks a conversation discarded.
+
+    ``tz_name_provider`` is called at most once, and only when the transcript is
+    empty, so the common path costs no lookup.
+    """
+    sentence = first_sentence(transcript_text(conversation))
+    if sentence:
+        return truncate_on_word_boundary(sentence)
+    tz_name = tz_name_provider() if tz_name_provider is not None else None
+    return fallback_title(
+        getattr(conversation, 'started_at', None),
+        source_label=source_label,
+        tz_name=tz_name,
+    )
+
+
+def build_deterministic_minimum_structured(
+    conversation: Any,
+    *,
+    source_label: str = DEFAULT_SOURCE_LABEL,
+    tz_name_provider: Optional[Callable[[], Optional[str]]] = None,
+) -> Structured:
+    """The whole §1.7 row: deterministic title, empty overview, category ``other``,
+    no action items, no events. Every other field keeps its model default."""
+    return Structured(
+        title=deterministic_minimum_title(
+            conversation,
+            source_label=source_label,
+            tz_name_provider=tz_name_provider,
+        ),
+        overview='',
+        category=MINIMUM_CATEGORY,
+        sections=[],
+        action_items=[],
+        events=[],
+    )

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -57,7 +57,13 @@ from models.conversation import (
     CreateConversation,
     ExternalIntegrationCreateConversation,
 )
-from models.conversation_enums import ConversationSource, ConversationStatus, ExternalIntegrationConversationSource
+from models.conversation_enums import (
+    ConversationProcessingState,
+    ConversationSource,
+    ConversationStatus,
+    ExternalIntegrationConversationSource,
+)
+from utils.conversations.deterministic_minimum import build_deterministic_minimum_structured
 from utils.conversations.factory import deserialize_conversation
 from utils.conversations.projection_payload import (
     client_processing_mutation,
@@ -85,6 +91,7 @@ from utils.subscription import is_trial_paywalled, should_defer_desktop_processi
 from utils.free_tier_processing_policy import (
     FreeTierProcessingPlan,
     free_tier_local_processing_enabled,
+    minimum_processing_state,
     resolve_free_tier_processing_plan,
 )
 from utils.managed_compute import Decision, authorize_managed_compute, request_carries_validated_byok_key
@@ -2050,7 +2057,15 @@ def _store_deterministic_minimum(
 ) -> Tuple[Conversation, bool]:
     """Persist a conversation at the no-LLM deterministic minimum, terminally.
 
-    Reuses ``_build_deferred_structured`` but does not set ``deferred=True`` or
+    ``structured`` is §1.7's deterministic minimum
+    (``build_deterministic_minimum_structured``): a title derived from the
+    transcript's first sentence with no model in the path, an empty overview,
+    category ``other``, and no action items or events. It is NOT
+    ``_build_deferred_structured`` — that one is the JIT first-open placeholder
+    and stays on the deferred path, where a later luna enrichment overwrites it.
+    Here nothing overwrites it, so the values have to be the spec's.
+
+    This does not set ``deferred=True`` or
     ``status=processing`` — those are the first-open reprocess markers
     ``get_conversation_by_id`` reads. This path emits no managed call, no JIT
     obligation, no memory extraction, no app fan-out, and no folder assignment.
@@ -2069,10 +2084,17 @@ def _store_deterministic_minimum(
     ingest site, not through this persist.
     """
     is_initial_creation = _is_ingress_create(conversation)
-    structured = _build_deferred_structured(conversation)
+    structured = build_deterministic_minimum_structured(
+        conversation,
+        tz_name_provider=lambda: notification_db.get_user_time_zone(uid),
+    )
     conversation = _get_conversation_obj(uid, structured, conversation)
     conversation.deferred = False
     conversation.status = ConversationStatus.completed
+    minimum_state = minimum_processing_state(
+        getattr(conversation, 'source', None), has_projection=client_projection is not None
+    )
+    conversation.processing_state = ConversationProcessingState(minimum_state) if minimum_state else None
     _attach_client_projection(conversation, client_projection)
     payload = _terminal_persist_payload(conversation)
     if is_initial_creation and client_projection is not None:

--- a/backend/utils/free_tier_processing_policy.py
+++ b/backend/utils/free_tier_processing_policy.py
@@ -23,7 +23,7 @@ import logging
 import os
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 from utils.managed_compute import DECISION_REASONS, Decision
 
@@ -168,10 +168,51 @@ def _resolve(
     )
 
 
-def _is_desktop_source(source: str | None) -> bool:
+def is_desktop_source(source: str | None) -> bool:
+    """True for the one source that can carry a client projection today.
+
+    S3 reads this to decide whether the §1.7 minimum is ``local_pending`` (a
+    capable client is expected to deliver) or ``none`` (nothing is coming), so
+    the two answers cannot drift from the policy's own source test.
+    """
     if source is None:
         return False
     return str(source).strip().lower() == DESKTOP_SOURCE
+
+
+# Historic private name; kept so the policy's own call sites read unchanged.
+_is_desktop_source = is_desktop_source
+
+
+def minimum_processing_state(source: Any, *, has_projection: bool) -> str | None:
+    """Why a conversation's ``structured`` is the §1.7 deterministic minimum.
+
+    Returns ``ConversationProcessingState``'s raw values (the model coerces) so
+    this module keeps importing nothing but the policy's own vocabulary.
+
+    Takes projection *presence* as a bool, never the projection itself: the
+    answer depends only on whether one exists, so this stays outside the
+    display-only trust boundary and the pinned reference set does not have to
+    grow to admit it.
+
+    A projection already in hand means nothing is pending, so the field stays
+    absent. Otherwise the answer is whether a capable client is expected to
+    deliver one, which today is exactly the desktop source — read through this
+    module's own source test so the two cannot drift.
+
+    This is not re-derived when a projection arrives later: the existing-row
+    stamp writes ``client_processing`` alone (its single-key payload is pinned
+    by the trust-boundary test), so a projected conversation can still read
+    ``local_pending``. Clients resolve that by checking ``client_processing``
+    first; ``ConversationProcessingState``'s docstring is the contract.
+    """
+    if has_projection:
+        return None
+    # ``source`` arrives as either the raw string or a ``ConversationSource``;
+    # unwrap here so ``str(enum)`` never becomes the literal
+    # ``'conversationsource.desktop'`` and silently answer ``none``.
+    raw_source = getattr(source, 'value', source)
+    return 'local_pending' if is_desktop_source(raw_source) else 'none'
 
 
 __all__ = [
@@ -182,5 +223,7 @@ __all__ = [
     'FreeTierProcessingPlan',
     'ProcessingMode',
     'free_tier_local_processing_enabled',
+    'is_desktop_source',
+    'minimum_processing_state',
     'resolve_free_tier_processing_plan',
 ]

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -1428,6 +1428,7 @@ public enum OmiAPI {
     public let privateCloudSyncEnabled: Bool?
     public let processingConversationId: String?
     public let processingMemoryId: String?
+    public let processingState: ConversationProcessingState?
     public let screenshotSharingEnabled: Bool?
     public let source: ConversationSource?
     public let starred: Bool?
@@ -1472,6 +1473,7 @@ public enum OmiAPI {
       case privateCloudSyncEnabled = "private_cloud_sync_enabled"
       case processingConversationId = "processing_conversation_id"
       case processingMemoryId = "processing_memory_id"
+      case processingState = "processing_state"
       case screenshotSharingEnabled = "screenshot_sharing_enabled"
       case source
       case starred
@@ -1518,6 +1520,7 @@ public enum OmiAPI {
       privateCloudSyncEnabled = try c.decodeIfPresent(Bool.self, forKey: .privateCloudSyncEnabled)
       processingConversationId = try c.decodeIfPresent(String.self, forKey: .processingConversationId)
       processingMemoryId = try c.decodeIfPresent(String.self, forKey: .processingMemoryId)
+      processingState = try c.decodeIfPresent(ConversationProcessingState.self, forKey: .processingState)
       screenshotSharingEnabled = try c.decodeIfPresent(Bool.self, forKey: .screenshotSharingEnabled)
       source = try c.decodeIfPresent(ConversationSource.self, forKey: .source)
       starred = try c.decodeIfPresent(Bool.self, forKey: .starred)
@@ -1532,7 +1535,7 @@ public enum OmiAPI {
       visibility = try c.decodeIfPresent(ConversationVisibility.self, forKey: .visibility)
     }
 
-    public init(appId: String? = nil, appsResults: [AppResult]? = nil, audioFiles: [AudioFile]? = nil, calendarEvent: CalendarEventLink? = nil, callId: String? = nil, clientDeviceId: String? = nil, clientPlatform: String? = nil, clientProcessing: ClientProcessing? = nil, conversationAudio: ConversationAudio? = nil, createdAt: String, dataProtectionLevel: String? = nil, deferred: Bool? = nil, discarded: Bool? = nil, externalData: [String: OmiAnyCodable]? = nil, finishedAt: String? = nil, folderId: String? = nil, geolocation: Geolocation? = nil, id: String, imported: Bool? = nil, isLocked: Bool? = nil, language: String? = nil, meetingDedupSpeechS: Double? = nil, meetingDurationS: Double? = nil, meetingTreatmentEligible: Bool? = nil, meetingTreatmentReason: String? = nil, photos: [ConversationPhoto]? = nil, pluginsResults: [PluginResult]? = nil, privateCloudSyncEnabled: Bool? = nil, processingConversationId: String? = nil, processingMemoryId: String? = nil, screenshotSharingEnabled: Bool? = nil, source: ConversationSource? = nil, starred: Bool? = nil, startedAt: String? = nil, status: ConversationStatus? = nil, structured: Structured, suggestedSummarizationApps: [String]? = nil, transcriptSegments: [TranscriptSegment]? = nil, transcriptSegmentsCompressed: Bool? = nil, updatedAt: String? = nil, usesCustomStt: Bool? = nil, visibility: ConversationVisibility? = nil) {
+    public init(appId: String? = nil, appsResults: [AppResult]? = nil, audioFiles: [AudioFile]? = nil, calendarEvent: CalendarEventLink? = nil, callId: String? = nil, clientDeviceId: String? = nil, clientPlatform: String? = nil, clientProcessing: ClientProcessing? = nil, conversationAudio: ConversationAudio? = nil, createdAt: String, dataProtectionLevel: String? = nil, deferred: Bool? = nil, discarded: Bool? = nil, externalData: [String: OmiAnyCodable]? = nil, finishedAt: String? = nil, folderId: String? = nil, geolocation: Geolocation? = nil, id: String, imported: Bool? = nil, isLocked: Bool? = nil, language: String? = nil, meetingDedupSpeechS: Double? = nil, meetingDurationS: Double? = nil, meetingTreatmentEligible: Bool? = nil, meetingTreatmentReason: String? = nil, photos: [ConversationPhoto]? = nil, pluginsResults: [PluginResult]? = nil, privateCloudSyncEnabled: Bool? = nil, processingConversationId: String? = nil, processingMemoryId: String? = nil, processingState: ConversationProcessingState? = nil, screenshotSharingEnabled: Bool? = nil, source: ConversationSource? = nil, starred: Bool? = nil, startedAt: String? = nil, status: ConversationStatus? = nil, structured: Structured, suggestedSummarizationApps: [String]? = nil, transcriptSegments: [TranscriptSegment]? = nil, transcriptSegmentsCompressed: Bool? = nil, updatedAt: String? = nil, usesCustomStt: Bool? = nil, visibility: ConversationVisibility? = nil) {
       self.appId = appId
       self.appsResults = appsResults
       self.audioFiles = audioFiles
@@ -1563,6 +1566,7 @@ public enum OmiAPI {
       self.privateCloudSyncEnabled = privateCloudSyncEnabled
       self.processingConversationId = processingConversationId
       self.processingMemoryId = processingMemoryId
+      self.processingState = processingState
       self.screenshotSharingEnabled = screenshotSharingEnabled
       self.source = source
       self.starred = starred
@@ -1689,6 +1693,18 @@ public enum OmiAPI {
       self.discarded = discarded
       self.id = id
       self.storageId = storageId
+    }
+  }
+
+
+  public enum ConversationProcessingState: String, Codable, CaseIterable {
+    case local_pending
+    case none_ = "none"
+    case _unknown = "__unknown__"
+    public init(from decoder: Decoder) throws {
+      let c = try decoder.singleValueContainer()
+      let raw = try c.decode(String.self)
+      self = ConversationProcessingState(rawValue: raw) ?? ._unknown
     }
   }
 

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -1145,6 +1145,7 @@ export interface Conversation {
   private_cloud_sync_enabled?: boolean;
   processing_conversation_id?: string | null;
   processing_memory_id?: string | null;
+  processing_state?: ConversationProcessingState | null;
   screenshot_sharing_enabled?: boolean;
   source?: ConversationSource | null;
   starred?: boolean;
@@ -1263,6 +1264,8 @@ export interface ConversationPhoto {
   storage_id?: string | null;
 }
 
+export type ConversationProcessingState = "local_pending" | "none";
+
 export interface ConversationRecordingResponse {
   has_recording: boolean;
 }
@@ -1323,6 +1326,7 @@ export interface ConversationSearchItem {
   private_cloud_sync_enabled?: boolean;
   processing_conversation_id?: string | null;
   processing_memory_id?: string | null;
+  processing_state?: ConversationProcessingState | null;
   screenshot_sharing_enabled?: boolean;
   source?: ConversationSource | null;
   starred?: boolean;
@@ -4991,6 +4995,7 @@ export interface OmiApiSchemas {
   "ConversationLinkSpec": ConversationLinkSpec;
   "ConversationMutationResponse": ConversationMutationResponse;
   "ConversationPhoto": ConversationPhoto;
+  "ConversationProcessingState": ConversationProcessingState;
   "ConversationRecordingResponse": ConversationRecordingResponse;
   "ConversationScreenFrame": ConversationScreenFrame;
   "ConversationScreenFrameSet": ConversationScreenFrameSet;

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -7355,6 +7355,16 @@
             ],
             "title": "Processing Memory Id"
           },
+          "processing_state": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ConversationProcessingState"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "screenshot_sharing_enabled": {
             "default": true,
             "title": "Screenshot Sharing Enabled",
@@ -7995,6 +8005,15 @@
         "title": "ConversationPhoto",
         "type": "object"
       },
+      "ConversationProcessingState": {
+        "description": "Why a conversation's ``structured`` holds the §1.7 deterministic minimum.\n\nAbsent (``None``) on every conversation the server enriched itself, and on a\nconversation that already carries a ``client_processing`` projection.\nClients check ``client_processing`` FIRST: a projection that arrives after\nthe terminal persist is stamped by its own ingress mutation and does not\nrewrite this field, so a projected conversation may still read\n``local_pending`` and must render the projection regardless.\n\n- ``local_pending``: a capable client is expected to deliver a projection.\n  Render a spinner with a timeout, not a permanent empty state.\n- ``none``: no projection is coming. Render \"Summary unavailable on the\n  free plan\".",
+        "enum": [
+          "local_pending",
+          "none"
+        ],
+        "title": "ConversationProcessingState",
+        "type": "string"
+      },
       "ConversationRecordingResponse": {
         "properties": {
           "has_recording": {
@@ -8438,6 +8457,16 @@
               }
             ],
             "title": "Processing Memory Id"
+          },
+          "processing_state": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ConversationProcessingState"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "screenshot_sharing_enabled": {
             "default": true,

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -1145,6 +1145,7 @@ export interface Conversation {
   private_cloud_sync_enabled?: boolean;
   processing_conversation_id?: string | null;
   processing_memory_id?: string | null;
+  processing_state?: ConversationProcessingState | null;
   screenshot_sharing_enabled?: boolean;
   source?: ConversationSource | null;
   starred?: boolean;
@@ -1263,6 +1264,8 @@ export interface ConversationPhoto {
   storage_id?: string | null;
 }
 
+export type ConversationProcessingState = "local_pending" | "none";
+
 export interface ConversationRecordingResponse {
   has_recording: boolean;
 }
@@ -1323,6 +1326,7 @@ export interface ConversationSearchItem {
   private_cloud_sync_enabled?: boolean;
   processing_conversation_id?: string | null;
   processing_memory_id?: string | null;
+  processing_state?: ConversationProcessingState | null;
   screenshot_sharing_enabled?: boolean;
   source?: ConversationSource | null;
   starred?: boolean;
@@ -4991,6 +4995,7 @@ export interface OmiApiSchemas {
   "ConversationLinkSpec": ConversationLinkSpec;
   "ConversationMutationResponse": ConversationMutationResponse;
   "ConversationPhoto": ConversationPhoto;
+  "ConversationProcessingState": ConversationProcessingState;
   "ConversationRecordingResponse": ConversationRecordingResponse;
   "ConversationScreenFrame": ConversationScreenFrame;
   "ConversationScreenFrameSet": ConversationScreenFrameSet;

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -1145,6 +1145,7 @@ export interface Conversation {
   private_cloud_sync_enabled?: boolean;
   processing_conversation_id?: string | null;
   processing_memory_id?: string | null;
+  processing_state?: ConversationProcessingState | null;
   screenshot_sharing_enabled?: boolean;
   source?: ConversationSource | null;
   starred?: boolean;
@@ -1263,6 +1264,8 @@ export interface ConversationPhoto {
   storage_id?: string | null;
 }
 
+export type ConversationProcessingState = "local_pending" | "none";
+
 export interface ConversationRecordingResponse {
   has_recording: boolean;
 }
@@ -1323,6 +1326,7 @@ export interface ConversationSearchItem {
   private_cloud_sync_enabled?: boolean;
   processing_conversation_id?: string | null;
   processing_memory_id?: string | null;
+  processing_state?: ConversationProcessingState | null;
   screenshot_sharing_enabled?: boolean;
   source?: ConversationSource | null;
   starred?: boolean;
@@ -4991,6 +4995,7 @@ export interface OmiApiSchemas {
   "ConversationLinkSpec": ConversationLinkSpec;
   "ConversationMutationResponse": ConversationMutationResponse;
   "ConversationPhoto": ConversationPhoto;
+  "ConversationProcessingState": ConversationProcessingState;
   "ConversationRecordingResponse": ConversationRecordingResponse;
   "ConversationScreenFrame": ConversationScreenFrame;
   "ConversationScreenFrameSet": ConversationScreenFrameSet;

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -1145,6 +1145,7 @@ export interface Conversation {
   private_cloud_sync_enabled?: boolean;
   processing_conversation_id?: string | null;
   processing_memory_id?: string | null;
+  processing_state?: ConversationProcessingState | null;
   screenshot_sharing_enabled?: boolean;
   source?: ConversationSource | null;
   starred?: boolean;
@@ -1263,6 +1264,8 @@ export interface ConversationPhoto {
   storage_id?: string | null;
 }
 
+export type ConversationProcessingState = "local_pending" | "none";
+
 export interface ConversationRecordingResponse {
   has_recording: boolean;
 }
@@ -1323,6 +1326,7 @@ export interface ConversationSearchItem {
   private_cloud_sync_enabled?: boolean;
   processing_conversation_id?: string | null;
   processing_memory_id?: string | null;
+  processing_state?: ConversationProcessingState | null;
   screenshot_sharing_enabled?: boolean;
   source?: ConversationSource | null;
   starred?: boolean;
@@ -4991,6 +4995,7 @@ export interface OmiApiSchemas {
   "ConversationLinkSpec": ConversationLinkSpec;
   "ConversationMutationResponse": ConversationMutationResponse;
   "ConversationPhoto": ConversationPhoto;
+  "ConversationProcessingState": ConversationProcessingState;
   "ConversationRecordingResponse": ConversationRecordingResponse;
   "ConversationScreenFrame": ConversationScreenFrame;
   "ConversationScreenFrameSet": ConversationScreenFrameSet;


### PR DESCRIPTION
## S3 — converge the terminal store on the §1.7 deterministic minimum

Shard S3 of the ratified local-models free-tier program (`60-shards.md` row S3;
spec `10-backend-plumbing.md` §1.7). Branched from `main` after S4 and S7.

S6 already made the free-tier store *terminal and spendless*. What it did not do
is make the stored values §1.7's. It reused `_build_deferred_structured`, whose
title is the first eight words of the first non-empty segment with a bare
`'Recording'` when the transcript is empty — an algorithm written for the JIT
deferred path, where a later luna enrichment overwrites it. On the free path
nothing overwrites it, so those values are what the user keeps. This PR makes
them the spec's.

### What changed

- **`backend/utils/conversations/deterministic_minimum.py` (new)** — §1.7 as a
  pure module. Title = the transcript's first sentence (through the first
  `.`/`!`/`?`) truncated to 60 chars on a word boundary; empty transcript falls
  back to `"Recording · 3:14 PM"` derived from `started_at`. The other columns —
  overview `''`, category `other`, no action items, no events, no sections —
  already held by accident, because `_build_deferred_structured` returned a
  `Structured` with nothing but a title and let the model defaults stand. They
  are now **stated and tested** rather than inherited, so a change to a default
  cannot silently give a free conversation a fabricated overview or an inferred
  category. The behavioural change in this PR is the title and
  `processing_state`; the rest is pinning what was already true.

  Same input, same output; `started_at` is the only clock. The timezone is resolved through a
  provider callable that is invoked **only** on the empty-transcript branch, so
  the common path costs no lookup, and an unknown zone degrades to UTC rather
  than raising — this path is the fail-closed store and must not be able to
  throw.
- **`backend/models/conversation_enums.py`** — `ConversationProcessingState`
  (`local_pending` | `none`), §1.7 row 5. Absent on every conversation the
  server enriched itself and on every conversation that already carries a
  projection.
- **`backend/models/conversation.py`** — `Conversation.processing_state`.
- **`backend/utils/conversations/process_conversation.py`** —
  `_store_deterministic_minimum` builds §1.7's `Structured` and stamps
  `processing_state`. `_store_deferred_conversation` is untouched: the JIT
  placeholder keeps its own algorithm on its own path.
- **`backend/utils/free_tier_processing_policy.py`** — `_is_desktop_source`
  promoted to public `is_desktop_source` (private alias kept) so S3's
  "is a projection coming?" answer reads the policy's own source test instead
  of a second copy of it.
- Regenerated wire types and the app-client OpenAPI surface. Additive only —
  the Swift client's `// Total: N methods` footer does not move.

### Automatic-or-dead check

`tests/unit/test_deterministic_minimum.py::test_deterministic_minimum_module_reaches_no_managed_call`
walks the module's **real static import closure** from the file on disk and
asserts nothing in it reaches a model client or contains `get_llm(`. It is not a
copy of the import list — route the minimum through anything that can spend and
it goes red. That is what lets the minimum be the deny-fallback for
`authorize_managed_compute`: it cannot itself spend.

Paired with `test_minimum_structured_is_the_spec_row_not_the_deferred_placeholder`,
whose red-proof is reverting `_store_deterministic_minimum` to
`_build_deferred_structured`.

### Proof

- `tests/unit/test_deterministic_minimum.py` — **24 passed**. Table-driven over
  §1.7: sentence termination by `.`/`!`/`?`, no-terminator whole-text, blank
  leading segments, multi-segment join, whitespace collapse, word-boundary
  truncation, single-token hard cut, empty-transcript fallback, `started_at`
  (not the wall clock) as the only time source, user-zone rendering, unknown
  zone → UTC, no timezone lookup when the transcript has text, naive datetime
  read as UTC, missing `started_at` still yielding a non-empty title (an empty
  title is what `_get_conversation_obj` reads as *discarded*).
- `tests/unit/test_client_processing_acceptance.py` — **26 passed**, including
  four new coordinator-level assertions with red-proofs in comments:
  desktop-without-projection ⇒ `local_pending`; non-desktop ⇒ `none`;
  projection in hand ⇒ field absent; stored `structured` is §1.7's row and not
  the deferred placeholder's first-eight-words title.
- Generators re-run and `--check` clean: Dart, TS, Swift, app-client OpenAPI.
- `pyright` on every touched backend module: 0 errors.

### A consequence worth stating plainly

`client_processing_mutation` writes exactly one key, and that single-key payload
is pinned by the trust-boundary test. So when a projection arrives **after** the
terminal persist (the normal case — local inference finishes after upload), it
does not clear `processing_state`, and a projected conversation can still read
`local_pending`. That is deliberate rather than overlooked: clients check
`client_processing` first and render the projection regardless. The contract is
written into the enum's docstring and into `_minimum_processing_state`. The
alternative — a second mutation that writes both fields — would widen the
ingress-owned payload that S4 deliberately pinned to one key.

### Two trust-boundary pins repaired on the way through

`test_client_processing_trust_boundary.py` failed for two reasons, only one of
them mine:

1. **Mine.** `Conversation` gained `processing_state`, so the field-set pin went
   red and demanded a classification. It is **not** projection-family: it is
   server-authored and carries no client text, so it stays out of
   `PROJECTION_FAMILY_FIELDS` (the integration redactor must not strip it) and
   goes into `PINNED_CONVERSATION_FIELDS`. Separately, my first draft of
   `_minimum_processing_state` took the `ClientProcessing | None` and tripped the
   reference pin. It only ever needed *presence*, so it now takes a `bool` and
   the pinned reference set does not have to grow to admit it — the narrower
   signature is the better one anyway.
2. **Not mine.** `PINNED_CONVERSATION_DUMPS` has been red on `main` since
   `25a7d764bc` ("fold desktop watching and proactive counts into daily
   summaries"), which added two `model_dump()` calls in
   `utils/llm/external_integrations.py`. Both dump a
   `DailySummaryDayStatsPayload`, not a `Conversation` — the scanner keys on the
   call, not the receiver's type — so neither can carry `client_processing`.
   Reviewed and pinned here with that reasoning in a comment, because this
   branch cannot be green while `main` is red on a test it also runs.

3. **Also not mine, and this one needed a judgement.**
   `test_task_intelligence_contract_freeze.py` is red on `main` for the same
   structural reason. `44d48884cf` ("remove the retired onboarding wizard
   views") deleted two Swift files that
   `backend/config/task_intelligence_sources_v1.json` still lists as
   `desktop_manual` owner paths. Removing the dead paths then uncovered a
   **second** failure the first was masking:
   `ProactiveAssistants/ContextReminders/ContextReminderCoordinator.swift`
   calls `client.createActionItem` and `client.updateActionItem` and is
   registered nowhere.

   **Please sanity-check this classification.** I registered it under
   `desktop_manual` (`policy_class: direct_command`), not as a proactive
   writer. The directory says `ProactiveAssistants`, which is exactly why I
   read it rather than assumed: the create runs inside a user-invoked reminder
   flow on the user's own text — its failure strings are tool replies ("Bring
   the document to the front and **ask again**") — and `updateActionItem` is
   reached from `markDone`, a button on a card. Neither fires on a timer or on
   observed context alone. Under `INV-TASK-2` that is a direct command, not
   automatic capture. If context reminders are meant to *propose* rather than
   write, the manifest entry is wrong and the code is what should change.

The second and third share a cause worth naming beyond this PR: neither change
touched a file that *selects* the test it broke, so the unit-test selector never
ran it. An exact-set pin whose subject files are wider than its selection
trigger can go red on `main` without any PR seeing it. Three instances turned up
in one afternoon — these two and the LLM-endpoint inventory pin, which is what
#12727 is about.

### Cut list

- Extending §1.7 past the desktop source. S6's gate is desktop-only, so
  non-desktop free conversations still take the legacy path; `processing_state`
  is `none` for them because no projection is coming, which is accurate today
  and becomes wrong the moment a mobile engine exists. That is S5's decision,
  not this PR's.
- Clearing `processing_state` on late projection arrival (see above).
- Any client rendering of `local_pending` / `none`. The field is now on the wire
  in Swift, Dart and TS; S9/W4 consume it.

### Line-count ratchet

The §1.7 builder is a new module and the processing-state decision lives in
`free_tier_processing_policy.py` beside the source test it reads, so the
coordinator keeps only the call. What is left in `process_conversation.py` is
the structured build, the state assignment, one import, and the docstring that
says why this store is not `_build_deferred_structured`.

Line-Count-Exception: backend/utils/conversations/process_conversation.py | 2882 -> 2904 | §1.7 builder and the processing-state decision were both placed outside this file; the +22 is the call site, one import, and the docstring distinguishing the terminal store from the deferred placeholder

### Product invariants

- `INV-MEM-4` — no memory promotion, admission, or Long-term authority path is
  touched. §1.7's `Structured` is server-authored and terminal; nothing on this
  path forms, promotes, or admits a memory, and the module's import closure is
  asserted to reach no model client at all.
- `INV-TASK-2` — `process_conversation.py` is a task-capture authority path.
  §1.7 makes `action_items` **empty by construction** — the minimum proposes
  nothing and writes no task. That is strictly less capture than the placeholder
  it replaces.

### Failure class

No `fix:` commits in this range.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
