### PR TITLE
fix(agent): persist external-surface run text into runs.final_text

### DIFF
--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -2465,6 +2465,7 @@ async function main(): Promise<void> {
             ok: true,
             terminalStatus: result.terminalStatus,
             duplicate: result.duplicate,
+            finalTextPersisted: result.finalTextPersisted,
           });
         } catch (error) {
           send({

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -2451,6 +2451,7 @@ async function main(): Promise<void> {
             runId: request.runId,
             attemptId: request.attemptId,
             terminalStatus: request.terminalStatus,
+            finalText: request.finalText,
             errorCode: request.errorCode,
           });
           send({

--- a/desktop/macos/agent/src/protocol.ts
+++ b/desktop/macos/agent/src/protocol.ts
@@ -127,6 +127,17 @@ export interface ExternalSurfaceRunCompleteMessage extends ProtocolEnvelope {
   runId: string;
   attemptId: string;
   terminalStatus: "completed" | "failed" | "cancelled";
+  /**
+   * The response text the external surface streamed to the user.
+   *
+   * An external surface owns its own streaming, so the kernel never observes this
+   * run's output — it has to be handed back at terminalization or it is lost.
+   * Without it `runs.final_text` stays null and every consumer that reads a run's
+   * answer is content-free: the completion lane can only report that an agent
+   * finished, and a spawn receipt that delegates its journal exchange to the run
+   * result writes no assistant row at all (#12731).
+   */
+  finalText?: string;
   errorCode?: string;
 }
 

--- a/desktop/macos/agent/src/protocol.ts
+++ b/desktop/macos/agent/src/protocol.ts
@@ -128,14 +128,18 @@ export interface ExternalSurfaceRunCompleteMessage extends ProtocolEnvelope {
   attemptId: string;
   terminalStatus: "completed" | "failed" | "cancelled";
   /**
-   * The response text the external surface streamed to the user.
+   * The answer text the external surface reports for this run.
    *
    * An external surface owns its own streaming, so the kernel never observes this
    * run's output — it has to be handed back at terminalization or it is lost.
    * Without it `runs.final_text` stays null and every consumer that reads a run's
    * answer is content-free: the completion lane can only report that an agent
-   * finished, and a spawn receipt that delegates its journal exchange to the run
-   * result writes no assistant row at all (#12731).
+   * finished, and a spawn-agent child's receipt, which builds its journal block
+   * from the child's final text, has nothing to write (#12731).
+   *
+   * What a surface can actually report is its own problem: for a realtime voice
+   * deferral the text must be accumulated over the turn stream, because the
+   * turn-end hub property is already cleared by the time terminalization runs.
    */
   finalText?: string;
   errorCode?: string;
@@ -764,6 +768,12 @@ export interface ExternalSurfaceRunCompleteResultMessage extends OutboundEnvelop
   ok: boolean;
   terminalStatus?: "completed" | "failed" | "cancelled";
   duplicate?: boolean;
+  /**
+   * Whether the kernel stored `finalText` for this run. Absent from an older
+   * kernel, which lets a surface keep its own journal fallback instead of
+   * trusting a silent no-op (#12731).
+   */
+  finalTextPersisted?: boolean;
   error?: ExternalAuthorityError;
 }
 

--- a/desktop/macos/agent/src/runtime/kernel-core.ts
+++ b/desktop/macos/agent/src/runtime/kernel-core.ts
@@ -404,9 +404,14 @@ export class KernelCore {
       const latestAttempt = latestAttemptRow ? attemptFromRow(latestAttemptRow) : undefined;
       if (run.status === "orphaned" || !latestAttempt || TERMINAL_STATUSES.includes(latestAttempt.status)) {
         this.withTransaction(() => {
+          // A recycled run must not carry the previous attempt's answer while it
+          // is queued again: the context snapshot and control list both read
+          // final_text for active runs (#12731).
           this.updateRun(run.runId, {
             status: "queued",
             completedAtMs: null,
+            finalText: null,
+            resultJson: null,
             errorCode: null,
             errorMessage: null,
             updatedAtMs: Date.now(),
@@ -631,7 +636,10 @@ export class KernelCore {
     const persistedStatus = input.terminalStatus === "completed" ? "succeeded" : input.terminalStatus;
     if (TERMINAL_STATUSES.includes(run.status) || TERMINAL_STATUSES.includes(attempt.status)) {
       if (run.status === persistedStatus && attempt.status === persistedStatus) {
-        return { ...input, duplicate: true };
+        // First write wins, so a replayed frame's text is deliberately not
+        // stored. Say so rather than letting the surface read ok and assume it
+        // landed — that silence is the shape of #12731 itself.
+        return { ...input, duplicate: true, finalTextPersisted: false };
       }
       throw new ExternalSurfaceAuthorityError("run_terminal", "External surface run already has a different terminal state");
     }
@@ -655,11 +663,13 @@ export class KernelCore {
     }
     // The kernel never observes an external surface's stream, so terminalization is
     // the only point at which this run's answer can be captured. Persisted for every
-    // terminal status, matching the internal adapter path, which likewise stores
-    // whatever text was produced and marks failure through errorCode instead. An
-    // empty string collapses to null so "produced no text" reads identically whether
-    // the surface omitted the field or sent "" (#12731).
-    const finalText = input.finalText ? input.finalText : null;
+    // terminal status, following the internal adapter path, which likewise stores
+    // whatever text was produced and marks failure through errorCode instead. The
+    // internal path stores "" as-is; here an empty string collapses to null so
+    // "produced no text" reads identically whether the surface omitted the field
+    // or sent "" (#12731).
+    const trimmed = input.finalText?.trim();
+    const finalText = trimmed ? trimmed : null;
     this.withTransaction(() => {
       this.finishAttemptAndRun({
         sessionId: input.sessionId,
@@ -671,7 +681,7 @@ export class KernelCore {
         errorMessage: persistedStatus === "failed" ? "External surface execution failed" : null,
       });
     });
-    return { ...input, duplicate: false };
+    return { ...input, duplicate: false, finalTextPersisted: finalText !== null };
   }
 
   private assertExternalRunIdentity(

--- a/desktop/macos/agent/src/runtime/kernel-core.ts
+++ b/desktop/macos/agent/src/runtime/kernel-core.ts
@@ -650,13 +650,23 @@ export class KernelCore {
     if (errorCode && !/^[a-z0-9_]{1,64}$/.test(errorCode)) {
       throw new ExternalSurfaceAuthorityError("invalid_external_request", "External surface errorCode is invalid");
     }
+    if (input.finalText !== undefined && typeof input.finalText !== "string") {
+      throw new ExternalSurfaceAuthorityError("invalid_external_request", "External surface finalText must be a string");
+    }
+    // The kernel never observes an external surface's stream, so terminalization is
+    // the only point at which this run's answer can be captured. Persisted for every
+    // terminal status, matching the internal adapter path, which likewise stores
+    // whatever text was produced and marks failure through errorCode instead. An
+    // empty string collapses to null so "produced no text" reads identically whether
+    // the surface omitted the field or sent "" (#12731).
+    const finalText = input.finalText ? input.finalText : null;
     this.withTransaction(() => {
       this.finishAttemptAndRun({
         sessionId: input.sessionId,
         runId: input.runId,
         attemptId: input.attemptId,
         status: persistedStatus,
-        finalText: null,
+        finalText,
         errorCode: persistedStatus === "failed" ? errorCode ?? "external_surface_failed" : null,
         errorMessage: persistedStatus === "failed" ? "External surface execution failed" : null,
       });

--- a/desktop/macos/agent/src/runtime/kernel-types.ts
+++ b/desktop/macos/agent/src/runtime/kernel-types.ts
@@ -125,6 +125,8 @@ export interface CompleteExternalSurfaceRunInput {
   runId: string;
   attemptId: string;
   terminalStatus: "completed" | "failed" | "cancelled";
+  /** Text the external surface streamed, persisted to `runs.final_text` (#12731). */
+  finalText?: string;
   errorCode?: string;
 }
 

--- a/desktop/macos/agent/src/runtime/kernel-types.ts
+++ b/desktop/macos/agent/src/runtime/kernel-types.ts
@@ -137,6 +137,8 @@ export interface CompleteExternalSurfaceRunResult {
   attemptId: string;
   terminalStatus: "completed" | "failed" | "cancelled";
   duplicate: boolean;
+  /** Whether this call wrote `finalText`, so an older kernel is detectable by its absence. */
+  finalTextPersisted: boolean;
 }
 
 export type ExternalSurfaceAuthorityErrorCode =

--- a/desktop/macos/agent/tests/external-surface-authority.test.ts
+++ b/desktop/macos/agent/tests/external-surface-authority.test.ts
@@ -1600,7 +1600,22 @@ describe("external realtime surface authority", () => {
       finalText: "",
     });
 
-    for (const runId of [omitted.runId, empty.runId]) {
+    // Whitespace-only is "produced no text" too, collapsed the same way.
+    const blank = fixture.kernel.beginExternalSurfaceRun({
+      ...beginInput(fixture.sessionId),
+      turnId: "voice-turn-3",
+      requestId: "begin-3",
+    });
+    fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: blank.runId,
+      attemptId: blank.attemptId,
+      terminalStatus: "completed",
+      finalText: "   ",
+    });
+
+    for (const runId of [omitted.runId, empty.runId, blank.runId]) {
       expect(fixture.store.getRow("SELECT final_text FROM runs WHERE run_id = ?", [runId]).final_text).toBeNull();
     }
     fixture.store.close();
@@ -1660,6 +1675,114 @@ describe("external realtime surface authority", () => {
       "SELECT status, final_text FROM runs WHERE run_id = ?",
       [run.runId],
     )).toEqual({ status: "succeeded", final_text: "Recovered after the rejected call." });
+    fixture.store.close();
+  });
+
+  it("reports whether the answer was actually stored", () => {
+    // A surface cannot otherwise tell a successful write from an older kernel
+    // that ignored the field entirely.
+    const fixture = createFixture();
+    const withText = fixture.kernel.beginExternalSurfaceRun(beginInput(fixture.sessionId));
+    expect(fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: withText.runId,
+      attemptId: withText.attemptId,
+      terminalStatus: "completed",
+      finalText: "Three parts sand to one part clay.",
+    }).finalTextPersisted).toBe(true);
+
+    const withoutText = fixture.kernel.beginExternalSurfaceRun({
+      ...beginInput(fixture.sessionId),
+      turnId: "voice-turn-2",
+      requestId: "begin-2",
+    });
+    expect(fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: withoutText.runId,
+      attemptId: withoutText.attemptId,
+      terminalStatus: "completed",
+    }).finalTextPersisted).toBe(false);
+    fixture.store.close();
+  });
+
+  it("clears a superseded answer when an orphaned turn is re-begun", () => {
+    // The requeue branch recycles the run row. Until this PR final_text was
+    // always null on external runs, so nothing could survive the reset; now a
+    // stale answer would sit in an active run and reach the context snapshot.
+    const fixture = createFixture();
+    const run = fixture.kernel.beginExternalSurfaceRun(beginInput(fixture.sessionId));
+
+    fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: run.runId,
+      attemptId: run.attemptId,
+      terminalStatus: "completed",
+      finalText: "Three parts sand to one part clay.",
+    });
+    fixture.store.execute("UPDATE runs SET status = 'orphaned' WHERE run_id = ?", [run.runId]);
+
+    fixture.kernel.beginExternalSurfaceRun({ ...beginInput(fixture.sessionId), requestId: "begin-requeue" });
+
+    expect(fixture.store.getRow(
+      "SELECT status, final_text, result_json FROM runs WHERE run_id = ?",
+      [run.runId],
+    )).toEqual({ status: "running", final_text: null, result_json: null });
+    fixture.store.close();
+  });
+
+  it("keeps the first answer when the surface replays the same terminal status", () => {
+    // Swift retries this RPC on timeout, so a late replay must not rewrite an
+    // answer the kernel already sealed.
+    const fixture = createFixture();
+    const run = fixture.kernel.beginExternalSurfaceRun(beginInput(fixture.sessionId));
+    const complete = (finalText: string) => fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: run.runId,
+      attemptId: run.attemptId,
+      terminalStatus: "completed",
+      finalText,
+    });
+
+    complete("Three parts sand to one part clay.");
+    const replay = complete("A different answer from a retried frame.");
+
+    expect(replay.duplicate).toBe(true);
+    // The replay's text was dropped by design, and the result says so.
+    expect(replay.finalTextPersisted).toBe(false);
+    expect(fixture.store.getRow(
+      "SELECT final_text FROM runs WHERE run_id = ?",
+      [run.runId],
+    ).final_text).toBe("Three parts sand to one part clay.");
+    fixture.store.close();
+  });
+
+  it("keeps text produced before a cancelled terminalization", () => {
+    // cancelled is a distinct persisted status from failed, and the failed-only
+    // errorCode default must not fire for it.
+    const fixture = createFixture();
+    const run = fixture.kernel.beginExternalSurfaceRun(beginInput(fixture.sessionId));
+
+    fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: run.runId,
+      attemptId: run.attemptId,
+      terminalStatus: "cancelled",
+      finalText: "Half an answer before the user cut in.",
+    });
+
+    expect(fixture.store.getRow(
+      "SELECT final_text, status, error_code FROM runs WHERE run_id = ?",
+      [run.runId],
+    )).toEqual({
+      final_text: "Half an answer before the user cut in.",
+      status: "cancelled",
+      error_code: null,
+    });
     fixture.store.close();
   });
 });

--- a/desktop/macos/agent/tests/external-surface-authority.test.ts
+++ b/desktop/macos/agent/tests/external-surface-authority.test.ts
@@ -1522,6 +1522,133 @@ describe("external realtime surface authority", () => {
     expect(store.getRow("SELECT COUNT(*) AS count FROM runs").count).toBe(1);
     store.close();
   });
+
+  // #12731: the kernel never observes an external surface's stream, so unless the
+  // text comes back at terminalization `runs.final_text` stays null and every
+  // consumer of a run's answer — the completion lane, spawn-receipt journaling —
+  // is structurally content-free.
+  it("persists the text an external surface streamed into runs.final_text", () => {
+    const fixture = createFixture();
+    const run = fixture.kernel.beginExternalSurfaceRun(beginInput(fixture.sessionId));
+
+    fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: run.runId,
+      attemptId: run.attemptId,
+      terminalStatus: "completed",
+      finalText: "The hopper recipe is three parts sand to one part clay.",
+    });
+
+    expect(fixture.store.getRow(
+      "SELECT final_text FROM runs WHERE run_id = ?",
+      [run.runId],
+    ).final_text).toBe("The hopper recipe is three parts sand to one part clay.");
+    fixture.store.close();
+  });
+
+  it("puts the streamed text on the message.completed event, not an empty payload", () => {
+    // The trace in #12731 shows these events carrying literally {"text":""}. The
+    // event is emitted from finishAttemptAndRun off the same finalText the run row
+    // stores, so both the completion lane and the journal starve together.
+    const fixture = createFixture();
+    const run = fixture.kernel.beginExternalSurfaceRun(beginInput(fixture.sessionId));
+
+    fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: run.runId,
+      attemptId: run.attemptId,
+      terminalStatus: "completed",
+      finalText: "Three parts sand to one part clay.",
+    });
+
+    const completed = fixture.store.allRows(
+      "SELECT payload_json FROM events WHERE run_id = ? AND type = 'message.completed'",
+      [run.runId],
+    );
+    expect(completed).toHaveLength(1);
+    expect(JSON.parse(String(completed[0].payload_json))).toEqual({ text: "Three parts sand to one part clay." });
+    fixture.store.close();
+  });
+
+  it("leaves final_text null when the surface reports no text", () => {
+    const fixture = createFixture();
+    const omitted = fixture.kernel.beginExternalSurfaceRun(beginInput(fixture.sessionId));
+
+    fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: omitted.runId,
+      attemptId: omitted.attemptId,
+      terminalStatus: "completed",
+    });
+
+    // An empty string means the same thing as an absent field, so both land as
+    // null and no consumer has to special-case "" separately.
+    const empty = fixture.kernel.beginExternalSurfaceRun({
+      ...beginInput(fixture.sessionId),
+      turnId: "voice-turn-2",
+      requestId: "begin-2",
+    });
+    fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: empty.runId,
+      attemptId: empty.attemptId,
+      terminalStatus: "completed",
+      finalText: "",
+    });
+
+    for (const runId of [omitted.runId, empty.runId]) {
+      expect(fixture.store.getRow("SELECT final_text FROM runs WHERE run_id = ?", [runId]).final_text).toBeNull();
+    }
+    fixture.store.close();
+  });
+
+  it("keeps text produced before a failed terminalization", () => {
+    // Matches the internal adapter path, which stores whatever text was produced
+    // and signals failure through errorCode rather than by discarding the answer.
+    const fixture = createFixture();
+    const run = fixture.kernel.beginExternalSurfaceRun(beginInput(fixture.sessionId));
+
+    fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: run.runId,
+      attemptId: run.attemptId,
+      terminalStatus: "failed",
+      finalText: "Partial answer before the surface gave up.",
+      errorCode: "external_surface_failed",
+    });
+
+    const row = fixture.store.getRow(
+      "SELECT final_text, status, error_code FROM runs WHERE run_id = ?",
+      [run.runId],
+    );
+    expect(row.final_text).toBe("Partial answer before the surface gave up.");
+    expect(row.status).toBe("failed");
+    expect(row.error_code).toBe("external_surface_failed");
+    fixture.store.close();
+  });
+
+  it("rejects a non-string finalText", () => {
+    const fixture = createFixture();
+    const run = fixture.kernel.beginExternalSurfaceRun(beginInput(fixture.sessionId));
+
+    expectCode(() => fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: run.runId,
+      attemptId: run.attemptId,
+      terminalStatus: "completed",
+      finalText: { text: "not a string" } as unknown as string,
+    }), "invalid_external_request");
+
+    // The rejection must leave the run terminalizable, not half-sealed.
+    expect(fixture.store.getRow("SELECT status FROM runs WHERE run_id = ?", [run.runId]).status).not.toBe("succeeded");
+    fixture.store.close();
+  });
 });
 
 function createFixture() {

--- a/desktop/macos/agent/tests/external-surface-authority.test.ts
+++ b/desktop/macos/agent/tests/external-surface-authority.test.ts
@@ -1645,8 +1645,21 @@ describe("external realtime surface authority", () => {
       finalText: { text: "not a string" } as unknown as string,
     }), "invalid_external_request");
 
-    // The rejection must leave the run terminalizable, not half-sealed.
-    expect(fixture.store.getRow("SELECT status FROM runs WHERE run_id = ?", [run.runId]).status).not.toBe("succeeded");
+    // A rejected call must leave the run terminalizable rather than half-sealed,
+    // which only a valid retry landing on a terminal status actually proves.
+    fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: run.runId,
+      attemptId: run.attemptId,
+      terminalStatus: "completed",
+      finalText: "Recovered after the rejected call.",
+    });
+
+    expect(fixture.store.getRow(
+      "SELECT status, final_text FROM runs WHERE run_id = ?",
+      [run.runId],
+    )).toEqual({ status: "succeeded", final_text: "Recovered after the rejected call." });
     fixture.store.close();
   });
 });

--- a/desktop/macos/agent/tests/protocol-v2.test.ts
+++ b/desktop/macos/agent/tests/protocol-v2.test.ts
@@ -393,6 +393,7 @@ describe("protocol v2", () => {
       runId: invoke.runId,
       attemptId: invoke.attemptId,
       terminalStatus: "completed",
+      finalText: "Three parts sand to one part clay.",
     };
     const completed: ExternalSurfaceRunCompleteResultMessage = {
       type: "external_surface_run_complete_result",
@@ -406,6 +407,7 @@ describe("protocol v2", () => {
       ok: true,
       terminalStatus: "completed",
       duplicate: false,
+      finalTextPersisted: true,
     };
     expect([begin, invoke, complete] satisfies InboundMessage[]).toHaveLength(3);
     expect([began, invoked, completed] satisfies OutboundMessage[]).toHaveLength(3);

--- a/desktop/macos/changelog/unreleased/2026-09-realtime-answer-journalling.json
+++ b/desktop/macos/changelog/unreleased/2026-09-realtime-answer-journalling.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "An answer that Omi speaks after deferring a voice question (\"Let me verify...\") is now written to the conversation journal, so a follow-up no longer gets answered from the earlier reply it already corrected."
+  ]
+}


### PR DESCRIPTION
## What changed and why

Refs #12731. **This PR does not close that issue** — see "What this does not repair" below.

An external surface owns its own streaming, so the kernel never observes what a realtime-voice deferral run actually answered. `completeExternalSurfaceRun` was the only point where that text could be captured, and it passed `finalText: null` unconditionally. `CompleteExternalSurfaceRunInput` had no field to carry the text, so the surface could not hand its answer back even if it wanted to.

The fix threads the text through the four layers between the surface and the row:

```
external_surface_run_complete (protocol.ts)
  -> IPC handler (index.ts)
  -> CompleteExternalSurfaceRunInput (kernel-types.ts)
  -> completeExternalSurfaceRun -> finishAttemptAndRun -> runs.final_text
```

No new persistence machinery. `finishAttemptAndRun` already accepted `finalText: string | null` and wrote it through `updateRun`; only external runs were never fed anything.

**Decisions worth naming, all taken from existing precedent rather than preference:**

*Persisted on every terminal status, not only `completed`.* The internal adapter path passes `finalText: result.text` regardless of status and signals failure through `errorCode` rather than by discarding the answer. A realtime run that spoke a partial answer before failing keeps it, and `final_text` keeps meaning "what this run produced".

*Empty and whitespace-only text collapse to `null`.* "Produced no text" then reads identically however the surface expresses it, so no consumer has to special-case the difference. A non-string is rejected as `invalid_external_request` rather than persisted. This is a deliberate divergence from the internal path, which stores `""` as-is.

*The result echoes `finalTextPersisted`.* A surface talking to an older kernel would otherwise read `ok: true` with its answer silently dropped, which is the failure mode of #12731 one layer up. Absence of the field identifies an old kernel; `false` on a `duplicate` replay says first-write-wins kept the earlier text.

*The requeue path now clears `final_text` and `result_json`.* `beginExternalSurfaceRun` is idempotent per `turnId`, and its requeue branch reset `status`/`errorCode`/`errorMessage` but not the answer. That was unreachable while external `final_text` was always null; making the column writable makes it reachable. A recycled run in `queued`/`running` is read live by the context snapshot's `activeRuns` projection (`context-snapshot.ts:299` selects `r.final_text`, and those statuses are in `ACTIVE_RUN_STATUSES`) and by `latestActivity` in the control list. A superseded answer sitting in model context is the #12731 staleness bug one level down.

*No length bound on `finalText`.* `errorCode` is capped, this is not. Deliberate: it matches the internal path, where `result.text` is likewise uncapped, and consumers bound it downstream. Flagging it as a conscious choice rather than an oversight.

## What this does not repair

Being explicit, because the first draft of this description overstated it and two reviewers were right to push back:

1. **Nothing sends `finalText` yet, so merged alone this changes no field behavior.** `externalSurfaceRunCompleteWireMessage` (`AgentRuntimeProcess.swift:1522`) writes `sessionId`, `runId`, `attemptId`, `terminalStatus`, `errorCode` and no text; `completeExternalRunAuthority` / `terminalizeExternalRun` take no text parameter. That is the only producer of this message in the repo. Until the Swift half in #12732 lands, `runs.final_text` for `swift_realtime` runs stays NULL and the issue's evidence query returns the same rows the day after this merges.

2. **The incident's journal loss is not fixed by this PR under any `finalText` supply.** No kernel path materializes a `conversation_turns` assistant row from a plain external-surface run's `final_text`: `completeExternalSurfaceRun` writes the run row and the event, and `ensureAgentSpawnJournal` requires `producerJournal` metadata that only `spawn_agent` children carry. run_659c came from the `think_deeper` voice tool, not `spawn_agent`, so the spawn-receipt framing holds for that run class but not for the incident run itself.

3. **A future Swift producer must accumulate text over the turn stream, not read the turn-end hub property.** For run_659c the streamed reply lived on the voice session hub and was already cleared by the time the journal capture ran, so a companion reading hub state at terminalization would hand this PR an empty string, which collapses to null. Noted in the `protocol.ts` doc comment so whoever builds #12732 meets it before the field trace does.

So: this is the correct receiving half and #12732's stated prerequisite. It should not be recorded as the repair of #12731, and the closing verb is deliberately "Refs".

## Product invariants affected

- INV-AGENT-*
- INV-CHAT-1

Both match on `desktop/macos/agent/src/runtime/**` via `kernel-core.ts` and `kernel-types.ts`. The change is compatible with each, and INV-CHAT-1 is arguably the reason to make it.

**INV-CHAT-1 — "Every canonical conversation has one kernel-owned transcript."** The spoken answer of a realtime-spawned run reaches `omi-agentd.sqlite3` nowhere today, so the one kernel-owned transcript has a hole exactly where the user was answered. Persisting it puts that answer into the canonical store. No second store, no per-surface continuity ring, no mirroring — one new column value on the existing `runs` row.

On the MUST NOT that Swift may not own run truth: the surface **reports** an outcome only it observed, and the kernel validates and writes it. That is the shape the external-surface authority mechanism already has — `terminalStatus` arrives the same way today — and every existing guard still runs ahead of the write: owner and attempt assertions, the pending-invocation check, and the terminal-state guard.

**INV-AGENT-\* — "Omi owns session/run/attempt identity, authority, and lifecycle."** Identity is untouched — `runId` and `attemptId` are still kernel-minted and re-asserted on completion. Of the twelve MUST NOTs the nearest is *"assemble policy or model context from Swift-supplied prompt fragments"*; `finalText` is a record of what a run produced, written after terminalization. The requeue fix above exists precisely so it cannot leak into context assembly through a recycled run.

## How it was verified

Rebased onto current `main` (was 55 behind; #12730 landed in that window and the earlier baseline predated it). Windows, Node 24.14.0, vitest 4.1.10, `npm ci` from the checked-in lockfile.

| Command | Result |
|---|---|
| `npx tsc --noEmit` | clean |
| `npx vitest run tests/external-surface-authority.test.ts` | **27 passed** (18 before) |
| `npx vitest run tests/protocol-v2.test.ts` | **13 passed** |
| `npx vitest run` (full suite, this branch) | 31 failed / **717 passed** |
| `npx vitest run` (full suite, `upstream/main`) | 31 failed / **708 passed** |

Both full-suite runs are on the same machine against the same base, each after `npm run build`. Identical failure count, +9 passing — exactly the nine cases added here. No new failures.

Those 31 are pre-existing, and every one I can account for is a Windows environment failure: `EACCES` binding an `AF_UNIX` socket under `%TEMP%`, `EPERM` from `rmSync` while SQLite still holds a handle, `EPERM: symlink` without Developer Mode, and POSIX path assumptions. A macOS run is the more useful absolute number; the delta above is the part my machine can speak to.

**The tests fail without the fix.** Reverting only `src/runtime/kernel-core.ts` and keeping the tests fails the persistence assertion, the `message.completed` payload assertion, the failed-status retention, and the non-string rejection.

`scripts/pr-preflight --base upstream/main` passes all 14 selected checks.

## Tests

Nine cases in `tests/external-surface-authority.test.ts`:

- text streamed by the surface lands in `runs.final_text`
- the emitted `message.completed` event carries that text rather than `{"text":""}`
- an omitted field, an empty string, and whitespace-only all leave `final_text` null
- text produced before a `failed` terminalization is kept, alongside `status` and `error_code`
- text produced before a `cancelled` terminalization is kept, and the failed-only `errorCode` default does not fire
- a non-string `finalText` is rejected, and a valid retry then lands on `succeeded`, proving the rejection left the run terminalizable rather than half-sealed
- a same-status replay with different text keeps the first answer and returns `duplicate: true`
- `finalTextPersisted` is true when text was stored and false when none was
- an orphaned turn re-begun clears `final_text` and `result_json` instead of carrying a superseded answer into an active run

Plus `finalText` and `finalTextPersisted` pinned on the v2 wire shape in `tests/protocol-v2.test.ts`.

**One gap I have not closed.** The `finalText: request.finalText` glue in `index.ts` is covered at the type level by the v2 wire test, but not by a runtime round-trip — every kernel test calls `completeExternalSurfaceRun` directly. The stdio harness that would prove it (`runtime-stdio-contract`) does not run on this machine, so I would be writing a test I cannot execute. Saying so rather than shipping one I have not watched pass.

Failure-Class: FC-decoded-outcome-discarded-before-canonical-record

The class's contract is that when a boundary decodes an outcome signal, the record downstream consumers treat as canonical must carry it.

## Scope

TypeScript side only. #12732 is the Swift-side delivery half and needs a Mac to build and test.
