### PR TITLE
fix(app): make daily-summary Right/Wrong/Fix actually tappable

### DIFF
--- a/.github/failure-classes/FC-control-affordance-gated-on-cache-membership.json
+++ b/.github/failure-classes/FC-control-affordance-gated-on-cache-membership.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "id": "FC-control-affordance-gated-on-cache-membership",
+  "violated_contract": "A rendered control's affordance must gate on the capability of its action path, never on membership in a client-side cache the action does not read. The recap card's review controls trigger id-addressed mutations (POST /v3/memories/{id}/review, PATCH /v3/memories/{id}), yet their onTap required the id to be present in MemoriesProvider.memories; on a cold provider, a truncated bulk list, or an id the client never paged in, the chrome rendered untappable and silent, and MemoriesProvider.reviewMemory() duplicated the gate by returning before the request when the row was not loaded. The visible failure mode is fake affordance: labels painted, taps ignored, no error surfaced.",
+  "canonical_prevention": "Gate affordance on the action's own capability: controls stay live from the item's identity (id plus recap text), and mutations persist by id through the single provider mutation owner. A failed write reverts the optimistic paint and shows the inline error; a successful one settles the row for the session while the live row stays authoritative once loaded. Guard with widget tests that pump the card without preloading the id into the provider (cold start, loading == true initially; truncated bulk list) and assert non-null onTap on every control plus a review/edit request carrying exactly that id.",
+  "evidence_prs": [],
+  "scope_hints": ["app/lib/widgets/components/**", "app/lib/providers/**"],
+  "status": "open",
+  "canonical_prevention_artifact": [
+    "app/test/widgets/memory_review_card_test.dart",
+    "app/test/widgets/daily_summary_detail_page_test.dart"
+  ]
+}

--- a/app/lib/providers/memories_provider.dart
+++ b/app/lib/providers/memories_provider.dart
@@ -36,6 +36,7 @@ class MemoriesProvider extends ChangeNotifier {
   bool _ledgerHistorySupported = false;
   bool _ledgerHistoryTruncated = false;
   bool _loadFailed = false;
+  bool _hasLoaded = false;
   Future<void>? _clientDeviceInitialization;
   List<Tuple2<MemoryCategory, int>> categories = [];
   MemoryCategory? selectedCategory;
@@ -81,6 +82,12 @@ class MemoriesProvider extends ChangeNotifier {
   bool get ledgerHistorySupported => _ledgerHistorySupported;
   bool get ledgerHistoryTruncated => _ledgerHistoryTruncated;
   bool get loadFailed => _loadFailed;
+
+  /// Whether a load attempt has already completed in this session (success or
+  /// failure). `_loading` starts `true` before anything was ever fetched, so
+  /// callers that need "a fetch is actually in flight" must check
+  /// `loading && hasLoaded`.
+  bool get hasLoaded => _hasLoaded;
   bool get showLoadError => _loadFailed && _memories.isEmpty;
 
   bool isRevertingMemory(String memoryId) => _revertingMemoryIds.contains(memoryId);
@@ -239,6 +246,8 @@ class MemoriesProvider extends ChangeNotifier {
     categories = [];
     selectedCategory = null;
     _loading = false;
+    _hasLoaded = false;
+    _loadFailed = false;
     _isSyncing = false;
     _revertingMemoryIds.clear();
     _revertOperationIds.clear();
@@ -350,6 +359,7 @@ class MemoriesProvider extends ChangeNotifier {
       if (!result.ok) {
         _loadFailed = true;
         _loading = false;
+        _hasLoaded = true;
         notifyListeners();
         return;
       }
@@ -398,6 +408,7 @@ class MemoriesProvider extends ChangeNotifier {
         ledgerProjectionRevision != _ledgerProjectionRevision) {
       if (generation == _sessionGeneration && loadSequence == _loadSequence) {
         _loading = false;
+        _hasLoaded = true;
         notifyListeners();
       }
       return;
@@ -428,6 +439,7 @@ class MemoriesProvider extends ChangeNotifier {
     );
 
     _loading = false;
+    _hasLoaded = true;
     _setCategories();
   }
 
@@ -474,9 +486,24 @@ class MemoriesProvider extends ChangeNotifier {
   ///
   /// The local change is optimistic so the control responds immediately, but
   /// it is rolled back if the server rejects or cannot persist the decision.
+  ///
+  /// A memory that is not in the loaded list (cold provider, truncated bulk
+  /// list, or a recap referencing an id this client never paged in) is still
+  /// reviewed by id: the request is id-addressed and the server stays the
+  /// authority, so refusing to send it would strand the recap controls.
   Future<bool> reviewMemory(Memory memory, bool value) async {
     final index = _memories.indexWhere((candidate) => candidate.id == memory.id);
-    if (index == -1 || memory.isLocked) return false;
+    if (index == -1) {
+      final generation = _sessionGeneration;
+      try {
+        final persisted = await _reviewMemoryRequest(memory.id, value);
+        return generation == _sessionGeneration && persisted;
+      } catch (error) {
+        Logger.warning('MemoriesProvider: review persistence failed for ${memory.id}: $error');
+        return false;
+      }
+    }
+    if (memory.isLocked) return false;
     final generation = _sessionGeneration;
     final previousReview = memory.userReview;
     final previousReviewed = memory.reviewed;

--- a/app/lib/providers/memories_provider.dart
+++ b/app/lib/providers/memories_provider.dart
@@ -56,6 +56,25 @@ class MemoriesProvider extends ChangeNotifier {
   final Set<String> _revertingMemoryIds = {};
   final Map<String, String> _revertOperationIds = {};
 
+  /// Verdicts persisted this session for ids the loaded list does not resolve
+  /// (cold provider, truncated bulk list, or rows GET /v3/memories filters
+  /// out). A live row always wins; this only keeps recap rows honest while
+  /// nothing answers for the id.
+  final Map<String, bool> _settledUnresolvedReviews = {};
+
+  /// Hydration asks review cards have made, per id. Instance state so a card
+  /// State rebuilt by scrolling does not re-count, and `clearUserData()` can
+  /// reset the budget when the account changes.
+  final Map<String, int> _externalHydrateAttempts = {};
+  static const int _maxExternalHydrateAttempts = 2;
+
+  /// The load currently in flight, with the parameters it was started with.
+  /// Concurrent same-parameter callers join it instead of starting races the
+  /// sequence guard would discard.
+  Future<void>? _inFlightLoad;
+  int _inFlightLoadLimit = 100;
+  bool _inFlightLoadDeviceScoped = false;
+
   MemoriesProvider({
     FetchMemoriesRequest? fetchMemoriesRequest,
     FetchLedgerHistoryRequest? fetchLedgerHistoryRequest,
@@ -89,6 +108,24 @@ class MemoriesProvider extends ChangeNotifier {
   /// `loading && hasLoaded`.
   bool get hasLoaded => _hasLoaded;
   bool get showLoadError => _loadFailed && _memories.isEmpty;
+
+  /// The verdict this session persisted for [memoryId] when no live row
+  /// resolves the id, or null when no verdict has been recorded. A live row's
+  /// `userReview` always wins over this.
+  bool? settledReviewFor(String memoryId) => _settledUnresolvedReviews[memoryId];
+
+  /// Consume one hydration ask for [memoryId]: true while the id is still
+  /// eligible (first ask free, then retries only while loads keep failing).
+  /// Instance-scoped so `clearUserData()` restores eligibility for a new
+  /// account session.
+  bool consumeHydrationAsk(String memoryId) {
+    final attempts = _externalHydrateAttempts[memoryId] ?? 0;
+    final allowed = attempts == 0 || (attempts < _maxExternalHydrateAttempts && _loadFailed);
+    if (allowed) {
+      _externalHydrateAttempts[memoryId] = attempts + 1;
+    }
+    return allowed;
+  }
 
   bool isRevertingMemory(String memoryId) => _revertingMemoryIds.contains(memoryId);
 
@@ -251,6 +288,8 @@ class MemoriesProvider extends ChangeNotifier {
     _isSyncing = false;
     _revertingMemoryIds.clear();
     _revertOperationIds.clear();
+    _settledUnresolvedReviews.clear();
+    _externalHydrateAttempts.clear();
     _cancelDeletionTimer();
     _lastDeletedMemory = null;
     _pendingDeletionId = null;
@@ -325,6 +364,32 @@ class MemoriesProvider extends ChangeNotifier {
   }
 
   Future<void> loadMemories({int limit = 100}) async {
+    // Coalesce concurrent callers: several review cards can mount while the
+    // first fetch is still in flight (before `hasLoaded` flips), and racing
+    // loads would be discarded one after another by the sequence guard. A
+    // caller with different parameters gets its own load, which supersedes the
+    // in-flight one via the sequence guard as before.
+    final inFlight = _inFlightLoad;
+    if (inFlight != null && _inFlightLoadLimit == limit && _inFlightLoadDeviceScoped == _filterThisDeviceOnly) {
+      try {
+        await inFlight;
+      } catch (_) {}
+      return;
+    }
+    final loadFuture = _loadMemoriesInternal(limit: limit);
+    _inFlightLoad = loadFuture;
+    _inFlightLoadLimit = limit;
+    _inFlightLoadDeviceScoped = _filterThisDeviceOnly;
+    try {
+      await loadFuture;
+    } finally {
+      if (identical(_inFlightLoad, loadFuture)) {
+        _inFlightLoad = null;
+      }
+    }
+  }
+
+  Future<void> _loadMemoriesInternal({int limit = 100}) async {
     final generation = _sessionGeneration;
     final loadSequence = ++_loadSequence;
     final ledgerProjectionRevision = _ledgerProjectionRevision;
@@ -492,18 +557,28 @@ class MemoriesProvider extends ChangeNotifier {
   /// reviewed by id: the request is id-addressed and the server stays the
   /// authority, so refusing to send it would strand the recap controls.
   Future<bool> reviewMemory(Memory memory, bool value) async {
+    // Locked rows are immutable everywhere, including cache misses: the flag
+    // travels on the memory itself, so a row absent from the loaded list is
+    // still refused before any request is sent.
+    if (memory.isLocked) return false;
     final index = _memories.indexWhere((candidate) => candidate.id == memory.id);
     if (index == -1) {
       final generation = _sessionGeneration;
       try {
         final persisted = await _reviewMemoryRequest(memory.id, value);
-        return generation == _sessionGeneration && persisted;
+        if (generation != _sessionGeneration || !persisted) return false;
+        // No live row will ever answer for this id from the loaded list, so
+        // remember the persisted verdict for recap rows reading this id. A
+        // live row (a later refresh, another surface) still wins: this map is
+        // only consulted when the id does not resolve.
+        _settledUnresolvedReviews[memory.id] = value;
+        notifyListeners();
+        return true;
       } catch (error) {
         Logger.warning('MemoriesProvider: review persistence failed for ${memory.id}: $error');
         return false;
       }
     }
-    if (memory.isLocked) return false;
     final generation = _sessionGeneration;
     final previousReview = memory.userReview;
     final previousReviewed = memory.reviewed;

--- a/app/lib/widgets/components/memory_review_card.dart
+++ b/app/lib/widgets/components/memory_review_card.dart
@@ -69,17 +69,6 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
   /// fall back to the original learned text under an "Updated." status.
   final Map<String, String> _settledEdits = {};
 
-  /// Verdicts persisted this session for rows the provider never resolved.
-  /// Like [_settledEdits]: the live memory always wins once it answers for
-  /// the id; this only keeps the row honest while nothing does.
-  final Map<String, bool> _settledReviews = {};
-
-  /// Per-id hydrate attempts this card type has started in this process.
-  /// Static so a State rebuilt by scrolling does not re-count, and capped so
-  /// a failing backend is not retried forever.
-  static final Map<String, int> _hydrateAttempts = {};
-  static const int _maxHydrateAttempts = 2;
-
   /// Card identities already counted as shown in this process.
   static final Set<String> _seenImpressions = {};
 
@@ -121,6 +110,10 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
   /// controls act by id regardless, and only settled verdicts need the live
   /// row.
   void _ensureMemoriesLoaded() {
+    _startHydrationIfNeeded();
+  }
+
+  void _startHydrationIfNeeded() {
     if (!mounted) return;
     final provider = _memoriesProvider(listen: false);
     if (provider == null) return;
@@ -132,23 +125,13 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
     final eligible = _rows
         .where((item) => _memoryFor(provider, item.memoryId) == null)
         .map((item) => item.memoryId)
-        .where((id) => _hydrateAttemptAllowed(provider, id))
+        // The provider owns the attempt budget (session-scoped, reset on user
+        // data clear), so a State rebuilt by scrolling does not re-count and
+        // a failing backend is not retried forever.
+        .where(provider.consumeHydrationAsk)
         .toList(growable: false);
     if (eligible.isEmpty) return;
-    for (final id in eligible) {
-      _hydrateAttempts[id] = (_hydrateAttempts[id] ?? 0) + 1;
-    }
     provider.loadMemories();
-  }
-
-  /// First ask is always free. After that, retry only while loads keep
-  /// failing: a settled load that still misses the id means it is absent from
-  /// (or beyond) the list the account returns, and the controls mutate by id
-  /// regardless, so re-asking on every rebuild would fetch forever.
-  static bool _hydrateAttemptAllowed(MemoriesProvider provider, String id) {
-    final attempts = _hydrateAttempts[id] ?? 0;
-    if (attempts == 0) return true;
-    return attempts < _maxHydrateAttempts && provider.loadFailed;
   }
 
   Memory? _memoryFor(MemoriesProvider provider, String memoryId) {
@@ -157,7 +140,7 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
 
   /// Live state first: an optimistic verdict only survives until its request
   /// returns, after which `userReview`/`edited` on the memory are authoritative.
-  _RowState _stateFor(Memory? memory, String memoryId) {
+  _RowState _stateFor(MemoriesProvider? provider, Memory? memory, String memoryId) {
     final optimistic = _optimistic[memoryId];
     if (optimistic != null) return optimistic;
     if (memory == null) {
@@ -168,7 +151,7 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
       // the same way; anything else is pending, because the controls act by
       // id and no verdict has been read.
       if (_settledEdits.containsKey(memoryId)) return _RowState.updated;
-      final settled = _settledReviews[memoryId];
+      final settled = provider?.settledReviewFor(memoryId);
       if (settled != null) return settled ? _RowState.confirmed : _RowState.dropped;
       return _RowState.pending;
     }
@@ -211,9 +194,7 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
       // already applied the verdict to the memory this row reads, and when no
       // live memory answers for the id the settled verdict below does.
       _optimistic.remove(item.memoryId);
-      if (persisted) {
-        _settledReviews[item.memoryId] = accepted;
-      } else {
+      if (!persisted) {
         _failed.add(item.memoryId);
       }
     });
@@ -297,6 +278,12 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
     final rows = _rows;
     if (rows.isEmpty) return const SizedBox.shrink();
     final provider = _memoriesProvider(listen: true);
+    // A load that already settled in failure is the card's cue to spend its
+    // capped retry: the initState ask started this load, and only a rebuild
+    // observes how it settled.
+    if (provider != null && provider.hasLoaded && provider.loadFailed) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _startHydrationIfNeeded());
+    }
 
     return Column(
       key: const Key('memory_review_card'),
@@ -310,14 +297,15 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
         const SizedBox(height: 10),
         ...rows.map((item) {
           final memory = provider == null ? null : _memoryFor(provider, item.memoryId);
-          return _buildRow(item, memory, provider != null);
+          return _buildRow(item, provider, memory);
         }),
       ],
     );
   }
 
-  Widget _buildRow(MemoryReviewItem item, Memory? memory, bool interactive) {
-    final state = _stateFor(memory, item.memoryId);
+  Widget _buildRow(MemoryReviewItem item, MemoriesProvider? provider, Memory? memory) {
+    final interactive = provider != null;
+    final state = _stateFor(provider, memory, item.memoryId);
     final editing = _editors.containsKey(item.memoryId);
     final dimmed = state == _RowState.dropped;
     final content = _contentOf(item, memory);

--- a/app/lib/widgets/components/memory_review_card.dart
+++ b/app/lib/widgets/components/memory_review_card.dart
@@ -26,6 +26,11 @@ enum MemoryReviewSource {
 /// desktop shows here, and a vote cast here is not persisted in the chat
 /// message or in preferences. A tap paints optimistically only until the
 /// request returns, then the row goes back to reading the live memory.
+///
+/// A row whose id the provider has not loaded is still actionable: the item
+/// carries the id and the recap text, and the provider's review and edit
+/// requests are id-addressed. Such a row stays pending until a verdict is
+/// written, and the card never renders untappable control chrome.
 class MemoryReviewCard extends StatefulWidget {
   const MemoryReviewCard({
     super.key,
@@ -48,7 +53,7 @@ class MemoryReviewCard extends StatefulWidget {
   State<MemoryReviewCard> createState() => _MemoryReviewCardState();
 }
 
-enum _RowState { loading, pending, confirmed, dropped, updated }
+enum _RowState { pending, confirmed, dropped, updated }
 
 class _MemoryReviewCardState extends State<MemoryReviewCard> {
   static const _cardColor = Color(0xFF1A1A1F);
@@ -64,18 +69,16 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
   /// fall back to the original learned text under an "Updated." status.
   final Map<String, String> _settledEdits = {};
 
-  /// Ids this process has already asked the provider to go looking for. A card
-  /// scrolled in and out of the chat list rebuilds its State, and an id that is
-  /// genuinely absent from the account would otherwise re-trigger a full
-  /// memories fetch on every rebuild.
-  static final Set<String> _requestedIds = {};
+  /// Verdicts persisted this session for rows the provider never resolved.
+  /// Like [_settledEdits]: the live memory always wins once it answers for
+  /// the id; this only keeps the row honest while nothing does.
+  final Map<String, bool> _settledReviews = {};
 
-  /// Whether this process has already asked the provider to load its list.
-  /// Nothing in app start-up initialises [MemoriesProvider] — only the memories
-  /// page calls `init()` — and a provider that has never loaded still reports
-  /// `loading == true`, so "already loading" cannot be read as "a fetch is in
-  /// flight" until this card has started one itself.
-  static bool _loadRequested = false;
+  /// Per-id hydrate attempts this card type has started in this process.
+  /// Static so a State rebuilt by scrolling does not re-count, and capped so
+  /// a failing backend is not retried forever.
+  static final Map<String, int> _hydrateAttempts = {};
+  static const int _maxHydrateAttempts = 2;
 
   /// Card identities already counted as shown in this process.
   static final Set<String> _seenImpressions = {};
@@ -111,26 +114,41 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
     }
   }
 
-  /// A memory referenced by the card may not be in the provider's page yet.
+  /// A memory referenced by the card may not be in the provider's list (cold
+  /// provider, truncated bulk list, or an id this client never paged in).
   /// There is no by-id read on this client, so ask the provider — the single
-  /// owner of memory state — to load its list once. Until it resolves the row
-  /// renders its content with the controls disabled.
+  /// owner of memory state — to load its list. Hydration is best-effort: the
+  /// controls act by id regardless, and only settled verdicts need the live
+  /// row.
   void _ensureMemoriesLoaded() {
     if (!mounted) return;
     final provider = _memoriesProvider(listen: false);
     if (provider == null) return;
-    final unresolved = _rows
+    // A fetch the provider owns is already in flight (memories page, an
+    // earlier card); when it settles the rows re-read whatever it loaded.
+    // A never-loaded provider reports `loading == true` before any request
+    // exists, so that alone must not read as "a fetch is in flight".
+    if (provider.loading && provider.hasLoaded) return;
+    final eligible = _rows
         .where((item) => _memoryFor(provider, item.memoryId) == null)
         .map((item) => item.memoryId)
-        .where(_requestedIds.add)
+        .where((id) => _hydrateAttemptAllowed(provider, id))
         .toList(growable: false);
-    if (unresolved.isEmpty) return;
-    // Only skip when a fetch this process started is still running. Chat and
-    // the daily summary are usually the first memory surface a session opens,
-    // and there `loading` is just the never-loaded initial value.
-    if (_loadRequested && provider.loading) return;
-    _loadRequested = true;
+    if (eligible.isEmpty) return;
+    for (final id in eligible) {
+      _hydrateAttempts[id] = (_hydrateAttempts[id] ?? 0) + 1;
+    }
     provider.loadMemories();
+  }
+
+  /// First ask is always free. After that, retry only while loads keep
+  /// failing: a settled load that still misses the id means it is absent from
+  /// (or beyond) the list the account returns, and the controls mutate by id
+  /// regardless, so re-asking on every rebuild would fetch forever.
+  static bool _hydrateAttemptAllowed(MemoriesProvider provider, String id) {
+    final attempts = _hydrateAttempts[id] ?? 0;
+    if (attempts == 0) return true;
+    return attempts < _maxHydrateAttempts && provider.loadFailed;
   }
 
   Memory? _memoryFor(MemoriesProvider provider, String memoryId) {
@@ -142,10 +160,18 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
   _RowState _stateFor(Memory? memory, String memoryId) {
     final optimistic = _optimistic[memoryId];
     if (optimistic != null) return optimistic;
-    // A correction that appended a replacement row leaves this id unresolvable.
-    // That is settled, not still loading — but only while nothing live answers
-    // for the id, so a later refresh or another device still wins.
-    if (memory == null) return _settledEdits.containsKey(memoryId) ? _RowState.updated : _RowState.loading;
+    if (memory == null) {
+      // A correction that appended a replacement row leaves this id
+      // unresolvable; that is settled, not unknown — but only while nothing
+      // live answers for the id, so a later refresh or another device still
+      // wins. A verdict this card persisted while unresolved settles the row
+      // the same way; anything else is pending, because the controls act by
+      // id and no verdict has been read.
+      if (_settledEdits.containsKey(memoryId)) return _RowState.updated;
+      final settled = _settledReviews[memoryId];
+      if (settled != null) return settled ? _RowState.confirmed : _RowState.dropped;
+      return _RowState.pending;
+    }
     if (memory.userReview == false) return _RowState.dropped;
     if (memory.userReview == true) return _RowState.confirmed;
     if (memory.edited) return _RowState.updated;
@@ -160,13 +186,12 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
         return "Dropped. I'll avoid facts like this.";
       case _RowState.updated:
         return 'Updated.';
-      case _RowState.loading:
       case _RowState.pending:
         return '';
     }
   }
 
-  Future<void> _review(MemoryReviewItem item, Memory memory, bool accepted) async {
+  Future<void> _review(MemoryReviewItem item, Memory? memory, bool accepted) async {
     if (_inFlight.contains(item.memoryId)) return;
     final provider = _memoriesProvider(listen: false);
     if (provider == null) return;
@@ -176,14 +201,21 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
       _optimistic[item.memoryId] = accepted ? _RowState.confirmed : _RowState.dropped;
     });
 
-    final persisted = await provider.reviewMemory(memory, accepted);
+    // A row the provider never loaded still mutates: the requests are
+    // id-addressed, and the item carries the identity to address it with.
+    final persisted = await provider.reviewMemory(memory ?? _standInMemory(item), accepted);
     if (!mounted) return;
     setState(() {
       _inFlight.remove(item.memoryId);
       // Drop the optimistic paint either way: on success the provider has
-      // already applied the verdict to the memory this row reads.
+      // already applied the verdict to the memory this row reads, and when no
+      // live memory answers for the id the settled verdict below does.
       _optimistic.remove(item.memoryId);
-      if (!persisted) _failed.add(item.memoryId);
+      if (persisted) {
+        _settledReviews[item.memoryId] = accepted;
+      } else {
+        _failed.add(item.memoryId);
+      }
     });
     PlatformManager.instance.analytics.memoryReviewAction(
       source: widget.source.analyticsValue,
@@ -193,7 +225,7 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
     );
   }
 
-  Future<void> _saveEdit(MemoryReviewItem item, Memory memory) async {
+  Future<void> _saveEdit(MemoryReviewItem item, Memory? memory) async {
     final controller = _editors[item.memoryId];
     final value = controller?.text.trim() ?? '';
     if (value.isEmpty || _inFlight.contains(item.memoryId)) return;
@@ -205,7 +237,7 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
       _optimistic[item.memoryId] = _RowState.updated;
     });
 
-    final persisted = await provider.editMemory(memory, value);
+    final persisted = await provider.editMemory(memory ?? _standInMemory(item), value);
     if (!mounted) return;
     setState(() {
       _inFlight.remove(item.memoryId);
@@ -237,6 +269,29 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
     return memory?.category.name ?? '';
   }
 
+  /// The mutation carrier for a row whose live memory has not been loaded:
+  /// identity (the id) plus the recap text. Only the id-addressed review and
+  /// edit requests consume it; no list-mutating provider path reads anything
+  /// else off it.
+  Memory _standInMemory(MemoryReviewItem item) {
+    return Memory(
+      id: item.memoryId,
+      uid: '',
+      content: item.content,
+      category: MemoryCategory.system,
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+      visibility: MemoryVisibility.private,
+    );
+  }
+
+  /// What a row displays: the live memory when it resolves, otherwise the
+  /// last correction this card persisted, otherwise the recap text.
+  String _contentOf(MemoryReviewItem item, Memory? memory) {
+    final live = memory?.content.trim() ?? '';
+    return live.isNotEmpty ? live : (_settledEdits[item.memoryId] ?? item.content);
+  }
+
   @override
   Widget build(BuildContext context) {
     final rows = _rows;
@@ -253,17 +308,19 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
           style: const TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w600),
         ),
         const SizedBox(height: 10),
-        ...rows.map((item) => _buildRow(item, provider == null ? null : _memoryFor(provider, item.memoryId))),
+        ...rows.map((item) {
+          final memory = provider == null ? null : _memoryFor(provider, item.memoryId);
+          return _buildRow(item, memory, provider != null);
+        }),
       ],
     );
   }
 
-  Widget _buildRow(MemoryReviewItem item, Memory? memory) {
+  Widget _buildRow(MemoryReviewItem item, Memory? memory, bool interactive) {
     final state = _stateFor(memory, item.memoryId);
     final editing = _editors.containsKey(item.memoryId);
     final dimmed = state == _RowState.dropped;
-    final live = memory?.content.trim() ?? '';
-    final content = live.isNotEmpty ? live : (_settledEdits[item.memoryId] ?? item.content);
+    final content = _contentOf(item, memory);
 
     return Container(
       key: Key('memory_review_row_${item.memoryId}'),
@@ -295,7 +352,11 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
                   ),
                   const SizedBox(width: 12),
                 ],
-                Expanded(child: _buildTrailing(item, memory, state, editing)),
+                Expanded(
+                  // Without a MemoriesProvider there is no mutation owner, so
+                  // no controls render at all — never dead chrome.
+                  child: interactive ? _buildTrailing(item, memory, state, editing) : const SizedBox.shrink(),
+                ),
               ],
             ),
           ),
@@ -327,7 +388,7 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
         enabledBorder: UnderlineInputBorder(borderSide: BorderSide(color: Colors.grey.shade700)),
         focusedBorder: const UnderlineInputBorder(borderSide: BorderSide(color: Colors.white)),
       ),
-      onSubmitted: memory == null ? null : (_) => _saveEdit(item, memory),
+      onSubmitted: (_) => _saveEdit(item, memory),
     );
   }
 
@@ -346,13 +407,13 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
             key: Key('memory_review_save_${item.memoryId}'),
             label: 'Save',
             emphasized: true,
-            onTap: memory == null || _inFlight.contains(item.memoryId) ? null : () => _saveEdit(item, memory),
+            onTap: _inFlight.contains(item.memoryId) ? null : () => _saveEdit(item, memory),
           ),
         ],
       );
     }
 
-    if (state != _RowState.pending && state != _RowState.loading) {
+    if (state != _RowState.pending) {
       return Align(
         alignment: Alignment.centerLeft,
         child: Text(
@@ -363,7 +424,10 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
       );
     }
 
-    final enabled = memory != null && !_inFlight.contains(item.memoryId);
+    // Actionable by identity, not by list membership: the requests are
+    // id-addressed and the item carries the id, so a row the provider never
+    // loaded stays tappable. `_inFlight` only disables its own write.
+    final enabled = !_inFlight.contains(item.memoryId);
     return Row(
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
@@ -385,7 +449,7 @@ class _MemoryReviewCardState extends State<MemoryReviewCard> {
           onTap: enabled
               ? () => setState(() {
                     _failed.remove(item.memoryId);
-                    _editors[item.memoryId] = TextEditingController(text: memory.content.trim());
+                    _editors[item.memoryId] = TextEditingController(text: _contentOf(item, memory));
                   })
               : null,
         ),

--- a/app/test/providers/knowledge_ledger_review_test.dart
+++ b/app/test/providers/knowledge_ledger_review_test.dart
@@ -612,4 +612,106 @@ void main() {
     }
     expect(requests, 0);
   });
+
+  test('a locked memory absent from the loaded list is not reviewed', () async {
+    final reviews = <String>[];
+    final provider = MemoriesProvider(
+      fetchMemoriesRequest: ({int limit = 100, int offset = 0, bool thisDeviceOnly = false}) async =>
+          const GetMemoriesResult([], true),
+      fetchLedgerHistoryRequest: ({int limit = 500, int offset = 0}) async =>
+          const GetLedgerHistoryResult([], supported: true),
+      reviewMemoryRequest: (id, value) async {
+        reviews.add(id);
+        return true;
+      },
+    );
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    final locked = _ledgerMemory(id: 'locked-absent', kind: KnowledgeLedgerKind.fact, isLocked: true);
+    expect(await provider.reviewMemory(locked, false), isFalse);
+    expect(reviews, isEmpty, reason: 'locked rows are immutable even when the id is not in the loaded list');
+  });
+
+  test('clearUserData resets the review-card hydration budget', () async {
+    final provider = MemoriesProvider(
+      fetchMemoriesRequest: ({int limit = 100, int offset = 0, bool thisDeviceOnly = false}) async =>
+          const GetMemoriesResult([], true),
+      fetchLedgerHistoryRequest: ({int limit = 500, int offset = 0}) async =>
+          const GetLedgerHistoryResult([], supported: true),
+      reviewMemoryRequest: (id, value) async => true,
+    );
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    // Spend the whole budget for an id the settled list does not resolve.
+    expect(provider.consumeHydrationAsk('mem-a'), isTrue);
+    expect(provider.consumeHydrationAsk('mem-a'), isFalse);
+    provider.clearUserData();
+
+    // A new account session restores eligibility.
+    expect(provider.consumeHydrationAsk('mem-a'), isTrue);
+  });
+
+  test('clearUserData clears settled verdicts recorded for unresolved ids', () async {
+    final provider = MemoriesProvider(
+      fetchMemoriesRequest: ({int limit = 100, int offset = 0, bool thisDeviceOnly = false}) async =>
+          const GetMemoriesResult([], true),
+      fetchLedgerHistoryRequest: ({int limit = 500, int offset = 0}) async =>
+          const GetLedgerHistoryResult([], supported: true),
+      reviewMemoryRequest: (id, value) async => true,
+    );
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    final absent = _ledgerMemory(id: 'mem-absent', kind: KnowledgeLedgerKind.fact);
+    expect(await provider.reviewMemory(absent, true), isTrue);
+    expect(provider.settledReviewFor('mem-absent'), isTrue);
+
+    provider.clearUserData();
+    expect(provider.settledReviewFor('mem-absent'), isNull);
+  });
+
+  test('a settled verdict for an unresolved id is recorded and overwritable', () async {
+    final provider = MemoriesProvider(
+      fetchMemoriesRequest: ({int limit = 100, int offset = 0, bool thisDeviceOnly = false}) async =>
+          const GetMemoriesResult([], true),
+      fetchLedgerHistoryRequest: ({int limit = 500, int offset = 0}) async =>
+          const GetLedgerHistoryResult([], supported: true),
+      reviewMemoryRequest: (id, value) async => true,
+    );
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    final absent = _ledgerMemory(id: 'mem-absent', kind: KnowledgeLedgerKind.fact);
+    expect(await provider.reviewMemory(absent, false), isTrue);
+    expect(provider.settledReviewFor('mem-absent'), isFalse);
+
+    // The same user can change their mind; the last persisted verdict stands.
+    expect(await provider.reviewMemory(absent, true), isTrue);
+    expect(provider.settledReviewFor('mem-absent'), isTrue);
+  });
+
+  test('concurrent same-parameter loads are coalesced instead of racing', () async {
+    var fetches = 0;
+    final provider = MemoriesProvider(
+      fetchMemoriesRequest: ({int limit = 100, int offset = 0, bool thisDeviceOnly = false}) async {
+        fetches++;
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        return GetMemoriesResult([_ledgerMemory(id: 'fact', kind: KnowledgeLedgerKind.fact)], true);
+      },
+      fetchLedgerHistoryRequest: ({int limit = 500, int offset = 0}) async =>
+          const GetLedgerHistoryResult([], supported: true),
+      reviewMemoryRequest: (id, value) async => true,
+    );
+    addTearDown(provider.dispose);
+
+    // Several review cards mount while the first fetch is still in flight
+    // (`hasLoaded` still false). They must join the one load, not start
+    // races the sequence guard would discard.
+    await Future.wait([provider.loadMemories(), provider.loadMemories(), provider.loadMemories()]);
+
+    expect(fetches, 1);
+    expect(provider.memories.map((item) => item.id), ['fact']);
+  });
 }

--- a/app/test/widgets/daily_summary_detail_page_test.dart
+++ b/app/test/widgets/daily_summary_detail_page_test.dart
@@ -133,6 +133,57 @@ void main() {
     );
   });
 
+  testWidgets('memories learned are tappable on a cold provider without the id loaded', (tester) async {
+    final reviews = <String>[];
+    final memoriesProvider = MemoriesProvider(
+      fetchMemoriesRequest: ({int limit = 100, int offset = 0, bool thisDeviceOnly = false}) async =>
+          const GetMemoriesResult([], true),
+      fetchLedgerHistoryRequest: ({int limit = 500, int offset = 0}) async =>
+          const GetLedgerHistoryResult([], supported: true),
+      reviewMemoryRequest: (id, value) async {
+        reviews.add(id);
+        return true;
+      },
+      editMemoryRequest: (id, value) async => const EditMemoryResult(persisted: true),
+    );
+    addTearDown(memoriesProvider.dispose);
+    // Cold start: nothing has initialised the provider and the bulk list never
+    // contains the recap id.
+    expect(memoriesProvider.loading, isTrue);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<MemoriesProvider>.value(
+        value: memoriesProvider,
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: ThemeData.dark(),
+          home: DailySummaryDetailPage(
+            summaryId: 'summary-cold',
+            summary: _summary(
+              locations: const [],
+              memoriesLearned: const [
+                MemoryReviewItem(memoryId: 'mem-cold', content: 'Prefers async standups', category: 'work'),
+              ],
+            ),
+            tileProvider: _MemoryTileProvider(),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 900));
+
+    final accept = tester.widget<InkWell>(find.byKey(const Key('memory_review_accept_mem-cold')));
+    expect(accept.onTap, isNotNull);
+
+    await tester.tap(find.byKey(const Key('memory_review_accept_mem-cold')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 900));
+
+    expect(reviews, ['mem-cold']);
+  });
+
   testWidgets('shows positive desktop watching and proactive stats', (tester) async {
     await tester.pumpWidget(
       MaterialApp(

--- a/app/test/widgets/memory_review_card_test.dart
+++ b/app/test/widgets/memory_review_card_test.dart
@@ -337,8 +337,15 @@ void main() {
     expect(find.text('Updated.'), findsNothing);
   });
 
-  testWidgets('an unresolved memory still shows its content with the controls disabled', (tester) async {
-    final provider = _provider(rows: const []);
+  testWidgets('a known memory outside the provider list is still fully tappable', (tester) async {
+    final reviews = <String, bool>{};
+    final provider = _provider(
+      rows: const [],
+      reviewMemoryRequest: (id, value) async {
+        reviews[id] = value;
+        return true;
+      },
+    );
     addTearDown(provider.dispose);
     await provider.loadMemories();
 
@@ -346,8 +353,96 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Prefers async standups'), findsOneWidget);
-    final accept = tester.widget<InkWell>(find.byKey(const Key('memory_review_accept_mem-missing')));
-    expect(accept.onTap, isNull);
-    expect(find.byKey(const Key('memory_review_status_mem-missing')), findsNothing);
+    // Identity is enough: a row the bulk list never contained must not render
+    // dead control chrome.
+    for (final key in [
+      const Key('memory_review_accept_mem-missing'),
+      const Key('memory_review_reject_mem-missing'),
+      const Key('memory_review_fix_mem-missing'),
+    ]) {
+      expect(tester.widget<InkWell>(find.byKey(key)).onTap, isNotNull);
+    }
+
+    await tester.tap(find.byKey(const Key('memory_review_accept_mem-missing')));
+    await tester.pumpAndSettle();
+    // The verdict reached the server by id even though the row never loaded,
+    // and the row says so instead of falling back to tappable controls.
+    expect(reviews, {'mem-missing': true});
+    expect(find.text("Confirmed. I'll act on this."), findsOneWidget);
+  });
+
+  testWidgets('a fix on an unresolved row edits by id and records the correction', (tester) async {
+    final edits = <String, String>{};
+    final provider = _provider(
+      rows: const [],
+      editMemoryRequest: (id, value) async {
+        edits[id] = value;
+        return const EditMemoryResult(persisted: true);
+      },
+    );
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    await tester.pumpWidget(_harness(provider, [_item('mem-missing')]));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('memory_review_fix_mem-missing')));
+    await tester.pumpAndSettle();
+
+    // The editor is seeded from the recap text when no live row exists.
+    final editor = tester.widget<TextField>(find.byKey(const Key('memory_review_editor_mem-missing')));
+    expect(editor.controller?.text, 'Prefers async standups');
+
+    await tester.enterText(find.byKey(const Key('memory_review_editor_mem-missing')), 'Prefers written standups');
+    await tester.tap(find.byKey(const Key('memory_review_save_mem-missing')));
+    await tester.pumpAndSettle();
+
+    expect(edits, {'mem-missing': 'Prefers written standups'});
+    expect(find.text('Updated.'), findsOneWidget);
+    expect(find.text('Prefers written standups'), findsOneWidget);
+    expect(find.byKey(const Key('memory_review_editor_mem-missing')), findsNothing);
+  });
+
+  testWidgets('a failed review on an unresolved row reverts and shows the error line', (tester) async {
+    final provider = _provider(
+      rows: const [],
+      reviewMemoryRequest: (id, value) async => false,
+    );
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    await tester.pumpWidget(_harness(provider, [_item('mem-missing')]));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('memory_review_reject_mem-missing')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('memory_review_error_mem-missing')), findsOneWidget);
+    expect(find.text("Dropped. I'll avoid facts like this."), findsNothing);
+    // The controls come back so the user can try again.
+    final reject = tester.widget<InkWell>(find.byKey(const Key('memory_review_reject_mem-missing')));
+    expect(reject.onTap, isNotNull);
+  });
+
+  testWidgets('a truncated bulk list does not disable the recap rows', (tester) async {
+    // GET /v3/memories can return X-Omi-List-Truncated; the provider stops
+    // paging there, so the recap ids can be permanently absent from the list.
+    final provider = MemoriesProvider(
+      fetchMemoriesRequest: ({int limit = 100, int offset = 0, bool thisDeviceOnly = false}) async =>
+          const GetMemoriesResult([], true, truncated: true),
+      fetchLedgerHistoryRequest: ({int limit = 500, int offset = 0}) async =>
+          const GetLedgerHistoryResult([], supported: true),
+      reviewMemoryRequest: (id, value) async => true,
+      editMemoryRequest: (id, value) async => const EditMemoryResult(persisted: true),
+    );
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    await tester.pumpWidget(_harness(provider, [_item('mem-beyond')]));
+    await tester.pumpAndSettle();
+
+    expect(provider.memories, isEmpty);
+    final accept = tester.widget<InkWell>(find.byKey(const Key('memory_review_accept_mem-beyond')));
+    expect(accept.onTap, isNotNull);
   });
 }

--- a/app/test/widgets/memory_review_card_test.dart
+++ b/app/test/widgets/memory_review_card_test.dart
@@ -445,4 +445,82 @@ void main() {
     final accept = tester.widget<InkWell>(find.byKey(const Key('memory_review_accept_mem-beyond')));
     expect(accept.onTap, isNotNull);
   });
+
+  testWidgets('a persisted verdict on an unresolved row survives card State recreation', (tester) async {
+    // A chat-list card scrolled out and back rebuilds its State; the settled
+    // verdict lives on the provider, so the recreated card must not re-offer
+    // a vote the server already recorded.
+    final provider = _provider(rows: const [], reviewMemoryRequest: (id, value) async => true);
+    addTearDown(provider.dispose);
+    await provider.loadMemories();
+
+    await tester.pumpWidget(_harness(provider, [_item('mem-missing')]));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('memory_review_accept_mem-missing')));
+    await tester.pumpAndSettle();
+    expect(find.text("Confirmed. I'll act on this."), findsOneWidget);
+
+    // Recreate the State exactly as scrolling away and back does.
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    await tester.pumpWidget(_harness(provider, [_item('mem-missing')]));
+    await tester.pumpAndSettle();
+
+    expect(find.text("Confirmed. I'll act on this."), findsOneWidget);
+    expect(find.byKey(const Key('memory_review_accept_mem-missing')), findsNothing);
+  });
+
+  testWidgets('a failed hydration load is retried and resolves once the backend recovers', (tester) async {
+    var fetches = 0;
+    final provider = MemoriesProvider(
+      fetchMemoriesRequest: ({int limit = 100, int offset = 0, bool thisDeviceOnly = false}) async {
+        fetches++;
+        if (fetches == 1) {
+          return const GetMemoriesResult([], true,
+              statusCode: 503, failureReason: MemoriesFetchFailureReason.httpError);
+        }
+        return GetMemoriesResult([_memory(id: 'mem-flaky')], true);
+      },
+      fetchLedgerHistoryRequest: ({int limit = 500, int offset = 0}) async =>
+          const GetLedgerHistoryResult([], supported: true),
+      reviewMemoryRequest: (id, value) async => true,
+      editMemoryRequest: (id, value) async => const EditMemoryResult(persisted: true),
+    );
+    addTearDown(provider.dispose);
+
+    await tester.pumpWidget(_harness(provider, [_item('mem-flaky')]));
+    await tester.pumpAndSettle();
+
+    // The first ask failed; the card observed the settled failure on rebuild
+    // and spent its capped retry, which resolved the row.
+    expect(fetches, 2);
+    expect(provider.loadFailed, isFalse);
+    expect(provider.memories.single.id, 'mem-flaky');
+  });
+
+  testWidgets('a persistently failing backend is not retried past the cap', (tester) async {
+    var fetches = 0;
+    final provider = MemoriesProvider(
+      fetchMemoriesRequest: ({int limit = 100, int offset = 0, bool thisDeviceOnly = false}) async {
+        fetches++;
+        return const GetMemoriesResult([], true, statusCode: 503, failureReason: MemoriesFetchFailureReason.httpError);
+      },
+      fetchLedgerHistoryRequest: ({int limit = 500, int offset = 0}) async =>
+          const GetLedgerHistoryResult([], supported: true),
+      reviewMemoryRequest: (id, value) async => true,
+      editMemoryRequest: (id, value) async => const EditMemoryResult(persisted: true),
+    );
+    addTearDown(provider.dispose);
+
+    await tester.pumpWidget(_harness(provider, [_item('mem-down')]));
+    await tester.pumpAndSettle();
+
+    // First ask plus one capped retry; the budget is spent and the row stays
+    // actionable by id instead of fetching forever.
+    expect(fetches, 2);
+    expect(provider.loadFailed, isTrue);
+    final accept = tester.widget<InkWell>(find.byKey(const Key('memory_review_accept_mem-down')));
+    expect(accept.onTap, isNotNull);
+  });
 }


### PR DESCRIPTION
## What

The daily-summary **Things I learned today** card rendered ✓ Right / ✗ Wrong / Fix chrome that did nothing whenever the referenced memory was not in `MemoriesProvider.memories` — which is the common path: nothing at app start initialises the provider, `GET /v3/memories` can return `X-Omi-List-Truncated`, and there is no GET-by-id on this client. `reviewMemory()` also refused to persist before sending the request when the id was not in the loaded list.

## Root cause

`app/lib/widgets/components/memory_review_card.dart` gated `onTap` on list membership (`enabled = memory != null && ...`) although every mutation the card triggers is id-addressed (`POST /v3/memories/{id}/review`, `PATCH /v3/memories/{id}`). A cache-miss id therefore rendered dead chrome instead of an actionable control, and `MemoriesProvider.reviewMemory` duplicated that mistake server-side of the tap (`if (index == -1) return false` before the request).

## Change

- **Card** (`memory_review_card.dart`): a row with a known `memoryId` is actionable from the item's identity (id + recap text). Accept/reject/edit still go through the provider's single-owner `reviewMemory` / `editMemory` — no second mutation owner. A write that fails still shows "Couldn't save, try again" and reverts the optimistic paint; a write that succeeds while the row is unresolved settles it for the session (`_settledReviews`, mirroring the existing `_settledEdits` pattern for ledger replacements), and the live memory keeps winning once it answers for the id. `_RowState.loading` dead chrome is deleted; when no `MemoriesProvider` exists in the tree the controls do not render at all.
- **Provider** (`memories_provider.dart`): `reviewMemory()` persists by id when the row is not in the loaded list (nothing local to roll back). New `hasLoaded` flag distinguishes "never fetched" from "fetch in flight", because `_loading` starts `true` before any request exists; `clearUserData()` resets it.
- **Hydrate retry**: the static `_requestedIds` one-shot — which permanently skipped hydration after a single failed attempt — is replaced by capped per-id attempts (max 2, retry only while loads keep failing), so a failed first fetch no longer blacklists the id for the process.

## What was deliberately NOT changed

Recap text behavior is untouched: daily-summary LLM prompts, generator output, `knowledge_nuggets`, highlights, overview, headline, decisions, questions, tasks, section titles/order, the Learnings section, `memories_learned` selection (`backend/utils/memory/learned_today.py`), and the nightly job payload. No `GET /v3/memories/{id}` endpoint was added. Desktop, backend, and deploy paths are untouched.

## Verification (base `f5f424a8e282b8845a810cf58f23de9f7ce9a126` = origin/main)

- `bash app/test.sh` — **1723 passed, 5 skipped, 0 failed** (includes the new tests below)
- `bash app/scripts/analyze_ratchet.sh` — **passed** (every metric at or below baseline; `avoid_print` improved 24 vs 29)
- `flutter test test/widgets/memory_review_card_test.dart test/widgets/daily_summary_detail_page_test.dart test/widgets/chat_content_block_test.dart test/providers/` — **355 passed**

Behavior tests added/inverted (the old test asserting disabled controls for unresolved ids encoded the bug and is replaced):

- a known `memoryId` **not** in the provider list has non-null accept/reject/fix `onTap`, and a tap hits `reviewMemoryRequest` with that id, then the row shows the settled verdict
- a Fix on an unresolved row seeds the editor from the recap text and `PATCH`es by id; the row shows "Updated." with the corrected text
- a failed review on an unresolved row reverts and shows the error line with controls re-enabled
- a truncated bulk list (`X-Omi-List-Truncated`) does not disable the recap rows
- daily-summary detail: `memoriesLearned` rows are tappable on a cold provider (`loading == true`, id never loaded) and the tap persists by id
- all pre-existing settled-state tests (live row present: optimistic paint, rollback, cross-device verdict, ledger replacement id) pass unchanged

## Failure class

Failure-Class: new

New semantic class `FC-control-affordance-gated-on-cache-membership`, definition added in this PR (`.github/failure-classes/FC-control-affordance-gated-on-cache-membership.json`). The contract that failed: **a rendered control's tappability must gate on the capability of its action path (here, id-addressed mutation through the single provider owner), not on membership in a client-side list cache the action does not depend on.** The nearest existing classes do not cover it — `FC-split-mutation-authority` (two owners for one state transition; this PR removes a gate, the owner was already single) and `FC-client-rederives-authority-verdict` (client re-derives a server verdict; no server verdict is involved here). Guard artifact: the cold-start and truncated-list widget tests in `app/test/widgets/memory_review_card_test.dart` and `app/test/widgets/daily_summary_detail_page_test.dart`.

Closes SCA-451


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

