### PR TITLE
fix(deps): bump mistune to 3.3.3 in plugins

### DIFF
--- a/plugins/requirements.txt
+++ b/plugins/requirements.txt
@@ -106,7 +106,7 @@ marshmallow==3.26.2
 matplotlib-inline==0.2.2
 mdurl==0.1.2
 memo==0.2.4
-mistune==3.3.0
+mistune==3.3.3
 monotonic==1.6
 multidict==6.7.1
 mypy-extensions==1.1.0


### PR DESCRIPTION
Updates `mistune` to address GHSA-6m44-fpc8-c3rq (denial of service via RecursionError).

Evidence:
- `plugins/requirements.txt` pinned `mistune==3.3.0`
- OSV reports GHSA-6m44-fpc8-c3rq for `mistune 3.3.0` through `3.3.2`
- updated version: `3.3.3`

Validation:
- OSV reports no advisory for `mistune@3.3.3`
- `mistune==3.3.3` installs cleanly alongside the pinned `nbconvert==7.17.1` and `jupyter-client==8.8.0` from the same file
- `import mistune` plus a markdown render round trip under that combination works
- `pip check` reports no broken requirements
- plugin CI (`gcp_plugins.yml`) builds `plugins/Dockerfile` from this file; no direct `mistune` import exists in `plugins/`, it is a transitive dependency of `nbconvert`

Scope: dependency pin update only (`plugins/requirements.txt`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

