### PR TITLE
SCA-447: restore Backend Unit Tests after model_config import

### DIFF
--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -119,6 +119,7 @@ _SYS_MODULE_NAMES = [
     "utils.llm.conversation_folder",
     "utils.llm.conversation_prompt_prefix",
     "utils.llm.conversation_processing",
+    "utils.llm.model_config",
     "utils.retrieval",
     "utils.retrieval.tools",
     "utils.retrieval.tools.action_item_tools",
@@ -339,6 +340,11 @@ _load_module_from_file("utils.llm.discard_parser", BACKEND_DIR / "utils" / "llm"
 # empty __path__ above, which leaves conversation_processing's absolute import of it
 # unresolvable.
 _load_module_from_file("utils.llm.prompt_cache", BACKEND_DIR / "utils" / "llm" / "prompt_cache.py")
+
+# model_config pulls in gateway_client; stub the one constant conversation_processing
+# imports so the isolated load does not need the real module tree.
+model_config_stub = _stub_module("utils.llm.model_config")
+model_config_stub.FOREGROUND_REQUEST_TIMEOUT_SECONDS = 60.0
 
 prompt_prefix_stub = _stub_module("utils.llm.conversation_prompt_prefix")
 prompt_prefix_stub.ConversationPromptPrefix = MagicMock

--- a/backend/tests/unit/test_conversation_structure_timezone.py
+++ b/backend/tests/unit/test_conversation_structure_timezone.py
@@ -143,6 +143,11 @@ _load_module_from_file("utils.llm.discard_parser", BACKEND_DIR / "utils" / "llm"
 # cache floor the preflight assertions below depend on.
 _load_module_from_file("utils.llm.prompt_cache", BACKEND_DIR / "utils" / "llm" / "prompt_cache.py")
 
+# model_config pulls in gateway_client; stub the one constant conversation_processing
+# imports so the isolated load does not need the real module tree.
+model_config_stub = _stub_module("utils.llm.model_config")
+model_config_stub.FOREGROUND_REQUEST_TIMEOUT_SECONDS = 60.0
+
 prompt_prefix_stub = _stub_module("utils.llm.conversation_prompt_prefix")
 prompt_prefix_stub.ConversationPromptPrefix = MagicMock
 prompt_prefix_stub.shared_conversation_cache_supported = MagicMock(return_value=False)

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -441,10 +441,17 @@ class TestGetLlm:
         assert llm1 is llm2
 
     def test_different_models_return_different_instances(self):
-        # memories and conv_structure both resolve to Luna in premium.
+        llm1 = get_llm('memories')
+        llm2 = get_llm('persona_chat')
+        assert llm1 is not llm2
+
+    def test_foreground_timeout_does_not_share_cached_client(self):
+        # Both resolve to Luna in premium, but conv_structure carries
+        # FOREGROUND_REQUEST_TIMEOUT_SECONDS and request_timeout is part of the
+        # client cache key.
         llm1 = get_llm('memories')
         llm2 = get_llm('conv_structure')
-        assert llm1 is llm2
+        assert llm1 is not llm2
 
     def test_streaming_returns_different_instance(self):
         llm = get_llm('conv_action_items')


### PR DESCRIPTION
## Cause

`#12750` made `conversation_processing` import `utils.llm.model_config.FOREGROUND_REQUEST_TIMEOUT_SECONDS`. Isolated unit files stub `utils.llm` as a package with an empty `__path__`, so collection cannot see the real module and two files abort with `ModuleNotFoundError: No module named 'utils.llm.model_config'`. The same commit puts `request_timeout` on the LLM client cache key, so `memories` and `conv_structure` no longer share a cached client even though both resolve to Luna.

## Fix

- Stub `utils.llm.model_config` (the one imported constant) in `test_action_item_date_validation.py` and `test_conversation_structure_timezone.py`, the same way those files already stub other `utils.llm` siblings.
- Update `test_omi_qos_tiers.py` so different models are distinct instances, and pin that a foreground-timeout feature does not share the cached client.

## Reproduction

From `backend/` on `origin/main` (commit `6113376f8e`, after `#12750`):

```
: > /tmp/omi-backend-unit-failures.txt
echo tests/unit/test_action_item_date_validation.py >> /tmp/omi-backend-unit-failures.txt
echo tests/unit/test_conversation_structure_timezone.py >> /tmp/omi-backend-unit-failures.txt
echo tests/unit/test_omi_qos_tiers.py >> /tmp/omi-backend-unit-failures.txt
PYTHON=backend/.venv/bin/python BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-backend-unit-failures.txt BACKEND_PYTEST_WORKERS=1 bash test.sh
```

Before: collection errors on the first two files (`status 2`) and `TestGetLlm.test_different_models_return_different_instances` failed (`status 1`). After: 26 + 16 + 96 passed.

Failure-Class: none

Closes SCA-447

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

