### PR TITLE
SCA: stop managed memory formation for basic, without taking any memories away (S5)

### DIFF
--- a/backend/tests/unit/test_daily_memory_sweep.py
+++ b/backend/tests/unit/test_daily_memory_sweep.py
@@ -2019,3 +2019,102 @@ def test_scheduler_proceeds_for_ledger_mode_accounts(monkeypatch):
     # into ordinary day planning for this account (which asks the source
     # provider for the pending day's packet).
     assert source_calls != []
+
+
+# --- S5 (§1.8): a basic account is not admitted to the sweep -----------------
+
+
+def _ledger_control(monkeypatch):
+    """An account that has completed ledger cutover, so the writer-mode skip
+    above the plan gate does not fire and the plan gate is what is under test."""
+    control = MemoryControlState(
+        uid="user-1",
+        head_commit_id="head0",
+        account_generation=4,
+        source_generation=7,
+        writer_mode=WriterMode.ledger,
+    )
+    monkeypatch.setattr(
+        "utils.memory.daily_memory_sweep.read_account_deletion_projection_fence",
+        lambda _uid, db_client: type("Fence", (), {"blocks_projection_writes": False})(),
+    )
+    monkeypatch.setattr(
+        "utils.memory.daily_memory_sweep.ensure_canonical_apply_control_state",
+        lambda _uid, db_client: control,
+    )
+    monkeypatch.setattr(
+        "utils.memory.daily_memory_sweep.firestore.transactional",
+        lambda function: lambda transaction, *args: function(transaction, *args),
+    )
+    return control
+
+
+def _plan_decision(*, allowed: bool, reason: str):
+    from config.plan_catalog import PlanType
+    from utils.managed_compute import Decision
+
+    return Decision(
+        allowed=allowed,
+        reason=reason,
+        feature="memories",
+        funding_owner="omi",
+        plan=PlanType.basic if not allowed else PlanType.unlimited,
+        plan_resolved=True,
+    )
+
+
+def _run_sweep_for_plan(monkeypatch, *, suppression_on: bool, allowed: bool, reason: str):
+    db = _Db()
+    _ledger_control(monkeypatch)
+    source_calls = []
+    monkeypatch.setattr(
+        "utils.memory.daily_memory_sweep.free_tier_memory_suppression_enabled",
+        lambda: suppression_on,
+    )
+    monkeypatch.setattr(
+        "utils.memory.daily_memory_sweep.authorize_managed_compute",
+        lambda *_args, **_kwargs: _plan_decision(allowed=allowed, reason=reason),
+    )
+    summary = run_daily_memory_sweep_scheduler(
+        db_client=db,
+        now=datetime(2026, 8, 24, 12, tzinfo=timezone.utc),
+        uid_inventory=("user-1",),
+        source_provider=lambda *_args, **_kwargs: source_calls.append(True),
+        timezone_resolver=lambda _uid: "UTC",
+        timezone_reconciler=lambda *_args: True,
+        authority=SweepAuthorityState(enabled=True),
+        cohort_authority=DailySweepCohortAuthority(enabled=True, cohort_name="memory-sweep"),
+        cohort_authorizer=lambda *_args: DailySweepCohortDecision.enabled,
+    )
+    return summary, source_calls, db
+
+
+# red-proof: delete the `if free_tier_memory_suppression_enabled():` block in the scheduler
+def test_basic_account_is_not_admitted_by_the_sweep_producer(monkeypatch):
+    """Named proof (b). Acked, not rejected: a definite plan answer is a
+    successful bounded decision, so the fair page cursor may advance. A reject
+    would burn receipt leases and strand the tail behind an account that is
+    never going to be swept."""
+    summary, source_calls, db = _run_sweep_for_plan(
+        monkeypatch, suppression_on=True, allowed=False, reason="basic_not_entitled"
+    )
+    assert source_calls == [], "a basic account must not reach the candidate producer"
+    assert summary.completed_uids == ("user-1",)
+    assert summary.failed_uids == ()
+    assert summary.blocked_users == 1
+    assert db.store == {}, "a suppressed account must not write cursor or receipt state"
+
+
+def test_paid_account_is_still_swept_with_the_flag_on(monkeypatch):
+    _summary, source_calls, _db = _run_sweep_for_plan(
+        monkeypatch, suppression_on=True, allowed=True, reason="plan_paid"
+    )
+    assert source_calls != [], "a paid account must still reach the candidate producer"
+
+
+def test_flag_off_admits_a_basic_account_exactly_as_today(monkeypatch):
+    """Dark rollout: with the flag off the plan is not consulted at all."""
+    _summary, source_calls, _db = _run_sweep_for_plan(
+        monkeypatch, suppression_on=False, allowed=False, reason="basic_not_entitled"
+    )
+    assert source_calls != []

--- a/backend/tests/unit/test_free_tier_memory_policy.py
+++ b/backend/tests/unit/test_free_tier_memory_policy.py
@@ -1,0 +1,216 @@
+"""S5 / decision 9 first half: managed memory formation stops for basic.
+
+Spec `10-backend-plumbing.md` §1.8, flag `FREE_TIER_MEMORY_SUPPRESSION`.
+
+The policy is pure: one `Decision`, one verdict, never raises. What it decides
+is whether a *managed* extractor may run — it never deletes and never hides.
+The three named proofs live here and in
+`test_free_tier_memory_suppression_gate.py`: (a) a basic uid forms no managed
+memory, (b) a basic uid is not admitted by the sweep producer, (c) a
+paid → basic downgrade leaves prior memories readable.
+
+Automatic-or-dead: `test_the_gate_is_wired_into_both_spending_call_sites` reads
+the two production files and fails if either stops consulting this module. The
+decision table alone would stay green with the gate deleted.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+os.environ.setdefault('OPENAI_API_KEY', 'test-openai-key-not-real')
+
+from config.plan_catalog import PlanType
+from utils.free_tier_memory_policy import (
+    MEMORY_FORMATION_FEATURE,
+    free_tier_memory_suppression_enabled,
+    memory_formation_verdict,
+)
+from utils.managed_compute import DECISION_REASONS, Decision
+
+_BACKEND = Path(__file__).resolve().parents[2]
+
+UID = 'uid'
+
+
+def _decision(*, allowed: bool, reason: str, plan: PlanType | None = None, plan_resolved: bool = True) -> Decision:
+    return Decision(
+        allowed=allowed,
+        reason=reason,
+        feature=MEMORY_FORMATION_FEATURE,
+        funding_owner='omi',
+        plan=plan,
+        plan_resolved=plan_resolved,
+    )
+
+
+def _verdict_for(decision: Decision):
+    return memory_formation_verdict(decision_for=lambda _feature: decision)
+
+
+# ------------------------------------------------------------- decision table
+
+
+def test_basic_is_suppressed() -> None:
+    verdict = _verdict_for(_decision(allowed=False, reason='basic_not_entitled', plan=PlanType.basic))
+    assert verdict.suppressed is True
+    assert verdict.reason == 'basic_not_entitled'
+
+
+def test_paid_still_forms_memories() -> None:
+    verdict = _verdict_for(_decision(allowed=True, reason='plan_paid', plan=PlanType.unlimited))
+    assert verdict.allowed is True
+
+
+def test_byok_still_forms_memories() -> None:
+    # The user is paying the provider directly; nothing Omi-billed is spent.
+    assert _verdict_for(_decision(allowed=True, reason='byok')).allowed is True
+
+
+def test_unidentified_plan_fails_open() -> None:
+    """An account we could not identify keeps forming memories.
+
+    Suppression is permanent and invisible — an un-formed memory is never
+    backfilled — so an identification miss must not silently cost a paying user
+    their memories. Mirrors `free_tier_processing_policy`'s fail-open.
+    """
+    verdict = _verdict_for(_decision(allowed=True, reason='plan_unknown_fail_open', plan=None, plan_resolved=False))
+    assert verdict.allowed is True
+
+
+def test_broken_authorization_fails_closed() -> None:
+    """A broken authorization path does NOT fail open: the alternative is
+    spending on a provider we could not authorize."""
+    verdict = _verdict_for(_decision(allowed=False, reason='authorization_unavailable', plan=None, plan_resolved=False))
+    assert verdict.suppressed is True
+
+
+def test_a_raising_decision_source_is_suppressed_not_propagated() -> None:
+    """A raise inside funding-owner resolution must not escape into
+    finalization; it becomes `policy_unavailable`."""
+
+    def boom(_feature: str) -> Decision:
+        raise RuntimeError('owner lookup exploded')
+
+    verdict = memory_formation_verdict(decision_for=boom)
+    assert verdict.suppressed is True
+    assert verdict.reason == 'policy_unavailable'
+    assert verdict.decision is None
+
+
+def test_the_feature_authorized_is_the_one_actually_spent() -> None:
+    """`utils/llm/memories.py` spends `get_llm('memories')`. Authorizing a
+    different literal would gate nothing."""
+    seen: list[str] = []
+    memory_formation_verdict(
+        decision_for=lambda feature: (seen.append(feature), _decision(allowed=True, reason='plan_paid'))[1]
+    )
+    assert seen == ['memories']
+    source = (_BACKEND / 'utils' / 'llm' / 'memories.py').read_text(encoding='utf-8')
+    assert "get_llm('memories')" in source
+
+
+def test_every_reason_reported_is_from_s1s_closed_vocabulary() -> None:
+    for reason in sorted(DECISION_REASONS):
+        verdict = _verdict_for(_decision(allowed=False, reason=reason))
+        assert verdict.reason in DECISION_REASONS
+
+
+def test_policy_unavailable_is_the_only_reason_this_module_invents() -> None:
+    def boom(_feature: str) -> Decision:
+        raise RuntimeError('x')
+
+    assert memory_formation_verdict(decision_for=boom).reason not in DECISION_REASONS
+
+
+# ------------------------------------------------------------------- the flag
+
+
+def test_flag_defaults_off() -> None:
+    """Dark rollout: unset means today's behaviour, byte for byte."""
+    assert free_tier_memory_suppression_enabled() is False
+
+
+def test_flag_is_read_from_the_environment_not_a_plan_quota() -> None:
+    source = (_BACKEND / 'utils' / 'free_tier_memory_policy.py').read_text(encoding='utf-8')
+    tree = ast.parse(source)
+    env_reads = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == 'getenv'
+    ]
+    assert len(env_reads) == 1, 'the policy reads exactly one environment variable: the boolean flag'
+    literal = env_reads[0].args[0]
+    assert isinstance(literal, ast.Constant) and literal.value == 'FREE_TIER_MEMORY_SUPPRESSION'
+
+
+# --------------------------------------------------- automatic-or-dead wiring
+
+
+@pytest.mark.parametrize(
+    'relpath,scope',
+    [
+        ('utils/conversations/process_conversation.py', 'extract_memories'),
+        ('utils/memory/daily_memory_sweep.py', 'sweep producer admission'),
+    ],
+)
+def test_the_gate_is_wired_into_both_spending_call_sites(relpath: str, scope: str) -> None:
+    """Delete either call and this fails. The decision table above would not.
+
+    Both sites must consult the flag *and* the verdict: a site that reads the
+    flag without the verdict suppresses everyone, and a site that reads the
+    verdict without the flag is not a dark rollout.
+    """
+    source = (_BACKEND / relpath).read_text(encoding='utf-8')
+    assert 'free_tier_memory_suppression_enabled()' in source, f'{relpath} ({scope}) no longer reads the flag'
+    assert 'memory_formation_verdict(' in source, f'{relpath} ({scope}) no longer consults the policy'
+
+
+def test_the_policy_cannot_reach_a_model_client() -> None:
+    """It is the deny path for spending; it must not itself be able to spend.
+
+    Asserted over the parsed module, not the raw text: the docstring names
+    `get_llm` on purpose, and a token scan would either fail on the comment or
+    have to be loosened until it proved nothing.
+    """
+    source = (_BACKEND / 'utils' / 'free_tier_memory_policy.py').read_text(encoding='utf-8')
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                imported.add(node.module)
+            imported.update(f'{node.module}.{alias.name}' for alias in node.names if node.module)
+    assert not any('llm' in name or 'gateway' in name for name in imported), sorted(imported)
+    called = {
+        node.func.attr if isinstance(node.func, ast.Attribute) else getattr(node.func, 'id', '')
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+    }
+    assert 'get_llm' not in called
+    literals = {node.value for node in ast.walk(tree) if isinstance(node, ast.Constant) and isinstance(node.value, str)}
+    assert not any('googleapis.com' in v or 'openai.com' in v or 'anthropic.com' in v for v in literals)
+
+
+def test_the_policy_never_deletes_or_hides() -> None:
+    """Downgrade stops formation. It is not a data event — proof (c).
+
+    Retention is proven by absence at the only layer that could remove
+    something: this module names no delete, archive, hide, or expiry verb.
+    """
+    source = (_BACKEND / 'utils' / 'free_tier_memory_policy.py').read_text(encoding='utf-8')
+    tree = ast.parse(source)
+    called = {
+        node.func.attr if isinstance(node.func, ast.Attribute) else getattr(node.func, 'id', '')
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+    }
+    forbidden = {'delete', 'delete_memory', 'archive', 'hide', 'expire', 'reject_or_hide', 'update'}
+    assert not (called & forbidden), f'the suppression policy must not mutate memories: {sorted(called & forbidden)}'

--- a/backend/tests/unit/test_process_conversation_free_tier_branch.py
+++ b/backend/tests/unit/test_process_conversation_free_tier_branch.py
@@ -18,6 +18,7 @@ import pytest
 
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
 
+from config.plan_catalog import PlanType
 from models.conversation import Conversation, CreateConversation
 from models.conversation_enums import ConversationSource, ConversationStatus
 from models.structured import Structured
@@ -1101,3 +1102,126 @@ def test_terminal_persist_writes_marker_and_normal_persist_clears_it(monkeypatch
     ), 'normal persist must write the marker as None so merge=True clears a stale terminal'
     assert normal_payloads[-1][field] is None
     assert terminal_payloads[-1][field] is True
+
+
+# --- S5 (§1.8): managed memory formation stops for basic ----------------------
+
+
+def _memory_decision(pc, *, allowed: bool, reason: str, plan: Any = None):
+    return pc.Decision(
+        allowed=allowed,
+        reason=reason,
+        feature='memories',
+        funding_owner='omi',
+        plan=plan,
+        plan_resolved=plan is not None,
+    )
+
+
+def _extract_memories_probe(monkeypatch, pc, *, suppression_on: bool, decision) -> MagicMock:
+    """Drive the real `extract_memories` down to (or past) the §1.8 gate."""
+    # A MagicMock result, not a SimpleNamespace: past the gate the real
+    # telemetry reads attributes this test does not care about, and the point
+    # here is only whether the extractor was reached.
+    inner = MagicMock(return_value=MagicMock(count=1, path='eager'))
+    monkeypatch.setattr(pc, '_extract_memories_inner', inner)
+    monkeypatch.setattr(pc, 'MemoryService', MagicMock())
+    monkeypatch.setattr(pc, '_sweep_owned_writer_mode', lambda _uid: None)
+    monkeypatch.setattr(pc, 'free_tier_memory_suppression_enabled', lambda: suppression_on)
+    monkeypatch.setattr(pc, '_funding_owner_for_feature', lambda _feature: 'omi')
+    monkeypatch.setattr(pc, 'authorize_managed_compute', lambda *args, **kwargs: decision)
+    return inner
+
+
+# red-proof: delete the `if free_tier_memory_suppression_enabled():` block in extract_memories
+def test_basic_uid_forms_no_managed_memory(monkeypatch, pc) -> None:
+    """Named proof (a): a finalized conversation on basic makes zero
+    memory-extraction provider-lane calls."""
+    inner = _extract_memories_probe(
+        monkeypatch,
+        pc,
+        suppression_on=True,
+        decision=_memory_decision(pc, allowed=False, reason='basic_not_entitled', plan=PlanType.basic),
+    )
+    pc.extract_memories('basic-uid', _existing_desktop('basic-conv'))
+    inner.assert_not_called()
+
+
+def test_paid_uid_still_forms_memories_with_the_flag_on(monkeypatch, pc) -> None:
+    inner = _extract_memories_probe(
+        monkeypatch,
+        pc,
+        suppression_on=True,
+        decision=_memory_decision(pc, allowed=True, reason='plan_paid', plan=PlanType.unlimited),
+    )
+    pc.extract_memories('paid-uid', _existing_desktop('paid-conv'))
+    inner.assert_called_once()
+
+
+def test_flag_off_is_byte_identical_for_basic(monkeypatch, pc) -> None:
+    """Dark rollout: with the flag off, a basic uid extracts exactly as today —
+    the policy is not even consulted."""
+    consulted: list[str] = []
+    inner = _extract_memories_probe(
+        monkeypatch,
+        pc,
+        suppression_on=False,
+        decision=_memory_decision(pc, allowed=False, reason='basic_not_entitled', plan=PlanType.basic),
+    )
+    monkeypatch.setattr(
+        pc,
+        'memory_formation_verdict',
+        lambda **kwargs: consulted.append('called') or pytest.fail('policy consulted with the flag off'),
+    )
+    pc.extract_memories('basic-uid', _existing_desktop('flag-off-conv'))
+    inner.assert_called_once()
+    assert consulted == []
+
+
+def test_sweep_owned_writer_still_short_circuits_before_the_plan_gate(monkeypatch, pc) -> None:
+    """The plan gate is a *second* early return in the same boundary, not a
+    replacement: a ledger-cutover account is still skipped for its own reason,
+    and the plan lookup never runs for it."""
+    inner = _extract_memories_probe(
+        monkeypatch,
+        pc,
+        suppression_on=True,
+        decision=_memory_decision(pc, allowed=True, reason='plan_paid', plan=PlanType.unlimited),
+    )
+    monkeypatch.setattr(pc, '_sweep_owned_writer_mode', lambda _uid: 'ledger')
+    asked: list[str] = []
+    monkeypatch.setattr(pc, 'memory_formation_verdict', lambda **kwargs: asked.append('asked'))
+    pc.extract_memories('ledger-uid', _existing_desktop('ledger-conv'))
+    inner.assert_not_called()
+    assert asked == [], 'the sweep-owned early return must win before any plan lookup'
+
+
+def test_replayed_finalization_of_a_suppressed_conversation_still_spends_nothing(monkeypatch, pc) -> None:
+    """S6's worst defect was request-scoped terminal state: a Cloud Task retry
+    re-ran memory extraction for a basic user. The gate must hold on replay."""
+    inner = _extract_memories_probe(
+        monkeypatch,
+        pc,
+        suppression_on=True,
+        decision=_memory_decision(pc, allowed=False, reason='basic_not_entitled', plan=PlanType.basic),
+    )
+    conversation = _existing_desktop('replayed-conv')
+    for _ in range(3):
+        pc.extract_memories('basic-uid', conversation)
+    inner.assert_not_called()
+
+
+def test_a_raising_plan_lookup_suppresses_instead_of_failing_finalization(monkeypatch, pc) -> None:
+    inner = _extract_memories_probe(
+        monkeypatch,
+        pc,
+        suppression_on=True,
+        decision=_memory_decision(pc, allowed=True, reason='plan_paid', plan=PlanType.unlimited),
+    )
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError('authorization exploded')
+
+    monkeypatch.setattr(pc, 'authorize_managed_compute', boom)
+    pc.extract_memories('erroring-uid', _existing_desktop('erroring-conv'))
+    inner.assert_not_called()

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -88,6 +88,10 @@ from utils.observability.finalization import FinalizationFailureReason, record_f
 from utils.product_telemetry import emit_product_event
 from utils.task_intelligence.workstream_association import associate_canonical_evidence
 from utils.subscription import is_trial_paywalled, should_defer_desktop_processing
+from utils.free_tier_memory_policy import (
+    free_tier_memory_suppression_enabled,
+    memory_formation_verdict,
+)
 from utils.free_tier_processing_policy import (
     FreeTierProcessingPlan,
     free_tier_local_processing_enabled,
@@ -971,6 +975,19 @@ def extract_memories(uid: str, conversation: Conversation) -> None:
             conversation.id,
         )
         return
+    # §1.8: plan denial is a second early return in this same boundary, not a
+    # parallel branch. Everything below spends `get_llm('memories')`, so the
+    # gate has to sit above it rather than inside the extractor.
+    if free_tier_memory_suppression_enabled():
+        verdict = memory_formation_verdict(decision_for=_managed_compute_decision_for(uid))
+        if verdict.suppressed:
+            logger.info(
+                'memory extraction skipped: plan denies managed formation uid=%s conv=%s reason=%s',
+                uid,
+                conversation.id,
+                verdict.reason,
+            )
+            return
     source = source_for_conversation(conversation)
     parity_capture = SurfaceParityCapture.from_environ(
         principal_id=uid,

--- a/backend/utils/free_tier_memory_policy.py
+++ b/backend/utils/free_tier_memory_policy.py
@@ -1,0 +1,100 @@
+"""Decision 9, first half: stop SERVER-side memory formation for basic.
+
+Spec: `10-backend-plumbing.md` §1.8. Flag: `FREE_TIER_MEMORY_SUPPRESSION`
+(`50-rollout-and-verification.md`) — its own flag, not S6's, because turning
+off the deterministic-minimum store must not silently restart managed memory
+formation, and vice versa. No flag gates two workstreams.
+
+The module is pure and never raises: it consults S1's ``Decision`` exactly once
+through an injected ``decision_for`` and returns a verdict. Callers read the
+flag; this module does not, so a test can exercise the decision table without
+touching the environment.
+
+**What it never does is delete.** A basic user keeps every memory formed while
+they were paid, and keeps reading them. Only *formation* stops. Downgrade is
+not a data event.
+
+**The asymmetry worth knowing.** A conversation denied the managed summary still
+exists and still shows a title — the user can see what happened. A memory that
+was never formed is invisible and, per the flag's own rollout note, is never
+backfilled. So suppression is a permanent, silent loss when it fires on the
+wrong account, which is why an *unidentified* plan fails open here exactly as it
+does in `free_tier_processing_policy`: we decline to punish a user we could not
+identify. A broken authorization path still fails closed, because the
+alternative is spending on a provider we could not authorize.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from utils.managed_compute import Decision
+
+logger = logging.getLogger(__name__)
+
+# Boolean rollout flag only. Plan quotas and allowlists never come from the env.
+FREE_TIER_MEMORY_SUPPRESSION = os.getenv('FREE_TIER_MEMORY_SUPPRESSION', 'false').lower() == 'true'
+
+# Eager per-conversation extraction spends `get_llm('memories')`
+# (`utils/llm/memories.py`). That literal is the feature this gate authorizes.
+MEMORY_FORMATION_FEATURE = 'memories'
+
+_POLICY_UNAVAILABLE = 'policy_unavailable'
+
+DecisionFor = Callable[[str], Decision]
+
+
+def free_tier_memory_suppression_enabled() -> bool:
+    """Read the rollout flag. Tests monkeypatch this (or the module constant)."""
+    return FREE_TIER_MEMORY_SUPPRESSION
+
+
+@dataclass(frozen=True)
+class MemoryFormationVerdict:
+    """Whether managed memory formation may run for one account."""
+
+    allowed: bool
+    reason: str
+    decision: Decision | None
+
+    @property
+    def suppressed(self) -> bool:
+        return not self.allowed
+
+
+def memory_formation_verdict(*, decision_for: DecisionFor) -> MemoryFormationVerdict:
+    """May managed memory formation run for this account?
+
+    Flag-agnostic (pure): the coordinator and the sweep each read
+    ``free_tier_memory_suppression_enabled()`` and do not call this when the
+    flag is off, so the flag-off path is byte-identical to today.
+
+    ``decision_for`` closes over the uid and the funding owner, so a raising
+    owner lookup is caught here and becomes ``policy_unavailable`` — suppressed
+    — rather than escaping into finalization.
+    """
+    try:
+        decision = decision_for(MEMORY_FORMATION_FEATURE)
+    except Exception as exc:
+        logger.warning('free-tier memory policy unavailable: %s', type(exc).__name__)
+        return MemoryFormationVerdict(allowed=False, reason=_POLICY_UNAVAILABLE, decision=None)
+
+    if decision.allowed:
+        # Includes `plan_unknown_fail_open`: an account we could not identify
+        # keeps forming memories. See the module docstring on why this one
+        # fails open while a broken authorization path does not.
+        return MemoryFormationVerdict(allowed=True, reason=decision.reason, decision=decision)
+
+    return MemoryFormationVerdict(allowed=False, reason=decision.reason, decision=decision)
+
+
+__all__ = [
+    'FREE_TIER_MEMORY_SUPPRESSION',
+    'MEMORY_FORMATION_FEATURE',
+    'MemoryFormationVerdict',
+    'free_tier_memory_suppression_enabled',
+    'memory_formation_verdict',
+]

--- a/backend/utils/memory/daily_memory_sweep.py
+++ b/backend/utils/memory/daily_memory_sweep.py
@@ -71,6 +71,11 @@ from models.product_memory import (
     MemorySubjectScope,
     normalized_memory_content_key,
 )
+from utils.free_tier_memory_policy import (
+    free_tier_memory_suppression_enabled,
+    memory_formation_verdict,
+)
+from utils.managed_compute import authorize_managed_compute
 from utils.memory.canonical_memory_adapter import read_canonical_memory_item
 from utils.memory.daily_memory_sweep_queue import ProcessOutcome, drain_sweep_uids
 from utils.memory.knowledge_ledger import (
@@ -4898,6 +4903,27 @@ def run_daily_memory_sweep_scheduler(
                 blocked_users += 1
                 completed_uids.append(uid)
                 return ProcessOutcome.ack()
+            if free_tier_memory_suppression_enabled():
+                # §1.8: a basic account is not admitted to the sweep at all, so
+                # an account that downgrades stops being swept rather than
+                # having its already-claimed day fail late. Ack like the
+                # disabled-cohort branch above: a definite plan answer is a
+                # successful bounded decision and may advance the fair page
+                # cursor. Rejecting instead would burn receipt leases and
+                # strand the tail. The sweep is a cron with no request, so the
+                # funding owner is always the platform.
+                verdict = memory_formation_verdict(
+                    decision_for=lambda feature: authorize_managed_compute(uid, feature, "omi")
+                )
+                if verdict.suppressed:
+                    logger.info(
+                        "daily-memory-sweep skipping uid=%s: plan denies managed formation reason=%s",
+                        uid,
+                        verdict.reason,
+                    )
+                    blocked_users += 1
+                    completed_uids.append(uid)
+                    return ProcessOutcome.ack()
             timezone_name = str(timezone_resolver(uid) or "UTC")
             cursor = _read_cursor(db_client, uid, control)
             if cursor.last_completed_local_date is not None and cursor.timezone_name != timezone_name:


### PR DESCRIPTION
## S5 — managed memory formation stops for basic (decision 9, first half)

Shard S5 of the ratified local-models free-tier program (`60-shards.md` row S5;
spec `10-backend-plumbing.md` §1.8). Branched from `main` after S3.

S6 already suppresses eager extraction for basic **desktop** conversations,
because its terminal store returns before `extract_memories` is ever reached.
S5 is the rest: every other source, the daily sweep's own producer admission,
and the downgrade semantics.

### What changed

- **`backend/utils/free_tier_memory_policy.py` (new)** — one pure decision.
  Consults S1's `Decision` exactly once through an injected `decision_for`,
  never raises, and returns a verdict. Callers read the flag; the module does
  not, so the decision table is testable without touching the environment.
- **`extract_memories`** — the gate is a **second early return in the same
  boundary** as `_sweep_owned_writer_mode`, per the brief, not a parallel
  branch. Everything below it spends `get_llm('memories')`, so it has to sit
  above rather than inside the extractor.
- **`daily_memory_sweep.py` producer admission** — a basic account is skipped
  beside the existing writer-mode skip. It **acks**, exactly like the
  `cohort_decision is disabled` branch: a definite plan answer is a successful
  bounded decision and may advance the fair page cursor. Rejecting would burn
  receipt leases and strand the tail behind an account that is never going to
  be swept. The sweep is a cron with no request, so the funding owner is always
  the platform.

### Two decisions worth reviewing rather than skimming

**`FREE_TIER_MEMORY_SUPPRESSION` is its own flag, not S6's.**
`50-rollout-and-verification.md` lists it separately, and the rule there is *no
flag gates two workstreams*. Turning off the deterministic-minimum store to fix
a summary bug must not silently restart managed memory formation, and vice
versa. Unset means off means byte-identical to today.

**An unidentified plan fails OPEN; a broken authorization path fails CLOSED.**
This is deliberate asymmetry, and it is the one place S5 departs from a flat
reading of "fail closed". A conversation denied its managed summary still
exists and still shows a title — the user can see what happened. A memory that
was never formed is invisible, and per that flag's own rollout note it is
**never backfilled**. So an identification miss must not silently cost a paying
user their memories; that is the same fail-open
`free_tier_processing_policy` already takes on `plan_unknown_fail_open`. A
*broken* authorization path still suppresses, because the alternative is
spending on a provider we could not authorize.

### Automatic-or-dead check

`test_the_gate_is_wired_into_both_spending_call_sites` reads the two production
files and fails if either stops consulting the flag **or** the verdict. Both
halves matter: a site that reads the flag without the verdict suppresses
everyone, and a site that reads the verdict without the flag is not a dark
rollout. The decision table alone would stay green with the gate deleted from
both call sites — which is exactly why the wiring check exists next to it.

### Proof — the three named §1.8 proofs, behavioural

- **(a) basic ⇒ zero managed formation.**
  `test_basic_uid_forms_no_managed_memory` drives the real `extract_memories`
  and asserts the extractor is never reached. Paired with
  `test_paid_uid_still_forms_memories_with_the_flag_on`, so the gate is proven
  to discriminate rather than to be off.
- **(b) basic is not admitted by the sweep producer.**
  `test_basic_account_is_not_admitted_by_the_sweep_producer` runs the real
  scheduler and asserts the candidate producer is never called, the uid is
  **completed not failed**, `blocked_users == 1`, and `db.store == {}` — no
  cursor or receipt write for a suppressed account.
- **(c) downgrade is not a data event.**
  `test_the_policy_never_deletes_or_hides` asserts over the parsed module that
  the suppression policy names no delete, archive, hide, or expire verb.
  Retention is proven by absence at the only layer that could remove something.

Plus the replay case S6 learned the hard way:
`test_replayed_finalization_of_a_suppressed_conversation_still_spends_nothing`
finalizes the same conversation three times and asserts zero extractor calls.
And `test_sweep_owned_writer_still_short_circuits_before_the_plan_gate` proves
the new return is genuinely *second* — a ledger-cutover account is still skipped
for its own reason and never reaches a plan lookup.

Totals on the branch: **308 passed** across `test_daily_memory_sweep` (60),
`test_free_tier_memory_policy` (15), `test_process_conversation_free_tier_branch`
(23), `test_free_tier_entrypoint_matrix` (173), `test_free_tier_processing_policy`
(29), `test_daily_memory_sweep_job` (8). `pyright`: 0 errors.

### Cut list

- Registering the flag in `backend/deploy/runtime_env` manifests. S6's flag is
  not registered either, and unset already fails closed; doing one and not the
  other would be worse than doing neither.
- W1 §1.9 — admitting locally-formed memories. That is the second half of
  decision 9 and its own shard; this PR only stops the managed writer.
- Any change to what a basic user can *read*. Nothing here deletes, hides, or
  expires a memory.

### Line-count ratchet

The decision itself is a new module, so what lands in the two large files is the
call and its reason — a gate that has to sit at the top of the spending path
cannot be moved out of that path.

Line-Count-Exception: backend/utils/conversations/process_conversation.py | 2926 -> 2943 | §1.8's plan gate is a second early return in extract_memories' existing boundary; the decision lives in the new utils/free_tier_memory_policy.py
Line-Count-Exception: backend/utils/memory/daily_memory_sweep.py | 5048 -> 5074 | producer admission skips a basic account beside the existing writer-mode skip, with the ack-not-reject reasoning inline

### Product invariants

- `INV-MEM-1` — `backend/utils/memory/**` is a locked path, so this names it
  explicitly: the shard adds **no tier**, no collection, and no access-policy
  change. The sweep gate is an admission decision taken *before* any candidate
  exists, so nothing reaches a tier at all; the default Short-term + Long-term
  access policy and the canonical `memory_items` collection are untouched. A
  downgraded user's existing rows keep their tiers and stay readable — the one
  thing this shard is careful never to do is move or hide a row.
- `INV-MEM-4` — no promotion, admission, or Long-term authority path changes.
  This gate sits strictly *above* formation: when it fires, no candidate is
  produced at all, so no consolidation route is left dangling. When it does not
  fire, every existing route runs unchanged.
- `INV-TASK-2` — no capture path changes; this shard removes a writer for basic
  accounts and adds none.

### Failure class

No `fix:` commits in this range.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

