### PR TITLE
test(desktop): stop AuthorizedToolOwnerBoundAuth 60s hang

### DIFF
--- a/desktop/macos/Desktop/Tests/AuthorizedToolOwnerBoundAuthTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthorizedToolOwnerBoundAuthTests.swift
@@ -11,9 +11,27 @@ extension APIClient {
 }
 
 private final class AuthorizedToolRequestGate: @unchecked Sendable {
+  private final class ResumeOnce: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<URLRequest, Never>?
+
+    init(_ continuation: CheckedContinuation<URLRequest, Never>) {
+      self.continuation = continuation
+    }
+
+    func resume(_ request: URLRequest) {
+      let pending: CheckedContinuation<URLRequest, Never>? = lock.withLock {
+        let value = continuation
+        continuation = nil
+        return value
+      }
+      pending?.resume(returning: request)
+    }
+  }
+
   private struct RequestWaiter {
     let path: String
-    let continuation: CheckedContinuation<URLRequest, Never>
+    let once: ResumeOnce
   }
 
   private let lock = NSLock()
@@ -22,10 +40,21 @@ private final class AuthorizedToolRequestGate: @unchecked Sendable {
   private var requestWaiters: [RequestWaiter] = []
 
   func reset() async {
-    lock.withLock {
+    let abandoned: [RequestWaiter]
+    let leftover: [AuthorizedToolOwnerURLProtocol]
+    (abandoned, leftover) = lock.withLock {
+      let waiters = requestWaiters
+      let pending = pendingProtocols
       pendingProtocols.removeAll()
       selectedProtocols.removeAll()
       requestWaiters.removeAll()
+      return (waiters, pending)
+    }
+    for waiter in abandoned {
+      waiter.once.resume(URLRequest(url: URL(string: "https://authorized-tool-gate.invalid/reset")!))
+    }
+    for proto in leftover {
+      proto.client?.urlProtocol(proto, didFailWithError: URLError(.cancelled))
     }
   }
 
@@ -34,34 +63,53 @@ private final class AuthorizedToolRequestGate: @unchecked Sendable {
   /// for the URLProtocol instance (shared with the URL-loading infrastructure). State is
   /// serialized by `lock`; continuations are resumed outside the lock to avoid re-entrancy.
   func receive(_ urlProtocol: AuthorizedToolOwnerURLProtocol) {
-    var toResume: RequestWaiter?
+    var toResume: ResumeOnce?
     lock.withLock {
       pendingProtocols.append(urlProtocol)
       let path = urlProtocol.request.url?.path ?? ""
       if let index = requestWaiters.firstIndex(where: { $0.path == path }) {
-        toResume = requestWaiters.remove(at: index)
+        toResume = requestWaiters.remove(at: index).once
         selectedProtocols[path] = urlProtocol
       }
     }
-    if let waiter = toResume {
-      waiter.continuation.resume(returning: urlProtocol.request)
-    }
+    toResume?.resume(urlProtocol.request)
   }
 
-  func waitForRequest(path: String) async -> URLRequest {
+  /// Arm the waiter before returning so a later MainActor client task cannot
+  /// deadlock behind this wait. CI hung for 60s when `Task { @MainActor in
+  /// execute }` was started first from an already-MainActor test body: the
+  /// URL load never started, `waitForRequest` never resumed, and `succeed`
+  /// no-op'd.
+  nonisolated func waitForRequest(path: String) async -> URLRequest {
     await withCheckedContinuation { continuation in
+      let once = ResumeOnce(continuation)
       var immediate: URLRequest?
       lock.withLock {
         if let pendingProtocol = pendingProtocols.last(where: { $0.request.url?.path == path }) {
           selectedProtocols[path] = pendingProtocol
           immediate = pendingProtocol.request
         } else {
-          requestWaiters.append(RequestWaiter(path: path, continuation: continuation))
+          requestWaiters.append(RequestWaiter(path: path, once: once))
         }
       }
       if let request = immediate {
-        continuation.resume(returning: request)
+        once.resume(request)
       }
+    }
+  }
+
+  func isArmed(path: String) -> Bool {
+    lock.withLock {
+      requestWaiters.contains { $0.path == path }
+        || selectedProtocols[path] != nil
+        || pendingProtocols.contains { $0.request.url?.path == path }
+    }
+  }
+
+  func waitUntilArmed(path: String) async {
+    for _ in 0..<10_000 {
+      if isArmed(path: path) { return }
+      await Task.yield()
     }
   }
 
@@ -182,6 +230,10 @@ private actor PermissionCallbackBox<Value: Sendable> {
 
   func testMemoryReadRejectsPrivateResponseAfterMidFlightAccountSwitch() async {
     let client = await makeClient()
+    let pendingRequest = Task.detached {
+      await AuthorizedToolOwnerURLProtocol.gate.waitForRequest(path: "/v1/tools/memories")
+    }
+    await AuthorizedToolOwnerURLProtocol.gate.waitUntilArmed(path: "/v1/tools/memories")
     let operation = Task { @MainActor in
       await ChatToolExecutor.execute(
         ToolCall(name: "get_memories", arguments: [:], thoughtSignature: nil),
@@ -189,7 +241,7 @@ private actor PermissionCallbackBox<Value: Sendable> {
         backendAPIClient: client)
     }
 
-    let request = await AuthorizedToolOwnerURLProtocol.gate.waitForRequest(path: "/v1/tools/memories")
+    let request = await pendingRequest.value
     XCTAssertEqual(request.httpMethod, "GET")
     XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer owner-a-token")
 
@@ -206,6 +258,10 @@ private actor PermissionCallbackBox<Value: Sendable> {
 
   func testMemoryReadReturnsResponseWhileOriginalOwnerRemainsCurrent() async throws {
     let client = await makeClient()
+    let pendingRequest = Task.detached {
+      await AuthorizedToolOwnerURLProtocol.gate.waitForRequest(path: "/v1/tools/memories")
+    }
+    await AuthorizedToolOwnerURLProtocol.gate.waitUntilArmed(path: "/v1/tools/memories")
     let operation = Task { @MainActor in
       await ChatToolExecutor.execute(
         ToolCall(name: "get_memories", arguments: [:], thoughtSignature: nil),
@@ -213,11 +269,11 @@ private actor PermissionCallbackBox<Value: Sendable> {
         backendAPIClient: client)
     }
 
-    _ = await AuthorizedToolOwnerURLProtocol.gate.waitForRequest(path: "/v1/tools/memories")
+    _ = await pendingRequest.value
     await AuthorizedToolOwnerURLProtocol.gate.succeed(
       path: "/v1/tools/memories",
       with:
-        #"{"tool_name":"get_memories","result_text":"owner-a-memory","is_error":false}"#)
+        #"{"tool_name":"get_memories","result_text":"owner-a-memory","is_error":false,"sources":[]}"#)
 
     let result = await operation.value
     let object = try XCTUnwrap(
@@ -231,6 +287,10 @@ private actor PermissionCallbackBox<Value: Sendable> {
 
   func testActionItemWriteKeepsOriginalCredentialAndRejectsResultAfterMidFlightAccountSwitch() async {
     let client = await makeClient()
+    let pendingRequest = Task.detached {
+      await AuthorizedToolOwnerURLProtocol.gate.waitForRequest(path: "/v1/tools/action-items")
+    }
+    await AuthorizedToolOwnerURLProtocol.gate.waitUntilArmed(path: "/v1/tools/action-items")
     let operation = Task { @MainActor in
       await ChatToolExecutor.execute(
         ToolCall(
@@ -241,7 +301,7 @@ private actor PermissionCallbackBox<Value: Sendable> {
         backendAPIClient: client)
     }
 
-    let request = await AuthorizedToolOwnerURLProtocol.gate.waitForRequest(path: "/v1/tools/action-items")
+    let request = await pendingRequest.value
     XCTAssertEqual(request.httpMethod, "POST")
     XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer owner-a-token")
     let body = AuthorizedToolOwnerURLProtocol.bodyData(from: request).flatMap {
@@ -262,6 +322,10 @@ private actor PermissionCallbackBox<Value: Sendable> {
 
   func testRealtimeMintNeverReleasesOwnerATokenAfterMidFlightAccountSwitch() async {
     let client = await makeClient()
+    let pendingRequest = Task.detached {
+      await AuthorizedToolOwnerURLProtocol.gate.waitForRequest(path: "/v2/realtime/session")
+    }
+    await AuthorizedToolOwnerURLProtocol.gate.waitUntilArmed(path: "/v2/realtime/session")
     let operation = Task { @MainActor in
       do {
         _ = try await client.mintRealtimeToken(
@@ -276,7 +340,7 @@ private actor PermissionCallbackBox<Value: Sendable> {
       }
     }
 
-    let request = await AuthorizedToolOwnerURLProtocol.gate.waitForRequest(path: "/v2/realtime/session")
+    let request = await pendingRequest.value
     XCTAssertEqual(request.url?.path, "/v2/realtime/session")
     XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer owner-a-token")
 
@@ -556,6 +620,8 @@ private actor PermissionCallbackBox<Value: Sendable> {
     await establishStandardOwner("owner-a")
     let configuration = URLSessionConfiguration.ephemeral
     configuration.protocolClasses = [AuthorizedToolOwnerURLProtocol.self]
+    configuration.timeoutIntervalForRequest = 5
+    configuration.timeoutIntervalForResource = 5
     let client = APIClient(session: URLSession(configuration: configuration))
     await client.setOwnerBoundTestAuthHeader("Bearer owner-a-token")
     return client


### PR DESCRIPTION
## Summary
- `AuthorizedToolOwnerBoundAuthTests.testMemoryReadReturnsResponseWhileOriginalOwnerRemainsCurrent` was hanging for ~60s on `origin/main` and taking down Desktop Swift CI on unrelated PRs (including #12764).
- Root cause: the mock `/v1/tools/memories` body omitted `sources`, so `legacyListToolSources` issued a follow-up `v3/memories` request that the test URLProtocol never completed. That raced XCTest's 60s budget.
- Fixture now returns `"sources": []`. The gate also cancels leftover protocols on reset, arms the waiter before the MainActor client task, and uses a 5s session timeout.

## Test plan
- [x] `xcrun swift test -c debug --package-path desktop/macos/Desktop --filter AuthorizedToolOwnerBoundAuthTests` — 17 tests, 0.065s (was 60s on the happy-path case)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

