### PR TITLE
fix(ci): exclude gitignored files from the dead-code ratchet

### DIFF
--- a/.github/scripts/check_dead_code.py
+++ b/.github/scripts/check_dead_code.py
@@ -109,10 +109,13 @@ def _git_ignored_paths(root: Path) -> set[Path]:
             ],
             capture_output=True,
             text=True,
+            # A filename whose bytes are invalid for the locale must degrade to the
+            # filesystem fallback, not raise out of a checker that has to keep running.
+            errors="surrogateescape",
             timeout=60,
             check=True,
         )
-    except (OSError, subprocess.SubprocessError):
+    except (OSError, subprocess.SubprocessError, UnicodeError):
         return set()
     return {(root / entry).resolve() for entry in completed.stdout.split("\0") if entry}
 
@@ -159,6 +162,11 @@ def scan_flutter(root: Path) -> AreaScan:
     if not entry.is_file():
         return AreaScan("flutter", error=f"flutter entry {FLUTTER_LIB_REL}/{FLUTTER_ENTRY} is missing; nothing to anchor reachability")
     is_ignored = _ignore_predicate(root)
+    if is_ignored(entry):
+        # Reachability is seeded from this entry below. Excluding it from `files`
+        # while still walking from it would strand every other file and report
+        # the whole area dead, so fail closed the way a missing entry does.
+        return AreaScan("flutter", error=f"flutter entry {FLUTTER_LIB_REL}/{FLUTTER_ENTRY} is gitignored; nothing to anchor reachability")
     files: dict[str, Path] = {}
     for path in lib.rglob("*.dart"):
         rel = path.relative_to(lib).as_posix()

--- a/.github/scripts/check_dead_code.py
+++ b/.github/scripts/check_dead_code.py
@@ -39,7 +39,9 @@ Ratchet contract (monorepo rules: deterministic, hermetic, actionable):
   file, or add it to the area allowlist with a reason.
 - `--update-baseline` rewrites the baseline from the current state (deletions
   shrink it; the allowlist is never touched or auto-pruned).
-- No network, no git history: pure filesystem analysis of the checkout.
+- No network, no git history: pure filesystem analysis of the checkout. Files
+  git ignores are not part of that checkout — CI never sees them — so they are
+  excluded before reachability runs (see `_git_ignored_paths`).
 """
 
 from __future__ import annotations
@@ -48,6 +50,7 @@ import argparse
 import json
 import posixpath
 import re
+import subprocess
 import sys
 from collections import defaultdict
 from dataclasses import dataclass
@@ -73,6 +76,72 @@ class AreaScan:
 
 
 # ---------------------------------------------------------------------------
+# gitignore
+# ---------------------------------------------------------------------------
+
+def _git_ignored_paths(root: Path) -> set[Path]:
+    """Absolute paths git ignores under `root`.
+
+    The scan walks the working tree, but the contract is about the tree CI
+    checks out. A developer machine also carries gitignored siblings — generated
+    config like `app/lib/firebase_options_dev.dart`, build output, `.claude/`
+    worktrees — none of which exist in CI. Reporting them as newly dead fails
+    the gate only locally, which reads as the checker being broken.
+
+    Mirrors `_git_ignored_paths` in backend/scripts/generate_plan_catalog.py,
+    added for the same reason in #12476.
+
+    Returns an empty set when git cannot answer, leaving the pure-filesystem
+    behaviour unchanged.
+    """
+    try:
+        completed = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(root),
+                "ls-files",
+                "--others",
+                "--ignored",
+                "--exclude-standard",
+                "--directory",
+                "-z",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    return {(root / entry).resolve() for entry in completed.stdout.split("\0") if entry}
+
+
+def _ignore_predicate(root: Path):
+    """Return `is_ignored(path)`; git is consulted once per scan."""
+    ignored = _git_ignored_paths(root)
+    if not ignored:
+        return lambda path: False
+    resolved_root = root.resolve()
+
+    def is_ignored(path: Path) -> bool:
+        # `--directory` collapses an ignored directory to one entry, so a file
+        # inside it matches through an ancestor rather than directly.
+        current = path.resolve()
+        while True:
+            if current in ignored:
+                return True
+            if current == resolved_root:
+                return False
+            parent = current.parent
+            if parent == current:
+                return False
+            current = parent
+
+    return is_ignored
+
+
+# ---------------------------------------------------------------------------
 # flutter
 # ---------------------------------------------------------------------------
 
@@ -89,10 +158,11 @@ def scan_flutter(root: Path) -> AreaScan:
     entry = lib / FLUTTER_ENTRY
     if not entry.is_file():
         return AreaScan("flutter", error=f"flutter entry {FLUTTER_LIB_REL}/{FLUTTER_ENTRY} is missing; nothing to anchor reachability")
+    is_ignored = _ignore_predicate(root)
     files: dict[str, Path] = {}
     for path in lib.rglob("*.dart"):
         rel = path.relative_to(lib).as_posix()
-        if not FLUTTER_SKIP.search(rel):
+        if not FLUTTER_SKIP.search(rel) and not is_ignored(path):
             files[rel] = path
     edges: dict[str, set[str]] = {}
     for rel, path in files.items():
@@ -136,10 +206,13 @@ def scan_backend(root: Path) -> AreaScan:
     backend = root / BACKEND_REL
     if not backend.is_dir():
         return AreaScan("backend", error="backend/ is missing; nothing to scan")
+    is_ignored = _ignore_predicate(root)
     files: dict[str, Path] = {}
     for path in backend.rglob("*.py"):
         rel = path.relative_to(backend).as_posix()
         if "__pycache__" in rel or rel.startswith(BACKEND_TEST_PREFIXES):
+            continue
+        if is_ignored(path):
             continue
         files[rel] = path
     modmap: dict[str, str] = {}
@@ -267,11 +340,12 @@ def scan_ts(root: Path, area: str, area_root_rel: str, entry_specs: list[str],
     base = root / area_root_rel / "src"
     if not base.is_dir():
         return AreaScan(area, error=f"{area_root_rel}/src is missing; nothing to scan")
+    is_ignored = _ignore_predicate(root)
     files: dict[str, Path] = {}
     for path in base.rglob("*"):
         if path.suffix in TS_SUFFIXES and path.is_file():
             rel = path.relative_to(base).as_posix()
-            if not TS_SKIP.search(rel):
+            if not TS_SKIP.search(rel) and not is_ignored(path):
                 files[rel] = path
     static_imp, dynamic_imp = _import_patterns(aliases)
     # Deterministic winner: rglob order is filesystem-dependent, so with bare-stem

--- a/.github/scripts/test_check_dead_code.py
+++ b/.github/scripts/test_check_dead_code.py
@@ -36,6 +36,11 @@ def git_init(root: Path) -> None:
     subprocess.run(["git", "init", "-q", str(root)], check=True, capture_output=True)
 
 
+def git_stage_all(root: Path) -> None:
+    """Track everything git does not ignore, so 'tracked' assertions mean it."""
+    subprocess.run(["git", "-C", str(root), "add", "-A"], check=True, capture_output=True)
+
+
 def write(root: Path, rel: str, content: str) -> None:
     path = root / rel
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -240,6 +245,7 @@ class DeadCodeRatchetTests(unittest.TestCase):
         # A file under an ignored *directory*: `ls-files --directory` collapses the
         # directory to one entry, so this matches through an ancestor.
         write(self.root, "app/lib/build_output/generated_widget.dart", "class GeneratedWidget {}\n")
+        git_stage_all(self.root)
 
         scan = scan_flutter(self.root)
 
@@ -252,11 +258,35 @@ class DeadCodeRatchetTests(unittest.TestCase):
         git_init(self.root)
         write(self.root, ".gitignore", "/backend/utils/local_secrets.py\n")
         write(self.root, "backend/utils/local_secrets.py", "TOKEN = 'x'\n")
+        git_stage_all(self.root)
 
         scan = scan_backend(self.root)
 
         self.assertNotIn("backend/utils/local_secrets.py", scan.dead)
         self.assertIn(DEAD_BY_AREA["backend"], scan.dead)
+
+    def test_gitignored_typescript_file_is_not_reported_dead(self) -> None:
+        """scan_ts is shared by the agent and windows areas, so it needs its own case."""
+        git_init(self.root)
+        write(self.root, ".gitignore", "/desktop/macos/agent/src/runtime/localOnly.ts\n")
+        write(self.root, "desktop/macos/agent/src/runtime/localOnly.ts", "export const localOnly = 1;\n")
+        git_stage_all(self.root)
+
+        scan = scan_agent(self.root)
+
+        self.assertNotIn("desktop/macos/agent/src/runtime/localOnly.ts", scan.dead)
+        self.assertIn(DEAD_BY_AREA["agent"], scan.dead)
+
+    def test_gitignored_flutter_entry_fails_closed(self) -> None:
+        """Reachability is seeded from the entry, so an ignored entry must error."""
+        git_init(self.root)
+        write(self.root, ".gitignore", "/app/lib/main.dart\n")
+        git_stage_all(self.root)
+
+        scan = scan_flutter(self.root)
+
+        self.assertIn("gitignored", scan.error or "")
+        self.assertEqual((), scan.dead)
 
     def test_scan_outside_a_git_repo_is_unchanged(self) -> None:
         """git cannot answer here, so the pure-filesystem behaviour must stand."""

--- a/.github/scripts/test_check_dead_code.py
+++ b/.github/scripts/test_check_dead_code.py
@@ -31,6 +31,11 @@ def run_checker(root: Path, *extra: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def git_init(root: Path) -> None:
+    """Make `root` a real repo so `git ls-files --ignored` can answer."""
+    subprocess.run(["git", "init", "-q", str(root)], check=True, capture_output=True)
+
+
 def write(root: Path, rel: str, content: str) -> None:
     path = root / rel
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -226,6 +231,41 @@ class DeadCodeRatchetTests(unittest.TestCase):
         result = run_checker(self.root)
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("no longer dead", result.stdout)
+
+    def test_gitignored_files_are_not_reported_dead(self) -> None:
+        """A file git ignores is not in the tree CI checks out (#12476 shape)."""
+        git_init(self.root)
+        write(self.root, ".gitignore", "/app/lib/widgets/ignored_widget.dart\nbuild_output/\n")
+        write(self.root, "app/lib/widgets/ignored_widget.dart", "class IgnoredWidget {}\n")
+        # A file under an ignored *directory*: `ls-files --directory` collapses the
+        # directory to one entry, so this matches through an ancestor.
+        write(self.root, "app/lib/build_output/generated_widget.dart", "class GeneratedWidget {}\n")
+
+        scan = scan_flutter(self.root)
+
+        self.assertNotIn("app/lib/widgets/ignored_widget.dart", scan.dead)
+        self.assertNotIn("app/lib/build_output/generated_widget.dart", scan.dead)
+        # The tracked dead file is still caught: this filters the checkout, not the verdict.
+        self.assertIn(DEAD_BY_AREA["flutter"], scan.dead)
+
+    def test_gitignored_backend_module_is_not_reported_dead(self) -> None:
+        git_init(self.root)
+        write(self.root, ".gitignore", "/backend/utils/local_secrets.py\n")
+        write(self.root, "backend/utils/local_secrets.py", "TOKEN = 'x'\n")
+
+        scan = scan_backend(self.root)
+
+        self.assertNotIn("backend/utils/local_secrets.py", scan.dead)
+        self.assertIn(DEAD_BY_AREA["backend"], scan.dead)
+
+    def test_scan_outside_a_git_repo_is_unchanged(self) -> None:
+        """git cannot answer here, so the pure-filesystem behaviour must stand."""
+        write(self.root, "app/lib/widgets/untracked_widget.dart", "class UntrackedWidget {}\n")
+
+        scan = scan_flutter(self.root)
+
+        self.assertIn("app/lib/widgets/untracked_widget.dart", scan.dead)
+        self.assertIn(DEAD_BY_AREA["flutter"], scan.dead)
 
     def test_scan_is_deterministic_across_runs(self) -> None:
         seed_allowlist(self.root)


### PR DESCRIPTION
## What changed and why

Closes #12755.

`check_dead_code.py` enumerates each area with a raw filesystem walk — `lib.rglob("*.dart")`, `backend.rglob("*.py")`, `base.rglob("*")` — and has no git awareness at all. Any gitignored file under `app/lib`, `backend/`, or a desktop `src` tree is therefore treated as production source and can be reported as newly dead.

Those files are not in the tree CI checks out. They are absent from every diff and from the runner, so the gate fails **only** on developer machines, on a file the reviewer cannot see. The failure also names a remediation that does not apply: you cannot delete a generated file your local build needs, and allowlisting a path CI never sees would put a permanent entry in the ratchet for something that does not exist there.

## Reproduction

On this repo, unmodified `main`:

```
$ python .github/scripts/check_dead_code.py --area flutter
dead-code[flutter]: FAILED, 1 problem(s):
  - app/lib/firebase_options_dev.dart
      fix: delete it, or add it to .github/scripts/dead_code/flutter.allowlist.json with a reason
```

`app/lib/firebase_options_dev.dart` is gitignored at `.gitignore:176` and is written during Flutter setup. It is in neither `main` nor the PR branch. Moving the file aside turns the same check green, which is what identifies it as a scan-input problem rather than a real ratchet failure.

I hit this while running `scripts/pr-preflight` for an unrelated desktop PR, where it presented as that PR having broken the dead-code gate.

## The fix

Filter each scan through `git ls-files --others --ignored --exclude-standard --directory`, mirroring `_git_ignored_paths` in `backend/scripts/generate_plan_catalog.py` — added there for this same failure, cited in its docstring as #12476.

Two details carried over from that precedent:

- `--directory` collapses an ignored directory to a single entry, so membership is tested through a path's ancestors rather than only the path itself. The test covers a file inside an ignored directory for that reason.
- When git cannot answer — not a repo, git absent, non-zero exit — the ignored set is empty and the previous pure-filesystem behaviour stands. The checker stays hermetic and works on a bare source tree.

The module docstring's "no git history: pure filesystem analysis of the checkout" line is updated rather than contradicted: `ls-files` reads working-tree state, not history, and the point of the change is that gitignored files were never part of the checkout being described.

## Verification

| Area | before | after |
|---|---|---|
| flutter | **FAILED** on `app/lib/firebase_options_dev.dart` | ok (2 at floor) |
| backend | ok (5 at floor) | ok (5 at floor) |
| agent | ok (5 at floor) | ok (5 at floor) |
| windows | ok (7 at floor) | ok (7 at floor) |

One area moves, and only from a false failure to ok. No verdict changes anywhere else — I ran each area with and without the patch on the same checkout to confirm that, rather than assuming it.

`python .github/scripts/test_check_dead_code.py` — **13 passed** (10 before).

**The tests fail without the fix.** Reverting only `check_dead_code.py` fails `test_gitignored_files_are_not_reported_dead` and `test_gitignored_backend_module_is_not_reported_dead`. The third new test asserts the non-git fallback, which holds in both directions by design, so it is an invariance check rather than a regression test.

## Tests

Three cases in `.github/scripts/test_check_dead_code.py`:

- a gitignored Dart file, and a file inside a gitignored directory, are not reported dead — while the tracked dead file in the same fixture still is, so this filters the checkout and not the verdict
- the same for a gitignored backend module
- a scan outside a git repo is unchanged, pinning the fallback that keeps the checker hermetic

The existing fixtures build a plain temp directory, which is not a repo, so every pre-existing test exercises the fallback path unchanged.

Failure-Class: FC-check-scope-exceeds-remediation-scope

The contract is that a gate which fails until an operator applies a remediation must only run where that remediation is permitted. Here the scan reaches files for which neither offered remediation is available, so the run fails on a condition the developer cannot clear. This is the nearest existing class rather than an exact match — its evidence is about environment scope and this is about scan-input scope. Happy to declare a narrower class instead if you would rather keep that one's meaning tight.

## Scope

The three scan sites in `check_dead_code.py` only. I have not touched the baselines or allowlists, and no ratchet entry changes as a result of this.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

