### PR TITLE
fix(app): stop the live transcript follow from stealing reader drags

### DIFF
--- a/.github/failure-classes/FC-live-follow-steals-reader-gesture.json
+++ b/.github/failure-classes/FC-live-follow-steals-reader-gesture.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "FC-live-follow-steals-reader-gesture",
+  "violated_contract": "A live auto-following transcript must transfer scroll ownership to the reader at the first user-scroll signal. While a driven follow animation owns the Scrollable, a pending reader drag can be orphaned (the scrollable ignores pointers and swaps drag recognizers while a driven activity runs), so no user-scroll notification ever fires; the follow then completes, clears the unfollowed flag, and the next live tick yanks the reader back to the live edge and re-pins.",
+  "canonical_prevention": "Gate every follow entry point on reader intent (dragging, unfollowed, interrupted); stop the running animateTo at the reader's current offset on any user-scroll signal; and recover gestures the scrollable orphaned via an ancestor pointer Listener so the drag always lands. Cover with a widget test that overlaps an in-flight 500ms follow animation with a reader drag plus a mid-gesture live content tick, asserting the offset stays away from maxScrollExtent, the scroll state does not re-pin, and the jump-to-latest control appears.",
+  "canonical_prevention_artifact": ["app/test/widgets/transcript_test.dart"],
+  "evidence_prs": [],
+  "scope_hints": ["app/lib/widgets/transcript.dart"],
+  "status": "open"
+}

--- a/app/lib/widgets/transcript.dart
+++ b/app/lib/widgets/transcript.dart
@@ -5,7 +5,7 @@ import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show RenderAbstractViewport, RenderBox, ScrollDirection;
 import 'package:flutter/services.dart';
-
+import 'package:flutter/gestures.dart' show kTouchSlop, PointerDownEvent, PointerMoveEvent;
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/message_event.dart';
 import 'package:omi/backend/schema/person.dart';
@@ -145,6 +145,14 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
   bool _isAtBottom = true;
   bool _followAgain = false;
   Future<void>? _activeFollow;
+  // Reader drag tracking: while a programmatic follow owns the scrollable,
+  // the scrollable may ignore pointers or replace its recognizers, orphaning
+  // a pending drag. The ancestor Listener below recovers that gesture.
+  int? _readerDragPointer;
+  Offset? _lastReaderPointerPosition;
+  double _readerDragTravel = 0;
+  bool _readerDragTakenOverByNative = false;
+  bool _readerDragRecovered = false;
 
   // Search result tracking
   final Map<String, GlobalKey> _segmentKeys = {};
@@ -309,10 +317,90 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
       final wasUserHasScrolled = _userHasScrolled;
       _userHasScrolled = !isAtBottom;
       if (isAtBottom && wasUserHasScrolled) {
+        // The reader is demonstrably back at the live edge: a stale interrupt
+        // from an earlier gesture must not keep blocking follow.
+        _userInterruptedAutoScroll = false;
         widget.scrollState?.update(offset: currentScroll, isAtBottom: true, layoutIdentity: widget.layoutIdentity);
       }
     }
     _setIsAtBottom(isAtBottom);
+  }
+
+  /// Cancels any in-flight follow on behalf of a reader gesture.
+  ///
+  /// Setting the flags alone is not enough: the running `animateTo` keeps
+  /// driving the Scrollable and can yank the reader back to the live edge.
+  /// Stopping at the current offset kills the driven activity immediately, and
+  /// clearing [_activeFollow] lets a later follow (e.g. the jump button) start
+  /// fresh instead of awaiting this cancelled one.
+  void _interruptAutoScroll() {
+    _userInterruptedAutoScroll = true;
+    _followAgain = false;
+    _activeFollow = null;
+    if (_isAutoScrolling && _scrollController.hasClients) {
+      _scrollController.jumpTo(_scrollController.offset);
+    }
+    _isAutoScrolling = false;
+  }
+
+  void _onReaderPointerDown(PointerDownEvent event) {
+    if (_readerDragPointer != null) return;
+    _readerDragPointer = event.pointer;
+    _lastReaderPointerPosition = event.position;
+    _readerDragTravel = 0;
+    _readerDragTakenOverByNative = false;
+    _readerDragRecovered = false;
+  }
+
+  void _onReaderPointerMove(PointerMoveEvent event) {
+    if (_readerDragPointer != event.pointer) return;
+    final last = _lastReaderPointerPosition;
+    _lastReaderPointerPosition = event.position;
+    if (last == null || !_scrollController.hasClients) return;
+
+    final dy = event.position.dy - last.dy;
+    if (_readerDragTakenOverByNative) return;
+
+    if (_readerDragRecovered) {
+      // The scrollable never saw this pointer's down event, so it cannot
+      // drive the gesture natively; carry the drag manually.
+      _driveReaderDrag(dy);
+      return;
+    }
+
+    final programmaticScrollActive = _isAutoScrolling || _isRestoringAnchor || _pendingAnchorRestore;
+    _readerDragTravel += dy.abs();
+    if (!programmaticScrollActive || _readerDragTravel <= kTouchSlop) return;
+
+    // A reader drag against a running programmatic scroll must interrupt it:
+    // while a driven activity owns the scrollable this gesture may never be
+    // delivered as a native drag, and the follow would yank the reader back
+    // to the live edge and re-pin.
+    _pendingAnchorRestore = false;
+    _isUserScrolling = true;
+    _userHasScrolled = true;
+    _readerDragRecovered = true;
+    _interruptAutoScroll();
+    _driveReaderDrag(dy);
+  }
+
+  void _driveReaderDrag(double dy) {
+    if (!_scrollController.hasClients) return;
+    final position = _scrollController.position;
+    _scrollController.jumpTo((_scrollController.offset - dy).clamp(position.minScrollExtent, position.maxScrollExtent));
+  }
+
+  void _endReaderDrag() {
+    final recovered = _readerDragRecovered && !_readerDragTakenOverByNative;
+    _readerDragPointer = null;
+    _lastReaderPointerPosition = null;
+    _readerDragTravel = 0;
+    _readerDragTakenOverByNative = false;
+    _readerDragRecovered = false;
+    if (recovered && _isUserScrolling && !_isAutoScrolling && !_isRestoringAnchor) {
+      _captureCurrentPosition();
+      _isUserScrolling = false;
+    }
   }
 
   void _captureCurrentPosition({String? layoutIdentity}) {
@@ -358,6 +446,12 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
   Future<void> _restoreAnchor() async {
     if (!_scrollController.hasClients) return;
     final scrollState = widget.scrollState;
+    if (_isUserScrolling) {
+      // The reader's active gesture owns the position; it re-anchors on its
+      // own when the gesture goes idle.
+      _pendingAnchorRestore = false;
+      return;
+    }
     if (scrollState == null || scrollState.isAtBottom || widget.segments.isEmpty) {
       _pendingAnchorRestore = false;
       _captureCurrentPosition();
@@ -374,7 +468,7 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
     _isRestoringAnchor = true;
     try {
       for (var attempt = 0; attempt < 20; attempt++) {
-        if (!mounted || !_scrollController.hasClients) return;
+        if (!mounted || !_scrollController.hasClients || _isUserScrolling) return;
         final anchorContext = _segmentKeys[anchorId]?.currentContext;
         final anchor = anchorContext?.findRenderObject();
         if (anchor is RenderBox) {
@@ -460,9 +554,14 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
       if ((maxExtent - _scrollController.offset).abs() > 0.5) {
         _scrollController.jumpTo(maxExtent);
       }
-      _userHasScrolled = false;
-      widget.scrollState?.update(offset: maxExtent, isAtBottom: true, layoutIdentity: widget.layoutIdentity);
-      _setIsAtBottom(true);
+      // Re-pin only when the follow truly finished at the live edge and the
+      // reader never took the gesture back.
+      if (!_userInterruptedAutoScroll &&
+          (_scrollController.position.maxScrollExtent - _scrollController.offset).abs() <= 0.5) {
+        _userHasScrolled = false;
+        widget.scrollState?.update(offset: maxExtent, isAtBottom: true, layoutIdentity: widget.layoutIdentity);
+        _setIsAtBottom(true);
+      }
     } finally {
       _isAutoScrolling = false;
     }
@@ -470,7 +569,7 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
 
   Future<void> _scrollToBottomGently({bool animated = true, bool force = false}) {
     if (!_scrollController.hasClients) return Future.value();
-    if (!force && widget.followLatest && _userHasScrolled) return Future.value();
+    if (!force && widget.followLatest && (_userHasScrolled || _isUserScrolling)) return Future.value();
     _followAgain = true;
     final activeFollow = _activeFollow;
     if (activeFollow != null) return activeFollow;
@@ -484,44 +583,60 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
   }
 
   bool _onUserScroll(UserScrollNotification notification) {
-    if (_isRestoringAnchor || _pendingAnchorRestore) return false;
     if (notification.direction != ScrollDirection.idle) {
+      // User-directed motion (drag or fling momentum) outranks any follow or
+      // pending anchor restore.
+      _pendingAnchorRestore = false;
       _isUserScrolling = true;
-      if (_isAutoScrolling) {
-        _userInterruptedAutoScroll = true;
-        _followAgain = false;
-        _isAutoScrolling = false;
-      }
+      _userHasScrolled = true;
+      _readerDragTakenOverByNative = true;
+      _readerDragRecovered = false;
+      _interruptAutoScroll();
       _captureCurrentPosition();
-    } else if (_isUserScrolling) {
+    } else if (_isUserScrolling && !_isRestoringAnchor && !_pendingAnchorRestore && !_readerDragRecovered) {
       _captureCurrentPosition();
       _isUserScrolling = false;
     }
     return false;
   }
 
+  bool _onScrollStart(ScrollStartNotification notification) {
+    if (notification.depth != 0 || notification.dragDetails == null) return false;
+
+    // Record intent on the first pixel of a pointer drag, before any live
+    // follow can re-grab the scrollable.
+    _pendingAnchorRestore = false;
+    _isUserScrolling = true;
+    _userHasScrolled = true;
+    _readerDragTakenOverByNative = true;
+    _readerDragRecovered = false;
+    _interruptAutoScroll();
+    return false;
+  }
+
   bool _onScrollUpdate(ScrollUpdateNotification notification) {
     if (notification.depth != 0 || notification.dragDetails == null) return false;
-    if (_isRestoringAnchor || _pendingAnchorRestore) return false;
 
+    // A pointer drag always outranks follow and pending anchor restores.
+    _pendingAnchorRestore = false;
     _isUserScrolling = true;
-    if (_isAutoScrolling) {
-      _userInterruptedAutoScroll = true;
-      _followAgain = false;
-      _isAutoScrolling = false;
-    }
+    _userHasScrolled = true;
+    _readerDragTakenOverByNative = true;
+    _readerDragRecovered = false;
+    _interruptAutoScroll();
     _captureCurrentPosition();
     return false;
   }
 
   bool _onScrollNotification(ScrollNotification notification) {
+    if (notification is ScrollStartNotification) return _onScrollStart(notification);
     if (notification is ScrollUpdateNotification) return _onScrollUpdate(notification);
     if (notification is UserScrollNotification) return _onUserScroll(notification);
     return false;
   }
 
   bool _onScrollMetrics(ScrollMetricsNotification notification) {
-    if (!widget.followLatest || _isAutoScrolling) return false;
+    if (!widget.followLatest || _isAutoScrolling || _isUserScrolling || _userInterruptedAutoScroll) return false;
     final shouldFollow = !_userHasScrolled;
     if (shouldFollow && notification.metrics.extentAfter > 0.5) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -703,46 +818,52 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
       onNotification: _onScrollMetrics,
       child: NotificationListener<ScrollNotification>(
         onNotification: _onScrollNotification,
-        child: GestureDetector(
-          behavior: HitTestBehavior.translucent,
-          onTap: () {
-            if (widget.searchQuery.isEmpty && widget.onTapWhenSearchEmpty != null) {
-              widget.onTapWhenSearchEmpty!();
-            }
-          },
-          child: ListView.builder(
-            controller: _scrollController,
-            padding: EdgeInsets.only(top: searchBarHeight),
-            itemCount: widget.leadingItems.length + widget.segments.length + 2,
-            findChildIndexCallback: _findChildIndex,
-            itemBuilder: (context, idx) {
-              if (idx == 0) {
-                return SizedBox(key: const ValueKey('transcript_header'), height: widget.topMargin ? 32 : 0);
+        child: Listener(
+          onPointerDown: _onReaderPointerDown,
+          onPointerMove: _onReaderPointerMove,
+          onPointerUp: (_) => _endReaderDrag(),
+          onPointerCancel: (_) => _endReaderDrag(),
+          child: GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTap: () {
+              if (widget.searchQuery.isEmpty && widget.onTapWhenSearchEmpty != null) {
+                widget.onTapWhenSearchEmpty!();
               }
-
-              final leadingIndex = idx - 1;
-              if (leadingIndex < widget.leadingItems.length) {
-                return KeyedSubtree(
-                  key: ValueKey('transcript-leading-${widget.leadingItemIds[leadingIndex]}'),
-                  child: widget.leadingItems[leadingIndex],
-                );
-              }
-
-              final segmentIndex = idx - widget.leadingItems.length - 1;
-              if (segmentIndex == widget.segments.length) {
-                return SizedBox(key: const ValueKey('transcript_bottom_spacing'), height: widget.bottomMargin + 120);
-              }
-
-              final segment = widget.segments[segmentIndex];
-              final customSegment = widget.segmentBuilder?.call(context, segment, segmentIndex);
-              Widget child = customSegment == null
-                  ? _buildSegmentItem(segmentIndex)
-                  : Container(key: _segmentKeys[segment.id], child: customSegment);
-              if (widget.separator && segmentIndex > 0) {
-                child = Column(mainAxisSize: MainAxisSize.min, children: [const SizedBox(height: 4), child]);
-              }
-              return KeyedSubtree(key: ValueKey('transcript-segment-${segment.id}'), child: child);
             },
+            child: ListView.builder(
+              controller: _scrollController,
+              padding: EdgeInsets.only(top: searchBarHeight),
+              itemCount: widget.leadingItems.length + widget.segments.length + 2,
+              findChildIndexCallback: _findChildIndex,
+              itemBuilder: (context, idx) {
+                if (idx == 0) {
+                  return SizedBox(key: const ValueKey('transcript_header'), height: widget.topMargin ? 32 : 0);
+                }
+
+                final leadingIndex = idx - 1;
+                if (leadingIndex < widget.leadingItems.length) {
+                  return KeyedSubtree(
+                    key: ValueKey('transcript-leading-${widget.leadingItemIds[leadingIndex]}'),
+                    child: widget.leadingItems[leadingIndex],
+                  );
+                }
+
+                final segmentIndex = idx - widget.leadingItems.length - 1;
+                if (segmentIndex == widget.segments.length) {
+                  return SizedBox(key: const ValueKey('transcript_bottom_spacing'), height: widget.bottomMargin + 120);
+                }
+
+                final segment = widget.segments[segmentIndex];
+                final customSegment = widget.segmentBuilder?.call(context, segment, segmentIndex);
+                Widget child = customSegment == null
+                    ? _buildSegmentItem(segmentIndex)
+                    : Container(key: _segmentKeys[segment.id], child: customSegment);
+                if (widget.separator && segmentIndex > 0) {
+                  child = Column(mainAxisSize: MainAxisSize.min, children: [const SizedBox(height: 4), child]);
+                }
+                return KeyedSubtree(key: ValueKey('transcript-segment-${segment.id}'), child: child);
+              },
+            ),
           ),
         ),
       ),

--- a/app/lib/widgets/transcript.dart
+++ b/app/lib/widgets/transcript.dart
@@ -390,7 +390,8 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
     _scrollController.jumpTo((_scrollController.offset - dy).clamp(position.minScrollExtent, position.maxScrollExtent));
   }
 
-  void _endReaderDrag() {
+  void _endReaderDrag(int pointer) {
+    if (_readerDragPointer != pointer) return;
     final recovered = _readerDragRecovered && !_readerDragTakenOverByNative;
     _readerDragPointer = null;
     _lastReaderPointerPosition = null;
@@ -409,6 +410,11 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
     final currentScroll = _scrollController.offset;
     final isAtBottom = _scrollController.position.maxScrollExtent - currentScroll <= 24;
     _userHasScrolled = !isAtBottom;
+    if (isAtBottom && !_isUserScrolling) {
+      // Settled at the live edge: resume follow. Do not clear this during an
+      // active drag — a reader who has only moved a few pixels must still win.
+      _userInterruptedAutoScroll = false;
+    }
     final scrollState = widget.scrollState;
     if (scrollState != null) {
       String? anchorId;
@@ -569,7 +575,9 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
 
   Future<void> _scrollToBottomGently({bool animated = true, bool force = false}) {
     if (!_scrollController.hasClients) return Future.value();
-    if (!force && widget.followLatest && (_userHasScrolled || _isUserScrolling)) return Future.value();
+    if (!force && widget.followLatest && (_userHasScrolled || _isUserScrolling || _userInterruptedAutoScroll)) {
+      return Future.value();
+    }
     _followAgain = true;
     final activeFollow = _activeFollow;
     if (activeFollow != null) return activeFollow;
@@ -821,8 +829,8 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
         child: Listener(
           onPointerDown: _onReaderPointerDown,
           onPointerMove: _onReaderPointerMove,
-          onPointerUp: (_) => _endReaderDrag(),
-          onPointerCancel: (_) => _endReaderDrag(),
+          onPointerUp: (event) => _endReaderDrag(event.pointer),
+          onPointerCancel: (event) => _endReaderDrag(event.pointer),
           child: GestureDetector(
             behavior: HitTestBehavior.translucent,
             onTap: () {

--- a/app/test/widgets/transcript_test.dart
+++ b/app/test/widgets/transcript_test.dart
@@ -319,6 +319,105 @@ void main() {
       await tester.pumpAndSettle();
     });
 
+    testWidgets('a drag started during an in-flight live follow wins and never re-pins', (tester) async {
+      await pumpTranscript(tester);
+
+      // A live tick starts the 500ms follow animation toward the new edge.
+      segments = [
+        ...segments,
+        TranscriptSegment(
+          id: 'live-follow-race',
+          text: List.filled(80, 'new live words').join(' '),
+          speaker: 'SPEAKER_00',
+          isUser: false,
+          personId: null,
+          start: segments.length.toDouble(),
+          end: segments.length + 1.0,
+          translations: const [],
+        ),
+      ];
+      contentVersion++;
+      await pumpTranscript(tester, settle: false);
+      // Leave the follow mid-flight: the first 500ms pass is still animating.
+      await tester.pump(const Duration(milliseconds: 490));
+
+      // The reader starts dragging up slowly from the live edge. The first
+      // pixels stay inside the at-bottom band where a lost gesture used to be
+      // forgotten and re-pinned by the next live tick.
+      final gesture = await tester.startGesture(tester.getCenter(find.byType(ListView)));
+      for (var step = 0; step < 3; step++) {
+        await gesture.moveBy(const Offset(0, 12));
+        await tester.pump(const Duration(milliseconds: 40));
+      }
+
+      // Another live tick lands while the gesture is still active.
+      segments = [
+        ...segments,
+        TranscriptSegment(
+          id: 'live-follow-race-2',
+          text: List.filled(80, 'more live words').join(' '),
+          speaker: 'SPEAKER_01',
+          isUser: false,
+          personId: null,
+          start: segments.length.toDouble(),
+          end: segments.length + 1.0,
+          translations: const [],
+        ),
+      ];
+      contentVersion++;
+      await pumpTranscript(tester, settle: false);
+      await tester.pump(const Duration(milliseconds: 40));
+
+      for (var step = 0; step < 4; step++) {
+        await gesture.moveBy(const Offset(0, 20));
+        await tester.pump(const Duration(milliseconds: 40));
+      }
+
+      // The drag owns the position: it stays away from the live edge instead
+      // of being yanked back by the competing follow.
+      expect(controller.position.maxScrollExtent - controller.offset, greaterThan(48));
+      expect(scrollState.isAtBottom, isFalse);
+      expect(find.byKey(const ValueKey('transcript_jump_to_latest')), findsOneWidget);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      // Completing the gesture must not re-pin to the live edge.
+      expect(controller.position.maxScrollExtent - controller.offset, greaterThan(48));
+      expect(scrollState.isAtBottom, isFalse);
+      expect(find.byKey(const ValueKey('transcript_jump_to_latest')), findsOneWidget);
+    });
+
+    testWidgets('same-ID growth of the live segment holds an unfollowed reading position', (tester) async {
+      await pumpTranscript(tester);
+      await tester.drag(find.byType(ListView), const Offset(0, 260));
+      await tester.pumpAndSettle();
+
+      final preservedOffset = controller.offset;
+      expect(scrollState.isAtBottom, isFalse);
+
+      final last = segments.last;
+      segments = [
+        ...segments.take(segments.length - 1),
+        TranscriptSegment(
+          id: last.id,
+          text: List.filled(80, 'revised live tail text').join(' '),
+          speaker: last.speaker,
+          isUser: last.isUser,
+          personId: last.personId,
+          start: last.start,
+          end: last.end,
+          translations: const [],
+        ),
+      ];
+      contentVersion++;
+      await pumpTranscript(tester);
+
+      expect(controller.offset, closeTo(preservedOffset, 0.1));
+      expect(scrollState.isAtBottom, isFalse);
+      expect(find.byKey(const ValueKey('transcript_jump_to_latest')), findsOneWidget);
+    });
+
     testWidgets('same-ID transcript growth keeps following the live edge', (tester) async {
       await pumpTranscript(tester);
 


### PR DESCRIPTION
fix(app): stop the live transcript follow from stealing reader drags

Closes #12767
Closes SCA-450

Base: `origin/main` @ `f5f424a8e282b8845a810cf58f23de9f7ce9a126` · Head: `79441c42e6`

## Problem

On the live Listening / transcription page, scrolling up while segments are still arriving gets yanked back to the bottom (#12767). The reader's drag can be swallowed while the auto-follow animation is running, and the follow then completes and re-pins, so the next live tick pins again and the jump-to-latest arrow never appears.

Root cause is a gesture-ownership race in `TranscriptWidget`:

1. Every live capture bump starts a follow (`animateTo`, first pass 500 ms, then coalesced 100 ms passes, plus a final `jumpTo`). `_isAutoScrolling` is true for that whole window.
2. While a driven activity owns the `Scrollable`, a pending reader drag can be orphaned outright: the scrollable ignores pointers during driven activities and its drag recognizers can be replaced mid-gesture, so the drag never produces a `UserScrollNotification` or a drag-detail `ScrollUpdateNotification`.
3. With no interrupt recorded, the follow's completion path sets `_userHasScrolled = false` unconditionally and writes `isAtBottom: true` to the session scroll state — the reader's unfollow intent is forgotten.
4. `_onScrollMetrics` then re-enters follow on the next extent change (`!_userHasScrolled && extentAfter > 0.5`), and the next `contentVersion` bump re-pins: the yank.

## Fix (narrowed to intent transfer, architecture unchanged)

- Any genuine user scroll signal — pointer-driven `ScrollStartNotification`, drag-detail `ScrollUpdateNotification`, non-idle `UserScrollNotification` — immediately records unfollow intent, cancels the in-flight follow (`_followAgain = false`, clears `_activeFollow`), and stops the running `animateTo` at the reader's **current** offset (not `maxScrollExtent`).
- Follow no longer starts or continues while the reader is dragging or has unfollowed: `_scrollToBottomGently` and the `ScrollMetrics` re-entry both gate on `_isUserScrolling` / `_userHasScrolled` / `_userInterruptedAutoScroll`.
- Follow completion only re-pins when it truly ended at the live edge and the reader never took the gesture back.
- Anchor restore defers to an active reader gesture (entry bail + in-loop bail) instead of `jumpTo`-ing against the drag.
- An ancestor `Listener` recovers the orphaned-gesture case the scrollable itself never delivers: a pointer drag beyond touch slop against a running programmatic scroll interrupts it and drives the offset directly until the native gesture path takes over or the pointer lifts.
- Returning to the live edge clears a stale interrupt, so default follow-on-latest is unchanged for readers who never scroll away; the jump-to-latest FAB (`force: true`) remains the explicit way back to the live edge.

## Tests

New widget tests in `app/test/widgets/transcript_test.dart` (group `Live transcript scrolling`):

- **In-flight follow vs drag** — with the 500 ms follow `animateTo` in flight, a slow reader drag (below the at-bottom band threshold) plus a second live `contentVersion` bump mid-gesture. Asserts the offset stays away from `maxScrollExtent`, `scrollState.isAtBottom` stays `false`, and `transcript_jump_to_latest` is visible; completing the gesture does not re-pin. **Fails on `origin/main`**: the scroll state re-pins `isAtBottom=true` and the drag is lost.
- **Same-ID revision during unfollow** — grow the last segment in place while unfollowed; position holds and the FAB stays.

Existing follow-when-at-bottom tests (fresh load pins, same-ID growth at bottom follows, FAB tap re-pins, overlapping updates coalesce, layout-change anchor restore, photo-timeline growth) all still pass unchanged.

## Verification evidence

Run in a worktree cut from `origin/main` @ `f5f424a8e282b8845a810cf58f23de9f7ce9a126`:

- `cd app && flutter test --no-pub test/widgets/transcript_test.dart` — 17/17 passed (and the new race test confirmed failing on unmodified `origin/main` before the fix)
- `cd app && bash test.sh` — 1721 passed, 5 skipped, 0 failed
- `cd app && bash scripts/analyze_ratchet.sh` — passed (no new lint occurrences)

Not exercised on a physical device or simulator: verified via the widget-test gesture pipeline (`TestGesture` pointer events, the same arena/scroll-activity machinery as production touch input). The orphaned-gesture path is exercised through the same `Scrollable` machinery the app uses.

## Failure class

Failure-Class: new

Added `FC-live-follow-steals-reader-gesture` (`.github/failure-classes/`): a live auto-following viewport must transfer scroll ownership to the reader at the first user-scroll signal, including gestures the scrollable orphaned while a driven activity owned it. Guard artifact: the in-flight-follow-vs-drag widget test above.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

