### PR TITLE
fix(desktop): put attached spine rows on the same leading grid as loose ones

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineModel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineModel.swift
@@ -8,13 +8,14 @@
 //  actually happened in, newest first.
 //
 //  **Conversations stay dominant and every extracted record stays first-class.** Memories, tasks,
-//  and screen moments
-//  render *indented under* the conversation that produced them, which is what keeps a conversation
-//  the thing your eye lands on. They are not children of a card, though: they are rows of the same
-//  spine, so filtering to one kind is a real filter over the whole stream rather than a different
-//  screen. When one kind is soloed the indent collapses and every row states its own time (see
-//  `SpineRow.isAttached` and `SpineComposer.compose`), so the spine stays a clock rather than
-//  degrading into a flat list.
+//  and screen moments render *close under* the conversation that produced them — tighter air, no
+//  timestamp of their own — which is what keeps a conversation the thing your eye lands on. They
+//  are not children of a card, though: they are rows of the same spine, and every row sits on the
+//  same leading grid, so a strip of frames starts at the same left edge whether it hangs under a
+//  conversation or stands on its own. Filtering to one kind is a real filter over the whole stream
+//  rather than a different screen. When one kind is soloed the closeness collapses and every row
+//  states its own time (see `SpineRow.isAttached` and `SpineComposer.compose`), so the spine stays
+//  a clock rather than degrading into a flat list.
 //
 //  Everything here is a pure function of its inputs, deliberately: the composition is the part with
 //  rules in it (what attaches to what, what a day header counts, where the brain map is filed), and
@@ -245,8 +246,9 @@ struct SpineRow: Identifiable, Equatable {
   let anchor: Date
   /// Never `.everything`: a row is one kind of thing.
   let kind: SpineKind
-  /// True when this row was produced by the conversation directly above it. Indented while the
-  /// whole spine is shown; flattened — and given its own timestamp — the moment one kind is soloed.
+  /// True when this row was produced by the conversation directly above it. Set close under it —
+  /// on the same leading grid as every other row — while the whole spine is shown; flattened, and
+  /// given its own timestamp, the moment one kind is soloed.
   let isAttached: Bool
   let content: Content
 
@@ -631,7 +633,7 @@ enum SpineComposer {
 
     // Re-seat every attached row directly under its conversation. Sorting by anchor alone would
     // interleave them with anything that happened mid-conversation, which is the exact reading
-    // failure the indent exists to prevent.
+    // failure the attachment exists to prevent.
     rows = reseatAttachments(rows)
 
     // The brain map is filed under memories at the foot of the day, never as a destination.

--- a/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineRowViews.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineRowViews.swift
@@ -34,9 +34,6 @@ enum SpineMetrics {
   static let gutterWidth: CGFloat = 68
   /// Between the gutter's hairline and the content.
   static let gutterGap: CGFloat = 16
-  /// How far an attached row is indented past the conversation that produced it. Zero when one kind
-  /// is soloed, which is what turns the spine back into a flat clock.
-  static let attachmentIndent: CGFloat = 12
   /// The strip's thumbnail. 118 × 74 is 16:10, which is the shape of the screens these came off.
   static let thumbnailWidth: CGFloat = 118
   static let thumbnailHeight: CGFloat = 74
@@ -93,8 +90,8 @@ enum SpineMetrics {
 /// One spine row: its place on the clock, then whatever it is.
 struct SpineRowView: View {
   let row: SpineRow
-  /// True while the whole spine is shown, so attached rows indent. Soloed rows pass `false` and
-  /// state their own time instead.
+  /// True while the whole spine is shown, so an attached row tucks in close under the conversation
+  /// above it. Soloed rows pass `false` and state their own time instead.
   let showsIndent: Bool
   let onOpenConversation: (ServerConversation) -> Void
   let onOpenMemory: (SpineMemory) -> Void
@@ -108,8 +105,9 @@ struct SpineRowView: View {
   /// the moment it is soloed it needs one, because there is no longer anything above it to inherit.
   private var showsTimestamp: Bool { !row.isAttached }
 
-  /// True while this row is a child of the conversation above it — which decides both how far it
-  /// indents and how much air it gets, because those are the same statement made twice.
+  /// True while this row is a child of the conversation above it, which decides how much air it
+  /// gets. Every row sits on the one leading grid — attachment is air and the rail, never a
+  /// horizontal offset, so the same kind of row reads as the same kind of row wherever it lands.
   private var isNested: Bool { row.isAttached && showsIndent }
 
   /// A card row starts with its own padding before any type; an inline row starts with the type.
@@ -125,7 +123,7 @@ struct SpineRowView: View {
     HStack(alignment: .top, spacing: 0) {
       gutter
       content
-        .padding(.leading, SpineMetrics.gutterGap + (isNested ? SpineMetrics.attachmentIndent : 0))
+        .padding(.leading, SpineMetrics.gutterGap)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
     // The whole rhythm, in one place. Every row's content view draws from its own top edge, so the

--- a/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineStore.swift
@@ -29,7 +29,7 @@ final class SpineStore: ObservableObject {
   @Published private(set) var matchCount = 0
 
   /// Which kind the shell's chips have soloed. Read by the stream to decide whether attached rows
-  /// still indent.
+  /// still tuck in close under their conversation.
   private(set) var kind: SpineKind = .everything
 
   /// The calendar the days were composed in. Recap lookups must format `SpineDay.id` with this

--- a/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineStream.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineStream.swift
@@ -7,7 +7,7 @@
 //  (`queryShellMatchCount`), which is the whole of its contract with the shell.
 //
 //  **What it owns is the reading order.** One merged reverse-chronological stream grouped by day, with
-//  the conversation dominant and the memories and frames it produced indented beneath it — and an hour
+//  the conversation dominant and the memories and frames it produced attached beneath it — and an hour
 //  rail beside it running the same direction the list does.
 //
 //  A day can be **folded shut** from its own header. Folding is presentation and never a filter: the

--- a/desktop/macos/Desktop/Tests/SpineCompositionTests.swift
+++ b/desktop/macos/Desktop/Tests/SpineCompositionTests.swift
@@ -3,7 +3,7 @@
 //
 //  Every assertion here is about a decision that is otherwise only checkable by looking at a
 //  screenshot: what attaches to what, what a day header counts, what a soloed filter does to the
-//  indent, and which way the hour rail runs. Those are exactly the rules a later change breaks
+//  attachment, and which way the hour rail runs. Those are exactly the rules a later change breaks
 //  silently, so they are held here rather than in a rendered image.
 //
 
@@ -124,7 +124,7 @@ final class SpineCompositionTests: XCTestCase {
     XCTAssertEqual(summary.memoryCount, 1)
     XCTAssertEqual(summary.momentCount, 1, "only the frame inside the window attaches")
 
-    // Its memories and its frames follow it immediately, indented.
+    // Its memories and its frames follow it immediately, attached.
     XCTAssertEqual(rows[conversationIndex + 1].kind, .memories)
     XCTAssertTrue(rows[conversationIndex + 1].isAttached)
     XCTAssertEqual(rows[conversationIndex + 2].kind, .screen)
@@ -260,7 +260,7 @@ final class SpineCompositionTests: XCTestCase {
 
   // MARK: - Solo
 
-  func testSoloingOneKindCollapsesTheIndentSoEveryRowKeepsItsOwnTime() {
+  func testSoloingOneKindCollapsesTheAttachmentSoEveryRowKeepsItsOwnTime() {
     let start = date(6, 20, 0)
     let composed = SpineComposer.compose(
       conversations: [conversation(id: "c1", start: start)],
@@ -270,7 +270,7 @@ final class SpineCompositionTests: XCTestCase {
     )
     XCTAssertTrue(
       composed[0].rows.contains { $0.kind == .memories && $0.isAttached },
-      "unfiltered, the memory is indented under its conversation")
+      "unfiltered, the memory is attached under its conversation")
 
     let soloed = SpineComposer.filter(composed, kind: .memories, query: "")
     XCTAssertFalse(

--- a/desktop/macos/Desktop/Tests/SpineRowLeadingGridTests.swift
+++ b/desktop/macos/Desktop/Tests/SpineRowLeadingGridTests.swift
@@ -1,0 +1,105 @@
+//
+//  SpineRowLeadingGridTests.swift — one leading grid for every row.
+//
+//  Attachment on the spine is air and the rail, never a horizontal offset: a strip of frames under
+//  its conversation has to start at the same left edge as a strip standing on its own, or the same
+//  kind of row reads as two different grids a group apart — the drift a user reads as misaligned
+//  padding. The invariant is asserted on the mounted view tree, because it is a fact about frames,
+//  not about constants.
+//
+
+import AppKit
+import SwiftUI
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class SpineRowLeadingGridTests: XCTestCase {
+  // MARK: - Fixtures
+
+  private func moment(_ id: Int64) -> SpineMoment {
+    SpineMoment(
+      id: id,
+      timestamp: Date(timeIntervalSince1970: 1_785_000_000),
+      appName: "Cursor",
+      windowTitle: "omni",
+      imagePath: nil,
+      videoChunkPath: nil,
+      frameOffset: nil)
+  }
+
+  private func momentsRow(isAttached: Bool) -> SpineRow {
+    SpineRow(
+      id: isAttached ? "conv-shot:1" : "shot:1",
+      anchor: Date(timeIntervalSince1970: 1_785_000_000),
+      kind: .screen,
+      isAttached: isAttached,
+      content: .moments(shown: [moment(1)], total: 1),
+      searchText: "cursor")
+  }
+
+  // MARK: - The grid
+
+  func testAnAttachedMomentStripStartsOnTheSameLeftGridAsALooseOne() throws {
+    let loose = try stripLeadingX(row: momentsRow(isAttached: false))
+    let attached = try stripLeadingX(row: momentsRow(isAttached: true))
+
+    XCTAssertGreaterThan(loose, 0, "the strip should sit past the gutter")
+    XCTAssertEqual(
+      attached, loose, accuracy: 0.5,
+      "a strip attached to the conversation above it must share the leading grid of a loose strip; "
+        + "attachment is air and the rail, not a horizontal offset")
+  }
+
+  // MARK: - Mounting
+
+  /// Lays the row out at the panel's real width and returns the strip's leading x.
+  ///
+  /// The row mounts in an ordered (but parked, click-through) window: SwiftUI only builds its native
+  /// hierarchy — the part whose frames this test reads — once the view has window backing.
+  private func stripLeadingX(row: SpineRow) throws -> CGFloat {
+    let view = SpineRowView(
+      row: row,
+      showsIndent: true,
+      onOpenConversation: { _ in },
+      onOpenMemory: { _ in },
+      onToggleTask: { _ in },
+      onToggleStar: { _ in },
+      onOpenMoment: { _, _ in },
+      onShowAllMoments: {},
+      onOpenBrainMap: {})
+
+    let host = NSHostingView(rootView: view.frame(width: 900))
+    host.frame = NSRect(x: 0, y: 0, width: 900, height: 160)
+    let window = NSWindow(
+      contentRect: host.frame,
+      styleMask: [.borderless],
+      backing: .buffered,
+      defer: false)
+    window.contentView = host
+    NonintrusiveTestWindow.orderIn(window)
+    defer {
+      window.orderOut(nil)
+      window.contentView = nil
+    }
+    host.layoutSubtreeIfNeeded()
+
+    let scrollViews = Self.descendants(of: host).compactMap { $0 as? NSScrollView }
+    let strip = try XCTUnwrap(
+      scrollViews.min(by: { $0.frame.minX < $1.frame.minX }),
+      "the mounted moments row should contain a scroll-backed strip")
+    // Frames are parent-relative; the grid lives in the host's coordinates.
+    return host.convert(strip.frame, from: strip.superview).minX
+  }
+
+  private static func descendants(of view: NSView) -> [NSView] {
+    var result: [NSView] = []
+    var stack = view.subviews
+    while let next = stack.popLast() {
+      result.append(next)
+      stack.append(contentsOf: next.subviews)
+    }
+    return result
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260904-spine-one-leading-grid.json
+++ b/desktop/macos/changelog/unreleased/20260904-spine-one-leading-grid.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed screenshots sitting at a slightly different left edge than the rest of the activity timeline when they follow a conversation"
+}


### PR DESCRIPTION
## What changed and why

On the Activity spine, a strip of screen moments hanging under its conversation sat 12 pt right of the same strip standing on its own, because `SpineRowView` added `SpineMetrics.attachmentIndent` to the leading padding of attached rows. The same kind of row read as two different grids a group apart — a screenshot row's left edge moved depending on whether its group held a conversation. The same offset applied to attached memories and tasks.

Attachment stays legible without the offset: the tighter `attachedGap` above the row, the conversation's timestamp speaking for it, and no rail node. The indent is gone, so every row — conversation card, memories, tasks, strips — starts at `gutter + gutterGap`. Doc comments that described the indent now describe the one leading grid.

## Product invariants affected

none

## How it was verified

- Reproduced the user-visible geometry on a named bundle built from this branch (`omi-activity-alignment`, macOS 26, 2× display): seeded one strip inside a conversation's window (renders attached, subtitle "2 screen moments") and one outside all windows (renders standalone with its own timestamp). In-process window capture: the loose strip's tile left edge measures 582 px and the attached strip's tile left edge 582 px — Δ 0.0 pt. On the pre-fix build the same comparison measures 24 px = 12.0 pt, exactly `attachmentIndent`.
- `./scripts/agent-logic-harness.sh --cross-surface-smoke` green.
- `./scripts/swift-format-wrapper.sh lint` clean on changed files.

## Tests

New `Desktop/Tests/SpineRowLeadingGridTests.swift` mounts `SpineRowView` in a real `NSHostingView` (ordered, parked window) and asserts an attached moments strip and a loose moments strip report the same leading x. With the indent restored the test fails at 96.0 vs 84.0; with this fix it passes at 84.0/84.0. Full spine scope: `xcrun swift test --filter Spine` — 60 tests, 0 failures.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

