### PR TITLE
chore(ci): run the slow-marked backend guardrails — they have never run, and #12701 slipped past the LLM inventory pin because of it

### DIFF
--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -155,3 +155,12 @@ jobs:
           else
             bash scripts/run-unit-ci.sh --all
           fi
+
+      # `run-unit-ci.sh` runs `not integration and not slow`, which is correct
+      # for PR latency but meant every `slow`-marked codebase guardrail in the
+      # repository executed nowhere. This step runs exactly those, unselected
+      # and unconditional: a guardrail whose job is to notice a change nobody
+      # anticipated cannot be gated on the change set that triggered the run.
+      - name: Run slow-marked backend guardrails
+        working-directory: backend
+        run: PYTHON=.venv/bin/python bash scripts/run-slow-guardrails-ci.sh

--- a/backend/docs/llm/model_endpoint_inventory.yaml
+++ b/backend/docs/llm/model_endpoint_inventory.yaml
@@ -147,6 +147,8 @@ surfaces:
   - utils/llm/trends.py::feature:trends
   - utils/llm/wake_word_adjudication.py::feature:wake_word_adjudication
   - utils/llm/working_observations.py::feature:memory_l1
+  - utils/memory/belief_backfill.py::feature:<dynamic>
+  - utils/memory/belief_evidence.py::feature:memory_conflict
   - utils/memory/canonical_consolidation.py::feature:memory_conflict
   - utils/retrieval/graph.py::feature:chat_graph
   - utils/screen_frames/judge.py::feature:<dynamic>

--- a/backend/scripts/run-slow-guardrails-ci.sh
+++ b/backend/scripts/run-slow-guardrails-ci.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Run the `slow`-marked backend guardrails that `run-unit-ci.sh` excludes.
+#
+# `run-unit-ci.sh` runs `not integration and not slow`, which is right for the
+# PR latency budget but left every codebase-grep guardrail in the repository
+# executing nowhere. This lane runs exactly those tests, for the files listed in
+# tests/slow_guardrail_manifest.txt, and nothing else.
+#
+# Deliberately NOT file-isolated: these are static scans that import little, and
+# one session over the whole manifest is what keeps the lane under two minutes.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$BACKEND_DIR"
+
+PYTHON_BIN="${PYTHON:-python}"
+MANIFEST="tests/slow_guardrail_manifest.txt"
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "FAIL: $MANIFEST is missing; the guardrail lane cannot silently run nothing." >&2
+  exit 1
+fi
+
+files=()
+while IFS= read -r line; do
+  line="${line%%#*}"
+  line="$(printf '%s' "$line" | tr -d '[:space:]')"
+  [ -n "$line" ] || continue
+  if [ ! -f "$line" ]; then
+    echo "FAIL: $MANIFEST lists $line, which does not exist." >&2
+    exit 1
+  fi
+  files+=("$line")
+done < "$MANIFEST"
+
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "FAIL: $MANIFEST selected no files; a lane that runs nothing passes for the wrong reason." >&2
+  exit 1
+fi
+
+echo "Running slow-marked guardrails across ${#files[@]} file(s)."
+exec "$PYTHON_BIN" -m pytest -q -p no:cacheprovider -m "slow and not integration" "${files[@]}"

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -80,6 +80,15 @@ Genuinely non-unit tests (real `asyncio` sleeps, network/Redis, stress, codebase
 wiring, per-test fresh module reload) must be marked `@pytest.mark.slow` / `@pytest.mark.integration` so they
 leave the PR lane (`not integration and not slow`) rather than being allowlisted.
 
+**`slow` is not "does not run".** Until 2026-09-04 it was: `run-unit-ci.sh` was the only backend unit lane,
+so a `slow` marker took a test out of CI entirely and an exact-set guardrail that fails nothing is a comment.
+#12701 added two managed `get_llm` call sites the LLM-inventory pin rejects and merged anyway, within the
+hour, because nothing ran the pin. If you mark a **guardrail** `slow` — a codebase grep, a coverage ratchet,
+an exact-set pin — add its file to `tests/slow_guardrail_manifest.txt` so
+`scripts/run-slow-guardrails-ci.sh` runs it. That lane is unselected and unconditional by design: a check
+whose job is to notice a change nobody anticipated cannot be gated on the change set that triggered the run.
+Stress and network tests still belong in `slow` with no manifest entry.
+
 ## Integration Tests
 
 Integration tests live under `tests/integration/` and are not run by `bash test.sh`. They may require Redis,

--- a/backend/tests/slow_guardrail_manifest.txt
+++ b/backend/tests/slow_guardrail_manifest.txt
@@ -1,0 +1,47 @@
+# Backend unit-test files whose `@pytest.mark.slow` tests run in CI.
+#
+# Why this file exists. `scripts/run-unit-ci.sh` is the only backend unit lane
+# and it runs `not integration and not slow`. `tests/README.md` tells authors to
+# mark codebase greps `slow` "rather than being allowlisted" — a rule that
+# assumes `slow` means *runs in some other lane*. There was no other lane, so
+# every codebase guardrail in the repository was inert: an exact-set pin that
+# fails nothing is a comment.
+#
+# It was not theoretical. #12701 (belief model) added two managed `get_llm`
+# call sites that `test_managed_call_sites_absent_from_the_inventory_fail_ci`
+# rejects, and merged anyway, within the hour, because nothing ran the test.
+#
+# The marker's cost premise does not survive measurement either: the 22
+# slow-marked unit files run to completion in ~74s wall clock in total, and the
+# LLM-inventory pin in 2.6s. These are greps, not stress tests.
+#
+# Every file listed here is green as of 2026-09-04. Files are added, never
+# silently dropped: a guardrail that starts failing is fixed or removed with a
+# stated reason, not un-listed.
+#
+# NOT YET LISTED — red on `main` at the time this lane was built, each needs its
+# own fix and its own PR. They are named rather than omitted so the gap stays
+# countable:
+#   tests/unit/test_subscription_restructure.py       32 failed, 2 passed
+#   tests/unit/test_firestore_query_coverage_ratchet.py    1 failed, 1 passed
+#   tests/unit/test_sys_modules_hermeticity.py             1 failed, 1 passed
+
+tests/unit/test_async_tasks.py
+tests/unit/test_desktop_transcribe.py
+tests/unit/test_firestore_di_seam.py
+tests/unit/test_firestore_query_contract.py
+tests/unit/test_flush_pending_batch1.py
+tests/unit/test_llm_gateway_coverage_guardrails.py
+tests/unit/test_managed_spend_ledger.py
+tests/unit/test_memories_validation.py
+tests/unit/test_p1_5_tools_fastapi_testclient_readiness.py
+tests/unit/test_pusher_circuit_breaker.py
+tests/unit/test_pusher_ghost_connections.py
+tests/unit/test_pusher_heartbeat.py
+tests/unit/test_storage_fanout_limits.py
+tests/unit/test_streaming_deepgram_backoff.py
+tests/unit/test_subscription_import_cycle.py
+tests/unit/test_sync_ordered_assignment.py
+tests/unit/test_thread_join_elimination.py
+tests/unit/test_vad_gate.py
+tests/unit/test_ws_g_module_aliases.py


### PR DESCRIPTION
## The repository's codebase guardrails have never run in CI

`backend/scripts/run-unit-ci.sh` is the only backend unit lane, and it runs
`not integration and not slow`. No workflow anywhere overrides that mark
expression. So every test marked `@pytest.mark.slow` — 22 files, 126
assertions, including coverage ratchets, hermeticity contracts, the
direct-provider boundary guardrail and the LLM-endpoint inventory pin —
executes nowhere.

This is not one author's slip. `backend/tests/README.md` instructs that
codebase-wide greps be marked `slow` "rather than being allowlisted", and the
duration-allowlist header repeats it. The rule assumes `slow` means *runs in
some other lane*. There was no other lane.

**It is already costing us.** #12701 (belief model) added two managed `get_llm`
call sites:

```
utils/memory/belief_backfill.py::feature:<dynamic>
utils/memory/belief_evidence.py::feature:memory_conflict
```

`test_managed_call_sites_absent_from_the_inventory_fail_ci` rejects both. It
merged anyway, within an hour of the pin landing, because nothing ran the pin.
That is the exact failure the pin was written to prevent, on its first
opportunity.

The cost premise does not survive measurement either. These are greps, not
stress tests:

| | |
|---|---|
| LLM-inventory pin alone | **2.6s** |
| All 19 manifest files, one session | **31s**, 126 passed |

### What this adds

- **`backend/scripts/run-slow-guardrails-ci.sh`** — runs `slow and not
  integration` over the files named in a manifest. It fails loudly if the
  manifest is missing, names a file that does not exist, or selects nothing: a
  lane that runs zero tests must not pass.
- **`backend/tests/slow_guardrail_manifest.txt`** — the 19 files that are green
  today, and, named in the header rather than silently omitted, the three that
  are not:

  ```
  tests/unit/test_subscription_restructure.py        32 failed, 2 passed
  tests/unit/test_firestore_query_coverage_ratchet.py     1 failed, 1 passed
  tests/unit/test_sys_modules_hermeticity.py              1 failed, 1 passed
  ```

  Each needs its own fix and its own PR. Listing them keeps the gap countable
  instead of invisible — which is the whole failure being repaired here.
- **One step in `backend-unit-tests.yml`**, unselected and unconditional. A
  guardrail whose job is to notice a change nobody anticipated cannot be gated
  on the change set that triggered the run — that is the second half of why
  #12701 slipped through, since the file it changed does not select the test
  that pins it.
- **The two missing inventory rows**, so the pin is green the moment it starts
  running. Both belong to `langchain_feature_routing`: they are internal
  memory-formation calls reached through `canonical_memory_adapter`, not a new
  user-triggerable entrypoint.
- **`tests/README.md`** — the rule that produced this is now qualified, so the
  next guardrail author lands in the lane instead of outside it.

### Automatic-or-dead check

The lane is its own check, and it is not vacuous by construction: delete the
manifest, empty it, or list a path that does not exist and
`run-slow-guardrails-ci.sh` exits non-zero rather than reporting success over
nothing. Revert either inventory row and
`test_managed_call_sites_absent_from_the_inventory_fail_ci` fails **in CI** —
which is the thing that was not true before this PR.

### Proof

- `PYTHON=.venv/bin/python bash scripts/run-slow-guardrails-ci.sh` →
  **126 passed, 516 deselected, 31.03s**.
- Red-proof on the real inventory file: with the two rows removed,
  `pytest -m slow tests/unit/test_llm_gateway_coverage_guardrails.py` →
  `AssertionError: managed call sites absent from the inventory:
  utils/memory/belief_backfill.py::feature:<dynamic>;
  utils/memory/belief_evidence.py::feature:memory_conflict`. Restored by
  putting the lines back, not by `git checkout`.
- Every slow-marked unit file measured individually to build the manifest; the
  three exclusions are the measured failures, not guesses.

### Cut list

- Fixing the three red files. Each is someone's owned surface and deserves its
  own diagnosis; bundling them here would make this PR unreviewable and would
  couple a CI-plumbing change to three unrelated product judgements.
- Extending the lane to `tests/services/` or `tests/integration/`.
- Any change to what `run-unit-ci.sh` selects. The PR lane keeps its latency
  budget exactly as it is; this is a second, additive lane.

### Product invariants

none — no locked invariant path glob matched.

### Failure class

No `fix:` commits in this range.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

