### PR TITLE
test(rn): Home timeline order across second units

### DIFF
--- a/react-native/__tests__/useDesktopReads.test.tsx
+++ b/react-native/__tests__/useDesktopReads.test.tsx
@@ -140,6 +140,59 @@ async function renderReads(props: {enabled: boolean}) {
 beforeEach(() => {
   readsMock.mockReset();
 });
+
+test('orders Home timeline by normalized conversation and memory time', async () => {
+  // Port of superseded #12141 — memories are epoch seconds; conversations are ms.
+  const olderConversation = conversationItem('older-conversation', 'Older');
+  olderConversation.startedAt = '2026-09-01T10:00:00.000Z';
+  olderConversation.createdAt = '2026-09-01T10:00:00.000Z';
+  const newerConversation = conversationItem('newer-conversation', 'Newer');
+  newerConversation.startedAt = '2026-09-03T10:00:00.000Z';
+  newerConversation.createdAt = '2026-09-03T10:00:00.000Z';
+  const memorySeconds = Math.floor(
+    new Date('2026-09-02T12:00:00.000Z').getTime() / 1000,
+  );
+  const memory = {
+    kind: 'memory' as const,
+    id: 'mid-memory',
+    title: 'Memory',
+    summary: 'Memory',
+    searchableText: 'Memory',
+    citations: [] as never[],
+    timestamp: memorySeconds,
+    provenance: {
+      label: null,
+      synthesisVersion: 'v1',
+      inputDigest: 'a',
+      outputDigest: 'b',
+    },
+  };
+  const page = {
+    windowStatus: 'complete' as const,
+    complete: true,
+    hasMore: false,
+    nextCursor: null,
+    completenessStatus: 'complete' as const,
+    reasons: [] as string[],
+  };
+  readsMock.mockResolvedValue({
+    conversations: {
+      status: 'success',
+      value: {items: [olderConversation, newerConversation], page},
+    },
+    memories: {status: 'success', value: {items: [memory], page}},
+    tasks: {status: 'success', value: {items: [], page}},
+  });
+
+  const reads = await renderReads({enabled: true});
+  expect(reads.latest().reads.map(item => item.id)).toEqual([
+    'newer-conversation',
+    'mid-memory',
+    'older-conversation',
+  ]);
+  reads.unmount();
+});
+
 test('a successful refresh inside the live session lands as saved rows', async () => {
   readsMock.mockResolvedValue(successOutcomes(['Account A conversation']));
   const reads = await renderReads({enabled: true});
@@ -236,6 +289,9 @@ test('a retry exposes a dead session after successful reads', async () => {
 
   expect(reads.latest().readOutcomes).toEqual(errorOutcomes);
   expect(reads.latest().reads).toEqual([]);
+  // Non-transient auth failures replace prior rows — the shell must not claim
+  // it is still "showing saved data" once those rows are gone.
+  expect(reads.latest().readsPhase).toBe('unavailable');
   reads.unmount();
 });
 


### PR DESCRIPTION
## Summary
- Ports **only** the regression test from superseded draft #12141 onto current `v5`.
- Tip already sorts Home via `projectionTimestamp` in `useDesktopReads` (memory epoch seconds ×1000). This adds coverage so mixed-unit ordering cannot regress.
- No product code changes. Whole-PR rebase intentionally not done.

## Test plan
- [x] `bun run --cwd react-native test -- --runInBand __tests__/useDesktopReads.test.tsx` (9 passing)
- [x] Pre-push `bun run check` on push

Follow-up to closed #12141 (Max: close as superseded + cherry-pick test only).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime behavior modifications.
> 
> **Overview**
> This PR is **tests only**—no changes to `useDesktopReads` or other product code.
> 
> It adds a regression test ported from superseded #12141 that asserts the Home timeline sorts **conversations** (ISO/ms) and **memories** (epoch seconds) into one chronological order via normalized `projectionTimestamp`—expecting `newer-conversation`, then `mid-memory`, then `older-conversation`.
> 
> It also tightens the “retry exposes a dead session after successful reads” case: after a refresh returns non-transient auth errors and clears rows, **`readsPhase` must be `unavailable`**, not a “saved data” phase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f67a8c045c8ba6598828c078ce592d5237102582. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->