### PR TITLE
feat(catalog): recognize two still-billed older Unlimited prices

### DIFF
--- a/backend/config/plan_catalog.json
+++ b/backend/config/plan_catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "catalog_revision": 2,
+  "catalog_revision": 3,
   "authority": {
     "plan_identity": "catalog",
     "price_identity": "repository_ledger",
@@ -601,6 +601,18 @@
     },
     {
       "price_id": "price_1TNIHd1F8wnoWYvwlKywJ8TO",
+      "plan_id": "unlimited",
+      "interval": "year",
+      "environment": "prod"
+    },
+    {
+      "price_id": "price_1RrFym1F8wnoWYvwQgIFhRWD",
+      "plan_id": "unlimited",
+      "interval": "month",
+      "environment": "prod"
+    },
+    {
+      "price_id": "price_1RrG6k1F8wnoWYvwORsU26Mr",
       "plan_id": "unlimited",
       "interval": "year",
       "environment": "prod"

--- a/backend/config/plan_catalog_generated.py
+++ b/backend/config/plan_catalog_generated.py
@@ -25,8 +25,8 @@ WIRE_PLAN_ALIASES: Final[dict[str, PlanType]] = {
     'pro': PlanType.architect,
 }
 
-CATALOG_SHA256: Final = '67f5024782f1e55742395b4e32644a4a8e478282d37593dd8225e5fb00bda22d'
-CATALOG_REVISION: Final = 2
+CATALOG_SHA256: Final = 'faa5baad5119b596a5256cd1eb552ddf93f00aef37c560f558aabcf7eabc1831'
+CATALOG_REVISION: Final = 3
 CATALOG_AUTHORITY: Final = {'plan_identity': 'catalog',
  'price_identity': 'repository_ledger',
  'price_amount': 'stripe_live',
@@ -279,6 +279,8 @@ RECOGNIZED_STRIPE_PRICE_PLAN_TYPES: Final[dict[str, PlanType]] = {
     'price_1RtJQ71F8wnoWYvwKMPaGlGY': PlanType.unlimited,
     'price_1TNIHd1F8wnoWYvwkIrekcQZ': PlanType.unlimited,
     'price_1TNIHd1F8wnoWYvwlKywJ8TO': PlanType.unlimited,
+    'price_1RrFym1F8wnoWYvwQgIFhRWD': PlanType.unlimited,
+    'price_1RrG6k1F8wnoWYvwORsU26Mr': PlanType.unlimited,
     'price_1TLFXK1F8wnoWYvwG1TaUkZ3': PlanType.architect,
     'price_1TN7s21F8wnoWYvwG6JuEFm6': PlanType.architect,
     'price_1TN7sF1F8wnoWYvwd0QaLZNA': PlanType.architect,
@@ -299,6 +301,8 @@ RECOGNIZED_STRIPE_PRICE_INTERVALS: Final[dict[str, str]] = {'price_1RrxXL1F8wnoW
  'price_1RtJQ71F8wnoWYvwKMPaGlGY': 'year',
  'price_1TNIHd1F8wnoWYvwkIrekcQZ': 'month',
  'price_1TNIHd1F8wnoWYvwlKywJ8TO': 'year',
+ 'price_1RrFym1F8wnoWYvwQgIFhRWD': 'month',
+ 'price_1RrG6k1F8wnoWYvwORsU26Mr': 'year',
  'price_1TLFXK1F8wnoWYvwG1TaUkZ3': 'month',
  'price_1TN7s21F8wnoWYvwG6JuEFm6': 'month',
  'price_1TN7sF1F8wnoWYvwd0QaLZNA': 'year',

--- a/backend/tests/unit/test_plan_catalog_contract.py
+++ b/backend/tests/unit/test_plan_catalog_contract.py
@@ -116,6 +116,9 @@ def test_support_scanner_derives_every_paid_plan_and_retained_price():
         # B6: actively sold production IDs are retained without a "legacy" assumption.
         ('price_1RtJPm1F8wnoWYvwhVJ38kLb', PlanType.unlimited),
         ('price_1RtJQ71F8wnoWYvwKMPaGlGY', PlanType.unlimited),
+        # Older Unlimited $19/$199 extras still billed on prod_SmpevIU38nIEUO.
+        ('price_1RrFym1F8wnoWYvwQgIFhRWD', PlanType.unlimited),
+        ('price_1RrG6k1F8wnoWYvwORsU26Mr', PlanType.unlimited),
         ('price_1TAfBB1F8wnoWYvw8XBFM1dX', PlanType.architect),
         ('price_1TLFac1F8wnoWYvwtPxZhtzE', PlanType.architect),
         # Current production consumer-plan prices.


### PR DESCRIPTION
Recognize two still-billed older Unlimited prices that a live GET-only census found are active on `prod_SmpevIU38nIEUO`:

- `price_1RrFym1F8wnoWYvwQgIFhRWD` (month) → `unlimited/prod`
- `price_1RrG6k1F8wnoWYvwORsU26Mr` (year) → `unlimited/prod`

3 people are currently billed on these price IDs. `payment.py` could not resolve them prior to this change.

Bumps `catalog_revision` 2→3 and regenerates `plan_catalog_generated.py`.

**No dollar amounts recorded. No live Stripe writes.**

## Verification

```
python backend/scripts/generate_plan_catalog.py --check --base-ref origin/main
# plan catalog is valid and backend/config/plan_catalog_generated.py is current

pytest tests/unit/test_plan_catalog_contract.py -q --noconftest
# 24 passed, 1 skipped (support-scanner skipped: missing google.cloud in test env)
```

## Failure-Class

`Failure-Class: FC-unrecognized-price | none`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

