### PR TITLE
fix(macos): stop the voice journal sealing unspoken answers as completed

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/KernelTurnJournal.swift
+++ b/desktop/macos/Desktop/Sources/Chat/KernelTurnJournal.swift
@@ -162,6 +162,12 @@ struct KernelJournalTurnUpdate: Sendable {
   let resourcesJSON: String?
   let appendResourcesJSON: String?
   let metadataJSON: String?
+  /// Narrow authority flag for revising an optimistically sealed terminal row:
+  /// the same desktop client that sealed a row `.completed` before delivery
+  /// resolved may downgrade it to `.failed` when the answer never reached the
+  /// user (#12743). The kernel accepts this only as a payload-free downgrade
+  /// and merges — never replaces — the row's existing metadata.
+  let terminalRevision: Bool
 
   /// A terminal lifecycle update that deliberately carries no response
   /// payload. This is used after stop/supersession when the visible projection
@@ -179,7 +185,37 @@ struct KernelJournalTurnUpdate: Sendable {
       appendContentBlocksJSON: nil,
       resourcesJSON: nil,
       appendResourcesJSON: nil,
-      metadataJSON: nil
+      metadataJSON: nil,
+      terminalRevision: false
+    )
+  }
+
+  /// Downgrades an optimistically sealed `.completed` row to `.failed` with
+  /// its truncation cause, carrying no payload: content, content blocks,
+  /// resources, and existing metadata (model attribution, continuity) stay
+  /// untouched while `terminalReason` merges into the row's metadata.
+  static func sealedTerminalRevision(
+    turnId: String,
+    terminalReason: String
+  ) -> KernelJournalTurnUpdate {
+    let encodedReason: String
+    if let data = try? JSONSerialization.data(withJSONObject: ["terminalReason": terminalReason]),
+      let encoded = String(data: data, encoding: .utf8)
+    {
+      encodedReason = encoded
+    } else {
+      encodedReason = "{}"
+    }
+    return KernelJournalTurnUpdate(
+      turnId: turnId,
+      status: .failed,
+      content: nil,
+      contentBlocksJSON: nil,
+      appendContentBlocksJSON: nil,
+      resourcesJSON: nil,
+      appendResourcesJSON: nil,
+      metadataJSON: encodedReason,
+      terminalRevision: true
     )
   }
 
@@ -200,6 +236,7 @@ struct KernelJournalTurnUpdate: Sendable {
       value["appendResources"] = KernelJournalTurnWrite.jsonArray(appendResourcesJSON)
     }
     if let metadataJSON { value["metadataJson"] = metadataJSON }
+    if terminalRevision { value["terminalRevision"] = true }
     return value
   }
 }
@@ -395,7 +432,8 @@ extension ChatMessage {
       appendContentBlocksJSON: nil,
       resourcesJSON: ChatResource.encodeResourcesForPersistence(displayResources) ?? "[]",
       appendResourcesJSON: nil,
-      metadataJSON: metadataJSON
+      metadataJSON: metadataJSON,
+      terminalRevision: false
     )
   }
 }

--- a/desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
+++ b/desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift
@@ -140,7 +140,8 @@ enum KernelAgentLifecycleMutation {
       appendResourcesJSON: ChatResource.encodeResourcesForPersistence(
         result.resources
       ) ?? "[]",
-      metadataJSON: nil
+      metadataJSON: nil,
+      terminalRevision: false
     )
   }
 
@@ -620,6 +621,37 @@ final class KernelTurnProjection {
       return turn
     } catch {
       log("KernelTurnProjection: journal status update failed (code=journal_status_update_failed)")
+      return nil
+    }
+  }
+
+  /// Revises a row this client sealed `.completed` before delivery resolved,
+  /// downgrading it to `.failed` with its truncation cause when the answer
+  /// never reached the user (#12743). Payload-free by construction: the row's
+  /// content, blocks, resources, and existing metadata (model attribution,
+  /// continuity) are preserved; the kernel merges the terminal reason into
+  /// the row's metadata rather than replacing it.
+  @discardableResult
+  func reviseSealedTerminalTurn(
+    surface: AgentSurfaceReference,
+    turnId: String,
+    terminalReason: String,
+    ownerID: String? = nil
+  ) async -> KernelJournalTurn? {
+    guard let lease = captureOwnerLease(ownerID: ownerID), let host else { return nil }
+    guard await host.ensureBridgeStartedForKernel(), isCurrent(lease), let client else { return nil }
+    do {
+      let turn = try await client.updateJournalTurn(
+        surface: surface,
+        ownerID: lease.ownerID,
+        update: .sealedTerminalRevision(turnId: turnId, terminalReason: terminalReason)
+      )
+      guard isCurrent(lease) else { return nil }
+      _ = await refresh(surface: surface, lease: lease, publishPartialResults: true)
+      guard isCurrent(lease) else { return nil }
+      return turn
+    } catch {
+      log("KernelTurnProjection: journal terminal revision failed (code=journal_terminal_revision_failed)")
       return nil
     }
   }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarManager+RealtimeStreamingJournal.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarManager+RealtimeStreamingJournal.swift
@@ -70,30 +70,31 @@ extension FloatingControlBarManager {
 
   /// Revises an assistant row that was finalized `.completed` at
   /// provider-response-finish after its turn terminalized without delivering
-  /// the answer (#12743). This is the same kernel-journal update path the
-  /// streaming finalize uses — the journal stays the one transcript authority
-  /// (INV-CHAT-1); it only corrects the row's status and truncation cause, so
-  /// the model's next turns stop inheriting an answer the user never heard.
-  /// Bounded retry mirrors `completeStreamingRealtimeExchange` so a transient
-  /// rejection does not strand the optimistic status.
+  /// the answer (#12743). The revision is payload-free — it changes only the
+  /// row's status and truncation cause — so the sealed row's content blocks,
+  /// resources, and canonical metadata (model attribution, continuity) stay
+  /// exactly as the funnel wrote them; the kernel merges the terminal reason
+  /// into the existing metadata instead of replacing it. The journal stays
+  /// the one transcript authority (INV-CHAT-1). Bounded retry mirrors
+  /// `completeStreamingRealtimeExchange` so a transient rejection does not
+  /// strand the optimistic status.
   func reviseSealedRealtimeAssistantStatus(
     surface: AgentSurfaceReference,
     ownerID: String,
     continuityKey: String,
-    assistantText: String,
-    status: KernelJournalTurnStatus,
     terminalReason: String
   ) async -> Bool {
     guard RuntimeOwnerIdentity.currentOwnerId() == ownerID,
       let provider = sharedFloatingProvider
     else { return false }
-    let projection = RealtimeStreamingJournalProjection(
-      ownerID: ownerID, continuityKey: continuityKey, admissionSurface: surface)
+    let turnID = KernelTurnProjection.stableTurnID(
+      continuityKey: continuityKey, role: "assistant")
     for _ in 0..<3 {
-      if await provider.kernelTurnProjection.updateTurn(
+      if await provider.kernelTurnProjection.reviseSealedTerminalTurn(
         surface: surface,
-        message: projection.assistantMessage(text: assistantText, isStreaming: false),
-        status: status, terminalReason: terminalReason, ownerID: ownerID) != nil
+        turnId: turnID,
+        terminalReason: terminalReason,
+        ownerID: ownerID) != nil
       {
         return true
       }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarManager+RealtimeStreamingJournal.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarManager+RealtimeStreamingJournal.swift
@@ -67,4 +67,37 @@ extension FloatingControlBarManager {
     }
     return false
   }
+
+  /// Revises an assistant row that was finalized `.completed` at
+  /// provider-response-finish after its turn terminalized without delivering
+  /// the answer (#12743). This is the same kernel-journal update path the
+  /// streaming finalize uses — the journal stays the one transcript authority
+  /// (INV-CHAT-1); it only corrects the row's status and truncation cause, so
+  /// the model's next turns stop inheriting an answer the user never heard.
+  /// Bounded retry mirrors `completeStreamingRealtimeExchange` so a transient
+  /// rejection does not strand the optimistic status.
+  func reviseSealedRealtimeAssistantStatus(
+    surface: AgentSurfaceReference,
+    ownerID: String,
+    continuityKey: String,
+    assistantText: String,
+    status: KernelJournalTurnStatus,
+    terminalReason: String
+  ) async -> Bool {
+    guard RuntimeOwnerIdentity.currentOwnerId() == ownerID,
+      let provider = sharedFloatingProvider
+    else { return false }
+    let projection = RealtimeStreamingJournalProjection(
+      ownerID: ownerID, continuityKey: continuityKey, admissionSurface: surface)
+    for _ in 0..<3 {
+      if await provider.kernelTurnProjection.updateTurn(
+        surface: surface,
+        message: projection.assistantMessage(text: assistantText, isStreaming: false),
+        status: status, terminalReason: terminalReason, ownerID: ownerID) != nil
+      {
+        return true
+      }
+    }
+    return false
+  }
 }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+PushToTalk.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+PushToTalk.swift
@@ -52,7 +52,7 @@ extension RealtimeHubController {
     audioReceivedThisTurn = false
     lastExternalToolName = ""
     lastExternalToolErrorCode = ""
-    turnIdempotencyKey = "voice:\(turnID.rawValue.uuidString.lowercased())"
+    turnIdempotencyKey = Self.voiceContinuityKey(for: turnID)
     turnPublicWebEvidence = nil
     resetScreenGrounding(for: turnID)
     if let interruptedTurnTask, !supersedesPendingReplacement {
@@ -66,7 +66,7 @@ extension RealtimeHubController {
             terminal: .interruptedByBargeIn,
             idempotencyKey: interruptedTurn.idempotencyKey,
             acceptedSpawnOwnerID: interruptedTurn.acceptedSpawnOwnerID,
-            answerDelivered: interruptedTurn.answerDelivered) ?? false
+            delivery: interruptedTurn.answerDelivered ? .delivered : .notDelivered) ?? false
         }
       }
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
@@ -1122,6 +1122,17 @@ extension RealtimeHubController {
       let candidates = AssistantSettings.shared.voiceBaseLanguages
       let fullTask = fullLIDTask
       let provider = providerTag
+      // The optimistic `.success` seal is scheduled now, so its revision marker
+      // is registered synchronously now: the persist closure below first
+      // awaits transcript resolution (bounded by the 20s LID deadline), and a
+      // playback failure or barge-in terminalizing in that window must find
+      // the marker, or the `.completed` seal becomes permanent (#12743).
+      registerSealedCompletedVoiceJournalRow(
+        ownerID: completedTurnOwnerID,
+        assistantText: reply,
+        terminal: .success,
+        acceptedSpawnOwnerID: acceptedSpawnOwnerID,
+        idempotencyKey: completedTurnIdempotencyKey)
       enqueueTurnPersistence(
         idempotencyKey: completedTurnIdempotencyKey,
         retainingReceipt: true

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
@@ -263,7 +263,52 @@ extension RealtimeHubController {
     } else if screenEvidence?.descriptor.turnID == turnID {
       clearScreenGrounding(stage: "cancelled")
     }
+    reviseSealedJournalRowIfUndelivered(turnID: turnID)
     if pendingSessionRefreshReason != nil { applyPendingSessionRefreshIfIdle() }
+  }
+
+  /// The one stable continuity key for a voice turn. `beginTurn` assigns it and
+  /// the sealed-row revision derives it from the reducer's terminal turn ID, so
+  /// both must stay byte-identical.
+  nonisolated static func voiceContinuityKey(for turnID: VoiceTurnID) -> String {
+    "voice:\(turnID.rawValue.uuidString.lowercased())"
+  }
+
+  /// The reducer terminalized a turn whose assistant row was sealed
+  /// `.completed` at provider-response-finish. If the terminal proves the
+  /// answer never reached the user, revise the row through the same journal
+  /// update path that finalized it — never a second writer (INV-CHAT-1).
+  /// Delivered outcomes leave the sealed row untouched, and the revision
+  /// chains after the turn's in-flight funnel write so the next voice turn's
+  /// context fence still observes the journal settling.
+  private func reviseSealedJournalRowIfUndelivered(turnID: VoiceTurnID) {
+    let continuityKey = Self.voiceContinuityKey(for: turnID)
+    guard let sealed = sealedCompletedVoiceJournalRows.removeValue(forKey: continuityKey) else {
+      return
+    }
+    guard let terminal = VoiceTurnCoordinator.shared.model.lastTerminal,
+      terminal.turnID == turnID,
+      let revision = VoiceJournalSealedRowRevisionPolicy.revision(
+        forTerminalReason: terminal.reason,
+        answerDelivered: VoiceTurnCoordinator.shared.lastTerminalAnswerDelivered,
+        sealedCompletedRowExists: true)
+    else { return }
+    log(
+      "RealtimeHub: revising sealed voice journal row after undelivered answer "
+        + "turn=\(turnID.description) reason=\(revision.terminalReason)")
+    let ownerID = sealed.ownerID
+    let assistantText = sealed.assistantText
+    let surface = sealed.surface
+    _ = turnPersistenceLedger.enqueueFollowUp(continuityKey: continuityKey) {
+      guard AuthorizedToolExecution.isOwnerCurrent(ownerID) else { return false }
+      return await FloatingControlBarManager.shared.reviseSealedRealtimeAssistantStatus(
+        surface: surface,
+        ownerID: ownerID,
+        continuityKey: continuityKey,
+        assistantText: assistantText,
+        status: revision.status,
+        terminalReason: revision.terminalReason)
+    }
   }
 
   /// Managed users: fetch a short-lived ephemeral token from the backend (gated by
@@ -818,11 +863,15 @@ extension RealtimeHubController {
   /// a second durable queue.
   /// The single funnel every realtime voice turn is journaled through.
   ///
-  /// `terminal` and `answerDelivered` together decide the assistant row's
-  /// status: no caller can assert completion. The reason alone once sealed every
-  /// cut-off turn as completed; delivery state now keeps the inverse lie out too —
-  /// a reply the user fully heard before a barge-in is a delivered answer, not a
-  /// cut-off failure the model later re-delivers out of context.
+  /// `terminal` and `delivery` together decide the assistant row's status: no
+  /// caller can assert completion. The reason alone once sealed every cut-off
+  /// turn as completed; delivery state now keeps the inverse lie out too — a
+  /// reply the user fully heard before a barge-in is a delivered answer, not a
+  /// cut-off failure the model later re-delivers out of context. A `.success`
+  /// write defaults to `pending` delivery because this funnel runs at
+  /// provider-response-finish, while playback is usually still draining; the
+  /// reducer's terminal later revises the optimistic row if the answer never
+  /// reached the user (#12743).
   func persistTurnDirectlyToKernel(
     ownerID: String,
     userText: String,
@@ -830,10 +879,10 @@ extension RealtimeHubController {
     terminal: VoiceTurnTerminalReason,
     idempotencyKey: String,
     acceptedSpawnOwnerID: String?,
-    answerDelivered: Bool = false
+    delivery: VoiceTurnJournalStatusPolicy.AnswerDelivery = .pending
   ) async -> Bool {
     let journalStatus = VoiceTurnJournalStatusPolicy.status(
-      for: terminal, answerDelivered: answerDelivered)
+      for: terminal, delivery: delivery)
     let terminalReason = journalStatus == .completed ? nil : terminal.rawValue
     guard AuthorizedToolExecution.isOwnerCurrent(ownerID) else {
       log("RealtimeHub: refusing voice journal write after authenticated owner changed")
@@ -843,6 +892,21 @@ extension RealtimeHubController {
     let kernelOwnsExchange = RealtimeHubContinuityRestore.kernelOwnsExchange(
       continuityKey: idempotencyKey,
       kernelTurnIDs: prefetchedVoiceContextTurnIDs)
+    // A provider-owned `.success` row is sealed while playback is still
+    // pending; remember it so the reducer's terminal can revise the row when
+    // the answer never reaches the user. Spawn-owned and kernel-owned
+    // exchanges are sealed by another authority and stay untouched here.
+    if terminal == .success,
+      journalStatus == .completed,
+      acceptedSpawnOwnerID != ownerID,
+      !kernelOwnsExchange,
+      !assistantText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    {
+      sealedCompletedVoiceJournalRows[idempotencyKey] = SealedCompletedVoiceJournalRow(
+        ownerID: ownerID,
+        assistantText: assistantText,
+        surface: surface)
+    }
     if acceptedSpawnOwnerID == ownerID
       || (kernelOwnsExchange && !streamingJournalWriteLedger.contains(continuityKey: idempotencyKey))
     {
@@ -1117,7 +1181,7 @@ extension RealtimeHubController {
               terminal: .interruptedByBargeIn,
               idempotencyKey: turn.idempotencyKey,
               acceptedSpawnOwnerID: turn.acceptedSpawnOwnerID,
-              answerDelivered: turn.answerDelivered) ?? false
+              delivery: turn.answerDelivered ? .delivered : .notDelivered) ?? false
           }
           return await task.value
         },

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
@@ -274,10 +274,74 @@ extension RealtimeHubController {
     "voice:\(turnID.rawValue.uuidString.lowercased())"
   }
 
+  /// Inverse of `voiceContinuityKey(for:)`: the reducer's terminal turn ID for
+  /// a voice continuity key, so the funnel's write-time delivery re-check can
+  /// match the key against `model.lastTerminal` without extra plumbing.
+  /// Returns nil for any key that is not a `voice:` continuity key.
+  nonisolated static func turnID(forVoiceContinuityKey continuityKey: String) -> VoiceTurnID? {
+    guard continuityKey.hasPrefix("voice:") else { return nil }
+    let suffix = continuityKey.dropFirst("voice:".count)
+    guard let uuid = UUID(uuidString: String(suffix)) else { return nil }
+    return VoiceTurnID(uuid)
+  }
+
+  /// The reducer's already-emitted terminal for this continuity key, when that
+  /// terminal proves the answer never reached the user. Used both to skip a
+  /// now-unconsumable sealed-row marker and to carry the truthful outcome into
+  /// the funnel's own write.
+  static func undeliveredTerminalRevision(
+    forVoiceContinuityKey continuityKey: String,
+    coordinator: VoiceTurnCoordinator = .shared
+  ) -> VoiceJournalSealedRowRevisionPolicy.Revision? {
+    guard let turnID = turnID(forVoiceContinuityKey: continuityKey),
+      let terminal = coordinator.model.lastTerminal,
+      terminal.turnID == turnID
+    else { return nil }
+    return VoiceJournalSealedRowRevisionPolicy.revision(
+      forTerminalReason: terminal.reason,
+      answerDelivered: coordinator.lastTerminalAnswerDelivered,
+      sealedCompletedRowExists: true)
+  }
+
+  /// Registers the sealed-row marker for an optimistic `.success` seal
+  /// synchronously — at funnel enqueue time (provider-response-finish), never
+  /// inside the async persist closure. The funnel's write first awaits
+  /// transcript resolution (bounded by the 20s LID deadline), and the
+  /// reducer's playback fence can terminalize in that window (playback
+  /// failure, barge-in): the terminal's revision must always find the marker,
+  /// or the later `.completed` seal becomes permanent (#12743). Turns that
+  /// already terminalized register nothing — no later terminal can consume
+  /// the marker — and `persistTurnDirectlyToKernel`'s write-time re-check
+  /// carries their outcome instead.
+  func registerSealedCompletedVoiceJournalRow(
+    ownerID: String,
+    assistantText: String,
+    terminal: VoiceTurnTerminalReason,
+    acceptedSpawnOwnerID: String?,
+    idempotencyKey: String,
+    coordinator: VoiceTurnCoordinator = .shared
+  ) {
+    guard terminal == .success,
+      acceptedSpawnOwnerID != ownerID,
+      !RealtimeHubContinuityRestore.kernelOwnsExchange(
+        continuityKey: idempotencyKey,
+        kernelTurnIDs: prefetchedVoiceContextTurnIDs),
+      !assistantText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    else { return }
+    if let turnID = Self.turnID(forVoiceContinuityKey: idempotencyKey),
+      coordinator.model.lastTerminal?.turnID == turnID
+    {
+      return
+    }
+    sealedCompletedVoiceJournalRows[idempotencyKey] = SealedCompletedVoiceJournalRow(
+      ownerID: ownerID,
+      surface: FloatingControlBarManager.shared.mainChatSurfaceReference())
+  }
+
   /// The reducer terminalized a turn whose assistant row was sealed
   /// `.completed` at provider-response-finish. If the terminal proves the
-  /// answer never reached the user, revise the row through the same journal
-  /// update path that finalized it — never a second writer (INV-CHAT-1).
+  /// answer never reached the user, revise the row through the payload-free
+  /// terminal-revision update — never a second writer (INV-CHAT-1).
   /// Delivered outcomes leave the sealed row untouched, and the revision
   /// chains after the turn's in-flight funnel write so the next voice turn's
   /// context fence still observes the journal settling.
@@ -297,7 +361,6 @@ extension RealtimeHubController {
       "RealtimeHub: revising sealed voice journal row after undelivered answer "
         + "turn=\(turnID.description) reason=\(revision.terminalReason)")
     let ownerID = sealed.ownerID
-    let assistantText = sealed.assistantText
     let surface = sealed.surface
     _ = turnPersistenceLedger.enqueueFollowUp(continuityKey: continuityKey) {
       guard AuthorizedToolExecution.isOwnerCurrent(ownerID) else { return false }
@@ -305,8 +368,6 @@ extension RealtimeHubController {
         surface: surface,
         ownerID: ownerID,
         continuityKey: continuityKey,
-        assistantText: assistantText,
-        status: revision.status,
         terminalReason: revision.terminalReason)
     }
   }
@@ -845,6 +906,15 @@ extension RealtimeHubController {
   ) -> Task<Bool, Never> {
     let idempotencyKey = turnIdempotencyKey
     let userText = turnTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+    // The optimistic `.success` seal is scheduled now, so its revision marker
+    // is registered now too — the reducer's terminal may fire before the
+    // async persist closure runs.
+    registerSealedCompletedVoiceJournalRow(
+      ownerID: ownerID,
+      assistantText: assistantText,
+      terminal: .success,
+      acceptedSpawnOwnerID: nil,
+      idempotencyKey: idempotencyKey)
     return enqueueTurnPersistence(idempotencyKey: idempotencyKey, retainingReceipt: true) { [weak self] in
       await self?.persistTurnDirectlyToKernel(
         ownerID: ownerID,
@@ -881,9 +951,24 @@ extension RealtimeHubController {
     acceptedSpawnOwnerID: String?,
     delivery: VoiceTurnJournalStatusPolicy.AnswerDelivery = .pending
   ) async -> Bool {
-    let journalStatus = VoiceTurnJournalStatusPolicy.status(
+    var journalStatus = VoiceTurnJournalStatusPolicy.status(
       for: terminal, delivery: delivery)
-    let terminalReason = journalStatus == .completed ? nil : terminal.rawValue
+    var terminalReason = journalStatus == .completed ? nil : terminal.rawValue
+    // Delivery re-check at write time: this closure first awaited transcript
+    // resolution (bounded by the 20s LID deadline), and the reducer may have
+    // terminalized in that window — or even before the funnel was enqueued
+    // (a playback failure mid-generation). A `.success` seal must then carry
+    // the terminal's truthful outcome instead of the optimistic completion
+    // (#12743). This complements the sealed-row marker, whose follow-up
+    // revision covers terminals that fire *after* this write.
+    if terminal == .success,
+      journalStatus == .completed,
+      let revision = Self.undeliveredTerminalRevision(
+        forVoiceContinuityKey: idempotencyKey)
+    {
+      journalStatus = revision.status
+      terminalReason = revision.terminalReason
+    }
     guard AuthorizedToolExecution.isOwnerCurrent(ownerID) else {
       log("RealtimeHub: refusing voice journal write after authenticated owner changed")
       return false
@@ -892,21 +977,6 @@ extension RealtimeHubController {
     let kernelOwnsExchange = RealtimeHubContinuityRestore.kernelOwnsExchange(
       continuityKey: idempotencyKey,
       kernelTurnIDs: prefetchedVoiceContextTurnIDs)
-    // A provider-owned `.success` row is sealed while playback is still
-    // pending; remember it so the reducer's terminal can revise the row when
-    // the answer never reaches the user. Spawn-owned and kernel-owned
-    // exchanges are sealed by another authority and stay untouched here.
-    if terminal == .success,
-      journalStatus == .completed,
-      acceptedSpawnOwnerID != ownerID,
-      !kernelOwnsExchange,
-      !assistantText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    {
-      sealedCompletedVoiceJournalRows[idempotencyKey] = SealedCompletedVoiceJournalRow(
-        ownerID: ownerID,
-        assistantText: assistantText,
-        surface: surface)
-    }
     if acceptedSpawnOwnerID == ownerID
       || (kernelOwnsExchange && !streamingJournalWriteLedger.contains(continuityKey: idempotencyKey))
     {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -104,6 +104,11 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   let turnPersistenceLedger = RealtimeTurnPersistenceLedger()
   let streamingJournalWriteLedger = RealtimeStreamingJournalWriteLedger()
   var streamingJournalFlushTasks: [String: Task<Void, Never>] = [:]
+  /// Assistant rows this process sealed `.completed` at provider-response-finish
+  /// (delivery still pending), keyed by the turn's continuity key. Consumed by
+  /// the reducer's terminal, which revises a row whose answer never reached the
+  /// user (#12743). In-memory journal-write bookkeeping only.
+  var sealedCompletedVoiceJournalRows: [String: SealedCompletedVoiceJournalRow] = [:]
   /// (c) Shadow truth: mirrors a kernel-accepted spawn exchange for this process.
   /// Authoritative owner is the kernel journal / voice-context turn IDs; restore
   /// through `RealtimeHubContinuityRestore` + `RealtimeTurnJournalAuthority`.
@@ -408,6 +413,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     }
     ownerBoundaryGeneration &+= 1
     turnPersistenceLedger.cancelAll()
+    sealedCompletedVoiceJournalRows.removeAll()
     cancelStreamingJournalWrites()
     turnEpoch &+= 1
     realtimePlaybackEpoch &+= 1

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeToolAuthority.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeToolAuthority.swift
@@ -71,24 +71,55 @@ enum RealtimeExternalRunTerminalPolicy {
 /// followed by exactly that recurrence). A barge-in after playback drained is an
 /// interruption of the *silence*, not of the answer, and journals `.completed`.
 ///
+/// Delivery also gates `.success` itself: a turn the reducer terminalized without
+/// any full-answer playback draining never delivered its answer, and journals
+/// `.failed` (#12743: the 12:45 potion answer was sealed `.completed` while only
+/// "Let me verify." was ever spoken). The turn-done funnel writes while playback
+/// is still pending — that optimistic `.completed` is corrected by the reducer's
+/// terminal through `VoiceJournalSealedRowRevisionPolicy`, never by reading
+/// "still draining" as "never played".
+///
 /// `KernelJournalTurnStatus` has no `cancelled` case, so every non-delivered
 /// non-success reason maps to `.failed` and the precise reason travels in
 /// `metadata.terminalReason`. That distinction matters for measurement (a barge-in
 /// is not a defect), never for whether the turn may claim completion.
 enum VoiceTurnJournalStatusPolicy {
+  /// What the writer knows about full-answer playback delivery when it computes
+  /// the assistant row's status.
+  enum AnswerDelivery {
+    /// Playback had not resolved yet. The turn-done funnel journals at
+    /// provider-response-finish, while local playback is usually still
+    /// draining — "not yet drained" must never be read as "never played", so a
+    /// `.success` row stays optimistically `.completed` here and the reducer's
+    /// terminal revises it if the answer never reaches the user.
+    case pending
+    case delivered
+    case notDelivered
+  }
+
   static func status(for reason: VoiceTurnTerminalReason) -> KernelJournalTurnStatus {
-    status(for: reason, answerDelivered: false)
+    status(for: reason, delivery: .pending)
   }
 
   static func status(
     for reason: VoiceTurnTerminalReason,
     answerDelivered: Bool
   ) -> KernelJournalTurnStatus {
+    status(for: reason, delivery: answerDelivered ? .delivered : .notDelivered)
+  }
+
+  static func status(
+    for reason: VoiceTurnTerminalReason,
+    delivery: AnswerDelivery
+  ) -> KernelJournalTurnStatus {
     switch reason {
     case .success:
-      return .completed
+      // A turn the reducer terminalized `.success` without any full-answer
+      // playback draining never delivered its answer; the journal must not
+      // teach the model the user heard an answer they never did (#12743).
+      return delivery == .notDelivered ? .failed : .completed
     case .interruptedByBargeIn, .explicitInterrupt:
-      return answerDelivered ? .completed : .failed
+      return delivery == .delivered ? .completed : .failed
     case .tooShort, .silentRejected, .cancelled, .ownerChanged,
       .cleanup, .permissionDenied, .captureFailed, .captureNotReady,
       .transcriptionFailed, .providerFailed, .providerNoResponse, .hubWarmTimeout,
@@ -97,6 +128,50 @@ enum VoiceTurnJournalStatusPolicy {
       return .failed
     }
   }
+}
+
+/// Whether the reducer's terminal may revise an assistant row the turn-done
+/// funnel already sealed `.completed`.
+///
+/// The funnel journals at provider-response-finish — before the reducer's
+/// playback fence resolves — so a `.success` row is optimistic by design. When
+/// the reducer later terminalizes without having delivered the answer (playback
+/// failed, a barge-in cut the reply before it drained, or `.success` with no
+/// full-answer playback at all), the sealed row must stop claiming a completed
+/// answer: the journal is the model's only memory, and a completed row for an
+/// unheard answer is how later turns believe the user was answered (#12743).
+///
+/// Delivered outcomes never revise: a barge-in after playback drained
+/// interrupts the silence, not the answer (#12730 semantics), and a later
+/// journal failure must not rewrite a delivered response as missing. Reasons
+/// outside the delivery set either never reach a sealed row (capture-time
+/// journaling already carries their outcome) or must not be reinterpreted
+/// after the fact.
+enum VoiceJournalSealedRowRevisionPolicy {
+  struct Revision: Equatable {
+    let status: KernelJournalTurnStatus
+    let terminalReason: String
+  }
+
+  static func revision(
+    forTerminalReason reason: VoiceTurnTerminalReason,
+    answerDelivered: Bool,
+    sealedCompletedRowExists: Bool
+  ) -> Revision? {
+    guard sealedCompletedRowExists, revisableReasons.contains(reason) else { return nil }
+    guard
+      VoiceTurnJournalStatusPolicy.status(for: reason, answerDelivered: answerDelivered)
+        == .failed
+    else { return nil }
+    // The reducer terminal said `.success` while the answer never drained;
+    // "success" would be a false truncation cause on a failed row.
+    let terminalReason = reason == .success ? "answer_not_delivered" : reason.rawValue
+    return Revision(status: .failed, terminalReason: terminalReason)
+  }
+
+  private static let revisableReasons: Set<VoiceTurnTerminalReason> = [
+    .success, .interruptedByBargeIn, .explicitInterrupt, .playbackFailed,
+  ]
 }
 
 enum RealtimeExternalRunPromptPolicy {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeTurnPersistence.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeTurnPersistence.swift
@@ -326,6 +326,48 @@ final class RealtimeTurnPersistenceLedger {
     }
   }
 
+  /// Chains one follow-up write after the in-flight obligation for the same
+  /// continuity key, taking over that key's obligation slot so
+  /// `awaitPendingObligations` — the next voice turn's context fence — still
+  /// observes the follow-up before the journal settles. The follow-up runs
+  /// only after the original write's kernel result is known; a plain `enqueue`
+  /// would drop it entirely while the original is still in flight.
+  @discardableResult
+  func enqueueFollowUp(
+    continuityKey: String,
+    _ followUp: @escaping @MainActor () async -> Bool
+  ) -> Task<Bool, Never> {
+    guard let existing = obligations[continuityKey] else {
+      return enqueue(continuityKey: continuityKey, retainingReceipt: false, followUp)
+    }
+    let previous = existing.task
+    let retention = existing.retainingReceipt
+    let followUpID = UUID()
+    generation &+= 1
+    let task = Task { @MainActor [weak self] in
+      let originalAccepted = await previous.value
+      guard let self, self.obligations[continuityKey]?.id == followUpID else {
+        return originalAccepted
+      }
+      // The original write's epilogue no longer owns this slot, so its receipt
+      // semantics survive here: retention still reflects the original write's
+      // kernel result, never the follow-up's revision of an accepted row.
+      if retention, self.receipts[continuityKey] == nil {
+        self.receipts[continuityKey] = RealtimeTurnPersistenceReceipt(
+          continuityKey: continuityKey,
+          accepted: originalAccepted)
+      }
+      let accepted = await followUp()
+      if self.obligations[continuityKey]?.id == followUpID {
+        self.obligations.removeValue(forKey: continuityKey)
+      }
+      return accepted
+    }
+    obligations[continuityKey] = Obligation(
+      id: followUpID, task: task, retainingReceipt: retention)
+    return task
+  }
+
   /// Owner replacement revokes every local waiter.  An ignored cancellation can
   /// still complete its kernel RPC, but its old obligation is forbidden from
   /// removing or writing over any newer key's state.
@@ -371,6 +413,19 @@ struct InterruptedTurnPayload: Equatable {
   static func visibleAssistantText(partialAssistantText: String) -> String {
     partialAssistantText.trimmingCharacters(in: .whitespacesAndNewlines)
   }
+}
+
+/// The assistant row a voice turn's funnel sealed `.completed` at
+/// provider-response-finish, before the reducer's playback fence resolved.
+/// Consumed by the reducer's terminal: when the answer never reached the user,
+/// the sealed row is revised through the same journal update path that
+/// finalized it (`VoiceJournalSealedRowRevisionPolicy`). Journal-write
+/// bookkeeping only — the reducer remains the lifecycle owner (INV-VOICE-1),
+/// and the kernel journal stays the one transcript authority (INV-CHAT-1).
+struct SealedCompletedVoiceJournalRow {
+  let ownerID: String
+  let assistantText: String
+  let surface: AgentSurfaceReference
 }
 
 /// Resolves and records the visible portion of a provider-failed turn before

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeTurnPersistence.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeTurnPersistence.swift
@@ -332,13 +332,32 @@ final class RealtimeTurnPersistenceLedger {
   /// observes the follow-up before the journal settles. The follow-up runs
   /// only after the original write's kernel result is known; a plain `enqueue`
   /// would drop it entirely while the original is still in flight.
+  ///
+  /// When the original obligation already completed before this call, its
+  /// retained receipt (if any) is final and must survive the follow-up: a
+  /// later `consumeReceipt` still reports the original write's acceptance.
+  /// The follow-up therefore runs as a fresh non-retaining obligation that
+  /// never touches the receipt slot — unlike `enqueue`, which clears a key's
+  /// receipt when it starts a superseding write.
   @discardableResult
   func enqueueFollowUp(
     continuityKey: String,
     _ followUp: @escaping @MainActor () async -> Bool
   ) -> Task<Bool, Never> {
     guard let existing = obligations[continuityKey] else {
-      return enqueue(continuityKey: continuityKey, retainingReceipt: false, followUp)
+      generation &+= 1
+      let followUpID = UUID()
+      let task = Task { @MainActor [weak self] in
+        let accepted = await followUp()
+        guard let self, self.obligations[continuityKey]?.id == followUpID else {
+          return accepted
+        }
+        self.obligations.removeValue(forKey: continuityKey)
+        return accepted
+      }
+      obligations[continuityKey] = Obligation(
+        id: followUpID, task: task, retainingReceipt: false)
+      return task
     }
     let previous = existing.task
     let retention = existing.retainingReceipt
@@ -418,13 +437,13 @@ struct InterruptedTurnPayload: Equatable {
 /// The assistant row a voice turn's funnel sealed `.completed` at
 /// provider-response-finish, before the reducer's playback fence resolved.
 /// Consumed by the reducer's terminal: when the answer never reached the user,
-/// the sealed row is revised through the same journal update path that
-/// finalized it (`VoiceJournalSealedRowRevisionPolicy`). Journal-write
-/// bookkeeping only — the reducer remains the lifecycle owner (INV-VOICE-1),
-/// and the kernel journal stays the one transcript authority (INV-CHAT-1).
+/// the sealed row is revised through the payload-free terminal-revision update
+/// (`VoiceJournalSealedRowRevisionPolicy`) — its content and canonical
+/// metadata stay exactly as sealed. Journal-write bookkeeping only — the
+/// reducer remains the lifecycle owner (INV-VOICE-1), and the kernel journal
+/// stays the one transcript authority (INV-CHAT-1).
 struct SealedCompletedVoiceJournalRow {
   let ownerID: String
-  let assistantText: String
   let surface: AgentSurfaceReference
 }
 

--- a/desktop/macos/Desktop/Tests/VoiceTurnJournalDeliveryRevisionTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnJournalDeliveryRevisionTests.swift
@@ -277,6 +277,187 @@ import XCTest
       XCTAssertTrue(accepted)
       XCTAssertTrue(ledger.pendingContinuityKeys.isEmpty)
     }
+
+    func testFollowUpAfterCompletedObligationPreservesTheRetainedReceipt() async {
+      // cubic P1 interleaving: the funnel write completes and retains its
+      // accepted receipt BEFORE the reducer's terminal schedules the revision.
+      // Scheduling that follow-up must never delete the receipt — the later
+      // `finalizeJournal` still consumes the original acceptance.
+      let ledger = RealtimeTurnPersistenceLedger()
+      let gate = SuspendedFollowUpGate()
+
+      let original = ledger.enqueue(continuityKey: "voice:fm6-late", retainingReceipt: true) {
+        true
+      }
+      _ = await original.value
+      XCTAssertEqual(
+        ledger.receipt(for: "voice:fm6-late"),
+        .init(continuityKey: "voice:fm6-late", accepted: true))
+
+      let followUp = ledger.enqueueFollowUp(continuityKey: "voice:fm6-late") {
+        await gate.suspendOriginal()
+        return true
+      }
+      await gate.waitUntilSuspended()
+      XCTAssertEqual(
+        ledger.receipt(for: "voice:fm6-late"),
+        .init(continuityKey: "voice:fm6-late", accepted: true),
+        "the revision in flight must not delete the original write's receipt")
+
+      await gate.resumeOriginal()
+      _ = await followUp.value
+      let consumed = await ledger.consumeReceipt(for: "voice:fm6-late")
+      XCTAssertEqual(consumed, .init(continuityKey: "voice:fm6-late", accepted: true))
+    }
+
+    // MARK: - Revision wire shape: payload-free, reason-only metadata patch
+
+    func testSealedTerminalRevisionCarriesNoPayloadAndMergesOnlyItsReason() throws {
+      // cubic P2: the revision must not replace the sealed row's content
+      // blocks, resources, or metadata (model attribution, continuity). The
+      // update carries status and the terminal reason only; the kernel merges
+      // the reason into the row's existing metadata.
+      let update = KernelJournalTurnUpdate.sealedTerminalRevision(
+        turnId: "turn-assistant",
+        terminalReason: "answer_not_delivered")
+
+      XCTAssertEqual(update.turnId, "turn-assistant")
+      XCTAssertEqual(update.status, .failed)
+      XCTAssertNil(update.content)
+      XCTAssertNil(update.contentBlocksJSON)
+      XCTAssertNil(update.appendContentBlocksJSON)
+      XCTAssertNil(update.resourcesJSON)
+      XCTAssertNil(update.appendResourcesJSON)
+      XCTAssertTrue(update.terminalRevision)
+
+      let metadataObject = try XCTUnwrap(
+        update.metadataJSON.flatMap { raw in
+          (try? JSONSerialization.jsonObject(with: Data(raw.utf8))) as? [String: String]
+        })
+      XCTAssertEqual(metadataObject, ["terminalReason": "answer_not_delivered"])
+
+      let dictionary = update.dictionary
+      XCTAssertEqual(dictionary["turnId"] as? String, "turn-assistant")
+      XCTAssertEqual(dictionary["status"] as? String, "failed")
+      XCTAssertEqual(dictionary["terminalRevision"] as? Bool, true)
+      XCTAssertNil(dictionary["content"])
+      XCTAssertNil(dictionary["replaceContentBlocks"])
+      XCTAssertNil(dictionary["replaceResources"])
+      XCTAssertFalse(dictionary.keys.contains("appendContentBlocks"))
+      XCTAssertFalse(dictionary.keys.contains("appendResources"))
+    }
+
+    // MARK: - Sealed-row marker: synchronous at seal scheduling
+
+    func testSealedRowMarkerRegistersSynchronouslyAtSealScheduling() {
+      // cubic P2: the marker used to be registered inside the async persist
+      // closure — after a transcript-resolution await bounded by the 20s LID
+      // deadline. A terminal in that window found no marker and the
+      // `.completed` seal became permanent. Registration now happens at the
+      // enqueue site, before any async work.
+      let controller = RealtimeHubController()
+      let key = "voice:\(UUID().uuidString.lowercased())"
+
+      controller.registerSealedCompletedVoiceJournalRow(
+        ownerID: "owner-a",
+        assistantText: "Take the blue potion at 12:45.",
+        terminal: .success,
+        acceptedSpawnOwnerID: nil,
+        idempotencyKey: key,
+        coordinator: VoiceTurnCoordinator(scheduler: ManualDeadlineScheduler()))
+
+      XCTAssertNotNil(controller.sealedCompletedVoiceJournalRows[key])
+    }
+
+    func testSealedRowMarkerSkipsRegistrationWhenTheTurnAlreadyTerminalized() throws {
+      // A turn the reducer already terminalized (e.g. playback failed
+      // mid-generation) has no future terminal to consume the marker; the
+      // funnel's write-time delivery re-check carries the outcome instead.
+      let (coordinator, turnID) = try providerFinishedTurn()
+      guard
+        case .acquired(let lease) = coordinator.acquireOutput(
+          .selectedVoiceFallback, turnID: turnID)
+      else { return XCTFail("expected output lease") }
+      coordinator.publish(
+        .playbackFailedScoped(
+          turnID: turnID,
+          identity: lease.identity,
+          leaseID: lease.id,
+          message: "synthetic playback error"))
+      let key = RealtimeHubController.voiceContinuityKey(for: turnID)
+      XCTAssertNotNil(
+        RealtimeHubController.undeliveredTerminalRevision(
+          forVoiceContinuityKey: key, coordinator: coordinator))
+
+      let controller = RealtimeHubController()
+      controller.registerSealedCompletedVoiceJournalRow(
+        ownerID: "owner-a",
+        assistantText: "Take the blue potion at 12:45.",
+        terminal: .success,
+        acceptedSpawnOwnerID: nil,
+        idempotencyKey: key,
+        coordinator: coordinator)
+      XCTAssertNil(controller.sealedCompletedVoiceJournalRows[key])
+    }
+
+    func testWriteTimeDeliveryRecheckDowngradesTheFunnelSeal() throws {
+      // Terminal-before-funnel ordering: playback failed while the model was
+      // still generating, so the reducer terminalized before the turn-done
+      // funnel even ran. The funnel's write-time re-check derives the same
+      // downgrade revision from the turn's continuity key, so its write seals
+      // the truthful `.failed` outcome instead of another `.completed` lie.
+      let (coordinator, turnID) = try providerFinishedTurn()
+      guard
+        case .acquired(let lease) = coordinator.acquireOutput(
+          .selectedVoiceFallback, turnID: turnID)
+      else { return XCTFail("expected output lease") }
+      coordinator.publish(
+        .playbackFailedScoped(
+          turnID: turnID,
+          identity: lease.identity,
+          leaseID: lease.id,
+          message: "synthetic playback error"))
+      XCTAssertEqual(coordinator.model.lastTerminal?.reason, .playbackFailed)
+
+      let key = RealtimeHubController.voiceContinuityKey(for: turnID)
+      XCTAssertEqual(
+        RealtimeHubController.undeliveredTerminalRevision(
+          forVoiceContinuityKey: key, coordinator: coordinator),
+        .init(status: .failed, terminalReason: "playback_failed"))
+
+      // Another turn's continuity key is untouched by this terminal, and a
+      // delivered terminal never downgrades.
+      XCTAssertNil(
+        RealtimeHubController.undeliveredTerminalRevision(
+          forVoiceContinuityKey: "voice:\(UUID().uuidString.lowercased())",
+          coordinator: coordinator))
+    }
+
+    func testTurnDoneSiteRegistersTheMarkerBeforeEnqueueingPersistence() throws {
+      // The turn-done callback cannot be driven without a live socket, so the
+      // wiring is pinned at the source level (established pattern): the
+      // synchronous registration must precede the funnel's
+      // `enqueueTurnPersistence`, and `persistTurnDirectlyToKernel` itself
+      // must not re-register — a late registration there can never be
+      // consumed and the marker would leak.
+      let lifecycle = try RealtimeHubControllerSourceTestSupport.source(
+        named: "RealtimeHubController+SessionLifecycle.swift",
+        testFilePath: #filePath)
+      XCTAssertEqual(
+        lifecycle.ranges(of: "sealedCompletedVoiceJournalRows[idempotencyKey] =").count, 1,
+        "only registerSealedCompletedVoiceJournalRow may write the marker; "
+          + "persistTurnDirectlyToKernel must not re-register it")
+
+      let delegate = try RealtimeHubControllerSourceTestSupport.source(
+        named: "RealtimeHubController+SessionDelegate.swift",
+        testFilePath: #filePath)
+      let registration = try XCTUnwrap(
+        delegate.range(of: "registerSealedCompletedVoiceJournalRow("))
+      let enqueue = try XCTUnwrap(delegate.range(of: "enqueueTurnPersistence("))
+      XCTAssertLessThan(
+        registration.lowerBound, enqueue.lowerBound,
+        "the sealed-row marker must be registered before the funnel's async persistence is enqueued")
+    }
   }
 
   /// Deterministic deadline scheduler (mirrors the coordinator suite's): no

--- a/desktop/macos/Desktop/Tests/VoiceTurnJournalDeliveryRevisionTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnJournalDeliveryRevisionTests.swift
@@ -1,0 +1,332 @@
+import XCTest
+
+@testable import Omi_Computer
+@testable import VoiceTurnDomain
+
+#if DEBUG
+  /// FM6 (#12743): the turn-done funnel journals the assistant row at
+  /// provider-response-finish, before the reducer's playback fence resolves,
+  /// and `.success` used to seal that row `.completed` unconditionally — so an
+  /// answer that was never spoken became canonical completed history. These
+  /// tests pin the corrected contract through production APIs: the funnel's
+  /// optimistic write stays `.completed` while playback is still pending, and
+  /// the reducer's terminal revises the sealed row exactly when the terminal
+  /// proves the answer never reached the user.
+  @MainActor
+  final class VoiceTurnJournalDeliveryRevisionTests: XCTestCase {
+
+    // MARK: - Policy: `.success` is delivery-gated once delivery is known
+
+    func testSuccessWithoutDeliveryCannotClaimCompletion() {
+      // The FM6 probe: on merged main this returned `.completed`, sealing the
+      // 12:45 potion answer (turn_81b) as completed while only "Let me
+      // verify." was ever spoken.
+      XCTAssertEqual(
+        VoiceTurnJournalStatusPolicy.status(for: .success, answerDelivered: false), .failed)
+      XCTAssertEqual(
+        VoiceTurnJournalStatusPolicy.status(for: .success, delivery: .notDelivered), .failed)
+    }
+
+    func testSuccessWithDeliveryStillJournalsCompleted() {
+      XCTAssertEqual(
+        VoiceTurnJournalStatusPolicy.status(for: .success, answerDelivered: true), .completed)
+      XCTAssertEqual(
+        VoiceTurnJournalStatusPolicy.status(for: .success, delivery: .delivered), .completed)
+    }
+
+    func testPendingDeliveryAtTheTurnDoneWriteStaysCompleted() {
+      // The funnel writes while playback is usually still draining: "not yet
+      // drained" must never be read as "never played". The optimistic seal is
+      // what the reducer's terminal later revises.
+      XCTAssertEqual(VoiceTurnJournalStatusPolicy.status(for: .success), .completed)
+      XCTAssertEqual(
+        VoiceTurnJournalStatusPolicy.status(for: .success, delivery: .pending), .completed)
+    }
+
+    // MARK: - Revision policy: what may revise a sealed `.completed` row
+
+    func testUndeliveredSuccessTerminalRevisesTheSealedRow() {
+      XCTAssertEqual(
+        VoiceJournalSealedRowRevisionPolicy.revision(
+          forTerminalReason: .success, answerDelivered: false, sealedCompletedRowExists: true),
+        .init(status: .failed, terminalReason: "answer_not_delivered"))
+    }
+
+    func testDeliveredSuccessTerminalLeavesTheSealedRowAlone() {
+      XCTAssertNil(
+        VoiceJournalSealedRowRevisionPolicy.revision(
+          forTerminalReason: .success, answerDelivered: true, sealedCompletedRowExists: true))
+    }
+
+    func testPlaybackFailureAfterSealingRevisesTheSealedRow() {
+      XCTAssertEqual(
+        VoiceJournalSealedRowRevisionPolicy.revision(
+          forTerminalReason: .playbackFailed, answerDelivered: false, sealedCompletedRowExists: true),
+        .init(status: .failed, terminalReason: "playback_failed"))
+    }
+
+    func testBargeInKeepsMergedDeliverySemanticsOnTheSealedRow() {
+      // A barge-in after playback drained interrupts the silence, not the
+      // answer (#12730): the sealed row stays completed. A barge-in that cut
+      // the reply before it drained revises it.
+      XCTAssertNil(
+        VoiceJournalSealedRowRevisionPolicy.revision(
+          forTerminalReason: .interruptedByBargeIn, answerDelivered: true,
+          sealedCompletedRowExists: true))
+      XCTAssertNil(
+        VoiceJournalSealedRowRevisionPolicy.revision(
+          forTerminalReason: .explicitInterrupt, answerDelivered: true,
+          sealedCompletedRowExists: true))
+      XCTAssertEqual(
+        VoiceJournalSealedRowRevisionPolicy.revision(
+          forTerminalReason: .interruptedByBargeIn, answerDelivered: false,
+          sealedCompletedRowExists: true),
+        .init(status: .failed, terminalReason: "interrupted_by_barge_in"))
+    }
+
+    func testLaterJournalFailureNeverRewritesADeliveredAnswer() {
+      // Analytics contract: a later journal failure must not rewrite a
+      // delivered response as missing — and no non-delivery terminal may be
+      // reinterpreted after the fact.
+      XCTAssertNil(
+        VoiceJournalSealedRowRevisionPolicy.revision(
+          forTerminalReason: .journalFailed, answerDelivered: true, sealedCompletedRowExists: true))
+      XCTAssertNil(
+        VoiceJournalSealedRowRevisionPolicy.revision(
+          forTerminalReason: .journalFailed, answerDelivered: false,
+          sealedCompletedRowExists: true))
+      XCTAssertNil(
+        VoiceJournalSealedRowRevisionPolicy.revision(
+          forTerminalReason: .providerFailed, answerDelivered: true, sealedCompletedRowExists: true))
+    }
+
+    func testRevisionRequiresASealedRow() {
+      // Terminals for turns the funnel never sealed optimistically (the
+      // capture-time journaling paths already carry their outcome) revise
+      // nothing.
+      XCTAssertNil(
+        VoiceJournalSealedRowRevisionPolicy.revision(
+          forTerminalReason: .success, answerDelivered: false, sealedCompletedRowExists: false))
+      XCTAssertNil(
+        VoiceJournalSealedRowRevisionPolicy.revision(
+          forTerminalReason: .playbackFailed, answerDelivered: false,
+          sealedCompletedRowExists: false))
+    }
+
+    // MARK: - Coordinator: the real reducer produces the delivery verdict
+
+    /// Drives one non-hub voice turn through the production reducer to a
+    /// provider-finished state with a spoken full answer, mirroring the
+    /// turn-done funnel's preconditions.
+    private func providerFinishedTurn() throws -> (VoiceTurnCoordinator, VoiceTurnID) {
+      DesktopDiagnosticsManager.shared.resetForTests()
+      defer { DesktopDiagnosticsManager.shared.resetForTests() }
+      let coordinator = VoiceTurnCoordinator(scheduler: ManualDeadlineScheduler())
+      let turnID = coordinator.begin(intent: .hold)
+      coordinator.publish(.selectRoute(turnID: turnID, route: .deepgramBatch))
+      coordinator.publish(.finalize(turnID: turnID))
+      coordinator.publish(.transcriptionStarted(turnID: turnID))
+      coordinator.publish(.transcriptionFinal(turnID: turnID, text: "the potion question"))
+      let providerIdentity = try XCTUnwrap(coordinator.activeTurn?.providerEffectIdentity)
+      coordinator.publish(
+        .providerResponseStartedScoped(
+          turnID: turnID,
+          identity: providerIdentity,
+          sessionID: nil,
+          responseID: nil))
+      return (coordinator, turnID)
+    }
+
+    func testSuccessTerminalWithoutAnyPlaybackRevisesSealedRow() throws {
+      // The provider finished and the journal accepted, but no full-answer
+      // playback ever drained: the reducer still terminalizes `.success`, and
+      // the journal must not claim the user heard the answer.
+      let (coordinator, turnID) = try providerFinishedTurn()
+      let token = try XCTUnwrap(coordinator.nonHubCompletionToken(for: turnID))
+
+      XCTAssertTrue(coordinator.completeNonHubProvider(token, outcome: .journalAccepted))
+      XCTAssertEqual(coordinator.model.lastTerminal?.turnID, turnID)
+      XCTAssertEqual(coordinator.model.lastTerminal?.reason, .success)
+      XCTAssertFalse(coordinator.lastTerminalAnswerDelivered)
+
+      let terminal = try XCTUnwrap(coordinator.model.lastTerminal)
+      let status = VoiceTurnJournalStatusPolicy.status(
+        for: terminal.reason,
+        answerDelivered: coordinator.lastTerminalAnswerDelivered)
+      XCTAssertEqual(status, .failed)
+      XCTAssertEqual(
+        VoiceJournalSealedRowRevisionPolicy.revision(
+          forTerminalReason: terminal.reason,
+          answerDelivered: coordinator.lastTerminalAnswerDelivered,
+          sealedCompletedRowExists: true),
+        .init(status: .failed, terminalReason: "answer_not_delivered"))
+    }
+
+    func testDrainedSuccessTerminalKeepsSealedRowCompleted() throws {
+      // Healthy turn: playback drained before the terminal, so the funnel's
+      // optimistic `.completed` row was the truth all along.
+      let (coordinator, turnID) = try providerFinishedTurn()
+      guard
+        case .acquired(let lease) = coordinator.acquireOutput(
+          .selectedVoiceFallback, turnID: turnID)
+      else { return XCTFail("expected output lease") }
+      let token = try XCTUnwrap(coordinator.nonHubCompletionToken(for: turnID))
+
+      XCTAssertTrue(coordinator.releaseOutput(lease))
+      XCTAssertTrue(coordinator.fullAnswerDrained(turnID: turnID))
+      XCTAssertTrue(coordinator.completeNonHubProvider(token, outcome: .journalAccepted))
+      XCTAssertEqual(coordinator.model.lastTerminal?.reason, .success)
+      XCTAssertTrue(coordinator.lastTerminalAnswerDelivered)
+
+      XCTAssertEqual(
+        VoiceTurnJournalStatusPolicy.status(
+          for: .success, answerDelivered: coordinator.lastTerminalAnswerDelivered),
+        .completed)
+      XCTAssertNil(
+        VoiceJournalSealedRowRevisionPolicy.revision(
+          forTerminalReason: .success,
+          answerDelivered: coordinator.lastTerminalAnswerDelivered,
+          sealedCompletedRowExists: true))
+    }
+
+    func testPlaybackFailureAfterProviderFinishTerminalizesUndelivered() throws {
+      // The audio lane errored while the funnel's write was still sealing the
+      // row: the reducer terminalizes `.playbackFailed` and the sealed row is
+      // revised with that truncation cause.
+      let (coordinator, turnID) = try providerFinishedTurn()
+      guard
+        case .acquired(let lease) = coordinator.acquireOutput(
+          .selectedVoiceFallback, turnID: turnID)
+      else { return XCTFail("expected output lease") }
+
+      coordinator.publish(
+        .playbackFailedScoped(
+          turnID: turnID,
+          identity: lease.identity,
+          leaseID: lease.id,
+          message: "synthetic playback error"))
+
+      XCTAssertEqual(coordinator.model.lastTerminal?.turnID, turnID)
+      XCTAssertEqual(coordinator.model.lastTerminal?.reason, .playbackFailed)
+      XCTAssertFalse(coordinator.lastTerminalAnswerDelivered)
+      XCTAssertEqual(
+        VoiceJournalSealedRowRevisionPolicy.revision(
+          forTerminalReason: .playbackFailed,
+          answerDelivered: coordinator.lastTerminalAnswerDelivered,
+          sealedCompletedRowExists: true),
+        .init(status: .failed, terminalReason: "playback_failed"))
+    }
+
+    // MARK: - Ledger: the revision chains after the funnel's in-flight write
+
+    func testFollowUpRunsOnlyAfterTheOriginalWriteAndKeepsTheFence() async {
+      // The revision must never beat the funnel write it corrects, and the
+      // next turn's context fence (awaitPendingObligations) must still observe
+      // it before the journal settles.
+      let ledger = RealtimeTurnPersistenceLedger()
+      let gate = SuspendedFollowUpGate()
+      var order: [String] = []
+
+      let original = ledger.enqueue(continuityKey: "voice:fm6", retainingReceipt: true) {
+        await gate.suspendOriginal()
+        order.append("original")
+        return true
+      }
+      await gate.waitUntilSuspended()
+
+      let followUp = ledger.enqueueFollowUp(continuityKey: "voice:fm6") {
+        order.append("follow-up")
+        return true
+      }
+      XCTAssertEqual(order, [], "the follow-up must wait for the original write")
+
+      await gate.resumeOriginal()
+      await ledger.awaitPendingObligations()
+      XCTAssertEqual(order, ["original", "follow-up"])
+      _ = await original.value
+      _ = await followUp.value
+      XCTAssertTrue(ledger.pendingContinuityKeys.isEmpty)
+    }
+
+    func testFollowUpPreservesTheOriginalWriteRetainedReceipt() async {
+      // The chained follow-up takes over the obligation slot, so the original
+      // write's receipt semantics must survive through it: acceptance still
+      // reflects the original kernel write, not the follow-up's revision.
+      let ledger = RealtimeTurnPersistenceLedger()
+      let gate = SuspendedFollowUpGate()
+
+      _ = ledger.enqueue(continuityKey: "voice:fm6-receipt", retainingReceipt: true) {
+        await gate.suspendOriginal()
+        return true
+      }
+      await gate.waitUntilSuspended()
+      let followUp = ledger.enqueueFollowUp(continuityKey: "voice:fm6-receipt") { true }
+      await gate.resumeOriginal()
+      _ = await followUp.value
+
+      XCTAssertEqual(
+        ledger.receipt(for: "voice:fm6-receipt"),
+        .init(continuityKey: "voice:fm6-receipt", accepted: true))
+      XCTAssertTrue(ledger.pendingContinuityKeys.isEmpty)
+    }
+
+    func testFollowUpWithoutInFlightObligationRunsDirectly() async {
+      let ledger = RealtimeTurnPersistenceLedger()
+      let followUp = ledger.enqueueFollowUp(continuityKey: "voice:fm6-fresh") { true }
+      let accepted = await followUp.value
+      XCTAssertTrue(accepted)
+      XCTAssertTrue(ledger.pendingContinuityKeys.isEmpty)
+    }
+  }
+
+  /// Deterministic deadline scheduler (mirrors the coordinator suite's): no
+  /// wall-clock timers fire during these tests.
+  @MainActor
+  private final class ManualDeadlineScheduler: VoiceTurnDeadlineScheduling {
+    private final class Cancellation: VoiceTurnDeadlineCancellation {
+      var isCancelled = false
+      func cancel() { isCancelled = true }
+    }
+
+    func schedule(
+      deadline: VoiceTurnDeadline,
+      after interval: TimeInterval,
+      action: @escaping @MainActor () -> Void
+    ) -> VoiceTurnDeadlineCancellation {
+      _ = interval
+      _ = deadline
+      return Cancellation()
+    }
+  }
+
+  /// Deterministic suspension point for ledger tests: the original write parks
+  /// until the test releases it, so ordering is observed without wall-clock
+  /// sleeps.
+  private actor SuspendedFollowUpGate {
+    private var suspended = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var resumption: CheckedContinuation<Void, Never>?
+
+    func suspendOriginal() async {
+      await withCheckedContinuation { continuation in
+        resumption = continuation
+        suspended = true
+        let current = waiters
+        waiters.removeAll()
+        for waiter in current { waiter.resume() }
+      }
+    }
+
+    func waitUntilSuspended() async {
+      guard !suspended else { return }
+      await withCheckedContinuation { continuation in
+        waiters.append(continuation)
+      }
+    }
+
+    func resumeOriginal() {
+      resumption?.resume()
+      resumption = nil
+    }
+  }
+#endif

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -2735,6 +2735,7 @@ async function main(): Promise<void> {
               ? update.appendResources as ConversationResource[]
               : undefined,
             metadataJson: typeof update.metadataJson === "string" ? update.metadataJson : undefined,
+            terminalRevision: update.terminalRevision === true,
           };
           assertPublicJournalUpdatePolicy(store, parsedUpdate);
           const turn = updateJournalTurn(store, parsedUpdate);

--- a/desktop/macos/agent/src/runtime/conversation-journal.ts
+++ b/desktop/macos/agent/src/runtime/conversation-journal.ts
@@ -98,6 +98,14 @@ export interface UpdateJournalTurnInput {
   producingRunId?: string | null;
   producingAttemptId?: string | null;
   metadataJson?: string;
+  /**
+   * Narrow revision authority: the desktop client that optimistically sealed a
+   * row `completed` (before answer delivery resolved) downgrades it to
+   * `failed` once the reducer proves the answer never reached the user
+   * (#12743). Only a payload-free downgrade is accepted, and `metadataJson`
+   * merges into the row's existing metadata instead of replacing it.
+   */
+  terminalRevision?: boolean;
   nowMs?: number;
 }
 
@@ -678,7 +686,24 @@ export function updateJournalTurn(store: AgentStore, input: UpdateJournalTurnInp
   return store.withTransaction(() => {
     assertConversationOwner(store, input.conversationId, input.ownerId);
     const current = requireJournalTurn(store, input.conversationId, input.turnId);
-    if (input.status !== undefined) assertTurnStatusTransition(current.status, input.status);
+    if (input.terminalRevision === true) {
+      assertTerminalRevisionShape(input);
+    }
+    if (input.status !== undefined) {
+      // The one sanctioned exception to the terminal transition table: the
+      // desktop client that sealed a row `completed` optimistically (before
+      // answer delivery resolved) downgrades it to `failed` when the reducer
+      // proves the answer never reached the user (#12743). Everything else —
+      // including run-linked turns, which the caller rejects earlier — still
+      // goes through the strict table.
+      const sealedCompletionDowngrade =
+        input.terminalRevision === true
+        && current.status === "completed"
+        && input.status === "failed";
+      if (!sealedCompletionDowngrade) {
+        assertTurnStatusTransition(current.status, input.status);
+      }
+    }
     if (input.producingRunId !== undefined) {
       assertProducingRunOwner(store, input.producingRunId, input.ownerId);
       if (current.producingRunId !== null && current.producingRunId !== input.producingRunId) {
@@ -719,7 +744,9 @@ export function updateJournalTurn(store: AgentStore, input: UpdateJournalTurnInp
     const status = input.status ?? current.status;
     const metadataJson = input.metadataJson === undefined
       ? current.metadataJson
-      : validObjectJson(input.metadataJson, "metadataJson");
+      : input.terminalRevision === true
+        ? mergedObjectJson(current.metadataJson, input.metadataJson)
+        : validObjectJson(input.metadataJson, "metadataJson");
     const content = input.content ?? current.content;
     const producingRunId = input.producingRunId === undefined ? current.producingRunId : input.producingRunId;
     const producingAttemptId = input.producingAttemptId === undefined
@@ -4235,6 +4262,44 @@ function validObjectJson(raw: string, field: string): string {
     throw new Error(`${field} must contain a JSON object`);
   }
   return JSON.stringify(parsed);
+}
+
+/**
+ * Shallow key-merge used only by terminal revisions: the truncation cause
+ * joins the row's existing metadata (model attribution, continuity) instead
+ * of replacing it. The patch's keys win on conflict.
+ */
+function mergedObjectJson(base: string, patch: string): string {
+  const baseObject = parseObjectJson(base);
+  const patchObject = parseObjectJson(patch);
+  if (
+    baseObject === null || Array.isArray(baseObject) || typeof baseObject !== "object"
+    || patchObject === null || Array.isArray(patchObject) || typeof patchObject !== "object"
+  ) {
+    throw new Error("metadataJson must contain a JSON object");
+  }
+  return JSON.stringify({ ...(baseObject as Record<string, unknown>), ...(patchObject as Record<string, unknown>) });
+}
+
+/**
+ * A terminal revision is a payload-free downgrade of an optimistically sealed
+ * completion: status must be `failed`, and no payload or run-identity field
+ * may ride along — the sealed row's content, blocks, resources, and metadata
+ * (beyond the merged terminal reason) stay exactly as written.
+ */
+function assertTerminalRevisionShape(input: UpdateJournalTurnInput): void {
+  if (
+    input.status !== "failed"
+    || input.content !== undefined
+    || input.replaceContentBlocks !== undefined
+    || input.appendContentBlocks !== undefined
+    || input.replaceResources !== undefined
+    || input.appendResources !== undefined
+    || input.producingRunId !== undefined
+    || input.producingAttemptId !== undefined
+  ) {
+    throw new Error("Terminal journal revision must be a payload-free downgrade to failed");
+  }
 }
 
 function parseObjectJson(raw: string): unknown {

--- a/desktop/macos/agent/tests/conversation-journal.test.ts
+++ b/desktop/macos/agent/tests/conversation-journal.test.ts
@@ -4235,6 +4235,144 @@ describe("kernel conversation journal", () => {
     });
     fixture.store.close();
   });
+
+  it("revises an optimistically sealed completion to failed without touching payload or canonical metadata", () => {
+    // #12743: the desktop voice funnel seals a `.success` row `completed` at
+    // provider-response-finish while playback is still draining. When the
+    // reducer later proves the answer never reached the user, the revision
+    // must downgrade the row to `failed` while preserving exactly what the
+    // funnel sealed — content, blocks, resources, and canonical metadata such
+    // as model attribution and the continuity key.
+    const fixture = newSurface("main_chat", "chat", "sealed-terminal-revision");
+    const continuityKey = "voice:sealed-revision";
+    const turnId = `turn_${createHash("sha256")
+      .update(`${continuityKey}\0assistant`)
+      .digest("hex")
+      .slice(0, 32)}`;
+    recordJournalTurn(fixture.store, {
+      ownerId: fixture.ownerId,
+      conversationId: fixture.conversationId,
+      turnId,
+      role: "assistant",
+      surfaceKind: "main_chat",
+      origin: "realtime_voice",
+      status: "completed",
+      content: "Take the blue potion at 12:45.",
+      contentBlocks: [{ type: "text", id: `${turnId}:text`, text: "Take the blue potion at 12:45." }],
+      resources: [],
+      metadataJson: JSON.stringify({
+        continuityKey,
+        modelsUsed: ["gemini-3.1-flash-live-preview"],
+      }),
+      createdAtMs: 10,
+    });
+
+    const revised = updateJournalTurn(fixture.store, {
+      ownerId: fixture.ownerId,
+      conversationId: fixture.conversationId,
+      turnId,
+      status: "failed",
+      metadataJson: JSON.stringify({ terminalReason: "answer_not_delivered" }),
+      terminalRevision: true,
+      nowMs: 11,
+    });
+
+    expect(revised.status).toBe("failed");
+    expect(revised.content).toBe("Take the blue potion at 12:45.");
+    expect(revised.contentBlocks).toEqual([
+      { type: "text", id: `${turnId}:text`, text: "Take the blue potion at 12:45." },
+    ]);
+    expect(revised.resources).toEqual([]);
+    expect(JSON.parse(revised.metadataJson)).toMatchObject({
+      continuityKey,
+      modelsUsed: ["gemini-3.1-flash-live-preview"],
+      terminalReason: "answer_not_delivered",
+    });
+    fixture.store.close();
+  });
+
+  it("rejects a completed-to-failed downgrade without the terminal revision authority", () => {
+    const fixture = newSurface("main_chat", "chat", "sealed-downgrade-authority");
+    const turnId = "turn-downgrade-plain";
+    recordJournalTurn(fixture.store, {
+      ownerId: fixture.ownerId,
+      conversationId: fixture.conversationId,
+      turnId,
+      role: "assistant",
+      surfaceKind: "main_chat",
+      origin: "realtime_voice",
+      status: "completed",
+      content: "sealed",
+      contentBlocks: [],
+      resources: [],
+      metadataJson: "{}",
+      createdAtMs: 10,
+    });
+
+    expect(() => updateJournalTurn(fixture.store, {
+      ownerId: fixture.ownerId,
+      conversationId: fixture.conversationId,
+      turnId,
+      status: "failed",
+      metadataJson: JSON.stringify({ terminalReason: "answer_not_delivered" }),
+      nowMs: 11,
+    })).toThrow(/Invalid journal turn status transition completed -> failed/);
+    fixture.store.close();
+  });
+
+  it("rejects a terminal revision that mutates payload or targets a non-failed status", () => {
+    const fixture = newSurface("main_chat", "chat", "sealed-revision-shape");
+    const turnId = "turn-revision-shape";
+    recordJournalTurn(fixture.store, {
+      ownerId: fixture.ownerId,
+      conversationId: fixture.conversationId,
+      turnId,
+      role: "assistant",
+      surfaceKind: "main_chat",
+      origin: "realtime_voice",
+      status: "completed",
+      content: "sealed",
+      contentBlocks: [],
+      resources: [],
+      metadataJson: JSON.stringify({ continuityKey: "voice:shape" }),
+      createdAtMs: 10,
+    });
+
+    expect(() => updateJournalTurn(fixture.store, {
+      ownerId: fixture.ownerId,
+      conversationId: fixture.conversationId,
+      turnId,
+      status: "failed",
+      content: "rewritten answer",
+      terminalRevision: true,
+      nowMs: 11,
+    })).toThrow(/payload-free downgrade/);
+    expect(() => updateJournalTurn(fixture.store, {
+      ownerId: fixture.ownerId,
+      conversationId: fixture.conversationId,
+      turnId,
+      status: "completed",
+      metadataJson: JSON.stringify({ terminalReason: "x" }),
+      terminalRevision: true,
+      nowMs: 11,
+    })).toThrow(/payload-free downgrade/);
+    // The well-formed revision of the same sealed row still lands.
+    const revised = updateJournalTurn(fixture.store, {
+      ownerId: fixture.ownerId,
+      conversationId: fixture.conversationId,
+      turnId,
+      status: "failed",
+      metadataJson: JSON.stringify({ terminalReason: "playback_failed" }),
+      terminalRevision: true,
+      nowMs: 12,
+    });
+    expect(revised.status).toBe("failed");
+    expect(JSON.parse(revised.metadataJson)).toMatchObject({
+      continuityKey: "voice:shape",
+      terminalReason: "playback_failed",
+    });
+    fixture.store.close();
+  });
 });
 
 interface SurfaceFixture {

--- a/desktop/macos/changelog/unreleased/20260904-voice-journal-undelivered-answer.json
+++ b/desktop/macos/changelog/unreleased/20260904-voice-journal-undelivered-answer.json
@@ -1,0 +1,3 @@
+{
+  "change": "Push-to-talk answers that were never spoken are no longer recorded as delivered in your conversation history, so Omi no longer assumes you heard a reply it actually cut off"
+}


### PR DESCRIPTION
Fixes #12743 (FM6).

## Summary

The voice turn-done funnel journals the assistant row at
**provider-response-finish** — before the reducer's playback fence resolves
(`hubDidFinishTurn`'s own log line: "server turn done; waiting for local
playback to drain") — and `VoiceTurnJournalStatusPolicy` mapped
`.success → .completed` **unconditionally**. Assistant text that was never
spoken was therefore sealed `.completed` in the canonical journal, and the
model's later turns believed the user had received an answer they never heard
(2026-09-04 incident: the 12:45 AM potion question got a spoken "Let me
verify." only, while the full potion answer was journaled `.completed` as
`turn_81b`). A probe
(`status(for: .success, answerDelivered: false) == .failed`) failed on merged
main @ `71df4b0f19`.

## Design: optimistic seal at turn-done + reducer-terminal revision (option b)

The turn already has a delivery authority: the reducer gates its `.success`
terminal on the playback fence (`activeLease == nil` + journal accepted), and
merged #12730 added the delivery verdicts (`lastTerminalAnswerDelivered`,
`fullAnswerDrained(turnID:)`). The journal row was the only consumer that
ignored them for `.success`. This PR makes the row's **final** status a
function of that reducer verdict, without changing the write timing:

1. **The funnel write stays optimistic.** `persistTurnDirectlyToKernel` now
   computes status from a three-state delivery input (`pending` / `delivered` /
   `notDelivered`). Its default is `.pending`: at provider-response-finish
   playback is *usually still draining* for healthy turns, so "not yet
   drained" is never read as "never played" and a `.success` row still seals
   `.completed` there. When it does, the controller remembers the sealed row
   (owner, surface) keyed by the turn's continuity key — registered
   **synchronously at seal scheduling** (see review fix 3), not inside the
   async persist closure.
2. **The reducer's terminal revises the row only when delivery contradicts the
   seal.** `voiceTurnDidTerminate` feeds the terminal reason plus
   `lastTerminalAnswerDelivered` (both reducer-owned) into the new
   `VoiceJournalSealedRowRevisionPolicy`:
   - `.success` + never delivered → revise `.failed` / `answer_not_delivered`
   - `playbackFailed` → revise `.failed` / `playback_failed`
   - barge-in / explicit interrupt **before** drain → revise `.failed` + reason
   - barge-in **after** drain (delivered) → no revision (#12730 semantics intact)
   - every other reason (e.g. a later `journalFailed`) → no revision — a later
     journal failure never rewrites a delivered response as missing
3. **The revision is a payload-free kernel terminal-revision update.**
   `FloatingControlBarManager.reviseSealedRealtimeAssistantStatus` calls the
   new `KernelTurnProjection.reviseSealedTerminalTurn` RPC, keyed by the
   exchange's stable assistant turn ID. It carries **status + terminal reason
   only** — no content, blocks, resources, or metadata replacement — and the
   agent runtime (a) permits the narrow `completed → failed` downgrade only
   through an explicit `terminalRevision` flag with a payload-free shape, and
   (b) merges the terminal reason into the row's existing metadata instead of
   replacing it, so model attribution (`modelsUsed`) and continuity metadata
   survive the revision. No second writer; the kernel journal stays the
   transcript authority.
4. **The revision can't race the write it corrects.** It is chained through the
   turn-persistence ledger (`enqueueFollowUp`): if the funnel write is still in
   flight, the revision runs only after it lands, and because the follow-up
   takes over the key's obligation slot, `awaitTurnPersistenceFence` — the next
   voice turn's context refresh — still observes the journal settling before a
   snapshot reads it. Scheduling the follow-up after the original obligation
   already completed preserves the original's retained receipt (the later
   `finalizeJournal` still consumes the accepted kernel acknowledgement).

### Review fixes (cubic run cd8ae6da)

All three review findings were valid and are fixed:

1. **P1 — receipt deleted by a late follow-up** (`RealtimeTurnPersistence`
   `enqueueFollowUp`): when the funnel obligation had already completed, the
   else-branch went through `enqueue`, which clears the key's receipt slot —
   destroying the retained accepted receipt, so `finalizeJournal` treated the
   accepted turn as rejected. The follow-up now runs as a fresh non-retaining
   obligation that never touches the receipt slot. Test:
   `testFollowUpAfterCompletedObligationPreservesTheRetainedReceipt`.
2. **P2 — revision erased the sealed row's payload/metadata**
   (`FloatingControlBarManager+RealtimeStreamingJournal`): the old revision
   rebuilt a `ChatMessage` and used the generic `updateTurn`, whose wire
   payload replaces content, content blocks, resources, and metadata — erasing
   `modelsUsed`/continuity from the sealed row. Fixed by the payload-free
   `sealedTerminalRevision` update + kernel-side metadata merge described in
   (3) above; without the kernel change the revision was *doubly* broken: the
   journal's transition table rejects `completed → failed`, so the revision
   could never land at all. Tests: Swift
   `testSealedTerminalRevisionCarriesNoPayloadAndMergesOnlyItsReason`; agent
   `conversation-journal.test.ts` "revises an optimistically sealed completion
   …", "rejects a completed-to-failed downgrade without the terminal revision
   authority", "rejects a terminal revision that mutates payload…".
3. **P2 — sealed-row marker registered too late**
   (`RealtimeHubController+SessionLifecycle`): registration sat inside the
   funnel's async persist closure, which first awaits transcript resolution
   (bounded by the 20s LID deadline); a playback failure or barge-in
   terminalizing in that window found no marker, skipped the revision, and the
   later `.success` write sealed `.completed` permanently. The marker is now
   registered synchronously at the funnel enqueue sites (turn-done and the
   screen-evidence failure path), turns that already terminalized register
   nothing, and `persistTurnDirectlyToKernel` re-checks delivery at write time
   so a terminal that fired *before* the write downgrades it in the same
   single journal write. Tests: marker synchronicity, already-terminalized
   skip, write-time downgrade through the real coordinator, and a
   source-ordering pin of the turn-done wiring.

### Rejected alternatives

- **(a) Two-phase row (write `.streaming` at turn-done, finalize at terminal):**
  every healthy turn would carry an extra journal mutation and sit `.streaming`
  for the entire playback duration; a crash in that window orphans the row to
  startup repair, which terminalizes orphaned streaming rows — reintroducing
  exactly the delivered-but-failed lie #12730 fixed, now for every crashed
  healthy turn. It also changes what the kernel context renderer sees mid-turn
  for no behavioral gain, since the reducer already owns the truth.
- **(c) Incident-shape heuristic (text-length sniffing of deferral prefixes):**
  unprincipled and brittle; the reducer's drain state is the authority the
  product already maintains.

### Scope

Swift side plus one narrow agent-runtime change. The kernel gains exactly one
new capability: a payload-free `terminalRevision` downgrade of an
optimistically sealed completion, with metadata merge — guarded by shape
assertions, still rejected for run-linked turns, and pinned by new vitest
tests. Kernel-side spawn-journal sealing
(`agent/src/runtime/agent-spawn-journal.ts`) is #12731/#12734 territory and is
untouched; spawn-owned and kernel-owned exchanges are explicitly excluded from
the sealed-row marker.

Failure-Class: FC-decoded-outcome-discarded-before-canonical-record

The reducer decodes the delivery outcome (drain state at terminal), but the
canonical journal record dropped it for `.success` and asserted an outcome
nothing witnessed. The record's status is now a total function of the decoded
signal: the funnel requires an explicit `pending` delivery input (unknown is
represented, not substituted with a confident default), and the terminal-driven
revision derives the stored status from the decoded verdict.

## Product invariants affected

- INV-AGENT-*
- INV-CHAT-1
- INV-VOICE-1

## Invariant compliance

- **INV-AGENT-*** — the agent-runtime change touches no session/run/attempt
  identity, authority, or lifecycle. It adds one journal-update capability
  (`terminalRevision`), and runtime-produced turns keep kernel-authoritative
  terminalization: the handler still rejects every terminal-mutating public
  update on rows with a `producing_run_id` before the store is reached, and
  the store-side shape guard confines the new flag to a payload-free
  `completed → failed` downgrade of client-recorded rows.

- **INV-VOICE-1** — the reducer stays the only lifecycle owner. The revision is
  *driven by* the reducer's terminal effect and reads only reducer-owned state
  (`model.lastTerminal`, `lastTerminalAnswerDelivered`); the sealed-row marker
  is journal-write bookkeeping (which row text/owner the optimistic write used),
  not lifecycle state, and adds no parallel lifecycle enum, timer, or current-turn
  flag. "Durable outbox enqueue as journal acceptance" is unchanged —
  `finalizeJournal` still consumes the kernel-acknowledged receipt and the
  fence ordering is untouched: a `.success` terminal still requires provider,
  tools, playback, and journal fences closed.
- **INV-CHAT-1** — no second writer or store. The revision flows through the
  kernel journal update RPC on the shared projection, keyed by the exchange's
  stable turn IDs; it mutates the same canonical row the funnel wrote (status +
  merged `metadata.terminalReason` only, never content).

## Tests

New `VoiceTurnJournalDeliveryRevisionTests` (21 tests, behavioral only — 15
original plus 6 for the review fixes):
- the FM6 probe: `.success` + not delivered → `.failed`; delivered →
  `.completed`; **pending at the turn-done write stays `.completed`**
  (constraint: healthy draining turns must not be marked failed)
- the revision decision for every revisable/delivered/no-sealed-row case,
  including "later journal failure never rewrites a delivered answer"
- the real reducer driven through the production coordinator: success without
  any playback terminalizes undelivered and revises (`answer_not_delivered`);
  drained success keeps the row completed; playback failure after
  provider-finish revises with `playback_failed`
- the ledger follow-up: runs only after the original write, keeps the
  pending-obligations fence observing it, preserves the original's retained
  receipt (both while the original is in flight and when it already
  completed), and runs directly when nothing is in flight
- the revision wire shape: payload-free, `terminalRevision`-flagged,
  reason-only metadata patch
- the sealed-row marker: registers synchronously at seal scheduling, skips
  turns that already terminalized, the write-time downgrade re-check derives
  `playback_failed` from the real coordinator terminal, and the turn-done
  wiring order is pinned

Agent vitest `conversation-journal.test.ts`: 75/75 (72 existing + 3 new
covering the terminal-revision downgrade, its authority requirement, and its
payload-free shape). Full agent suite green after `npm run build` (the two
tool-surface and two stdio-contract tests require the built `dist/`, which the
worktree initially lacked — unrelated to this change).

Unmodified guard suites green: VoiceTurnJournalTruthfulnessTests (11),
VoiceTurnCoordinatorTests (30), LocalTranscriptionDuplicatePolicyTests (11),
CompletionDeltaPolicyTests (5) — 57/57 — plus the required
`RealtimeHub|RealtimeTurn|VoiceTurn|ListenEvents` filter = 278/278, and the
full `swift test --package-path Desktop` target passes. #12730's tests pass
unchanged. SwiftLint 0 violations; swift-format adds no new findings;
`check_desktop_test_quality.py` at baseline;
`check-agent-runtime-convergence-ratchet.py` OK; `tsc --noEmit` clean.

## Changelog

`desktop/macos/changelog/unreleased/20260904-voice-journal-undelivered-answer.json`

Closes #12743

## Line-count exceptions

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift | 1522 -> 1656 | the reducer-terminal journal revision (issue #12743) extends the funnel's own file: the synchronous sealed-row registration helper, the write-time delivery re-check, and voiceTurnDidTerminate's revision beside the terminal handling it already owns
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift | 1561 -> 1572 | review fix: the turn-done site registers the sealed-row marker synchronously before enqueueing the funnel's async persistence, closing the 20s transcript-resolution window in which a terminal could miss it
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift | 1533 -> 1539 | one in-memory journal-write bookkeeping field (sealedCompletedVoiceJournalRows) plus its owner-transition cleanup beside turnPersistenceLedger.cancelAll(); no new logic


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


