### PR TITLE
fix(ci): remove stale ws_g manifest entry — file deleted in a7bc5fd0c2

### DIFF
--- a/backend/tests/slow_guardrail_manifest.txt
+++ b/backend/tests/slow_guardrail_manifest.txt
@@ -25,6 +25,13 @@
 #   tests/unit/test_subscription_restructure.py       32 failed, 2 passed
 #   tests/unit/test_firestore_query_coverage_ratchet.py    1 failed, 1 passed
 #   tests/unit/test_sys_modules_hermeticity.py             1 failed, 1 passed
+#
+# REMOVED — file deleted, aliases it guarded no longer exist:
+#   tests/unit/test_ws_g_module_aliases.py  removed in a7bc5fd0c2
+#     ("chore(backend): remove dead modules and orphaned WS-G promotion family")
+#     The WS-G alias shims (WorkingObservation, L1MemoryArchiveItem, etc.) were
+#     deleted along with the rest of the WS-G promotion family. No replacement
+#     needed; the contract those aliases enforced is gone.
 
 tests/unit/test_async_tasks.py
 tests/unit/test_desktop_transcribe.py
@@ -44,4 +51,3 @@ tests/unit/test_subscription_import_cycle.py
 tests/unit/test_sync_ordered_assignment.py
 tests/unit/test_thread_join_elimination.py
 tests/unit/test_vad_gate.py
-tests/unit/test_ws_g_module_aliases.py


### PR DESCRIPTION
## Problem

`backend/tests/slow_guardrail_manifest.txt` listed `tests/unit/test_ws_g_module_aliases.py`, but that file was deleted in `a7bc5fd0c2` ("remove dead modules and orphaned WS-G promotion family"). The manifest was not updated at the time.

This caused **Backend unit suite** to fail on every PR touching backend files since the slow-guardrail lane started actually running (`84ec103325`).

Surfaced by: #12744

## Fix

Move the entry to the `REMOVED` comment block with the deletion commit cited, per the manifest's own policy ("removed with a stated reason, not un-listed"). The WS-G alias shims (`WorkingObservation`, `L1MemoryArchiveItem`, etc.) no longer exist — there is nothing to guard.

## Verification

```
bash backend/scripts/run-slow-guardrails-ci.sh
# Running slow-marked guardrails across 18 file(s).
# (file-existence pre-flight passes; full suite requires CI deps)
```

## Failure-Class

`Failure-Class: none`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

