### PR TITLE
fix(ci): repair two guardrails that are red on main and blocking unrelated PRs

### DIFF
--- a/backend/config/task_intelligence_sources_v1.json
+++ b/backend/config/task_intelligence_sources_v1.json
@@ -38,11 +38,10 @@
         "desktop/macos/Desktop/Sources/MainWindow/Dashboard/WhatMattersNowSection.swift",
         "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift",
         "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift",
-        "desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift",
         "desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift",
-        "desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift",
         "desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift",
         "desktop/macos/Desktop/Sources/FloatingControlBar/NotchMomentsCoordinator.swift",
+        "desktop/macos/Desktop/Sources/ProactiveAssistants/ContextReminders/ContextReminderCoordinator.swift",
         "backend/routers/desktop_core.py"
       ],
       "test_adapter": "direct_command_contract",
@@ -50,6 +49,8 @@
         {"path": "desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift", "symbol": "client.createTask", "discover": true},
         {"path": "desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift", "symbol": "client.createTask", "discover": true},
         {"path": "desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift", "symbol": "client.deleteTask", "discover": true},
+        {"path": "desktop/macos/Desktop/Sources/ProactiveAssistants/ContextReminders/ContextReminderCoordinator.swift", "symbol": "client.createActionItem", "discover": true},
+        {"path": "desktop/macos/Desktop/Sources/ProactiveAssistants/ContextReminders/ContextReminderCoordinator.swift", "symbol": "client.updateActionItem", "discover": true},
         {"path": "backend/routers/desktop_core.py", "symbol": "action_items_db.create_action_item", "discover": true}
       ]
     },

--- a/backend/tests/unit/test_client_processing_trust_boundary.py
+++ b/backend/tests/unit/test_client_processing_trust_boundary.py
@@ -476,6 +476,12 @@ _PRODUCTION_DUMPS = _scan_dumps()
 # dump in a scanned file fails until reviewed — receiver name is not a filter.
 PINNED_CONVERSATION_DUMPS: FrozenSet[DumpSite] = frozenset(
     {
+        # Daily-summary stats payloads (`DailySummaryDayStatsPayload`), not
+        # conversations: the scanner keys on the call, not the receiver's type,
+        # so these two land here. Reviewed 2026-09-04 — neither dump can carry
+        # `client_processing`, because neither subject is a `Conversation`.
+        DumpSite('utils/llm/external_integrations.py', '_basic_daily_summary', 'model_dump'),
+        DumpSite('utils/llm/external_integrations.py', 'generate_comprehensive_daily_summary', 'model_dump'),
         DumpSite('models/conversation.py', 'project_shared_conversation', 'model_dump'),
         DumpSite('models/conversation.py', 'as_dict_cleaned_dates', 'model_dump'),
         DumpSite('utils/conversations/render.py', 'conversation_to_dict', 'model_dump'),


### PR DESCRIPTION
## `main` is red on two backend guardrails, and it is blocking other people's PRs

Not a refactor and not a shard — this is stop-the-line. Two exact-set pins fail
on `main` right now, so any PR whose test selection reaches them goes red for
reasons that have nothing to do with its own diff. #12707
(`agent/memory-delete-gate`) is failing on this, as are #12726, #12727 and this
author's other work.

Both breakages share a cause: **the change that broke each one did not touch a
file that selects the test that pins it**, so the unit-test selector never ran
it on the PR that introduced it.

### 1. `PINNED_CONVERSATION_DUMPS`

`25a7d764bc` ("fold desktop watching and proactive counts into daily summaries")
added two `model_dump()` calls in `utils/llm/external_integrations.py`. The S4
trust-boundary scanner keys on **the call, not the receiver's type**, so both are
reported as conversation serialization sites and the exact-set assertion fails.

Reviewed rather than rubber-stamped: `_basic_daily_summary` and
`generate_comprehensive_daily_summary` both dump a
`DailySummaryDayStatsPayload`. Neither subject is a `Conversation`, so neither
dump can carry `client_processing`, and the display-only trust boundary is
intact. Pinned with that reasoning in a comment beside the entries.

### 2. `task_intelligence_sources_v1.json`

`44d48884cf` ("remove the retired onboarding wizard views") deleted
`OnboardingChatView.swift` and `OnboardingView.swift`, which
`backend/config/task_intelligence_sources_v1.json` still lists as
`desktop_manual` owner paths — so the manifest fails validation before any
contract is checked.

Removing the dead paths uncovers a **second failure the first was masking**:
`ProactiveAssistants/ContextReminders/ContextReminderCoordinator.swift` calls
`client.createActionItem` and `client.updateActionItem` and is registered
nowhere.

**This one is a judgement and deserves a second opinion.** It is registered here
under `desktop_manual` (`policy_class: direct_command`), not as a proactive
writer. The directory is named `ProactiveAssistants`, which is exactly why the
code was read rather than assumed:

- the create runs inside a user-invoked reminder flow, on the user's own text,
  and its failure strings are tool replies — *"Bring the document to the front
  and **ask again**"*;
- `updateActionItem` is reached from `markDone`, a button on a card;
- neither fires on a timer, nor on observed context alone.

Under `INV-TASK-2` — "automatic capture proposes" — that is a direct command, not
automatic capture. **If the intent is that context reminders propose rather than
write, this manifest entry is wrong and the code is what should change.**

### Automatic-or-dead check

The two repaired tests are themselves the check, and they are exact-set pins:
revert either hunk and they fail again. What this PR does *not* fix is the reason
they were able to go red unobserved — that is #12727, which gives the
`slow`-marked guardrails a lane at all and explains the same selector gap in
detail.

### Proof

- `tests/unit/test_client_processing_trust_boundary.py` +
  `tests/unit/test_task_intelligence_contract_freeze.py` → **70 passed**.
- Confirmed red before the change on a clean `origin/main` checkout, with the
  exact assertions quoted above.
- Confirmed the same two failures on #12707, a PR by another author that touches
  none of these files.

### Cut list

- The three other `slow`-marked files that are red (`test_subscription_restructure`,
  `test_firestore_query_coverage_ratchet`, `test_sys_modules_hermeticity`). They
  do not block anything today because nothing runs them; #12727 names them.
- Making the selector aware of manifest-referenced paths, which is the real fix
  for the class and is a bigger change than a stop-the-line repair should carry.

### Product invariants

- `INV-TASK-2` — this PR registers a previously unregistered action-item writer
  and classifies it as `direct_command`. No capture behaviour changes; the
  manifest gains the writer it was already missing. See the judgement above.

### Failure class

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

