### PR TITLE
fix(backend): rate-limit GET /v1/personas/twitter/initial-message (#12781)

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -1738,7 +1738,10 @@ async def verify_twitter_ownership_tweet(
 
 
 @router.get('/v1/personas/twitter/initial-message', tags=['v1'], response_model=TwitterInitialMessageResponse)
-def get_twitter_initial_message(username: str, uid: str = Depends(auth.get_current_user_uid)):
+def get_twitter_initial_message(
+    username: str,
+    uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "apps:twitter_initial_message")),
+):
     persona = get_persona_by_username_db(username)
     if persona:
         with track_usage(uid, Features.PERSONA):

--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -634,6 +634,7 @@ class TestRouterPolicyMapping(unittest.TestCase):
             "integration:memories",
             "test:prompt",
             "apps:generate_prompts",
+            "apps:twitter_initial_message",
         ]
         for policy in used_policies:
             self.assertIn(policy, RATE_POLICIES, f"Policy '{policy}' used in router but missing from config")
@@ -826,7 +827,14 @@ class TestRouterWiring(unittest.TestCase):
 
     def test_apps_router_has_rate_limit(self):
         matches = self._grep_file("routers/apps.py", r"with_rate_limit.*apps:")
-        self.assertGreaterEqual(len(matches), 1, "apps.py missing rate limit wiring")
+        self.assertGreaterEqual(len(matches), 2, "apps.py missing rate limit wiring")
+
+    def test_twitter_initial_message_endpoint_rate_limited(self):
+        """GET /v1/personas/twitter/initial-message runs a billable LLM call
+        (Features.PERSONA) and, unlike every other billable route in this
+        router, had neither a quota gate nor a rate limit (#12781)."""
+        matches = self._grep_file("routers/apps.py", r"with_rate_limit.*apps:twitter_initial_message")
+        self.assertEqual(len(matches), 1, "GET /v1/personas/twitter/initial-message must have a rate limit")
 
     def test_knowledge_graph_router_has_rate_limit(self):
         matches = self._grep_file("routers/knowledge_graph.py", r"with_rate_limit.*knowledge_graph:")

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -217,6 +217,10 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     "test:prompt": (30, 3600),
     # Apps
     "apps:generate_prompts": (30, 3600),
+    # Persona intro message is a billable LLM call (Features.PERSONA) with no
+    # quota gate, unlike its sibling generate_prompts. Same bound as that
+    # sibling until a quota-gate policy decision is made (see #12781).
+    "apps:twitter_initial_message": (30, 3600),
     # TTS — ElevenLabs proxy. Coarse outer ring; fine-grained burst + daily
     # char caps are enforced in database.redis_db.check_tts_rate_limit.
     "tts:synthesize": (300, 3600),


### PR DESCRIPTION
## Summary
`GET /v1/personas/twitter/initial-message` runs a billable, tracked LLM call (`track_usage(uid, Features.PERSONA)`) but had neither a quota gate nor a rate limit -- the only billable route in `backend/routers/apps.py` with neither (per #12781's own audit table). `track_usage` only attributes spend, it does not block, so a free user past the monthly cap could call it indefinitely.

This wires the same rate limiter its sibling `generate-prompts` already has: `auth.with_rate_limit(auth.get_current_user_uid, "apps:twitter_initial_message")`, 30/hour, matching `apps:generate_prompts`. Whether persona spend should also count against the chat quota is a separate billing-policy question the issue explicitly defers to a maintainer -- this PR only adds the request bound, per the issue's own "cheapest correct step" framing.

## Test plan
- Added `test_twitter_initial_message_endpoint_rate_limited` in `backend/tests/unit/test_rate_limiting.py` (fails on `main`, passes with this diff), and updated `test_all_router_policies_exist` / `test_apps_router_has_rate_limit` for the new policy.
- Ran `backend/tests/unit/test_rate_limiting.py`: 85 passed, 1 skipped (unrelated fakeredis-only test, skips without the optional dependency on both main and this branch).

Failure-Class: none

Line-Count-Exception: backend/routers/apps.py | 2468 -> 2471 | multi-line Depends() signature to fit the new rate-limit wrapper call within the line-length limit; no logic added beyond the one new Depends() dependency

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

