### PR TITLE
fix(backend): pin pyarrow 19.0.1 for GCP buildpack manylinux2014 (#12758)

### DIFF
--- a/backend/pylock.macos-x86_64.toml
+++ b/backend/pylock.macos-x86_64.toml
@@ -1089,6 +1089,8 @@ version = "0.2.3"
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", upload-time = 2024-07-21T12:58:21Z, size = 19752, hashes = { sha256 = "5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", upload-time = 2024-07-21T12:58:20Z, size = 11842, hashes = { sha256 = "1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0" } }]
 
+# TODO(#12758): pyarrow pinned at 19.0.1 for GCP buildpack/rmgpgab manylinux2014
+# (23.x is manylinux_2_28-only → sdist fail). Drop when trigger uses Dockerfile/uv.
 [[packages]]
 name = "pyarrow"
 version = "19.0.1"

--- a/backend/pylock.macos-x86_64.toml
+++ b/backend/pylock.macos-x86_64.toml
@@ -1091,9 +1091,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593
 
 [[packages]]
 name = "pyarrow"
-version = "23.0.1"
-sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", upload-time = 2026-02-16T10:14:12Z, size = 1167336, hashes = { sha256 = "b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/bf/4a/1472c00392f521fea03ae93408bf445cc7bfa1ab81683faf9bc188e36629/pyarrow-23.0.1-cp311-cp311-macosx_12_0_x86_64.whl", upload-time = 2026-02-16T10:09:11Z, size = 35850050, hashes = { sha256 = "0ae6e17c828455b6265d590100c295193f93cc5675eb0af59e49dbd00d2de350" } }]
+version = "19.0.1"
+sdist = { url = "https://files.pythonhosted.org/packages/7f/09/a9046344212690f0632b9c709f9bf18506522feb333c894d0de81d62341a/pyarrow-19.0.1.tar.gz", upload-time = 2025-02-18T18:55:57Z, size = 1129437, hashes = { sha256 = "3bf266b485df66a400f282ac0b6d1b500b9d2ae73314a153dbe97d6d5cc8a99e" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/13/12/428861540bb54c98a140ae858a11f71d041ef9e501e6b7eb965ca7909505/pyarrow-19.0.1-cp311-cp311-macosx_12_0_x86_64.whl", upload-time = 2025-02-18T18:52:25Z, size = 32135613, hashes = { sha256 = "7a544ec12de66769612b2d6988c36adc96fb9767ecc8ee0a4d270b10b1c51e00" } }]
 
 [[packages]]
 name = "pyasn1"

--- a/backend/pylock.macos.toml
+++ b/backend/pylock.macos.toml
@@ -1072,6 +1072,8 @@ version = "0.2.3"
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", upload-time = 2024-07-21T12:58:21Z, size = 19752, hashes = { sha256 = "5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", upload-time = 2024-07-21T12:58:20Z, size = 11842, hashes = { sha256 = "1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0" } }]
 
+# TODO(#12758): pyarrow pinned at 19.0.1 for GCP buildpack/rmgpgab manylinux2014
+# (23.x is manylinux_2_28-only → sdist fail). Drop when trigger uses Dockerfile/uv.
 [[packages]]
 name = "pyarrow"
 version = "19.0.1"

--- a/backend/pylock.macos.toml
+++ b/backend/pylock.macos.toml
@@ -1074,9 +1074,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593
 
 [[packages]]
 name = "pyarrow"
-version = "23.0.1"
-sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", upload-time = 2026-02-16T10:14:12Z, size = 1167336, hashes = { sha256 = "b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/b0/41/8e6b6ef7e225d4ceead8459427a52afdc23379768f54dd3566014d7618c1/pyarrow-23.0.1-cp311-cp311-macosx_12_0_arm64.whl", upload-time = 2026-02-16T10:09:03Z, size = 34302230, hashes = { sha256 = "6f0147ee9e0386f519c952cc670eb4a8b05caa594eeffe01af0e25f699e4e9bb" } }]
+version = "19.0.1"
+sdist = { url = "https://files.pythonhosted.org/packages/7f/09/a9046344212690f0632b9c709f9bf18506522feb333c894d0de81d62341a/pyarrow-19.0.1.tar.gz", upload-time = 2025-02-18T18:55:57Z, size = 1129437, hashes = { sha256 = "3bf266b485df66a400f282ac0b6d1b500b9d2ae73314a153dbe97d6d5cc8a99e" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/a0/55/f1a8d838ec07fe3ca53edbe76f782df7b9aafd4417080eebf0b42aab0c52/pyarrow-19.0.1-cp311-cp311-macosx_12_0_arm64.whl", upload-time = 2025-02-18T18:52:20Z, size = 30713987, hashes = { sha256 = "cc55d71898ea30dc95900297d191377caba257612f384207fe9f8293b5850f90" } }]
 
 [[packages]]
 name = "pyasn1"

--- a/backend/pylock.runtime.toml
+++ b/backend/pylock.runtime.toml
@@ -1055,9 +1055,12 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593
 
 [[packages]]
 name = "pyarrow"
-version = "23.0.1"
-sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", upload-time = 2026-02-16T10:14:12Z, size = 1167336, hashes = { sha256 = "b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/0b/62/96459ef5b67957eac38a90f541d1c28833d1b367f014a482cb63f3b7cd2d/pyarrow-23.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", upload-time = 2026-02-16T10:09:25Z, size = 47562811, hashes = { sha256 = "26d50dee49d741ac0e82185033488d28d35be4d763ae6f321f97d1140eb7a0e9" } }]
+version = "19.0.1"
+sdist = { url = "https://files.pythonhosted.org/packages/7f/09/a9046344212690f0632b9c709f9bf18506522feb333c894d0de81d62341a/pyarrow-19.0.1.tar.gz", upload-time = 2025-02-18T18:55:57Z, size = 1129437, hashes = { sha256 = "3bf266b485df66a400f282ac0b6d1b500b9d2ae73314a153dbe97d6d5cc8a99e" } }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/7a/845d151bb81a892dfb368bf11db584cf8b216963ccce40a5cf50a2492a18/pyarrow-19.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", upload-time = 2025-02-18T18:52:36Z, size = 42178045, hashes = { sha256 = "f24faab6ed18f216a37870d8c5623f9c044566d75ec586ef884e13a02a9d62c5" } },
+    { url = "https://files.pythonhosted.org/packages/b8/82/20f3c290d6e705e2ee9c1fa1d5a0869365ee477e1788073d8b548da8b64c/pyarrow-19.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", upload-time = 2025-02-18T18:52:48Z, size = 42084055, hashes = { sha256 = "49a3aecb62c1be1d822f8bf629226d4a96418228a42f5b40835c1f10d42e4db6" } },
+]
 
 [[packages]]
 name = "pyasn1"

--- a/backend/pylock.runtime.toml
+++ b/backend/pylock.runtime.toml
@@ -1053,6 +1053,8 @@ version = "0.2.3"
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", upload-time = 2024-07-21T12:58:21Z, size = 19752, hashes = { sha256 = "5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", upload-time = 2024-07-21T12:58:20Z, size = 11842, hashes = { sha256 = "1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0" } }]
 
+# TODO(#12758): pyarrow pinned at 19.0.1 for GCP buildpack/rmgpgab manylinux2014
+# (23.x is manylinux_2_28-only → sdist fail). Drop when trigger uses Dockerfile/uv.
 [[packages]]
 name = "pyarrow"
 version = "19.0.1"

--- a/backend/pylock.toml
+++ b/backend/pylock.toml
@@ -1077,6 +1077,8 @@ version = "0.2.3"
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", upload-time = 2024-07-21T12:58:21Z, size = 19752, hashes = { sha256 = "5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", upload-time = 2024-07-21T12:58:20Z, size = 11842, hashes = { sha256 = "1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0" } }]
 
+# TODO(#12758): pyarrow pinned at 19.0.1 for GCP buildpack/rmgpgab manylinux2014
+# (23.x is manylinux_2_28-only → sdist fail). Drop when trigger uses Dockerfile/uv.
 [[packages]]
 name = "pyarrow"
 version = "19.0.1"

--- a/backend/pylock.toml
+++ b/backend/pylock.toml
@@ -1079,9 +1079,12 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593
 
 [[packages]]
 name = "pyarrow"
-version = "23.0.1"
-sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", upload-time = 2026-02-16T10:14:12Z, size = 1167336, hashes = { sha256 = "b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/0b/62/96459ef5b67957eac38a90f541d1c28833d1b367f014a482cb63f3b7cd2d/pyarrow-23.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", upload-time = 2026-02-16T10:09:25Z, size = 47562811, hashes = { sha256 = "26d50dee49d741ac0e82185033488d28d35be4d763ae6f321f97d1140eb7a0e9" } }]
+version = "19.0.1"
+sdist = { url = "https://files.pythonhosted.org/packages/7f/09/a9046344212690f0632b9c709f9bf18506522feb333c894d0de81d62341a/pyarrow-19.0.1.tar.gz", upload-time = 2025-02-18T18:55:57Z, size = 1129437, hashes = { sha256 = "3bf266b485df66a400f282ac0b6d1b500b9d2ae73314a153dbe97d6d5cc8a99e" } }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/7a/845d151bb81a892dfb368bf11db584cf8b216963ccce40a5cf50a2492a18/pyarrow-19.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", upload-time = 2025-02-18T18:52:36Z, size = 42178045, hashes = { sha256 = "f24faab6ed18f216a37870d8c5623f9c044566d75ec586ef884e13a02a9d62c5" } },
+    { url = "https://files.pythonhosted.org/packages/b8/82/20f3c290d6e705e2ee9c1fa1d5a0869365ee477e1788073d8b548da8b64c/pyarrow-19.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", upload-time = 2025-02-18T18:52:48Z, size = 42084055, hashes = { sha256 = "49a3aecb62c1be1d822f8bf629226d4a96418228a42f5b40835c1f10d42e4db6" } },
+]
 
 [[packages]]
 name = "pyasn1"

--- a/backend/pylock.windows.toml
+++ b/backend/pylock.windows.toml
@@ -1076,6 +1076,8 @@ version = "0.2.3"
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", upload-time = 2024-07-21T12:58:21Z, size = 19752, hashes = { sha256 = "5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42" } }
 wheels = [{ url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", upload-time = 2024-07-21T12:58:20Z, size = 11842, hashes = { sha256 = "1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0" } }]
 
+# TODO(#12758): pyarrow pinned at 19.0.1 for GCP buildpack/rmgpgab manylinux2014
+# (23.x is manylinux_2_28-only → sdist fail). Drop when trigger uses Dockerfile/uv.
 [[packages]]
 name = "pyarrow"
 version = "19.0.1"

--- a/backend/pylock.windows.toml
+++ b/backend/pylock.windows.toml
@@ -1078,9 +1078,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593
 
 [[packages]]
 name = "pyarrow"
-version = "23.0.1"
-sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", upload-time = 2026-02-16T10:14:12Z, size = 1167336, hashes = { sha256 = "b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/00/ca/db94101c187f3df742133ac837e93b1f269ebdac49427f8310ee40b6a58f/pyarrow-23.0.1-cp311-cp311-win_amd64.whl", upload-time = 2026-02-16T10:09:50Z, size = 27527698, hashes = { sha256 = "f00f993a8179e0e1c9713bcc0baf6d6c01326a406a9c23495ec1ba9c9ebf2919" } }]
+version = "19.0.1"
+sdist = { url = "https://files.pythonhosted.org/packages/7f/09/a9046344212690f0632b9c709f9bf18506522feb333c894d0de81d62341a/pyarrow-19.0.1.tar.gz", upload-time = 2025-02-18T18:55:57Z, size = 1129437, hashes = { sha256 = "3bf266b485df66a400f282ac0b6d1b500b9d2ae73314a153dbe97d6d5cc8a99e" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/ff/77/e62aebd343238863f2c9f080ad2ef6ace25c919c6ab383436b5b81cbeef7/pyarrow-19.0.1-cp311-cp311-win_amd64.whl", upload-time = 2025-02-18T18:52:54Z, size = 25283133, hashes = { sha256 = "008a4009efdb4ea3d2e18f05cd31f9d43c388aad29c636112c2966605ba33466" } }]
 
 [[packages]]
 name = "pyasn1"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -151,6 +151,9 @@ proto-plus==1.24.0
 protobuf==5.29.6
 ptyprocess==0.7.0
 pure_eval==0.2.3
+# TODO(#12758): pin for GCP Functions Framework buildpack (rmgpgab) — pyarrow>=23
+# only ships manylinux_2_28 wheels so the builder falls back to sdist and fails.
+# Remove this pin when rmgpgab is retargeted/disabled to backend/Dockerfile (uv/pylock).
 pyarrow==19.0.1
 pyasn1==0.6.4
 pyasn1_modules==0.4.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -151,7 +151,7 @@ proto-plus==1.24.0
 protobuf==5.29.6
 ptyprocess==0.7.0
 pure_eval==0.2.3
-pyarrow==23.0.1
+pyarrow==19.0.1
 pyasn1==0.6.4
 pyasn1_modules==0.4.0
 pycparser==2.22

--- a/backend/tests/unit/test_batch_upload_storage.py
+++ b/backend/tests/unit/test_batch_upload_storage.py
@@ -78,6 +78,7 @@ def merge():
     models_pkg.__path__ = []  # type: ignore[attr-defined]
     model_submods = {
         "models.audio_file": ["AudioFile"],
+        "models.client_processing": ["PROJECTION_FAMILY_FIELDS"],
         "models.conversation": ["Conversation"],
         "models.conversation_enums": ["ConversationStatus"],
         "models.structured": ["Structured"],

--- a/backend/tests/unit/test_merge_validation.py
+++ b/backend/tests/unit/test_merge_validation.py
@@ -79,6 +79,7 @@ def merge():
     models_pkg.__path__ = []  # type: ignore[attr-defined]
     model_submods = {
         "models.audio_file": ["AudioFile"],
+        "models.client_processing": ["PROJECTION_FAMILY_FIELDS"],
         "models.conversation": ["Conversation"],
         "models.conversation_enums": ["ConversationStatus"],
         "models.structured": ["Structured"],


### PR DESCRIPTION
## Summary

Stopgap / diagnosis PR for #12758 (`cloudbuild-other` / `rmgpgab` red on main).

Failure-Class: none

### Hypothesis

- The GCP GitHub App buildpack (`rmgpgab-omi-…`) installs `backend/requirements.txt` via Functions Framework / pip.
- `pyarrow==23.0.1` publishes **only** `manylinux_2_28` linux wheels for cp311 (no `manylinux2014` / `manylinux_2_17`).
- Older buildpack base images that expect manylinux2014 therefore fall back to the **sdist** and fail at `Building wheel for pyarrow`.
- The real Docker/`uv pip sync` path is separate and already OK with the checked-in pylocks; this pin targets the buildpack install path.

### Change

- Pin `pyarrow` `23.0.1` → `19.0.1` in `backend/requirements.txt` (last cp311 release with manylinux2014 wheels; confirmed on PyPI).
- Regenerated platform pylocks via `backend/scripts/update-python-lock.sh` so linux locks now list `manylinux_2_17_x86_64.manylinux2014_x86_64` (and still include `manylinux_2_28`).

### Still needed (not claimed fixed)

- Full GCP Cloud Build log currently needs IAM (`PERMISSION_DENIED` for undivisible@vk.com on `based-hardware`). This PR encodes the public-failure hypothesis only.
- Please confirm or disable the `rmgpgab` trigger once someone with GCP access can inspect it.
- Do **not** treat #12758 as closed until `cloudbuild-other` / `rmgpgab` is green on **main**.
- Refs #12758 (no auto-close keyword — issue stays open until main is green).

### Reviewer notes

- Watch whether `rmgpgab` / `cloudbuild-other` runs on this PR (it may be main-only). If it does, that is the signal for this stopgap.
- Dockerfile / `uv pip sync` path should remain unaffected aside from the intentional pyarrow downgrade in locks.
- Dependabot may try to bump pyarrow again — hold until `rmgpgab` is retargeted/disabled toward the Dockerfile/`uv` path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Downgrading pyarrow affects every backend install path (not only the buildpack) and may change Arrow/pandas behavior; the change is intentional but worth watching in production data paths.
> 
> **Overview**
> **Downgrades `pyarrow` from 23.0.1 to 19.0.1** across `backend/requirements.txt` and all regenerated `pylock*` files so the GCP Functions Framework / `rmgpgab` buildpack can install a wheel on **manylinux2014** instead of falling back to an sdist build that fails on older Linux images. Comments reference **#12758** and note the pin should be removed once that trigger uses Dockerfile/`uv`.
> 
> On Linux locks, **19.0.1** adds **`manylinux_2_17_x86_64.manylinux2014_x86_64`** wheels (alongside `manylinux_2_28` where applicable).
> 
> Two unit tests that stub `models.*` at import time now also mock **`models.client_processing.PROJECTION_FAMILY_FIELDS`** so modules that import it can load under the existing test harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f6283147252a42d7024cedc3da9202831a0aba7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->