### PR TITLE
fix(desktop): omi-type follow-ups (review fixes, red ease-out, no empty pastes)

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1531,12 +1531,16 @@ final class DesktopAutomationActionRegistry {
         let pcm16k = try? Data(contentsOf: URL(fileURLWithPath: path)),
         !pcm16k.isEmpty
       else { return ["error": "missing or unreadable 'pcm' file (expected raw s16le 16k mono)"] }
-      let paceMs = UInt64(params["pace_ms"] ?? "") ?? 0
-      let settleMs = UInt64(params["settle_ms"] ?? "") ?? 0
+      // Bounded so the nanosecond conversion below cannot trap on a typo.
+      let maxWaitMs: UInt64 = 10 * 60 * 1_000
+      let paceMs = min(UInt64(params["pace_ms"] ?? "") ?? 0, maxWaitMs)
+      let settleMs = min(UInt64(params["settle_ms"] ?? "") ?? 0, maxWaitMs)
       // Default 100 ms. Pass 342 to mimic what the CoreAudio IOProc hands a
       // 48 kHz device's capture after resampling — chunk size has already
-      // hidden one bug that only a real microphone showed.
-      let chunkSize = max(2, Int(params["chunk_bytes"] ?? "") ?? 3_200)
+      // hidden one bug that only a real microphone showed. Always a whole
+      // number of 16-bit samples, so an odd size cannot shear the PCM framing.
+      let requestedChunk = Int(params["chunk_bytes"] ?? "") ?? 3_200
+      let chunkSize = max(2, requestedChunk - requestedChunk % 2)
 
       var result = PushToTalkManager.shared.beginRealtimePushToTalkForAutomation()
       guard result["listening"] == "true" else { return result }

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -179,6 +179,8 @@ struct DesktopAutomationSnapshot: Codable, Sendable {
   var askOmiFocused: Bool
   var floatingBarFrame: String?
   var floatingBarVoiceListening: Bool
+  /// The current hold has been recognised as a dictation (the notch's red tint).
+  var floatingBarVoiceDictating: Bool
   var floatingBarVoiceResponseActive: Bool
   var floatingBarUsesNotchIsland: Bool
   var updatedAt: String
@@ -485,6 +487,7 @@ final class DesktopAutomationStateStore {
     askOmiFocused: false,
     floatingBarFrame: nil,
     floatingBarVoiceListening: false,
+    floatingBarVoiceDictating: false,
     floatingBarVoiceResponseActive: false,
     floatingBarUsesNotchIsland: false,
     updatedAt: ISO8601DateFormatter().string(from: Date())
@@ -583,6 +586,7 @@ private func liveAutomationSnapshotFromMainActor() async -> DesktopAutomationSna
       isAskOmiFocused: floating.isAskOmiFocused,
       frame: floating.frame,
       isVoiceListening: floating.isVoiceListening,
+      isVoiceDictating: floating.isVoiceDictating,
       isVoiceResponseActive: floating.isVoiceResponseActive,
       usesNotchIsland: floating.usesNotchIsland,
       isAppActive: NSApp.isActive
@@ -594,6 +598,7 @@ private func liveAutomationSnapshotFromMainActor() async -> DesktopAutomationSna
     snapshot.askOmiFocused = floating.isAskOmiFocused
     snapshot.floatingBarFrame = floating.frame
     snapshot.floatingBarVoiceListening = floating.isVoiceListening
+    snapshot.floatingBarVoiceDictating = floating.isVoiceDictating
     snapshot.floatingBarVoiceResponseActive = floating.isVoiceResponseActive
     snapshot.floatingBarUsesNotchIsland = floating.usesNotchIsland
     snapshot.isAppActive = floating.isAppActive

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ARCHITECTURE.md
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ARCHITECTURE.md
@@ -59,10 +59,15 @@ owns the dictate-or-ask decision and the delivery, and nothing else does.
      recognizer (`/v2/voice-message/transcribe`, `velma-2` first) with the
      on-screen keywords as vocabulary, bounded to 12 s; on failure, timeout,
      or an empty result, the on-device model. With no network only the
-     on-device model runs. A route that already produced a backend transcript
-     (omni STT, batch STT after a warm-wait) hands it in as `knownTranscript`
-     so the audio is not transcribed twice. Every fallback is recorded
-     (`area=voice_typing`).
+     on-device model runs, and a route that latched offline at key-down stays
+     offline even if a path comes back mid-hold. A route that already
+     produced a backend transcript (omni STT, batch STT after a warm-wait)
+     hands it in as `knownTranscript` so the audio is not transcribed twice.
+     Every fallback is recorded (`area=voice_typing`). The 12 s cap (and the
+     polisher's 6 s) is enforced at the boundary by `DeadlinedOperation`: a
+     request stuck before its first cancellation check is abandoned at the
+     cap, not waited for. Cancelling the turn cancels the transcription and
+     tries no fallback.
   2. **No chat corrector.** `PTTTranscriptContextualCorrector` is not run on
      a dictation. Its greeting rule respells the first word of "<word>, …"
      from on-screen text; live it turned "So, this is a test" into "Sil, …"
@@ -76,8 +81,11 @@ owns the dictate-or-ask decision and the delivery, and nothing else does.
      corrections applied, spoken "new paragraph" honoured, numbers and
      addresses written out — with the target app and the keywords as context.
      Its output is *accepted*, never trusted: `accept` strips wrapped quotes
-     and refuses empty, narrated, or unrecognisably resized rewrites, and any
-     refusal, failure, or timeout keeps the formatted text.
+     and refuses empty, narrated, unrecognisably resized, or lexically
+     unrelated rewrites (at least 60 % of the rewrite's ordinary words must be
+     the speaker's; numbers and addresses are exempt, being what the model is
+     meant to rewrite), and any refusal, failure, or timeout keeps the
+     formatted text.
   5. **Deliver** (`VoiceTypeSession.deliver` → `PasteboardTextInsertionSink`):
      the text goes onto the pasteboard, marked transient for clipboard
      managers, one ⌘V is posted from a private-state event source (a locked
@@ -85,30 +93,48 @@ owns the dictate-or-ask decision and the delivery, and nothing else does.
      held), and the previous clipboard is put back 0.6 s later unless the user
      has copied something since. If focus has moved since key-up — live, a
      dock click brought Omi's own window forward mid-hold — the text is
-     copied instead and the bar says "Copied — press ⌘V to paste". An
-     unreadable current focus after a known release target is treated the same
-     way. A caret
-     sitting right after a word gets a separating space first
-     (`caretFollowsWordCharacter`, one character read through
-     `AXStringForRange`).
+     copied instead and the bar says "Copied — press ⌘V to paste". The
+     target is the frontmost app *and its key window* (from the window list,
+     no permission needed), so a document or thread switched inside the same
+     app while the recognizer ran also copies; an unreadable current focus
+     after a known release target is treated the same way. A caret sitting
+     right after a word or closing punctuation gets a separating space first
+     (`caretNeedsSeparatingSpace`, one character read through
+     `AXStringForRange`); after whitespace or an opener — bracket, quote,
+     slash, "@" — it does not.
 - **Hub commits are gated.** Before any hub commit (`commitHubTurn`, and the
   buffered warm-wait commit), `gateHubCommitOnFinalDictationCheck` decodes
   the opening of the turn on-device and claims a dictation the probes missed.
   Observed live without it: "type what is on my calendar" committed as a
   question, and the model spawned an agent to do the typing itself — not a
-  missed dictation but an unrequested action.
+  missed dictation but an unrequested action. The gate reads the decode
+  leniently, like the probes: it is the same model on the same opening and
+  mishears "type" the same ways, so a strict test would re-open exactly the
+  gap the probes' lenient test closes.
+- **Probe slots are spent when a probe starts**, not when it falls due
+  (`beginProbe`): one decode runs at a time, and a slow model load must not
+  silently consume the thresholds that pass while it is busy.
 - **Offline dictation.** `PTTRoutePolicy.decide` picks the route at key-down
   and checks the network first and unconditionally: with no path
-  (`NetworkReachability`, an `NWPathMonitor`), the turn takes the
-  `.onDeviceASR` route, is transcribed by the on-device model at key-up, and
-  is formatted without the polisher. Only dictation completes offline: a
-  question ends as `providerFailed` rather than pretending to be in flight.
+  (`NetworkReachability`, an `NWPathMonitor` started at launch so the first
+  turn already knows), the turn takes the `.onDeviceASR` route, is
+  transcribed by the on-device model at key-up, and is formatted without the
+  polisher. Only dictation completes offline: a question ends as
+  `noNetwork` ("No network — say “type …” to dictate offline") rather than
+  pretending to be in flight or blaming a provider that was never reached.
 - A claimed hub turn is **cancelled, never committed**, so the model never
   answers a dictation out loud.
 - A finished turn is journaled as `Typed: <text>` (or `Copied to clipboard:
   <text>`) through the ordinary `recordExchange` on the realtime voice
   surface, so a dictation persists and enters conversation context exactly
   like a spoken question. The continuity key is derived from the turn.
+- Every dictation close terminates the capture lifecycle exactly once
+  (`terminateVoiceTypingLifecycle`), whatever the outcome, and a
+  backend-transcribed dictation's terminal bookkeeping belongs to that close
+  alone — the STT finalization path does not emit its own first.
+- `voice_typing_dictate` (automation) runs the same pipeline with no voice
+  turn. It is refused while a turn is active and abandoned before delivery if
+  one starts mid-run; the real turn's session state is never touched.
 
 Guards: `Tests/VoiceTypingTests.swift` (parser, session, formatter, polisher
 acceptance and hint filtering, transcriber fallback order, probe schedule,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ARCHITECTURE.md
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ARCHITECTURE.md
@@ -39,8 +39,11 @@ owns the dictate-or-ask decision and the delivery, and nothing else does.
   eight dots ease to red (`NotchVoiceMorphGeometry.dictationTintDuration`,
   0.28 s ease-in) while
   keeping whatever motion they have — the waveform while listening, the ring
-  while the paste is prepared. A probe that misses is harmless: the closing
-  transcript decides on its own.
+  while the paste is prepared. When the dictation ends the red eases back out
+  over `dictationTintFadeDuration` (0.55 s) into whatever colour the dot is
+  returning to (`NotchDictationTint` owns the phases); it never snaps to
+  white. A probe that misses is harmless: the closing transcript decides on
+  its own.
 - **The decision latches one way** (`VoiceTypeSession.claim`): once typing,
   always typing for that turn. Not-typing never latches, because a probe hears
   a couple of seconds of a sentence the user has barely started.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ARCHITECTURE.md
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ARCHITECTURE.md
@@ -130,7 +130,10 @@ owns the dictate-or-ask decision and the delivery, and nothing else does.
 - A finished turn is journaled as `Typed: <text>` (or `Copied to clipboard:
   <text>`) through the ordinary `recordExchange` on the realtime voice
   surface, so a dictation persists and enters conversation context exactly
-  like a spoken question. The continuity key is derived from the turn.
+  like a spoken question. The continuity key is derived from the turn. The
+  write is awaited before the turn ends (bounded to 3 s; at the bound the
+  write finishes in the background and the miss is logged), so a lifecycle
+  change at turn end cannot drop it.
 - Every dictation close terminates the capture lifecycle exactly once
   (`terminateVoiceTypingLifecycle`), whatever the outcome, and a
   backend-transcribed dictation's terminal bookkeeping belongs to that close

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -3205,6 +3205,8 @@ class FloatingControlBarManager {
     let isAskOmiFocused: Bool
     let frame: String?
     let isVoiceListening: Bool
+    /// The current hold has been recognised as a dictation (the notch's red tint).
+    let isVoiceDictating: Bool
     let isVoiceResponseActive: Bool
     let usesNotchIsland: Bool
   }
@@ -3217,6 +3219,7 @@ class FloatingControlBarManager {
         isAskOmiFocused: false,
         frame: nil,
         isVoiceListening: false,
+        isVoiceDictating: false,
         isVoiceResponseActive: false,
         usesNotchIsland: false
       )
@@ -3228,6 +3231,7 @@ class FloatingControlBarManager {
       isAskOmiFocused: focused,
       frame: NSStringFromRect(window.frame),
       isVoiceListening: window.state.isVoiceListening,
+      isVoiceDictating: window.state.isVoiceDictating,
       isVoiceResponseActive: window.state.isVoiceResponseGlowActive,
       usesNotchIsland: window.state.usesNotchIsland
     )

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/NetworkReachability.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/NetworkReachability.swift
@@ -9,10 +9,11 @@ import Network
 /// fast — the alternative is holding the key while the realtime hub waits out
 /// its warm deadline, only to discover there was never a network to reach.
 ///
-/// Deliberately optimistic before the first path update: a turn taken in the
-/// first moments after launch must not be forced on-device on no evidence. Being
-/// wrong that way is safe, because the existing warm-deadline fallback still
-/// catches it.
+/// Started at launch (`applicationDidFinishLaunching`), so the first turn
+/// already has a real answer. Deliberately optimistic before the first path
+/// update: a turn taken in the first moments after launch must not be forced
+/// on-device on no evidence. Being wrong that way is safe, because the
+/// existing warm-deadline fallback still catches it.
 @MainActor
 final class NetworkReachability {
 
@@ -25,8 +26,8 @@ final class NetworkReachability {
 
   private init() {}
 
-  /// True while a network path is satisfied. Starts the monitor on first use so
-  /// no caller has to remember to.
+  /// True while a network path is satisfied. Also starts the monitor, for the
+  /// callers (tests, early paths) that run before launch has.
   var isOnline: Bool {
     start()
     return online

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/NotchVoiceMorphMark.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/NotchVoiceMorphMark.swift
@@ -150,14 +150,41 @@ enum NotchVoiceMorphGeometry {
     return t * t
   }
 
-  /// The dot colour for a blend: the listening white with the tint mixed in.
-  static func dictationDotColor(blend rawBlend: CGFloat) -> Color {
+  /// How long the red takes to fade back once the dictation ends — the key
+  /// came up, the turn closed. Slower than the ease-in: the arrival is a
+  /// signal worth noticing, the departure is not.
+  static let dictationTintFadeDuration: TimeInterval = 0.55
+
+  /// Ease-out blend `elapsed` seconds after the dictation ended, starting
+  /// from `peak` — wherever the ease-in had got to, so a release during the
+  /// ease-in fades from that partial red rather than jumping to full red
+  /// first. Smooth in and out of the fade, never below zero.
+  static func dictationFadeBlend(elapsed: TimeInterval, from peak: CGFloat, reduceMotion: Bool) -> CGFloat {
+    if reduceMotion { return 0 }
+    let t = clamp(CGFloat(elapsed / dictationTintFadeDuration))
+    return clamp(peak) * (1 - smoothStep(t))
+  }
+
+  /// The dot colour for a blend: `base` — the colour the dot would otherwise
+  /// be — with the tint mixed in. While dictating the base is the listening
+  /// white; during the fade it is whatever the dot is returning to, so the
+  /// red eases straight into a status colour rather than through white.
+  static func dictationDotColor(
+    blend rawBlend: CGFloat, base: (red: CGFloat, green: CGFloat, blue: CGFloat) = (1, 1, 1)
+  ) -> Color {
     let blend = clamp(rawBlend)
     return Color(
-      red: 1 + (dictationTint.red - 1) * blend,
-      green: 1 + (dictationTint.green - 1) * blend,
-      blue: 1 + (dictationTint.blue - 1) * blend
+      red: base.red + (dictationTint.red - base.red) * blend,
+      green: base.green + (dictationTint.green - base.green) * blend,
+      blue: base.blue + (dictationTint.blue - base.blue) * blend
     ).opacity(0.98)
+  }
+
+  /// sRGB components of a dot colour, for mixing. White when the colour
+  /// cannot be resolved (a dynamic system colour off the main thread).
+  static func components(of color: Color) -> (red: CGFloat, green: CGFloat, blue: CGFloat) {
+    guard let resolved = NSColor(color).usingColorSpace(.sRGB) else { return (1, 1, 1) }
+    return (resolved.redComponent, resolved.greenComponent, resolved.blueComponent)
   }
 
   private static func smoothStep(_ value: CGFloat) -> CGFloat {
@@ -257,19 +284,86 @@ final class VoiceLevelSmoother {
   }
 }
 
+/// Where the dictation tint is in its life: easing in from the moment the
+/// wake word was heard, easing out from the moment the dictation ended.
+/// Pure, so the transitions and the blend can be tested against a clock.
+struct NotchDictationTint: Equatable {
+  enum Phase: Equatable {
+    case off
+    case easingIn(since: Date)
+    /// Fading from `peak`, the blend at the instant the dictation ended.
+    case easingOut(since: Date, peak: CGFloat)
+  }
+
+  private(set) var phase: Phase = .off
+
+  /// Whether the dots still need frames: the timeline must not pause on the
+  /// last red frame while a fade is under way.
+  var isAnimating: Bool {
+    if case .off = phase { return false }
+    return true
+  }
+
+  /// Applies the presentation's dictating flag at `now`. Turning off begins a
+  /// fade from wherever the ease-in had got to; turning on again mid-fade
+  /// restarts the ease-in from that same partial red rather than from white.
+  mutating func update(isDictating: Bool, at now: Date, reduceMotion: Bool) {
+    switch (phase, isDictating) {
+    case (.off, true):
+      phase = .easingIn(since: now)
+    case (.easingOut(_, _), true):
+      let current = blend(at: now, reduceMotion: reduceMotion)
+      // Rewind the start so the ease-in resumes at `current`.
+      let resumed = NotchVoiceMorphGeometry.dictationTintDuration * Double(sqrt(current))
+      phase = .easingIn(since: now.addingTimeInterval(-resumed))
+    case (.easingIn(_), false):
+      let peak = blend(at: now, reduceMotion: reduceMotion)
+      phase = peak > 0 ? .easingOut(since: now, peak: peak) : .off
+    case (.easingIn, true), (.easingOut, false), (.off, false):
+      break
+    }
+  }
+
+  /// A fade that has run its course is over; called from the timeline so the
+  /// animation can pause once the dots are back to their resting colour.
+  mutating func settleIfFaded(at now: Date, reduceMotion: Bool) {
+    guard case .easingOut = phase else { return }
+    // Below what a 3.8pt dot can show; also sidesteps the last float ulp of
+    // an elapsed-versus-duration comparison.
+    if blend(at: now, reduceMotion: reduceMotion) < 0.005 {
+      phase = .off
+    }
+  }
+
+  /// 0 = the dot's own colour, 1 = full red.
+  func blend(at now: Date, reduceMotion: Bool) -> CGFloat {
+    switch phase {
+    case .off:
+      return 0
+    case .easingIn(let since):
+      return NotchVoiceMorphGeometry.dictationBlend(elapsed: now.timeIntervalSince(since), reduceMotion: reduceMotion)
+    case .easingOut(let since, let peak):
+      return NotchVoiceMorphGeometry.dictationFadeBlend(
+        elapsed: now.timeIntervalSince(since), from: peak, reduceMotion: reduceMotion)
+    }
+  }
+}
+
 struct NotchVoiceMorphMark: View {
   let dotColors: [Color]
   let isListening: Bool
   let isThinking: Bool
   var isSpeaking: Bool = false
   /// The hold has been recognised as a dictation: the dots ease to red and
-  /// keep whatever motion the presentation already has.
+  /// keep whatever motion the presentation already has. When it ends they
+  /// ease back out rather than snapping.
   var isDictating: Bool = false
 
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @State private var morphProgress: CGFloat = 0
-  /// When the dictation tint began easing in; nil while not dictating.
-  @State private var dictationTintStart: Date?
+  @State private var dictationTint = NotchDictationTint()
+  /// Ends the fade-out's claim on the timeline once it has run its course.
+  @State private var dictationFadeSettle: Task<Void, Never>?
   /// Reference peaks measured on real hardware: close-mic speech ~0.03–0.2
   /// RMS after the capture noise floor; post-mixer reply speech ~0.1–0.25.
   /// The mic side attacks tight so the wave snaps to syllables, but its peak
@@ -283,7 +377,9 @@ struct NotchVoiceMorphMark: View {
     minPeak: 0.1, attackTau: 0.012, releaseTau: 0.09)
 
   var body: some View {
-    TimelineView(.animation(paused: !isListening && !isThinking && !isSpeaking && !isDictating)) { timeline in
+    TimelineView(
+      .animation(paused: !isListening && !isThinking && !isSpeaking && !isDictating && !dictationTint.isAnimating)
+    ) { timeline in
       Canvas { context, size in
         draw(into: &context, size: size, date: timeline.date)
       }
@@ -295,7 +391,18 @@ struct NotchVoiceMorphMark: View {
       setMorphProgress(NotchVoiceMorphGeometry.targetProgress(isListening: listening))
     }
     .onChange(of: isDictating, initial: true) { _, dictating in
-      dictationTintStart = dictating ? (dictationTintStart ?? Date()) : nil
+      let now = Date()
+      dictationTint.update(isDictating: dictating, at: now, reduceMotion: reduceMotion)
+      dictationFadeSettle?.cancel()
+      dictationFadeSettle = nil
+      guard case .easingOut = dictationTint.phase else { return }
+      // The fade keeps the timeline running; once it is done, let it pause.
+      dictationFadeSettle = Task { @MainActor in
+        let fade = reduceMotion ? 0 : NotchVoiceMorphGeometry.dictationTintFadeDuration
+        try? await Task.sleep(nanoseconds: UInt64(fade * 1_000_000_000))
+        guard !Task.isCancelled else { return }
+        dictationTint.settleIfFaded(at: Date(), reduceMotion: reduceMotion)
+      }
     }
     .accessibilityElement(children: .ignore)
     .accessibilityLabel(
@@ -375,20 +482,28 @@ struct NotchVoiceMorphMark: View {
       // A dictation tints every dot red, eased in from the moment the wake
       // word was heard, on top of whatever motion the presentation has:
       // the waveform keeps spiking while listening, the ring keeps turning
-      // while the paste is prepared. Only the colour changes.
-      let dictationBlend = NotchVoiceMorphGeometry.dictationBlend(
-        elapsed: dictationTintStart.map { date.timeIntervalSince($0) },
-        reduceMotion: reduceMotion)
+      // while the paste is prepared. Only the colour changes. When the
+      // dictation ends the red eases back out into whatever the dot is
+      // returning to — the white of a still-listening bar, or an agent's
+      // status colour — instead of snapping.
+      let restingColor: Color =
+        isListening || speakingPresentation
+        ? NotchGlass.primary.opacity(0.98)
+        : dotColors.indices.contains(index)
+          ? dotColors[index]
+          : NotchGlass.primary.opacity(0.96)
+      let dictationBlend = dictationTint.blend(at: date, reduceMotion: reduceMotion)
       // Branch on the state, not the blend: the first dictation frame has a
       // zero blend, and it must start from white, never from a status colour.
-      let color =
-        isDictating
-        ? NotchVoiceMorphGeometry.dictationDotColor(blend: dictationBlend)
-        : isListening || speakingPresentation
-          ? NotchGlass.primary.opacity(0.98)
-          : dotColors.indices.contains(index)
-            ? dotColors[index]
-            : NotchGlass.primary.opacity(0.96)
+      let color: Color
+      if isDictating {
+        color = NotchVoiceMorphGeometry.dictationDotColor(blend: dictationBlend)
+      } else if dictationBlend > 0 {
+        color = NotchVoiceMorphGeometry.dictationDotColor(
+          blend: dictationBlend, base: NotchVoiceMorphGeometry.components(of: restingColor))
+      } else {
+        color = restingColor
+      }
       let rect = CGRect(
         x: position.x - dotDiameter / 2,
         y: position.y - dotDiameter / 2,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/NotchVoiceMorphMark.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/NotchVoiceMorphMark.swift
@@ -299,7 +299,7 @@ struct NotchVoiceMorphMark: View {
     }
     .accessibilityElement(children: .ignore)
     .accessibilityLabel(
-      isListening ? "Listening" : isSpeaking ? "Speaking" : isThinking ? "Thinking" : "Omi")
+      isDictating ? "Dictating" : isListening ? "Listening" : isSpeaking ? "Speaking" : isThinking ? "Thinking" : "Omi")
   }
 
   private func setMorphProgress(_ progress: CGFloat) {
@@ -379,8 +379,10 @@ struct NotchVoiceMorphMark: View {
       let dictationBlend = NotchVoiceMorphGeometry.dictationBlend(
         elapsed: dictationTintStart.map { date.timeIntervalSince($0) },
         reduceMotion: reduceMotion)
+      // Branch on the state, not the blend: the first dictation frame has a
+      // zero blend, and it must start from white, never from a status colour.
       let color =
-        dictationBlend > 0
+        isDictating
         ? NotchVoiceMorphGeometry.dictationDotColor(blend: dictationBlend)
         : isListening || speakingPresentation
           ? NotchGlass.primary.opacity(0.98)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PTTLanguageIdentifier.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PTTLanguageIdentifier.swift
@@ -77,28 +77,34 @@ actor PTTLanguageIdentifier {
     // Below ~0.4s there isn't enough speech for either the decoder or the detector.
     guard samples.count >= 6_400 else { return Verdict(languageCode: nil, transcript: nil) }
 
+    let started = Date()
+    guard let text = await decodeText(samples, with: manager, purpose: "decode") else {
+      return Verdict(languageCode: nil, transcript: nil)
+    }
+    let code = Self.detectLanguage(of: text, candidates: candidates)
+    log(
+      "PTTLanguageIdentifier: \(String(format: "%.1f", Double(samples.count) / 16_000))s → "
+        + "lang=\(code ?? "none") in \(Int(Date().timeIntervalSince(started) * 1000))ms"
+    )
+    return Verdict(languageCode: code, transcript: text)
+  }
+
+  /// One decode of `samples` to cleaned text, or nil when it produced no
+  /// letters or failed. Shared by both callers so transcript cleanup has one
+  /// home. The TDT decoder emits literal "<unk>" for out-of-vocabulary tokens
+  /// (slangy vowels etc.) — never show that in a chat bubble or paste it.
+  private func decodeText(_ samples: [Float], with manager: AsrManager, purpose: String) async -> String? {
     do {
       var ds = try TdtDecoderState()
-      let started = Date()
       let result = try await manager.transcribe(samples, decoderState: &ds, language: nil)
-      // The TDT decoder emits literal "<unk>" for out-of-vocabulary tokens (slangy
-      // vowels etc.) — never show that in a chat bubble.
       let text = result.text
         .replacingOccurrences(of: "<unk>", with: "")
         .replacingOccurrences(of: "  ", with: " ")
         .trimmingCharacters(in: .whitespacesAndNewlines)
-      guard text.contains(where: { $0.isLetter }) else {
-        return Verdict(languageCode: nil, transcript: nil)
-      }
-      let code = Self.detectLanguage(of: text, candidates: candidates)
-      log(
-        "PTTLanguageIdentifier: \(String(format: "%.1f", Double(samples.count) / 16_000))s → "
-          + "lang=\(code ?? "none") in \(Int(Date().timeIntervalSince(started) * 1000))ms"
-      )
-      return Verdict(languageCode: code, transcript: text)
+      return text.contains(where: { $0.isLetter }) ? text : nil
     } catch {
-      logError("PTTLanguageIdentifier: decode failed", error: error)
-      return Verdict(languageCode: nil, transcript: nil)
+      logError("PTTLanguageIdentifier: \(purpose) failed", error: error)
+      return nil
     }
   }
 
@@ -113,18 +119,7 @@ actor PTTLanguageIdentifier {
     guard let manager = await loadedManager() else { return nil }
     let samples = Self.int16ToFloat32(pcm16k)
     guard samples.count >= 6_400 else { return nil }
-    do {
-      var ds = try TdtDecoderState()
-      let result = try await manager.transcribe(samples, decoderState: &ds, language: nil)
-      let text = result.text
-        .replacingOccurrences(of: "<unk>", with: "")
-        .replacingOccurrences(of: "  ", with: " ")
-        .trimmingCharacters(in: .whitespacesAndNewlines)
-      return text.contains(where: { $0.isLetter }) ? text : nil
-    } catch {
-      logError("PTTLanguageIdentifier: voice-typing decode failed", error: error)
-      return nil
-    }
+    return await decodeText(samples, with: manager, purpose: "voice-typing decode")
   }
 
   /// Text-level language detection, biased toward (but not constrained to) `candidates`.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -3373,6 +3373,10 @@ class PushToTalkManager: ObservableObject {
   /// pasted, so the hint saying so can be read. Terminating the turn clears
   /// every hint with it.
   nonisolated static let voiceTypingCopiedHintSeconds: TimeInterval = 1.5
+  /// How long the closing turn waits for the journal to accept the dictation
+  /// before ending anyway. The paste has already landed; this only bounds
+  /// how long the bar keeps showing the turn as in progress.
+  nonisolated static let voiceTypingJournalWaitSeconds: TimeInterval = 3
 
   /// Closes a dictation on any route: the key came up, the whole turn is
   /// transcribed once with the best recognizer that can be reached, cleaned
@@ -3471,7 +3475,22 @@ class PushToTalkManager: ObservableObject {
       AnalyticsManager.shared.floatingBarPTTEnded(
         mode: self.finalizedMode, committed: true, transcriptLength: self.voiceTypingLastOutcome.characters)
       self.terminateVoiceTypingLifecycle(disposition: .committed, totalSec: totalSec)
-      self.recordVoiceTypingExchange(utterance: run.transcript ?? "", completion: run.completion, turnID: turnID)
+      // The journal write is awaited before the turn ends, so a lifecycle
+      // change at turn end cannot drop it; the wait is bounded so a slow
+      // bridge cannot hold the bar, and the write itself is not cancelled
+      // at the bound — it finishes in the background.
+      let utterance = run.transcript ?? ""
+      let completion = run.completion
+      let journal = Task { @MainActor in
+        await self.recordVoiceTypingExchange(utterance: utterance, completion: completion, turnID: turnID)
+      }
+      let journaled =
+        (try? await DeadlinedOperation.run(seconds: Self.voiceTypingJournalWaitSeconds) { await journal.value })
+        ?? false
+      if !journaled {
+        log("PushToTalkManager: voice typing exchange not confirmed journaled before the turn ended")
+      }
+      guard self.voiceTurnCoordinator.activeTurnID == turnID else { return }
       if case .copied = run.completion {
         self.voiceTurnCoordinator.publish(.hintChanged(turnID: turnID, text: "Copied — press ⌘V to paste"))
         try? await Task.sleep(nanoseconds: UInt64(Self.voiceTypingCopiedHintSeconds * 1_000_000_000))
@@ -3547,11 +3566,12 @@ class PushToTalkManager: ObservableObject {
   /// and enters conversation context exactly like every other voice turn. The
   /// continuity key is derived from the turn, so a retry cannot write a second
   /// copy.
+  /// Returns whether the journal accepted the exchange.
   private func recordVoiceTypingExchange(
     utterance: String, completion: VoiceTypeSession.Completion, turnID: VoiceTurnID
-  ) {
+  ) async -> Bool {
     guard let delivered = completion.text?.trimmingCharacters(in: .whitespacesAndNewlines), !delivered.isEmpty
-    else { return }
+    else { return false }
     let assistantText: String
     if case .copied = completion {
       assistantText = "Copied to clipboard: \(delivered)"
@@ -3559,21 +3579,20 @@ class PushToTalkManager: ObservableObject {
       assistantText = "Typed: \(delivered)"
     }
     let manager = FloatingControlBarManager.shared
-    Task { @MainActor in
-      // `realtime_voice`, not a voice-typing origin of its own: the journal
-      // runtime accepts a closed set of origins (agent/src/index.ts), and a
-      // dictation is a realtime voice turn — one that types instead of asking.
-      // The "Typed:" prefix is what distinguishes it in the transcript.
-      let recorded = await manager.recordExchange(
-        surface: manager.realtimeVoiceSurfaceReference(),
-        userText: utterance,
-        assistantText: assistantText,
-        origin: "realtime_voice",
-        continuityKey: "voice-typing-\(turnID)")
-      if !recorded {
-        log("PushToTalkManager: voice typing exchange not journaled")
-      }
+    // `realtime_voice`, not a voice-typing origin of its own: the journal
+    // runtime accepts a closed set of origins (agent/src/index.ts), and a
+    // dictation is a realtime voice turn — one that types instead of asking.
+    // The "Typed:" prefix is what distinguishes it in the transcript.
+    let recorded = await manager.recordExchange(
+      surface: manager.realtimeVoiceSurfaceReference(),
+      userText: utterance,
+      assistantText: assistantText,
+      origin: "realtime_voice",
+      continuityKey: "voice-typing-\(turnID)")
+    if !recorded {
+      log("PushToTalkManager: voice typing exchange not journaled")
     }
+    return recorded
   }
 
   private func handleTranscriptSegments(_ segments: [TranscriptionService.BackendSegment]) {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -1784,13 +1784,20 @@ class PushToTalkManager: ObservableObject {
     }
     let hasQuery = !query.isEmpty
     let wasFollowUp = isCurrentSessionFollowUp
+    // "Type <text>" dictates into whatever app owns the caret. Decided here,
+    // before the terminal bookkeeping, because a dictation's analytics and
+    // lifecycle snapshot are owned by `finishVoiceTypingTurn` — emitting them
+    // here too recorded every backend-transcribed dictation twice.
+    let dictates = hasQuery && voiceTypeSession.claim(transcript: query)
 
-    AnalyticsManager.shared.floatingBarPTTEnded(
-      mode: finalizedMode,
-      committed: hasQuery,
-      transcriptLength: query.count
-    )
-    if hasQuery {
+    if dictates {
+      // Bookkeeping deferred to the dictation close.
+    } else if hasQuery {
+      AnalyticsManager.shared.floatingBarPTTEnded(
+        mode: finalizedMode,
+        committed: true,
+        transcriptLength: query.count
+      )
       DesktopDiagnosticsManager.shared.recordPTTCommitted(mode: finalizedMode, hubActive: false)
       pttLifecycle.terminate(
         disposition: .committed,
@@ -1803,6 +1810,7 @@ class PushToTalkManager: ObservableObject {
         voicedAudioSeconds: nil,
         judgeable: true)
     } else {
+      AnalyticsManager.shared.floatingBarPTTEnded(mode: finalizedMode, committed: false, transcriptLength: 0)
       // Empty transcript after the turn reached finalization (e.g. a live-Deepgram
       // turn that returned nothing). The recorder's tracked capture state
       // (first-audio / first-usable-frame) classifies it; this resolves any pending
@@ -1834,11 +1842,10 @@ class PushToTalkManager: ObservableObject {
 
     voiceTurnCoordinator.publish(.transcriptionFinal(turnID: turnID, text: query))
 
-    // "Type <text>" dictates into whatever app owns the caret. This route's
-    // transcript already came from the backend, so it is the one pasted: the
-    // turn asks Omi nothing, so no query is dispatched and no response is
-    // awaited.
-    if voiceTypeSession.claim(transcript: query) {
+    // This route's transcript already came from the backend, so it is the one
+    // pasted: the turn asks Omi nothing, so no query is dispatched and no
+    // response is awaited.
+    if dictates {
       log("PushToTalkManager: voice typing consumed turn (\(query.count) chars)")
       finishVoiceTypingTurn(turnID: turnID, audio: nil, knownTranscript: query)
       return
@@ -3418,21 +3425,27 @@ class PushToTalkManager: ObservableObject {
         isCurrent: { [weak self] in self?.voiceTurnCoordinator.activeTurnID == turnID })
       guard !run.abandoned, self.voiceTurnCoordinator.activeTurnID == turnID else { return }
       self.voiceTypingLastOutcome.transcriber = run.transcriber
+      // Every outcome below terminates the capture lifecycle exactly once, so
+      // a dictation that could not be delivered is still a classified attempt
+      // rather than a hole in the telemetry.
       guard run.transcript != nil else {
         log("PushToTalkManager: dictation produced no transcript from any recognizer")
         self.voiceTypeSession.abandon()
         AnalyticsManager.shared.floatingBarPTTEnded(mode: self.finalizedMode, committed: false, transcriptLength: nil)
+        self.terminateVoiceTypingLifecycle(disposition: .silentRejected, totalSec: totalSec)
         let reason: VoiceTurnTerminalReason =
-          wasClaimed ? .transcriptionFailed : (offlineRoute ? .providerFailed : .silentRejected)
+          wasClaimed ? .transcriptionFailed : (offlineRoute ? .noNetwork : .silentRejected)
         self.voiceTurnCoordinator.publish(.finish(turnID: turnID, reason: reason))
         return
       }
       if run.notADictation {
         // Only the offline route reaches here unclaimed: its closing transcript
-        // is the first anyone has read. Nothing offline can answer a question.
+        // is the first anyone has read. Nothing offline can answer a question,
+        // and the turn says so rather than reporting a provider that failed.
         log("PushToTalkManager: offline turn was not a dictation — no provider to answer it")
         AnalyticsManager.shared.floatingBarPTTEnded(mode: self.finalizedMode, committed: false, transcriptLength: nil)
-        self.voiceTurnCoordinator.publish(.finish(turnID: turnID, reason: .providerFailed))
+        self.terminateVoiceTypingLifecycle(disposition: .cancelled, totalSec: totalSec)
+        self.voiceTurnCoordinator.publish(.finish(turnID: turnID, reason: .noNetwork))
         return
       }
       self.voiceTypingLastOutcome.polished = run.polished
@@ -3441,6 +3454,7 @@ class PushToTalkManager: ObservableObject {
       case .none:
         log("PushToTalkManager: dictation had nothing to paste (\(elapsed)ms)")
         AnalyticsManager.shared.floatingBarPTTEnded(mode: self.finalizedMode, committed: false, transcriptLength: nil)
+        self.terminateVoiceTypingLifecycle(disposition: .cancelled, totalSec: totalSec)
         self.voiceTurnCoordinator.publish(.cancel(turnID: turnID, reason: .cancelled))
         return
       case .pasted(let delivered):
@@ -3456,14 +3470,7 @@ class PushToTalkManager: ObservableObject {
           + "\(run.polished ? ", polished" : "") in \(elapsed)ms")
       AnalyticsManager.shared.floatingBarPTTEnded(
         mode: self.finalizedMode, committed: true, transcriptLength: self.voiceTypingLastOutcome.characters)
-      self.pttLifecycle.terminate(
-        disposition: .committed,
-        source: "voice_typing",
-        peak: nil,
-        rms: nil,
-        turnAudioSeconds: totalSec,
-        voicedAudioSeconds: nil,
-        judgeable: true)
+      self.terminateVoiceTypingLifecycle(disposition: .committed, totalSec: totalSec)
       self.recordVoiceTypingExchange(utterance: run.transcript ?? "", completion: run.completion, turnID: turnID)
       if case .copied = run.completion {
         self.voiceTurnCoordinator.publish(.hintChanged(turnID: turnID, text: "Copied — press ⌘V to paste"))
@@ -3472,6 +3479,19 @@ class PushToTalkManager: ObservableObject {
       }
       self.voiceTurnCoordinator.publish(.cancel(turnID: turnID, reason: .cancelled))
     }
+  }
+
+  private func terminateVoiceTypingLifecycle(
+    disposition: PTTAttemptLifecycleRecorder.TurnDisposition, totalSec: Double
+  ) {
+    pttLifecycle.terminate(
+      disposition: disposition,
+      source: "voice_typing",
+      peak: nil,
+      rms: nil,
+      turnAudioSeconds: totalSec,
+      voicedAudioSeconds: nil,
+      judgeable: true)
   }
 
   /// Runs the dictation pipeline on a recording without a voice turn, for the

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -3185,7 +3185,14 @@ class PushToTalkManager: ObservableObject {
     Task { @MainActor [weak self] in
       let decoded = await PTTLanguageIdentifier.shared.transcribe(pcm16k: opening)
       guard let self, self.voiceTurnCoordinator.activeTurnID == turnID else { return }
-      if let decoded, self.voiceTypeSession.claim(transcript: decoded) {
+      // Lenient, like the probes: this is the same on-device model reading the
+      // same opening, and it mishears "type" the same ways ("Tie", "Typed").
+      // A strict test here would re-open exactly the gap the probes' lenient
+      // test closes. The false-positive cost is the one already accepted
+      // mid-hold — a rare question opening "tap …" is pasted rather than
+      // answered — and the false-negative cost is the model acting on
+      // "type …" as an instruction, which was observed live.
+      if let decoded, self.voiceTypeSession.claim(transcript: decoded, lenient: true) {
         log("PushToTalkManager: closing decode caught a dictation the probes missed — not committing")
         self.finishVoiceTypingTurn(turnID: turnID, audio: turnAudio, knownTranscript: nil)
         return
@@ -3404,7 +3411,10 @@ class PushToTalkManager: ObservableObject {
         keywords: keywords,
         language: language,
         appName: appName,
-        allowNetwork: true,
+        // The route latched offline at key-down stays offline: connectivity
+        // that returned mid-hold does not send a turn the user began with no
+        // network to the backend.
+        allowNetwork: !offlineRoute,
         isCurrent: { [weak self] in self?.voiceTurnCoordinator.activeTurnID == turnID })
       guard !run.abandoned, self.voiceTurnCoordinator.activeTurnID == turnID else { return }
       self.voiceTypingLastOutcome.transcriber = run.transcriber

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -3190,7 +3190,9 @@ class PushToTalkManager: ObservableObject {
       return
     }
     Task { @MainActor [weak self] in
+      let started = Date()
       let decoded = await PTTLanguageIdentifier.shared.transcribe(pcm16k: opening)
+      let decodeMs = Int(Date().timeIntervalSince(started) * 1000)
       guard let self, self.voiceTurnCoordinator.activeTurnID == turnID else { return }
       // Lenient, like the probes: this is the same on-device model reading the
       // same opening, and it mishears "type" the same ways ("Tie", "Typed").
@@ -3200,10 +3202,14 @@ class PushToTalkManager: ObservableObject {
       // answered — and the false-negative cost is the model acting on
       // "type …" as an instruction, which was observed live.
       if let decoded, self.voiceTypeSession.claim(transcript: decoded, lenient: true) {
-        log("PushToTalkManager: closing decode caught a dictation the probes missed — not committing")
+        log(
+          "PushToTalkManager: closing decode (\(decodeMs)ms) caught a dictation the probes missed — not committing")
         self.finishVoiceTypingTurn(turnID: turnID, audio: turnAudio, knownTranscript: nil)
         return
       }
+      // The one serial cost every committed hub turn pays; logged so the
+      // latency is measurable from a real turn rather than estimated.
+      log("PushToTalkManager: closing decode (\(decodeMs)ms) heard no wake word — committing")
       commit()
     }
   }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -3497,7 +3497,11 @@ class PushToTalkManager: ObservableObject {
   /// Runs the dictation pipeline on a recording without a voice turn, for the
   /// automation bridge: the same transcription, cleanup, and paste a key-up
   /// performs, into whatever application is frontmost. Refused while a real
-  /// turn is active, so it can never paste into the middle of one.
+  /// turn is active, and abandoned — before anything reaches the focused app —
+  /// if one starts while the recording is being transcribed or polished, so
+  /// it can never paste into the middle of a real turn. The real turn's
+  /// `begin()` owns the session from that moment; the automation neither
+  /// claims nor resets it afterwards.
   func dictateForAutomation(pcm16k: Data, allowNetwork: Bool) async -> [String: String] {
     guard currentVoiceTurnID == nil else { return ["error": "a voice turn is active"] }
     voiceTypeSession.begin()
@@ -3510,7 +3514,10 @@ class PushToTalkManager: ObservableObject {
       language: AssistantSettings.shared.effectiveTranscriptionLanguage,
       appName: NSWorkspace.shared.frontmostApplication?.localizedName,
       allowNetwork: allowNetwork,
-      isCurrent: { true })
+      isCurrent: { [weak self] in self?.currentVoiceTurnID == nil })
+    guard !run.abandoned, currentVoiceTurnID == nil else {
+      return ["error": "a voice turn started while the recording was being transcribed — nothing was pasted"]
+    }
     voiceTypeSession.abandon()
     let delivery: String
     switch run.completion {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -3117,6 +3117,9 @@ class PushToTalkManager: ObservableObject {
       of: voiceTypingTurnAudio(), maxBytes: VoiceTypeWakeWordProbeSchedule.maxProbeBytes)
     // Below ~0.4 s the decoder has nothing to say.
     guard clip.count >= 12_800 else { return }
+    // The slot is spent here, not when it fell due: a decode still running
+    // from the last probe keeps it owed until the decoder is free.
+    voiceTypingProbeSchedule.beginProbe()
     voiceTypingProbeInFlight = true
     Task { @MainActor [weak self] in
       let started = Date()

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeToolAuthority.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeToolAuthority.swift
@@ -48,7 +48,7 @@ enum RealtimeExternalRunTerminalPolicy {
       .explicitInterrupt, .cleanup:
       return .cancelled
     case .permissionDenied, .captureFailed, .captureNotReady, .transcriptionFailed,
-      .providerFailed, .providerNoResponse, .hubWarmTimeout, .deferredCommitTimeout,
+      .providerFailed, .noNetwork, .providerNoResponse, .hubWarmTimeout, .deferredCommitTimeout,
       .bargeInReplacementTimeout, .toolTimeout, .playbackFailed, .journalFailed:
       return .failed
     }
@@ -122,7 +122,7 @@ enum VoiceTurnJournalStatusPolicy {
       return delivery == .delivered ? .completed : .failed
     case .tooShort, .silentRejected, .cancelled, .ownerChanged,
       .cleanup, .permissionDenied, .captureFailed, .captureNotReady,
-      .transcriptionFailed, .providerFailed, .providerNoResponse, .hubWarmTimeout,
+      .transcriptionFailed, .providerFailed, .noNetwork, .providerNoResponse, .hubWarmTimeout,
       .deferredCommitTimeout, .bargeInReplacementTimeout, .toolTimeout, .playbackFailed,
       .journalFailed:
       return .failed

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DeadlinedOperation.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DeadlinedOperation.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Runs an async operation under a hard deadline and returns the moment the
+/// deadline passes, whether or not the operation has noticed it was cancelled.
+///
+/// A task group races the operation against a sleeper, but the group scope
+/// waits for its cancelled child before returning — and an HTTP call stuck in
+/// a token refresh, or a decoder in the middle of a buffer, is not at a
+/// suspension point that honours cancellation. The dictation caps (12 s for the
+/// backend recognizer, 6 s for the polisher) are promises to a user watching an
+/// empty caret, so the deadline is enforced here at the boundary: the work is
+/// cancelled and abandoned, and its late result, if any, is dropped.
+///
+/// Cancelling the *calling* task cancels the work and surfaces as
+/// `CancellationError`, never as a timeout, so a superseded turn does not fall
+/// through to a fallback recognizer.
+enum DeadlinedOperation {
+
+  enum Failure: Error, Equatable {
+    case timedOut
+  }
+
+  static func run<T: Sendable>(
+    seconds: TimeInterval,
+    _ operation: @escaping @Sendable () async throws -> T
+  ) async throws -> T {
+    let outcome = Outcome<T>()
+    let work = Task { () -> Void in
+      do {
+        let value = try await operation()
+        outcome.settle(.success(value))
+      } catch {
+        outcome.settle(.failure(error))
+      }
+    }
+    let timer = Task { () -> Void in
+      try? await Task.sleep(nanoseconds: UInt64(max(0, seconds) * 1_000_000_000))
+      guard !Task.isCancelled else { return }
+      if outcome.settle(.failure(Failure.timedOut)) { work.cancel() }
+    }
+    return try await withTaskCancellationHandler {
+      try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
+        outcome.deliver(to: continuation)
+      }
+    } onCancel: {
+      if outcome.settle(.failure(CancellationError())) {
+        work.cancel()
+        timer.cancel()
+      }
+    }
+  }
+
+  /// The first result to arrive wins; every later one is dropped. The
+  /// continuation is resumed exactly once, whichever of the three parties
+  /// (work, timer, outer cancellation) gets there first.
+  private final class Outcome<T: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var result: Result<T, Error>?
+    private var continuation: CheckedContinuation<T, Error>?
+
+    /// Returns true when this call decided the outcome.
+    @discardableResult
+    func settle(_ new: Result<T, Error>) -> Bool {
+      lock.lock()
+      guard result == nil else {
+        lock.unlock()
+        return false
+      }
+      result = new
+      let pending = continuation
+      continuation = nil
+      lock.unlock()
+      pending?.resume(with: new)
+      return true
+    }
+
+    func deliver(to continuation: CheckedContinuation<T, Error>) {
+      lock.lock()
+      if let result {
+        lock.unlock()
+        continuation.resume(with: result)
+        return
+      }
+      self.continuation = continuation
+      lock.unlock()
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DictationFormatter.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DictationFormatter.swift
@@ -16,7 +16,9 @@ enum DictationFormatter {
   /// Fillers that are only fillers in English: "er" is a German pronoun, "ah"
   /// opens sentences in several languages, so these are stripped only when
   /// the transcript is known to be English.
-  private static let englishFillers = ["er", "erm", "ehm", "hmm", "mm", "mhm"]
+  /// "mm" is deliberately absent: it is a unit ("10 mm") far more often than
+  /// it is a transcribed murmur.
+  private static let englishFillers = ["er", "erm", "ehm", "hmm", "mhm"]
 
   static func format(_ text: String, language: String = "en") -> String {
     var result = text.replacingOccurrences(of: "\r\n", with: "\n")
@@ -31,22 +33,31 @@ enum DictationFormatter {
     return base == "en" ? universalFillers + englishFillers : universalFillers
   }
 
+  /// A filler is only a filler when it stands alone as a spoken token: not a
+  /// piece of an address ("john@um.com"), a hyphenated word ("uh-huh"), or a
+  /// path. These are the characters that glue a token to its neighbours.
+  private static let glue = "[\\w'@.\\-/]"
+
   private static func removingFillers(_ text: String, language: String) -> String {
     let words = fillers(for: language).map(NSRegularExpression.escapedPattern(for:)).joined(separator: "|")
     guard !words.isEmpty else { return text }
     var result = text
+    // ", um." at a sentence boundary: the filler and its comma go, the
+    // sentence punctuation the recognizer hung on the filler is kept.
+    result = result.replacingOccurrences(
+      of: "(?i),\\s*\\b(?:\(words))\\b([.!?])(?=\\s|$)", with: "$1", options: .regularExpression)
     // ", um, " between two clauses: the filler and one of its commas go, the
     // clause boundary stays.
     result = result.replacingOccurrences(
-      of: "(?i),\\s*\\b(?:\(words))\\b[,.]?(?=\\s|$)", with: ",", options: .regularExpression)
+      of: "(?i),\\s*\\b(?:\(words))\\b,?(?=\\s|$)", with: ",", options: .regularExpression)
     // A filler that closes a sentence ("hello uh.") goes, but the full stop
     // it was hung on is the sentence's, and stays.
     result = result.replacingOccurrences(
-      of: "(?i)\\s*(?<![\\w'])(?:\(words))\\b(?=[.!?])", with: "", options: .regularExpression)
-    // A filler anywhere else goes with the comma the recognizer hung on it
-    // ("Um, hello" → "hello").
+      of: "(?i)(?<=\\S)\\s+(?:\(words))(?=[.!?](?:\\s|$))", with: "", options: .regularExpression)
+    // A standalone filler anywhere else goes with the comma or full stop the
+    // recognizer hung on it ("Um, hello" → "hello").
     result = result.replacingOccurrences(
-      of: "(?i)(?<![\\w'])(?:\(words))\\b,?\\s*", with: "", options: .regularExpression)
+      of: "(?i)(?<!\(glue))(?:\(words))(?:[,.](?=\\s|$)|(?=\\s|$))\\s*", with: "", options: .regularExpression)
     return result
   }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DictationPolisher.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DictationPolisher.swift
@@ -158,19 +158,17 @@ enum DictationPolisher {
     timeout: TimeInterval = DictationPolisher.timeout
   ) async throws -> String? {
     let system = systemPrompt(context: context)
-    let candidate: String = try await withThrowingTaskGroup(of: String.self) { group in
-      group.addTask {
+    // The deadline is enforced at the boundary (`DeadlinedOperation`): a
+    // request stuck before its first cancellation check — in the auth header
+    // refresh, say — is abandoned at the cap, not waited for.
+    let candidate: String
+    do {
+      candidate = try await DeadlinedOperation.run(seconds: timeout) {
         try await client.sendTextRequest(
           prompt: text, systemPrompt: system, maxRetries: 0, timeout: timeout, thinkingBudget: 0)
       }
-      group.addTask {
-        try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
-        throw PolishError.timedOut
-      }
-      let first = try await group.next()
-      group.cancelAll()
-      guard let first else { throw PolishError.timedOut }
-      return first
+    } catch DeadlinedOperation.Failure.timedOut {
+      throw PolishError.timedOut
     }
     return accept(candidate, for: text)
   }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DictationPolisher.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DictationPolisher.swift
@@ -72,6 +72,14 @@ enum DictationPolisher {
   /// it by half.
   static let acceptableWordRatio: ClosedRange<Double> = 0.5...1.5
 
+  /// The least share of the rewrite's ordinary words that must already occur
+  /// in the original. A cleanup keeps the speaker's words; a rewrite that is
+  /// mostly new words is an answer, a summary, or a hallucination, whatever
+  /// its length. Words containing a digit or "@" are left out of the count:
+  /// numbers, times, and addresses are the words the model is *meant* to
+  /// rewrite ("four pm" → "4pm", "john at example dot com" → an address).
+  static let minimumSharedWordFraction = 0.6
+
   /// The model answering, apologising, or narrating instead of cleaning. Only
   /// refused when the original did not open the same way, since "I'm sorry I
   /// missed your call" is a perfectly good dictation.
@@ -146,7 +154,31 @@ enum DictationPolisher {
     } else if candidateWords > sourceWords + 3 {
       return nil
     }
+    guard sharesEnoughWords(candidate: text, source: source) else { return nil }
     return text
+  }
+
+  /// Whether `candidate` is lexically a version of `source` rather than a
+  /// different text of a similar length. Judged on the candidate's side: the
+  /// original may lose fillers, false starts, and self-corrections, but the
+  /// rewrite may not gain words the speaker never said. Too few comparable
+  /// words (a one- or two-word dictation) is not evidence either way.
+  static func sharesEnoughWords(candidate: String, source: String) -> Bool {
+    let comparable = contentWords(candidate).filter { word in
+      !word.contains(where: { $0.isNumber }) && !word.contains("@")
+    }
+    guard comparable.count >= 3 else { return true }
+    let sourceWords = Set(contentWords(source))
+    let shared = comparable.filter { sourceWords.contains($0) }.count
+    return Double(shared) / Double(comparable.count) >= minimumSharedWordFraction
+  }
+
+  private static func contentWords(_ text: String) -> [String] {
+    let edges = CharacterSet.punctuationCharacters.union(.symbols)
+    return text.lowercased()
+      .split(whereSeparator: { $0.isWhitespace || $0.isNewline })
+      .map { $0.trimmingCharacters(in: edges) }
+      .filter { !$0.isEmpty }
   }
 
   /// Runs the model with a hard deadline. Any failure is the caller's cue to

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DictationPolisher.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DictationPolisher.swift
@@ -137,7 +137,17 @@ enum DictationPolisher {
     where text.count >= 2 && text.first == open && text.last == close && source.first != open {
       text = String(text.dropFirst().dropLast()).trimmingCharacters(in: .whitespacesAndNewlines)
     }
-    guard !text.isEmpty else { return nil }
+    guard !text.isEmpty, hasContent(text) else { return nil }
+    // A note about the text instead of the text: "(No text provided)",
+    // "[inaudible]". Observed live — a near-empty dictation came back as the
+    // parenthesised placeholder and it was pasted. Only a rewrite that is
+    // wrapped whole, when the speaker's text was not, is refused.
+    if let open = text.first, let close = text.last,
+      [("(", ")"), ("[", "]"), ("{", "}")].contains(where: { $0.0 == open && $0.1 == close }),
+      source.first != open
+    {
+      return nil
+    }
     let loweredCandidate = text.lowercased()
     let loweredSource = source.lowercased()
     for opening in refusalOpenings
@@ -171,6 +181,12 @@ enum DictationPolisher {
     let sourceWords = Set(contentWords(source))
     let shared = comparable.filter { sourceWords.contains($0) }.count
     return Double(shared) / Double(comparable.count) >= minimumSharedWordFraction
+  }
+
+  /// Whether there is anything to type: at least one letter or digit.
+  /// Punctuation alone is a recognizer's shrug, not a dictation.
+  static func hasContent(_ text: String) -> Bool {
+    text.contains(where: { $0.isLetter || $0.isNumber })
   }
 
   private static func contentWords(_ text: String) -> [String] {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DictationTranscriber.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DictationTranscriber.swift
@@ -24,10 +24,6 @@ struct DictationTranscriber: Sendable {
     let source: Source
   }
 
-  enum BackendFailure: Error, Equatable {
-    case timedOut
-  }
-
   /// How long the backend gets before the on-device model takes the turn. The
   /// user is holding nothing and watching nothing; a paste that lands late is
   /// a paste the user has already given up on.
@@ -43,40 +39,32 @@ struct DictationTranscriber: Sendable {
   var didFallBack: @Sendable (String) async -> Void = { _ in }
   var backendTimeout: TimeInterval = DictationTranscriber.defaultBackendTimeout
 
+  /// Nil when nothing could transcribe the audio — or when the calling task
+  /// was cancelled, in which case no fallback is tried either: a superseded
+  /// turn must not keep working towards a paste.
   func transcribe(_ audio: Data) async -> Result? {
     guard !audio.isEmpty else { return nil }
     if isOnline {
+      let backend = self.backend
       do {
-        let text = try await Self.withTimeout(backendTimeout, backend, audio)
+        // Enforced at the boundary, not by cooperative cancellation alone: a
+        // request stuck in a token refresh does not get to hold the key-up.
+        let text = try await DeadlinedOperation.run(seconds: backendTimeout) { try await backend(audio) }
         if let text, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
           return Result(text: text, source: .backend)
         }
         await didFallBack("empty")
-      } catch BackendFailure.timedOut {
+      } catch is CancellationError {
+        return nil
+      } catch DeadlinedOperation.Failure.timedOut {
         await didFallBack("timeout")
       } catch {
         await didFallBack("other")
       }
     }
+    guard !Task.isCancelled else { return nil }
     guard let text = await onDevice(audio), !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     else { return nil }
     return Result(text: text, source: .onDevice)
-  }
-
-  private static func withTimeout(
-    _ seconds: TimeInterval,
-    _ operation: @escaping @Sendable (Data) async throws -> String?,
-    _ audio: Data
-  ) async throws -> String? {
-    try await withThrowingTaskGroup(of: String?.self) { group in
-      group.addTask { try await operation(audio) }
-      group.addTask {
-        try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-        throw BackendFailure.timedOut
-      }
-      guard let first = try await group.next() else { throw BackendFailure.timedOut }
-      group.cancelAll()
-      return first
-    }
   }
 }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/TextInsertionSink.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/TextInsertionSink.swift
@@ -13,17 +13,17 @@ protocol TextInsertionSink: AnyObject {
   func paste(_ text: String) -> Bool
   /// Leaves `text` on the clipboard for the user to paste themselves.
   func copy(_ text: String)
-  /// Whether the character just before the caret is part of a word — i.e. the
-  /// dictation is continuing a line, so it needs a separating space first.
-  /// False when there is no caret context to read.
-  func caretFollowsWordCharacter() -> Bool
+  /// Whether the dictation is continuing a line — the caret sits right after
+  /// a word or the punctuation that closed one — so it needs a separating
+  /// space first. False when there is no caret context to read.
+  func caretNeedsSeparatingSpace() -> Bool
   /// Identifies where a paste would land right now — the frontmost
-  /// application. Nil when it cannot be read.
+  /// application and its key window. Nil when it cannot be read.
   func focusTarget() -> String?
 }
 
 extension TextInsertionSink {
-  func caretFollowsWordCharacter() -> Bool { false }
+  func caretNeedsSeparatingSpace() -> Bool { false }
   func focusTarget() -> String? { nil }
 }
 
@@ -116,16 +116,52 @@ final class PasteboardTextInsertionSink: TextInsertionSink {
     pasteboard.setString(text, forType: .string)
   }
 
+  /// The frontmost application and its key window. The window is what
+  /// catches focus moving *within* the app while the recognizer runs — a new
+  /// document, a sheet, a chat switched to another thread — which a pid alone
+  /// cannot see. Read from the window list, which needs no permission: the
+  /// frontmost app's topmost normal-layer window is its key window.
   func focusTarget() -> String? {
     guard let app = NSWorkspace.shared.frontmostApplication else { return nil }
-    return "\(app.processIdentifier):\(app.bundleIdentifier ?? "")"
+    let window = Self.keyWindowNumber(ownedBy: app.processIdentifier).map(String.init) ?? "?"
+    return "\(app.processIdentifier):\(app.bundleIdentifier ?? ""):\(window)"
   }
+
+  private static func keyWindowNumber(ownedBy pid: pid_t) -> Int? {
+    let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+    guard let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[CFString: Any]] else {
+      return nil
+    }
+    // Front to back; the first normal-layer window the app owns is its key window.
+    for window in windows {
+      guard let owner = window[kCGWindowOwnerPID] as? pid_t, owner == pid,
+        let layer = window[kCGWindowLayer] as? Int, layer == 0,
+        let number = window[kCGWindowNumber] as? Int
+      else { continue }
+      return number
+    }
+    return nil
+  }
+
+  /// Whether dictation landing after `character` needs a space before it: yes
+  /// after a word or the punctuation that closes one ("sentence." + "Next"),
+  /// no after whitespace or anything that opens what follows — a bracket, a
+  /// quote, a slash, a hyphen, "@". A rule on all non-whitespace put a stray
+  /// space after "(" and after an opening quote.
+  nonisolated static func needsSeparatingSpace(after character: Character) -> Bool {
+    if character.isWhitespace || character.isNewline { return false }
+    if character.isLetter || character.isNumber { return true }
+    return !Self.openers.contains(character)
+  }
+  private nonisolated static let openers: Set<Character> = [
+    "(", "[", "{", "<", "\"", "'", "“", "‘", "«", "/", "\\", "-", "–", "—", "_", "@", "#", "$", "€", "£", "~", "`",
+  ]
 
   /// Reads one character behind the caret through Accessibility. A second
   /// dictation into the same line landed flush against the first ("voiceI
   /// think") because nothing knew what the caret was sitting after. Only the
   /// one character is fetched (`AXStringForRange`), never the document.
-  func caretFollowsWordCharacter() -> Bool {
+  func caretNeedsSeparatingSpace() -> Bool {
     var focusedRef: CFTypeRef?
     guard
       AXUIElementCopyAttributeValue(
@@ -149,7 +185,7 @@ final class PasteboardTextInsertionSink: TextInsertionSink {
         element, kAXStringForRangeParameterizedAttribute as CFString, parameter, &textRef) == .success,
       let text = textRef as? String, let character = text.last
     else { return false }
-    return !character.isWhitespace && !character.isNewline
+    return Self.needsSeparatingSpace(after: character)
   }
 
   private func postCommandV() -> Bool {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeSession.swift
@@ -123,7 +123,9 @@ final class VoiceTypeSession {
     }
     guard latch == .typing else { return .none }
     let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty else { return .none }
+    // Nothing detected means nothing typed: not an empty paste, and not a
+    // stray "." or "…" the recognizer produced from a breath.
+    guard DictationPolisher.hasContent(trimmed) else { return .none }
     if let aimed = releaseFocusTarget {
       let current = sink.focusTarget()
       if current == nil || current != aimed {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeSession.swift
@@ -134,14 +134,14 @@ final class VoiceTypeSession {
     }
     // Decided from where the caret is right now: the first word must not land
     // flush against the word before it ("voiceI think").
-    let separator = sink.caretFollowsWordCharacter() ? " " : ""
+    let separator = sink.caretNeedsSeparatingSpace() ? " " : ""
     guard sink.paste(separator + trimmed) else {
       log("VoiceTypeSession: paste could not be posted — copied \(trimmed.count) chars instead")
       sink.copy(trimmed)
       return .copied(trimmed)
     }
-    // The target's bundle id only — never the text.
-    let target = (releaseFocusTarget ?? "?").split(separator: ":").last.map(String.init) ?? "?"
+    // The target's bundle id only (pid:bundle:window) — never the text.
+    let target = (releaseFocusTarget ?? "?").split(separator: ":").dropFirst().first.map(String.init) ?? "?"
     log(
       "VoiceTypeSession: pasted \(trimmed.count) chars into \(target)"
         + (separator.isEmpty ? "" : " (continuing a line)"))

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeWakeWordProbeSchedule.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeWakeWordProbeSchedule.swift
@@ -40,7 +40,11 @@ struct VoiceTypeWakeWordProbeSchedule: Equatable {
   private var pending = Data()
   private static let windowBytes = 640
 
-  /// Feeds one mic chunk. Returns true when a probe is due now.
+  /// Feeds one mic chunk. Returns true while a probe is due — it stays due,
+  /// chunk after chunk, until `beginProbe` takes it. The caller can only run
+  /// one decode at a time, and a slow model load must not silently spend the
+  /// slots that fall while it is busy: the probe that was due simply runs on
+  /// the first chunk after the decoder is free.
   mutating func observe(chunk: Data) -> Bool {
     guard !isDecided, probesTaken < Self.voicedByteThresholds.count else { return false }
     pending.append(chunk)
@@ -49,9 +53,18 @@ struct VoiceTypeWakeWordProbeSchedule: Equatable {
       voicedBytes += VoiceTypeAudioTrim.speechBytes(in: Data(pending.prefix(whole)))
       pending = Data(pending.dropFirst(whole))
     }
-    guard voicedBytes >= Self.voicedByteThresholds[probesTaken] else { return false }
+    return isProbeDue
+  }
+
+  var isProbeDue: Bool {
+    !isDecided && probesTaken < Self.voicedByteThresholds.count
+      && voicedBytes >= Self.voicedByteThresholds[probesTaken]
+  }
+
+  /// The caller is starting the probe that is due. Consumes the slot.
+  mutating func beginProbe() {
+    guard isProbeDue else { return }
     probesTaken += 1
-    return true
   }
 
   /// The question is settled either way (claimed, rejected, or blocked); no

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -756,6 +756,7 @@ struct DesktopHomeView: View {
       askOmiFocused: FloatingControlBarManager.shared.automationState.isAskOmiFocused,
       floatingBarFrame: FloatingControlBarManager.shared.automationState.frame,
       floatingBarVoiceListening: FloatingControlBarManager.shared.automationState.isVoiceListening,
+      floatingBarVoiceDictating: FloatingControlBarManager.shared.automationState.isVoiceDictating,
       floatingBarVoiceResponseActive: FloatingControlBarManager.shared.automationState.isVoiceResponseActive,
       floatingBarUsesNotchIsland: FloatingControlBarManager.shared.automationState.usesNotchIsland,
       updatedAt: ISO8601DateFormatter().string(from: Date())

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -313,6 +313,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
 
     DesktopAutomationBridge.shared.startIfNeeded()
     DesktopAutomationWindowPresentation.installIfNeeded()
+    // Watching from launch, so the first push-to-talk turn already knows
+    // whether there is a network to route to instead of guessing.
+    NetworkReachability.shared.start()
     LocalAgentAPIServer.shared.startIfNeeded()
     publishNamedBundleRuntimeManifest()
 

--- a/desktop/macos/Desktop/Sources/VoiceTurnDomain/VoiceTurnStateMachine.swift
+++ b/desktop/macos/Desktop/Sources/VoiceTurnDomain/VoiceTurnStateMachine.swift
@@ -270,6 +270,10 @@ package enum VoiceTurnTerminalReason: String, Equatable, Sendable, CaseIterable 
   case captureNotReady = "capture_not_ready"
   case transcriptionFailed = "transcription_failed"
   case providerFailed = "provider_failed"
+  /// The turn was recorded with no network path and was not a dictation:
+  /// nothing offline can answer it. Distinct from `providerFailed`, which
+  /// blames a provider that was reached.
+  case noNetwork = "no_network"
   case providerNoResponse = "provider_no_response"
   case hubWarmTimeout = "hub_warm_timeout"
   case deferredCommitTimeout = "deferred_commit_timeout"
@@ -368,6 +372,8 @@ package enum VoiceTurnUICopy {
       return "Couldn't save that reply — try again"
     case .providerFailed, .providerNoResponse, .deferredCommitTimeout:
       return "Couldn't get a voice reply — try again"
+    case .noNetwork:
+      return "No network — say “type …” to dictate offline"
     case .bargeInReplacementTimeout:
       return "Previous reply was interrupted — try again"
     case .toolTimeout:

--- a/desktop/macos/Desktop/Tests/NotchVoiceMorphMarkTests.swift
+++ b/desktop/macos/Desktop/Tests/NotchVoiceMorphMarkTests.swift
@@ -253,6 +253,92 @@ final class NotchVoiceMorphDictationTintTests: XCTestCase {
     XCTAssertEqual(late, 1)
   }
 
+  func testTheTintEasesOutWhenTheDictationEndsInsteadOfSnapping() {
+    // Live: the dots went from full red to white in one frame at key-up.
+    let mid = NotchVoiceMorphGeometry.dictationFadeBlend(
+      elapsed: NotchVoiceMorphGeometry.dictationTintFadeDuration * 0.5, from: 1, reduceMotion: false)
+    XCTAssertEqual(NotchVoiceMorphGeometry.dictationFadeBlend(elapsed: 0, from: 1, reduceMotion: false), 1)
+    XCTAssertGreaterThan(mid, 0.2)
+    XCTAssertLessThan(mid, 0.8)
+    XCTAssertEqual(
+      NotchVoiceMorphGeometry.dictationFadeBlend(
+        elapsed: NotchVoiceMorphGeometry.dictationTintFadeDuration, from: 1, reduceMotion: false), 0)
+    XCTAssertEqual(NotchVoiceMorphGeometry.dictationFadeBlend(elapsed: 10, from: 1, reduceMotion: false), 0)
+    // A release during the ease-in fades from the partial red it had reached.
+    XCTAssertEqual(NotchVoiceMorphGeometry.dictationFadeBlend(elapsed: 0, from: 0.4, reduceMotion: false), 0.4)
+    // The departure is slower than the arrival: it is not a signal.
+    XCTAssertGreaterThan(
+      NotchVoiceMorphGeometry.dictationTintFadeDuration, NotchVoiceMorphGeometry.dictationTintDuration)
+  }
+
+  func testThePhaseFadesFromWhereTheEaseInWasAndKeepsAnimatingUntilDone() {
+    var tint = NotchDictationTint()
+    let t0 = Date(timeIntervalSinceReferenceDate: 1_000)
+    XCTAssertFalse(tint.isAnimating)
+    XCTAssertEqual(tint.blend(at: t0, reduceMotion: false), 0)
+
+    tint.update(isDictating: true, at: t0, reduceMotion: false)
+    XCTAssertTrue(tint.isAnimating)
+    let settled = t0.addingTimeInterval(NotchVoiceMorphGeometry.dictationTintDuration + 1)
+    XCTAssertEqual(tint.blend(at: settled, reduceMotion: false), 1)
+
+    // Key-up: the fade starts at full red and the timeline must keep running.
+    tint.update(isDictating: false, at: settled, reduceMotion: false)
+    XCTAssertTrue(tint.isAnimating, "a fade in progress still needs frames")
+    XCTAssertEqual(tint.blend(at: settled, reduceMotion: false), 1)
+    let halfway = settled.addingTimeInterval(NotchVoiceMorphGeometry.dictationTintFadeDuration / 2)
+    let midBlend = tint.blend(at: halfway, reduceMotion: false)
+    XCTAssertGreaterThan(midBlend, 0)
+    XCTAssertLessThan(midBlend, 1)
+    // Not yet over halfway through: still animating.
+    tint.settleIfFaded(at: halfway, reduceMotion: false)
+    XCTAssertTrue(tint.isAnimating)
+    // Over: back to the resting colour and the timeline may pause.
+    let done = settled.addingTimeInterval(NotchVoiceMorphGeometry.dictationTintFadeDuration)
+    XCTAssertEqual(tint.blend(at: done, reduceMotion: false), 0)
+    tint.settleIfFaded(at: done, reduceMotion: false)
+    XCTAssertFalse(tint.isAnimating)
+  }
+
+  func testAReleaseDuringTheEaseInFadesFromThePartialRed() {
+    var tint = NotchDictationTint()
+    let t0 = Date(timeIntervalSinceReferenceDate: 2_000)
+    tint.update(isDictating: true, at: t0, reduceMotion: false)
+    let early = t0.addingTimeInterval(NotchVoiceMorphGeometry.dictationTintDuration / 2)
+    let partial = tint.blend(at: early, reduceMotion: false)
+    XCTAssertGreaterThan(partial, 0)
+    XCTAssertLessThan(partial, 1)
+    tint.update(isDictating: false, at: early, reduceMotion: false)
+    XCTAssertEqual(tint.blend(at: early, reduceMotion: false), partial, accuracy: 0.0001)
+    // Claimed again mid-fade: the ease-in resumes from the current red.
+    let later = early.addingTimeInterval(0.1)
+    let midFade = tint.blend(at: later, reduceMotion: false)
+    tint.update(isDictating: true, at: later, reduceMotion: false)
+    XCTAssertEqual(tint.blend(at: later, reduceMotion: false), midFade, accuracy: 0.0001)
+  }
+
+  func testReduceMotionSnapsOutAsWellAsIn() {
+    var tint = NotchDictationTint()
+    let t0 = Date(timeIntervalSinceReferenceDate: 3_000)
+    tint.update(isDictating: true, at: t0, reduceMotion: true)
+    XCTAssertEqual(tint.blend(at: t0, reduceMotion: true), 1)
+    tint.update(isDictating: false, at: t0, reduceMotion: true)
+    XCTAssertEqual(tint.blend(at: t0, reduceMotion: true), 0)
+    tint.settleIfFaded(at: t0, reduceMotion: true)
+    XCTAssertFalse(tint.isAnimating)
+  }
+
+  func testTheFadeMixesTowardsTheDotsRestingColourNotWhite() {
+    // Halfway through a fade onto a status colour, the dot is between red
+    // and that colour; there is no detour through white.
+    let base: (red: CGFloat, green: CGFloat, blue: CGFloat) = (0.2, 0.8, 0.3)
+    let mixed = NotchVoiceMorphGeometry.components(
+      of: NotchVoiceMorphGeometry.dictationDotColor(blend: 0.5, base: base))
+    XCTAssertEqual(mixed.red, (base.red + NotchVoiceMorphGeometry.dictationTint.red) / 2, accuracy: 0.02)
+    XCTAssertEqual(mixed.green, (base.green + NotchVoiceMorphGeometry.dictationTint.green) / 2, accuracy: 0.02)
+    XCTAssertEqual(mixed.blue, (base.blue + NotchVoiceMorphGeometry.dictationTint.blue) / 2, accuracy: 0.02)
+  }
+
   func testReduceMotionSnapsToRedInsteadOfAnimating() {
     XCTAssertEqual(NotchVoiceMorphGeometry.dictationBlend(elapsed: 0, reduceMotion: true), 1)
     XCTAssertEqual(NotchVoiceMorphGeometry.dictationBlend(elapsed: nil, reduceMotion: true), 0)

--- a/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/VoiceTurnUIProjectionCopyTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/VoiceTurnUIProjectionCopyTests.swift
@@ -46,6 +46,10 @@ final class VoiceTurnUIProjectionCopyTests: XCTestCase {
     XCTAssertEqual(
       VoiceTurnUICopy.terminalHint(for: .toolTimeout),
       "A tool took too long — try again")
+    // An offline question is not a provider failure: nothing was reached.
+    XCTAssertEqual(
+      VoiceTurnUICopy.terminalHint(for: .noNetwork),
+      "No network — say “type …” to dictate offline")
     XCTAssertNil(VoiceTurnUICopy.terminalHint(for: .interruptedByBargeIn))
     XCTAssertNil(VoiceTurnUICopy.terminalHint(for: .hubWarmTimeout))
     XCTAssertNil(VoiceTurnUICopy.terminalHint(for: .success))

--- a/desktop/macos/Desktop/Tests/VoiceTypingTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTypingTests.swift
@@ -271,6 +271,18 @@ final class VoiceTypeSessionTests: XCTestCase {
     XCTAssertTrue(sink.copied.isEmpty)
   }
 
+  func testTextWithNothingInItDeliversNothing() {
+    // A breath decoded as "." or "…" is not a dictation: nothing is pasted
+    // and nothing is left on the clipboard.
+    for text in [".", "…", ", ,", "?!"] {
+      let (session, sink) = makeSession()
+      XCTAssertNotNil(session.payload(from: "Type hello"))
+      XCTAssertEqual(session.deliver(text), .none, text)
+      XCTAssertTrue(sink.pasted.isEmpty)
+      XCTAssertTrue(sink.copied.isEmpty)
+    }
+  }
+
   func testANewTurnForgetsThePreviousClaim() {
     let (session, sink) = makeSession()
     XCTAssertTrue(session.claim(transcript: "Type hello"))
@@ -383,6 +395,16 @@ final class DictationPolisherTests: XCTestCase {
     // into a paragraph.
     XCTAssertNil(DictationPolisher.accept("Hello there, how are you doing today my friend", for: "hello"))
     XCTAssertEqual(DictationPolisher.accept("Hello!", for: "hello"), "Hello!")
+  }
+
+  func testAPlaceholderAboutTheTextIsRefused() {
+    // Observed live: a near-empty dictation came back as "(No text provided)"
+    // and the placeholder was pasted into the document.
+    XCTAssertNil(DictationPolisher.accept("(No text provided)", for: "so"))
+    XCTAssertNil(DictationPolisher.accept("[inaudible]", for: "hm so"))
+    XCTAssertNil(DictationPolisher.accept("...", for: "so"))
+    // A dictation that itself opens with a bracket keeps it.
+    XCTAssertEqual(DictationPolisher.accept("(See attached.)", for: "(see attached)"), "(See attached.)")
   }
 
   func testARewriteOfTheSameLengthButDifferentWordsIsRefused() {

--- a/desktop/macos/Desktop/Tests/VoiceTypingTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTypingTests.swift
@@ -126,7 +126,7 @@ final class VoiceTypeSessionTests: XCTestCase {
       return true
     }
     func copy(_ text: String) { copied.append(text) }
-    func caretFollowsWordCharacter() -> Bool { caretAfterWord }
+    func caretNeedsSeparatingSpace() -> Bool { caretAfterWord }
     func focusTarget() -> String? { focus }
   }
 
@@ -202,6 +202,18 @@ final class VoiceTypeSessionTests: XCTestCase {
     // The space is on screen but not part of what the turn dictated.
     XCTAssertEqual(session.deliver("I think so"), .pasted("I think so"))
     XCTAssertEqual(sink.pasted, [" I think so"])
+  }
+
+  func testTheSeparatingSpaceFollowsWordsAndClosingPunctuationOnly() {
+    // Continuing a line: after a word, or after the punctuation that ended
+    // one. Never after whitespace or something that opens what follows — a
+    // rule on all non-whitespace put "( hello" and "\" hello" on screen.
+    for character: Character in ["a", "Z", "9", "é", ".", ",", "?", ")", "”", "%"] {
+      XCTAssertTrue(PasteboardTextInsertionSink.needsSeparatingSpace(after: character), "after \(character)")
+    }
+    for character: Character in [" ", "\n", "\t", "(", "[", "\"", "“", "/", "-", "@", "_"] {
+      XCTAssertFalse(PasteboardTextInsertionSink.needsSeparatingSpace(after: character), "after \(character)")
+    }
   }
 
   func testADictationAtALineStartAddsNoSpace() {
@@ -293,6 +305,22 @@ final class DictationFormatterTests: XCTestCase {
       "The hummer and the umbrella")
   }
 
+  func testAFillerSpellingInsideStructuredTextIsNotAFiller() {
+    // Only a standalone spoken token is a filler: not a piece of an address,
+    // a hyphenated word, a unit, or a path.
+    XCTAssertEqual(DictationFormatter.format("mail john@um.com today"), "Mail john@um.com today")
+    XCTAssertEqual(DictationFormatter.format("she said uh-huh and left"), "She said uh-huh and left")
+    XCTAssertEqual(DictationFormatter.format("the bolt is 10 mm long"), "The bolt is 10 mm long")
+    XCTAssertEqual(DictationFormatter.format("open /tmp/um/notes"), "Open /tmp/um/notes")
+  }
+
+  func testAFillerAtASentenceBoundaryKeepsTheSentencePunctuation() {
+    // ", um." carried the full stop: the filler goes, the sentence still ends.
+    XCTAssertEqual(DictationFormatter.format("I think, um. Next point"), "I think. Next point")
+    XCTAssertEqual(DictationFormatter.format("really, uh? Sure"), "Really? Sure")
+    XCTAssertEqual(DictationFormatter.format("Um. Hello there"), "Hello there")
+  }
+
   func testEnglishOnlyFillersAreKeptInOtherLanguages() {
     // "er" is a German pronoun; stripping it would rewrite the sentence.
     XCTAssertEqual(DictationFormatter.format("er kommt morgen", language: "de"), "Er kommt morgen")
@@ -355,6 +383,34 @@ final class DictationPolisherTests: XCTestCase {
     // into a paragraph.
     XCTAssertNil(DictationPolisher.accept("Hello there, how are you doing today my friend", for: "hello"))
     XCTAssertEqual(DictationPolisher.accept("Hello!", for: "hello"), "Hello!")
+  }
+
+  func testARewriteOfTheSameLengthButDifferentWordsIsRefused() {
+    // Word count alone let an answer, a summary, or a hallucination of a
+    // similar length through. The rewrite must be made of the speaker's words.
+    let original = "please send the report to the team by friday and copy me on it"
+    XCTAssertNil(
+      DictationPolisher.accept("The weather this weekend looks sunny with a light breeze from the west.", for: original)
+    )
+    XCTAssertNil(DictationPolisher.accept("Sure! I have sent the report to the team and copied you.", for: original))
+  }
+
+  func testNumbersAddressesAndSelfCorrectionsStillPassTheWordCheck() {
+    // The words the model is meant to rewrite are not held against it.
+    XCTAssertEqual(
+      DictationPolisher.accept(
+        "Call me on extension 4512 around 4pm.", for: "call me on extension four five one two around four pm"),
+      "Call me on extension 4512 around 4pm.")
+    XCTAssertEqual(
+      DictationPolisher.accept("My email is john@example.com.", for: "my email is john at example dot com"),
+      "My email is john@example.com.")
+    XCTAssertEqual(
+      DictationPolisher.accept("Meet at four, then dinner.", for: "um meet at three no four uh then dinner"),
+      "Meet at four, then dinner.")
+    // Spoken punctuation becomes punctuation; the words are unchanged.
+    XCTAssertEqual(
+      DictationPolisher.accept("Hello, how are you?", for: "hello comma how are you question mark"),
+      "Hello, how are you?")
   }
 
   func testOrdinaryOnScreenWordsAreNotOfferedAsSpellingHints() {
@@ -525,6 +581,33 @@ final class DictationTranscriberTests: XCTestCase {
     }
   }
 
+  func testCancellingTheTurnStopsTranscriptionWithoutFallingBack() async {
+    // A superseded turn must not keep working towards a paste: no on-device
+    // fallback, no fallback record, just nothing.
+    let calls = Calls()
+    let stalled = StalledRequest()
+    let transcriber = DictationTranscriber(
+      isOnline: true,
+      backend: { _ in
+        calls.backend()
+        return try await stalled.run()
+      },
+      onDevice: { _ in
+        calls.onDevice()
+        return "type hello from the device"
+      },
+      didFallBack: { calls.fallback($0) })
+    let audio = self.audio
+    let task = Task { await transcriber.transcribe(audio) }
+    // The backend has been asked (its call is synchronous up to the stall).
+    while calls.backendCalls == 0 { await Task.yield() }
+    task.cancel()
+    let result = await task.value
+    XCTAssertNil(result)
+    XCTAssertEqual(calls.onDeviceCalls, 0)
+    XCTAssertTrue(calls.fallbacks.isEmpty)
+  }
+
   func testABackendThatNeverAnswersIsTimedOutOntoTheDevice() async {
     let calls = Calls()
     let stalled = StalledRequest()
@@ -544,6 +627,68 @@ final class DictationTranscriberTests: XCTestCase {
     XCTAssertEqual(result?.source, .onDevice)
     XCTAssertEqual(calls.fallbacks, ["timeout"])
     XCTAssertEqual(calls.backendCalls, 1)
+  }
+}
+
+final class DeadlinedOperationTests: XCTestCase {
+
+  /// An operation that does not observe cancellation at all — the shape of a
+  /// request stuck in a token refresh or a decoder mid-buffer.
+  private final class Uncooperative: @unchecked Sendable {
+    private var continuation: CheckedContinuation<String, Error>?
+    private let lock = NSLock()
+    func run() async throws -> String {
+      try await withCheckedThrowingContinuation { continuation in
+        lock.lock()
+        self.continuation = continuation
+        lock.unlock()
+      }
+    }
+    func finish(_ value: String) {
+      lock.lock()
+      let pending = continuation
+      continuation = nil
+      lock.unlock()
+      pending?.resume(returning: value)
+    }
+  }
+
+  func testTheDeadlineDoesNotWaitForAnOperationThatIgnoresCancellation() async {
+    let stuck = Uncooperative()
+    let started = Date()
+    do {
+      _ = try await DeadlinedOperation.run(seconds: 0.02) { try await stuck.run() }
+      XCTFail("expected a timeout")
+    } catch DeadlinedOperation.Failure.timedOut {
+      // The cap is the promise: the return did not wait on the stuck work.
+      XCTAssertLessThan(Date().timeIntervalSince(started), 2)
+    } catch {
+      XCTFail("unexpected \(error)")
+    }
+    // A late answer is dropped, not delivered.
+    stuck.finish("too late")
+  }
+
+  func testAResultInsideTheDeadlineIsReturned() async throws {
+    let value = try await DeadlinedOperation.run(seconds: 5) { "prompt" }
+    XCTAssertEqual(value, "prompt")
+  }
+
+  func testCancellingTheCallerSurfacesAsCancellationNotTimeout() async {
+    let stuck = Uncooperative()
+    let task = Task { () throws -> String in
+      try await DeadlinedOperation.run(seconds: 5) { try await stuck.run() }
+    }
+    task.cancel()
+    do {
+      _ = try await task.value
+      XCTFail("expected cancellation")
+    } catch is CancellationError {
+      // Correct: the caller was cancelled, nothing timed out.
+    } catch {
+      XCTFail("unexpected \(error)")
+    }
+    stuck.finish("too late")
   }
 }
 
@@ -567,34 +712,64 @@ final class VoiceTypeWakeWordProbeScheduleTests: XCTestCase {
     XCTAssertEqual(schedule.probesTaken, 0)
   }
 
-  func testTheFirstProbeFiresUnderASecondOfVoiceAndThenRetries() {
+  /// Feeds voiced chunks the way the manager does — starting every probe the
+  /// moment it is due — and returns the 1-based chunk index each probe started on.
+  private static func probeStarts(chunkBytes: Int, chunks: Int) -> (VoiceTypeWakeWordProbeSchedule, [Int]) {
     var schedule = VoiceTypeWakeWordProbeSchedule()
-    var probeChunks: [Int] = []
-    for index in 1...100 where schedule.observe(chunk: Self.chunk(voiced: true)) {
-      probeChunks.append(index)
+    var starts: [Int] = []
+    for index in 1...chunks where schedule.observe(chunk: chunk(voiced: true, bytes: chunkBytes)) {
+      schedule.beginProbe()
+      starts.append(index)
     }
+    return (schedule, starts)
+  }
+
+  func testTheFirstProbeFiresUnderASecondOfVoiceAndThenRetries() {
+    let (schedule, probeChunks) = Self.probeStarts(chunkBytes: 3_200, chunks: 100)
     // 3,200 voiced bytes per chunk. The first probe must land well under a
     // second of voice so the dots turn red right after "type"; there are
     // several quick retries and then no more.
     XCTAssertEqual(schedule.probesTaken, VoiceTypeWakeWordProbeSchedule.voicedByteThresholds.count)
-    let firstProbeVoicedSeconds = Double(probeChunks[0] * 3_200) / 32_000
-    XCTAssertLessThan(firstProbeVoicedSeconds, 0.55)
+    guard let firstProbeChunk = probeChunks.first else { return XCTFail("no probe was ever due") }
+    XCTAssertLessThan(Double(firstProbeChunk * 3_200) / 32_000, 0.55)
   }
 
   func testRealMicrophoneChunksSmallerThanAWindowStillScheduleProbes() {
     // Live: the 48 kHz IOProc buffer resampled to 16 kHz arrives as ~342-byte
     // chunks, smaller than one 20 ms window, so no chunk ever measured as
     // voice and no probe ever ran on a real hold.
-    var schedule = VoiceTypeWakeWordProbeSchedule()
-    var probeChunks: [Int] = []
-    for index in 1...600 where schedule.observe(chunk: Self.chunk(voiced: true, bytes: 342)) {
-      probeChunks.append(index)
-    }
+    let (_, probeChunks) = Self.probeStarts(chunkBytes: 342, chunks: 600)
     // The first probe still lands under a second of voice with real-sized
     // chunks; all the configured retries fire and then no more.
     XCTAssertEqual(probeChunks.count, VoiceTypeWakeWordProbeSchedule.voicedByteThresholds.count)
-    let firstProbeVoicedSeconds = Double(probeChunks[0] * 342) / 32_000
-    XCTAssertLessThan(firstProbeVoicedSeconds, 0.6)
+    guard let firstProbeChunk = probeChunks.first else { return XCTFail("no probe was ever due") }
+    XCTAssertLessThan(Double(firstProbeChunk * 342) / 32_000, 0.6)
+  }
+
+  func testADueProbeWaitsForABusyDecoderInsteadOfBeingSpent() {
+    // A slow model load can hold one decode across several thresholds. The
+    // slots that fall meanwhile are not consumed: the probe stays due until
+    // the caller can start it, so the wake word is still listened for.
+    var schedule = VoiceTypeWakeWordProbeSchedule()
+    for _ in 0..<5 { _ = schedule.observe(chunk: Self.chunk(voiced: true)) }
+    XCTAssertTrue(schedule.isProbeDue)
+    schedule.beginProbe()
+    XCTAssertEqual(schedule.probesTaken, 1)
+    // The decoder is busy through the next two thresholds (0.7 s, 1.0 s).
+    var dueWhileBusy = 0
+    for _ in 0..<8 where schedule.observe(chunk: Self.chunk(voiced: true)) { dueWhileBusy += 1 }
+    XCTAssertGreaterThan(dueWhileBusy, 1, "the due probe is reported on every chunk until taken")
+    XCTAssertEqual(schedule.probesTaken, 1, "nothing was spent while the decoder was busy")
+    // Free again: the pending probe starts on the next chunk, and one only.
+    XCTAssertTrue(schedule.observe(chunk: Self.chunk(voiced: true)))
+    schedule.beginProbe()
+    XCTAssertEqual(schedule.probesTaken, 2)
+    XCTAssertTrue(schedule.isProbeDue, "the 1.0 s slot is still owed")
+    schedule.beginProbe()
+    XCTAssertEqual(schedule.probesTaken, 3)
+    XCTAssertFalse(schedule.isProbeDue)
+    schedule.beginProbe()
+    XCTAssertEqual(schedule.probesTaken, 3, "beginProbe without a due probe spends nothing")
   }
 
   func testSilenceBetweenWordsDoesNotCountTowardsTheThreshold() {
@@ -614,6 +789,7 @@ final class VoiceTypeWakeWordProbeScheduleTests: XCTestCase {
     var schedule = VoiceTypeWakeWordProbeSchedule()
     // Just past the first threshold (0.45 s ≈ 5 voiced chunks), before the next.
     for _ in 0..<5 { _ = schedule.observe(chunk: Self.chunk(voiced: true)) }
+    schedule.beginProbe()
     XCTAssertEqual(schedule.probesTaken, 1)
     schedule.decide()
     for _ in 0..<50 {

--- a/desktop/macos/changelog/unreleased/20260905-voice-typing-follow-ups.json
+++ b/desktop/macos/changelog/unreleased/20260905-voice-typing-follow-ups.json
@@ -1,0 +1,8 @@
+{
+  "changes": [
+    "Voice typing: the notch's red dots now ease back out when the dictation ends instead of snapping to white",
+    "Voice typing: a hold that heard nothing to type pastes nothing and leaves your clipboard alone, and the cleanup no longer strips letters out of addresses, hyphenated words, or units",
+    "Voice typing: if you switch documents in the same app while a dictation is being transcribed, the text is copied for you to paste instead of landing in the new document",
+    "Voice typing with no network: a spoken question now says \"No network — say “type …” to dictate offline\" instead of reporting a failed reply"
+  ]
+}

--- a/desktop/macos/e2e/flows/ptt-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/ptt-lifecycle.yaml
@@ -28,6 +28,7 @@ covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/NetworkReachability.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/PTTLanguageIdentifier.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DeadlinedOperation.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DictationFormatter.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DictationPolisher.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DictationTranscriber.swift


### PR DESCRIPTION
## What & why

Follow-ups to #12764 (omi-type voice typing): the review findings from cubic and the maintainer review, plus two behaviour changes from live use — the notch's red eases back out at release instead of snapping to white, and a dictation that heard nothing pastes nothing.

## Changes

**What gets pasted**
- Polisher output must reuse ≥60 % of the transcript's ordinary words (numbers and addresses exempt); bracketed placeholders like "(No text provided)" and text with no letter or digit are refused. Observed live: an 18-char placeholder pasted into TextEdit.
- Fillers are stripped only as standalone spoken tokens: `john@um.com`, `uh-huh`, `10 mm`, paths survive; ", um." keeps its full stop; "mm" is no longer a filler.
- The paste target includes the app's key window, so a document or thread switched inside the same app mid-run copies instead of pasting. The separating space is added only after letters, digits, and closing punctuation.

**Timing and routing**
- `DeadlinedOperation` enforces the 12 s transcribe / 6 s polish caps at the boundary; a request stuck before its first cancellation check is abandoned at the cap. Cancelling the turn cancels the transcription and tries no fallback.
- A turn routed offline stays offline even if connectivity returns mid-hold. Reachability is watched from launch.
- The hub-commit gate reads the opening leniently, like the probes (same model, same mishearings), with the trade-off written down. Decode cost logged; measured 94–221 ms per commit on a named bundle.
- A due wake-word probe stays owed while a decode is in flight instead of spending the slot.
- An offline question ends as the new typed reason `.noNetwork` ("No network — say “type …” to dictate offline") rather than `providerFailed`.

**Bookkeeping**
- One owner for a dictation's analytics and lifecycle snapshot on every outcome (the backend-STT path double-emitted; failure outcomes never terminated).
- The journal write is awaited before the turn ends, bounded to 3 s; at the bound it finishes in the background and the miss is logged.
- `voice_typing_dictate` abandons before delivery if a real turn starts and never resets that turn's session; `ptt_manager_turn` clamps `pace_ms`/`settle_ms` and rounds `chunk_bytes` to whole samples.

**Notch**
- `NotchDictationTint` owns the tint phases: ease in from the wake word, ease out over 0.55 s from wherever the ease-in had reached, mixing towards the dot's resting colour. The timeline keeps running until the fade is done. First dictation frame starts from white; VoiceOver reports "Dictating".
- `floatingBarVoiceDictating` on the automation snapshot.

**Smaller:** `PTTLanguageIdentifier` decode helper deduplicated; architecture note updated throughout; the `ptt-lifecycle` e2e flow watches the new source.

## Invariants

- **INV-VOICE-1:** preserved. `dictationRecognized` stays presentation-only; new terminal reason `noNetwork`; the turn still ends through `.cancel`/`.finish`. Guards: `VoiceTurnReducerTests`, reducer fuzz alphabet (CaseIterable), `VoiceTurnUIProjectionCopyTests` hint copy.
- **INV-CHAT-1:** preserved. Journaled through the existing `recordExchange`, now awaited.
- **INV-AUTH-1**, **INV-NAV-1:** path matches only (automation snapshot field on `DesktopHomeView`/bridge/`FloatingControlBarWindow.AutomationState`); no auth-session or navigation behaviour change.
- **INV-UI-1:** the tint is red (`testTheTintIsRedNotPurple`); no purple introduced.

## Failure-Class

Failure-Class: none

Line-Count-Exception: desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift | 4920 -> 4929 | harness value clamps and one snapshot field on an already-frozen file
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift | 5783 -> 5787 | one automation-state field
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift | 3889 -> 3954 | terminal bookkeeping owner, journal wait, gate timing on the existing PTT owner
Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift | 1705 -> 1706 | one automation-snapshot field
Line-Count-Exception: desktop/macos/Desktop/Sources/OmiApp.swift | 1657 -> 1660 | start network reachability at launch
Line-Count-Exception: desktop/macos/Desktop/Sources/VoiceTurnDomain/VoiceTurnStateMachine.swift | 2453 -> 2459 | noNetwork terminal reason and its hint

## Verification

- `xcrun swift build --build-tests` clean on top of current main.
- `xcrun swift test` — VoiceType*, Dictation*, DeadlinedOperation, PTTRoutePolicy, NotchVoiceMorph, PushToTalkStateMachine, VoiceTurnReducer/Fuzz/Coordinator/OutputOwnership/UIProjectionCopy, FloatingControlBarState, DesktopAutomationBridgeRoute, TranscriptionTransport, RealtimeToolAuthority: 307 tests, 0 failures. `check_desktop_test_quality.py` OK. `agent-logic-harness.sh --swift-only` passed. Full desktop suite: 3,540 passed; the one failure (`ChatDiscoverabilityTests` fixture) is identical on main.
- Exercised on the `omi-type` named bundle with real-time-paced injected audio and a real mic recording: dictation pasted online (backend STT + polish) and offline (on-device); clipboard restored; a bare "type." pasted nothing; a new TextEdit window opened mid-run resulted in a copy; a question routed to the hub with the gate decode at 94–221 ms; the notch dots eased red→white over ~0.6 s at turn end, measured per frame from a window capture (dot RGB green channel 73 → 84 → 111 → 156 → 200 → 223 → 231).
- Not verified live: the journal write landing. The named bundle's auth restore did not complete after a full rebuild, so `recordExchange` had no owner lease and refused immediately; the change is a straight await of the existing call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQF1KVKnaWHeu8dyADNjCt


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

