### PR TITLE
fix(backend): decline the daily recap when the day has nothing to summarize

### DIFF
--- a/.github/failure-classes/FC-summary-generated-from-titles-only-render.json
+++ b/.github/failure-classes/FC-summary-generated-from-titles-only-render.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-summary-generated-from-titles-only-render",
+  "violated_contract": "A generator must not be invoked on rendered input that cannot support its output contract. The daily-recap prompt renders each conversation through conversations_to_string(use_transcript=False), which shows the title plus the first app result or the structured overview — nothing else. When a day's conversations carry neither body field (the §1.7 deterministic minimum's shape), the model receives titles alone; the output it returns is thin or hallucinated from first sentences, and the delivery path then pushes it and stores it as the user's recap of their day. The spend (one managed luna call per user per day) happens even though the input made a faithful summary impossible, and the degenerate output is indistinguishable from a real one once delivered.",
+  "canonical_prevention": "Before the generation call, decline when no conversation in the bounded input carries the body fields the renderer actually consumes (mirroring the renderer's own field selection, not a parallel guess), the same way the existing empty-window guard declines — no model call, no record, no push, lock released. A guard that reads exactly the fields the prompt reads cannot drift from the input the model would see.",
+  "canonical_prevention_artifact": [
+    "backend/utils/other/notifications.py",
+    "backend/tests/unit/test_daily_summary_generation.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/utils/other/notifications.py",
+    "backend/utils/conversations/render.py",
+    "backend/utils/other/daily_summary_budget.py"
+  ],
+  "status": "open"
+}

--- a/backend/tests/unit/test_daily_summary_empty_overview.py
+++ b/backend/tests/unit/test_daily_summary_empty_overview.py
@@ -5,7 +5,13 @@ str(summary_data.get('overview', 'Tap to see your daily summary')). get's defaul
 an ABSENT key. DailySummaryPayload.overview defaults to "", so a thin day yields a present-but-empty
 overview -> get returns "" -> the fallback string is dead code -> an empty daily-summary push. The
 body now falls back to the default text when overview is empty.
+
+The day under test carries a conversation with a real overview so the pre-LLM summary-content
+gate (flip-review F-12) lets generation through: this file pins the *delivery* fallback for a
+generator that returned an empty overview, not the titles-only decline.
 """
+
+from types import SimpleNamespace
 
 import utils.other.notifications as notif
 
@@ -13,6 +19,10 @@ import utils.other.notifications as notif
 class _FakeConvo:
     transcript_segments = [object()]
     discarded = False
+    apps_results: list = []
+
+    def __init__(self) -> None:
+        self.structured = SimpleNamespace(overview='You had 3 conversations today.')
 
 
 def _drive(monkeypatch, overview):

--- a/backend/tests/unit/test_daily_summary_generation.py
+++ b/backend/tests/unit/test_daily_summary_generation.py
@@ -347,6 +347,78 @@ def test_an_app_result_content_alone_counts_as_summary_content(monkeypatch):
     assert generated_dates == ['2026-08-20']
 
 
+def test_action_items_alone_count_as_summary_content(monkeypatch):
+    """The renderer also emits ``structured.action_items`` into the prompt body
+    (render.py). A day whose conversations have empty overviews, no app
+    results, but real action items is summarizable — declining it would drop
+    recaps that previously generated."""
+    generated_dates, created, _sent, _released = _install_generation_fakes(monkeypatch)
+
+    class _ActionItemsConvo:
+        transcript_segments = [object()]
+        discarded = False
+        apps_results: list = []
+        structured = SimpleNamespace(overview='', action_items=[object()], events=[])
+
+    monkeypatch.setattr(notif, 'deserialize_conversation', lambda d: _ActionItemsConvo())
+    record, created_flag, declined = notif._generate_and_store_daily_summary(
+        'u1', '2026-08-20', datetime.utcnow(), datetime.utcnow()
+    )
+
+    assert record is not None and created_flag is True
+    assert declined is None
+    assert generated_dates == ['2026-08-20']
+    assert created, 'an action-items day must still persist a DailySummary'
+
+
+def test_events_alone_count_as_summary_content(monkeypatch):
+    """Same as above for ``structured.events``: the renderer emits them into
+    the prompt body, so they are summary content."""
+    generated_dates, _created, _sent, _released = _install_generation_fakes(monkeypatch)
+
+    class _EventsConvo:
+        transcript_segments = [object()]
+        discarded = False
+        apps_results: list = []
+        structured = SimpleNamespace(overview='', action_items=[], events=[object()])
+
+    monkeypatch.setattr(notif, 'deserialize_conversation', lambda d: _EventsConvo())
+    record, created, _declined = notif._generate_and_store_daily_summary(
+        'u1', '2026-08-20', datetime.utcnow(), datetime.utcnow()
+    )
+
+    assert record is not None and created is True
+    assert generated_dates == ['2026-08-20']
+
+
+def test_empty_action_items_and_events_do_not_rescue_a_titles_only_day(monkeypatch):
+    """``action_items=[]``/``events=[]`` are the §1.7 deterministic minimum's
+    neutral empties — they must not flip the gate, and neither do attendee
+    names (presence labels, not summary content): a titles-only day still
+    declines before the LLM."""
+    generated_dates, created, sent, released = _install_generation_fakes(monkeypatch)
+
+    class _EmptyListsConvo:
+        transcript_segments = [object()]
+        discarded = False
+        apps_results: list = []
+
+        def __init__(self) -> None:
+            self.structured = SimpleNamespace(overview='', action_items=[], events=[])
+
+    monkeypatch.setattr(notif, 'deserialize_conversation', lambda d: _EmptyListsConvo())
+    record, created_flag, declined = notif._generate_and_store_daily_summary(
+        'u1', '2026-08-20', datetime.utcnow(), datetime.utcnow()
+    )
+
+    assert record is None and created_flag is False
+    assert declined == notif._DECLINE_NOTHING_TO_SUMMARIZE
+    assert generated_dates == []
+    assert created == []
+    assert sent == []
+    assert released == ['2026-08-20']
+
+
 def test_a_day_declined_before_the_llm_releases_its_lock(monkeypatch):
     """The on-demand button used to poison the day it was pressed on.
 

--- a/backend/tests/unit/test_daily_summary_generation.py
+++ b/backend/tests/unit/test_daily_summary_generation.py
@@ -1,6 +1,7 @@
 """Daily summary generation is independent of push delivery, backfills missed days, and has a no-push create route."""
 
 from datetime import datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,8 +11,30 @@ import utils.other.notifications as notif
 
 
 class _FakeConvo:
+    """A conversation whose day has something to summarize (non-empty overview).
+
+    The pre-LLM gate declines a day whose conversations carry titles only, so
+    the default fixture must carry summary body content; the thin-day decline
+    has its own tests below.
+    """
+
     transcript_segments = [object()]
     discarded = False
+    apps_results: list = []
+
+    def __init__(self, overview: str = 'You had a productive day.') -> None:
+        self.structured = SimpleNamespace(overview=overview)
+
+
+class _MinimumConvo:
+    """The §1.7 deterministic minimum shape: a title, an empty overview, no app results."""
+
+    transcript_segments = [object()]
+    discarded = False
+    apps_results: list = []
+
+    def __init__(self) -> None:
+        self.structured = SimpleNamespace(overview='')
 
 
 def _install_generation_fakes(monkeypatch, *, existing_by_date=None, tokens_unused=True):
@@ -44,6 +67,10 @@ def _install_generation_fakes(monkeypatch, *, existing_by_date=None, tokens_unus
     )
     monkeypatch.setattr(notif.postprocess_executor, 'submit', lambda *a, **k: None)
     monkeypatch.setattr(notif, 'day_summary_webhook', lambda *a, **k: None)
+    # Without this stub the scheduled path reaches the real MemoryService and issues a
+    # live Firestore query from a unit test, which hangs under api_core's retry (the
+    # empty-overview suite documents the same trap).
+    monkeypatch.setattr(notif, 'memories_learned_payload', lambda *a, **k: [])
     monkeypatch.setattr(notif, 'send_notification', lambda *a, **k: sent.append({'args': a, 'kwargs': k}))
     return generated_dates, created, sent, released
 
@@ -233,6 +260,91 @@ def test_backfill_is_skipped_for_a_user_with_no_conversations(monkeypatch):
     assert len(lock_dates) == 1, f'backfill must not walk back for a dormant user: {lock_dates}'
     # The current day is looked at twice at most (generation guard + the has-conversations probe).
     assert len(conversation_queries) <= 2, conversation_queries
+
+
+def test_a_day_of_minimum_conversations_costs_zero_llm_calls_and_no_push(monkeypatch):
+    """A §1.7-minimum day (titles + empty overviews, no app results) renders as
+    titles only for the recap prompt; generating from that input is thin or
+    hallucinated and then pushed (flip-review F-12). Decline before the LLM:
+    no call, no record, no push — but the owner *was* recording, so backfill
+    still walks their earlier days."""
+    generated_dates, created, sent, released = _install_generation_fakes(monkeypatch)
+    display = notif._display_date_for_now('UTC')
+    today_str = display.strftime('%Y-%m-%d')
+    start_utc, end_utc = notif.local_day_bounds_utc(display, 'UTC')
+
+    def _conversations(uid, start_date=None, end_date=None, **_k):
+        if start_date and start_date.date() >= display:
+            return [{'is_locked': False, 'id': 'thin'}]
+        return [{'is_locked': False, 'id': 'full'}]
+
+    monkeypatch.setattr(notif.conversations_db, 'get_conversations', _conversations)
+    monkeypatch.setattr(
+        notif, 'deserialize_conversation', lambda d: _MinimumConvo() if d['id'] == 'thin' else _FakeConvo()
+    )
+
+    record, created_flag, declined = notif._generate_and_store_daily_summary('u1', today_str, start_utc, end_utc)
+
+    assert record is None and created_flag is False
+    assert declined == notif._DECLINE_NOTHING_TO_SUMMARIZE
+    assert generated_dates == [], 'the LLM must not be called for a titles-only day'
+    assert created == [], 'no DailySummary document may be written'
+    assert released == [today_str], 'a declined day must not stay locked'
+
+    notif._send_summary_notification(('u1', ['tok1'], 'UTC'))
+
+    assert sent == [], 'nothing may be pushed for a titles-only day'
+    assert today_str not in generated_dates
+    assert (
+        len(generated_dates) == notif._DAILY_SUMMARY_BACKFILL_GENERATE_CAP
+    ), 'the owner was recording, so the backfill walk still runs on content-bearing days'
+
+
+def test_a_day_with_one_nonempty_overview_generates_exactly_once(monkeypatch):
+    """The gate is an any(): a single conversation carrying summary body content
+    is a day worth summarizing. Paid / pre-flip / mobile days look like this —
+    they generate exactly as before."""
+    generated_dates, created, sent, _released = _install_generation_fakes(monkeypatch)
+    display = notif._display_date_for_now('UTC')
+
+    def _conversations(uid, start_date=None, end_date=None, **_k):
+        if start_date and start_date.date() >= display:
+            # The current day: one §1.7-minimum conversation and one enriched one.
+            return [{'is_locked': False, 'id': 'thin'}, {'is_locked': False, 'id': 'full'}]
+        return [{'is_locked': False, 'id': 'full'}]
+
+    monkeypatch.setattr(notif.conversations_db, 'get_conversations', _conversations)
+    monkeypatch.setattr(
+        notif, 'deserialize_conversation', lambda d: _MinimumConvo() if d['id'] == 'thin' else _FakeConvo()
+    )
+
+    notif._send_summary_notification(('u1', ['tok1'], 'UTC'))
+
+    assert len(generated_dates) == 1 + notif._DAILY_SUMMARY_BACKFILL_GENERATE_CAP
+    assert len(sent) == 1
+    assert created
+
+
+def test_an_app_result_content_alone_counts_as_summary_content(monkeypatch):
+    """The renderer prefers the first app result over the overview; a day whose
+    only content lives in ``apps_results[0].content`` is summarizable."""
+    generated_dates, _created, _sent, _released = _install_generation_fakes(monkeypatch)
+
+    class _AppResultConvo:
+        transcript_segments = [object()]
+        discarded = False
+        structured = SimpleNamespace(overview='')
+
+        def __init__(self) -> None:
+            self.apps_results = [SimpleNamespace(content='A busy day of meetings.')]
+
+    monkeypatch.setattr(notif, 'deserialize_conversation', lambda d: _AppResultConvo())
+    record, created, _declined = notif._generate_and_store_daily_summary(
+        'u1', '2026-08-20', datetime.utcnow(), datetime.utcnow()
+    )
+
+    assert record is not None and created is True
+    assert generated_dates == ['2026-08-20']
 
 
 def test_a_day_declined_before_the_llm_releases_its_lock(monkeypatch):

--- a/backend/tests/unit/test_daily_summary_job_resilience.py
+++ b/backend/tests/unit/test_daily_summary_job_resilience.py
@@ -13,7 +13,7 @@ import threading
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from typing import Any, Dict, Iterator, List, Tuple
 
 from testing.import_isolation import AutoMockModule, load_module_fresh, stub_modules
@@ -466,6 +466,11 @@ class _FakeConversation:
         self.discarded = False
         self.transcript_segments = ['segment']
         self.started_at = datetime(2026, 8, 23, 9, tzinfo=timezone.utc)
+        # The pre-LLM summary-content gate (flip-review F-12) declines a day
+        # whose conversations carry titles only; these tests pin the send path,
+        # so the fixture carries body content.
+        self.apps_results: list = []
+        self.structured = SimpleNamespace(overview='You shipped the thing.')
 
 
 @contextmanager

--- a/backend/tests/unit/test_daily_summary_race_condition.py
+++ b/backend/tests/unit/test_daily_summary_race_condition.py
@@ -186,6 +186,14 @@ def notification_harness() -> Iterator[SimpleNamespace]:
             'models.notification_message',
             NotificationMessage=notification_message,
         ),
+        # Without this stub the scheduled path reaches the real MemoryService and
+        # issues a live Firestore query from a unit test, which hangs under
+        # api_core's retry (the empty-overview suite documents the same trap).
+        'utils.memory.learned_today': _module(
+            'utils.memory.learned_today',
+            memories_learned_payload=MagicMock(return_value=[]),
+            memory_review_card_block=MagicMock(return_value=None),
+        ),
         'utils.conversations.factory': conversation_factory,
         'utils.llm.external_integrations': external_integrations,
         'utils.notifications': notifications,

--- a/backend/utils/other/notifications.py
+++ b/backend/utils/other/notifications.py
@@ -87,18 +87,29 @@ DAILY_SUMMARY_DECLINE_LOCKED = _DECLINE_LOCKED
 def _conversation_has_summary_content(conversation: Any) -> bool:
     """True when the recap renderer would show more than this conversation's title.
 
-    Reads exactly the fields ``conversations_to_string(use_transcript=False)``
+    Reads the content fields ``conversations_to_string(use_transcript=False)``
     renders as the body — the first app result's content when one exists, else
-    the structured overview — so the pre-LLM decline guard cannot drift from
+    the structured overview, plus ``structured.action_items`` and
+    ``structured.events`` — so the pre-LLM decline guard cannot drift from
     what the model would actually see.
+
+    Attendee names are rendered too, but deliberately do not count: they are
+    presence labels attached to the conversation, not summary content, and a
+    day that renders as titles plus a list of names is still the degenerate
+    F-12 shape this gate exists to decline.
     """
     apps_results = getattr(conversation, 'apps_results', None) or []
     if apps_results:
         content = getattr(apps_results[0], 'content', None)
         if content and content.strip():
             return True
-    overview = getattr(getattr(conversation, 'structured', None), 'overview', None)
-    return bool(overview and overview.strip())
+    structured = getattr(conversation, 'structured', None)
+    overview = getattr(structured, 'overview', None)
+    if overview and overview.strip():
+        return True
+    if getattr(structured, 'action_items', None):
+        return True
+    return bool(getattr(structured, 'events', None))
 
 
 def generate_and_store_daily_summary(uid, date_str, start_date_utc, end_date_utc) -> Optional[dict]:
@@ -111,8 +122,9 @@ def generate_and_store_daily_summary(uid, date_str, start_date_utc, end_date_utc
     3. conversations exist in the window and are not ``is_locked``
     4. at least one non-discarded conversation has ``transcript_segments``
     5. the bounded day carries more than titles for the prompt: some
-       conversation has a non-empty ``structured.overview`` or first app
-       result — the only body fields the recap renderer shows
+       conversation has a non-empty ``structured.overview``, a first app
+       result, action items, or events — the body fields the recap renderer
+       shows
     6. LLM generate → persist
 
     Returns the stored record (or the pre-existing one), or ``None`` when a guard declined.
@@ -205,8 +217,9 @@ def _generate_and_store_daily_summary(
 
     # The prompt is built by ``conversations_to_string(use_transcript=False)``,
     # which renders the title plus the first app result or the structured
-    # overview — nothing else. A bounded day where no conversation carries
-    # either leaves the model titles alone: the output is thin or hallucinated
+    # overview, plus action items and events. A bounded day where no
+    # conversation carries any of these leaves the model titles alone: the
+    # output is thin or hallucinated
     # and then pushed (flip-review F-12 / decision 4). Decline before the LLM
     # call — no call, no record, no push. Paid, pre-flip and mobile days are
     # unchanged by construction: their overviews are non-empty, so this guard

--- a/backend/utils/other/notifications.py
+++ b/backend/utils/other/notifications.py
@@ -75,12 +75,30 @@ def _display_date_for_now(tz_name: Optional[str]):
 # queries on holes it cannot fill.
 _DECLINE_LOCKED = 'locked'
 _DECLINE_NO_CONVERSATIONS = 'no_conversations'
-# The window held conversations, but none this job may summarize (all ``is_locked``, or none
-# carried transcript content). Distinct from ``no_conversations`` because the owner *was*
+# The window held conversations, but none this job may summarize (all ``is_locked``, none
+# carried transcript content, or nothing carried summary body content — titles alone).
+# Distinct from ``no_conversations`` because the owner *was*
 # active: their earlier days are worth walking back for, and the caller may say so.
 _DECLINE_NOTHING_TO_SUMMARIZE = 'nothing_to_summarize'
 # Public name for the one decline a caller outside this module has to act on differently.
 DAILY_SUMMARY_DECLINE_LOCKED = _DECLINE_LOCKED
+
+
+def _conversation_has_summary_content(conversation: Any) -> bool:
+    """True when the recap renderer would show more than this conversation's title.
+
+    Reads exactly the fields ``conversations_to_string(use_transcript=False)``
+    renders as the body — the first app result's content when one exists, else
+    the structured overview — so the pre-LLM decline guard cannot drift from
+    what the model would actually see.
+    """
+    apps_results = getattr(conversation, 'apps_results', None) or []
+    if apps_results:
+        content = getattr(apps_results[0], 'content', None)
+        if content and content.strip():
+            return True
+    overview = getattr(getattr(conversation, 'structured', None), 'overview', None)
+    return bool(overview and overview.strip())
 
 
 def generate_and_store_daily_summary(uid, date_str, start_date_utc, end_date_utc) -> Optional[dict]:
@@ -92,7 +110,10 @@ def generate_and_store_daily_summary(uid, date_str, start_date_utc, end_date_utc
     2. durable by-date idempotency (existing record → return it, no LLM)
     3. conversations exist in the window and are not ``is_locked``
     4. at least one non-discarded conversation has ``transcript_segments``
-    5. LLM generate → persist
+    5. the bounded day carries more than titles for the prompt: some
+       conversation has a non-empty ``structured.overview`` or first app
+       result — the only body fields the recap renderer shows
+    6. LLM generate → persist
 
     Returns the stored record (or the pre-existing one), or ``None`` when a guard declined.
     """
@@ -181,6 +202,19 @@ def _generate_and_store_daily_summary(
             from_mode='full_day', to_mode='truncated_day', reason='quota', outcome='degraded'
         )
     conversations = bounded.conversations
+
+    # The prompt is built by ``conversations_to_string(use_transcript=False)``,
+    # which renders the title plus the first app result or the structured
+    # overview — nothing else. A bounded day where no conversation carries
+    # either leaves the model titles alone: the output is thin or hallucinated
+    # and then pushed (flip-review F-12 / decision 4). Decline before the LLM
+    # call — no call, no record, no push. Paid, pre-flip and mobile days are
+    # unchanged by construction: their overviews are non-empty, so this guard
+    # never fires for them.
+    if not any(_conversation_has_summary_content(c) for c in conversations if not c.discarded):
+        logger.info(f'Skipping daily summary for uid={uid} on {date_str}: no conversations with summary content')
+        release_daily_summary_lock(uid, date_str)
+        return None, False, _DECLINE_NOTHING_TO_SUMMARIZE
 
     summary_data = generate_comprehensive_daily_summary(
         uid,


### PR DESCRIPTION
## What

Gate the daily recap on having something to summarize: `_generate_and_store_daily_summary` (`backend/utils/other/notifications.py`) now declines **before the LLM call** when no non-discarded conversation in the bounded day carries a non-empty `structured.overview` or `apps_results[0].content` — i.e. nothing to summarize beyond titles.

- The decline reuses the file's existing `_DECLINE_NOTHING_TO_SUMMARIZE` short-circuit and its lock-release contract (no model call, no `DailySummary` document, no push, day lock released). It does **not** fork a new decline path, and it stays out of the dormant-user set, so the backfill walk still treats the owner as active.
- The guard reads exactly the fields `conversations_to_string(use_transcript=False)` renders as the body (first app result's content, else the overview), so it cannot drift from the prompt input.
- The guard runs on the **bounded** conversation list — the exact input the generator receives.

## Why

Flip review 2026-09-04, finding **F-12**, David's decision 4: on a flags-on free day every conversation is the §1.7 deterministic minimum (title, empty overview, no app results), so the recap prompt received titles alone; `daily_summary` is free-allowlisted so the luna call still fired, and the output was thin or hallucinated-from-first-sentences — then pushed and stored as the user's recap. §1.7 rule (c) forbids `structured` ever holding the projection and S4's pin blocks repointing the shared renderer at `client_processing`, so the only correct pre-projection fix is to decline. The display-only projection-aware renderer remains the real fix (per the review's recommendation); this PR only stops the spend and the degenerate push.

Paid / pre-flip / mobile users are unchanged by construction: their overviews are non-empty, so the guard never fires for them. Flag-off days are unchanged for every day that has summary content — the guard only bites where the old output was already degenerate.

## Tests

`tests/unit/test_daily_summary_generation.py`:

- a day of §1.7-minimum conversations ⇒ zero LLM calls, zero `create_daily_summary`, no push, declined `nothing_to_summarize`, lock released, backfill still walks (owner was recording)
- a day with one non-empty overview (mixed with minimum conversations) ⇒ generation fires exactly once, push delivered
- `apps_results[0].content` alone (empty overview) ⇒ generation fires — mirrors the renderer's precedence
- existing empty-day / locked-day / lock-contention / route-cooldown tests untouched and green

Harness fixes (disclosed): `test_daily_summary_generation.py` and `test_daily_summary_race_condition.py` were missing the `memories_learned_payload` stub that `test_daily_summary_empty_overview.py` already documents — without it the real `MemoryService` read hangs under api_core retries on this machine (reproduced on clean `origin/main`, first test of the suite). Stubs added so the suites run hermetically; no production change involved. `test_daily_summary_empty_overview.py`'s fixture now carries a real overview so it keeps testing the *delivery* fallback (generator returned empty overview) rather than tripping the new gate.

Commands (program venv, cwd `backend/`):

- `pytest tests/unit/test_daily_summary_generation.py tests/unit/test_daily_summary_empty_overview.py tests/unit/test_daily_summary_race_condition.py` — 37 passed
- `pytest tests/unit/test_daily_summary_job_resilience.py tests/unit/test_daily_summary_hour_midnight.py tests/unit/test_daily_summary_memories_learned.py tests/unit/test_daily_summary_regenerate.py tests/unit/test_daily_summary_zero_coordinate_locations.py` — 58 passed
- `pytest tests/unit/test_lock_bypass_fixes.py tests/unit/test_async_webhooks.py tests/unit/test_daily_summary_e2e_fixture.py` — 98 passed

Failure-Class: new

Failure class: `FC-summary-generated-from-titles-only-render` (definition added in this change; evidence_prs is empty — this PR is the evidence).

## Do not merge until / notes

- **Do not merge before David reviews** — the author cannot approve; David merges.
- Disjoint files from #12760 (processing_state darkness); either merge order works.
- Follow-up (not this PR): the display-only projection-aware recap renderer the review recommends as the real fix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

