### PR TITLE
fix(backend): refresh task intelligence desktop owner paths after #12607

### DIFF
--- a/backend/config/task_intelligence_sources_v1.json
+++ b/backend/config/task_intelligence_sources_v1.json
@@ -17,13 +17,41 @@
       ],
       "test_adapter": "direct_command_contract",
       "writer_anchors": [
-        {"path": "backend/routers/action_items.py", "symbol": "action_items_db.create_action_item", "discover": true},
-        {"path": "backend/routers/action_items.py", "symbol": "action_items_db.create_action_items_batch", "discover": true},
-        {"path": "backend/routers/action_items.py", "symbol": "action_items_db.delete_action_item", "discover": true},
-        {"path": "backend/routers/action_items.py", "symbol": "action_items_db.delete_action_items_batch", "discover": true},
-        {"path": "backend/routers/action_items.py", "symbol": "action_items_db.delete_action_items_for_conversation", "discover": true},
-        {"path": "backend/routers/action_items.py", "symbol": "action_items_db.mark_action_item_completed", "discover": true},
-        {"path": "backend/routers/action_items.py", "symbol": "action_items_db.update_action_item", "discover": true}
+        {
+          "path": "backend/routers/action_items.py",
+          "symbol": "action_items_db.create_action_item",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/action_items.py",
+          "symbol": "action_items_db.create_action_items_batch",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/action_items.py",
+          "symbol": "action_items_db.delete_action_item",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/action_items.py",
+          "symbol": "action_items_db.delete_action_items_batch",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/action_items.py",
+          "symbol": "action_items_db.delete_action_items_for_conversation",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/action_items.py",
+          "symbol": "action_items_db.mark_action_item_completed",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/action_items.py",
+          "symbol": "action_items_db.update_action_item",
+          "discover": true
+        }
       ]
     },
     {
@@ -34,8 +62,6 @@
         "desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift",
         "desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift",
         "desktop/macos/Desktop/Sources/APIClient.swift",
-        "desktop/macos/Desktop/Sources/MainWindow/Dashboard/WhatMattersNowSection.swift",
-        "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift",
         "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift",
         "desktop/macos/Desktop/Sources/Onboarding/OnboardingPagedIntroCoordinator.swift",
         "desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift",
@@ -45,95 +71,223 @@
       ],
       "test_adapter": "direct_command_contract",
       "writer_anchors": [
-        {"path": "desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift", "symbol": "client.createTask", "discover": true},
-        {"path": "desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift", "symbol": "client.createTask", "discover": true},
-        {"path": "desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift", "symbol": "client.deleteTask", "discover": true},
-        {"path": "desktop/macos/Desktop/Sources/ProactiveAssistants/ContextReminders/ContextReminderCoordinator.swift", "symbol": "client.createActionItem", "discover": true},
-        {"path": "desktop/macos/Desktop/Sources/ProactiveAssistants/ContextReminders/ContextReminderCoordinator.swift", "symbol": "client.updateActionItem", "discover": true},
-        {"path": "backend/routers/desktop_core.py", "symbol": "action_items_db.create_action_item", "discover": true}
+        {
+          "path": "desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift",
+          "symbol": "client.createTask",
+          "discover": true
+        },
+        {
+          "path": "desktop/macos/Desktop/Sources/ProactiveAssistants/ContextReminders/ContextReminderCoordinator.swift",
+          "symbol": "client.createActionItem",
+          "discover": true
+        },
+        {
+          "path": "desktop/macos/Desktop/Sources/ProactiveAssistants/ContextReminders/ContextReminderCoordinator.swift",
+          "symbol": "client.updateActionItem",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/desktop_core.py",
+          "symbol": "action_items_db.create_action_item",
+          "discover": true
+        }
       ]
     },
     {
       "id": "chat_voice_tools",
       "policy_class": "direct_command",
-      "owner_paths": ["backend/utils/retrieval/tool_services/action_items.py", "backend/utils/retrieval/tools/action_item_tools.py", "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift"],
+      "owner_paths": [
+        "backend/utils/retrieval/tool_services/action_items.py",
+        "backend/utils/retrieval/tools/action_item_tools.py",
+        "desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift"
+      ],
       "test_adapter": "direct_command_contract",
       "writer_anchors": [
-        {"path": "backend/utils/retrieval/tool_services/action_items.py", "symbol": "action_items_db.create_action_item", "discover": true},
-        {"path": "backend/utils/retrieval/tool_services/action_items.py", "symbol": "action_items_db.update_action_item", "discover": true},
-        {"path": "backend/utils/retrieval/tools/action_item_tools.py", "symbol": "action_items_db.create_action_item", "discover": true},
-        {"path": "backend/utils/retrieval/tools/action_item_tools.py", "symbol": "action_items_db.update_action_item", "discover": true}
+        {
+          "path": "backend/utils/retrieval/tool_services/action_items.py",
+          "symbol": "action_items_db.create_action_item",
+          "discover": true
+        },
+        {
+          "path": "backend/utils/retrieval/tool_services/action_items.py",
+          "symbol": "action_items_db.update_action_item",
+          "discover": true
+        },
+        {
+          "path": "backend/utils/retrieval/tools/action_item_tools.py",
+          "symbol": "action_items_db.create_action_item",
+          "discover": true
+        },
+        {
+          "path": "backend/utils/retrieval/tools/action_item_tools.py",
+          "symbol": "action_items_db.update_action_item",
+          "discover": true
+        }
       ]
     },
     {
       "id": "mcp_tools",
       "policy_class": "direct_command",
-      "owner_paths": ["backend/utils/mcp_action_items.py", "backend/routers/mcp.py", "backend/routers/mcp_sse.py"],
+      "owner_paths": [
+        "backend/utils/mcp_action_items.py",
+        "backend/routers/mcp.py",
+        "backend/routers/mcp_sse.py"
+      ],
       "test_adapter": "direct_command_contract",
       "writer_anchors": [
-        {"path": "backend/utils/mcp_action_items.py", "symbol": "action_items_db.create_action_item", "discover": true},
-        {"path": "backend/utils/mcp_action_items.py", "symbol": "action_items_db.delete_action_item", "discover": true},
-        {"path": "backend/utils/mcp_action_items.py", "symbol": "action_items_db.mark_action_item_completed", "discover": true},
-        {"path": "backend/utils/mcp_action_items.py", "symbol": "action_items_db.update_action_item", "discover": true}
+        {
+          "path": "backend/utils/mcp_action_items.py",
+          "symbol": "action_items_db.create_action_item",
+          "discover": true
+        },
+        {
+          "path": "backend/utils/mcp_action_items.py",
+          "symbol": "action_items_db.delete_action_item",
+          "discover": true
+        },
+        {
+          "path": "backend/utils/mcp_action_items.py",
+          "symbol": "action_items_db.mark_action_item_completed",
+          "discover": true
+        },
+        {
+          "path": "backend/utils/mcp_action_items.py",
+          "symbol": "action_items_db.update_action_item",
+          "discover": true
+        }
       ]
     },
     {
       "id": "developer_api",
       "policy_class": "direct_command",
-      "owner_paths": ["backend/routers/developer.py"],
+      "owner_paths": [
+        "backend/routers/developer.py"
+      ],
       "test_adapter": "direct_command_contract",
       "writer_anchors": [
-        {"path": "backend/routers/developer.py", "symbol": "action_items_db.create_action_item", "discover": true},
-        {"path": "backend/routers/developer.py", "symbol": "action_items_db.create_action_items_batch", "discover": true},
-        {"path": "backend/routers/developer.py", "symbol": "action_items_db.delete_action_item", "discover": true},
-        {"path": "backend/routers/developer.py", "symbol": "action_items_db.update_action_item", "discover": true},
-        {"path": "backend/routers/developer.py", "symbol": "goals_db.create_goal", "discover": true},
-        {"path": "backend/routers/developer.py", "symbol": "goals_db.delete_goal", "discover": true},
-        {"path": "backend/routers/developer.py", "symbol": "goals_db.update_goal", "discover": true},
-        {"path": "backend/routers/developer.py", "symbol": "goals_db.update_goal_progress", "discover": true}
+        {
+          "path": "backend/routers/developer.py",
+          "symbol": "action_items_db.create_action_item",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/developer.py",
+          "symbol": "action_items_db.create_action_items_batch",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/developer.py",
+          "symbol": "action_items_db.delete_action_item",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/developer.py",
+          "symbol": "action_items_db.update_action_item",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/developer.py",
+          "symbol": "goals_db.create_goal",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/developer.py",
+          "symbol": "goals_db.delete_goal",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/developer.py",
+          "symbol": "goals_db.update_goal",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/developer.py",
+          "symbol": "goals_db.update_goal_progress",
+          "discover": true
+        }
       ]
     },
     {
       "id": "backend_conversation_extraction",
       "policy_class": "shared_capture_policy",
-      "owner_paths": ["backend/utils/conversations/process_conversation.py", "backend/utils/conversations/merge_conversations.py", "backend/routers/conversations.py"],
+      "owner_paths": [
+        "backend/utils/conversations/process_conversation.py",
+        "backend/utils/conversations/merge_conversations.py",
+        "backend/routers/conversations.py"
+      ],
       "test_adapter": "transcript_capture_v2",
       "writer_anchors": [
-        {"path": "backend/utils/conversations/merge_conversations.py", "symbol": "action_items_db.delete_action_items_for_conversation", "discover": true},
-        {"path": "backend/routers/conversations.py", "symbol": "action_items_db.delete_action_item", "discover": true},
-        {"path": "backend/routers/conversations.py", "symbol": "action_items_db.delete_action_items_for_conversation", "discover": true},
-        {"path": "backend/routers/conversations.py", "symbol": "action_items_db.mark_action_item_completed", "discover": true},
-        {"path": "backend/routers/conversations.py", "symbol": "action_items_db.update_action_item", "discover": true}
+        {
+          "path": "backend/utils/conversations/merge_conversations.py",
+          "symbol": "action_items_db.delete_action_items_for_conversation",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/conversations.py",
+          "symbol": "action_items_db.delete_action_item",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/conversations.py",
+          "symbol": "action_items_db.delete_action_items_for_conversation",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/conversations.py",
+          "symbol": "action_items_db.mark_action_item_completed",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/conversations.py",
+          "symbol": "action_items_db.update_action_item",
+          "discover": true
+        }
       ]
     },
     {
       "id": "mobile_conversation_extraction",
       "policy_class": "direct_command",
-      "owner_paths": ["backend/utils/conversations/process_conversation.py"],
+      "owner_paths": [
+        "backend/utils/conversations/process_conversation.py"
+      ],
       "test_adapter": "direct_command_contract",
       "writer_anchors": [
-        {"path": "backend/utils/conversations/process_conversation.py", "symbol": "action_items_db.create_action_items_batch", "discover": true},
-        {"path": "backend/utils/conversations/process_conversation.py", "symbol": "action_items_db.delete_action_items_for_conversation", "discover": true}
+        {
+          "path": "backend/utils/conversations/process_conversation.py",
+          "symbol": "action_items_db.create_action_items_batch",
+          "discover": true
+        },
+        {
+          "path": "backend/utils/conversations/process_conversation.py",
+          "symbol": "action_items_db.delete_action_items_for_conversation",
+          "discover": true
+        }
       ]
     },
     {
       "id": "desktop_screen_extraction",
       "policy_class": "shared_capture_policy",
-      "owner_paths": ["desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift"],
+      "owner_paths": [
+        "desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift"
+      ],
       "test_adapter": "screen_capture_v2",
       "writer_anchors": []
     },
     {
       "id": "sharing_imports",
       "policy_class": "direct_command",
-      "owner_paths": ["backend/routers/action_items.py"],
+      "owner_paths": [
+        "backend/routers/action_items.py"
+      ],
       "test_adapter": "direct_command_contract",
       "writer_anchors": []
     },
     {
       "id": "recurrence",
       "policy_class": "direct_command",
-      "owner_paths": ["desktop/macos/Desktop/Sources/Stores/TasksStore.swift"],
+      "owner_paths": [
+        "desktop/macos/Desktop/Sources/Stores/TasksStore.swift"
+      ],
       "test_adapter": "direct_command_contract",
       "writer_anchors": []
     },
@@ -149,22 +303,69 @@
         "desktop/macos/Desktop/Sources/MemoryExportExecutor.swift"
       ],
       "test_adapter": "direct_command_contract",
-      "writer_anchors": [{"path": "backend/utils/task_sync.py", "symbol": "action_items_db.update_action_item", "discover": true}]
+      "writer_anchors": [
+        {
+          "path": "backend/utils/task_sync.py",
+          "symbol": "action_items_db.update_action_item",
+          "discover": true
+        }
+      ]
     },
     {
       "id": "goal_manual_api",
       "policy_class": "direct_command",
       "owner_paths": [
         "backend/routers/goals.py",
-        "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift"
+        "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift",
+        "desktop/macos/Desktop/Sources/MainWindow/Dashboard/DashboardViewModel.swift"
       ],
       "test_adapter": "direct_command_contract",
       "writer_anchors": [
-        {"path": "backend/routers/goals.py", "symbol": "goals_db.create_goal", "discover": true},
-        {"path": "backend/routers/goals.py", "symbol": "goals_db.delete_goal", "discover": true},
-        {"path": "backend/routers/goals.py", "symbol": "goals_db.update_goal", "discover": true},
-        {"path": "backend/routers/goals.py", "symbol": "goals_db.update_goal_progress", "discover": true},
-        {"path": "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift", "symbol": "client.createGoal", "discover": true}
+        {
+          "path": "backend/routers/goals.py",
+          "symbol": "goals_db.create_goal",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/goals.py",
+          "symbol": "goals_db.delete_goal",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/goals.py",
+          "symbol": "goals_db.update_goal",
+          "discover": true
+        },
+        {
+          "path": "backend/routers/goals.py",
+          "symbol": "goals_db.update_goal_progress",
+          "discover": true
+        },
+        {
+          "path": "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift",
+          "symbol": "client.createGoal",
+          "discover": true
+        },
+        {
+          "path": "desktop/macos/Desktop/Sources/MainWindow/Dashboard/DashboardViewModel.swift",
+          "symbol": "client.createGoal",
+          "discover": true
+        },
+        {
+          "path": "desktop/macos/Desktop/Sources/MainWindow/Dashboard/DashboardViewModel.swift",
+          "symbol": "client.deleteGoal",
+          "discover": true
+        },
+        {
+          "path": "desktop/macos/Desktop/Sources/MainWindow/Dashboard/DashboardViewModel.swift",
+          "symbol": "client.updateGoal",
+          "discover": true
+        },
+        {
+          "path": "desktop/macos/Desktop/Sources/MainWindow/Dashboard/DashboardViewModel.swift",
+          "symbol": "client.updateGoalProgress",
+          "discover": true
+        }
       ]
     },
     {
@@ -175,16 +376,33 @@
         "desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Goals/GoalsAIService.swift"
       ],
       "test_adapter": "transcript_capture_v2",
-      "writer_anchors": [{"path": "backend/utils/llm/goals.py", "symbol": "goals_db.update_goal_progress", "discover": true}]
+      "writer_anchors": [
+        {
+          "path": "backend/utils/llm/goals.py",
+          "symbol": "goals_db.update_goal_progress",
+          "discover": true
+        }
+      ]
     },
     {
       "id": "legacy_staged_promotion",
       "policy_class": "compatibility_migration",
-      "owner_paths": ["backend/database/staged_tasks.py", "desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPromotionService.swift"],
+      "owner_paths": [
+        "backend/database/staged_tasks.py",
+        "desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPromotionService.swift"
+      ],
       "test_adapter": "legacy_reconciliation_contract",
       "writer_anchors": [
-        {"path": "backend/database/staged_tasks.py", "symbol": "action_items_db.create_action_item", "discover": true},
-        {"path": "backend/database/staged_tasks.py", "symbol": "action_items_db.update_action_item", "discover": true}
+        {
+          "path": "backend/database/staged_tasks.py",
+          "symbol": "action_items_db.create_action_item",
+          "discover": true
+        },
+        {
+          "path": "backend/database/staged_tasks.py",
+          "symbol": "action_items_db.update_action_item",
+          "discover": true
+        }
       ]
     },
     {
@@ -198,17 +416,32 @@
       ],
       "test_adapter": "direct_command_contract",
       "writer_anchors": [
-        {"path": "backend/database/candidates.py", "symbol": "canonical_firestore.action_items", "discover": true},
-        {"path": "backend/database/task_recommendations.py", "symbol": "canonical_firestore.action_items", "discover": true}
+        {
+          "path": "backend/database/candidates.py",
+          "symbol": "canonical_firestore.action_items",
+          "discover": true
+        },
+        {
+          "path": "backend/database/task_recommendations.py",
+          "symbol": "canonical_firestore.action_items",
+          "discover": true
+        }
       ]
     },
     {
       "id": "workstream_resolution",
       "policy_class": "direct_command",
-      "owner_paths": ["backend/database/workstreams.py", "backend/routers/workstreams.py"],
+      "owner_paths": [
+        "backend/database/workstreams.py",
+        "backend/routers/workstreams.py"
+      ],
       "test_adapter": "direct_command_contract",
       "writer_anchors": [
-        {"path": "backend/database/workstreams.py", "symbol": "canonical_firestore.action_items", "discover": true}
+        {
+          "path": "backend/database/workstreams.py",
+          "symbol": "canonical_firestore.action_items",
+          "discover": true
+        }
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- Drop stale `desktop_manual` owner paths for files removed in #12607 (`WhatMattersNowSection.swift`, `DashboardPage.swift`).
- Remove stale `client.createTask` / `client.deleteTask` writer anchors on `DesktopAutomationActivationActions.swift`.
- Register `DashboardViewModel` goal writers under `goal_manual_api` so discovered anchors stay owned.

Unblocks Backend unit suite red on main (`test_task_intelligence_contract_freeze` missing-owner-path).

## Product invariants affected

- INV-TASK-2

## Test plan
- [x] `BACKEND_UNIT_TEST_FILE_LIST=… bash test.sh` for `tests/unit/test_task_intelligence_contract_freeze.py` — 29 passed locally

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only changes to task intelligence ownership metadata; no runtime task or goal logic is modified.
> 
> **Overview**
> Updates **`task_intelligence_sources_v1.json`** so the task-intelligence contract freeze matches the current desktop codebase after #12607.
> 
> For **`desktop_manual`**, it removes owner paths for deleted dashboard files (`WhatMattersNowSection.swift`, `DashboardPage.swift`) and drops discovered writer anchors on `DesktopAutomationActivationActions.swift` for `client.createTask` / `client.deleteTask` that no longer belong there.
> 
> For **`goal_manual_api`**, it adds `DashboardViewModel.swift` as an owner and registers its `client.createGoal`, `deleteGoal`, `updateGoal`, and `updateGoalProgress` writers so goal mutations from the dashboard stay covered by the manifest.
> 
> The rest of the diff is **JSON formatting** (multi-line `writer_anchors` / `owner_paths`); behavior of those entries is unchanged aside from the edits above. This unblocks `test_task_intelligence_contract_freeze` failures for missing owner paths and unowned writers on main.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 830bc7dad84444c13155e5f93182287c700cdcc7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->