### PR TITLE
fix(backend): drop CI guardrail references to files deleted in WS-G cleanup

### DIFF
--- a/backend/docs/llm/model_endpoint_inventory.yaml
+++ b/backend/docs/llm/model_endpoint_inventory.yaml
@@ -142,8 +142,6 @@ surfaces:
   - utils/llm/persona.py::feature:<dynamic>
   - utils/llm/persona.py::feature:persona_clone
   - utils/llm/proactive_notification.py::feature:proactive_notification
-  - utils/llm/promotion_proposals.py::feature:memory_l2
-  - utils/llm/promotion_routes.py::feature:memory_l2
   - utils/llm/trends.py::feature:trends
   - utils/llm/wake_word_adjudication.py::feature:wake_word_adjudication
   - utils/llm/working_observations.py::feature:memory_l1

--- a/backend/tests/slow_guardrail_manifest.txt
+++ b/backend/tests/slow_guardrail_manifest.txt
@@ -19,6 +19,11 @@
 # silently dropped: a guardrail that starts failing is fixed or removed with a
 # stated reason, not un-listed.
 #
+# Removed: tests/unit/test_ws_g_module_aliases.py — the file itself was deleted
+# in a7bc5fd0c2 (WS-G11 dead-code removal) the day before this manifest was
+# built, so it was never actually green under this lane; there is no guardrail
+# left to track.
+#
 # NOT YET LISTED — red on `main` at the time this lane was built, each needs its
 # own fix and its own PR. They are named rather than omitted so the gap stays
 # countable:
@@ -44,4 +49,3 @@ tests/unit/test_subscription_import_cycle.py
 tests/unit/test_sync_ordered_assignment.py
 tests/unit/test_thread_join_elimination.py
 tests/unit/test_vad_gate.py
-tests/unit/test_ws_g_module_aliases.py


### PR DESCRIPTION
## Bug

The `Backend unit suite` CI lane (added in c094859b3c, merged this morning) fails unconditionally on every PR to main:

- `backend/tests/slow_guardrail_manifest.txt` lists `tests/unit/test_ws_g_module_aliases.py`, which was deleted by `a7bc5fd0c2` (WS-G dead-code removal) the day before the manifest was built, so `run-slow-guardrails-ci.sh` exits 1 before running anything.
- Once that's fixed, `test_managed_call_sites_absent_from_the_inventory_fail_ci` (`backend/tests/unit/test_llm_gateway_coverage_guardrails.py`) fails because `backend/docs/llm/model_endpoint_inventory.yaml` still lists call sites in `utils/llm/promotion_proposals.py` and `utils/llm/promotion_routes.py`, also removed by `a7bc5fd0c2`.

Both are stale references left behind by that same dead-code-removal commit, not code bugs. Verified 5 of 6 currently-open backend PRs (#12739, #12721, #12719, #12714, #12712) show this exact "Backend unit suite" FAILURE — this is blocking essentially all backend merges to main right now.

## Fix

Remove the stale manifest line (with a dated note per the file's own "never silently dropped" convention) and the two stale inventory entries.

## Tests

`PYTHON=.venv/bin/python bash scripts/run-slow-guardrails-ci.sh` now passes: 103 passed, 1 skipped (was: hard-failing before any test ran). Also ran `test_llm_gateway_coverage_guardrails.py` + `test_firestore_query_contract.py` directly: 72 passed.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

