### PR TITLE
fix(desktop): fence local inference against HTTP redirects and stop retrying refused requests

### DIFF
--- a/desktop/macos/Desktop/Sources/LocalInference/LocalInferenceRuntime.swift
+++ b/desktop/macos/Desktop/Sources/LocalInference/LocalInferenceRuntime.swift
@@ -130,6 +130,13 @@ struct LocalInferenceRuntime: Sendable {
       let value: T = try await engine.generateStructured(prompt: prompt, schema: schema)
       return .engine(value, engineID: engine.engineID)
     } catch {
+      guard Self.isRetryable(error) else {
+        // A refusal, a permanent 4xx, an undecodable response, or a cancelled
+        // task: attempting it a second time cannot change the answer, and a
+        // fail-closed component must not re-attempt an operation policy has
+        // already refused.
+        return failClosed(from: engine.engineID.rawValue, reason: reason(for: error), input: minimumInput)
+      }
       do {
         let value: T = try await engine.generateStructured(prompt: prompt, schema: schema)
         fallback.recordLocalInferenceFallback(
@@ -161,6 +168,29 @@ struct LocalInferenceRuntime: Sendable {
       outcome: .exhausted
     )
     return .deterministicMinimum(DeterministicConversationMinimum.make(from: input))
+  }
+
+  /// Only a failure a second identical attempt could plausibly survive.
+  ///
+  /// Transport faults, 429, and 5xx are the engine being briefly unavailable.
+  /// Everything else — policy refusal, capability mismatch, unknown engine,
+  /// undecodable output, any other 4xx, cancellation — is deterministic, and
+  /// retrying it doubles the work and (for `nonLoopbackBaseURL`) attempts a
+  /// refused request twice.
+  static func isRetryable(_ error: Error) -> Bool {
+    if error is CancellationError { return false }
+    switch error as? LocalInferenceError {
+    case .httpStatus(let status):
+      return status == 429 || status >= 500
+    case .disabled, .nonLoopbackBaseURL, .capabilityUnavailable, .unknownEngine, .engineUnavailable,
+      .invalidResponse:
+      return false
+    case .engineFailed:
+      return true
+    case .none:
+      // Not one of ours: a URLError or another transport-layer failure.
+      return true
+    }
   }
 
   private func reason(for error: Error) -> String {

--- a/desktop/macos/Desktop/Sources/LocalInference/LocalServerInferenceAdapter.swift
+++ b/desktop/macos/Desktop/Sources/LocalInference/LocalServerInferenceAdapter.swift
@@ -4,8 +4,51 @@ protocol LocalInferenceHTTPClient: Sendable {
   func send(_ request: URLRequest) async throws -> (Data, URLResponse)
 }
 
+/// Refuses every HTTP redirect.
+///
+/// `requireLoopback` validates the *configured* base URL. `URLSession` with no
+/// delegate follows up to 20 redirects on its own, and a 307/308 preserves the
+/// method and body — so a process answering on the configured loopback port
+/// could reply `307 Location: https://<anywhere>` and the POST, prompt and
+/// transcript included, would be re-sent there under the user's network
+/// identity. `requireLoopback` never sees that URL, because the redirect is
+/// resolved below the adapter.
+///
+/// A local OpenAI-compatible server has no legitimate reason to redirect, so
+/// the policy is refusal rather than re-validation: there is no correct
+/// redirect for this adapter to follow, and refusing is the only rule with no
+/// second URL to get wrong.
+final class LocalInferenceRedirectPolicy: NSObject, URLSessionTaskDelegate, Sendable {
+  func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    willPerformHTTPRedirection response: HTTPURLResponse,
+    newRequest request: URLRequest,
+    completionHandler: @escaping (URLRequest?) -> Void
+  ) {
+    completionHandler(nil)
+  }
+}
+
 struct URLSessionLocalInferenceHTTPClient: LocalInferenceHTTPClient {
-  var session: URLSession = .shared
+  private static let redirectPolicy = LocalInferenceRedirectPolicy()
+
+  /// Never `URLSession.shared`: the shared session carries no delegate, so it
+  /// follows redirects, and it cannot be given this policy without changing
+  /// behaviour for every other caller in the app. One session for the process,
+  /// because a session created per request would retain its delegate until
+  /// invalidated and leak.
+  static let fencedSession = URLSession(
+    configuration: .ephemeral,
+    delegate: redirectPolicy,
+    delegateQueue: nil
+  )
+
+  var session: URLSession
+
+  init(session: URLSession? = nil) {
+    self.session = session ?? Self.fencedSession
+  }
 
   func send(_ request: URLRequest) async throws -> (Data, URLResponse) {
     try await session.data(for: request)
@@ -16,7 +59,15 @@ enum LocalInferenceLoopback {
   /// Fail closed: the local-server adapter may only speak to a loopback host.
   /// A misconfigured paid or remote endpoint is an error, never a silent
   /// route onto a cloud provider.
+  static let allowedSchemes: Set<String> = ["http", "https"]
+
   static func isAllowed(_ url: URL) -> Bool {
+    // A non-HTTP scheme is not a local model server. `file:` in particular
+    // would make the "base URL" a path read, and a custom scheme can be
+    // claimed by any installed app.
+    guard let scheme = url.scheme?.lowercased(), allowedSchemes.contains(scheme) else {
+      return false
+    }
     guard let host = url.host?.trimmingCharacters(in: .whitespacesAndNewlines), !host.isEmpty else {
       return false
     }

--- a/desktop/macos/Desktop/Tests/LocalInferenceRuntimeFailClosedTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalInferenceRuntimeFailClosedTests.swift
@@ -98,6 +98,49 @@ private func minimumInput() -> DeterministicMinimumInput {
       super.tearDown()
     }
 
+    // red-proof: delete the `guard Self.isRetryable(error)` in `invoke`
+    func testPolicyRefusalIsNotAttemptedTwice() async {
+      let local = CallCountingEngine(
+        engineID: .localServer,
+        generateResults: [
+          .failure(LocalInferenceError.nonLoopbackBaseURL("https://api.openai.com/v1")),
+          .success(ProbeSummary(title: "a retry must never reach this")),
+        ]
+      )
+      let runtime = LocalInferenceRuntime(
+        engines: [local],
+        killSwitches: .enabled,
+        fallback: DesktopLocalInferenceFallbackRecorder(),
+        defaultEngineID: .localServer
+      )
+
+      let result: LocalInferenceGeneration<ProbeSummary> = await runtime.generateStructuredFailClosed(
+        prompt: "summarize",
+        schema: ProbeSchema.json,
+        minimumInput: minimumInput()
+      )
+
+      guard case .deterministicMinimum = result else {
+        return XCTFail("a refused request must fail closed, and its retry must not be able to succeed")
+      }
+      XCTAssertEqual(local.generateCallCount, 1, "a fail-closed component must not re-attempt a refused request")
+    }
+
+    func testRetryClassifierSeparatesTransientFromDeterministic() {
+      XCTAssertTrue(LocalInferenceRuntime.isRetryable(LocalInferenceError.httpStatus(429)))
+      XCTAssertTrue(LocalInferenceRuntime.isRetryable(LocalInferenceError.httpStatus(503)))
+      XCTAssertTrue(LocalInferenceRuntime.isRetryable(LocalInferenceError.engineFailed("transport")))
+      XCTAssertTrue(LocalInferenceRuntime.isRetryable(URLError(.cannotConnectToHost)))
+
+      XCTAssertFalse(LocalInferenceRuntime.isRetryable(LocalInferenceError.httpStatus(400)))
+      XCTAssertFalse(LocalInferenceRuntime.isRetryable(LocalInferenceError.httpStatus(401)))
+      XCTAssertFalse(LocalInferenceRuntime.isRetryable(LocalInferenceError.nonLoopbackBaseURL("https://x")))
+      XCTAssertFalse(LocalInferenceRuntime.isRetryable(LocalInferenceError.capabilityUnavailable("tool_loop")))
+      XCTAssertFalse(LocalInferenceRuntime.isRetryable(LocalInferenceError.invalidResponse("empty_content")))
+      XCTAssertFalse(LocalInferenceRuntime.isRetryable(LocalInferenceError.disabled))
+      XCTAssertFalse(LocalInferenceRuntime.isRetryable(CancellationError()))
+    }
+
     func testForcedEngineFailureReturnsDeterministicMinimumRecordsFallbackAndDoesNotCallCloud() async throws {
       let local = CallCountingEngine(
         engineID: .localServer,

--- a/desktop/macos/Desktop/Tests/LocalServerInferenceAdapterTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalServerInferenceAdapterTests.swift
@@ -30,6 +30,62 @@ private actor RecordingLocalInferenceHTTPClient: LocalInferenceHTTPClient {
 }
 
 final class LocalServerInferenceAdapterTests: XCTestCase {
+  // red-proof: return `request` instead of `nil` from the delegate
+  func testRedirectPolicyRefusesEveryRedirect() throws {
+    let policy = LocalInferenceRedirectPolicy()
+    let session = URLSession(configuration: .ephemeral)
+    let original = try XCTUnwrap(URL(string: "http://127.0.0.1:11434/v1/chat/completions"))
+    let task = session.dataTask(with: original)
+    let response = try XCTUnwrap(
+      HTTPURLResponse(url: original, statusCode: 307, httpVersion: "HTTP/1.1", headerFields: nil)
+    )
+
+    for target in [
+      "https://api.openai.com/v1/chat/completions",
+      "http://127.0.0.1:9999/v1/chat/completions",
+    ] {
+      let expectation = expectation(description: "redirect decision for \(target)")
+      var followed: URLRequest? = URLRequest(url: try XCTUnwrap(URL(string: target)))
+      policy.urlSession(
+        session,
+        task: task,
+        willPerformHTTPRedirection: response,
+        newRequest: try XCTUnwrap(followed)
+      ) { decision in
+        followed = decision
+        expectation.fulfill()
+      }
+      wait(for: [expectation], timeout: 1)
+      XCTAssertNil(followed, "a local model server has no legitimate redirect; \(target) must not be followed")
+    }
+    task.cancel()
+    session.invalidateAndCancel()
+  }
+
+  // red-proof: change the default back to `URLSession.shared`
+  func testDefaultHTTPClientSessionRefusesRedirects() {
+    let client = URLSessionLocalInferenceHTTPClient()
+    XCTAssertFalse(
+      client.session === URLSession.shared,
+      "URLSession.shared carries no delegate, so it follows redirects past the loopback fence"
+    )
+    XCTAssertTrue(
+      client.session.delegate is LocalInferenceRedirectPolicy,
+      "the adapter's session must carry the redirect fence"
+    )
+  }
+
+  func testNonHTTPSchemesAreRejectedEvenOnLoopback() throws {
+    // `file:` would turn the "base URL" into a path read; a custom scheme can
+    // be claimed by any installed application.
+    for raw in ["file:///etc/passwd", "omi://127.0.0.1/v1", "ftp://localhost/v1"] {
+      let url = try XCTUnwrap(URL(string: raw))
+      XCTAssertFalse(LocalInferenceLoopback.isAllowed(url), "\(raw) is not a local model server")
+    }
+    XCTAssertTrue(LocalInferenceLoopback.isAllowed(try XCTUnwrap(URL(string: "http://127.0.0.1:11434/v1"))))
+    XCTAssertTrue(LocalInferenceLoopback.isAllowed(try XCTUnwrap(URL(string: "https://localhost:8443/v1"))))
+  }
+
   func testRejectsNonLoopbackURLWithoutSendingHTTP() async throws {
     let http = RecordingLocalInferenceHTTPClient()
     let adapter = LocalServerInferenceAdapter(

--- a/desktop/macos/changelog/unreleased/20260904-local-inference-redirect-fence.json
+++ b/desktop/macos/changelog/unreleased/20260904-local-inference-redirect-fence.json
@@ -1,0 +1,4 @@
+{
+  "kind": "none",
+  "reason": "Fences the local-inference adapter against HTTP redirects and stops the runtime retrying refused requests. The runtime is not wired into finalization yet (S11), so no shipped behavior changes."
+}


### PR DESCRIPTION
## The loopback fence was enforced one layer above where the request is resolved

Follow-up to #12716 (S9), which merged before this review landed. Two defects,
same root: `LocalInferenceLoopback.requireLoopback` validates
`configuration.baseURL`, and then the request is handed to a session that can
go somewhere else.

### 1. `URLSession.shared` follows redirects past the fence

`URLSessionLocalInferenceHTTPClient` used `URLSession.shared`. With no delegate,
`URLSession` follows up to twenty redirects on its own, and a `307`/`308`
preserves the method **and the body**.

So a process answering on the configured loopback port — which is not
necessarily the runtime the user believes is listening — can reply:

```
307 Location: https://api.openai.com/v1/chat/completions
```

and the POST is re-sent there, prompt and transcript included, under the user's
network identity. `requireLoopback` never sees that URL, because the redirect is
resolved below the adapter. The existing tests cannot reach this: they replace
the transport, and the transport is where the behaviour lives.

The adapter now owns an ephemeral session whose delegate refuses **every**
redirect. Refusal rather than re-validation, deliberately: a local
OpenAI-compatible server has no legitimate reason to redirect, so there is no
correct redirect to follow, and refusing is the only rule with no second URL to
get wrong. One session for the process — a session created per request would
retain its delegate until invalidated and leak.

`isAllowed` also pins the scheme to `http`/`https` now. `file:` would turn the
"base URL" into a path read, and a custom scheme can be claimed by any installed
application.

### 2. A fail-closed component was attempting refused requests twice

`LocalInferenceRuntime.invoke` retried after *any* thrown error — including
`.nonLoopbackBaseURL` (a policy refusal), `.capabilityUnavailable`, decode
failures, permanent `4xx`, and `CancellationError`.

`isRetryable` now admits only what a second identical attempt could plausibly
survive: transport faults, `429`, `5xx`. Everything else fails closed on the
first attempt.

### Automatic-or-dead check

`testDefaultHTTPClientSessionRefusesRedirects` asserts the default client's
session is not `URLSession.shared` and that its delegate is the fence. Revert
the default and it goes red — which is the shape of the original defect, not a
proxy for it.

`testPolicyRefusalIsNotAttemptedTwice` scripts the engine to fail with
`.nonLoopbackBaseURL` and then **succeed**. If the classifier is removed, the
retry reaches the success and the test fails on both the result and the call
count. A test that only scripted two failures would pass with the bug present.

### Proof

- `testRedirectPolicyRefusesEveryRedirect` — drives the delegate directly with a
  real `HTTPURLResponse` 307 and asserts `nil` for both a cloud target and a
  *different loopback port*. The fence is not "reject non-loopback", it is
  "reject redirects".
- `testRetryClassifierSeparatesTransientFromDeterministic` — the full taxonomy,
  both directions.
- `testNonHTTPSchemesAreRejectedEvenOnLoopback` — `file:`, a custom scheme, and
  `ftp:` rejected; `http://127.0.0.1` and `https://localhost` still allowed.
- `swift-format lint --strict` and `swiftlint` clean on every changed file.

**I could not compile this locally and am not claiming otherwise.** CI pins
Xcode 16.4; this machine has 26.6, so `scripts/run-swift-ci.sh --test` refuses
to run. `Desktop Swift Static & Test Contracts` is the compile and the test run
for this PR — it should be green before merge, and unlike #12716's release
compile, this is hand-written Swift, so the release compile matters here too.

### Not fixed here

`localhost` remains an allowed host even though it is resolver-dependent.
Changing it would break anyone whose config uses the name, and the attack it
enables needs write access to `/etc/hosts` — which is root, and root has already
won. Named rather than silently kept.

### Cut list

- Wiring the runtime into finalization (S11).
- A shared backend/Swift fixture for the deterministic minimum. The two
  algorithms agree as of #12726, but nothing pins them to each other.

### Product invariants

none — no locked invariant path glob matched.

### Failure class

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

