### PR TITLE
fix(backend): gate app generate-prompts on the free chat quota

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -1532,6 +1532,7 @@ def generate_description_and_emoji_endpoint(
 @router.get('/v1/app/generate-prompts', tags=['v1'], response_model=AppPromptsGenerationResponse)
 async def generate_sample_prompts_endpoint(
     uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "apps:generate_prompts")),
+    x_app_platform: Optional[str] = Header(None, alias='X-App-Platform'),
 ):
     """
     Generate sample app prompts for the AI app generator.
@@ -1539,6 +1540,9 @@ async def generate_sample_prompts_endpoint(
     """
     from utils.llm.clients import get_llm
     import json
+
+    # User-initiated LLM generation — same free-tier gate as chat (402 past cap).
+    enforce_chat_quota(uid, platform=x_app_platform)
 
     system_prompt = """Generate 5 creative and diverse ideas for apps that are either:
 1. Conversation summary based apps - analyze user's recorded conversations and extract/organize information

--- a/backend/tests/unit/test_free_quota_gate_wiring.py
+++ b/backend/tests/unit/test_free_quota_gate_wiring.py
@@ -14,7 +14,7 @@ router module (the sanctioned monkeypatch-on-module seam).
 import asyncio
 import os
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -236,6 +236,31 @@ class TestAppGeneratorGates:
                 asyncio.run(apps_router.generate_app_icon_endpoint(data, uid='u1', x_app_platform='macos'))
             assert exc_info.value.status_code == 402
             gate.assert_called_once_with('u1', platform='macos')
+
+    def test_generate_prompts_blocked_past_cap(self):
+        # The last ungated managed-spend route in this router. #12739 closed
+        # /v1/app/generate and /v1/app/generate-icon; generate_sample_prompts_endpoint
+        # still ran the same Features.APP_GENERATOR spend behind rate limiting alone,
+        # so a free user past cap could keep drawing billable suggestions from it.
+        import routers.apps as apps_router
+
+        with patch.object(apps_router, 'enforce_chat_quota', side_effect=_quota_402()) as gate, patch(
+            'utils.llm.clients.get_llm'
+        ) as llm:
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(apps_router.generate_sample_prompts_endpoint(uid='u1', x_app_platform='macos'))
+            assert exc_info.value.status_code == 402
+            gate.assert_called_once_with('u1', platform='macos')
+            llm.assert_not_called()
+
+    def test_generate_prompts_proceeds_within_cap(self):
+        import routers.apps as apps_router
+
+        with patch.object(apps_router, 'enforce_chat_quota') as gate, patch('utils.llm.clients.get_llm') as llm:
+            llm.return_value.ainvoke = AsyncMock(return_value=SimpleNamespace(content='["a","b","c","d","e"]'))
+            asyncio.run(apps_router.generate_sample_prompts_endpoint(uid='u1', x_app_platform='macos'))
+            gate.assert_called_once_with('u1', platform='macos')
+            llm.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -6322,7 +6322,7 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  public static func generateSamplePromptsEndpointV1AppGeneratePromptsGet(client: OmiApiClient, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil) async throws -> OmiAnyCodable {
+  public static func generateSamplePromptsEndpointV1AppGeneratePromptsGet(client: OmiApiClient, xAppPlatform: String? = nil, authorization: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil) async throws -> OmiAnyCodable {
     let _path = "/v1/app/generate-prompts"
     guard let components = URLComponents(string: client.baseURL + _path) else {
       throw OmiApiError.invalidURL
@@ -6334,8 +6334,8 @@ public enum OmiAPI {
     if let token = client.token {
       req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
     }
-    if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
     if let xAppPlatform { req.setValue(String(xAppPlatform), forHTTPHeaderField: "X-App-Platform") }
+    if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
     if let xDeviceIdHash { req.setValue(String(xDeviceIdHash), forHTTPHeaderField: "X-Device-Id-Hash") }
     if let xAppVersion { req.setValue(String(xAppVersion), forHTTPHeaderField: "X-App-Version") }
     let (data, resp) = try await URLSession.shared.data(for: req)

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -10596,7 +10596,7 @@ export async function generate_app_icon_endpoint_v1_app_generate_icon_post(heade
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function generate_sample_prompts_endpoint_v1_app_generate_prompts_get(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<AppPromptsGenerationResponse> {
+export async function generate_sample_prompts_endpoint_v1_app_generate_prompts_get(header: { X_App_Platform?: string, authorization?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<AppPromptsGenerationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/app/generate-prompts`;
   const _search = "";
@@ -10605,8 +10605,8 @@ export async function generate_sample_prompts_endpoint_v1_app_generate_prompts_g
     headers: {
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
       ...init?.headers,
-      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
       ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
       ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
       ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
     },

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -32693,19 +32693,19 @@
         "parameters": [
           {
             "in": "header",
-            "name": "authorization",
+            "name": "X-App-Platform",
             "required": false,
             "schema": {
-              "title": "Authorization",
+              "title": "X-App-Platform",
               "type": "string"
             }
           },
           {
             "in": "header",
-            "name": "X-App-Platform",
+            "name": "authorization",
             "required": false,
             "schema": {
-              "title": "X-App-Platform",
+              "title": "Authorization",
               "type": "string"
             }
           },

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -10596,7 +10596,7 @@ export async function generate_app_icon_endpoint_v1_app_generate_icon_post(heade
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function generate_sample_prompts_endpoint_v1_app_generate_prompts_get(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<AppPromptsGenerationResponse> {
+export async function generate_sample_prompts_endpoint_v1_app_generate_prompts_get(header: { X_App_Platform?: string, authorization?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<AppPromptsGenerationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/app/generate-prompts`;
   const _search = "";
@@ -10605,8 +10605,8 @@ export async function generate_sample_prompts_endpoint_v1_app_generate_prompts_g
     headers: {
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
       ...init?.headers,
-      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
       ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
       ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
       ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
     },

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -10596,7 +10596,7 @@ export async function generate_app_icon_endpoint_v1_app_generate_icon_post(heade
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function generate_sample_prompts_endpoint_v1_app_generate_prompts_get(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<AppPromptsGenerationResponse> {
+export async function generate_sample_prompts_endpoint_v1_app_generate_prompts_get(header: { X_App_Platform?: string, authorization?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<AppPromptsGenerationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/app/generate-prompts`;
   const _search = "";
@@ -10605,8 +10605,8 @@ export async function generate_sample_prompts_endpoint_v1_app_generate_prompts_g
     headers: {
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
       ...init?.headers,
-      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
       ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
       ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
       ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
     },

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -10596,7 +10596,7 @@ export async function generate_app_icon_endpoint_v1_app_generate_icon_post(heade
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function generate_sample_prompts_endpoint_v1_app_generate_prompts_get(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<AppPromptsGenerationResponse> {
+export async function generate_sample_prompts_endpoint_v1_app_generate_prompts_get(header: { X_App_Platform?: string, authorization?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<AppPromptsGenerationResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/app/generate-prompts`;
   const _search = "";
@@ -10605,8 +10605,8 @@ export async function generate_sample_prompts_endpoint_v1_app_generate_prompts_g
     headers: {
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
       ...init?.headers,
-      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
       ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
       ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
       ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
     },


### PR DESCRIPTION
Follow-up to #12739, which fixed #12715.

## What changed and why

`/v1/app/generate-prompts` runs the same billable `Features.APP_GENERATOR` spend as the other AI-app generators, but sat behind `auth.with_rate_limit(...)` alone with no `enforce_chat_quota` call:

```python
async def generate_sample_prompts_endpoint(
    uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "apps:generate_prompts")),
):
    ...
    with track_usage(uid, Features.APP_GENERATOR):
```

`track_usage` attributes spend; it does not block. #12739 closed `/v1/app/generate` and `/v1/app/generate-icon`, and correctly left this one alone because it was outside #12715's scope. That makes it the last ungated **`APP_GENERATOR`** route in the router — a free user past the monthly cap can keep drawing LLM-generated app suggestions from it indefinitely.

> **Correction.** This originally read "the last ungated managed-spend route in the router", which is wrong, as [Git-on-my-level caught](https://github.com/BasedHardware/omi/pull/12749). `/v1/personas/twitter/initial-message` (`apps.py:1744`) also runs tracked LLM spend, under `Features.PERSONA`, and is gated by neither a quota nor a rate limiter — strictly less protected than this route was. It is out of scope here and tracked separately; the claim above is now scoped to `APP_GENERATOR`, which it can actually support.

This adds the same gate the other four generators use, in the shape #12739 established: `enforce_chat_quota(uid, platform=x_app_platform)` before any provider work, with the `X-App-Platform` header accepted so the desktop trial paywall applies here too rather than silently never firing on `platform=None`.

Rate limiting and quota enforcement solve different problems, which is why one does not substitute for the other: the limiter bounds request frequency, the quota bounds monthly billable spend against the user's plan.

## On the generated-client churn

The six generated artifacts change by a **reordering, not an addition**. `X-App-Platform` was already advertised on this route through the shared auth dependency; declaring it explicitly on the handler moves it ahead of the injected headers. That is exactly the ordering the sibling routes already have:

```
POST /v1/app/generate              ['X-App-Platform', 'authorization', 'X-Device-Id-Hash', 'X-App-Version']
POST /v1/app/generate-icon         ['X-App-Platform', 'authorization', 'X-Device-Id-Hash', 'X-App-Version']
POST /v1/app/generate-description  ['X-App-Platform', 'authorization', 'X-Device-Id-Hash', 'X-App-Version']
GET  /v1/app/generate-prompts      ['X-App-Platform', 'authorization', 'X-Device-Id-Hash', 'X-App-Version']  ← this PR
```

So the route converges on the router's existing convention rather than introducing a new shape. No wire-level parameter is added or removed.

## How it was verified

Mutation-checked — with the gate removed, both new tests fail:

```
2 failed, 14 deselected
```

- `pytest tests/unit/test_free_quota_gate_wiring.py` — 16 passed
- `scripts/openapi_runner.sh scripts/export_openapi.py --surface app-client --check` — up to date
- Swift, TypeScript (×4) and Dart generators re-run; only the four TS/Swift artifacts changed, Dart models unaffected

## Tests

- `test_generate_prompts_blocked_past_cap` — asserts the 402 propagates **and** that `get_llm` is never called, so the gate precedes spend rather than merely accompanying it
- `test_generate_prompts_proceeds_within_cap` — asserts the proceed path still reaches the provider, and pins `enforce_chat_quota('u1', platform='macos')` so the platform argument cannot be silently dropped

## Honest gaps

- No live free-tier Firebase/Redis integration run (hermetic gate patching only).
- Physical / on-device smoke not run — backend-only change.

Failure-Class: none

Line-Count-Exception: backend/routers/apps.py | 2468 -> 2472 | Four lines: the X-App-Platform header parameter and the enforce_chat_quota call, matching the four sibling generators in this router. Splitting the file is a larger refactor than a one-gate wiring fix should carry.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


