### PR TITLE
fix(backend): gate the connector memory-formation doors behind the §1.8 policy

### DIFF
--- a/.github/failure-classes/FC-shared-spend-gate-missing-on-sibling-producers.json
+++ b/.github/failure-classes/FC-shared-spend-gate-missing-on-sibling-producers.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "id": "FC-shared-spend-gate-missing-on-sibling-producers",
+  "violated_contract": "When a managed-compute spend is gated at one producer of a shared feature, every other producer that invokes the same feature must consult the same gate through the same decision closure before its spend. The memory-formation gate (FREE_TIER_MEMORY_SUPPRESSION) was wired into the conversation coordinator's extraction boundary, while app-integration text extraction, the twitter persona producer and the X connector kept calling get_llm('memories') ungated — so the shard's own proof (zero managed extractor rows for basic) stayed green at the gated boundary while the ungated siblings spent, and the §1.8 proof read a dry pen for any user with such an app or connection.",
+  "canonical_prevention": "Enumerate the producers of a gated feature (callers of its spend seam, here extract_memories_from_text) when the gate lands, and give each one the plan check in the same shape: read the rollout flag first so flag-off performs no lookups, then one verdict through the single shared decision_for closure so funding-owner resolution and fail-closed behaviour cannot drift per producer. Pin each producer with a per-site test covering basic-suppressed, paid, BYOK, and flag-off-performs-no-lookup.",
+  "canonical_prevention_artifact": [
+    "backend/utils/managed_compute.py",
+    "backend/utils/conversations/memories.py",
+    "backend/utils/x_connector.py",
+    "backend/tests/unit/test_free_tier_connector_memory_gates.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/utils/llm/memories.py",
+    "backend/utils/conversations/memories.py",
+    "backend/utils/x_connector.py",
+    "backend/utils/free_tier_memory_policy.py"
+  ],
+  "status": "open"
+}

--- a/backend/tests/unit/test_client_processing_acceptance.py
+++ b/backend/tests/unit/test_client_processing_acceptance.py
@@ -42,6 +42,7 @@ from models.transcript_segment import TranscriptSegment
 from utils.conversations.projection_payload import PROVENANCE_LOG_MAX_CHARS
 from testing.import_isolation import AutoMockModule, load_module_fresh, stub_modules
 from utils.conversations.transcript_hash import transcript_sha256
+import utils.managed_compute as managed_compute
 from utils.managed_compute import Decision
 
 _BACKEND = Path(__file__).resolve().parents[2]
@@ -332,8 +333,8 @@ def _enable_flag(monkeypatch, pc) -> None:
 
 
 def _authorize(monkeypatch, pc, decision: Decision) -> None:
-    monkeypatch.setattr(pc, 'authorize_managed_compute', lambda *_args, **_kwargs: decision)
-    monkeypatch.setattr(pc, 'request_carries_validated_byok_key', lambda _feature: False)
+    monkeypatch.setattr(managed_compute, 'authorize_managed_compute', lambda *_args, **_kwargs: decision)
+    monkeypatch.setattr(managed_compute, 'request_carries_validated_byok_key', lambda _feature: False)
 
 
 def _spy_managed_effects(monkeypatch, pc) -> dict[str, MagicMock]:

--- a/backend/tests/unit/test_client_processing_finalize.py
+++ b/backend/tests/unit/test_client_processing_finalize.py
@@ -75,6 +75,7 @@ from models.transcript_segment import TranscriptSegment
 from testing.import_isolation import AutoMockModule, load_module_fresh, stub_modules
 from tests.unit.fixtures.strict_firestore_transaction import StrictFirestore
 from utils.conversations.transcript_hash import transcript_sha256
+import utils.managed_compute as managed_compute
 from utils.managed_compute import Decision
 
 _BACKEND = Path(__file__).resolve().parents[2]
@@ -432,8 +433,8 @@ def _enable_flag(monkeypatch: pytest.MonkeyPatch, pc: Any) -> None:
 
 
 def _authorize(monkeypatch: pytest.MonkeyPatch, pc: Any, decision: Decision) -> None:
-    monkeypatch.setattr(pc, 'authorize_managed_compute', lambda *_args, **_kwargs: decision)
-    monkeypatch.setattr(pc, 'request_carries_validated_byok_key', lambda _feature: False)
+    monkeypatch.setattr(managed_compute, 'authorize_managed_compute', lambda *_args, **_kwargs: decision)
+    monkeypatch.setattr(managed_compute, 'request_carries_validated_byok_key', lambda _feature: False)
 
 
 def _spy_managed_effects(monkeypatch: pytest.MonkeyPatch, pc: Any) -> dict[str, MagicMock]:

--- a/backend/tests/unit/test_free_tier_connector_memory_gates.py
+++ b/backend/tests/unit/test_free_tier_connector_memory_gates.py
@@ -30,6 +30,7 @@ import pytest
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
 
 from config.plan_catalog import PlanType
+import utils.free_tier_memory_policy as memory_policy
 import utils.managed_compute as managed_compute
 from models.integrations import ExternalIntegrationCreateMemory, ExternalIntegrationMemory
 from models.memories import Memory, MemoryCategory
@@ -49,7 +50,10 @@ def _decision(allowed: bool, reason: str, plan: PlanType | None) -> Any:
 
 
 def _set_flag(monkeypatch, module, enabled: bool) -> None:
-    monkeypatch.setattr(module, 'free_tier_memory_suppression_enabled', lambda: enabled)
+    # The shared producer gate (managed_memory_formation_suppressed) reads the
+    # flag inside utils.free_tier_memory_policy, not at the producer module,
+    # so that is the one seam that steers every site.
+    monkeypatch.setattr(memory_policy, 'free_tier_memory_suppression_enabled', lambda: enabled)
 
 
 def _authorize_as(monkeypatch, *, decision: Any, byok_key: bool = False, spy: list | None = None) -> None:

--- a/backend/tests/unit/test_free_tier_connector_memory_gates.py
+++ b/backend/tests/unit/test_free_tier_connector_memory_gates.py
@@ -1,0 +1,322 @@
+"""The connector memory-formation doors are gated by the §1.8 policy (flip-review F-3).
+
+App integrations (``process_external_integration_memory``), the twitter persona
+producer (``process_twitter_memories``, called from utils/social.py on persona
+create and update) and the X connector (``x_connector._extract_and_index``) all
+spent ``get_llm('memories')`` for a basic user without consulting
+``utils/free_tier_memory_policy`` — the same plan gate the coordinator's
+extraction boundary has had since S5. Each test here drives the real gate: the
+flag, the real ``memory_formation_verdict``, and the shared
+``managed_compute_decision_for`` closure with only
+``utils.managed_compute.authorize_managed_compute`` /
+``request_carries_validated_byok_key`` stubbed, so a gate that consults nothing,
+or consults something other than the policy, fails.
+
+red-proof: delete the ``free_tier_memory_suppression_enabled()`` block at a site
+→ its basic+flag-on row calls the extractor (and writes) again.
+red-proof: consult a verdict built from a forked decision closure that skips the
+BYOK lookup → the BYOK row loses formation.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+from config.plan_catalog import PlanType
+import utils.managed_compute as managed_compute
+from models.integrations import ExternalIntegrationCreateMemory, ExternalIntegrationMemory
+from models.memories import Memory, MemoryCategory
+from utils import x_connector
+from utils.conversations import memories as conv_memories
+
+
+def _decision(allowed: bool, reason: str, plan: PlanType | None) -> Any:
+    return managed_compute.Decision(
+        allowed=allowed,
+        reason=reason,
+        feature='memories',
+        funding_owner='omi',
+        plan=plan,
+        plan_resolved=plan is not None,
+    )
+
+
+def _set_flag(monkeypatch, module, enabled: bool) -> None:
+    monkeypatch.setattr(module, 'free_tier_memory_suppression_enabled', lambda: enabled)
+
+
+def _authorize_as(monkeypatch, *, decision: Any, byok_key: bool = False, spy: list | None = None) -> None:
+    """Stub the closure's two seams at their shared home."""
+
+    def authorize(uid, feature, funding_owner, **_kwargs):
+        if spy is not None:
+            spy.append((uid, feature, funding_owner))
+        return decision
+
+    monkeypatch.setattr(managed_compute, 'authorize_managed_compute', authorize)
+    monkeypatch.setattr(managed_compute, 'request_carries_validated_byok_key', lambda _feature: byok_key)
+
+
+_BASIC_DENY = staticmethod(lambda: _decision(False, 'basic_not_entitled', PlanType.basic))
+_PAID = _decision(True, 'plan_paid', PlanType.plus)
+_BYOK = _decision(True, 'byok', PlanType.basic)
+
+
+# ---------------------------------------------------------------------------
+# utils/conversations/memories.py — app integration text
+# ---------------------------------------------------------------------------
+
+
+def _integration_payload(*, text: str | None = 'I drink coffee every morning', explicit: bool = False):
+    memories = None
+    if explicit:
+        memories = [
+            ExternalIntegrationMemory(content='User lives in Berlin', tags=None, source_id=None),
+        ]
+    return ExternalIntegrationCreateMemory(
+        text=text,
+        text_source='email',
+        memories=memories,
+    )
+
+
+def _stub_memory_writes(monkeypatch, conv_memories_mod) -> dict[str, Any]:
+    calls: dict[str, Any] = {'batch': [], 'extract': []}
+
+    def extract(uid, text, source, **_kwargs):
+        calls['extract'].append((uid, text, source))
+        return [Memory(content=f'fact from {uid}', category=MemoryCategory.system, tags=[])]
+
+    monkeypatch.setattr(conv_memories_mod, 'extract_memories_from_text', extract)
+    service = MagicMock()
+    service.create_external_memory_batch = lambda *args, **kwargs: calls['batch'].append(args)
+    monkeypatch.setattr(conv_memories_mod, 'MemoryService', MagicMock(return_value=service))
+    monkeypatch.setattr(conv_memories_mod.users_db, 'get_user_language_preference', lambda _uid: 'en')
+    return calls
+
+
+def test_integration_text_extraction_skipped_for_basic_with_flag_on(monkeypatch):
+    calls = _stub_memory_writes(monkeypatch, conv_memories)
+    _set_flag(monkeypatch, conv_memories, True)
+    _authorize_as(monkeypatch, decision=_BASIC_DENY())
+
+    result = conv_memories.process_external_integration_memory('basic-uid', _integration_payload(), 'app-1')
+
+    assert result == []
+    assert calls['extract'] == [], 'no managed extractor spend for basic'
+    assert calls['batch'] == [], 'no memory is written from a skipped extraction'
+
+
+def test_integration_explicit_memories_still_written_but_not_model_formed(monkeypatch):
+    """Explicit facts are data the app already holds, not model formation; §1.8
+    stops the managed extractor, not the write path. The extracted text is
+    skipped alongside the explicit item in the same request."""
+    calls = _stub_memory_writes(monkeypatch, conv_memories)
+    _set_flag(monkeypatch, conv_memories, True)
+    _authorize_as(monkeypatch, decision=_BASIC_DENY())
+
+    result = conv_memories.process_external_integration_memory(
+        'basic-uid', _integration_payload(text='some text', explicit=True), 'app-1'
+    )
+
+    assert calls['extract'] == []
+    assert len(calls['batch']) == 1, 'the explicit app fact is still persisted'
+    assert len(result) == 1
+    assert result[0].evidence[0].extractor_id == 'external_integration_explicit'
+
+
+def test_integration_extraction_runs_for_paid(monkeypatch):
+    calls = _stub_memory_writes(monkeypatch, conv_memories)
+    _set_flag(monkeypatch, conv_memories, True)
+    _authorize_as(monkeypatch, decision=_PAID)
+
+    result = conv_memories.process_external_integration_memory('paid-uid', _integration_payload(), 'app-1')
+
+    assert len(calls['extract']) == 1
+    assert len(calls['batch']) == 1
+    assert len(result) == 1
+
+
+def test_integration_extraction_runs_for_basic_byok_with_validated_key(monkeypatch):
+    calls = _stub_memory_writes(monkeypatch, conv_memories)
+    _set_flag(monkeypatch, conv_memories, True)
+    _authorize_as(monkeypatch, decision=_BYOK, byok_key=True)
+
+    result = conv_memories.process_external_integration_memory('byok-uid', _integration_payload(), 'app-1')
+
+    assert len(calls['extract']) == 1, 'BYOK keeps forming memories'
+    assert len(calls['batch']) == 1
+    assert len(result) == 1
+
+
+def test_integration_flag_off_does_no_plan_lookup(monkeypatch):
+    calls = _stub_memory_writes(monkeypatch, conv_memories)
+    _set_flag(monkeypatch, conv_memories, False)
+    authorize_spy: list = []
+    _authorize_as(
+        monkeypatch,
+        decision=MagicMock(side_effect=AssertionError('flag off must not authorize')),
+        spy=authorize_spy,
+    )
+
+    conv_memories.process_external_integration_memory('any-uid', _integration_payload(), 'app-1')
+
+    assert authorize_spy == [], 'flag-off path must not perform a single plan lookup'
+    assert len(calls['extract']) == 1
+
+
+# ---------------------------------------------------------------------------
+# utils/conversations/memories.py — twitter persona
+# ---------------------------------------------------------------------------
+
+
+def test_twitter_persona_extraction_skipped_for_basic_with_flag_on(monkeypatch):
+    calls = _stub_memory_writes(monkeypatch, conv_memories)
+    _set_flag(monkeypatch, conv_memories, True)
+    _authorize_as(monkeypatch, decision=_BASIC_DENY())
+
+    result = conv_memories.process_twitter_memories('basic-uid', 'tweets text', 'persona-1')
+
+    assert result == []
+    assert calls['extract'] == []
+    assert calls['batch'] == []
+
+
+def test_twitter_persona_extraction_runs_for_paid(monkeypatch):
+    calls = _stub_memory_writes(monkeypatch, conv_memories)
+    _set_flag(monkeypatch, conv_memories, True)
+    _authorize_as(monkeypatch, decision=_PAID)
+
+    result = conv_memories.process_twitter_memories('paid-uid', 'tweets text', 'persona-1')
+
+    assert len(calls['extract']) == 1
+    assert len(result) == 1
+
+
+def test_twitter_persona_extraction_runs_for_basic_byok(monkeypatch):
+    calls = _stub_memory_writes(monkeypatch, conv_memories)
+    _set_flag(monkeypatch, conv_memories, True)
+    _authorize_as(monkeypatch, decision=_BYOK, byok_key=True)
+
+    result = conv_memories.process_twitter_memories('byok-uid', 'tweets text', 'persona-1')
+
+    assert len(result) == 1
+
+
+def test_twitter_persona_flag_off_does_no_plan_lookup(monkeypatch):
+    calls = _stub_memory_writes(monkeypatch, conv_memories)
+    _set_flag(monkeypatch, conv_memories, False)
+    authorize_spy: list = []
+    _authorize_as(
+        monkeypatch,
+        decision=MagicMock(side_effect=AssertionError('flag off must not authorize')),
+        spy=authorize_spy,
+    )
+
+    conv_memories.process_twitter_memories('any-uid', 'tweets text', 'persona-1')
+
+    assert authorize_spy == []
+    assert len(calls['extract']) == 1
+
+
+# ---------------------------------------------------------------------------
+# utils/x_connector.py — X sync extraction
+# ---------------------------------------------------------------------------
+
+
+_POST = {'id': 'post-1', 'text': 'I prefer tea', 'created_at': '2026-07-14T00:00:00Z', 'kind': 'tweet'}
+
+
+def _stub_x_extraction(monkeypatch) -> dict[str, Any]:
+    calls: dict[str, Any] = {'extract': [], 'batch': []}
+
+    def extract(uid, text, source, **_kwargs):
+        calls['extract'].append((uid, text, source))
+        return [Memory(content=f'fact from {uid}', category=MemoryCategory.system, tags=[])]
+
+    monkeypatch.setattr(x_connector, 'extract_memories_from_text', extract)
+    service = MagicMock()
+    service.create_external_memory_batch = lambda *args, **kwargs: calls['batch'].append(args)
+    monkeypatch.setattr(x_connector, 'MemoryService', MagicMock(return_value=service))
+    # The parity capture persists a real Firestore document; this suite's subject
+    # is the gate, so observe the call without the live write.
+    monkeypatch.setattr(x_connector, 'capture_memory_write', MagicMock())
+    # Same for the per-chunk raw-post acknowledgement.
+    monkeypatch.setattr(x_connector.x_posts_db, 'mark_memory_extraction_completed', lambda *_a: None)
+    return calls
+
+
+def test_x_connector_extraction_skipped_for_basic_with_flag_on(monkeypatch):
+    calls = _stub_x_extraction(monkeypatch)
+    _set_flag(monkeypatch, x_connector, True)
+    _authorize_as(monkeypatch, decision=_BASIC_DENY())
+
+    total = x_connector._extract_and_index('basic-uid', [dict(_POST)])
+
+    assert total == 0
+    assert calls['extract'] == [], 'no managed extractor spend for basic'
+    assert calls['batch'] == []
+
+
+def test_x_connector_extraction_runs_for_paid(monkeypatch):
+    calls = _stub_x_extraction(monkeypatch)
+    _set_flag(monkeypatch, x_connector, True)
+    _authorize_as(monkeypatch, decision=_PAID)
+
+    total = x_connector._extract_and_index('paid-uid', [dict(_POST)])
+
+    assert total == 1
+    assert len(calls['extract']) == 1
+    assert len(calls['batch']) == 1
+
+
+def test_x_connector_extraction_runs_for_basic_byok(monkeypatch):
+    calls = _stub_x_extraction(monkeypatch)
+    _set_flag(monkeypatch, x_connector, True)
+    _authorize_as(monkeypatch, decision=_BYOK, byok_key=True)
+
+    total = x_connector._extract_and_index('byok-uid', [dict(_POST)])
+
+    assert total == 1
+
+
+def test_x_connector_flag_off_does_no_plan_lookup(monkeypatch):
+    calls = _stub_x_extraction(monkeypatch)
+    _set_flag(monkeypatch, x_connector, False)
+    authorize_spy: list = []
+    _authorize_as(
+        monkeypatch,
+        decision=MagicMock(side_effect=AssertionError('flag off must not authorize')),
+        spy=authorize_spy,
+    )
+
+    x_connector._extract_and_index('any-uid', [dict(_POST)])
+
+    assert authorize_spy == []
+    assert len(calls['extract']) == 1
+
+
+def test_x_connector_gate_consults_once_for_a_multi_chunk_day(monkeypatch):
+    """One plan answer covers the whole sync; the gate sits above the chunk
+    loop, so a day of many chunks costs one lookup and zero extractor calls
+    when suppressed."""
+    calls = _stub_x_extraction(monkeypatch)
+    _set_flag(monkeypatch, x_connector, True)
+    authorize_spy: list = []
+    _authorize_as(monkeypatch, decision=_BASIC_DENY(), spy=authorize_spy)
+
+    posts = [
+        {'id': f'post-{i}', 'text': 'x' * 40, 'created_at': '2026-07-14T00:00:00Z', 'kind': 'tweet'} for i in range(12)
+    ]
+    total = x_connector._extract_and_index('basic-uid', posts)
+
+    assert total == 0
+    assert calls['extract'] == []
+    assert len(authorize_spy) == 1, 'one plan consultation per sync, not per chunk'

--- a/backend/tests/unit/test_free_tier_entrypoint_matrix.py
+++ b/backend/tests/unit/test_free_tier_entrypoint_matrix.py
@@ -42,6 +42,7 @@ from models.conversation_enums import ConversationSource, ConversationStatus
 from models.structured import Structured  # type: ignore[reportAttributeAccessIssue]
 from models.transcript_segment import TranscriptSegment
 from testing.import_isolation import AutoMockModule, load_module_fresh, package_submodule_stubs, stub_modules
+import utils.managed_compute as managed_compute
 from utils.managed_compute import Decision
 
 _BACKEND = Path(__file__).resolve().parents[2]
@@ -810,8 +811,10 @@ def test_entrypoint_matrix(
     def fake_authorize(uid: str, feature: str, funding_owner: str, **_kwargs: Any) -> Decision:
         return _decision_for_cell(cell, funding_owner)
 
-    monkeypatch.setattr(pc, 'authorize_managed_compute', fake_authorize)
-    monkeypatch.setattr(pc, 'request_carries_validated_byok_key', lambda _feature: cell == 'byok')
+    # The decision_for closure lives in utils.managed_compute (hoisted when the
+    # connector memory producers started sharing it), so its seams patch there.
+    monkeypatch.setattr(managed_compute, 'authorize_managed_compute', fake_authorize)
+    monkeypatch.setattr(managed_compute, 'request_carries_validated_byok_key', lambda _feature: cell == 'byok')
 
     if flag_on and cell == 'basic_with_projection':
         real_resolve = pc.resolve_free_tier_processing_plan
@@ -875,7 +878,7 @@ def test_red_proof_flag_on_ignoring_plan_makes_basic_desktop_call_structured(mon
     monkeypatch.setattr(pc, 'free_tier_local_processing_enabled', lambda: True)
     spies = _spy_managed_effects(monkeypatch, pc)
     monkeypatch.setattr(
-        pc,
+        managed_compute,
         'authorize_managed_compute',
         lambda *args, **kwargs: _decision_for_cell('basic_no_projection', 'omi'),
     )
@@ -906,7 +909,7 @@ def test_red_proof_minimum_must_report_actual_persistence(monkeypatch: Any, pc: 
     monkeypatch.setattr(pc, 'free_tier_local_processing_enabled', lambda: True)
     _spy_managed_effects(monkeypatch, pc)
     monkeypatch.setattr(
-        pc,
+        managed_compute,
         'authorize_managed_compute',
         lambda *args, **kwargs: _decision_for_cell('basic_no_projection', 'omi'),
     )
@@ -932,7 +935,7 @@ def test_red_proof_desktop_merge_flag_on_basic_is_minimum_not_legacy(monkeypatch
     monkeypatch.setattr(pc, 'free_tier_local_processing_enabled', lambda: True)
     spies = _spy_managed_effects(monkeypatch, pc)
     monkeypatch.setattr(
-        pc,
+        managed_compute,
         'authorize_managed_compute',
         lambda *args, **kwargs: _decision_for_cell('basic_no_projection', 'omi'),
     )

--- a/backend/tests/unit/test_process_conversation_free_tier_branch.py
+++ b/backend/tests/unit/test_process_conversation_free_tier_branch.py
@@ -1131,8 +1131,12 @@ def _extract_memories_probe(monkeypatch, pc, *, suppression_on: bool, decision) 
     monkeypatch.setattr(pc, 'MemoryService', MagicMock())
     monkeypatch.setattr(pc, '_sweep_owned_writer_mode', lambda _uid: None)
     monkeypatch.setattr(pc, 'free_tier_memory_suppression_enabled', lambda: suppression_on)
-    # The §1.8 gate's decision_for closure is the shared one in utils.managed_compute;
-    # the stubbed utils.byok below already resolves the funding owner to 'omi'.
+    # The §1.8 gate's decision_for closure lives in utils.managed_compute, so
+    # its authorize seam patches there. The funding-owner resolution is not
+    # controlled by any stub in this file: managed_compute binds utils.byok's
+    # functions at its own import, and only the stubbed
+    # authorize_managed_compute (which ignores its funding_owner argument)
+    # matters for the verdict.
     monkeypatch.setattr(managed_compute, 'authorize_managed_compute', lambda *args, **kwargs: decision)
     return inner
 

--- a/backend/tests/unit/test_process_conversation_free_tier_branch.py
+++ b/backend/tests/unit/test_process_conversation_free_tier_branch.py
@@ -24,6 +24,7 @@ from models.conversation_enums import ConversationSource, ConversationStatus
 from models.structured import Structured
 from models.transcript_segment import TranscriptSegment
 from testing.import_isolation import AutoMockModule, load_module_fresh, package_submodule_stubs, stub_modules
+import utils.managed_compute as managed_compute
 from tests.unit.fixtures.strict_firestore_transaction import StrictFirestore
 from database.first_open_obligations import claim_first_open_work
 from utils.conversations import meeting_receipt as meeting_receipt_mod
@@ -530,9 +531,11 @@ def test_funding_owner_is_computed_inside_decision_for_not_before_policy(
         kwargs['decision_for']('conv_structure')
         return _plan(pc, 'process_normally', 'plan_paid')
 
-    monkeypatch.setattr(pc, 'authorize_managed_compute', fake_authorize)
+    # The decision_for closure lives in utils.managed_compute (hoisted when the
+    # connector memory producers started sharing it), so its seams patch there.
+    monkeypatch.setattr(managed_compute, 'authorize_managed_compute', fake_authorize)
     monkeypatch.setattr(
-        pc,
+        managed_compute,
         'request_carries_validated_byok_key',
         lambda feature: carries_validated_key,
     )
@@ -850,12 +853,12 @@ def test_raising_byok_lookup_is_deterministic_minimum_not_a_crash(monkeypatch, p
     _enable_flag(monkeypatch, pc)
     spies = _spy_managed_effects(monkeypatch, pc)
     monkeypatch.setattr(
-        pc,
+        managed_compute,
         'request_carries_validated_byok_key',
         MagicMock(side_effect=RuntimeError('byok lookup boom')),
     )
     authorize = MagicMock(side_effect=AssertionError('must not authorize'))
-    monkeypatch.setattr(pc, 'authorize_managed_compute', authorize)
+    monkeypatch.setattr(managed_compute, 'authorize_managed_compute', authorize)
     monkeypatch.setattr(pc.lifecycle_service, 'create_completed_conversation', MagicMock(return_value=True))
 
     result = pc.process_conversation('uid', 'en', _desktop_create())
@@ -1108,7 +1111,7 @@ def test_terminal_persist_writes_marker_and_normal_persist_clears_it(monkeypatch
 
 
 def _memory_decision(pc, *, allowed: bool, reason: str, plan: Any = None):
-    return pc.Decision(
+    return managed_compute.Decision(
         allowed=allowed,
         reason=reason,
         feature='memories',
@@ -1128,8 +1131,9 @@ def _extract_memories_probe(monkeypatch, pc, *, suppression_on: bool, decision) 
     monkeypatch.setattr(pc, 'MemoryService', MagicMock())
     monkeypatch.setattr(pc, '_sweep_owned_writer_mode', lambda _uid: None)
     monkeypatch.setattr(pc, 'free_tier_memory_suppression_enabled', lambda: suppression_on)
-    monkeypatch.setattr(pc, '_funding_owner_for_feature', lambda _feature: 'omi')
-    monkeypatch.setattr(pc, 'authorize_managed_compute', lambda *args, **kwargs: decision)
+    # The §1.8 gate's decision_for closure is the shared one in utils.managed_compute;
+    # the stubbed utils.byok below already resolves the funding owner to 'omi'.
+    monkeypatch.setattr(managed_compute, 'authorize_managed_compute', lambda *args, **kwargs: decision)
     return inner
 
 
@@ -1222,6 +1226,6 @@ def test_a_raising_plan_lookup_suppresses_instead_of_failing_finalization(monkey
     def boom(*_args, **_kwargs):
         raise RuntimeError('authorization exploded')
 
-    monkeypatch.setattr(pc, 'authorize_managed_compute', boom)
+    monkeypatch.setattr(managed_compute, 'authorize_managed_compute', boom)
     pc.extract_memories('erroring-uid', _existing_desktop('erroring-conv'))
     inner.assert_not_called()

--- a/backend/utils/conversations/memories.py
+++ b/backend/utils/conversations/memories.py
@@ -5,40 +5,14 @@ import database._client as db_client_module
 import database.users as users_db
 from models.memories import MemoryDB, Memory, MemoryCategory
 from models.integrations import ExternalIntegrationCreateMemory
-from utils.free_tier_memory_policy import free_tier_memory_suppression_enabled, memory_formation_verdict
+from utils.free_tier_memory_policy import managed_memory_formation_suppressed
 from utils.llm.memories import extract_memories_from_text
-from utils.managed_compute import managed_compute_decision_for
 from utils.memory.memory_authority import MemorySystem
 from utils.memory.memory_service import MemoryService
 from testing.parity_pack_v0.live_capture import SurfaceParityCapture
 import logging
 
 logger = logging.getLogger(__name__)
-
-
-def _managed_formation_suppressed(uid: str, source: str) -> bool:
-    """§1.8 (flip-review F-3): no managed model forms a memory for basic.
-
-    Same gate shape as the coordinator's extraction boundary
-    (``process_conversation._extract_memories``): read the rollout flag first so
-    the flag-off path performs no lookups at all, then consult the
-    memory-formation verdict through the one shared ``decision_for`` closure
-    (``managed_compute_decision_for``) so BYOK keeps forming and a raising
-    lookup is suppressed by the policy rather than escaping. Suppression is a
-    skip, never a delete: memories formed while the user was paid stay.
-    """
-    if not free_tier_memory_suppression_enabled():
-        return False
-    verdict = memory_formation_verdict(decision_for=managed_compute_decision_for(uid))
-    if verdict.suppressed:
-        logger.info(
-            'memory extraction skipped: plan denies managed formation uid=%s source=%s reason=%s',
-            uid,
-            source,
-            verdict.reason,
-        )
-        return True
-    return False
 
 
 def _stable_source_id(*parts: str) -> str:
@@ -138,7 +112,7 @@ def process_external_integration_memory(
     if (
         memory_data.text
         and len(memory_data.text.strip()) > 0
-        and not _managed_formation_suppressed(uid, f'external_integration:{app_id}')
+        and not managed_memory_formation_suppressed(uid, f'external_integration:{app_id}')
     ):
         extracted_memories = extract_memories_from_text(
             uid,
@@ -201,7 +175,7 @@ def process_external_integration_memory(
 def process_twitter_memories(uid: str, tweets_text: str, persona_id: str) -> List[MemoryDB]:
     # §1.8: the persona/twitter persona producer is one of the ungated managed
     # formation doors flip-review F-3 closed — gate before any extractor spend.
-    if _managed_formation_suppressed(uid, 'twitter_persona'):
+    if managed_memory_formation_suppressed(uid, 'twitter_persona'):
         return []
     # Extract memories from tweets using the LLM
     language = users_db.get_user_language_preference(uid)

--- a/backend/utils/conversations/memories.py
+++ b/backend/utils/conversations/memories.py
@@ -5,13 +5,40 @@ import database._client as db_client_module
 import database.users as users_db
 from models.memories import MemoryDB, Memory, MemoryCategory
 from models.integrations import ExternalIntegrationCreateMemory
+from utils.free_tier_memory_policy import free_tier_memory_suppression_enabled, memory_formation_verdict
 from utils.llm.memories import extract_memories_from_text
+from utils.managed_compute import managed_compute_decision_for
 from utils.memory.memory_authority import MemorySystem
 from utils.memory.memory_service import MemoryService
 from testing.parity_pack_v0.live_capture import SurfaceParityCapture
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def _managed_formation_suppressed(uid: str, source: str) -> bool:
+    """§1.8 (flip-review F-3): no managed model forms a memory for basic.
+
+    Same gate shape as the coordinator's extraction boundary
+    (``process_conversation._extract_memories``): read the rollout flag first so
+    the flag-off path performs no lookups at all, then consult the
+    memory-formation verdict through the one shared ``decision_for`` closure
+    (``managed_compute_decision_for``) so BYOK keeps forming and a raising
+    lookup is suppressed by the policy rather than escaping. Suppression is a
+    skip, never a delete: memories formed while the user was paid stay.
+    """
+    if not free_tier_memory_suppression_enabled():
+        return False
+    verdict = memory_formation_verdict(decision_for=managed_compute_decision_for(uid))
+    if verdict.suppressed:
+        logger.info(
+            'memory extraction skipped: plan denies managed formation uid=%s source=%s reason=%s',
+            uid,
+            source,
+            verdict.reason,
+        )
+        return True
+    return False
 
 
 def _stable_source_id(*parts: str) -> str:
@@ -104,8 +131,15 @@ def process_external_integration_memory(
             memory_db.app_id = app_id
             saved_memories.append(memory_db)
 
-    # Extract memories from text if provided
-    if memory_data.text and len(memory_data.text.strip()) > 0:
+    # Extract memories from text if provided. Model-formed memories are plan-gated
+    # (§1.8): an app-provided explicit fact is data the app already holds and is
+    # written as before, but luna extraction must not run for a plan the policy
+    # denies.
+    if (
+        memory_data.text
+        and len(memory_data.text.strip()) > 0
+        and not _managed_formation_suppressed(uid, f'external_integration:{app_id}')
+    ):
         extracted_memories = extract_memories_from_text(
             uid,
             memory_data.text,
@@ -165,6 +199,10 @@ def process_external_integration_memory(
 
 
 def process_twitter_memories(uid: str, tweets_text: str, persona_id: str) -> List[MemoryDB]:
+    # §1.8: the persona/twitter persona producer is one of the ungated managed
+    # formation doors flip-review F-3 closed — gate before any extractor spend.
+    if _managed_formation_suppressed(uid, 'twitter_persona'):
+        return []
     # Extract memories from tweets using the LLM
     language = users_db.get_user_language_preference(uid)
     extracted_memories = extract_memories_from_text(uid, tweets_text, "twitter_tweets", language=language)

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -98,7 +98,16 @@ from utils.free_tier_processing_policy import (
     minimum_processing_state,
     resolve_free_tier_processing_plan,
 )
-from utils.managed_compute import Decision, authorize_managed_compute, request_carries_validated_byok_key
+
+# The injected ``decision_for`` closure and its funding-owner resolution live in
+# ``utils/managed_compute`` (next to ``authorize_managed_compute`` and the BYOK
+# lookup they compose) and are shared with the app-integration, X-connector and
+# twitter-persona memory producers (flip-review F-3). Imported under the historic
+# private name so the coordinator's call sites and this module's tests read
+# unchanged.
+from utils.managed_compute import (
+    managed_compute_decision_for as _managed_compute_decision_for,
+)
 from models.other import Person
 from models.structured import Structured  # type: ignore[reportAttributeAccessIssue]  # SDK/fallback export is runtime-complete.
 from utils.notifications import send_important_conversation_message
@@ -1988,32 +1997,6 @@ def _store_deferred_conversation(
 
     logger.info("lazy: stored deferred desktop conversation uid=%s conv=%s", uid, conversation.id)
     return conversation
-
-
-def _funding_owner_for_feature(feature: str) -> str:
-    """``byok`` only when this request carries a validated key for ``feature``'s provider.
-
-    Reuses S1's ``request_carries_validated_byok_key`` so the only dynamic
-    ``get_provider(feature)`` site stays inside ``utils/managed_compute.py``.
-    Called only from the injected ``decision_for`` closure so a raising BYOK
-    lookup is caught by the policy's exception guard.
-    """
-    return 'byok' if request_carries_validated_byok_key(feature) else 'omi'
-
-
-def _managed_compute_decision_for(uid: str) -> Callable[[str], Decision]:
-    """Injected ``decision_for(feature) -> Decision`` for the S6 policy.
-
-    Funding owner is computed inside this closure, not before the policy call.
-    A raising BYOK/provider lookup therefore becomes ``policy_unavailable``
-    (deterministic minimum) instead of crashing the coordinator.
-    """
-
-    def decision_for(feature: str) -> Decision:
-        owner = _funding_owner_for_feature(feature)
-        return authorize_managed_compute(uid, feature, owner)
-
-    return decision_for
 
 
 def _terminal_persist_payload(conversation: Conversation) -> dict[str, Any]:

--- a/backend/utils/free_tier_memory_policy.py
+++ b/backend/utils/free_tier_memory_policy.py
@@ -31,7 +31,7 @@ import os
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from utils.managed_compute import Decision
+from utils.managed_compute import Decision, managed_compute_decision_for
 
 logger = logging.getLogger(__name__)
 
@@ -91,10 +91,43 @@ def memory_formation_verdict(*, decision_for: DecisionFor) -> MemoryFormationVer
     return MemoryFormationVerdict(allowed=False, reason=decision.reason, decision=decision)
 
 
+def managed_memory_formation_suppressed(uid: str, source: str) -> bool:
+    """§1.8 producer gate: should this managed memory-formation producer skip?
+
+    The one shared gate shape for the sibling producers the coordinator's
+    extraction boundary does not cover (app-integration text, the twitter
+    persona, the X connector — flip-review F-3). Read the rollout flag first
+    so the flag-off path performs no lookups at all, then consult
+    ``memory_formation_verdict`` through the one shared
+    ``managed_compute_decision_for`` closure so BYOK keeps forming and a
+    raising lookup is suppressed by the policy instead of escaping into a
+    sync. Suppression is a skip, never a delete: memories formed while the
+    user was paid stay.
+
+    The coordinator (``process_conversation.extract_memories``) keeps its own
+    copy of this shape at its boundary because its log carries the
+    conversation id; every other producer funnels through here so the gate
+    shape, logging, and fail-closed behavior cannot drift between them.
+    """
+    if not free_tier_memory_suppression_enabled():
+        return False
+    verdict = memory_formation_verdict(decision_for=managed_compute_decision_for(uid))
+    if verdict.suppressed:
+        logger.info(
+            'memory extraction skipped: plan denies managed formation uid=%s source=%s reason=%s',
+            uid,
+            source,
+            verdict.reason,
+        )
+        return True
+    return False
+
+
 __all__ = [
     'FREE_TIER_MEMORY_SUPPRESSION',
     'MEMORY_FORMATION_FEATURE',
     'MemoryFormationVerdict',
     'free_tier_memory_suppression_enabled',
+    'managed_memory_formation_suppressed',
     'memory_formation_verdict',
 ]

--- a/backend/utils/managed_compute.py
+++ b/backend/utils/managed_compute.py
@@ -24,6 +24,7 @@ quota or allowlist is read from the environment.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -402,3 +403,34 @@ def _authorize_omi(uid: str, feature: str, *, subscription: Any) -> Decision:
         plan=plan,
         plan_resolved=plan_resolved,
     )
+
+
+def funding_owner_for_feature(feature: str) -> str:
+    """``byok`` only when this request carries a validated key for ``feature``'s provider.
+
+    Reuses ``request_carries_validated_byok_key`` so the only dynamic
+    ``get_provider(feature)`` site stays inside this module. Called only from
+    inside an injected ``decision_for`` closure so a raising BYOK lookup is
+    caught by the caller's exception guard.
+    """
+    return 'byok' if request_carries_validated_byok_key(feature) else 'omi'
+
+
+def managed_compute_decision_for(uid: str) -> Callable[[str], Decision]:
+    """Injected ``decision_for(feature) -> Decision`` for a free-tier policy.
+
+    Funding owner is computed inside the closure, not before the policy call.
+    A raising BYOK/provider lookup therefore becomes the policy's
+    ``policy_unavailable`` (deterministic minimum / suppressed) instead of
+    crashing the caller. Defined here, next to ``authorize_managed_compute``
+    and the BYOK lookup it composes, so every producer of the same managed
+    spend injects the same closure — the coordinator's copy moved here when
+    the app-integration, X-connector and twitter-persona producers started
+    consulting the memory-formation policy (flip-review F-3).
+    """
+
+    def decision_for(feature: str) -> Decision:
+        owner = funding_owner_for_feature(feature)
+        return authorize_managed_compute(uid, feature, owner)
+
+    return decision_for

--- a/backend/utils/x_connector.py
+++ b/backend/utils/x_connector.py
@@ -34,7 +34,9 @@ from database._client import db
 from database.vector_db import upsert_x_post_vectors_batch
 from models.memories import MemoryDB
 from models.memory_contracts import MemoryExtractionError
+from utils.free_tier_memory_policy import free_tier_memory_suppression_enabled, memory_formation_verdict
 from utils.llm.memories import extract_memories_from_text
+from utils.managed_compute import managed_compute_decision_for
 from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem
 from utils.memory.promotion_flex import PromotionFlexDeferred, PromotionFlexRunRouter
@@ -339,6 +341,23 @@ def _extract_and_index(
     vector-index the resulting memories. Returns memories created."""
     if not posts:
         return 0
+    # §1.8 (flip-review F-3): the X connector is one of the managed
+    # memory-formation doors that ran ungated for basic. The plan gate sits
+    # above every chunk's extractor spend, exactly like the coordinator's
+    # extraction boundary. Skipped posts stay pending — unformed memories are
+    # never backfilled (the eager-extraction asymmetry), so a later upgrade
+    # forms them on the next sync instead of a suppression window mass-forming
+    # a backlog.
+    if free_tier_memory_suppression_enabled():
+        verdict = memory_formation_verdict(decision_for=managed_compute_decision_for(uid))
+        if verdict.suppressed:
+            logger.info(
+                'memory extraction skipped: plan denies managed formation uid=%s source=x_connector posts=%d reason=%s',
+                uid,
+                len(posts),
+                verdict.reason,
+            )
+            return 0
 
     chunks: List[Tuple[str, List[str]]] = []
     buf: List[str] = []

--- a/backend/utils/x_connector.py
+++ b/backend/utils/x_connector.py
@@ -34,9 +34,8 @@ from database._client import db
 from database.vector_db import upsert_x_post_vectors_batch
 from models.memories import MemoryDB
 from models.memory_contracts import MemoryExtractionError
-from utils.free_tier_memory_policy import free_tier_memory_suppression_enabled, memory_formation_verdict
+from utils.free_tier_memory_policy import managed_memory_formation_suppressed
 from utils.llm.memories import extract_memories_from_text
-from utils.managed_compute import managed_compute_decision_for
 from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem
 from utils.memory.promotion_flex import PromotionFlexDeferred, PromotionFlexRunRouter
@@ -342,22 +341,14 @@ def _extract_and_index(
     if not posts:
         return 0
     # §1.8 (flip-review F-3): the X connector is one of the managed
-    # memory-formation doors that ran ungated for basic. The plan gate sits
-    # above every chunk's extractor spend, exactly like the coordinator's
-    # extraction boundary. Skipped posts stay pending — unformed memories are
-    # never backfilled (the eager-extraction asymmetry), so a later upgrade
-    # forms them on the next sync instead of a suppression window mass-forming
-    # a backlog.
-    if free_tier_memory_suppression_enabled():
-        verdict = memory_formation_verdict(decision_for=managed_compute_decision_for(uid))
-        if verdict.suppressed:
-            logger.info(
-                'memory extraction skipped: plan denies managed formation uid=%s source=x_connector posts=%d reason=%s',
-                uid,
-                len(posts),
-                verdict.reason,
-            )
-            return 0
+    # memory-formation doors that ran ungated for basic. The shared producer
+    # gate sits above every chunk's extractor spend, exactly like the
+    # coordinator's extraction boundary. Skipped posts stay pending —
+    # unformed memories are never backfilled (the eager-extraction
+    # asymmetry), so a later upgrade forms them on the next sync instead of
+    # a suppression window mass-forming a backlog.
+    if managed_memory_formation_suppressed(uid, 'x_connector'):
+        return 0
 
     chunks: List[Tuple[str, List[str]]] = []
     buf: List[str] = []


### PR DESCRIPTION
## What

Close the three ungated managed memory-formation doors (§1.8: no managed model forms a memory for basic). Each site now consults `utils/free_tier_memory_policy` exactly the way `process_conversation.py`'s extraction boundary does, before any `get_llm('memories')` spend:

1. **App integration text** — `process_external_integration_memory` (`backend/utils/conversations/memories.py`, called from `backend/routers/integration.py:230`): the extraction call is skipped for a plan the policy denies. App-provided **explicit facts are not model-formed** and keep writing as before.
2. **Twitter persona** — `process_twitter_memories` (same file; called from `create_memories_from_twitter_tweets`, which `backend/utils/social.py:195,266` invoke on persona create and update): returns `[]` when suppressed.
3. **X connector** — `_extract_and_index` (`backend/utils/x_connector.py:363,365`): the plan gate sits **above the chunk loop**, so one plan answer covers the whole sync; skipped posts stay pending.

Gate shape at every site: read `free_tier_memory_suppression_enabled()` first — **flag-off performs no lookups at all** — then consult the real `memory_formation_verdict` through the one shared `managed_compute_decision_for(uid)` closure. Suppressed ⇒ skip with the coordinator's log shape (`memory extraction skipped: plan denies managed formation … reason=`). Suppression is a skip, never a delete: memories formed while paid stay, BYOK keeps forming (the verdict's own funding-owner resolution), and a raising plan lookup is suppressed by the policy instead of escaping into a sync.

## Why

Flip review 2026-09-04, finding **F-3**: the S5 proof ("zero managed extractor rows for basic") was measured at the coordinator boundary while these three sibling producers kept spending ungated — §1.8's proof read a dry pen for any user with such an app or connection.

## The hoist (commit 1, separate for review)

`managed_compute_decision_for` / `funding_owner_for_feature` moved from `process_conversation.py` to `backend/utils/managed_compute.py` (next to `authorize_managed_compute` and the BYOK lookup they compose) and are imported back under the coordinator's historic private name, so its call sites read unchanged. Importing the coordinator from the connector modules is **not importable as-is**: `process_conversation` pulls `utils.apps`, which pulls the connector/twitter-persona modules — a partial-initialization cycle — and it would drag the coordinator's whole graph into the sync worker. The closure's test seams (7 patch sites in 4 test files) moved with it to `utils.managed_compute`; no behaviour change in that commit.

## Tests

New `backend/tests/unit/test_free_tier_connector_memory_gates.py` — 14 tests, per door × {basic+flag-on ⇒ no extractor call, no memory written; paid ⇒ unchanged; basic BYOK with validated key ⇒ unchanged; flag-off ⇒ zero plan lookups (the authorize stub asserts)}, driving the real policy and the real shared closure with only `authorize_managed_compute` / `request_carries_validated_byok_key` stubbed; plus one X test pinning one-consultation-per-sync across a multi-chunk day. Red-proof notes in the module docstring: deleting a gate block fails its basic row; a forked closure that skips the BYOK lookup fails the BYOK row.

Commands (program venv, cwd `backend/`, per file — see the multi-file hang note in #12760, pre-existing on `main`):

- `pytest tests/unit/test_free_tier_connector_memory_gates.py` — 14 passed
- hoist-affected seams: entrypoint matrix 173 passed; branch 23 passed; acceptance 26; finalize 55; usage-context 53
- policy and producers: free-tier-memory-policy 15; authorize-managed-compute 100; x-memory-extraction-retry 6; sync-route-fanout 4; integration-sync-telemetry 5; free-tier-processing-policy 29; universal-memory-task-authority 5

Failure-Class: new

Failure class: `FC-shared-spend-gate-missing-on-sibling-producers` (definition added in this change; evidence_prs is empty — this PR is the evidence).

## Product invariants affected

- INV-MEM-4
- INV-TASK-2

## Do not merge until / notes

- **Do not merge before David reviews** — the author cannot approve; David merges.
- X-suppressed posts stay pending by design (documented in the code): the hourly sync then costs one plan lookup and zero LLM; an upgrade forms memories from the pending history on the next sync rather than a suppression window mass-forming a backlog. If David prefers ack-on-skip (never backfilled, bounded pending set), it is a two-line change at the same site.
- Review decision worth confirming: explicit app facts keep writing while extraction is suppressed — §1.8 stops the *managed model*, not the app's own data.
- Disjoint from #12760 (touches `process_conversation.py` only via the hoisted-helper import, lines ~100) — trivially rebasable over it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

