### PR TITLE
test(backend): pin MEMORY_BELIEF_MODEL_ENABLED in the dev pusher binding contract

### DIFF
--- a/backend/tests/unit/test_verify_pusher_config_references.py
+++ b/backend/tests/unit/test_verify_pusher_config_references.py
@@ -181,6 +181,7 @@ def test_rendered_dev_pusher_direct_bindings_match_source_contract(preflight: Si
     assert literals == {
         "GOOGLE_CLOUD_PROJECT": "based-hardware-dev",
         "HOSTED_PARAKEET_API_URL": "http://parakeet.omiapi.com",
+        "MEMORY_BELIEF_MODEL_ENABLED": "true",
         "MEMORY_ENABLED": "on",
         "OMI_ENV_STAGE": "dev",
         "OMI_LLM_CHAT_AGENT_ROUTE": "gateway",


### PR DESCRIPTION
## Cause

#12751 declared `MEMORY_BELIEF_MODEL_ENABLED='true'` on the dev pusher (manifest and Helm values). `test_rendered_dev_pusher_direct_bindings_match_source_contract` pins the exact set of dev pusher literal bindings, so main's Backend Unit Tests fail with one extra item, `{'MEMORY_BELIEF_MODEL_ENABLED': 'true'}`. The PR's own CI did not show this because the unit suite was aborting at collection on the earlier `utils.llm.model_config` import (fixed in #12757); once that was fixed, this assertion became reachable.

## Fix

Add the new literal to the pinned contract. The rendered deployment already matched the manifest; only the explicit dict in the test was behind.

## Verification

- `tests/unit/test_verify_pusher_config_references.py` — 22 passed
- Full hermetic unit run (`scripts/run-unit-ci.sh --all`) result is noted in the PR comments.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

