### PR TITLE
fix(backend): defer the client_processing import that breaks unrelated test collection

### DIFF
--- a/backend/tests/unit/test_client_processing_acceptance.py
+++ b/backend/tests/unit/test_client_processing_acceptance.py
@@ -1134,3 +1134,57 @@ def test_rejected_payload_provenance_is_sanitized_single_line(monkeypatch, stack
     assert device_class == oversize[:PROVENANCE_LOG_MAX_CHARS]
     assert len(device_class) == PROVENANCE_LOG_MAX_CHARS
     _assert_no_managed(spies)
+
+
+def test_projection_payload_imports_while_the_models_package_is_stubbed() -> None:
+    """Importing this module must survive a stubbed ``models`` package (#12779).
+
+    ``utils.conversations.projection_payload`` is deliberately import-light — its own
+    docstring says importing it must not drag in the coordinator's module graph. A
+    module-scope ``from models.client_processing import ...`` broke that quietly: seven
+    suites under ``tests/unit`` replace ``sys.modules['models']`` with a stub, and while
+    one is installed, merely *collecting* any module that reaches this one fails with
+    ``ModuleNotFoundError: No module named 'models.client_processing'``.
+
+    That is how `main` went red for unrelated PRs: the failure lands during collection of
+    a later, alphabetically-sorted suite, so it reads as a broken test file rather than as
+    leaked global state. This drives the real mechanism — stub the package the way those
+    suites do, then import through a fresh module object.
+    """
+    import sys
+    import importlib
+    from types import ModuleType
+
+    saved = sys.modules.get('models')
+    saved_module = sys.modules.pop('utils.conversations.projection_payload', None)
+    # Also evict the submodule. Leaving it cached makes this test vacuous: a cached
+    # models.client_processing satisfies the import without ever consulting the stub's
+    # __path__, so the module-scope version passes too. In CI the submodule genuinely
+    # has not been imported yet when the polluted collection happens.
+    saved_submodule = sys.modules.pop('models.client_processing', None)
+    try:
+        # Exactly the shape the polluting suites install: a bare package whose empty
+        # __path__ makes every models.* submodule unimportable.
+        stub = ModuleType('models')
+        stub.__path__ = []  # type: ignore[attr-defined]
+        sys.modules['models'] = stub
+
+        module = importlib.import_module('utils.conversations.projection_payload')
+        assert module is not None
+    finally:
+        sys.modules.pop('utils.conversations.projection_payload', None)
+        if saved is None:
+            sys.modules.pop('models', None)
+        else:
+            sys.modules['models'] = saved
+        if saved_submodule is not None:
+            sys.modules['models.client_processing'] = saved_submodule
+        if saved_module is not None:
+            sys.modules['utils.conversations.projection_payload'] = saved_module
+
+    # The deferred import still resolves once the stub is gone, so laziness bought
+    # collection-time resilience without breaking the function itself.
+    from utils.conversations.projection_payload import strip_client_processing
+
+    payload = {'client_processing': {'x': 1}, 'keep': 'me'}
+    assert strip_client_processing(payload) == {'keep': 'me'}

--- a/backend/utils/conversations/projection_payload.py
+++ b/backend/utils/conversations/projection_payload.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 import unicodedata
 from typing import Any
 
-from models.client_processing import PROJECTION_FAMILY_FIELDS
-
 PROVENANCE_LOG_MAX_CHARS = 64
 _UNSAFE_LOG_CHAR_CATEGORIES = frozenset({'Cc', 'Cf', 'Cs', 'Co', 'Cn', 'Zl', 'Zp'})
 
@@ -51,6 +49,14 @@ def strip_client_processing(payload: dict[str, Any]) -> dict[str, Any]:
     ``client_processing_mutation`` at an ingest-owner site — never by a
     processor persist of a conversation that already exists.
     """
+    # Imported here, not at module scope. This module is deliberately import-light
+    # (see the module docstring), and a module-scope `from models.client_processing
+    # import ...` makes merely *collecting* an unrelated test file fail whenever any
+    # earlier test has stubbed the `models` package in sys.modules -- seven suites in
+    # tests/unit currently do. The import then resolves at call time, by which point
+    # the stub is long torn down. See #12779.
+    from models.client_processing import PROJECTION_FAMILY_FIELDS
+
     for field in PROJECTION_FAMILY_FIELDS:
         payload.pop(field, None)
     return payload


### PR DESCRIPTION
Fixes the collection failure that has had `main`'s **Backend unit suite** red across several commits and is blocking unrelated PRs. Tracked in #12779.

## The failure

```
ModuleNotFoundError: No module named 'models.client_processing'
utils/conversations/projection_payload.py:19

ERROR tests/unit/test_batch_upload_storage.py
ERROR tests/unit/test_merge_validation.py
```

`utils/conversations/projection_payload.py` imported `models.client_processing` at module scope. **Seven suites** under `tests/unit` replace `sys.modules['models']` with a bare stub:

```
test_sync_silent_failure.py      test_sync_v2.py            test_sync_pcm_decode.py
test_payment_promotion_codes.py  test_sync_opus_decode.py   test_conversation_jit_processing.py
test_sync_cloud_tasks.py
```

While one of those stubs is installed, *collecting* any later module that reaches `projection_payload` fails. The error then lands on a different test file than the one that caused it, which is why it reads as a broken suite rather than as leaked global state.

## The fix

Defer the import into `strip_client_processing`, its only consumer. The name resolves at call time, by which point the stub is torn down.

This is what the module already claimed to be. Its docstring says it lives outside `process_conversation` precisely so that importing it "must not drag in the coordinator's module graph" — a module-scope import of a `models` submodule is the same mistake one level down.

**Why not fix the polluting tests instead.** There are seven today and nothing stops an eighth. Each would need its own teardown audit, and the failure only appears in whole-suite ordering, so a regression would be invisible until CI went red again on someone else's PR. Deferring the import removes the ordering dependency at the single point that has it.

## Verification

Every polluter, paired with the two suites that were erroring — all now collect and run:

| polluter | result |
| --- | --- |
| `test_sync_silent_failure` | 112 passed |
| `test_payment_promotion_codes` | 87 passed |
| `test_sync_cloud_tasks` | 158 passed |
| `test_sync_v2` | 236 passed |
| `test_conversation_jit_processing` | 96 passed |
| `test_sync_opus_decode` / `test_sync_pcm_decode` | collect and run |

Before this change the same pairings produce 40 collection errors.

Suites covering the changed module are unchanged: `test_client_processing_acceptance` 27, `test_client_processing_trust_boundary` 41, `test_process_conversation_usage_context` 53.

**The regression test is mutation-checked.** Restoring the module-scope import fails it with the exact production error at the exact line. It installs the same bare `models` stub the polluting suites use and imports through a fresh module object, so it exercises the real mechanism rather than asserting on source text.

One detail worth keeping: the test also evicts `models.client_processing` from `sys.modules`. Without that a cached submodule satisfies the import regardless of the stub's `__path__`, and the test passes with or without the fix — my first version did exactly that and the mutation check caught it.

## Two honest notes

~~**This does not prove CI goes green.**~~ **Update — CI has now confirmed it.** The `Backend unit suite` on this head is **green in 3m29s** ([run 33961213829](https://github.com/BasedHardware/omi/actions/runs/33961213829)), with `1072 backend unit test files selected` and **zero** occurrences of `No module named 'models.client_processing'` in the log. The same required check is red with that exact error on every other open PR right now. I could not reproduce CI's ordering locally, so I hedged here originally; the lane itself settled it.

**It unmasks a second, unrelated pollution.** With collection fixed, `test_sync_opus_decode` / `test_sync_pcm_decode` running *before* `test_batch_upload_storage` leak `MagicMock`s for `utils.other.storage`, producing `assert 0 == 1` on `upload_audio_chunks_batch`. Those tests never executed before — they died at collection — so this is pre-existing breakage becoming visible, not a regression from this change. In the alphabetical order CI uses, `test_batch_upload_storage` sorts *before* both, so the direction that triggers it should not arise there; I am flagging it rather than claiming it cannot bite. Worth its own issue if it does.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


