### PR TITLE
fix(backend): drop the last two references to a file deleted in WS-G cleanup

### DIFF
--- a/backend/pyrightconfig.json
+++ b/backend/pyrightconfig.json
@@ -59,7 +59,6 @@
         "scripts/stt/a_generate_samples_from_device.py",
         "scripts/stt/b_clean_samples.py",
         "scripts/stt/c_generate_models.py",
-        "scripts/stt/d_test_models.py",
         "scripts/stt/e_upload_test_samples.py",
         "scripts/stt/f_test_picovoice.py",
         "scripts/stt/g_pyannote_api.py",

--- a/backend/tests/.import_time_side_effects_legacy
+++ b/backend/tests/.import_time_side_effects_legacy
@@ -8,7 +8,7 @@
 #
 # Terminal state: this file is deleted (PLAN.md §4, condition #2).
 #
-# Total: 29 entries.
+# Total: 28 entries.
 #
 # The 4 entries marked "surfaced by P2" below were discovered by the alias-
 # resolution hardening of scan_import_time_side_effects.py: the old checker

--- a/backend/tests/.import_time_side_effects_legacy
+++ b/backend/tests/.import_time_side_effects_legacy
@@ -31,7 +31,6 @@ backend/scripts/chat/stream_test.py
 backend/scripts/rag/_shared.py
 backend/scripts/rag/memories.py
 backend/scripts/stt/c_generate_models.py
-backend/scripts/stt/d_test_models.py
 backend/scripts/stt/h_brainstorming.py
 backend/scripts/stt/j_apply_vad_to_speech_profiles.py
 backend/scripts/stt/k_compare_transcripts_performance.py


### PR DESCRIPTION
Follow-up to #12740.

## What changed and why

`a7bc5fd0c2` ("chore(backend): remove dead modules and orphaned WS-G promotion family") deleted `backend/scripts/stt/d_test_models.py`. #12740 swept the CI guardrail references to files that cleanup removed — the `slow_guardrail_manifest.txt` entry that was failing the Backend unit suite. Two references were left behind:

```
backend/pyrightconfig.json:62                      "scripts/stt/d_test_models.py",
backend/tests/.import_time_side_effects_legacy:34  backend/scripts/stt/d_test_models.py
```

The pyright one is the visible symptom. Every backend type check prints this before doing its work:

```
File or directory ".../backend/scripts/stt/d_test_models.py" does not exist.
```

It does not fail the run, and that is the reason to fix it rather than leave it: a config that always reports one missing include is a config where the next genuinely missing include reads as normal output. The same argument #12740 made for the manifest applies here, one layer down.

## Scope

Audited both files rather than deleting only the entry that surfaced, since the point of a follow-up to a partial sweep is not to be partial again:

- `.import_time_side_effects_legacy` — 29 non-comment entries, this is the only one whose path is absent from the tree.
- `pyrightconfig.json` — every non-glob path checked. Besides this entry only `.venv` and `pretrained_models` are absent, and both are gitignored directories that are correctly excluded rather than stale.

So this is the complete remainder, not another instalment.

## How it was verified

```
cd backend && PYRIGHT_PYTHON=.venv/bin/python bash scripts/typecheck.sh
0 errors, 5642 warnings, 0 informations
```

No missing-file line in the output. `pyrightconfig.json` still parses as valid JSON.

Two deletions, no behaviour change: `d_test_models.py` does not exist, so nothing was being type-checked or allow-listed through either entry.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

